### PR TITLE
Bug: 83900 Fix issue with dfu jobs left running

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -253,7 +253,13 @@ class CDFUengine: public CInterface, implements IDFUengine
                         case DFUservermode_run: {
                                 PROGLOG("DFU %s running job: %s",serv,wuid.get());
                                 setRunningStatus(queuename.get(),wuid,true);
-                                parent->runWU(wuid);
+                                try {
+                                    parent->runWU(wuid);
+                                }
+                                catch (IException *) {
+                                    setRunningStatus(queuename.get(),wuid,false);
+                                    throw;
+                                }
                                 if (!ismon) {
                                     setRunningStatus(queuename.get(),wuid,false);
                                     PROGLOG("DFU %s finished job: %s",serv,wuid.get());


### PR DESCRIPTION
If an exception occured within runWU within dfu server, it would leave the
dfu workunit tracked as running (within /Status/Server in Dali).
Consequently queuedJobs as used by EclWatch would still think the jobs were
running and list them as such on the Activity page

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
