### PR TITLE
FIX #71 - Compiler warnings from modern g++

### DIFF
--- a/common/roxiemanager/roxiewuprocessor.cpp
+++ b/common/roxiemanager/roxiewuprocessor.cpp
@@ -1172,11 +1172,11 @@ public:
         if (useRemoteRoxieLocation)  // only do the work here if the source has the files already copied to it
         {
             StringBuffer elem;
-            elem.appendf("Part[@num='%d']");
+            elem.appendf("Part[@num='%d']", partno);
             IPropertyTree *partlocation = location->queryPropTree(elem.str());
             if (!partlocation)
             {
-                elem.clear().appendf("Part_%d");
+                elem.clear().appendf("Part_%d", partno);
                 partlocation = location->queryPropTree(elem.str());  // legacy format
             }
 

--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -1270,7 +1270,7 @@ bool CConfigEnvHelper::AddNewNodes(IPropertyTree* pThor, const char* szType, int
 
     if (validate)
     {
-        for (size_t i = 0; i < computers.size(); i++)
+        for (int i = 0; i < (int) computers.size(); i++)
             CheckTopologyComputerUse(computers[i], pThor, usageList);
     }
 
@@ -1278,7 +1278,7 @@ bool CConfigEnvHelper::AddNewNodes(IPropertyTree* pThor, const char* szType, int
         return false;
 
     // Iterate through computer list
-    for (size_t i = 0; i < computers.size(); i++)
+    for (int i = 0; i < (int) computers.size(); i++)
     {
         // Check if we can add this computer
         if (skipExisting && !CheckTopologyComputerUse(computers[i], pThor, usageList))

--- a/deployment/deployutils/deployutils.cpp
+++ b/deployment/deployutils/deployutils.cpp
@@ -558,7 +558,7 @@ public:
           m_colIndex.appendf("colIndex['nameTopology']=%d;", index++); 
           m_colIndex.appendf("colIndex['processTopology']=%d;", index++);
           m_colIndex.appendf("colIndex['netAddressTopology']=%d;", index++);
-          m_jsStrBuf.appendf("compTabToNode['Topology']= 'Topology';");
+          m_jsStrBuf.append("compTabToNode['Topology']= 'Topology';");
         }
       }
 
@@ -591,7 +591,7 @@ public:
         {
           if(attr.hasProp("./xs:annotation/xs:appinfo/autogenforwizard"))
           {
-            value.clear().appendf(attr.queryProp("./xs:annotation/xs:appinfo/autogenforwizard"));
+            value.clear().append(attr.queryProp("./xs:annotation/xs:appinfo/autogenforwizard"));
             if(!strcmp(value.str(),"1"))
             {
                     getValueForTypeInXSD(attr, compName, wizDefVal);  
@@ -1388,12 +1388,12 @@ public:
         if (!strcmp(m_compName.str(), "Eclserver"))
           m_compName.clear().append(XML_TAG_ECLSERVERPROCESS);
 
-        m_jsStrBuf.appendf("var compTabs = new Array(); ");
+        m_jsStrBuf.append("var compTabs = new Array(); ");
         m_jsStrBuf.appendf("compTabs['%s'] = new Array();", m_compName.str());
-        m_jsStrBuf.appendf("var hiddenTabs = new Array(); ");
+        m_jsStrBuf.append("var hiddenTabs = new Array(); ");
         m_jsStrBuf.appendf("hiddenTabs['%s'] = new Array();", m_compName.str());
-        m_jsStrBuf.appendf("var compTabToNode = new Array(); ");
-        m_jsStrBuf.appendf("var cS = new Array();");
+        m_jsStrBuf.append("var compTabToNode = new Array(); ");
+        m_jsStrBuf.append("var cS = new Array();");
 
         Owned<IPropertyTreeIterator> iter = schemaNode->getElements("*");
         ForEach(*iter)
@@ -1541,7 +1541,7 @@ public:
              {
                if(m_wizard->getNumOfNodes(m_pEnv->queryProp(tempPath.str())) > 1)
                {
-                 tempPath.clear().appendf("./xs:annotation/xs:appinfo/autogendefaultformultinode");
+                 tempPath.clear().append("./xs:annotation/xs:appinfo/autogendefaultformultinode");
                  if(attr.hasProp(tempPath.str()))
                    wizDefVal.clear().append(attr.queryProp(tempPath.str()));
                }
@@ -1595,8 +1595,8 @@ public:
                    IPropertyTree* pHard = m_pEnv->queryPropTree(tempPath.str());
                    if(pHard)
                    {
-                     tempPath.clear().appendf("@name");
-                     wizDefVal.clear().appendf(pHard->queryProp(tempPath.str()));
+                     tempPath.clear().append("@name");
+                     wizDefVal.clear().append(pHard->queryProp(tempPath.str()));
                    }
                 }
               }
@@ -1827,9 +1827,9 @@ bool generateHardwareHeaders(const IPropertyTree* pEnv, StringBuffer& sbDefn, bo
   else
   {
     StringBuffer jsStrBuf("var compTabs = new Array();");
-    jsStrBuf.appendf("compTabs['Hardware'] = new Array();");
-    jsStrBuf.appendf("var compTabToNode = new Array();");
-    jsStrBuf.appendf("var cS = new Array();");
+    jsStrBuf.append("compTabs['Hardware'] = new Array();");
+    jsStrBuf.append("var compTabToNode = new Array();");
+    jsStrBuf.append("var cS = new Array();");
     addItem(jsStrBuf, pEnv, XML_TAG_COMPUTERTYPE, TAG_NAME, "", 0, 1, "", 1);
     addItem(jsStrBuf, pEnv, XML_TAG_COMPUTERTYPE,  TAG_MANUFACTURER, "", 0, 1, "", 1);
     addItem(jsStrBuf, pEnv, XML_TAG_COMPUTERTYPE, TAG_COMPUTERTYPE, "", 0, 1, "", 1);
@@ -1845,17 +1845,17 @@ bool generateHardwareHeaders(const IPropertyTree* pEnv, StringBuffer& sbDefn, bo
     addItem(jsStrBuf, pEnv, XML_TAG_COMPUTER,  TAG_NETADDRESS, "", 0, 1, "", 1);
     addItem(jsStrBuf, pEnv, XML_TAG_COMPUTER,  TAG_DOMAIN, "", 0, 1, XML_TAG_HARDWARE"/"XML_TAG_DOMAIN, 4);
     addItem(jsStrBuf, pEnv, XML_TAG_COMPUTER,  TAG_COMPUTERTYPE, "", 0, 1, XML_TAG_HARDWARE"/"XML_TAG_COMPUTERTYPE, 4);
-    jsStrBuf.appendf("compTabs['Hardware'][compTabs['Hardware'].length]= 'Computer Types';");
-    jsStrBuf.appendf("compTabs['Hardware'][compTabs['Hardware'].length]= 'Switches';");
-    jsStrBuf.appendf("compTabs['Hardware'][compTabs['Hardware'].length]= 'Domains';");
-    jsStrBuf.appendf("compTabs['Hardware'][compTabs['Hardware'].length]= 'Computers';");
-    jsStrBuf.appendf("compTabToNode['Computer Types']= 'ComputerType';");
-    jsStrBuf.appendf("compTabToNode['Switches']= 'Switch';");
-    jsStrBuf.appendf("compTabToNode['Domains']= 'Domain';");
-    jsStrBuf.appendf("compTabToNode['Computers']= 'Computer';");
+    jsStrBuf.append("compTabs['Hardware'][compTabs['Hardware'].length]= 'Computer Types';");
+    jsStrBuf.append("compTabs['Hardware'][compTabs['Hardware'].length]= 'Switches';");
+    jsStrBuf.append("compTabs['Hardware'][compTabs['Hardware'].length]= 'Domains';");
+    jsStrBuf.append("compTabs['Hardware'][compTabs['Hardware'].length]= 'Computers';");
+    jsStrBuf.append("compTabToNode['Computer Types']= 'ComputerType';");
+    jsStrBuf.append("compTabToNode['Switches']= 'Switch';");
+    jsStrBuf.append("compTabToNode['Domains']= 'Domain';");
+    jsStrBuf.append("compTabToNode['Computers']= 'Computer';");
 
     int index = 0;
-    jsStrBuf.appendf("var colIndex = new Array();");
+    jsStrBuf.append("var colIndex = new Array();");
     jsStrBuf.appendf("colIndex['nameComputer Types']=%d;", index++);
     jsStrBuf.appendf("colIndex['manufacturerComputer Types']=%d;", index++);
     jsStrBuf.appendf("colIndex['computerTypeComputer Types']=%d;", index++);
@@ -1883,15 +1883,15 @@ bool generateHardwareHeaders(const IPropertyTree* pEnv, StringBuffer& sbDefn, bo
 bool generateHeadersForEnvSettings(const IPropertyTree* pEnv, StringBuffer& sbDefn, bool writeOut)
 {
   StringBuffer jsStrBuf("var compTabs = new Array();");
-  jsStrBuf.appendf("compTabs['EnvSettings'] = new Array();");
-  jsStrBuf.appendf("var compTabToNode = new Array();");
-  jsStrBuf.appendf("var cS = new Array();");
+  jsStrBuf.append("compTabs['EnvSettings'] = new Array();");
+  jsStrBuf.append("var compTabToNode = new Array();");
+  jsStrBuf.append("var cS = new Array();");
   addItem(jsStrBuf, pEnv, "", TAG_SRCPATH, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, "", TAG_LOCK, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, "", TAG_CONFIGS, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, "", TAG_PATH, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, "", TAG_RUNTIME, "", 0, 1, "", 0);
-  jsStrBuf.appendf("compTabs['EnvSettings'][compTabs['EnvSettings'].length]= 'Attributes';");
+  jsStrBuf.append("compTabs['EnvSettings'][compTabs['EnvSettings'].length]= 'Attributes';");
 
   sbDefn.clear().append(jsStrBuf);
 
@@ -1904,10 +1904,10 @@ bool generateHeadersForEnvSettings(const IPropertyTree* pEnv, StringBuffer& sbDe
 bool generateHeadersForEnvXmlView(const IPropertyTree* pEnv, StringBuffer& sbDefn, bool writeOut)
 {
   StringBuffer jsStrBuf("var compTabs = new Array();");
-  jsStrBuf.appendf("compTabs['Environment'] = new Array();");
-  jsStrBuf.appendf("var compTabToNode = new Array();");
-  jsStrBuf.appendf("var cS = new Array();");
-  jsStrBuf.appendf("var colIndex = new Array();");
+  jsStrBuf.append("compTabs['Environment'] = new Array();");
+  jsStrBuf.append("var compTabToNode = new Array();");
+  jsStrBuf.append("var cS = new Array();");
+  jsStrBuf.append("var colIndex = new Array();");
 
   int index = 0;
   jsStrBuf.appendf("colIndex['nameEnvironment']=%d;", index++);
@@ -1945,7 +1945,7 @@ bool generateHeadersForEnvXmlView(const IPropertyTree* pEnv, StringBuffer& sbDef
   jsStrBuf.appendf("attr%s%s.ctrlType = 1;", TAG_VALUE, TAG_ELEMENT);
   jsStrBuf.appendf("cS['%s%s']=attr%s%s;", TAG_VALUE, TAG_ELEMENT, TAG_VALUE, TAG_ELEMENT);
 
-  jsStrBuf.appendf("compTabs['Environment'][compTabs['Environment'].length]= 'Environment';");
+  jsStrBuf.append("compTabs['Environment'][compTabs['Environment'].length]= 'Environment';");
 
   sbDefn.clear().append(jsStrBuf);
 
@@ -1959,17 +1959,17 @@ bool generateHeaderForDeployableComps(const IPropertyTree* pEnv, StringBuffer& s
 {
   short index = 0;
   StringBuffer jsStrBuf("var compTabs = new Array();");
-  jsStrBuf.appendf("compTabs['Deploy'] = new Array();");
-  jsStrBuf.appendf("var compTabToNode = new Array();");
-  jsStrBuf.appendf("var cS = new Array();");
-  jsStrBuf.appendf("var colIndex = new Array();");
+  jsStrBuf.append("compTabs['Deploy'] = new Array();");
+  jsStrBuf.append("var compTabToNode = new Array();");
+  jsStrBuf.append("var cS = new Array();");
+  jsStrBuf.append("var colIndex = new Array();");
   addItem(jsStrBuf, pEnv, XML_TAG_COMPONENT, TAG_BUILD, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, XML_TAG_COMPONENT, TAG_BUILDSET, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, XML_TAG_COMPONENT, TAG_NAME, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, XML_TAG_INSTANCES, TAG_BUILDSET, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, XML_TAG_INSTANCES, TAG_DIRECTORY, "", 0, 1, "", 0);
   addItem(jsStrBuf, pEnv, XML_TAG_INSTANCES, TAG_NODENAME, "", 0, 1, "", 0);
-  jsStrBuf.appendf("compTabs['Deploy'][compTabs['Deploy'].length]= 'Deploy';");
+  jsStrBuf.append("compTabs['Deploy'][compTabs['Deploy'].length]= 'Deploy';");
   jsStrBuf.appendf("colIndex['nameDeploy']=%d;", index++);
   jsStrBuf.appendf("colIndex['buildDeploy']=%d;", index++);
   jsStrBuf.appendf("colIndex['buildSetDeploy']=%d;", index++);
@@ -1985,9 +1985,9 @@ bool generateHeaderForTopology(const IPropertyTree* pEnv, StringBuffer& sbDefn, 
 {
   short index = 0;
   StringBuffer jsStrBuf("var compTabs = new Array();");
-  jsStrBuf.appendf("compTabs['Topology'] = new Array();");
-  jsStrBuf.appendf("var compTabToNode = new Array();");
-  jsStrBuf.appendf("var cS = new Array();");
+  jsStrBuf.append("compTabs['Topology'] = new Array();");
+  jsStrBuf.append("var compTabToNode = new Array();");
+  jsStrBuf.append("var cS = new Array();");
   addTopologyType(jsStrBuf, pEnv, "", TAG_NAME, "", 1, 1, "", 1);
   addTopologyType(jsStrBuf, pEnv, "", TAG_BUILDSET, "", 1, 1, "", 1);
   addTopologyType(jsStrBuf, pEnv, XML_TAG_ECLCCSERVERPROCESS,  TAG_PROCESS, "", 0, 1, XML_TAG_SOFTWARE"/EclCCServerProcess", 4);
@@ -1997,8 +1997,8 @@ bool generateHeaderForTopology(const IPropertyTree* pEnv, StringBuffer& sbDefn, 
   addTopologyType(jsStrBuf, pEnv, XML_TAG_ROXIECLUSTER,  TAG_PROCESS, "", 0, 1, XML_TAG_SOFTWARE"/RoxieCluster", 4);
   addTopologyType(jsStrBuf, pEnv, XML_TAG_CLUSTER,  TAG_NAME, "", 0, 1, "", 1);
   addTopologyType(jsStrBuf, pEnv, XML_TAG_CLUSTER,  TAG_PREFIX, "", 0, 1, "", 1);
-  jsStrBuf.appendf("compTabs['Topology'][compTabs['Topology'].length]= 'Topology';");
-  jsStrBuf.appendf("var colIndex = new Array();");
+  jsStrBuf.append("compTabs['Topology'][compTabs['Topology'].length]= 'Topology';");
+  jsStrBuf.append("var colIndex = new Array();");
   jsStrBuf.appendf("colIndex['nameTopology']=%d;", index++);
   jsStrBuf.appendf("colIndex['valueTopology']=%d;", index++);
 
@@ -2014,9 +2014,9 @@ bool generateBuildHeaders(const IPropertyTree* pEnv, bool isPrograms, StringBuff
 {
   short index = 0;
   StringBuffer jsStrBuf("var compTabs = new Array();");
-  jsStrBuf.appendf("compTabs['Programs'] = new Array();");
-  jsStrBuf.appendf("var compTabToNode = new Array();");
-  jsStrBuf.appendf("var cS = new Array();");
+  jsStrBuf.append("compTabs['Programs'] = new Array();");
+  jsStrBuf.append("var compTabToNode = new Array();");
+  jsStrBuf.append("var cS = new Array();");
   addItem(jsStrBuf, pEnv, XML_TAG_PROGRAMS, TAG_NAME, "", 0, 1, "", 1);
   addItem(jsStrBuf, pEnv, XML_TAG_PROGRAMS,  TAG_URL, "", 0, 1, "", 1);
   addItem(jsStrBuf, pEnv, XML_TAG_PROGRAMS, TAG_PATH, "", 0, 1, "", 1);
@@ -2024,8 +2024,8 @@ bool generateBuildHeaders(const IPropertyTree* pEnv, bool isPrograms, StringBuff
   addItem(jsStrBuf, pEnv, XML_TAG_PROGRAMS,  TAG_PROCESSNAME, "", 0, 1, "", 1);
   addItem(jsStrBuf, pEnv, XML_TAG_PROGRAMS,  TAG_SCHEMA, "", 0, 1, "", 1);
   addItem(jsStrBuf, pEnv, XML_TAG_PROGRAMS,  TAG_DEPLOYABLE, "", 0, 1, "", 1);
-  jsStrBuf.appendf("compTabs['Programs'][compTabs['Programs'].length]= 'Programs';");
-  jsStrBuf.appendf("var colIndex = new Array();");
+  jsStrBuf.append("compTabs['Programs'][compTabs['Programs'].length]= 'Programs';");
+  jsStrBuf.append("var colIndex = new Array();");
   jsStrBuf.appendf("colIndex['namePrograms']=%d;", index++);
   jsStrBuf.appendf("colIndex['pathPrograms']=%d;", index++);
   jsStrBuf.appendf("colIndex['installSetPrograms']=%d;", index++);
@@ -2039,16 +2039,16 @@ bool generateBuildHeaders(const IPropertyTree* pEnv, bool isPrograms, StringBuff
   if (writeOut)
     writeToFile(CONFIGMGR_JSPATH"programs.js", jsStrBuf);
 
-  jsStrBuf.clear().appendf("var compTabs = new Array();");
-  jsStrBuf.appendf("compTabs['BuildSet'] = new Array();");
-  jsStrBuf.appendf("var compTabToNode = new Array();");
-  jsStrBuf.appendf("var cS = new Array();");
+  jsStrBuf.clear().append("var compTabs = new Array();");
+  jsStrBuf.append("compTabs['BuildSet'] = new Array();");
+  jsStrBuf.append("var compTabToNode = new Array();");
+  jsStrBuf.append("var cS = new Array();");
   addItem(jsStrBuf, pEnv, XML_TAG_BUILDSET, TAG_NAME, "", 0, 1, "", 1);
   addItem(jsStrBuf, pEnv, XML_TAG_BUILDSET,  TAG_METHOD, "", 0, 1, "", 1);
   addItem(jsStrBuf, pEnv, XML_TAG_BUILDSET, TAG_SRCPATH, "", 0, 1, "", 1);
   addItem(jsStrBuf, pEnv, XML_TAG_BUILDSET,  TAG_DESTPATH, "", 0, 1, "", 1);
   addItem(jsStrBuf, pEnv, XML_TAG_BUILDSET,  TAG_DESTNAME, "", 0, 1, "", 1);
-  jsStrBuf.appendf("compTabs['BuildSet'][compTabs['BuildSet'].length]= 'BuildSet';");
+  jsStrBuf.append("compTabs['BuildSet'][compTabs['BuildSet'].length]= 'BuildSet';");
 
   if (!isPrograms)
     sbDefn.clear().append(jsStrBuf);
@@ -3199,7 +3199,7 @@ void runScript(StringBuffer& output, StringBuffer& errMsg, const char* pathToScr
   if(checkFileExists(pathToScript))
   {
     char buffer[128];
-    cmdLine.clear().appendf(pathToScript);
+    cmdLine.clear().append(pathToScript);
 #ifdef _WINDOWS
     FILE *fp = _popen(cmdLine.str(), "r");
 #else
@@ -3215,17 +3215,17 @@ void runScript(StringBuffer& output, StringBuffer& errMsg, const char* pathToScr
         }
       }
       if(ferror(fp))
-          errMsg.clear().appendf("Some file operation error");
+          errMsg.clear().append("Some file operation error");
 #ifdef _WINDOWS
       _pclose(fp);
 #else
        pclose(fp);
 #endif
      if( output.length() == 0)
-       errMsg.clear().appendf("No IPAddresses found for environment.");
+       errMsg.clear().append("No IPAddresses found for environment.");
     }
     else
-      errMsg.clear().appendf("Could not open or run autodiscovery script ").appendf(pathToScript);
+      errMsg.clear().append("Could not open or run autodiscovery script ").append(pathToScript);
  }
  else
     throw MakeStringException(-1,"The Script [%s] for getting IP addresses for environment does not exist", pathToScript);

--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -471,11 +471,11 @@ void CWizardInputs::generateSoftwareTree(IPropertyTree* pNewEnvTree)
       {
         IMapping &cur = iter.query();
         StringBuffer* dirvalue = m_overrideDirs->mapToValue(&cur);
-        xpath.clear().appendf(XML_TAG_SOFTWARE"/Directories/Category[@name='%s']", cur.getKey());
-        StringBuffer sbkey((const char*)cur.getKey());
-        if (!strcmp(sbkey.str(), "log"))
+        const char * key = (const char*)cur.getKey();
+        xpath.clear().appendf(XML_TAG_SOFTWARE"/Directories/Category[@name='%s']", key);
+        if (!strcmp(key, "log"))
           ovrLog = false;
-        else if (!strcmp(sbkey.str(), "run"))
+        else if (!strcmp(key, "run"))
           ovrRun = false;
 
         IPropertyTree* pDir = m_buildSetTree->queryPropTree(xpath.str());
@@ -542,7 +542,7 @@ void CWizardInputs::generateSoftwareTree(IPropertyTree* pNewEnvTree)
             for(unsigned i = 0; i < m_ipaddress.ordinality(); i++)
             {
               sbl.clear().appendf("s").append(i+1);
-              assignedIP.clear().appendf(m_ipaddress.item(i));
+              assignedIP.clear().append(m_ipaddress.item(i));
               addInstanceToTree(pNewEnvTree, assignedIP, processName, buildSetName,sbl.str());
             }
           }
@@ -588,12 +588,12 @@ void CWizardInputs::addInstanceToTree(IPropertyTree* pNewEnvTree, StringBuffer a
   xpath.clear().appendf("./%s/%s[%s=\"%s\"]", XML_TAG_HARDWARE, XML_TAG_COMPUTER, XML_ATTR_NETADDRESS, attrName.str());
   IPropertyTree* pHardTemp = pNewEnvTree->queryPropTree(xpath.str());
   if(pHardTemp)
-    nodeName.clear().appendf(pHardTemp->queryProp("./"XML_ATTR_NAME));//NodeName
+    nodeName.clear().append(pHardTemp->queryProp("./"XML_ATTR_NAME));//NodeName
 
   xpath.clear().appendf("./%s/%s[%s=\"%s\"]", XML_TAG_SOFTWARE, processName, XML_ATTR_BUILDSET, buildSetName);
   
   IPropertyTree* pComp = pNewEnvTree->queryPropTree(xpath.str());
-  compName.clear().appendf(pComp->queryProp(XML_ATTR_NAME));//compName
+  compName.clear().append(pComp->queryProp(XML_ATTR_NAME));//compName
 
   sb.clear().appendf("<Instance buildSet=\"%s\" compName=\"%s\" ><Instance name=\"%s\" /></Instance>", buildSetName, compName.str(), nodeName.str());
   Owned<IPropertyTree> pInstance = createPTreeFromXMLString(sb.str(),false);


### PR DESCRIPTION
Fix a number of compiler warnings related to use of ... with format
strings that don't (or might not) match the supplied parameters.

Most were most likely harmless but a couple looked like they would
cause unintended results.

g++ does not like use of printf etc with a variable for the format
string parameter (because it will behave unpredicatably if the
string passed to it contains a %). I don't like using appendf with a
single constant string parameter (because it's inefficient).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
