### PR TITLE
FIX #150 - Regression - #82816 Preserve file part TLK

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2798,7 +2798,7 @@ void FileSprayer::updateTargetProperties()
 
                     curProps.setProp("@modified", temp.getString(timestr).str());
                 }
-                if (replicate && (distributedSource != distributedTarget))
+                if (replicate && distributedSource && (distributedSource != distributedTarget))
                 {
                     Owned<IDistributedFilePart> curSourcePart = distributedSource->getPart(cur.whichInput);
                     Owned<IAttributeIterator> aiter = curSourcePart->queryProperties().getAttributes();


### PR DESCRIPTION
The change made in commit 23ba18b will cause dfuserver to core when
spraying from a non-distributed file, as the distributedSource
will be NULL. This patch adds a test for that case.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
