### PR TITLE
FIX: #167 Some files have bad copyright messages

### DIFF
--- a/cmake_modules/distrocheck.sh
+++ b/cmake_modules/distrocheck.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 #############################################
- 
 #    Copyright (C) 2011 HPCC Systems.
 #
 #    All rights reserved. This program is free software: you can redistribute it and/or modify
@@ -16,7 +15,6 @@
 #
 #    You should have received a copy of the GNU Affero General Public License
 #    along with All rights reserved. This program is free software: you can redistribute program.  If not, see <http://www.gnu.org/licenses/>.
-    
 #############################################
 
 if [ -e /etc/debian_version ]; then

--- a/initfiles/bash-vars.in
+++ b/initfiles/bash-vars.in
@@ -1,5 +1,3 @@
-## Copyright © 2011 HPCC Systems.  All rights reserved.
-
 INSTALL_DIR=${INSTALL_DIR}
 CONFIG_DIR=${CONFIG_DIR}
 ENV_XML_FILE=${ENV_XML_FILE}

--- a/initfiles/bash/etc/init.d/configmgr.in
+++ b/initfiles/bash/etc/init.d/configmgr.in
@@ -1,8 +1,24 @@
 #!/bin/bash
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
 #------------------------------------------------------------------------------
 #                       Common Function                                         
-##------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 
 ###<REPLACE>###
 

--- a/initfiles/bash/etc/init.d/dafilesrv.in
+++ b/initfiles/bash/etc/init.d/dafilesrv.in
@@ -1,27 +1,35 @@
 #!/bin/bash
-##
-## Copyright © 2011 HPCC Systems.  All rights reserved.
-##
-## version v0.1
-## author Philip Schwartz <philip.schwartz@lexisnexis.com>
-##
-##
-##########################################################################
-##                                                                       #
-##                          System Flow                                  #
-##                                                                       #
-##########################################################################
-##                                                                       #
-##      1. Parse Passed In arguments                                     #
-##      2. Get the component and specific information                    #
-##      3. Generate component related config files (runtime directory)   #
-##      4. CD to the runtime Directory                                   #
-##      5. Start the component                                           #
-##                                                                       #
-##########################################################################
-
-###PATH_PRE=`type -path hpcc_setenv`
-#source ${PATH_PRE}
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+#
+#
+#########################################################################
+#                                                                       #
+#                          System Flow                                  #
+#                                                                       #
+#########################################################################
+#                                                                       #
+#      1. Parse Passed In arguments                                     #
+#      2. Get the component and specific information                    #
+#      3. Generate component related config files (runtime directory)   #
+#      4. CD to the runtime Directory                                   #
+#      5. Start the component                                           #
+#                                                                       #
+#########################################################################
 
 ###<REPLACE>###
 

--- a/initfiles/bash/etc/init.d/get_ip_address.sh.in
+++ b/initfiles/bash/etc/init.d/get_ip_address.sh.in
@@ -1,6 +1,20 @@
 #!/bin/bash
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 
 ###<REPLACE>###
 

--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -1,24 +1,34 @@
 #!/bin/bash
-##
-## Copyright © 2011 HPCC Systems.  All rights reserved.
-##
-## version v0.1
-## author Philip Schwartz <philip.schwartz@lexisnexis.com>
-##
-##
-##########################################################################
-##                                                                       #
-##                          System Flow                                  #
-##                                                                       #
-##########################################################################
-##                                                                       #
-##      1. Parse Passed In arguments                                     #
-##      2. Get the component and specific information                    #
-##      3. Generate component related config files (runtime directory)   #
-##      4. CD to the runtime Directory                                   #
-##      5. Start the component                                           #
-##                                                                       #
-##########################################################################
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+#
+#########################################################################
+#                                                                       #
+#                          System Flow                                  #
+#                                                                       #
+#########################################################################
+#                                                                       #
+#      1. Parse Passed In arguments                                     #
+#      2. Get the component and specific information                    #
+#      3. Generate component related config files (runtime directory)   #
+#      4. CD to the runtime Directory                                   #
+#      5. Start the component                                           #
+#                                                                       #
+#########################################################################
 
 ##-----------------------------------------------------------------------------
 #                         General Purpose Functions                           

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -1,11 +1,23 @@
 ## hpcc_common.lib
-## Copyright © 2011 HPCC Systems.  All rights reserved.
-##
-## A series of functions that are common to all hpcc-init processes 
-##
-## version v0.1
-## author Philip Schwartz <philip.schwartz@lexisnexis.com>
-##
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+#
+# A series of functions that are common to all hpcc-init processes
+#
 
 ## cfg.parser parses an ini format file and when given a section places
 ## the associated variables with the section in to local scope.

--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -1,6 +1,20 @@
 #!/bin/bash
-
-## Copyright © 2011 HPCC Systems.  All rights reserved. 
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 
 ###<REPLACE>###
 

--- a/initfiles/bash/etc/init.d/uninstall-init.in
+++ b/initfiles/bash/etc/init.d/uninstall-init.in
@@ -1,5 +1,21 @@
 #!/bin/bash
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
 ###<REPLACE>###
 
 source ${INSTALL_DIR}/etc/init.d/hpcc_common

--- a/initfiles/bash/sbin/bash_postinst.in
+++ b/initfiles/bash/sbin/bash_postinst.in
@@ -1,5 +1,20 @@
 #!/bin/bash 
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 
 ###<REPLACE>###
 

--- a/initfiles/bash/sbin/deb/postinst.in
+++ b/initfiles/bash/sbin/deb/postinst.in
@@ -1,5 +1,20 @@
 #!/bin/bash 
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 
 ###<REPLACE>###
 

--- a/initfiles/bash/sbin/deb/postrm.in
+++ b/initfiles/bash/sbin/deb/postrm.in
@@ -1,5 +1,20 @@
 #!/bin/bash
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 
 ###<REPLACE>###
 

--- a/initfiles/bin/init_dafilesrv.in
+++ b/initfiles/bin/init_dafilesrv.in
@@ -1,5 +1,20 @@
 #!/bin/bash
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 
 ###<REPLACE>###
 

--- a/initfiles/bin/init_eclagent.in
+++ b/initfiles/bin/init_eclagent.in
@@ -1,5 +1,20 @@
 #!/bin/bash
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 
 ###<REPLACE>###
 

--- a/initfiles/componentfiles/configxml/buildsetCC.xml.in
+++ b/initfiles/componentfiles/configxml/buildsetCC.xml.in
@@ -1,7 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 <Environment>
 <Software>

--- a/initfiles/componentfiles/configxml/buildsetEE.xml.in
+++ b/initfiles/componentfiles/configxml/buildsetEE.xml.in
@@ -1,7 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 <Environment>
 <Software>

--- a/initfiles/componentfiles/configxml/dropzone.xsd.in
+++ b/initfiles/componentfiles/configxml/dropzone.xsd.in
@@ -1,6 +1,20 @@
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/initfiles/componentfiles/configxml/eclagent_config.xsd.in
+++ b/initfiles/componentfiles/configxml/eclagent_config.xsd.in
@@ -1,6 +1,20 @@
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -1,6 +1,20 @@
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/initfiles/componentfiles/configxml/ftslave_linux.xsd.in
+++ b/initfiles/componentfiles/configxml/ftslave_linux.xsd.in
@@ -1,6 +1,20 @@
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -1,6 +1,20 @@
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/initfiles/componentfiles/configxml/thor.xsd.in
+++ b/initfiles/componentfiles/configxml/thor.xsd.in
@@ -1,6 +1,20 @@
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/initfiles/componentfiles/ftslave/run_ftslave.in
+++ b/initfiles/componentfiles/ftslave/run_ftslave.in
@@ -1,6 +1,19 @@
 #!/bin/bash
 ################################################################################
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 ###<REPLACE>###

--- a/initfiles/etc/DIR_NAME/configmgr/configmgr.conf.in
+++ b/initfiles/etc/DIR_NAME/configmgr/configmgr.conf.in
@@ -1,4 +1,4 @@
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+## Default configuration file for configmgr
 
 [components]
 configmgr=esp;${CONFIG_DIR}/configmgr

--- a/initfiles/etc/DIR_NAME/configmgr/esp.xml.in
+++ b/initfiles/etc/DIR_NAME/configmgr/esp.xml.in
@@ -1,7 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
 -->
 
 <Environment>

--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -1,4 +1,4 @@
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+## Default environment configuration file
 
 [DEFAULT]
 configs=${CONFIG_DIR}

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+## Default environment file single-node hpcc installation
 -->
 
-<!-- Edited with ConfigMgr by smeda from ip 172.16.48.173 on 2010-09-21T20:27:40 -->
 <Environment>
  <EnvSettings>
   <configs>${CONFIG_DIR}</configs>

--- a/initfiles/processor.cpp
+++ b/initfiles/processor.cpp
@@ -1,7 +1,20 @@
-/*
-## Copyright © 2011 HPCC Systems.  All rights reserved.
-*/
+/*##############################################################################
 
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
 #include <string> 
 #include <vector>
 #include <iostream>

--- a/initfiles/sbin/add_conf_settings.sh.in
+++ b/initfiles/sbin/add_conf_settings.sh.in
@@ -1,6 +1,19 @@
 #!/bin/bash
 ################################################################################
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 ###<REPLACE>###

--- a/initfiles/sbin/hpcc-push.sh.in
+++ b/initfiles/sbin/hpcc-push.sh.in
@@ -1,14 +1,25 @@
 #!/bin/bash
-##
-## Copyright (c) 2011 HPCC Systems.  All rights reserved.
-##
-## version v0.1
-## author Philip Schwartz <philip.schwartz@lexisnexis.com>
-##
-## Usage: hpcc-push.sh <from> <to>
-##
-## This is acomplished with a standard scp command with the use of the 
-## runtime users id_rsa file.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+#
+# Usage: hpcc-push.sh <from> <to>
+#
+# This is acomplished with a standard scp command with the use of the
+# runtime users id_rsa file.
 
 ###<REPLACE>###
 

--- a/initfiles/sbin/hpcc-run.sh.in
+++ b/initfiles/sbin/hpcc-run.sh.in
@@ -1,14 +1,25 @@
 #!/bin/bash
-##
-## Copyright (c) 2011 HPCC Systems.  All rights reserved.
-##
-## version v0.1
-## author Philip Schwartz <philip.schwartz@lexisnexis.com>
-##
-## Usage: hpcc-run.sh [hpcc-init | dafilesrv] [-c component] <cmd>
-##
-## This is acomplished with a standard ssh command with the use of the 
-## runtime users id_rsa file.
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+#
+# Usage: hpcc-run.sh [hpcc-init | dafilesrv] [-c component] <cmd>
+#
+# This is acomplished with a standard ssh command with the use of the
+# runtime users id_rsa file.
 
 ###<REPLACE>###
 

--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -1,6 +1,19 @@
 #!/bin/bash
 ################################################################################
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 #
 # HPCC Set Environment

--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -1,26 +1,37 @@
 #!/bin/bash
-##
-## Copyright (c) 2011 HPCC Systems.  All rights reserved.
-##
-## version v0.1
-## author Philip Schwartz <philip.schwartz@lexisnexis.com>
-##
-## Usage: install-cluster.sh
-##
-## This script is used as a remote engine for a cluster installation.
-##
-## Flow:
-##
-## 1. SSH Keys Generated.
-## 2. Script copied to node.
-## 3. Install package copied to node.
-## 4. SSH Keys copied to node.
-## 5. Run CheckInstall to determine if  package is installed.
-## 6. Install/Upgrade if needed.
-## 7. Run CheckKeys to determine if sshkeys are installed.
-## 8. Install keys if different then installed or no keys installed.
-## 9. Return.
-##
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+#
+# Usage: install-cluster.sh
+#
+# This script is used as a remote engine for a cluster installation.
+#
+# Flow:
+#
+# 1. SSH Keys Generated.
+# 2. Script copied to node.
+# 3. Install package copied to node.
+# 4. SSH Keys copied to node.
+# 5. Run CheckInstall to determine if  package is installed.
+# 6. Install/Upgrade if needed.
+# 7. Run CheckKeys to determine if sshkeys are installed.
+# 8. Install keys if different then installed or no keys installed.
+# 9. Return.
+#
 
 ###<REPLACE>###
 

--- a/initfiles/sbin/keygen.sh.in
+++ b/initfiles/sbin/keygen.sh.in
@@ -1,6 +1,19 @@
 #!/bin/bash
 ################################################################################
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 ###<REPLACE>###

--- a/initfiles/sbin/prerm.in
+++ b/initfiles/sbin/prerm.in
@@ -1,6 +1,19 @@
 #!/bin/bash
 ################################################################################
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 ###<REPLACE>###

--- a/initfiles/sbin/remote-install-engine.sh.in
+++ b/initfiles/sbin/remote-install-engine.sh.in
@@ -1,26 +1,37 @@
 #!/bin/bash
-##
-## Copyright (c) 2011 HPCC Systems.  All rights reserved.
-##
-## version v0.1
-## author Philip Schwartz <philip.schwartz@lexisnexis.com>
-##
-## Usage: remote-install-engine.sh
-##
-## This script is used as a remote engine for a cluster installation.
-##
-## Flow:
-##
-## 1. SSH Keys Generated.
-## 2. Script copied to node.
-## 3. Install package copied to node.
-## 4. SSH Keys copied to node.
-## 5. Run CheckInstall to determine if  package is installed.
-## 6. Install/Upgrade if needed.
-## 7. Run CheckKeys to determine if sshkeys are installed.
-## 8. Install keys if different then installed or no keys installed.
-## 9. Return.
-##
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+#
+# Usage: remote-install-engine.sh
+#
+# This script is used as a remote engine for a cluster installation.
+#
+# Flow:
+#
+# 1. SSH Keys Generated.
+# 2. Script copied to node.
+# 3. Install package copied to node.
+# 4. SSH Keys copied to node.
+# 5. Run CheckInstall to determine if  package is installed.
+# 6. Install/Upgrade if needed.
+# 7. Run CheckKeys to determine if sshkeys are installed.
+# 8. Install keys if different then installed or no keys installed.
+# 9. Return.
+#
 
 ###<REPLACE>###
 

--- a/initfiles/sbin/rm_conf_settings.sh.in
+++ b/initfiles/sbin/rm_conf_settings.sh.in
@@ -1,6 +1,19 @@
 #!/bin/bash
 ################################################################################
-## Copyright © 2011 HPCC Systems.  All rights reserved.
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 ###<REPLACE>###


### PR DESCRIPTION
Many files in the initfiles directory had temporary copyright messages
appropriate only until the code was released. Some files intended as
the defaults for user-edited configuration files should not have any
copyright.

This patch replaces them with the proper copyright blocks.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
