### PR TITLE
Bug:82832 - fix autoCopyBackup=false issue

### DIFF
--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -988,7 +988,6 @@ bool getBestFilePart(CActivityBase *activity, IPartDescriptor &partDesc, OwnedIF
                         if (!eHandler)
                             throw e;
                         eHandler->fireException(e);
-                        return false;
                     }
                     path.append(locationName);
                     return true;


### PR DESCRIPTION
If autoCopyBackup is disabled, Thor does not pick up replicate
(unless it's local e.g. via mount)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
