### PR TITLE
FIXED: #82556 - new workunits not being picked after lock out

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -900,9 +900,11 @@ int WUSchedule::run()
                         wu.getClusterName(cluster);
                         if (!isRoxieCluster(cluster.str()))
                         {
-                            Owned<IWorkUnit> lwu = &wu.lock();
-                            lwu->setState(WUStateSubmitted);
-                            lwu->commit();
+                            {
+                                Owned<IWorkUnit> lwu = &wu.lock();
+                                lwu->setState(WUStateSubmitted);
+                                lwu->commit();
+                            } //Release the lock here. Otherwise, submitWorkUnit() will not work.
                             
                             SCMStringBuffer user, password, token;
                             wu.getSecurityToken(token).str();


### PR DESCRIPTION
The submitWorkUnit() will not work without releasing the lock.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
