### PR TITLE
BUG: #82816 Preserve file part TLK

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2803,6 +2803,20 @@ void FileSprayer::updateTargetProperties()
 
                     curProps.setProp("@modified", temp.getString(timestr).str());
                 }
+                if (replicate && (distributedSource != distributedTarget))
+                {
+                    Owned<IDistributedFilePart> curSourcePart = distributedSource->getPart(cur.whichInput);
+                    Owned<IAttributeIterator> aiter = curSourcePart->queryProperties().getAttributes();
+                    //At the moment only clone the topLevelKey indicator (stored in kind), but make it easy to add others.
+                    ForEach(*aiter) {
+                        const char *aname = aiter->queryName();
+                        if (strieq(aname,"@kind")
+                            ) {
+                            if (!curProps.hasProp(aname))
+                                curProps.setProp(aname,aiter->queryValue());
+                        }
+                    }
+                }
                 curPart->unlockProperties();
                 partCRC.clear();
                 partLength = 0;
@@ -2836,7 +2850,7 @@ void FileSprayer::updateTargetProperties()
                      (stricmp(aname,"@formatCrc")==0)||
                      (stricmp(aname,"@owner")==0)||
                      ((stricmp(aname,FArecordCount)==0)&&!gotrc))
-                     ) 
+                    )
                     curProps.setProp(aname,aiter->queryValue());
             }
 


### PR DESCRIPTION
When replicating an index (but not mirroring which updates backups) ensure that the "kind" attribute on the file part is preserved - since this indicates if the file part is a top level key.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
