### PR TITLE
Fix Bug:#83904 Corrected permissions on config directory for HPCC.

### DIFF
--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -234,3 +234,4 @@ fi
 
 chown root:$group ${configs}
 chown -R $user:$group ${configs}/*
+chmod 775 ${configs}


### PR DESCRIPTION
Permissions for a group member to access a folder owned by another user
that has group rights must be 775 in order to write new files to the
directory.

The default permissions set when creating a directory are 755
which allows group members to read and execute items in the directory, but
not create new files.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
