### PR TITLE
BUG: 82956 - Fix eclagent hang on locked index file

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -1045,7 +1045,7 @@ CHThorIndexWriteActivity::CHThorIndexWriteActivity(IAgentContext &_agent, unsign
 {
     incomplete = false;
     StringBuffer lfn;
-    Owned<ILocalOrDistributedFile> ldf = agent.resolveLFN(helper.getFileName(),"Cannot write, invalid logical name",true,false,true,&lfn);
+    expandLogicalFilename(lfn, helper.getFileName(), agent);
     if (!agent.queryResolveFilesLocally())
     {
         Owned<IDistributedFile> f = queryDistributedFileDirectory().lookup(lfn, agent.queryCodeContext()->queryUserDescriptor(), true);


### PR DESCRIPTION
IndexWriteActivity incorrectly calls resolveLFN, which locks the file,
then calls expandLogicalFilename before attempting to delete. This fix
removes the incorrect call and replaces with expandLogicalFilename,
allowing the file to be deleted.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
