### PR TITLE
Fixed: 82758 Changed method of output redirect in remote install.

### DIFF
--- a/initfiles/sbin/remote-install-engine.sh.in
+++ b/initfiles/sbin/remote-install-engine.sh.in
@@ -85,15 +85,10 @@ installPkg(){
     checkInstall
     if [ "${_INSTALLED}" == "0" ]; then
         pkgCmd $OSPKG "install"
-        RUN=`$PKGCMD $PKG 2>&1 1>/dev/null; echo $?`
+        $PKGCMD $PKG 1>/dev/null 2>&1;
     elif [ "${_UPGRADE}" == "1" ]; then
         pkgCmd $OSPKG "upgrade"
-        RUN=`$PKGCMD $PKG 2>&1 1>/dev/null; echo $?`
-    else
-        RUN=0
-    fi
-    if [ ${RUN} -eq 0 ]; then
-        return $RUN
+        $PKGCMD $PKG 1>/dev/null 2>&1;
     fi
 }
 
@@ -147,7 +142,7 @@ checkKeys(){
 }
 
 installKeys(){
-    mkdir -p  ~/hpcc/.ssh
+    mkdir -p  ~hpcc/.ssh
     rm -f ~hpcc/.ssh/authorized_keys
     /bin/cp $1/$2 ~hpcc/.ssh/$2
     /bin/cp $1/$2.pub ~hpcc/.ssh/$2.pub
@@ -178,4 +173,6 @@ if [ -e ${REMOTE_INSTALL}/${ENV_XML_FILE} ]; then
 	cp -r ${REMOTE_INSTALL}/${ENV_XML_FILE}  ${CONFIG_DIR}/${ENV_XML_FILE} 
 	chown hpcc:hpcc ${CONFIG_DIR}/${ENV_XML_FILE}
 fi
+rm -rf ${REMOTE_INSTALL}
+rm -rf ~/remote_install.tgz
 exit 0


### PR DESCRIPTION
remote-install-engine.sh used an incorrect output redirection that
at times would cause an error display on run that was of no bearing
to the action.

Moved output redirect from 2>&1 1>/dev/null to 1>/dev/null 2>&1

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
