### PR TITLE
FIXED: #82344 - Updating Deps system used for building packages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,12 @@ if ( CMAKE_SYSTEM MATCHES Linux )
                     OUTPUT_VARIABLE packageRevisionArch
                         ERROR_VARIABLE  packageRevisionArch
                 )
+    EXECUTE_PROCESS (
+                COMMAND ${HPCC_SOURCE_DIR}/cmake_modules/getpackagerevisionarch.sh --noarch
+                    OUTPUT_VARIABLE packageRevision
+                        ERROR_VARIABLE  packageRevision
+                )
+		
     message ( "-- Auto Detecting Packaging type")
     message ( "-- distro uses ${packageManagement}, revision is ${packageRevisionArch}" )
 
@@ -363,7 +369,6 @@ if (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.1")
                 ###
                 ## CPack instruction required for Debian
                 ###
-                set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex-dev, libicu-dev, libxalan110, libxerces-c28, binutils, libldap2-dev, openssl, zlib1g, g++, openssh-client, openssh-server")
                 message ("-- Packing BASH installation files")
                 set ( CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_BINARY_DIR}/initfiles/bash/sbin/deb/postinst;${CMAKE_BINARY_DIR}/initfiles/sbin/prerm;${CMAKE_BINARY_DIR}/initfiles/bash/sbin/deb/postrm" )
             endif ()
@@ -374,7 +379,6 @@ if (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.1")
             ## CPack instruction required for RPM 
             ###
             message("-- Will build RPM package")
-            set ( CPACK_RPM_PACKAGE_REQUIRES "boost, openldap, libicu, m4, libtool, xalan-c, xerces-c, gcc-c++, openssh-server, openssh-clients")
             message ("-- Packing BASH installation files")
             set ( CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/initfiles/bash/sbin/deb/postinst" )
 
@@ -385,7 +389,12 @@ if (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.1")
         endif ()
 
     endif ( CMAKE_SYSTEM MATCHES Linux )
-
+    if ( EXISTS ${CMAKE_MODULE_PATH}/dependencies/${packageRevision}.cmake )
+        include( ${CMAKE_MODULE_PATH}/dependencies/${packageRevision}.cmake )
+    else()
+        message("-- WARNING: DEPENDENCY FILE FOR ${packageRevision} NOT FOUND, Using deps template.")
+        include( ${CMAKE_MODULE_PATH}/dependencies/template.cmake )
+    endif()
 else()
     message("WARNING: CMAKE 2.8.1 or later required to create RPMs from this project")
 endif()

--- a/cmake_modules/dependencies/el5.cmake
+++ b/cmake_modules/dependencies/el5.cmake
@@ -1,0 +1,1 @@
+set ( CPACK_RPM_PACKAGE_REQUIRES "boost, openldap, libicu, m4, libtool, xalan-c, xerces-c, gcc-c++, openssh-server, openssh-clients")

--- a/cmake_modules/dependencies/lucid.cmake
+++ b/cmake_modules/dependencies/lucid.cmake
@@ -1,0 +1,1 @@
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex-dev, libicu-dev, libxalan110, libxerces-c28, binutils, libldap2-dev, openssl, zlib1g, g++, openssh-client, openssh-server")

--- a/cmake_modules/dependencies/natty.cmake
+++ b/cmake_modules/dependencies/natty.cmake
@@ -1,0 +1,1 @@
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex-dev, libicu-dev, libxalan110, libxerces-c28, binutils, libldap2-dev, openssl, zlib1g, g++, openssh-client, openssh-server")

--- a/cmake_modules/dependencies/suse11.3.cmake
+++ b/cmake_modules/dependencies/suse11.3.cmake
@@ -1,0 +1,1 @@
+set ( CPACK_RPM_PACKAGE_REQUIRES  "binutils, gcc-c++, openssh, libldap-2_4-2, libicu, libboost_regex1_42_0, libxerces-c-3_0, libxalan-c110" )

--- a/cmake_modules/dependencies/suse11.4.cmake
+++ b/cmake_modules/dependencies/suse11.4.cmake
@@ -1,0 +1,1 @@
+set ( CPACK_RPM_PACKAGE_REQUIRES  "binutils, gcc-c++, openssh, libldap-2_4-2, libicu, libboost_regex1_44_0, libxerces-c-3_0, libxalan-c110" )

--- a/cmake_modules/dependencies/template.cmake
+++ b/cmake_modules/dependencies/template.cmake
@@ -1,0 +1,12 @@
+# This is a template of what is needed to create a dependency file for your distribution.
+
+# Steps to follow.
+# 1. Copy template.cmake to <distribution name>.cmake
+#       ex. Ubuntu 11.04      natty.cmake
+#       ex. Centos 5.x            el5.cmake
+#
+# 2. Add a DEPENDS line based on the package system of your distribution.
+#       ex. set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libicu,libboost-regex1.42.0")
+#       ex. set ( CPACK_RPM_PACKAGE_REQUIRES "libicu, boost")
+#
+# 3. Save your changes and create a build from your build directory with `make package`


### PR DESCRIPTION
Updating CMake to load os specific dependencies from an external file.

Added suse11.4 dep files along with update to disable make package if dep file does not exist.

Added a template deps file that is used if the os does not have a deps file.

Fixing spacing.

Moved to using a --noarch flag to getpackagerevisionarch.sh in order to have one dep file per distribution.

Updating template file to remove usage of _<arch>

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
