### PR TITLE
FIX: 82056 Set YUI loader base to local path

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -6,11 +6,13 @@
 /*global YAHOO*/
 (function() {
   var loader = new YAHOO.util.YUILoader();
-  loader.loadOptional = true;
 
-  loader.require("reset-fonts-grids", "base", "datatable", "selector", "progressbar");
   loader.insert({
-    filter: 'raw',
+    require: ["reset-fonts-grids", "base", "datatable", "selector", "progressbar"],
+    base: '/esp/files/yui/build/',
+    loadOptional: true,
+    filter: "MIN",
+    allowRollup: true,
     onSuccess: function() {
       var invokeWiz = true;
     


### PR DESCRIPTION
Set YUI loader base to local path to avoid loading files from
the default base of http://yui.yahooapis.com.

Also, load "MIN" version of files rather than the "raw" version.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
