### PR TITLE
BUG: #82295 Resolve definitions with no scope in an archive

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -8884,11 +8884,14 @@ IPropertyTree * resolveDefinitionInArchive(IPropertyTree * archive, const char *
     {
         xpath.clear().append("Module[@key='").appendLower(dot-path, path).append("']");
         module = archive->queryPropTree(xpath);
-        if (!module)
-            return module;
 
         path = dot+1;
     }
+    else
+        module = archive->queryPropTree("Module[@key='']");
+
+    if (!module)
+        return NULL;
 
     xpath.clear().append("Attribute[@key='").appendLower(strlen(path), path).append("']");
     return module->queryPropTree(xpath);


### PR DESCRIPTION
When searching for a definition "x" in the root of an archive the code
should have been looking for an Attribute tag inside a Module tag (with
a blank name). Instead it was incorrectly searching for a global
Attribute tag (not inside any tag).
This meant that the text for queries that came from definitions in the
root of the source tree didn't get displayed in esp.

I think the format changed in the past and this function wasn't updated to reflect the correct structure.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
