### PR TITLE
BUG:83306 Ordered IPT impl.+cleanup createPTree*

### DIFF
--- a/common/deftype/deffield.cpp
+++ b/common/deftype/deffield.cpp
@@ -254,7 +254,7 @@ extern DEFTYPE_API IDefRecordMeta * deserializeRecordMeta(const IPropertyTree * 
 static void addElementToPTree(IPropertyTree * root, IDefRecordElement * elem)
 {
     byte kind = elem ? elem->getKind() : DEKnone;
-    Owned<IPTree> branch = createPTree(false);
+    Owned<IPTree> branch = createPTree();
     StringAttr branchName;
     switch (kind)
     {
@@ -303,7 +303,7 @@ static void addElementToPTree(IPropertyTree * root, IDefRecordElement * elem)
 
 extern DEFTYPE_API StringBuffer & getRecordMetaAsString(StringBuffer & out, IDefRecordMeta const * meta)
 {
-    Owned<IPropertyTree> tree = createPTree("RecordMeta", false);
+    Owned<IPropertyTree> tree = createPTree("RecordMeta");
     tree->setPropInt("@numKeyedFields", meta->numKeyedFields());
     addElementToPTree(tree, meta->queryRecord());
     toXML(tree, out);

--- a/common/dllserver/dllserver.cpp
+++ b/common/dllserver/dllserver.cpp
@@ -558,7 +558,7 @@ void DllServer::doRegisterDll(const char * name, const char * kind, const char *
         conn->queryRoot()->setProp("@uid", name);
     }
 
-    IPropertyTree * locationTree = createPTree("location", false);
+    IPropertyTree * locationTree = createPTree("location");
     locationTree->setProp("@ip", ipText.str());
     locationTree->setProp("@dll", dllText.str());
 

--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -143,7 +143,7 @@ public:
 
          //copy const environment to our member environment
          Owned<IPropertyTree> pSrc = conn2->getRoot();
-         c.setown( new CLocalEnvironment(NULL, createPTree(pSrc)));
+         c.setown( new CLocalEnvironment(NULL, createPTreeFromIPT(pSrc)));
          conn2->rollback();
       }
       else

--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -487,14 +487,14 @@ public:
 
     virtual IEnvironment * loadLocalEnvironmentFile(const char * filename)
     {
-        Owned<IPropertyTree> ptree = createPTreeFromXMLFile(filename, false);
+        Owned<IPropertyTree> ptree = createPTreeFromXMLFile(filename);
         Owned<CLocalEnvironment> pLocalEnv = new CLocalEnvironment(NULL, ptree);
         return new CLockedEnvironment(pLocalEnv);
     }
 
     virtual IEnvironment * loadLocalEnvironment(const char * xml)
     {
-        Owned<IPropertyTree> ptree = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> ptree = createPTreeFromXMLString(xml);
         Owned<CLocalEnvironment> pLocalEnv = new CLocalEnvironment(NULL, ptree);
         return new CLockedEnvironment(pLocalEnv);
     }
@@ -972,7 +972,7 @@ CLocalEnvironment::CLocalEnvironment(const char* environmentFile)
 {
    if (environmentFile && *environmentFile)
    {
-       IPropertyTree* root = createPTreeFromXMLFile(environmentFile, false);
+       IPropertyTree* root = createPTreeFromXMLFile(environmentFile);
        if (root)
            p.set(root);
    }
@@ -1253,7 +1253,7 @@ void CLocalEnvironment::preload()
 
 void CLocalEnvironment::setXML(const char *xml)
 {
-    Owned<IPropertyTree> newRoot = createPTreeFromXMLString(xml, false);
+    Owned<IPropertyTree> newRoot = createPTreeFromXMLString(xml);
     Owned<IPropertyTreeIterator> it = p->getElements("*");
     ForEach(*it)
     {

--- a/common/roxiecommlib/roxiecommunicationclient.cpp
+++ b/common/roxiecommlib/roxiecommunicationclient.cpp
@@ -81,7 +81,7 @@ protected:
             _WINREV(sendlen);
             sock->read(response.reserveTruncate(sendlen), sendlen);
         }
-        Owned<IPropertyTree> ret = createPTreeFromXMLString(response.str(), false);
+        Owned<IPropertyTree> ret = createPTreeFromXMLString(response.str());
         Owned<IMultiException> me = MakeMultiException();
         Owned<IPropertyTreeIterator> endpoints = ret->getElements("Endpoint");
         ForEach(*endpoints)
@@ -123,7 +123,7 @@ protected:
             sock->read(block, sendlen);
             if (!exception && sendlen > 11 && memicmp(block, "<Exception>", 11) == 0)
             {
-                Owned<IPropertyTree> eTree = createPTreeFromXMLString(sendlen, block, true);
+                Owned<IPropertyTree> eTree = createPTreeFromXMLString(sendlen, block, ipt_caseInsensitive);
                 exception.setown(MakeStringException(eTree->getPropInt("Code", 0), eTree->queryProp("Message")));
             }
         }
@@ -206,7 +206,7 @@ protected:
             _WINREV(sendlen);
             sock->read(lockResponse.reserveTruncate(sendlen), sendlen);
         }
-        Owned<IPropertyTree> lockRet = createPTreeFromXMLString(lockResponse.str(), false);
+        Owned<IPropertyTree> lockRet = createPTreeFromXMLString(lockResponse.str());
         if (lockAll)
         {
             int lockCount = lockRet->getPropInt("Lock", 0);
@@ -220,7 +220,7 @@ protected:
     void buildPackageFileInfo(IPropertyTree *packageTree, const char *filename)
     {
         StringBuffer packageInfo;
-        IPropertyTree *pkgInfo = createPTreeFromXMLFile(filename, true);
+        IPropertyTree *pkgInfo = createPTreeFromXMLFile(filename, ipt_caseInsensitive);
 
         StringBuffer baseFileName;
         splitFilename(filename, NULL, NULL, &baseFileName, &baseFileName);
@@ -398,7 +398,7 @@ public:
             return sendRoxieControlQuery(xpath.str(), true);
         else
         {
-            IPropertyTree *tree = createPTree("Control", false);
+            IPropertyTree *tree = createPTree("Control");
             ForEachItemIn(idx, ipList)
             {
                 StringBuffer ip(ipList.item(idx));

--- a/common/roxiehelper/roxiedebug.cpp
+++ b/common/roxiehelper/roxiedebug.cpp
@@ -1744,7 +1744,7 @@ void CBaseServerDebugContext::debugPrint(IXmlWriter *output, const char *edgeId,
 #if 1
     CommonXmlWriter dummyOutput(0, 0);
     activityCtx->printEdge(&dummyOutput, startRow, numRows); // MORE - need to suppress the <Edge> if we want backward compatibility!
-    Owned<IPropertyTree> result = createPTreeFromXMLString(dummyOutput.str(), false);
+    Owned<IPropertyTree> result = createPTreeFromXMLString(dummyOutput.str());
     if (result)
     {
         Owned<IAttributeIterator> attributes = result->getAttributes();

--- a/common/roxiemanager/roxiequerycompiler.cpp
+++ b/common/roxiemanager/roxiequerycompiler.cpp
@@ -217,7 +217,7 @@ public:
             StringBuffer options(compileInfo.queryWuDebugOptions());
             if (options.length())
             {
-                Owned<IPropertyTree> dbgOptions = createPTreeFromXMLString(options, true);
+                Owned<IPropertyTree> dbgOptions = createPTreeFromXMLString(options, ipt_caseInsensitive);
                 Owned<IPropertyTreeIterator> iter = dbgOptions->getElements("Option");
                 ForEach(*iter)
                 {

--- a/common/roxiemanager/roxiequerymanager.cpp
+++ b/common/roxiemanager/roxiequerymanager.cpp
@@ -407,7 +407,7 @@ public:
         }
         xml.append("</QueryNames>");
 
-        Owned<IPropertyTree> tree = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> tree = createPTreeFromXMLString(xml);
         return tree.getClear();
     }
 

--- a/common/roxiemanager/roxiewuprocessor.cpp
+++ b/common/roxiemanager/roxiewuprocessor.cpp
@@ -146,7 +146,7 @@ private:
     // helper methods
     inline static IPropertyTree *addAttribute(IPropertyTree &node, const char * name)
     {
-        IPropertyTree * att = createPTree(false);
+        IPropertyTree * att = createPTree();
         att->setProp("@name", name);
         return node.addPropTree("att", att);
     }
@@ -181,7 +181,7 @@ private:
     void addDllFile(IPropertyTree *xml, const char* name, StringBuffer &fileLocation, const char* version, int codeVersion, unsigned crc, const char* fileType, bool loaddataonly)
     {
         // only 1 part for a dll file
-        IPropertyTree *file = createPTree(false);
+        IPropertyTree *file = createPTree();
         file->setProp("@id", name);
         if (stricmp(fileType, "plugin") == 0)
             file->setProp("@version", version);
@@ -199,8 +199,8 @@ private:
     
         if (fileLocation.length())
         {
-            IPropertyTree *part = createPTree(false);
-            IPropertyTree *location = createPTree(false);
+            IPropertyTree *part = createPTree();
+            IPropertyTree *location = createPTree();
             location->setProp(NULL, fileLocation);
             part->addPropTree("Loc", location);
             part->setPropInt("@num", 1);
@@ -392,7 +392,7 @@ private:
             processFileInfoInDali(xml, numParts, file_crc, recordCount, totalSize, formatCrc, isCompressed, fileName, remoteRoxieClusterName, epStr, processingInfo.queryUserDescriptor(), (isPatch || isBaseIndex) ? false :updateDali);
         }
 
-        IPropertyTree *file = createPTree(false);
+        IPropertyTree *file = createPTree();
         file->setProp("@mode", "add");
 
         if (numParts > 1)
@@ -445,12 +445,12 @@ private:
 
                 }
 
-                IPropertyTree *patchTree = createPTree(false);
+                IPropertyTree *patchTree = createPTree();
                 patchName.insert(0, "~");
                 patchTree->setProp("@name", patchName);
                 patchTree->setPropInt64("@crc", patch_crc);
                 
-                IPropertyTree *baseIndex = createPTree(false);
+                IPropertyTree *baseIndex = createPTree();
                 baseIndexName.insert(0, "~");
                 baseIndex->setProp("@name", baseIndexName);
                 baseIndex->setPropInt64("@crc", baseIndex_crc);
@@ -554,7 +554,7 @@ private:
 
         if (superPackageTree)
         {
-            IPropertyTree *subFileTree = createPTree("SubFile", false);
+            IPropertyTree *subFileTree = createPTree("SubFile");
             subFileTree->addProp("@value", fileName);
             superPackageTree->addPropTree("SubFile", subFileTree);
         }
@@ -564,7 +564,7 @@ private:
             IPartDescriptor *partdesc = fdesc->queryPart(partIdx);
             IPropertyTree &partProps = partdesc->queryProperties();
             offset_t dfsSize = partProps.getPropInt64("@size", -1);
-            IPropertyTree *part = createPTree(false);
+            IPropertyTree *part = createPTree();
             part->setPropInt64("@size", dfsSize);
             StringBuffer modifiedDt;
             partProps.getProp("@modified", modifiedDt);
@@ -593,7 +593,7 @@ private:
                             delim.append(common_dir_name[common_dir_name.length()-1]);
                     }
 
-                    IPropertyTree *location = createPTree(false);
+                    IPropertyTree *location = createPTree();
                     location->setProp("@path", origName.str());
                     part->addPropTree("Loc", location);
                 }
@@ -763,7 +763,7 @@ private:
 
                     if (superkeyFileInfo)
                     {
-                        temptree = superkeyFileInfo->addPropTree("SKeyName", createPTree(false));
+                        temptree = superkeyFileInfo->addPropTree("SKeyName", createPTree());
                         temptree->addProp("@name", fullName.str() + 1);
                         temptree->addPropInt("@numsubfiles", n);
                         temptree->addProp("@filetype", filetype);
@@ -773,15 +773,15 @@ private:
                     IPropertyTree *superPackageTree = 0;
                     if (queryPackageTree)
                     {
-                        ptree = createPTree("Package", false);
+                        ptree = createPTree("Package");
 
                         ptree->addProp("@id", non_foreignSuperName.str()+1);
                     
-                        IPropertyTree *basePackageTree = createPTree("Base", false);
+                        IPropertyTree *basePackageTree = createPTree("Base");
                         basePackageTree->addProp("@id", non_foreignSuperName.str()+1);
                         queryPackageTree->addPropTree("Base", basePackageTree);
                     }
-                    superPackageTree = createPTree("SuperFile", false);
+                    superPackageTree = createPTree("SuperFile");
                     superPackageTree->addProp("@id", non_foreignSuperName.str());
                     
                     StringBuffer path;
@@ -819,7 +819,7 @@ private:
                             
                             if (strcmp(subtree->queryName(),"SuperFile")==0)
                             {
-                                Owned<IPropertyTree> newNameNode = createPTree("att", false);
+                                Owned<IPropertyTree> newNameNode = createPTree("att");
                                 newNameNode->setProp("@value", subName.str());
                                 newNameNode->setProp("@superOwner", non_foreignSuperName.str());
                     
@@ -947,7 +947,7 @@ public:
         , roxieCommClient(_roxieCommClient)
         , logLevel(_logLevel)
     {
-        packageInfo.setown(createPTree("RoxiePackages", false));
+        packageInfo.setown(createPTree("RoxiePackages"));
     }
 
     bool lookupFileNames(IWorkUnit *wu, IRoxieQueryProcessingInfo &processingInfo, SCMStringBuffer &status)
@@ -975,7 +975,7 @@ public:
         SCMStringBuffer dllName;
         wu->getDebugValue("queryId", dllName);
 
-        IPropertyTree *xml = createPTree("FILES", false);
+        IPropertyTree *xml = createPTree("FILES");
         IPropertyTree *queryPackageTree = NULL;
         
         if (dllName.length() == 0)
@@ -984,7 +984,7 @@ public:
             q->getQueryDllName(dllName);        
         }
 
-        Owned<IPropertyTree> superKeyInfo = createPTree("SuperKeyInfo", true);
+        Owned<IPropertyTree> superKeyInfo = createPTree("SuperKeyInfo", ipt_caseInsensitive);
                         
         ForEach(*graphs)
         {
@@ -1185,7 +1185,7 @@ public:
                 Owned<IAttributeIterator> aIter = partlocation->getAttributes();
 
                 location->removeTree(partlocation);
-                partlocation = location->addPropTree(elem.str(), createPTree(false));
+                partlocation = location->addPropTree(elem.str(), createPTree());
 
                 ForEach (*aIter)
                 {
@@ -1200,7 +1200,7 @@ public:
                 {
                     StringBuffer filelocation(peerLocations.item(idx));
 
-                    IPropertyTree *t = partlocation->addPropTree("Loc", createPTree(false));
+                    IPropertyTree *t = partlocation->addPropTree("Loc", createPTree());
                     if (isDll)
                     {
                         if (name)
@@ -1249,7 +1249,7 @@ public:
                     Owned<IPropertyTree> tree;
 
                     if (storeResults)
-                        tree.setown(createPTree(false));
+                        tree.setown(createPTree());
 
                     dfuHelper->cloneFileRelationships(lookupDaliIp,// where src relationships are retrieved from (can be NULL for local)
                                                       srcfiles,     // file names on source
@@ -1284,7 +1284,7 @@ public:
                                 IPropertyTree *relTree = primTree->queryPropTree("AllRelationships");
                                 if (!relTree)
                                 {
-                                    relTree = primTree->addPropTree("AllRelationships", createPTree(false));
+                                    relTree = primTree->addPropTree("AllRelationships", createPTree());
                                     relTree->addProp("@origClusterName", roxieClusterName.str());
                                 }
                                 if (relTree)
@@ -1304,7 +1304,7 @@ public:
                                 IPropertyTree *relTree = secTree->queryPropTree("AllRelationships");
                                 if (!relTree)
                                 {
-                                    relTree = secTree->addPropTree("AllRelationships", createPTree(false));
+                                    relTree = secTree->addPropTree("AllRelationships", createPTree());
                                     relTree->addProp("@origClusterName", roxieClusterName.str());
                                 }
 
@@ -1347,7 +1347,7 @@ public:
                 removeForeign(primary, primaryName, foreignIP);
                 removeForeign(secondary, secondaryName, foreignIP);
 
-                IPropertyTree *tree = relationshipTree->addPropTree("Relationship", createPTree(false));
+                IPropertyTree *tree = relationshipTree->addPropTree("Relationship", createPTree());
                 tree->addProp("@primaryName", primaryName);
                 tree->addProp("@secondaryName", secondaryName);
 
@@ -1452,16 +1452,16 @@ public:
             {
                 IPropertyTree *metaTree = xml->queryPropTree("MetaFileInfo");
                 if (!metaTree)
-                    metaTree = xml->addPropTree("MetaFileInfo", createPTree(false));
+                    metaTree = xml->addPropTree("MetaFileInfo", createPTree());
 
                 IPropertyTree *relationshipTree = metaTree->queryPropTree("Relationships");
                 if (!relationshipTree)
-                    relationshipTree = metaTree->addPropTree("Relationships", createPTree(false));
+                    relationshipTree = metaTree->addPropTree("Relationships", createPTree());
 
                 if (buf.length() == 0)
                     throw MakeStringException(ROXIEMANAGER_DALI_LOOKUP_ERROR, "No meta file information found.");
 
-                IPropertyTree *tree = metaTree->addPropTree("File", createPTreeFromXMLString(buf.str(), false));
+                IPropertyTree *tree = metaTree->addPropTree("File", createPTreeFromXMLString(buf.str()));
                 if (!tree)
                     throw MakeStringException(ROXIEMANAGER_DALI_LOOKUP_ERROR, "Could not parse information");
                 StringBuffer id(dest_filename);
@@ -1512,8 +1512,8 @@ public:
         if (!dfuHelper)
             dfuHelper.setown(createIDFUhelper());
 
-        Owned<IPropertyTree> tree = createPTree("Relationships", false);
-        IPropertyTree *relationshipTree = tree->addPropTree("Relationships", createPTree(false));
+        Owned<IPropertyTree> tree = createPTree("Relationships");
+        IPropertyTree *relationshipTree = tree->addPropTree("Relationships", createPTree());
 
         lookupRelationships(relationshipTree, src_filename, NULL, remoteRoxieClusterName, lookupDaliIp);
         lookupRelationships(relationshipTree, NULL, src_filename, remoteRoxieClusterName, lookupDaliIp);
@@ -1622,7 +1622,7 @@ public:
 
                     DBGLOG("ERROR!!!! = \n%s", errMsg.str());
 
-                    IPropertyTree *err = createPTree(false);
+                    IPropertyTree *err = createPTree();
                     err->setProp("@error", errMsg.str());
                     err->setProp("@id", dest_filename.str());
                     xml->addPropTree("File_Error", err);

--- a/common/roxiemanager/roxiewuprocessor.cpp
+++ b/common/roxiemanager/roxiewuprocessor.cpp
@@ -1658,7 +1658,7 @@ public:
                 if (remoteRoxieClusterName.length())
                     local->setProp("@remoteCluster", remoteRoxieClusterName); 
                 updateLocations(local, 1, useRemoteRoxieLocation, true, true, remoteTopology, dllName);
-                xml->addPropTree("DLL", createPTree(local));
+                xml->addPropTree("DLL", createPTreeFromIPT(local));
             }
 
             Owned<IPropertyTreeIterator> plugins = remoteQuery->getElements("Plugin");
@@ -1674,7 +1674,7 @@ public:
                         local->setProp("@remoteCluster", remoteRoxieClusterName); 
 
                     updateLocations(local, 1, useRemoteRoxieLocation, true, true, remoteTopology, pluginName);
-                    xml->addPropTree("DLL", createPTree(local));
+                    xml->addPropTree("DLL", createPTreeFromIPT(local));
                 }
             }
             if (!copyFileLocationInfo)
@@ -1736,7 +1736,7 @@ public:
                                         updateLocations(local, i, useRemoteRoxieLocation, false, false, remoteTopology, NULL);
                                         //updateLocations(local, i, useRemoteRoxieLocation, (i == numparts) ? true : false, false, topology, NULL);
 
-                                    xml->addPropTree("File", createPTree(local));
+                                    xml->addPropTree("File", createPTreeFromIPT(local));
                                 }
                             }
                         }
@@ -1769,7 +1769,7 @@ public:
                                             for (int i = 1; i <= numparts; i++)
                                                 updateLocations(local, i, useRemoteRoxieLocation, (i == numparts) ? true : false, false, remoteTopology, NULL);
 
-                                            xml->addPropTree("Key", createPTree(local));
+                                            xml->addPropTree("Key", createPTreeFromIPT(local));
                                         }
                                     }
                                 }

--- a/common/thorhelper/layouttrans.cpp
+++ b/common/thorhelper/layouttrans.cpp
@@ -699,11 +699,11 @@ extern THORHELPER_API IRecordLayoutTranslator * createRecordLayoutTranslator(siz
 
 IPropertyTree * convertFieldMappingsToPTree(FieldMapping::List const & mappings)
 {
-    Owned<IPropertyTree> tree = createPTree("Record", false);
+    Owned<IPropertyTree> tree = createPTree("Record");
     ForEachItemIn(mappingIdx, mappings)
     {
         FieldMapping const & m = mappings.item(mappingIdx);
-        Owned<IPropertyTree> branch = createPTree(false);
+        Owned<IPropertyTree> branch = createPTree();
         branch->setPropInt("@diskFieldNum", m.queryDiskFieldNum());
         branch->setProp("@diskFieldName", m.queryDiskFieldName());
         switch(m.queryType())

--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -700,10 +700,10 @@ IDataVal & CCsvToRawTransformer::transform(IDataVal & result, size32_t len, cons
 
 //=====================================================================================================
 
-extern thorhelper_decl IXmlToRawTransformer * createXmlRawTransformer(IXmlToRowTransformer * xmlTransformer, bool stripWhitespace)
+extern thorhelper_decl IXmlToRawTransformer * createXmlRawTransformer(IXmlToRowTransformer * xmlTransformer, XmlReaderOptions xmlReadFlags)
 {
     if (xmlTransformer)
-        return new CXmlToRawTransformer(*xmlTransformer, stripWhitespace);
+        return new CXmlToRawTransformer(*xmlTransformer, xmlReadFlags);
     return NULL;
 }
 

--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -1133,7 +1133,7 @@ public:
 class CPTreeWithOffsets : public LocalPTree
 {
 public:
-    CPTreeWithOffsets(const char *name) : LocalPTree(name, false) { startOffset = endOffset = 0; }      
+    CPTreeWithOffsets(const char *name) : LocalPTree(name) { startOffset = endOffset = 0; }
 
     offset_t startOffset, endOffset;
 };

--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -569,7 +569,7 @@ void XmlSetColumnProvider::readUtf8X(size32_t & len, char * & target, const char
 IDataVal & CXmlToRawTransformer::transform(IDataVal & result, size32_t len, const void * text, bool isDataSet)
 {
     // MORE - should redo using a pull parser sometime
-    Owned<IPropertyTree> root = createPTreeFromXMLString(len, (const char *)text, stripWhitespace);
+    Owned<IPropertyTree> root = createPTreeFromXMLString(len, (const char *)text, ipt_none, xmlReadFlags);
     return transformTree(result, *root, isDataSet);
 }
 
@@ -600,7 +600,7 @@ IDataVal & CXmlToRawTransformer::transformTree(IDataVal & result, IPropertyTree 
                     try
                     {
                         decodedXML.append("<root>").append(body).append("</root>");
-                        decodedTree.setown(createPTreeFromXMLString(decodedXML.str(), true));
+                        decodedTree.setown(createPTreeFromXMLString(decodedXML.str(), ipt_caseInsensitive));
                         rows.setown(decodedTree->getElements("Row"));
                     }
                     catch (IException *E)
@@ -652,7 +652,7 @@ IDataVal & CXmlToRawTransformer::transformTree(IDataVal & result, IPropertyTree 
 
 size32_t createRowFromXml(ARowBuilder & rowBuilder, size32_t size, const char * utf8, IXmlToRowTransformer * xmlTransformer, bool stripWhitespace)
 {
-    Owned<IPropertyTree> root = createPTreeFromXMLString(size, utf8, stripWhitespace);
+    Owned<IPropertyTree> root = createPTreeFromXMLString(size, utf8, ipt_none, stripWhitespace ? xr_ignoreWhiteSpace : xr_none);
     if (!root)
     {
         throwError(THORCERR_InvalidXmlFromXml);
@@ -1650,7 +1650,7 @@ class CXMLParse : public CInterface, implements IXMLParse
         {
             level = 0;
             Owned<COffsetNodeCreator> nodeCreator = new COffsetNodeCreator();
-            maker = createRootLessPTreeMaker(false, NULL, nodeCreator);
+            maker = createRootLessPTreeMaker(ipt_none, NULL, nodeCreator);
             bool f;
             utf8Translator = rtlOpenCodepageConverter("utf-8", "latin1", f);
             if (f)

--- a/common/thorhelper/thorxmlread.hpp
+++ b/common/thorhelper/thorxmlread.hpp
@@ -150,7 +150,6 @@ public:
 protected:
     Linked<IXmlToRowTransformer> rowTransformer;
     XmlReaderOptions xmlReadFlags;
-    bool stripWhitespace;
 };
 
 class thorhelper_decl CCsvToRawTransformer : public CInterface, implements ICsvToRawTransformer

--- a/common/thorhelper/thorxmlread.hpp
+++ b/common/thorhelper/thorxmlread.hpp
@@ -137,9 +137,10 @@ public:
 class thorhelper_decl CXmlToRawTransformer : public CInterface, implements IXmlToRawTransformer
 {
 public:
-    CXmlToRawTransformer(IXmlToRowTransformer & _rowTransformer, bool _stripWhitespace)
-    : rowTransformer(&_rowTransformer), stripWhitespace(_stripWhitespace)
+    CXmlToRawTransformer(IXmlToRowTransformer & _rowTransformer, bool stripWhitespace)
+    : rowTransformer(&_rowTransformer)
     {
+        xmlReadFlags = stripWhitespace ? xr_ignoreWhiteSpace : xr_none;
     }
     IMPLEMENT_IINTERFACE
 
@@ -148,6 +149,7 @@ public:
 
 protected:
     Linked<IXmlToRowTransformer> rowTransformer;
+    XmlReaderOptions xmlReadFlags;
     bool stripWhitespace;
 };
 

--- a/common/thorhelper/thorxmlread.hpp
+++ b/common/thorhelper/thorxmlread.hpp
@@ -137,10 +137,9 @@ public:
 class thorhelper_decl CXmlToRawTransformer : public CInterface, implements IXmlToRawTransformer
 {
 public:
-    CXmlToRawTransformer(IXmlToRowTransformer & _rowTransformer, bool stripWhitespace)
-    : rowTransformer(&_rowTransformer)
+    CXmlToRawTransformer(IXmlToRowTransformer & _rowTransformer, XmlReaderOptions _xmlReadFlags)
+    : rowTransformer(&_rowTransformer), xmlReadFlags(_xmlReadFlags)
     {
-        xmlReadFlags = stripWhitespace ? xr_ignoreWhiteSpace : xr_none;
     }
     IMPLEMENT_IINTERFACE
 
@@ -193,7 +192,7 @@ protected:
     CSVColumnProvider csvSplitter;
 };
 #endif
-extern thorhelper_decl IXmlToRawTransformer * createXmlRawTransformer(IXmlToRowTransformer * xmlTransformer, bool stripWhitespace);
+extern thorhelper_decl IXmlToRawTransformer * createXmlRawTransformer(IXmlToRowTransformer * xmlTransformer, XmlReaderOptions xmlReadFlags=xr_ignoreWhiteSpace);
 extern thorhelper_decl ICsvToRawTransformer * createCsvRawTransformer(ICsvToRowTransformer * csvTransformer);
 
 

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -197,9 +197,9 @@ class CConstGraphProgress : public CInterface, implements IConstWUGraphProgress
         IPropertyTree *node = progress->queryPropTree(path.str());
         if (!node)
         {
-            node = progress->addPropTree("node", createPTree(false));
+            node = progress->addPropTree("node", createPTree());
             node->setPropInt("@id", (int)nodeId);
-            elem = node->addPropTree(elemName, createPTree(false));
+            elem = node->addPropTree(elemName, createPTree());
             elem->setProp("@id", id);
         }
         else
@@ -208,7 +208,7 @@ class CConstGraphProgress : public CInterface, implements IConstWUGraphProgress
             elem = node->queryPropTree(path.str());
             if (!elem)
             {
-                elem = node->addPropTree(elemName, createPTree(false));
+                elem = node->addPropTree(elemName, createPTree());
                 elem->setProp("@id", id);
             }
         }
@@ -302,7 +302,7 @@ public:
         IPropertyTree *node = progress->queryPropTree(path.str());
         if (!node)
         {
-            node = progress->addPropTree("node", createPTree(false));
+            node = progress->addPropTree("node", createPTree());
             node->setPropInt("@id", (int)nodeId);
         }
         node->setPropInt("@_state", (unsigned)state);
@@ -313,7 +313,7 @@ public:
             {
                 StringBuffer path;
                 Owned<IRemoteConnection> conn = querySDS().connect(path.append("/GraphProgress/").append(wuid).str(), myProcessSession(), RTM_LOCK_WRITE|RTM_CREATE_QUERY, SDS_LOCK_TIMEOUT);
-                IPropertyTree *running = conn->queryRoot()->setPropTree("Running", createPTree(false));
+                IPropertyTree *running = conn->queryRoot()->setPropTree("Running", createPTree());
                 running->setProp("@graph", graphName);
                 running->setPropInt64("@subId", nodeId);
                 break;
@@ -373,7 +373,7 @@ public:
         else {
             if (!pack)
                 return true;
-            newt.setown(createPTree(wuid,false));
+            newt.setown(createPTree(wuid));
             IPropertyTree *running = root->queryPropTree("Running");
             if (running) {
                 newt->setPropTree("Running",createPTree(running));
@@ -2529,7 +2529,7 @@ CLocalWorkUnit::CLocalWorkUnit(const char *_wuid, const char *parentWuid, ISecMa
 {
     connectAtRoot = true;
     init();
-    p.setown(createPTree(_wuid, false));
+    p.setown(createPTree(_wuid));
     p->setProp("@xmlns:xsi", "http://www.w3.org/1999/XMLSchema-instance");
     if (parentWuid)
         p->setProp("@parentWuid", parentWuid);
@@ -2707,7 +2707,7 @@ bool CLocalWorkUnit::archiveWorkUnit(const char *base,bool del,bool ignoredllerr
     xpath.append(wuid);
     Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
     if (conn) {
-        Owned<IPropertyTree> tmp = createPTree("GraphProgress",false);
+        Owned<IPropertyTree> tmp = createPTree("GraphProgress");
         mergePTree(tmp,conn->queryRoot());
         toXML(tmp,extraWorkUnitXML,1,XML_Format);
         conn->close();
@@ -2730,14 +2730,14 @@ bool CLocalWorkUnit::archiveWorkUnit(const char *base,bool del,bool ignoredllerr
     Owned<IException> exception;
     Owned<IDllLocation> loc;
     StringBuffer dst, locpath;
-    Owned<IPropertyTree> generatedDlls = createPTree("GeneratedDlls", false);
+    Owned<IPropertyTree> generatedDlls = createPTree("GeneratedDlls");
     ForEach(*iter) {
         IConstWUAssociatedFile & cur = iter->query();
         cur.getName(name);
         if (name.length()) {
             Owned<IDllEntry> entry = queryDllServer().getEntry(name.str());
             if (entry.get()) {
-                Owned<IPropertyTree> generatedDllBranch = createPTree(false);
+                Owned<IPropertyTree> generatedDllBranch = createPTree();
                 generatedDllBranch->setProp("@name", entry->queryName());
                 generatedDllBranch->setProp("@kind", entry->queryKind());
                 bool removeDllFiles = true;
@@ -2860,7 +2860,7 @@ bool restoreWorkUnit(const char *base,const char *wuid)
     Owned<IFileIO> fileio = file->open(IFOread);
     if (!fileio)
         return false;
-    Owned<IPropertyTree> pt = createPTree(*fileio, false);
+    Owned<IPropertyTree> pt = createPTree(*fileio);
     if (!pt)
         return false;
     CDateTime dt;
@@ -2919,7 +2919,11 @@ void CLocalWorkUnit::loadXML(const char *xml)
 {
     CriticalBlock block(crit);
     init();
-    p.setown(loadPropertyTree(xml, false));
+    assertex(xml);
+    if ('<' == *xml)
+        p.setown(createPTreeFromXMLString(xml));
+    else
+        p.setown(createPTreeFromXMLFile(xml));
 }
 
 void CLocalWorkUnit::serialize(MemoryBuffer &tgt)
@@ -4502,7 +4506,7 @@ IWUQuery* CLocalWorkUnit::updateQuery()
     {
         IPropertyTree *s = p->queryPropTree("Query");
         if (!s)
-            s = p->addPropTree("Query", createPTreeFromXMLString("<Query fetchEntire='1'/>", false));
+            s = p->addPropTree("Query", createPTreeFromXMLString("<Query fetchEntire='1'/>"));
         s->Link();
         query.setown(new CLocalWUQuery(s)); 
     }
@@ -4643,7 +4647,7 @@ void CLocalWorkUnit::setTimerInfo(const char *name, const char *subname, unsigne
     CriticalBlock block(crit);
     IPropertyTree *timings = p->queryPropTree("Timings");
     if (!timings)
-        timings = p->addPropTree("Timings", createPTree("Timings", false));
+        timings = p->addPropTree("Timings", createPTree("Timings"));
     StringBuffer fullname;
     if (subname)
         fullname.append('.').append(subname);
@@ -4653,7 +4657,7 @@ void CLocalWorkUnit::setTimerInfo(const char *name, const char *subname, unsigne
     IPropertyTree *timing = timings->queryPropTree(xpath.str());
     if (!timing)
     {
-        timing = timings->addPropTree("Timing", createPTree("Timing", false));
+        timing = timings->addPropTree("Timing", createPTree("Timing"));
         timing->setProp("@name", fullname.str());
     }
     timing->setPropInt("@count", count);
@@ -4680,7 +4684,7 @@ void CLocalWorkUnit::setTimeStamp(const char *application, const char *instance,
 #endif //_WIN32
     IPropertyTree *ts = p->queryPropTree("TimeStamps");
     if (!ts) {
-        ts = p->addPropTree("TimeStamps", createPTree("TimeStamps", false));
+        ts = p->addPropTree("TimeStamps", createPTree("TimeStamps"));
         add = true;
     }
     IPropertyTree *t=NULL;
@@ -4690,7 +4694,7 @@ void CLocalWorkUnit::setTimeStamp(const char *application, const char *instance,
         t = ts->queryBranch(path.str());
     }
     if (!t) {
-        t = createPTree("TimeStamp", false);
+        t = createPTree("TimeStamp");
         t->setProp("@application", application);
         add = true;
     }
@@ -4760,9 +4764,9 @@ IWUPlugin* CLocalWorkUnit::updatePluginByName(const char *qname)
     if (existing)
         return (IWUPlugin *) existing;
     if (!plugins.length())
-        p->addPropTree("Plugins", createPTree("Plugins", false));
+        p->addPropTree("Plugins", createPTree("Plugins"));
     IPropertyTree *pl = p->queryPropTree("Plugins");
-    IPropertyTree *s = pl->addPropTree("Plugin", createPTree("Plugin", false));
+    IPropertyTree *s = pl->addPropTree("Plugin", createPTree("Plugin"));
     s->Link();
     IWUPlugin* q = new CLocalWUPlugin(s); 
     q->Link();
@@ -4796,9 +4800,9 @@ IWULibrary* CLocalWorkUnit::updateLibraryByName(const char *qname)
     if (existing)
         return (IWULibrary *) existing;
     if (!libraries.length())
-        p->addPropTree("Libraries", createPTree("Libraries", false));
+        p->addPropTree("Libraries", createPTree("Libraries"));
     IPropertyTree *pl = p->queryPropTree("Libraries");
-    IPropertyTree *s = pl->addPropTree("Library", createPTree("Library", false));
+    IPropertyTree *s = pl->addPropTree("Library", createPTree("Library"));
     s->Link();
     IWULibrary* q = new CLocalWULibrary(s); 
     q->Link();
@@ -4858,9 +4862,9 @@ IWUException* CLocalWorkUnit::createException()
     loadExceptions();
 
     if (!exceptions.length())
-        p->addPropTree("Exceptions", createPTree("Exceptions", false));
+        p->addPropTree("Exceptions", createPTree("Exceptions"));
     IPropertyTree *r = p->queryPropTree("Exceptions");
-    IPropertyTree *s = r->addPropTree("Exception", createPTree("Exception", false));
+    IPropertyTree *s = r->addPropTree("Exception", createPTree("Exception"));
     IWUException* q = new CLocalWUException(LINK(s)); 
     exceptions.append(*LINK(q));
 
@@ -4897,7 +4901,7 @@ IWUWebServicesInfo* CLocalWorkUnit::updateWebServicesInfo(bool create)
         if (!s)
         {
             if (create)
-                s = p->addPropTree("WebServicesInfo", createPTreeFromXMLString("<WebServicesInfo />", false));
+                s = p->addPropTree("WebServicesInfo", createPTreeFromXMLString("<WebServicesInfo />"));
             else
                 return NULL;
         }
@@ -4931,7 +4935,7 @@ IWURoxieQueryInfo* CLocalWorkUnit::updateRoxieQueryInfo(const char *wuid, const 
     {
         IPropertyTree *s = p->queryPropTree("RoxieQueryInfo");
         if (!s)
-            s = p->addPropTree("RoxieQueryInfo", createPTreeFromXMLString("<RoxieQueryInfo />", false));
+            s = p->addPropTree("RoxieQueryInfo", createPTreeFromXMLString("<RoxieQueryInfo />"));
         if (wuid && *wuid)
             s->addProp("@wuid", wuid);
 
@@ -5011,9 +5015,9 @@ IWUResult* CLocalWorkUnit::createResult()
     // For this to be legally called, we must have the write-able interface. So we are already locked for write.
     loadResults();
     if (!results.length())
-        p->addPropTree("Results", createPTree("Results", false));
+        p->addPropTree("Results", createPTree("Results"));
     IPropertyTree *r = p->queryPropTree("Results");
-    IPropertyTree *s = r->addPropTree("Result", createPTreeFromXMLString("<Result fetchEntire='1'/>", false));
+    IPropertyTree *s = r->addPropTree("Result", createPTreeFromXMLString("<Result fetchEntire='1'/>"));
 
     s->Link();
     IWUResult* q = new CLocalWUResult(s); 
@@ -5163,9 +5167,9 @@ IWUResult* CLocalWorkUnit::updateTemporaryByName(const char *qname)
     if (existing)
         return (IWUResult *) existing;
     if (!temporaries.length())
-        p->addPropTree("Temporaries", createPTree("Temporaries", false));
+        p->addPropTree("Temporaries", createPTree("Temporaries"));
     IPropertyTree *vars = p->queryPropTree("Temporaries");
-    IPropertyTree *s = vars->addPropTree("Variable", createPTree("Variable", false));
+    IPropertyTree *s = vars->addPropTree("Variable", createPTree("Variable"));
     s->Link();
     IWUResult* q = new CLocalWUResult(s); 
     q->Link();
@@ -5181,9 +5185,9 @@ IWUResult* CLocalWorkUnit::updateVariableByName(const char *qname)
     if (existing)
         return (IWUResult *) existing;
     if (!variables.length())
-        p->addPropTree("Variables", createPTree("Variables", false));
+        p->addPropTree("Variables", createPTree("Variables"));
     IPropertyTree *vars = p->queryPropTree("Variables");
-    IPropertyTree *s = vars->addPropTree("Variable", createPTree("Variable", false));
+    IPropertyTree *s = vars->addPropTree("Variable", createPTree("Variable"));
     s->Link();
     IWUResult* q = new CLocalWUResult(s); 
     q->Link();
@@ -5251,7 +5255,7 @@ static void _noteFileRead(IDistributedFile *file, IPropertyTree *filesRead)
     {
         StringBuffer cluster;
         file->getClusterName(0,cluster);
-        fileTree = createPTree(false);
+        fileTree = createPTree();
         fileTree->setProp("@name", fname.str());
         fileTree->setProp("@cluster", cluster.str());
         fileTree->setPropInt("@useCount", 1);
@@ -5266,7 +5270,7 @@ static void _noteFileRead(IDistributedFile *file, IPropertyTree *filesRead)
             IDistributedFile &file = iter->query();
             StringBuffer fname;
             file.getLogicalName(fname);
-            Owned<IPropertyTree> subfile = createPTree(false);
+            Owned<IPropertyTree> subfile = createPTree();
             subfile->setProp("@name", fname.str());
             fileTree->addPropTree("Subfile", subfile.getClear());
             _noteFileRead(&file, filesRead);
@@ -5279,7 +5283,7 @@ void CLocalWorkUnit::noteFileRead(IDistributedFile *file)
     CriticalBlock block(crit);
     IPropertyTree *files = p->queryPropTree("FilesRead");
     if (!files)
-        files = p->addPropTree("FilesRead", createPTree(false));
+        files = p->addPropTree("FilesRead", createPTree());
     _noteFileRead(file, files);
 }
 
@@ -5291,7 +5295,7 @@ static void addFile(IPropertyTree *files, const char *fileName, const char *clus
         path.append("[@cluster=\"").append(cluster).append("\"]");
     IPropertyTree *file = files->queryPropTree(path.str());
     if (file) files->removeTree(file);
-    file = createPTree(false);
+    file = createPTree();
     file->setProp("@name", fileName);
     if (cluster)
         file->setProp("@cluster", cluster);
@@ -5308,7 +5312,7 @@ void CLocalWorkUnit::addFile(const char *fileName, StringArray *clusters, unsign
     CriticalBlock block(crit);
     IPropertyTree *files = p->queryPropTree("Files");
     if (!files)
-        files = p->addPropTree("Files", createPTree(false));
+        files = p->addPropTree("Files", createPTree());
     if (!clusters)
         addFile(fileName, NULL, usageCount, fileKind, graphOwner);
     else
@@ -5384,7 +5388,7 @@ void CLocalWorkUnit::addDiskUsageStats(__int64 _avgNodeUsage, unsigned _minNode,
         maxNodeUsage = stats->getPropInt64("@maxNodeUsage");
     else
     {
-        stats = p->addPropTree("DiskUsageStats", createPTree(false));
+        stats = p->addPropTree("DiskUsageStats", createPTree());
         maxNodeUsage = 0;
     }
 
@@ -5427,9 +5431,9 @@ IWUActivity * CLocalWorkUnit::updateActivity(__int64 id)
     if (existing)
         return (IWUActivity *) existing;
     if (!activities.length())
-        p->addPropTree("Activities", createPTree("Activities", false));
+        p->addPropTree("Activities", createPTree("Activities"));
     IPropertyTree *pl = p->queryPropTree("Activities");
-    IPropertyTree *s = pl->addPropTree("Activity", createPTree("Activity", false));
+    IPropertyTree *s = pl->addPropTree("Activity", createPTree("Activity"));
     IWUActivity * q = new CLocalWUActivity(LINK(s), id); 
     activities.append(*LINK(q));
     return q;
@@ -5658,7 +5662,7 @@ const IPropertyTree *CLocalWorkUnit::getXmlParams() const
 void CLocalWorkUnit::setXmlParams(const char *params)
 {
     CriticalBlock block(crit);
-    p->setPropTree("Parameters", createPTreeFromXMLString(params, false));
+    p->setPropTree("Parameters", createPTreeFromXMLString(params));
 }
 
 void CLocalWorkUnit::setXmlParams(IPropertyTree *tree)
@@ -5754,9 +5758,9 @@ IWUGraph* CLocalWorkUnit::createGraph()
     ensureGraphsUnpacked();
     loadGraphs();
     if (!graphs.length())
-        p->addPropTree("Graphs", createPTree("Graphs", false));
+        p->addPropTree("Graphs", createPTree("Graphs"));
     IPropertyTree *r = p->queryPropTree("Graphs");
-    IPropertyTree *s = r->addPropTree("Graph", createPTreeFromXMLString("<Graph fetchEntire='1'/>", false));
+    IPropertyTree *s = r->addPropTree("Graph", createPTreeFromXMLString("<Graph fetchEntire='1'/>"));
     s->Link();
     IWUGraph* q = new CLocalWUGraph(s, p->queryName());
     q->Link();
@@ -5796,13 +5800,13 @@ void CLocalWUGraph::setName(const char *str)
 
 void CLocalWUGraph::setXGMML(const char *str)
 {
-    setXGMMLTree(createPTreeFromXMLString(str, false, true));
+    setXGMMLTree(createPTreeFromXMLString(str));
 }
 
 void CLocalWUGraph::setXGMMLTree(IPropertyTree *graph)
 {
     assertex(strcmp(graph->queryName(), "graph")==0);
-    IPropertyTree *xgmml = createPTree("xgmml", false);
+    IPropertyTree *xgmml = createPTree("xgmml");
     xgmml->setPropTree("graph", graph);
     p->setPropTree("xgmml", xgmml);
 }
@@ -5836,7 +5840,7 @@ void CLocalWUGraph::mergeProgress(IPropertyTree &rootNode, IPropertyTree &progre
                         const char *aName = aIter->queryName()+1;
                         if (0 != stricmp("id", aName)) // "id" reserved.
                         {
-                            IPropertyTree *att = graphEdge->addPropTree("att", createPTree(false));
+                            IPropertyTree *att = graphEdge->addPropTree("att", createPTree());
                             att->setProp("@name", aName);
                             att->setProp("@value", aIter->queryValue());
                         }
@@ -5846,7 +5850,7 @@ void CLocalWUGraph::mergeProgress(IPropertyTree &rootNode, IPropertyTree &progre
                     ForEach (*iter)
                     {
                         IPropertyTree &t = iter->query();
-                        IPropertyTree *att = graphEdge->addPropTree("att", createPTree(false));
+                        IPropertyTree *att = graphEdge->addPropTree("att", createPTree());
                         att->setProp("@name", t.queryName());
                         att->setProp("@value", t.queryProp(NULL));
                     }
@@ -5872,7 +5876,7 @@ void CLocalWUGraph::mergeProgress(IPropertyTree &rootNode, IPropertyTree &progre
                         const char *aName = aIter->queryName()+1;
                         if (0 != stricmp("id", aName)) // "id" reserved.
                         {
-                            IPropertyTree *att = _node->addPropTree("att", createPTree(false));
+                            IPropertyTree *att = _node->addPropTree("att", createPTree());
                             att->setProp("@name", aName);
                             att->setProp("@value", aIter->queryValue());
                         }
@@ -6019,7 +6023,7 @@ IStringVal& CLocalWUQuery::getQueryShortText(IStringVal &str) const
     const char * text = p->queryProp("Text");
     if (isArchiveQuery(text))
     {
-        Owned<IPropertyTree> xml = createPTreeFromXMLString(text, true);
+        Owned<IPropertyTree> xml = createPTreeFromXMLString(text, ipt_caseInsensitive);
         const char * path = xml->queryProp("Query/@attributePath");
         if (path)
         {
@@ -6088,9 +6092,9 @@ void CLocalWUQuery::addAssociatedFile(WUFileType type, const char * name, const 
     CriticalBlock block(crit);
     loadAssociated();
     if (!associated.length())
-        p->addPropTree("Associated", createPTree("Associated", false));
+        p->addPropTree("Associated", createPTree("Associated"));
     IPropertyTree *pl = p->queryPropTree("Associated");
-    IPropertyTree *s = pl->addPropTree("File", createPTree("File", false));
+    IPropertyTree *s = pl->addPropTree("File", createPTree("File"));
     setEnum(s, "@type", type, queryFileTypes);
     s->setProp("@filename", name);
     s->setProp("@ip", ip);
@@ -6131,7 +6135,7 @@ void CLocalWUQuery::addSpecialCaseAssociated(WUFileType type, const char * propn
     const char * name = p->queryProp(propname);
     if (name)
     {
-        IPropertyTree *s = createPTree("File", false);
+        IPropertyTree *s = createPTree("File");
         setEnum(s, "@type", type, queryFileTypes);
         s->setProp("@filename", name);
         if (crc)
@@ -6351,7 +6355,7 @@ void CLocalWURoxieQueryInfo::setQueryInfo(const char *info)
     if (queryTree)
         p->removeTree(queryTree);
 
-    IPropertyTree * tempTree = p->addPropTree("query", createPTreeFromXMLString(info, false));
+    IPropertyTree * tempTree = p->addPropTree("query", createPTreeFromXMLString(info));
 
     if (!p->hasProp("@roxieClusterName"))
     {
@@ -7252,7 +7256,7 @@ void CLocalWULibrary::addActivity(unsigned id)
     StringBuffer s;
     s.append("activity[@id=\"").append(id).append("\"]");
     if (!p->hasProp(s.str()))
-        p->addPropTree("activity", createPTree(false))->setPropInt("@id", id); 
+        p->addPropTree("activity", createPTree())->setPropInt("@id", id);
 }
 
 //==========================================================================================
@@ -7580,7 +7584,7 @@ IWorkflowItem * CLocalWorkUnit::addWorkflowItem(unsigned wfid, WFType type, WFMo
     workflowIteratorCached = false;
     IPropertyTree * s = p->queryPropTree("Workflow");
     if(!s)
-        s = p->addPropTree("Workflow", createPTree("Workflow", false));
+        s = p->addPropTree("Workflow", createPTree("Workflow"));
     return createWorkflowItem(s, wfid, type, mode, success, failure, recovery, retriesAllowed, contingencyFor);
 }
 
@@ -7592,7 +7596,7 @@ IWorkflowItemIterator * CLocalWorkUnit::updateWorkflowItems()
     {
         IPropertyTree * s = p->queryPropTree("Workflow");
         if(!s)
-            s = p->addPropTree("Workflow", createPTree("Workflow", false));
+            s = p->addPropTree("Workflow", createPTree("Workflow"));
         workflowIterator.setown(createWorkflowItemIterator(s)); 
         workflowIteratorCached = true;
     }
@@ -7713,7 +7717,7 @@ public:
     CLocalFileUpload(IPropertyTree * _tree) : tree(_tree) {}
     CLocalFileUpload(unsigned id, LocalFileUploadType type, char const * source, char const * destination, char const * eventTag)
     {
-        tree.setown(createPTree(false));
+        tree.setown(createPTree());
         tree->setPropInt("@id", id);
         setEnum(tree, "@type", type, localFileUploadTypes);
         tree->setProp("@source", source);
@@ -7793,7 +7797,7 @@ unsigned CLocalWorkUnit::addLocalFileUpload(LocalFileUploadType type, char const
     CriticalBlock block(crit);
     IPropertyTree * s = p->queryPropTree("LocalFileUploads");
     if(!s)
-        s = p->addPropTree("LocalFileUploads", createPTree(false));
+        s = p->addPropTree("LocalFileUploads", createPTree());
     unsigned id = s->numChildren();
     Owned<CLocalFileUpload> upload = new CLocalFileUpload(id, type, source, destination, eventTag);
     s->addPropTree("LocalFileUpload", upload->getTree());
@@ -8374,7 +8378,7 @@ public:
         Owned<IPropertyTree> root = baseconn->getRoot();
         ensurePTree(root, "EventQueue");
         Owned<IPropertyTree> eventQueue = root->getPropTree("EventQueue");
-        Owned<IPropertyTree> eventItem = createPTree(false);
+        Owned<IPropertyTree> eventItem = createPTree();
         eventItem->setProp("@name", name);
         eventItem->setProp("@text", text);
         eventQueue->addPropTree("Item", eventItem.getLink());
@@ -8530,7 +8534,7 @@ IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, 
 
     StringBuffer id;
     id.append(lcName).append(".").append(seq);
-    IPropertyTree * newEntry = createPTree("Query", true);
+    IPropertyTree * newEntry = createPTree("Query", ipt_caseInsensitive);
     newEntry->setProp("@name", lcName);
     newEntry->setProp("@wuid", wuid);
     newEntry->setProp("@dll", dll);
@@ -8584,7 +8588,7 @@ void setQueryAlias(IPropertyTree * queryRegistry, const char * name, const char 
     IPropertyTree * match = queryRegistry->queryPropTree(xpath);
     if (!match)
     {
-        IPropertyTree * newEntry = createPTree("Alias", false);
+        IPropertyTree * newEntry = createPTree("Alias");
         newEntry->setProp("@name", lcName);
         match = queryRegistry->addPropTree("Alias", newEntry);
     }
@@ -8684,7 +8688,7 @@ extern WORKUNIT_API IPropertyTree * getQueryRegistry(const char * wsEclId, bool 
     {
         if (readonly)
             return NULL;
-        Owned<IPropertyTree> querySet = createPTree(false);
+        Owned<IPropertyTree> querySet = createPTree();
         querySet->setProp("@id", wsEclId);
         globalLock->queryRoot()->addPropTree("QuerySet", querySet.getClear());
         globalLock->commit();
@@ -8741,7 +8745,7 @@ extern WORKUNIT_API IPropertyTree * getPackageSetRegistry(const char * wsEclId, 
     { 
         if (readonly)
             return NULL;
-        Owned<IPropertyTree> querySet = createPTree(false);
+        Owned<IPropertyTree> querySet = createPTree();
         querySet->setProp("@id", wsEclId);
         globalLock->queryRoot()->addPropTree("PackageSet", querySet.getClear());
         globalLock->commit();

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -368,7 +368,7 @@ public:
             newt.setown(createPTree(buf));
             IPropertyTree *running = root->queryPropTree("Running");
             if (running)
-                newt->setPropTree("Running",createPTree(running));
+                newt->setPropTree("Running",createPTreeFromIPT(running));
         }
         else {
             if (!pack)
@@ -376,7 +376,7 @@ public:
             newt.setown(createPTree(wuid));
             IPropertyTree *running = root->queryPropTree("Running");
             if (running) {
-                newt->setPropTree("Running",createPTree(running));
+                newt->setPropTree("Running",createPTreeFromIPT(running));
                 root->removeTree(running);
             }
             root->serialize(buf);
@@ -2842,7 +2842,7 @@ IPropertyTree * pruneBranch(IPropertyTree * from, char const * xpath)
     Owned<IPropertyTree> ret;
     IPropertyTree * branch = from->queryPropTree(xpath);
     if(branch) {
-        ret.setown(createPTree(branch));
+        ret.setown(createPTreeFromIPT(branch));
         from->removeTree(branch);
     }
     return ret.getClear();
@@ -2920,10 +2920,7 @@ void CLocalWorkUnit::loadXML(const char *xml)
     CriticalBlock block(crit);
     init();
     assertex(xml);
-    if ('<' == *xml)
-        p.setown(createPTreeFromXMLString(xml));
-    else
-        p.setown(createPTreeFromXMLFile(xml));
+    p.setown(createPTreeFromXMLString(xml));
 }
 
 void CLocalWorkUnit::serialize(MemoryBuffer &tgt)
@@ -4339,7 +4336,7 @@ void CLocalWorkUnit::copyWorkUnit(IConstWorkUnit *cached)
             StringBuffer xpath;
             xpath.append("Variable[@name='").append(name).append("']");
             IPropertyTree *ptTgtVariable = ptTgtVariables->queryPropTree(xpath.str());
-            IPropertyTree *merged = createPTree(ptSrcVariable); // clone entire source info...
+            IPropertyTree *merged = createPTreeFromIPT(ptSrcVariable); // clone entire source info...
             merged->removeProp("Value"); // except value and status
             merged->setProp("@status", "undefined");
             if (!merged->getPropBool("@isScalar"))
@@ -5898,7 +5895,7 @@ IPropertyTree * CLocalWUGraph::getXGMMLTree(bool doMergeProgress) const
     {
         IPropertyTree *src = p->queryPropTree("xgmml/graph");
         if (!src) return NULL;
-        Owned<IPropertyTree> copy = createPTree(src);
+        Owned<IPropertyTree> copy = createPTreeFromIPT(src);
         Owned<IConstWUGraphProgress> _progress;
         if (progress) _progress.set(progress);
         else

--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -118,7 +118,7 @@ public:
 
     IPropertyTree *createBranch(CJobQueueItem)
     {
-        IPropertyTree *item = createPTree("Item",false);
+        IPropertyTree *item = createPTree("Item");
         assignBranch(item,this);
         return item;
     }
@@ -519,7 +519,7 @@ public:
                         StringBuffer cpath;
                         cpath.appendf("Queue[@name=\"%s\"]",qd->qname.get());
                         if (!proot->hasProp(cpath.str())) {
-                            IPropertyTree *pt = proot->addPropTree("Queue",createPTree("Queue",false));
+                            IPropertyTree *pt = proot->addPropTree("Queue",createPTree("Queue"));
                             pt->setProp("@name",qd->qname.get());
                             pt->setProp("@state","active");
                             pt->setPropInt("@count", 0);
@@ -682,7 +682,7 @@ public:
         IPropertyTree *ret = qd.root->queryPropTree(path.str());
         if (!ret&&(idx==(unsigned)-1)) {
             Cconnlockblock block(this,true);
-            ret = createPTree("Client",false);
+            ret = createPTree("Client");
             ret = qd.root->addPropTree("Client",ret);
             ret->setPropInt64("@session",sessionid);
             StringBuffer eps;
@@ -967,7 +967,7 @@ public:
                 idx--;
             }
         }
-        CJobQueueItem::assignBranch(addItem(qd,createPTree("Item",false),idx,count),qi);
+        CJobQueueItem::assignBranch(addItem(qd,createPTree("Item"),idx,count),qi);
         qd.root->setPropInt("@count",count+1);
     }
 

--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -471,13 +471,13 @@ public:
         IPropertyTree  *t=NULL;
         OwnedIFile ifile = createIFile(storename.get());
         if (ifile->exists())
-            t = createPTree(*ifile, true);
+            t = createPTree(*ifile, ipt_caseInsensitive);
         if (t) {
             setServerId(myrank,t->getPropInt64("ServerID"));
             setCovenId(t->getPropInt64("CovenID"));
         }
         else {
-            t = createPTree("Coven",false);
+            t = createPTree("Coven");
             t->setPropInt("UIDbase",1);
             t->setPropInt("SDSedition",0);
             if (myrank==0) {

--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -65,7 +65,7 @@ class MonitoredChildMap : public ChildMap
 {
     CClientRemoteTree &owner;
 public:
-    MonitoredChildMap(CClientRemoteTree &_owner) : ChildMap(false), owner(_owner) { }
+    MonitoredChildMap(CClientRemoteTree &_owner) : ChildMap(), owner(_owner) { }
 
     
     virtual bool replace(const char *name, IPropertyTree *tree)
@@ -485,7 +485,7 @@ void extractServerIds(IPropertyTree &tree, MemoryBuffer &mb, bool completeTailBr
 
 static void walkAndFill(IPropertyTree &tree, CClientRemoteTree &parent, MemoryBuffer &mb, bool childrenCanBeMissing)
 {
-    parent.createChildMap(false);
+    parent.createChildMap();
     bool r;
     if (childrenCanBeMissing)
         mb.read(r);
@@ -609,7 +609,7 @@ void CClientRemoteTree::deserializeChildrenRT(MemoryBuffer &src)
         size32_t pos = src.getPos();
         src.read(eName);
         if (eName.length())
-            createChildMap(false);
+            createChildMap();
         src.reset(pos);
     }
     CRemoteTreeBase::deserializeChildrenRT(src);
@@ -760,7 +760,7 @@ ChildMap *CClientRemoteTree::_checkChildren()
         if (queryLazyFetch())
         {
             serverTreeInfo &= ~STI_HaveChildren;
-            createChildMap(false);
+            createChildMap();
             if (serverId)
                 queryManager().getChildren(*this, connection);
         }
@@ -780,13 +780,7 @@ IPropertyTree *CClientRemoteTree::ownPTree(IPropertyTree *tree)
         return PTree::ownPTree(tree);
 }
 
-IPropertyTree *CClientRemoteTree::create(IPTArrayValue *value)
-{
-    assertex(false);
-    return NULL;
-}
-
-IPropertyTree *CClientRemoteTree::create(const char *name, bool nocase, IPTArrayValue *value, ChildMap *children, bool existing)
+IPropertyTree *CClientRemoteTree::create(const char *name, IPTArrayValue *value, ChildMap *children, bool existing)
 {
     CClientRemoteTree *newTree = new CClientRemoteTree(name, value, children, connection);
     if (existing)
@@ -810,7 +804,7 @@ IPropertyTree *CClientRemoteTree::create(MemoryBuffer &mb)
     return tree;
 }
 
-void CClientRemoteTree::createChildMap(bool caseInsensitive)
+void CClientRemoteTree::createChildMap()
 {
     children = new MonitoredChildMap(*this);
 }
@@ -1018,7 +1012,7 @@ void CClientRemoteTree::checkExt() const
             queryManager().getExternalValueFromServerId(serverId, mb);
             if (mb.length())
             {
-                bool binary = PtFlagTst(flags, PtFlag_Binary);
+                bool binary = IptFlagTst(flags, ipt_binary);
                 const_cast<CClientRemoteTree *>(this)->setValue(new CPTValue(mb), binary);
             }
             else
@@ -1030,7 +1024,7 @@ void CClientRemoteTree::checkExt() const
         if (STI_External & serverTreeInfo)
         {
             MemoryBuffer mb;
-            bool binary = PtFlagTst(flags, PtFlag_Binary);
+            bool binary = IptFlagTst(flags, ipt_binary);
             queryManager().getExternalValueFromServerId(serverId, mb);
             if (mb.length())
             {
@@ -1374,7 +1368,7 @@ void CClientSDSManager::getChildrenFor(CRTArray &childLessList, CRemoteConnectio
     ForEachItemIn(f2, childLessList)
     {
         CRemoteTreeBase &parent = childLessList.item(f2);
-        parent.createChildMap(false);
+        parent.createChildMap();
         if (parent.queryServerId())
         {
             bool r;

--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -1763,7 +1763,7 @@ IPropertyTree &CClientSDSManager::queryProperties() const
     }
     properties = createPTree(mb);
     if (!properties->hasProp("Client"))
-        properties->setPropTree("Client", createPTree(false));
+        properties->setPropTree("Client", createPTree());
     return *properties;
 }
 

--- a/dali/base/dacsds.ipp
+++ b/dali/base/dacsds.ipp
@@ -317,10 +317,9 @@ public:
 
     virtual bool setLazyFetch(bool fetch) { return connection.setLazyFetch(fetch); }
     virtual ChildMap *checkChildren() const;
-    virtual IPropertyTree *create(IPTArrayValue *value=NULL);
-    virtual IPropertyTree *create(const char *name, bool nocase=false, IPTArrayValue *value=NULL, ChildMap *children=NULL, bool existing=false);
+    virtual IPropertyTree *create(const char *name, IPTArrayValue *value=NULL, ChildMap *children=NULL, bool existing=false);
     virtual IPropertyTree *create(MemoryBuffer &mb);
-    virtual void createChildMap(bool caseInsensitive=false);
+    virtual void createChildMap();
     virtual IPropertyTree *ownPTree(IPropertyTree *tree);
     virtual void setLocal(size32_t size, const void *data, bool _binary);
     virtual void appendLocal(size32_t size, const void *data, bool binary);

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -128,7 +128,7 @@ static IPropertyTree *getCreatePropTree(IPropertyTree *parent,const char * name)
     assertex(strchr(name,'/')==NULL);
     IPropertyTree *t = parent->queryPropTree(name);
     if (!t) {
-        t = parent->setPropTree(name,createPTree(name,false)); // takes ownership
+        t = parent->setPropTree(name,createPTree(name)); // takes ownership
     }
     return LINK(t);
 }
@@ -162,7 +162,7 @@ static IPropertyTreeIterator *getNamedPropIter(IPropertyTree *parent,const char 
 
 static IPropertyTree *addNamedPropTree(IPropertyTree *parent,const char *sub,const char *key,const char *name, IPropertyTree* init=NULL)
 {  
-    IPropertyTree* ret = init?createPTree(init):createPTree(sub,false);
+    IPropertyTree* ret = init?createPTree(init):createPTree(sub);
     assertex(key[0]=='@');
     ret->setProp(key,name);
     ret = parent->addPropTree(sub,ret);
@@ -203,7 +203,7 @@ const char *normalizeLFN(const char *s,StringBuffer &tmp)
 
 static IPropertyTree *getEmptyAttr()
 {
-    return createPTree("Attr",false);
+    return createPTree("Attr");
 }
 
 
@@ -2752,7 +2752,7 @@ public:
             while ((pt=t->queryPropTree("Cluster[1]"))!=NULL)
                 t->removeTree(pt);
             ForEachItemIn(i,clusters) {
-                IPropertyTree *pt = createPTree("Cluster",false);
+                IPropertyTree *pt = createPTree("Cluster");
                 clusters.item(i).serializeTree(pt,IFDSF_EXCLUDE_GROUPS);
                 if (!isEmptyPTree(pt)) {
                     t->addPropTree("Cluster",pt);
@@ -3073,7 +3073,7 @@ public:
         LOGFDESC("CDistributedFile.b fdesc",fdesc);
 #endif
         parent = _parent;
-        root.setown(createPTree(queryDfsXmlBranchName(DXB_File),false));
+        root.setown(createPTree(queryDfsXmlBranchName(DXB_File)));
 //      fdesc->serializeTree(*root,IFDSF_EXCLUDE_NODES); 
         setFileAttrs(fdesc,true);
         setClusters(fdesc);
@@ -4276,7 +4276,7 @@ protected:
                 throw MakeStringException(-1,"C(2): Corrupt subfile file part %d cannot be found",i);
             sub->setPropInt("@num",i+1);
         }
-        sub = createPTree(false);
+        sub = createPTree();
         sub->setPropInt("@num",pos+1);
         sub->setProp("@name",file->queryLogicalName());
         if (pos==0) {
@@ -6235,7 +6235,7 @@ public:
     {
         if (!group)
             return;
-        IPropertyTree *val = createPTree("Group",false);
+        IPropertyTree *val = createPTree("Group");
         val->setProp("@name",name);
         if (cluster)
             val->setPropInt("@cluster",1);
@@ -6245,7 +6245,7 @@ public:
         INodeIterator &gi = *group->getIterator();
         StringBuffer str;
         ForEach(gi) {
-            IPropertyTree *n = createPTree("Node",false);
+            IPropertyTree *n = createPTree("Node");
             n = val->addPropTree("Node",n);
             gi.query().endpoint().getIpText(str.clear());
             n->setProp("@ip",str.str());
@@ -6744,7 +6744,7 @@ IDistributedSuperFile *CDistributedFileDirectory::createSuperFile(const char *_l
     checkLogicalName(logicalname,user,true,true,false,"have a superfile with");
     //assertex(!transaction); // transaction TBD
     StringBuffer tail;
-    IPropertyTree *root = createPTree(false);
+    IPropertyTree *root = createPTree();
     root->setPropInt("@interleaved",_interleaved?2:0);  
     addEntry(logicalname,root,true,ifdoesnotexist);
     StringBuffer query;
@@ -7642,7 +7642,7 @@ class CInitGroups
         }
         if (!group)
             return;
-        IPropertyTree *val = createPTree("Group",false);
+        IPropertyTree *val = createPTree("Group");
         val->setProp("@name",name);
         if (realcluster)
             val->setPropInt("@cluster",1);
@@ -7655,7 +7655,7 @@ class CInitGroups
         INodeIterator &gi = *group->getIterator();
         StringBuffer str;
         ForEach(gi) {
-            IPropertyTree *n = createPTree("Node",false);
+            IPropertyTree *n = createPTree("Node");
             n = val->addPropTree("Node",n);
             gi.query().endpoint().getIpText(str.clear());
             n->setProp("@ip",str.str());
@@ -8501,7 +8501,7 @@ IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, const I
         }
         else
             throw MakeStringException(-1,"Unknown GetFileTree serialization version %d",ver);
-        ret.setown(createPTree(queryDfsXmlBranchName(DXB_File),false));
+        ret.setown(createPTree(queryDfsXmlBranchName(DXB_File)));
         fdesc->serializeTree(*ret,expandnodes?0:CPDMSF_packParts);
         if (!modified.isNull()) {
             StringBuffer dts;
@@ -9343,7 +9343,7 @@ public:
         if (!lock.init(title,lfn,DXB_SuperFile,!readonly,true,timeout)) {
             if (!autocreate)        // NB not !*autocreate here !
                 return false;
-            IPropertyTree *root = createPTree(false);
+            IPropertyTree *root = createPTree();
             root->setPropInt("@interleaved",2); 
             root->setPropInt("@numsubfiles",0); 
             root->setPropTree("Attr",getEmptyAttr());   
@@ -9415,12 +9415,12 @@ public:
         root->setPropInt("@numsubfiles",toadd.ordinality());
         const char *supername = root->queryProp("OrigName");
         ForEachItemIn(i,toadd) {
-            IPropertyTree *t = root->addPropTree("SubFile",createPTree("SubFile",false));
+            IPropertyTree *t = root->addPropTree("SubFile",createPTree("SubFile"));
             const char *sname = toadd.item(i);
             t->setProp("@name",sname);
             t->setPropInt("@num",i+1);
             IRemoteConnection *cc = connectChild(sname);
-            t = cc->queryRoot()->addPropTree("SuperOwner",createPTree("SuperOwner",false));
+            t = cc->queryRoot()->addPropTree("SuperOwner",createPTree("SuperOwner"));
             t->setProp("@name",supername);
         }
         migrateAttr((children.ordinality()==1)?children.item(0).queryRoot():NULL,root);
@@ -9943,7 +9943,7 @@ void CDistributedFileDirectory::addFileRelationship(
 {
     if (!kind||!*kind)
         kind = S_LINK_RELATIONSHIP_KIND;
-    Owned<IPropertyTree> pt = createPTree("Relationship",false);
+    Owned<IPropertyTree> pt = createPTree("Relationship");
     if (isWild(primary,true)||isWild(secondary,true)||isWild(primflds,false)||isWild(secflds,false)||isWild(cardinality,false))
         throw MakeStringException(-1,"Wildcard not allowed in addFileRelation");
     CDfsLogicalFileName pfn;
@@ -9985,7 +9985,7 @@ void CDistributedFileDirectory::addFileRelationship(
             CConnectLock connlock2("addFileRelation.2",querySdsFilesRoot(),true,false,defaultTimeout);
             if (!connlock2.conn)
                 return;
-            Owned<IPropertyTree> ptr = createPTree("Relationships",false);
+            Owned<IPropertyTree> ptr = createPTree("Relationships");
             connlock2.conn->queryRoot()->addPropTree("Relationships",ptr.getClear());
             continue;
         }   

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -162,7 +162,7 @@ static IPropertyTreeIterator *getNamedPropIter(IPropertyTree *parent,const char 
 
 static IPropertyTree *addNamedPropTree(IPropertyTree *parent,const char *sub,const char *key,const char *name, IPropertyTree* init=NULL)
 {  
-    IPropertyTree* ret = init?createPTree(init):createPTree(sub);
+    IPropertyTree* ret = init?createPTreeFromIPT(init):createPTree(sub);
     assertex(key[0]=='@');
     ret->setProp(key,name);
     ret = parent->addPropTree(sub,ret);
@@ -1993,7 +1993,7 @@ public:
 
     void setAttr(IPropertyTree &pt)
     {
-        attr.setown(createPTree(&pt));      // take a copy 
+        attr.setown(createPTreeFromIPT(&pt));      // take a copy
         dirty = false;
     }
 
@@ -2989,7 +2989,7 @@ protected:
                 CDistributedFilePart &part = parts.item(0);
                 while ((pt=root->queryPropTree("Part[1]"))!=NULL)
                     root->removeTree(pt);
-                pt = createPTree(part.queryAttr());
+                pt = createPTreeFromIPT(part.queryAttr());
                 pt->setPropInt("@num",1);
                 const char *grp = root->queryProp("@group");
                 if (!grp||!*grp) {
@@ -3186,7 +3186,7 @@ public:
         if (isEmptyPTree(t)) 
             root->removeProp("Attr");
         else
-            root->setPropTree("Attr",createPTree(t));
+            root->setPropTree("Attr",createPTreeFromIPT(t));
     }
 
     void setClusters(IFileDescriptor *fdesc)
@@ -4235,7 +4235,7 @@ protected:
                             if (sub)
                                 sub->setPropInt("@num",j);
                             if (j==1) {
-                                root->setPropTree("Attr",createPTree(sub->queryPropTree("Attr")));
+                                root->setPropTree("Attr",createPTreeFromIPT(sub->queryPropTree("Attr")));
                                 attr.clear();
                             }
                             subtrees.subs[j-1] = sub;
@@ -4281,7 +4281,7 @@ protected:
         sub->setProp("@name",file->queryLogicalName());
         if (pos==0) {
             attr.clear();
-            root->setPropTree("Attr",createPTree(&file->queryProperties()));
+            root->setPropTree("Attr",createPTreeFromIPT(&file->queryProperties()));
         }
         root->addPropTree("SubFile",sub);
         subfiles.add(*file,pos);
@@ -4308,7 +4308,7 @@ protected:
         if (pos==0) {
             attr.clear();
             if (subfiles.ordinality())
-                root->setPropTree("Attr",createPTree(&subfiles.item(0).queryProperties()));
+                root->setPropTree("Attr",createPTreeFromIPT(&subfiles.item(0).queryProperties()));
             else
                 root->setPropTree("Attr",getEmptyAttr());
         }
@@ -8167,7 +8167,7 @@ public:
                         ver = 0;
                 }
                 if (ver==0) {
-                    tree.setown(createPTree(tree));
+                    tree.setown(createPTreeFromIPT(tree));
                     StringBuffer cname;
                     logicalname->getCluster(cname);
                     expandFileTree(tree,true,cname.str()); // resolve @node values that may not be set
@@ -9444,7 +9444,7 @@ public:
             IPropertyTree *tree = srcroot->queryPropTree(subpath.str());
             if (!tree)
                 break;
-            newt = createPTree(tree);
+            newt = createPTreeFromIPT(tree);
             srcroot->removeTree(tree);
             newt = dstroot->addPropTree("SubFile",newt);
             IRemoteConnection *cc = dst.connectChild(newt->queryProp("@name"));
@@ -9459,7 +9459,7 @@ public:
         // replace Attr
         IPropertyTree *attr = srcroot->queryPropTree("Attr[1]");  
         if (attr) {
-            newt = createPTree(attr);
+            newt = createPTreeFromIPT(attr);
             srcroot->removeTree(attr);
         }
         else
@@ -10161,7 +10161,7 @@ bool CDistributedFileDirectory::publishMetaFileXML(const CDfsLogicalFileName &lo
                     StringBuffer tail("META__");
                     splitFilename(path.str(), &outpath, &outpath, &tail, NULL);
                     outpath.append(tail).append(".xml");
-                    Owned<IPropertyTree> pt = createPTree(file);
+                    Owned<IPropertyTree> pt = createPTreeFromIPT(file);
                     filterParts(pt,parts);
                     StringBuffer str;
                     toXML(pt, str);

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -633,14 +633,14 @@ public:
             props->removeProp("@node");
         }
         else
-            props.setown(createPTree("Part",false));
+            props.setown(createPTree("Part"));
     }
 
     void set(unsigned idx, const char *_tail, IPropertyTree *pt)
     {
         partIndex = idx;
         setOverrideName(_tail);
-        props.setown(pt?createPTree(pt):createPTree("Part",false));
+        props.setown(pt?createPTree(pt):createPTree("Part"));
     }
 
     CPartDescriptor(CFileDescriptorBase &_parent, unsigned idx, MemoryBuffer &mb)
@@ -1295,7 +1295,7 @@ public:
         }
         attr.setown(createPTree(mb));
         if (!attr)
-            attr.setown(createPTree("Attr",false)); // doubt can happen
+            attr.setown(createPTree("Attr")); // doubt can happen
         if (version==SERIALIZATION_VERSION2) {
             if (subcounts)
                 *subcounts = new UnsignedArray;
@@ -1322,7 +1322,7 @@ public:
         pending = NULL;
         if ((flags&IFDSF_ATTR_ONLY)||!tree) {
             if (!tree)
-                tree = createPTree("Attr",false);
+                tree = createPTree("Attr");
             attr.setown(tree);
             setupdone = false;
             return;
@@ -1373,7 +1373,7 @@ public:
                     if (!num)
                         continue;
                     while (num>trees.ordinality()+1)
-                        trees.append(*createPTree("Part",false));
+                        trees.append(*createPTree("Part"));
                     cpt.Link();
                     if (num>trees.ordinality())
                         trees.append(cpt);
@@ -1396,7 +1396,7 @@ public:
         if (at)
             attr.setown(createPTree(at));
         else
-            attr.setown(createPTree("Attr",false));
+            attr.setown(createPTree("Attr"));
         if (totalsize!=(offset_t)-1)
             attr->setPropInt64("@size",totalsize);
     }
@@ -1432,7 +1432,7 @@ public:
         unsigned cn = 0;
         StringBuffer grplist;
         ForEachItemIn(i1,clusters) {
-            Owned<IPropertyTree> ct = createPTree("Cluster",false);
+            Owned<IPropertyTree> ct = createPTree("Cluster");
             clusters.item(i1).serializeTree(ct,flags);
             if (!isEmptyPTree(ct)) {
                 const char *cname = ct->queryProp("@name");
@@ -1455,7 +1455,7 @@ public:
         if ((flags&IFDSF_EXCLUDE_PARTS)==0) {
             if ((n==1)||((flags&CPDMSF_packParts)==0)) {
                 for (unsigned i2=0;i2<n;i2++) {
-                    Owned<IPropertyTree> p = createPTree("Part",false);
+                    Owned<IPropertyTree> p = createPTree("Part");
                     if (part(i2)->subserializeTree(p))
                         pt.addPropTree("Part",p.getClear());
                 }
@@ -1464,7 +1464,7 @@ public:
                 MemoryBuffer mb;
                 for (unsigned i2=0;i2<n;i2++) {
                     // this seems a bit excessive in conversions
-                    Owned<IPropertyTree> p = createPTree("Part",false);
+                    Owned<IPropertyTree> p = createPTree("Part");
                     part(i2)->subserializeTree(p);
                     serializePartAttr(mb,p);
                 }
@@ -1478,7 +1478,7 @@ public:
 
     IPropertyTree *getFileTree(unsigned flags)
     {
-        Owned<IPropertyTree> ret = createPTree(queryDfsXmlBranchName(DXB_File),false);
+        Owned<IPropertyTree> ret = createPTree(queryDfsXmlBranchName(DXB_File));
         serializeTree(*ret,flags);
         return ret.getClear();
     }
@@ -2634,7 +2634,7 @@ IFileDescriptor *createFileDescriptorFromRoxieXML(IPropertyTree *tree,const char
     if (!tree)
         return NULL;
     bool iskey = (strcmp(tree->queryName(),"Key")==0);
-    Owned<IPropertyTree> attr = createPTree("Attr",false);
+    Owned<IPropertyTree> attr = createPTree("Attr");
     Owned<IFileDescriptor> res = createFileDescriptor(attr.getLink());
     const char *id = tree->queryProp("@id");
     if (id) {

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -627,7 +627,7 @@ public:
                 overridename.clear();
             else
                 ismulti = ::isMulti(overridename);
-            props.setown(createPTree(pt));
+            props.setown(createPTreeFromIPT(pt));
             //props->removeProp("@num");        // keep these for legacy
             //props->removeProp("@name");
             props->removeProp("@node");
@@ -640,7 +640,7 @@ public:
     {
         partIndex = idx;
         setOverrideName(_tail);
-        props.setown(pt?createPTree(pt):createPTree("Part"));
+        props.setown(pt?createPTreeFromIPT(pt):createPTree("Part"));
     }
 
     CPartDescriptor(CFileDescriptorBase &_parent, unsigned idx, MemoryBuffer &mb)
@@ -782,7 +782,7 @@ public:
             Owned<IPropertyTreeIterator> iter = props->getElements("*");
             ForEach(*iter) {
                 ret = true;
-                pt->addPropTree(iter->query().queryName(),createPTree(&iter->query()));
+                pt->addPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
             }
         }
         if (!overridename.isEmpty()) {
@@ -1394,7 +1394,7 @@ public:
         }
         piter.clear();
         if (at)
-            attr.setown(createPTree(at));
+            attr.setown(createPTreeFromIPT(at));
         else
             attr.setown(createPTree("Attr"));
         if (totalsize!=(offset_t)-1)
@@ -1473,7 +1473,7 @@ public:
         }
         IPropertyTree *t = &queryProperties();
         if (!isEmptyPTree(t))
-            pt.addPropTree("Attr",createPTree(t));
+            pt.addPropTree("Attr",createPTreeFromIPT(t));
     }
 
     IPropertyTree *getFileTree(unsigned flags)
@@ -2516,7 +2516,7 @@ bool setReplicateDir(const char *dir,StringBuffer &out,bool isrep,const char *ba
 
 IFileDescriptor *createMultiCopyFileDescriptor(IFileDescriptor *in,unsigned num)
 {
-    Owned<IFileDescriptor> out = createFileDescriptor(createPTree(&in->queryProperties()));
+    Owned<IFileDescriptor> out = createFileDescriptor(createPTreeFromIPT(&in->queryProperties()));
     IPropertyTree &t = out->queryProperties();
     __int64 rc = t.getPropInt64("@recordCount",-1);
     if (rc>0)

--- a/dali/base/danqs.cpp
+++ b/dali/base/danqs.cpp
@@ -760,7 +760,7 @@ public:
     {
         Owned<IRemoteConnection> conn = connectSDS(name,true);
         IPropertyTree * root = conn->queryRoot();
-        IPropertyTree *item = createPTree("Item",false);
+        IPropertyTree *item = createPTree("Item");
         item->setPropBin("",qblen,data);
         if (priority) {
             item->setPropInt("@priority",priority);
@@ -776,7 +776,7 @@ public:
             add = root->queryPropTree(path.str());
             if(!add)
             {
-                add = createPTree(branch, false);
+                add = createPTree(branch);
                 add->setPropInt64("@id", transactionId);
                 add->setPropInt("@count", 0);
                 root->addPropTree(branch, add);

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -1487,7 +1487,7 @@ public:
         else
         {
             Owned<IPropertyTree> tree;
-            tree.setown(createPTreeFromXMLFile(filename.str(), false));
+            tree.setown(createPTreeFromXMLFile(filename.str()));
             IPTArrayValue *v = ((PTree *)tree.get())->queryValue();
             if (v)
                 v->serialize(mb);
@@ -1511,13 +1511,13 @@ public:
             LOG(MCoperatorWarning, unknownJob, e, s.str());
             StringBuffer str("EXTERNAL XML FILE: \"");
             str.append(filename.str()).append("\" MISSING");
-            tree.setown(createPTree(owner.queryName(), false));
+            tree.setown(createPTree(owner.queryName()));
             if (withValue)
                 tree->setProp(NULL, str.toCharArray());
         }
         else
         {
-            tree.setown(createPTreeFromXMLFile(filename.str(), false));
+            tree.setown(createPTreeFromXMLFile(filename.str()));
             if (!withValue)
                 tree->setProp(NULL, (char *)NULL);
         }
@@ -2137,13 +2137,13 @@ IPropertyTree *CRemoteTreeBase::collateData()
     {
         ChangeTree(IPropertyTree *donor=NULL) { ptree = LINK(donor); }
         ~ChangeTree() { ::Release(ptree); }
-        inline void createTree() { assertex(!ptree); ptree = createPTree(RESERVED_CHANGE_NODE, false); }
+        inline void createTree() { assertex(!ptree); ptree = createPTree(RESERVED_CHANGE_NODE); }
         inline IPropertyTree *queryTree() { return ptree; }
         inline IPropertyTree *getTree() { return LINK(ptree); }
         inline IPropertyTree *queryCreateTree()
         {
             if (!ptree)
-                ptree = createPTree(RESERVED_CHANGE_NODE, false);
+                ptree = createPTree(RESERVED_CHANGE_NODE);
             return ptree;
         }
     private:
@@ -2165,7 +2165,7 @@ IPropertyTree *CRemoteTreeBase::collateData()
         Owned<IAttributeIterator> iter = getAttributes();
         if (iter->count())
         {
-            IPropertyTree *t = createPTree(false);
+            IPropertyTree *t = createPTree();
             ForEach(*iter)
                 t->setProp(iter->queryName(), queryProp(iter->queryName()));
             ct.queryTree()->addPropTree(ATTRCHANGE_TAG, t);
@@ -2181,7 +2181,7 @@ IPropertyTree *CRemoteTreeBase::collateData()
             {
                 ct.queryTree()->removeTree(ac);
                 Owned<IAttributeIterator> iter = ac->getAttributes();
-                IPropertyTree *t = createPTree(false);
+                IPropertyTree *t = createPTree();
                 ForEach(*iter)
                     t->setProp(iter->queryName(), queryProp(iter->queryName()));
                 ct.queryTree()->addPropTree(ATTRCHANGE_TAG, t);
@@ -2830,7 +2830,7 @@ PDState CServerRemoteTree::checkChange(IPropertyTree &changeTree, CBranchChange 
             {
                 IPropertyTree *t = changeTree.queryPropTree(ATTRDELETE_TAG);
                 if (!t)
-                    t = changeTree.addPropTree(ATTRDELETE_TAG, createPTree(false));
+                    t = changeTree.addPropTree(ATTRDELETE_TAG, createPTree());
                 t->addProp(EXT_ATTR, "");
             }
             else
@@ -2843,7 +2843,7 @@ PDState CServerRemoteTree::checkChange(IPropertyTree &changeTree, CBranchChange 
                 SDSManager->writeExternal(*this);
                 IPropertyTree *t = changeTree.queryPropTree(ATTRCHANGE_TAG);
                 if (!t)
-                    t = changeTree.addPropTree(ATTRCHANGE_TAG, createPTree(false));
+                    t = changeTree.addPropTree(ATTRCHANGE_TAG, createPTree());
                 changeTree.setProp(NULL, (const char *)NULL);
                 t->setProp(EXT_ATTR, queryProp(EXT_ATTR));
             }
@@ -3676,7 +3676,7 @@ bool checkOldFormat(CServerRemoteTree *parentServerTree, IPropertyTree *tree, Me
                     if (NotFound == pos)
                         throw MakeSDSException(SDSExcpt_ClientCacheDirty, "::checkChange - child(%s) not found in parent(%s) at %s(%d)", child->queryName(), parentServerTree->queryName(), __FILE__, __LINE__);
 
-                    IPropertyTree *t = createPTree(false);
+                    IPropertyTree *t = createPTree();
                     t->setProp("@from", child->queryName());
                     t->setProp("@to", newName);
                     t->setPropInt64("@id", id);
@@ -3706,7 +3706,7 @@ bool checkOldFormat(CServerRemoteTree *parentServerTree, IPropertyTree *tree, Me
                     if (NotFound == pos)
                         continue;
 
-                    IPropertyTree *t = createPTree(false);
+                    IPropertyTree *t = createPTree();
                     t->setProp("@name", child->queryName());
                     t->setPropInt64("@id", id);
 #ifdef SIBLING_MOVEMENT_CHECK
@@ -3725,7 +3725,7 @@ bool checkOldFormat(CServerRemoteTree *parentServerTree, IPropertyTree *tree, Me
             if (count)
             {
                 IPropertyTree *ct = tree->queryPropTree(ATTRCHANGE_TAG);
-                IPropertyTree *t = tree->addPropTree(ATTRDELETE_TAG, createPTree(false));
+                IPropertyTree *t = tree->addPropTree(ATTRDELETE_TAG, createPTree());
                 for (c=0; c<count; c++)
                 {
                     StringAttr attr;
@@ -3757,7 +3757,7 @@ bool checkOldFormat(CServerRemoteTree *parentServerTree, IPropertyTree *tree, Me
                 ((PTree *)tree)->setValue(new CPTValue(0, NULL, false, true, false), false);
 
             Owned<IAttributeIterator> attrs = clientTree->getAttributes();
-            IPropertyTree *t = createPTree(false);
+            IPropertyTree *t = createPTree();
             if (attrs->first())
             {
                 do
@@ -3790,7 +3790,7 @@ bool translateOldFormat(CServerRemoteTree *parentServerTree, IPropertyTree *pare
                 break;
             mb.read(pos);
             CServerRemoteTree *serverTree = NULL;
-            Owned<IPropertyTree> tree = createPTree(RESERVED_CHANGE_NODE, false);
+            Owned<IPropertyTree> tree = createPTree(RESERVED_CHANGE_NODE);
             if (0 == id)
             {
                 StringAttr childName;
@@ -4138,7 +4138,7 @@ void CSDSTransactionServer::processMessage(CMessageBuffer &mb)
                     {
                         if (oldFormat)
                         {
-                            Owned<IPropertyTree> t = createPTree(RESERVED_CHANGE_NODE, false);
+                            Owned<IPropertyTree> t = createPTree(RESERVED_CHANGE_NODE);
                             t->setProp("@name", tree->queryName());
                             if (translateOldFormat(tree, t, mb))
                                 changeTree.setown(LINK(t));
@@ -4522,7 +4522,7 @@ void initializeInternals(IPropertyTree *root)
     ensurePTree(root, "DFU/WorkUnits");
     ensurePTree(root, "Files/Relationships");
     root->removeProp("Status/Servers");
-    root->addPropTree("Status/Servers",createPTree(false));
+    root->addPropTree("Status/Servers",createPTree());
 }
 
 IPropertyTree *loadStore(const char *storeFilename, IPTreeMaker *iMaker, unsigned crcValidation, bool logErrorsOnly=false, const bool *abort=NULL)
@@ -4540,7 +4540,7 @@ IPropertyTree *loadStore(const char *storeFilename, IPTreeMaker *iMaker, unsigne
         Owned<IFileIOStream> fstream = createIOStream(iFileIOStore);
         Owned<ICrcIOStream> crcPipeStream = createCrcPipeStream(fstream);
         Owned<IIOStream> ios = createBufferedIOStream(crcPipeStream);
-        root.setown((CServerRemoteTree *) createPTree(*ios, false, true, iMaker));
+        root.setown((CServerRemoteTree *) createPTree(*ios, ipt_none, xr_ignoreWhiteSpace, iMaker));
         ios.clear();
         unsigned crc = crcPipeStream->queryCrc();
 
@@ -5496,8 +5496,8 @@ CCovenSDSManager::CCovenSDSManager(ICoven &_coven, IPropertyTree &_config, const
     Owned<CBinaryFileExternal> binaryExternalHandler = new CBinaryFileExternal(dataPath, backupHandler);
     externalHandlers.replace(* new CExternalHandlerMapping(EF_BinaryValue, *binaryExternalHandler));
 
-    properties.setown(createPTree("Properties", false));
-    IPropertyTree *clientProps = properties->setPropTree("Client", config.hasProp("Client") ? config.getPropTree("Client") : createPTree(false));
+    properties.setown(createPTree("Properties"));
+    IPropertyTree *clientProps = properties->setPropTree("Client", config.hasProp("Client") ? config.getPropTree("Client") : createPTree());
     clientProps->setPropBool("@serverIterAvailable", true);
     clientProps->setPropBool("@useAppendOpt", true);
     clientProps->setPropBool("@serverGetIdsAvailable", true);
@@ -5663,7 +5663,7 @@ void CCovenSDSManager::loadStore(const char *storeName, const bool *abort)
     class CSDSTreeMaker : public CPTreeMaker
     {
     public:
-        CSDSTreeMaker(IPTreeNodeCreator *nodeCreator) : CPTreeMaker(false, nodeCreator) { }
+        CSDSTreeMaker(IPTreeNodeCreator *nodeCreator) : CPTreeMaker(ipt_none, nodeCreator) { }
         virtual void endNode(const char *tag, unsigned length, const void *value, bool binary, offset_t endOffset)
         {
             IPropertyTree *node = queryCurrentNode();
@@ -5713,7 +5713,7 @@ void CCovenSDSManager::loadStore(const char *storeName, const bool *abort)
             OwnedIFileIO iFileIO = envFile->open(IFOread);
             if (!iFileIO)
                 throw MakeStringException(0, "Failed to open '%s'", environment);
-            Owned<IPropertyTree> envTree = createPTreeFromXMLFile(environment, false);
+            Owned<IPropertyTree> envTree = createPTreeFromXMLFile(environment);
             if (0 != stricmp("Environment", envTree->queryName()))
                 throw MakeStringException(0, "External environment file '%s', has '%s' as root, expecting a 'Environment' xml node.", environment, envTree->queryName());
             Owned<IPropertyTree> existingEnvTree = root->getPropTree("Environment");
@@ -5979,7 +5979,7 @@ void CCovenSDSManager::loadStore(const char *storeName, const bool *abort)
                     extHandler->getFilename(fname, itm.name);
                     PROGLOG("Converting legacy external type(%s) to new, file=%s", itm.ext.get(), fname.str());
                     MemoryBuffer mb;
-                    Owned<IPropertyTree> tree = createPTree("tmp", false);
+                    Owned<IPropertyTree> tree = createPTree("tmp");
                     extHandler->read(itm.name, *tree, mb, true);
                     mb.append(""); // no children
                     tree.setown(createPTree(mb));
@@ -6156,9 +6156,9 @@ void CCovenSDSManager::saveDelta(const char *path, IPropertyTree &changeTree)
     }
     cleanChangeTree(changeTree);
     // write out with header details (e.g. path)
-    Owned<IPropertyTree> header = createPTree("Header", false);
+    Owned<IPropertyTree> header = createPTree("Header");
     header->setProp("@path", path);
-    IPropertyTree *delta = header->addPropTree("Delta", createPTree(false));
+    IPropertyTree *delta = header->addPropTree("Delta", createPTree());
     delta->addPropTree(changeTree.queryName(), LINK(&changeTree));
 
     StringBuffer fname(dataPath);
@@ -6913,7 +6913,7 @@ CServerConnection *CCovenSDSManager::createConnectionInstance(CRemoteTreeBase *r
     {
         writeTransactions++;
         // add tree into stack temporarily, or add manually at end.
-        deltaChange.setown(createPTree(RESERVED_CHANGE_NODE, false));
+        deltaChange.setown(createPTree(RESERVED_CHANGE_NODE));
         IPropertyTree *tail = deltaChange;
         if (created) // some elems in "head" created
         {
@@ -6952,7 +6952,7 @@ CServerConnection *CCovenSDSManager::createConnectionInstance(CRemoteTreeBase *r
             {   
                 
                 IPropertyTree &tree = connection->queryPTreePath().item(s);
-                IPropertyTree *n = tail->addPropTree(RESERVED_CHANGE_NODE, createPTree(false));
+                IPropertyTree *n = tail->addPropTree(RESERVED_CHANGE_NODE, createPTree());
                 n->setProp("@name", tree.queryName());
                 n->setPropBool("@new", true);
                 tail = n;
@@ -6969,7 +6969,7 @@ CServerConnection *CCovenSDSManager::createConnectionInstance(CRemoteTreeBase *r
             connection->queryPTreePath().getAbsolutePath(s);
             const char *t = splitXPath(s.str(), _deltaPath);
             deltaPath->set(_deltaPath.str());
-            IPropertyTree *n = tail->addPropTree(RESERVED_CHANGE_NODE, createPTree(false));
+            IPropertyTree *n = tail->addPropTree(RESERVED_CHANGE_NODE, createPTree());
             n->setProp("@name", tree->queryName());
             if (replaceNode)
                 n->setPropBool("@replace", true);
@@ -7568,8 +7568,8 @@ void CCovenSDSManager::disconnect(ConnectionId id, bool deleteRoot, Owned<CLCLoc
         writeTransactions++;
     if (!orphaned && deleteRoot)
     {
-        Owned<IPropertyTree> changeTree = createPTree(RESERVED_CHANGE_NODE, false);
-        IPropertyTree *d = changeTree->setPropTree(DELETE_TAG, createPTree(false));
+        Owned<IPropertyTree> changeTree = createPTree(RESERVED_CHANGE_NODE);
+        IPropertyTree *d = changeTree->setPropTree(DELETE_TAG, createPTree());
         d->setProp("@name", tree->queryName());
         d->setPropInt("@pos", index+1);
 
@@ -8325,7 +8325,7 @@ public:
         if (config)
             sdsConfig.setown(config->getPropTree("SDS"));
         if (!sdsConfig)
-            sdsConfig.setown(createPTree(false));
+            sdsConfig.setown(createPTree());
         manager = new CCovenSDSManager(coven, *sdsConfig, config?config->queryProp("@dataPath"):NULL);
         SDSManager = manager;
         addThreadExceptionHandler(manager);
@@ -8359,7 +8359,7 @@ public:
 
         Owned<IRemoteConnection> conn = manager->connect("/", 0, 0, 0);
         IPropertyTree *root = conn->queryRoot();
-        IPropertyTree *tree = root->setPropTree("test", createPTree(false));
+        IPropertyTree *tree = root->setPropTree("test", createPTree());
 
         setNotifyHandlerName("testHandler", tree);
 
@@ -8448,7 +8448,7 @@ bool applyXmlDeltas(IPropertyTree &root, IIOStream &stream, bool stopOnError)
         {
             sectionEndOffset = 0;
             hadError = false;
-            maker = createRootLessPTreeMaker(false);
+            maker = createRootLessPTreeMaker();
         }
         ~CDeltaProcessor()
         {
@@ -8542,12 +8542,12 @@ bool applyXmlDeltas(IPropertyTree &root, IIOStream &stream, bool stopOnError)
                     const char *name = child.queryProp("@name");
                     if (child.getPropBool("@new"))
                     {
-                        IPropertyTree *newBranch = currentBranch.addPropTree(name, createPTree(false));
+                        IPropertyTree *newBranch = currentBranch.addPropTree(name, createPTree());
                         apply(child, *newBranch);
                     }
                     else if (child.getPropBool("@replace"))
                     {
-                        IPropertyTree *newBranch = currentBranch.setPropTree(name, createPTree(false));
+                        IPropertyTree *newBranch = currentBranch.setPropTree(name, createPTree());
                         apply(child, *newBranch);
                     }
                     else

--- a/dali/base/dasds.ipp
+++ b/dali/base/dasds.ipp
@@ -233,7 +233,6 @@ public:
 
     CRemoteTreeBase(MemoryBuffer &mb, CPState _state=CPS_Unchanged);
     CRemoteTreeBase(const char *name=NULL, IPTArrayValue *value=NULL, ChildMap *children=NULL, CPState _state=CPS_Unchanged);
-    ~CRemoteTreeBase();
     void reset(unsigned state, bool sub=false);
 
     void deserializeRT(MemoryBuffer &src);
@@ -257,7 +256,7 @@ public:
 
 // PTree
     virtual bool isEquivalent(IPropertyTree *tree) { return (NULL != QUERYINTERFACE(tree, CRemoteTreeBase)); }
-    virtual IPropertyTree *create(const char *name=NULL, bool nocase=false, IPTArrayValue *value=NULL, ChildMap *children=NULL, bool existing=false) = 0;
+    virtual IPropertyTree *create(const char *name=NULL, IPTArrayValue *value=NULL, ChildMap *children=NULL, bool existing=false) = 0;
     virtual IPropertyTree *create(MemoryBuffer &mb) = 0;
 
 // ITrackChanges

--- a/dali/base/dasds.ipp
+++ b/dali/base/dasds.ipp
@@ -106,7 +106,7 @@ class ChangeInfo : public CInterface, implements IInterface
 public:
     IMPLEMENT_IINTERFACE;
 
-    ChangeInfo(IPropertyTree &_owner) : owner(&_owner) { INIT_NAMEDCOUNT; tree.setown(createPTree(RESERVED_CHANGE_NODE, false)); }
+    ChangeInfo(IPropertyTree &_owner) : owner(&_owner) { INIT_NAMEDCOUNT; tree.setown(createPTree(RESERVED_CHANGE_NODE)); }
     const IPropertyTree *queryOwner() const { return owner; }
     const void *queryFindParam() const { return &owner; }
 public: // data
@@ -300,7 +300,7 @@ public:
     void registerRenamed(IPropertyTree &owner, const char *newName, const char *oldName, unsigned pos, __int64 id)
     {
         ChangeInfo *changes = queryCreateChangeInfo(owner);
-        IPropertyTree *t = createPTree(false);
+        IPropertyTree *t = createPTree();
         t->setProp("@from", oldName);
         t->setProp("@to", newName);
         t->setPropInt64("@id", id);
@@ -313,7 +313,7 @@ public:
     void registerDeleted(IPropertyTree &owner, const char *name, unsigned pos, __int64 id)
     {
         ChangeInfo *changes = queryCreateChangeInfo(owner);
-        IPropertyTree *t = createPTree(false);
+        IPropertyTree *t = createPTree();
         t->setProp("@name", name);
         t->setPropInt64("@id", id);
 #ifdef SIBLING_MOVEMENT_CHECK
@@ -329,7 +329,7 @@ public:
         if (t) t->removeProp(attr);
         t = changes->tree->queryPropTree("AC");
         if (!t)
-            t = changes->tree->addPropTree("AC", createPTree(false));
+            t = changes->tree->addPropTree("AC", createPTree());
         t->setProp(attr, "");
     }
 
@@ -340,7 +340,7 @@ public:
         if (t) t->removeProp(attr);
         t = changes->tree->queryPropTree("AD");
         if (!t)
-            t = changes->tree->addPropTree("AD", createPTree(false));
+            t = changes->tree->addPropTree("AD", createPTree());
         t->addProp(attr, "");
     }
 
@@ -349,7 +349,7 @@ public:
         ChangeInfo *changes = queryCreateChangeInfo(owner);
         IPropertyTree *t = changes->tree->queryPropTree(APPEND_TAG);
         if (!t)
-            t = changes->tree->setPropTree(APPEND_TAG, createPTree(false));
+            t = changes->tree->setPropTree(APPEND_TAG, createPTree());
         t->setPropInt(NULL, l);
     }
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -574,11 +574,11 @@ IPropertyTree *CDfsLogicalFileName::createSuperTree() const
 {
     if (!multi)
         return NULL;
-    IPropertyTree *ret = createPTree("SuperFile",false);
+    IPropertyTree *ret = createPTree("SuperFile");
     unsigned numsub = 0;
     ForEachItemIn(i1,*multi) {
         const CDfsLogicalFileName &sub = multi->item(i1);
-        IPropertyTree *st = createPTree(false);
+        IPropertyTree *st = createPTree();
         st->setProp("@name",sub.get());
         st->setPropInt("@num",++numsub);
         ret->addPropTree("SubFile",st);
@@ -1138,7 +1138,7 @@ MemoryBuffer &serializePartAttr(MemoryBuffer &mb,IPropertyTree *tree)
 
 IPropertyTree *deserializePartAttr(MemoryBuffer &mb)
 {
-    IPropertyTree *pt = createPTree("Part",false);
+    IPropertyTree *pt = createPTree("Part");
     byte flags;
     mb.read(flags);
     if (flags&PAF_HAS_SIZE) {
@@ -1380,7 +1380,7 @@ bool shrinkFileTree(IPropertyTree *file)
     }
     for (i=0;i<n;i++) {
         if (!parts[i])
-            parts[i] = createPTree("Part",false);
+            parts[i] = createPTree("Part");
         serializePartAttr(mb,parts[i]);
     }
     file->setPropBin("Parts",mb.length(),mb.toByteArray());
@@ -2293,7 +2293,7 @@ public:
                     throw MakeStringException(-1,"CDaliMutex::enter Cannot create /Locks branch");
                 path.clear().appendf("Mutex[@name=\"%s\"]",name.get());
                 if (!pconn->queryRoot()->hasProp(name))
-                    pconn->queryRoot()->addPropTree("Mutex",createPTree("Mutex",false))->setProp("@name",name);
+                    pconn->queryRoot()->addPropTree("Mutex",createPTree("Mutex"))->setProp("@name",name);
                 continue; // try again
             }
             unsigned remaining;
@@ -2379,7 +2379,7 @@ bool getSwapNodeInfo(IPropertyTree *options,StringAttr &grpname,Owned<IGroup> &g
             PROGLOG("SWAPNODE: no information for group %s",grpname.get());
             return false;
         }
-        info.set(conn->queryRoot()->addPropTree("Thor",createPTree("Thor",false)));
+        info.set(conn->queryRoot()->addPropTree("Thor",createPTree("Thor")));
         info->setProp("@group",grpname.get());
     }
     return true;
@@ -2452,7 +2452,7 @@ bool checkThorNodeSwap(IPropertyTree *options,const char *failedwuid, unsigned m
                 xpath.clear().appendf("BadNode[@netAddress=\"%s\"]",ips.str());
                 IPropertyTree *bnt = info->queryPropTree(xpath.str());
                 if (!bnt) {
-                    bnt = info->addPropTree("BadNode",createPTree("BadNode",false));
+                    bnt = info->addPropTree("BadNode",createPTree("BadNode"));
                     bnt->setProp("@netAddress",ips.str());
                 }
                 bnt->setPropInt("@numTimes",bnt->getPropInt("@numTimes",0)+1);
@@ -2466,7 +2466,7 @@ bool checkThorNodeSwap(IPropertyTree *options,const char *failedwuid, unsigned m
                 xpath.clear().appendf("WorkUnit[@id=\"%s\"]",failedwuid);
                 IPropertyTree *wut = info->queryPropTree(xpath.str());
                 if (!wut) {
-                    wut = info->addPropTree("WorkUnit",createPTree("WorkUnit",false));
+                    wut = info->addPropTree("WorkUnit",createPTree("WorkUnit"));
                     wut->setProp("@id",failedwuid);
                 }
                 wut->setProp("@time",ts.str());

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -1860,7 +1860,7 @@ static void convertBinBranch(IPropertyTree &cluster,const char *branch)
 static void getxref(const char *dst)
 {
     Owned<IRemoteConnection> conn = querySDS().connect("DFU/XREF",myProcessSession(),RTM_LOCK_READ, INFINITE);
-    Owned<IPropertyTree> root = createPTree(conn->getRoot());
+    Owned<IPropertyTree> root = createPTreeFromIPT(conn->getRoot());
     Owned<IPropertyTreeIterator> iter = root->getElements("Cluster");
     ForEach(*iter) {
         IPropertyTree &cluster = iter->query();

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -253,7 +253,7 @@ static void import(const char *path,const char *src,bool add)
     size32_t sz = (size32_t)iFile->size();
     StringBuffer xml;
     iFileIO->read(0, sz, xml.reserve(sz));
-    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str(), false, true);
+    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str());
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
@@ -538,7 +538,7 @@ static void dfsfile(const char *lname,IUserDescriptor *userDesc, UnsignedArray *
         Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname,userDesc);
         if (file) {
             Owned<IFileDescriptor> fdesc = file->getFileDescriptor();
-            Owned<IPropertyTree> t = createPropertyTree(false,"File");
+            Owned<IPropertyTree> t = createPTree("File");
             fdesc->serializeTree(*t);
             filterParts(t,*partslist);
             toXML(t, str.clear());
@@ -1119,7 +1119,7 @@ static void checksuperfile(const char *lfn,bool fix=false)
                     OUTLOG("Candidate %s",pname.str());
                 }
                 if (fix&&doFix()) {
-                    Owned<IPropertyTree> t = createPTree("SuperOwner",false);
+                    Owned<IPropertyTree> t = createPTree("SuperOwner");
                     t->setProp("@name",lname.get());
                     subroot->addPropTree("SuperOwner",t.getClear());
 
@@ -1767,7 +1767,7 @@ static void coalesce()
     StringBuffer storeFilename(daliDataPath);
     iStoreHelper->getCurrentStoreFilename(storeFilename);
     OUTLOG("Loading store: %s", storeFilename.str());
-    Owned<IPropertyTree> root = createPTreeFromXMLFile(storeFilename.str(), false);
+    Owned<IPropertyTree> root = createPTreeFromXMLFile(storeFilename.str());
     OUTLOG("Loaded: %s", storeFilename.str());
 
     if (baseEdition != iStoreHelper->queryCurrentEdition())
@@ -1851,7 +1851,7 @@ static void convertBinBranch(IPropertyTree &cluster,const char *branch)
     if (buf.length()) {
         StringBuffer xml;
         xml.append(buf.length(),buf.toByteArray());
-        t = createPTreeFromXMLString(xml.str(),false );
+        t = createPTreeFromXMLString(xml.str());
         cluster.removeProp(query.str());
         cluster.addPropTree(query.str(),t);
     }

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -1797,81 +1797,6 @@ void TestSDS1()
     return;
 #endif
 #if 1
-    conn = sdsManager.connect("/", myProcessSession(), RTM_LOCK_WRITE, 2000*MDELAY);
-    root = conn->queryRoot();
-
-    // root->removeProp("newTree");
-    IPropertyTree *nt = root->setPropTree("newTree", createPTree());
-    IPropertyTree *s1 = nt->setPropTree("_subNT1", createPTree());
-    IPropertyTree *s2 = nt->setPropTree("_subNT2", createPTree());
-    
-    nt->setPropInt("t1", 1);
-
-    conn->commit();
-
-//  IPropertyTree *t1_2 = nt->addPropTree("t1", createPTree());
-    nt->addPropInt("t1", 2);
-    IPropertyTree *t1_2 = nt->queryPropTree("t1[2]");
-//  nt->addPropInt("t1", 3);
-
-    conn->commit();
-
-    nt->removeTree(s1);
-
-    conn->commit();
-
-    nt->removeProp("_subNT2");
-
-    conn->commit();
-
-//  nt->removeTree(t1_2);
-    nt->removeProp("t1[2]");
-    nt->removeProp("t1[1]");
-
-    conn->commit();
-
-    conn->Release();
-
-    return;
-
-#endif
-#if 0
-    conn = sdsManager.connect("/", myProcessSession(), RTM_LOCK_WRITE | RTM_LOCK_SUB, 2000*MDELAY);
-    Owned<IPropertyTreeIterator> biter = conn->queryRoot()->getElements("baba");
-    ForEach (*biter)
-    {
-        conn->queryRoot()->removeTree(&biter->query());
-    }
-    conn->commit();
-    conn->Release();
-
-    conn = sdsManager.connect("/baba", myProcessSession(), RTM_CREATE_ADD | RTM_LOCK_SUB, 2000*MDELAY);
-    root = conn->queryRoot();
-
-    root->setProp("@bugtest1", "hello");
-    conn->commit();                         // suspect problem here with old..
-
-//  PrintLog("paused");
-//  getchar();
-
-    root->setProp("@bugtest3", "aa");
-    conn->commit();
-
-    conn->Release();
-
-//  PrintLog("paused");
-//  getchar();
-
-    conn = sdsManager.connect("/baba[@bugtest1=\"hello\"]", myProcessSession(), RTM_LOCK_WRITE | RTM_LOCK_SUB, 2000*MDELAY);
-    root = conn->queryRoot();
-    root->addProp("under", "here");
-
-    conn->close(false);
-    conn->Release();
-    
-//  return;
-#endif
-#if 1
     conn = sdsManager.connect("/", myProcessSession(), RTM_LOCK_WRITE | RTM_LOCK_SUB, 2000*MDELAY);
     root = conn->queryRoot();
 
@@ -1905,35 +1830,8 @@ void TestSDS1()
         root->removeTree(&child);
     }
 
-#if 1
-    IPropertyTree *newTree = createPTreeFromXMLFile("c:\\seisint\\deployment\\xmlenv\\jorge.xml");
-    diter.setown(newTree->getElements("*"));
-    ForEach (*diter)
-    {
-        IPropertyTree &child = diter->get();
-        root->setPropTree(child.queryName(), &child);
-    }
-    newTree->Release();
-#endif
     conn->commit();
 
-    conn->Release();
-
-//  return;
-#endif
-
-
-#if 1 // test attribute deletion etc.
-    conn = sdsManager.connect("/", myProcessSession(), RTM_LOCK_WRITE, 2000*MDELAY);
-    root = conn->queryRoot();
-    root->setProp("@test1", "1");
-    root->setProp("@test2", "2a");
-    conn->Release();
-
-    conn = sdsManager.connect("/", myProcessSession(), RTM_LOCK_WRITE, 2000*MDELAY);
-    root = conn->queryRoot();
-    root->removeProp("@test1");
-    root->setProp("@test1", "2");
     conn->Release();
 #endif
 
@@ -1968,7 +1866,6 @@ void TestSDS1()
     root = conn->queryRoot();
     verifyex(root->removeProp("attrtree"));
     conn->Release();
-
 #endif
 
 
@@ -1993,6 +1890,7 @@ void TestSDS1()
     conn->Release();
 
 #endif
+
 #if 1 // test2 qualified add/set
     conn = sdsManager.connect("/", myProcessSession(), RTM_LOCK_WRITE, 2000*MDELAY);
     root = conn->queryRoot();
@@ -2502,7 +2400,7 @@ NULL
 
             Owned<IRemoteConnection> conn = querySDS().connect("/", myProcessSession(), RTM_LOCK_WRITE, 2000*MDELAY);
             conn->queryRoot()->setPropTree("ROOT", LINK(originalTree));
-            tree.setown(createPTree(conn->queryRoot()->queryPropTree("ROOT")));
+            tree.setown(createPTreeFromIPT(conn->queryRoot()->queryPropTree("ROOT")));
         }
         unsigned test = 0;
         while (xpathTests[test] != NULL)
@@ -3079,4 +2977,3 @@ int main(int argc, char* argv[])
     
     return 0;
 }
-

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -60,7 +60,7 @@ static void addTestFile(const char *name,unsigned n)
         epa.append(ep);
     }
     Owned<IGroup> group = createIGroup(epa); 
-    Owned<IPropertyTree> fileInfo = createPTree(false);
+    Owned<IPropertyTree> fileInfo = createPTree();
     Owned<IFileDescriptor> fileDesc = createFileDescriptor();
     StringBuffer dir;
     makePhysicalPartName(name, 0, 0, dir, false, DFD_OSdefault);
@@ -71,7 +71,7 @@ static void addTestFile(const char *name,unsigned n)
         RemoteFilename rfn;
         constructPartFilename(group,m+1,n,NULL,partmask.str(),dir.str(),false,1,rfn);
         rfn.getLocalPath(path.clear());
-        Owned<IPropertyTree> pp = createPTree("Part",false);
+        Owned<IPropertyTree> pp = createPTree("Part");
         pp->setPropInt64("@size",1234*(m+1));
         fileDesc->setPart(m,&group->queryNode(m), path.str(), pp);
     }
@@ -446,7 +446,7 @@ void Test_DFS()
     dfiler->Release();
     return;
 #endif
-    Owned<IPropertyTree> pp = createPTree("Part",false);
+    Owned<IPropertyTree> pp = createPTree("Part");
     IFileDescriptor *fdesc = createFileDescriptor();
     fdesc->setDefaultDir("c:\\thordata\\test");
     INode *node = createINode("192.168.0.1");
@@ -553,7 +553,7 @@ void Test_DFS()
 
 void Test_DFSU()
 {
-    Owned<IPropertyTree> pp = createPTree("Part",false);
+    Owned<IPropertyTree> pp = createPTree("Part");
     IFileDescriptor *fdesc = createFileDescriptor();
     fdesc->setDefaultDir("/c$/thordata/test");
     INode *node = createINode("192.168.0.1");
@@ -636,7 +636,7 @@ void testcode()
 
 void Test_MultiFile()
 {
-    Owned<IPropertyTree> pp = createPTree("Part",false);
+    Owned<IPropertyTree> pp = createPTree("Part");
     Owned<IFileDescriptor> fdesc = createFileDescriptor();
     fdesc->setDefaultDir("c:\\thordata\\test");
     INode *node = createINode("10.150.10.16");
@@ -1114,7 +1114,7 @@ myProcessSession(), RTM_CREATE_QUERY, 1000000);
                 i = _i%subscriptions;
                     StringBuffer key;
                     key.append("TEST").append(i);
-                    root->setPropTree(key.str(), createPTree(false));
+                    root->setPropTree(key.str(), createPTree());
 
             }
             conn->commit();
@@ -1248,7 +1248,7 @@ void TestStress()
     {
         StringBuffer branch(branchPrefix);
         branch.append(b+1);
-        root->setPropTree(branch.str(), createPTree(false));
+        root->setPropTree(branch.str(), createPTree());
     }
     conn->commit();
 
@@ -1801,15 +1801,15 @@ void TestSDS1()
     root = conn->queryRoot();
 
     // root->removeProp("newTree");
-    IPropertyTree *nt = root->setPropTree("newTree", createPTree(false));
-    IPropertyTree *s1 = nt->setPropTree("_subNT1", createPTree(false));
-    IPropertyTree *s2 = nt->setPropTree("_subNT2", createPTree(false));
+    IPropertyTree *nt = root->setPropTree("newTree", createPTree());
+    IPropertyTree *s1 = nt->setPropTree("_subNT1", createPTree());
+    IPropertyTree *s2 = nt->setPropTree("_subNT2", createPTree());
     
     nt->setPropInt("t1", 1);
 
     conn->commit();
 
-//  IPropertyTree *t1_2 = nt->addPropTree("t1", createPTree(false));
+//  IPropertyTree *t1_2 = nt->addPropTree("t1", createPTree());
     nt->addPropInt("t1", 2);
     IPropertyTree *t1_2 = nt->queryPropTree("t1[2]");
 //  nt->addPropInt("t1", 3);
@@ -1875,12 +1875,12 @@ void TestSDS1()
     conn = sdsManager.connect("/", myProcessSession(), RTM_LOCK_WRITE | RTM_LOCK_SUB, 2000*MDELAY);
     root = conn->queryRoot();
 
-    IPropertyTree *t1 = createPTree(false);
-    IPropertyTree *t2 = root->setPropTree("t2", createPTree(false));
+    IPropertyTree *t1 = createPTree();
+    IPropertyTree *t2 = root->setPropTree("t2", createPTree());
     IPropertyTree *_t1 = t2->setPropTree("t1", t1);
-    _t1->setPropTree("under_t1", createPTree(false));
+    _t1->setPropTree("under_t1", createPTree());
 
-    IPropertyTree *t3 = root->setPropTree("t3", createPTree(false));
+    IPropertyTree *t3 = root->setPropTree("t3", createPTree());
 
     conn->commit();
 
@@ -1906,7 +1906,7 @@ void TestSDS1()
     }
 
 #if 1
-    IPropertyTree *newTree = loadPropertyTree("c:\\seisint\\deployment\\xmlenv\\jorge.xml", false);
+    IPropertyTree *newTree = createPTreeFromXMLFile("c:\\seisint\\deployment\\xmlenv\\jorge.xml");
     diter.setown(newTree->getElements("*"));
     ForEach (*diter)
     {
@@ -1942,7 +1942,7 @@ void TestSDS1()
     root = conn->queryRoot();
 
     root->removeProp("attrtree");
-    IPropertyTree *attrTree = createPTree(false);
+    IPropertyTree *attrTree = createPTree();
     attrTree->addProp("@rattr1", "a");
     attrTree->addProp("@rattr2", "b");
     attrTree->addProp("@rattr3", "c");
@@ -2035,18 +2035,18 @@ void TestSDS1()
 
 #if 1 // test similar to DFS file release.
     // create f (local)
-    IPropertyTree *f = createPTree("file",true);
-    IPropertyTree *p = createPTree("part",true);
+    IPropertyTree *f = createPTree("file", ipt_caseInsensitive);
+    IPropertyTree *p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","1");
     p->setProp("filename","testfile1.d00._1_of_3");
     p->setProp("node","192.168.0.3");
     f->addPropTree("part",p);
-    p = createPTree("part",true);
+    p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","2");
     p->setProp("filename","testfile1.d00._2_of_3");
     p->setProp("node","192.168.0.3");
     f->addPropTree("part",p);
-    p = createPTree("part",true);
+    p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","3");
     p->setProp("filename","testfile1.d00._3_of_3");
     p->setProp("node","192.168.0.3");
@@ -2054,18 +2054,18 @@ void TestSDS1()
     f->setProp("directory","c:\\thordata");
     f->setProp("@name","testfile1");
     
-    IPropertyTree *f2 = createPTree("file",true);
-    p = createPTree("part",true);
+    IPropertyTree *f2 = createPTree("file", ipt_caseInsensitive);
+    p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","1");
     p->setProp("filename","testfile2.d00._1_of_3");
     p->setProp("node","192.168.0.3");
     f2->addPropTree("part",p);
-    p = createPTree("part",true);
+    p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","2");
     p->setProp("filename","testfile2.d00._2_of_3");
     p->setProp("node","192.168.0.3");
     f2->addPropTree("part",p);
-    p = createPTree("part",true);
+    p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","3");
     p->setProp("f2ilename","testfile2.d00._3_of_3");
     p->setProp("node","192.168.0.3");
@@ -2073,18 +2073,18 @@ void TestSDS1()
     f2->setProp("directory","c:\\thordata");
     f2->setProp("@name","testfile2");
     
-    IPropertyTree *f3 = createPTree("file",true);
-    p = createPTree("part",true);
+    IPropertyTree *f3 = createPTree("file", ipt_caseInsensitive);
+    p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","1");
     p->setProp("filename","testfile3.d00._1_of_3");
     p->setProp("node","192.168.0.3");
     f3->addPropTree("part",p);
-    p = createPTree("part",true);
+    p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","2");
     p->setProp("filename","testfile3.d00._2_of_3");
     p->setProp("node","192.168.0.3");
     f3->addPropTree("part",p);
-    p = createPTree("part",true);
+    p = createPTree("part", ipt_caseInsensitive);
     p->setProp("@num","3");
     p->setProp("filename","testfile3.d00._3_of_3");
     p->setProp("node","192.168.0.3");
@@ -2097,10 +2097,10 @@ void TestSDS1()
     const char *name = root->queryName();
 
 
-    IPropertyTree *sroot = createPTree(false);
+    IPropertyTree *sroot = createPTree();
     sroot->setProp("@name","nigel");
     sroot = root->addPropTree("scope",sroot);
-    IPropertyTree *sroot2 = createPTree(false);
+    IPropertyTree *sroot2 = createPTree();
     sroot2->setProp("@name","test");
     sroot2 = sroot->addPropTree("scope",sroot2);
 
@@ -2155,7 +2155,7 @@ void TestSDS1()
 
     root->setPropInt("@id", 5);
 
-    IPropertyTree *a = createPTree(true);
+    IPropertyTree *a = createPTree(ipt_caseInsensitive);
     a->setProp("@attr1", "123");
 
     root->setPropTree("file", LINK(a));
@@ -2178,7 +2178,7 @@ void TestSDS1()
     root->setPropInt("sub1", 5);
     IPropertyTree *sub = root->queryPropTree("sub1");
 
-    IPropertyTree *subsub = createPTree(false);
+    IPropertyTree *subsub = createPTree();
     subsub->setProp("hello", "there");
     sub->setPropTree("hellosubsub", subsub);
     root->Release();
@@ -2481,7 +2481,7 @@ NULL
     OwnedIFile newFileSecondary = createIFile("xpathTestsSecondary.out");
     Owned<IIOStream> newFileIOStream;
 
-    Owned<IPropertyTree> originalTree = createPTreeFromXMLString(testXML, false);
+    Owned<IPropertyTree> originalTree = createPTreeFromXMLString(testXML);
     Owned<IPropertyTree> tree;
     unsigned l;
     MemoryBuffer newOutput, secondary;

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -189,7 +189,7 @@ class CDFUengine: public CInterface, implements IDFUengine
             mask.clear().appendf("Job[@wuid=\"%s\"]",wuid);
             if (set&&!t->hasProp(mask.str())) {
                 
-                t->addPropTree("Job",createPTree(false))->setProp("@wuid",wuid);
+                t->addPropTree("Job",createPTree())->setProp("@wuid",wuid);
             }
             else 
                 t->removeProp(mask.str());

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -969,7 +969,7 @@ public:
         IConstDFUfileSpec *source = wu->querySource();
         IConstDFUfileSpec *destination = wu->queryDestination();
         IConstDFUoptions *options = wu->queryOptions();
-        Owned<IPropertyTree> opttree = createPTree(options->queryTree());
+        Owned<IPropertyTree> opttree = createPTreeFromIPT(options->queryTree());
         StringAttr encryptkey;
         StringAttr decryptkey;
         if (options->getEncDec(encryptkey,decryptkey)) {

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -78,9 +78,9 @@ inline void XF(IPropertyTree &pt,const char *p,IProperties &from,const char *fp)
 
 IPropertyTree *readOldIni()
 {
-    IPropertyTree *ret = createPTree("DFUSERVER",true);
+    IPropertyTree *ret = createPTree("DFUSERVER", ipt_caseInsensitive);
     ret->setProp("@name","mydfuserver");
-    ret->addPropTree("SSH",createPTree("SSH",true));
+    ret->addPropTree("SSH",createPTree("SSH", ipt_caseInsensitive));
     Owned<IProperties> props = createProperties("dfuserver.ini", true);
     if (props) {
         XF(*ret,"@name",*props,"name");
@@ -107,7 +107,7 @@ int main(int argc, const char *argv[])
 
     Owned<IFile> file = createIFile("dfuserver.xml");
     if (file->exists())
-        globals.setown(createPTreeFromXMLFile("dfuserver.xml", true));
+        globals.setown(createPTreeFromXMLFile("dfuserver.xml", ipt_caseInsensitive));
     else
         globals.setown(readOldIni());
 
@@ -209,7 +209,7 @@ int main(int argc, const char *argv[])
                 if (t)
                     t->setPropInt("@num",t->getPropInt("@num",0)+1);
                 else {
-                    t = createPTree(false);
+                    t = createPTree();
                     t->setProp("@name",subq.str());
                     t->setPropInt("@num",1);
                     serverstatus->queryProperties()->addPropTree("Queue",t);
@@ -230,7 +230,7 @@ int main(int argc, const char *argv[])
                 stopDFUserver(q);
             }
             else {
-                IPropertyTree *t=serverstatus->queryProperties()->addPropTree("MonitorQueue",createPTree(false));
+                IPropertyTree *t=serverstatus->queryProperties()->addPropTree("MonitorQueue",createPTree());
                 t->setProp("@name",q);
                 engine->startMonitor(q,serverstatus,globals->getPropInt("@MONITORINTERVAL",60)*1000);
             }

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -851,7 +851,7 @@ public:
 
     void addFileXML(const char *lfn,const StringBuffer &xml,IUserDescriptor *user=NULL)
     {
-        Owned<IPropertyTree> t = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> t = createPTreeFromXMLString(xml);
         Owned<IFileDescriptor> fdesc = deserializeFileDescriptorTree(t,&queryNamedGroupStore(),0);
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc,true);
         if (file)

--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -781,7 +781,7 @@ public:
             }
             throw MakeStringException(-1,"CDFUfileSpec: No parts found for file!");
         }
-        IPropertyTree *p = createPTree(queryProperties());
+        IPropertyTree *p = createPTreeFromIPT(queryProperties());
         if (iskey) {
             p->removeProp("@blockCompressed");      // can't compress keys
         }

--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -279,7 +279,7 @@ public:
         if (!root) {
             root.set(parent->root->queryPropTree(name.get()));
             if (!root)
-                root.set(parent->root->setPropTree(name,createPTree(name,false)));
+                root.set(parent->root->setPropTree(name,createPTree(name)));
             assertex(root);
         }
         return root.get();
@@ -925,7 +925,7 @@ public:
         if (!ret) {
             ret = nullattr.get();
             if (!ret) {
-                nullattr.setown(createPTree("Attr",false));
+                nullattr.setown(createPTree("Attr"));
                 ret = nullattr.get();
             }
         }
@@ -935,7 +935,7 @@ public:
     {
         IPropertyTree *ret = queryRoot()->queryPropTree("Attr");
         if (!ret)
-            ret = setProperties(createPTree("Attr",false));
+            ret = setProperties(createPTree("Attr"));
         return ret;
     }
     size32_t getRecordSize() const 
@@ -1101,7 +1101,7 @@ public:
         path.append("Part[@num=\"").append(partidx+1).append("\"]");
         IPropertyTree *ret = queryRoot()->queryPropTree(path.str());
         if (!ret) {
-            ret = queryRoot()->addPropTree("Part",createPTree("Part",false));
+            ret = queryRoot()->addPropTree("Part",createPTree("Part"));
             ret->setPropInt("@num",partidx+1);
         }
         return ret;
@@ -1270,7 +1270,7 @@ public:
         }
         setFileMask(mask.str());
         queryRoot()->setPropInt("@numparts",1);
-        IPropertyTree * part = queryRoot()->setPropTree("Part",createPTree("Part",false));
+        IPropertyTree * part = queryRoot()->setPropTree("Part",createPTree("Part"));
         part->setPropInt("@num",1);
         StringBuffer url;
         rmfn.queryEndpoint().getUrlStr(url);
@@ -1354,7 +1354,7 @@ public:
     void setFromXML(const char *xml)
     {
         // the following is slightly odd: xml->tree->file->tree
-        Owned<IPropertyTree> t = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> t = createPTreeFromXMLString(xml);
         Owned<IFileDescriptor> fdesc = deserializeFileDescriptorTree(t,&queryNamedGroupStore(),0);
         setFromFileDescriptor(*fdesc);
     }
@@ -1479,7 +1479,7 @@ public:
         if (!clustername) {
             if (!iter->first()) {
                 iter.clear();
-                IPropertyTree *pt= createPTree("Cluster",false);
+                IPropertyTree *pt= createPTree("Cluster");
                 ClusterPartDiskMapSpec spec;
                 spec.toProp(pt);
                 StringBuffer grpname; // this shouldn't be set but if it is then use
@@ -1527,7 +1527,7 @@ public:
             clustername = _clustername.append(clustername).trim().toLowerCase().str();
         unsigned clusternum;
         if (!findCluster(clustername,clusternum)) {
-            IPropertyTree *pt = createPTree("Cluster",false);   
+            IPropertyTree *pt = createPTree("Cluster");
             if (clustername&&*clustername)
                 pt->setProp("@name",clustername);
             queryRoot()->addPropTree("Cluster",pt);
@@ -2594,7 +2594,7 @@ public:
         _conn = conn;
         _tree = root->queryPropTree("Recovery");
         if (!_tree)
-            _tree = root->addPropTree("Recovery",createPTree("Recovery",false));
+            _tree = root->addPropTree("Recovery",createPTree("Recovery"));
         getXPath(runningpath,queryId()).append("/Running");
     }
 
@@ -2608,8 +2608,8 @@ public:
     {
         IPropertyTree *tree = root->queryPropTree("Exceptions");
         if (!tree)
-            tree = root->addPropTree("Exceptions",createPTree("Exceptions",false));
-        IPropertyTree *et = tree->addPropTree("Exception",createPTree("Exception",false));
+            tree = root->addPropTree("Exceptions",createPTree("Exceptions"));
+        IPropertyTree *et = tree->addPropTree("Exception",createPTree("Exception"));
         et->setPropInt("@exceptionCode", e->errorCode());
         StringBuffer msg;
         et->setProp("@exceptionMessage",e->errorMessage(msg).str());
@@ -2648,10 +2648,10 @@ public:
     {
         IPropertyTree *tree = root->queryPropTree("Application");
         if (!tree) 
-            tree = root->addPropTree("Application",createPTree("Application",false));
+            tree = root->addPropTree("Application",createPTree("Application"));
         IPropertyTree *sub = tree->queryPropTree(app);
         if (!sub) 
-            sub = tree->addPropTree(app,createPTree(app,false));
+            sub = tree->addPropTree(app,createPTree(app));
         if (overwrite || !sub->hasProp(propname)) 
             sub->setProp(propname, value); 
     }
@@ -2677,7 +2677,7 @@ public:
     {
         IPropertyTree *tree = root->queryPropTree("Debug");
         if (!tree) 
-            tree = root->addPropTree("Debug",createPTree("Debug",false));
+            tree = root->addPropTree("Debug",createPTree("Debug"));
         if (overwrite || !tree->hasProp(propname))
             tree->setProp(propname, value); 
     }

--- a/dali/dfuXRefLib/XRefFilesNode.cpp
+++ b/dali/dfuXRefLib/XRefFilesNode.cpp
@@ -89,7 +89,7 @@ IPropertyTree& CXRefFilesNode::getDataTree()
     {
         StringBuffer dataStr;
         Serialize(dataStr);
-        m_DataTree.setown(createPTreeFromXMLString(dataStr.str(),false ));
+        m_DataTree.setown(createPTreeFromXMLString(dataStr.str()));
     }
     return *m_DataTree.get();
 }

--- a/dali/dfuXRefLib/XRefNodeManager.cpp
+++ b/dali/dfuXRefLib/XRefNodeManager.cpp
@@ -77,7 +77,7 @@ IXRefNode * CXRefNodeManager::CreateXRefNode(const char* NodeName)
 {
     Owned<IRemoteConnection> conn = querySDS().connect("/DFU/XREF",myProcessSession(),RTM_CREATE_QUERY|RTM_LOCK_WRITE ,INFINITE);
     IPropertyTree* xref_ptree = conn->queryRoot();
-    IPropertyTree* cluster_ptree = xref_ptree->addPropTree("Cluster", createPTree(false));
+    IPropertyTree* cluster_ptree = xref_ptree->addPropTree("Cluster", createPTree());
     cluster_ptree->setProp("@name",NodeName);
     conn->commit();
     conn->changeMode(RTM_NONE);
@@ -145,7 +145,7 @@ bool CXRefNode::useSasha()
 IPropertyTree& CXRefNode::getDataTree()
 {
     if(m_XRefDataTree.get() == 0)
-        m_XRefDataTree.setown(createPTreeFromXMLString(m_dataStr.str(),false ));
+        m_XRefDataTree.setown(createPTreeFromXMLString(m_dataStr.str()));
 
     return *m_XRefDataTree.get();
 
@@ -189,7 +189,7 @@ IXRefFilesNode* CXRefNode::getLostFiles()
         IPropertyTree* lostBranch = m_XRefTree->queryPropTree("Lost");
         if(lostBranch == 0)
         {
-            lostBranch = m_XRefTree->addPropTree("Lost",createPTree(false));
+            lostBranch = m_XRefTree->addPropTree("Lost",createPTree());
             commit();
         }
         const char *rootdir = m_XRefTree.get()?m_XRefTree->queryProp("@rootdir"):NULL;
@@ -206,7 +206,7 @@ IXRefFilesNode* CXRefNode::getFoundFiles()
         IPropertyTree* foundBranch = m_XRefTree->queryPropTree("Found");
         if(foundBranch == 0)
         {
-            foundBranch = m_XRefTree->addPropTree("Found",createPTree(false));
+            foundBranch = m_XRefTree->addPropTree("Found",createPTree());
             commit();
         }
         const char *rootdir = m_XRefTree.get()?m_XRefTree->queryProp("@rootdir"):NULL;
@@ -223,7 +223,7 @@ IXRefFilesNode* CXRefNode::getOrphanFiles()
         IPropertyTree* orphanBranch = m_XRefTree->queryPropTree("Orphans");
         if(orphanBranch == 0)
         {
-            orphanBranch = m_XRefTree->addPropTree("Orphans",createPTree(false));
+            orphanBranch = m_XRefTree->addPropTree("Orphans",createPTree());
             commit();
         }
         const char *rootdir = m_XRefTree.get()?m_XRefTree->queryProp("@rootdir"):NULL;
@@ -240,7 +240,7 @@ StringBuffer &CXRefNode::serializeMessages(StringBuffer &buf)
         IPropertyTree* messagesBranch = m_XRefTree->queryPropTree("Messages");
         if(messagesBranch == 0)
         {
-            messagesBranch = m_XRefTree->addPropTree("Messages",createPTree(false));
+            messagesBranch = m_XRefTree->addPropTree("Messages",createPTree());
             commit();
         }
         StringBuffer tmpbuf;
@@ -263,7 +263,7 @@ void CXRefNode::deserializeMessages(IPropertyTree& inTree)
         IPropertyTree* messagesBranch = m_XRefTree->queryPropTree("Messages");
         if(messagesBranch == 0)
         {
-            messagesBranch = m_XRefTree->addPropTree("Messages",createPTree(false));
+            messagesBranch = m_XRefTree->addPropTree("Messages",createPTree());
             commit();
         }
         StringBuffer tmpbuf;
@@ -281,7 +281,7 @@ StringBuffer &CXRefNode::serializeDirectories(StringBuffer &buf)
         IPropertyTree* directoriesBranch = m_XRefTree->queryPropTree("Directories");
         if(directoriesBranch == 0)
         {
-            directoriesBranch = m_XRefTree->addPropTree("Directories",createPTree(false));
+            directoriesBranch = m_XRefTree->addPropTree("Directories",createPTree());
             commit();
         }
         StringBuffer tmpbuf;
@@ -304,7 +304,7 @@ void CXRefNode::deserializeDirectories(IPropertyTree& inTree)
         IPropertyTree* directoriesBranch = m_XRefTree->queryPropTree("Directories");
         if(directoriesBranch == 0)
         {
-            directoriesBranch = m_XRefTree->addPropTree("Directories",createPTree(false));
+            directoriesBranch = m_XRefTree->addPropTree("Directories",createPTree());
             commit();
         }
         StringBuffer tmpbuf;
@@ -405,7 +405,7 @@ bool CXRefNode::removeEmptyDirectories(StringBuffer &errstr)
     serializeDirectories(dataStr);
     if (dataStr.length()==0)
         return true;
-    Owned<IPropertyTree> t = createPTreeFromXMLString(dataStr.str(),false );
+    Owned<IPropertyTree> t = createPTreeFromXMLString(dataStr.str());
     Owned<IPropertyTreeIterator> iter = t->getElements("Directory");
     const char *clustername = t->queryProp("Cluster");
     if (!clustername||!*clustername)

--- a/dali/dfuXRefLib/dfurdir.cpp
+++ b/dali/dfuXRefLib/dfurdir.cpp
@@ -52,7 +52,7 @@ class XREFDirectoryBuilder
         mask.appendf("directory[@name=\"%s\"]",tail);
         IPropertyTree *ret = parent->queryPropTree(mask.str());
         if (!ret) {
-            ret = parent->addPropTree("directory", createPTree(false));
+            ret = parent->addPropTree("directory", createPTree());
             ret->setProp("@name", tail);
         }
         return ret;
@@ -87,7 +87,7 @@ public:
         }
         StringBuffer path;
         const char * tag = "directory";
-        IPropertyTree * dirTree = result->addPropTree(tag, createPTree(false));
+        IPropertyTree * dirTree = result->addPropTree(tag, createPTree());
         dirTree->setProp("@name", directory);
         walkDirectory(dir,"", dirTree);
     }
@@ -163,7 +163,7 @@ public:
                     }
                 }
                 mask.clear().appendf("file[@name=\"%s\"]",tailname);
-                IPropertyTree *entry = parent->addPropTree("file", createPTree(false));
+                IPropertyTree *entry = parent->addPropTree("file", createPTree());
                 __int64 fsz = iter->getFileSize();
                 entry->setPropInt64("@size", fsz);
                 parentfsz += fsz;
@@ -185,7 +185,7 @@ IPropertyTree *getDirectory(const char * directory, INode * node, unsigned short
     loop {
         StringAttr nextDir;
         try {
-            Owned<IPropertyTree> dirTree = createPTree("machine",false);
+            Owned<IPropertyTree> dirTree = createPTree("machine");
             StringBuffer url;
             node->endpoint().getIpText(url);
             dirTree->setProp("@ip", url.str());

--- a/dali/dfuXRefLib/dfuxreflib.cpp
+++ b/dali/dfuXRefLib/dfuxreflib.cpp
@@ -89,7 +89,7 @@ void testGetDir()
 
 static IPropertyTree *addBranch(IPropertyTree *dst,const char *name)
 {
-    return dst->addPropTree(name,createPTree(false));
+    return dst->addPropTree(name,createPTree());
 }
 
 
@@ -1454,7 +1454,7 @@ void loadFromDFS(CXRefManagerBase &manager,IGroup *grp,unsigned numdirs,const ch
             else { // slow but should be going anyway
                 iter.setown(root.getElements("Part")); // use parts
                 IArrayOf<IPropertyTree> parts;
-                Owned<IPropertyTree> empty = createPTree("Attr",false);
+                Owned<IPropertyTree> empty = createPTree("Attr");
                 unsigned i;
                 for (i=0;i<numparts;i++)
                     parts.append(*empty.getLink());
@@ -2484,7 +2484,7 @@ class CXRefManager: public CXRefManagerBase
     IPropertyTree * outputTree()
     {
         log("Collating output");
-        IPropertyTree *out = createPTree("XREF",false);
+        IPropertyTree *out = createPTree("XREF");
         IPropertyTree *orphans = addBranch(out,"Orphans");
         IPropertyTree *found = addBranch(out,"Found");
         IPropertyTree *lost = addBranch(out,"Lost");

--- a/dali/dfuXRefLib/dfuxreflib.cpp
+++ b/dali/dfuXRefLib/dfuxreflib.cpp
@@ -1463,7 +1463,7 @@ void loadFromDFS(CXRefManagerBase &manager,IGroup *grp,unsigned numdirs,const ch
                     IPropertyTree &part = iter->query();
                     unsigned partno = part.getPropInt("@num",0);
                     if (partno&&(partno!=lastpartno)&&(partno<=numparts)) {
-                        parts.replace(*createPTree(&part),partno-1);
+                        parts.replace(*createPTreeFromIPT(&part),partno-1);
                         lastpartno = partno;
                     }
                 }

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -162,8 +162,8 @@ void CDistributedFileSystem::directory(const char * directory, IGroup * machines
 
 void CDistributedFileSystem::physicalCopy(const char * source, const char * target, IPropertyTree * options, IDaftCopyProgress * progress)
 {
-    Owned<IPropertyTree> dirOptions = createPTree("options", false);
-    Owned<IPropertyTree> files = createPTree("files", false);
+    Owned<IPropertyTree> dirOptions = createPTree("options");
+    Owned<IPropertyTree> files = createPTree("files");
 
     dirOptions->setPropBool("@time", false);
     if (options)

--- a/dali/ft/daftdir.cpp
+++ b/dali/ft/daftdir.cpp
@@ -121,7 +121,7 @@ void DirectoryBuilder::rootDirectory(const char * directory, INode * node, IProp
         path.insert(0, drive.str());
     }
 
-    IPropertyTree * dirTree = result->addPropTree(tag, createPTree(true));
+    IPropertyTree * dirTree = result->addPropTree(tag, createPTree(ipt_caseInsensitive));
     dirTree->setProp("@name", path.str());
 
     if (addTimes)
@@ -182,11 +182,11 @@ bool DirectoryBuilder::walkDirectory(const char * path, IPropertyTree * director
             if (info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
             {
                 if (implicitWildcard && !recurse)
-                    entry = directory->addPropTree(tag, createPTree(true));
+                    entry = directory->addPropTree(tag, createPTree(ipt_caseInsensitive));
             }
             else
             {
-                entry = directory->addPropTree(tag, createPTree(true));
+                entry = directory->addPropTree(tag, createPTree(ipt_caseInsensitive));
 
                 entry->setPropInt64("@size", ((unsigned __int64)info.nFileSizeHigh) << 32 | info.nFileSizeLow);
                 if (calcCRC)
@@ -249,7 +249,7 @@ bool DirectoryBuilder::walkDirectory(const char * path, IPropertyTree * director
                     if (directory->hasProp(prev.str()))
                         continue;
 
-                    IPropertyTree * entry = directory->addPropTree("directory", createPTree(true));
+                    IPropertyTree * entry = directory->addPropTree("directory", createPTree(ipt_caseInsensitive));
                     entry->setProp("@name", info.cFileName);
                     pending.append(*LINK(entry));
 
@@ -310,7 +310,7 @@ bool DirectoryBuilder::walkDirectory(const char * path, IPropertyTree * director
             if (file->isDirectory()==foundYes)
             {
                 if (implicitWildcard && !recurse)
-                    entry = directory->addPropTree(tag, createPTree(true));
+                    entry = directory->addPropTree(tag, createPTree(ipt_caseInsensitive));
                 else if(recurse)
                 {
                     StringBuffer prev;
@@ -318,13 +318,13 @@ bool DirectoryBuilder::walkDirectory(const char * path, IPropertyTree * director
                     if (directory->hasProp(prev.str()))
                         continue;
 
-                    entry = directory->addPropTree("directory", createPTree(true));
+                    entry = directory->addPropTree("directory", createPTree(ipt_caseInsensitive));
                     pending.append(*LINK(entry));
                 }
             }
             else
             {
-                entry = directory->addPropTree(tag, createPTree(true));
+                entry = directory->addPropTree(tag, createPTree(ipt_caseInsensitive));
 
                 entry->setPropInt64("@size", file->size());
                 if (calcCRC)
@@ -393,7 +393,7 @@ bool processDirCommand(ISocket * masterSocket, MemoryBuffer & cmd, MemoryBuffer 
     DirectoryBuilder builder(masterSocket, options);
     StringBuffer url;
     
-    Owned<IPropertyTree> dirTree = createPTree("machine", true);
+    Owned<IPropertyTree> dirTree = createPTree("machine", ipt_caseInsensitive);
     node->endpoint().getIpText(url.clear());
     dirTree->setProp("@ip", url.str());
 
@@ -549,7 +549,7 @@ void doDirectoryCommand(const char * directory, IGroup * machines, IPropertyTree
     {
         INode & node = machines->queryNode(idx);
         node.endpoint().getIpText(url.clear());
-        IPropertyTree * machine = createPTree("machine", true);
+        IPropertyTree * machine = createPTree("machine", ipt_caseInsensitive);
         machine->setProp("@ip", url.str());
         result->addPropTree("machine", machine);
         builder.rootDirectory(directory, &node, machine);
@@ -786,7 +786,7 @@ void doPhysicalCopy(IPropertyTree * source, const char * target, IPropertyTree *
 
     Linked<IPropertyTree> options = _options;
     if (!options)
-        options.setown(createPTree("options", true));
+        options.setown(createPTree("options", ipt_caseInsensitive));
 
     if (progress)
         options->setPropBool("@verbose", true);

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2286,7 +2286,7 @@ void FileSprayer::setReplicate(bool _replicate)
 void FileSprayer::setSource(IDistributedFile * source)
 {
     distributedSource.set(source);
-    srcAttr.setown(createPTree(&source->queryProperties()));
+    srcAttr.setown(createPTreeFromIPT(&source->queryProperties()));
     extractSourceFormat(srcAttr);
     unsigned numParts = source->numParts();
     for (unsigned idx=0; idx < numParts; idx++)
@@ -2322,7 +2322,7 @@ void FileSprayer::setSource(IFileDescriptor * source, unsigned copy, unsigned mi
 {
     IPropertyTree *attr = &source->queryProperties();
     extractSourceFormat(attr);
-    srcAttr.setown(createPTree(&source->queryProperties()));
+    srcAttr.setown(createPTreeFromIPT(&source->queryProperties()));
     extractSourceFormat(srcAttr);
 
     RemoteFilename filename;
@@ -2856,7 +2856,7 @@ void FileSprayer::updateTargetProperties()
             // and simple (top level) elements
             Owned<IPropertyTreeIterator> iter = srcAttr->getElements("*");
             ForEach(*iter) {
-                curProps.addPropTree(iter->query().queryName(),createPTree(&iter->query()));
+                curProps.addPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
             }
         }
         distributedTarget->unlockProperties();

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -554,9 +554,9 @@ FileSprayer::FileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IR
     recoveryConnection = _recoveryConnection;
     options.set(_options);
     if (!options)
-        options.setown(createPTree(false));
+        options.setown(createPTree());
     if (!progressTree)
-        progressTree.setown(createPTree("progress", true));
+        progressTree.setown(createPTree("progress", ipt_caseInsensitive));
 
     //split prefix messes up recovery because the target filenames aren't saved in the recovery info.
     allowRecovery = !options->getPropBool(ANnoRecover) && !querySplitPrefix();
@@ -1538,7 +1538,7 @@ void FileSprayer::derivePartitionExtra()
             next.whichPartition=idx;
             if (allowRecovery)
             {
-                IPropertyTree * progressInfo = progressTree->addPropTree(PNprogress, createPTree(PNprogress, true));
+                IPropertyTree * progressInfo = progressTree->addPropTree(PNprogress, createPTree(PNprogress, ipt_caseInsensitive));
                 next.tree.set(progressInfo);
                 next.save(progressInfo);
             }
@@ -2229,7 +2229,7 @@ void FileSprayer::savePartition()
     {
         ForEachItemIn(idx, partition)
         {
-            IPropertyTree * child = createPTree(PNpartition, true);
+            IPropertyTree * child = createPTree(PNpartition, ipt_caseInsensitive);
             partition.item(idx).save(child);
             progressTree->addPropTree(PNpartition, child);
         }

--- a/dali/hellodali/hellodali.cpp
+++ b/dali/hellodali/hellodali.cpp
@@ -74,7 +74,7 @@ void doStuff()
     else {
         // save as tree
         printf("TestBranch3: set (as tree)\n",s.str());
-        br3 =  createPTreeFromXMLString(MyTestXML,false); // parses and creates object tree
+        br3 =  createPTreeFromXMLString(MyTestXML); // parses and creates object tree
         root->setPropTree("TestBranch3", br3);
     }
 }

--- a/dali/regress/daregdfs.cpp
+++ b/dali/regress/daregdfs.cpp
@@ -428,7 +428,7 @@ void mt(const char *s)
 void dispFDesc(IFileDescriptor *fdesc)
 {
     printf("======================================\n");
-    Owned<IPropertyTree> pt = createPTree("File",false);
+    Owned<IPropertyTree> pt = createPTree("File");
     fdesc->serializeTree(*pt);
     StringBuffer out;
     toXML(pt,out);
@@ -481,7 +481,7 @@ void dispFDesc(IFileDescriptor *fdesc)
                     );
                     if (strcmp(out.str(),out2.str())!=0)
                         printf("FAILED!\n%s\n%s\n",out.str(),out2.str());
-                    pt.setown(createPTree("File",false));
+                    pt.setown(createPTree("File"));
                     copypart->queryOwner().serializeTree(*pt);
                     StringBuffer out;
                     toXML(pt,out);
@@ -573,7 +573,7 @@ void testGrp()
 void testDF1()
 {
     Owned<IFileDescriptor> fdesc = createFileDescriptor();
-    Owned<IPropertyTree> pt = createPTree("Attr",false);
+    Owned<IPropertyTree> pt = createPTree("Attr");
     RemoteFilename rfn;
     rfn.setRemotePath("//10.150.10.80/c$/thordata/test/part._1_of_3");
     pt->setPropInt("@size",123);
@@ -594,7 +594,7 @@ void testDF1()
 void testDF2() // 4*3 superfile
 {
     Owned<IFileDescriptor> fdesc = createFileDescriptor();
-    Owned<IPropertyTree> pt = createPTree("Attr",false);
+    Owned<IPropertyTree> pt = createPTree("Attr");
     RemoteFilename rfn;
     rfn.setRemotePath("//10.150.10.80/c$/thordata/test/partone._1_of_3");
     pt->setPropInt("@size",1231);

--- a/dali/regress/daregress.cpp
+++ b/dali/regress/daregress.cpp
@@ -74,7 +74,7 @@ static unsigned fn(unsigned n, unsigned m, unsigned seed, unsigned depth, IPrope
     name[i] = 0;
     IPropertyTree *child = parent->queryPropTree(name);
     if (!child) 
-        child = parent->addPropTree(name, createPTree(name,false));
+        child = parent->addPropTree(name, createPTree(name));
     return fn(fn(n,seed,seed*17+11,depth+1,child),fn(seed,m,seed*11+17,depth+1,child),seed*19+7,depth+1,child);
 }
 
@@ -131,7 +131,7 @@ static unsigned fn2(unsigned n, unsigned m, unsigned seed, unsigned depth, Strin
     parentname.append(name);
     IPropertyTree *child = parent->queryPropTree(name);
     if (!child) 
-        child = parent->addPropTree(name, createPTree(name,false));
+        child = parent->addPropTree(name, createPTree(name));
     unsigned ret = fn2(fn2(n,seed,seed*17+11,depth+1,parentname),fn2(seed,m,seed*11+17,depth+1,parentname),seed*19+7,depth+1,parentname);
     parentname.setLength(l);
     return ret;
@@ -141,7 +141,7 @@ static unsigned fn2(unsigned n, unsigned m, unsigned seed, unsigned depth, Strin
 static void test1()
 {
     printf("Test SDS read/write\n");
-    Owned<IPropertyTree> ref = createPTree("DAREGRESS",false);
+    Owned<IPropertyTree> ref = createPTree("DAREGRESS");
     fn(1,2,3,0,ref);
     StringBuffer refstr;
     toXML(ref,refstr,0,XML_SortTags|XML_Format);
@@ -213,7 +213,7 @@ static void test2()
         ERROR("named group lookup failed");
     printf("Named group created    - 400 nodes\n");
     for (i=0;i<100;i++) {
-        Owned<IPropertyTree> pp = createPTree("Part",false);
+        Owned<IPropertyTree> pp = createPTree("Part");
         Owned<IFileDescriptor>fdesc = createFileDescriptor();
         fdesc->setDefaultDir("c:\\thordata\\regress");
         n = 9;
@@ -428,7 +428,7 @@ void testSubscription(bool subscriber, int subs, int comms)
                 i = _i%subscriptions;
                     StringBuffer key;
                     key.append("TEST").append(i);
-                    root->setPropTree(key.str(), createPTree(false));
+                    root->setPropTree(key.str(), createPTree());
 
             }
             conn->commit();

--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -181,7 +181,7 @@ void WUiterate(ISashaCommand *cmd, const char *mask)
                             bool haseclcontains = eclcontains&&*eclcontains;
                             if ((cmd->getAction()==SCA_GET)||haswusoutput||hasowner||hasstate||hascluster||hasjobname||hascommand||(hasoutput&&inrange)||haspriority||hasfileread||hasfilewritten||hasroxiecluster||haseclcontains) {
                                 try {
-                                    t.setown(createPTree(di2->query(), false));
+                                    t.setown(createPTree(di2->query()));
                                     if (!t)
                                         continue;
                                     if (hasowner&&(!t->getProp("@submitID",val.clear())||!WildMatch(val.str(),owner,true))) 
@@ -401,7 +401,7 @@ public:
         if (archprops->hasProp(branchname))
             props.setown(archprops->getPropTree(branchname));
         else
-            props.setown(createPTree(branchname,false));
+            props.setown(createPTree(branchname));
         schedule.init(props,definterval,definterval/4);
         limit = props->getPropInt("@limit",deflimit);
         cutoffdays = props->getPropInt("@cutoff",defcutoff);
@@ -682,7 +682,7 @@ static bool doRestoreDfuWorkUnit(const char *wuid, StringBuffer &res)
         if (file) {
             Owned<IFileIO> fileio = file->open(IFOread);
             if (fileio) {
-                Owned<IPropertyTree> pt = createPTree(*fileio, false);
+                Owned<IPropertyTree> pt = createPTree(*fileio);
                 StringBuffer buf;
                 StringBuffer xpath("DFU/WorkUnits");
                 Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), RTM_LOCK_WRITE, 5*60*1000);  
@@ -1205,7 +1205,7 @@ public:
     {
         Owned<IPropertyTree> archprops = serverConfig->getPropTree("Archiver");
         if (!archprops)
-            archprops.setown(createPTree("Archiver",false));
+            archprops.setown(createPTree("Archiver"));
         unsigned definterval = archprops->getPropInt("@interval",DEFAULT_INTERVAL); // no longer used
         if (definterval==0)
             definterval = DEFAULT_INTERVAL;

--- a/dali/sasha/sacoalescer.cpp
+++ b/dali/sasha/sacoalescer.cpp
@@ -33,7 +33,7 @@ void coalesceDatastore(bool force)
     {
         Owned<IPropertyTree> coalesceProps = serverConfig->getPropTree("Coalescer");
         if (!coalesceProps)
-            coalesceProps.setown(createPTree("Coalescer",false));
+            coalesceProps.setown(createPTree("Coalescer"));
         StringBuffer dataPath, backupPath;
         IPropertyTree &confProps = querySDS().queryProperties();
         confProps.getProp("@dataPathUrl", dataPath); 
@@ -92,14 +92,14 @@ void coalesceDatastore(bool force)
             if (storeIFile->exists())
             {
                 PROGLOG("Loading store: %s, size=%"I64F"d", storeFilename.str(), storeIFile->size());
-                _root.setown(createPTreeFromXMLFile(storeFilename.str(), false));
+                _root.setown(createPTreeFromXMLFile(storeFilename.str()));
                 PROGLOG("Loaded: %s", storeFilename.str());
             }
             else
             {
                 if (baseEdition==0) {
                     PROGLOG("Creating base store");
-                    _root.setown(createPTree("SDS", false));
+                    _root.setown(createPTree("SDS"));
                 }
                 else {
                     ERRLOG("Base store %d not found, exiting",baseEdition);
@@ -234,7 +234,7 @@ public:
         {
             Owned<IPropertyTree> coalesceProps = serverConfig->getPropTree("Coalescer");
             if (!coalesceProps)
-                coalesceProps.setown(createPTree("Coalescer",false));
+                coalesceProps.setown(createPTree("Coalescer"));
             unsigned interval = coalesceProps->getPropInt("@interval",DEFAULT_INTERVAL);
             if (!interval)
             {

--- a/dali/sasha/saqmon.cpp
+++ b/dali/sasha/saqmon.cpp
@@ -206,7 +206,7 @@ public:
     {
         Owned<IPropertyTree> qmonprops = serverConfig->getPropTree("ThorQMon");
         if (!qmonprops)
-            qmonprops.setown(createPTree("ThorQMon",false));
+            qmonprops.setown(createPTree("ThorQMon"));
         unsigned interval = qmonprops->getPropInt("@interval",DEFAULT_QMONITOR_INTERVAL); // probably always 1
         unsigned autoswitch = qmonprops->getPropInt("@switchMinTime",0);
         if (!interval)

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -278,7 +278,7 @@ int main(int argc, const char* argv[])
 #endif
 
     OwnedIFile ifile = createIFile("sashaconf.xml");
-    serverConfig.setown(ifile->exists()?createPTreeFromXMLFile("sashaconf.xml", false):createPTree(false));
+    serverConfig.setown(ifile->exists()?createPTreeFromXMLFile("sashaconf.xml"):createPTree());
     StringBuffer daliServer;
     if (!serverConfig->getProp("@DALISERVERS", daliServer)||(daliServer.length()==0)) {
         printf("DALISERVERS not specified in sashaconf.xml");

--- a/dali/sasha/sasha.cpp
+++ b/dali/sasha/sasha.cpp
@@ -465,7 +465,7 @@ int main(int argc, char* argv[])
                                     StringBuffer res;
                                     if (cmd->getResult(i,res)) {
                                         if (extractTimings) {
-                                            Owned<IPropertyTree> pt = createPTreeFromXMLString(res.str(),false);
+                                            Owned<IPropertyTree> pt = createPTreeFromXMLString(res.str());
                                             if (pt) 
                                                 DumpWorkunitTimings(pt);
                                         }

--- a/dali/sasha/saverify.cpp
+++ b/dali/sasha/saverify.cpp
@@ -404,7 +404,7 @@ public:
     {
         Owned<IPropertyTree> verifprops = serverConfig->getPropTree("Verifier");
         if (!verifprops)
-            verifprops.setown(createPTree("Verifier",false));
+            verifprops.setown(createPTree("Verifier"));
         unsigned interval = verifprops->getPropInt("@interval",DEFAULT_VERIFY_INTERVAL);
         if (!interval)
             stopped = true;
@@ -612,7 +612,7 @@ public:
     {
         Owned<IPropertyTree> monprops = serverConfig->getPropTree("DaFileSrvMonitor");
         if (!monprops)
-            monprops.setown(createPTree("DaFSMonitorServer",false));
+            monprops.setown(createPTree("DaFSMonitorServer"));
         unsigned interval = monprops->getPropInt("@interval",DEFAULT_DAFSMONITOR_INTERVAL);
         if (!interval)
             stopped = true;

--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -561,7 +561,7 @@ public:
         branch->setProp("Cluster",clustname);
         StringBuffer datastr;
         toXML(branch,datastr);
-        root->addPropTree(name,createPTree(name,false))->setPropBin("data",datastr.length(),datastr.toCharArray());
+        root->addPropTree(name,createPTree(name))->setPropBin("data",datastr.length(),datastr.toCharArray());
     }
 
     CNewXRefManagerBase()
@@ -599,16 +599,16 @@ public:
 
     void addErrorsWarnings(IPropertyTree *croot)
     {
-        Owned<IPropertyTree> message = createPTree("Messages",false);
+        Owned<IPropertyTree> message = createPTree("Messages");
         ForEachItemIn(i1,errors) {
             cMessage &item = errors.item(i1);
-            IPropertyTree *t = message->addPropTree("Error",createPTree("Error",false));
+            IPropertyTree *t = message->addPropTree("Error",createPTree("Error"));
             t->addProp("File",item.lname.get());
             t->addProp("Text",item.msg.get());
         }
         ForEachItemIn(i2,warnings) {
             cMessage &item = warnings.item(i2);
-            IPropertyTree *t = message->addPropTree("Warning",createPTree("Warning",false));
+            IPropertyTree *t = message->addPropTree("Warning",createPTree("Warning"));
             t->addProp("File",item.lname.get());
             t->addProp("Text",item.msg.get());
         }
@@ -622,7 +622,7 @@ public:
         if (abort)
             return;
         log("Saving information");
-        Owned<IPropertyTree> croot = createPTree("Cluster",false);
+        Owned<IPropertyTree> croot = createPTree("Cluster");
         croot->setProp("@name",clustname);
         if (!rootdir.isEmpty()) 
             croot->setProp("@rootdir",rootdir);
@@ -689,10 +689,10 @@ public:
         verbose = true;
         iphash = NULL;
         ipnum = NULL;
-        foundbranch.setown(createPTree("Found",false));
-        lostbranch.setown(createPTree("Lost",false));
-        orphansbranch.setown(createPTree("Orphans",false));
-        dirbranch.setown(createPTree("Directories",false));
+        foundbranch.setown(createPTree("Found"));
+        lostbranch.setown(createPTree("Lost"));
+        orphansbranch.setown(createPTree("Orphans"));
+        dirbranch.setown(createPTree("Directories"));
     }
 
     ~CNewXRefManager()
@@ -1164,13 +1164,13 @@ public:
     void addOrphanPartNode(Owned<IPropertyTree> &branch,const SocketEndpoint &ep,unsigned i,bool rep)
     {
         if (!branch)
-            branch.setown(createPTree("File",false));
+            branch.setown(createPTree("File"));
         i++;
         StringBuffer tmp;
         tmp.appendf("Part[Num=\"%d\"]",i);
         IPropertyTree* pb = branch->queryPropTree(tmp.str());
         if (!pb) {
-            pb = createPTree("Part",false);
+            pb = createPTree("Part");
             pb->setPropInt("Num",i);
             pb = branch->addPropTree("Part",pb);
         }
@@ -1377,7 +1377,7 @@ public:
                 return;
             if ((d->files.ordinality()!=0)||(d->totalsize[drv]!=0)||d->empty(drv)) { // final empty() is to make sure only truly empty dirs get added
                                                                                   // but not empty parents
-                Owned<IPropertyTree> dt = createPTree("Directory",false);
+                Owned<IPropertyTree> dt = createPTree("Directory");
                 if (drv) {
                     StringBuffer tmp(name);
                     setReplicateFilename(tmp,drv);
@@ -1518,7 +1518,7 @@ public:
                 continue;
             }
             CDateTime dt;
-            Owned<IPropertyTree> ft = createPTree("File",false);
+            Owned<IPropertyTree> ft = createPTree("File");
             if (file->getModificationTime(dt)) {
                 CDateTime now;
                 now.setNow();
@@ -1586,7 +1586,7 @@ public:
                     if (!ok)
                         break;
                     if (lost) {
-                        Owned<IPropertyTree> pt = createPTree("Part",false);
+                        Owned<IPropertyTree> pt = createPTree("Part");
                         StringBuffer tmp;
                         rfn.queryEndpoint().getIpText(tmp);
                         pt->setProp("Node",tmp.str());
@@ -1844,7 +1844,7 @@ public:
                             path.appendf("SuperOwner[@name=\"%s\"]",owner);
                             if (!conn->queryRoot()->hasProp(path.str())) {
                                 if (fix) {
-                                    Owned<IPropertyTree> t = createPTree("SuperOwner",false);
+                                    Owned<IPropertyTree> t = createPTree("SuperOwner");
                                     t->setProp("@name",owner);
                                     conn->queryRoot()->addPropTree("SuperOwner",t.getClear());
                                 }
@@ -2176,7 +2176,7 @@ public:
             StringBuffer xpath2;
             xpath2.appendf("Cluster[@name=\"%s\"]",cluster);
             if (!conn->queryRoot()->hasProp(xpath2.str()))
-                conn->queryRoot()->addPropTree("Cluster",createPTree("Cluster",false))->setProp("@name",cluster);
+                conn->queryRoot()->addPropTree("Cluster",createPTree("Cluster"))->setProp("@name",cluster);
         }
     }
 
@@ -2190,7 +2190,7 @@ public:
     {
         Owned<IPropertyTree> props = serverConfig->getPropTree("DfuXRef");
         if (!props)
-            props.setown(createPTree("DfuXRef",false));
+            props.setown(createPTree("DfuXRef"));
         bool eclwatchprovider = props->getPropBool("@eclwatchProvider");
         unsigned interval = props->getPropInt("@interval",DEFAULT_XREF_INTERVAL);
         const char *clusters = props->queryProp("@clusterlist");
@@ -2366,7 +2366,7 @@ public:
     {
         Owned<IPropertyTree> props = serverConfig->getPropTree("DfuExpiry");
         if (!props)
-            props.setown(createPTree("DfuExpiry",false));
+            props.setown(createPTree("DfuExpiry"));
         unsigned interval = props->getPropInt("@interval",DEFAULT_EXPIRY_INTERVAL);
         if (!interval)
             stopped = true;

--- a/dali/sdsfix/sdsfix.cpp
+++ b/dali/sdsfix/sdsfix.cpp
@@ -4757,7 +4757,7 @@ void XmlMemSize(const char *filename)
     size32_t sz = iFile->size();
     StringBuffer xml;
     iFileIO->read(0, sz, xml.reserve(sz));
-    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str(), ipt_none, xr_ignoreWhiteSpace);
+    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str());
     unsigned tm = setAllocHook(true);
     branch.clear();
     tm -= setAllocHook(false);

--- a/dali/sdsfix/sdsfix.cpp
+++ b/dali/sdsfix/sdsfix.cpp
@@ -596,7 +596,7 @@ void dfsFile(const char *lname,const char *dali, bool lookup)
 //**
             Owned<IFileDescriptor> fdesc = file->getFileDescriptor();
             printf("compressed = %s\n", fdesc->isCompressed()?"true":"false");
-            Owned<IPropertyTree> t = createPropertyTree(false,"File");
+            Owned<IPropertyTree> t = createPTree("File");
             fdesc->serializeTree(*t);
             toXML(t, str.clear());
             printf("%s\n",str.str());
@@ -1810,7 +1810,7 @@ void import(const char *path,const char *src,bool add)
     size32_t sz = iFile->size();
     StringBuffer xml;
     iFileIO->read(0, sz, xml.reserve(sz));
-    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str(), false, true);
+    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str());
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
@@ -1870,7 +1870,7 @@ void bimport(const char *path,const char *src,bool add)
     size32_t sz = iFile->size();
     StringBuffer xml;
     iFileIO->read(0, sz, xml.reserve(sz));
-    Owned<IPropertyTree> branch = createPTree(false);
+    Owned<IPropertyTree> branch = createPTree();
     branch->setPropBin("data",xml.length(),(void*)xml.toCharArray());
     StringBuffer head;
     StringBuffer tmp;
@@ -4009,7 +4009,7 @@ void makeTestFile(const char *lname,const char *cluster, offset_t fsize, size32_
         ERRLOG("File %s already exists",lname);
         return;
     }
-    IPropertyTree* attr = createPTree("Attr",false);
+    IPropertyTree* attr = createPTree("Attr");
     attr->setProp("@owner","sdsfix");
     attr->setPropInt64("@size",fsize);
     attr->setPropInt("@recordSize",rs);
@@ -4264,7 +4264,7 @@ void fixTilde()
         if (!top) {
             top = root->queryPropTree("Scope[@name=\".\"]");
             if (!top) {
-                top = createPTree("Scope",false);
+                top = createPTree("Scope");
                 top->setProp("@name",".");
                 top = root->addPropTree("Scope",top);
             }
@@ -4324,7 +4324,7 @@ void dirtocsv(const char *src)
     size32_t sz = iFile->size();
     StringBuffer xml;
     iFileIO->read(0, sz, xml.reserve(sz));
-    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str(), false, true);
+    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str());
     IPropertyTree *dirs = branch->queryPropTree("Directories");
     Owned<IPropertyTreeIterator> iter = dirs->getElements("Directory");
     ForEach(*iter) {
@@ -4434,7 +4434,7 @@ void testFileDescriptor()
         RemoteFilename rfn;
         constructPartFilename(grp,1,2,"test::xxx","file._$P$_of_$N$","/c$/roxiedata",0,mspec,rfn);
     }
-    Owned<IPropertyTree> pp = createPTree("Part",false);
+    Owned<IPropertyTree> pp = createPTree("Part");
     Owned<IFileDescriptor> fdesc = createFileDescriptor();
     fdesc->setDefaultDir("/c$/thordata/test");
     Owned<INode> node = createINode("192.168.0.1");
@@ -4757,7 +4757,7 @@ void XmlMemSize(const char *filename)
     size32_t sz = iFile->size();
     StringBuffer xml;
     iFileIO->read(0, sz, xml.reserve(sz));
-    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str(), false, true);
+    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str(), ipt_none, xr_ignoreWhiteSpace);
     unsigned tm = setAllocHook(true);
     branch.clear();
     tm -= setAllocHook(false);
@@ -4777,7 +4777,7 @@ void xmlFormat(const char *fni,const char *fno)
     PROGLOG("%s",trc.str());
     PROGLOG("Loading...");
     unsigned t = msTick();
-    Owned<IPropertyTree> pt = createPTreeFromXMLFile(fni, false);
+    Owned<IPropertyTree> pt = createPTreeFromXMLFile(fni);
     PROGLOG("Loaded took %dms",msTick()-t);
     getSystemTraceInfo(trc.clear(),PerfMonStandard);
     PROGLOG("%s",trc.str());
@@ -4793,7 +4793,7 @@ void xmlFormat(const char *fni,const char *fno)
 void xmlScan(const char *fni,const char *pat,bool mem)
 {
     StringArray results;
-    Owned<IPropertyTree> pt = createPTreeFromXMLFile(fni, false);
+    Owned<IPropertyTree> pt = createPTreeFromXMLFile(fni);
     StringBuffer full;
     PTreeScan(pt,pat,full,results,mem);
     ForEachItemIn(i,results)
@@ -4816,12 +4816,12 @@ static int scompare(const char **s1,const char **s2)
 void xmlCompare(const char *fni1,const char *fni2,const char *pat)
 {
     StringArray results1;
-    Owned<IPropertyTree> pt = createPTreeFromXMLFile(fni1, false);
+    Owned<IPropertyTree> pt = createPTreeFromXMLFile(fni1);
     StringBuffer full;
     PTreeScan(pt,pat,full,results1,false);
     StringArray results2;
     pt.clear();
-    pt.setown(createPTreeFromXMLFile(fni2, false));
+    pt.setown(createPTreeFromXMLFile(fni2));
     PTreeScan(pt,pat,full,results2,false);
     results1.sort(scompare);
     results2.sort(scompare);
@@ -4895,7 +4895,7 @@ void convertBinBranch(IPropertyTree &cluster,const char *branch)
     if (buf.length()) {
         StringBuffer xml;
         xml.append(buf.length(),buf.toByteArray());
-        t = createPTreeFromXMLString(xml.str(),false );
+        t = createPTreeFromXMLString(xml.str());
         cluster.removeProp(query.str());
         cluster.addPropTree(query.str(),t);
     }
@@ -5336,8 +5336,8 @@ void testbinsz(const char *path)
     size32_t sz = iFile->size();
     StringBuffer xml;
     iFileIO->read(0, sz, xml.reserve(sz));
-    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str(), false, true);
-    Owned<IPropertyTree> t1 = createPTree("test1",false);
+    Owned<IPropertyTree> branch = createPTreeFromXMLString(xml.str());
+    Owned<IPropertyTree> t1 = createPTree("test1");
     StringBuffer str;
     toXML(branch,str);
     t1->setPropBin("data",str.length(),str.str());
@@ -5346,7 +5346,7 @@ void testbinsz(const char *path)
     Owned<IFileIO> io1 = f1->open(IFOcreate);
     Owned<IFileIOStream> fstream1 = createBufferedIOStream(io1);
     toXML(t1, *fstream1);           // formatted (default)
-    Owned<IPropertyTree> t2 = createPTree("test2",false);
+    Owned<IPropertyTree> t2 = createPTree("test2");
     MemoryBuffer mb;
     branch->serialize(mb);
     t2->setPropBin("data",mb.length(),mb.toByteArray());
@@ -5425,7 +5425,7 @@ void testLostFile(const char *_lfn)
     StringBuffer tmpname;
     StringBuffer tmp;
     CDateTime dt;
-    Owned<IPropertyTree> ft = createPTree("File",false);
+    Owned<IPropertyTree> ft = createPTree("File");
     if (file->getModificationTime(dt)) {
         CDateTime now;
         now.setNow();
@@ -5483,7 +5483,7 @@ void testLostFile(const char *_lfn)
             if (!ok)
                 break;
             if (lost) {
-                Owned<IPropertyTree> pt = createPTree("Part",false);
+                Owned<IPropertyTree> pt = createPTree("Part");
                 StringBuffer tmp;
                 rfn.queryEndpoint().getIpText(tmp);
                 pt->setProp("Node",tmp.str());
@@ -5703,7 +5703,7 @@ void XMLscanfix(IPropertyTree &tree,StringBuffer &path, bool fix, bool check)
 
 void XMLscanfix(const char *filename,bool fix,bool check)
 {
-    Owned<IPropertyTree> tree = createPTreeFromXMLFile(filename, false);
+    Owned<IPropertyTree> tree = createPTreeFromXMLFile(filename);
     StringBuffer path("/");
     XMLscanfix(*tree,path,fix,check);
 }
@@ -6254,7 +6254,7 @@ int main(int argc, char* argv[])
                     }
                 }
                 else {
-                    Owned<IPropertyTree> pt = loadPropertyTree(argv[3], false);
+                    Owned<IPropertyTree> pt = createPTreeFromXMLFile(argv[3]);
                     DumpWorkunitTimings(pt);
                 }
             }

--- a/dali/sdsfix/sdsfix.cpp
+++ b/dali/sdsfix/sdsfix.cpp
@@ -969,7 +969,7 @@ void fileTree(const char *lfn)
     StringBuffer str;
     toXML(root, str);
     printf("%s\n",str.str());
-    Owned<IPropertyTree> tree2 = createPTree(root);
+    Owned<IPropertyTree> tree2 = createPTreeFromIPT(root);
     expandFileTree(tree2,false);
     toXML(tree2, str.clear());
     printf("%s\n",str.str());
@@ -3627,7 +3627,7 @@ void PrintWUsizes()
     ForEach(*iter) {
         IPropertyTree &wu=iter->query();
         setAllocHook(true);
-        IPropertyTree *wucopy=createPTree(&wu);
+        IPropertyTree *wucopy=createPTreeFromIPT(&wu);
         unsigned tm = setAllocHook(true);
         wucopy->Release();
         tm -= setAllocHook(false);
@@ -4254,7 +4254,7 @@ void fixTilde()
     StringArray todelete;
     ForEach(*iter) {
         IPropertyTree &f = iter->query();
-        IPropertyTree *n = createPTree(&f);
+        IPropertyTree *n = createPTreeFromIPT(&f);
         StringBuffer name;
         if (!n->getProp("@name",name))
             continue;
@@ -4905,7 +4905,7 @@ void convertBinBranch(IPropertyTree &cluster,const char *branch)
 void getDFUXREF(const char *dst)
 {
     Owned<IRemoteConnection> conn = querySDS().connect("DFU/XREF",myProcessSession(),RTM_LOCK_READ, INFINITE);
-    Owned<IPropertyTree> root = createPTree(conn->getRoot());
+    Owned<IPropertyTree> root = createPTreeFromIPT(conn->getRoot());
     Owned<IPropertyTreeIterator> iter = root->getElements("Cluster");
     ForEach(*iter) {
         IPropertyTree &cluster = iter->query();

--- a/dali/sdsfix/sdsfix2.cpp
+++ b/dali/sdsfix/sdsfix2.cpp
@@ -506,7 +506,7 @@ void checkExternals(unsigned argc, char **args)
         // Check referenced externals have corresponding external declaration.
         Owned<IPropertyTree> externalTree;
         if (createExternalBranch)
-            externalTree.setown(createPTree("External", false));
+            externalTree.setown(createPTree("External"));
         ForEachItemIn(r, parser.matches)
         {
             unsigned index = parser.matches.item(r);
@@ -538,7 +538,7 @@ void checkExternals(unsigned argc, char **args)
                 referencedFiles.append(filename.str());
             if (createExternalBranch)
             {
-                Owned<IPropertyTree> ext = createPTree(false);
+                Owned<IPropertyTree> ext = createPTree();
                 ext->setPropInt("@index", index);
                 ext->setProp("@format", "EFBinaryV2");
                 StringBuffer name(EXTERNAL_NAME_PREFIX);
@@ -570,7 +570,7 @@ void checkExternals(unsigned argc, char **args)
         void *dst = extMb.reserveTruncate(externalEnd-externalStart);
         inFileStream->read(externalEnd-externalStart, dst);
         Owned<IFileIO> memIFileIO = createIFileIO(extMb);
-        Owned<IPropertyTree> externalTree = createPTree(*memIFileIO, false);
+        Owned<IPropertyTree> externalTree = createPTree(*memIFileIO);
 
         // Check referenced externals have corresponding external declaration.
         ForEachItemIn(r, parser.matches)
@@ -584,7 +584,7 @@ void checkExternals(unsigned argc, char **args)
                 if (fixXml)
                 {
                     PROGLOG("Creating replacement declaration for missing reference: %d", index);
-                    IPropertyTree *ext = createPTree(false);
+                    IPropertyTree *ext = createPTree();
                     ext->setPropInt("@index", index);
                     ext->setProp("@format", "EFBinaryV2");
                     StringBuffer name(EXTERNAL_NAME_PREFIX);
@@ -728,7 +728,7 @@ void coalesceStore()
     StringBuffer storeFilename(daliDataPath);
     iStoreHelper->getCurrentStoreFilename(storeFilename);
     PROGLOG("Loading store: %s", storeFilename.str());
-    Owned<IPropertyTree> root = createPTreeFromXMLFile(storeFilename.str(), false);
+    Owned<IPropertyTree> root = createPTreeFromXMLFile(storeFilename.str());
     PROGLOG("Loaded: %s", storeFilename.str());
 
     if (baseEdition != iStoreHelper->queryCurrentEdition())

--- a/dali/sdsfix/sdsfix3.cpp
+++ b/dali/sdsfix/sdsfix3.cpp
@@ -109,7 +109,7 @@ void checkClusterCRCs(const char *cluster,bool fix,bool verbose,const char *csvf
             }
             Owned<IPropertyTree> fileattr = file.getPropTree("Attr");
             if (!fileattr)
-                fileattr.setown(createPTree("Attr",false));
+                fileattr.setown(createPTree("Attr"));
             bool compressedfile = isCompressed(*fileattr);
             IPropertyTree **parts = (IPropertyTree **)calloc(n,sizeof(IPropertyTree *));
             Owned<IPropertyTreeIterator> it;

--- a/dali/security/dacaplib.cpp
+++ b/dali/security/dacaplib.cpp
@@ -149,7 +149,7 @@ class CDaliCapabilityCreator: public CInterface, implements IDaliCapabilityCreat
     void addcap(const char *tag,CSystemCapability &cap)
     { // cap is plain
         cap.setSystem(sysid.get());
-        IPropertyTree *tree = root->addPropTree(tag,createPTree(tag,false));
+        IPropertyTree *tree = root->addPropTree(tag,createPTree(tag));
         crc = crc32(tag,strlen(tag),crc);
         if (clientpassword)
             cap.secure((const byte *)clientpassword.get(), clientpassword.length());
@@ -221,7 +221,7 @@ public:
     }
     void reset()
     {
-        root.setown(createPTree("DACAP",false));
+        root.setown(createPTree("DACAP"));
         crc = 0;
     }
 };
@@ -244,7 +244,7 @@ unsigned importDaliCapabilityXML_basic(const char *filename)
 
     Owned<IPropertyTree> root;
     try {
-        root.setown(createPTreeFromXMLFile(filename, false));
+        root.setown(createPTreeFromXMLFile(filename));
     }
     catch (IException *e) {
         // no specific error (file missing)
@@ -266,7 +266,7 @@ unsigned importDaliCapabilityXML_basic(const char *filename)
         return 71;
     Owned<IPropertyTree>conf;
     try {
-        conf.setown(createPTreeFromXMLFile(DACONF_FILENAME, false));
+        conf.setown(createPTreeFromXMLFile(DACONF_FILENAME));
     }
     catch (IException *e) {
         // no specific error (file missing)
@@ -290,9 +290,9 @@ unsigned importDaliCapabilityXML_basic(const char *filename)
             if (!update) {
                 update = conf->queryPropTree(UPDATE_XPATH);
                 if (!update)
-                    update = conf->addPropTree(UPDATE_XPATH,createPTree(UPDATE_XPATH,false));
+                    update = conf->addPropTree(UPDATE_XPATH,createPTree(UPDATE_XPATH));
             }
-            IPropertyTree *tree = update->addPropTree(tag,createPTree(tag,false));
+            IPropertyTree *tree = update->addPropTree(tag,createPTree(tag));
             tree->setProp("@cap",it->query().queryProp("@cap"));
             modified = true;
         }

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
         StringBuffer auditDir;
         if (confIFile->exists())
         {
-            serverConfig.setown(createPTreeFromXMLFile(DALICONF, false));
+            serverConfig.setown(createPTreeFromXMLFile(DALICONF));
             if (getConfigurationDirectory(serverConfig->queryPropTree("Directories"),"log","dali",serverConfig->queryProp("@name"),logName)) {
                 addPathSepChar(auditDir.append(logName)).append("audit");
                 addPathSepChar(logName).append("server");
@@ -343,7 +343,7 @@ int main(int argc, char* argv[])
             }
         }
         else
-            serverConfig.setown(createPTree(false));
+            serverConfig.setown(createPTree());
 #ifdef _WIN32
         Owned<CReleaseMutex> globalNamedMutex;
         if (!serverConfig->getPropBool("allowMultipleDalis"))

--- a/dali/treeview/connect.cpp
+++ b/dali/treeview/connect.cpp
@@ -64,7 +64,7 @@ private:
         IPropertyTree * r = NULL;
         try
         {
-            r = createPTreeFromXMLFile(fname, false);
+            r = createPTreeFromXMLFile(fname);
         }
         catch(IException * e)
         {

--- a/dali/treeview/inspectctrl.cpp
+++ b/dali/treeview/inspectctrl.cpp
@@ -1023,7 +1023,7 @@ void CInspectorTreeCtrl::OnAddProperty()
     {
         if(connection->lockWrite())
         {
-            IPropertyTree * t = createPTree(false);
+            IPropertyTree * t = createPTree();
             t->setProp(NULL, value);
             t = GetTreeListItem(hParent)->queryPropertyTree()->addPropTree(name, t);    
 

--- a/dali/updtdalienv/updtdalienv.cpp
+++ b/dali/updtdalienv/updtdalienv.cpp
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
 
     Owned<IPropertyTree> env;
     try {
-        env.setown(createPTreeFromXMLFile(argv[1],false));
+        env.setown(createPTreeFromXMLFile(argv[1]));
         if (!env.get()) {
             fprintf(stderr,"Could not load Environment from %s\n",argv[1]);
             return 1;

--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -191,7 +191,7 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
                    bool listComps, bool verbose, bool listallComps, bool listdirs, 
                    bool listcommondirs, bool listMachines, bool validateOnly) 
 {
-  Owned<IPropertyTree> pEnv = createPTreeFromXMLFile(in_cfgname, false);
+  Owned<IPropertyTree> pEnv = createPTreeFromXMLFile(in_cfgname);
   short nodeIndex = 1;
   short index = 1;
   short compTypeIndex = 0;

--- a/deployment/deploy/DeployLog.cpp
+++ b/deployment/deploy/DeployLog.cpp
@@ -34,7 +34,7 @@ public:
       m_filename(filename)
    {
       assertex(filename);
-      m_tree.setown(createPTree("DeployLog", false));
+      m_tree.setown(createPTree("DeployLog"));
       m_tree->addProp("@environmentArchive", envFilename);
       m_tree->addProp("@startTime", getTimestamp());
    }
@@ -60,7 +60,7 @@ public:
       assertex(tasksNode);
 
       // Add new task
-      IPropertyTree* node = createPTree("Task", false);
+      IPropertyTree* node = createPTree("Task");
       node->addProp("@action", task.getCaption());
       node->addProp("@source", task.getFileSpec(DT_SOURCE));
       node->addProp("@target", task.getFileSpec(DT_TARGET));
@@ -99,7 +99,7 @@ public:
       char ppath[_MAX_PATH];
       strcpy(ppath, path);
       removeTrailingPathSepChar(ppath);
-      IPropertyTree* node = createPTree("Directory", false);
+      IPropertyTree* node = createPTree("Directory");
       node->addProp("@name", ppath);
       getDirList(ppath, node);
       return compNode->addPropTree("Directory", node);
@@ -122,9 +122,9 @@ private:
       }
 
       // If node not found, create it and add Tasks subnode
-      IPropertyTree* compNode = createPTree("Component", false);
+      IPropertyTree* compNode = createPTree("Component");
       compNode->addProp("@name", comp);
-      compNode->addPropTree("Tasks", createPTree("Tasks", false));
+      compNode->addPropTree("Tasks", createPTree("Tasks"));
       return m_tree->addPropTree("Component", compNode);
    }
    //---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ private:
             StringBuffer newPath(path);
             newPath.append('\\').append(dirEntryName);
 
-            IPropertyTree* node = createPTree("Directory", false);
+            IPropertyTree* node = createPTree("Directory");
             node->addProp("@name", newPath.str());
 
             getDirList(newPath.str(), parentNode->addPropTree("Directory", node));
@@ -161,7 +161,7 @@ private:
 
             offset_t filesize = iFile.size();
 
-            IPropertyTree* node = createPTree("File", false);
+            IPropertyTree* node = createPTree("File");
             node->addProp("@name", dirEntryName);
             node->addProp("@date", timestamp.str());
             node->addPropInt64("@size", filesize);

--- a/deployment/deploy/DeploymentEngine.cpp
+++ b/deployment/deploy/DeploymentEngine.cpp
@@ -1794,7 +1794,7 @@ IPropertyTree* CDeploymentEngine::getDeployMapNode(IPropertyTree* buildNode, IPr
     
     // Read in deploy map file and process file elements
     
-    IPropertyTree* deployNode = createPTreeFromXMLFile(deployFile.str(), true);
+    IPropertyTree* deployNode = createPTreeFromXMLFile(deployFile.str(), ipt_caseInsensitive);
     assertex(deployNode);
     return deployNode;
 }
@@ -2357,7 +2357,7 @@ void CDeploymentEngine::siteCertificate(IPropertyTree& process, const char *inst
             IPropertyTree* pCertNode    = pInstanceNode->queryPropTree("Certificate");
             
             if (!pCertNode)
-                pCertNode = pInstanceNode->addPropTree("Certificate", createPTree(false));
+                pCertNode = pInstanceNode->addPropTree("Certificate", createPTree());
             else
                 sCertificate.append( pCertNode->queryProp(NULL) );
             
@@ -2365,7 +2365,7 @@ void CDeploymentEngine::siteCertificate(IPropertyTree& process, const char *inst
             IPropertyTree* pPrivKeyNode = pInstanceNode->queryPropTree("PrivateKey" );
             
             if (!pPrivKeyNode)
-                pPrivKeyNode = pInstanceNode->addPropTree("PrivateKey", createPTree(false));
+                pPrivKeyNode = pInstanceNode->addPropTree("PrivateKey", createPTree());
             else
                 sPrivKey.append( pPrivKeyNode->queryProp(NULL) );
             
@@ -2373,7 +2373,7 @@ void CDeploymentEngine::siteCertificate(IPropertyTree& process, const char *inst
             StringBuffer sCSR;
             
             if (!pCsrNode)
-                pCsrNode = pInstanceNode->addPropTree("CSR", createPTree(false));
+                pCsrNode = pInstanceNode->addPropTree("CSR", createPTree());
             else
                 sCSR.append( pCsrNode->queryProp(NULL) );
             

--- a/deployment/deploy/configgenengine.cpp
+++ b/deployment/deploy/configgenengine.cpp
@@ -56,7 +56,7 @@ int CConfigGenEngine::determineInstallFiles(IPropertyTree& processNode, CInstall
         if (m_inDir.length())
             compListPath.clear().append(m_inDir).append(PATHSEPCHAR).append(CONFIGGEN_COMP_LIST);
 
-        Owned<IPropertyTree> deployNode = createPTreeFromXMLFile(compListPath.str(), true);
+        Owned<IPropertyTree> deployNode = createPTreeFromXMLFile(compListPath.str(), ipt_caseInsensitive);
         StringBuffer srcFilePath;
         srcFilePath.ensureCapacity(_MAX_PATH);
         const bool bFindStartable = &m_process == &processNode && m_startable == unknown;

--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -1108,7 +1108,7 @@ bool matchDeployAddress(const char *searchIP, const char *envIP)
 IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName, 
                             const char* compType, const char* ipAddr, bool listall)
 {
-  Owned<IPropertyTree> pSelComps(createPTree("SelectedComponents", false));
+  Owned<IPropertyTree> pSelComps(createPTree("SelectedComponents"));
   Owned<IPropertyTreeIterator> iter = pEnvRoot->getElements("Software/*");
   const char* instanceNodeNames[] = { "Instance", "RoxieServerProcess", "RoxieSlaveProcess" };
   const char* logDirNames[] = { "@logDir", "@LogDir", "@dfuLogDir", "@eclLogDir" };
@@ -1165,7 +1165,7 @@ IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName,
             {
               if (!bAdded)
               {
-                pSelComp = pSelComps->addPropTree(pComponent->queryName(), createPTree(false));
+                pSelComp = pSelComps->addPropTree(pComponent->queryName(), createPTree());
                 pSelComp->addProp("@name", name);
                 pSelComp->addProp("@buildSet", buildSet);
                 pSelComp->addProp("@logDir", logDir);
@@ -1174,7 +1174,7 @@ IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName,
 
               if (listall)
               {
-                IPropertyTree* pInstance = pSelComp->addPropTree(pInst->queryName(), createPTree(false));
+                IPropertyTree* pInstance = pSelComp->addPropTree(pInst->queryName(), createPTree());
                 pInstance->addProp("@name", pInst->queryProp("@name"));
                 pInstance->addProp("@computer", computer);
                 pInstance->addProp("@netAddress", netAddr);
@@ -1186,7 +1186,7 @@ IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName,
           {
             if (!bAdded)
             {
-              pSelComp = pSelComps->addPropTree(pComponent->queryName(), createPTree(false));
+              pSelComp = pSelComps->addPropTree(pComponent->queryName(), createPTree());
               pSelComp->addProp("@name", name);
               pSelComp->addProp("@buildSet", buildSet);
               pSelComp->addProp("@logDir", logDir);
@@ -1201,7 +1201,7 @@ IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName,
                 //allow multiple instances but do not allow either roxie servers or slaves more than once per computer
                 if (listall || sb.str()[0] != 'R' || !pSelComp->queryPropTree(StringBuffer().appendf("*[@computer=\"%s\"]", computer)))
                 {
-                  IPropertyTree* pInstance = pSelComp->addPropTree(sb.str(), createPTree(false));
+                  IPropertyTree* pInstance = pSelComp->addPropTree(sb.str(), createPTree());
                   pInstance->addProp("@name", pInst->queryProp("@name"));
                   pInstance->addProp("@computer", pInst->queryProp("@computer"));
                   pInstance->addProp("@port", pInst->queryProp("@port"));

--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -485,7 +485,7 @@ public:
         IPropertyTree* pDeploy = tree->queryPropTree("DeployComponents");
         if (pDeploy)
             tree->removeTree(pDeploy);
-        pDeploy = tree->addPropTree("DeployComponents", createPTree(pSelectedComponents));
+        pDeploy = tree->addPropTree("DeployComponents", createPTreeFromIPT(pSelectedComponents));
         
         StringBuffer xml;
         toXML(tree, xml);

--- a/deployment/deployutils/buildset.cpp
+++ b/deployment/deployutils/buildset.cpp
@@ -140,7 +140,7 @@ IPropertyTree *loadInstallSet(IPropertyTree *pBuild, IPropertyTree *pBuildSet, I
     else
       sFilename.append(DEFAULT_INSTALLSET);
 
-    pInstallSet = createPTreeFromXMLFile(sFilename, false);
+    pInstallSet = createPTreeFromXMLFile(sFilename);
   }
   return pInstallSet;
 }
@@ -158,7 +158,7 @@ IPropertyTree *loadSchema(IPropertyTree *pBuild, IPropertyTree *pBuildSet, Strin
       if (schemaName && *schemaName)
       {
         sSchemaPath.append(schemaName);
-        pSchema = createPTreeFromXMLFile(sSchemaPath, false);
+        pSchema = createPTreeFromXMLFile(sSchemaPath);
       }
       else
       {
@@ -181,7 +181,7 @@ IPropertyTree *loadSchema(IPropertyTree *pBuild, IPropertyTree *pBuildSet, Strin
             sSchemaPath = szXsdPath;
           }
 
-          pSchema = createPTreeFromXMLFile(sSchemaPath, false);
+          pSchema = createPTreeFromXMLFile(sSchemaPath);
           if (pSchema)
           {
             IPropertyTree* pNode = pSchema->queryPropTree("xs:element");
@@ -248,5 +248,5 @@ IPropertyTree *loadDefaultSchema()
     "       </xs:complexType>"
     "   </xs:element>"
     "</xs:schema>"
-    , false);
+    );
 }

--- a/deployment/deployutils/computerpicker.cpp
+++ b/deployment/deployutils/computerpicker.cpp
@@ -246,11 +246,11 @@ void CComputerPicker::NoteUsage(const char *computer, const char* componType,
 void CComputerPicker::CreateComputerFilterTree()
 {
   m_pFilterTree.clear();
-  m_pFilterTree.setown(createPTree("Filter", false));
-  IPropertyTree* pComponents= m_pFilterTree->addPropTree("Components",    createPTree("Components",   false));
-  IPropertyTree* pDomains   = m_pFilterTree->addPropTree("Domains",       createPTree("Domains",       false));
-  IPropertyTree* pCompTypes = m_pFilterTree->addPropTree("ComputerTypes", createPTree("ComputerTypes", false));
-  IPropertyTree* pSubnets   = m_pFilterTree->addPropTree("Subnets",       createPTree("Subnets",       false));
+  m_pFilterTree.setown(createPTree("Filter"));
+  IPropertyTree* pComponents= m_pFilterTree->addPropTree("Components",    createPTree("Components"));
+  IPropertyTree* pDomains   = m_pFilterTree->addPropTree("Domains",       createPTree("Domains"));
+  IPropertyTree* pCompTypes = m_pFilterTree->addPropTree("ComputerTypes", createPTree("ComputerTypes"));
+  IPropertyTree* pSubnets   = m_pFilterTree->addPropTree("Subnets",       createPTree("Subnets"));
 
   // Generate computer usage map
   if (m_pRootNode)
@@ -387,13 +387,13 @@ void CComputerPicker::NoteFilter(IPropertyTree* pFilter, const char *componentTy
     IPropertyTree* pComponentType = pFilter->queryPropTree(xPath);
     if (!pComponentType)
     {
-      pComponentType = pFilter->addPropTree(sComponentType, createPTree(sComponentType, false));
+      pComponentType = pFilter->addPropTree(sComponentType, createPTree(sComponentType));
       pComponentType->addProp("@name", component);
     }
 
     if (computer && *computer)
     {
-      IPropertyTree* pComputer = pComponentType->addPropTree( "Computer", createPTree(false) );
+      IPropertyTree* pComputer = pComponentType->addPropTree( "Computer", createPTree() );
       pComputer->addProp("@name", computer);
       pComputer->addPropBool("@__bHidden", true);
     }
@@ -405,7 +405,7 @@ void CComputerPicker::Refresh()
   // Passed all filters so add the computers left in the usage map
   int iItem = 0;
   m_pComputerTree.clear();
-  m_pComputerTree.setown(createPTree("ComputerList", false));
+  m_pComputerTree.setown(createPTree("ComputerList"));
   Owned<IPropertyTreeIterator> iComputer = m_pRootNode->getElements(XML_TAG_HARDWARE"/"XML_TAG_COMPUTER);
   ForEach (*iComputer)
   {
@@ -416,7 +416,7 @@ void CComputerPicker::Refresh()
 
     if (szComputer && *szComputer && GetUsage(szComputer, sUsage, false))
     {
-      IPropertyTree* pComponentType = m_pComputerTree->addPropTree("Machine", createPTree("Machine", false));
+      IPropertyTree* pComponentType = m_pComputerTree->addPropTree("Machine", createPTree("Machine"));
       pComponentType->addProp("@name", szComputer);
       pComponentType->addProp("@netAddress", pNode->queryProp(XML_ATTR_NETADDRESS));
       pComponentType->addProp("@usage", sUsage.str());

--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -527,7 +527,7 @@ void CConfigEnvHelper::setAttribute(IPropertyTree* pNode, const char* szName, co
         pNode->removeTree(pProperties);
       }
       if (pNewProperties)
-        pNode->addPropTree("Properties", createPTree(pNewProperties));
+        pNode->addPropTree("Properties", createPTreeFromIPT(pNewProperties));
     }
     pNode->setProp(szName, szValue);
   }
@@ -592,7 +592,7 @@ void CConfigEnvHelper::mergeServiceAuthenticationWithBinding(IPropertyTree* pBin
 
     if (!pBinding->queryPropTree(xpath.str()))
     {
-      pNode = pBinding->addPropTree(NodeName, createPTree(pNode));
+      pNode = pBinding->addPropTree(NodeName, createPTreeFromIPT(pNode));
       if (bAuthenticateFeature)
         pNode->addProp("@authenticate", "Yes");
     }
@@ -852,7 +852,7 @@ void CConfigEnvHelper::addComponent(const char* pszBuildSet, StringBuffer& sbNew
 
       Owned<IPropertyTree> pProperties = pBuildSet->getPropTree("Properties");
       if (pProperties)
-        pCompTree->addPropTree("Properties", createPTree(pProperties));
+        pCompTree->addPropTree("Properties", createPTreeFromIPT(pProperties));
 
       addNode(pCompTree, m_pRoot->queryPropTree("Software"));
     }

--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -42,7 +42,7 @@ bool CConfigEnvHelper::handleThorTopologyOp(const char* cmd, const char* xmlArg,
     bool retVal = false;
     StringBuffer xpath;
 
-    Owned<IPropertyTree> pParams = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<ThorData/>", false);
+    Owned<IPropertyTree> pParams = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<ThorData/>");
     const char* thorName = pParams->queryProp(XML_ATTR_NAME);
     const char* newType = pParams->queryProp(XML_ATTR_TYPE);
     const char* validate = pParams->queryProp("@validateComputers");
@@ -172,7 +172,7 @@ IPropertyTree* CConfigEnvHelper::getSoftwareNode(const char* compType, const cha
 
 bool CConfigEnvHelper::addRoxieServers(const char* xmlArg)
 {
-  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<RoxieData/>", false);
+  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<RoxieData/>");
   const char* pszFarm = pSrcTree->queryProp("@parentName");
   const char* pszRoxieCluster = pSrcTree->queryProp("@roxieName");
   unsigned int nComputers = 0;//computers.size();
@@ -251,7 +251,7 @@ bool CConfigEnvHelper::addRoxieServers(const char* xmlArg)
     }
 
     xpath.clear().appendf("RoxieCluster[@name='%s']/"XML_TAG_ROXIE_FARM, pszRoxieCluster);
-    pFarm = pParent->addPropTree(xpath.str(), createPTree(false));
+    pFarm = pParent->addPropTree(xpath.str(), createPTree());
     pFarm->addProp    (XML_ATTR_NAME,       sFarmName.str());
     pFarm->addPropInt("@port",          9876);
     pFarm->addProp    (XML_ATTR_DATADIRECTORY,  sDataDir.str());
@@ -278,7 +278,7 @@ bool CConfigEnvHelper::addRoxieServers(const char* xmlArg)
       createUniqueName(sServerName.str(), xpath.str(), sbUniqueName);
 
       // Add process node
-      IPropertyTree* pServer = createPTree( XML_TAG_ROXIE_SERVER, false );
+      IPropertyTree* pServer = createPTree(XML_TAG_ROXIE_SERVER);
       pServer->setProp(XML_ATTR_NAME, sbUniqueName.str());
       pServer->addProp(XML_ATTR_COMPUTER, pszName);
       addNode(pServer, pFarm);
@@ -310,7 +310,7 @@ bool CConfigEnvHelper::addRoxieServers(const char* xmlArg)
 
 bool CConfigEnvHelper::handleReplaceRoxieServer(const char* xmlArg)
 {
-  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<RoxieData/>", false);
+  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<RoxieData/>");
   const char* pszRoxieCluster = pSrcTree->queryProp("@roxieName");
   IPropertyTree* pParent = m_pRoot->queryPropTree("Software");
   StringBuffer xpath;
@@ -638,7 +638,7 @@ void CConfigEnvHelper::createUniqueName(const char* szPrefix, const char* parent
 //---------------------------------------------------------------------------
 IPropertyTree* CConfigEnvHelper::addNode(const char* szTag, IPropertyTree* pParentNode, IPropertyTree* pInsertAfterNode)
 {
-  IPropertyTree* pNode = createPTree(szTag, false);
+  IPropertyTree* pNode = createPTree(szTag);
   if (pNode)
   {
     addNode(pNode, pParentNode, pInsertAfterNode);
@@ -731,7 +731,7 @@ IPropertyTree* CConfigEnvHelper::findLegacyServer(IPropertyTree* pRoxieCluster, 
 
 bool CConfigEnvHelper::deleteRoxieServers(const char* xmlArg)
 {
-  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<RoxieData/>", false);
+  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<RoxieData/>");
   const char* pszRoxieCluster = pSrcTree->queryProp("@roxieName");
   unsigned int nComputers = 0;//computers.size();
   StringBuffer xpath;
@@ -898,7 +898,7 @@ bool CConfigEnvHelper::handleRoxieSlaveConfig(const char* xmlArg)
 {
     try
     {
-        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<RoxieData/>", false);
+        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<RoxieData/>");
         const char* type = pSrcTree->queryProp(XML_ATTR_TYPE);
         const char* pszRoxie = pSrcTree->queryProp("@roxieName");
         const char* val1 = pSrcTree->queryProp("@val1");
@@ -1039,12 +1039,12 @@ void CConfigEnvHelper::addReplicateConfig(IPropertyTree* pSlaveNode, int channel
     directory.appendf("%s", dir);
     makePlatformSpecificAbsolutePath( pSlaveNode->queryProp(XML_ATTR_COMPUTER), directory);
 
-    IPropertyTree* pInstance = pSlaveNode->addPropTree(XML_TAG_ROXIE_CHANNEL, createPTree(false));
+    IPropertyTree* pInstance = pSlaveNode->addPropTree(XML_TAG_ROXIE_CHANNEL, createPTree());
     pInstance->setPropInt("@number", channel);
     pInstance->addProp(XML_ATTR_DATADIRECTORY, directory.str());
     
     //maintain a copy as an old style slave procss
-    IPropertyTree* pSlaveProcess = pRoxie->addPropTree(XML_TAG_ROXIE_SLAVE, createPTree(false));
+    IPropertyTree* pSlaveProcess = pRoxie->addPropTree(XML_TAG_ROXIE_SLAVE, createPTree());
     pSlaveProcess->addProp(XML_ATTR_COMPUTER, pSlaveNode->queryProp(XML_ATTR_COMPUTER));
     pSlaveProcess->addPropInt("@channel", channel);
     pSlaveProcess->addProp(XML_ATTR_DATADIRECTORY, directory.str());
@@ -1086,7 +1086,7 @@ bool CConfigEnvHelper::GenerateCyclicRedConfig(IPropertyTree* pRoxie, IPropertyT
         StringBuffer name;
         name.appendf("s%d", i+1);
 
-        IPropertyTree* pSlave = pRoxie->addPropTree(XML_TAG_ROXIE_ONLY_SLAVE, createPTree(false));
+        IPropertyTree* pSlave = pRoxie->addPropTree(XML_TAG_ROXIE_ONLY_SLAVE, createPTree());
         pSlave->addProp(XML_ATTR_NAME, name.str());
         pSlave->addProp(XML_ATTR_COMPUTER, szComputer);
 
@@ -1129,7 +1129,7 @@ bool CConfigEnvHelper::GenerateOverloadedConfig(IPropertyTree* pRoxie, IProperty
         StringBuffer name;
         name.appendf("s%d", i+1);
 
-        IPropertyTree* pSlave = pRoxie->addPropTree(XML_TAG_ROXIE_ONLY_SLAVE, createPTree(false));
+        IPropertyTree* pSlave = pRoxie->addPropTree(XML_TAG_ROXIE_ONLY_SLAVE, createPTree());
         pSlave->addProp(XML_ATTR_NAME, name.str());
         pSlave->addProp(XML_ATTR_COMPUTER, szComputer);
 
@@ -1172,7 +1172,7 @@ bool CConfigEnvHelper::GenerateFullRedConfig(IPropertyTree* pRoxie, int copies, 
         StringBuffer name;
         name.appendf("s%d", i+1);
 
-        IPropertyTree* pSlave = pRoxie->addPropTree(XML_TAG_ROXIE_ONLY_SLAVE, createPTree(false));
+        IPropertyTree* pSlave = pRoxie->addPropTree(XML_TAG_ROXIE_ONLY_SLAVE, createPTree());
         pSlave->addProp(XML_ATTR_NAME, name.str());
         pSlave->addProp(XML_ATTR_COMPUTER, szComputer);
 
@@ -1290,7 +1290,7 @@ bool CConfigEnvHelper::AddNewNodes(IPropertyTree* pThor, const char* szType, int
             sName.appendf("temp%d", i + j + 1);
 
             // Add process node
-            IPropertyTree* pProcessNode = createPTree(szType, false);
+            IPropertyTree* pProcessNode = createPTree(szType);
             pProcessNode->addProp(XML_ATTR_NAME, sName);
             pProcessNode->addProp(XML_ATTR_COMPUTER, computers[i]->queryProp(XML_ATTR_NAME));
             if (nPort != 0) pProcessNode->addPropInt(XML_ATTR_PORT, nPort);
@@ -1318,12 +1318,12 @@ bool CConfigEnvHelper::AddNewNodes(IPropertyTree* pThor, const char* szType, int
             if (!pNode)
             {
                 // Add topology node
-                pNode = createPTree(XML_TAG_NODE, false);
+                pNode = createPTree(XML_TAG_NODE);
                 pNode->addProp(XML_ATTR_PROCESS, sName);
 
                 IPropertyTree* pTopoNode = pThor->queryPropTree(XML_TAG_TOPOLOGY);
                 if (!pTopoNode)
-                    pTopoNode = pThor->addPropTree(XML_TAG_TOPOLOGY, createPTree(false));
+                    pTopoNode = pThor->addPropTree(XML_TAG_TOPOLOGY, createPTree());
 
                 if (!strcmp(szType, XML_TAG_THORSLAVEPROCESS))
                 {

--- a/deployment/deployutils/deployutils.cpp
+++ b/deployment/deployutils/deployutils.cpp
@@ -178,7 +178,7 @@ void getInstalledComponents(const char* pszInstallDir, StringBuffer& sbOutComps,
             Owned<IFile> depfile(createIFile(fileName));
             if(depfile->exists())
             {
-              Owned<IPropertyTree> pInstallSet = createPTreeFromXMLFile(fileName, false);
+              Owned<IPropertyTree> pInstallSet = createPTreeFromXMLFile(fileName);
               const char* szDeployable = pInstallSet->queryProp("@deployable");
               const char* szProcessName = pInstallSet->queryProp("@processName");
               if (!szDeployable || strcmp(szDeployable, "no"))
@@ -581,7 +581,7 @@ public:
             IPropertyTree* pChild = m_pCompTree->queryPropTree(xpath.str());
 
             if(!pChild)
-              pChild = m_pCompTree->addPropTree(childElementName, createPTree(false));
+              pChild = m_pCompTree->addPropTree(childElementName, createPTree());
           }
 
           return;
@@ -616,14 +616,14 @@ public:
           IPropertyTree* pProcess = m_pDefTree->queryPropTree(compName.str());
 
           if (!pProcess)
-            pProcess = m_pDefTree->addPropTree(compName, createPTree(false));
+            pProcess = m_pDefTree->addPropTree(compName, createPTree());
 
           IPropertyTree* pTab = m_pDefTree->queryPropTree(getRealTabName(tabName));
 
           if (!pTab)
-            pTab = pProcess->addPropTree(getRealTabName(tabName), createPTree(false));
+            pTab = pProcess->addPropTree(getRealTabName(tabName), createPTree());
           
-          pField = pTab->addPropTree("Field", createPTree(false));
+          pField = pTab->addPropTree("Field", createPTree());
         }
 
         const char *defaultValue = attr.queryProp("@default");
@@ -659,7 +659,7 @@ public:
             IPropertyTree* pChild = m_pCompTree->queryPropTree(xpath.str());
 
             if(!pChild)
-              pChild = m_pCompTree->addPropTree(childElementName, createPTree(false));
+              pChild = m_pCompTree->addPropTree(childElementName, createPTree());
 
             xpath.clear().append("@").append(attr.queryProp(XML_ATTR_NAME));
             pChild->addProp(xpath, sbdefaultValue.str());
@@ -1127,7 +1127,7 @@ public:
           if (childElementName && !strcmp(childElementName, XML_TAG_INSTANCE))
           {
             const char* pszNameAttr = "<xs:attribute name='name' type='xs:string' use='optional'><xs:annotation><xs:appinfo><viewType>hidden</viewType></xs:appinfo></xs:annotation></xs:attribute>";
-            Owned<IPropertyTree> pSchemaAttrNode = createPTreeFromXMLString(pszNameAttr, false);
+            Owned<IPropertyTree> pSchemaAttrNode = createPTreeFromXMLString(pszNameAttr);
             AddAttributeFromSchema(*pSchemaAttrNode, "", compName, tabName, childElementName);
           }
 
@@ -1242,7 +1242,7 @@ public:
                     IPropertyTree* pNewInstanceNode = pInstanceNode->queryPropTree(szElementName);
 
                     if (!pNewInstanceNode)
-                      pNewInstanceNode = pInstanceNode->addPropTree(szElementName, createPTree(false));
+                      pNewInstanceNode = pInstanceNode->addPropTree(szElementName, createPTree());
 
                     pInstanceNode = pNewInstanceNode;
                   }
@@ -1291,10 +1291,10 @@ public:
                   {
                     StringBuffer sb(sbCompName);
                     if (!m_pCompTree->queryPropTree(sbCompName.str()))
-                      m_pCompTree->addPropTree(sbCompName.str(), createPTree(false));
+                      m_pCompTree->addPropTree(sbCompName.str(), createPTree());
 
                     sb.append("/").append(szElementName);
-                    m_pCompTree->addPropTree(sb.str()/*szElementName*/, createPTree(false));
+                    m_pCompTree->addPropTree(sb.str()/*szElementName*/, createPTree());
                   }
                 }
               }
@@ -1378,7 +1378,7 @@ public:
         StringBuffer sbPropName;
 
         if (!m_pSchemaRoot)
-          m_pSchemaRoot.setown(createPTreeFromXMLFile(m_xsdName, false));
+          m_pSchemaRoot.setown(createPTreeFromXMLFile(m_xsdName));
 
         IPropertyTree *schemaNode = m_pSchemaRoot->queryPropTree("xs:element");
 
@@ -1447,9 +1447,9 @@ public:
       void getDefnString(StringBuffer& compDefn, StringBuffer& viewChildNodes, StringBuffer& multiRowNodes)
       {
         m_viewChildNodes.clear();
-        m_viewChildNodes.setown(createPTree("viewChildNodes", false));
+        m_viewChildNodes.setown(createPTree("viewChildNodes"));
         m_multiRowNodes.clear();
-        m_multiRowNodes.setown(createPTree("multiRowNodes", false));
+        m_multiRowNodes.setown(createPTree("multiRowNodes"));
         
         generateHeaders();
         compDefn.clear().append(m_jsStrBuf);
@@ -1772,7 +1772,7 @@ bool generateHeadersFromXsd(IPropertyTree* pEnv, const char* xsdName, const char
 
 IPropertyTree* generateTreeFromXsd(const IPropertyTree* pEnv, IPropertyTree* pSchema, const char* compName, bool allSubTypes, bool wizFlag, CWizardInputs* pWInputs, bool genOptional)
 {
-  Owned<IPropertyTree> pCompTree(createPTree(compName, false));
+  Owned<IPropertyTree> pCompTree(createPTree(compName));
   CGenerateJSFromXSD obj(pEnv, pSchema, "", compName);
   obj.setCompTree(pCompTree, allSubTypes);
   obj.setWizardFlag(wizFlag);
@@ -1787,7 +1787,7 @@ bool generateHardwareHeaders(const IPropertyTree* pEnv, StringBuffer& sbDefn, bo
   if (pCompTree)
   {
     StringBuffer xpath,sbdefaultValue("");
-    IPropertyTree* pComputerType = pCompTree->addPropTree(XML_TAG_COMPUTERTYPE, createPTree(false));
+    IPropertyTree* pComputerType = pCompTree->addPropTree(XML_TAG_COMPUTERTYPE, createPTree());
     xpath.clear().append(XML_ATTR_NAME);
     pComputerType->addProp(xpath, sbdefaultValue.str());
     xpath.clear().append(XML_ATTR_MANUFACTURER);
@@ -1801,7 +1801,7 @@ bool generateHardwareHeaders(const IPropertyTree* pEnv, StringBuffer& sbDefn, bo
     xpath.clear().append(XML_ATTR_NICSPEED);
     pComputerType->addProp(xpath, sbdefaultValue.str());
 
-    IPropertyTree* pComputer = pCompTree->addPropTree(XML_TAG_COMPUTER, createPTree(false));
+    IPropertyTree* pComputer = pCompTree->addPropTree(XML_TAG_COMPUTER, createPTree());
     xpath.clear().append(XML_ATTR_NAME);
     pComputer->addProp(xpath, sbdefaultValue.str());
     xpath.clear().append(XML_ATTR_NETADDRESS);
@@ -1811,10 +1811,10 @@ bool generateHardwareHeaders(const IPropertyTree* pEnv, StringBuffer& sbDefn, bo
     xpath.clear().append(XML_ATTR_COMPUTERTYPE);
     pComputer->addProp(xpath, sbdefaultValue.str());
 
-    IPropertyTree* pSwitch = pCompTree->addPropTree(XML_TAG_SWITCH, createPTree(false));
+    IPropertyTree* pSwitch = pCompTree->addPropTree(XML_TAG_SWITCH, createPTree());
     xpath.clear().append(XML_ATTR_NAME);
 
-    IPropertyTree* pDomain = pCompTree->addPropTree(XML_TAG_DOMAIN, createPTree(false));
+    IPropertyTree* pDomain = pCompTree->addPropTree(XML_TAG_DOMAIN, createPTree());
     xpath.clear().append(XML_ATTR_NAME);
     pDomain->addProp(xpath, sbdefaultValue.str());
     xpath.clear().append(XML_ATTR_USERNAME);
@@ -2817,7 +2817,7 @@ IPropertyTree* getNewRange(const IPropertyTree* pEnv, const char* prefix, const 
    if (sNode.length() > 10)
    {
     sNode.append("</"XML_TAG_HARDWARE">");
-    IPropertyTree* pTree = createPTreeFromXMLString(sNode, false);
+    IPropertyTree* pTree = createPTreeFromXMLString(sNode);
     return pTree;
    }
    else 
@@ -2999,7 +2999,7 @@ bool onChangeAttribute(const IPropertyTree* pEnv,
         StringBuffer ret;
         if (xsltTransform(xml, sXsltPath, params, ret))
         {
-          Owned<IPropertyTree> result = createPTreeFromXMLString(ret.str(), false);
+          Owned<IPropertyTree> result = createPTreeFromXMLString(ret.str());
           
           Owned<IAttributeIterator> iAttr = result->getAttributes();
           ForEach(*iAttr)
@@ -3077,7 +3077,7 @@ void addInstanceToCompTree(const IPropertyTree* pEnvRoot,const IPropertyTree* pI
       dups.appendf("\n%s", pComputerNode->queryProp(XML_ATTR_NETADDRESS));
       continue;
     }
-    IPropertyTree* pNode = pCompTree->addPropTree(XML_TAG_INSTANCE, createPTree(false));
+    IPropertyTree* pNode = pCompTree->addPropTree(XML_TAG_INSTANCE, createPTree());
     if (pSchema)
     {
       Owned<IPropertyTreeIterator> iter = pSchema->getElements("xs:element/xs:complexType/xs:sequence/xs:element[@name=\"Instance\"]/xs:complexType/xs:attribute");
@@ -3257,7 +3257,7 @@ void getSummary(const IPropertyTree* pEnvRoot, StringBuffer& respXmlStr, bool pr
   if(pEnvRoot)
   {
     StringBuffer xpath, compName, ipAssigned, computerName, linkString, buildSetName;
-    Owned<IPropertyTree> pSummaryTree = createPTree("ComponentList", false);
+    Owned<IPropertyTree> pSummaryTree = createPTree("ComponentList");
     IPropertyTree* pSWCompTree  = pEnvRoot->queryPropTree(XML_TAG_SOFTWARE);
         
     if(pSWCompTree)
@@ -3392,7 +3392,7 @@ void getSummary(const IPropertyTree* pEnvRoot, StringBuffer& respXmlStr, bool pr
          
           if(ipAssigned.length() && compName.length())
           {
-            IPropertyTree* pComponentType = pSummaryTree->addPropTree("Component", createPTree("Component", false));
+            IPropertyTree* pComponentType = pSummaryTree->addPropTree("Component", createPTree("Component"));
             pComponentType->addProp("@name", compName.str());
             pComponentType->addProp("@netaddresses", ipAssigned.str());
             pComponentType->addProp("@buildset", ( buildSetName.length() ? buildSetName.str(): ""));
@@ -3409,7 +3409,7 @@ void getSummary(const IPropertyTree* pEnvRoot, StringBuffer& respXmlStr, bool pr
            DelimToStringArray(linkString.str(), sArray, "-");
            if(sArray.ordinality() == 3)
            {
-             IPropertyTree* pEspServiceType = pSummaryTree->addPropTree("Component", createPTree("Component", false));
+             IPropertyTree* pEspServiceType = pSummaryTree->addPropTree("Component", createPTree("Component"));
              pEspServiceType->addProp("@name", sArray.item(0));
              pEspServiceType->addProp("@buildset", sArray.item(1));
              pEspServiceType->addProp("@netaddresses", sArray.item(2));
@@ -3441,7 +3441,7 @@ void mergeAttributes(IPropertyTree* pTo, IPropertyTree* pFrom)
 
 void addEspBindingInformation(const char* xmlArg, IPropertyTree* pEnvRoot, StringBuffer& sbNewName, IConstEnvironment* pEnvironment)
 {
-  Owned<IPropertyTree> pBindings = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<EspServiceBindings/>", false);
+  Owned<IPropertyTree> pBindings = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<EspServiceBindings/>");
   const char* type = pBindings->queryProp(XML_ATTR_TYPE);
   const char* espName = pBindings->queryProp("@compName");
 

--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -408,8 +408,8 @@ IPropertyTree* CWizardInputs::createEnvironment()
     }
   }
 
-  Owned<IPropertyTree> pProgramTree = createPTree(m_buildSetTree);
-  pNewEnvTree->addPropTree(XML_TAG_PROGRAMS, createPTree(pProgramTree->queryPropTree("./"XML_TAG_PROGRAMS)));
+  Owned<IPropertyTree> pProgramTree = createPTreeFromIPT(m_buildSetTree);
+  pNewEnvTree->addPropTree(XML_TAG_PROGRAMS, createPTreeFromIPT(pProgramTree->queryPropTree("./"XML_TAG_PROGRAMS)));
 
   Owned<IPropertyTree> pCompTree = createPTree(XML_TAG_HARDWARE);
   generateHardwareHeaders(pNewEnvTree, sbTemp, false, pCompTree);
@@ -449,7 +449,7 @@ IPropertyTree* CWizardInputs::createEnvironment()
     pComputer->addProp(XML_ATTR_NAME, name.str());
     pComputer->addProp(XML_ATTR_NETADDRESS, m_ipaddress.item(i));
   }
-  pNewEnvTree->addPropTree(XML_TAG_HARDWARE, createPTree(pCompTree));
+  pNewEnvTree->addPropTree(XML_TAG_HARDWARE, createPTreeFromIPT(pCompTree));
   //Before we generate software tree check for dependencies of component for do_not_generate ,roxie, thor
   checkForDependencies();
   generateSoftwareTree(pNewEnvTree);
@@ -490,7 +490,7 @@ void CWizardInputs::generateSoftwareTree(IPropertyTree* pNewEnvTree)
       }
     }
 
-    pNewEnvTree->addPropTree(XML_TAG_SOFTWARE,createPTree(m_buildSetTree->queryPropTree("./"XML_TAG_SOFTWARE)));   
+    pNewEnvTree->addPropTree(XML_TAG_SOFTWARE,createPTreeFromIPT(m_buildSetTree->queryPropTree("./"XML_TAG_SOFTWARE)));
     xpath.clear().appendf("%s/%s/%s[%s='%s']/LocalEnvConfFile", XML_TAG_SOFTWARE, XML_TAG_ESPPROCESS, XML_TAG_ESPSERVICE, XML_ATTR_NAME, m_service.str());
     const char* tmp = m_cfg->queryProp(xpath.str());
     if (tmp && *tmp)
@@ -612,7 +612,7 @@ void CWizardInputs::addInstanceToTree(IPropertyTree* pNewEnvTree, StringBuffer a
 void CWizardInputs::getDefaultsForWizard(IPropertyTree* pNewEnvTree)
 {
   StringBuffer xpath, tempName, value;
-  Owned<IPropertyTree> pBuildTree = createPTree(pNewEnvTree->queryPropTree("./"XML_TAG_PROGRAMS));
+  Owned<IPropertyTree> pBuildTree = createPTreeFromIPT(pNewEnvTree->queryPropTree("./"XML_TAG_PROGRAMS));
   xpath.clear().appendf("./%s/%s/", XML_TAG_BUILD, XML_TAG_BUILDSET);
   Owned<IPropertyTreeIterator> buildSetInsts = pBuildTree->getElements(xpath.str());
   bool genOptional = true;
@@ -672,7 +672,7 @@ void CWizardInputs::getDefaultsForWizard(IPropertyTree* pNewEnvTree)
             IPropertyTree* pNewSubElem = pSWCompTree->queryPropTree(pElem->queryName());
             if (!pNewSubElem)
             {
-              pNewSubElem = pSWCompTree->addPropTree(pElem->queryName(), createPTree(pElem));
+              pNewSubElem = pSWCompTree->addPropTree(pElem->queryName(), createPTreeFromIPT(pElem));
               break;
             }
             else
@@ -888,7 +888,7 @@ void CWizardInputs::getEspBindingInformation(IPropertyTree* pNewEnvTree)
            Owned<IPropertyTreeIterator> i = pSvcProps->getElements("Authenticate");
            ForEach(*i)
            {
-             IPropertyTree* pAuthCopy = createPTree(&i->query());
+             IPropertyTree* pAuthCopy = createPTreeFromIPT(&i->query());
              mergeAttributes(pAuthCopy, pCompTree->queryPropTree("Authenticate"));
              IPropertyTree* pNewNode = pEspBindingInfo->addPropTree("Authenticate", pAuthCopy);
            }
@@ -896,7 +896,7 @@ void CWizardInputs::getEspBindingInformation(IPropertyTree* pNewEnvTree)
            i.setown( pSvcProps->getElements("AuthenticateFeature") );
            ForEach(*i)
            {
-             IPropertyTree* pAuthCopy = createPTree(&i->query());
+             IPropertyTree* pAuthCopy = createPTreeFromIPT(&i->query());
              //Adding authentication to true for espbinding.
              pAuthCopy->addProp("@authenticate","Yes");
              mergeAttributes(pAuthCopy, pCompTree->queryPropTree("AuthenticateFeature"));
@@ -905,7 +905,7 @@ void CWizardInputs::getEspBindingInformation(IPropertyTree* pNewEnvTree)
            i.setown( pSvcProps->getElements("AuthenticateSetting") );
            ForEach(*i)
            {
-             IPropertyTree* pAuthCopy = createPTree(&i->query());
+             IPropertyTree* pAuthCopy = createPTreeFromIPT(&i->query());
              mergeAttributes(pAuthCopy, pCompTree->queryPropTree("AuthenticateSetting"));
              IPropertyTree* pNewNode = pEspBindingInfo->addPropTree("AuthenticateSetting", pAuthCopy);
            }

--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -40,7 +40,7 @@ CWizardInputs::CWizardInputs(const char* xmlArg,const char *service,
                              MapStringTo<StringBuffer>* dirMap): m_service(service), 
                              m_cfg(cfg), m_overrideDirs(dirMap)
 {
-  m_pXml.setown(createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false));
+  m_pXml.setown(createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>"));
 }
 //----------------------------------------------------------------------
 CWizardInputs::~CWizardInputs()
@@ -109,7 +109,7 @@ void CWizardInputs::setEnvironment()
      fileName.append((pParams->queryProp("buildset") != NULL ? (sb.clear().append(pParams->queryProp("buildset"))) : STANDARD_CONFIG_BUILDSETFILE));
 
      if(fileName.length() && checkFileExists(fileName.str()))
-       m_buildSetTree.setown(createPTreeFromXMLFile(fileName.str(), false));
+       m_buildSetTree.setown(createPTreeFromXMLFile(fileName.str()));
      else
        throw MakeStringException( -1 , "The buildSetFile %s does not exists", fileName.str());
      
@@ -387,9 +387,9 @@ IPropertyTree* CWizardInputs::createEnvironment()
   StringBuffer xpath, sbTemp, name ;
  
   sbTemp.clear().appendf("<%s><%s></%s>", XML_HEADER, XML_TAG_ENVIRONMENT, XML_TAG_ENVIRONMENT);
-  IPropertyTree* pNewEnvTree = createPTreeFromXMLString(sbTemp.str(),false);
+  IPropertyTree* pNewEnvTree = createPTreeFromXMLString(sbTemp.str());
 
-  IPropertyTree* pSettings = pNewEnvTree->addPropTree(XML_TAG_ENVSETTINGS, createPTree(false));
+  IPropertyTree* pSettings = pNewEnvTree->addPropTree(XML_TAG_ENVSETTINGS, createPTree());
   xpath.clear().appendf("%s/%s/%s[%s='%s']/LocalEnvFile", XML_TAG_SOFTWARE, XML_TAG_ESPPROCESS, XML_TAG_ESPSERVICE, XML_ATTR_NAME, m_service.str());
   const char* pConfFile = m_cfg->queryProp(xpath.str());
 
@@ -411,7 +411,7 @@ IPropertyTree* CWizardInputs::createEnvironment()
   Owned<IPropertyTree> pProgramTree = createPTree(m_buildSetTree);
   pNewEnvTree->addPropTree(XML_TAG_PROGRAMS, createPTree(pProgramTree->queryPropTree("./"XML_TAG_PROGRAMS)));
 
-  Owned<IPropertyTree> pCompTree = createPTree(XML_TAG_HARDWARE,false);
+  Owned<IPropertyTree> pCompTree = createPTree(XML_TAG_HARDWARE);
   generateHardwareHeaders(pNewEnvTree, sbTemp, false, pCompTree);
   pCompTree->removeProp(XML_TAG_COMPUTER);
   xpath.clear().appendf("./%s/%s", XML_TAG_COMPUTERTYPE, XML_ATTR_MEMORY);
@@ -442,7 +442,7 @@ IPropertyTree* CWizardInputs::createEnvironment()
   pCompTree->setProp(xpath.str(), "linux"); 
   for(unsigned i = 0; i < m_ipaddress.ordinality(); i++)
   { 
-    IPropertyTree* pComputer = pCompTree->addPropTree(XML_TAG_COMPUTER,createPTree(false));
+    IPropertyTree* pComputer = pCompTree->addPropTree(XML_TAG_COMPUTER,createPTree());
     name.clear().appendf("node%03d", (i + 1));
     pComputer->addProp(XML_ATTR_COMPUTERTYPE, "linuxmachine");
     pComputer->addProp(XML_ATTR_DOMAIN, "localdomain");
@@ -483,7 +483,7 @@ void CWizardInputs::generateSoftwareTree(IPropertyTree* pNewEnvTree)
           pDir->setProp("@dir", dirvalue->str());
         else
         {
-          pDir = m_buildSetTree->queryPropTree(XML_TAG_SOFTWARE"/Directories/")->addPropTree("Category", createPTree(false));
+          pDir = m_buildSetTree->queryPropTree(XML_TAG_SOFTWARE"/Directories/")->addPropTree("Category", createPTree());
           pDir->setProp(XML_ATTR_NAME, (const char*)cur.getKey());
           pDir->setProp("@dir", dirvalue->str());
         }
@@ -596,7 +596,7 @@ void CWizardInputs::addInstanceToTree(IPropertyTree* pNewEnvTree, StringBuffer a
   compName.clear().appendf(pComp->queryProp(XML_ATTR_NAME));//compName
 
   sb.clear().appendf("<Instance buildSet=\"%s\" compName=\"%s\" ><Instance name=\"%s\" /></Instance>", buildSetName, compName.str(), nodeName.str());
-  Owned<IPropertyTree> pInstance = createPTreeFromXMLString(sb.str(),false);
+  Owned<IPropertyTree> pInstance = createPTreeFromXMLString(sb.str());
 
   if(pInstance)
     addInstanceToCompTree(pNewEnvTree, pInstance, sbl.clear(), sb.clear(),NULL);
@@ -919,7 +919,7 @@ void CWizardInputs::addTopology(IPropertyTree* pNewEnvTree)
 {
   StringBuffer xpath;
   if(!pNewEnvTree->hasProp("./"XML_TAG_SOFTWARE"/"XML_TAG_TOPOLOGY))
-    pNewEnvTree->addPropTree("./"XML_TAG_SOFTWARE"/"XML_TAG_TOPOLOGY, createPTree(false));
+    pNewEnvTree->addPropTree("./"XML_TAG_SOFTWARE"/"XML_TAG_TOPOLOGY, createPTree());
  
   HashIterator sIter(m_compForTopology);
   for(sIter.first();sIter.isValid();sIter.next())
@@ -946,12 +946,12 @@ IPropertyTree* CWizardInputs::createTopologyForComp(IPropertyTree* pNewEnvTree, 
 
    clusterStr.clear().appendf("<Cluster name=\"%s\" prefix=\"%s\"></Cluster>", component, component);
  
-   IPropertyTree* pCluster = createPTreeFromXMLString(clusterStr.str(), false);
+   IPropertyTree* pCluster = createPTreeFromXMLString(clusterStr.str());
    if(pCluster)
    {
      if(pNewEnvTree->hasProp(xpath.str()))
      {
-       IPropertyTree* pComponent = pCluster->addPropTree(xmlTag.str(), createPTree(false));
+       IPropertyTree* pComponent = pCluster->addPropTree(xmlTag.str(), createPTree());
        pComponent->addProp(XML_ATTR_PROCESS, pNewEnvTree->queryProp(xpath.str()));
      }
 
@@ -972,7 +972,7 @@ IPropertyTree* CWizardInputs::createTopologyForComp(IPropertyTree* pNewEnvTree, 
                 const char* processName = pBuildset->queryProp(XML_ATTR_PROCESS_NAME);
                 if(processName && *processName)
                 {
-                   IPropertyTree* pElement = pCluster->addPropTree(processName,createPTree(false));
+                   IPropertyTree* pElement = pCluster->addPropTree(processName,createPTree());
                    xpath.clear().appendf("./%s/%s[1]/%s", XML_TAG_SOFTWARE, processName, XML_ATTR_NAME);
                    if(pElement && pNewEnvTree->hasProp(xpath.str()))
                      pElement->addProp(XML_ATTR_PROCESS, pNewEnvTree->queryProp(xpath.str()));

--- a/deployment/envgen/main.cpp
+++ b/deployment/envgen/main.cpp
@@ -160,7 +160,7 @@ int main(int argc, char** argv)
     validateIPS(ipAddrs.str());
     StringBuffer optionsXml, envXml;
     const char* pServiceName = "WsDeploy_wsdeploy_esp";
-    Owned<IPropertyTree> pCfg = createPTreeFromXMLFile(ENVGEN_PATH_TO_ESP_CONFIG, false);
+    Owned<IPropertyTree> pCfg = createPTreeFromXMLFile(ENVGEN_PATH_TO_ESP_CONFIG);
 
     optionsXml.appendf("<XmlArgs roxieNodes=\"%d\" thorNodes=\"%d\" slavesPerNode=\"%d\" ipList=\"%s\"/>", roxieNodes,
                       thorNodes, slavesPerNode, ipAddrs.str());

--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -60,7 +60,7 @@ void CEclAgentExecutionServer::start(StringBuffer & codeDir)
     try
     {
         DBGLOG("AgentExec: Loading properties file '%s'\n", propertyFile.str());
-        properties.setown(createPTreeFromXMLFile(propertyFile.str(), false));
+        properties.setown(createPTreeFromXMLFile(propertyFile.str()));
     }
     catch (IException *e) 
     {

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -374,7 +374,7 @@ public:
 
             try
             {
-                queryXml.setown(createPTreeFromXMLString(rawText.str(), true, true, NULL, true));
+                queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, (XmlReaderOptions)(xr_ignoreWhiteSpace|xr_ignoreNameSpaces)));
             }
             catch (IException *E)
             {
@@ -529,15 +529,15 @@ EclAgent::EclAgent(IConstWorkUnit *wu, const char *_wuid, bool _checkVersion, bo
     logfile.getRemotePath(logname);
     if (wu->getDebugValueBool("Debug", false))
     {
-        Owned<IPropertyTree> destTree = createPTree("Query", false);
+        Owned<IPropertyTree> destTree = createPTree("Query");
         Owned<IConstWUGraphIterator> graphs = &wu->getGraphs(GraphTypeActivities);
         SCMStringBuffer graphName;
         ForEach(*graphs)
         {
             graphs->query().getName(graphName);
-            Owned<IPropertyTree> graphTree = createPTree("Graph", false);
+            Owned<IPropertyTree> graphTree = createPTree("Graph");
             graphTree->addProp("@id", graphName.str());
-            Owned<IPropertyTree> xgmmlTree = createPTree("xgmml", false);
+            Owned<IPropertyTree> xgmmlTree = createPTree("xgmml");
             Owned<IPropertyTree> graphXgmml = graphs->query().getXGMMLTree(false);
             xgmmlTree->addPropTree("graph", graphXgmml.getClear());
             graphTree->addPropTree("xgmml", xgmmlTree.getClear());
@@ -2994,15 +2994,15 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
     {
         try
         {
-            agentTopology.setown(createPTreeFromXMLFile("agentexec.xml", true));
+            agentTopology.setown(createPTreeFromXMLFile("agentexec.xml", ipt_caseInsensitive));
         }
         catch (IException *) 
         {
-            agentTopology.setown(createPTree("AGENTEXEC", false));
+            agentTopology.setown(createPTree("AGENTEXEC"));
         }
     }
     else
-        agentTopology.setown(createPTree("AGENTEXEC", false));
+        agentTopology.setown(createPTree("AGENTEXEC"));
 
     StringBuffer logfilespec;
     if (!globals->getProp("LOGFILE", logfilespec) && !standAloneExe)
@@ -3090,9 +3090,9 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
         if (queryXML)
         {
             if (queryXML[0]=='@')
-                query.setown(createPTreeFromXMLFile(queryXML+1, false));
+                query.setown(createPTreeFromXMLFile(queryXML+1));
             else
-                query.setown(createPTreeFromXMLString(queryXML, false));
+                query.setown(createPTreeFromXMLString(queryXML));
         }
         Owned<IPropertyIterator> it = globals->getIterator();
         ForEach(*it)
@@ -3101,11 +3101,11 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
             if (key && key[0] == '/')
             {
                 if (!query)
-                    query.setown(createPTree("Query", false));
+                    query.setown(createPTree("Query"));
                 const char *val = globals->queryProp(key);
                 if (val[0]=='<')
                 {
-                    Owned<IPropertyTree> valtree = createPTreeFromXMLString(val, false);
+                    Owned<IPropertyTree> valtree = createPTreeFromXMLString(val);
                     query->setPropTree(key+1, valtree.getClear());
                 }
                 else 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -956,7 +956,7 @@ void EclAgent::getResultRaw(unsigned & tlen, void * & tgt, const char * stepname
     tgt = NULL;
     PROTECTED_GETRESULT(stepname, sequence, "Raw", "raw",
         Variable2IDataVal result(&tlen, &tgt);
-        Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer, true);
+        Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer);
         Owned<ICsvToRawTransformer> rawCsvTransformer = createCsvRawTransformer(csvTransformer);
         r->getResultRaw(result, rawXmlTransformer, rawCsvTransformer);
     );
@@ -967,7 +967,7 @@ void EclAgent::getResultSet(bool & tisAll, size32_t & tlen, void * & tgt, const 
     tgt = NULL;
     PROTECTED_GETRESULT(stepname, sequence, "Raw", "raw",
         Variable2IDataVal result(&tlen, &tgt);
-        Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer, true);
+        Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer);
         Owned<ICsvToRawTransformer> rawCsvTransformer = createCsvRawTransformer(csvTransformer);
         tisAll = r->getResultIsAll();
         r->getResultRaw(result, rawXmlTransformer, rawCsvTransformer);
@@ -1008,7 +1008,7 @@ void EclAgent::getExternalResultRaw(unsigned & tlen, void * & tgt, const char * 
         if (!r) failv(0, "Failed to find raw value %s:%d in workunit %s", nullText(stepname),sequence, wuid);
         
         Variable2IDataVal result(&tlen, &tgt);
-        Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer, true);
+        Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer);
         Owned<ICsvToRawTransformer> rawCsvTransformer = createCsvRawTransformer(csvTransformer);
         r->getResultRaw(result, rawXmlTransformer, rawCsvTransformer);
     }
@@ -1031,7 +1031,7 @@ void EclAgent::getResultRowset(size32_t & tcount, byte * * & tgt, const char * s
     PROTECTED_GETRESULT(stepname, sequence, "Rowset", "rowset",
         MemoryBuffer datasetBuffer;
         MemoryBuffer2IDataVal result(datasetBuffer);
-        Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer, true);
+        Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer);
         Owned<ICsvToRawTransformer> rawCsvTransformer = createCsvRawTransformer(csvTransformer);
         r->getResultRaw(result, rawXmlTransformer, rawCsvTransformer);
         rtlDataset2RowsetX(tcount, tgt, _rowAllocator, deserializer, datasetBuffer.length(), datasetBuffer.toByteArray(), isGrouped);

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -988,7 +988,7 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
 
 void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML)
 {
-    Owned<IPropertyTree> xml = createPTreeFromXMLString(archiveXML, true);
+    Owned<IPropertyTree> xml = createPTreeFromXMLString(archiveXML, ipt_caseInsensitive);
     Owned<IEclRepository> dataServer = createXmlDataServer(xml, libraryRepository);
     Owned<IPropertyTreeIterator> iter = xml->getElements("Option");
     ForEach(*iter) 

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -539,7 +539,7 @@ int main(int argc, const char *argv[])
 
     try
     {
-        globals.setown(loadPropertyTree("eclccserver.xml", true));
+        globals.setown(createPTreeFromXMLFile("eclccserver.xml", ipt_caseInsensitive));
     }
     catch (IException * e)
     {

--- a/ecl/eclplus/QueryHelper.cpp
+++ b/ecl/eclplus/QueryHelper.cpp
@@ -123,7 +123,7 @@ bool QueryHelper::doit(FILE * fp)
                 const char *xml = globals->queryProp(key);
                 try
                 {
-                    Owned<IPropertyTree> checkValid = createPTreeFromXMLString(xml, false);
+                    Owned<IPropertyTree> checkValid = createPTreeFromXMLString(xml);
                 }
                 catch (IException *E)
                 {
@@ -149,7 +149,7 @@ bool QueryHelper::doit(FILE * fp)
                 }
                 try
                 {
-                    Owned<IPropertyTree> checkValid = createPTreeFromXMLString(xml, false);
+                    Owned<IPropertyTree> checkValid = createPTreeFromXMLString(xml);
                 }
                 catch (IException *E)
                 {

--- a/ecl/eclscheduler/eclscheduler.cpp
+++ b/ecl/eclscheduler/eclscheduler.cpp
@@ -192,7 +192,7 @@ int main(int argc, const char *argv[])
     }
     try
     {
-        globals.setown(loadPropertyTree(iniFileName, true));
+        globals.setown(createPTreeFromXMLFile(iniFileName, ipt_caseInsensitive));
     }
     catch(...)
     {

--- a/ecl/hql/hqlesp.cpp
+++ b/ecl/hql/hqlesp.cpp
@@ -155,7 +155,7 @@ class WebServicesExtractor
 public:
     WebServicesExtractor(HqlLookupContext & _lookupCtx) : lookupCtx(_lookupCtx) 
     {
-        root.setown(createPTree("Cache", false));
+        root.setown(createPTree("Cache"));
     }
 
     void addRootReference(const char * attribute);
@@ -232,7 +232,7 @@ IPropertyTree * WebServicesExtractor::ensureCacheEntry(const char * name)
     if (match)
         return match;
 
-    Owned<IPropertyTree> tree = createPTree("attr", false);
+    Owned<IPropertyTree> tree = createPTree("attr");
     tree->setProp("@name", name);
     
     StringBuffer lowerName;
@@ -417,7 +417,7 @@ IPropertyTree * retrieveWebServicesInfo(const char * queryText, HqlLookupContext
     StringPairArray results;
     extractor.getResults(results);
 
-    Owned<IPropertyTree> result = createPTree("WebServicesInfo", false);
+    Owned<IPropertyTree> result = createPTree("WebServicesInfo");
     ForEachItemIn(i, results)
     {
         StringPairItem & cur = results.item(i);

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -7208,7 +7208,7 @@ void exportSymbols(IPropertyTree* data, IHqlScope * scope, HqlLookupContext & ct
         IHqlExpression *cur = &allSymbols.item(i);
         if (cur && cur->isObject(ob_declaration) && (cur->getOperator() != no_remotescope))
         {
-            IPropertyTree * attr=createPropertyTree(true, "Attribute");
+            IPropertyTree * attr=createPTree("Attribute", ipt_caseInsensitive);
             attr->setProp("@name", *cur->queryName());
             unsigned obFlags = cur->getObType();
             if (cur->isExported())
@@ -12064,7 +12064,7 @@ unsigned exportField(IPropertyTree *table, IHqlExpression *field, unsigned & off
     if (field->isAttribute())
         return 0;
     IHqlExpression *defValue = field->queryChild(0);
-    IPropertyTree *f = createPropertyTree(true, "Field");
+    IPropertyTree *f = createPTree("Field", ipt_caseInsensitive);
     ITypeInfo * type = field->queryType();
     if (type->getTypeCode() == type_row)
         type = type->queryChildType();
@@ -12116,7 +12116,7 @@ unsigned exportField(IPropertyTree *table, IHqlExpression *field, unsigned & off
         {
             thisSize = exportRecord(table, record, offset, flatten);
 
-            IPropertyTree *end = createPropertyTree(true, "Field");
+            IPropertyTree *end = createPTree("Field", ipt_caseInsensitive);
             end->setPropBool("@isEnd", true);
             end->setProp("@name", field->queryName()->getAtomNamePtr());
             end = table->addPropTree(end->queryName(), end);
@@ -12152,7 +12152,7 @@ static unsigned exportRecord(IPropertyTree *dataNode, IHqlExpression * record, u
                 }
                 else
                 {
-                    IPropertyTree * ifblock = dataNode->addPropTree("IfBlock", createPropertyTree(true, "IfBlock"));
+                    IPropertyTree * ifblock = dataNode->addPropTree("IfBlock", createPTree("IfBlock", ipt_caseInsensitive));
                     ifblock->setPropInt("@position", idx);
                     exportRecord(ifblock, cur->queryChild(1), flatten);
                     size = UNKNOWN_LENGTH;
@@ -12208,10 +12208,10 @@ void exportMap(IPropertyTree *dataNode, IHqlExpression *destTable, IHqlExpressio
     IPropertyTree *maps = dataNode->queryPropTree("./Map");
     if (!maps)
     {
-        maps = createPropertyTree(true, "Map");
+        maps = createPTree("Map", ipt_caseInsensitive);
         dataNode->addPropTree("Map", maps);
     }
-    IPropertyTree *map = createPropertyTree(true, "MapTables");
+    IPropertyTree *map = createPTree("MapTables", ipt_caseInsensitive);
     StringBuffer name;
     map->setProp("@destTable", getExportName(destTable, name).str());
     map->setProp("@sourceTable", getExportName(sourceTable, name.clear()).str());
@@ -12230,7 +12230,7 @@ void exportData(IPropertyTree *data, IHqlExpression *table, bool flatten)
             mode->toString(prefix);
             prefix.toLowerCase();
             prefix.setCharAt(0, (char)(prefix.charAt(0) - 0x20));
-            tt = createPropertyTree(true, StringBuffer(prefix).append("Table").str());
+            tt = createPTree(StringBuffer(prefix).append("Table").str(), ipt_caseInsensitive);
             StringBuffer name;
             tt->setProp("@name", getExportName(table, name).str());
             CHqlNamedSymbol *a = QUERYINTERFACE(table, CHqlNamedSymbol);
@@ -12253,7 +12253,7 @@ void exportData(IPropertyTree *data, IHqlExpression *table, bool flatten)
             }
             exportMap(data, table, base);
             exportData(data, base);
-            tt = createPropertyTree(true, "LogicalTable");
+            tt = createPTree("LogicalTable", ipt_caseInsensitive);
             StringBuffer name;
             tt->setProp("@name", getExportName(table, name).str());
             CHqlNamedSymbol *a = QUERYINTERFACE(table, CHqlNamedSymbol);
@@ -14631,7 +14631,7 @@ static void safeLookupSymbol(HqlLookupContext & ctx, IHqlScope * modScope, _ATOM
         
         if (!attr)
         {
-            attr = localContext.dependTree->addPropTree("Attr", createPTree(false));
+            attr = localContext.dependTree->addPropTree("Attr", createPTree());
             attr->setProp("@module", moduleName->str());
             attr->setProp("@name", name->str());
         }
@@ -14693,7 +14693,7 @@ static void gatherAttributeDependencies(HqlLookupContext & ctx, const char * ite
 extern HQL_API IPropertyTree * gatherAttributeDependencies(IEclRepository * dataServer, const char * items)
 {
     HqlLookupContext ctx(NULL, NULL, NULL, dataServer);
-    ctx.dependTree.setown(createPTree("Dependencies", false));
+    ctx.dependTree.setown(createPTree("Dependencies"));
 
     if (items && *items)
     {

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -10844,7 +10844,7 @@ void HqlGram::reportExternalSymbol(IHqlScope * scope, IHqlExpression *expr)
         _ATOM module = scope->queryName();
         if (module)
         {
-            IPropertyTree * depend = lookupCtx.curAttrTree->addPropTree("Depend", createPTree(false));
+            IPropertyTree * depend = lookupCtx.curAttrTree->addPropTree("Depend", createPTree());
             depend->setProp("@module", module->str());
             depend->setProp("@name", expr->queryName()->str());
         }
@@ -10855,7 +10855,7 @@ void HqlGram::reportExternalSymbol(IHqlScope * scope, IHqlExpression *expr)
 
 extern HQL_API IPropertyTree * createAttributeArchive()
 {
-    Owned<IPropertyTree> archive = createPTree("Archive", false);
+    Owned<IPropertyTree> archive = createPTree("Archive");
     archive->setProp("@build", BUILD_TAG);
     archive->setProp("@eclVersion", LANGUAGE_VERSION);
     return archive.getClear();
@@ -10874,7 +10874,7 @@ IPropertyTree * queryEnsureArchiveModule(IPropertyTree * archive, const char * n
     IPropertyTree * module = archive->queryPropTree(xpath);
     if (!module)
     {
-        module = archive->addPropTree("Module", createPTree(false));
+        module = archive->addPropTree("Module", createPTree());
         module->setProp("@name", name ? name : "");
         module->setProp("@key", lowerName);
         if (scope)
@@ -10911,7 +10911,7 @@ extern HQL_API IPropertyTree * createArchiveAttribute(IPropertyTree * module, co
 {
     StringBuffer lowerName;
     lowerName.append(name).toLowerCase();
-    IPropertyTree * attr = module->addPropTree("Attribute", createPTree(false));
+    IPropertyTree * attr = module->addPropTree("Attribute", createPTree());
     attr->setProp("@name", name);
     attr->setProp("@key", lowerName);
     return attr;
@@ -11008,7 +11008,7 @@ void parseAttribute(IHqlScope * scope, IFileContents * contents, HqlLookupContex
     HqlLookupContext attrCtx(ctx);
     if (attrCtx.dependTree)
     {
-        IPropertyTree * attr = attrCtx.dependTree->addPropTree("Attr", createPTree(false));
+        IPropertyTree * attr = attrCtx.dependTree->addPropTree("Attr", createPTree());
         attrCtx.curAttrTree.set(attr);
         attr->setProp("@module", scope->queryName()->str());
         attr->setProp("@name", name->str());

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -1000,7 +1000,7 @@ void HqlLex::doExport(YYSTYPE & returnToken, bool toXml)
         reportError(returnToken, ERR_EXPECTED_COMMA, ", expected"); 
         return;
     }
-    IPropertyTree *data = createPropertyTree(true, "Data");
+    IPropertyTree *data = createPTree("Data", ipt_caseInsensitive);
     for (;;)
     {
         StringBuffer curParam("SIZEOF(");
@@ -2062,7 +2062,7 @@ IPropertyTree * HqlLex::getClearJavadoc()
     if (javaDocComment.length() == 0)
         return NULL;
 
-    IPropertyTree * tree = createPTree("javadoc", false);
+    IPropertyTree * tree = createPTree("javadoc");
     extractJavadoc(tree, javaDocComment.str());
     javaDocComment.clear();
     return tree;

--- a/ecl/hql/hqlplugininfo.cpp
+++ b/ecl/hql/hqlplugininfo.cpp
@@ -43,7 +43,7 @@ IPropertyTree * createPluginPropertyTree(IEclRepository * plugins, bool includeM
     HqlScopeArray scopes;
     plugins->getRootScopes(scopes, ctx);
 
-    Owned<IPropertyTree> map = createPropertyTree(true, "Plugins");
+    Owned<IPropertyTree> map = createPTree("Plugins", ipt_caseInsensitive);
     ForEachItemIn(idx, scopes)
     {
         IHqlScope * module = &scopes.item(idx);
@@ -51,7 +51,7 @@ IPropertyTree * createPluginPropertyTree(IEclRepository * plugins, bool includeM
         if (!(flags & SOURCEFILE_CONSTANT))
             continue;
 
-        IPropertyTree* prop = createPropertyTree(true,"Module");
+        IPropertyTree* prop = createPTree("Module", ipt_caseInsensitive);
         prop->setProp("@name", module->queryFullName());
         prop->setProp("@path", module->querySourcePath()->str());
         prop->setPropInt("@access", module->getPropInt(accessAtom, 3));

--- a/ecl/hql/hqlremote.cpp
+++ b/ecl/hql/hqlremote.cpp
@@ -431,7 +431,7 @@ IPropertyTree* RemoteXmlEclRepository::getModules(timestamp_t from)
     try
     {
         repository.getModules(modNames, user, from);
-        repositoryTree = createPTreeFromXMLString(modNames.str());
+        repositoryTree = createPTreeFromXMLString(modNames.str(), ipt_caseInsensitive);
     }
     catch(IException *e) 
     {

--- a/ecl/hql/hqlremote.cpp
+++ b/ecl/hql/hqlremote.cpp
@@ -431,7 +431,7 @@ IPropertyTree* RemoteXmlEclRepository::getModules(timestamp_t from)
     try
     {
         repository.getModules(modNames, user, from);
-        repositoryTree = loadPropertyTree(modNames.str(),true);
+        repositoryTree = createPTreeFromXMLString(modNames.str());
     }
     catch(IException *e) 
     {
@@ -458,7 +458,7 @@ IPropertyTree* RemoteXmlEclRepository::getAttributes(const char *module, const c
 
         repository.getAttributes(xml, user, module, attr, version, infoLevel, snapshot.length() ? snapshot.str() : NULL, sandbox4snapshot);
         if (xml.length())
-            repositoryTree = loadPropertyTree(xml, true);
+            repositoryTree = createPTreeFromXMLString(xml, ipt_caseInsensitive);
     }
     catch(IException *e) 
     {

--- a/ecl/hql/hqlxmldb.cpp
+++ b/ecl/hql/hqlxmldb.cpp
@@ -229,7 +229,7 @@ void CXmlScope::loadXML(const char * text, const char * element)
 HQL_API IXmlScope* loadXML(const char* xml)
 {
     assertex(xml);
-    IPropertyTree * ptree = ('<' == *xml) ? createPTreeFromXMLString(xml, ipt_caseInsensitive) : createPTreeFromXMLFile(xml, ipt_caseInsensitive);
+    IPropertyTree * ptree = createPTreeFromXMLString(xml, ipt_caseInsensitive);
     return ptree ? new CXmlScope(ptree, NULL) : NULL;
 }
 

--- a/ecl/hql/hqlxmldb.cpp
+++ b/ecl/hql/hqlxmldb.cpp
@@ -222,13 +222,14 @@ bool CXmlScope::appendValue(const char *name, const char *value)
 
 void CXmlScope::loadXML(const char * text, const char * element)
 {
-    IPropertyTree * ptree = loadPropertyTree(text, true);
+    IPropertyTree * ptree = createPTreeFromXMLString(text, ipt_caseInsensitive);
     root->setPropTree(element, ptree);
 }
 
-HQL_API IXmlScope* loadXML(const char* filename)
+HQL_API IXmlScope* loadXML(const char* xml)
 {
-    IPropertyTree * ptree = loadPropertyTree(filename, true);
+    assertex(xml);
+    IPropertyTree * ptree = ('<' == *xml) ? createPTreeFromXMLString(xml, ipt_caseInsensitive) : createPTreeFromXMLFile(xml, ipt_caseInsensitive);
     return ptree ? new CXmlScope(ptree, NULL) : NULL;
 }
 

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1130,12 +1130,12 @@ void HqlCppInstance::addPlugin(const char *plugin, const char *version, bool inT
             p->setPluginHole(true);
     }
     if (!plugins)
-        plugins.setown(createPTree("Plugins", false));
+        plugins.setown(createPTree("Plugins"));
     StringBuffer xpath;
     xpath.append("Plugin[@dll='").append(dllname).append("']");
     if (!plugins->hasProp(xpath.str()))
     {
-        IPropertyTree * pluginNode = createPTree("Plugin", false);
+        IPropertyTree * pluginNode = createPTree("Plugin");
         pluginNode->setProp("@dll", dllname.str());
         pluginNode->setProp("@version", version);
         plugins->addPropTree("Plugin", pluginNode);
@@ -1274,7 +1274,7 @@ void HqlCppInstance::flushHints()
 IPropertyTree * HqlCppInstance::ensureWebServiceInfo()
 {
     if (!webServiceInfo)
-        webServiceInfo.setown(createPTree("WebServicesInfo", false));
+        webServiceInfo.setown(createPTree("WebServicesInfo"));
     return webServiceInfo;
 }
 

--- a/ecl/hqlcpp/hqlgraph.cpp
+++ b/ecl/hqlcpp/hqlgraph.cpp
@@ -46,7 +46,7 @@
 
 IPropertyTree * addGraphAttribute(IPropertyTree * node, const char * name)
 {
-    IPropertyTree * att = createPTree(false);
+    IPropertyTree * att = createPTree();
     att->setProp("@name", name);
     return node->addPropTree("att", att);
 }
@@ -69,7 +69,7 @@ void addGraphAttributeBool(IPropertyTree * node, const char * name, bool value)
 
 void addSimpleGraphEdge(IPropertyTree * subGraph, unsigned __int64 source, unsigned __int64 target, unsigned outputIndex, unsigned inputIndex, _ATOM kind, const char * label, bool nWay)
 {
-    IPropertyTree *edge = createPTree(false);
+    IPropertyTree *edge = createPTree();
     edge->setPropInt64("@target", target);
     edge->setPropInt64("@source", source);
     if (outputIndex != 0)
@@ -94,7 +94,7 @@ void addSimpleGraphEdge(IPropertyTree * subGraph, unsigned __int64 source, unsig
 void addComplexGraphEdge(IPropertyTree * graph, unsigned __int64 sourceGraph, unsigned __int64 targetGraph, unsigned __int64 sourceActivity, unsigned __int64 targetActivity, unsigned outputIndex, _ATOM kind, const char * label)
 {
     StringBuffer idText;
-    IPropertyTree *edge = createPTree(false);
+    IPropertyTree *edge = createPTree();
     edge->setProp("@id", idText.clear().append(sourceGraph).append('_').append(targetGraph).append("_").append(outputIndex).str());
     edge->setPropInt64("@target", sourceGraph);
     edge->setPropInt64("@source", targetGraph);
@@ -180,7 +180,7 @@ void LogicalGraphCreator::addAttributeBool(const char * name, bool value)
 
 void LogicalGraphCreator::beginActivity(const char * label, unique_id_t id)
 {
-    activityNode.set(curSubGraph()->addPropTree("node", createPTree(false)));
+    activityNode.set(curSubGraph()->addPropTree("node", createPTree()));
     if (label)
         activityNode->setProp("@label", label);
     activityNode->setPropInt64("@id", id);
@@ -200,12 +200,12 @@ void LogicalGraphCreator::beginSubGraph(const char * label, bool nested)
     }
 
     subGraphId = ++seq;
-    IPropertyTree * node = createPTree("node", false);
+    IPropertyTree * node = createPTree("node");
     node = curSubGraph()->addPropTree("node", node);
     node->setPropInt64("@id", subGraphId);
 
-    IPropertyTree * graphAttr = node->addPropTree("att", createPTree("att", false));
-    IPropertyTree * subGraph = graphAttr->addPropTree("graph", createPTree("graph", false));
+    IPropertyTree * graphAttr = node->addPropTree("att", createPTree("att"));
+    IPropertyTree * subGraph = graphAttr->addPropTree("graph", createPTree("graph"));
     subGraphs.append(*LINK(subGraph));
     if (!rootSubGraph)
     {
@@ -242,7 +242,7 @@ void LogicalGraphCreator::connectActivities(IHqlExpression * fromExpr, IHqlExpre
 
 void LogicalGraphCreator::createLogicalGraph(HqlExprArray & exprs)
 {
-    graph.setown(createPTree("graph", false));
+    graph.setown(createPTree("graph"));
 
 //  beginSubGraph(NULL, false);
     ForEachItemIn(i, exprs)

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -2081,7 +2081,7 @@ void ActivityInstance::processHint(IHqlExpression * attr)
     if (value.length() == 0)
         value.append("1");
 
-    IPropertyTree * att = createPTree(false);
+    IPropertyTree * att = createPTree();
     att->setProp("@name", name->str());
     att->setProp("@value", value.str());
     graphNode->addPropTree("hint", att);
@@ -2130,7 +2130,7 @@ void ActivityInstance::createGraphNode(IPropertyTree * defaultSubGraph, bool alw
     if (!parentGraphNode)
         return;
     assertex(kind < TAKlast);
-    graphNode.set(parentGraphNode->addPropTree("node", createPTree(false)));
+    graphNode.set(parentGraphNode->addPropTree("node", createPTree()));
 
     graphNode->setPropInt64("@id", activityId);
     StringBuffer label;
@@ -6657,7 +6657,7 @@ void HqlCppTranslator::addDependency(BuildCtx & ctx, ABoundActivity * element, A
 //  if (outputIndex)
 //      idText.append("_").append(outputIndex);
 
-    IPropertyTree *edge = createPTree(false);
+    IPropertyTree *edge = createPTree();
     edge->setProp("@id", idText.str());
     edge->setPropInt64("@target", sinkActivity->queryGraphId());
     edge->setPropInt64("@source", sourceActivity->queryGraphId());
@@ -8804,7 +8804,7 @@ unsigned HqlCppTranslator::doBuildThorChildSubGraph(BuildCtx & ctx, IHqlExpressi
 //NB: Need to create the graph in the correct order so the references to property trees we retain
 // remain live..
     SubGraphInfo * activeSubgraph = queryActiveSubGraph(ctx);
-    IPropertyTree * node = createPTree("node", false);
+    IPropertyTree * node = createPTree("node");
     if (activeSubgraph)
         node = activeSubgraph->tree->addPropTree("node", node);
     else
@@ -8813,8 +8813,8 @@ unsigned HqlCppTranslator::doBuildThorChildSubGraph(BuildCtx & ctx, IHqlExpressi
     unsigned thisId = reservedId ? reservedId : nextActivityId();
     node->setPropInt("@id", thisId);
 
-    IPropertyTree * graphAttr = node->addPropTree("att", createPTree("att", false));
-    IPropertyTree * subGraph = graphAttr->addPropTree("graph", createPTree("graph", false));
+    IPropertyTree * graphAttr = node->addPropTree("att", createPTree("att"));
+    IPropertyTree * subGraph = graphAttr->addPropTree("graph", createPTree("graph"));
 
     Owned<SubGraphInfo> graphInfo = new SubGraphInfo(subGraph, thisId, graphTag, kind);
     ctx.associate(*graphInfo);
@@ -8902,7 +8902,7 @@ void HqlCppTranslator::beginGraph(BuildCtx & ctx, const char * _graphName)
         graphName.append(_graphName);
     activeGraphName.set(graphName.str());
 
-    graph.setown(createPTree("graph", false));
+    graph.setown(createPTree("graph"));
     if (graphLabel)
     {
         graph->setProp("@label", graphLabel);
@@ -10388,14 +10388,14 @@ void HqlCppTranslator::addSchemaResource(int seq, const char * name, IHqlExpress
 
 void HqlCppTranslator::addSchemaResource(int seq, const char * name, const char * schemaXml)
 {
-    Owned<IPropertyTree> resultTree = createPTree("Result", false);
+    Owned<IPropertyTree> resultTree = createPTree("Result");
     resultTree->setPropInt("@sequence", seq);
     resultTree->setProp("@name", name);
-    resultTree->addPropTree("xs:schema", createPTreeFromXMLString(schemaXml, false));
+    resultTree->addPropTree("xs:schema", createPTreeFromXMLString(schemaXml));
     IPropertyTree * web = code->ensureWebServiceInfo();
     IPropertyTree * schema = web->queryPropTree("SCHEMA");
     if (!schema)
-        schema = web->addPropTree("SCHEMA", createPTree("SCHEMA", false));
+        schema = web->addPropTree("SCHEMA", createPTree("SCHEMA"));
     schema->addPropTree("Result", resultTree.getClear());
 }
 
@@ -17343,7 +17343,7 @@ void HqlCppTranslator::buildConnectOrders(BuildCtx & ctx, ABoundActivity * slave
     //I'm not sure we even use this information, but at least it's there if needed.
     if (targetThor())
     {
-        IPropertyTree *edge = createPTree(false);
+        IPropertyTree *edge = createPTree();
         edge->setPropInt64("@target", slaveActivity->queryActivityId());
         edge->setPropInt64("@source", masterActivity->queryActivityId());
         addGraphAttributeBool(edge, "cosort", true);

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -635,7 +635,7 @@ void CHThorDiskWriteActivity::publish()
 
     Owned<IPropertyTree> attrs;
     if(clusterHandler) 
-        attrs.setown(createPTree("Part", false)); // clusterHandler is going to set attributes
+        attrs.setown(createPTree("Part")); // clusterHandler is going to set attributes
     else 
     {
         // add cluster
@@ -1186,7 +1186,7 @@ void CHThorIndexWriteActivity::execute()
     //properties of the first file part.
     Owned<IPropertyTree> attrs;
     if(clusterHandler) 
-        attrs.setown(createPTree("Part", false));  // clusterHandler is going to set attributes
+        attrs.setown(createPTree("Part"));  // clusterHandler is going to set attributes
     else 
     {
         // add cluster
@@ -1302,14 +1302,14 @@ void CHThorIndexWriteActivity::buildUserMetadata(Owned<IPropertyTree> & metadata
             throw MakeStringException(0, "Invalid name %s in user metadata for index %s (names beginning with underscore are reserved)", name.str(), helper.getFileName());
         if(!validateXMLTag(name.str()))
             throw MakeStringException(0, "Invalid name %s in user metadata for index %s (not legal XML element name)", name.str(), helper.getFileName());
-        if(!metadata) metadata.setown(createPTree("metadata", false));
+        if(!metadata) metadata.setown(createPTree("metadata"));
         metadata->setProp(name.str(), value.str());
     }
 }
 
 void CHThorIndexWriteActivity::buildLayoutMetadata(Owned<IPropertyTree> & metadata)
 {
-    if(!metadata) metadata.setown(createPTree("metadata", false));
+    if(!metadata) metadata.setown(createPTree("metadata"));
     metadata->setProp("_record_ECL", helper.queryRecordECL());
 
     void * layoutMetaBuff;

--- a/ecl/schedulectrl/scheduleread.cpp
+++ b/ecl/schedulectrl/scheduleread.cpp
@@ -339,7 +339,7 @@ protected:
         Owned<IRemoteConnection> connection = querySDS().connect(rootPath.str(), myProcessSession(), RTM_LOCK_READ | RTM_CREATE_QUERY, connectionTimeout);
         Owned<IPropertyTree> root(connection->queryRoot()->getBranch("."));
         if(root)
-            scheduleBranch.setown(createPTree(root));
+            scheduleBranch.setown(createPTreeFromIPT(root));
         if(subscribeAfter)
             subscribe(rootPath.str());
     }
@@ -388,7 +388,7 @@ protected:
         Owned<IRemoteConnection> connection = querySDS().connect(rootPath.str(), myProcessSession(), RTM_LOCK_READ | RTM_CREATE_QUERY, connectionTimeout);
         Owned<IPropertyTree> root(connection->queryRoot()->getBranch(xpath.str()));
         if(root)
-            nameBranch.setown(createPTree(root));
+            nameBranch.setown(createPTreeFromIPT(root));
         if(subscribeAfter)
             subscribe(fullPath.str());
     }

--- a/esp/bindings/SOAP/ws_ecl_client/ws_ecl_client_bind.hpp
+++ b/esp/bindings/SOAP/ws_ecl_client/ws_ecl_client_bind.hpp
@@ -352,7 +352,7 @@ public:
             // child elements
             if (m_children.length())
             {
-                Owned<IPropertyTree> pChildIndexMap = createPTree(false);
+                Owned<IPropertyTree> pChildIndexMap = createPTree();
                 ForEachItemIn(idx, m_children)
                 {
                     CClientRequestNode* child = (CClientRequestNode *)m_children.item(idx);
@@ -439,7 +439,7 @@ public:
 
     virtual void appendSerializedContent(const char* content) 
     { 
-        Owned<IPropertyTree> pTree = createPTreeFromXMLString(content, false);
+        Owned<IPropertyTree> pTree = createPTreeFromXMLString(content);
         Owned<IPTreeIterator> it = pTree->getElements("*");
         // NOTE: this does not support hierarchy yet (which is sufficient for flat style roxie request).
         ForEach(*it)

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -153,7 +153,7 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
                         realm = srv_cfg->queryProp("@type");
                         const char *ssfile=srv_cfg->queryProp("@subservices");
                         if (ssfile && checkFileExists(ssfile))
-                            m_subservices.setown(loadPropertyTree(ssfile, true));
+                            m_subservices.setown(createPTreeFromXMLFile(ssfile, ipt_caseInsensitive));
                     }
                 }
                 
@@ -811,7 +811,7 @@ static void filterXmlBySchema(IPTree* in, IXmlType* type, const char* tag, Strin
 static void filterXmlBySchema(StringBuffer& in, StringBuffer& schema, StringBuffer& out)
 {
     Owned<IXmlSchema> sp = createXmlSchema(schema);
-    Owned<IPTree> tree = createPTreeFromXMLString(in,false);
+    Owned<IPTree> tree = createPTreeFromXMLString(in);
 
     //VStringBuffer name("tns:%s", tree->queryName());
     const char* name = tree->queryName();
@@ -927,7 +927,7 @@ static void filterXmlBySchema(IPTree* in, IXmlType* type, const char* tag, Strin
 static void filterXmlBySchema(StringBuffer& in, StringBuffer& schema, StringBuffer& out,int indent)
 {
     Owned<IXmlSchema> sp = createXmlSchema(schema);
-    Owned<IPTree> tree = createPTreeFromXMLString(in,false);
+    Owned<IPTree> tree = createPTreeFromXMLString(in);
 
     //VStringBuffer name("tns:%s", tree->queryName());
     const char* name = tree->queryName();
@@ -1235,7 +1235,7 @@ bool EspHttpBinding::getSchema(StringBuffer& schema, IEspContext &ctx, CHttpRequ
     const char *sqName = serviceQName.str();
     const char *mqName = methodQName.str();
 
-    Owned<IPropertyTree> namespaces = createPTree(false);
+    Owned<IPropertyTree> namespaces = createPTree();
     appendSchemaNamespaces(namespaces, ctx, req, service, method);
     Owned<IPropertyTreeIterator> nsiter = namespaces->getElements("namespace");
 
@@ -2130,7 +2130,7 @@ int EspHttpBinding::onGetForm(IEspContext &context, CHttpRequest* request, CHttp
                           
 int EspHttpBinding::formatHtmlResultSet(IEspContext &context, const char *serv, const char *method, const char *resultsXml, StringBuffer &html)
 {
-    Owned<IPropertyTree> ptree = createPTreeFromXMLString(resultsXml, false);
+    Owned<IPropertyTree> ptree = createPTreeFromXMLString(resultsXml);
     
     Owned<IPropertyTreeIterator> exceptions = ptree->getElements("//Exception");
     ForEach(*exceptions.get())
@@ -2305,7 +2305,7 @@ void EspHttpBinding::validateResponse(IEspContext& context, CHttpRequest* reques
     // XML
     Owned<IPropertyTree> tree; 
     try {
-        tree.setown(createPTreeFromXMLString(content.length(), content.toByteArray(),false));
+        tree.setown(createPTreeFromXMLString(content.length(), content.toByteArray()));
         // format it for better error message
         toXML(tree, xml, 1);
 
@@ -2354,8 +2354,8 @@ void EspHttpBinding::validateResponse(IEspContext& context, CHttpRequest* reques
     v->setSchemaSource(xsd, strlen(xsd));
     v->setTargetNamespace(ns);
 
-    Owned<IPropertyTree> result = createPTree("ModifiedResponse",false);
-    IPropertyTree* e = createPTree(false);
+    Owned<IPropertyTree> result = createPTree("ModifiedResponse");
+    IPropertyTree* e = createPTree();
     try {
         v->validate();
         e->appendProp("Result", "No error found");

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -316,7 +316,7 @@ void CHttpMessage::addRawXMLParameter(const char* path, const char *value)
     Owned<IPropertyTree> tree;
     try
     {
-        tree.setown(createPTreeFromXMLString(value, false));
+        tree.setown(createPTreeFromXMLString(value));
     }
     catch(IException* e)
     {

--- a/esp/bindings/http/platform/msgbuilder.cpp
+++ b/esp/bindings/http/platform/msgbuilder.cpp
@@ -53,7 +53,7 @@
 //  ===========================================================================
 CSoapMsgBuilder::CSoapMsgBuilder(const char * xml)
 {
-    m_properties.setown(createPTreeFromXMLString(xml, false));
+    m_properties.setown(createPTreeFromXMLString(xml));
 }
 
 void CSoapMsgBuilder::setPropertyValue(const char * key, const char * val)
@@ -130,7 +130,7 @@ StringBuffer & CSoapMsgArrayBuilder::getSoapResponse(StringBuffer & soapResponse
 
 CSoapMsgXsdBuilder::CSoapMsgXsdBuilder(const char * structLabel, const char * var)
 {
-    m_properties.set(createPTree(structLabel, false));
+    m_properties.set(createPTree(structLabel));
     m_structLabel.append(structLabel);
     m_var.append(var);
 }
@@ -196,7 +196,7 @@ const char * CSoapMsgXsdBuilder::getXsdTypeLabel(XSD_TYPES type)
 
 CSoapMsgBuilder * CSoapMsgXsdBuilder::newMsgBuilder()
 {
-    Owned<IPropertyTree>newXml = createPTree(m_structLabel.str(), false);
+    Owned<IPropertyTree>newXml = createPTree(m_structLabel.str());
 
     IPropertyTreeIterator * itr = m_properties->getElements("*");
     itr->first();

--- a/esp/clients/LoggingClient/LogThread.cpp
+++ b/esp/clients/LoggingClient/LogThread.cpp
@@ -327,7 +327,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int Reco
 {
     StringBuffer dataStr;
     serializeRequest(context,logInfo,dataStr);
-    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(dataStr.str());
+    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(dataStr.str(), ipt_none, xr_none);
     return queueLog(context,serviceName,RecordsReturned,LogArray, *pLogTreeInfo);
 }
 
@@ -339,7 +339,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int Reco
 
     serializeRequest(context,logInfo,_LogStruct.RequestStr);
 
-    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(_LogStruct.RequestStr.str());
+    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(_LogStruct.RequestStr.str(), ipt_none, xr_none);
 
 
     addLogInfo(LogArray,*pLogTreeInfo.get());
@@ -530,7 +530,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int Reco
 
 bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int RecordsReturned,IArrayOf<IEspLogInfo>& LogArray, StringBuffer& logInfo)
 {
-    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(logInfo);
+    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(logInfo, ipt_none, xr_none);
     return queueLog(context,serviceName,RecordsReturned,LogArray, *pLogTreeInfo.get());
 }
 
@@ -549,7 +549,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName, const c
     else
         context.getRealm(UserRealm);
 
-    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(request);
+    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(request, ipt_none, xr_none);
     IArrayOf<IEspLogInfo> LogArray;
     addLogInfo(LogArray, *pLogTreeInfo.get());
 
@@ -569,7 +569,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName, const c
 bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int RecordsReturned, const char* logInfo)
 {
     try {
-        Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(logInfo);
+        Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(logInfo, ipt_none, xr_none);
         return queueLog(context,serviceName,RecordsReturned,*pLogTreeInfo);
     } catch (IException* e) {
         StringBuffer msg;
@@ -922,7 +922,7 @@ IClientLOGServiceUpdateRequest* CLogThread::DeserializeRequest(const char* reque
     m_LogFailSafe->SplitLogRecord(requestStr,GUID,Cache);
     _Info.GUID = GUID.str();
 
-    Owned<IPropertyTree> pLogTree = createPTreeFromXMLString(Cache.str());
+    Owned<IPropertyTree> pLogTree = createPTreeFromXMLString(Cache.str(), ipt_none, xr_none);
     pRequest->setUserName(pLogTree->queryProp("UserName"));
     pRequest->setDomainName(pLogTree->queryProp("DomainName"));
     pRequest->setRecordCount(pLogTree->getPropInt("RecordCount"));

--- a/esp/clients/LoggingClient/LogThread.cpp
+++ b/esp/clients/LoggingClient/LogThread.cpp
@@ -327,7 +327,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int Reco
 {
     StringBuffer dataStr;
     serializeRequest(context,logInfo,dataStr);
-    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(dataStr.str(), false,false);
+    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(dataStr.str());
     return queueLog(context,serviceName,RecordsReturned,LogArray, *pLogTreeInfo);
 }
 
@@ -339,7 +339,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int Reco
 
     serializeRequest(context,logInfo,_LogStruct.RequestStr);
 
-    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(_LogStruct.RequestStr.str(), false, false);
+    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(_LogStruct.RequestStr.str());
 
 
     addLogInfo(LogArray,*pLogTreeInfo.get());
@@ -530,7 +530,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int Reco
 
 bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int RecordsReturned,IArrayOf<IEspLogInfo>& LogArray, StringBuffer& logInfo)
 {
-    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(logInfo, false,false);
+    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(logInfo);
     return queueLog(context,serviceName,RecordsReturned,LogArray, *pLogTreeInfo.get());
 }
 
@@ -549,7 +549,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName, const c
     else
         context.getRealm(UserRealm);
 
-    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(request, false,false);
+    Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(request);
     IArrayOf<IEspLogInfo> LogArray;
     addLogInfo(LogArray, *pLogTreeInfo.get());
 
@@ -569,7 +569,7 @@ bool CLogThread::queueLog(IEspContext & context,const char* serviceName, const c
 bool CLogThread::queueLog(IEspContext & context,const char* serviceName,int RecordsReturned, const char* logInfo)
 {
     try {
-        Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(logInfo, false,false);
+        Owned<IPropertyTree> pLogTreeInfo = createPTreeFromXMLString(logInfo);
         return queueLog(context,serviceName,RecordsReturned,*pLogTreeInfo);
     } catch (IException* e) {
         StringBuffer msg;
@@ -922,7 +922,7 @@ IClientLOGServiceUpdateRequest* CLogThread::DeserializeRequest(const char* reque
     m_LogFailSafe->SplitLogRecord(requestStr,GUID,Cache);
     _Info.GUID = GUID.str();
 
-    Owned<IPropertyTree> pLogTree = createPTreeFromXMLString(Cache.str(), false,false);
+    Owned<IPropertyTree> pLogTree = createPTreeFromXMLString(Cache.str());
     pRequest->setUserName(pLogTree->queryProp("UserName"));
     pRequest->setDomainName(pLogTree->queryProp("DomainName"));
     pRequest->setRecordCount(pLogTree->getPropInt("RecordCount"));

--- a/esp/esdl/esdl2ecl.cpp
+++ b/esp/esdl/esdl2ecl.cpp
@@ -60,7 +60,7 @@ public:
     
     EsdlIndexedPropertyTrees()
     {
-        all.setown(createPTree("ESDL_files", false));
+        all.setown(createPTree("ESDL_files"));
     }
 
     ~EsdlIndexedPropertyTrees()
@@ -108,7 +108,7 @@ public:
             }
             FileName.append(srcfile).append(".xml");
 
-            IPropertyTree *src = createPTreeFromXMLFile(FileName.str(), false);
+            IPropertyTree *src = createPTreeFromXMLFile(FileName.str());
             if (!src)
             {
                 StringBuffer msg("EsdlInclude file not found - ");
@@ -319,12 +319,12 @@ void addFlatTagList(EsdlIndexedPropertyTrees &trees, IPropertyTree &dst, IProper
             if (flat_tag && *flat_tag)
             {
                 xml.appendf("<InputTag flat_name=\"%s\" path=\"%s/%s\" type=\"%s\"/>", flat_tag, path.str(), item.queryProp("@name"), item.queryProp("@type"));
-                dst.addPropTree("InputTag", createPTreeFromXMLString(xml.str(), false));
+                dst.addPropTree("InputTag", createPTreeFromXMLString(xml.str()));
             }
             else
             {
                 xml.appendf("<NoInputTag path=\"%s/%s\" type=\"%s\"/>", path.str(), item.queryProp("@name"), item.queryProp("@type"));
-                dst.addPropTree("NoInputTag", createPTreeFromXMLString(xml.str(), false));
+                dst.addPropTree("NoInputTag", createPTreeFromXMLString(xml.str()));
             }
 
         }

--- a/esp/esdl/esdl_transformer.cpp
+++ b/esp/esdl/esdl_transformer.cpp
@@ -1223,7 +1223,7 @@ int EsdlTransformer::process(IEspContext &ctx, EsdlProcessMode mode, const char 
                 EsdlRequest *rootreq = dynamic_cast<EsdlRequest *>(*root);
                 if (rootreq)
                 {
-                    Owned<IPropertyTree> req=createPTreeFromXMLString(out.str(), false);
+                    Owned<IPropertyTree> req=createPTreeFromXMLString(out.str());
                     rootreq->addDefaults(req);
                     toXML(req.get(), out.clear());
                 }
@@ -1361,7 +1361,7 @@ void EsdlTransformer::ptreeLoadInclude(const char *srcfile)
         StringBuffer FileName("esdl_files/");
         FileName.append(srcfile).append(".xml");
 
-        IPropertyTree *src = createPTreeFromXMLFile(FileName.str(), false);
+        IPropertyTree *src = createPTreeFromXMLFile(FileName.str());
         if (!src)
         {
             StringBuffer msg("EsdlInclude file not found - ");
@@ -1408,7 +1408,7 @@ void EsdlTransformer::loadFromFile(const char *file, StringArray *types)
 
 void EsdlTransformer::loadFromFiles(StringArray &files, StringArray *types)
 {
-    Owned<IPropertyTree> esdlxml = createPTree(false);
+    Owned<IPropertyTree> esdlxml = createPTree();
     ForEachItemIn(idx, files)
         ptreeLoadInclude(files.item(idx));
     load(types);
@@ -1418,7 +1418,7 @@ void EsdlTransformer::loadFromString(const char *xml)
 {
     DBGLOG("ESDL Loading from xml string");
 
-    IPropertyTree *src = createPTreeFromXMLString(xml, false);
+    IPropertyTree *src = createPTreeFromXMLString(xml);
 
     if (!src)
         throw MakeStringException(-1, "ESDL Initialization Error loading xml string: %s", xml);

--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -359,7 +359,7 @@ void CEspConfig::initDali(const char *servers)
 
 void CEspConfig::initPtree(const char *location, bool isDali)
 {
-    IPropertyTree* cfg = createPTreeFromXMLFile(location, true);
+    IPropertyTree* cfg = createPTreeFromXMLFile(location, ipt_caseInsensitive);
     if (cfg)
     {
         cfg->addProp("@config", location);
@@ -425,7 +425,7 @@ void CEspConfig::loadBinding(binding_cfg &xcfg)
                 xcfg.bind.setown(bind);
                 if (serverstatus)
                 {
-                    IPropertyTree *stTree= serverstatus->queryProperties()->addPropTree("ESPservice", createPTree("ESPservice", true));
+                    IPropertyTree *stTree= serverstatus->queryProperties()->addPropTree("ESPservice", createPTree("ESPservice", ipt_caseInsensitive));
                     if (stTree)
                     {
                         stTree->setProp("@type", xcfg.service->getServiceType());

--- a/esp/platform/espp.cpp
+++ b/esp/platform/espp.cpp
@@ -286,7 +286,7 @@ int init_main(int argc, char* argv[])
         if(!cfgfile || !*cfgfile)
             cfgfile = "esp.xml";
 
-        Owned<IPropertyTree> envpt= createPTreeFromXMLFile(cfgfile, true);
+        Owned<IPropertyTree> envpt= createPTreeFromXMLFile(cfgfile, ipt_caseInsensitive);
         Owned<IPropertyTree> procpt = NULL;
         if (envpt)
         {

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -167,7 +167,7 @@ const StringBuffer &CEspApplicationPort::getNavBarContent(IEspContext &context, 
 {
     if (xslp)
     {
-        Owned<IPropertyTree> navtree=createPTree("EspNavigationData", false);
+        Owned<IPropertyTree> navtree=createPTree("EspNavigationData");
         int count = getBindingCount();
         for (int idx = 0; idx<count; idx++)
             bindings[idx]->queryBinding()->getNavigationData(context, *navtree.get());
@@ -209,7 +209,7 @@ const StringBuffer &CEspApplicationPort::getNavBarContent(IEspContext &context, 
 const StringBuffer &CEspApplicationPort::getDynNavData(IEspContext &context, IProperties *params, StringBuffer &content, 
                                                        StringBuffer &contentType, bool& bVolatile)
 {
-    Owned<IPropertyTree> navtree=createPTree("EspDynNavData", false);
+    Owned<IPropertyTree> navtree=createPTree("EspDynNavData");
     bVolatile = false;
     int count = getBindingCount();
     for (int idx = 0; idx<count; idx++)
@@ -344,7 +344,7 @@ IPropertyTree *CEspBinding::ensureNavFolder(IPropertyTree &root, const char *nam
     IPropertyTree *ret = root.queryPropTree(xpath.str());
     if (!ret)
     {
-        ret=createPTree("Folder", false);
+        ret=createPTree("Folder");
         ret->addProp("@name", name);
         ret->addProp("@tooltip", tooltip);
         ret->setProp("@menu", menuname);
@@ -365,7 +365,7 @@ IPropertyTree *CEspBinding::ensureNavMenu(IPropertyTree &root, const char *name)
     IPropertyTree *ret = root.queryPropTree(xpath.str());
     if (!ret)
     {
-        ret=createPTree("Menu", false);
+        ret=createPTree("Menu");
         ret->addProp("@name", name);
         root.addPropTree("Menu", ret);
     }
@@ -379,7 +379,7 @@ IPropertyTree *CEspBinding::ensureNavMenuItem(IPropertyTree &root, const char *n
     IPropertyTree *ret = root.queryPropTree(xpath.str());
     if (!ret)
     {
-        ret=createPTree("MenuItem", false);
+        ret=createPTree("MenuItem");
         ret->addProp("@name", name);
         ret->addProp("@tooltip", tooltip);
         ret->addProp("@action", action);
@@ -396,7 +396,7 @@ IPropertyTree *CEspBinding::ensureNavDynFolder(IPropertyTree &root, const char *
     IPropertyTree *ret = root.queryPropTree(xpath.str());
     if (!ret)
     {
-        ret=createPTree("DynamicFolder", false);
+        ret=createPTree("DynamicFolder");
         ret->addProp("@name", name);
         ret->addProp("@tooltip", tooltip);
         ret->addProp("@params", params);
@@ -423,7 +423,7 @@ IPropertyTree *CEspBinding::ensureNavLink(IPropertyTree &folder, const char *nam
     }
 
     if (addNew)
-        ret=createPTree("Link", false);
+        ret=createPTree("Link");
 
     ret->setProp("@name", name);
     ret->setProp("@tooltip", tooltip);
@@ -442,7 +442,7 @@ IPropertyTree *CEspBinding::ensureNavLink(IPropertyTree &folder, const char *nam
 
 IPropertyTree *CEspBinding::addNavException(IPropertyTree &folder, const char *message/*=NULL*/, int code/*=0*/, const char *source/*=NULL*/)
 {
-    IPropertyTree *ret = folder.addPropTree("Exception", createPTree(false));
+    IPropertyTree *ret = folder.addPropTree("Exception", createPTree());
     ret->addProp("@message", message ? message : "Unknown exception");
     ret->setPropInt("@code", code); 
     ret->setProp("@source", source);
@@ -464,7 +464,7 @@ void CEspBinding::getNavigationData(IEspContext &context, IPropertyTree & data)
         if (params.length())
             params.setCharAt(0,'&');
         
-        IPropertyTree *folder=createPTree("Folder", false);
+        IPropertyTree *folder=createPTree("Folder");
         folder->addProp("@name", serviceName.str());
         folder->addProp("@info", serviceName.str());
         folder->addProp("@urlParams", params.str());
@@ -476,7 +476,7 @@ void CEspBinding::getNavigationData(IEspContext &context, IPropertyTree & data)
         ForEachItemIn(idx, methods)
         {
             CMethodInfo &method = methods.item(idx);
-            IPropertyTree *link=createPTree("Link", false);
+            IPropertyTree *link=createPTree("Link");
             link->addProp("@name", method.m_label.str());
             link->addProp("@info", method.m_label.str());
             StringBuffer path;

--- a/esp/services/WsDeploy/WsDeployEngine.cpp
+++ b/esp/services/WsDeploy/WsDeployEngine.cpp
@@ -86,9 +86,9 @@ m_bEnvUpdated(false),
 m_errorCount(0),
 m_version(version),
 m_depInfo(deployInfo),
-m_pDeploy(createPTreeFromXMLString(selComps, false))
+m_pDeploy(createPTreeFromXMLString(selComps))
 {
-  m_pResponseXml.setown( createPTreeFromXMLString(selComps, false) );
+  m_pResponseXml.setown( createPTreeFromXMLString(selComps) );
 
   if (!m_pResponseXml)
     return;
@@ -101,7 +101,7 @@ m_pDeploy(createPTreeFromXMLString(selComps, false))
     if (pTasks)
       pComp->removeTree(pTasks);
 
-    pTasks =    pComp->addPropTree("Tasks", createPTree(false));
+    pTasks =    pComp->addPropTree("Tasks", createPTree());
 
     Owned<IPropertyTreeIterator> itInstances = pComp->getElements("Instance");
 
@@ -138,7 +138,7 @@ m_version(1)
   CDeployInfo& depInfo = dynamic_cast<CDeployInfo&>( deployInfo );
   depInfo.serialize(ctx,xml);
 
-  m_pResponseXml.setown( createPTreeFromXMLString(xml.str(), false) );
+  m_pResponseXml.setown( createPTreeFromXMLString(xml.str()) );
   m_pSelComps = m_pResponseXml->queryPropTree("Components");
 
   //save a copy of component in request into our internal tree that we maintain and 
@@ -152,7 +152,7 @@ m_version(1)
     if (pTasks)
       pComp->removeTree(pTasks);
 
-    pTasks =    pComp->addPropTree("Tasks", createPTree(false));
+    pTasks =    pComp->addPropTree("Tasks", createPTree());
 
     string key;
     //key += comp.getType();
@@ -173,8 +173,8 @@ void CWsDeployEngine::initComponents(IArrayOf<IConstComponent>& components)
 {
   unsigned int nComps = components.ordinality();
 
-  m_pDeploy.set(createPTree("Deploy", false));
-  IPropertyTree* pComps = m_pDeploy->addPropTree("SelectedComponents", createPTree(false));
+  m_pDeploy.set(createPTree("Deploy"));
+  IPropertyTree* pComps = m_pDeploy->addPropTree("SelectedComponents", createPTree());
 
   for (unsigned int i=0; i<nComps; i++)
   {
@@ -192,11 +192,11 @@ void CWsDeployEngine::initComponents(IArrayOf<IConstComponent>& components)
     IPropertyTree* pComp = pComps->queryPropTree(xpath.str());
     if (!pComp)
     {
-      pComp = pComps->addPropTree(type, createPTree(false));
+      pComp = pComps->addPropTree(type, createPTree());
       pComp->addProp("@name", name);
     }
     const char* instType = comp.getInstanceType();
-    IPropertyTree* pInst = pComp->addPropTree(instType, createPTree(false));
+    IPropertyTree* pInst = pComp->addPropTree(instType, createPTree());
     pInst->addProp("@name", comp.getInstance());
     pInst->addProp("@computer", comp.getComputer());
   }
@@ -556,7 +556,7 @@ void CWsDeployEngine::printStatus(IDeployTask* task)
 
   if (!pTask)
   {
-    pTask = pTasks->addPropTree("Task", createPTree(false));
+    pTask = pTasks->addPropTree("Task", createPTree());
     pTask->setPropInt64("@id", (__int64)task);
 
     const char* sourceFile = task->getFileName(DT_SOURCE);
@@ -613,7 +613,7 @@ void CWsDeployEngine::printStatus(StatusType type, const char* processType, cons
   {
     IPropertyTree* pTasks = findTasksForComponent(process, instance);
 
-    IPropertyTree* pTask = pTasks->addPropTree("Task", createPTree(false));
+    IPropertyTree* pTask = pTasks->addPropTree("Task", createPTree());
     //pTask->setProp( "Caption",    buf );
     pTask->setProp( "Message",  buf );
     pTask->setPropInt("Status",type);

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -208,7 +208,7 @@ void expandRange(IPropertyTree* pComputers)
 
         for(unsigned i = 0 ; i < ipList.ordinality(); i++)
         {
-          IPropertyTree* pElem = pComputers->addPropTree(XML_TAG_COMPUTER,createPTree(false));
+          IPropertyTree* pElem = pComputers->addPropTree(XML_TAG_COMPUTER,createPTree());
           pElem->addProp(XML_ATTR_NETADDRESS,ipList.item(i));
         }
 
@@ -382,12 +382,12 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
     Owned<IPropertyTree> pEnvRoot = getEnvTree(context, &req.getReqInfo());
     IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree(XML_TAG_SOFTWARE);
 
-    Owned<IPropertyTree> pDeploy = createPTree("Deploy", false);
-    IPropertyTree* pComponents = pDeploy->addPropTree("Components", createPTree(false));
+    Owned<IPropertyTree> pDeploy = createPTree("Deploy");
+    IPropertyTree* pComponents = pDeploy->addPropTree("Components", createPTree());
 
     if (pEnvSoftware)
     {
-      Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+      Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
       IPropertyTree* pSoftwareFolder = pSrcTree->queryPropTree("Folder[@name='Environment']/Folder[@name='Software']");
 
       if (pSoftwareFolder)
@@ -508,12 +508,12 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
       </SelectedComponents>
       </Deploy>
       */
-      Owned<IPropertyTree> pDeploy = createPTree("Deploy", false);
-      IPropertyTree* pComponents = pDeploy->addPropTree("Components", createPTree(false));
+      Owned<IPropertyTree> pDeploy = createPTree("Deploy");
+      IPropertyTree* pComponents = pDeploy->addPropTree("Components", createPTree());
 
       if (xmlArg && *xmlArg)
       {
-        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString( xmlArg, false);
+        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString( xmlArg);
         IPropertyTree* pComputersFolder = pSrcTree->queryPropTree("Folder[@name='Environment']/Folder[@name='Hardware']/Folder[@name='Computers']");
 
         if (pComputersFolder)
@@ -557,7 +557,7 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
           if (m_bCloud)
           {
             StringBuffer sbMsg;
-            Owned<IPropertyTree> pComputers = createPTreeFromXMLString(xmlArg, false);
+            Owned<IPropertyTree> pComputers = createPTreeFromXMLString(xmlArg);
             
             CCloudActionHandler lockCloud(this, CLOUD_LOCK_ENV, CLOUD_UNLOCK_ENV, sbName.str(), "8015", pComputers);
             bool ret = lockCloud.start(sbMsg);
@@ -595,7 +595,7 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
           StringBuffer sbxml;
           if (m_pFileIO.get())
           {
-            Owned <IPropertyTree> pTree = createPTree(*m_pFileIO, false);
+            Owned <IPropertyTree> pTree = createPTree(*m_pFileIO);
             toXML(pTree, sbxml);
           }
           else
@@ -692,7 +692,7 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
 
         if (!stricmp(m_userWithLock.str(), sbUser.str()) && !stricmp(sbUserIp.str(), m_userIp.str()))
         {
-          Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+          Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
           IPropertyTree* pSaveEnv = pSrcTree->queryPropTree("SaveEnv[@flag='true']");
 
           if (pSaveEnv)
@@ -807,7 +807,7 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
       sbUser.clear().append(req.getReqInfo().getUserId());
       context.getPeer(sbIp);
       const char* xmlArg = req.getXmlArgs();
-      Owned<IPropertyTree> pParamTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+      Owned<IPropertyTree> pParamTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
       const char* envSaveAs = pParamTree->queryProp("@envSaveAs");
       if (envSaveAs && *envSaveAs)
       {
@@ -926,7 +926,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
   IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree(XML_TAG_SOFTWARE);
   IPropertyTree* pEnvHardware = pEnvRoot->queryPropTree(XML_TAG_HARDWARE);
 
-  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
   IPropertyTree* pSoftwareFolder = pSrcTree->queryPropTree("Setting[@category='Software']");
   IPropertyTree* pTopologyFolder = pSrcTree->queryPropTree("Setting[@category='Topology']");
   IPropertyTree* pHardwareFolder = pSrcTree->queryPropTree("Setting[@category='Hardware']");
@@ -1093,7 +1093,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
                   pBuildSet = &buildSetIter->query();
                 else if (!strcmp(pszCompType, "Directories"))
                 {      
-                  pBuildSet = createPTree(XML_TAG_BUILDSET, false);
+                  pBuildSet = createPTree(XML_TAG_BUILDSET);
                   pBuildSet->addProp(XML_ATTR_NAME, pszCompName);
                   pBuildSet->addProp(XML_ATTR_SCHEMA, "directories.xsd");
                   pBuildSet->addProp(XML_ATTR_PROCESS_NAME, "Directories");
@@ -1144,13 +1144,13 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
                   if (pElem)
                     pComp = pTmpComp->addPropTree(pszSubType, createPTree(pElem));
                   else
-                    pComp = pTmpComp->addPropTree(pszSubType, createPTree(false));
+                    pComp = pTmpComp->addPropTree(pszSubType, createPTree());
 
                   break;
                 }
 
                 if (!pComp)
-                  pComp = pTmpComp->addPropTree(pszSubType, createPTree(false));
+                  pComp = pTmpComp->addPropTree(pszSubType, createPTree());
 
                 if (pComp && !strcmp(pszAttrName, "name"))
                   pComp->setProp(XML_ATTR_NAME, pszNewValue);
@@ -1827,7 +1827,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
           StringBuffer sb, sbMsg;
           {
             sb.clear().appendf("<Computers><Computer netAddress='%s'/></Computers>", pszNewValue);
-            Owned<IPropertyTree> pComputer = createPTreeFromXMLString(sb.str(), false);
+            Owned<IPropertyTree> pComputer = createPTreeFromXMLString(sb.str());
             CCloudActionHandler lockCloud(this, CLOUD_LOCK_ENV, CLOUD_NONE, m_userWithLock.str(), "8015", pComputer);
             bool ret = lockCloud.start(sbMsg.clear());
             if (!ret || sbMsg.length())
@@ -1837,7 +1837,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
           if (pszOldValue && *pszOldValue)
           {
             sb.clear().appendf("<Computers><Computer netAddress='%s'/></Computers>", pszOldValue);
-            Owned<IPropertyTree> pComputer = createPTreeFromXMLString(sb.str(), false);
+            Owned<IPropertyTree> pComputer = createPTreeFromXMLString(sb.str());
             CCloudActionHandler unlockCloud(this, CLOUD_UNLOCK_ENV, CLOUD_NONE, m_userWithLock.str(), "8015", pComputer);
             bool ret = unlockCloud.start(sbMsg.clear());
             if (!ret || sbMsg.length())
@@ -1845,7 +1845,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
               //Unlock the new node.
               {
                 sb.clear().appendf("<Computers><Computer netAddress='%s'/></Computers>", pszNewValue);
-                Owned<IPropertyTree> pComputer = createPTreeFromXMLString(sb.str(), false);
+                Owned<IPropertyTree> pComputer = createPTreeFromXMLString(sb.str());
                 CCloudActionHandler unlockPrevCloud(this, CLOUD_UNLOCK_ENV, CLOUD_NONE, m_userWithLock.str(), "8015", pComputer);
                 ret = unlockPrevCloud.start(sbMsg.clear());
               }
@@ -2332,7 +2332,7 @@ bool CWsDeployFileInfo::rollbackEnvironmentForCloud(IEspContext &context, IEspRo
                 Owned<IFileIO> pFileIO = pFile->open(IFOreadwrite);
                 StringBuffer sbxml;
                 {
-                    Owned <IPropertyTree> pTree = createPTree(*pFileIO, false);
+                    Owned <IPropertyTree> pTree = createPTree(*pFileIO);
                     toXML(pTree, sbxml);
                     setEnvironment(context, &req.getReqInfo(), sbxml, "RollbackEnvironmentForCloud", sbBackup);
                 }
@@ -2734,7 +2734,7 @@ bool CWsDeployFileInfo::getEnvironment(IEspContext &context, IEspGetEnvironmentR
   StringBuffer sb;
   if (m_pFileIO.get())
   {
-    Owned <IPropertyTree> pTree = createPTree(*m_pFileIO, false);
+    Owned <IPropertyTree> pTree = createPTree(*m_pFileIO);
     toXML(pTree, sb);
     resp.setEnvXml(sb.str());
   }
@@ -2783,7 +2783,7 @@ void CWsDeployFileInfo::setEnvironment(IEspContext &context, IConstWsDeployReqIn
     Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
     Owned<IConstEnvironment>    constEnv = factory->loadLocalEnvironment(pszEnv);
 
-    Owned<IPropertyTree> pEnvRoot = createPTreeFromXMLString(pszEnv, false);
+    Owned<IPropertyTree> pEnvRoot = createPTreeFromXMLString(pszEnv);
     Owned<IPropertyTreeIterator> dalis = pEnvRoot->getElements("Software/DaliServerProcess/Instance");
 
     if (validate)
@@ -2897,8 +2897,8 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
   StringBuffer sbDefn, sbViewChildNodes, sbMultiRowNodes;
 
   Owned<IPropertyTree> pEnvRoot = getEnvTree(context, &req.getReqInfo());
-  Owned<IPropertyTree> pSettings = createPTree("Settings", false);
-  Owned<IPropertyTree> pParamTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+  Owned<IPropertyTree> pSettings = createPTree("Settings");
+  Owned<IPropertyTree> pParamTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
   IPropertyTree* pSoftwareFolder = pParamTree->queryPropTree("Component[@parent='Software']");
   IPropertyTree* pBuildFolder = pParamTree->queryPropTree("Component[@name='Programs']");
   IPropertyTree* pHardwareFolder = pParamTree->queryPropTree("Component[@name='Hardware']");
@@ -2939,7 +2939,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
         pBuildSet = &buildSetIter->query();
       else if (!strcmp(pszCompName, "Directories"))
       {      
-        pBuildSet = createPTree(XML_TAG_BUILDSET, false);
+        pBuildSet = createPTree(XML_TAG_BUILDSET);
         pBuildSet->addProp(XML_ATTR_NAME, pszCompName);
         pBuildSet->addProp(XML_ATTR_SCHEMA, "directories.xsd");
         pBuildSet->addProp(XML_ATTR_PROCESS_NAME, "Directories");
@@ -2970,7 +2970,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
       xml.replaceString("\\","\\\\");
 
       //add any missing parameters
-      Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml, false);
+      Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml);
       Owned<IPropertyTree> pNewCompTree = generateTreeFromXsd(pEnvRoot, pSchema, processName, true);
 
       if (pNewCompTree)
@@ -3056,7 +3056,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
 
       if (!strcmp(pszCompType, "Directories"))
       {
-        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml);
         Owned<IPropertyTreeIterator> iterCats = pSrcTree->getElements("Category");
 
         ForEach (*iterCats)
@@ -3073,7 +3073,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
           {
             IPropertyTree* pOver = pCat->queryPropTree("Override[1]");
             if (!pOver)
-              pOver = pCat->addPropTree("Override", createPTree(false));
+              pOver = pCat->addPropTree("Override", createPTree());
             if (!pOver->queryProp("@component"))
               pOver->addProp("@component", "");
             if (!pOver->queryProp("@dir"))
@@ -3088,7 +3088,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
       }
       else if (!strcmp(pszCompType, XML_TAG_THORCLUSTER))
       {
-        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml);
         xpath.clear().append("Topology/Node");
         Owned<IPropertyTreeIterator> iterMNodes = pSrcTree->getElements(xpath.str());
 
@@ -3175,7 +3175,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
       }
       else if (!strcmp(pszCompType, "RoxieCluster"))
       {
-        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml);
         pNewCompTree.setown(generateTreeFromXsd(pEnvRoot, pSchema, processName));
 
         if (!strcmp(pszCompType, "RoxieCluster"))
@@ -3258,7 +3258,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
       }
       else if (!strcmp(pszCompType, XML_TAG_ESPPROCESS))
       {
-        Owned<IPropertyTree> pTree = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> pTree = createPTreeFromXMLString(xml);
         
         Owned<IPropertyTreeIterator> iterBindings = pTree->getElements(XML_TAG_ESPBINDING);
         ForEach (*iterBindings)
@@ -3275,7 +3275,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
 
           if (!flag)
           {
-            IPropertyTree* pAuthFeature = pBinding->addPropTree( "AuthenticateFeature", createPTree(false) );
+            IPropertyTree* pAuthFeature = pBinding->addPropTree( "AuthenticateFeature", createPTree() );
             pAuthFeature->addProp("@authenticate", "");
             pAuthFeature->addProp("@description", "");
             pAuthFeature->addProp("@path", "");
@@ -3293,7 +3293,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
 
           if (!flag)
           {
-            IPropertyTree* pAuth = pBinding->addPropTree( "Authenticate", createPTree(false) );
+            IPropertyTree* pAuth = pBinding->addPropTree( "Authenticate", createPTree() );
             pAuth->addProp("@access", "");
             pAuth->addProp("@description", "");
             pAuth->addProp("@method", "");
@@ -3325,13 +3325,13 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
           }
           
           if (!pInst->hasProp("CSR"))
-            pInst->addPropTree("CSR", createPTree(false));
+            pInst->addPropTree("CSR", createPTree());
 
           if (!pInst->hasProp("Certificate"))
-            pInst->addPropTree("Certificate", createPTree(false));
+            pInst->addPropTree("Certificate", createPTree());
 
           if (!pInst->hasProp("PrivateKey"))
-            pInst->addPropTree("PrivateKey", createPTree(false));
+            pInst->addPropTree("PrivateKey", createPTree());
         }
       
         xml.clear();
@@ -3358,7 +3358,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
     generateHardwareHeaders(pEnvRoot, sbDefn);
     resp.setCompDefn(sbDefn.str());
     StringBuffer sb;
-    Owned<IPropertyTree> multiRowNodes = createPTree("multiRowNodes", false);
+    Owned<IPropertyTree> multiRowNodes = createPTree("multiRowNodes");
     multiRowNodes->addProp("Node", "ComputerType");
     multiRowNodes->addProp("Node", "Domain");
     multiRowNodes->addProp("Node", "Computer");
@@ -3371,9 +3371,9 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
     xml.replaceString("switch=","Switch=");
 
     //add any missing parameters
-    Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml, false);
+    Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xml);
     StringBuffer sbTemp;
-    Owned<IPropertyTree> pNewCompTree = createPTree(XML_TAG_HARDWARE, false);
+    Owned<IPropertyTree> pNewCompTree = createPTree(XML_TAG_HARDWARE);
     generateHardwareHeaders(pEnvRoot, sbTemp, false, pNewCompTree);
     const char* pElemNames[] = {XML_TAG_COMPUTER};
     bool modified = false;
@@ -3459,7 +3459,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
         StringBuffer fileName;
         connectBuildSet(b, bs, fileName, m_Environment);
         fileName.append(bs->queryProp("@installSet"));
-        pParentNode = createPTreeFromXMLFile(fileName.str(), false);
+        pParentNode = createPTreeFromXMLFile(fileName.str());
         pFiles = pParentNode->queryPropTree("File");
       }
 
@@ -3534,7 +3534,7 @@ bool CWsDeployFileInfo::getDeployableComps(IEspContext &context, IEspGetDeployab
   synchronized block(m_mutex);
   Owned<IPropertyTree> pEnvRoot = getEnvTree(context, &req.getReqInfo());
   Owned<IPropertyTreeIterator> iter = pEnvRoot->getElements("Software/*");
-  Owned<IPropertyTree> pDeploy = createPTree("Deploy", false);
+  Owned<IPropertyTree> pDeploy = createPTree("Deploy");
 
   ForEach(*iter)
   {
@@ -3557,7 +3557,7 @@ bool CWsDeployFileInfo::getDeployableComps(IEspContext &context, IEspGetDeployab
 
       if (name && *name && build && *build && bDeployable)
       {
-        IPropertyTree* pCompNode = pDeploy->addPropTree( XML_TAG_COMPONENT, createPTree(false) );
+        IPropertyTree* pCompNode = pDeploy->addPropTree( XML_TAG_COMPONENT, createPTree() );
         pCompNode->addProp(XML_ATTR_NAME, name);
         pCompNode->addProp(XML_ATTR_BUILD,  build); 
         pCompNode->addProp(XML_ATTR_BUILDSET, type);
@@ -3578,7 +3578,7 @@ bool CWsDeployFileInfo::getDeployableComps(IEspContext &context, IEspGetDeployab
               {
                 if (*nodeName != 'R')// || //neither RoxieServerProcess nor RoxieSlaveProcess
                 {
-                  IPropertyTree* pInstanceNode = pCompNode->addPropTree(XML_TAG_INSTANCES, createPTree(false));
+                  IPropertyTree* pInstanceNode = pCompNode->addPropTree(XML_TAG_INSTANCES, createPTree());
                   const char* directory = pNode->queryProp(*nodeName == 'R' ? XML_ATTR_DATADIRECTORY : XML_ATTR_DIRECTORY);
                   if (directory && *directory)
                     pInstanceNode->addProp(XML_ATTR_BUILD, directory);
@@ -3647,8 +3647,8 @@ bool CWsDeployFileInfo::getBuildSetInfo(IEspContext &context, IEspGetBuildSetInf
   const char* xmlArg = req.getXmlArgs();
   Owned<IPropertyTree> pEnvRoot = getEnvTree(context, &req.getReqInfo());
 
-  Owned<IPropertyTree> pSettings = createPTree("Settings", false);
-  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+  Owned<IPropertyTree> pSettings = createPTree("Settings");
+  Owned<IPropertyTree> pSrcTree = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
   IPropertyTree* pBuildSet = pSrcTree->queryPropTree(XML_TAG_BUILDSET);
 
   if (pBuildSet)
@@ -3687,7 +3687,7 @@ bool CWsDeployFileInfo::getBuildSetInfo(IEspContext &context, IEspGetBuildSetInf
         connectBuildSet(b, bs, fileName, m_Environment);
         fileName.append(bs->queryProp("@installSet"));
 
-        pParentNode = createPTreeFromXMLFile(fileName.str(), false);
+        pParentNode = createPTreeFromXMLFile(fileName.str());
         pFiles = pParentNode->queryPropTree("File");
       }
 
@@ -3707,8 +3707,8 @@ bool CWsDeployFileInfo::importBuild(IEspContext &context, IEspImportBuildRequest
   checkForRefresh(context, &req.getReqInfo(), true);
 
   const char* xmlArg = req.getBuildSets();
-  IPropertyTree* buildSets = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<BuildSets/>", false);
-  IPropertyTree* buildNode = createPTree(XML_TAG_BUILD, false);
+  IPropertyTree* buildSets = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<BuildSets/>");
+  IPropertyTree* buildNode = createPTree(XML_TAG_BUILD);
   const char* buildName = buildSets->queryProp(XML_ATTR_NAME);
   const char* buildUrl = buildSets->queryProp("@path");
   buildNode->setProp(XML_ATTR_NAME, buildName);
@@ -3722,7 +3722,7 @@ bool CWsDeployFileInfo::importBuild(IEspContext &context, IEspImportBuildRequest
     const char* bsName = pBuildSet->queryProp(XML_ATTR_NAME);
     const char* bsPath = pBuildSet->queryProp("@path");
 
-    IPropertyTree* pBuildsetNode = createPTree(false);
+    IPropertyTree* pBuildsetNode = createPTree();
     pBuildsetNode->addProp(XML_ATTR_NAME, bsName);
     pBuildsetNode->addProp(XML_ATTR_PATH, bsPath);
     pBuildsetNode->addProp(XML_ATTR_INSTALLSET, "deploy_map.xml");
@@ -3757,7 +3757,7 @@ bool CWsDeployFileInfo::importBuild(IEspContext &context, IEspImportBuildRequest
   IPropertyTree* pEnvPrograms = pEnvRoot->queryPropTree(XML_TAG_PROGRAMS);
 
   if (!pEnvPrograms)
-    pEnvPrograms = pEnvRoot->addPropTree(XML_TAG_PROGRAMS, createPTree(false) );
+    pEnvPrograms = pEnvRoot->addPropTree(XML_TAG_PROGRAMS, createPTree() );
 
   pEnvPrograms->addPropTree(XML_TAG_BUILD, buildNode);
   resp.setStatus("true");
@@ -3785,7 +3785,7 @@ bool CWsDeployFileInfo::getBuildServerDirs(IEspContext &context, IEspGetBuildSer
   if (!strcmp(cmd, "SubDirs"))
   {
     Owned<IFile> inFiles = NULL;
-    IPropertyTree* pParentNode = createPTree("BuildServerDirs", false);
+    IPropertyTree* pParentNode = createPTree("BuildServerDirs");
 
     try
     {
@@ -3821,7 +3821,7 @@ bool CWsDeployFileInfo::getBuildServerDirs(IEspContext &context, IEspGetBuildSer
       {
         StringBuffer sb;
         de->modifiedTime.getString(sb);
-        IPropertyTree* pCompNode = pParentNode->addPropTree( "Directory", createPTree(false) );
+        IPropertyTree* pCompNode = pParentNode->addPropTree( "Directory", createPTree() );
         pCompNode->addProp(XML_ATTR_NAME, de->name.get());
         pCompNode->addProp("@modified", sb.str());  
       }
@@ -3835,7 +3835,7 @@ bool CWsDeployFileInfo::getBuildServerDirs(IEspContext &context, IEspGetBuildSer
   else 
   {
     Owned<IFile> inFiles = NULL;
-    IPropertyTree* pParentNode = createPTree("BuildServerComps", false);
+    IPropertyTree* pParentNode = createPTree("BuildServerComps");
 
     if (!strcmp(cmd, "Release"))
       sourceDir.append(PATHSEPCHAR).append("release");
@@ -3893,7 +3893,7 @@ bool CWsDeployFileInfo::getBuildServerDirs(IEspContext &context, IEspGetBuildSer
             Owned<IFile> depfile(createIFile(fileName));
             if(depfile->exists())
             {
-              IPropertyTree* pCompNode = pParentNode->addPropTree("Comp", createPTree(false) );
+              IPropertyTree* pCompNode = pParentNode->addPropTree("Comp", createPTree() );
               pCompNode->addProp(XML_ATTR_NAME, compName.str());
               pCompNode->addProp("@path", sbPath.str());
             }
@@ -3918,7 +3918,7 @@ bool CWsDeployFileInfo::handleComponent(IEspContext &context, IEspHandleComponen
   checkForRefresh(context, &req.getReqInfo(), true);
 
   const char* xmlArg = req.getXmlArgs();
-  Owned<IPropertyTree> pComponents = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<Components/>", false);
+  Owned<IPropertyTree> pComponents = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<Components/>");
 
   const char* operation = req.getOperation();
   StringBuffer sbNewName;
@@ -3998,7 +3998,7 @@ bool CWsDeployFileInfo::handleInstance(IEspContext &context, IEspHandleInstanceR
 
   const char* operation = req.getOperation();
   const char* xmlArg = req.getXmlArgs();
-  Owned<IPropertyTree> instances = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<Instances/>", false);
+  Owned<IPropertyTree> instances = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<Instances/>");
   const char* buildSet = instances->queryProp(XML_ATTR_BUILDSET);
   const char* compName = instances->queryProp("@compName");
   Owned<IPropertyTree> pEnvRoot = getEnvTree(context, &req.getReqInfo());
@@ -4032,7 +4032,7 @@ bool CWsDeployFileInfo::handleInstance(IEspContext &context, IEspHandleInstanceR
         continue;
       }
 
-      IPropertyTree* pNode = pCompTree->addPropTree(XML_TAG_INSTANCE, createPTree(false));
+      IPropertyTree* pNode = pCompTree->addPropTree(XML_TAG_INSTANCE, createPTree());
 
       if (pSchema)
       {
@@ -4151,7 +4151,7 @@ bool CWsDeployFileInfo::handleEspServiceBindings(IEspContext &context, IEspHandl
   checkForRefresh(context, &req.getReqInfo(), true);
 
   const char* xmlArg = req.getXmlArgs();
-  Owned<IPropertyTree> pBindings = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<EspServiceBindings/>", false);
+  Owned<IPropertyTree> pBindings = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<EspServiceBindings/>");
   const char* type = pBindings->queryProp(XML_ATTR_TYPE);
   const char* espName = pBindings->queryProp("@compName");
 
@@ -4345,7 +4345,7 @@ bool CWsDeployFileInfo::handleComputer(IEspContext &context, IEspHandleComputerR
   checkForRefresh(context, &req.getReqInfo(), true);
 
   const char* xmlArg = req.getXmlArgs();
-  Owned<IPropertyTree> pParams = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+  Owned<IPropertyTree> pParams = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
   const char* type = pParams->queryProp(XML_ATTR_TYPE);
   const char* operation = req.getOperation();
   StringBuffer sbNewName;
@@ -4356,7 +4356,7 @@ bool CWsDeployFileInfo::handleComputer(IEspContext &context, IEspHandleComputerR
   if (!strcmp(operation, "New"))
   {
     StringBuffer sbTemp;
-    IPropertyTree* pCompTree = createPTree(XML_TAG_HARDWARE, false);
+    IPropertyTree* pCompTree = createPTree(XML_TAG_HARDWARE);
     generateHardwareHeaders(pEnvRoot, sbTemp, false, pCompTree);
 
     StringBuffer sbNewName(type);
@@ -4453,7 +4453,7 @@ bool CWsDeployFileInfo::handleComputer(IEspContext &context, IEspHandleComputerR
           sb.appendf("<Computer netAddress='%s'/>", pTree->queryProp(XML_ATTR_NETADDRESS));
         }
         sb.append("</Computers>");
-        Owned<IPropertyTree> pComputers = createPTreeFromXMLString(sb.str(), false);
+        Owned<IPropertyTree> pComputers = createPTreeFromXMLString(sb.str());
 
         CCloudActionHandler unlockCloud(this, CLOUD_UNLOCK_ENV, CLOUD_LOCK_ENV, m_userWithLock.str(), "8015", pComputers);
         bool ret = unlockCloud.start(sbMsg);
@@ -4483,7 +4483,7 @@ bool CWsDeployFileInfo::handleTopology(IEspContext &context, IEspHandleTopologyR
   checkForRefresh(context, &req.getReqInfo(), true);
 
   const char* xmlArg = req.getXmlArgs();
-  Owned<IPropertyTree> pParams = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+  Owned<IPropertyTree> pParams = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
   const char* compType = pParams->queryProp("@compType");
   const char* name = pParams->queryProp(XML_ATTR_NAME);
   const char* newType = pParams->queryProp("@newType");
@@ -4550,7 +4550,7 @@ bool CWsDeployFileInfo::handleTopology(IEspContext &context, IEspHandleTopologyR
     else if (!strcmp(newType, "Roxie"))
       sbNewType.clear().append(XML_TAG_ROXIECLUSTER);
 
-    IPropertyTree* pNode = createPTree(sbNewType.str(), false);
+    IPropertyTree* pNode = createPTree(sbNewType.str());
 
     if (!strcmp(sbNewType.str(), XML_TAG_ECLCCSERVERPROCESS) || 
       !strcmp(sbNewType.str(), XML_TAG_ECLAGENTPROCESS) ||
@@ -4619,7 +4619,7 @@ bool CWsDeployFileInfo::handleRows(IEspContext &context, IEspHandleRowsRequest &
   checkForRefresh(context, &req.getReqInfo(), true);
 
   const char* xmlArg = req.getXmlArgs();
-  Owned<IPropertyTree> pParams = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>", false);
+  Owned<IPropertyTree> pParams = createPTreeFromXMLString(xmlArg && *xmlArg ? xmlArg : "<XmlArgs/>");
   const char* buildSet = pParams->queryProp(XML_ATTR_BUILDSET);
   const char* name = pParams->queryProp("@compName");
   const char* rowType = pParams->queryProp("@rowType");
@@ -4657,7 +4657,7 @@ bool CWsDeployFileInfo::handleRows(IEspContext &context, IEspHandleRowsRequest &
         IPropertyTree* pOver = pCat->queryPropTree("Override[@component=''][@dir=''][@instance='']");
         if (!pOver)
         {
-          pOver = pCat->addPropTree("Override", createPTree(false));
+          pOver = pCat->addPropTree("Override", createPTree());
           pOver->addProp("@component", "");
           pOver->addProp("@dir", "");
           pOver->addProp("@instance", "");
@@ -4985,7 +4985,7 @@ void CWsDeployFileInfo::addInstance(IPropertyTree* pDst,  const char* comp, cons
                               const char* compName, const char* build, const char* instType, 
                               const char* instName, const char* computer)
 {
-  IPropertyTree* pCompNode = pDst->addPropTree( XML_TAG_COMPONENT, createPTree(false) );
+  IPropertyTree* pCompNode = pDst->addPropTree( XML_TAG_COMPONENT, createPTree() );
   pCompNode->addProp("Type",                comp);
   pCompNode->addProp("DisplayType", displayType);   
   pCompNode->addProp("Name",                compName);
@@ -5341,9 +5341,9 @@ void CWsDeployFileInfo::unlockEnvironment(IEspContext* context, IConstWsDeployRe
   if (m_bCloud)
   {
     StringBuffer sbMsg;
-    Owned<IPropertyTree> pComputers = createPTreeFromXMLString(xmlArg, false);
-    Owned<IPropertyTree> unlockComputers = createPTree("ComputerList", false);
-    Owned<IPropertyTree> lockComputers = createPTree("ComputerList", false);
+    Owned<IPropertyTree> pComputers = createPTreeFromXMLString(xmlArg);
+    Owned<IPropertyTree> unlockComputers = createPTree("ComputerList");
+    Owned<IPropertyTree> lockComputers = createPTree("ComputerList");
     Owned<IPropertyTreeIterator> iter;
     StringBuffer xpath;
     if (pComputers && pComputers->numChildren() && m_lockedNodesBeforeEnv.get() != NULL)
@@ -5697,7 +5697,7 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite)
   {
     fileExists = false;
     StringBuffer s("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Environment></Environment>");
-    Owned<IPropertyTree> pNewTree = createPTreeFromXMLString(s, false);
+    Owned<IPropertyTree> pNewTree = createPTreeFromXMLString(s);
 
     xpath.clear().appendf("Software/EspProcess/EspService[@name='%s']/LocalConfFile", m_pService->getName());
     const char* pConfFile = m_pService->getCfg()->queryProp(xpath.str());
@@ -5718,7 +5718,7 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite)
 
         try
         {
-          Owned<IPropertyTree> pDefBldSet = createPTreeFromXMLFile(bldSetFile, false);
+          Owned<IPropertyTree> pDefBldSet = createPTreeFromXMLFile(bldSetFile);
           pNewTree->addPropTree(XML_TAG_PROGRAMS, createPTree(pDefBldSet->queryPropTree("./Programs")));
           pNewTree->addPropTree(XML_TAG_SOFTWARE, createPTree(pDefBldSet->queryPropTree("./Software")));
         }
@@ -5731,13 +5731,13 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite)
 
     if(!pNewTree->queryPropTree(XML_TAG_SOFTWARE))
     {
-      pNewTree->addPropTree(XML_TAG_SOFTWARE, createPTree(false));
-      pNewTree->addPropTree("./Software/Directories", createPTreeFromXMLString(DEFAULT_DIRECTORIES, false));
+      pNewTree->addPropTree(XML_TAG_SOFTWARE, createPTree());
+      pNewTree->addPropTree("./Software/Directories", createPTreeFromXMLString(DEFAULT_DIRECTORIES));
     }
-    pNewTree->addPropTree(XML_TAG_HARDWARE, createPTree(false));
+    pNewTree->addPropTree(XML_TAG_HARDWARE, createPTree());
 
     if (!pNewTree->queryPropTree(XML_TAG_PROGRAMS))
-      pNewTree->addPropTree(XML_TAG_PROGRAMS, createPTree(false));
+      pNewTree->addPropTree(XML_TAG_PROGRAMS, createPTree());
 
     toXML(pNewTree, s.clear());
     sbxml.clear().append(s);
@@ -5777,7 +5777,7 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite)
     m_pFileIO.setown(m_pFile->open(IFOreadwrite));
   
     {
-      Owned <IPropertyTree> pTree = createPTree(*m_pFileIO, false);
+      Owned <IPropertyTree> pTree = createPTree(*m_pFileIO);
       toXML(pTree, sbxml.clear());
     }
   }
@@ -5792,7 +5792,7 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite)
 
   if (!pSettings)
   {
-    pSettings = pEnvRoot->addPropTree(XML_TAG_ENVSETTINGS, createPTree(false));
+    pSettings = pEnvRoot->addPropTree(XML_TAG_ENVSETTINGS, createPTree());
     modified = true;
   }
 
@@ -5841,7 +5841,7 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite)
     if (fileExists)
     {
       sbxml.clear();
-      Owned <IPropertyTree> pTree = createPTree(*m_pFileIO, false);
+      Owned <IPropertyTree> pTree = createPTree(*m_pFileIO);
       toXML(pTree, sbxml);
     }
 
@@ -6093,7 +6093,7 @@ bool CWsDeployExCE::onGetValue(IEspContext &context, IEspGetValueRequest &req, I
             sb.append(PATHSEPCHAR).append(it->getName(name.clear()));
             try
             {
-              Owned<IPropertyTree> pTree = createPTreeFromXMLFile(sb.str(), false);
+              Owned<IPropertyTree> pTree = createPTreeFromXMLFile(sb.str());
 
               if (pTree && pTree->queryName() && !strcmp(XML_TAG_ENVIRONMENT, pTree->queryName()))
                 sbMultiple.append(it->getName(name.clear())).append(";");

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -261,7 +261,7 @@ void CWsDeployExCE::init(IPropertyTree *cfg, const char *process, const char *se
     m_lastStarted.setNow();
 
   if (m_pCfg.get() == NULL)
-    m_pCfg.setown(createPTree(cfg));
+    m_pCfg.setown(createPTreeFromIPT(cfg));
   
   if (m_process.length() == 0)
     m_process.append(process);
@@ -1142,7 +1142,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
                     IPropertyTree* pElem = &iterElems->query();
                 
                   if (pElem)
-                    pComp = pTmpComp->addPropTree(pszSubType, createPTree(pElem));
+                    pComp = pTmpComp->addPropTree(pszSubType, createPTreeFromIPT(pElem));
                   else
                     pComp = pTmpComp->addPropTree(pszSubType, createPTree());
 
@@ -1565,7 +1565,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
               Owned<IPropertyTreeIterator> i = pSvcProps->getElements("Authenticate");
               ForEach(*i)
               {
-                IPropertyTree* pAuthCopy = createPTree(&i->query());
+                IPropertyTree* pAuthCopy = createPTreeFromIPT(&i->query());
                 mergeAttributes(pAuthCopy, pCompTree->queryPropTree("Authenticate"));
                 IPropertyTree* pNewNode = pComp->addPropTree("Authenticate", pAuthCopy);
               }
@@ -1573,14 +1573,14 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
               i.setown( pSvcProps->getElements("AuthenticateFeature") );
               ForEach(*i)
               {
-                IPropertyTree* pAuthCopy = createPTree(&i->query());
+                IPropertyTree* pAuthCopy = createPTreeFromIPT(&i->query());
                 mergeAttributes(pAuthCopy, pCompTree->queryPropTree("AuthenticateFeature"));
                 IPropertyTree* pNewNode = pComp->addPropTree("AuthenticateFeature", pAuthCopy);
               }
               i.setown( pSvcProps->getElements("AuthenticateSetting") );
               ForEach(*i)
               {
-                IPropertyTree* pAuthCopy = createPTree(&i->query());
+                IPropertyTree* pAuthCopy = createPTreeFromIPT(&i->query());
                 mergeAttributes(pAuthCopy, pCompTree->queryPropTree("AuthenticateSetting"));
                 IPropertyTree* pNewNode = pComp->addPropTree("AuthenticateSetting", pAuthCopy);
               }
@@ -3028,7 +3028,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
               }
 
               if (!pSrcSubElem)
-                pSrcSubElem = pSrcElem->addPropTree(pSubElem->queryName(), createPTree(pSubElem));
+                pSrcSubElem = pSrcElem->addPropTree(pSubElem->queryName(), createPTreeFromIPT(pSubElem));
             }
           }
         }
@@ -3226,7 +3226,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
 
             if (!pAcl->queryPropTree("Access") && pNewCompTree->queryPropTree("Access"))
             {
-              IPropertyTree* pAccess = pAcl->addPropTree("Access", createPTree(pNewCompTree->queryPropTree("Access")));
+              IPropertyTree* pAccess = pAcl->addPropTree("Access", createPTreeFromIPT(pNewCompTree->queryPropTree("Access")));
 
               Owned<IAttributeIterator> iAttrElem = pNewCompTree->queryPropTree("Access")->getAttributes();
                     ForEach(*iAttrElem)
@@ -3238,7 +3238,7 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
 
             if (!pAcl->queryPropTree("BaseList") && pNewCompTree->queryPropTree("BaseList"))
             {
-              IPropertyTree* pBaseList = pAcl->addPropTree("BaseList", createPTree(pNewCompTree->queryPropTree("BaseList")));
+              IPropertyTree* pBaseList = pAcl->addPropTree("BaseList", createPTreeFromIPT(pNewCompTree->queryPropTree("BaseList")));
               Owned<IAttributeIterator> iAttrElem = pNewCompTree->queryPropTree("BaseList")->getAttributes();
                     ForEach(*iAttrElem)
                     {
@@ -4087,7 +4087,7 @@ bool CWsDeployFileInfo::handleInstance(IEspContext &context, IEspHandleInstanceR
             IPropertyTree* pElem = &iterElems->query();
            
             if (!pNode->queryProp(pElem->queryName()))
-              pNode->addPropTree(pElem->queryName(), createPTree(pElem));
+              pNode->addPropTree(pElem->queryName(), createPTreeFromIPT(pElem));
           }
         }
       }
@@ -5356,7 +5356,7 @@ void CWsDeployFileInfo::unlockEnvironment(IEspContext* context, IConstWsDeployRe
         xpath.clear().appendf(XML_TAG_COMPUTER"["XML_ATTR_NETADDRESS"='%s']", pComputer->queryProp(XML_ATTR_NETADDRESS));
 
         if (!m_lockedNodesBeforeEnv->queryPropTree(xpath.str()))
-          lockComputers->addPropTree(XML_TAG_COMPUTER, createPTree(pComputer));
+          lockComputers->addPropTree(XML_TAG_COMPUTER, createPTreeFromIPT(pComputer));
       }
     }
 
@@ -5371,7 +5371,7 @@ void CWsDeployFileInfo::unlockEnvironment(IEspContext* context, IConstWsDeployRe
         xpath.clear().appendf(XML_TAG_COMPUTER"["XML_ATTR_NETADDRESS"='%s']", pComputer->queryProp(XML_ATTR_NETADDRESS));
 
         if (!pComputers->queryPropTree(xpath.str()))
-          unlockComputers->addPropTree(XML_TAG_COMPUTER, createPTree(pComputer));
+          unlockComputers->addPropTree(XML_TAG_COMPUTER, createPTreeFromIPT(pComputer));
       }
     }
 
@@ -5719,8 +5719,8 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite)
         try
         {
           Owned<IPropertyTree> pDefBldSet = createPTreeFromXMLFile(bldSetFile);
-          pNewTree->addPropTree(XML_TAG_PROGRAMS, createPTree(pDefBldSet->queryPropTree("./Programs")));
-          pNewTree->addPropTree(XML_TAG_SOFTWARE, createPTree(pDefBldSet->queryPropTree("./Software")));
+          pNewTree->addPropTree(XML_TAG_PROGRAMS, createPTreeFromIPT(pDefBldSet->queryPropTree("./Programs")));
+          pNewTree->addPropTree(XML_TAG_SOFTWARE, createPTreeFromIPT(pDefBldSet->queryPropTree("./Software")));
         }
         catch(IException* e)
         {

--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -202,7 +202,7 @@ private:
       m_brokenConnTimeout = brokenConnTimeout;
       StringBuffer sb;
       sb.appendf("<Computers><Computer netAddress='%s'/></Computers>", ip);
-      m_pComputers.setown(createPTreeFromXMLString(sb.str(), false));
+      m_pComputers.setown(createPTreeFromXMLString(sb.str()));
       m_user.clear().append(uname);
     }
     virtual ~CLockerAliveThread() 
@@ -645,7 +645,7 @@ public:
             soapclient->setUsernameToken("soapclient", "", "");
             StringBuffer soapAction, resultbuf;
             int result = soapclient->postRequest("text/xml","", *rpccall.get(), resultbuf, NULL);
-            IPropertyTree* pResult = createPTreeFromXMLString(resultbuf, false);
+            IPropertyTree* pResult = createPTreeFromXMLString(resultbuf);
             StringBuffer xpath;
             xpath.appendf("soap:Body/%sResponse/Msg", getFnString(m_eA));
             const char* msg = pResult->queryProp(xpath.str());

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1528,7 +1528,7 @@ void CWsDfuEx::getDefFile(IUserDescriptor* udesc, const char* FileName,StringBuf
     if(!record)
         throw MakeStringException(ECLWATCH_CANNOT_PARSE_ECL_QUERY, "Failed in parsing ECL query.");
 
-    Owned<IPropertyTree> data = createPropertyTree(true, "Table");
+    Owned<IPropertyTree> data = createPTree("Table", ipt_caseInsensitive);
     exportData(data, record);
 
     const char* fname=strrchr(FileName,':');
@@ -1665,7 +1665,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     df->getModificationTime(dt);
     const char* lname=df->queryLogicalName(), *fname=strrchr(lname,':');
 
-    ////Owned<IPropertyTree> fileDetail = createPTree("FileDetail", false);
+    ////Owned<IPropertyTree> fileDetail = createPTree("FileDetail");
 
     FileDetails.setName(lname);
     FileDetails.setFilename(fname ? fname+1 : lname);
@@ -4586,7 +4586,7 @@ void CWsDfuEx::readColumnsForDisplay(StringBuffer& schemaText, StringArray& colu
     if (schemaText.length() < 1)
         return;
 
-    Owned<IPropertyTree> schema = createPTreeFromXMLString(schemaText.str(),false);
+    Owned<IPropertyTree> schema = createPTreeFromXMLString(schemaText.str());
     if (!schema)
         return;
 
@@ -4625,8 +4625,8 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
 //DBGLOG("First schema returns:%s", schemaText.str());
 //DBGLOG("Second schema returns:%s", schemaText2.str());
 
-    Owned<IPropertyTree> schema = createPTreeFromXMLString(schemaText.str(),false);
-    Owned<IPropertyTree> schema2 = createPTreeFromXMLString(schemaText2.str(),false);
+    Owned<IPropertyTree> schema = createPTreeFromXMLString(schemaText.str());
+    Owned<IPropertyTree> schema2 = createPTreeFromXMLString(schemaText2.str());
     if (!schema || !schema2)
         return;
 
@@ -4850,8 +4850,8 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, StringBuffer dataRow1, StringB
     if (dataRow2.length() < 1)
         return;
 
-    Owned<IPropertyTree> data1 = createPTreeFromXMLString(dataRow1.str(),false);
-    Owned<IPropertyTree> data2 = createPTreeFromXMLString(dataRow2.str(),false);
+    Owned<IPropertyTree> data1 = createPTreeFromXMLString(dataRow1.str());
+    Owned<IPropertyTree> data2 = createPTreeFromXMLString(dataRow2.str());
     if (!data1 || !data2)
         return;
 

--- a/esp/services/ws_dfu/ws_dfuView.cpp
+++ b/esp/services/ws_dfu/ws_dfuView.cpp
@@ -124,10 +124,10 @@ const char * CLogicalView::getXsd()
 {
     if (xsd_.length() == 0)
     {
-        Owned<IPropertyTree> dataset = createPTree("DataSet", true);
+        Owned<IPropertyTree> dataset = createPTree("DataSet", ipt_caseInsensitive);
         dataset->setProp("@xmlns", "urn:hpccsystems:ws:dfu");
 
-        IPropertyTree * schema = createPTree("xsd:schema", true);
+        IPropertyTree * schema = createPTree("xsd:schema", ipt_caseInsensitive);
         schema->setProp("@id", "DFUDataSet");
 //      schema->setProp("@targetNamespace", "http://tempuri.org/colTotals.xsd");
 //      schema->setProp("@elementFormDefault", "qualified");
@@ -137,25 +137,25 @@ const char * CLogicalView::getXsd()
         schema->setProp("@xmlns:xsd", "http://www.w3.org/2001/XMLSchema");
         schema->setProp("@xmlns:msdata", "urn:schemas-microsoft-com:xml-msdata");
 
-        IPropertyTree * element = createPTree("xsd:element", true);
+        IPropertyTree * element = createPTree("xsd:element", ipt_caseInsensitive);
         element->setProp("@name", "DFUDataSet");
         element->setProp("@msdata:IsDataSet", "true");
 
-        IPropertyTree * complexType = createPTree("xsd:complexType", true);
+        IPropertyTree * complexType = createPTree("xsd:complexType", ipt_caseInsensitive);
 
-        IPropertyTree * choice = createPTree("xsd:choice", true);
+        IPropertyTree * choice = createPTree("xsd:choice", ipt_caseInsensitive);
         choice->setProp("@maxOccurs", "unbounded");
 
-        IPropertyTree * element2 = createPTree("xsd:element", true);
+        IPropertyTree * element2 = createPTree("xsd:element", ipt_caseInsensitive);
         element2->setProp("@name", label_.str());
 
-        IPropertyTree * complexType2 = createPTree("xsd:complexType", true);
+        IPropertyTree * complexType2 = createPTree("xsd:complexType", ipt_caseInsensitive);
 
-        IPropertyTree * sequence = createPTree("xsd:sequence", true);
+        IPropertyTree * sequence = createPTree("xsd:sequence", ipt_caseInsensitive);
 
         for (int i = 0; i < rsmd_->getColumnCount(); ++i)
         {
-            IPropertyTree * element3 = createPTree("xsd:element", true);
+            IPropertyTree * element3 = createPTree("xsd:element", ipt_caseInsensitive);
             CStringVal label, type;
             rsmd_->getColumnLabel(label, i);
             element3->setProp("@name", label.str());
@@ -180,7 +180,7 @@ const char * CLogicalView::getXsd()
 
 void CLogicalView::getPage(StringBuffer &page, StringBuffer &state, bool backFlag)
 {
-    Owned<IPropertyTree> dataset = createPTree("dataset", true);
+    Owned<IPropertyTree> dataset = createPTree("dataset", ipt_caseInsensitive);
 
     int prevState = atoi(state.str());
     if (rs_->absolute(prevState))
@@ -193,7 +193,7 @@ void CLogicalView::getPage(StringBuffer &page, StringBuffer &state, bool backFla
             else if (!backFlag && rs_->isAfterLast())
                 break;
 
-            IPropertyTree *datarow = createPTree("table", true);
+            IPropertyTree *datarow = createPTree("table", ipt_caseInsensitive);
             for(int i = 0; i < rsmd_->getColumnCount(); ++i)
             {
                 CStringVal label, val;

--- a/esp/services/ws_dfu/ws_dfuXRefService.cpp
+++ b/esp/services/ws_dfu/ws_dfuXRefService.cpp
@@ -39,7 +39,7 @@ static void appendReplyMessage(StringBuffer &reply, const char *href,const char 
     loop {
         char c=*(s++);
         if (!c||(c=='\n')) {
-            Owned<IPropertyTree> tree = createPTree("Message",false);
+            Owned<IPropertyTree> tree = createPTree("Message");
             tree->addProp("Value",fmsg.str());
             if (href) {
                 tree->addProp("href",href);
@@ -340,7 +340,7 @@ bool CWsDfuXRefEx::onDFUXRefDirectories(IEspContext &context, IEspDFUXRefDirecto
         StringBuffer buf0;
         xRefNode->serializeDirectories(buf0);
 
-        Owned <IPropertyTree> dirs = createPTreeFromXMLString(buf0.str(), false); // Why are we doing this?
+        Owned <IPropertyTree> dirs = createPTreeFromXMLString(buf0.str()); // Why are we doing this?
         Owned<IPropertyTreeIterator> iter = dirs->getElements("Directory");
         ForEach(*iter)
         {
@@ -470,12 +470,12 @@ bool CWsDfuXRefEx::onDFUXRefList(IEspContext &context, IEspDFUXRefListRequest &r
         _topology.getClusterProcessList(eqThorCluster,clusters,false,true);
         ///_topology.getClusterList(eqRoxieCluster,clusters,false,true);
 
-        Owned<IPropertyTree> pXRefNodeTree = createPTree("XRefNodes",false);
+        Owned<IPropertyTree> pXRefNodeTree = createPTree("XRefNodes");
         //DBGLOG("CWsDfuXRefEx::onDFUXRefList1\n");
 
         for (unsigned x=0;x<=clusters.ordinality();x++)
         {
-            IPropertyTree* XRefTreeNode = pXRefNodeTree->addPropTree("XRefNode", createPTree(true));
+            IPropertyTree* XRefTreeNode = pXRefNodeTree->addPropTree("XRefNode", createPTree(ipt_caseInsensitive));
             
             IEspTpCluster* cluster = x<clusters.ordinality()?&clusters.item(x):NULL;        
             const char *clustername = cluster?cluster->getName():"SuperFiles";

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -803,7 +803,7 @@ void CWsEclBinding::buildSampleResponseXml(StringBuffer& msg, IEspContext &conte
 
     Owned<IPropertyTree> xsds_tree;
     if (xsds.length())
-        xsds_tree.setown(createPTreeFromXMLString(xsds.str(), false));
+        xsds_tree.setown(createPTreeFromXMLString(xsds.str()));
 
     if (xsds_tree)
     {
@@ -830,7 +830,7 @@ int CWsEclBinding::getWsEclLinks(IEspContext &context, CHttpRequest* request, CH
 
     Owned<IPropertyTree> xsdtree;
     if (xsds.length())
-        xsdtree.setown(createPTreeFromXMLString(xsds.str(), false));
+        xsdtree.setown(createPTreeFromXMLString(xsds.str()));
 
     if (xsdtree)
     {
@@ -898,7 +898,7 @@ int CWsEclBinding::getWsEcl2TabView(CHttpRequest* request, CHttpResponse* respon
         wsinfo->getSchemas(xsds);
         Owned<IPropertyTree> xsdtree;
         if (xsds.length())
-            xsdtree.setown(createPTreeFromXMLString(xsds.str(), false));
+            xsdtree.setown(createPTreeFromXMLString(xsds.str()));
 
         if (xsdtree)
         {
@@ -952,7 +952,7 @@ void CWsEclBinding::appendSchemaNamespaces(IPropertyTree *namespaces, IEspContex
 
         Owned<IPropertyTree> xsdtree;
         if (xsds.length())
-            xsdtree.setown(createPTreeFromXMLString(xsds.str(), false));
+            xsdtree.setown(createPTreeFromXMLString(xsds.str()));
 
         if (xsdtree)
         {
@@ -965,7 +965,7 @@ void CWsEclBinding::appendSchemaNamespaces(IPropertyTree *namespaces, IEspContex
                 appendNamespaceSpecificString(urn, wsinfo.queryname.get()).append(":result:");
                 appendNamespaceSpecificString(urn, resultname);
                 VStringBuffer nsxml("<namespace nsvar=\"ds%d\" ns=\"%s\" import=\"1\" location=\"../result/%s.xsd\"/>", count++, urn.toLowerCase().str(), resultname);
-                namespaces->addPropTree("namespace", createPTreeFromXMLString(nsxml.str(), false));
+                namespaces->addPropTree("namespace", createPTreeFromXMLString(nsxml.str()));
             }
         }
 }
@@ -1138,7 +1138,7 @@ void appendEclInputXsds(StringBuffer &content, IPropertyTree *xsd, BoolHash &add
 
 void CWsEclBinding::SOAPSectionToXsd(WsWuInfo &wsinfo, const char *parmXml, StringBuffer &schema, bool isRequest, IPropertyTree *xsdtree)
 {
-    Owned<IPropertyTree> tree = createPTreeFromXMLString(parmXml, false, true, NULL, false, true);
+    Owned<IPropertyTree> tree = createPTreeFromXMLString(parmXml, ipt_none, (XmlReaderOptions)(xr_ignoreWhiteSpace|xr_noRoot));
 
     schema.appendf("<xsd:element name=\"%s%s\">", wsinfo.queryname.sget(), isRequest ? "Request" : "Response");
     schema.append("<xsd:complexType>");
@@ -1194,7 +1194,7 @@ int CWsEclBinding::getXsdDefinition(IEspContext &context, CHttpRequest *request,
         wsinfo.getSchemas(xsds);
         Owned<IPropertyTree> xsdtree;
         if (xsds.length())
-            xsdtree.setown(createPTreeFromXMLString(xsds.str(), false));
+            xsdtree.setown(createPTreeFromXMLString(xsds.str()));
 
         //common types
         content.append(
@@ -1281,7 +1281,7 @@ int CWsEclBinding::getXsdDefinition(IEspContext &context, CHttpRequest *request,
 
 bool CWsEclBinding::getSchema(StringBuffer& schema, IEspContext &ctx, CHttpRequest* req, WsWuInfo &wsinfo)
 {
-    Owned<IPropertyTree> namespaces = createPTree(false);
+    Owned<IPropertyTree> namespaces = createPTree();
     appendSchemaNamespaces(namespaces, ctx, req, wsinfo);
     Owned<IPropertyTreeIterator> nsiter = namespaces->getElements("namespace");
     
@@ -1453,7 +1453,7 @@ void buildParametersXml(IPropertyTree *parmtree, IProperties *parms)
 
 void CWsEclBinding::getWsEcl2XmlRequest(StringBuffer& soapmsg, IEspContext &context, CHttpRequest* request, WsWuInfo &wsinfo, const char *xmltype, const char *ns, unsigned flags)
 {
-    Owned<IPropertyTree> parmtree = createPTree(false);
+    Owned<IPropertyTree> parmtree = createPTree();
     IProperties *parms = context.queryRequestParameters();
 
     buildParametersXml(parmtree, parms);
@@ -1479,7 +1479,7 @@ void CWsEclBinding::getWsEcl2XmlRequest(StringBuffer& soapmsg, IEspContext &cont
 
 void CWsEclBinding::getWsEclJsonRequest(StringBuffer& jsonmsg, IEspContext &context, CHttpRequest* request, WsWuInfo &wsinfo, const char *xmltype, const char *ns, unsigned flags)
 {
-    Owned<IPropertyTree> parmtree = createPTree(false);
+    Owned<IPropertyTree> parmtree = createPTree();
     IProperties *parms = context.queryRequestParameters();
 
     buildParametersXml(parmtree, parms);
@@ -1506,7 +1506,7 @@ void CWsEclBinding::getWsEclJsonRequest(StringBuffer& jsonmsg, IEspContext &cont
 
 void CWsEclBinding::getWsEclJsonResponse(StringBuffer& jsonmsg, IEspContext &context, CHttpRequest *request, const char *xml, WsWuInfo &wsinfo)
 {
-    Owned<IPropertyTree> parmtree = createPTreeFromXMLString(xml, false, true, 0, true);
+    Owned<IPropertyTree> parmtree = createPTreeFromXMLString(xml, ipt_none, (XmlReaderOptions)(xr_ignoreWhiteSpace|xr_ignoreNameSpaces));
 
     StringBuffer element;
     element.append(wsinfo.queryname.sget());
@@ -1818,7 +1818,7 @@ int CWsEclBinding::submitWsEclWorkunit(IEspContext & context, WsWuInfo &wsinfo, 
     workunit->setState(WUStateSubmitted);
     workunit->commit();
 
-    Owned<IPropertyTree> req = createPTreeFromXMLString(xml, false, true, 0, true, false);
+    Owned<IPropertyTree> req = createPTreeFromXMLString(xml, ipt_none, (XmlReaderOptions)(xr_ignoreWhiteSpace|xr_ignoreNameSpaces));
     IPropertyTree *start = req.get();
     if (start->hasProp("Envelope"))
         start=start->queryPropTree("Envelope");
@@ -2252,7 +2252,7 @@ int CWsEclBinding::getWsEclDefinition(CHttpRequest* request, CHttpResponse* resp
 
             Owned<IPropertyTree> xsds_tree;
             if (xsds.length())
-                xsds_tree.setown(createPTreeFromXMLString(xsds.str(), false));
+                xsds_tree.setown(createPTreeFromXMLString(xsds.str()));
             if (xsds_tree)
             {
                 StringBuffer xpath;
@@ -2274,7 +2274,7 @@ int CWsEclBinding::getWsEclDefinition(CHttpRequest* request, CHttpResponse* resp
                     selected_xsd->setProp("@xmlns", urn.str());
                     IPropertyTree *dstree = selected_xsd->queryPropTree("xs:element[@name='Dataset']/xs:complexType");
                     if (dstree && !dstree->hasProp("xs:attribute[@name='name']"))
-                        dstree->addPropTree("xs:attribute", createPTreeFromXMLString("<xs:attribute name=\"name\" type=\"xs:string\"/>", false));
+                        dstree->addPropTree("xs:attribute", createPTreeFromXMLString("<xs:attribute name=\"name\" type=\"xs:string\"/>"));
                     Owned<IPropertyTreeIterator> elements = selected_xsd->getElements("xs:element//xs:element");
                     ForEach(*elements)
                         elements->query().setPropInt("@minOccurs", 0);

--- a/esp/services/ws_ecl/wswuinfo.cpp
+++ b/esp/services/ws_ecl/wswuinfo.cpp
@@ -131,7 +131,7 @@ IPropertyTree *WsWuInfo::queryParamInfo()
     {
         StringBuffer xml;
         if (getWsResource("SOAP", xml))
-            paraminfo.setown(createPTreeFromXMLString(xml.str(), false));
+            paraminfo.setown(createPTreeFromXMLString(xml.str()));
     }
     return paraminfo.get();
 }
@@ -227,7 +227,7 @@ IPropertyTreeIterator *WsWuInfo::getInputSchemas()
     {
         updateSchemaCache();
         if (schemacache.length())   
-            xsds.setown(createPTreeFromXMLString(schemacache.str(), false));
+            xsds.setown(createPTreeFromXMLString(schemacache.str()));
     }
 
     return (xsds) ? xsds->getElements("Input") : NULL;
@@ -239,7 +239,7 @@ IPropertyTreeIterator *WsWuInfo::getResultSchemas()
     {
         updateSchemaCache();
         if (schemacache.length())   
-            xsds.setown(createPTreeFromXMLString(schemacache.str(), false));
+            xsds.setown(createPTreeFromXMLString(schemacache.str()));
     }
 
     return (xsds) ? xsds->getElements("Result") : NULL;

--- a/esp/services/ws_fileio/ws_fileioservice.cpp
+++ b/esp/services/ws_fileio/ws_fileioservice.cpp
@@ -48,8 +48,8 @@ bool CWsFileIOEx::CheckServerAccess(const char* server, const char* relPath, Str
 
     Owned<IPropertyTree> pEnvRoot = &env->getPTree();
     IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
-    IPropertyTree* pRoot = createPTreeFromXMLString("<Environment/>", false);
-    IPropertyTree* pSoftware = pRoot->addPropTree("Software", createPTree("Software", false));
+    IPropertyTree* pRoot = createPTreeFromXMLString("<Environment/>");
+    IPropertyTree* pSoftware = pRoot->addPropTree("Software", createPTree("Software"));
     if (pEnvSoftware && pSoftware)
     {
         Owned<IPropertyTreeIterator> it = pEnvSoftware->getElements("DropZone");

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -203,8 +203,8 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
     Owned<IPropertyTree> pEnvRoot = &m_constEnv->getPTree();
     IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
 
-    Owned<IPropertyTree> pRoot = createPTreeFromXMLString("<Environment/>", false);
-    IPropertyTree* pSoftware = pRoot->addPropTree("Software", createPTree("Software", false));
+    Owned<IPropertyTree> pRoot = createPTreeFromXMLString("<Environment/>");
+    IPropertyTree* pSoftware = pRoot->addPropTree("Software", createPTree("Software"));
 
     if (pEnvSoftware)
     {
@@ -217,7 +217,7 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
             {   
                 dfuwu->toXML(wuxml);
 
-                Owned<IPropertyTree> wu = createPTreeFromXMLString(wuxml.str(), false);
+                Owned<IPropertyTree> wu = createPTreeFromXMLString(wuxml.str());
                 if (wu)
                 {
                     const char* ip = wu->queryProp("Source/Part/@node");
@@ -345,7 +345,7 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
         }
 
         if (wuxml.length() > 0)
-            pSoftware->addPropTree("DfuWorkunit", createPTreeFromXMLString(wuxml.str(), false));
+            pSoftware->addPropTree("DfuWorkunit", createPTreeFromXMLString(wuxml.str()));
     }
     return pRoot.getClear();
 }

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1101,7 +1101,7 @@ void CFileSprayEx::getInfoFromSasha(IEspContext &context, const char *sashaServe
     if(res.length() < 1)
         return;
     
-    Owned<IPropertyTree> wu = createPTreeFromXMLString(res.str(),false);
+    Owned<IPropertyTree> wu = createPTreeFromXMLString(res.str());
     if (!wu)
         return;
 
@@ -2668,8 +2668,8 @@ int CFileSprayEx::doFileCheck(const char* mask, const char* netaddr, const char*
         Owned<IConstEnvironment> env = factory->openEnvironmentByFile();
         Owned<IPropertyTree> pEnvRoot = &env->getPTree();
         IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
-        IPropertyTree* pRoot = createPTreeFromXMLString("<Environment/>", false);
-        IPropertyTree* pSoftware = pRoot->addPropTree("Software", createPTree("Software", false));
+        IPropertyTree* pRoot = createPTreeFromXMLString("<Environment/>");
+        IPropertyTree* pSoftware = pRoot->addPropTree("Software", createPTree("Software"));
         if (pEnvSoftware && pSoftware)
         {
             Owned<IPropertyTreeIterator> it = pEnvSoftware->getElements("DropZone");

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -2543,7 +2543,7 @@ void Cws_machineEx::getTargetClusterProcesses(StringArray& targetClusters, Strin
         if (type && !stricmp(type, eqHoleCluster) && (roxieClusters->first() || thorClusters->first()))
             continue;
 
-        IPropertyTree *pTargetClusterInfo = pTargetClusterTree->addPropTree("TargetCluster", createPropertyTree(false, "TargetCluster"));
+        IPropertyTree *pTargetClusterInfo = pTargetClusterTree->addPropTree("TargetCluster", createPTree("TargetCluster"));
         if (!pTargetClusterInfo)
             throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed in creating an XML tree");
 
@@ -2563,7 +2563,7 @@ void Cws_machineEx::getTargetClusterProcesses(StringArray& targetClusters, Strin
                 const char* process = thorCluster.queryProp("@process");
                 if (process && *process)
                 {
-                    IPropertyTree *pThorClusterInfo = pTargetClusterInfo->addPropTree("Process", createPropertyTree(false, "Process"));
+                    IPropertyTree *pThorClusterInfo = pTargetClusterInfo->addPropTree("Process", createPTree("Process"));
                     if (!pThorClusterInfo)
                         throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed in creating an XML tree");
 
@@ -2608,7 +2608,7 @@ void Cws_machineEx::getTargetClusterProcesses(StringArray& targetClusters, Strin
                 const char* process = roxieCluster.queryProp("@process");
                 if (process && *process)
                 {
-                    IPropertyTree *pRoxieClusterInfo = pTargetClusterInfo->addPropTree("Process", createPropertyTree(false, "Process"));
+                    IPropertyTree *pRoxieClusterInfo = pTargetClusterInfo->addPropTree("Process", createPTree("Process"));
                     if (!pRoxieClusterInfo)
                         throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed in creating an XML tree");
 
@@ -2648,7 +2648,7 @@ void Cws_machineEx::getTargetClusterProcesses(StringArray& targetClusters, Strin
             const char* process = eclCCServerProcess.queryProp("@process");
             if (process && *process)
             {
-                IPropertyTree *pEclCCServerInfo = pTargetClusterInfo->addPropTree("Process", createPropertyTree(false, "Process"));
+                IPropertyTree *pEclCCServerInfo = pTargetClusterInfo->addPropTree("Process", createPTree("Process"));
                 if (!pEclCCServerInfo)
                     throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed in creating an XML tree");
 
@@ -2679,7 +2679,7 @@ void Cws_machineEx::getTargetClusterProcesses(StringArray& targetClusters, Strin
             const char* process = eclAgentProcess.queryProp("@process");
             if (process && *process)
             {
-                IPropertyTree *pEclAgentInfo = pTargetClusterInfo->addPropTree("Process", createPropertyTree(false, "Process"));
+                IPropertyTree *pEclAgentInfo = pTargetClusterInfo->addPropTree("Process", createPTree("Process"));
                 if (!pEclAgentInfo)
                     throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed in creating an XML tree");
 
@@ -2710,7 +2710,7 @@ void Cws_machineEx::getTargetClusterProcesses(StringArray& targetClusters, Strin
             const char* process = eclSchedulerProcess.queryProp("@process");
             if (process && *process)
             {
-                IPropertyTree *pEclSchedulerInfo = pTargetClusterInfo->addPropTree("Process", createPropertyTree(false, "Process"));
+                IPropertyTree *pEclSchedulerInfo = pTargetClusterInfo->addPropTree("Process", createPTree("Process"));
                 if (!pEclSchedulerInfo)
                     throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed in creating an XML tree");
 
@@ -2776,7 +2776,7 @@ bool Cws_machineEx::onGetTargetClusterInfo(IEspContext &context, IEspGetTargetCl
 
         StringArray& targetClusters = req.getTargetClusters();
         StringArray processTypes, processNames, processAddresses;
-        Owned<IPropertyTree> pTargetClusterTree = createPTreeFromXMLString("<Root/>",false);
+        Owned<IPropertyTree> pTargetClusterTree = createPTreeFromXMLString("<Root/>");
 
         getTargetClusterProcesses(targetClusters, processTypes, processNames, processAddresses, pTargetClusterTree);
 

--- a/esp/services/ws_roxie/ws_roxieService.cpp
+++ b/esp/services/ws_roxie/ws_roxieService.cpp
@@ -88,22 +88,22 @@ bool CRoxieEx::onIndex(IEspContext &context, IEspIndexRequest &req, IEspIndexRes
 
 bool CRoxieEx::onContent(IEspContext &context, IEspContentRequest &req, IEspContentResponse &resp)
 {
-    Owned<IPropertyTree> Index = createPTree("Index", false);
-    IPropertyTree * Contents = Index->addPropTree("Contents", createPTree("Contents", false));
+    Owned<IPropertyTree> Index = createPTree("Index");
+    IPropertyTree * Contents = Index->addPropTree("Contents", createPTree("Contents"));
 
-    IPropertyTree * Content = Contents->addPropTree("Content", createPTree("Content", false));
+    IPropertyTree * Content = Contents->addPropTree("Content", createPTree("Content"));
     Content->setProp("Label", "Local Configuration");
     Content->setProp("URL", "GetQueryList?");
 
-    Content = Contents->addPropTree("Content", createPTree("Content", false));
+    Content = Contents->addPropTree("Content", createPTree("Content"));
     Content->setProp("Label", "Publish Doxie Query");
     Content->setProp("URL", "GetDoxieList?");
 
-    Content = Contents->addPropTree("Content", createPTree("Content", false));
+    Content = Contents->addPropTree("Content", createPTree("Content"));
     Content->setProp("Label", "Add Query");
     Content->setProp("URL", "AddQuery?");
 
-    Content = Contents->addPropTree("Content", createPTree("Content", false));
+    Content = Contents->addPropTree("Content", createPTree("Content"));
     Content->setProp("Label", "View Config XML");
     Content->setProp("URL", "DebugXML?");
 
@@ -130,11 +130,11 @@ bool CRoxieEx::onAddQuery(IEspContext &context, IEspAddQueryRequest &req, IEspAd
     StringArray items, infos;
     if (attrResolver->getIndex("GOSMITH","PASSWORD", module, "SOAP", items, infos))
     {
-        Owned<IPropertyTree> moduleTree = createPTree("Module", false);
+        Owned<IPropertyTree> moduleTree = createPTree("Module");
         moduleTree->setProp("@Label", module);
         for (int i = 0; i < items.ordinality(); ++i)
         {
-            IPropertyTree *attr = moduleTree->addPropTree("Attribute", createPTree("Attribute", false)); 
+            IPropertyTree *attr = moduleTree->addPropTree("Attribute", createPTree("Attribute"));
             attr->setProp("@Label", items.item(i));
             attr->setProp("Description", infos.item(i));
         }
@@ -388,8 +388,8 @@ void CRoxieEx::GenerateCurrentXml(const char * localXml, const char * statusXml,
 //  DBGLOG(localXml);
 //  writeFile("c:\\roxie.xml", statusXml);
 //  DBGLOG(statusXml);
-    Owned<IPropertyTree> local = createPTreeFromXMLString(localXml, false);
-    Owned<IPropertyTree> status = createPTreeFromXMLString(statusXml, false);
+    Owned<IPropertyTree> local = createPTreeFromXMLString(localXml);
+    Owned<IPropertyTree> status = createPTreeFromXMLString(statusXml);
 
     Owned<IPropertyTreeIterator> itr = status->getElements("Summary/File");
     ForEach(*itr)
@@ -400,7 +400,7 @@ void CRoxieEx::GenerateCurrentXml(const char * localXml, const char * statusXml,
         xpath.appendf("Query[@dll=\"%s\"]", dll.str());
         if (!local->hasProp(xpath.str()))
         {
-            IPropertyTree * orphan = local->addPropTree("Orphan", createPTree("Orphan", false));
+            IPropertyTree * orphan = local->addPropTree("Orphan", createPTree("Orphan"));
             orphan->setProp("@dll", dll.str());
             if (file.hasProp("@locked") && strcmp(file.queryProp("@locked"), "true") == 0)
                 orphan->setProp("@locked", "true");

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1425,7 +1425,7 @@ bool CWsSMCEx::onBrowseResources(IEspContext &context, IEspBrowseResourcesReques
                 continue;
             }
 
-            Owned<IPropertyTree> desc = createPTreeFromXMLString(tmpBuf.str(),false);
+            Owned<IPropertyTree> desc = createPTreeFromXMLString(tmpBuf.str());
             if (!desc)
             {
                 DBGLOG("Invalid description file for %s", folder.str());

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -678,7 +678,7 @@ void adjustRowvalues(IPropertyTree* xgmml, const char* popupId)
 
             try
             {
-                IPropertyTree *rv_dataset=value.setPropTree("Dataset",createPTreeFromXMLString(value.queryProp("@value"),true));
+                IPropertyTree *rv_dataset=value.setPropTree("Dataset",createPTreeFromXMLString(value.queryProp("@value"), ipt_caseInsensitive));
                 value.setProp("@value","");
                     rv_dataset->setProp("@xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
 
@@ -5027,7 +5027,7 @@ void CWsWorkunitsEx::getResult(IEspContext &context, IConstWUResult &r,IArrayOf<
             SCMStringBuffer x;
             r.getResultXml(x);
 
-            Owned<IPropertyTree> props = loadPropertyTree(x.str(), true);
+            Owned<IPropertyTree> props = createPTreeFromXMLString(x.str(), ipt_caseInsensitive);
             
             //StringBuffer buf;
             //toXML(props, buf);
@@ -5036,7 +5036,7 @@ void CWsWorkunitsEx::getResult(IEspContext &context, IConstWUResult &r,IArrayOf<
             //  DBGLOG("getResult returns:%s", buf.str());
             //}
             IPropertyTree *val = props->queryPropTree("Row/*");
-         if(val)
+            if(val)
             {
                 value<<val->queryProp(NULL);
             }
@@ -5557,7 +5557,7 @@ int i = 0;
 #ifndef TESTSUBFILE
                 IPropertyTree &query = f->query();
 #else
-Owned<IPropertyTree> filesRead = createPTree(false);
+Owned<IPropertyTree> filesRead = createPTree();
 {
     if (i > 1)
         break;
@@ -5567,11 +5567,11 @@ Owned<IPropertyTree> filesRead = createPTree(false);
     filesRead->setProp("@cluster", "thor200");
     filesRead->setPropInt("@useCount", 1);
 
-    Owned<IPropertyTree> subfile = createPTree(false);
+    Owned<IPropertyTree> subfile = createPTree();
     subfile->setProp("@name", "subfile1");
     filesRead->addPropTree("Subfile", subfile.getClear());
 
-    Owned<IPropertyTree> subfile2 = createPTree(false);
+    Owned<IPropertyTree> subfile2 = createPTree();
     subfile2->setProp("@name", "subfile2");
     filesRead->addPropTree("Subfile", subfile2.getClear());
     }
@@ -5581,21 +5581,21 @@ Owned<IPropertyTree> filesRead = createPTree(false);
     filesRead->setProp("@cluster", "thor200");
     filesRead->setPropInt("@useCount", 1);
 
-    Owned<IPropertyTree> subfile21 = createPTree(false);
+    Owned<IPropertyTree> subfile21 = createPTree();
     subfile21->setProp("@name", "subfile21");
     subfile21->setProp("@cluster", "thor50");
     filesRead->addPropTree("Subfile", subfile21.getClear());
 
-    Owned<IPropertyTree> subfile22 = createPTree(false);
+    Owned<IPropertyTree> subfile22 = createPTree();
     subfile22->setProp("@name", "subfile22");
     subfile22->setProp("@cluster", "thor50");
 
-    Owned<IPropertyTree> subfile221 = createPTree(false);
+    Owned<IPropertyTree> subfile221 = createPTree();
     subfile221->setProp("@name", "subfile221");
     subfile221->setProp("@cluster", "thor50");
     subfile22->addPropTree("Subfile", subfile221.getClear());
 
-    Owned<IPropertyTree> subfile222 = createPTree(false);
+    Owned<IPropertyTree> subfile222 = createPTree();
     subfile222->setProp("@name", "subfile222");
     subfile222->setProp("@cluster", "thor50");
     subfile22->addPropTree("Subfile", subfile222.getClear());
@@ -6272,7 +6272,7 @@ bool CWsWorkunitsEx::getInfoFromSasha(IEspContext &context, const char *sashaSer
         return false;
     
     //DBGLOG("Result: %s", res.str());
-    Owned<IPropertyTree> wu = createPTreeFromXMLString(res.str(),false);
+    Owned<IPropertyTree> wu = createPTreeFromXMLString(res.str());
     if (!wu)
         return false;
 
@@ -7029,7 +7029,7 @@ IPropertyTree * getArchivedWorkUnitProperties(const char * wuid)
             cmd->getResult(0,res);
             if(res.length() > 0)
             {
-                Owned<IPropertyTree> wuTree = createPTreeFromXMLString(res.str(),false);
+                Owned<IPropertyTree> wuTree = createPTreeFromXMLString(res.str());
                 return wuTree.getLink();
             }
             break;
@@ -8237,7 +8237,7 @@ bool CWsWorkunitsEx::onWUCompileECL(IEspContext &context, IEspWUCompileECLReques
                 wu->getApplicationValue("SyntaxCheck",StringBuffer("Dependency").append(count).str(),buf);
                 if(!buf.length())
                     break;
-                Owned<IPropertyTree> res=createPTreeFromXMLString(buf.str(),true);
+                Owned<IPropertyTree> res=createPTreeFromXMLString(buf.str(), ipt_caseInsensitive);
                 if(!res)
                     continue;
 

--- a/esp/smc/SMCLib/WUXMLInfo.cpp
+++ b/esp/smc/SMCLib/WUXMLInfo.cpp
@@ -181,14 +181,14 @@ bool CWUXMLInfo::buildXmlGraphList(IConstWorkUnit &wu,IPropertyTree& XMLStructur
     try {
       SCMStringBuffer buf;
 
-        IPropertyTree* resultTree = XMLStructure.addPropTree("WUGraphs", createPTree(true));    
+        IPropertyTree* resultTree = XMLStructure.addPropTree("WUGraphs", createPTree(ipt_caseInsensitive));
         Owned<IConstWUGraphIterator> graphs = &wu.getGraphs(GraphTypeAny);
         ForEach(*graphs)
         {
             IConstWUGraph &graph = graphs->query();
             if(!graph.isValid())
                 continue;
-            IPropertyTree * p   =   resultTree->addPropTree("WUGraph", createPTree(true));
+            IPropertyTree * p   =   resultTree->addPropTree("WUGraph", createPTree(ipt_caseInsensitive));
             p->setProp("Wuid",      wu.getWuid(buf).str());
          buf.clear();
             p->setProp("Name",      graph.getName(buf).str());
@@ -218,7 +218,7 @@ bool CWUXMLInfo::buildXmlExceptionList(IConstWorkUnit &wu,IPropertyTree& XMLStru
             ForEach(*exceptions)
             {
                 SCMStringBuffer x, y;
-                IPropertyTree * p   =   XMLStructure.addPropTree("Exceptions", createPTree(true));
+                IPropertyTree * p   =   XMLStructure.addPropTree("Exceptions", createPTree(ipt_caseInsensitive));
                 p->setProp("Source",exceptions->query().getExceptionSource(x).str());
                 p->setProp("Message",exceptions->query().getExceptionMessage(y).str());
             }
@@ -239,7 +239,7 @@ bool CWUXMLInfo::buildXmlExceptionList(IConstWorkUnit &wu,IPropertyTree& XMLStru
 bool CWUXMLInfo::buildXmlResultList(IConstWorkUnit &wu,IPropertyTree& XMLStructure)
 {
     try{
-        IPropertyTree* resultsTree = XMLStructure.addPropTree("WUResults", createPTree(true));  
+        IPropertyTree* resultsTree = XMLStructure.addPropTree("WUResults", createPTree(ipt_caseInsensitive));
         Owned<IConstWUResultIterator> results = &wu.getResults();
         ForEach(*results)
         {
@@ -264,7 +264,7 @@ bool CWUXMLInfo::buildXmlResultList(IConstWorkUnit &wu,IPropertyTree& XMLStructu
                     r.getResultXml(x);
                     try
                     {
-                        Owned<IPropertyTree> props = loadPropertyTree(x.str(), true);
+                        Owned<IPropertyTree> props = createPTreeFromXMLString(x.str(), ipt_caseInsensitive);
                         IPropertyTree *row = props->queryPropTree("Row");
                         IPropertyTree *val = row->queryPropTree("*");
                         value.append(val->queryProp(NULL));
@@ -281,7 +281,7 @@ bool CWUXMLInfo::buildXmlResultList(IConstWorkUnit &wu,IPropertyTree& XMLStructu
                     value.append(" rows]");
                     link.append(r.getResultSequence());
                 }
-                IPropertyTree* result = resultsTree->addPropTree("WUResult", createPTree(true));    
+                IPropertyTree* result = resultsTree->addPropTree("WUResult", createPTree(ipt_caseInsensitive));
                 result->setProp("Name",x.str());
                 result->setProp("Link",link.str());
                 result->setProp("Value",value.str());
@@ -312,7 +312,7 @@ bool CWUXMLInfo::buildXmlResultList(IConstWorkUnit &wu,IPropertyTree& XMLStructu
 bool CWUXMLInfo::buildXmlTimimgList(IConstWorkUnit &wu,IPropertyTree& XMLStructure)
 {
     try{
-        IPropertyTree* timingTree = XMLStructure.addPropTree("Timings", createPTree(true)); 
+        IPropertyTree* timingTree = XMLStructure.addPropTree("Timings", createPTree(ipt_caseInsensitive));
         Owned<IStringIterator> times = &wu.getTimers();
         ForEach(*times)
         {
@@ -327,7 +327,7 @@ bool CWUXMLInfo::buildXmlTimimgList(IConstWorkUnit &wu,IPropertyTree& XMLStructu
                 if (name.s.charAt(i)=='_') 
                     name.s.setCharAt(i, ' ');
 
-            IPropertyTree* Timer = timingTree->addPropTree("Timer", createPTree(true)); 
+            IPropertyTree* Timer = timingTree->addPropTree("Timer", createPTree(ipt_caseInsensitive));
             Timer->setProp("Name",name.str());
             Timer->setProp("Value",fd.str());
             Timer->setPropInt("Count",count);
@@ -349,7 +349,7 @@ bool CWUXMLInfo::buildXmlTimimgList(IConstWorkUnit &wu,IPropertyTree& XMLStructu
 bool CWUXMLInfo::buildXmlLogList(IConstWorkUnit &wu,IPropertyTree& XMLStructure)
 {
     try{
-        IPropertyTree* logTree = XMLStructure.addPropTree("WULog", createPTree(true));  
+        IPropertyTree* logTree = XMLStructure.addPropTree("WULog", createPTree(ipt_caseInsensitive));
         Owned <IConstWUQuery> query = wu.getQuery();
         if(query)
         {

--- a/esp/test/httptest/main.cpp
+++ b/esp/test/httptest/main.cpp
@@ -220,7 +220,7 @@ int main(int argc, char* argv[])
     {
         Owned<IPropertyTree> sslconfig;
         if(scfname.length() > 0)
-            sslconfig.setown(createPTreeFromXMLFile(scfname.str(), true));
+            sslconfig.setown(createPTreeFromXMLFile(scfname.str(), ipt_caseInsensitive));
         FILE* ofile = NULL;
         if(out_fname.length() != 0)
         {

--- a/esp/tools/soapplus/http.cpp
+++ b/esp/tools/soapplus/http.cpp
@@ -1683,7 +1683,7 @@ int SimpleServer::start()
                 if(xmlBuf.length())
                 {
                     bool bfound = false;
-                    Owned<IPropertyTree> intree(createPTreeFromXMLString(xmlBuf.str(), false));
+                    Owned<IPropertyTree> intree(createPTreeFromXMLString(xmlBuf.str()));
                     Owned<IPropertyTreeIterator> elems = intree->getElements("soap:Body");
 
                     for (elems->first(); elems->isValid() && !bfound; elems->next())

--- a/esp/tools/soapplus/main.cpp
+++ b/esp/tools/soapplus/main.cpp
@@ -110,7 +110,7 @@ void doTestSchemaParser(IProperties* globals, const char* url, const char* in_fn
             e->Release();
         }
 
-        Owned<IPTree> xml = createPTreeFromXMLString(s,false);
+        Owned<IPTree> xml = createPTreeFromXMLString(s);
         IPTree* schema = xml->queryBranch(VStringBuffer("Results/Result/XmlSchema[@name='%s']/*[1]", element));
         if (schema)
             xsd.setown(createXmlSchemaFromPTree(LINK(schema)));
@@ -692,7 +692,7 @@ int main(int argc, char** argv)
             const char* cfg = globals->queryProp("cfg");
             try
             {
-                cfgtree.setown(createPTreeFromXMLFile(cfg,false));
+                cfgtree.setown(createPTreeFromXMLFile(cfg));
             }
             catch(IException* e)
             {

--- a/esp/tools/soapplus/msggenerator.cpp
+++ b/esp/tools/soapplus/msggenerator.cpp
@@ -50,7 +50,7 @@ MessageGenerator::MessageGenerator(const char* path, bool keepfile, SchemaType s
     {
         StringBuffer cfg;
         if (loadFile(cfg, globals->queryProp("cfg")))
-            m_cfg.setown(createPTreeFromXMLString(cfg,false));
+            m_cfg.setown(createPTreeFromXMLString(cfg));
         else
             ERRLOG("Can not load cfg file; ignored");
     }
@@ -96,7 +96,7 @@ MessageGenerator::MessageGenerator(const char* path, bool keepfile, SchemaType s
         throw MakeStringException(-1, "wsdl is empty");
     }
 
-    Owned<IPropertyTree> schema = createPTreeFromXMLString(m_schema.str(), false);
+    Owned<IPropertyTree> schema = createPTreeFromXMLString(m_schema.str());
     if (m_isRoxie)
         m_roxieSchemaRoot.set(schema->queryBranch("//Result"));
     else
@@ -352,7 +352,7 @@ void MessageGenerator::genNonRoxieMessage(const char* method, const char* templa
 
                 if (templatemsg && *templatemsg)
                 {
-                    Owned<IPropertyTree> tmplat = createPTreeFromXMLString(templatemsg, false);
+                    Owned<IPropertyTree> tmplat = createPTreeFromXMLString(templatemsg);
                     if(!tmplat.get())
                         throw MakeStringException(-1, "can't generate property tree from input, please make sure it's valid xml.");
                     IPropertyTree* tmp = NULL;
@@ -384,7 +384,7 @@ void MessageGenerator::genRoxieMessage(const char* templatemsg, StringBuffer& me
 
     if (templatemsg)
     {
-        tmplat.setown(createPTreeFromXMLString(templatemsg, false));
+        tmplat.setown(createPTreeFromXMLString(templatemsg));
         if(!tmplat.get())
             throw MakeStringException(-1, "can't generate property tree from input, please make sure it's valid xml.");
         root = tmplat->queryName();

--- a/esp/tools/soapplus/xmldiff.cpp
+++ b/esp/tools/soapplus/xmldiff.cpp
@@ -160,7 +160,7 @@ bool CXmlDiff::compare()
         Owned<IPropertyTree> ltree;
         try
         {
-            ltree.setown(createPTreeFromXMLFile(left, false));
+            ltree.setown(createPTreeFromXMLFile(left));
         }
         catch(...)
         {
@@ -174,7 +174,7 @@ bool CXmlDiff::compare()
 
                 if(leftxml)
                 {
-                    ltree.setown(createPTreeFromXMLString(leftxml, false));
+                    ltree.setown(createPTreeFromXMLString(leftxml));
                 }
             }
             catch(...)
@@ -186,7 +186,7 @@ bool CXmlDiff::compare()
 
         try
         {
-            rtree.setown(createPTreeFromXMLFile(right, false));
+            rtree.setown(createPTreeFromXMLFile(right));
         }
         catch(...)
         {
@@ -200,7 +200,7 @@ bool CXmlDiff::compare()
 
                 if(rightxml)
                 {
-                    rtree.setown(createPTreeFromXMLString(rightxml, false));
+                    rtree.setown(createPTreeFromXMLString(rightxml));
                 }
             }
             catch(...)

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -197,7 +197,7 @@ static IPropertyTree *getEnvironment()
     if (daliClientActive()) {
         Owned<IRemoteConnection> conn = querySDS().connect("/Environment", myProcessSession(), 0, SDS_LOCK_TIMEOUT);
         if (conn)
-            env.setown(createPTree(conn->queryRoot())); // we don't really need to copy here
+            env.setown(createPTreeFromIPT(conn->queryRoot())); // we don't really need to copy here
     }
     if (!env.get())
         env.setown(getHPCCenvironment());

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -439,7 +439,7 @@ static IPropertyTree *getWorkUnitBranch(ICodeContext *ctx,const char *wuid,const
             if (cmd->numIds()) {
                 StringBuffer res;
                 if (cmd->getResult(0,res)) 
-                    return createPTreeFromXMLString(res.str(),false);
+                    return createPTreeFromXMLString(res.str());
             }
             if (i+1>=sashaeps.ordinality()) 
                 break;

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -423,7 +423,7 @@ static IPropertyTree *getWorkUnitBranch(ICodeContext *ctx,const char *wuid,const
         IPropertyTree *ret = t->queryBranch(branch);
         if (!ret)
             return NULL;
-        return createPTree(ret);
+        return createPTreeFromIPT(ret);
     }
     // look up in sasha - this could be improved with server support
     SocketEndpointArray sashaeps;

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -388,7 +388,7 @@ extern bool simpleLocalKeyedJoins;
 extern bool enableKeyDiff;
 extern bool enableForceKeyDiffCopy;
 extern bool useTreeCopy;
-extern bool defaultStripLeadingWhitespace;
+extern XmlReaderOptions defaultXmlReadFlags;
 extern bool mergeSlaveStatistics;
 extern bool roxieMulticastEnabled;   // enable use of multicast for sending requests to slaves
 

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -77,7 +77,7 @@ extern void putStatsValue(IPropertyTree *node, const char *statName, const char 
         IPropertyTree *att = node->queryPropTree(xpath.str());
         if (!att)
         {
-            att = node->addPropTree("att", createPTree(false));
+            att = node->addPropTree("att", createPTree());
             att->setProp("@name", statName);
         }
         att->setProp("@type", statType);
@@ -238,14 +238,14 @@ protected:
             const char *id = strchr(levelx, '[');
             if (!id)
             {
-                child = createPTree(levelx, false);
+                child = createPTree(levelx);
                 parent->addPropTree(levelx, child);
             }
             else
             {
                 StringBuffer elem;
                 elem.append(id-levelx, levelx);
-                child = createPTree(elem, false);
+                child = createPTree(elem);
                 parent->addPropTree(elem, child);
                 loop
                 {

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -178,7 +178,7 @@ private:
             if (conn)
             {
                 Owned <IPropertyTree> daliTree = conn->getRoot();
-                localTree.setown(createPTree(daliTree));
+                localTree.setown(createPTreeFromIPT(daliTree));
             }
             writeCache(xpath, localTree);
         }

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -138,12 +138,12 @@ private:
             StringBuffer cacheFileName(queryDirectory);
             cacheFileName.append(roxieStateName);
             if (checkFileExists(cacheFileName))
-                cache.setown(createPTreeFromXMLFile(cacheFileName, false));
+                cache.setown(createPTreeFromXMLFile(cacheFileName));
             else
             {
-                IPropertyTree *tree = createPTree("Roxie", false);
-                tree->addPropTree("QuerySets", createPTree("QuerySets", false));
-                tree->addPropTree("Files", createPTree("Files", false));
+                IPropertyTree *tree = createPTree("Roxie");
+                tree->addPropTree("QuerySets", createPTree("QuerySets"));
+                tree->addPropTree("Files", createPTree("Files"));
                 cache.setown(tree);
             }
         }
@@ -206,7 +206,7 @@ public:
         Owned<IPropertyTree> ret = loadDaliTree(getQuerySetPath(xpath, id));
         if (!ret)
         {
-            ret.setown(createPTree("QuerySet", false));
+            ret.setown(createPTree("QuerySet"));
             ret->setProp("@id", id);
         }
         return ret.getClear();
@@ -224,7 +224,7 @@ public:
         Owned<IPropertyTree> ret = loadDaliTree(getPackageSetPath(xpath, id));
         if (!ret)
         {
-            ret.setown(createPTree("QuerySet", false));
+            ret.setown(createPTree("QuerySet"));
             ret->setProp("@id", id);
         }
         return ret.getClear();
@@ -238,7 +238,7 @@ public:
         Owned<IPropertyTree> ret = loadDaliTree(xpath);
         if (!ret)
         {
-            ret.setown(createPTree("RoxieStates", false));
+            ret.setown(createPTree("RoxieStates"));
             ret->setProp("@id", id);
         }
         return ret.getClear();

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2452,7 +2452,7 @@ public:
                     }
                 }
                 // add Patch name to delete delta state file info
-                IPropertyTree *goer = createPTree("Patch", false);
+                IPropertyTree *goer = createPTree("Patch");
                 goer->setProp("@id", id);
                 goer->setProp("@mode", "delete");
                 goers->addPropTree("Patch", goer);

--- a/roxie/ccd/ccdkey.cpp
+++ b/roxie/ccd/ccdkey.cpp
@@ -2016,7 +2016,7 @@ protected:
         d.clear();
         di.deprecate();
 
-        Owned<IPropertyTree> keyInfo = createPTreeFromXMLString("<R><FieldSet><Field isLittleEndian='1' isSigned='0' offset='0' size='4'/><Field isLittleEndian='1' isSigned='1' offset='0' size='4'/></FieldSet></R>", false);
+        Owned<IPropertyTree> keyInfo = createPTreeFromXMLString("<R><FieldSet><Field isLittleEndian='1' isSigned='0' offset='0' size='4'/><Field isLittleEndian='1' isSigned='1' offset='0' size='4'/></FieldSet></R>");
         indexes.setKeyInfo(*keyInfo.get());
         Sleep(1000); // to give key time to build!
 

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -84,7 +84,7 @@ bool fieldTranslationEnabled = false;
 bool syncCluster = false;  // should we sync an out of sync cluster (always send a trap)
 bool useTreeCopy = true;
 bool mergeSlaveStatistics = true;
-bool defaultStripLeadingWhitespace = true;
+XmlReaderOptions defaultXmlReadFlags = xr_ignoreWhiteSpace;
 bool runOnce = false;
 
 unsigned udpMulticastBufferSize = 262142;
@@ -767,7 +767,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         defaultWarnTimeLimit[1] = (unsigned) topology->getPropInt64("@defaultHighPriorityTimeWarning", 0);
         defaultWarnTimeLimit[2] = (unsigned) topology->getPropInt64("@defaultSLAPriorityTimeWarning", 0);
 
-        defaultStripLeadingWhitespace = topology->getPropBool("@defaultStripLeadingWhitespace", true);
+        defaultXmlReadFlags = topology->getPropBool("@defaultStripLeadingWhitespace", true) ? xr_ignoreWhiteSpace : xr_none;
         defaultParallelJoinPreload = topology->getPropInt("@defaultParallelJoinPreload", 0);
         defaultConcatPreload = topology->getPropInt("@defaultConcatPreload", 0);
         defaultFetchPreload = topology->getPropInt("@defaultFetchPreload", 0);

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -258,7 +258,7 @@ void getAccessList(const char *aclName, IPropertyTree *topology, IPropertyTree *
     xpath.append("ACL[@name='").append(aclName).append("']");
     if (serverInfo->queryPropTree(xpath))
         throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - recursive ACL definition of %s", aclName);
-    Owned<IPropertyTree> X = createPTree("ACL", false);
+    Owned<IPropertyTree> X = createPTree("ACL");
     X->setProp("@name", aclName);
     serverInfo->addPropTree("ACL", X.getClear());
 
@@ -292,7 +292,7 @@ void addServerChannel(const char *dataDirectory, unsigned port, unsigned threads
         if (f.getPropInt("@port", 0) == port)
             throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - Roxie server port repeated");
     }
-    IPropertyTree *ci = createPTree("RoxieServerProcess", false);
+    IPropertyTree *ci = createPTree("RoxieServerProcess");
     ci->setProp("@dataDirectory", dataDirectory);
     ci->setPropInt("@port", port);
     ci->setPropInt("@numThreads", threads);
@@ -314,7 +314,7 @@ void addSlaveChannel(unsigned channel, const char *dataDirectory, bool suspended
     xpath.appendf("RoxieSlaveProcess[@channel=\"%d\"]", channel);
     if (ccdChannels->hasProp(xpath.str()))
         throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - channel %d repeated", channel);
-    IPropertyTree *ci = createPTree("RoxieSlaveProcess", false);
+    IPropertyTree *ci = createPTree("RoxieSlaveProcess");
     ci->setPropInt("@channel", channel);
     ci->setPropBool("@suspended", suspended);
     ci->setPropInt("@subChannel", numSlaves[channel]);
@@ -462,7 +462,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
     Thread::setDefaultStackSize(0x10000);   // NB under windows requires linker setting (/stack:)
 #endif
     srand( (unsigned)time( NULL ) );
-    ccdChannels = createPTree("Channels", false);
+    ccdChannels = createPTree("Channels");
     EnableSEHtoExceptionMapping();
     setTerminateOnSEH();
 
@@ -498,7 +498,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         if (checkFileExists(topologyFile.str()))
         {
             DBGLOG("Loading topology file %s", topologyFile.str());
-            topology = createPTreeFromXMLFile(topologyFile.str(), false, true);
+            topology = createPTreeFromXMLFile(topologyFile.str());
         }
         else
         {
@@ -511,8 +511,8 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                 "<RoxieTopology numChannels='1' localSlave='1'>"
                  "<RoxieServerProcess dataDirectory='.' netAddress='.'/>"
                  "<RoxieSlaveProcess dataDirectory='.' netAddress='.' channel='1'/>"
-                "</RoxieTopology>", 
-                false, true);
+                "</RoxieTopology>"
+                );
             int port = globals->getPropInt("port", 9876);
             topology->setPropInt("RoxieServerProcess/@port", port);
             topology->setProp("@daliServers", globals->queryProp("daliServers"));

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1038,7 +1038,7 @@ public:
     {
         throwUnexpected();   // only implemented in derived server class
     }
-    virtual IRoxieServerContext *createContext(IPropertyTree *xml, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, bool _stripLeadingWhitespace) const
+    virtual IRoxieServerContext *createContext(IPropertyTree *xml, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions xmlReadFlags) const
     {
         throwUnexpected();   // only implemented in derived server class
     }
@@ -1186,7 +1186,7 @@ public:
         }
     }
 
-    virtual IRoxieServerContext *createContext(IPropertyTree *context, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const IRoxieContextLogger &_logctx, const SocketEndpoint &_poolEndpoint, bool _stripLeadingWhitespace) const
+    virtual IRoxieServerContext *createContext(IPropertyTree *context, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const IRoxieContextLogger &_logctx, const SocketEndpoint &_poolEndpoint, XmlReaderOptions _xmlReadFlags) const
     {
         if (isSuspended)
         {
@@ -1196,7 +1196,7 @@ public:
             throw MakeStringException(ROXIE_QUERY_SUSPENDED, "Query %s is suspended%s", id.get(), err.str());
         }
         checkOnceDone(_logctx);
-        return createRoxieServerContext(context, this, client, isXml, isRaw, isBlocked, httpHelper, trim, priority, _logctx, _poolEndpoint, _stripLeadingWhitespace);
+        return createRoxieServerContext(context, this, client, isXml, isRaw, isBlocked, httpHelper, trim, priority, _logctx, _poolEndpoint, _xmlReadFlags);
     }
 
     virtual WorkflowMachine *createWorkflowMachine(bool isOnce, const IRoxieContextLogger &logctx) const

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -865,7 +865,7 @@ public:
     virtual IPropertyTree* cloneQueryXGMML() const
     {
         assertex(dll->queryWorkUnit());
-        Owned<IPropertyTree> tree = createPTree("Query", false);
+        Owned<IPropertyTree> tree = createPTree("Query");
         Owned<IConstWUGraphIterator> graphs = &dll->queryWorkUnit()->getGraphs(GraphTypeActivities);
         SCMStringBuffer graphNameStr;
         ForEach(*graphs)
@@ -873,9 +873,9 @@ public:
             graphs->query().getName(graphNameStr);
             const char *graphName = graphNameStr.s.str();
             Owned<IPropertyTree> graphXgmml = graphs->query().getXGMMLTree(false);
-            IPropertyTree *newGraph = createPTree(false);
+            IPropertyTree *newGraph = createPTree();
             newGraph->setProp("@id", graphName);
-            IPropertyTree *newXGMML = createPTree(false);
+            IPropertyTree *newXGMML = createPTree();
             newXGMML->addPropTree("graph", graphXgmml.getLink());
             newGraph->addPropTree("xgmml", newXGMML);
             tree->addPropTree("Graph", newGraph);
@@ -1161,7 +1161,7 @@ public:
             CriticalBlock b(onceCrit);
             if (!onceContext)
             {
-                onceContext.setown(createPTree(false));
+                onceContext.setown(createPTree());
                 onceResultStore.setown(createDeserializedResultStore());
                 Owned <IRoxieServerContext> ctx = createOnceServerContext(this, _logctx);
                 onceManager.set(&ctx->queryRowManager());

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -837,7 +837,7 @@ public:
 
     void getGraphStats(StringBuffer &reply, const IPropertyTree &thisGraph) const
     {
-        Owned<IPropertyTree> graph = createPTree(&thisGraph);
+        Owned<IPropertyTree> graph = createPTreeFromIPT(&thisGraph);
         Owned<IPropertyTreeIterator> edges = graph->getElements(".//edge");
         ForEach(*edges)
         {

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -109,7 +109,7 @@ interface IQueryFactory : extends IInterface
     virtual int getDebugValueInt(const char * propname, int defVal) const = 0;
     virtual bool getDebugValueBool(const char * propname, bool defVal) const = 0;
 
-    virtual IRoxieServerContext *createContext(IPropertyTree *xml, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, bool _stripLeadingWhitespace) const = 0;
+    virtual IRoxieServerContext *createContext(IPropertyTree *xml, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions xmlReadFlags) const = 0;
     virtual void noteQuery(time_t startTime, bool failed, unsigned elapsed, unsigned memused, unsigned slavesReplyLen, unsigned bytesOut) = 0;
     virtual IPropertyTree *getQueryStats(time_t from, time_t to) = 0;
     virtual void getGraphNames(StringArray &ret) const = 0;

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -30842,10 +30842,10 @@ readAnother:
                             client->setHttpMode(queryName, isRequestArray);
                         if (queryFactory)
                         {
-                            bool stripLeadingWhitespace = queryFactory->getDebugValueBool("stripWhitespaceFromStoredDataset", 0 != (xr_ignoreWhiteSpace & defaultXmlReadFlags));
-                            stripLeadingWhitespace = queryXml->getPropBool("_stripWhitespaceFromStoredDataset", stripLeadingWhitespace);
+                            bool stripWhitespace = queryFactory->getDebugValueBool("stripWhitespaceFromStoredDataset", 0 != (xr_ignoreWhiteSpace & defaultXmlReadFlags));
+                            stripWhitespace = queryXml->getPropBool("_stripWhitespaceFromStoredDataset", stripWhitespace);
                             XmlReaderOptions xmlReadFlags = (XmlReaderOptions)((defaultXmlReadFlags & ~xr_ignoreWhiteSpace) |
-                                                                               (stripLeadingWhitespace ? xr_ignoreWhiteSpace : xr_none));
+                                                                               (stripWhitespace ? xr_ignoreWhiteSpace : xr_none));
                             if (xmlReadFlags != defaultXmlReadFlags)
                             {
                                 // we need to reparse input xml, as global whitespace setting has been overridden

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -2650,7 +2650,7 @@ void throwRemoteException(IMessageUnpackCursor *extra)
     {
         char *xml = (char *) extra->getNext(*rowlen);
         ReleaseRoxieRow(rowlen);
-        Owned<IPropertyTree> p = createPTreeFromXMLString(xml, false);
+        Owned<IPropertyTree> p = createPTreeFromXMLString(xml);
         ReleaseRoxieRow(xml);
         unsigned code = p->getPropInt("Code", 0);
         const char *msg = p->queryProp("Message");
@@ -10578,7 +10578,7 @@ protected:
             desc->setDefaultDir(dir.str());
 
             //properties of the first file part.
-            Owned<IPropertyTree> attrs = createPTree("Part", false);
+            Owned<IPropertyTree> attrs = createPTree("Part");
             if(blockcompressed)
             {
                 attrs->setPropInt64("@size", uncompressedBytesWritten);
@@ -24614,7 +24614,7 @@ public:
                                 IPropertyTree *att = edge.queryPropTree("att[@name=\"_roxieStarted\"]");
                                 if (!att)
                                 {
-                                    att = edge.addPropTree("att", createPTree(false));
+                                    att = edge.addPropTree("att", createPTree());
                                     att->setProp("@name", "_roxieStarted");
                                 }
                                 else
@@ -24644,7 +24644,7 @@ public:
                                     IPropertyTree *att = edge.queryPropTree("att[@name=\"_roxieStarted\"]");
                                     if (!att)
                                     {
-                                        att = edge.addPropTree("att", createPTree(false));
+                                        att = edge.addPropTree("att", createPTree());
                                         att->setProp("@name", "_roxieStarted");
                                     }
                                     else
@@ -25801,7 +25801,7 @@ public:
                 DebugRequestLookupActivityByEdgeId request(proxyId, edgeId);
                 CommonXmlWriter reply(0);
                 sendProxyRequest(&reply, request);
-                Owned<IPropertyTree> response = createPTreeFromXMLString(reply.str(), false);
+                Owned<IPropertyTree> response = createPTreeFromXMLString(reply.str());
                 if (response)
                 {
                     memsize_t proxyId = (memsize_t) response->getPropInt64("@proxyId", 0);
@@ -25894,7 +25894,7 @@ public:
         reply.outputBeginNested("Counts", true);
         sendProxyRequest(&reply, request);
         reply.outputEndNested("Counts"); // strange way to do it...
-        Owned<IPropertyTree> response = createPTreeFromXMLString(reply.str(), false);
+        Owned<IPropertyTree> response = createPTreeFromXMLString(reply.str());
         if (response)
         {
             Owned<IPropertyTreeIterator> edges = response->getElements("edge");
@@ -27911,7 +27911,7 @@ protected:
             {
                 CriticalBlock b(contextCrit);
                 if (!temporaries)
-                    temporaries = createPTree(false);
+                    temporaries = createPTree();
                 return *temporaries;
             }
         case ResultSequenceOnce:
@@ -27922,7 +27922,7 @@ protected:
             {
                 CriticalBlock b(contextCrit);
                 if (!rereadResults)
-                    rereadResults = createPTree(false);
+                    rereadResults = createPTree();
                 return *rereadResults;
             }
         }
@@ -27984,7 +27984,7 @@ public:
         init();
         rowManager->setMemoryLimit(serverQueryFactory->getMemoryLimit());
         workflow.setown(_factory->createWorkflowMachine(true, logctx));
-        context.setown(createPTree(true));
+        context.setown(createPTree(ipt_caseInsensitive));
     }
 
     CRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, bool _isXml, bool _isRaw, bool _isBlocked, HttpHelper &httpHelper, bool _trim, unsigned _priority, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, bool _stripLeadingWhitespace)
@@ -28028,7 +28028,7 @@ public:
             if (workUnit->getXmlParams(wuParams).length())
             {
                 // Merge in params from WU. Ones on command line take precedence though...
-                Owned<IPropertyTree> wuParamTree = createPTreeFromXMLString(wuParams.str(), true);
+                Owned<IPropertyTree> wuParamTree = createPTreeFromXMLString(wuParams.str(), ipt_caseInsensitive);
                 Owned<IPropertyTreeIterator> params = wuParamTree ->getElements("*");
                 ForEach(*params)
                 {
@@ -28361,7 +28361,7 @@ public:
         else
         {
             if (!val)
-                val = ctx.addPropTree(name, createPTree(false));
+                val = ctx.addPropTree(name, createPTree());
             val->setProp("@format", "deserialized");
             val->setPropInt("@id", resultStore.addResult(data, meta));
         }
@@ -28506,7 +28506,7 @@ public:
     virtual void setResultXml(const char *name, unsigned sequence, const char *xml) 
     {
         CriticalBlock b(contextCrit);
-        useContext(sequence).setPropTree(name, createPTreeFromXMLString(xml, true));
+        useContext(sequence).setPropTree(name, createPTreeFromXMLString(xml, ipt_caseInsensitive));
     }
 
     virtual void setResultDecimal(const char *name, unsigned sequence, int len, int precision, bool isSigned, const void *val) 
@@ -29758,7 +29758,7 @@ public:
         StringBuffer lockQuery;
         lockQuery.appendf("<control:childlock thisEndpoint='%d' parent='%d'/>", activeIdxes.item(idx), myEndpoint);
         doChildQuery(idx, lockQuery.str(), lockReply);
-        Owned<IPropertyTree> lockResult = createPTreeFromXMLString(lockReply.str(), true);
+        Owned<IPropertyTree> lockResult = createPTreeFromXMLString(lockReply.str(), ipt_caseInsensitive);
         int lockCount = lockResult->getPropInt("Lock", 0);
         if (lockCount)
         {
@@ -29895,7 +29895,7 @@ public:
         if (traceLevel > 5)
             DBGLOG("doLockChild: %s", queryText);
         isMaster = false;
-        Owned<IPropertyTree> xml = createPTreeFromXMLString(queryText, false);
+        Owned<IPropertyTree> xml = createPTreeFromXMLString(queryText);
         bool unlock = xml->getPropBool("@unlock", false);
         if (unlock)
         {
@@ -29985,7 +29985,7 @@ public:
         // So do the query ourselves and in all child threads;
         Owned<IPropertyTree> mergedStats;
         if (strstr(queryText, "querystats"))
-            mergedStats.setown(createPTree("Endpoint", false));
+            mergedStats.setown(createPTree("Endpoint"));
         
         class casyncfor: public CAsyncFor
         {
@@ -30014,7 +30014,7 @@ public:
                 {
                     StringBuffer childReply;
                     parent->doChildQuery(i, queryText, childReply);
-                    Owned<IPropertyTree> xml = createPTreeFromXMLString(childReply, false);
+                    Owned<IPropertyTree> xml = createPTreeFromXMLString(childReply);
                     if (!xml)
                     {
                         StringBuffer err;
@@ -30043,7 +30043,7 @@ public:
                 myReply.append("'>\n");
                 try
                 {
-                    Owned<IPropertyTree> xml = createPTreeFromXMLString(queryText, false); // control queries are case sensitive
+                    Owned<IPropertyTree> xml = createPTreeFromXMLString(queryText); // control queries are case sensitive
                     doControlMessage(xml, myReply, logctx);
                 }
                 catch(IException *E)
@@ -30058,7 +30058,7 @@ public:
                 CriticalBlock cb(crit);
                 if (mergedStats)
                 {
-                    Owned<IPropertyTree> xml = createPTreeFromXMLString(myReply, false);
+                    Owned<IPropertyTree> xml = createPTreeFromXMLString(myReply);
                     mergeStats(mergedStats, xml, 0);
                 }
                 else
@@ -30701,7 +30701,7 @@ readAnother:
             }
             else if (strnicmp(rawText.str(), "<control:", 9)==0)
             {
-                Owned<IPropertyTree> queryXML = createPTreeFromXMLString(rawText.str(), false); // This is just done to check it is valid XML and make error reporting better...
+                Owned<IPropertyTree> queryXML = createPTreeFromXMLString(rawText.str()); // This is just done to check it is valid XML and make error reporting better...
                 queryXML.clear();
                 bool doControlQuery = true;
                 
@@ -30710,7 +30710,7 @@ readAnother:
 
                 if (strnicmp(rawText.str(), "<control:aclupdate", 18)==0)
                 {
-                    queryXml.setown(createPTreeFromXMLString(rawText.str(), true, true, NULL, true));
+                    queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, (XmlReaderOptions)(xr_ignoreWhiteSpace|xr_ignoreNameSpaces)));
                     IPropertyTree *aclTree = queryXml->queryPropTree("ACL");
                     if (aclTree)
                     {
@@ -30764,7 +30764,9 @@ readAnother:
             {
                 try
                 {
-                    queryXml.setown(createPTreeFromXMLString(rawText.str(), true, defaultStripLeadingWhitespace, NULL, true));
+                    XmlReaderOptions xmlReadFlags = defaultStripLeadingWhitespace ? xr_ignoreWhiteSpace : xr_none;
+                    xmlReadFlags = (XmlReaderOptions)(xmlReadFlags | xr_ignoreNameSpaces);
+                    queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, xmlReadFlags));
                 }
                 catch (IException *E)
                 {
@@ -30848,7 +30850,9 @@ readAnother:
                             if (stripLeadingWhitespace != defaultStripLeadingWhitespace)
                             {
                                 // we need to reparse input xml, as global whitespace setting has been overridden
-                                queryXml.setown(createPTreeFromXMLString(rawText.str(), true, stripLeadingWhitespace , NULL, true));
+                                XmlReaderOptions xmlReadFlags = stripLeadingWhitespace ? xr_ignoreWhiteSpace : xr_none;
+                                xmlReadFlags = (XmlReaderOptions)(xmlReadFlags | xr_ignoreNameSpaces);
+                                queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, xmlReadFlags));
                                 sanitizeQuery(queryXml, queryName, sanitizedText, isHTTP, uid, isRequest, isRequestArray, isBlind, isDebug);
                             }
                             IArrayOf<IPropertyTree> requestArray;
@@ -30862,7 +30866,7 @@ readAnother:
                                     Owned<IPropertyTreeIterator> reqIter = queryXml->getElements(reqIterString.str());
                                     ForEach(*reqIter)
                                     {
-                                        IPropertyTree *fixedreq = createPTree(queryName, true);
+                                        IPropertyTree *fixedreq = createPTree(queryName, ipt_caseInsensitive);
                                         Owned<IPropertyTreeIterator> iter = reqIter->query().getElements("*");
                                         ForEach(*iter)
                                         {
@@ -30873,7 +30877,7 @@ readAnother:
                                 }
                                 else
                                 {
-                                    IPropertyTree *fixedreq = createPTree(queryName, true);
+                                    IPropertyTree *fixedreq = createPTree(queryName, ipt_caseInsensitive);
                                     Owned<IPropertyTreeIterator> iter = queryXml->getElements("*");
                                     ForEach(*iter)
                                     {

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -27838,7 +27838,7 @@ class CRoxieServerContext : public CSlaveContext, implements IRoxieServerContext
     bool sendHeartBeats;
     bool trim;
     bool traceMemoryUsage;
-    bool stripWhitespaceFromStoredDataset;
+    XmlReaderOptions xmlStoredDatasetReadFlags;
     unsigned warnTimeLimit;
     unsigned lastSocketCheckTime;
     unsigned lastHeartBeat;
@@ -27971,7 +27971,7 @@ protected:
         ctxFetchPreload = defaultFetchPreload;
         ctxPrefetchProjectPreload = defaultPrefetchProjectPreload;
 
-        stripWhitespaceFromStoredDataset = false;
+        xmlStoredDatasetReadFlags = xr_none;
         traceActivityTimes = false;
     }
 
@@ -27987,7 +27987,7 @@ public:
         context.setown(createPTree(ipt_caseInsensitive));
     }
 
-    CRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, bool _isXml, bool _isRaw, bool _isBlocked, HttpHelper &httpHelper, bool _trim, unsigned _priority, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, bool _stripLeadingWhitespace)
+    CRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, bool _isXml, bool _isRaw, bool _isBlocked, HttpHelper &httpHelper, bool _trim, unsigned _priority, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions _xmlReadFlags)
         : CSlaveContext(_factory, _logctx, 0, 0, NULL, false, false), serverQueryFactory(_factory)
     {
         init();
@@ -27999,6 +27999,7 @@ public:
         isHttp = httpHelper.isHttp();
         trim = _trim;
         priority = _priority;
+        xmlStoredDatasetReadFlags = _xmlReadFlags;
         sendHeartBeats = enableHeartBeat && isRaw && isBlocked && priority==0;
         timeLimit = context->getPropInt("_TimeLimit", timeLimit);
         warnTimeLimit = context->getPropInt("_warnTimeLimit", warnTimeLimit);
@@ -28086,7 +28087,6 @@ public:
         ctxFetchPreload = context->getPropInt("_FetchPreload", defaultFetchPreload);
         ctxPrefetchProjectPreload = context->getPropInt("_PrefetchProjectPreload", defaultPrefetchProjectPreload);
 
-        stripWhitespaceFromStoredDataset = _stripLeadingWhitespace;
         traceActivityTimes = context->getPropBool("_TraceActivityTimes", false) || context->getPropBool("@timing", false);
     }
 
@@ -28877,7 +28877,7 @@ public:
                 {
                     assertex(xmlTransformer);
                     Variable2IDataVal result(&tlen, &tgt);
-                    CXmlToRawTransformer rawTransformer(*xmlTransformer, stripWhitespaceFromStoredDataset);
+                    CXmlToRawTransformer rawTransformer(*xmlTransformer, xmlStoredDatasetReadFlags);
                     rawTransformer.transformTree(result, *val, !isSet);
                 }
                 else if (strcmp(format, "deserialized")==0)
@@ -28924,7 +28924,7 @@ public:
         else if (xmlTransformer)
         {
             Fixed2IDataVal result(tlen, tgt);
-            CXmlToRawTransformer rawTransformer(*xmlTransformer, stripWhitespaceFromStoredDataset);
+            CXmlToRawTransformer rawTransformer(*xmlTransformer, xmlStoredDatasetReadFlags);
             rawTransformer.transformTree(result, *val, !isSet);
         }
         else if (csvTransformer)
@@ -29549,8 +29549,8 @@ private:
     StringAttr queryName;
 
 public:
-    CSoapRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, HttpHelper &httpHelper, unsigned _priority, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, bool _stripLeadingWhitespace) 
-        : CRoxieServerContext(_context, _factory, _client, true, false, false, httpHelper, true, _priority, _logctx, poolEndpoint, _stripLeadingWhitespace)
+    CSoapRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, HttpHelper &httpHelper, unsigned _priority, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions xmlReadFlags)
+        : CRoxieServerContext(_context, _factory, _client, true, false, false, httpHelper, true, _priority, _logctx, poolEndpoint, xmlReadFlags)
     {
         queryName.set(_context->queryName());
     }
@@ -29602,12 +29602,12 @@ public:
     }
 };
 
-IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, const IQueryFactory *factory, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, unsigned priority, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, bool _stripLeadingWhitespace)
+IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, const IQueryFactory *factory, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, unsigned priority, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions xmlReadFlags)
 {
     if (httpHelper.isHttp())
-        return new CSoapRoxieServerContext(context, factory, client, httpHelper, priority, _logctx, poolEndpoint, _stripLeadingWhitespace);
+        return new CSoapRoxieServerContext(context, factory, client, httpHelper, priority, _logctx, poolEndpoint, xmlReadFlags);
     else
-        return new CRoxieServerContext(context, factory, client, isXml, isRaw, isBlocked, httpHelper, trim, priority, _logctx, poolEndpoint, _stripLeadingWhitespace);
+        return new CRoxieServerContext(context, factory, client, isXml, isRaw, isBlocked, httpHelper, trim, priority, _logctx, poolEndpoint, xmlReadFlags);
 }
 
 IRoxieServerContext *createOnceServerContext(const IQueryFactory *factory, const IRoxieContextLogger &_logctx)
@@ -30120,14 +30120,14 @@ private:
     SafeSocket &client;
     HttpHelper &httpHelper;
     const SocketEndpoint &poolEndpoint;
-    bool stripLeadingWhitespace;
+    XmlReaderOptions xmlReadFlags;
     unsigned &memused;
     unsigned &slaveReplyLen;
     CriticalSection crit;
 
 public:
-    CSoapRequestAsyncFor(const char *_queryName, IQueryFactory *_f, IArrayOf<IPropertyTree> &_requestArray, SafeSocket &_client, HttpHelper &_httpHelper, unsigned &_memused, unsigned &_slaveReplyLen, const char *_queryText, const IRoxieContextLogger &_logctx, const SocketEndpoint &_poolEndpoint, bool _stripLeadingWhitespace) :
-      f(_f), requestArray(_requestArray), client(_client), httpHelper(_httpHelper), memused(_memused), slaveReplyLen(_slaveReplyLen), logctx(_logctx), poolEndpoint(_poolEndpoint), stripLeadingWhitespace(_stripLeadingWhitespace)
+    CSoapRequestAsyncFor(const char *_queryName, IQueryFactory *_f, IArrayOf<IPropertyTree> &_requestArray, SafeSocket &_client, HttpHelper &_httpHelper, unsigned &_memused, unsigned &_slaveReplyLen, const char *_queryText, const IRoxieContextLogger &_logctx, const SocketEndpoint &_poolEndpoint, XmlReaderOptions _xmlReadFlags) :
+      f(_f), requestArray(_requestArray), client(_client), httpHelper(_httpHelper), memused(_memused), slaveReplyLen(_slaveReplyLen), logctx(_logctx), poolEndpoint(_poolEndpoint), xmlReadFlags(_xmlReadFlags)
     {
         queryName = _queryName;
         queryText = _queryText;
@@ -30151,7 +30151,7 @@ public:
         try
         {
             IPropertyTree &request = requestArray.item(idx);
-            Owned<IRoxieServerContext> ctx = f->createContext(&request, client, true, false, false, httpHelper, true, logctx, poolEndpoint, stripLeadingWhitespace);
+            Owned<IRoxieServerContext> ctx = f->createContext(&request, client, true, false, false, httpHelper, true, logctx, poolEndpoint, xmlReadFlags);
             ctx->process();
             ctx->flush(idx);
             CriticalBlock b(crit);
@@ -30764,9 +30764,7 @@ readAnother:
             {
                 try
                 {
-                    XmlReaderOptions xmlReadFlags = defaultStripLeadingWhitespace ? xr_ignoreWhiteSpace : xr_none;
-                    xmlReadFlags = (XmlReaderOptions)(xmlReadFlags | xr_ignoreNameSpaces);
-                    queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, xmlReadFlags));
+                    queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, (XmlReaderOptions)(defaultXmlReadFlags | xr_ignoreNameSpaces)));
                 }
                 catch (IException *E)
                 {
@@ -30844,15 +30842,14 @@ readAnother:
                             client->setHttpMode(queryName, isRequestArray);
                         if (queryFactory)
                         {
-                            bool stripLeadingWhitespace = defaultStripLeadingWhitespace;
-                            stripLeadingWhitespace = queryFactory->getDebugValueBool("stripWhitespaceFromStoredDataset", stripLeadingWhitespace);
+                            bool stripLeadingWhitespace = queryFactory->getDebugValueBool("stripWhitespaceFromStoredDataset", 0 != (xr_ignoreWhiteSpace & defaultXmlReadFlags));
                             stripLeadingWhitespace = queryXml->getPropBool("_stripWhitespaceFromStoredDataset", stripLeadingWhitespace);
-                            if (stripLeadingWhitespace != defaultStripLeadingWhitespace)
+                            XmlReaderOptions xmlReadFlags = (XmlReaderOptions)((defaultXmlReadFlags & ~xr_ignoreWhiteSpace) |
+                                                                               (stripLeadingWhitespace ? xr_ignoreWhiteSpace : xr_none));
+                            if (xmlReadFlags != defaultXmlReadFlags)
                             {
                                 // we need to reparse input xml, as global whitespace setting has been overridden
-                                XmlReaderOptions xmlReadFlags = stripLeadingWhitespace ? xr_ignoreWhiteSpace : xr_none;
-                                xmlReadFlags = (XmlReaderOptions)(xmlReadFlags | xr_ignoreNameSpaces);
-                                queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, xmlReadFlags));
+                                queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, (XmlReaderOptions)(xmlReadFlags|xr_ignoreNameSpaces)));
                                 sanitizeQuery(queryXml, queryName, sanitizedText, isHTTP, uid, isRequest, isRequestArray, isBlind, isDebug);
                             }
                             IArrayOf<IPropertyTree> requestArray;
@@ -30925,12 +30922,12 @@ readAnother:
                             unknownQueryStats.noteComplete();
                             if (isHTTP)
                             {
-                                CSoapRequestAsyncFor af(queryName, queryFactory, requestArray, *client, httpHelper, memused, slavesReplyLen, sanitizedText, logctx, pool->queryEndpoint(), stripLeadingWhitespace);
+                                CSoapRequestAsyncFor af(queryName, queryFactory, requestArray, *client, httpHelper, memused, slavesReplyLen, sanitizedText, logctx, pool->queryEndpoint(), xmlReadFlags);
                                 af.For(requestArray.length(), numRequestArrayThreads);
                             }
                             else
                             {
-                                Owned<IRoxieServerContext> ctx = queryFactory->createContext(queryXml, *client, isXml, isRaw, isBlocked, httpHelper, trim, logctx, pool->queryEndpoint(), stripLeadingWhitespace);
+                                Owned<IRoxieServerContext> ctx = queryFactory->createContext(queryXml, *client, isXml, isRaw, isBlocked, httpHelper, trim, logctx, pool->queryEndpoint(), xmlReadFlags);
                                 if (client && !ctx->outputResultsToSocket())
                                 {
                                     unsigned replyLen = 0;

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -342,7 +342,7 @@ extern IActivityGraph *createActivityGraph(const char *graphName, unsigned id, A
 extern IProbeManager *createProbeManager();
 extern IProbeManager *createDebugManager(IDebuggableContext *debugContext, const char *graphName);
 extern IRoxieSlaveContext *createSlaveContext(const IQueryFactory *factory, const SlaveContextLogger &logctx, unsigned timeLimit, memsize_t memoryLimit, IRoxieQueryPacket *packet);
-extern IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, const IQueryFactory *factory, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, unsigned priority, const IRoxieContextLogger &logctx, const SocketEndpoint &poolEndpoint, bool _stripLeadingWhitespace);
+extern IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, const IQueryFactory *factory, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, unsigned priority, const IRoxieContextLogger &logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions xmlReadFlags);
 extern IRoxieServerContext *createOnceServerContext(const IQueryFactory *factory, const IRoxieContextLogger &_logctx);
 extern WorkflowMachine *createRoxieWorkflowMachine(IPropertyTree *_workflowInfo, bool doOnce, const IRoxieContextLogger &_logctx);
 

--- a/roxie/ccd/ccdsnmp.cpp
+++ b/roxie/ccd/ccdsnmp.cpp
@@ -866,7 +866,7 @@ public:
 
     static IPropertyTree *getAllQueryStats(time_t from, time_t to)
     {
-        Owned<IPTree> result = createPTree("QueryStats", false);
+        Owned<IPTree> result = createPTree("QueryStats");
         SpinBlock b(allStatsCrit);
         ForEachItemIn(idx, allStats)
         {
@@ -907,7 +907,7 @@ public:
     {
         time_t timeNow;
         time(&timeNow);
-        Owned<IPropertyTree> result = createPTree("Query", false);
+        Owned<IPropertyTree> result = createPTree("Query");
         result->setProp("@id", queryName);
         if (expirySeconds && difftime(timeNow, from) <= expirySeconds)
         {

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -575,7 +575,7 @@ public:
         }
         else
         {
-            Owned<IPropertyTree> xml = createPTree(*packageFile, false);
+            Owned<IPropertyTree> xml = createPTree(*packageFile);
             if (strcmp(xml->queryName(), "RoxiePackages")==0)
             {
                 Owned<IPropertyTreeIterator> allpackages = xml->getElements("Package");
@@ -603,7 +603,7 @@ public:
                 {
                     IPropertyTree &item= allQuerySets->query();
                     if (!querySets)
-                        querySets.setown(createPTree("QuerySets", false));
+                        querySets.setown(createPTree("QuerySets"));
                     querySets->addPropTree("QuerySet", item.getBranch("."));
                 }
                 DBGLOG("Loaded package file %s", fileName.str());
@@ -961,7 +961,7 @@ public:
                     throw MakeStringException(ROXIE_INVALID_TOPOLOGY, "Invalid topology file - channel %d repeated for this slave", channelNo);
             }
         }
-        Owned<IPropertyTree> newQuerySets = createPTree("QuerySets", false);
+        Owned<IPropertyTree> newQuerySets = createPTree("QuerySets");
         Owned<IPropertyTree> loadSets = packages->getQuerySets();
         if (loadSets)
         {
@@ -983,7 +983,7 @@ public:
         }
         if (standaloneDll)
         {
-            Owned<IPropertyTree> newQuerySet = createPTree("QuerySet", false);
+            Owned<IPropertyTree> newQuerySet = createPTree("QuerySet");
             newQuerySet->setProp("@name", "_standalone");
             newQuerySet->addPropTree("Query", standaloneDll.getLink());
             newQuerySets->addPropTree("QuerySet", newQuerySet.getClear());
@@ -1564,13 +1564,13 @@ public:
                     id = f->queryQueryName();
                     StringBuffer freply;
                     serverManager->getStats(id, graphName, freply, logctx);
-                    Owned<IPropertyTree> stats = createPTreeFromXMLString(freply.str(), false);
+                    Owned<IPropertyTree> stats = createPTreeFromXMLString(freply.str());
                     for (unsigned channel = 0; channel < numChannels; channel++)
                         if (slaveManagers[channel])
                         {
                             StringBuffer sreply;
                             slaveManagers[channel]->getStats(id, graphName, sreply, logctx);
-                            Owned<IPropertyTree> cstats = createPTreeFromXMLString(sreply.str(), false);
+                            Owned<IPropertyTree> cstats = createPTreeFromXMLString(sreply.str());
                             mergeStats(stats, cstats, 1);
                         }
                     toXML(stats, reply);
@@ -2094,7 +2094,7 @@ extern void createResourceManagers(const IQueryDll *standAloneDll, unsigned numC
         Owned<IPropertyTree> standAloneDllTree;
         if (standAloneDll)
         {
-            standAloneDllTree.setown(createPTree("Query", false));
+            standAloneDllTree.setown(createPTree("Query"));
             standAloneDllTree->setProp("@id", "roxie");
             standAloneDllTree->setProp("@dll", standAloneDll->queryDll()->queryName());
         }
@@ -2481,9 +2481,9 @@ class MergeStatsTest : public CppUnit::TestFixture
 protected:
     void test1()
     {
-        Owned<IPropertyTree> p1 = createPTreeFromXMLString(g1, false);
-        Owned<IPropertyTree> p2 = createPTreeFromXMLString(g2, false);
-        Owned<IPropertyTree> e = createPTreeFromXMLString(expected, false);
+        Owned<IPropertyTree> p1 = createPTreeFromXMLString(g1);
+        Owned<IPropertyTree> p2 = createPTreeFromXMLString(g2);
+        Owned<IPropertyTree> e = createPTreeFromXMLString(expected);
         mergeStats(p1, p2, 0);
         StringBuffer s1, s2;
         toXML(p1, s1);

--- a/roxie/roxieclient/roxieclient.cpp
+++ b/roxie/roxieclient/roxieclient.cpp
@@ -372,7 +372,7 @@ void RoxieThread::processQuery()
                     StringBuffer body(x.length() - (payload-obuf), payload);
                     StringBuffer xml;
                     xml.append("<Exception>").append(body).append("</Exception>");
-                    Owned<IPropertyTree> ep = createPTreeFromXMLString(xml.str(), false);
+                    Owned<IPropertyTree> ep = createPTreeFromXMLString(xml.str());
                     int code = ep->getPropInt("./Code", 0);
                     SocketEndpoint peerEp;
                     StringBuffer peerStr;
@@ -578,7 +578,7 @@ void CRoxieClient::runQuery(const char* query, bool trim)
     StringBuffer qxml;
     if(trim)
     {
-        Owned<IPropertyTree> qtree = createPTreeFromXMLString(query, false, true);
+        Owned<IPropertyTree> qtree = createPTreeFromXMLString(query);
         if(qtree)
         {
             qtree->setPropBool("@trim", true);

--- a/roxie/roxiepipe/roxiepipe.cpp
+++ b/roxie/roxiepipe/roxiepipe.cpp
@@ -275,7 +275,7 @@ public:
                         delete x;
                         StringBuffer xml;
                         xml.append("<Exception>").append(body).append("</Exception>");
-                        Owned<IPropertyTree> ep = createPTreeFromXMLString(xml.str(), false);
+                        Owned<IPropertyTree> ep = createPTreeFromXMLString(xml.str());
                         int code = ep->getPropInt("./Code", 0);
                         SocketEndpoint peerEp;
                         StringBuffer peerStr;
@@ -297,7 +297,7 @@ public:
             }
             else
             {
-                Owned<IPropertyTree> ep = createPTreeFromXMLString(x->length(), x->toByteArray(), false);
+                Owned<IPropertyTree> ep = createPTreeFromXMLString(x->length(), x->toByteArray());
 
                 if (strcmp(ep->queryName(), "Exception") == 0)
                 {
@@ -310,7 +310,7 @@ public:
                     int code = 0;
                     try
                     {
-                        Owned<IPropertyTree> ep = createPTreeFromXMLString(xml.str(), false);
+                        Owned<IPropertyTree> ep = createPTreeFromXMLString(xml.str());
                         code = ep->getPropInt("./Code", 0);
                     }
                     catch (IException *E)

--- a/rtl/eclrtl/workflow.cpp
+++ b/rtl/eclrtl/workflow.cpp
@@ -128,7 +128,7 @@ public:
     CWorkflowItem(IPropertyTree & _tree) { tree.setown(&_tree); }
     CWorkflowItem(IPropertyTree * ptree, unsigned wfid, WFType type, WFMode mode, unsigned success, unsigned failure, unsigned recovery, unsigned retriesAllowed, unsigned contingencyFor)
     {
-        tree.setown(LINK(ptree->addPropTree("Item", createPTree(false))));
+        tree.setown(LINK(ptree->addPropTree("Item", createPTree())));
         tree->setPropInt("@wfid", wfid);
         setEnum(tree, "@type", type, wftypes);
         setEnum(tree, "@mode", mode, wfmodes);
@@ -138,7 +138,7 @@ public:
         {
             tree->setPropInt("@recovery", recovery);
             tree->setPropInt("@retriesAllowed", retriesAllowed);
-            tree->addPropTree("Dependency", createPTree(false))->setPropInt("@wfid", recovery);
+            tree->addPropTree("Dependency", createPTree())->setPropInt("@wfid", recovery);
         }
         if(contingencyFor) tree->setPropInt("@contingencyFor", contingencyFor);
         reset();
@@ -164,11 +164,11 @@ public:
     virtual IStringVal & getPersistName(IStringVal & val) const { val.set(tree->queryProp("@persistName")); return val; }
     virtual unsigned     queryPersistWfid() const { return tree->getPropInt("@persistWfid", 0); }
     virtual IStringVal & queryCluster(IStringVal & val) const { val.set(tree->queryProp("@cluster")); return val; }
-    virtual void         setScheduledNow() { tree->setPropTree("Schedule", createPTree(false)); setEnum(tree, "@state", WFStateReqd, wfstates); }
-    virtual void         setScheduledOn(char const * name, char const * text) { IPropertyTree * stree = createPTree(false); stree->setProp("@name", name); stree->setProp("@text", text); tree->setPropTree("Schedule", createPTree(false))->setPropTree("Event", stree); setEnum(tree, "@state", WFStateWait, wfstates); }
+    virtual void         setScheduledNow() { tree->setPropTree("Schedule", createPTree()); setEnum(tree, "@state", WFStateReqd, wfstates); }
+    virtual void         setScheduledOn(char const * name, char const * text) { IPropertyTree * stree = createPTree(); stree->setProp("@name", name); stree->setProp("@text", text); tree->setPropTree("Schedule", createPTree())->setPropTree("Event", stree); setEnum(tree, "@state", WFStateWait, wfstates); }
     virtual void         setSchedulePriority(unsigned priority) { assertex(tree->hasProp("Schedule")); tree->setPropInt("Schedule/@priority", priority); }
     virtual void         setScheduleCount(unsigned count) { assertex(tree->hasProp("Schedule")); tree->setPropInt("Schedule/@count", count); tree->setPropInt("Schedule/@countRemaining", count); }
-    virtual void         addDependency(unsigned wfid) { tree->addPropTree("Dependency", createPTree(false))->setPropInt("@wfid", wfid); }
+    virtual void         addDependency(unsigned wfid) { tree->addPropTree("Dependency", createPTree())->setPropInt("@wfid", wfid); }
     virtual void         setPersistInfo(char const * name, unsigned wfid) { tree->setProp("@persistName", name); tree->setPropInt("@persistWfid", wfid); }
     virtual void         setCluster(const char * cluster) { tree->setProp("@cluster", cluster); }
     //info set at run time

--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -1590,7 +1590,7 @@ IPropertyTree * CKeyIndex::getMetadata()
     IPropertyTree * ret;
     try
     {
-        ret = createPTreeFromXMLString(xml.str(), false);
+        ret = createPTreeFromXMLString(xml.str());
     }
     catch(IXMLReadException * e)
     {

--- a/system/jhtree/keydiff.cpp
+++ b/system/jhtree/keydiff.cpp
@@ -514,7 +514,7 @@ class CKeyFileWriter: public CInterface, extends IKeyFileRowWriter
 public:
     IMPLEMENT_IINTERFACE;
     CKeyFileWriter(const char *filename, IPropertyTree *_header, bool overwrite, unsigned nodeSize)
-        : header(createPTree(_header))
+        : header(createPTreeFromIPT(_header))
     {
         writer.init(filename,overwrite,header->getPropInt("@keyedSize"), header->getPropInt("@rowSize"), header->getPropBool("@variableWidth"), header->getPropBool("@quickCompressed"), header->getPropInt("@nodeSize", NODESIZE));
         size32_t rowsize = header->getPropInt("@rowSize");

--- a/system/jhtree/keydiff.cpp
+++ b/system/jhtree/keydiff.cpp
@@ -379,7 +379,7 @@ public:
         crecsize.maxrecsize = buffer.buffSize();
         crecsize.frecsize = isvar?0:crecsize.maxrecsize;
 
-        header.setown(createPTree("Index",false));
+        header.setown(createPTree("Index"));
         header->setPropInt("@rowSize",rowsize);
         header->setPropInt("@keyedSize",reader.queryKeyedSize());
         header->setPropBool("@variableWidth",isvar);

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -397,7 +397,7 @@ public:
         
         if (strncmp(xml, "<Exceptions>", 12))
             xml = wrapper.appendf("<Exceptions>%s</Exceptions>", xml).str();
-        Owned<IPropertyTree> pTree = createPTreeFromXMLString(xml, false, true);
+        Owned<IPropertyTree> pTree = createPTreeFromXMLString(xml, ipt_none, xr_ignoreWhiteSpace);
         if (!pTree)
             throw MakeStringException(-1, "Failed to deserialize IMultiException!");
         Owned<IPropertyTreeIterator> i = pTree->getElements("Exception");

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -397,7 +397,7 @@ public:
         
         if (strncmp(xml, "<Exceptions>", 12))
             xml = wrapper.appendf("<Exceptions>%s</Exceptions>", xml).str();
-        Owned<IPropertyTree> pTree = createPTreeFromXMLString(xml, ipt_none, xr_ignoreWhiteSpace);
+        Owned<IPropertyTree> pTree = createPTreeFromXMLString(xml);
         if (!pTree)
             throw MakeStringException(-1, "Failed to deserialize IMultiException!");
         Owned<IPropertyTreeIterator> i = pTree->getElements("Exception");

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -610,28 +610,28 @@ void LogMsg::fprintTableHead(FILE * handle, unsigned fields)
 
 void PassAllLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "all");
     tree->addPropTree("filter", filterTree);
 }
 
 void PassLocalLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "local");
     tree->addPropTree("filter", filterTree);
 }
 
 void PassNoneLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "none");
     tree->addPropTree("filter", filterTree);
 }
 
 void CategoryLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "category");
     filterTree->setPropInt("@audience", audienceMask);
     filterTree->setPropInt("@class", classMask);
@@ -642,7 +642,7 @@ void CategoryLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void PIDLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "pid");
     filterTree->setPropInt("@pid", pid);
     if(localFlag) filterTree->setPropInt("@local", 1);
@@ -651,7 +651,7 @@ void PIDLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void TIDLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "tid");
     filterTree->setPropInt("@tid", tid);
     if(localFlag) filterTree->setPropInt("@local", 1);
@@ -660,7 +660,7 @@ void TIDLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void NodeLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "node");
     StringBuffer buff;
     node.getIpText(buff);
@@ -672,7 +672,7 @@ void NodeLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void IpLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "ip");
     StringBuffer buff;
     ip.getIpText(buff);
@@ -683,7 +683,7 @@ void IpLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void JobLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "job");
     filterTree->setPropInt("@job", (int)job);
     if(localFlag) filterTree->setPropInt("@local", 1);
@@ -692,7 +692,7 @@ void JobLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void UserLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "user");
     filterTree->setPropInt("@user", (int)user);
     if(localFlag) filterTree->setPropInt("@local", 1);
@@ -701,7 +701,7 @@ void UserLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void SessionLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "session");
     filterTree->setPropInt("@session", (int)session);
     if(localFlag) filterTree->setPropInt("@local", 1);
@@ -710,7 +710,7 @@ void SessionLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void ComponentLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "component");
     filterTree->setPropInt("@component", component);
     if(localFlag) filterTree->setPropInt("@local", 1);
@@ -726,7 +726,7 @@ bool RegexLogMsgFilter::includeMessage(const LogMsg & msg) const
 
 void RegexLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "regex");
     filterTree->setProp("@regex", regexText);
     if(localFlag) filterTree->setPropInt("@local", 1);
@@ -735,7 +735,7 @@ void RegexLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void NotLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "not");
     arg->addToPTree(filterTree);
     tree->addPropTree("filter", filterTree);
@@ -743,7 +743,7 @@ void NotLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void AndLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "and");
     arg1->addToPTree(filterTree);
     arg2->addToPTree(filterTree);
@@ -752,7 +752,7 @@ void AndLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void OrLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "or");
     arg1->addToPTree(filterTree);
     arg2->addToPTree(filterTree);
@@ -761,7 +761,7 @@ void OrLogMsgFilter::addToPTree(IPropertyTree * tree) const
 
 void SwitchLogMsgFilter::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * filterTree = createPTree(true);
+    IPropertyTree * filterTree = createPTree(ipt_caseInsensitive);
     filterTree->setProp("@type", "switch");
     cond->addToPTree(filterTree);
     yes->addToPTree(filterTree);
@@ -787,7 +787,7 @@ void CategoryLogMsgFilter::reset()
 
 void HandleLogMsgHandlerTable::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * handlerTree = createPTree(true);
+    IPropertyTree * handlerTree = createPTree(ipt_caseInsensitive);
     if(handle==stderr)
         handlerTree->setProp("@type", "stderr");
     else
@@ -798,7 +798,7 @@ void HandleLogMsgHandlerTable::addToPTree(IPropertyTree * tree) const
 
 void HandleLogMsgHandlerXML::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * handlerTree = createPTree(true);
+    IPropertyTree * handlerTree = createPTree(ipt_caseInsensitive);
     if(handle==stderr)
         handlerTree->setProp("@type", "stderr");
     else
@@ -870,7 +870,7 @@ void FileLogMsgHandler::enable()
 
 void FileLogMsgHandlerTable::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * handlerTree = createPTree(true);
+    IPropertyTree * handlerTree = createPTree(ipt_caseInsensitive);
     handlerTree->setProp("@type", "file");
     handlerTree->setProp("@filename", filename.get());
     if(headerText) handlerTree->setProp("@headertext", headerText.get());
@@ -883,7 +883,7 @@ void FileLogMsgHandlerTable::addToPTree(IPropertyTree * tree) const
 
 void FileLogMsgHandlerXML::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * handlerTree = createPTree(true);
+    IPropertyTree * handlerTree = createPTree(ipt_caseInsensitive);
     handlerTree->setProp("@type", "file");
     handlerTree->setProp("@filename", filename.get());
     if(headerText) handlerTree->setProp("@headertext", headerText.get());
@@ -928,7 +928,7 @@ void RollingFileLogMsgHandler::enable()
 
 void RollingFileLogMsgHandler::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * handlerTree = createPTree(true);
+    IPropertyTree * handlerTree = createPTree(ipt_caseInsensitive);
     handlerTree->setProp("@type", "rollingfile");
     handlerTree->setProp("@filebase", filebase.get());
     handlerTree->setProp("@fileextn", fileextn.get());
@@ -1035,7 +1035,7 @@ void BinLogMsgHandler::handleMessage(const LogMsg & msg) const
 
 void BinLogMsgHandler::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * handlerTree = createPTree(true);
+    IPropertyTree * handlerTree = createPTree(ipt_caseInsensitive);
     handlerTree->setProp("@type", "binary");
     handlerTree->setProp("@filename", filename.get());
     if(append) handlerTree->setProp("@append", "true");
@@ -1284,7 +1284,7 @@ IException * LogMsgPrepender::report(IException * e, const char * prefix, LogMsg
 
 void LogMsgMonitor::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * monitorTree = createPTree(true);
+    IPropertyTree * monitorTree = createPTree(ipt_caseInsensitive);
     handler->addToPTree(monitorTree);
     filter->addToPTree(monitorTree);
     tree->addPropTree("monitor", monitorTree);
@@ -2497,7 +2497,7 @@ void SysLogMsgHandler::handleMessage(const LogMsg & msg) const
 
 void SysLogMsgHandler::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * handlerTree = createPTree(true);
+    IPropertyTree * handlerTree = createPTree(ipt_caseInsensitive);
     handlerTree->setProp("@type", "audit");
     tree->addPropTree("handler", handlerTree);
 }

--- a/system/jlib/jlzw.cpp
+++ b/system/jlib/jlzw.cpp
@@ -2429,7 +2429,7 @@ IExpander *createAESExpander256(size32_t len, const void *key)
 
 IPropertyTree *getBlockedFileDetails(IFile *file)
 {
-    Owned<IPropertyTree> tree = createPTree("BlockedFile",false);
+    Owned<IPropertyTree> tree = createPTree("BlockedFile");
     Owned<IFileIO> fileio = file?file->open(IFOread):NULL;
     if (fileio) {
         offset_t fsize = fileio->size();
@@ -2449,7 +2449,7 @@ IPropertyTree *getBlockedFileDetails(IFile *file)
                         offset_t s = 0;
                         const offset_t *index = (const offset_t *)indexbuf.bufferBase();
                         for (unsigned i=0;i<nb;i++) {
-                            IPropertyTree * t = tree->addPropTree("Block",createPTree("Block",false));
+                            IPropertyTree * t = tree->addPropTree("Block",createPTree("Block"));
                             t->addPropInt64("@start",s);
                             offset_t p = s;
                             s = index[i];

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -5931,8 +5931,8 @@ class COrderedPTree : public PTree
         }
     };
 public:
-    COrderedPTree(const char *name=NULL, byte flags=ipt_ordered, IPTArrayValue *value=NULL, ChildMap *children=NULL)
-        : PTree(name, flags, value, children) { }
+    COrderedPTree(const char *name=NULL, byte flags=ipt_none, IPTArrayValue *value=NULL, ChildMap *children=NULL)
+        : PTree(name, flags|ipt_ordered, value, children) { }
 
     virtual bool isEquivalent(IPropertyTree *tree) { return (NULL != QUERYINTERFACE(tree, COrderedPTree)); }
     virtual IPropertyTree *create(const char *name=NULL, IPTArrayValue *value=NULL, ChildMap *children=NULL, bool existing=false)

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -162,9 +162,10 @@ interface IPTreeNodeCreator : extends IInterface
     virtual IPropertyTree *create(const char *tag) = 0;
 };
 
-enum ipt_flags { ipt_none=0x00, ipt_caseInsensitive=0x01, ipt_ordered=0x02 };
-jlib_decl IPTreeMaker *createPTreeMaker(ipt_flags flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
-jlib_decl IPTreeMaker *createRootLessPTreeMaker(ipt_flags flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
+// NB ipt_ext5 - used by SDS
+enum ipt_flags { ipt_none=0x00, ipt_caseInsensitive=0x01, ipt_ordered=0x02, ipt_binary=0x04, ipt_ext1=0x08, ipt_ext2=16, ipt_ext3=32, ipt_ext4=64, ipt_ext5=128 };
+jlib_decl IPTreeMaker *createPTreeMaker(byte flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
+jlib_decl IPTreeMaker *createRootLessPTreeMaker(byte flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
 jlib_decl IXMLReader *createXMLStreamReader(ISimpleReadStream &stream, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace, size32_t bufSize=0);
 jlib_decl IXMLReader *createXMLStringReader(const char *xml, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace);
 jlib_decl IXMLReader *createXMLBufferReader(const void *buf, size32_t bufLength, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace);
@@ -180,15 +181,16 @@ jlib_decl bool areMatchingPTrees(IPropertyTree * left, IPropertyTree * right);
 jlib_decl IPropertyTree *createPTree(MemoryBuffer &src);
 jlib_decl IPropertyTree *createPTree(const IPropertyTree *srcTree);
 
-jlib_decl IPropertyTree *createPTree(ipt_flags flags=ipt_none);
-jlib_decl IPropertyTree *createPTree(const char *name, ipt_flags flags=ipt_none);
-jlib_decl IPropertyTree *createPTree(IFile &ifile, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
-jlib_decl IPropertyTree *createPTree(IFileIO &ifileio, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
-jlib_decl IPropertyTree *createPTree(ISimpleReadStream &stream, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
-jlib_decl IPropertyTree *createPTreeFromXMLString(const char *xml, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
-jlib_decl IPropertyTree *createPTreeFromXMLString(unsigned len, const char *xml, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
-jlib_decl IPropertyTree *createPTreeFromXMLFile(const char *filename, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTree(byte flags=ipt_none);
+jlib_decl IPropertyTree *createPTree(const char *name, byte flags=ipt_none);
+jlib_decl IPropertyTree *createPTree(IFile &ifile, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTree(IFileIO &ifileio, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTree(ISimpleReadStream &stream, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTreeFromXMLString(const char *xml, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTreeFromXMLString(unsigned len, const char *xml, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTreeFromXMLFile(const char *filename, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
 
+enum { };
 #define XML_SortTags 0x01
 #define XML_Format   0x02
 #define XML_NoEncode 0x04

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -137,6 +137,7 @@ interface jlib_thrown_decl IXMLReadException : extends IException
 extern jlib_decl IXMLReadException *createXmlReadException(int code, const char *msg, const char *context, unsigned line, offset_t offset);
 
 enum XmlReaderOptions { xr_none=0x00, xr_ignoreWhiteSpace=0x01, xr_noRoot=0x02, xr_ignoreNameSpaces=0x04 };
+
 interface IXMLReader : extends IInterface
 {
     virtual void load() = 0;
@@ -161,8 +162,9 @@ interface IPTreeNodeCreator : extends IInterface
     virtual IPropertyTree *create(const char *tag) = 0;
 };
 
-jlib_decl IPTreeMaker *createPTreeMaker(bool caseInsensitive, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
-jlib_decl IPTreeMaker *createRootLessPTreeMaker(bool caseInsensitive, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
+enum ipt_flags { ipt_none=0x00, ipt_caseInsensitive=0x01, ipt_ordered=0x02 };
+jlib_decl IPTreeMaker *createPTreeMaker(ipt_flags flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
+jlib_decl IPTreeMaker *createRootLessPTreeMaker(ipt_flags flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
 jlib_decl IXMLReader *createXMLStreamReader(ISimpleReadStream &stream, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace, size32_t bufSize=0);
 jlib_decl IXMLReader *createXMLStringReader(const char *xml, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace);
 jlib_decl IXMLReader *createXMLBufferReader(const void *buf, size32_t bufLength, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace);
@@ -170,22 +172,22 @@ jlib_decl IPullXMLReader *createPullXMLStreamReader(ISimpleReadStream &stream, I
 jlib_decl IPullXMLReader *createPullXMLStringReader(const char *xml, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace);
 jlib_decl IPullXMLReader *createPullXMLBufferReader(const void *buf, size32_t bufLength, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace);
 
-jlib_decl IPropertyTree *createPTree(bool nocase);
-jlib_decl IPropertyTree *createPTree(const char *name, bool nocase);
-jlib_decl IPropertyTree *createPTree(MemoryBuffer &src);
-jlib_decl IPropertyTree *createPTree(const IPropertyTree *srcTree);
 jlib_decl void mergePTree(IPropertyTree *target, IPropertyTree *toMerge);
 jlib_decl void synchronizePTree(IPropertyTree *target, IPropertyTree *source);
 jlib_decl IPropertyTree *ensurePTree(IPropertyTree *root, const char *xpath);
 jlib_decl bool areMatchingPTrees(IPropertyTree * left, IPropertyTree * right);
 
-jlib_decl IPropertyTree *createPTree(IFile &ifile, bool caseInsensitive, bool ignoreWhiteSpace=true, IPTreeMaker *iMaker=NULL, bool ignoreCheckRoot=false);
-jlib_decl IPropertyTree *createPTree(IFileIO &ifileio, bool caseInsensitive, bool ignoreWhiteSpace=true, IPTreeMaker *iMaker=NULL, bool ignoreCheckRoot=false);
-jlib_decl IPropertyTree *createPTree(ISimpleReadStream &stream, bool caseInsensitive, bool ignoreWhiteSpace=true, IPTreeMaker *iMaker=NULL, bool ignoreCheckRoot=false);
-jlib_decl IPropertyTree *createPTreeFromXMLString(const char *xml, bool caseInsensitive, bool ignoreWhiteSpace=true, IPTreeMaker *iMaker=NULL, bool ignoreNameSpaces=false, bool ignoreCheckRoot=false);
-jlib_decl IPropertyTree *createPTreeFromXMLString(unsigned len, const char *xml, bool caseInsensitive, bool ignoreWhiteSpace=true, IPTreeMaker *iMaker=NULL, bool ignoreCheckRoot=false);
-jlib_decl IPropertyTree *createPTreeFromXMLFile(const char *filename, bool caseInsensitive, bool ignoreWhiteSpace=true, IPTreeMaker *iMaker=NULL, bool ignoreCheckRoot=false);
-jlib_decl void loadXMLFileToPTree(IPropertyTree *tree, const char *filename, bool caseInsensitive, bool ignoreWhiteSpace=true, IPTreeMaker *iMaker=NULL, bool ignoreCheckRoot=false);
+jlib_decl IPropertyTree *createPTree(MemoryBuffer &src);
+jlib_decl IPropertyTree *createPTree(const IPropertyTree *srcTree);
+
+jlib_decl IPropertyTree *createPTree(ipt_flags flags=ipt_none);
+jlib_decl IPropertyTree *createPTree(const char *name, ipt_flags flags=ipt_none);
+jlib_decl IPropertyTree *createPTree(IFile &ifile, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTree(IFileIO &ifileio, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTree(ISimpleReadStream &stream, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTreeFromXMLString(const char *xml, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTreeFromXMLString(unsigned len, const char *xml, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTreeFromXMLFile(const char *filename, ipt_flags flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
 
 #define XML_SortTags 0x01
 #define XML_Format   0x02
@@ -201,8 +203,6 @@ jlib_decl void saveXML(const char *filename, const IPropertyTree *tree, unsigned
 jlib_decl void saveXML(IFile &ifile, const IPropertyTree *tree, unsigned indent = 0, byte flags=XML_Format);
 jlib_decl void saveXML(IFileIO &ifileio, const IPropertyTree *tree, unsigned indent = 0, byte flags=XML_Format);
 jlib_decl void saveXML(IIOStream &stream, const IPropertyTree *tree, unsigned indent = 0, byte flags=XML_Format);
-jlib_decl IPropertyTree *loadPropertyTree(const char *filename, bool nocase, bool ignoreWhiteSpace=true);
-#define createPropertyTree(CASE, NAME) createPTree(NAME, CASE)
 
 jlib_decl const char *splitXPath(const char *xpath, StringBuffer &head); // returns tail, fills 'head' with leading xpath
 jlib_decl bool validateXPathSyntax(const char *xpath, StringBuffer *error=NULL);

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -179,7 +179,6 @@ jlib_decl IPropertyTree *ensurePTree(IPropertyTree *root, const char *xpath);
 jlib_decl bool areMatchingPTrees(IPropertyTree * left, IPropertyTree * right);
 
 jlib_decl IPropertyTree *createPTree(MemoryBuffer &src);
-jlib_decl IPropertyTree *createPTree(const IPropertyTree *srcTree);
 
 jlib_decl IPropertyTree *createPTree(byte flags=ipt_none);
 jlib_decl IPropertyTree *createPTree(const char *name, byte flags=ipt_none);
@@ -189,8 +188,8 @@ jlib_decl IPropertyTree *createPTree(ISimpleReadStream &stream, byte flags=ipt_n
 jlib_decl IPropertyTree *createPTreeFromXMLString(const char *xml, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
 jlib_decl IPropertyTree *createPTreeFromXMLString(unsigned len, const char *xml, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
 jlib_decl IPropertyTree *createPTreeFromXMLFile(const char *filename, byte flags=ipt_none, XmlReaderOptions readFlags=xr_ignoreWhiteSpace, IPTreeMaker *iMaker=NULL);
+jlib_decl IPropertyTree *createPTreeFromIPT(const IPropertyTree *srcTree, ipt_flags flags=ipt_none);
 
-enum { };
 #define XML_SortTags 0x01
 #define XML_Format   0x02
 #define XML_NoEncode 0x04

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -2263,7 +2263,7 @@ IPropertyTree *getHPCCenvironment(const char *confloc)
             if (file) {
                 Owned<IFileIO> fileio = file->open(IFOread);
                 if (fileio)
-                    return createPTree(*fileio, false);
+                    return createPTree(*fileio);
             }
         }
     }

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -2276,7 +2276,7 @@ static IPropertyTree *getOSSdirTree()
     if (envtree) {
         IPropertyTree *ret = envtree->queryPropTree("Software/Directories");
         if (ret) 
-            return createPTree(ret);
+            return createPTreeFromIPT(ret);
     }
     return NULL;
 }

--- a/system/mp/mplog.cpp
+++ b/system/mp/mplog.cpp
@@ -362,7 +362,7 @@ void LinkToParentLogMsgHandler::handleMessage(const LogMsg & msg) const
 
 void LinkToParentLogMsgHandler::addToPTree(IPropertyTree * tree) const
 {
-    IPropertyTree * handlerTree = createPTree(true);
+    IPropertyTree * handlerTree = createPTree(ipt_caseInsensitive);
     handlerTree->setProp("@type", "linktoparent");
     StringBuffer buff;
     parentNode->endpoint().getUrlStr(buff);

--- a/system/security/LdapSecurity/aci.cpp
+++ b/system/security/LdapSecurity/aci.cpp
@@ -892,7 +892,7 @@ AciProcessor::AciProcessor(IPropertyTree* cfg)
         throw MakeStringException(-1, "AciProcessor() - config is NULL");
     m_cfg.set(cfg);
 
-    m_sidcache.setown(createPTree(false));
+    m_sidcache.setown(createPTree());
     m_cfg->getProp(".//@ldapAddress", m_server);
 }
 

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -500,7 +500,7 @@ ISecProperty* CLdapSecResourceList::findProperty(const char* name)
  **********************************************************/
 CLdapSecManager::CLdapSecManager(const char *serviceName, const char *config)
 {
-    IPropertyTree* cfg = createPTreeFromXMLString(config, true);
+    IPropertyTree* cfg = createPTreeFromXMLString(config, ipt_caseInsensitive);
 
     if(cfg == NULL)
     {

--- a/system/security/LdapSecurity/permissions.cpp
+++ b/system/security/LdapSecurity/permissions.cpp
@@ -57,7 +57,7 @@ PermissionProcessor::PermissionProcessor(IPropertyTree* config)
         throw MakeStringException(-1, "PermissionProcessor() - config is NULL");
     m_cfg.set(config);
 
-    m_sidcache.setown(createPTree(false));
+    m_sidcache.setown(createPTree());
     m_cfg->getProp(".//@ldapAddress", m_server);
 }
 

--- a/system/security/shared/basesecurity.cpp
+++ b/system/security/shared/basesecurity.cpp
@@ -33,7 +33,7 @@
 
 CBaseSecurityManager::CBaseSecurityManager(const char *serviceName, const char *config)
 {
-    Owned<IPropertyTree> cfg = createPTreeFromXMLString(config, true);
+    Owned<IPropertyTree> cfg = createPTreeFromXMLString(config, ipt_caseInsensitive);
     if(cfg.get() == NULL)
         throw MakeStringException(-1, "createPTreeFromXMLString() failed for %s", config);
     init(serviceName,cfg);

--- a/system/security/test/ldapsecuritytest/ldapsecuritytest.cpp
+++ b/system/security/test/ldapsecuritytest/ldapsecuritytest.cpp
@@ -251,7 +251,7 @@ int main(int argc, char* argv[])
     
     try
     {
-        Owned<IPropertyTree> cfg = createPTreeFromXMLFile(configfile, false);
+        Owned<IPropertyTree> cfg = createPTreeFromXMLFile(configfile);
         Owned<IPropertyTree> seccfg = cfg->getPropTree(".//ldapSecurity");
         if(seccfg == NULL)
         {

--- a/system/xmllib/xmlvalidator.cpp
+++ b/system/xmllib/xmlvalidator.cpp
@@ -296,7 +296,7 @@ void CDomXmlValidator::validate()
         // Insert namesapce if necessary: 
         try 
         {
-            Owned<IPTree> xml = createPTreeFromXMLString(m_xmlBuf,false);
+            Owned<IPTree> xml = createPTreeFromXMLString(m_xmlBuf);
 
             bool hasXmlns = false;
             Owned<IAttributeIterator> attrs = xml->getAttributes();

--- a/system/xmllib/xsdparser.cpp
+++ b/system/xmllib/xsdparser.cpp
@@ -661,7 +661,7 @@ CXmlSchema::CXmlSchema(const char* schemaSrc)
 {
     m_unnamedIdx = 0;
     try {
-        m_schema.setown(createPTreeFromXMLString(schemaSrc,false));     
+        m_schema.setown(createPTreeFromXMLString(schemaSrc));
         setSchemaNamespace();
     } catch (IException* e) {
         StringBuffer msg;
@@ -669,7 +669,7 @@ CXmlSchema::CXmlSchema(const char* schemaSrc)
     }   
 
     if (!m_schema.get())
-        m_schema.setown(createPTree("xsd:schema", false));
+        m_schema.setown(createPTree("xsd:schema"));
 }
 
 CXmlSchema::CXmlSchema(IPTree* schema) 

--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -214,14 +214,14 @@ public:
                 throw MakeActivityException(this, 0, "Invalid name %s in user metadata for index %s (names beginning with underscore are reserved)", name.str(), helper->getFileName());
             if(!validateXMLTag(name.str()))
                 throw MakeActivityException(this, 0, "Invalid name %s in user metadata for index %s (not legal XML element name)", name.str(), helper->getFileName());
-            if(!metadata) metadata.setown(createPTree("metadata", false));
+            if(!metadata) metadata.setown(createPTree("metadata"));
             metadata->setProp(name.str(), value.str());
         }
     }
 
     void buildLayoutMetadata(Owned<IPropertyTree> & metadata)
     {
-        if(!metadata) metadata.setown(createPTree("metadata", false));
+        if(!metadata) metadata.setown(createPTree("metadata"));
         metadata->setProp("_record_ECL", helper->queryRecordECL());
 
         void * layoutMetaBuff;

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -188,13 +188,13 @@ public:
         StringBuffer path("Patch[@name=\"");
         path.append(scopedName.str()).append("\"]");
         IPropertyTree *patch = fileProps.queryPropTree(path.str());
-        if (!patch) patch = fileProps.addPropTree("Patch", createPTree(false));
+        if (!patch) patch = fileProps.addPropTree("Patch", createPTree());
         patch->setProp("@name", scopedName.str());
         unsigned checkSum;
         if (patchFile->getFileCheckSum(checkSum))
             patch->setPropInt64("@checkSum", checkSum);
 
-        IPropertyTree *index = patch->setPropTree("Index", createPTree(false));
+        IPropertyTree *index = patch->setPropTree("Index", createPTree());
         index->setProp("@name", originalIndexFile->queryLogicalName());
         if (originalIndexFile->getFileCheckSum(checkSum))
             index->setPropInt64("@checkSum", checkSum);

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -392,7 +392,7 @@ CGraphElementBase *createGraphElement(IPropertyTree &node, CGraphBase &owner, CG
 
 CGraphElementBase::CGraphElementBase(CGraphBase &_owner, IPropertyTree &_xgmml) : owner(&_owner)
 {
-    xgmml.setown(createPTree(&_xgmml));
+    xgmml.setown(createPTreeFromIPT(&_xgmml));
     eclText.set(xgmml->queryProp("att[@name=\"ecl\"]/@value"));
     id = xgmml->getPropInt("@id", 0);
     kind = (ThorActivityKind)xgmml->getPropInt("att[@name=\"_kind\"]/@value", TAKnone);
@@ -1757,7 +1757,7 @@ void CGraphBase::createFromXGMML(IPropertyTree *_node, CGraphBase *_owner, CGrap
 {
     owner = _owner;
     parent = _parent?_parent:owner;
-    node.setown(createPTree(_node));
+    node.setown(createPTreeFromIPT(_node));
     xgmml = node->queryPropTree("att/graph");
     sink = xgmml->getPropBool("att[@name=\"rootGraph\"]/@value", false);
     graphId = node->getPropInt("@id");

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1809,7 +1809,7 @@ void CGraphBase::createFromXGMML(IPropertyTree *_node, CGraphBase *_owner, CGrap
                         // not a loop graph, force it to be local child graph
                         if (!e.getPropBool("att[@name=\"coLocal\"]/@value", false))
                         {
-                            IPropertyTree *att = createPTree("att", false);
+                            IPropertyTree *att = createPTree("att");
                             att->setProp("@name", "coLocal");
                             att->setPropBool("@value", true);
                             e.addPropTree("att", att);

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -876,7 +876,7 @@ public:
         tgt = NULL;
         PROTECTED_GETRESULT(stepname, sequence, "Raw", "raw",
             Variable2IDataVal result(&tlen, &tgt);
-            Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer, true);
+            Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer);
             Owned<ICsvToRawTransformer> rawCsvTransformer = createCsvRawTransformer(csvTransformer);
             r->getResultRaw(result, rawXmlTransformer, rawCsvTransformer);
         );
@@ -886,7 +886,7 @@ public:
         tgt = NULL;
         PROTECTED_GETRESULT(stepname, sequence, "Raw", "raw",
             Variable2IDataVal result(&tlen, &tgt);
-            Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer, true);
+            Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer);
             Owned<ICsvToRawTransformer> rawCsvTransformer = createCsvRawTransformer(csvTransformer);
             isAll = r->getResultIsAll();
             r->getResultRaw(result, rawXmlTransformer, rawCsvTransformer);
@@ -961,7 +961,7 @@ public:
         PROTECTED_GETRESULT(stepname, sequence, "Rowset", "rowset",
             MemoryBuffer datasetBuffer;
             MemoryBuffer2IDataVal result(datasetBuffer);
-            Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer, true);
+            Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer);
             Owned<ICsvToRawTransformer> rawCsvTransformer = createCsvRawTransformer(csvTransformer);
             r->getResultRaw(result, rawXmlTransformer, rawCsvTransformer);
             rtlDataset2RowsetX(tcount, tgt, _rowAllocator, deserializer, datasetBuffer.length(), datasetBuffer.toByteArray(), isGrouped);
@@ -976,7 +976,7 @@ public:
 
             Variable2IDataVal result(&tlen, &tgt);
             Owned<IConstWUResult> r = getExternalResult(wuid, stepname, sequence);
-            Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer, true);
+            Owned<IXmlToRawTransformer> rawXmlTransformer = createXmlRawTransformer(xmlTransformer);
             Owned<ICsvToRawTransformer> rawCsvTransformer = createCsvRawTransformer(csvTransformer);
             r->getResultRaw(result, rawXmlTransformer, rawCsvTransformer);
         }

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1305,7 +1305,7 @@ void CJobMaster::initNodeDUCache()
 
 IPropertyTree *CJobMaster::prepareWorkUnitInfo()
 {
-    Owned<IPropertyTree> workUnitInfo = createPTree("workUnitInfo", false);
+    Owned<IPropertyTree> workUnitInfo = createPTree("workUnitInfo");
     workUnitInfo->setProp("wuid", wuid);
     workUnitInfo->setProp("user", user);
     workUnitInfo->setProp("token", token);
@@ -1319,14 +1319,14 @@ IPropertyTree *CJobMaster::prepareWorkUnitInfo()
         if (thisplugin.getPluginThor() || thisplugin.getPluginHole()) // JCSMORE ..Hole..
         {
             if (!plugins)
-                plugins = workUnitInfo->addPropTree("plugins", createPTree(false));
+                plugins = workUnitInfo->addPropTree("plugins", createPTree());
             SCMStringBuffer name;
             thisplugin.getPluginName(name);
-            IPropertyTree *plugin = plugins->addPropTree("plugin", createPTree(false));
+            IPropertyTree *plugin = plugins->addPropTree("plugin", createPTree());
             plugin->setProp("@name", name.str());
         }
     }
-    IPropertyTree *debug = workUnitInfo->addPropTree("Debug", createPTree(true));
+    IPropertyTree *debug = workUnitInfo->addPropTree("Debug", createPTree(ipt_caseInsensitive));
     SCMStringBuffer debugStr, valueStr;
     Owned<IStringIterator> debugIter = &queryWorkUnit().getDebugValues();
     ForEach (*debugIter)
@@ -1360,7 +1360,7 @@ void CJobMaster::sendQuery()
         msg.append(sz);
         read(iFileIO, 0, sz, msg);
     }
-    Owned<IPropertyTree> deps = createPTree(queryXGMML()->queryName(), false);
+    Owned<IPropertyTree> deps = createPTree(queryXGMML()->queryName());
     Owned<IPropertyTreeIterator> edgeIter = queryXGMML()->getElements("edge"); // JCSMORE trim to those actually needed
     ForEach (*edgeIter)
     {

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -443,9 +443,10 @@ int main( int argc, char *argv[]  )
     loadMasters(); // actually just a dummy call to ensure dll linked
     InitModuleObjects();
     NoQuickEditSection xxx;
-
-    Owned<IFile> thorConfFile = createIFile("thor.xml");
-    globals = thorConfFile->exists() ? createPTreeFromXMLFile("thor.xml", ipt_caseInsensitive) : createPTree(ipt_caseInsensitive);
+    {
+        Owned<IFile> iFile = createIFile("thor.xml");
+        globals = iFile->exists() ? createPTree(*iFile, ipt_caseInsensitive) : createPTree("Thor", ipt_caseInsensitive);
+    }
     char **pp = argv+1;
     while (*pp)
         loadCmdProp(globals, *pp++);

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -445,7 +445,7 @@ int main( int argc, char *argv[]  )
     NoQuickEditSection xxx;
 
     Owned<IFile> thorConfFile = createIFile("thor.xml");
-    globals = thorConfFile->exists() ? createPTreeFromXMLFile("thor.xml", true) : createPTree(true);
+    globals = thorConfFile->exists() ? createPTreeFromXMLFile("thor.xml", ipt_caseInsensitive) : createPTree(ipt_caseInsensitive);
     char **pp = argv+1;
     while (*pp)
         loadCmdProp(globals, *pp++);

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -236,9 +236,12 @@ int main( int argc, char *argv[]  )
     Owned<CReleaseMutex> globalNamedMutex;
 #endif 
 
-    if (globals) globals->Release();
-    { Owned<IFile> ifile = createIFile("thor.xml");
-        globals = ifile->exists() ? createPTreeFromXMLFile("thor.xml", ipt_caseInsensitive) : createPTree("Thor", ipt_caseInsensitive);
+    if (globals)
+        globals->Release();
+
+    {
+        Owned<IFile> iFile = createIFile("thor.xml");
+        globals = iFile->exists() ? createPTree(*iFile, ipt_caseInsensitive) : createPTree("Thor", ipt_caseInsensitive);
     }
     unsigned multiThorMemoryThreshold = 0;
     try {

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -238,7 +238,7 @@ int main( int argc, char *argv[]  )
 
     if (globals) globals->Release();
     { Owned<IFile> ifile = createIFile("thor.xml");
-        globals = ifile->exists() ? createPTreeFromXMLFile("thor.xml", true) : createPTree("Thor", true);
+        globals = ifile->exists() ? createPTreeFromXMLFile("thor.xml", ipt_caseInsensitive) : createPTree("Thor", ipt_caseInsensitive);
     }
     unsigned multiThorMemoryThreshold = 0;
     try {

--- a/tools/swapnode/swapnode.cpp
+++ b/tools/swapnode/swapnode.cpp
@@ -489,7 +489,7 @@ static bool doSingleSwapNode(IRemoteConnection *connEnv,IRemoteConnection *connF
 
             // TBD tie up with bad node in auto?
 
-            IPropertyTree *swap = info->addPropTree("Swap",createPTree("Swap",false));
+            IPropertyTree *swap = info->addPropTree("Swap",createPTree("Swap"));
             swap->setProp("@inNetAddress",newip);
             swap->setProp("@outNetAddress",oldip);
             swap->setProp("@time",times.str());
@@ -538,7 +538,7 @@ static bool doSwapNode(IPropertyTree *options,bool doswap,const char* cluster,co
             ensureThorIsDown(cluster,false,false);
             Owned<IPropertyTree> info;
 #ifndef _ESP
-            Owned<IPropertyTree> opt = createPTree(true);
+            Owned<IPropertyTree> opt = createPTree(ipt_caseInsensitive);
             opt->setProp("@nodeGroup",cluster);
             Owned<IGroup> grp;
             Owned<IRemoteConnection> connSwapNode;
@@ -1165,13 +1165,13 @@ int main(int argc,char** argv)
             const char* daliserver;
             Owned<IPropertyTree> options;
             if (isauto||ishistory|isswapped|isemail) {
-                options.setown(createPTreeFromXMLFile("thor.xml", true));
+                options.setown(createPTreeFromXMLFile("thor.xml", ipt_caseInsensitive));
                 daliserver = options?options->queryProp("@daliServers"):NULL;
                 if (!daliserver||!*daliserver)
                     throw MakeStringException(-1,"Either thor.xml not found or DALISERVERS not found in thor.xml");
             }
             else {
-                options.setown(createPTree(true)); // don't use thor.xml
+                options.setown(createPTree(ipt_caseInsensitive)); // don't use thor.xml
                 daliserver = argv[1];
             }
 

--- a/tools/testsocket/testsocket.cpp
+++ b/tools/testsocket/testsocket.cpp
@@ -426,7 +426,7 @@ int doSendQuery(const char * ip, unsigned port, const char * base)
     if (useHTTP)
     {
         StringBuffer newQuery;
-        Owned<IPTree> p = createPTreeFromXMLString(base, false, false);
+        Owned<IPTree> p = createPTreeFromXMLString(base, ipt_none, xr_none);
         const char *queryName = p->queryName();
         if ((stricmp(queryName, "envelope") != 0) && (stricmp(queryName, "envelope") != 0))
         {
@@ -468,7 +468,7 @@ int doSendQuery(const char * ip, unsigned port, const char * base)
         {
             try
             {
-                Owned<IPTree> p = createPTreeFromXMLString(base, false, false);
+                Owned<IPTree> p = createPTreeFromXMLString(base, ipt_none, xr_none);
                 p->renameProp("/", queryNameOverride);
                 toXML(p, fullQuery.clear());
             }


### PR DESCRIPTION
Add an optional ordered IPropertyTree implementation.
Rationalize the various createPTree\* methods.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com

Note, there's a corresponding pull request in LN
