### PR TITLE
BUG: 80438 - Enable index activities in stand alone

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -2827,9 +2827,9 @@ public:
             else if (!lfn.isExternal())
                 gotlocal = false;
             if (gotlocal) {
-                Owned<IFile> file = getPartFile(0,0);
-                if (onlylocal)
+                if (!write)
                     dfile.setown(queryDistributedFileDirectory().lookup(lfn,user,write));
+                Owned<IFile> file = getPartFile(0,0);
                 if (file.get()&&(write||file->exists()))
                     return true;
             }

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -2828,6 +2828,8 @@ public:
                 gotlocal = false;
             if (gotlocal) {
                 Owned<IFile> file = getPartFile(0,0);
+                if (onlylocal)
+                    dfile.setown(queryDistributedFileDirectory().lookup(lfn,user,write));
                 if (file.get()&&(write||file->exists()))
                     return true;
             }

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -1051,7 +1051,7 @@ CHThorIndexWriteActivity::CHThorIndexWriteActivity(IAgentContext &_agent, unsign
 {
     incomplete = false;
     StringBuffer lfn;
-    Owned<ILocalOrDistributedFile> ldf = agent.resolveLFN(helper.getFileName(),"Cannot write, invalid logical name",true,false,true,&lfn);
+    expandLogicalFilename(lfn, helper.getFileName(), agent);
     if (!agent.queryResolveFilesLocally())
     {
         Owned<IDistributedFile> f = queryDistributedFileDirectory().lookup(lfn, agent.queryCodeContext()->queryUserDescriptor(), true);

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -116,7 +116,7 @@ StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fn
 {
     if (fname[0]=='~')
         logicalName.append(fname+1);
-    else if (agent.queryResolveFilesLocally() && strchr(fname,(int)PATHSEPCHAR))
+    else if (agent.queryResolveFilesLocally())
         logicalName.append(fname);
     else
     {
@@ -125,6 +125,12 @@ StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fn
         if(lfn.length())
             logicalName.append(lfn.s).append("::");
         logicalName.append(fname);
+    }
+    if (agent.queryResolveFilesLocally())
+    {
+        StringBuffer sb(logicalName.str());
+        sb.replaceString("::",PATHSEPSTR);
+        makeAbsolutePath(sb.str(), logicalName.clear());
     }
     return logicalName;
 }


### PR DESCRIPTION
Enable stand alone index activities to access index files by generating
a well formed local filename, and by enabling dautils to return a file
descriptor.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
