### PR TITLE
BUG: #82345 - JLIB - fix thread unsafeness in dumping namecount table (no

### DIFF
--- a/system/jlib/jsuperhash.hpp
+++ b/system/jlib/jsuperhash.hpp
@@ -423,6 +423,7 @@ friend class AtomRefTable;
 typedef const char constcharptr;
 class jlib_decl AtomRefTable : public SuperHashTableOf<HashKeyElement, constcharptr>
 {
+protected:
     CriticalSection crit;
     bool nocase;
 


### PR DESCRIPTION
BUG: #82345 - JLIB - fix thread unsafeness in dumping namecount table (not enabled by default anyway)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
