### PR TITLE
ISSUE:179 Remove duplicate message definitions

### DIFF
--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -448,9 +448,14 @@
 #define HQLERR_EquivalenceNotYetSupported       3116
 #define HQLERR_CouldNotConnectEclServer         3117
 #define HQLERR_VersionMismatch                  3118
-
-#define HQLERR_UnexpectedOperator               4831
-#define HQLERR_UnexpectedType                   4832
+#define HQLERR_VirtualFieldInTempTable          3119
+#define HQLERR_IncompatiableInitailiser         3120
+#define HQLERR_NoDefaultProvided                3121
+#define HQLERR_TooManyInitializers              3122
+#define HQLERR_IncompatibleTypesForField        3123
+#define HQLWRN_CouldNotConstantFoldIf           3124
+#define HQLERR_UnexpectedOperator               3125
+#define HQLERR_UnexpectedType                   3126
 
 #define HQLERR_DedupFieldNotFound_Text          "Field removed from dedup could not be found"
 #define HQLERR_CycleWithModuleDefinition_Text   "Module definition contain an illegal cycle/recursive definition %s"
@@ -473,15 +478,6 @@
 #define HQLERR_EquivalenceNotYetSupported_Text  "Equivalence class symbols not yet supported"
 #define HQLERR_CouldNotConnectEclServer_Text    "Could not connect to any ECL server"
 #define HQLERR_VersionMismatch_Text             "Mismatch in major version number (%s v %s)"
-
-//Cloned from hqlcerrors
-#define HQLERR_VirtualFieldInTempTable          4019
-#define HQLERR_IncompatiableInitailiser         4076
-#define HQLERR_NoDefaultProvided                4077
-#define HQLERR_TooManyInitializers              4080
-#define HQLERR_IncompatibleTypesForField        4101
-#define HQLWRN_CouldNotConstantFoldIf           4514
-
 #define HQLERR_VirtualFieldInTempTable_Text     "Virtual field %s not supported in constant table - please provide a value"
 #define HQLERR_IncompatiableInitailiser_Text    "Inline DATASET field '%s' cannot be initialized with a list of values"
 #define HQLERR_NoDefaultProvided_Text           "No value or default provided for field %s in inline table"

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -19,16 +19,11 @@
 #define HQLCERRORS_HPP
 
 #include "jexcept.hpp"
-//Note: Some of the errors below have been moved into hqlerrors.hpp.  If so the number is preserved here
-//(and will error if it differs) but the error message text is only included in hqlerrors.hpp.
 #include "hqlerrors.hpp"
-
 
 /* Code Generation errors - defined in hqlcerrors.hpp */
 #define ERR_CODEGEN_FIRST       4000
 #define ERR_CODEGEN_LAST        4999
-
-#define HQLERR_ASSERT_WRONGSCOPING              2131 /* Incorrect assertion scoping */
 
 #define HQLERR_NullSetCannotGenerate            4000
 #define HQLERR_NoMultiDimIndex                  4001
@@ -49,7 +44,6 @@
 #define HQLERR_UnsupportedHashWorkunit          4016
 #define HQLERR_UnknownVirtualAttr               4017
 #define HQLERR_IllegalPattern                   4018
-#define HQLERR_VirtualFieldInTempTable          4019
 #define HQLERR_VarSizeSortUseThor               4020
 #define HQLERR_SubstringOutOfRange              4021
 #define HQLERR_RankOnStored                     4022
@@ -105,12 +99,9 @@
 #define HQLERR_DuplicateNameOutput              4073
 #define HQLERR_ExtendTypeMismatch               4074
 #define HQLERR_OverwriteMismatch                4075
-#define HQLERR_ExtendOverwriteMismatch          4075
-#define HQLERR_IncompatiableInitailiser         4076
-#define HQLERR_NoDefaultProvided                4077
+#define HQLERR_ExtendOverwriteMismatch          4076
 #define HQLERR_EmbeddedCppNotAllowed            4078
 #define HQLERR_ContentsInSoapCall               4079
-#define HQLERR_TooManyInitializers              4080
 #define HQLERR_FullKeyedNeedsFile               4081
 #define HQLERR_ExpectedConstant                 4082
 #define HQLERR_AccessRowBlobInsideChildQuery    4083
@@ -131,7 +122,6 @@
 #define HQLERR_KeyAccessNeedCast                4098
 #define HQLERR_KeyAccessNoKeyField              4099
 #define HQLERR_MaxLengthNotSetOnRecord          4100
-#define HQLERR_IncompatibleTypesForField        4101
 #define HQLERR_NotSupportedInsideNoThor         4102
 #define HQLERR_RegexNoTransformSupport          4103
 #define HQLERR_AccessMatchAttrInChildQuery      4104
@@ -228,7 +218,6 @@
 #define HQLWRN_RecursiveDependendencies         4510
 #define HQLWRN_MaxSizeExceedsSafeLimit          4512
 #define HQLWRN_TomitaMatchPattern               4513
-#define HQLWRN_CouldNotConstantFoldIf           4514
 #define HQLWRN_KeyedFollowsGap                  4515
 #define HQLWRN_LocalHasNoEffect                 4516
 #define HQLWRN_CsvMaxLengthMismatch             4517
@@ -301,8 +290,6 @@
 #define HQLERR_LibraryMustBeFunctional          4828
 #define HQLERR_InconsistentNaryInput            4829
 #define HQLERR_LinkedDatasetNoContext           4830
-#define HQLERR_UnexpectedOperator               4831
-#define HQLERR_UnexpectedType                   4832
 #define HQLERR_InternalError                    4833
 #define HQLERR_CannotGenerateSerializedCompare  4834
 #define HQLERR_ReadSpillBeforeWrite             4835
@@ -563,8 +550,6 @@
 #define HQLERR_NoParentExtract_Text             "INTERNAL: No active parent extract - activity has incorrect localisation?"
 #define HQLERR_InconsistentNaryInput_Text       "INTERNAL: Inputs to nary operation have inconsistent record structures"
 #define HQLERR_LinkedDatasetNoContext_Text      "INTERNAL: Linked child rows required without legal context available"
-#define HQLERR_UnexpectedOperator_Text          "INTERNAL: Unexpected '%s' at %s(%d)"
-#define HQLERR_UnexpectedType_Text              "INTERNAL: Unexpected type '%s' at %s(%d)"
 #define HQLERR_CannotGenerateSerializedCompare_Text "INTERNAL: Cannot generated serialized compare function"
 #define HQLERR_ReadSpillBeforeWrite_Text        "INTERNAL: Attempt to read spill file %s before it is written"
 #define HQLERR_DependencyWithinGraph_Text       "INTERNAL: Dependency within a graph incorrectly generated for hThor (%u)"

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -19,6 +19,10 @@
 #define HQLCERRORS_HPP
 
 #include "jexcept.hpp"
+//Note: Some of the errors below have been moved into hqlerrors.hpp.  If so the number is preserved here
+//(and will error if it differs) but the error message text is only included in hqlerrors.hpp.
+#include "hqlerrors.hpp"
+
 
 /* Code Generation errors - defined in hqlcerrors.hpp */
 #define ERR_CODEGEN_FIRST       4000
@@ -327,7 +331,6 @@
 #define HQLERR_UnsupportedHashWorkunit_Text     "Unsupported option #WORKUNIT ('%s')"
 #define HQLERR_UnknownVirtualAttr_Text          "INTERNAL: Unsupported virtual attribute '%s'"
 #define HQLERR_IllegalPattern_Text              "Illegal pattern '%s..%s'"
-#define HQLERR_VirtualFieldInTempTable_Text     "Virtual field %s not supported in constant table - please provide a value"
 #define HQLERR_VarSizeSortUseThor_Text          "THOR must be used for sorting or joining datasets with variable width rows"
 #define HQLERR_SubstringOutOfRange_Text         "Substring index %d is outside the field range"
 #define HQLERR_RankOnStored_Text                "RANK/RANKED not supported on list %s"
@@ -384,11 +387,8 @@
 #define HQLERR_ExtendTypeMismatch_Text          "OUTPUTs to NAMED(%s) have incompatible types"
 #define HQLERR_OverwriteMismatch_Text           "OVERWRITE is required on all outputs to NAMED(%s)"
 #define HQLERR_ExtendOverwriteMismatch_Text     "OVERWRITE/EXTEND should be consistent on all outputs to NAMED(%s)"
-#define HQLERR_IncompatiableInitailiser_Text    "Inline DATASET field '%s' cannot be initialized with a list of values"
-#define HQLERR_NoDefaultProvided_Text           "No value or default provided for field %s in inline table"
 #define HQLERR_EmbeddedCppNotAllowed_Text       "Insufficient access rights to use embedded C++"
 #define HQLERR_ContentsInSoapCall_Text          "Tag contents syntax <> is not supported by SOAPCALL"
-#define HQLERR_TooManyInitializers_Text         "Too many initializers (value %s) for inline dataset definition"
 #define HQLERR_FullKeyedNeedsFile_Text          "RIGHT side of a full keyed join must be a disk file"
 #define HQLERR_ExpectedConstant_Text            "Expression is not constant: %s"
 #define HQLERR_AccessRowBlobInsideChildQuery_Text "Unimplemented: Cannot access row blob inside a child query, contact tech support"
@@ -410,7 +410,6 @@
 #define HQLERR_KeyAccessNoKeyField_Text         "Key condition (%s) does not have any comparisons against key fields"
 #define HQLERR_MaxLengthNotSetOnRecord_Text     "No explicit maxlength provided for record %s"
 #define HQLERR_MinusOnString_Text               "unary - cannot be performed on a string"
-#define HQLERR_IncompatibleTypesForField_Text   "Initializer for field %s in inline dataset has the wrong type"
 #define HQLERR_NotSupportedInsideNoThor_Text    "%s is not supported inside NOTHOR()"
 #define HQLERR_RegexNoTransformSupport_Text     "Regular expression parsing doesn't support productions - need to use tomita"
 #define HQLERR_AccessMatchAttrInChildQuery_Text "Unimplemented: Cannot yet access $<n> inside a child query"
@@ -497,7 +496,6 @@
 #define HQLWRN_RecursiveDependendencies_Text    "Recursive filename dependency"
 #define HQLWRN_MaxSizeExceedsSafeLimit_Text     "Maximum row size of %u exceeds the recommended maximum (%u)"
 #define HQLWRN_TomitaMatchPattern_Text          "MATCHED(%s) will not work on a pattern"
-#define HQLWRN_CouldNotConstantFoldIf_Text      "Could not constant fold the condition on a IFBLOCK for a inline table"
 #define HQLWRN_KeyedFollowsGap_Text             "keyed filter on %s follows unkeyed component %s in the key%s"
 #define HQLWRN_LocalHasNoEffect_Text            "LOCAL(dataset) only has an effect in roxie and in thor child queries"
 #define HQLWRN_CsvMaxLengthMismatch_Text        "CSV read: Max length of record (%d) exceeds the max length (%d) specified on the csv attribute"
@@ -572,24 +570,9 @@
 #define HQLERR_DependencyWithinGraph_Text       "INTERNAL: Dependency within a graph incorrectly generated for hThor (%u)"
 #define HQLERR_UnknownCompoundAssign_Text       "INTERNAL: Unrecognised compound assign %s"
 
-#define ECODETEXT(x)                (x), (x##_Text)
-
-#define WARNING(x)                  reportWarning(x, x##_Text)
-#define WARNING1(x, a)              reportWarning(x, x##_Text, a)
-#define WARNING2(x, a, b)           reportWarning(x, x##_Text, a, b)
-#define WARNING3(x, a, b, c)        reportWarning(x, x##_Text, a, b, c)
-
 #define WARNINGAT(e, x)                 reportWarning(e, x, x##_Text)
 #define WARNINGAT1(e, x, a)             reportWarning(e, x, x##_Text, a)
 #define WARNINGAT2(e, x, a, b)          reportWarning(e, x, x##_Text, a, b)
 #define WARNINGAT3(e, x, a, b, c)       reportWarning(e, x, x##_Text, a, b, c)
-
-#define ERRORAT(e, x)               reportError(e, x, x##_Text)
-#define ERRORAT1(e, x, a)           reportError(e, x, x##_Text, a)
-#define ERRORAT2(e, x, a, b)        reportError(e, x, x##_Text, a, b)
-#define ERRORAT3(e, x, a, b, c)     reportError(e, x, x##_Text, a, b, c)
-
-#define throwUnexpectedOp(op)       throw MakeStringException(ECODETEXT(HQLERR_UnexpectedOperator), getOpString(op), __FILE__, __LINE__)
-#define throwUnexpectedType(type)   throw MakeStringException(ECODETEXT(HQLERR_UnexpectedType), type->queryTypeName(), __FILE__, __LINE__)
 
 #endif

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -9015,7 +9015,7 @@ void HqlScopeTagger::reportError(const char * msg, bool warning)
     int startLine= location ? location->getStartLine() : 0;
     int startColumn = location ? location->getStartColumn() : 0;
     ISourcePath * sourcePath = location ? location->querySourcePath() : NULL;
-    Owned<IECLError> err = createECLError(!warning, HQLERR_ASSERT_WRONGSCOPING, msg, sourcePath->str(), startLine, startColumn, 0);
+    Owned<IECLError> err = createECLError(!warning, ERR_ASSERT_WRONGSCOPING, msg, sourcePath->str(), startLine, startColumn, 0);
     collector.report(NULL, errors, err);        // will throw immediately if it is an error.
 }
 


### PR DESCRIPTION
Remove some code which had been moved from hqlcerrors to hqlerrors

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
