### PR TITLE
Fix missing include in sourcedoc.xml

### DIFF
--- a/roxie/sourcedoc.xml
+++ b/roxie/sourcedoc.xml
@@ -10,7 +10,6 @@
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="roxie/sourcedoc.xml" />
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="roxieclient/sourcedoc.xml" />
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="roxieclient/sourcedoc.xml" />
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="roxieconfig/sourcedoc.xml" />
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="roxiemem/sourcedoc.xml" />
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="roxiepipe/sourcedoc.xml" />
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="udplib/sourcedoc.xml" />


### PR DESCRIPTION
Delete the reference to the (deleted) directory roxie/roxieconfig

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
