### PR TITLE
fixes #90 Removed error with component type check

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -16,7 +16,7 @@
 ###<REPLACE>###
 
 which_service(){
-    SERV=`which service`
+    SERV=`type --path service`
     if [ "${SERV}" == "" ]; then
         if [ -e "/sbin/service" ]; then
             SERV=/sbin/service
@@ -27,7 +27,7 @@ which_service(){
 }
 
 which_pidof(){
-    PIDOF=`which pidof`
+    PIDOF=`type --path pidof`
     if [ "${PIDOF}" == "" ]; then
         if [ -e /bin/pidof ]; then
 	    PIDOF=/bin/pidof
@@ -50,7 +50,6 @@ cfg.parser () {
     if [ ! -e $1 ] || [ $# -lt 1 ]; then
     [[ "${VERBOSE:-0}" -eq 1 ]] && log_end_msg 1 && return 1 || return 1
     fi
-    OLD_IFS=$IFS
     IFS=$'\n' && ini=( $(cat $1 | sed -e 's/[ \t]*=[ \t]*/=/') )              # convert to line-array
     ini=( ${ini[*]//[;#]*/} )                   # remove comments
     ini=( ${ini[*]/#[/\}$'\n'cfg.section.} ) # set section prefix
@@ -63,7 +62,6 @@ cfg.parser () {
     ini[${#ini[*]} + 1]='}'                  # add the last brace
     #echo "${ini[*]}"               # echoing the result
     eval "$(echo "${ini[*]}")"               # eval the result
-    IFS=$OLD_IFS
     [[ "${VERBOSE:-0}" -eq 1 ]] && log_end_msg 0
 }
 
@@ -78,7 +76,6 @@ dir.parser() {
         if [ $# -lt 1 ]; then
             [[ "${VERBOSE:-0}" -eq 1 ]] && log_end_msg 1 && return 1 || return 1
         fi
-	OLD_IFS=$IFS
         IFS=$'\n' && cmp=( $@ )
         cmp=( ${cmp[*]/#/dir_} )
         cmp=( ${cmp[*]/=/= dirItem=} )
@@ -88,7 +85,6 @@ dir.parser() {
         for i in ${!dir_*}; do
             dirArray=( ${dirArray[@]} $i )
         done
-	IFS=$OLD_IFS
     [[ "${VERBOSE:-0}" -eq 1 ]] && log_end_msg 0
 }
 
@@ -130,7 +126,6 @@ comp.parser() {
         if [ $# -lt 1 ]; then
             [[ "${VERBOSE:-0}" -eq 1 ]] && log_end_msg 1 && return 1 || return 1
         fi
-	OLD_IFS=$IFS
         IFS=$'\n' && cmp=( $@ )
         cmp=( ${cmp[*]/#/comp_} )
         cmp=( ${cmp[*]/=/= compType=} )
@@ -142,7 +137,6 @@ comp.parser() {
         for i in ${!comp_*}; do
             compArray=( ${compArray[@]} $i )
         done
-	IFS=$OLD_IFS
     [[ "${VERBOSE:-0}" -eq 1 ]] && log_end_msg 0
 }
 

--- a/initfiles/sbin/hpcc-run.sh.in
+++ b/initfiles/sbin/hpcc-run.sh.in
@@ -32,16 +32,16 @@ getDali(){
 }
 
 buildCmd(){
-        if [ -z $3 ]; then
-                CMD="sudo /etc/init.d/$1 $2"
-        else
-                CMD="sudo /etc/init.d/$1 -c $3 $2"
-        fi
+    if [ -z $3 ]; then
+        CMD="sudo /etc/init.d/$1 $2"
+    else
+        CMD="sudo /etc/init.d/$1 -c $3 $2"
+    fi
 }
 
 runCmd(){
-        echo "$IP: Running $@";
-        ssh -i $home/$user/.ssh/id_rsa $user@$IP $@;
+    echo "$IP: Running $@";
+    ssh -i $home/$user/.ssh/id_rsa $user@$IP $@;
 }
 
 set_envrionmentvars
@@ -49,9 +49,6 @@ envfile=$configs/$environment
 
 getIPS
 getDali
-
-IPS=${IPS//$DIP[^0-9]/ }
-
 
 TEMP=`/usr/bin/getopt -o a:c:h --long help,action -n 'hpcc-run' -- "$@"`
 if [ $? != 0 ] ; then echo "Failure to parse commandline." >&2 ; exit 1 ; fi
@@ -98,7 +95,7 @@ for arg; do
 done
 
 if [ ${cnt} -gt 1 ]; then
-        print_usage
+    print_usage
 fi
 
 case "$action" in
@@ -133,6 +130,9 @@ if [ "${cmd}" == "restart" ]; then
         fi
 
         for IP in $IPS; do
+            if [ "$IP" == "$DIP" ]; then
+                continue
+            fi
             if ping -c 1 -w 5 -n $IP > /dev/null 2>&1; then
                 echo "$IP: Host is alive."
                 CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$IP exit > /dev/null 2>&1; echo $?`"
@@ -181,6 +181,9 @@ else
     fi
 
     for IP in $IPS; do
+        if [ "$IP" == "$DIP" ]; then
+            continue
+        fi
         if ping -c 1 -w 5 -n $IP > /dev/null 2>&1; then
             echo "$IP: Host is alive."
             CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$IP exit > /dev/null 2>&1; echo $?`"


### PR DESCRIPTION
Removed the change of bashes internal file seperator (IFS) in hpcc_common.

Changed the usage of which to type --path as which can throw errors when a
search executable is not found on the path.

Removed regex pruning of the IP list given from configgen and added an if
statement in the ip loops to skip dali's ip.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
