### PR TITLE
Bug: 80278 Remove test code uploaded by mistake

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -7099,20 +7099,10 @@ void CWsWorkunitsEx::getWorkunitArchiveQuery(IEspContext &context, const char* w
 
 void CWsWorkunitsEx::getWorkunitDll(IEspContext &context, const char* wuid,MemoryBuffer& buf)
 {
-    /*
     CQuery query(wuid, context);
     SCMStringBuffer dllname;
     query->getQueryDllName(dllname);
     queryDllServer().getDll(dllname.str(), buf);
-*/
-    RemoteFilename rfn;
-    rfn.setRemotePath("/mnt/disk1/var/lib/HPCCSystems/myeclccserver/libW20110616-112955.so");
-    SocketEndpoint ep("10.239.219.6");
-    rfn.setIp(ep);
-
-    Owned<IFile> file = createIFile(rfn);
-    OwnedIFileIO io = file->open(IFOread);
-    read(io, 0, (size32_t)-1, buf);
 }
 
 void CWsWorkunitsEx::getWorkunitResults(IEspContext &context, const char* wuid, unsigned index,__int64 start, unsigned& count,__int64& total,IStringVal& resname,bool raw,MemoryBuffer& buf)


### PR DESCRIPTION
The test code was uploaded by mistake when I worked on Bug: 80278.
Now, I am changing the code back to the original code.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
