### PR TITLE
ISSUE #172: Move IDFUWorkUnit::submit() to a standalone function.

### DIFF
--- a/dali/datest/dfuwutest.cpp
+++ b/dali/datest/dfuwutest.cpp
@@ -120,7 +120,7 @@ void copyTest()
         destination->setLogicalName(dstname.str());
         options->setReplicate(true);
         options->setOverwrite(true);
-        wu->submit();
+        submitDFUWorkUnit(wu.getClear());
     }
 }
 
@@ -159,7 +159,7 @@ void importTest()
     destination->setLogicalName(dstname.str());
     options->setReplicate(true);
     options->setOverwrite(true);
-    wu->submit();
+    submitDFUWorkUnit(wu.getClear());
 }
 
 void SprayTest(unsigned num)
@@ -207,7 +207,7 @@ void SprayTest(unsigned num)
                 options->setOverwrite(true);
             }
             PROGLOG("submitting %s",wu->queryId()); 
-            wu->submit();
+            submitDFUWorkUnit(wu.getClear());
         }
     }
 }
@@ -410,7 +410,7 @@ void testWUcreate(int kind,StringBuffer &wuidout)
         break;
     }
     wuidout.append(wu->queryId());  
-    wu->submit();
+    submitDFUWorkUnit(wu.getClear());
 }
 
 IFileDescriptor *createRoxieFileDescriptor(const char *cluster, const char *lfn, bool servers)
@@ -744,8 +744,7 @@ void testRepeatedFiles1(StringBuffer &wuid)
     destination->setLogicalName("thor_dev::nigel::testspray1");
     options->setReplicate(true);
     options->setOverwrite(true);
-    wu->submit();
-
+    submitDFUWorkUnit(wu.getClear());
 }
 
 void testRepeatedFiles2(StringBuffer &wuid)
@@ -781,8 +780,7 @@ void testRepeatedFiles2(StringBuffer &wuid)
     destination->setLogicalName("thor_dev::nigel::testcopy1");
     options->setReplicate(true);
     options->setOverwrite(true);
-    wu->submit();
-
+    submitDFUWorkUnit(wu.getClear());
 }
 
 static IGroup *getAuxGroup()
@@ -837,8 +835,7 @@ void testRepeatedFiles3(StringBuffer &wuid)
     destination->setLogicalName("thor_dev::nigel::testspray2");
     options->setReplicate(true);
     options->setOverwrite(true);
-    wu->submit();
-
+    submitDFUWorkUnit(wu.getClear());
 }
 
 void testRepeatedFiles4(StringBuffer &wuid)
@@ -868,8 +865,7 @@ void testRepeatedFiles4(StringBuffer &wuid)
     destination->setWrap(true);
     options->setReplicate(true);
     options->setOverwrite(true);
-    wu->submit();
-
+    submitDFUWorkUnit(wu.getClear());
 }
 
 void testRepeatedFiles5(StringBuffer &wuid)
@@ -902,8 +898,7 @@ void testRepeatedFiles5(StringBuffer &wuid)
     options->setReplicate(true);
     options->setOverwrite(true);
     options->setSuppressNonKeyRepeats(true);                            // **** only repeat last part when src kind = key
-    wu->submit();
-
+    submitDFUWorkUnit(wu.getClear());
 }
 
 void testSuperCopy1(StringBuffer &wuid)
@@ -934,8 +929,7 @@ void testSuperCopy1(StringBuffer &wuid)
     options->setReplicate(true);
     options->setOverwrite(true);
     options->setSuppressNonKeyRepeats(true);
-    wu->submit();
-
+    submitDFUWorkUnit(wu.getClear());
 }
 
 

--- a/dali/dfu/dfuwu.hpp
+++ b/dali/dfu/dfuwu.hpp
@@ -312,6 +312,7 @@ interface IDFUprogress: extends IConstDFUprogress
     virtual void setPercentDone(unsigned pc)=0;
     virtual void setSubInProgress(const char *str) = 0;     // set sub-DFUWUs in progress
     virtual void setSubDone(const char *str) = 0;           // set sub-DFUWUs done
+    virtual void clearProgress() = 0;
 };
 
 interface IDFUprogressSubscriber: extends IInterface
@@ -398,7 +399,6 @@ interface IDFUWorkUnit : extends IConstDFUWorkUnit
     virtual void addOptions(IPropertyTree *tree) = 0;       // used by DFU command line (for moment)
     virtual IDFUprogress *queryUpdateProgress() = 0;
     virtual IDFUmonitor *queryUpdateMonitor() = 0;
-    virtual void submit() = 0;                              // should Release after submitted
     virtual void closeUpdate() = 0;                     // called before WU obtained by openUpdate is released
     virtual void queryRecoveryStore(IRemoteConnection *& conn,IPropertyTree *&tree,StringBuffer &runningpath) = 0; // not nice - needed by daft 
     virtual void removeRecoveryStore() = 0;
@@ -409,6 +409,7 @@ interface IDFUWorkUnit : extends IConstDFUWorkUnit
     virtual void setApplicationValueInt(const char * application, const char * propname, int value, bool overwrite) = 0;
     virtual void setDebugValue(const char *propname, const char *value, bool overwrite) = 0;
     virtual bool removeQueue() = 0;
+    virtual void clearExceptions() = 0;
 };
 
 
@@ -446,6 +447,8 @@ interface IDFUWorkUnitFactory : extends IInterface
 
 
 extern dfuwu_decl IDFUWorkUnitFactory * getDFUWorkUnitFactory();
+extern dfuwu_decl void submitDFUWorkUnit(IDFUWorkUnit *wu);
+extern dfuwu_decl void submitDFUWorkUnit(const char *wuid);
 
 extern dfuwu_decl DFUcmd decodeDFUcommand(const char * str);
 extern dfuwu_decl StringBuffer &encodeDFUcommand(DFUcmd cmd,StringBuffer &str);


### PR DESCRIPTION
ISSUE #172: Move IDFUWorkUnit::submit() to standalone functions.

Move IDFUWorkUnit::submit() to a standalone function named
"submitDFUWorknit()".

Modeled after the submitWorkunit() function for ECL workunits it will
release the IDFUWorkunit interface before putting the workunit on a queue.

This should help prevent race conditions related to having locked
workunits on a queue.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
