### PR TITLE
fixes #92 added call to basename in the expect call to install.

### DIFF
--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -122,6 +122,7 @@ expandPayload(){
 }
 
 runPayload(){
+    basepkg=`basename ${PKG}`
     expect -c "set timeout 3;
         spawn ssh $USER@$1;
         expect {
@@ -137,7 +138,7 @@ runPayload(){
             }
         }
         expect "${USER}@" {
-            send \"${CMDPREFIX} ${REMOTE_INSTALL}/remote-install-engine.sh ${REMOTE_INSTALL}/${PKG}\r\";
+            send \"${CMDPREFIX} ${REMOTE_INSTALL}/remote-install-engine.sh ${REMOTE_INSTALL}/${basepkg}\r\";
             expect *?assword* {
                 send \"${PASS}\r\";
             }


### PR DESCRIPTION
added basename usage to remove directory information from the function that
generates the expect call to install the package via remote-install-engine.sh.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
