### PR TITLE
Bug: 84908 Get correct cluster name to retrieve 'prefix' for cluster

### DIFF
--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -949,7 +949,7 @@ void CTpWrapper::queryTargetClusterProcess(double version, const char* processNa
 
     //this is defined in the Topology attribute for the Cluster.
     StringBuffer prefix;
-    getPrefixName(processName,prefix);
+    getPrefixName(clusterType, processName,prefix);
     clusterInfo->setPrefix(prefix.str());
 
     if(pClusterTree->hasProp("@dataBuild"))
@@ -1261,7 +1261,7 @@ void CTpWrapper::getClusterProcessList(const char* ClusterType, IArrayOf<IEspTpC
 
                     //this is defined in the Topology attribute for the Cluster.
                     StringBuffer prefix;
-                    getPrefixName(name,prefix);
+                    getPrefixName(ClusterType, name,prefix);
                     clusterInfo->setPrefix(prefix.str());
 
                     if(cluster.hasProp("@dataBuild"))
@@ -1517,13 +1517,20 @@ void CTpWrapper::resolveGroupInfo(const char* groupName,StringBuffer& Cluster, S
     }
 }
 
-StringBuffer& CTpWrapper::getPrefixName(const char* clusterName,StringBuffer& prefixName)
+StringBuffer& CTpWrapper::getPrefixName(const char* clusterType, const char* processName,StringBuffer& prefixName)
 {
     try
     {
-        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(clusterName);
+        Owned <IStringIterator> clusterNames = getTargetClusters(clusterType, processName);
+        if (!clusterNames->first())
+            throw MakeStringException(ECLWATCH_CLUSTER_NOT_IN_ENV_INFO, "Cluster not found for cluster type: %s and process name: %s", clusterType, processName);
+
+        SCMStringBuffer clusterName;
+        clusterNames->str(clusterName);
+        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(clusterName.str());
         if (!clusterInfo)
-            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
+            throw MakeStringException(ECLWATCH_CLUSTER_NOT_IN_ENV_INFO, "Unknown cluster %s", clusterName.str());
+
         StringBufferAdaptor adaptor(prefixName);
         clusterInfo->getScope(adaptor);
     }

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -161,7 +161,7 @@ public:
     void setMachineInfo(const char* name,const char* type,IEspTpMachine& machine);
     void resolveGroupInfo(const char* groupName,StringBuffer& Cluster, StringBuffer& ClusterPrefix);
     void getMachineInfo(IEspTpMachine& machineInfo,IPropertyTree& machine,const char* ParentPath,const char* MachineType,const char* nodenametag);
-    StringBuffer& getPrefixName(const char* clusterName,StringBuffer& prefixName);
+    StringBuffer& getPrefixName(const char* clusterType,const char* processName,StringBuffer& prefixName);
 
     void getTpDaliServers(IArrayOf<IConstTpDali>& list);
     void getTpEclServers(IArrayOf<IConstTpEclServer>& ServiceList);


### PR DESCRIPTION
When a user opens the ECLWatch Activity page, the ESP log contains
a warning message: "WARNING: Failed to get environment information".
The message was created when ECLWatch tried to retrieve the 'prefix'
for each target cluster. The old code retrieves the prefix using
a process name, which is incorrect. The code is modified to convert
the process name to target cluster name and use the cluster name to
retrieve the prefix.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
