### PR TITLE
ISSUE:#64 - Get rid of the SVN $HeadURL keyword expansions

### DIFF
--- a/common/commonext/thorport.cpp
+++ b/common/commonext/thorport.cpp
@@ -36,8 +36,6 @@
 #include "portlist.h"
 #include "thorport.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/shared/thorport.cpp $ $Id: thorport.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #define WATCHDOGINC        1
 
 static CriticalSection *portallocsection;

--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -43,8 +43,6 @@
  #define new new(_NORMAL_BLOCK, __FILE__, __LINE__)
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/deftype/deftype.cpp $ $Id: deftype.cpp 65583 2011-06-20 13:29:24Z ghalliday $");
-
 //#define DATA_STRING_COMPATIBLE
 #define HASHFIELD(p) hashcode = hashc((unsigned char *) &p, sizeof(p), hashcode)
 

--- a/common/deftype/defvalue.cpp
+++ b/common/deftype/defvalue.cpp
@@ -35,8 +35,6 @@
  #define new new(_NORMAL_BLOCK, __FILE__, __LINE__)
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/deftype/defvalue.cpp $ $Id: defvalue.cpp 65491 2011-06-16 07:42:49Z ghalliday $");
-
 BoolValue *BoolValue::trueconst;
 BoolValue *BoolValue::falseconst;
 static _ATOM asciiAtom;

--- a/common/environment/dalienv.cpp
+++ b/common/environment/dalienv.cpp
@@ -32,10 +32,6 @@
 #include "dalienv.hpp"
 #include "rmtfile.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/environment/dalienv.cpp $ $Id: dalienv.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
-
 struct CIpInstance
 {
     unsigned hash;

--- a/common/remote/rmtfile.cpp
+++ b/common/remote/rmtfile.cpp
@@ -30,8 +30,6 @@
 #include "rmtfile.hpp"
 #include "remoteerr.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/remote/rmtfile.cpp $ $Id: rmtfile.cpp 64457 2011-05-09 17:28:42Z yma $");
-
 //----------------------------------------------------------------------------
 
 //#define TEST_DAFILESRV_FOR_UNIX_PATHS     // probably not needed

--- a/common/remote/rmtpass.cpp
+++ b/common/remote/rmtpass.cpp
@@ -30,8 +30,6 @@
 #include "rmtfile.hpp"
 #include "rmtpass.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/remote/rmtpass.cpp $ $Id: rmtpass.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 void CachedPasswordProvider::addPasswordForFilename(const char * filename)
 {
     RemoteFilename remote;

--- a/common/remote/rmtsmtp.cpp
+++ b/common/remote/rmtsmtp.cpp
@@ -25,10 +25,6 @@
 
 #include "rmtsmtp.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/remote/rmtsmtp.cpp $ $Id: rmtfile.cpp 59036 2010-08-31 17:54:39Z nhicks $");
-
-
 class CSMTPValidator
 {
 public:

--- a/common/remote/rmtspawn.cpp
+++ b/common/remote/rmtspawn.cpp
@@ -30,8 +30,6 @@
 
 
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/remote/rmtspawn.cpp $ $Id: rmtspawn.cpp 64028 2011-04-14 14:28:10Z nhicks $");
-
 LogMsgCategory MCdetailDebugInfo(MCdebugInfo(1000));
 
 /*

--- a/common/remote/rmtssh.cpp
+++ b/common/remote/rmtssh.cpp
@@ -33,9 +33,6 @@
 #include <wordexp.h>
 #endif
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/remote/rmtssh.cpp $ $Id: rmtssh.cpp 64028 2011-04-14 14:28:10Z nhicks $");
-
 //----------------------------------------------------------------------------
 
 //#define PLINK_USE_CMD

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -38,8 +38,6 @@
 
 #include "remoteerr.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/remote/sockfile.cpp $ $Id: sockfile.cpp 62595 2011-02-17 14:30:45Z rchapman $");
-
 #define SOCKET_CACHE_MAX 500
 
 #define MAX_THREADS             100
@@ -163,14 +161,12 @@ struct dummyReadWrite
 // backward compatible modes
 typedef enum { compatIFSHnone, compatIFSHread, compatIFSHwrite, compatIFSHexec, compatIFSHall} compatIFSHmode;
 
-
 static const char *VERSTRING= "DS V1.7e - 6 "       // dont forget FILESRV_VERSION in header
 #ifdef _WIN32
-"Windows "
+"Windows ";
 #else
-"Linux "
+"Linux ";
 #endif
-"$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/remote/sockfile.cpp $ $Id: sockfile.cpp 62595 2011-02-17 14:30:45Z rchapman $";
 
 typedef unsigned char RemoteFileCommandType;
 typedef int RemoteFileIOHandle;

--- a/common/thorhelper/csvsplitter.cpp
+++ b/common/thorhelper/csvsplitter.cpp
@@ -28,11 +28,6 @@
 #include "csvsplitter.hpp"
 #include "eclrtl.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/thorhelper/csvsplitter.cpp $ $Id: csvsplitter.cpp 62567 2011-02-16 16:01:41Z rchapman $");
-
-//=====================================================================================================
-
-
 CSVSplitter::CSVSplitter()
 {
     lengths = NULL;

--- a/common/thorhelper/thorstep.cpp
+++ b/common/thorhelper/thorstep.cpp
@@ -28,8 +28,6 @@
 #define CHECK_CONSISTENCY
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/thorhelper/thorstep.cpp $ $Id: thorstep.cpp 65884 2011-06-29 11:25:52Z ghalliday $");
-
 const static SmartStepExtra knownLowestFrequencyTermStepExtra(SSEFreadAhead, NULL);
 const static SmartStepExtra unknownFrequencyTermStepExtra(SSEFreturnMismatches, NULL);
 const static SmartStepExtra nonSeekStepExtra(SSEFreturnUnbufferedMatches, NULL);                    // if doing next() instead of nextGE()

--- a/common/thorhelper/thorstep2.cpp
+++ b/common/thorhelper/thorstep2.cpp
@@ -23,8 +23,6 @@
 #include "thorcommon.hpp"
 #include "thorstep2.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/thorhelper/thorstep2.cpp $ $Id: thorstep2.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 const static SmartStepExtra knownLowestFrequencyTermStepExtra(SSEFreadAhead, NULL);

--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -24,7 +24,6 @@
 #include "jfile.hpp"
 #include "jlog.hpp"
 
-
 #include "csvsplitter.hpp"
 #include "thorcerror.hpp"
 #include "thorxmlread.hpp"
@@ -33,10 +32,7 @@
 
 #include "jptree.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/thorhelper/thorxmlread.cpp $ $Id: thorxmlread.cpp 65310 2011-06-10 08:37:45Z ghalliday $");
-
 #define XMLTAG_CONTENT "<>"
-
 
 //=====================================================================================================
 XmlColumnIterator::XmlColumnIterator(IPropertyTreeIterator * _iter) : iter(_iter)

--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -26,8 +26,6 @@
 #include "dautils.hpp"
 #include "portlist.h"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/common/workunit/wujobq.cpp $ $Id: wujobq.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "dacoven.hpp"
 #include "daclient.hpp"
 #include "dasds.hpp"

--- a/dali/base/daclient.cpp
+++ b/dali/base/daclient.cpp
@@ -23,8 +23,6 @@
 #include "jptree.hpp"
 #include "jtime.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/daclient.cpp $ $Id: daclient.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "mpcomm.hpp"
 #include "mplog.hpp"
 #include "dasess.hpp"

--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -27,13 +27,8 @@
 #include "mputil.hpp"
 #include "jmisc.hpp"
 #include "daclient.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/dacoven.cpp $ $Id: dacoven.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "daserver.hpp"
-
 #include "dacoven.hpp"
-
 #include "mpcomm.hpp"
 
 extern void closedownDFS();

--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -22,11 +22,7 @@
 #include "jlib.hpp"
 #include "javahash.hpp"
 #include "javahash.tpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/dacsds.cpp $ $Id: dacsds.cpp 62962 2011-03-04 11:10:12Z jsmith $");
-
 #include "jptree.ipp"
-
 #include "mpbuff.hpp"
 #include "mpcomm.hpp"
 #include "mputil.hpp"
@@ -36,7 +32,6 @@ static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ba
 #include "daclient.hpp"
 
 #include "dasds.ipp" // common header for client/server sds
-
 #include "dacsds.ipp"
 
 #define CLIENT_THROTTLE_LIMIT 10

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -37,11 +37,7 @@
 #include "danqs.hpp"
 #include "mputil.hpp"
 #include "rmtfile.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/dadfs.cpp $ $Id: dadfs.cpp 63465 2011-03-25 10:43:19Z nhicks $");
-
 #include "dadfs.hpp"
-
 
 #ifdef _DEBUG
 //#define EXTRA_LOGGING

--- a/dali/base/dadiags.cpp
+++ b/dali/base/dadiags.cpp
@@ -19,9 +19,6 @@
 #define da_decl __declspec(dllexport)
 #include "platform.h"
 #include "jlib.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/dadiags.cpp $ $Id: dadiags.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "dacoven.hpp"
 #include "daclient.hpp"
 #include "mpbuff.hpp"
@@ -31,7 +28,6 @@ static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ba
 #include "daserver.hpp"
 #include "dasds.hpp"
 #include "dasubs.ipp"
-
 #include "dadiags.hpp"
 
 #ifdef _MSC_VER

--- a/dali/base/danqs.cpp
+++ b/dali/base/danqs.cpp
@@ -20,9 +20,6 @@
 #include "platform.h"
 #include "jlib.hpp"
 #include "jsuperhash.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/danqs.cpp $ $Id: danqs.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "dacoven.hpp"
 #include "daclient.hpp"
 #include "dasds.hpp"
@@ -31,7 +28,6 @@ static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ba
 #include "mputil.hpp"
 #include "mputil.hpp"
 #include "daserver.hpp"
-
 #include "danqs.hpp"
 
 #ifdef _MSC_VER

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -30,8 +30,6 @@
 #include "jptree.ipp"
 #include "jqueue.tpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/dasds.cpp $ $Id: dasds.cpp 63291 2011-03-18 16:21:00Z jsmith $");
-
 #define DEBUG_DIR "debug"
 #define DEFAULT_KEEP_LASTN_STORES 1
 #define MAXDELAYS 5

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -23,10 +23,6 @@
 #include "jsuperhash.hpp"
 #include "jmisc.hpp"
 #include "jencrypt.hpp"
-
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/dasess.cpp $ $Id: dasess.cpp 64657 2011-05-18 11:46:07Z jsmith $");
-
 #include "dacoven.hpp"
 #include "mpbuff.hpp"
 #include "mpcomm.hpp"

--- a/dali/base/dasubs.cpp
+++ b/dali/base/dasubs.cpp
@@ -28,8 +28,6 @@
 //#define SUPRESS_REMOVE_ABORTED
 #define TRACE_QWAITING
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/base/dasubs.cpp $ $Id: dasubs.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "dacoven.hpp"
 #include "mpbuff.hpp"
 #include "mpcomm.hpp"

--- a/dali/dafilesrv/dafilesrv.cpp
+++ b/dali/dafilesrv/dafilesrv.cpp
@@ -26,9 +26,6 @@
 #include "jlog.hpp"
 #include "jmisc.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/dafilesrv/dafilesrv.cpp $ $Id: dafilesrv.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 #ifdef _MSC_VER
 #pragma warning (disable : 4355)
 #endif

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -31,12 +31,8 @@
 #include "dfuerror.hpp"
 #include "dautils.hpp"
 #include "dalienv.hpp"
-
 #include "rmtfile.hpp"
-
 #include "dfuutil.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/dfu/dfuutil.cpp $ $Id: dfuutil.cpp 62376 2011-02-04 21:59:58Z sort $");
 
 // savemap
 // superkey functions

--- a/dali/dfuXRefLib/dfurdir.cpp
+++ b/dali/dfuXRefLib/dfurdir.cpp
@@ -20,10 +20,6 @@
 #include "mpbase.hpp"
 #include "rmtfile.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/dfuXRefLib/dfurdir.cpp $ $Id: dfurdir.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 #define REMOVE_DUPLICATE_DIRS
 //#define LOGERRORS
 

--- a/dali/dfuXRefLib/dfuxreflib.cpp
+++ b/dali/dfuXRefLib/dfuxreflib.cpp
@@ -23,9 +23,6 @@
 #include "jptree.hpp"
 #include "mpbase.hpp"
 #include "mpcomm.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/dfuXRefLib/dfuxreflib.cpp $ $Id: dfuxreflib.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "daclient.hpp"
 #include "dadiags.hpp"
 #include "danqs.hpp"

--- a/dali/dfuXRefLib/dfuxrenv.cpp
+++ b/dali/dfuXRefLib/dfuxrenv.cpp
@@ -24,9 +24,6 @@
 #include "mpbase.hpp"
 #include "mpcomm.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/dfuXRefLib/dfuxrenv.cpp $ $Id: dfuxrenv.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 #include "daclient.hpp"
 #include "dadiags.hpp"
 #include "danqs.hpp"

--- a/dali/dfuplus/CMakeLists.txt
+++ b/dali/dfuplus/CMakeLists.txt
@@ -51,6 +51,8 @@ include_directories (
          ./../../esp/bindings 
          ./../../common/workunit 
          ./../../common/remote 
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 set_source_files_properties (../../common/remote/rmtfile.cpp PROPERTIES COMPILE_FLAGS -DDAFILESRV_LOCAL)

--- a/dali/dfuplus/main.cpp
+++ b/dali/dfuplus/main.cpp
@@ -17,6 +17,7 @@
 ############################################################################## */
 
 #pragma warning (disable : 4786)
+#include <build-config.h>
 #include "daftcfg.hpp"
 #include "dfuerror.hpp"
 #include "dfuplus.hpp"
@@ -24,14 +25,9 @@
 #include "termios.h"
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/dfuplus/main.cpp $ $Id: main.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 void printVersion()
 {
-    StringBuffer buildVersion;
-    CBuildVersion::toString(buildVersion);
-    if (buildVersion.length() == 0) buildVersion.append("\n");
-    printf("DFU Version: %d %s", DAFT_VERSION, buildVersion.str());
+    printf("DFU Version: %d %s\n", DAFT_VERSION, BUILD_TAG);
 }
 
 void handleSyntax()

--- a/dali/dfuxref/dfuxrefmain.cpp
+++ b/dali/dfuxref/dfuxrefmain.cpp
@@ -24,8 +24,6 @@
 #include "dalienv.hpp"
 #include "daclient.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/dfuxref/dfuxrefmain.cpp $ $Id: dfuxrefmain.cpp 62561 2011-02-16 13:59:53Z nhicks $");
-
 static bool AddCompleteOrphans = false;
 static bool DeleteEmptyFiles = false;
 static bool fixSizes = false;

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -37,9 +37,6 @@
 #include "daft.ipp"
 #include "daftmc.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/daft.cpp $ $Id: daft.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 CDistributedFileSystem::CDistributedFileSystem()
 {
 }

--- a/dali/ft/daftdir.cpp
+++ b/dali/ft/daftdir.cpp
@@ -32,8 +32,6 @@
 #include <glob.h>
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/daftdir.cpp $ $Id: daftdir.cpp 64047 2011-04-15 09:01:54Z nhicks $");
-
 #ifdef _WIN32
 #define DEFAULT_DRIVE       "c:"                    // What about solaris machines.
 #else

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -37,8 +37,6 @@
 #include "daftformat.ipp"
 #include "junicode.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/daftformat.cpp $ $Id: daftformat.cpp 62850 2011-03-01 18:12:54Z nhicks $");
-
 //----------------------------------------------------------------------------
 
 /*

--- a/dali/ft/daftmc.cpp
+++ b/dali/ft/daftmc.cpp
@@ -20,8 +20,6 @@
 
 #include "daftmc.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/daftmc.cpp $ $Id: daftmc.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 const LogMsgCategory MCdebugInfoDetail(MCdebugInfo(1000));
 const LogMsgCategory MCdebugProgressDetail(MCdebugProgress(1000));
 

--- a/dali/ft/daftprogress.cpp
+++ b/dali/ft/daftprogress.cpp
@@ -44,8 +44,6 @@
 #include "jlog.hpp"
 #include "daftprogress.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/daftprogress.cpp $ $Id: daftprogress.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 DaftProgress::DaftProgress() 
 { 
     startTime = get_cycles_now(); 

--- a/dali/ft/daftsize.cpp
+++ b/dali/ft/daftsize.cpp
@@ -39,8 +39,6 @@
 #include "daftsize.hpp"
 #include "daftmc.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/daftsize.cpp $ $Id: daftsize.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 bool processSizesCommand(ISocket *, MemoryBuffer & cmd, MemoryBuffer & result)
 {
     LOG(MCdebugProgress, unknownJob, "Start gather remote file sizes");

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -43,14 +43,10 @@
 #include "jlog.hpp"
 #include "dalienv.hpp"
 
-
-
 #define DEFAULT_MAX_CONNECTIONS 25
 #define PARTITION_RECOVERY_LIMIT 1000
 #define EXPECTED_RESPONSE_TIME          (60 * 1000)
 #define RESPONSE_TIME_TIMEOUT           (60 * 60 * 1000)
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/filecopy.cpp $ $Id: filecopy.cpp 62376 2011-02-04 21:59:58Z sort $");
 
 //#define CLEANUP_RECOVERY
 

--- a/dali/ft/ftbase.cpp
+++ b/dali/ft/ftbase.cpp
@@ -17,12 +17,9 @@
 ############################################################################## */
 
 #include "jliball.hpp"
-
 #include "platform.h"
-
 #include "jlib.hpp"
 #include "jio.hpp"
-
 #include "jmutex.hpp"
 #include "jfile.hpp"
 #include "jsocket.hpp"
@@ -37,8 +34,6 @@
 #include "environment.hpp"
 #include "dalienv.hpp"
 #include "rmtspawn.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/ftbase.cpp $ $Id: ftbase.cpp 62376 2011-02-04 21:59:58Z sort $");
 
 #define DEFAULT_MAX_CSV_SIZE     8096
 

--- a/dali/ft/ftslave.cpp
+++ b/dali/ft/ftslave.cpp
@@ -17,12 +17,9 @@
 ############################################################################## */
 
 #include "jliball.hpp"
-
 #include "platform.h"
-
 #include "jlib.hpp"
 #include "jio.hpp"
-
 #include "jmutex.hpp"
 #include "jfile.hpp"
 #include "jsocket.hpp"
@@ -38,8 +35,6 @@
 #include "daftsize.hpp"
 #include "daftcfg.hpp"
 #include "mptag.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/ftslave.cpp $ $Id: ftslave.cpp 64048 2011-04-15 12:44:57Z nhicks $");
 
 bool processPullCommand(ISocket * masterSocket, MemoryBuffer & msg)
 {

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -17,12 +17,9 @@
 ############################################################################## */
 
 #include "jliball.hpp"
-
 #include "platform.h"
-
 #include "jlib.hpp"
 #include "jio.hpp"
-
 #include "jmutex.hpp"
 #include "jfile.hpp"
 #include "jsocket.hpp"
@@ -31,12 +28,9 @@
 #include "dadfs.hpp"
 #include "daftcfg.hpp"
 #include "daftmc.hpp"
-
 #include "rmtspawn.hpp"
 #include "fttransform.ipp"
 #include "ftbase.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/ft/fttransform.cpp $ $Id: fttransform.cpp 62376 2011-02-04 21:59:58Z sort $");
 
 #define OPTIMIZE_COMMON_TRANSFORMS
 

--- a/dali/sasha/CMakeLists.txt
+++ b/dali/sasha/CMakeLists.txt
@@ -56,6 +56,8 @@ include_directories (
          ${HPCC_SOURCE_DIR}/system/jlib 
          ${HPCC_SOURCE_DIR}/common/remote 
          ${HPCC_SOURCE_DIR}/plugins/workunitservices 
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/dali/sasha/packetstore.cpp
+++ b/dali/sasha/packetstore.cpp
@@ -14,9 +14,6 @@
   get changed
 */
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/sasha/packetstore.cpp $ $Id: packetstore.cpp 36518 2007-03-09 00:15:14Z pkapp $");
-
 #include "mpbuff.hpp"
 #include "mpcomm.hpp"
 #include "mputil.hpp"

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -1,3 +1,22 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#include "build-config.h"
 #include "platform.h"
 #include "thirdparty.h"
 #include "portlist.h"
@@ -311,7 +330,7 @@ int main(int argc, const char* argv[])
         aliaslogname.append(".log");
         fileMsgHandler = getRollingFileLogMsgHandler(logname.str(), ".log", MSGFIELD_STANDARD, false, true, NULL, aliaslogname.str());
         queryLogMsgManager()->addMonitorOwn(fileMsgHandler, getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, TopDetail));
-        CBuildVersion::log();
+        DBGLOG("Build %s", BUILD_TAG);
     }
 
     bool enableSNMP = false;

--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -24,8 +24,6 @@
 #include "sacoalescer.hpp"
 #include "sacmd.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/sasha/saxref.cpp $ $Id: saxref.cpp 61615 2011-01-07 15:01:55Z jsmith $");
-
 //#define _SINGLETHREAD
 #ifdef _SINGLETHREAD
 #define NUMTHREADS 1

--- a/dali/security/dacaplib.cpp
+++ b/dali/security/dacaplib.cpp
@@ -27,8 +27,6 @@
 #include "jarray.hpp"
 #include "jfile.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/security/dacaplib.cpp $ $Id: dacaplib.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "dacaplib.hpp"
 #include "dasess.hpp"
 

--- a/dali/server/CMakeLists.txt
+++ b/dali/server/CMakeLists.txt
@@ -40,6 +40,8 @@ include_directories (
          ./../../system/security/shared 
          ./../../system/security/LdapSecurity 
          ./../../system/jlib 
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -22,8 +22,6 @@
 #include "jencrypt.hpp"
 #include "thirdparty.h"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/dali/server/daldap.cpp $ $Id: daldap.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "dasds.hpp"
 #include "daldap.hpp"
 

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+#include "build-config.h"
 #include "platform.h"
 #include "thirdparty.h"
 #include "jlib.hpp"
@@ -193,8 +194,7 @@ int main(int argc, char* argv[])
         fileMsgHandler = getRollingFileLogMsgHandler(logName.str(), ".log", MSGFIELD_STANDARD, false, true, NULL, aliasLogName.str());
         queryLogMsgManager()->addMonitorOwn(fileMsgHandler, getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, TopDetail));
 
-        CBuildVersion::log();
-
+        DBGLOG("Build %s", BUILD_TAG);
 
         if (serverConfig)
         {

--- a/ecl/eclagent/CMakeLists.txt
+++ b/ecl/eclagent/CMakeLists.txt
@@ -16,33 +16,35 @@
 ################################################################################
 
 
-# Component: eclagent 
+# Component: eclagent
 #####################################################
 # Description:
 # ------------
 #    Cmake Input File for eclagent
 #####################################################
 
-project( eclagent ) 
+project( eclagent )
 
-set ( SRCS 
-      eclagentmain.cpp 
+set ( SRCS
+      eclagentmain.cpp
     )
 
-include_directories ( 
-      .
-      ./../hthor 
-      ./../../system/jlib
-      ./../../system/include
-      ./../../rtl/include
+include_directories (
+         .
+         ${HPCC_SOURCE_DIR}/ecl/hthor
+         ${HPCC_SOURCE_DIR}/system/jlib
+         ${HPCC_SOURCE_DIR}/system/include
+         ${HPCC_SOURCE_DIR}/rtl/include
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 ADD_DEFINITIONS( -DNO_SYBASE -D_CONSOLE )
 
 add_executable ( eclagent ${SRCS} )
 install ( TARGETS eclagent DESTINATION ${OSSDIR}/bin )
-target_link_libraries ( eclagent 
-      hthor            
+target_link_libraries ( eclagent
+      hthor           
       ${CPPUNIT_LIBRARIES}
     )
 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -15,6 +15,8 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
+
+#include "build-config.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jdebug.hpp"
@@ -58,9 +60,6 @@
 
 #define MONITOR_ECLAGENT_STATUS     
  
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclagent/eclagent.cpp $ $Id: eclagent.cpp 66010 2011-07-06 13:36:28Z wwhitehead $");
-
-static const char buildTag[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclagent/eclagent.cpp $";
 static const char XMLHEADER[] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
 //#define ROOT_DRIVE      "c:"
@@ -1842,7 +1841,7 @@ void EclAgent::doProcess()
             LOG(MCrunlock, unknownJob, "Obtained workunit lock");
             if (w->hasDebugValue("traceLevel"))
                 traceLevel = w->getDebugValueInt("traceLevel", 10);
-            w->setTracingValue("EclAgentBuild", buildTag);  
+            w->setTracingValue("EclAgentBuild", BUILD_TAG);  
             w->setDebugValue("EclAgentLog", logname.str(), true);
             if (checkVersion && ((w->getCodeVersion() > ACTIVITY_INTERFACE_VERSION) || (w->getCodeVersion() < MIN_ACTIVITY_INTERFACE_VERSION)))
                 failv(0, "Workunit was compiled for eclagent interface version %d, this eclagent requires version %d..%d", w->getCodeVersion(), MIN_ACTIVITY_INTERFACE_VERSION, ACTIVITY_INTERFACE_VERSION);
@@ -3076,11 +3075,11 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
 
     if (logfilespec.length())
         appendLogFile(logfilespec.str());
-
-    if (globals->getPropInt("VERSIONS"))
-        CBuildVersion::log();   
     if (traceLevel)
+    {
         printStart(argc, argv);
+        DBGLOG("Build %s", BUILD_TAG);
+    }
 
     // Extract any params into stored - primarily for standalone case but handy for debugging eclagent sometimes too
     Owned<IPropertyTree> query;
@@ -3164,10 +3163,7 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
                 MTIME_SECTION(timer, "Environment_Initialize");
                 setPasswordsFromSDS();
             }
-
-            if (strlen(buildTag) > 6)
-                PrintLog("ECLAGENT build %s", buildTag);
-
+            PrintLog("ECLAGENT build %s", BUILD_TAG);
             startLogMsgParentReceiver();    
             connectLogMsgManagerToDali();
             StringBuffer datadir;

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -31,8 +31,6 @@
 #include <dllserver.hpp>
 #include <thorplugin.hpp>
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclserver/eclserver.cpp $ $Id: eclserver.cpp 59036 2010-08-31 17:54:39Z sort $");
-
 static unsigned traceLevel;
 static StringAttr dllPath;
 Owned<IPropertyTree> globals;

--- a/ecl/eclplus/DeleteHelper.cpp
+++ b/ecl/eclplus/DeleteHelper.cpp
@@ -18,8 +18,6 @@
 #include "jlib.hpp"
 #include "DeleteHelper.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclplus/DeleteHelper.cpp $ $Id: DeleteHelper.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 DeleteHelper::DeleteHelper(IProperties * _globals, IFormatType * _format) : globals(_globals), format(_format), wuclient(createWorkunitsClient(_globals))
 {
 }

--- a/ecl/eclplus/DumpHelper.cpp
+++ b/ecl/eclplus/DumpHelper.cpp
@@ -18,8 +18,6 @@
 #include "jlib.hpp"
 #include "DumpHelper.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclplus/DumpHelper.cpp $ $Id: DumpHelper.cpp 64954 2011-05-27 14:50:31Z jprichard $");
-
 DumpHelper::DumpHelper(IProperties * _globals, IFormatType * _format) : globals(_globals), format(_format), wuclient(createWorkunitsClient(_globals))
 {
 }

--- a/ecl/eclplus/ListHelper.cpp
+++ b/ecl/eclplus/ListHelper.cpp
@@ -20,8 +20,6 @@
 
 #define NUMCOLUMNS 4
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclplus/ListHelper.cpp $ $Id: ListHelper.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 static StringAttr columns[NUMCOLUMNS] = {"WUID", "OWNER", "JOBNAME", "STATUS"};
 
 ListHelper::ListHelper(IProperties * _globals, IFormatType * _format) : globals(_globals), format(_format), wuclient(createWorkunitsClient(_globals))

--- a/ecl/eclplus/QueryHelper.cpp
+++ b/ecl/eclplus/QueryHelper.cpp
@@ -21,8 +21,6 @@
 #include "QueryHelper.ipp"
 #include "ViewHelper.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclplus/QueryHelper.cpp $ $Id: QueryHelper.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 QueryHelper::QueryHelper(IProperties * _globals, IFormatType * _format) : globals(_globals), format(_format), wuclient(createWorkunitsClient(_globals))
 {
 }

--- a/ecl/eclplus/ViewHelper.cpp
+++ b/ecl/eclplus/ViewHelper.cpp
@@ -20,8 +20,6 @@
 #include "jmisc.hpp"
 #include "ViewHelper.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclplus/ViewHelper.cpp $ $Id: ViewHelper.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #define DEFAULT_PAGESIZE 500
 
 SCMStringBuffer resultName;

--- a/ecl/eclplus/eclplus.cpp
+++ b/ecl/eclplus/eclplus.cpp
@@ -25,8 +25,6 @@
 #include "ws_workunits.hpp"
 #include "bindutil.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclplus/eclplus.cpp $ $Id: eclplus.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 IClientWsWorkunits * createWorkunitsClient(IProperties * _globals)
 {
     Owned<IClientWsWorkunits> wuclient = createWsWorkunitsClient();

--- a/ecl/eclplus/main.cpp
+++ b/ecl/eclplus/main.cpp
@@ -36,9 +36,6 @@
 #define ERROR_NO_SERVER                   3
 #define ERROR_CODE_USAGE                  4
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclplus/main.cpp $ $Id: main.cpp 63912 2011-04-08 09:20:18Z rchapman $");
-
 //copied from workunit.dll to avoid a dependency.  Should possibly go in jlib.
 static bool localLooksLikeAWuid(const char * wuid)
 {

--- a/ecl/eclscheduler/eclscheduler.cpp
+++ b/ecl/eclscheduler/eclscheduler.cpp
@@ -29,8 +29,6 @@
 #include <wujobq.hpp>
 #include "eventqueue.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/eclserver/eclserver.cpp $ $Id: eclserver.cpp 59036 2010-08-31 17:54:39Z sort $");
-
 static unsigned traceLevel;
 Owned<IPropertyTree> globals;
 

--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -38,8 +38,6 @@
 #include "hqlattr.hpp"
 #include "hqlmeta.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlattr.cpp $ $Id: hqlattr.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 static CriticalSection * attributeCS;
 
 MODULE_INIT(INIT_PRIORITY_HQLINTERNAL)

--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -20,8 +20,6 @@
 #include "hqlerror.hpp"
 #include "hqlerrors.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlerror.cpp $ $Id: hqlerror.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 void MultiErrorReceiver::reportError(int errNo, const char* msg, const char * filename, int lineno, int column, int position)
 {
     Owned<IECLError> err = createECLError(errNo,msg,filename,lineno,column,position);

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -47,8 +47,6 @@
 #include "hqlmeta.hpp"
 #include "workunit.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlexpr.cpp $ $Id: hqlexpr.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 //This nearly works - but there are still some examples which have problems - primarily libraries, old parameter syntax, enums and other issues.
 
 //#define ANNOTATE_EXPR_POSITION

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -35,9 +35,6 @@
 #include "hqlfold.hpp"
 #include "hqlthql.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlfold.cpp $ $Id: hqlfold.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
-
 //---------------------------------------------------------------------------
 // The following functions work purely on constant expressions - they do not attempt to process datasets.
 

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -50,8 +50,6 @@
 #include "hqlattr.hpp"
 #include "hqlmeta.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlgram.y $ $Id: hqlgram.y 66009 2011-07-06 12:28:32Z ghalliday $");
-
 #define REDEF_MSG(name)     StringBuffer msg;           \
                             msg.append(w"Identifier '"); \
                             msg.append(name.queryExpr()->queryName()->str()); \

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -54,8 +54,6 @@
 #define MANYFIELDS_THRESHOLD                        2000
 #define MAX_SENSIBLE_FIELD_LENGTH                   1000000000
 
-static CBuildVersion _bv1("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlgram2.cpp $ $Id: hqlgram2.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 struct TokenMap
 {
     int lexToken;

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -67,8 +67,6 @@ extern void hex2str(char * target, const char * digits, unsigned len);
 #define RETURNHARD(sym) \
         setupdatepos; return sym;
 
-static CBuildVersion _bv1("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqllex.l $ $Id: hqllex.l 66009 2011-07-06 12:28:32Z ghalliday $");
-
 int HqlLex::lookupIdentifierToken(YYSTYPE & returnToken, HqlLex * lexer, bool lookup, const short * activeState, const char * tokenText)
 {
     if ((tokenText[0] == '$') && tokenText[1]==0)

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -28,8 +28,6 @@
 #include "hqlattr.hpp"
 #include "hqlmeta.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlopt.cpp $ $Id: hqlopt.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 #define MIGRATE_JOIN_CONDITIONS             // This works, but I doubt it is generally worth the effort. - maybe on a flag.
 //#define TRACE_USAGE
 

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -32,8 +32,6 @@
 
 //#define TIMING_DEBUG
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlparse.cpp $ $Id: hqlparse.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 #define  MAX_LOOP_TIMES 10000
 
 // =========================== local helper functions ===================================

--- a/ecl/hql/hqlrepository.cpp
+++ b/ecl/hql/hqlrepository.cpp
@@ -23,8 +23,6 @@
 #include "eclrtl.hpp"
 #include "hqlexpr.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlrepository.cpp $ $Id: hqlrepository.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 bool isPluginDllScope(IHqlScope * scope)
 {
     if (!scope)

--- a/ecl/hql/hqlscope.cpp
+++ b/ecl/hql/hqlscope.cpp
@@ -27,8 +27,6 @@
 #include "hqlthql.hpp"
 #include "hqlerror.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlscope.cpp $ $Id: hqlscope.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 static void getECL(IHqlExpression * expr, StringBuffer & s)
 {
     toUserECL(s, expr, false);

--- a/ecl/hql/hqlstack.cpp
+++ b/ecl/hql/hqlstack.cpp
@@ -19,8 +19,6 @@
 #include <string.h>
 #include "hqlstack.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlstack.cpp $ $Id: hqlstack.cpp 65973 2011-07-04 15:37:51Z ghalliday $");
-
 FuncCallStack::FuncCallStack() {
     sp = 0;
     tos = DEFAULTSTACKSIZE;

--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -83,8 +83,6 @@ public:
 typedef CIArrayOf<StringBufferItem> StringBufferArray;
 MAKEPointerArray(HqlExprArray, HqlExprArrayArray);
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlthql.cpp $ $Id: hqlthql.cpp 65973 2011-07-04 15:37:51Z ghalliday $");
-
 class HqltHql
 {
 public:

--- a/ecl/hql/hqlwuerr.cpp
+++ b/ecl/hql/hqlwuerr.cpp
@@ -18,9 +18,6 @@
 #include "jliball.hpp"
 #include "hqlwuerr.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlwuerr.cpp $ $Id: hqlwuerr.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 static void formatError(StringBuffer & out, int errNo, const char *msg, _ATOM modulename, _ATOM attributename, int lineno, int column)
 {
     out.append(modulename);

--- a/ecl/hql/hqlxmldb.cpp
+++ b/ecl/hql/hqlxmldb.cpp
@@ -21,9 +21,6 @@
 #include "jexcept.hpp"
 #include "jprop.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hql/hqlxmldb.cpp $ $Id: hqlxmldb.cpp 65973 2011-07-04 15:37:51Z ghalliday $");
-
 class CXmlScope : public IXmlScope, public CInterface
 {
     friend class CXmlScopeIterator;

--- a/ecl/hqlcpp/hqlccommon.cpp
+++ b/ecl/hqlcpp/hqlccommon.cpp
@@ -19,8 +19,6 @@
 #include "hqlexpr.hpp"
 #include "hqlcatom.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlccommon.cpp $ $Id: hqlccommon.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //===========================================================================
 
 IHqlExpression * activeActivityMarkerExpr;

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -53,8 +53,6 @@
 #include "hqlcse.ipp"
 #include "thorplugin.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlcpp.cpp $ $Id: hqlcpp.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 #ifdef _DEBUG
 //#define ADD_ASSIGNMENT_COMMENTS
 //#define ADD_RESOURCE_AS_CPP_COMMENT

--- a/ecl/hqlcpp/hqlcppc.cpp
+++ b/ecl/hqlcpp/hqlcppc.cpp
@@ -29,8 +29,6 @@
 #include "hqlwcpp.hpp"
 #include "hqlcpp.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlcppc.cpp $ $Id: hqlcppc.cpp 63158 2011-03-11 22:39:30Z ghalliday $");
-
 IHqlExpression * convertAddressToValue(IHqlExpression * address, ITypeInfo * columnType)
 {
     if (isTypePassedByAddress(columnType) && !columnType->isReference())

--- a/ecl/hqlcpp/hqlcppcase.cpp
+++ b/ecl/hqlcpp/hqlcppcase.cpp
@@ -34,8 +34,6 @@
 #include "hqlcatom.hpp"
 #include "hqlcerrors.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlcppcase.cpp $ $Id: hqlcppcase.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 #define INTEGER_SEARCH_THRESHOLD                    30      // above this, a table search is generated.
 #define MAX_NUM_NOBREAK_CASE                        80      // maximum number of case: without a break - compiler workaround
 #define INLINE_COMPARE_THRESHOLD                    2       // above this, a loop is generated

--- a/ecl/hqlcpp/hqlcpputil.cpp
+++ b/ecl/hqlcpp/hqlcpputil.cpp
@@ -35,8 +35,6 @@
 #include "hqlcpp.ipp"
 #include "hqlcpputil.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlcpputil.cpp $ $Id: hqlcpputil.cpp 65799 2011-06-27 14:07:27Z ghalliday $");
-
 //===========================================================================
 
 static ITypeInfo * cachedVoidType;

--- a/ecl/hqlcpp/hqlcset.cpp
+++ b/ecl/hqlcpp/hqlcset.cpp
@@ -41,8 +41,6 @@
 #include "hqlutil.hpp"
 #include "hqliter.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlcset.cpp $ $Id: hqlcset.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 #ifdef CREATE_DEAULT_ROW_IF_NULL
 #define CREATE_DEAULT_ROW_IF_NULL_VALUE 1
 #else

--- a/ecl/hqlcpp/hqlecl.cpp
+++ b/ecl/hqlcpp/hqlecl.cpp
@@ -15,6 +15,8 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
+
+#include "build-config.h"
 #include "jliball.hpp"
 #include "jmisc.hpp"
 #include "jstream.hpp"
@@ -34,9 +36,6 @@
 
 #include "workunit.hpp"
 #include "thorplugin.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlecl.cpp $ $Id: hqlecl.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-static const char buildTag[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlecl.cpp $";
 
 #define MAIN_MODULE_TEMPLATE        "thortpl.cpp"
 #define HEADER_TEMPLATE             "thortpl.hpp"
@@ -545,7 +544,7 @@ extern HQLCPP_API unsigned getLibraryCRC(IHqlExpression * library)
 void setWorkunitHash(IWorkUnit * wu, IHqlExpression * expr)
 {
     //Assuming builds come from different branches this will change the crc for each one.
-    unsigned cacheCRC = crc32(buildTag, strlen(buildTag), ACTIVITY_INTERFACE_VERSION);
+    unsigned cacheCRC = crc32(BUILD_TAG, strlen(BUILD_TAG), ACTIVITY_INTERFACE_VERSION);
     cacheCRC += getExpressionCRC(expr);
 #ifdef _WIN32
     cacheCRC++; // make sure CRC is different in windows/linux

--- a/ecl/hqlcpp/hqliter.cpp
+++ b/ecl/hqlcpp/hqliter.cpp
@@ -41,8 +41,6 @@
 #include "hqlcse.ipp"
 #include "hqliter.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqliter.cpp $ $Id: hqliter.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 //===========================================================================
 
 bool isSequenceRoot(IHqlExpression * expr)

--- a/ecl/hqlcpp/hqlpopt.cpp
+++ b/ecl/hqlcpp/hqlpopt.cpp
@@ -33,9 +33,6 @@
 #include "hqlcpp.ipp"
 #include "hqlpopt.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlpopt.cpp $ $Id: hqlpopt.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 //Optimize IF(a,b,c) op x to IF(a,b op x, c OP x)
 //But be careful because it uncommons attributes increasing the size of the queries.
 static IHqlExpression * peepholeOptimizeCompare(BuildCtx & ctx, IHqlExpression * expr)

--- a/ecl/hqlcpp/hqlres.cpp
+++ b/ecl/hqlcpp/hqlres.cpp
@@ -27,8 +27,6 @@
 #include "bfd.h"
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlres.cpp $ $Id: hqlres.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 #define RESOURCE_BASE 101
 
 class ResourceItem : public CInterface

--- a/ecl/hqlcpp/hqlstmt.cpp
+++ b/ecl/hqlcpp/hqlstmt.cpp
@@ -34,8 +34,6 @@
 #include "hqlcpputil.hpp"
 #include "hqlutil.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlstmt.cpp $ $Id: hqlstmt.cpp 65973 2011-07-04 15:37:51Z ghalliday $");
-
 #define CLEAR_COPY_THRESHOLD            100
 
 //---------------------------------------------------------------------------

--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -34,8 +34,6 @@
 #include "hqlwcpp.hpp"
 #include "hqlwcpp.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hqlcpp/hqlwcpp.cpp $ $Id: hqlwcpp.cpp 66009 2011-07-06 12:28:32Z ghalliday $");
-
 #define INDENT_SOURCE
 #define FILE_CHUNK_SIZE         65000
 #define PREFERRED_LINE_LIMIT    160

--- a/ecl/hthor/CMakeLists.txt
+++ b/ecl/hthor/CMakeLists.txt
@@ -16,7 +16,7 @@
 ################################################################################
 
 
-# Component: hthor 
+# Component: hthor
 
 #####################################################
 # Description:
@@ -25,73 +25,75 @@
 #####################################################
 
 
-project( hthor ) 
+project( hthor )
 
-set (    SRCS 
-         hthor.cpp 
-         hthorkey.cpp 
-         hthorstep.cpp 
+set (    SRCS
+         hthor.cpp
+         hthorkey.cpp
+         hthorstep.cpp
          ../eclagent/eclagent.cpp
          ../eclagent/eclgraph.cpp
          sourcedoc.xml
     )
 
-set (    INCLUDES 
-         hthor.ipp 
+set (    INCLUDES
+         hthor.ipp
          hthor.hpp
-         hthorstep.ipp 
+         hthorstep.ipp
          ../eclagent/agentctx.hpp
          ../eclagent/eclagent.ipp
     )
 
-include_directories ( 
+include_directories (
          .
-         ./../../common/remote 
-         ./../../system/jhtree 
-         ./../../system/hrpc 
-         ./../../system/mp 
-         ./../../common/ns 
-         ./../../common/workunit 
-         ./../../system/icu/include 
-         ./../../common/deftype 
-         ./../../system/include 
-         ./../../dali/base 
-         ./../../rtl/include 
-         ./../../ecl/eclagent 
-         ./../../system/jlib 
-         ./../../common/thorhelper 
-         ./../../rtl/eclrtl 
-         ./../../roxie/roxiemem 
-         ./../../roxie/roxie
-         ./../../roxie/ccd
-         ./../../common/roxiehelper 
-         ./../../common/dllserver
-         ./../../common/environment
-         ./../schedulectrl
-         ./../../common/commonext
+         ${HPCC_SOURCE_DIR}/common/remote
+         ${HPCC_SOURCE_DIR}/system/jhtree
+         ${HPCC_SOURCE_DIR}/system/hrpc
+         ${HPCC_SOURCE_DIR}/system/mp
+         ${HPCC_SOURCE_DIR}/common/ns
+         ${HPCC_SOURCE_DIR}/common/workunit
+         ${HPCC_SOURCE_DIR}/system/icu/include
+         ${HPCC_SOURCE_DIR}/common/deftype
+         ${HPCC_SOURCE_DIR}/system/include
+         ${HPCC_SOURCE_DIR}/dali/base
+         ${HPCC_SOURCE_DIR}/rtl/include
+         ${HPCC_SOURCE_DIR}/ecl/eclagent
+         ${HPCC_SOURCE_DIR}/system/jlib
+         ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${HPCC_SOURCE_DIR}/rtl/eclrtl
+         ${HPCC_SOURCE_DIR}/roxie/roxiemem
+         ${HPCC_SOURCE_DIR}/roxie/roxie
+         ${HPCC_SOURCE_DIR}/roxie/ccd
+         ${HPCC_SOURCE_DIR}/common/roxiehelper
+         ${HPCC_SOURCE_DIR}/common/dllserver
+         ${HPCC_SOURCE_DIR}/common/environment
+         ${HPCC_SOURCE_DIR}/ecl/schedulectrl
+         ${HPCC_SOURCE_DIR}/common/commonext
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DHTHOR_EXPORTS -DSTARTQUERY_EXPORTS )
 
 HPCC_ADD_LIBRARY( hthor SHARED ${SRCS} ${INCLUDES} )
 install ( TARGETS hthor DESTINATION ${OSSDIR}/lib )
-target_link_libraries ( hthor 
+target_link_libraries ( hthor
          jlib
-         mp 
-         hrpc 
-         remote 
-         dalibase 
-         environment 
-         dllserver 
-         nbcd 
-         eclrtl 
-         deftype 
-         workunit 
-         jhtree 
-         securesocket 
-         thorhelper 
-         roxiemem 
-         roxiehelper 
+         mp
+         hrpc
+         remote
+         dalibase
+         environment
+         dllserver
+         nbcd
+         eclrtl
+         deftype
+         workunit
+         jhtree
+         securesocket
+         thorhelper
+         roxiemem
+         roxiehelper
          commonext
          schedulectrl
     )

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -45,8 +45,6 @@
 
 #define EMPTY_LOOP_LIMIT 1000
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hthor/hthor.cpp $ $Id: hthor.cpp 66008 2011-07-06 09:31:54Z rchapman $");
-
 static unsigned const hthorReadBufferSize = 0x10000;
 static memsize_t const defaultHThorSpillThreshold = 512*1024*1024;  // MORE - should increase on 64-bit platform?
 static offset_t const defaultHThorDiskWriteSizeLimit = I64C(10*1024*1024*1024); //10 GB, per Nigel

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -27,8 +27,6 @@
 #include "thorstep.ipp"
 #include "roxiedebug.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hthor/hthorkey.cpp $ $Id: hthorkey.cpp 63707 2011-04-01 14:24:52Z wwhitehead $");
-
 #define MAX_FETCH_LOOKAHEAD 1000
 #define IGNORE_FORMAT_CRC_MISMATCH_WHEN_NO_METADATA
 #define DEFAULT_KJ_PRESERVES_ORDER 1

--- a/ecl/hthor/hthorstep.cpp
+++ b/ecl/hthor/hthorstep.cpp
@@ -37,8 +37,6 @@
 #include "thorparse.ipp"
 #include "hthorstep.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/ecl/hthor/hthorstep.cpp $ $Id: hthorstep.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //---------------------------------------------------------------------------
 
 CHThorSteppedInput::CHThorSteppedInput(IHThorInput * _input)

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -648,7 +648,6 @@ const char* getBuildVersion()
 {
     return g_buildVersion.str();
 }
-
 static StringBuffer g_buildLevel;
 
 void setBuildLevel(const char* buildLevel)

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -62,7 +62,6 @@ ESPHTTP_API const char* getCFD();
 
 ESPHTTP_API void setBuildVersion(const char* buildVersion);
 ESPHTTP_API const char* getBuildVersion();
-
 ESPHTTP_API void setBuildLevel(const char* buildLevel);
 ESPHTTP_API const char* getBuildLevel();
 #endif

--- a/esp/platform/espp.cpp
+++ b/esp/platform/espp.cpp
@@ -209,12 +209,12 @@ void openEspLogFile(const char* logdir, IPropertyTree* globals)
     queryLogMsgManager()->addMonitorOwn(getRollingFileLogMsgHandler(logbase.str(), ".log", MSGFIELD_STANDARD, false, true, NULL, alias.str()), getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, DefaultDetail));
     if (globals->getPropBool("@enableSysLog", false))
         UseSysLogForOperatorMessages();
-    DBGLOG("Esp starting %s", "$HeadURL: https://svn.br.seisint.com/ecl/trunk/esp/platform/espp.cpp $");
+    DBGLOG("Esp starting %s", BUILD_TAG);
 }   
 
 static void usage()
 {
-    puts("ESP - Enterprise Service Platform server. (C) 2001-2005, Seisint Inc.");
+    puts("ESP - Enterprise Service Platform server. (C) 2001-2011, HPCC Systems.");
     puts("Usage:");
     puts("  esp [options]");
     puts("Options:");

--- a/plugins/auditlib/auditlib.cpp
+++ b/plugins/auditlib/auditlib.cpp
@@ -19,8 +19,6 @@
 #include "jlog.hpp"
 #include "auditlib.hpp"
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/auditlib/auditlib.cpp $ $Id: auditlib.cpp 62376 2011-02-04 21:59:58Z sort $";
-
 #define AUDITLIB_VERSION "AUDITLIB 1.0.1"
 static const char * compatibleVersions[] = {
     "AUDITLIB 1.0.0 [29933bc38c1f07bcf70f938ad18775c1]", // linux version

--- a/plugins/debugservices/debugservices.cpp
+++ b/plugins/debugservices/debugservices.cpp
@@ -19,8 +19,6 @@
 #include "platform.h"
 #include "debugservices.hpp"
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/debugservices/debugservices.cpp $ $Id: debugservices.cpp 62376 2011-02-04 21:59:58Z sort $";
-
 #define DEBUGSERVICES_VERSION "DEBUGSERVICES 1.0.1"
 
 const char * EclDefinition = 
@@ -50,7 +48,7 @@ DEBUGSERVICES_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb)
 
 DEBUGSERVICES_API char * DEBUGSERVICES_CALL dsGetBuildInfo(void)
 { 
-    return strdup(buildVersion);
+    return strdup(DEBUGSERVICES_VERSION);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------

--- a/plugins/examplelib/examplelib.cpp
+++ b/plugins/examplelib/examplelib.cpp
@@ -22,8 +22,6 @@
 #include <ctype.h>
 #include "examplelib.hpp"
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/examplelib/examplelib.cpp $ $Id: examplelib.cpp 62376 2011-02-04 21:59:58Z sort $";
-
 #define EXAMPLELIB_VERSION "EXAMPLELIB 1.0.00"
 
 const char * HoleDefinition = NULL;

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -39,8 +39,6 @@
 #define USE_DALIDFS
 #define SDS_LOCK_TIMEOUT  10000
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/fileservices/fileservices.cpp $ $Id: fileservices.cpp 64628 2011-05-17 13:19:55Z ghalliday $";
-
 #define FILESERVICES_VERSION "FILESERVICES 2.1.3"
 
 static const char * compatibleVersions[] = {
@@ -338,7 +336,7 @@ FILESERVICES_API void setPluginContext(IPluginContext * _ctx) { parentCtx = _ctx
 
 FILESERVICES_API char * FILESERVICES_CALL fsGetBuildInfo(void)
 {
-    return CTXSTRDUP(parentCtx, buildVersion);
+    return CTXSTRDUP(parentCtx, FILESERVICES_VERSION);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------

--- a/plugins/logging/logging.cpp
+++ b/plugins/logging/logging.cpp
@@ -23,8 +23,6 @@
 #include "logging.hpp"
 #include "jlog.hpp"
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/logging/logging.cpp $ $Id: logging.cpp 62376 2011-02-04 21:59:58Z sort $";
-
 #define LOGGING_VERSION "LOGGING 1.0.1"
 static const char * compatibleVersions[] = {
     "LOGGING 1.0.0 [66aec3fb4911ceda247c99d6a2a5944c]", // linux version

--- a/plugins/parselib/parselib.cpp
+++ b/plugins/parselib/parselib.cpp
@@ -24,8 +24,6 @@
 #include "thorparse.hpp"
 #include "parselib.hpp"
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/parselib/parselib.cpp $ $Id: parselib.cpp 62376 2011-02-04 21:59:58Z sort $";
-
 #define PARSELIB_VERSION "PARSELIB 1.0.1"
 
 _ATOM separatorTagAtom;

--- a/plugins/stringlib/stringlib.cpp
+++ b/plugins/stringlib/stringlib.cpp
@@ -23,8 +23,6 @@
 #include "stringlib.hpp"
 #include "wildmatch.tpp"
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/stringlib/stringlib.cpp $ $Id: stringlib.cpp 65375 2011-06-13 13:22:13Z rchapman $";
-
 static const char * compatibleVersions[] = {
     "STRINGLIB 1.1.06 [fd997dc3feb4ca385d59a12b9dc4beab]", // windows version
     "STRINGLIB 1.1.06 [f8305e66ca26a1447dee66d4a36d88dc]", // linux version
@@ -814,7 +812,7 @@ STRINGLIB_API void STRINGLIB_CALL slGetDateYYYYMMDD2(char * ret)
 
 STRINGLIB_API char * STRINGLIB_CALL slGetBuildInfo(void)
 { 
-    return CTXSTRDUP(parentCtx, buildVersion);
+    return CTXSTRDUP(parentCtx, STRINGLIB_VERSION);
 }
 
 STRINGLIB_API void STRINGLIB_CALL slData2String(size32_t & __ret_len,char * & __ret_str,unsigned _len_y, const void * y)
@@ -1196,11 +1194,11 @@ STRINGLIB_API void STRINGLIB_CALL slStringExtract50(char *tgt, unsigned srcLen, 
 
 STRINGLIB_API void STRINGLIB_CALL slGetBuildInfo100(char *tgt)
 {
-    size32_t len = (size32_t)strlen(buildVersion);
+    size32_t len = (size32_t) strlen(STRINGLIB_VERSION);
     if (len >= 100)
         len = 100;
-    memcpy(tgt,buildVersion,len);
-    memset(tgt+len,' ',100-len);
+    memcpy(tgt, STRINGLIB_VERSION, len);
+    memset(tgt+len, ' ', 100-len);
 }
 
 // -----------------------------------------------------------------

--- a/plugins/unicodelib/unicodelib.cpp
+++ b/plugins/unicodelib/unicodelib.cpp
@@ -30,8 +30,6 @@
 #include "unicode/rbbi.h"
 #include "../stringlib/wildmatch.tpp"
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/unicodelib/unicodelib.cpp $ $Id: unicodelib.cpp 65100 2011-06-02 18:23:08Z muhareex@risk $";
-
 #define UNICODELIB_VERSION "UNICODELIB 1.1.05"
 
 UChar32 const u32comma = ',';

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -52,8 +52,6 @@ Persists changed?
 #include "workunitservices.hpp"
 #include "workunitservices.ipp"
 
-static char buildVersion[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/plugins/workunitservices/workunitservices.cpp $ $Id: workunitservices.cpp 62376 2011-02-04 21:59:58Z sort $";
-
 #define WORKUNITSERVICES_VERSION "WORKUNITSERVICES 1.0.1"
 
 static const char * compatibleVersions[] = {
@@ -705,5 +703,5 @@ WORKUNITSERVICES_API void setPluginContext(IPluginContext * _ctx) { parentCtx = 
 
 WORKUNITSERVICES_API char * WORKUNITSERVICES_CALL fsGetBuildInfo(void)
 { 
-    return CTXSTRDUP(parentCtx, buildVersion);
+    return CTXSTRDUP(parentCtx, WORKUNITSERVICES_VERSION);
 }

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -668,15 +668,14 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         if (restarts)
         {
             if (traceLevel)
-                DBGLOG("Roxie restarting: restarts = %d", restarts);
+                DBGLOG("Roxie restarting: restarts = %d build = %s", restarts, BUILD_TAG);
             setStartRuid(restarts);
         }
         else
         {
             if (traceLevel)
             {
-                DBGLOG("Roxie starting");
-                CBuildVersion::log();
+                DBGLOG("Roxie starting, build = %s", BUILD_TAG);
             }
         }
 

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -99,10 +99,6 @@ using roxiemem::IRowManager;
 
 #define TRACE_STARTSTOP  // This determines if it is available - it is enabled/disabled by a configuration option
  
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/roxie/ccd/ccdserver.cpp $ $Id: ccdserver.cpp 65965 2011-07-04 09:57:58Z rchapman $");
-
-static const char buildTag[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/roxie/ccd/ccdserver.cpp $";
-
 static const SmartStepExtra dummySmartStepExtra(SSEFreadAhead, NULL);
 
 typedef IEclProcess* (* EclProcessFactory)();

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -18,7 +18,7 @@
 
 #include <platform.h>
 #include <jlib.hpp>
-#include <build-config.h>
+#include "build-config.h"
 
 #include "jisem.hpp"
 #include "jsort.hpp"

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -55,8 +55,6 @@
 #define UTF8_CODEPAGE "UTF-8"
 #define UTF8_MAXSIZE     4
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/rtl/eclrtl/eclrtl.cpp $ $Id: eclrtl.cpp 66106 2011-07-08 15:27:44Z ghalliday $");
-
 IRandomNumberGenerator * random_;
 static CriticalSection random_Sect;
 

--- a/rtl/eclrtl/rtldistr.cpp
+++ b/rtl/eclrtl/rtldistr.cpp
@@ -25,8 +25,6 @@
 #include "jlib.hpp"
 #include "rtldistr.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/rtl/eclrtl/rtldistr.cpp $ $Id: rtldistr.cpp 64094 2011-04-19 08:13:22Z ghalliday $");
-
 #define DISTRIBUTION_THRESHOLD 10000
 
 //---------------------------------------------------------------------------

--- a/rtl/eclrtl/rtlfield.cpp
+++ b/rtl/eclrtl/rtlfield.cpp
@@ -25,9 +25,6 @@
 #include "eclrtl_imp.hpp"
 #include "rtlfield_imp.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/rtl/eclrtl/rtlfield.cpp $ $Id: rtlfield.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 static const char * queryXPath(const RtlFieldInfo * field)
 {
     const char * xpath = field->xpath;

--- a/rtl/eclrtl/rtlint.cpp
+++ b/rtl/eclrtl/rtlint.cpp
@@ -27,10 +27,7 @@
 #include "eclrtl.hpp"
 #include "bcd.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/rtl/eclrtl/rtlint.cpp $ $Id: rtlint.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //#define _FAST_AND_LOOSE_
-
 
 #ifdef _FAST_AND_LOOSE_
 

--- a/rtl/eclrtl/rtlqstr.cpp
+++ b/rtl/eclrtl/rtlqstr.cpp
@@ -46,8 +46,6 @@
 #define __stdcall
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/rtl/eclrtl/rtlqstr.cpp $ $Id: rtlqstr.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //=============================================================================
 // Miscellaneous string functions...
 

--- a/rtl/eclrtl/rtlrank.cpp
+++ b/rtl/eclrtl/rtlrank.cpp
@@ -25,8 +25,6 @@
 #include "jlib.hpp"
 #include "eclrtl.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/rtl/eclrtl/rtlrank.cpp $ $Id: rtlrank.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //=============================================================================
 // Miscellaneous string functions...
 

--- a/rtl/eclrtl/rtlsize.cpp
+++ b/rtl/eclrtl/rtlsize.cpp
@@ -26,8 +26,6 @@
 
 #include "rtlsize.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/rtl/eclrtl/rtlsize.cpp $ $Id: rtlsize.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 /*************** This file is not yet used.  WIP ******************************/
 class OffsetInfoArray : public PointerArray
 {

--- a/rtl/eclrtl/rtltype.cpp
+++ b/rtl/eclrtl/rtltype.cpp
@@ -23,8 +23,6 @@
 #include "jlib.hpp"
 #include "rtltype.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/rtl/eclrtl/rtltype.cpp $ $Id: rtltype.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //=============================================================================
 // Pascal string helper functions...
 

--- a/services/runagent/frunagent.cpp
+++ b/services/runagent/frunagent.cpp
@@ -43,9 +43,6 @@
 #include "jsocket.hpp"
 #include "hodisp_base.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/services/runagent/frunagent.cpp $ $Id: frunagent.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #ifdef _WIN32
 const char* statcmd = "cmd /c dir c:\\hoagent.txt";
 #else

--- a/services/runagent/frunssh.cpp
+++ b/services/runagent/frunssh.cpp
@@ -24,11 +24,6 @@
 #include "jmisc.hpp"
 #include "rmtssh.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/services/runagent/frunssh.cpp $ $Id: frunssh.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
-
 int main( int argc, char *argv[] )
 {
     int res=0;

--- a/system/hrpc/hrpc.cpp
+++ b/system/hrpc/hrpc.cpp
@@ -42,8 +42,6 @@ static const char *trcfile="hrpctrc.txt";
 #include <time.h>
 #include "jdebug.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/hrpc/hrpc.cpp $ $Id: hrpc.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 void HRPCtrace(const char *fmt, ...)
 {
     static char buf[0x4000];

--- a/system/hrpc/hrpcmp.cpp
+++ b/system/hrpc/hrpcmp.cpp
@@ -30,9 +30,6 @@
 #include <mpbase.hpp> 
 #include <mpcomm.hpp> 
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/hrpc/hrpcmp.cpp $ $Id: hrpcmp.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 interface IMpTransportState : extends IInterface
 {
 public:

--- a/system/hrpc/hrpcsock.cpp
+++ b/system/hrpc/hrpcsock.cpp
@@ -27,8 +27,6 @@
 #include "jmutex.hpp"
 #include "jexcept.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/hrpc/hrpcsock.cpp $ $Id: hrpcsock.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class HRPCsockettransport: public CInterface, implements IHRPCtransport 
 {
 public:

--- a/system/hrpc/hrpcutil.cpp
+++ b/system/hrpc/hrpcutil.cpp
@@ -26,8 +26,6 @@
 #include "jmutex.hpp"
 #include "jthread.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/hrpc/hrpcutil.cpp $ $Id: hrpcutil.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 void SplitIpPort(StringAttr & ip, unsigned & port, const char * address)
 {
   const char * colon = strchr(address, ':');

--- a/system/jlib/jaio.cpp
+++ b/system/jlib/jaio.cpp
@@ -22,8 +22,6 @@
 #include <stdio.h>
 #include "jaio.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jaio.cpp $ $Id: jaio.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #ifdef _WIN32
 #define ASYNC_READ_TIMEOUT  5000        // milliseconds
 #define ASYNC_MAX_TIMEOUTS  10          // avoid 'deadlock' if something goes very wrong

--- a/system/jlib/jarray.cpp
+++ b/system/jlib/jarray.cpp
@@ -26,8 +26,6 @@
 
 #include <assert.h>
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jarray.cpp $ $Id: jarray.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #define FIRST_CHUNK_SIZE  8
 #define DOUBLE_LIMIT      0x100000          // must be a power of 2
 #define ALLOCA_LIMIT      64

--- a/system/jlib/javahash.cpp
+++ b/system/jlib/javahash.cpp
@@ -20,6 +20,4 @@
 #include "jlib.hpp"
 #include "javahash.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/javahash.cpp $ $Id: javahash.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "javahash.tpp"

--- a/system/jlib/jbsocket.cpp
+++ b/system/jlib/jbsocket.cpp
@@ -20,8 +20,6 @@
 #include "jlog.hpp"
 #include "jsocket.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jbsocket.cpp $ $Id: jbsocket.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #define BSOCKET_BUFSIZE 1024
 
 class BufferedSocket : public CInterface, implements IBufferedSocket

--- a/system/jlib/jbuff.cpp
+++ b/system/jlib/jbuff.cpp
@@ -39,9 +39,6 @@
 #include "jutil.hpp"
 #include "jvmem.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jbuff.cpp $ $Id: jbuff.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #ifdef _DEBUG
 #define KILL_CLEARS_MEMORY  
 //#define TRACE_LARGEMEM  

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -41,8 +41,6 @@
 #include "jdebug.hpp"
 #include "jcomp.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jcomp.cpp $ $Id: jcomp.cpp 65969 2011-07-04 13:03:29Z ghalliday $");
-
 #define CC_EXTRA_OPTIONS        ""
 #ifdef GENERATE_LISTING
 #undef CC_EXTRA_OPTIONS

--- a/system/jlib/jcrc.cpp
+++ b/system/jlib/jcrc.cpp
@@ -22,8 +22,6 @@
 #include "jlib.hpp"
 #include "jfile.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jcrc.cpp $ $Id: jcrc.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 static unsigned short crc_16_tab[256] = { // x^16+x^15+x^2+1
       0x0000,0xc0c1,0xc181,0x0140,0xc301,0x03c0,0x0280,0xc241,
       0xc601,0x06c0,0x0780,0xc741,0x0500,0xc5c1,0xc481,0x0440,

--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -46,8 +46,6 @@
 #endif
 
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jdebug.cpp $ $Id: jdebug.cpp 65715 2011-06-23 14:10:16Z rchapman $");
-
 //===========================================================================
 #ifdef _DEBUG
 //#define _USE_MALLOC_HOOK  

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -40,8 +40,6 @@
 #endif
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jexcept.cpp $ $Id: jexcept.cpp 65025 2011-06-01 11:23:50Z rchapman $");
-
 //#define NOSEH
 
 #define NO_LINUX_SEH

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -58,12 +58,8 @@
 #include "portlist.h"
 
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jfile.cpp $ $Id: jfile.cpp 65976 2011-07-05 11:24:53Z ghalliday $");
-
-
 // #define REMOTE_DISCONNECT_ON_DESTRUCTOR  // enable to disconnect on IFile destructor
                                             // this should not be enabled in WindowRemoteDirectory used
-
 
 #ifdef _DEBUG
 #define ASSERTEX(e) assertex(e); 

--- a/system/jlib/jhash.cpp
+++ b/system/jlib/jhash.cpp
@@ -30,8 +30,6 @@
 #include "jhash.hpp"
 #include "jmutex.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jhash.cpp $ $Id: jhash.cpp 62965 2011-03-04 12:34:40Z ghalliday $");
-
 #define PSTRINGDATA INT_MIN
 
 #define mix(a,b,c) \

--- a/system/jlib/jiface.cpp
+++ b/system/jlib/jiface.cpp
@@ -22,8 +22,6 @@
 #include <assert.h>
 #include "jmutex.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jiface.cpp $ $Id: jiface.cpp 62933 2011-03-03 17:00:04Z nhicks $");
-
 //===========================================================================
 
 void CInterface::beforeDispose()

--- a/system/jlib/jio.cpp
+++ b/system/jlib/jio.cpp
@@ -30,8 +30,6 @@
 #include "jexcept.hpp"
 #include "jqueue.tpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jio.cpp $ $Id: jio.cpp 63504 2011-03-26 13:46:15Z nhicks $");
-
 #ifdef _WIN32
 #include <io.h>
 #endif

--- a/system/jlib/jiter.cpp
+++ b/system/jlib/jiter.cpp
@@ -21,8 +21,6 @@
 #include "jiter.hpp"
 #include "jiter.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jiter.cpp $ $Id: jiter.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //==============================================================================================================
 
 CArrayIteratorBase::CArrayIteratorBase(const Array &_values, aindex_t _start, IInterface *_owner) : owner(_owner), values (_values), start(_start)

--- a/system/jlib/jlib.cpp
+++ b/system/jlib/jlib.cpp
@@ -199,42 +199,6 @@ ModExit::~ModExit()
 }
 #endif
 
-CBuildVersion::CBuildVersion(const char* this_Version): my_version(this_Version)
-{
-    // Builds straight out of SAOP will not have these substituted
-    // Broken up to avoid SVN substituting this literal!
-    if (strcmp(this_Version, "$Head" "URL$ $I" "d$") != 0)
-    {
-        next = VersionHead;
-        VersionHead = this;
-    }
-}
-
-
-StringBuffer &CBuildVersion::toString(StringBuffer &to)
-{
-    CBuildVersion *finger = VersionHead;
-    while (finger)
-    {
-        to.append(finger->my_version).append('\n');
-        finger = finger->next;
-    }
-    return to;
-}
-
-void CBuildVersion::log()
-{
-    CBuildVersion *finger = VersionHead;
-    while (finger)
-    {
-        LOG(MCdebugInfo, unknownJob, "%s", finger->my_version);
-        finger = finger->next;
-    }
-}
-
-CBuildVersion* CBuildVersion::VersionHead = 0;
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jlib.cpp $ $Id: jlib.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 // check that everything compiles correctly
 #if 0
 

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -34,8 +34,6 @@
 #define AUDIT_DATA_LOG_TEMPLATE "/var/log/seisint/log_data_XXXXXX"
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jlog.cpp $ $Id: jlog.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 // Time, in nanoseconds, after which the clock field loops --- 3600000000000ns = 1hr
 #define CLOCK_LOOP_NANOSECONDS I64C(3600000000000)
 

--- a/system/jlib/jlzw.cpp
+++ b/system/jlib/jlzw.cpp
@@ -26,8 +26,6 @@
 #include "jencrypt.hpp"
 #include "jflz.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jlzw.cpp $ $Id: jlzw.cpp 64790 2011-05-20 15:20:41Z jsmith $");
-
 #ifdef _WIN32
 #include <io.h>
 #endif

--- a/system/jlib/jmemleak.cpp
+++ b/system/jlib/jmemleak.cpp
@@ -19,5 +19,4 @@
 
 #include "jlib.hpp"
 #include "jmemleak.h"
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jmemleak.cpp $ $Id: jmemleak.cpp 62376 2011-02-04 21:59:58Z sort $");
 

--- a/system/jlib/jmisc.cpp
+++ b/system/jlib/jmisc.cpp
@@ -32,8 +32,6 @@
 #include <sys/wait.h>
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jmisc.cpp $ $Id: jmisc.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #ifdef LOGCLOCK
 #define MSGFIELD_PRINTLOG MSGFIELD_timeDate | MSGFIELD_msgID | MSGFIELD_process | MSGFIELD_thread | MSGFIELD_code | MSGFIELD_milliTime
 #else

--- a/system/jlib/jmutex.cpp
+++ b/system/jlib/jmutex.cpp
@@ -25,8 +25,6 @@
 #include <stdio.h>
 #include <assert.h>
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jmutex.cpp $ $Id: jmutex.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //===========================================================================
 #ifndef _WIN32
 

--- a/system/jlib/jobserve.cpp
+++ b/system/jlib/jobserve.cpp
@@ -22,8 +22,6 @@
 #include "jlib.hpp"
 #include "jobserve.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jobserve.cpp $ $Id: jobserve.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //-----------------------------------------------------------------------
 //-- Classes for helping with notification
 //-----------------------------------------------------------------------

--- a/system/jlib/jprop.cpp
+++ b/system/jlib/jprop.cpp
@@ -31,8 +31,6 @@
  extern char **environ;
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jprop.cpp $ $Id: jprop.cpp 62965 2011-03-04 12:34:40Z ghalliday $");
-
 const char *conv2char_ptr(const char *p) { return p; }
 const char *convchar_ptr2(const char *p) { return p; }
 const char *tokvchar_ptr(const void *p) { return (const char *)p; }

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -41,8 +41,6 @@
     memcpy((char *) name, (src), (length)); \
     *(char *) (name+(length)) = '\0';
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jptree.cpp $ $Id: jptree.cpp 62962 2011-03-04 11:10:12Z jsmith $");
-
 #include "jfile.hpp"
 #include "jlog.hpp"
 #include "jptree.ipp"

--- a/system/jlib/jregexp.cpp
+++ b/system/jlib/jregexp.cpp
@@ -21,10 +21,6 @@
 #include "jmisc.hpp"
 #include "jregexp.hpp"
 
-
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jregexp.cpp $ $Id: jregexp.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #define FAIL(s) { /*assert(!s);*/ return NULL; }
 
 #define SUBPARENL '{'

--- a/system/jlib/jsem.cpp
+++ b/system/jlib/jsem.cpp
@@ -22,8 +22,6 @@
 #include "jisem.hpp"
 #include "jmutex.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jsem.cpp $ $Id: jsem.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #ifndef _WIN32
 
 #include <sys/time.h>

--- a/system/jlib/jset.cpp
+++ b/system/jlib/jset.cpp
@@ -22,8 +22,6 @@
 #include "jmutex.hpp"
 #include "jexcept.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jset.cpp $ $Id: jset.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //-----------------------------------------------------------------------
 
 // Simple BitSet // 0 based all, intermediate items exist, operations threadsafe and atomic

--- a/system/jlib/jsmartsock.cpp
+++ b/system/jlib/jsmartsock.cpp
@@ -20,8 +20,6 @@
 #include "jsmartsock.ipp"
 #include "jdebug.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jsmartsock.cpp $ $Id: jsmartsock.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class SmartSocketListParser
 {
 public:

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -65,8 +65,6 @@
 #include "jdebug.hpp"
 #include "build-config.h"
 
-//static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jsocket.cpp $ $Id: jsocket.cpp 66016 2011-07-06 17:43:49Z rchapman $");
-
 // various options 
 
 #define CONNECT_TIMEOUT_REFUSED_WAIT    1000        // maximum to sleep on connect_timeout

--- a/system/jlib/jsort.cpp
+++ b/system/jlib/jsort.cpp
@@ -28,10 +28,6 @@
 #include "jthread.hpp"
 #include "jqueue.tpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jsort.cpp $ $Id: jsort.cpp 63168 2011-03-14 11:27:12Z nhicks $");
-
-
 #ifdef _DEBUG
 // #define PARANOID
 // #define DOUBLE_COMPARE

--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -21,8 +21,6 @@
 #include "jstats.h"
 #include "jexcept.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jstats.cpp $ $Id: jstats.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 extern jlib_decl const char *getStatName(unsigned i)
 {
     switch (i)

--- a/system/jlib/jstream.cpp
+++ b/system/jlib/jstream.cpp
@@ -28,8 +28,6 @@
 #include <io.h>
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jstream.cpp $ $Id: jstream.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 CByteInputStream::CByteInputStream()
 {
     eofseen = false;

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -35,8 +35,6 @@
 #include "jdebug.hpp"
 #include "jutil.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jstring.cpp $ $Id: jstring.cpp 62922 2011-03-03 14:18:20Z nhicks $");
-
 #define DOUBLE_FORMAT   "%.16g"
 #define FLOAT_FORMAT    "%.7g"
 

--- a/system/jlib/jsuperhash.cpp
+++ b/system/jlib/jsuperhash.cpp
@@ -21,8 +21,6 @@
 #include "jsuperhash.hpp"
 #include <assert.h>
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jsuperhash.cpp $ $Id: jsuperhash.cpp 64069 2011-04-18 14:15:50Z rchapman $");
-
 #ifndef HASHSIZE_POWER2
 #define HASHSIZE_POWER2
 #endif

--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -40,8 +40,6 @@
  #define new new(_NORMAL_BLOCK, __FILE__, __LINE__)
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jthread.cpp $ $Id: jthread.cpp 64340 2011-05-03 09:41:15Z rchapman $");
-
 #define LINUX_STACKSIZE_CAP (0x200000)
 
 //#define NO_CATCHALL

--- a/system/jlib/jtime.cpp
+++ b/system/jlib/jtime.cpp
@@ -24,7 +24,6 @@
 #include "jexcept.hpp"
 #include "jerror.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jtime.cpp $ $Id: jtime.cpp 62376 2011-02-04 21:59:58Z sort $");
 static int tzDelta = 0;                 // Mainly for testing, but could be used for a cache
 
 #ifndef __GNUC__

--- a/system/jlib/junicode.cpp
+++ b/system/jlib/junicode.cpp
@@ -22,8 +22,6 @@
 #include "jerror.hpp"
 #include "junicode.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/junicode.cpp $ $Id: junicode.cpp 64453 2011-05-09 08:23:35Z ghalliday $");
-
 /* Based on code extracted from the following source...  Changed quite signficantly */
 
 /*

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -47,8 +47,6 @@
 #include "build-config.h"
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/jlib/jutil.cpp $ $Id: jutil.cpp 65678 2011-06-22 16:57:45Z rchapman $");
-
 static SpinLock * cvtLock;
 
 #ifdef _WIN32

--- a/system/mp/mpbase.cpp
+++ b/system/mp/mpbase.cpp
@@ -21,8 +21,6 @@
 #include "jlib.hpp"
 #include "jlog.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/mp/mpbase.cpp $ $Id: mpbase.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "mpbase.hpp"
 
 static INode *MyNode=NULL;

--- a/system/mp/mpcomm.cpp
+++ b/system/mp/mpcomm.cpp
@@ -29,8 +29,6 @@
 #include "jlib.hpp"
 #include <limits.h>
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/mp/mpcomm.cpp $ $Id: mpcomm.cpp 66046 2011-07-07 10:56:16Z rchapman $");
-
 #include "jsocket.hpp"
 #include "jmutex.hpp"
 #include "jutil.hpp"

--- a/system/mp/mplog.cpp
+++ b/system/mp/mplog.cpp
@@ -22,8 +22,6 @@
 #include "mplog.ipp"
 #include "mpcomm.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/system/mp/mplog.cpp $ $Id: mplog.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 LogMsgChildReceiverThread * childReceiver;
 LogMsgParentReceiverThread * parentReceiver;
 ILogMsgManager * listener;

--- a/thorlcr/activities/action/thaction.cpp
+++ b/thorlcr/activities/action/thaction.cpp
@@ -21,8 +21,6 @@
 
 #include "thexception.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/action/thaction.cpp $ $Id: thaction.cpp 64945 2011-05-27 13:20:16Z jsmith $");
-
 #include "thactivitymaster.ipp"
 #include "thaction.ipp"
 

--- a/thorlcr/activities/aggregate/thaggregate.cpp
+++ b/thorlcr/activities/aggregate/thaggregate.cpp
@@ -25,9 +25,6 @@
 #define NO_BWD_COMPAT_MAXSIZE
 #include "thorcommon.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/aggregate/thaggregate.cpp $ $Id: thaggregate.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
-
 class CAggregateMasterBase : public CMasterActivity
 {
     mptag_t replyTag;

--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -30,9 +30,6 @@
 #include "thactivityutil.ipp"
 #include "thaggregateslave.ipp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/aggregate/thaggregateslave.cpp $ $Id: thaggregateslave.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 class AggregateSlaveBase : public CSlaveActivity, public CThorDataLink
 {
 public:

--- a/thorlcr/activities/aggregate/thgroupaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thgroupaggregateslave.cpp
@@ -18,12 +18,6 @@
 
 #include "thgroupaggregateslave.ipp"
 
-
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/aggregate/thgroupaggregateslave.cpp $ $Id: thgroupaggregateslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
-
 class GroupAggregateSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
 

--- a/thorlcr/activities/apply/thapply.cpp
+++ b/thorlcr/activities/apply/thapply.cpp
@@ -18,8 +18,6 @@
 
 #include "thapply.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/apply/thapply.cpp $ $Id: thapply.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CApplyActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/apply/thapplyslave.cpp
+++ b/thorlcr/activities/apply/thapplyslave.cpp
@@ -19,9 +19,6 @@
 #include "thapplyslave.ipp"
 #include "thactivityutil.ipp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/apply/thapplyslave.cpp $ $Id: thapplyslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CApplySlaveActivity : public ProcessSlaveActivity
 {
     IHThorApplyArg *helper;

--- a/thorlcr/activities/catch/thcatch.cpp
+++ b/thorlcr/activities/catch/thcatch.cpp
@@ -18,8 +18,6 @@
 
 #include "thcatch.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/catch/thcatch.cpp $ $Id: thcatch.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CSkipCatchActivity : public CMasterActivity
 {
     Owned<IBarrier> barrier;

--- a/thorlcr/activities/catch/thcatchslave.cpp
+++ b/thorlcr/activities/catch/thcatchslave.cpp
@@ -23,9 +23,6 @@
 #include "commonext.hpp"
 #include "slave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/catch/thcatchslave.cpp $ $Id: thcatchslave.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
-
 class CCatchSlaveActivityBase : public CSlaveActivity, public CThorDataLink
 {
 protected:

--- a/thorlcr/activities/choosesets/thchoosesets.cpp
+++ b/thorlcr/activities/choosesets/thchoosesets.cpp
@@ -19,10 +19,6 @@
 #include "thchoosesets.ipp"
 #include "thbufdef.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/choosesets/thchoosesets.cpp $ $Id: thchoosesets.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
-
 class CChooseSetsActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/choosesets/thchoosesetsslave.cpp
+++ b/thorlcr/activities/choosesets/thchoosesetsslave.cpp
@@ -20,10 +20,6 @@
 #include "thactivityutil.ipp"
 #include "thbufdef.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/choosesets/thchoosesetsslave.cpp $ $Id: thchoosesetsslave.cpp 65252 2011-06-08 08:41:27Z jsmith $");
-
-
 class BaseChooseSetsActivity : public CSlaveActivity,  public CThorDataLink
 {
 protected:

--- a/thorlcr/activities/countproject/thcountproject.cpp
+++ b/thorlcr/activities/countproject/thcountproject.cpp
@@ -19,9 +19,6 @@
 #include "thcountproject.ipp"
 #include "thbufdef.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/countproject/thcountproject.cpp $ $Id: thcountproject.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CountProjectActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/countproject/thcountprojectslave.cpp
+++ b/thorlcr/activities/countproject/thcountprojectslave.cpp
@@ -20,10 +20,6 @@
 #include "thactivityutil.ipp"
 #include "thbufdef.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/countproject/thcountprojectslave.cpp $ $Id: thcountprojectslave.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
-
 class BaseCountProjectActivity : public CSlaveActivity,  public CThorDataLink, implements ISmartBufferNotify
 {
 protected:

--- a/thorlcr/activities/csvread/thcsvread.cpp
+++ b/thorlcr/activities/csvread/thcsvread.cpp
@@ -24,8 +24,6 @@
 #include "thdiskbase.ipp"
 #include "thcsvread.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/csvread/thcsvread.cpp $ $Id: thcsvread.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CCsvReadActivityMaster : public CDiskReadMasterBase
 {
 public:

--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -24,7 +24,6 @@
 #include "jtime.hpp"
 #include "jsort.hpp"
 
-
 #include "thormisc.hpp"
 #include "thmfilemanager.hpp"
 #include "thorport.hpp"
@@ -35,9 +34,6 @@
 #include "thactivityutil.ipp"
 #include "csvsplitter.hpp"
 #include "thdiskbaseslave.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/csvread/thcsvrslave.cpp $ $Id: thcsvrslave.cpp 65710 2011-06-23 13:22:19Z ghalliday $");
-
 
 class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDataLink
 {

--- a/thorlcr/activities/degroup/thdegroupslave.cpp
+++ b/thorlcr/activities/degroup/thdegroupslave.cpp
@@ -18,11 +18,6 @@
 
 #include "thdegroupslave.ipp"
 
-
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/degroup/thdegroupslave.cpp $ $Id: thdegroupslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CDegroupSlaveActivity : public CSlaveActivity, public CThorDataLink, public CThorSteppable
 {
     IThorDataLink *input;

--- a/thorlcr/activities/diskread/thdiskread.cpp
+++ b/thorlcr/activities/diskread/thdiskread.cpp
@@ -26,9 +26,6 @@
 
 #include "thdiskread.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/diskread/thdiskread.cpp $ $Id: thdiskread.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
-
 class CDiskReadMasterVF : public CDiskReadMasterBase
 {
 public:

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -40,8 +40,6 @@
 #include "../hashdistrib/thhashdistribslave.ipp"
 #include "thdiskreadslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/diskread/thdiskreadslave.cpp $ $Id: thdiskreadslave.cpp 64498 2011-05-11 11:45:08Z jsmith $");
-
 #define ASYNC_BUFFER_SIZE   64 * 1024       // 64k
 
 #define RECORD_BUFFER_SIZE  64 * 1024       // 64k

--- a/thorlcr/activities/diskwrite/thdiskwrite.cpp
+++ b/thorlcr/activities/diskwrite/thdiskwrite.cpp
@@ -28,10 +28,6 @@
 
 #include "thdiskwrite.ipp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/diskwrite/thdiskwrite.cpp $ $Id: thdiskwrite.cpp 63406 2011-03-23 17:33:52Z jsmith $");
-
-
 class CDiskWriteActivityMaster : public CWriteMasterBase
 {
 public:

--- a/thorlcr/activities/diskwrite/thdwslave.cpp
+++ b/thorlcr/activities/diskwrite/thdwslave.cpp
@@ -31,9 +31,6 @@
 #include "thdiskbaseslave.ipp"
 #include "thdwslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/diskwrite/thdwslave.cpp $ $Id: thdwslave.cpp 63406 2011-03-23 17:33:52Z jsmith $");
-
-
 class CDiskWriteSlaveActivity : public CDiskWriteSlaveActivityBase
 {
 protected:

--- a/thorlcr/activities/distribution/thdistribution.cpp
+++ b/thorlcr/activities/distribution/thdistribution.cpp
@@ -19,10 +19,6 @@
 #include "thdistribution.ipp"
 #include "thexception.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/distribution/thdistribution.cpp $ $Id: thdistribution.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
-
 class CDistributionActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/distribution/thdistributionslave.cpp
+++ b/thorlcr/activities/distribution/thdistributionslave.cpp
@@ -19,9 +19,6 @@
 #include "thdistributionslave.ipp"
 #include "thactivityutil.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/distribution/thdistributionslave.cpp $ $Id: thdistributionslave.cpp 62742 2011-02-24 16:57:20Z nhicks $");
-
-
 class CDistributionSlaveActivity : public ProcessSlaveActivity
 {
     IHThorDistributionArg * helper;

--- a/thorlcr/activities/enth/thenth.cpp
+++ b/thorlcr/activities/enth/thenth.cpp
@@ -21,10 +21,6 @@
 
 #include "thbufdef.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/enth/thenth.cpp $ $Id: thenth.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CEnthActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/enth/thenthslave.cpp
+++ b/thorlcr/activities/enth/thenthslave.cpp
@@ -20,8 +20,6 @@
 #include "thactivityutil.ipp"
 #include "thbufdef.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/enth/thenthslave.cpp $ $Id: thenthslave.cpp 65251 2011-06-08 08:38:02Z jsmith $");
-
 class BaseEnthActivity : public CSlaveActivity, public CThorDataLink, implements ISmartBufferNotify
 {
 protected:

--- a/thorlcr/activities/fetch/thfetch.cpp
+++ b/thorlcr/activities/fetch/thfetch.cpp
@@ -26,8 +26,6 @@
 #include "../hashdistrib/thhashdistrib.ipp"
 #include "thfetch.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/fetch/thfetch.cpp $ $Id: thfetch.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CFetchActivityMaster : public CMasterActivity
 {
     Owned<CSlavePartMapping> mapping;

--- a/thorlcr/activities/fetch/thfetchslave.cpp
+++ b/thorlcr/activities/fetch/thfetchslave.cpp
@@ -40,8 +40,6 @@
 #include "../hashdistrib/thhashdistribslave.ipp"
 #include "thfetchslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/fetch/thfetchslave.cpp $ $Id: thfetchslave.cpp 62831 2011-03-01 12:56:25Z jsmith $");
-
 #define NUMSLAVEPORTS       2
 
 struct FPosTableEntryIFileIO : public FPosTableEntry

--- a/thorlcr/activities/filter/thfilter.cpp
+++ b/thorlcr/activities/filter/thfilter.cpp
@@ -18,8 +18,6 @@
 
 #include "thfilter.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/filter/thfilter.cpp $ $Id: thfilter.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CFilterActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/filter/thfilterslave.cpp
+++ b/thorlcr/activities/filter/thfilterslave.cpp
@@ -18,10 +18,6 @@
 
 #include "thfilterslave.ipp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/filter/thfilterslave.cpp $ $Id: thfilterslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CFilterSlaveActivityBase : public CSlaveActivity, public CThorDataLink
 {
 protected:

--- a/thorlcr/activities/firstn/thfirstn.cpp
+++ b/thorlcr/activities/firstn/thfirstn.cpp
@@ -22,8 +22,6 @@
 #include "thfirstn.ipp"
 #include "thbufdef.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/firstn/thfirstn.cpp $ $Id: thfirstn.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 class CFirstNActivityMaster : public CMasterActivity
 {
     static CriticalSection singlefirstnterm;

--- a/thorlcr/activities/firstn/thfirstnslave.cpp
+++ b/thorlcr/activities/firstn/thfirstnslave.cpp
@@ -26,8 +26,6 @@
 
 #include "thfirstnslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/firstn/thfirstnslave.cpp $ $Id: thfirstnslave.cpp 65251 2011-06-08 08:38:02Z jsmith $");
-
 class CFirstNSlaveBase : public CSlaveActivity, public CThorDataLink
 {
 protected:

--- a/thorlcr/activities/funnel/thfunnel.cpp
+++ b/thorlcr/activities/funnel/thfunnel.cpp
@@ -22,9 +22,6 @@
 #include "thexception.hpp"
 #include "thfunnel.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/funnel/thfunnel.cpp $ $Id: thfunnel.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
-
 //
 // CNonEmptyActivityMaster
 //

--- a/thorlcr/activities/funnel/thfunnelslave.cpp
+++ b/thorlcr/activities/funnel/thfunnelslave.cpp
@@ -29,8 +29,6 @@
 
 #include "thfunnelslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/funnel/thfunnelslave.cpp $ $Id: thfunnelslave.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 class CParallelFunnel : public CSimpleInterface, implements IRowStream
 {
     class CInputHandler : public CInterface, implements IThreaded

--- a/thorlcr/activities/group/thgroupslave.cpp
+++ b/thorlcr/activities/group/thgroupslave.cpp
@@ -21,9 +21,6 @@
 #include "thactivityutil.ipp"
 #include "thorport.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/group/thgroupslave.cpp $ $Id: thgroupslave.cpp 63605 2011-03-30 10:42:56Z nhicks $");
-
-
 class GroupSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
 

--- a/thorlcr/activities/hashdistrib/thhashdistrib.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistrib.cpp
@@ -29,9 +29,6 @@
 #include "thmem.hpp"
 #include "thexception.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/hashdistrib/thhashdistrib.cpp $ $Id: thhashdistrib.cpp 63849 2011-04-06 15:20:02Z jsmith $");
-
-
 #define NUMINPARALLEL 16
 
 enum DistributeMode { DM_distrib, DM_dedup, DM_join , DM_groupaggregate, DM_index, DM_redistribute, DM_distribmerge };

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -38,9 +38,6 @@
 #include "thexception.hpp"
 #include "jhtree.hpp"
 #include "thalloc.hpp"
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/hashdistrib/thhashdistribslave.cpp $ $Id: thhashdistribslave.cpp 64790 2011-05-20 15:20:41Z jsmith $");
-
-
 
 #ifdef _DEBUG
 //#define TRACE_UNIQUE

--- a/thorlcr/activities/indexread/thindexread.cpp
+++ b/thorlcr/activities/indexread/thindexread.cpp
@@ -24,9 +24,6 @@
 #include "thdiskbase.ipp"
 #include "thindexread.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/indexread/thindexread.cpp $ $Id: thindexread.cpp 64422 2011-05-05 16:51:53Z jsmith $");
-
-
 class CIndexReadBase : public CMasterActivity
 {
 protected:

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -37,10 +37,6 @@
 #include "thdiskbaseslave.ipp"
 #include "thindexreadslave.ipp"
 
-
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/indexread/thindexreadslave.cpp $ $Id: thindexreadslave.cpp 64673 2011-05-18 15:15:16Z rchapman $");
-
 static IKeyManager *getKeyManager(IKeyIndex *keyIndex, IHThorIndexReadBaseArg *helper, size32_t fixedDiskRecordSize)
 {
     Owned<IKeyManager> klManager = createKeyManager(keyIndex, fixedDiskRecordSize, NULL);

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -26,8 +26,6 @@
 #include "eclrtl.hpp"
 #include "thorfile.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/indexwrite/thindexwrite.cpp $ $Id: thindexwrite.cpp 65578 2011-06-20 11:49:27Z jsmith $");
-
 class IndexWriteActivityMaster : public CMasterActivity
 {
     rowcount_t recordsProcessed;

--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -31,8 +31,6 @@
 #include "thbufdef.hpp"
 #include "backup.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/indexwrite/thindexwriteslave.cpp $ $Id: thindexwriteslave.cpp 64655 2011-05-18 08:08:09Z rchapman $");
-
 #define SINGLEPART_KEY_TRANSFER_SIZE 0x10000
 #define FEWWARNCAP 10
 

--- a/thorlcr/activities/iterate/thgroupiterateslave.cpp
+++ b/thorlcr/activities/iterate/thgroupiterateslave.cpp
@@ -22,10 +22,6 @@
 #include "thgroupiterateslave.ipp"
 #include "thactivityutil.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/iterate/thgroupiterateslave.cpp $ $Id: thgroupiterateslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
-
 class GroupIterateSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
 

--- a/thorlcr/activities/iterate/thiterate.cpp
+++ b/thorlcr/activities/iterate/thiterate.cpp
@@ -19,9 +19,6 @@
 #include "thiterate.ipp"
 #include "thbufdef.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/iterate/thiterate.cpp $ $Id: thiterate.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CIterateActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/iterate/thiterateslave.cpp
+++ b/thorlcr/activities/iterate/thiterateslave.cpp
@@ -24,9 +24,6 @@
 
 #include "thiterateslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/iterate/thiterateslave.cpp $ $Id: thiterateslave.cpp 62939 2011-03-03 18:47:12Z jsmith $");
-
-
 class IterateSlaveActivityBase : public CSlaveActivity, public CThorDataLink
 {
     OwnedConstThorRow first;

--- a/thorlcr/activities/join/thjoin.cpp
+++ b/thorlcr/activities/join/thjoin.cpp
@@ -31,9 +31,6 @@
 
 #define JOIN_SOCKETS 2
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/join/thjoin.cpp $ $Id: thjoin.cpp 65756 2011-06-24 15:48:52Z jsmith $");
-
-
 class JoinActivityMaster : public CMasterActivity
 {
     IThorSorterMaster *imaster;

--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -37,15 +37,7 @@
 #include "tsortm.hpp"
 
 #define BUFFERSIZE 0x10000
-
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/join/thjoinslave.cpp $ $Id: thjoinslave.cpp 62878 2011-03-02 13:14:35Z jsmith $");
-
-
-
-
 #define NUMSLAVEPORTS 2     // actually should be num MP tags
-
 
 class JoinSlaveActivity : public CSlaveActivity, public CThorDataLink, implements ISmartBufferNotify
 {

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -25,9 +25,6 @@
 #include "thexception.hpp"
 #include "thkeydiff.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/keydiff/thkeydiff.cpp $ $Id: thkeydiff.cpp 65578 2011-06-20 11:49:27Z jsmith $");
-
-
 class CKeyDiffMaster : public CMasterActivity
 {
     IHThorKeyDiffArg *helper;

--- a/thorlcr/activities/keydiff/thkeydiffslave.cpp
+++ b/thorlcr/activities/keydiff/thkeydiffslave.cpp
@@ -31,8 +31,6 @@
 #include "slave.ipp"
 #include "thactivityutil.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/keydiff/thkeydiffslave.cpp $ $Id: thkeydiffslave.cpp 64773 2011-05-20 13:47:42Z jsmith $");
-
 class CKeyDiffSlave : public ProcessSlaveActivity
 {
     IHThorKeyDiffArg *helper;

--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -22,13 +22,7 @@
 
 #include "../hashdistrib/thhashdistrib.ipp"
 #include "thkeyedjoin.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/keyedjoin/thkeyedjoin.cpp $ $Id: thkeyedjoin.cpp 64422 2011-05-05 16:51:53Z jsmith $");
-
-
 #include "jhtree.hpp"
-
-
 
 class CKeyedJoinMaster : public CMasterActivity
 {

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -68,7 +68,6 @@
 
 #endif // NEWFETCHSTRESS
 #define KJ_BUFFER_SIZE (0x100000*8)
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp $ $Id: thkeyedjoinslave.cpp 66093 2011-07-08 12:52:18Z jsmith $");
 
 #define KEYLOOKUP_HEADER_SIZE (sizeof(offset_t)+sizeof(CJoinGroup *))
 #define FETCHKEY_HEADER_SIZE (sizeof(offset_t)+sizeof(void *))

--- a/thorlcr/activities/keypatch/thkeypatch.cpp
+++ b/thorlcr/activities/keypatch/thkeypatch.cpp
@@ -25,9 +25,6 @@
 #include "thexception.hpp"
 #include "thkeypatch.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/keypatch/thkeypatch.cpp $ $Id: thkeypatch.cpp 65578 2011-06-20 11:49:27Z jsmith $");
-
-
 class CKeyPatchMaster : public CMasterActivity
 {
     IHThorKeyPatchArg *helper;

--- a/thorlcr/activities/keypatch/thkeypatchslave.cpp
+++ b/thorlcr/activities/keypatch/thkeypatchslave.cpp
@@ -30,8 +30,6 @@
 #include "slave.ipp"
 #include "thactivityutil.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/keypatch/thkeypatchslave.cpp $ $Id: thkeypatchslave.cpp 64773 2011-05-20 13:47:42Z jsmith $");
-
 class CKeyPatchSlave : public ProcessSlaveActivity
 {
     IHThorKeyPatchArg *helper;

--- a/thorlcr/activities/limit/thlimit.cpp
+++ b/thorlcr/activities/limit/thlimit.cpp
@@ -18,10 +18,7 @@
 
 #include "platform.h"
 #include "eclhelper.hpp"
-
 #include "thlimit.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/limit/thlimit.cpp $ $Id: thlimit.cpp 63725 2011-04-01 17:40:45Z jsmith $");
 
 #define NUMINPARALLEL 16
 

--- a/thorlcr/activities/lookupjoin/thlookupjoin.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoin.cpp
@@ -21,9 +21,6 @@
 #include "thexception.hpp"
 #include "thbufdef.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/lookupjoin/thlookupjoin.cpp $ $Id: thlookupjoin.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CLookupJoinActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -34,8 +34,6 @@
 #define _TRACEBROADCAST
 #endif
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp $ $Id: thlookupjoinslave.cpp 65660 2011-06-22 13:00:59Z jsmith $");
-
 enum join_t { JT_Undefined, JT_Inner, JT_LeftOuter, JT_RightOuter, JT_LeftOnly, JT_RightOnly, JT_LeftOnlyTransform };
 enum joinkind_t { join_lookup, join_all, denormalize_lookup, denormalize_all };
 const char *joinActName[4] = { "LOOKUPJOIN", "ALLJOIN", "LOOKUPDENORMALIZE", "ALLDENORMALIZE" };

--- a/thorlcr/activities/loop/thloop.cpp
+++ b/thorlcr/activities/loop/thloop.cpp
@@ -25,10 +25,6 @@
 
 #include "thloop.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/loop/thloop.cpp $ $Id: thloop.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
-
-
 class CLoopActivityMasterBase : public CMasterActivity
 {
 protected:

--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -29,8 +29,6 @@
 #include "eclrtl_imp.hpp"
 #include "thcompressutil.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/loop/thloopslave.cpp $ $Id: thloopslave.cpp 64284 2011-04-28 17:40:46Z jsmith $");
-
 class CNextRowFeeder : public CSimpleInterface, implements IThreaded, implements IRowStream
 {
     CThreaded threaded;

--- a/thorlcr/activities/merge/thmerge.cpp
+++ b/thorlcr/activities/merge/thmerge.cpp
@@ -20,8 +20,6 @@
 #include "thmem.hpp"
 #include "tsorta.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/merge/thmerge.cpp $ $Id: thmerge.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 #ifdef _DEBUG
 #define _TRACE
 #endif

--- a/thorlcr/activities/merge/thmergeslave.cpp
+++ b/thorlcr/activities/merge/thmergeslave.cpp
@@ -28,8 +28,6 @@
 
 #include "thmergeslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/merge/thmergeslave.cpp $ $Id: thmergeslave.cpp 62878 2011-03-02 13:14:35Z jsmith $");
-
 #ifdef _DEBUG
 //#define _FULL_TRACE
 #endif

--- a/thorlcr/activities/msort/thgroupsortslave.cpp
+++ b/thorlcr/activities/msort/thgroupsortslave.cpp
@@ -33,9 +33,6 @@
 #include "jsort.hpp"
 #include "thactivityutil.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/msort/thgroupsortslave.cpp $ $Id: thgroupsortslave.cpp 63605 2011-03-30 10:42:56Z nhicks $");
-
-
 class CCGroupSortSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
 private:

--- a/thorlcr/activities/msort/thmsort.cpp
+++ b/thorlcr/activities/msort/thmsort.cpp
@@ -28,8 +28,6 @@
 
 #define SORT_SOCKETS 2
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/msort/thmsort.cpp $ $Id: thmsort.cpp 65756 2011-06-24 15:48:52Z jsmith $");
-
 //
 // CMSortActivityMaster
 //

--- a/thorlcr/activities/msort/thmsortslave.cpp
+++ b/thorlcr/activities/msort/thmsortslave.cpp
@@ -29,9 +29,6 @@
 #include "thactivityutil.ipp"
 #include "thexception.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/msort/thmsortslave.cpp $ $Id: thmsortslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 #define NUMSLAVEPORTS 2     // actually should be num MP tags
 
 

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -39,10 +39,6 @@
 
 #include "thsortu.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/msort/thsortu.cpp $ $Id: thsortu.cpp 65200 2011-06-07 13:00:18Z jsmith $");
-
-
-
 struct CRollingCacheElem
 {
     int cmp;

--- a/thorlcr/activities/normalize/thnormalizeslave.cpp
+++ b/thorlcr/activities/normalize/thnormalizeslave.cpp
@@ -26,9 +26,6 @@
 #include "thexception.hpp"
 
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/normalize/thnormalizeslave.cpp $ $Id: thnormalizeslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class NormalizeSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
     IHThorNormalizeArg * helper;

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -23,8 +23,6 @@
 #include "thexception.hpp"
 #include "thbufdef.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/nsplitter/thnsplitterslave.cpp $ $Id: thnsplitterslave.cpp 65545 2011-06-17 15:25:30Z jsmith $");
-
 interface ISharedSmartBuffer;
 class NSplitterSlaveActivity;
 

--- a/thorlcr/activities/null/thnullslave.cpp
+++ b/thorlcr/activities/null/thnullslave.cpp
@@ -19,8 +19,6 @@
 #include "thnullslave.ipp"
 #include "thactivityutil.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/null/thnullslave.cpp $ $Id: thnullslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CNullSinkSlaveActivity : public ProcessSlaveActivity
 {
 public:

--- a/thorlcr/activities/nullaction/thnullaction.cpp
+++ b/thorlcr/activities/nullaction/thnullaction.cpp
@@ -18,9 +18,6 @@
 
 #include "jlib.hpp"
 #include "thexception.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/nullaction/thnullaction.cpp $ $Id: thnullaction.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "thactivitymaster.ipp"
 #include "thnullaction.ipp"
 

--- a/thorlcr/activities/nullaction/thnullactionslave.cpp
+++ b/thorlcr/activities/nullaction/thnullactionslave.cpp
@@ -25,9 +25,6 @@
 
 #include "thnullactionslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/nullaction/thnullactionslave.cpp $ $Id: thnullactionslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CNullActionSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
 public:

--- a/thorlcr/activities/parse/thparseslave.cpp
+++ b/thorlcr/activities/parse/thparseslave.cpp
@@ -29,9 +29,6 @@
 
 #include "thparseslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/parse/thparseslave.cpp $ $Id: thparseslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CParseSlaveActivity : public CSlaveActivity, public CThorDataLink, implements IMatchedAction
 {
     IHThorParseArg *helper;

--- a/thorlcr/activities/piperead/thprslave.cpp
+++ b/thorlcr/activities/piperead/thprslave.cpp
@@ -27,8 +27,6 @@
 #include "thcrc.hpp"
 #include "thexception.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/piperead/thprslave.cpp $ $Id: thprslave.cpp 65337 2011-06-10 18:02:00Z ghalliday $");
-
 /////////////////////////
 
 class CPipeSlaveBase : public CSlaveActivity

--- a/thorlcr/activities/pipethrough/thptslave.cpp
+++ b/thorlcr/activities/pipethrough/thptslave.cpp
@@ -30,8 +30,6 @@
 #include "thexception.hpp"
 #include "thbufdef.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/pipethrough/thptslave.cpp $ $Id: thptslave.cpp 65274 2011-06-09 13:42:22Z jsmith $");
-
 //---------------------------------------------------------------------------
 
 class CPipeThroughSlaveActivity;

--- a/thorlcr/activities/pipewrite/thpipewrite.cpp
+++ b/thorlcr/activities/pipewrite/thpipewrite.cpp
@@ -17,15 +17,9 @@
 ############################################################################## */
 
 #include "thmfilemanager.hpp"
-
-
 #include "eclhelper.hpp"
 #include "deftype.hpp"
-
 #include "thpipewrite.ipp"
-
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/pipewrite/thpipewrite.cpp $ $Id: thpipewrite.cpp 64114 2011-04-19 16:17:47Z jsmith $");
 
 //
 // CPipeWriteActivityMaster

--- a/thorlcr/activities/pipewrite/thpwslave.cpp
+++ b/thorlcr/activities/pipewrite/thpwslave.cpp
@@ -25,8 +25,6 @@
 #include "thpwslave.ipp"
 #include "thexception.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/pipewrite/thpwslave.cpp $ $Id: thpwslave.cpp 65274 2011-06-09 13:42:22Z jsmith $");
-
 #define PIPEWRITE_BUFFER_SIZE (0x10000)
 
 class CPipeWriteSlaveActivity : public ProcessSlaveActivity

--- a/thorlcr/activities/project/thprojectslave.cpp
+++ b/thorlcr/activities/project/thprojectslave.cpp
@@ -20,10 +20,6 @@
 #include "thprojectslave.ipp"
 #include "eclrtl_imp.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/project/thprojectslave.cpp $ $Id: thprojectslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
-
 //  IThorDataLink needs only be implemented once, since there is only one output,
 //  therefore may as well implement it here.
 

--- a/thorlcr/activities/pull/thpullslave.cpp
+++ b/thorlcr/activities/pull/thpullslave.cpp
@@ -22,11 +22,6 @@
 #include "thbufdef.hpp"
 #include "thpullslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/pull/thpullslave.cpp $ $Id: thpullslave.cpp 65251 2011-06-08 08:38:02Z jsmith $");
-
-
-
-
 class PullSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
     Owned<IThorDataLink> input;

--- a/thorlcr/activities/result/thresult.cpp
+++ b/thorlcr/activities/result/thresult.cpp
@@ -27,9 +27,6 @@
 #include "thresult.ipp"
 #include "deftype.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/result/thresult.cpp $ $Id: thresult.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 class CResultActivityMaster : public CMasterActivity
 {
     mptag_t replyTag;

--- a/thorlcr/activities/result/thresultslave.cpp
+++ b/thorlcr/activities/result/thresultslave.cpp
@@ -23,9 +23,6 @@
 
 #include "thresultslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/result/thresultslave.cpp $ $Id: thresultslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CResultSlaveActivity : public ProcessSlaveActivity
 {
     mptag_t masterMpTag;

--- a/thorlcr/activities/rollup/throllup.cpp
+++ b/thorlcr/activities/rollup/throllup.cpp
@@ -22,8 +22,6 @@
 #include "throllup.ipp"
 #include "thbufdef.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/rollup/throllup.cpp $ $Id: throllup.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class DedupRollupActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/rollup/throllupslave.cpp
+++ b/thorlcr/activities/rollup/throllupslave.cpp
@@ -19,9 +19,6 @@
 // Handling Rollup and Dedup
 
 #include "throllupslave.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/rollup/throllupslave.cpp $ $Id: throllupslave.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 #include "thactivityutil.ipp"
 #include "thorport.hpp"
 #include "thbufdef.hpp"

--- a/thorlcr/activities/sample/thsampleslave.cpp
+++ b/thorlcr/activities/sample/thsampleslave.cpp
@@ -19,9 +19,6 @@
 
 #include "thsampleslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/sample/thsampleslave.cpp $ $Id: thsampleslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class SampleSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
 

--- a/thorlcr/activities/selectnth/thselectnth.cpp
+++ b/thorlcr/activities/selectnth/thselectnth.cpp
@@ -19,10 +19,6 @@
 #include "thselectnth.ipp"
 #include "eclhelper.hpp"        // for IHThorSelectNthArg
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/selectnth/thselectnth.cpp $ $Id: thselectnth.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CSelectNthActivityMaster : public CMasterActivity
 {
 public:

--- a/thorlcr/activities/selectnth/thselectnthslave.cpp
+++ b/thorlcr/activities/selectnth/thselectnthslave.cpp
@@ -20,9 +20,6 @@
 #include "thactivityutil.ipp"
 #include "thbufdef.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/selectnth/thselectnthslave.cpp $ $Id: thselectnthslave.cpp 65251 2011-06-08 08:38:02Z jsmith $");
-
-
 class CSelectNthSlaveActivity : public CSlaveActivity, public CThorDataLink, implements ISmartBufferNotify
 {
     bool first, isLocal, seenNth;

--- a/thorlcr/activities/selfjoin/thselfjoinslave.cpp
+++ b/thorlcr/activities/selfjoin/thselfjoinslave.cpp
@@ -30,8 +30,6 @@
 #include "thbufdef.hpp"
 #include "thorxmlwrite.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/selfjoin/thselfjoinslave.cpp $ $Id: thselfjoinslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #define NUMSLAVEPORTS 2     // actually should be num MP tags
 
 class SelfJoinSlaveActivity : public CSlaveActivity, public CThorDataLink

--- a/thorlcr/activities/soapcall/thsoapcall.cpp
+++ b/thorlcr/activities/soapcall/thsoapcall.cpp
@@ -20,9 +20,6 @@
 #include "thsoapcall.ipp"
 #include "dasess.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/soapcall/thsoapcall.cpp $ $Id: thsoapcall.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class SoapCallActivityMaster : public CMasterActivity
 {
 private:

--- a/thorlcr/activities/soapcall/thsoapcallslave.cpp
+++ b/thorlcr/activities/soapcall/thsoapcallslave.cpp
@@ -19,8 +19,6 @@
 #include "thsoapcallslave.ipp"
 #include "thactivityutil.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/soapcall/thsoapcallslave.cpp $ $Id: thsoapcallslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 //---------------------------------------------------------------------------
 
 class SoapRowCallSlaveActivity : public CSlaveActivity, public CThorDataLink, implements ISoapCallRowProvider

--- a/thorlcr/activities/spill/thspill.cpp
+++ b/thorlcr/activities/spill/thspill.cpp
@@ -17,14 +17,9 @@
 ############################################################################## */
 
 #include "jiface.hpp"
-
 #include "dadfs.hpp"
-
 #include "eclhelper.hpp"
-
 #include "thspill.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/spill/thspill.cpp $ $Id: thspill.cpp 62376 2011-02-04 21:59:58Z sort $");
 
 class SpillActivityMaster : public CMasterActivity
 {

--- a/thorlcr/activities/spill/thspillslave.cpp
+++ b/thorlcr/activities/spill/thspillslave.cpp
@@ -21,19 +21,13 @@
 #include "jbuff.hpp"
 #include "jlzw.hpp"
 #include "jtime.hpp"
-
 #include "dadfs.hpp"
-
 #include "thbuf.hpp"
 #include "thexception.hpp"
 #include "thmfilemanager.hpp"
 #include "slave.ipp"
 #include "thactivityutil.ipp"
-
 #include "thspillslave.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/spill/thspillslave.cpp $ $Id: thspillslave.cpp 62878 2011-03-02 13:14:35Z jsmith $");
-
 
 class SpillSlaveActivity : public CSlaveActivity, public CThorDataLink
 {

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -21,11 +21,7 @@
 #include "thormisc.hpp"
 #include "thtmptableslave.ipp"
 #include "thorport.hpp"
-
 #include "thactivityutil.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/temptable/thtmptableslave.cpp $ $Id: thtmptableslave.cpp 62939 2011-03-03 18:47:12Z jsmith $");
-
 
 class CTempTableSlaveActivity : public CSlaveActivity, public CThorDataLink
 {

--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -39,9 +39,6 @@
 #include "thormisc.hpp"
 #include "thorport.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/thactivityutil.cpp $ $Id: thactivityutil.cpp 64338 2011-05-03 08:37:58Z jsmith $");
-
-
 //#define TRACE_STARTSTOP_EXCEPTIONS
 
 #ifdef _DEBUG

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -29,8 +29,6 @@
 #include "eclhelper.hpp" // tmp for IHThorArg interface
 #include "thdiskbase.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/thdiskbase.cpp $ $Id: thdiskbase.cpp 65337 2011-06-10 18:02:00Z ghalliday $");
-
 CDiskReadMasterBase::CDiskReadMasterBase(CMasterGraphElement *info) : CMasterActivity(info)
 {
     hash = NULL;

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -41,8 +41,6 @@
 
 #include "thdiskbaseslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/thdiskbaseslave.cpp $ $Id: thdiskbaseslave.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 void getPartsMetaInfo(ThorDataLinkMetaInfo &metaInfo, CThorDataLink &link, unsigned nparts, IPartDescriptor **partDescs, CDiskPartHandlerBase *partHandler)
 {
     ThorDataLinkMetaInfo *metaInfos = new ThorDataLinkMetaInfo[nparts];

--- a/thorlcr/activities/topn/thtopn.cpp
+++ b/thorlcr/activities/topn/thtopn.cpp
@@ -17,12 +17,8 @@
 ############################################################################## */
 
 #include "jiface.hpp"
-
 #include "eclhelper.hpp"
-
 #include "thtopn.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/topn/thtopn.cpp $ $Id: thtopn.cpp 62376 2011-02-04 21:59:58Z sort $");
 
 #define MERGE_GRANULARITY 4
 

--- a/thorlcr/activities/topn/thtopnslave.cpp
+++ b/thorlcr/activities/topn/thtopnslave.cpp
@@ -27,8 +27,6 @@
 #include "slave.ipp"
 #include "thactivityutil.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/topn/thtopnslave.cpp $ $Id: thtopnslave.cpp 62878 2011-03-02 13:14:35Z jsmith $");
-
 IRowStream *createFirstNReadSeqVar(IRowStream *input, unsigned limit)
 {
     class CFirstNReadSeqVar : public CSimpleInterface, implements IRowStream

--- a/thorlcr/activities/when/thwhen.cpp
+++ b/thorlcr/activities/when/thwhen.cpp
@@ -18,8 +18,6 @@
 
 #include "thwhen.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/when/thcatch.cpp $ $Id: thcatch.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CWhenActivityMaster : public CMasterActivity
 {
     Owned<IBarrier> barrier;

--- a/thorlcr/activities/when/thwhenslave.cpp
+++ b/thorlcr/activities/when/thwhenslave.cpp
@@ -23,9 +23,6 @@
 #include "commonext.hpp"
 #include "slave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/when/thwhenslave.cpp $ $Id: thwhenslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CDependencyExecutorSlaveActivity : public CSimpleInterface
 {
 protected:

--- a/thorlcr/activities/wuidread/thwuidread.cpp
+++ b/thorlcr/activities/wuidread/thwuidread.cpp
@@ -17,14 +17,8 @@
 ############################################################################## */
 
 #include "jlib.hpp"
-
-
 #include "thexception.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/wuidread/thwuidread.cpp $ $Id: thwuidread.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "thorfile.hpp"
-
 #include "thactivitymaster.ipp"
 #include "../diskread/thdiskread.ipp"
 #include "thwuidread.ipp"

--- a/thorlcr/activities/wuidread/thwuidreadslave.cpp
+++ b/thorlcr/activities/wuidread/thwuidreadslave.cpp
@@ -26,9 +26,6 @@
 
 #include "thwuidreadslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/wuidread/thwuidreadslave.cpp $ $Id: thwuidreadslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
-
 class CWuidReadSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
     Owned<ISerialStream> replyStream;

--- a/thorlcr/activities/wuidwrite/thwuidwrite.cpp
+++ b/thorlcr/activities/wuidwrite/thwuidwrite.cpp
@@ -25,8 +25,6 @@
 #include "thwuidwrite.ipp"
 #include "thbufdef.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/wuidwrite/thwuidwrite.cpp $ $Id: thwuidwrite.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 #define INVALID_SEQUENCE_VALUE  -1
 #define DEFAULT_WUIDWRITE_LIMIT 10
 

--- a/thorlcr/activities/wuidwrite/thwuidwriteslave.cpp
+++ b/thorlcr/activities/wuidwrite/thwuidwriteslave.cpp
@@ -29,9 +29,6 @@
 #include "eclhelper.hpp"        // for IHThorWorkUnitWriteArg
 #include "slave.ipp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/wuidwrite/thwuidwriteslave.cpp $ $Id: thwuidwriteslave.cpp 63725 2011-04-01 17:40:45Z jsmith $");
-
 #define PIPE_BUFFER_SIZE         0x20000
 
 class CWorkUnitWriteSlaveBase : public ProcessSlaveActivity

--- a/thorlcr/activities/xmlparse/thxmlparseslave.cpp
+++ b/thorlcr/activities/xmlparse/thxmlparseslave.cpp
@@ -23,8 +23,6 @@
 #include "thactivityutil.ipp"
 #include "eclrtl.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/xmlparse/thxmlparseslave.cpp $ $Id: thxmlparseslave.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 class CXmlParseSlaveActivity : public CSlaveActivity, public CThorDataLink, implements IXMLSelect
 {
     IHThorXmlParseArg *helper;

--- a/thorlcr/activities/xmlread/thxmlread.cpp
+++ b/thorlcr/activities/xmlread/thxmlread.cpp
@@ -17,9 +17,6 @@
 ############################################################################## */
 
 #include "jlib.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/xmlread/thxmlread.cpp $ $Id: thxmlread.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #include "thdiskbase.ipp"
 #include "thxmlread.ipp"
 

--- a/thorlcr/activities/xmlread/thxmlreadslave.cpp
+++ b/thorlcr/activities/xmlread/thxmlreadslave.cpp
@@ -33,9 +33,6 @@
 #include "thorxmlread.hpp"
 #include "thdiskbaseslave.ipp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/xmlread/thxmlreadslave.cpp $ $Id: thxmlreadslave.cpp 65930 2011-06-30 11:02:57Z ghalliday $");
-
-
 class CXmlReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDataLink
 {
     IHThorXmlReadArg *helper;

--- a/thorlcr/activities/xmlwrite/thxmlwrite.cpp
+++ b/thorlcr/activities/xmlwrite/thxmlwrite.cpp
@@ -18,19 +18,12 @@
 
 #include "jiface.hpp"
 #include "jtime.hpp"
-
 #include "dadfs.hpp"
-
 #include "thexception.hpp"
 #include "thmfilemanager.hpp"
-
-
 #include "eclhelper.hpp"
 #include "deftype.hpp"
-
 #include "thxmlwrite.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/xmlwrite/thxmlwrite.cpp $ $Id: thxmlwrite.cpp 63406 2011-03-23 17:33:52Z jsmith $");
 
 class CXmlWriteActivityMaster : public CWriteMasterBase
 {

--- a/thorlcr/activities/xmlwrite/thxmlwriteslave.cpp
+++ b/thorlcr/activities/xmlwrite/thxmlwriteslave.cpp
@@ -20,19 +20,14 @@
 #include "jio.hpp"
 #include "jtime.hpp"
 #include "jfile.ipp"
-
 #include "thbuf.hpp"
 #include "thexception.hpp"
 #include "thbufdef.hpp"
 #include "thmfilemanager.hpp"
-
 #include "slave.ipp"
 #include "thactivityutil.ipp"
 #include "thorxmlwrite.hpp"
 #include "thxmlwriteslave.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/activities/xmlwrite/thxmlwriteslave.cpp $ $Id: thxmlwriteslave.cpp 63466 2011-03-25 11:09:22Z jsmith $");
-
 
 class CXmlWriteSlaveActivity : public CDiskWriteSlaveActivityBase
 {

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -17,21 +17,15 @@
 ############################################################################## */
 
 #include "thgraph.hpp"
-
 #include "jptree.hpp"
-
 #include "commonext.hpp"
 #include "dasess.hpp"
 #include "jhtree.hpp"
-
 #include "thcodectx.hpp"
 #include "thcrc.hpp"
 #include "thbuf.hpp"
 #include "thormisc.hpp"
 #include "thbufdef.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/graph/thgraph.cpp $ $Id: thgraph.cpp 65511 2011-06-16 16:12:24Z jsmith $");
-
 
 PointerArray createFuncs;
 void registerCreateFunc(CreateFunc func)

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -24,38 +24,26 @@
 #include "jsocket.hpp"
 #include "jset.hpp"
 #include "jsort.hpp"
-
 #include "portlist.h"
 #include "jhtree.hpp"
 #include "mputil.hpp"
-
 #include "dllserver.hpp"
-
 #include "dautils.hpp"
 #include "danqs.hpp"
 #include "daclient.hpp"
 #include "daaudit.hpp"
-
 #include "wujobq.hpp"
-
-
-
 #include "thorport.hpp"
 #include "commonext.hpp"
 #include "thorxmlread.hpp"
 #include "thorplugin.hpp"
-
 #include "thormisc.hpp"
 #include "thgraphmaster.ipp"
 #include "thdemonserver.hpp"
-
 #include "rtlds_imp.hpp"
 #include "eclhelper.hpp"
 #include "thexception.hpp"
-
 #include "thactivitymaster.ipp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/graph/thgraphmaster.cpp $ $Id: thgraphmaster.cpp 65511 2011-06-16 16:12:24Z jsmith $");
 
 static CriticalSection *jobManagerCrit;
 MODULE_INIT(INIT_PRIORITY_STANDARD)

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -27,8 +27,6 @@
 #include "slwatchdog.hpp"
 #include "thgraphslave.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/graph/thgraphslave.cpp $ $Id: thgraphslave.cpp 65511 2011-06-16 16:12:24Z jsmith $");
-
 //////////////////////////////////
 
 class CBarrierSlave : public CInterface, implements IBarrier

--- a/thorlcr/master/CMakeLists.txt
+++ b/thorlcr/master/CMakeLists.txt
@@ -55,6 +55,8 @@ include_directories (
          ./../../rtl/eclrtl 
          ./../master 
          ./../../common/thorhelper 
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/thorlcr/master/thactivitymaster.cpp
+++ b/thorlcr/master/thactivitymaster.cpp
@@ -28,9 +28,6 @@
 #include "thactivitymaster.ipp"
 #include "thexception.hpp"
 
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/master/thactivitymaster.cpp $ $Id: thactivitymaster.cpp 64945 2011-05-27 13:20:16Z jsmith $");
-
 actmaster_decl CGraphElementBase *createMasterContainer(IPropertyTree &xgmml, CGraphBase &owner, CGraphBase *resultsGraph);
 MODULE_INIT(INIT_PRIORITY_STANDARD)
 {

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -16,8 +16,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+#include "build-config.h"
 #include "platform.h"
-
 #include "jarray.hpp"
 #include "jfile.hpp"
 #include "jmutex.hpp"
@@ -44,10 +44,6 @@
 #include "thactivitymaster.ipp"
 #include "thdemonserver.hpp"
 #include "thgraphmanager.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/master/thgraphmanager.cpp $ $Id: thgraphmanager.cpp 63990 2011-04-13 11:25:29Z nhicks $");
-
-static const char buildTag[] = "$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/master/thgraphmanager.cpp $";
 
 class CJobManager: public CSimpleInterface, implements IJobManager, implements IExceptionHandler
 {
@@ -638,7 +634,7 @@ bool CJobManager::executeGraph(IConstWorkUnit &workunit, const char *graphName, 
 {
     {
         Owned<IWorkUnit> wu = &workunit.lock();
-        wu->setTracingValue("ThorBuild", buildTag);
+        wu->setTracingValue("ThorBuild", BUILD_TAG);
         // expect there to be 1 or 2 of these, so scan/check if log exists already and add if not
         const char *nLog = globals->queryProp("@logURL");
         Owned<IStringIterator> siter = &wu->getDebugValues("ThorLog*");

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -30,6 +30,7 @@
 #include <direct.h> 
 #endif
 
+#include "build-config.h"
 #include "jlib.hpp"
 #include "jdebug.hpp"
 #include "jfile.hpp"
@@ -507,7 +508,7 @@ int main( int argc, char *argv[]  )
         openLogFile(logName.toCharArray());
         createUNCFilename(logName.str(), logUrl, false);
         LOG(MCdebugProgress, thorJob, "Opened log file %s", logUrl.toCharArray());
-        CBuildVersion::log();
+        LOG(MCdebugProgress, thorJob, "Build %s", BUILD_TAG);
         globals->setProp("@logURL", logUrl.str());
 
         Owned<IGroup> serverGroup = createIGroup(daliServer.str(), DALI_SERVER_PORT);

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -39,7 +39,6 @@
 
 #include "workunit.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/mfilemanager/thmfilemanager.cpp $ $Id: thmfilemanager.cpp 63701 2011-04-01 13:43:13Z jsmith $");
 #define CHECKPOINTSCOPE "checkpoints"
 #define TMPSCOPE "temporary"
 

--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -42,8 +42,6 @@
 #include "thmem.hpp"
 #include "thbuf.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/msort/tsorta.cpp $ $Id: tsorta.cpp 63605 2011-03-30 10:42:56Z nhicks $");
-
 #ifdef _DEBUG
 //#define _FULL_TRACE
 #endif

--- a/thorlcr/msort/tsortl.cpp
+++ b/thorlcr/msort/tsortl.cpp
@@ -38,8 +38,6 @@
 
 #define DEFAULTTIMEOUT 3600 // 60 minutes 
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/msort/tsortl.cpp $ $Id: tsortl.cpp 62742 2011-02-24 16:57:20Z nhicks $");
-
 #ifdef _MSC_VER
 #pragma warning( disable : 4355 )
 #endif

--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -40,8 +40,6 @@
 #include "thexception.hpp"
 #include "thgraph.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/msort/tsortm.cpp $ $Id: tsortm.cpp 65756 2011-06-24 15:48:52Z jsmith $");
-
 #define PROGNAME "tsort"
 
 #include "tsorts.hpp"

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -18,33 +18,21 @@
 
 #include "platform.h"
 #include <limits.h>
-
 #include <mpbase.hpp>
 #include <mpcomm.hpp>
 #include "thorport.hpp"
-
 #include "jsocket.hpp"
 #include "jthread.hpp"
-
 #include "thormisc.hpp"
-
 #include "jlib.hpp"
 #include "jsort.hpp"
-
-
 #include "tsorts.hpp"
 #include "tsorta.hpp"
 #include "tsortm.hpp"
 #include "tsortmp.hpp"
 #include "thbuf.hpp"
 #include "thcrc.hpp"
-
-
 #include "thmem.hpp"
-
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/msort/tsorts.cpp $ $Id: tsorts.cpp 64678 2011-05-18 15:57:28Z jsmith $");
-
 
 #define _TRACE
 

--- a/thorlcr/msort/tsorttr.cpp
+++ b/thorlcr/msort/tsorttr.cpp
@@ -30,8 +30,6 @@
 
 #include "tsorttr.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/msort/tsorttr.cpp $ $Id: tsorttr.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #define MULTI
 
 #ifdef TRACEINTERCEPT

--- a/thorlcr/slave/CMakeLists.txt
+++ b/thorlcr/slave/CMakeLists.txt
@@ -54,6 +54,8 @@ include_directories (
          ./../master 
          ./../graph 
          ./../../common/thorhelper 
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -34,8 +34,6 @@
 
 #include "thgraphslave.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/slave/slave.cpp $ $Id: slave.cpp 64945 2011-05-27 13:20:16Z jsmith $");
-
 #include "slave.ipp"
 
 #define FATAL_ACTJOIN_TIMEOUT (5*60*1000)

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -43,9 +43,6 @@
 #include "thormisc.hpp"
 #include "thorport.hpp"
 #include "thgraphslave.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/slave/slavmain.cpp $ $Id: slavmain.cpp 64376 2011-05-04 11:22:29Z jsmith $");
-
 #include "slave.ipp"
 
 //---------------------------------------------------------------------------

--- a/thorlcr/slave/slwatchdog.cpp
+++ b/thorlcr/slave/slwatchdog.cpp
@@ -18,23 +18,16 @@
 
 // Slave Watchdog
 #include "platform.h"
-
 #include <stdio.h>
-
 #include "jsocket.hpp"
 #include "jmisc.hpp"
-
 #include "portlist.h"
-
 #include "thorport.hpp"
 #include "thormisc.hpp"
 #include "thcompressutil.hpp"
 #include "thwatchdog.hpp"
 #include "slwatchdog.hpp"
-
 #include "thgraphslave.hpp"
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/slave/slwatchdog.cpp $ $Id: slwatchdog.cpp 62376 2011-02-04 21:59:58Z sort $");
 
 class CGraphProgressHandler : public CSimpleInterface, implements ISlaveWatchdog, implements IThreaded
 {

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -26,6 +26,7 @@
 #include <stdio.h> 
 #include <stdlib.h> 
 
+#include "build-config.h"
 #include "jlib.hpp"
 #include "jdebug.hpp"
 #include "jexcept.hpp"
@@ -50,8 +51,6 @@
 #include "slavmain.hpp"
 
 // #define USE_MP_LOG
-
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/slave/thslavemain.cpp $ $Id: thslavemain.cpp 65471 2011-06-15 17:29:33Z jsmith $");
 
 static INode *masterNode = NULL;
 MODULE_INIT(INIT_PRIORITY_STANDARD)
@@ -209,7 +208,7 @@ void startSlaveLog(const char *dir)
     StringBuffer url;
     createUNCFilename(logname.str(), url);
     LOG(MCdebugProgress, thorJob, "Opened log file %s", url.toCharArray());
-    CBuildVersion::log();
+    LOG(MCdebugProgress, thorJob, "Build %s", BUILD_TAG);
     globals->setProp("@logURL", url.str());
 }
 

--- a/thorlcr/thorcodectx/thcodectx.cpp
+++ b/thorlcr/thorcodectx/thcodectx.cpp
@@ -32,8 +32,6 @@
 #include "thgraph.hpp"
 #include "thorxmlwrite.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/thorcodectx/thcodectx.cpp $ $Id: thcodectx.cpp 64760 2011-05-20 11:16:30Z jsmith $");
-
 CThorCodeContextBase::CThorCodeContextBase(CJobBase &_job, ILoadedDllEntry &_querySo, IUserDescriptor &_userDesc) : job(_job), querySo(_querySo), userDesc(&_userDesc)
 {
 }

--- a/thorlcr/thorutil/mcorecache.cpp
+++ b/thorlcr/thorutil/mcorecache.cpp
@@ -24,8 +24,6 @@
 
 #include "mcorecache.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/thorutil/mcorecache.cpp $ $Id: mcorecache.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 #ifdef _DEBUG
 #define _FULL_TRACE
 #endif

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -36,8 +36,6 @@
 #include "eclrtl.hpp"
 #include "thgraph.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/thorutil/thbuf.cpp $ $Id: thbuf.cpp 63605 2011-03-30 10:42:56Z nhicks $");
-
 #ifdef _DEBUG
 //#define _FULL_TRACE
 //#define TRACE_CREATE

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -48,8 +48,6 @@
 #include "thbuf.hpp"
 #include "thmem.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/thorutil/thmem.cpp $ $Id: thmem.cpp 63807 2011-04-05 16:07:37Z nhicks $");
-
 #ifdef _DEBUG
 //#define _TESTING
 #define ASSERTEX(c) assertex(c)

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -52,8 +52,6 @@ namespace thormisc {  // Make sure we can't clash with generated versions or ver
 
 #define SDS_LOCK_TIMEOUT 30000
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/thorutil/thormisc.cpp $ $Id: thormisc.cpp 65752 2011-06-24 14:26:58Z jsmith $");
-
 static IGroup *clusterGroup;
 static IGroup *slaveGroup;
 static IGroup *dfsGroup;
@@ -588,7 +586,7 @@ void SetLogName(const char *prefix, const char *logdir, const char *thorname, bo
     logname.append(".log");
     openLogFile(logname.toCharArray());
     PrintLog("Opened log file %s", logname.toCharArray());
-    CBuildVersion::log();
+    PrintLog("Build %s", BUILD_TAG);
 }
 #endif
 

--- a/thorlcr/thorutil/throlling.cpp
+++ b/thorlcr/thorutil/throlling.cpp
@@ -21,8 +21,6 @@
 
 #include "throlling.hpp"
 
-static CBuildVersion _bv("$HeadURL: https://svn.br.seisint.com/ecl/trunk/thorlcr/thorutil/throlling.cpp $ $Id: throlling.cpp 62376 2011-02-04 21:59:58Z sort $");
-
 const unsigned RollingArray::defaultSize = 20;
 
 RollingArray::RollingArray(unsigned _size)


### PR DESCRIPTION
Remove all $HeadURL entries in the code.
Use BUILD_TAG in place of any $HeadURL: output to logs.
Update include paths and include build-info.h as needed.
Clean up some unnecessary blank lines.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
