### PR TITLE
fix #201 Added bash vars and environment.conf usage to complete-uninstall

### DIFF
--- a/initfiles/bash/etc/init.d/dafilesrv.in
+++ b/initfiles/bash/etc/init.d/dafilesrv.in
@@ -54,7 +54,7 @@ VERBOSE=${VERBOSE:-0}
 configgen_path=${INSTALL_DIR}/sbin
 basepath=`pwd`
 daemon_path="${INSTALL_DIR}/bin"
-set_envrionmentvars 
+set_environmentvars
 envfile=$configs/$environment
 bin_path=${INSTALL_DIR}/bin
 

--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -88,7 +88,7 @@ VERBOSE=${VERBOSE:-0}
 COMP_BY_TYPE=${COMP_BY_TYPE:-0}
 DAFILESRV=${DAFILESRV:-0}
 
-set_envrionmentvars 
+set_environmentvars
 envfile=$configs/$environment
 
 #Sourcing the hpcc environment

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -243,7 +243,7 @@ strstr() {
   return 0
 }
 
-set_envrionmentvars() {
+set_environmentvars() {
     HPCC_CONFIG=${HPCC_CONFIG:-${CONFIG_DIR}/${ENV_CONF_FILE}}
     
     ## Retrieve the Section to use from environment variable and if not set

--- a/initfiles/sbin/CMakeLists.txt
+++ b/initfiles/sbin/CMakeLists.txt
@@ -25,5 +25,6 @@ GENERATE_BASH(processor ${bash-vars} "hpcc-push.sh.in" outFiles)
 GENERATE_BASH(processor ${bash-vars} "hpcc-run.sh.in" outFiles)
 GENERATE_BASH(processor ${bash-vars} "install-cluster.sh.in" outFiles)
 GENERATE_BASH(processor ${bash-vars} "remote-install-engine.sh.in" outFiles)
+GENERATE_BASH(processor ${bash-vars} "complete-uninstall.sh.in" outFiles)
 ADD_CUSTOM_TARGET(ProcessFiles-initfiles-sbin ALL DEPENDS ${outFiles})
 

--- a/initfiles/sbin/complete-uninstall.sh.in
+++ b/initfiles/sbin/complete-uninstall.sh.in
@@ -16,6 +16,12 @@
 #    along with All rights reserved. This program is free software: you can redistribute program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################
 
+###<REPLACE>###
+
+source  ${INSTALL_DIR}/etc/init.d/hpcc_common
+
+set_environmentvars
+
 if [ -e /etc/debian_version ]; then
     dpkg --purge hpccsystems-platform
     dpkg --purge hpccsystems-clienttools
@@ -29,24 +35,31 @@ elif [ -e /etc/redhat-release -o -e /etc/SuSE-release ]; then
     rpm -e hpccsystems-platform
 fi
 
-echo "Removing Directory - /opt/HPCCSystems/*"
-rm -rf /opt/HPCCSystems/*
+echo "Removing Directory - ${path}"
+rm -rf ${path}
 
-echo "Removing Directory - /etc/HPCCSystems/*"
-rm -rf /etc/HPCCSystems/*
+echo "Removing Directory - ${configs}"
+rm -rf ${configs}
 
-for i in lock run log lib; do 
-    echo "Removing Directory - /var/$i/HPCCSystems/*"
-    rm -rf /var/$i/HPCCSystems/*; 
-done
+echo "Removing Directory - ${lock}"
+rm -rf ${lock}
 
-echo "Removing user"
+echo "Removing Directory - ${log}"
+rm -rf ${log}
+
+echo "Removing Directory - ${pid}"
+rm -rf ${pid}
+
+echo "Removing Directory - ${runtime}"
+rm -rf ${runtime}
+
+echo "Removing user - ${user}"
 if [ -e /usr/sbin/userdel ]; then
-    /usr/sbin/userdel -r hpcc
+    /usr/sbin/userdel -r ${user}
 elif [ -e /usr/bin/userdel ]; then
-    /usr/bin/userdel -r hpcc
+    /usr/bin/userdel -r ${user}
 elif [ -e /bin/userdel ]; then
-    /bin/userdel -r hpcc
+    /bin/userdel -r ${user}
 fi
 
 exit 0

--- a/initfiles/sbin/hpcc-push.sh.in
+++ b/initfiles/sbin/hpcc-push.sh.in
@@ -49,7 +49,7 @@ if [ $# -ne 2 ]; then
 	echo "usage: hpcc-push.sh [user@]host1:]file1 [[user@]host2:]file2"
 fi
 
-set_envrionmentvars
+set_environmentvars
 envfile=$configs/$environment
 
 getIPS

--- a/initfiles/sbin/hpcc-run.sh.in
+++ b/initfiles/sbin/hpcc-run.sh.in
@@ -55,7 +55,7 @@ runCmd(){
         ssh -i $home/$user/.ssh/id_rsa $user@$IP $@;
 }
 
-set_envrionmentvars
+set_environmentvars
 envfile=$configs/$environment
 
 getIPS


### PR DESCRIPTION
fix #201 Added bash vars and environment.conf usage to complete-uninstall.

Moved complete-uninstall.sh to complete-uninstall.sh.in and add it to config
time processor list.

Moved all directory and user removal to using environment vars from environment.conf.

Corrected type in function name set_environmentvars.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
