### PR TITLE
FIX 81293 Check for invalid strings

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -1346,7 +1346,8 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
             resp.setRefresh("true");
         }
 
-        if (!strcmp(pszCompType, XML_TAG_ROXIECLUSTER) && !strcmp(pszSubType, XML_TAG_ROXIE_FARM)
+        if (pszCompType && *pszCompType && pszSubType && *pszSubType &&
+            !strcmp(pszCompType, XML_TAG_ROXIECLUSTER) && !strcmp(pszSubType, XML_TAG_ROXIE_FARM)
             && pszAttrName && *pszAttrName)
         {
           Owned<IPropertyTreeIterator> iter = pComp->getElements(XML_TAG_ROXIE_SERVER);


### PR DESCRIPTION
Check for null and empty strings before attempting a
string comparision.

Tested and found that Roxie starts normally and empty
RoxieServerProcess nodes are not being generated.

Roxie rename fails due to null string comparision and
this commit fixes the issue.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
