### PR TITLE
FIXED: #82343 - Make xmllib compile on newer versions of xerces

### DIFF
--- a/system/xmllib/xmlvalidator.cpp
+++ b/system/xmllib/xmlvalidator.cpp
@@ -32,19 +32,7 @@
 
 #include <xercesc/util/PlatformUtils.hpp>
 #include <xercesc/parsers/AbstractDOMParser.hpp>
-#include <xercesc/dom/DOMImplementation.hpp>
-#include <xercesc/dom/DOMImplementationLS.hpp>
-#include <xercesc/dom/DOMImplementationRegistry.hpp>
-#include <xercesc/dom/DOMBuilder.hpp>
-#include <xercesc/dom/DOMException.hpp>
-#include <xercesc/dom/DOMDocument.hpp>
-#include <xercesc/dom/DOMNodeList.hpp>
-#include <xercesc/dom/DOMError.hpp>
-#include <xercesc/dom/DOMLocator.hpp>
-#include <xercesc/dom/DOMNamedNodeMap.hpp>
-#include <xercesc/dom/DOMAttr.hpp>
-#include <xercesc/dom/DOMErrorHandler.hpp>
-#include <xercesc/dom/DOMInputSource.hpp>
+#include <xercesc/dom/DOM.hpp>
 #include <xercesc/validators/common/Grammar.hpp>
 #include <xercesc/util/BinFileInputStream.hpp>
 #include <xercesc/sax/SAXException.hpp>
@@ -294,7 +282,7 @@ void CDomXmlValidator::validate()
     parser->setExitOnFirstFatalError(false);
 
     parser->setDoNamespaces(true);
-    parser->setDoValidation(true);
+    parser->setValidationScheme(XercesDOMParser::Val_Always);
     parser->setDoSchema(true);
 
     if (m_targetNamespace.get())


### PR DESCRIPTION
Changes allow us to compile correctly on xerces 3.x as well as xerces 2.x

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
