### PR TITLE
FIX #162 Unrecognized interface resolved as 0.0.0.0

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -13,3 +13,4 @@ home=${HOME_DIR}
 environment=${ENV_XML_FILE}
 sourcedir=${CONFIG_SOURCE_PATH}
 blockname=${DIR_NAME}
+interface=*

--- a/system/jlib/jsocket.hpp
+++ b/system/jlib/jsocket.hpp
@@ -600,8 +600,8 @@ extern jlib_decl bool setPreferredSubnet(const char *ip,const char *mask); // al
 
 extern jlib_decl StringBuffer lookupHostName(const IpAddress &ip,StringBuffer &ret);
 
-extern jlib_decl bool lookupInterfaceIp(IpAddress &ip,const char *ifname,bool test); // if test true returns true if ip matches interface 
-                                                                                     // if test false returns first ip for interface
+extern jlib_decl bool isInterfaceIp(const IpAddress &ip, const char *ifname);
+extern jlib_decl bool getInterfaceIp(IpAddress &ip, const char *ifname);
 
 #endif
 


### PR DESCRIPTION
If the interface named in environment.conf does not exist, the code
was supposed to fall into using hostname when resolving the '.' net
address. However due to a flaw in the logic it will actually use
0.0.0.0, and various components will fail to start as a result.

This patch splits the 'test' and 'retrieve' functionality into
separate functions to make them easier to follow, and adds the ability
to use a wildcard in the interface specification. When searching for
an interface ip, loopback interfaces are always searched AFTER
non-loopback ones.

With this fix in place, the most appropriate value for interface= in
environment.conf is *

Signed-off-by: Richard Chapman rchapman@hpccsystems.com

@jakesmith please review
