### PR TITLE
Fixed: 83514 Changed configmgr to run as hpcc. fixes #77

### DIFF
--- a/initfiles/bash/etc/init.d/configmgr.in
+++ b/initfiles/bash/etc/init.d/configmgr.in
@@ -196,7 +196,7 @@ cd ${runtime}/${compName}
 
 #start configesp
 EXEC_COMMAND="${exec_script_path}/init_configesp >> $logFile 2>&1"
-startcmd="${daemon_path}/start-stop-daemon -S -p ${initPidFile} -d ${runtime}/${compName} -m -x ${EXEC_COMMAND} -b"
+startcmd="${daemon_path}/start-stop-daemon -S -p ${initPidFile} -c ${user}:${group} -d ${runtime}/${compName} -m -x ${EXEC_COMMAND} -b"
 eval ${startcmd}
 started=$?
 


### PR DESCRIPTION
Updated the call to start-stop-daemon to have configmgr
run as hpcc instead of root allowing all files created
under /etc/HPCCSystems/source to be owned by hpcc.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
