### PR TITLE
Issue:174 Minor change to eclcc regress batch file

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -829,6 +829,7 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
         withinRepository = checkWithinRepository(attributePath, sourcePathname);
 
         //Disable this for the moment when running the regression suite.
+        //It also doesn't work in batch mode for files in nested directories since filename is reduced to basename
         if (!optBatchMode && !withinRepository)
         {
             StringBuffer expandedSourceName;
@@ -899,7 +900,7 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
             {
                 StringBuffer msg;
                 msg.append("Could not resolve attribute ").append(attributePath.str());
-                errs->reportError(3, msg.str(), sourcePathname ? sourcePathname : attributePath.str(), 1, 0, 0);
+                errs->reportError(3, msg.str(), sourcePathname ? sourcePathname : attributePath.str(), 0, 0, 0);
             }
         }
         else

--- a/ecl/regress/r1.bat
+++ b/ecl/regress/r1.bat
@@ -20,4 +20,4 @@ rem ############################################################################
 setlocal enableextensions
 md %regresstgt% 2>nul
 call %~dp0\regress1 -m %*
-if EXIST %~dp0\rcompare.bat. call %~dp0\rcompare %*
+if EXIST %~dp0\rcompare.bat. call %~dp0\rcompare %~n1


### PR DESCRIPTION
Use the base name instead of the full pathname as the filter for the
regression comparison.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
