### PR TITLE
BUG: #82295 Attributes that were in the root scope were not resolved corr

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -8884,11 +8884,14 @@ IPropertyTree * resolveDefinitionInArchive(IPropertyTree * archive, const char *
     {
         xpath.clear().append("Module[@key='").appendLower(dot-path, path).append("']");
         module = archive->queryPropTree(xpath);
-        if (!module)
-            return module;
 
         path = dot+1;
     }
+    else
+        module = archive->queryPropTree("Module[@key='']");
+
+    if (!module)
+        return NULL;
 
     xpath.clear().append("Attribute[@key='").appendLower(strlen(path), path).append("']");
     return module->queryPropTree(xpath);


### PR DESCRIPTION
BUG: #82295 Attributes that were in the root scope were not resolved correctly in an archive

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
