### PR TITLE
ISSUE: #79 Support adding resources using a manifest file

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1269,35 +1269,43 @@ void HqlCppInstance::flushHints()
     }
 }
 
-IPropertyTree * HqlCppInstance::ensureWebServiceInfo()
+IPropertyTree * HqlCppInstance::ensureManifestInfo()
 {
-    if (!webServiceInfo)
-        webServiceInfo.setown(createPTree("WebServicesInfo"));
-    return webServiceInfo;
+    if (!manifestInfo)
+        manifestInfo.setown(createPTree("ManifestInfo", false));
+    return manifestInfo;
 }
 
 
-void HqlCppInstance::addWebServicesResource()
+void HqlCppInstance::addManifestResources()
 {
-    if (webServiceInfo)
+    if (manifestInfo)
     {
-        StringBuffer webXML;
-        toXML(webServiceInfo, webXML);
-        addCompressResource("SOAPINFO", 1000, webXML.length(), webXML.str());
+        Owned<IPropertyTreeIterator> itres = manifestInfo->getElements("resource");
+        ForEach(*itres)
+        {
+            IPropertyTree &resource = itres->query();
+            if (resource.hasProp("@type"))
+            {
+                StringBuffer resXML;
+                toXML(&resource, resXML);
+                addCompressResource(resource.queryProp("@type"), resource.getPropInt("@id"), resXML.length(), resXML.str());
+            }
+        }
     }
 }
 
 
-void HqlCppInstance::addWebServices(IPropertyTree * info)
+void HqlCppInstance::addManifestInfo(IPropertyTree * info)
 {
     if (info)
-        mergePTree(ensureWebServiceInfo(), info);
+        mergePTree(ensureManifestInfo(), info);
 }
 
 void HqlCppInstance::flushResources(const char *filename, ICodegenContextCallback * ctxCallback)
 {
     addPluginsAsResource();
-    addWebServicesResource();
+    addManifestResources();
     if (resources.count())
     {
         bool flushText = workunit->getDebugValueBool("flushResourceAsText", false);

--- a/ecl/hqlcpp/hqlcpp.hpp
+++ b/ecl/hqlcpp/hqlcpp.hpp
@@ -126,7 +126,7 @@ public:
     virtual HqlStmts * querySection(_ATOM section) = 0;
     virtual void addResource(const char * type, unsigned id, unsigned len, const void * data) = 0;
     virtual void addCompressResource(const char * type, unsigned id, unsigned len, const void * data) = 0;
-    virtual void addWebServices(IPropertyTree * info) = 0;
+    virtual void addManifestInfo(IPropertyTree * info)=0;
     virtual void flushHints() = 0;
     virtual void flushResources(const char *filename, ICodegenContextCallback * ctxCallback) = 0;
 };

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -125,8 +125,8 @@ public:
     virtual void flushResources(const char *filename, ICodegenContextCallback * ctxCallback);
     virtual void addResource(const char * type, unsigned id, unsigned len, const void * data);
     virtual void addCompressResource(const char * type, unsigned id, unsigned len, const void * data);
-    virtual void addWebServices(IPropertyTree * info);
-    virtual IPropertyTree * ensureWebServiceInfo();
+    virtual void addManifestInfo(IPropertyTree * info);
+    virtual IPropertyTree * ensureManifestInfo();
     
     bool useFunction(IHqlExpression * funcdef);
     void useInclude(const char * include);
@@ -139,7 +139,7 @@ public:
         
 private:
     void addPluginsAsResource();
-    void addWebServicesResource();
+    void addManifestResources();
     void appendHintText(const char * xml);
 
 public:
@@ -153,7 +153,7 @@ public:
     StringAttr          wupathname;
     Owned<IPropertyTree> plugins;
     Owned<IFileIOStream> hintFile;
-    Owned<IPropertyTree> webServiceInfo;
+    Owned<IPropertyTree> manifestInfo;
 };
 
 //---------------------------------------------------------------------------

--- a/ecl/hqlcpp/hqlecl.cpp
+++ b/ecl/hqlcpp/hqlecl.cpp
@@ -74,7 +74,7 @@ public:
     virtual bool generateExe(ICppCompiler * compiler);
     virtual bool generatePackage(const char * packageName);
     virtual void setMaxCompileThreads(unsigned value) { defaultMaxCompileThreads = value; }
-    virtual void setWebServiceInfo(IPropertyTree * webServiceInfo) { if (webServiceInfo) code->addWebServices(webServiceInfo); }
+    virtual void setManifestInfo(IPropertyTree * manifestInfo) { if (manifestInfo) code->addManifestInfo(manifestInfo); }
 
     virtual double getECLcomplexity(IHqlExpression * exprs);
     virtual void generateCppPrototypes(IHqlScope * scope);

--- a/ecl/hqlcpp/hqlecl.hpp
+++ b/ecl/hqlcpp/hqlecl.hpp
@@ -46,7 +46,7 @@ public:
     virtual bool generatePackage(const char * packageName) = 0;
     virtual bool processQuery(IHqlExpression * expr, EclGenerateTarget generateTarget) = 0;
     virtual void setMaxCompileThreads(unsigned max) = 0;
-    virtual void setWebServiceInfo(IPropertyTree * webServiceInfo) = 0;
+    virtual void setManifestInfo(IPropertyTree * manifestInfo) = 0;
     virtual void setSaveGeneratedFiles(bool value) = 0;
 };
 

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -5114,6 +5114,7 @@ void HqlCppTranslator::buildSetResultInfo(BuildCtx & ctx, IHqlExpression * origi
                 schema.append((unsigned)0);
                 result->setResultSchemaRaw(schema.length(), schema.toByteArray());
 
+                /*
                 StringBuffer xml;
                 {
                     XmlSchemaBuilder xmlbuilder(false);
@@ -5121,6 +5122,7 @@ void HqlCppTranslator::buildSetResultInfo(BuildCtx & ctx, IHqlExpression * origi
                     xmlbuilder.getXml(xml);
                 }
                 addSchemaResource(sequence, resultName.str(), xml.str());
+                */
             }
         }
     }
@@ -10380,23 +10382,28 @@ void HqlCppTranslator::addSchemaFields(IHqlExpression * record, MemoryBuffer &sc
 
 void HqlCppTranslator::addSchemaResource(int seq, const char * name, IHqlExpression * record)
 {
+    /*
     StringBuffer xml;
     getRecordXmlSchema(xml, record, true);
     addSchemaResource(seq, name, xml.str());
+    */
 }
 
 
 void HqlCppTranslator::addSchemaResource(int seq, const char * name, const char * schemaXml)
 {
+/*
     Owned<IPropertyTree> resultTree = createPTree("Result");
     resultTree->setPropInt("@sequence", seq);
     resultTree->setProp("@name", name);
     resultTree->addPropTree("xs:schema", createPTreeFromXMLString(schemaXml));
+
     IPropertyTree * web = code->ensureWebServiceInfo();
     IPropertyTree * schema = web->queryPropTree("SCHEMA");
     if (!schema)
         schema = web->addPropTree("SCHEMA", createPTree("SCHEMA"));
     schema->addPropTree("Result", resultTree.getClear());
+*/
 }
 
 
@@ -10422,7 +10429,7 @@ IWUResult * HqlCppTranslator::createDatasetResultSchema(IHqlExpression * sequenc
 
     SCMStringBuffer resultName;
     result->getResultName(resultName);
-    addSchemaResource(sequence, resultName.str(), record);
+    //addSchemaResource(sequence, resultName.str(), record);
 
     result->setResultSchemaRaw(schema.length(), schema.toByteArray());
     result->setResultScalar(false);


### PR DESCRIPTION
Both @ghalliday and @richardkchapman may want to review.

Note that hqlhtcpp.cpp has commented out code, it may not have been necessary, but 
I wanted to highlight that I didn't think that code (and maybe a bit more) was needed any more.

If agreed, I will delete.

---

Add eclcc command line support for adding arbitrary resources using a
manifest file.

Usage:

eclcc -manifest filename queryfile.ecl

The manifest can can contain both individual and composite resources.

The manifest file should contain xml of the following format:

&lt;manifest>
&nbsp;&nbsp;&lt;resource type="TYPENAME" filepath="path/file.ext"/>
&nbsp;&nbsp;&lt;resource type="TYPENAME">
&nbsp;&nbsp;&nbsp;&nbsp;&lt;resource type="TYPENAME" filepath="path/file.ext"/>
&nbsp;&nbsp;&lt;/resource>
&lt;/manifest>

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
