### PR TITLE
FIXED: #81553 - Should /boot be monitored by default?

### DIFF
--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -111,7 +111,7 @@
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="excludePartitions" type="xs:string" use="optional" default="/dev*,/sys,/proc/*">
+        <xs:attribute name="excludePartitions" type="xs:string" use="optional" default="/dev*,/sys,/proc/*,/boot">
             <xs:annotation>
                 <xs:appinfo>
                     <tooltip>Comma, space or semicolon delimited list of partitions not to be monitored for free space</tooltip>


### PR DESCRIPTION
Based on the discussion inside the Bugzilla, /boot is added into the exclude list as default.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
