### PR TITLE
fixes #113 Bug:#84024 Environment.conf added to remote install payload.

### DIFF
--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -80,6 +80,7 @@ createPayload(){
     fi
     cp -r ${PKG} ${REMOTE_INSTALL}
     cp -r ${CONFIG_DIR}/${ENV_XML_FILE} ${REMOTE_INSTALL}
+    cp -r ${CONFIG_DIR}/${ENV_CONF_FILE} ${REMOTE_INSTALL}
     cp -r ${INSTALL_DIR}/sbin/remote-install-engine.sh ${REMOTE_INSTALL}
     tar -zcvf remote_install.tgz ${REMOTE_INSTALL}/*
 	rm -rf ${REMOTE_INSTALL}

--- a/initfiles/sbin/remote-install-engine.sh.in
+++ b/initfiles/sbin/remote-install-engine.sh.in
@@ -173,6 +173,10 @@ if [ -e ${REMOTE_INSTALL}/${ENV_XML_FILE} ]; then
 	cp -r ${REMOTE_INSTALL}/${ENV_XML_FILE}  ${CONFIG_DIR}/${ENV_XML_FILE} 
 	chown hpcc:hpcc ${CONFIG_DIR}/${ENV_XML_FILE}
 fi
+if [ -e ${REMOTE_INSTALL}/${ENV_CONF_FILE} ]; then
+	cp -r ${REMOTE_INSTALL}/${ENV_CONF_FILE}  ${CONFIG_DIR}/${ENV_CONF_FILE}
+	chown hpcc:hpcc ${CONFIG_DIR}/${ENV_CONF_FILE}
+fi
 rm -rf ${REMOTE_INSTALL}
 rm -rf ~/remote_install.tgz
 exit 0


### PR DESCRIPTION
fixes #113 Bug:#84024 Environment.conf added to remote install payload and install.

environment.conf should be deployed to all nodes in a cluster when install-cluster.sh
is run because of the nature of the file having a chance to have changes needed
for a users cluster.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
