### PR TITLE
BUG: 80885 Set and show Compiled state for WUActionCompile WU

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -551,6 +551,7 @@ public:
     virtual bool aborting() const;
     virtual void forceReload();
     virtual WUAction getAction() const;
+    virtual IStringVal& getActionEx(IStringVal & str) const;
     virtual IStringVal & getApplicationValue(const char * application, const char * propname, IStringVal & str) const;
     virtual int getApplicationValueInt(const char * application, const char * propname, int defVal) const;
     virtual IConstWUAppValueIterator & getApplicationValues() const;
@@ -875,6 +876,8 @@ public:
             { UNIMPLEMENTED; }
     virtual WUAction getAction() const
             { return c->getAction(); }
+    virtual IStringVal& getActionEx(IStringVal & str) const
+            { return c->getActionEx(str); }
     virtual IStringVal & getApplicationValue(const char * application, const char * propname, IStringVal & str) const
             { return c->getApplicationValue(application, propname, str); }
     virtual int getApplicationValueInt(const char * application, const char * propname, int defVal) const
@@ -3658,6 +3661,13 @@ WUAction CLocalWorkUnit::getAction() const
 {
     CriticalBlock block(crit);
     return (WUAction) getEnum(p, "Action", actions);
+}
+
+IStringVal& CLocalWorkUnit::getActionEx(IStringVal & str) const
+{
+    CriticalBlock block(crit);
+    str.set(p->queryProp("Action"));
+    return str;
 }
 
 IStringVal& CLocalWorkUnit::getApplicationValue(const char *app, const char *propname, IStringVal &str) const

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -824,6 +824,7 @@ interface IConstWorkUnit : extends IInterface
     virtual bool aborting() const = 0;
     virtual void forceReload() = 0;
     virtual WUAction getAction() const = 0;
+    virtual IStringVal& getActionEx(IStringVal & str) const = 0;
     virtual IStringVal & getApplicationValue(const char * application, const char * propname, IStringVal & str) const = 0;
     virtual int getApplicationValueInt(const char * application, const char * propname, int defVal) const = 0;
     virtual IConstWUAppValueIterator & getApplicationValues() const = 0;

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -290,7 +290,7 @@ public:
                     workunit->setState(WUStateFailed);
             }
             else if (workunit->getAction()==WUActionCompile)
-                workunit->setState(WUStateCompleted);
+                workunit->setState(WUStateCompiled);
         }
         else if (workunit->getState() != WUStateAborted)
             workunit->setState(WUStateFailed);

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -43,13 +43,19 @@
                   <xsl:value-of select="$wuid"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <!--a href="/esp/iframe/WsWorkunits/WUFile?Wuid={$wuid}&amp;Type=XML&amp;esp_iframe_title=ECL Workunit XML - {$wuid}"
-                                   -->
                   <a href="/esp/iframe?esp_iframe_title=ECL Workunit XML - {$wuid}&amp;inner=/WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Type%3dXML" >
                     <xsl:value-of select="$wuid"/>
                   </a>
                 </xsl:otherwise>
               </xsl:choose>
+            </td>
+          </tr>
+          <tr>
+            <td class="eclwatch entryprompt">
+              Action:
+            </td>
+            <td>
+              <xsl:value-of select="ActionEx"/>
             </td>
           </tr>
           <tr>
@@ -249,14 +255,6 @@
               </xsl:choose>
             </td>
           </tr>
-          <!--tr>
-                            <td class="eclwatch entryprompt">
-                  Cluster:
-              </td>
-                            <td>
-                                <xsl:value-of select="Cluster"/>
-                            </td>
-                        </tr-->
           <xsl:variable name="defaultcluster" select="Cluster"/>
           <tr>
             <td class="eclwatch entryprompt">
@@ -633,7 +631,6 @@
                 </A>
               </div>
             </div>
-            <!--xsl:apply-templates select="Workflows" mode="list"/-->
             <div id="Workflows" class="wusectioncontent">
               <xsl:choose>
                 <xsl:when test="WorkflowsDesc != ''">
@@ -698,37 +695,6 @@
       </xsl:if>
 
       <xsl:if test="number(Archived) &lt; 1">
-        <!--tr>
-                                <th>Helpers:</th>
-                                <td>
-                                    <table class="list">
-                                        <tr>
-                                            <xsl:if test="string-length(Query/Cpp)">
-                                                <td>
-                                                <a href="/WsWorkunits/WUFile/{$wuid}.cpp?Wuid={$wuid}&amp;Type=cpp" >cpp</a>
-                                                </td>
-                                            </xsl:if>
-                                            <xsl:if test="string-length(Query/Dll)">
-                                                <td>
-                                                <a href="/WsWorkunits/WUFile/{$wuid}.dll?Wuid={$wuid}&amp;Type=dll" >dll</a>
-                                                </td>
-                                            </xsl:if>
-                                            <xsl:if test="string-length(Query/ResTxt)">
-                                                <td>
-                                                <a href="/WsWorkunits/WUFile/res.txt?Wuid={$wuid}&amp;Type=res"
-                                                   >res.txt</a>
-                                                </td>
-                                            </xsl:if>
-                                            <xsl:if test="string-length(Query/ThorLog)">
-                                                <td>
-                                                <a href="/WsWorkunits/WUFile/ThorLog?Wuid={$wuid}&amp;Type=ThorLog" 
-                                                    >thormaster.log</a>
-                                                </td>
-                                            </xsl:if>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr-->
         <xsl:if test="count(Helpers/ECLHelpFile)">
           <p>
             <div class="wugroup">
@@ -1206,12 +1172,6 @@
         </xsl:if>
         <xsl:if test="not(GraphName)">
           <xsl:value-of select="Value"/>
-          <!--
-          (  <xsl:call-template name="timeformat">
-            <xsl:with-param name="toformat" select="Value"/>
-          </xsl:call-template>
-          )
-          -->
         </xsl:if>
       </td>
       <td>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -168,8 +168,8 @@ ESPStruct [nil_remove] ECLWorkunit
     string Description;
     bool Protected;
     bool Active;
-    //bool Aborting;
     int Action;
+    [min_ver("1.33")] string ActionEx;
     xsdDateTime DateTimeScheduled;
     int PriorityClass;
     int PriorityLevel;
@@ -1046,7 +1046,7 @@ ESPresponse [exceptions_inline] WUQuerySetActionAliasesResponse
 
 
 ESPservice [
-    version("1.32"), default_client_version("1.32"),
+    version("1.33"), default_client_version("1.33"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPuses ESPStruct ECLException;

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -5198,8 +5198,8 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
     wuidStr.trim();
     const char* wuid = wuidStr.str();
 
-   CWUWrapper wu(wuid, context);
-   ensureWorkunitAccess(context, *wu, SecAccess_Read);
+    CWUWrapper wu(wuid, context);
+    ensureWorkunitAccess(context, *wu, SecAccess_Read);
 
     bool helpersException = false;
     bool graphsException = false;
@@ -5211,7 +5211,7 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
     bool applicationValuesException = false;
     bool workflowsException = false;
 
-   SecAccessFlags accessFlag = getWorkunitAccess(context, *wu);
+    SecAccessFlags accessFlag = getWorkunitAccess(context, *wu);
 
     SCMStringBuffer buf;
     info->setWuid(wu->getWuid(buf).str());
@@ -5221,10 +5221,8 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
 
     if ((wu->getState() == WUStateScheduled) && wu->aborting())
     {
-        //info->setAborting(true);
         info->setStateID(WUStateAborting);
         info->setState("aborting");
-        //info->setStateEx(WUStateAborting);
     }
 
     double version = context.getClientVersion();
@@ -5232,8 +5230,11 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
     {       
         info->setArchived(false);
     }
+    if (version > 1.32)
+    {
+        info->setActionEx(wu->getActionEx(buf).str());
+    }
     info->setProtected(wu->isProtected() ? 1 : 0);
-    //info->setCluster(wu->getClusterName(buf).str());
 
     SCMStringBuffer roxieClusterName;
     Owned<IConstWURoxieQueryInfo> roxieQueryInfo = wu->getRoxieQueryInfo();
@@ -5241,13 +5242,7 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
     if (roxieQueryInfo)
         roxieQueryInfo->getRoxieClusterName(roxieClusterName);
 
-    StringBuffer ClusterName;
-    //if (roxieClusterName.length() == 0)
-    //  ClusterName = wu->getClusterName(buf).str();
-    //else
-    //  ClusterName = roxieClusterName.str();
-
-    ClusterName = wu->getClusterName(buf).str();
+    StringBuffer ClusterName = wu->getClusterName(buf).str();
     info->setCluster(ClusterName.str());
     if (version > 1.06 && roxieClusterName.length() > 0)
     {
@@ -5324,18 +5319,11 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
 
     if (version > 1.16)
     {       
-
-        //char countBuf[23];
-        unsigned sectionCount;
-
-        sectionCount = wu->getGraphCount();
+        unsigned sectionCount = wu->getGraphCount();
         info->setGraphCount(sectionCount);
 
         sectionCount = wu->getSourceFileCount();
         info->setSourceFileCount(sectionCount);
-
-        //sectionCount = wu->getResultCount();
-        //info->setResultCount(sectionCount);
 
         sectionCount = wu->getVariableCount();
         info->setVariableCount(sectionCount);
@@ -5545,67 +5533,12 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
         }
         else
         {
-//#define TESTSUBFILE
-#ifdef TESTSUBFILE
-int i = 0;
-#endif
             StringArray fileNames;
 
             Owned<IPropertyTreeIterator> f=&wu->getFilesReadIterator();
             ForEach(*f)
             {
-#ifndef TESTSUBFILE
                 IPropertyTree &query = f->query();
-#else
-Owned<IPropertyTree> filesRead = createPTree(false);
-{
-    if (i > 1)
-        break;
-    if (i < 1)
-    {
-    filesRead->setProp("@name", "file1");
-    filesRead->setProp("@cluster", "thor200");
-    filesRead->setPropInt("@useCount", 1);
-
-    Owned<IPropertyTree> subfile = createPTree(false);
-    subfile->setProp("@name", "subfile1");
-    filesRead->addPropTree("Subfile", subfile.getClear());
-
-    Owned<IPropertyTree> subfile2 = createPTree(false);
-    subfile2->setProp("@name", "subfile2");
-    filesRead->addPropTree("Subfile", subfile2.getClear());
-    }
-    else
-    {
-    filesRead->setProp("@name", "file2");
-    filesRead->setProp("@cluster", "thor200");
-    filesRead->setPropInt("@useCount", 1);
-
-    Owned<IPropertyTree> subfile21 = createPTree(false);
-    subfile21->setProp("@name", "subfile21");
-    subfile21->setProp("@cluster", "thor50");
-    filesRead->addPropTree("Subfile", subfile21.getClear());
-
-    Owned<IPropertyTree> subfile22 = createPTree(false);
-    subfile22->setProp("@name", "subfile22");
-    subfile22->setProp("@cluster", "thor50");
-
-    Owned<IPropertyTree> subfile221 = createPTree(false);
-    subfile221->setProp("@name", "subfile221");
-    subfile221->setProp("@cluster", "thor50");
-    subfile22->addPropTree("Subfile", subfile221.getClear());
-
-    Owned<IPropertyTree> subfile222 = createPTree(false);
-    subfile222->setProp("@name", "subfile222");
-    subfile222->setProp("@cluster", "thor50");
-    subfile22->addPropTree("Subfile", subfile222.getClear());
-
-    filesRead->addPropTree("Subfile", subfile22.getClear());
-    }
-    i++;
-}
-IPropertyTree &query = *filesRead;
-#endif
                 const char *clusterName = query.queryProp("@cluster");
                 const char *fileName = query.queryProp("@name");
                 int fileCount = query.getPropInt("@useCount");


### PR DESCRIPTION
Existing code sets and displays a Completed state for a workunit even
if a user wants to just do compile using Compile buttons in ECL IDE.
The user may not be able to distinguish between the WU's they have
submitted and those they have only compiled.

I change the eclccserver code to set the Compiled state if the action
is WUActionCompile. ECLWatch dispays the state in WU Details page. To
avoid people thinking it is 'stuck' in compiled state, I add an Action
field on the top of the state field. The Action is read from WU xml.
For this situation, the Action shows Compile.

In addition, the code inside the CWsWorkunitsEx::getInfo() is cleaned by
removing the lines which were commented out.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
