### PR TITLE
BUG: #82181 - All slaves subscribing to all channels

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -58,6 +58,7 @@ extern IException *MakeRoxieException(int code, const char *format, ...);
 extern Owned<ISocket> multicastSocket;
 extern size32_t channelWrite(unsigned channel, void const* buf, size32_t size);
 void addEndpoint(unsigned channel, const IpAddress &slaveIp, unsigned port);
+void joinMulticastChannel(unsigned channel);
 
 extern unsigned channels[MAX_CLUSTER_SIZE];     // list of all channel numbers for this node
 extern unsigned channelCount;                   // number of channels this node is doing

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -988,6 +988,8 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                         slaveCount++;
                     }
                     addChannel(channel, dataDirectory, isMe, suspended, slaveIp);
+                    if (isMe)
+                        joinMulticastChannel(channel);
                 }
                 else
                     throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - missing or invalid channel attribute on RoxieSlaveProcess element");
@@ -995,6 +997,9 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             else
                 throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - missing netAddress attribute on RoxieSlaveProcess element");
         }
+        if (numActiveChannels)
+            joinMulticastChannel(0); // all slaves also listen on channel 0
+
         for (unsigned n = 1; n < numActiveChannels; n++)
         {
             if (primaries[n].isNull())


### PR DESCRIPTION
Since the refactoring to allow operation without using multicast, all
slaves will subscribe to all channels, which will be inefficient and will
fail if there are 20 more more channels.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
