### PR TITLE
BUG:83218 Clean up the public regression suite

### DIFF
--- a/ecl/regress/rall.bat
+++ b/ecl/regress/rall.bat
@@ -16,14 +16,7 @@ rem
 rem     You should have received a copy of the GNU Affero General Public License
 rem     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 rem ############################################################################## */
-rem
-rem Rename this file, and then modify the following values below to match your local system
-rem
-rem The directory you wanr the target results to be written to
-set regresstgt=d:\regression
 
-rem The directory that contains the "correct" results from a previous run
-set regresskey=c:\regression
-
-rem Any includes which need to be passed to eclcc
-set regressinclude=-Ic:\hpcc\HPCC-Platform\ecl\regress\modules
+setlocal
+call %~dp0\regress.bat -m *.ecl *.eclxml %*
+endlocal

--- a/ecl/regress/rcompare.bat.sample
+++ b/ecl/regress/rcompare.bat.sample
@@ -17,7 +17,9 @@ rem     You should have received a copy of the GNU Affero General Public License
 rem     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 rem ############################################################################## */
 
-setlocal enableextensions
-md %regresstgt% 2>nul
-call %~dp0\regress1 -m %*
-if EXIST %~dp0\rcompare.bat. call %~dp0\rcompare %*
+if '%1'=='' goto compareall;
+call "\Program Files (x86)\Beyond Compare 2"\bc2.exe "/filters=%1*" /expandall %regresstgt% %regresskey%
+goto end;
+:compareall
+call "\Program Files (x86)\Beyond Compare 2"\bc2.exe /expandall %regresstgt% %regresskey%
+:end

--- a/ecl/regress/regress.bat
+++ b/ecl/regress/regress.bat
@@ -17,6 +17,8 @@ rem     You should have received a copy of the GNU Affero General Public License
 rem     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 rem ############################################################################## */
 
+setlocal enableextensions enabledelayedexpansion
+
 if '%regresstgt%'=='' goto novars
 rd /s /q %regresstgt%
 md %regresstgt% 2>nul
@@ -24,19 +26,18 @@ md %regresstgt% 2>nul
 set flags=-P%regresstgt% -legacy -target=thorlcr -fforceGenerate -fdebugNlp=1 -fnoteRecordSizeInGraph -fregressionTest -b -m -S -shared -faddTimingToWorkunit=0 -fshowRecordCountInGraph
 set flags=%flags% %regressinclude%
 
-if NOT '%numParallel%'=='' goto multiway
+if NOT '%regressProcesses%'=='' goto multiway
 eclcc %flags% %* > out.log
-if '%nocompare%'=='1' goto done;
-call bc regressNew
-goto done
+goto compare;
+
 :multiway
-for /l %%c in (2,1,%numParallel%) do (
+for /l %%c in (2,1,%regressProcesses%) do (
    set ECL_CCLOG=cclog%%c.txt
-   start "Regress%%c" /min  eclcc -split %%c%%:%numParallel% %flags% %*
+   start "Regress%%c" /min  eclcc -split %%c%%:%regressProcesses% %flags% %*
 )
 
 set ECL_CCLOG=cclog1.txt
-eclcc -split 1:%numParallel% %flags% %*
+eclcc -split 1:%regressProcesses% %flags% %*
 set ECL_CCLOG=
 
 pause Press space when done
@@ -47,8 +48,8 @@ for %%f in (%regresstgt%\_batch_.*.log) do type %%f >> %regresstgt%\_batch_.tmp
 sort %regresstgt%\_batch_.tmp > %regresstgt%\_batch_.log
 del %regresstgt%\_batch_.tmp
 
-if '%nocompare%'=='1' goto done;
-call bc regressNew
+:compare
+if EXIST %~dp0\rcompare.bat. call %~dp0\rcompare %*
 goto done;
 
 :novars

--- a/ecl/regress/setreg.bat.sample
+++ b/ecl/regress/setreg.bat.sample
@@ -16,9 +16,17 @@ rem
 rem     You should have received a copy of the GNU Affero General Public License
 rem     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 rem ############################################################################## */
+rem
+rem Rename this file, and then modify the following values below to match your local system
+rem
+rem The directory you wanr the target results to be written to
+set regresstgt=d:\regression
 
-setlocal
-set numParallel=6
-set files=*.ecl *.eclxml
-cmd /e:on /v:on /c regress.bat %files% %*
-endlocal
+rem The directory that contains the "correct" results from a previous run
+set regresskey=c:\regression
+
+rem Any includes which need to be passed to eclcc
+set regressinclude=-I<hppc-directory>\ecl\regress\modules
+
+rem Number of processes to run in parallel from rall.bat
+set regressprocesses=7

--- a/ecl/regress/sourcedoc.xml
+++ b/ecl/regress/sourcedoc.xml
@@ -4,6 +4,29 @@
     <title>ecl/regress</title>
 
     <para>
-        The ecl/regress directory contains the sources for the ecl/regress library.
+The ecl/regress directory contains the sources for the compiler regression suite.  This regression suite is used to
+check any changes to the eclcc compiler.  The recommended approach is
+
+a) Run the regression suite and save the generated output.
+b) Make the changes to the source code.
+c) Re run the regression suite, compare the generated code, and check that all the changes are expected.
+
+The regression suite should contain at least one example of any language feature that is added to the system.
+
+
+
+
+
+To run the regression suite under windows:
+a) Ensure path to eclcc is set up correctly
+b) Copy setreg.bat.sample to setreg.bat and modify the contents to reflect your set up.
+c) Copy rcompare.bat.sample to rcompare.bat and update to reflect your comparison program.
+
+r1.bat.sample can be used to run the regression test for a single file.
+E.g.,
+r1 dataset.ecl
+
+rall.bat runs the full regression test
+
     </para>
 </section>

--- a/ecl/regress/sourcedoc.xml
+++ b/ecl/regress/sourcedoc.xml
@@ -4,29 +4,47 @@
     <title>ecl/regress</title>
 
     <para>
-The ecl/regress directory contains the sources for the compiler regression suite.  This regression suite is used to
-check any changes to the eclcc compiler.  The recommended approach is
+        The ecl/regress directory contains the sources for the compiler regression suite.  This regression suite is used to
+        check any changes to the eclcc compiler.  The recommended approach is
+    </para>
 
-a) Run the regression suite and save the generated output.
-b) Make the changes to the source code.
-c) Re run the regression suite, compare the generated code, and check that all the changes are expected.
+    <orderedlist numeration="loweralpha">
+        <listitem>
+Run the regression suite and save the generated output.
+        </listitem>
+        <listitem>
+Make the changes to the source code.
+        </listitem>
+        <listitem>
+Re run the regression suite, compare the generated code, and check that all the changes are expected.
+        </listitem>
+    </orderedlist>
 
-The regression suite should contain at least one example of any language feature that is added to the system.
 
+    <para>
+        The regression suite should contain at least one example of any language feature that is added to the system.
+    </para>
+    <para>
+        To run the regression suite under windows:
+    <orderedlist numeration="loweralpha">
+        <listitem>
+Ensure path to eclcc is set up correctly
+        </listitem>
+        <listitem>
+Copy setreg.bat.sample to setreg.bat and modify the contents to reflect your set up.
+        </listitem>
+        <listitem>
+Copy rcompare.bat.sample to rcompare.bat and update to reflect your comparison program.
+        </listitem>
+    </orderedlist>
 
-
-
-
-To run the regression suite under windows:
-a) Ensure path to eclcc is set up correctly
-b) Copy setreg.bat.sample to setreg.bat and modify the contents to reflect your set up.
-c) Copy rcompare.bat.sample to rcompare.bat and update to reflect your comparison program.
-
-r1.bat.sample can be used to run the regression test for a single file.
-E.g.,
-r1 dataset.ecl
-
-rall.bat runs the full regression test
-
+        r1.bat.sample can be used to run the regression test for a single file, e.g.,
+        <programlisting>
+        r1 dataset.ecl
+</programlisting>
+To run the full regression test use rall.bat, e.g.,
+ <programlisting>
+        rall
+</programlisting>
     </para>
 </section>


### PR DESCRIPTION
Removes some internal paths from the regression suite batch file, makes
the comparison program configurable, and moves all settings to one file

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
