### PR TITLE
Fix #164 - Thor script error, causing restart fail

### DIFF
--- a/initfiles/componentfiles/thor/run_thor
+++ b/initfiles/componentfiles/thor/run_thor
@@ -54,7 +54,7 @@ while [ 1 ]; do
         echo failed to start thormaster$LCR, pausing for 30 seconds
         sleep 30
     fi
-    if [! -e $sentinelfile ]; then
+    if [ ! -e $sentinelfile ]; then
         echo $sentinelfile 'has been removed or thormaster did not fully start - script stopping'
         exit 0
     fi


### PR DESCRIPTION
A missing space in a bash expression causing run_thor
to fail when thormaster exited. As a result Thor would not
auto restart

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
