### PR TITLE
Bug: 84374 Set 'showhttp' flag to show Headers in SOAP Test Page

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1009,6 +1009,7 @@ int EspHttpBinding::onGetSoapBuilder(IEspContext &context, CHttpRequest* request
     xform->setStringParameter("methodName", methodQName.str());
     xform->setStringParameter("soapbody", soapmsg.str());
     xform->setStringParameter("header", header.str());
+    xform->setStringParameter("showhttp", "true()");
 
     ISecUser* user = context.queryUser();
     bool inhouse = user && (user->getStatus()==SecUserStatus_Inhouse);


### PR DESCRIPTION
The 'Send Request' button does not work due to missing the Headers
section on SOAP Test page. To show the the Headers section, the
'showhttp' flag should be set to true. A code line is added to
set the 'showhttp' flag.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
