### PR TITLE
fix #113 Bug #84034 - Force install-cluster.sh to deploy new keys.

### DIFF
--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -184,14 +184,19 @@ if [ ${NEW_KEY} -eq 1 ]; then
     generateKey
 fi
 
+createPayload;
+
 for IP in $IPS; do
     if ping -c 1 -w 5 -n $IP > /dev/null 2>&1; then
         echo "$IP: Host is alive."
-        CAN_SSH="`ssh -i /home/hpcc/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no hpcc@$IP exit > /dev/null 2>&1; echo $?`"
+        if [ ${NEW_KEY} -ne 1 ]; then
+            CAN_SSH="`ssh -i /home/hpcc/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no hpcc@$IP exit > /dev/null 2>&1; echo $?`"
+        else
+            CAN_SSH=255
+        fi
         if [ "$CAN_SSH" -eq 255 ]; then
             echo "$IP: Cannot SSH to host with key..";
             echo "$IP: Connecting with password.";
-			createPayload;
 			copyPayload $IP;
 			expandPayload $IP;
 			runPayload $IP;


### PR DESCRIPTION
When the newkey option was given to install-cluster.sh it was failing to install
the newkey to the head node because of the default keys allowing valid ssh.

Checking that a newkey is wanted and then forcing the keys to install on all
nodes was required.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
