### PR TITLE
Fixed: #82571 Updated hpcc-run to allow for correct run order.

### DIFF
--- a/initfiles/sbin/hpcc-run.sh.in
+++ b/initfiles/sbin/hpcc-run.sh.in
@@ -19,31 +19,39 @@ source  ${INSTALL_DIR}/etc/init.d/init-functions
 source  ${INSTALL_DIR}/etc/init.d/export-path
 
 print_usage(){
-	echo "usage: hpcc-run.sh [-c component] [-a {hpcc-init|dafilesrv}] {start|stop|restart|status|setup}"
-	exit 1
+        echo "usage: hpcc-run.sh [-c component] [-a {hpcc-init|dafilesrv}] {start|stop|restart|status|setup}"
+        exit 1
 }
 
 getIPS(){
-	IPS=`${INSTALL_DIR}/sbin/configgen -env ${envfile} -machines | awk -F, '{print \$1}'  | sort | uniq`
+        IPS=`${INSTALL_DIR}/sbin/configgen -env ${envfile} -machines | awk -F, '{print \$1}'  | sort | uniq`
+}
+
+getDali(){
+        DIP=`${INSTALL_DIR}/sbin/configgen -env ${envfile} -listall | grep Dali | awk -F, '{print \$3}'  | sort | uniq`
 }
 
 buildCmd(){
-	if [ -z $3 ]; then
-		CMD="sudo /etc/init.d/$1 $2"
-	else
-		CMD="sudo /etc/init.d/$1 -c $3 $2"
-	fi
+        if [ -z $3 ]; then
+                CMD="sudo /etc/init.d/$1 $2"
+        else
+                CMD="sudo /etc/init.d/$1 -c $3 $2"
+        fi
 }
 
 runCmd(){
-	echo "$IP: Running $@";
-	ssh -i $home/$user/.ssh/id_rsa $user@$IP $@;
+        echo "$IP: Running $@";
+        ssh -i $home/$user/.ssh/id_rsa $user@$IP $@;
 }
 
 set_envrionmentvars
 envfile=$configs/$environment
 
 getIPS
+getDali
+
+IPS=${IPS//$DIP[^0-9]/ }
+
 
 TEMP=`/usr/bin/getopt -o a:c:h --long help,action -n 'hpcc-run' -- "$@"`
 if [ $? != 0 ] ; then echo "Failure to parse commandline." >&2 ; exit 1 ; fi
@@ -52,8 +60,8 @@ while true ; do
     case "$1" in
         -c) comp=$2
             shift 2 ;;
-	-a|--action) action=$2
-	    shift 2 ;;
+        -a|--action) action=$2
+            shift 2 ;;
         -h|--help) print_usage
                    shift ;;
         --) shift ; break ;;
@@ -89,32 +97,117 @@ for arg; do
     esac
 done
 
-if [ ${cnt} -gt 1 ];
-	print_usage
+if [ ${cnt} -gt 1 ]; then
+        print_usage
 fi
 
 case "$action" in
     hpcc-init) ;;
     dafilesrv) ;;
     *) if [ -z $action ]; then
-	    action="hpcc-init"
-	else
-	    print_usage 
+            action="hpcc-init"
+        else
+            print_usage 
         fi
-	;;
+        ;;
 esac
 
-for IP in $IPS; do
-	if ping -c 1 -w 5 -n $IP > /dev/null 2>&1; then
-		echo "$IP: Host is alive."
-		CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$IP exit > /dev/null 2>&1; echo $?`"
-		if [ "$CAN_SSH" -eq 255 ]; then
-			echo "$IP: Cannot SSH to host.";
-		else
-			buildCmd $action $cmd $comp
-			runCmd $CMD
-		fi
-	else
-		echo "$IP: FAIL"
-	fi
-done
+if [ "${cmd}" == "restart" ]; then
+    for i in stop start; do
+        cmd=$i
+        echo "Running '${cmd}' on cluster."
+        if [ "${cmd}" == "start" ]; then
+            if ping -c 1 -w 5 -n $DIP > /dev/null 2>&1; then
+                echo "$DIP: Host is alive."
+                CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$DIP exit > /dev/null 2>&1; echo $?`"
+                if [ "$CAN_SSH" -eq 255 ]; then
+                    echo "$DIP: Cannot SSH to host.";
+                else
+                    IP=$DIP
+                    buildCmd $action $cmd $comp
+                    runCmd $CMD
+                fi
+            else
+                echo "$DIP: FAIL"
+            fi 
+        fi
+
+        for IP in $IPS; do
+            if ping -c 1 -w 5 -n $IP > /dev/null 2>&1; then
+                echo "$IP: Host is alive."
+                CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$IP exit > /dev/null 2>&1; echo $?`"
+                if [ "$CAN_SSH" -eq 255 ]; then
+                    echo "$IP: Cannot SSH to host.";
+                else
+                    buildCmd $action $cmd $comp
+                    runCmd $CMD
+                fi
+            else
+                echo "$IP: FAIL"
+            fi
+        done
+        
+        if [ "${cmd}" == "stop" ]; then
+            if ping -c 1 -w 5 -n $DIP > /dev/null 2>&1; then
+                echo "$DIP: Host is alive."
+                CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$DIP exit > /dev/null 2>&1; echo $?`"
+                if [ "$CAN_SSH" -eq 255 ]; then
+                    echo "$DIP: Cannot SSH to host.";
+                else
+                    IP=$DIP
+                    buildCmd $action $cmd $comp
+                    runCmd $CMD
+                fi
+            else
+                echo "$DIP: FAIL"
+            fi
+        fi
+    done
+else
+    if [ "${cmd}" == "start" ] || [ "${cmd}" == "status" ]; then
+        if ping -c 1 -w 5 -n $DIP > /dev/null 2>&1; then
+            echo "$DIP: Host is alive."
+            CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$DIP exit > /dev/null 2>&1; echo $?`"
+            if [ "$CAN_SSH" -eq 255 ]; then
+                echo "$DIP: Cannot SSH to host.";
+            else
+                IP=$DIP
+                buildCmd $action $cmd $comp
+                runCmd $CMD
+            fi
+        else
+            echo "$DIP: FAIL"
+        fi 
+    fi
+
+    for IP in $IPS; do
+        if ping -c 1 -w 5 -n $IP > /dev/null 2>&1; then
+            echo "$IP: Host is alive."
+            CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$IP exit > /dev/null 2>&1; echo $?`"
+            if [ "$CAN_SSH" -eq 255 ]; then
+                echo "$IP: Cannot SSH to host.";
+            else
+                buildCmd $action $cmd $comp
+                runCmd $CMD
+            fi
+        else
+            echo "$IP: FAIL"
+        fi
+    done
+        
+    if [ "${cmd}" == "stop" ]; then
+        if ping -c 1 -w 5 -n $DIP > /dev/null 2>&1; then
+            echo "$DIP: Host is alive."
+            CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$DIP exit > /dev/null 2>&1; echo $?`"
+            if [ "$CAN_SSH" -eq 255 ]; then
+                echo "$DIP: Cannot SSH to host.";
+            else
+                IP=$DIP
+                buildCmd $action $cmd $comp
+                runCmd $CMD
+            fi
+        else
+             echo "$DIP: FAIL"
+        fi
+    fi
+fi


### PR DESCRIPTION
Previously hpcc-run was starting and stopping all component in
order based on the ip's in the environment.xml as returned by
configgen and parsed by sort | uniq.

I have added code to locate which node has Dali along with
remove the ip from the list of ip's and then run the commands
in the correct order.

Start - dali node > other nodes
Stop - other nodes > dali node

I have also added code to change how restart works. Previously
restart would run on each node in ascending order. I have
changed this to run a for loop setting cmd to stop and then
start when a restart command is given.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
