### PR TITLE
Bug: 83861 Add more debugging/postmortem information to ESP log

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -584,6 +584,8 @@ bool EspHttpBinding::basicAuth(IEspContext* ctx)
         return authorized;
 
     m_secmgr->updateSettings(*user,securitySettings);
+
+    ctx->addTraceSummaryTimeStamp("basicAuth");
     return authorized;
 }
     

--- a/esp/bindings/http/platform/httpprot.cpp
+++ b/esp/bindings/http/platform/httpprot.cpp
@@ -423,31 +423,8 @@ CHttpThread::~CHttpThread()
 {
 }
 
-static atomic_t gActiveRequests;
-
-class ActiveRequests
-{
-public:
-    
-    ActiveRequests() { inc(); }
-    virtual ~ActiveRequests()  { dec(); }
-
-    void inc() 
-    {   
-        atomic_inc(&gActiveRequests);
-        DBGLOG("*** Active requests: %u ***", (int)atomic_read(&gActiveRequests)); 
-    }
-    
-    void dec() 
-    { 
-        atomic_dec(&gActiveRequests);
-        DBGLOG("*** Active requests: %u ***", (int)atomic_read(&gActiveRequests)); 
-    }
-};
-
 bool CHttpThread::onRequest()
 {
-    EspTimeSection timing("CHttpThread::onRequest()");
     ActiveRequests recording;
 
     Owned<CEspHttpServer> httpserver;
@@ -491,8 +468,7 @@ bool CHttpThread::onRequest()
     time_t t = time(NULL);  
     initThreadLocal(sizeof(t), &t);
 
-    if (httpserver->processRequest()==-1)
-        timing.clear();
+    httpserver->processRequest();
     clearThreadLocal();
     
     return false;

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -27,6 +27,7 @@
 //Jlib
 #include "jliball.hpp"
 
+#include "espcontext.hpp"
 #include "esphttp.hpp"
 
 //ESP Bindings
@@ -35,16 +36,15 @@
 
 #include "htmlpage.hpp"
 
-
 /***************************************************************************
  *              CEspHttpServer Implementation
  ***************************************************************************/
 CEspHttpServer::CEspHttpServer(ISocket& sock, bool viewConfig, int maxRequestEntityLength):m_socket(sock), m_MaxRequestEntityLength(maxRequestEntityLength)
 {
+    IEspContext* ctx = createEspContext();
     m_request.setown(new CHttpRequest(sock));
     m_request->setMaxRequestEntityLength(maxRequestEntityLength);
     m_response.setown(new CHttpResponse(sock));
-    IEspContext* ctx = createEspContext();
     m_request->setOwnContext(ctx);
     m_response->setOwnContext(LINK(ctx));
     m_viewConfig=viewConfig;
@@ -52,10 +52,10 @@ CEspHttpServer::CEspHttpServer(ISocket& sock, bool viewConfig, int maxRequestEnt
 
 CEspHttpServer::CEspHttpServer(ISocket& sock, CEspApplicationPort* apport, bool viewConfig, int maxRequestEntityLength):m_socket(sock), m_MaxRequestEntityLength(maxRequestEntityLength)
 {
+    IEspContext* ctx = createEspContext();
     m_request.setown(new CHttpRequest(sock));
     m_request->setMaxRequestEntityLength(maxRequestEntityLength);
     m_response.setown(new CHttpResponse(sock));
-    IEspContext* ctx = createEspContext();
     m_request->setOwnContext(ctx);
     m_response->setOwnContext(LINK(ctx));
     m_apport = apport;
@@ -68,6 +68,66 @@ CEspHttpServer::~CEspHttpServer()
 {
     try
     {
+        IEspContext* ctx = m_request->queryContext();
+        if (ctx)
+        {
+            //Request is logged only when there is an exception or the request time is very long.
+            //If the flag of 'EspLogRequests' is set or the log level > LogNormal, the Request should
+            //has been logged and it should not be logged here.
+            ctx->setProcessingTime();
+            if ((ctx->queryHasException() || (ctx->queryProcessingTime() > getSlowProcessingTime())) &&
+                !getEspLogRequests() && (getEspLogLevel() <= LogNormal))
+            {
+                StringBuffer logStr;
+                logStr.appendf("%s %s", m_request->queryMethod(), m_request->queryPath());
+
+                const char* paramStr = m_request->queryParamStr();
+                if (paramStr && *paramStr)
+                    logStr.appendf("?%s", paramStr);
+
+                if (m_request->isSoapMessage())
+                {
+                    StringBuffer requestStr;
+                    m_request->getContent(requestStr);
+
+                    if (requestStr.length() > 0)
+                    {
+                        bool trimSpace = true;
+                        StringBuffer requestBuf;
+                        const char* s = requestStr.str();
+                        while (s && *s)
+                        {
+                            if ((s[0] != '\r') && (s[0] != '\n'))
+                            {
+                                if (s[0] != ' ')
+                                {
+                                    requestBuf.append(s[0]);
+                                    trimSpace = false;
+                                }
+                                else if (!trimSpace)
+                                {
+                                    requestBuf.append(s[0]);
+                                }
+                            }
+                            else
+                            {
+                                trimSpace = true;
+                            }
+
+                            s++;
+                        }
+
+                        if (requestBuf.length() > 0)
+                        {
+                            logStr.newline();
+                            logStr.append(requestBuf.str());
+                        }
+                    }
+                }
+                DBGLOG("Request[%s]", logStr.str());
+            }
+        }
+
         m_request.clear();
         m_response.clear();
     }
@@ -402,6 +462,7 @@ int CEspHttpServer::processRequest()
                 else
                     unsupported();
             }
+            ctx->addTraceSummaryTimeStamp("handleHttp");
         }
     }
     catch(IEspHttpException* e)

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -498,6 +498,7 @@ int CHttpMessage::receive(bool alwaysReadContent, IMultiException *me)
     if (isUpload())
         return 0;
 
+    m_context->addTraceSummaryValue("contLen", m_content_length);
     if(m_content_length > 0)
     {
         readContent();
@@ -1451,6 +1452,7 @@ int CHttpRequest::receive(IMultiException *me)
         }
     }
 
+    m_context->addTraceSummaryTimeStamp("rcv");
     return 0;
 }
 

--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -137,6 +137,7 @@ CEspConfig::CEspConfig(IProperties* inputs, IPropertyTree* envpt, IPropertyTree*
     m_options.logReq = m_cfg->getPropBool("@logRequests", false);
     m_options.logResp = m_cfg->getPropBool("@logResponses", false);
     m_options.frameTitle.set(m_cfg->queryProp("@name"));
+    m_options.slowProcessingTime = m_cfg->getPropInt("@slowProcessingTime", 30) * 1000; //in msec
 
 #ifdef USE_ENV_CONF_FILE
     // load environment parameters

--- a/esp/platform/espcfg.ipp
+++ b/esp/platform/espcfg.ipp
@@ -91,8 +91,9 @@ struct esp_option
     bool logReq;
     bool logResp;
     StringAttr frameTitle;
+    unsigned slowProcessingTime; //default 30 seconds
 
-    esp_option() : logReq(false), logResp(false), logLevel(1) 
+    esp_option() : logReq(false), logResp(false), logLevel(1), slowProcessingTime(30000)
     { }
 };
 

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -50,6 +50,7 @@ ESPHTTP_API LogLevel getEspLogLevel(IEspContext* );
 ESPHTTP_API LogLevel getEspLogLevel();
 ESPHTTP_API bool getEspLogRequests();
 ESPHTTP_API bool getEspLogResponses();
+ESPHTTP_API unsigned getSlowProcessingTime();
 
 ESPHTTP_API void ESPLOG(IEspContext* ctx, LogLevel level, const char* fmt, ...);
 ESPHTTP_API void ESPLOG(LogLevel level, const char* fmt, ...);

--- a/esp/platform/espp.hpp
+++ b/esp/platform/espp.hpp
@@ -57,6 +57,7 @@ private:
     LogLevel m_logLevel;
     bool m_logReq;
     bool m_logResp;
+    unsigned m_slowProcessingTime;
     StringAttr m_frameTitle;
     Mutex abortMutex;
     bool m_SEHMappingEnabled;
@@ -76,6 +77,7 @@ public:
         m_logLevel = config->m_options.logLevel;
         m_logReq = config->m_options.logReq;
         m_logResp = config->m_options.logResp;
+        m_slowProcessingTime = config->m_options.slowProcessingTime;
         m_frameTitle.set(config->m_options.frameTitle);
         m_SEHMappingEnabled = false;
     }
@@ -148,6 +150,7 @@ public:
     bool getLogResponses() { return m_logResp; }
     void setFrameTitle(const char* title)  { m_frameTitle.set(title); }
     const char* getFrameTitle()  { return m_frameTitle.get(); }
+    unsigned getSlowProcessingTime() { return m_slowProcessingTime; }
 
     void log(LogLevel level, const char* fmt, ...)
     {

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -30,6 +30,22 @@
 
 typedef IXslProcessor * (*getXslProcessor_func)();
 
+static atomic_t gActiveRequests;
+
+long ActiveRequests::getCount()
+{
+    return atomic_read(&gActiveRequests);
+}
+
+void ActiveRequests::inc()
+{
+    atomic_inc(&gActiveRequests);
+}
+
+void ActiveRequests::dec()
+{
+    atomic_dec(&gActiveRequests);
+}
 
 CEspApplicationPort::CEspApplicationPort(bool viewcfg) : bindingCount(0), defBinding(-1), viewConfig(viewcfg), rootAuth(false), navWidth(165), navResize(false), navScroll(false)
 {

--- a/esp/platform/espprotocol.hpp
+++ b/esp/platform/espprotocol.hpp
@@ -32,6 +32,19 @@
 #include <map>
 using namespace std;
 
+class ActiveRequests
+{
+public:
+
+    ActiveRequests() { inc(); }
+    ~ActiveRequests()  { dec(); }
+
+    void inc();
+    void dec();
+
+    static long getCount();
+};
+
 class CEspBindingEntry : public CInterface
 {
 private:

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -157,6 +157,13 @@ interface IEspContext : extends IInterface
 
     virtual void setServiceName(const char *name)=0;
     virtual const char * queryServiceName(const char *name)=0;
+    virtual void setCreationTime()=0;
+    virtual const unsigned queryCreationTime()=0;
+    virtual void setProcessingTime()=0;
+    virtual const unsigned queryProcessingTime()=0;
+    virtual void setException(int exceptionCode)=0;
+    virtual const bool queryException(int& exceptionCode, unsigned& exceptionTime)=0;
+    virtual const bool queryHasException()=0;
 
     virtual IProperties *   queryRequestParameters()=0;
     virtual void            setRequestParameters(IProperties * Parameters)=0;
@@ -184,6 +191,11 @@ interface IEspContext : extends IInterface
     
     virtual StringArray& queryCustomHeaders() = 0;
     virtual void addCustomerHeader(const char* name, const char* val) = 0;
+
+    virtual void addTraceSummaryValue(const char *name, const char *value)=0;
+    virtual void addTraceSummaryValue(const char *name, int value)=0;
+    virtual void addTraceSummaryTimeStamp(const char *name)=0;
+    virtual void flushTraceSummary()=0;
 };
 
 
@@ -200,6 +212,7 @@ interface IEspContainer : extends IInterface
     virtual LogLevel getLogLevel() = 0;
     virtual bool getLogRequests() = 0;
     virtual bool getLogResponses() = 0;
+    virtual unsigned getSlowProcessingTime() = 0;
     virtual void log(LogLevel level, const char*,...) = 0;
     virtual void setFrameTitle(const char* title) = 0;
     virtual const char* getFrameTitle() = 0;

--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -78,7 +78,7 @@ bool Cws_accountEx::onVerifyUser(IEspContext &context, IEspVerifyUserRequest &re
     }
     catch(IException* e)
     {
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -172,7 +172,7 @@ bool CWsDfuEx::onDFUSearch(IEspContext &context, IEspDFUSearchRequest & req, IEs
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -282,7 +282,7 @@ bool CWsDfuEx::onDFUQuery(IEspContext &context, IEspDFUQueryRequest & req, IEspD
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -318,7 +318,7 @@ bool CWsDfuEx::onDFUInfo(IEspContext &context, IEspDFUInfoRequest &req, IEspDFUI
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -553,7 +553,7 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1139,7 +1139,7 @@ bool CWsDfuEx::onAddtoSuperfile(IEspContext &context, IEspAddtoSuperfileRequest 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1402,40 +1402,34 @@ bool CWsDfuEx::onDFUArrayAction(IEspContext &context, IEspDFUArrayActionRequest 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
 
 bool CWsDfuEx::onDFUAction(IUserDescriptor* udesc, const char* LogicalFileName, const char* ClusterName,const char* ActionType,bool nodelete, StringBuffer& returnStr)
 {
-    try
+    //No 'try/catch' is needed for this method since it will be called internally.
+    if (strcmp(Action_Delete ,ActionType) == 0)
     {
-        if (strcmp(Action_Delete ,ActionType) == 0)
-        {
-            LogicFileWrapper Logicfile;
-            if (!Logicfile.doDeleteFile(LogicalFileName,ClusterName,nodelete, returnStr, udesc))
-                return false;
-        }
-        else if (strcmp(Action_AddtoSuperfile ,ActionType) == 0)
-        {
-            Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(LogicalFileName, udesc, true);  
-            if (df)
-            {
-                if (returnStr.length() > 0)
-                    returnStr.appendf(",%s", LogicalFileName);
-                else
-                    returnStr.appendf("%s", LogicalFileName);
-                return false;
-            }
-        }
-        else
-            DBGLOG("Unknown Action type:%s\n",ActionType);
+        LogicFileWrapper Logicfile;
+        if (!Logicfile.doDeleteFile(LogicalFileName,ClusterName,nodelete, returnStr, udesc))
+            return false;
     }
-    catch(IException* e)
-    {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+    else if (strcmp(Action_AddtoSuperfile ,ActionType) == 0)
+    {
+        Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(LogicalFileName, udesc, true);
+        if (df)
+        {
+            if (returnStr.length() > 0)
+                returnStr.appendf(",%s", LogicalFileName);
+            else
+                returnStr.appendf("%s", LogicalFileName);
+            return false;
+        }
     }
+    else
+        DBGLOG("Unknown Action type:%s\n",ActionType);
     
     return true;
 }
@@ -1484,7 +1478,7 @@ bool CWsDfuEx::onDFUDefFile(IEspContext &context,IEspDFUDefFileRequest &req, IEs
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -2131,7 +2125,7 @@ bool CWsDfuEx::onDFUFileView(IEspContext &context, IEspDFUFileViewRequest &req, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3034,7 +3028,7 @@ bool CWsDfuEx::onSuperfileList(IEspContext &context, IEspSuperfileListRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3093,7 +3087,7 @@ bool CWsDfuEx::onSuperfileAction(IEspContext &context, IEspSuperfileActionReques
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3153,7 +3147,7 @@ bool CWsDfuEx::onSuperfileAddRaw(IEspContext &context, IEspSuperfileAddRawReques
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3182,7 +3176,7 @@ bool CWsDfuEx::onSavexml(IEspContext &context, IEspSavexmlRequest &req, IEspSave
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3207,7 +3201,7 @@ bool CWsDfuEx::onAdd(IEspContext &context, IEspAddRequest &req, IEspAddResponse 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3251,7 +3245,7 @@ bool CWsDfuEx::onAddRemote(IEspContext &context, IEspAddRemoteRequest &req, IEsp
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3727,7 +3721,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3901,7 +3895,7 @@ bool CWsDfuEx::onDFUSearchData(IEspContext &context, IEspDFUSearchDataRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -4338,7 +4332,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }

--- a/esp/services/ws_dfu/ws_dfuXRefService.cpp
+++ b/esp/services/ws_dfu/ws_dfuXRefService.cpp
@@ -159,7 +159,7 @@ bool CWsDfuXRefEx::onDFUXRefArrayAction(IEspContext &context, IEspDFUXRefArrayAc
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -200,7 +200,7 @@ bool CWsDfuXRefEx::onDFUXRefLostFiles(IEspContext &context, IEspDFUXRefLostFiles
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -229,7 +229,7 @@ bool CWsDfuXRefEx::onDFUXRefFoundFiles(IEspContext &context, IEspDFUXRefFoundFil
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -258,7 +258,7 @@ bool CWsDfuXRefEx::onDFUXRefOrphanFiles(IEspContext &context, IEspDFUXRefOrphanF
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -286,7 +286,7 @@ bool CWsDfuXRefEx::onDFUXRefMessages(IEspContext &context, IEspDFUXRefMessagesQu
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -315,7 +315,7 @@ bool CWsDfuXRefEx::onDFUXRefCleanDirectories(IEspContext &context, IEspDFUXRefCl
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -386,7 +386,7 @@ bool CWsDfuXRefEx::onDFUXRefDirectories(IEspContext &context, IEspDFUXRefDirecto
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -424,7 +424,7 @@ bool CWsDfuXRefEx::onDFUXRefBuild(IEspContext &context, IEspDFUXRefBuildRequest 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -447,7 +447,7 @@ bool CWsDfuXRefEx::onDFUXRefBuildCancel(IEspContext &context, IEspDFUXRefBuildCa
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -503,7 +503,7 @@ bool CWsDfuXRefEx::onDFUXRefList(IEspContext &context, IEspDFUXRefListRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -452,7 +452,7 @@ void CFileSpraySoapBindingEx::downloadFile(IEspContext &context, CHttpRequest* r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return;
 }

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -581,7 +581,7 @@ bool CFileSprayEx::onDFUWUSearch(IEspContext &context, IEspDFUWUSearchRequest & 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1054,7 +1054,7 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1243,7 +1243,7 @@ bool CFileSprayEx::onGetDFUWorkunit(IEspContext &context, IEspGetDFUWorkunit &re
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1292,7 +1292,7 @@ bool CFileSprayEx::onGetDFUProgress(IEspContext &context, IEspProgressRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1320,7 +1320,7 @@ bool CFileSprayEx::onCreateDFUWorkunit(IEspContext &context, IEspCreateDFUWorkun
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1347,7 +1347,7 @@ bool CFileSprayEx::onUpdateDFUWorkunit(IEspContext &context, IEspUpdateDFUWorkun
 
             prog->setState((enum DFUstate)reqWU.getState());
         }
-        
+
         const char* clusterOrig = req.getClusterOrig();
         const char* cluster = reqWU.getClusterName();
         if(cluster && (!clusterOrig || stricmp(clusterOrig, cluster)))
@@ -1371,7 +1371,7 @@ bool CFileSprayEx::onUpdateDFUWorkunit(IEspContext &context, IEspUpdateDFUWorkun
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1416,7 +1416,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                 res->setID(wuids.item(i));
                 res->setAction("Delete");
                 res->setResult("Success");
-                
+
                 try
                 {
                     if (markWUFailed(factory, wuids.item(i)))
@@ -1462,14 +1462,14 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
             Owned<ISashaCommand> cmd = createSashaCommand();
             cmd->setAction(SCA_RESTORE);
             cmd->setDFU(true);  
-            
+
             StringArray & wuids = req.getWuids();
             for(unsigned ii = 0; ii < wuids.ordinality(); ++ii)
             {
                 StringBuffer msg;
                 const char *wuid = wuids.item(ii);
                 cmd->addId(wuid);
-                
+
                 if (!cmd->send(node,1*60*1000)) 
                 {
                     throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,"Cannot connect to archive server at %s.",sashaAddress.str());
@@ -1491,7 +1491,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                 res->setID(wuid);
                 res->setAction("Restore");
                 res->setResult(msg.str());
-                
+
                 results.append(*LINK(res.getClear()));
             }
         }
@@ -1505,7 +1505,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                 res->setID(wuids.item(i));
                 res->setAction("Protect");
                 res->setResult("Success");
-                
+
                 try
                 {
                     Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
@@ -1541,7 +1541,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                 res->setID(wuids.item(i));
                 res->setAction("Unprotect");
                 res->setResult("Success");
-                
+
                 try
                 {
                     Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
@@ -1622,7 +1622,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1646,7 +1646,7 @@ bool CFileSprayEx::onDeleteDFUWorkunits(IEspContext &context, IEspDeleteDFUWorku
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1658,7 +1658,7 @@ bool CFileSprayEx::onDeleteDFUWorkunit(IEspContext &context, IEspDeleteDFUWorkun
     {
         if (!context.validateFeatureAccess(DFU_WU_URL, SecAccess_Write, false))
             throw MakeStringException(ECLWATCH_DFU_WU_ACCESS_DENIED, "Failed to delete DFU workunit. Permission denied.");
-        
+
         Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
         if (markWUFailed(factory, req.getWuid()))
             resp.setResult(factory->deleteWorkUnit(req.getWuid()));
@@ -1669,7 +1669,7 @@ bool CFileSprayEx::onDeleteDFUWorkunit(IEspContext &context, IEspDeleteDFUWorkun
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1692,7 +1692,7 @@ bool CFileSprayEx::onSubmitDFUWorkunit(IEspContext &context, IEspSubmitDFUWorkun
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1715,7 +1715,7 @@ bool CFileSprayEx::onAbortDFUWorkunit(IEspContext &context, IEspAbortDFUWorkunit
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1751,7 +1751,7 @@ bool CFileSprayEx::onGetDFUExceptions(IEspContext &context, IEspGetDFUExceptions
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1843,27 +1843,27 @@ bool CFileSprayEx::onSprayFixed(IEspContext &context, IEspSprayFixed &req, IEspS
         if(recordsize > 0)
             source->setRecordSize(recordsize);
         else if (recordsize == RECFMVB_RECSIZE_ESCAPE) {
-            source->setFormat(DFUff_recfmvb);       
-            destination->setFormat(DFUff_variable);     
+            source->setFormat(DFUff_recfmvb);
+            destination->setFormat(DFUff_variable);
         }
         else if (recordsize == RECFMV_RECSIZE_ESCAPE) {
-            source->setFormat(DFUff_recfmv);        
-            destination->setFormat(DFUff_variable);     
+            source->setFormat(DFUff_recfmv);
+            destination->setFormat(DFUff_variable);
         }
         else if (recordsize == PREFIX_VARIABLE_RECSIZE_ESCAPE) {
-            source->setFormat(DFUff_variable);      
-            destination->setFormat(DFUff_variable);     
+            source->setFormat(DFUff_variable);
+            destination->setFormat(DFUff_variable);
         }
         else if (recordsize == PREFIX_VARIABLE_BIGENDIAN_RECSIZE_ESCAPE) {
-            source->setFormat(DFUff_variablebigendian);     
-            destination->setFormat(DFUff_variable);     
+            source->setFormat(DFUff_variablebigendian);
+            destination->setFormat(DFUff_variable);
         }
         destination->setLogicalName(destname);
         destination->setDirectory(destFolder.str());
 
         StringBuffer fileMask;
         constructFileMask(destTitle.str(), fileMask);
-        destination->setFileMask(fileMask.str()); 
+        destination->setFileMask(fileMask.str());
         destination->setGroupName(gName.str());
         const char * encryptkey = req.getEncrypt();
         if(req.getCompress()||(encryptkey&&*encryptkey))
@@ -1914,7 +1914,7 @@ bool CFileSprayEx::onSprayFixed(IEspContext &context, IEspSprayFixed &req, IEspS
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1999,7 +1999,7 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
         }
         source->setMaxRecordSize(req.getSourceMaxRecordSize());
         source->setFormat((DFUfileformat)req.getSourceFormat());
-        
+
         // if rowTag specified, it means it's xml format, otherwise it's csv
         const char* rowtag = req.getSourceRowTag();
         if(rowtag != NULL && *rowtag != '\0')
@@ -2070,7 +2070,7 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -2119,7 +2119,7 @@ bool CFileSprayEx::onReplicate(IEspContext &context, IEspReplicate &req, IEspRep
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -2179,12 +2179,12 @@ bool CFileSprayEx::onDespray(IEspContext &context, IEspDespray &req, IEspDespray
         {
             dstxml.append('\0');
             destination->setFromXML((const char*)dstxml.toByteArray());
-        }   
+        }
         destination->setTitle(srcTitle.str());
 
         options->setKeepHeader(true);
         options->setOverwrite(req.getOverwrite());             // needed if target already exists
-        
+
         const char* splitprefix = req.getSplitprefix();
         if(splitprefix && *splitprefix)
             options->setSplitPrefix(splitprefix);
@@ -2215,7 +2215,7 @@ bool CFileSprayEx::onDespray(IEspContext &context, IEspDespray &req, IEspDespray
             options->setPush();             // I think needed for a despray
             destination->setWrap(true);
         }
-        if (req.getMultiCopy()) 
+        if (req.getMultiCopy())
             destination->setMultiCopy(true);
 
         const char * encryptkey = req.getEncrypt();
@@ -2229,19 +2229,19 @@ bool CFileSprayEx::onDespray(IEspContext &context, IEspDespray &req, IEspDespray
         resp.setWuid(wu->queryId());
 
         wu->submit();                            // enqueue job(does implicit commit)
-         resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());
+        resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
 }
 
 bool CFileSprayEx::doCopyForRoxie(IEspContext &context,     const char * srcName, const char * srcDali, const char * srcUser, const char * srcPassword,
-    const char * dstName, const char * destCluster, bool compressed, bool overwrite, bool supercopy,
-    DFUclusterPartDiskMapping val, StringBuffer baseDir, StringBuffer fileMask, IEspCopyResponse &resp)
+                                  const char * dstName, const char * destCluster, bool compressed, bool overwrite, bool supercopy,
+                                  DFUclusterPartDiskMapping val, StringBuffer baseDir, StringBuffer fileMask, IEspCopyResponse &resp)
 {
     StringBuffer user, passwd;
     Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
@@ -2318,7 +2318,7 @@ bool CFileSprayEx::doCopyForRoxie(IEspContext &context,     const char * srcName
 
         options->setSuppressNonKeyRepeats(true);                            // **** only repeat last part when src kind = key
     }
-    
+
     resp.setResult(wu->queryId());
     wu->submit();                            // enqueue job(does implicit commit)
     resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());
@@ -2338,7 +2338,7 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "Source logical file not specified.");
         if(!dstname || !*dstname)
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "Destination logical file not specified.");
-        
+
         StringBuffer destFolder, destTitle, defaultFolder, defaultReplicateFolder;
         StringBuffer srcCluster, destCluster, destClusterName;
         bool bRoxie = false;
@@ -2437,9 +2437,9 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
         IDFUfileSpec *source = wu->queryUpdateSource();
         IDFUfileSpec *destination = wu->queryUpdateDestination();
         IDFUoptions *options = wu->queryUpdateOptions();
-        
-        if (supercopy)  
-            wu->setCommand(DFUcmd_supercopy);   
+
+        if (supercopy)
+            wu->setCommand(DFUcmd_supercopy);
         else
             wu->setCommand(DFUcmd_copy);
 
@@ -2470,13 +2470,13 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
                 destination->setReplicateOffset(offset);
             }
         }
-            
+
         if (srcDiffKeyName&&*srcDiffKeyName)
             source->setDiffKey(srcDiffKeyName);
         if (destDiffKeyName&&*destDiffKeyName)
             destination->setDiffKey(destDiffKeyName);
 
-        if (!bRoxie) 
+        if (!bRoxie)
         {
             destination->setDirectory(destFolder.str());
             ClusterPartDiskMapSpec mspec;
@@ -2493,7 +2493,7 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
         if(req.getCompress()||(encryptkey&&*encryptkey))
             destination->setCompressed(true);
 
-        if (!bRoxie) 
+        if (!bRoxie)
         {
             options->setReplicate(req.getReplicate());
             destination->setWrap(req.getWrap());
@@ -2530,8 +2530,8 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
         resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());
     }
     catch(IException* e)
-    {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -2573,7 +2573,7 @@ bool CFileSprayEx::onRename(IEspContext &context, IEspRename &req, IEspRenameRes
             Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(srcname, udesc);
             if(df)
             {
-                StringBuffer cluster0; 
+                StringBuffer cluster0;
                 df->getClusterName(0,cluster0);                     // TBD - Handling for multiple clusters?
                 if (cluster0.length()!=0)
                 {
@@ -2603,8 +2603,8 @@ bool CFileSprayEx::onRename(IEspContext &context, IEspRename &req, IEspRenameRes
         resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());
     }
     catch(IException* e)
-    {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -2643,8 +2643,8 @@ bool CFileSprayEx::onDFUWUFile(IEspContext &context, IEspDFUWUFileRequest &req, 
         }
     }
     catch(IException* e)
-    {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -2664,7 +2664,7 @@ int CFileSprayEx::doFileCheck(const char* mask, const char* netaddr, const char*
         iRet = 2;
 
         Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-       factory->validateCache();
+        factory->validateCache();
         Owned<IConstEnvironment> env = factory->openEnvironmentByFile();
         Owned<IPropertyTree> pEnvRoot = &env->getPTree();
         IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
@@ -2683,7 +2683,7 @@ int CFileSprayEx::doFileCheck(const char* mask, const char* netaddr, const char*
                 xpath.appendf("Hardware/Computer[@name='%s']/@netAddress", pszComputer);
                 const char* pszNetAddr = pEnvRoot->queryProp(xpath.str());
                 if (strcmp(pszNetAddr, "."))
-                {       
+                {
                     sNetAddr.append(pszNetAddr);
                 }
                 else
@@ -2781,7 +2781,7 @@ bool CFileSprayEx::onFileList(IEspContext &context, IEspFileListRequest &req, IE
         Owned<IDirectoryIterator> di = f->directoryFiles(NULL, false, true);
         if(di.get() != NULL)
         {
-            ForEach(*di) 
+            ForEach(*di)
             {
                 StringBuffer fname;
                 di->getName(fname);
@@ -2805,7 +2805,7 @@ bool CFileSprayEx::onFileList(IEspContext &context, IEspFileListRequest &req, IE
                 files.append(*onefile.getLink());
             }
         }
-        
+
         sPath.replace('\\', '/');//XSLT cannot handle backslashes
         resp.setPath(sPath);
         resp.setFiles(files);
@@ -2822,8 +2822,8 @@ bool CFileSprayEx::onFileList(IEspContext &context, IEspFileListRequest &req, IE
         resp.setDirectoryOnly(directoryOnly);
     }
     catch(IException* e)
-    {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -2868,7 +2868,7 @@ bool CFileSprayEx::onDfuMonitor(IEspContext &context, IEspDfuMonitorRequest &req
             else
                 throw MakeStringException(ECLWATCH_INVALID_INPUT, "Neither logical name nor network ip/file specified for monitor.");
         }
-        if (eventname) 
+        if (eventname)
             monitor->setEventName(eventname);
         monitor->setShotLimit(req.getShotLimit());
         monitor->setSub(req.getSub());
@@ -2880,8 +2880,8 @@ bool CFileSprayEx::onDfuMonitor(IEspContext &context, IEspDfuMonitorRequest &req
         resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());
     }
     catch(IException* e)
-    {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -2915,15 +2915,15 @@ bool CFileSprayEx::onOpenSave(IEspContext &context, IEspOpenSaveRequest &req, IE
             resp.setViewable(false);
     }
     catch(IException* e)
-    {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
 }
 
 bool CFileSprayEx::getDropZoneFiles(IEspContext &context, const char* netaddr, const char* osStr, const char* path,
-                                                IEspDropZoneFilesRequest &req, IEspDropZoneFilesResponse &resp)
+                                    IEspDropZoneFilesRequest &req, IEspDropZoneFilesResponse &resp)
 {
     bool directoryOnly = req.getDirectoryOnly();
 
@@ -2950,7 +2950,7 @@ bool CFileSprayEx::getDropZoneFiles(IEspContext &context, const char* netaddr, c
     Owned<IDirectoryIterator> di = f->directoryFiles(NULL, false, true);
     if(di.get() != NULL)
     {
-        ForEach(*di) 
+        ForEach(*di)
         {
             StringBuffer fname;
             di->getName(fname);
@@ -2974,7 +2974,7 @@ bool CFileSprayEx::getDropZoneFiles(IEspContext &context, const char* netaddr, c
             files.append(*onefile.getLink());
         }
     }
-    
+
     resp.setFiles(files);
 
     return true;
@@ -3023,7 +3023,7 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
                 StringBuffer sNetAddr;
                 const char* pszNetAddr = pEnvRoot->queryProp(xpath.str());
                 if (strcmp(pszNetAddr, "."))
-                {       
+                {
                     sNetAddr.append(pszNetAddr);
                 }
                 else
@@ -3054,17 +3054,17 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
                 StringBuffer dir;
                 pDropZone.getProp("@directory", dir);
 
-            Owned<IEspDropZone> aDropZone= createDropZone("","");
+                Owned<IEspDropZone> aDropZone= createDropZone("","");
 
                 if (machine)
                 {
                     if (machine->getOS() == MachineOsLinux || machine->getOS() == MachineOsSolaris)
-                    {         
+                    {
                         dir.replace('\\', '/');//replace all '\\' by '/'
                         aDropZone->setLinux("true");
                     }
                     else
-                    {       
+                    {
                         dir.replace('/', '\\');
                         dir.replace('$', ':');
                     }
@@ -3100,7 +3100,7 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
         }
 
         directoryStr.replace(pathSep=='\\'?'/':'\\', pathSep);
-        
+
         if (subfolder && *subfolder)
         {
             if (*(directoryStr.str() + directoryStr.length() -1) != pathSep)
@@ -3116,14 +3116,14 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
 
         if (pathSep=='\\')
             directoryStr.replaceString("\\", "\\\\");
-        
+
         resp.setNetAddress(netAddressStr.str());
         resp.setPath(directoryStr.str());
         resp.setOS(atoi(osStr.str()));
     }
     catch(IException* e)
-    {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -3190,7 +3190,7 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
             res->setID(files.item(i));
             res->setAction("Delete");
             res->setResult("Success");
-            
+
             try
             {
                 StringBuffer fileToDelete = sPath;
@@ -3225,7 +3225,7 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -441,7 +441,7 @@ bool Cws_machineEx::onGetMachineInfo(IEspContext &context, IEspGetMachineInfoReq
     }
     catch(IException* e)
     {
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 #ifdef DETECT_WS_MC_MEM_LEAKS
     DBGLOG("Allocated=%d", setAllocHook(false));
@@ -481,7 +481,7 @@ bool Cws_machineEx::onGetMachineInfoEx(IEspContext &context, IEspGetMachineInfoR
     }
     catch(IException* e)
     {
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 
@@ -2803,7 +2803,7 @@ bool Cws_machineEx::onGetTargetClusterInfo(IEspContext &context, IEspGetTargetCl
     }
     catch(IException* e)
     {
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 #ifdef DETECT_WS_MC_MEM_LEAKS
     DBGLOG("Allocated=%d", setAllocHook(false));

--- a/esp/services/ws_machine/ws_machineServiceMetrics.cpp
+++ b/esp/services/ws_machine/ws_machineServiceMetrics.cpp
@@ -790,7 +790,7 @@ bool Cws_machineEx::onGetMetrics(IEspContext &context, IEspMetricsRequest &req,
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }

--- a/esp/services/ws_machine/ws_machineServiceRexec.cpp
+++ b/esp/services/ws_machine/ws_machineServiceRexec.cpp
@@ -791,7 +791,7 @@ bool Cws_machineEx::onStartStop( IEspContext &context, IEspStartStopRequest &req
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -881,7 +881,7 @@ bool Cws_machineEx::onStartStopBegin( IEspContext &context, IEspStartStopBeginRe
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -944,7 +944,7 @@ bool Cws_machineEx::onStartStopDone( IEspContext &context, IEspStartStopDoneRequ
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }

--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
@@ -255,7 +255,7 @@ bool CWsRoxieQueryEx::onRoxieQuerySearch(IEspContext &context, IEspRoxieQuerySea
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -522,7 +522,7 @@ bool CWsRoxieQueryEx::onRoxieQueryList(IEspContext &context, IEspRoxieQueryListR
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -632,7 +632,7 @@ bool CWsRoxieQueryEx::onQueryDetails(IEspContext &context, IEspRoxieQueryDetails
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -895,7 +895,7 @@ if (buf.length() > 0)
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -951,7 +951,7 @@ bool CWsSMCEx::onMoveJobDown(IEspContext &context, IEspSMCJobRequest &req, IEspS
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -978,7 +978,7 @@ bool CWsSMCEx::onMoveJobUp(IEspContext &context, IEspSMCJobRequest &req, IEspSMC
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1023,7 +1023,7 @@ bool CWsSMCEx::onMoveJobBack(IEspContext &context, IEspSMCJobRequest &req, IEspS
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1068,7 +1068,7 @@ bool CWsSMCEx::onMoveJobFront(IEspContext &context, IEspSMCJobRequest &req, IEsp
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1096,7 +1096,7 @@ bool CWsSMCEx::onRemoveJob(IEspContext &context, IEspSMCJobRequest &req, IEspSMC
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1113,7 +1113,7 @@ bool CWsSMCEx::onStopQueue(IEspContext &context, IEspSMCQueueRequest &req, IEspS
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1130,7 +1130,7 @@ bool CWsSMCEx::onResumeQueue(IEspContext &context, IEspSMCQueueRequest &req, IEs
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1147,7 +1147,7 @@ bool CWsSMCEx::onPauseQueue(IEspContext &context, IEspSMCQueueRequest &req, IEsp
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1169,7 +1169,7 @@ bool CWsSMCEx::onClearQueue(IEspContext &context, IEspSMCQueueRequest &req, IEsp
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1198,7 +1198,7 @@ bool CWsSMCEx::onSetJobPriority(IEspContext &context, IEspSMCPriorityRequest &re
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1246,7 +1246,7 @@ bool CWsSMCEx::onGetThorQueueAvailability(IEspContext &context, IEspGetThorQueue
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1323,7 +1323,7 @@ bool CWsSMCEx::onSetBanner(IEspContext &context, IEspSetBannerRequest &req, IEsp
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1482,7 +1482,7 @@ bool CWsSMCEx::onBrowseResources(IEspContext &context, IEspBrowseResourcesReques
     }
     catch(IException* e)
     {
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -1523,7 +1523,7 @@ int CWsSMCSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* request, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return onGetForm(context, request, response, service, method);
 }

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -128,7 +128,7 @@ bool CWsTopologyEx::onTpSwapNode(IEspContext &context,IEspTpSwapNodeRequest  &re
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -146,7 +146,7 @@ bool CWsTopologyEx::onTpSetMachineStatus(IEspContext &context,IEspTpSetMachineSt
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -415,7 +415,7 @@ bool CWsTopologyEx::onTpLogFile(IEspContext &context,IEspTpLogFileRequest  &req,
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -567,7 +567,7 @@ bool CWsTopologyEx::onSystemLog(IEspContext &context,IEspSystemLogRequest  &req,
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -592,7 +592,7 @@ bool CWsTopologyEx::onTpXMLFile(IEspContext &context,IEspTpXMLFileRequest  &req,
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1207,7 +1207,7 @@ bool CWsTopologyEx::onTpClusterQuery(IEspContext &context, IEspTpClusterQueryReq
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return false;
 }
@@ -1258,7 +1258,7 @@ bool CWsTopologyEx::onTpTargetClusterQuery(IEspContext &context, IEspTpTargetClu
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return false;
 }
@@ -1301,7 +1301,7 @@ bool CWsTopologyEx::onTpLogicalClusterQuery(IEspContext &context, IEspTpLogicalC
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     
     return true;
@@ -1322,7 +1322,7 @@ bool CWsTopologyEx::onTpGroupQuery(IEspContext &context, IEspTpGroupQueryRequest
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1378,7 +1378,7 @@ bool CWsTopologyEx::onTpClusterInfo(IEspContext &context, IEspTpClusterInfoReque
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1441,7 +1441,7 @@ bool CWsTopologyEx::onTpServiceQuery(IEspContext &context, IEspTpServiceQueryReq
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -1510,7 +1510,7 @@ bool CWsTopologyEx::onTpMachineQuery(IEspContext &context, IEspTpMachineQueryReq
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return false;
 }
@@ -1814,7 +1814,7 @@ bool CWsTopologyEx::onTpGetComponentFile(IEspContext &context,
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1154,7 +1154,7 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return onGetNotFound(context, request, response, service);
 }
@@ -2112,7 +2112,7 @@ int CWsWorkunitsSoapBindingEx::onGet(CHttpRequest* request, CHttpResponse* respo
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(*request->queryContext(), e,  ECLWATCH_INTERNAL_ERROR);
     }
 
 
@@ -2507,7 +2507,7 @@ bool CWsWorkunitsEx::onWUProcessGraph(IEspContext &context,IEspWUProcessGraphReq
 
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -2614,7 +2614,7 @@ bool CWsWorkunitsEx::onWUGetGraph(IEspContext& context, IEspWUGetGraphRequest& r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -2845,7 +2845,7 @@ bool CWsWorkunitsEx::onWUResultBin(IEspContext &context,IEspWUResultBinRequest &
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -2974,7 +2974,7 @@ bool CWsWorkunitsEx::onWUResult(IEspContext &context, IEspWUResultRequest &req, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -3096,7 +3096,7 @@ bool CWsWorkunitsEx::onWUResultSummary(IEspContext &context, IEspWUResultSummary
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -3285,7 +3285,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -3731,7 +3731,7 @@ bool CWsWorkunitsEx::onWUQuery(IEspContext &context, IEspWUQueryRequest & req, I
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -4938,7 +4938,7 @@ bool CWsWorkunitsEx::onWUShowScheduled(IEspContext &context, IEspWUShowScheduled
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -4967,7 +4967,7 @@ bool CWsWorkunitsEx::onWUExport(IEspContext &context, IEspWUExportRequest &req, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -6327,7 +6327,6 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
     try
     {
         const char *type = req.getType();
-        
 
         if (type && *type && !stricmp(type, "archived workunits"))
         {
@@ -6377,7 +6376,7 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -6406,7 +6405,7 @@ bool CWsWorkunitsEx::onWUGraphInfo(IEspContext &context,IEspWUGraphInfoRequest &
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -6431,7 +6430,7 @@ bool CWsWorkunitsEx::onGVCAjaxGraph(IEspContext &context, IEspGVCAjaxGraphReques
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -6491,7 +6490,7 @@ bool CWsWorkunitsEx::onWUGVCGraphInfo(IEspContext &context,IEspWUGVCGraphInfoReq
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     
     return true;
@@ -6656,7 +6655,7 @@ bool CWsWorkunitsEx::onWUGraphTiming(IEspContext &context, IEspWUGraphTimingRequ
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
     return true;
@@ -7583,7 +7582,7 @@ bool CWsWorkunitsEx::onWUUpdate(IEspContext &context, IEspWUUpdateRequest &req, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -7610,7 +7609,7 @@ bool CWsWorkunitsEx::onWUPushEvent(IEspContext &context, IEspWUPushEventRequest 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return false;
 }
@@ -7727,7 +7726,7 @@ bool CWsWorkunitsEx::onWUAction(IEspContext &context, IEspWUActionRequest &req, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -7745,7 +7744,7 @@ bool CWsWorkunitsEx::onWUDelete(IEspContext &context, IEspWUDeleteRequest &req, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -7763,7 +7762,7 @@ bool CWsWorkunitsEx::onWUAbort(IEspContext &context, IEspWUAbortRequest &req, IE
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -7786,7 +7785,7 @@ bool CWsWorkunitsEx::onWUProtect(IEspContext &context, IEspWUProtectRequest &req
         }
         catch(IException* e)
         {   
-            FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+            FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -7864,7 +7863,7 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -7935,7 +7934,7 @@ bool CWsWorkunitsEx::onWUSchedule(IEspContext &context, IEspWUScheduleRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -7969,7 +7968,7 @@ bool CWsWorkunitsEx::onWUSubmit(IEspContext &context, IEspWUSubmitRequest &req, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -7992,7 +7991,7 @@ bool CWsWorkunitsEx::onWUCreate(IEspContext &context, IEspWUCreateRequest &req, 
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -8014,7 +8013,7 @@ bool CWsWorkunitsEx::onWUCreateAndUpdate(IEspContext &context, IEspWUUpdateReque
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return onWUUpdate(context, req, resp);
 }
@@ -8028,7 +8027,7 @@ bool CWsWorkunitsEx::onWUWaitCompiled(IEspContext &context, IEspWUWaitRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -8041,7 +8040,7 @@ bool CWsWorkunitsEx::onWUWaitComplete(IEspContext &context, IEspWUWaitRequest &r
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -8056,7 +8055,7 @@ bool CWsWorkunitsEx::onWUCDebug(IEspContext &context, IEspWUDebugRequest &req, I
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -8108,7 +8107,7 @@ bool CWsWorkunitsEx::onWUSyntaxCheckECL(IEspContext &context, IEspWUSyntaxCheckR
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -8203,7 +8202,7 @@ bool CWsWorkunitsEx::onWUCompileECL(IEspContext &context, IEspWUCompileECLReques
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -9113,7 +9112,7 @@ bool CWsWorkunitsEx::onWUClusterJobQueueXLS(IEspContext &context, IEspWUClusterJ
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -9213,7 +9212,7 @@ bool CWsWorkunitsEx::onWUClusterJobQueueLOG(IEspContext &context,IEspWUClusterJo
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -9279,7 +9278,7 @@ bool CWsWorkunitsEx::onWUClusterJobXLS(IEspContext &context, IEspWUClusterJobXLS
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -9346,7 +9345,7 @@ bool CWsWorkunitsEx::onWUClusterJobSummaryXLS(IEspContext &context, IEspWUCluste
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -9438,7 +9437,7 @@ bool CWsWorkunitsEx::onWUGetDependancyTrees(IEspContext& context, IEspWUGetDepen
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
@@ -9492,7 +9491,7 @@ bool CWsWorkunitsEx::onWUListLocalFileRequired(IEspContext& context, IEspWUListL
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }
@@ -9616,7 +9615,7 @@ bool CWsWorkunitsEx::onWUAddLocalFileToWorkunit(IEspContext& context, IEspWUAddL
     }
     catch(IException* e)
     {   
-        FORWARDEXCEPTION(e, ECLWATCH_INTERNAL_ERROR);
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
 }

--- a/esp/smc/SMCLib/exception_util.hpp
+++ b/esp/smc/SMCLib/exception_util.hpp
@@ -114,47 +114,28 @@
 #define ECLWATCH_PSEXEC_NOT_INSTALLED           ECLWATCH_ERROR_START+94
 #define ECLWATCH_NO_WUID_SPECIFIED          ECLWATCH_ERROR_START+95
 
-inline void FORWARDEXCEPTION(IException *e, unsigned codeNew)
+inline void FORWARDEXCEPTION(IEspContext &context, IException *e, unsigned codeNew)
 {
     if (!e)
         return;
 
-    StringBuffer eMsg;
+    time_t tNow;
+    struct tm timeStruct;
+    char timeString[32];
+    StringBuffer eMsg, eMsgDisplay;
+
     int err = e->errorCode();
     e->errorMessage(eMsg);
     e->Release();
 
+    context.setException(err);
+
     //set time stamp in the result for this machine
-    time_t tNow;
     time(&tNow);
-
-    char timeStamp[256];
-#ifdef _WIN32
-    struct tm * ltNow = gmtime(&tNow);
-    strftime(timeStamp, 32, "%m/%d/%y %H:%M:%S GMT", ltNow);
-#else
-    struct tm ltNow;
-    gmtime_r(&tNow, &ltNow);
-    strftime(timeStamp, 32, "%m/%d/%y %H:%M:%S GMT", &ltNow);
-#endif
-
-#if 0
-    if (err < ERRORID_UNKNOWN)
-    {
-        StringBuffer eMsg_Log, eMsg_Display;
-        eMsg_Log.appendf("%s: %s", timeStamp, eMsg.str());
-        eMsg_Display.appendf("%s: %s", timeStamp, ERRORMSG_INTERNAL);
-
-        ERRLOG(eMsg_Log.str()); //log original exception
-        throw MakeStringException(codeNew, eMsg_Display.str()); //Update message and display "" to indicate where the exception comes from
-    }
-    else
-#endif
-    {
-        StringBuffer eMsg_Display;
-        eMsg_Display.appendf("%s: %s", timeStamp, eMsg.str());
-        throw MakeStringException(err, "%s", eMsg_Display.str());
-    }
+    gmtime_r(&tNow, &timeStruct);
+    strftime(timeString, 32, "%Y-%m-%d %H:%M:%S GMT", &timeStruct);
+    eMsgDisplay.appendf("%s: %s", timeString, eMsg.str());
+    throw MakeStringException(err, eMsgDisplay.str());
         
     return;
 }


### PR DESCRIPTION
Existing ESP log contains a log line to trace ESP processing time
for each HTTP request. The code is modified to add more information
(about user, IP, service name, method name, etc) into the log line.
HTTP/SOAP request will be logged only if the 'logRequests' is set
to 'true' in esp.xml. If exception or slow, more details of the HTTP
/SOAP request will be logged.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
