### PR TITLE
BUG: 82862 Fix a mistake for the 'sort' attribute of menu folder tree

### DIFF
--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -348,7 +348,8 @@ IPropertyTree *CEspBinding::ensureNavFolder(IPropertyTree &root, const char *nam
         ret->addProp("@name", name);
         ret->addProp("@tooltip", tooltip);
         ret->setProp("@menu", menuname);
-        ret->setPropBool("@sort", true);
+        if (sort)
+            ret->addPropBool("@sort", true);
         ret->addPropInt("@relPosition", relPosition);
 
         root.addPropTree("Folder", ret);


### PR DESCRIPTION
There is a mistake in my previous changes for BUG: 82862. Before those
changes, the 'sort' attribute of a menu folder tree was set only when
requested. One of my changes forced the 'sort' attribute to be true. The 
true value will force menu items list in alphabetical order, which is 
incorrect. Now, the old code is switched back.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
