### PR TITLE
Bug: 83223 Add more debugging/postmortem information to ESP log

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -551,6 +551,7 @@ public:
     virtual bool aborting() const;
     virtual void forceReload();
     virtual WUAction getAction() const;
+    virtual IStringVal& getActionEx(IStringVal & str) const;
     virtual IStringVal & getApplicationValue(const char * application, const char * propname, IStringVal & str) const;
     virtual int getApplicationValueInt(const char * application, const char * propname, int defVal) const;
     virtual IConstWUAppValueIterator & getApplicationValues() const;
@@ -875,6 +876,8 @@ public:
             { UNIMPLEMENTED; }
     virtual WUAction getAction() const
             { return c->getAction(); }
+    virtual IStringVal& getActionEx(IStringVal & str) const
+            { return c->getActionEx(str); }
     virtual IStringVal & getApplicationValue(const char * application, const char * propname, IStringVal & str) const
             { return c->getApplicationValue(application, propname, str); }
     virtual int getApplicationValueInt(const char * application, const char * propname, int defVal) const
@@ -3658,6 +3661,13 @@ WUAction CLocalWorkUnit::getAction() const
 {
     CriticalBlock block(crit);
     return (WUAction) getEnum(p, "Action", actions);
+}
+
+IStringVal& CLocalWorkUnit::getActionEx(IStringVal & str) const
+{
+    CriticalBlock block(crit);
+    str.set(p->queryProp("Action"));
+    return str;
 }
 
 IStringVal& CLocalWorkUnit::getApplicationValue(const char *app, const char *propname, IStringVal &str) const

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -824,6 +824,7 @@ interface IConstWorkUnit : extends IInterface
     virtual bool aborting() const = 0;
     virtual void forceReload() = 0;
     virtual WUAction getAction() const = 0;
+    virtual IStringVal& getActionEx(IStringVal & str) const = 0;
     virtual IStringVal & getApplicationValue(const char * application, const char * propname, IStringVal & str) const = 0;
     virtual int getApplicationValueInt(const char * application, const char * propname, int defVal) const = 0;
     virtual IConstWUAppValueIterator & getApplicationValues() const = 0;

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -290,7 +290,7 @@ public:
                     workunit->setState(WUStateFailed);
             }
             else if (workunit->getAction()==WUActionCompile)
-                workunit->setState(WUStateCompleted);
+                workunit->setState(WUStateCompiled);
         }
         else if (workunit->getState() != WUStateAborted)
             workunit->setState(WUStateFailed);

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -584,6 +584,8 @@ bool EspHttpBinding::basicAuth(IEspContext* ctx)
         return authorized;
 
     m_secmgr->updateSettings(*user,securitySettings);
+
+    ctx->addTraceSummaryTimeStamp("basicAuth");
     return authorized;
 }
     

--- a/esp/bindings/http/platform/httpprot.cpp
+++ b/esp/bindings/http/platform/httpprot.cpp
@@ -423,31 +423,8 @@ CHttpThread::~CHttpThread()
 {
 }
 
-static atomic_t gActiveRequests;
-
-class ActiveRequests
-{
-public:
-    
-    ActiveRequests() { inc(); }
-    virtual ~ActiveRequests()  { dec(); }
-
-    void inc() 
-    {   
-        atomic_inc(&gActiveRequests);
-        DBGLOG("*** Active requests: %u ***", (int)atomic_read(&gActiveRequests)); 
-    }
-    
-    void dec() 
-    { 
-        atomic_dec(&gActiveRequests);
-        DBGLOG("*** Active requests: %u ***", (int)atomic_read(&gActiveRequests)); 
-    }
-};
-
 bool CHttpThread::onRequest()
 {
-    EspTimeSection timing("CHttpThread::onRequest()");
     ActiveRequests recording;
 
     Owned<CEspHttpServer> httpserver;
@@ -491,8 +468,7 @@ bool CHttpThread::onRequest()
     time_t t = time(NULL);  
     initThreadLocal(sizeof(t), &t);
 
-    if (httpserver->processRequest()==-1)
-        timing.clear();
+    httpserver->processRequest();
     clearThreadLocal();
     
     return false;

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -41,10 +41,10 @@
  ***************************************************************************/
 CEspHttpServer::CEspHttpServer(ISocket& sock, bool viewConfig, int maxRequestEntityLength):m_socket(sock), m_MaxRequestEntityLength(maxRequestEntityLength)
 {
+    IEspContext* ctx = createEspContext();
     m_request.setown(new CHttpRequest(sock));
     m_request->setMaxRequestEntityLength(maxRequestEntityLength);
     m_response.setown(new CHttpResponse(sock));
-    IEspContext* ctx = createEspContext();
     m_request->setOwnContext(ctx);
     m_response->setOwnContext(LINK(ctx));
     m_viewConfig=viewConfig;
@@ -52,10 +52,10 @@ CEspHttpServer::CEspHttpServer(ISocket& sock, bool viewConfig, int maxRequestEnt
 
 CEspHttpServer::CEspHttpServer(ISocket& sock, CEspApplicationPort* apport, bool viewConfig, int maxRequestEntityLength):m_socket(sock), m_MaxRequestEntityLength(maxRequestEntityLength)
 {
+    IEspContext* ctx = createEspContext();
     m_request.setown(new CHttpRequest(sock));
     m_request->setMaxRequestEntityLength(maxRequestEntityLength);
     m_response.setown(new CHttpResponse(sock));
-    IEspContext* ctx = createEspContext();
     m_request->setOwnContext(ctx);
     m_response->setOwnContext(LINK(ctx));
     m_apport = apport;
@@ -222,6 +222,8 @@ int CEspHttpServer::processRequest()
         m_request->updateContext();
         IEspContext* ctx = m_request->queryContext();
         ctx->setServiceName(serviceName.str());
+        ctx->setServiceMethod(methodName.str());
+        ctx->setHTTPMethod(method.toUpperCase().str());
 
         bool isSoapPost=(stricmp(method.str(), POST_METHOD) == 0 && m_request->isSoapMessage());
         if (!isSoapPost)
@@ -402,6 +404,8 @@ int CEspHttpServer::processRequest()
                 else
                     unsupported();
             }
+
+            ctx->addTraceSummaryTimeStamp("httpServ");
         }
     }
     catch(IEspHttpException* e)

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -498,6 +498,8 @@ int CHttpMessage::receive(bool alwaysReadContent, IMultiException *me)
     if (isUpload())
         return 0;
 
+    m_context->addTraceSummaryValue("contLen", m_content_length);
+
     if(m_content_length > 0)
     {
         readContent();
@@ -1451,6 +1453,7 @@ int CHttpRequest::receive(IMultiException *me)
         }
     }
 
+    m_context->addTraceSummaryTimeStamp("rcv");
     return 0;
 }
 

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -43,13 +43,19 @@
                   <xsl:value-of select="$wuid"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <!--a href="/esp/iframe/WsWorkunits/WUFile?Wuid={$wuid}&amp;Type=XML&amp;esp_iframe_title=ECL Workunit XML - {$wuid}"
-                                   -->
                   <a href="/esp/iframe?esp_iframe_title=ECL Workunit XML - {$wuid}&amp;inner=/WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Type%3dXML" >
                     <xsl:value-of select="$wuid"/>
                   </a>
                 </xsl:otherwise>
               </xsl:choose>
+            </td>
+          </tr>
+          <tr>
+            <td class="eclwatch entryprompt">
+              Action:
+            </td>
+            <td>
+              <xsl:value-of select="ActionEx"/>
             </td>
           </tr>
           <tr>
@@ -249,14 +255,6 @@
               </xsl:choose>
             </td>
           </tr>
-          <!--tr>
-                            <td class="eclwatch entryprompt">
-                  Cluster:
-              </td>
-                            <td>
-                                <xsl:value-of select="Cluster"/>
-                            </td>
-                        </tr-->
           <xsl:variable name="defaultcluster" select="Cluster"/>
           <tr>
             <td class="eclwatch entryprompt">
@@ -633,7 +631,6 @@
                 </A>
               </div>
             </div>
-            <!--xsl:apply-templates select="Workflows" mode="list"/-->
             <div id="Workflows" class="wusectioncontent">
               <xsl:choose>
                 <xsl:when test="WorkflowsDesc != ''">
@@ -698,37 +695,6 @@
       </xsl:if>
 
       <xsl:if test="number(Archived) &lt; 1">
-        <!--tr>
-                                <th>Helpers:</th>
-                                <td>
-                                    <table class="list">
-                                        <tr>
-                                            <xsl:if test="string-length(Query/Cpp)">
-                                                <td>
-                                                <a href="/WsWorkunits/WUFile/{$wuid}.cpp?Wuid={$wuid}&amp;Type=cpp" >cpp</a>
-                                                </td>
-                                            </xsl:if>
-                                            <xsl:if test="string-length(Query/Dll)">
-                                                <td>
-                                                <a href="/WsWorkunits/WUFile/{$wuid}.dll?Wuid={$wuid}&amp;Type=dll" >dll</a>
-                                                </td>
-                                            </xsl:if>
-                                            <xsl:if test="string-length(Query/ResTxt)">
-                                                <td>
-                                                <a href="/WsWorkunits/WUFile/res.txt?Wuid={$wuid}&amp;Type=res"
-                                                   >res.txt</a>
-                                                </td>
-                                            </xsl:if>
-                                            <xsl:if test="string-length(Query/ThorLog)">
-                                                <td>
-                                                <a href="/WsWorkunits/WUFile/ThorLog?Wuid={$wuid}&amp;Type=ThorLog" 
-                                                    >thormaster.log</a>
-                                                </td>
-                                            </xsl:if>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr-->
         <xsl:if test="count(Helpers/ECLHelpFile)">
           <p>
             <div class="wugroup">
@@ -1206,12 +1172,6 @@
         </xsl:if>
         <xsl:if test="not(GraphName)">
           <xsl:value-of select="Value"/>
-          <!--
-          (  <xsl:call-template name="timeformat">
-            <xsl:with-param name="toformat" select="Value"/>
-          </xsl:call-template>
-          )
-          -->
         </xsl:if>
       </td>
       <td>

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -30,6 +30,24 @@
 
 typedef IXslProcessor * (*getXslProcessor_func)();
 
+static atomic_t gActiveRequests;
+
+long ActiveRequests::getCount()
+{
+    return atomic_read(&gActiveRequests);
+}
+
+void ActiveRequests::inc()
+{
+    atomic_inc(&gActiveRequests);
+    DBGLOG("*** Active requests: %d ***", (int)atomic_read(&gActiveRequests));
+}
+
+void ActiveRequests::dec()
+{
+    atomic_dec(&gActiveRequests);
+    DBGLOG("*** Active requests: %d ***", (int)atomic_read(&gActiveRequests));
+}
 
 CEspApplicationPort::CEspApplicationPort(bool viewcfg) : bindingCount(0), defBinding(-1), viewConfig(viewcfg), rootAuth(false), navWidth(165), navResize(false), navScroll(false)
 {

--- a/esp/platform/espprotocol.hpp
+++ b/esp/platform/espprotocol.hpp
@@ -32,6 +32,19 @@
 #include <map>
 using namespace std;
 
+class ActiveRequests
+{
+public:
+
+    ActiveRequests() { inc(); }
+    ~ActiveRequests()  { dec(); }
+
+    void inc();
+    void dec();
+
+    static long getCount();
+};
+
 class CEspBindingEntry : public CInterface
 {
 private:

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -157,6 +157,10 @@ interface IEspContext : extends IInterface
 
     virtual void setServiceName(const char *name)=0;
     virtual const char * queryServiceName(const char *name)=0;
+    virtual void setServiceMethod(const char *name)=0;
+    virtual const char * queryServiceMethod()=0;
+    virtual void setHTTPMethod(const char *name)=0;
+    virtual const char * queryHTTPMethod()=0;
 
     virtual IProperties *   queryRequestParameters()=0;
     virtual void            setRequestParameters(IProperties * Parameters)=0;
@@ -184,6 +188,11 @@ interface IEspContext : extends IInterface
     
     virtual StringArray& queryCustomHeaders() = 0;
     virtual void addCustomerHeader(const char* name, const char* val) = 0;
+
+    virtual void addTraceSummaryValue(const char *name, const char *value)=0;
+    virtual void addTraceSummaryValue(const char *name, int value)=0;
+    virtual void addTraceSummaryTimeStamp(const char *name)=0;
+    virtual void flushTraceSummary()=0;
 };
 
 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -168,8 +168,8 @@ ESPStruct [nil_remove] ECLWorkunit
     string Description;
     bool Protected;
     bool Active;
-    //bool Aborting;
     int Action;
+    [min_ver("1.33")] string ActionEx;
     xsdDateTime DateTimeScheduled;
     int PriorityClass;
     int PriorityLevel;
@@ -1046,7 +1046,7 @@ ESPresponse [exceptions_inline] WUQuerySetActionAliasesResponse
 
 
 ESPservice [
-    version("1.32"), default_client_version("1.32"),
+    version("1.33"), default_client_version("1.33"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPuses ESPStruct ECLException;

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -5198,8 +5198,8 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
     wuidStr.trim();
     const char* wuid = wuidStr.str();
 
-   CWUWrapper wu(wuid, context);
-   ensureWorkunitAccess(context, *wu, SecAccess_Read);
+    CWUWrapper wu(wuid, context);
+    ensureWorkunitAccess(context, *wu, SecAccess_Read);
 
     bool helpersException = false;
     bool graphsException = false;
@@ -5211,7 +5211,7 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
     bool applicationValuesException = false;
     bool workflowsException = false;
 
-   SecAccessFlags accessFlag = getWorkunitAccess(context, *wu);
+    SecAccessFlags accessFlag = getWorkunitAccess(context, *wu);
 
     SCMStringBuffer buf;
     info->setWuid(wu->getWuid(buf).str());
@@ -5221,10 +5221,8 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
 
     if ((wu->getState() == WUStateScheduled) && wu->aborting())
     {
-        //info->setAborting(true);
         info->setStateID(WUStateAborting);
         info->setState("aborting");
-        //info->setStateEx(WUStateAborting);
     }
 
     double version = context.getClientVersion();
@@ -5232,8 +5230,11 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
     {       
         info->setArchived(false);
     }
+    if (version > 1.32)
+    {
+        info->setActionEx(wu->getActionEx(buf).str());
+    }
     info->setProtected(wu->isProtected() ? 1 : 0);
-    //info->setCluster(wu->getClusterName(buf).str());
 
     SCMStringBuffer roxieClusterName;
     Owned<IConstWURoxieQueryInfo> roxieQueryInfo = wu->getRoxieQueryInfo();
@@ -5241,13 +5242,7 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
     if (roxieQueryInfo)
         roxieQueryInfo->getRoxieClusterName(roxieClusterName);
 
-    StringBuffer ClusterName;
-    //if (roxieClusterName.length() == 0)
-    //  ClusterName = wu->getClusterName(buf).str();
-    //else
-    //  ClusterName = roxieClusterName.str();
-
-    ClusterName = wu->getClusterName(buf).str();
+    StringBuffer ClusterName = wu->getClusterName(buf).str();
     info->setCluster(ClusterName.str());
     if (version > 1.06 && roxieClusterName.length() > 0)
     {
@@ -5324,18 +5319,11 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
 
     if (version > 1.16)
     {       
-
-        //char countBuf[23];
-        unsigned sectionCount;
-
-        sectionCount = wu->getGraphCount();
+        unsigned sectionCount = wu->getGraphCount();
         info->setGraphCount(sectionCount);
 
         sectionCount = wu->getSourceFileCount();
         info->setSourceFileCount(sectionCount);
-
-        //sectionCount = wu->getResultCount();
-        //info->setResultCount(sectionCount);
 
         sectionCount = wu->getVariableCount();
         info->setVariableCount(sectionCount);
@@ -5545,67 +5533,12 @@ void CWsWorkunitsEx::getInfo(IEspContext &context,const char* wuid0,IEspECLWorku
         }
         else
         {
-//#define TESTSUBFILE
-#ifdef TESTSUBFILE
-int i = 0;
-#endif
             StringArray fileNames;
 
             Owned<IPropertyTreeIterator> f=&wu->getFilesReadIterator();
             ForEach(*f)
             {
-#ifndef TESTSUBFILE
                 IPropertyTree &query = f->query();
-#else
-Owned<IPropertyTree> filesRead = createPTree(false);
-{
-    if (i > 1)
-        break;
-    if (i < 1)
-    {
-    filesRead->setProp("@name", "file1");
-    filesRead->setProp("@cluster", "thor200");
-    filesRead->setPropInt("@useCount", 1);
-
-    Owned<IPropertyTree> subfile = createPTree(false);
-    subfile->setProp("@name", "subfile1");
-    filesRead->addPropTree("Subfile", subfile.getClear());
-
-    Owned<IPropertyTree> subfile2 = createPTree(false);
-    subfile2->setProp("@name", "subfile2");
-    filesRead->addPropTree("Subfile", subfile2.getClear());
-    }
-    else
-    {
-    filesRead->setProp("@name", "file2");
-    filesRead->setProp("@cluster", "thor200");
-    filesRead->setPropInt("@useCount", 1);
-
-    Owned<IPropertyTree> subfile21 = createPTree(false);
-    subfile21->setProp("@name", "subfile21");
-    subfile21->setProp("@cluster", "thor50");
-    filesRead->addPropTree("Subfile", subfile21.getClear());
-
-    Owned<IPropertyTree> subfile22 = createPTree(false);
-    subfile22->setProp("@name", "subfile22");
-    subfile22->setProp("@cluster", "thor50");
-
-    Owned<IPropertyTree> subfile221 = createPTree(false);
-    subfile221->setProp("@name", "subfile221");
-    subfile221->setProp("@cluster", "thor50");
-    subfile22->addPropTree("Subfile", subfile221.getClear());
-
-    Owned<IPropertyTree> subfile222 = createPTree(false);
-    subfile222->setProp("@name", "subfile222");
-    subfile222->setProp("@cluster", "thor50");
-    subfile22->addPropTree("Subfile", subfile222.getClear());
-
-    filesRead->addPropTree("Subfile", subfile22.getClear());
-    }
-    i++;
-}
-IPropertyTree &query = *filesRead;
-#endif
                 const char *clusterName = query.queryProp("@cluster");
                 const char *fileName = query.queryProp("@name");
                 int fileCount = query.getPropInt("@useCount");


### PR DESCRIPTION
Existing ESP log contains a log line to trace ESP processing time
for each HTTP request. The code is modified to add more information
about user, IP, service name, method name, etc. The new code is 
based on ESP's TxSummary from another project.

Bug 83862 will clean some noise in the esp logs.
