### PR TITLE
FIX: 84415 Check for NULL object

### DIFF
--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -463,7 +463,7 @@ void CWizardInputs::generateSoftwareTree(IPropertyTree* pNewEnvTree)
   if(m_buildSetTree)
   {
     bool ovrLog = true, ovrRun = true;
-    if (m_overrideDirs->count() > 0)
+    if (m_overrideDirs && m_overrideDirs->count() > 0)
     {
       HashIterator iter(*m_overrideDirs);
 


### PR DESCRIPTION
Issue occurs when trying to build a new environment via the Wizard. The
code causing the problem was added as part of the "envgen" tool that
lets users generate an environment via the command line.

The envgen tool lets the user specify override directories via a
command line option. Since the same code is used to generate the
environment both via the Wizard and the envgen tool and the override
directories object is NULL in the case of the Wizard, ConfigMgr crashes
when trying to generate an environment via the Wizard. Hence, added fix
to check for NULL object before accessing the override directories.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
