### PR TITLE
BUG: 83070 Fix message misspellings in eclagent

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1733,7 +1733,7 @@ IConstWorkUnit * EclAgent::resolveLibrary(const char * libraryName, unsigned exp
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
     Owned<IConstWorkUnit> wu = factory->openWorkUnit(libraryWuid, false);
     if (!wu)
-        throw MakeStringException(0, "Could not open workunit %s implementating library %s", libraryWuid, libraryName);
+        throw MakeStringException(0, "Could not open workunit %s implementing library %s", libraryWuid, libraryName);
 
     unsigned interfaceHash = wu->getApplicationValueInt("LibraryModule", "interfaceHash", 0);
     if (interfaceHash != expectedInterfaceHash)

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -240,7 +240,7 @@ void CHThorActivityBase::createRowAllocator()
 
 __int64 CHThorActivityBase::getCount()
 {
-    throw MakeStringException(2, "Internal error: CHThorActivityBase::count");
+    throw MakeStringException(2, "Internal error: CHThorActivityBase::getCount");
     return 0;
 }
 
@@ -1085,7 +1085,7 @@ void CHThorIndexWriteActivity::execute()
     unsigned __int64 fileSize = 0;
     if (helper.getDatasetName())
     {
-        Owned<ILocalOrDistributedFile> ldFile = agent.resolveLFN(helper.getDatasetName(),"IndedWrite::execute",false,true,true);
+        Owned<ILocalOrDistributedFile> ldFile = agent.resolveLFN(helper.getDatasetName(),"IndexWrite::execute",false,true,true);
         if (ldFile)
         {
             IDistributedFile * dFile = ldFile->queryDistributedFile();
@@ -1753,10 +1753,9 @@ const void *CHThorProcessActivity::nextInGroup()
 
 CHThorNormalizeActivity::CHThorNormalizeActivity(IAgentContext &_agent, unsigned _activityId, unsigned _subgraphId, IHThorNormalizeArg &_arg, ThorActivityKind _kind) : CHThorSimpleActivityBase(_agent, _activityId, _subgraphId, _arg, _kind), helper(_arg)
 {
-    // JF: bug - use of null pointer 
     IRecordSize* recSize = outputMeta;
     if (recSize == NULL)
-        throw MakeStringException(2, "Unexpect null pointer from helper.queryOutputMeta()");
+        throw MakeStringException(2, "Unexpected null pointer from helper.queryOutputMeta()");
 }
 
 CHThorNormalizeActivity::~CHThorNormalizeActivity()


### PR DESCRIPTION
Fix misspelled words and incorrect method names in log messages and
exception strings.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
