### PR TITLE
FIXED: 83253 Updating password setting procedure for hpcc user.

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -746,6 +746,7 @@ add_user(){
         else
             printf "Adding %s to system ..." "${USER}"
             useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} ${USER}
+            passwd -d ${USER} 1>/dev/null 2>&1
             if [ $? -eq 0 ];
             then
                 log_success_msg
@@ -779,6 +780,7 @@ add_user(){
         else
             printf "Adding %s to system ..." "${USER}"
             useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} ${USER}
+            passwd -d ${USER} 1>/dev/null 2>&1
             if [ $? -eq 0 ];
             then
                 log_success_msg


### PR DESCRIPTION
I have added a passwd command to the add_user funciton in hpcc_common.

passwd -d ${USER}

Fixing indent issue.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
