### PR TITLE
BUG:83808 Speed up regex and add algorithm option

### DIFF
--- a/common/thorhelper/thorparse.cpp
+++ b/common/thorhelper/thorparse.cpp
@@ -716,8 +716,8 @@ INlpParseAlgorithm * createThorParser(MemoryBuffer & buffer, IOutputMetaData * o
 
     switch (kind)
     {
-    case NLPAregex:
-    case NLPAregex2:
+    case NLPAregexStack:
+    case NLPAregexHeap:
         return createRegexParser(buffer, outRecordSize, kind);
     case NLPAtomita:
         return createTomitaParser(buffer, outRecordSize);

--- a/common/thorhelper/thorparse.hpp
+++ b/common/thorhelper/thorparse.hpp
@@ -30,7 +30,7 @@
 #endif
 
 typedef unsigned regexid_t;
-enum { NLPAregex, NLPAtomita, NLPAregex2 };
+enum { NLPAregexStack, NLPAtomita, NLPAregexHeap };
 
 interface IMatchWalker : public IInterface
 {

--- a/common/thorhelper/thorrparse.cpp
+++ b/common/thorhelper/thorrparse.cpp
@@ -1974,15 +1974,16 @@ void RegexNamedPattern::getTraceText(StringBuffer & s)
 
 RegexMatchAction RegexNamedPattern::match(RegexState & state)
 {
-    //RegexMatchState matched(def);
-    //return def->match(state, &end, matched);
-    {
+#ifdef __64BIT__
+    RegexMatchState matched(def);
+    return def->match(state, &end, matched);
+#else
     //Allocate on the heap to make a stack fault less likely
     RegexMatchState * matched = new RegexMatchState(def);
     RegexMatchAction ret = def->match(state, &end, *matched);
     delete matched;
     return ret;
-    }
+#endif
 }
 
 void RegexNamedPattern::dispose()
@@ -3110,7 +3111,7 @@ RegexPattern * deserializeRegex(MemoryBuffer & in)
 
 void RegexState::processPattern(RegexPattern * grammar)
 {
-    if (implementation == NLPAregex)
+    if (implementation == NLPAregexStack)
     {
         grammar->MATCH(*this);
         return;

--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -26,6 +26,7 @@ _ATOM activeFailureAtom;
 _ATOM activeNlpAtom;
 _ATOM afterAtom;
 _ATOM aggregateAtom;
+_ATOM algorithmAtom;
 _ATOM allAtom;
 _ATOM allocatorAtom;
 _ATOM alreadyVisitedAtom;
@@ -396,6 +397,7 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKEATOM(activeNlp);
     MAKEATOM(after);
     MAKEATOM(aggregate);
+    MAKEATOM(algorithm);
     MAKEATOM(all);
     MAKEATOM(allocator);
     MAKEATOM(alreadyVisited);

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -30,6 +30,7 @@ extern HQL_API _ATOM activeNlpAtom;
 extern HQL_API _ATOM afterAtom;
 extern HQL_API _ATOM aggregateAtom;
 extern HQL_API _ATOM allAtom;
+extern HQL_API _ATOM algorithmAtom;
 extern HQL_API _ATOM allocatorAtom;
 extern HQL_API _ATOM _alreadyAssignedNestedTag_Atom;
 extern HQL_API _ATOM alreadyVisitedAtom;

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -9811,6 +9811,7 @@ parseFlag
                             $$.setExpr(createAttribute(parallelAtom));
                             $$.setPosition($1);
                         }
+    | hintAttribute
     ;
 
 xmlParseFlags

--- a/ecl/hqlcpp/hqlnlp.cpp
+++ b/ecl/hqlcpp/hqlnlp.cpp
@@ -687,7 +687,16 @@ ABoundActivity * HqlCppTranslator::doBuildActivityParse(BuildCtx & ctx, IHqlExpr
     if (expr->hasProperty(tomitaAtom))
         nlpParse = createTomitaContext(expr, code->workunit, options, reporter);
     else
-        nlpParse = createRegexContext(expr, code->workunit, options, reporter);
+    {
+        byte algorithm = (options.regexVersion == 1) ? NLPAregexStack : NLPAregexHeap;
+        IHqlExpression * algorithmHint = queryHintChild(expr, algorithmAtom, 0);
+        if (matchesConstantString(algorithmHint, "stack", true))
+            algorithm = NLPAregexStack;
+        else if (matchesConstantString(algorithmHint, "heap", true))
+            algorithm = NLPAregexHeap;
+
+        nlpParse = createRegexContext(expr, code->workunit, options, reporter, algorithm);
+    }
 
     gatherExplicitMatched(expr);
     doBuildParseTransform(instance->startctx, expr);            // also gathers all the MATCHED() definitions.

--- a/ecl/hqlcpp/hqlnlp.ipp
+++ b/ecl/hqlcpp/hqlnlp.ipp
@@ -153,7 +153,7 @@ void getCheckRange(IHqlExpression * range, unsigned & minLength, unsigned & maxL
 enum ValidateKind { ValidateIsString, ValidateIsUnicode, ValidateIsEither };
 ValidateKind getValidateKind(IHqlExpression * expr);
 
-NlpParseContext * createRegexContext(IHqlExpression * expr, IWorkUnit * wu, const HqlCppOptions & options, ITimeReporter * timeReporter);
+NlpParseContext * createRegexContext(IHqlExpression * expr, IWorkUnit * wu, const HqlCppOptions & options, ITimeReporter * timeReporter, byte algorithm);
 NlpParseContext * createTomitaContext(IHqlExpression * expr, IWorkUnit * wu, const HqlCppOptions & options, ITimeReporter * timeReporter);
 
 #endif

--- a/ecl/hqlcpp/hqlregex.cpp
+++ b/ecl/hqlcpp/hqlregex.cpp
@@ -2319,16 +2319,7 @@ with some clever code to walk through and retain lists of which ones are active.
 
 //---------------------------------------------------------------------------
 
-inline byte queryRegexKind(const HqlCppOptions & options)
-{
-    switch (options.regexVersion)
-    {
-    case 1: return NLPAregex;
-    default: return NLPAregex2;
-    }
-}
-
-RegexContext::RegexContext(IHqlExpression * _expr, IWorkUnit * _wu, const HqlCppOptions & _options, ITimeReporter * _timeReporter) : NlpParseContext(_expr, _wu, _options, _timeReporter), parser(NULL, queryRegexKind(_options))
+RegexContext::RegexContext(IHqlExpression * _expr, IWorkUnit * _wu, const HqlCppOptions & _options, ITimeReporter * _timeReporter, byte _algorithm) : NlpParseContext(_expr, _wu, _options, _timeReporter), parser(NULL, _algorithm)
 {
     info.addedSeparators = false;
     switch (info.type)
@@ -2705,9 +2696,9 @@ void RegexContext::getDebugText(StringBuffer & s, unsigned detail)
     regexToXml(s, parser.grammar, detail);
 }
 
-NlpParseContext * createRegexContext(IHqlExpression * expr, IWorkUnit * wu, const HqlCppOptions & options, ITimeReporter * timeReporter)
+NlpParseContext * createRegexContext(IHqlExpression * expr, IWorkUnit * wu, const HqlCppOptions & options, ITimeReporter * timeReporter, byte algorithm)
 {
-    return new RegexContext(expr, wu, options, timeReporter);
+    return new RegexContext(expr, wu, options, timeReporter, algorithm);
 }
 
 //-- Lexer creation

--- a/ecl/hqlcpp/hqlregex.ipp
+++ b/ecl/hqlcpp/hqlregex.ipp
@@ -307,7 +307,7 @@ class RegexContext : public NlpParseContext
     friend class HqlNamedRegex;
     friend class HqlRegexExpr;
 public:
-    RegexContext(IHqlExpression * _expr, IWorkUnit * wu, const HqlCppOptions & options, ITimeReporter * _timeReporter);
+    RegexContext(IHqlExpression * _expr, IWorkUnit * wu, const HqlCppOptions & options, ITimeReporter * _timeReporter, byte _algorithm);
     ~RegexContext();
 
     virtual void compileSearchPattern();

--- a/ecl/hqlcpp/hqltomita.cpp
+++ b/ecl/hqlcpp/hqltomita.cpp
@@ -1403,7 +1403,7 @@ void TomitaContext::generateLexer()
     //nested scope
     try
     {
-        RegexContext regex(expr, wu(), translatorOptions, timeReporter);
+        RegexContext regex(expr, wu(), translatorOptions, timeReporter, NLPAregexStack);
 
         regex.beginLexer();
         ForEachItemIn(idx, tokens)
@@ -1426,7 +1426,7 @@ void TomitaContext::generateLexer()
     IHqlExpression * separator = expr->queryProperty(separatorAtom);
     if (separator)
     {
-        RegexContext regex2(expr, wu(), translatorOptions, timeReporter);
+        RegexContext regex2(expr, wu(), translatorOptions, timeReporter, NLPAregexStack);
 
         regex2.beginLexer();
         regex2.addLexerToken(1, separator->queryChild(0));

--- a/ecl/regress/bug83808.ecl
+++ b/ecl/regress/bug83808.ecl
@@ -1,0 +1,38 @@
+R := RECORD
+  STRING Txt;
+  END;
+
+d :=  DATASET('~n:\\temp\\weblogs',R,CSV(SEPARATOR('')));
+
+PATTERN Num := PATTERN('[0-9]')+;
+PATTERN Tok_IP := Num '.' Num '.' Num '.' Num;
+PATTERN Stuff := ANY+;
+PATTERN QuoteString := '"' ANY* '"';
+PATTERN ws := ' '+;
+PATTERN DateForm := '[' ANY* ']';
+
+PATTERN WebLine := FIRST Tok_IP ws Stuff ws Stuff ws DateForm ws QuoteString ws Num ws Num ws QuoteString ws QuoteString LAST;
+
+ResForm := RECORD
+  STRING15 Ip := MATCHTEXT(Tok_Ip);
+ STRING1 S1 := MATCHTEXT(Stuff[1]);
+ STRING19 S2 := MATCHTEXT(Stuff[2]);
+ STRING28 Dte := MATCHTEXT(DateForm);
+ UNSIGNED2 N1 := (UNSIGNED)MATCHTEXT(Num[1]);
+ UNSIGNED2 N2 := (UNSIGNED)MATCHTEXT(Num[2]);
+ STRING S3 := MATCHTEXT(QuoteString[1]);
+ STRING S4 := MATCHTEXT(QuoteString[2]);
+ STRING S5 := MATCHTEXT(QuoteString[3]);
+  END;
+
+p := PARSE(d,Txt,WebLine,ResForm);
+
+Errs := RECORD
+  STRING T := d.Txt;
+  END;
+e := PARSE(d,Txt,WebLine,Errs,NOT MATCHED ONLY);
+//EXPORT File_Weblogs := p : PERSIST('TMP::ParsedWeblogs');
+output(choosen(p,20000),,'out.tmp',overwrite);
+import std.system.debug;
+startTime := debug.msTick() : independent;
+output('Time taken = ' + (debug.msTick() - startTime));

--- a/ecl/regress/bug83808b.ecl
+++ b/ecl/regress/bug83808b.ecl
@@ -1,0 +1,39 @@
+R := RECORD
+  STRING Txt;
+  END;
+
+d :=  DATASET('~n:\\temp\\weblogs',R,CSV(SEPARATOR('')));
+
+PATTERN Num := PATTERN('[0-9]')+;
+PATTERN Tok_IP := Num '.' Num '.' Num '.' Num;
+PATTERN XNum := Num;
+PATTERN Stuff := ANY+?;
+PATTERN QuoteString := '"' PATTERN('[^"]')* '"';
+PATTERN ws := ' '+;
+PATTERN DateForm := '[' PATTERN('[^\\]]')* ']';
+
+PATTERN WebLine := FIRST Tok_IP ws Stuff ws DateForm ws QuoteString ws XNum ws XNum ws QuoteString ws QuoteString LAST;
+
+ResForm := RECORD
+  STRING15 Ip := MATCHTEXT(Tok_Ip);
+ STRING1 S1 := MATCHTEXT(Stuff[1]);
+ STRING19 S2 := MATCHTEXT(Stuff[2]);
+ STRING28 Dte := MATCHTEXT(DateForm);
+ UNSIGNED2 N1 := (UNSIGNED)MATCHTEXT(XNum[1]);
+ UNSIGNED2 N2 := (UNSIGNED)MATCHTEXT(XNum[2]);
+ STRING S3 := MATCHTEXT(QuoteString[1]);
+ STRING S4 := MATCHTEXT(QuoteString[2]);
+ STRING S5 := MATCHTEXT(QuoteString[3]);
+  END;
+
+p := PARSE(d,Txt,WebLine,ResForm,HINT(ALGORITHM('stack')));
+
+Errs := RECORD
+  STRING T := d.Txt;
+  END;
+e := PARSE(d,Txt,WebLine,Errs,NOT MATCHED ONLY);
+//EXPORT File_Weblogs := p : PERSIST('TMP::ParsedWeblogs');
+output(choosen(p,20000),,'out.tmp',overwrite);
+import std.system.debug;
+startTime := debug.msTick() : independent;
+output('Time taken = ' + (debug.msTick() - startTime));


### PR DESCRIPTION
Re-enables some old code in 64bit that was previously disabled because
it used too much stack in 32bit.  It also allows a HINT to be specified
on a PARSE to allow the stack or heap implementation to be selected.
Add HINT(ALGORITHM('stack')) to select the recursive stack based version
Add HINT(ALGORITHM('heap')) to select the heap based version.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
