### PR TITLE
FIX #83402 - Fix csvSeparator typo

### DIFF
--- a/thorlcr/activities/csvread/thcsvread.cpp
+++ b/thorlcr/activities/csvread/thcsvread.cpp
@@ -38,7 +38,7 @@ public:
             IHThorCsvReadArg *helper = (IHThorCsvReadArg *)queryHelper();
             if (fileDesc->queryProperties().hasProp("@csvQuote")) dst.append(true).append(fileDesc->queryProperties().queryProp("@csvQuote"));
             else dst.append(false);
-            if (fileDesc->queryProperties().hasProp("@csvSeperate")) dst.append(true).append(fileDesc->queryProperties().queryProp("@csvSeperate"));
+            if (fileDesc->queryProperties().hasProp("@csvSeparate")) dst.append(true).append(fileDesc->queryProperties().queryProp("@csvSeparate"));
             else dst.append(false);
             if (fileDesc->queryProperties().hasProp("@csvTerminate")) dst.append(true).append(fileDesc->queryProperties().queryProp("@csvTerminate"));
             else dst.append(false);

--- a/thorlcr/activities/fetch/thfetchslave.cpp
+++ b/thorlcr/activities/fetch/thfetchslave.cpp
@@ -541,7 +541,7 @@ public:
         Owned<IPropertyTree> lFProps = createPTree(data);
 
         const char * quotes = lFProps->hasProp("@csvQuote")?lFProps->queryProp("@csvQuote"):NULL;
-        const char * separators = lFProps->hasProp("@csvSeperate")?lFProps->queryProp("@csvSeperate"):NULL;
+        const char * separators = lFProps->hasProp("@csvSeparate")?lFProps->queryProp("@csvSeparate"):NULL;
         const char * terminators = lFProps->hasProp("@csvTerminate")?lFProps->queryProp("@csvTerminate"):NULL;      
         csvSplitter.init(helper->getMaxColumns(), csvInfo, quotes, separators, terminators);
     }


### PR DESCRIPTION
A sprayed CSV file that published a @csvSeparator attribute was not being
picked up by Thor due to a typo

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
