### PR TITLE
FIXED: #81558 - exclude partitions

### DIFF
--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -111,7 +111,7 @@
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="excludePartitions" type="xs:string" use="optional" default="/,/dev*,/sys,/usr,/proc/*">
+        <xs:attribute name="excludePartitions" type="xs:string" use="optional" default="/dev*,/sys,/proc/*">
             <xs:annotation>
                 <xs:appinfo>
                     <tooltip>Comma, space or semicolon delimited list of partitions not to be monitored for free space</tooltip>


### PR DESCRIPTION
All partions should be monitored with the exception of /proc, /sys, /dev.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
