### PR TITLE
Added support for building on Debian Lenny

### DIFF
--- a/cmake_modules/dependencies/lenny.cmake
+++ b/cmake_modules/dependencies/lenny.cmake
@@ -1,0 +1,1 @@
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo openssh-client, openssh-server")

--- a/cmake_modules/distrocheck.sh
+++ b/cmake_modules/distrocheck.sh
@@ -19,6 +19,17 @@
     
 #############################################
 
+if [ -e /etc/debian_version ]; then
+    echo -n "DEB"
+    exit 2;
+elif [ -e /etc/redhat-release ]; then
+    echo -n "RPM"
+    exit 1;
+elif [ -e /etc/SuSE-release ]; then
+    echo -n "RPM"
+    exit 1;
+fi
+
 cat /etc/*release > temp.txt
 
 ############### RPM DISTROS ##################


### PR DESCRIPTION
Adds the required dependency list to build a package on Debian Lenny.
Fixes the distrocheck to handle Debian Lenny (and others) better, and be
more consistent with the distro checking code in getpackagerevisionarch.sh

Signed-off-by: Richard Chapman rchapman@hpccsystems.com

@pschwartz Please review
