### PR TITLE
FIX: #130 - Fix badly formatted pipewrite exception

### DIFF
--- a/thorlcr/activities/pipewrite/thpwslave.cpp
+++ b/thorlcr/activities/pipewrite/thpwslave.cpp
@@ -110,7 +110,7 @@ public:
                     e->Release();
                 }
             }
-            throw MakeActivityException(this, TE_PipeReturnedFailure, "Process returned %d:%s - PIPE(%s)", container.queryId(), retcode, stdError.str(), pipeCommand.get());    
+            throw MakeActivityException(this, TE_PipeReturnedFailure, "Process returned %d:%s - PIPE(%s)", retcode, stdError.str(), pipeCommand.get());    
         }
     }
     void process()


### PR DESCRIPTION
An exception generated by pipewrite if the process returned an error code,
had a rogue extra parameter, which was likely to cause it to crash in printf
formatting

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
