### PR TITLE
BUG: 80438 Enable stand alone index activities

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -2828,6 +2828,8 @@ public:
                 gotlocal = false;
             if (gotlocal) {
                 Owned<IFile> file = getPartFile(0,0);
+                if (onlylocal)
+                    dfile.setown(queryDistributedFileDirectory().lookup(lfn,user,write));
                 if (file.get()&&(write||file->exists()))
                     return true;
             }

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -116,8 +116,10 @@ StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fn
 {
     if (fname[0]=='~')
         logicalName.append(fname+1);
-    else if (agent.queryResolveFilesLocally() && strchr(fname,(int)PATHSEPCHAR))
+    else if (agent.queryResolveFilesLocally())
+    {
         logicalName.append(fname);
+    }
     else
     {
         SCMStringBuffer lfn;
@@ -125,6 +127,12 @@ StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fn
         if(lfn.length())
             logicalName.append(lfn.s).append("::");
         logicalName.append(fname);
+    }
+    if (agent.queryResolveFilesLocally())
+    {
+        StringBuffer sb(logicalName.str());
+        sb.replaceString("::",PATHSEPSTR);
+        makeAbsolutePath(sb.str(), logicalName.clear());
     }
     return logicalName;
 }


### PR DESCRIPTION
Enable stand alone index activities to access index files by generating
a well formed local filename, and by enabling dautils to return a file
descriptor . Also don't display successful index file delete message
until file is actually deleted.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
