### PR TITLE
BUG:#111 Fix loopback problems with ftslave

### DIFF
--- a/common/remote/rmtspawn.cpp
+++ b/common/remote/rmtspawn.cpp
@@ -137,7 +137,7 @@ ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoin
 #if defined(_WIN32)
         //Run the program directly if it is being run on the local machine - so ssh doesn't need to be running...
         //Change once we have solved the problems with ssh etc. on windows?
-        if (childEP.isHost())
+        if (childEP.isLocal())
         {
             DWORD runcode;
             if (!invoke_program(cmd.str(), runcode, false))

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -575,7 +575,7 @@ void TransferServer::deserializeAction(MemoryBuffer & msg, unsigned action)
 {
     SocketEndpoint ep;
     ep.deserialize(msg);
-    if (!ep.isHost())
+    if (!ep.isLocal())
         assertex(!"Command transferred to the wrong computer!!!");
 
     srcFormat.deserialize(msg);


### PR DESCRIPTION
Changes the consistency check from isHost to isLocal to allow an
ftslave instance to be started on a loopback ip as well as the
real network ip

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
