### PR TITLE
BUG: #82910 Run spawned program locally on windows (temporary fix)

### DIFF
--- a/common/remote/rmtspawn.cpp
+++ b/common/remote/rmtspawn.cpp
@@ -102,7 +102,7 @@ void getRemoteSpawnSSH(
 }
 
 
-ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoint & childEP, unsigned version, const char *logdir, IAbortRequestCallback * abort, bool debug, const char *extra)
+ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoint & childEP, unsigned version, const char *logdir, IAbortRequestCallback * abort, const char *extra)
 {
     SocketEndpoint myEP;
     myEP.setLocalHost(0);
@@ -120,45 +120,43 @@ ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoin
         args.append(' ').append(logdir);
 
 
-    //Run the program directly if it is being run on the local machine - so hoagent/ssh doesn't need to be running...
-#if 0 // this doesn't necessarily work as relies on hoagent account dir so disable
-    if (!debug && childEP.isHost())
+    StringBuffer cmd;
+    if (SSHexeprefix.isEmpty())
+        cmd.append(exe);
+    else {
+        const char * tail = splitDirTail(exe,cmd);
+        size32_t l = strlen(tail);
+        addPathSepChar(cmd).append(SSHexeprefix);
+        if ((l>4)&&(memcmp(tail+l-4,".exe",4)==0))  // bit odd but want .bat if prefix on windows
+            cmd.append(l-4,tail).append(".bat");
+        else
+            cmd.append(tail);
+    }
+    cmd.append(' ').append(args);
+
+    if (SSHusername.isEmpty())
     {
-        StringBuffer command;
-        command.append(exe).append(" ").append(args);
-        DWORD runcode;
-        if (!invoke_program(command.str(), runcode, false))
+#if defined(_WIN32)
+        //Run the program directly if it is being run on the local machine - so ssh doesn't need to be running...
+        //Change once we have solved the problems with ssh etc. on windows?
+        if (childEP.isHost())
         {
-            //Try running remote if not on the path.
-            if (!runRemoteProgram(exe, args.str(), childEP, debug))
+            DWORD runcode;
+            if (!invoke_program(cmd.str(), runcode, false))
                 return NULL;
         }
-    }
-    else
+        else
 #endif
-    if (SSHusername.isEmpty()) 
-        throw MakeStringException(-1,"SSH user not specified");
+
+            throw MakeStringException(-1,"SSH user not specified");
+    }
     else {
         Owned<IFRunSSH> runssh = createFRunSSH();
-        StringBuffer cmd;
-        if (SSHexeprefix.isEmpty())
-            cmd.append(exe);
-        else {
-            const char * tail = splitDirTail(exe,cmd);
-            size32_t l = strlen(tail);
-            addPathSepChar(cmd).append(SSHexeprefix);
-            if ((l>4)&&(memcmp(tail+l-4,".exe",4)==0))  // bit odd but want .bat if prefix on windows
-                cmd.append(l-4,tail).append(".bat");
-            else
-                cmd.append(tail);
-        }
-        cmd.append(' ').append(args);
         runssh->init(cmd.str(),SSHidentfilename,SSHusername,SSHpasswordenc,SSHtimeout,SSHretries);
         runssh->exec(childEP,NULL,true); // need workdir? TBD
     }
+
     //Have to now try and connect to the child and get back the port it is listening on
-    bool connected;
-    unsigned slaveTag;
     unsigned attempts = 20;
     SocketEndpoint connectEP(childEP);
     connectEP.port = port;
@@ -188,6 +186,8 @@ ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoin
                     buffer.append(replyTag);
                     writeBuffer(socket, buffer);
 
+                    bool connected;
+                    unsigned slaveTag;
                     readBuffer(socket, buffer.clear(), 100*1000);
                     buffer.read(connected);
                     buffer.read(slaveTag);

--- a/common/remote/rmtspawn.hpp
+++ b/common/remote/rmtspawn.hpp
@@ -39,7 +39,7 @@ enum SpawnKind
 
 interface IAbortRequestCallback;
 
-extern REMOTE_API ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoint & remoteEP, unsigned version, const char *logdir, IAbortRequestCallback * abort = NULL, bool debug=false, const char *extra=NULL);
+extern REMOTE_API ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoint & remoteEP, unsigned version, const char *logdir, IAbortRequestCallback * abort = NULL, const char *extra=NULL);
 extern REMOTE_API void setRemoteSpawnSSH(
                 const char *identfilename,
                 const char *username, // if NULL then disable SSH

--- a/dali/ft/daftdir.cpp
+++ b/dali/ft/daftdir.cpp
@@ -454,7 +454,7 @@ bool DirectoryThread::performCommand()
 
     LOG(MCdebugProgressDetail, job, "Starting to generate part %s [%lx]", url.str(), this);
     StringBuffer tmp;
-    Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, queryFtSlaveExecutable(node->endpoint(), tmp), node->endpoint(), DAFT_VERSION, queryFtSlaveLogDir(), NULL, false, NULL);
+    Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, queryFtSlaveExecutable(node->endpoint(), tmp), node->endpoint(), DAFT_VERSION, queryFtSlaveLogDir(), NULL, NULL);
     if (socket)
     {
         observer.addSlave(socket);
@@ -817,7 +817,7 @@ void doPhysicalCopy(IPropertyTree * source, const char * target, IPropertyTree *
 
     LOG(MCdebugProgressDetail, unknownJob, "Starting to generate part %s", url.str());
     StringBuffer tmp;
-    Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, queryFtSlaveExecutable(targetIP, tmp), targetName.queryEndpoint(), DAFT_VERSION, queryFtSlaveLogDir(), NULL, false); 
+    Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, queryFtSlaveExecutable(targetIP, tmp), targetName.queryEndpoint(), DAFT_VERSION, queryFtSlaveLogDir(), NULL);
     if (socket)
     {
         broadcaster.addSlave(socket);

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -1222,7 +1222,7 @@ void CRemotePartitioner::callRemote()
         StringBuffer url, tmp;
         ep.getUrlStr(url);
         
-        Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, slave, ep, DAFT_VERSION, queryFtSlaveLogDir(), NULL, false, wuid);
+        Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, slave, ep, DAFT_VERSION, queryFtSlaveLogDir(), NULL, wuid);
         if (socket)
         {
             LogMsgJobInfo job(unknownJob);

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -49,7 +49,6 @@
 #define PARTITION_RECOVERY_LIMIT 1000
 #define EXPECTED_RESPONSE_TIME          (60 * 1000)
 #define RESPONSE_TIME_TIMEOUT           (60 * 60 * 1000)
-#define DEBUG_FTSLAVE   false
 
 static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/filecopy.cpp $ $Id: filecopy.cpp 62376 2011-02-04 21:59:58Z sort $");
 
@@ -326,7 +325,7 @@ bool FileTransferThread::performTransfer()
 
     LOG(MCdebugProgressDetail, job, "Start generate part %s [%lx]", url.str(), this);
     StringBuffer tmp;
-    Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, sprayer.querySlaveExecutable(ep, tmp), ep, DAFT_VERSION, queryFtSlaveLogDir(), this, DEBUG_FTSLAVE, wuid);
+    Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, sprayer.querySlaveExecutable(ep, tmp), ep, DAFT_VERSION, queryFtSlaveLogDir(), this, wuid);
     if (socket)
     {
         MemoryBuffer msg;


### PR DESCRIPTION
If no ssh password is provided, and program to execute is local then execute the program directly.  This allows a one node system to work on windows without an ssh server set up.  Also remove unsued debug parameter.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
