### PR TITLE
Bug: 83862 Clean code for other C++ files in ESP/ECLWatch

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -55,8 +55,6 @@
 #include "hqlerror.hpp"
 #include "eclrtl.hpp"
 
-///#define TESTDATASET 1
-
 #define     Action_Delete           "Delete"
 #define     Action_AddtoSuperfile   "Add To Superfile"
 static const char* FEATURE_URL="DfuAccess";
@@ -80,7 +78,6 @@ short days[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 void CWsDfuEx::init(IPropertyTree *cfg, const char *process, const char *service)
 {
-
     StringBuffer xpath;
     
     DBGLOG("Initializing %s service [process = %s]", service, process);
@@ -128,7 +125,6 @@ bool CWsDfuEx::onDFUSearch(IEspContext &context, IEspDFUSearchRequest & req, IEs
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuEx::onDFUSearch User=%s",username.str());
 
         Owned<IUserDescriptor> userdesc;
         if(username.length() > 0)
@@ -249,7 +245,6 @@ void parseTwoStringArrays(const char *input, StringArray& strarray1, StringArray
             tmp.set(inputText, columnNameLen);
             strarray1.append(tmp.get());
             tmp.set(colon, columnValueLen);
-            //tmp.toUpperCase(); 
             strarray2.append(tmp.get());
                 
             inputText = colon + columnValueLen;
@@ -268,8 +263,6 @@ bool CWsDfuEx::onDFUQuery(IEspContext &context, IEspDFUQueryRequest & req, IEspD
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuEx::onDFUQuery User=%s",username.str());
-
         Owned<IUserDescriptor> userdesc;
         if(username.length() > 0)
         {
@@ -297,8 +290,6 @@ bool CWsDfuEx::onDFUInfo(IEspContext &context, IEspDFUInfoRequest &req, IEspDFUI
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuEx::onDFUInfo User=%s",username.str());
-
         Owned<IUserDescriptor> userdesc;
         if(username.length() > 0)
         {
@@ -333,7 +324,6 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuEx::onDFUSpace User=%s",username.str());
 
         Owned<IUserDescriptor> userdesc;
         if(username.length() > 0)
@@ -413,8 +403,6 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
                 {
                     IPropertyTree &attr=fi->query();
                     StringBuffer modf(attr.queryProp("@modified"));
-                    //char* t=strchr(modf.str(),'T');
-                    //if(t) *t=' ';
 
                     if (bFirst)
                     {
@@ -1216,15 +1204,8 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                 superFileNames.append(logicalFileName);
             }
 
-            DBGLOG("CWsDfuEx::DFUDeleteFiles User=%s Action=Delete File=%s",username.str(), logicalFileName.str());
             try
             {
-                //onDFUAction(userdesc.get(), curfile, cluster, req.getType(), req.getNoDelete(), returnStr);
-                ///LogicFileWrapper Logicfile;
-                ///if (!Logicfile.doDeleteFile(logicalFileName.str(), cluster, req.getNoDelete(), returnStr, userdesc))
-                /// return false;
-
-
                 CDfsLogicalFileName lfn;
                 StringBuffer cname(cluster);
                 lfn.set(logicalFileName.str());
@@ -1245,7 +1226,6 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                     }
                     else 
                     {
-                        PrintLog("Deleted Logical File: %s\n",logicalFileName.str());
                         returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>",logicalFileName.str());
                     }
                 }
@@ -1304,26 +1284,6 @@ bool CWsDfuEx::onDFUArrayAction(IEspContext &context, IEspDFUArrayActionRequest 
 
         if (strcmp(req.getType(), Action_Delete) == 0)
         {
-            /*StringArray roxieQueries;
-            checkRoxieQueryFilesOnDelete(req, roxieQueries);
-            if (roxieQueries.length() > 0)
-            {
-                returnStr.append("<Message><Value>Cannot delete the files because of the following roxie queries: ");
-                for(int i = 0; i < roxieQueries.length();i++)
-                {
-                    const char* query = roxieQueries.item(i);
-                    if(!query || !*query)
-                        continue;
-
-                    if (i==0)
-                        returnStr.append(query);
-                    else
-                        returnStr.appendf(",%s", query);
-                }
-                returnStr.append("</Value></Message>");
-                resp.setDFUArrayActionResult(returnStr.str());
-                return true;
-            }*/
             return  DFUDeleteFiles(context, req, resp);
         }
 
@@ -1359,7 +1319,6 @@ bool CWsDfuEx::onDFUArrayAction(IEspContext &context, IEspDFUArrayActionRequest 
             strncpy(curfile, file, len);
             curfile[len] = 0;
             
-            DBGLOG("CWsDfuEx::onDFUArrayAction User=%s Action=%s File=%s",username.str(),req.getType(), file);
             try
             {
                 onDFUAction(userdesc.get(), curfile, cluster, req.getType(), req.getNoDelete(), returnStr);
@@ -1429,7 +1388,7 @@ bool CWsDfuEx::onDFUAction(IUserDescriptor* udesc, const char* LogicalFileName, 
         }
     }
     else
-        DBGLOG("Unknown Action type:%s\n",ActionType);
+        WARNLOG("Unknown Action type:%s\n",ActionType);
     
     return true;
 }
@@ -1438,14 +1397,11 @@ bool CWsDfuEx::onDFUDefFile(IEspContext &context,IEspDFUDefFileRequest &req, IEs
 {
     try
     {
-        DBGLOG("CWsDfuEx::onDFUDefFile\n");
-
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_DFU_ACCESS_DENIED, "Failed to access DFUDefFile. Permission denied.");
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuEx::onDFUDefFile User=%s",username.str());
 
         StringBuffer rawStr,returnStr;
 
@@ -1499,7 +1455,6 @@ void CWsDfuEx::xsltTransformer(const char* xsltPath,StringBuffer& source,StringB
 
 void CWsDfuEx::getDefFile(IUserDescriptor* udesc, const char* FileName,StringBuffer& returnStr)
 {
-    DBGLOG("CWsDfuEx::getDefFile\n");
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(FileName, udesc);
     if(!df)
         throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",FileName);
@@ -1603,21 +1558,7 @@ bool FindInStringArray(StringArray& clusters, const char *cluster)
     }
     else
     {
-#if 0 //Comment out since clusters are not set for some old files  
-        if (!clusters.ordinality())
-            return true;
-
-        ForEachItemIn(i, clusters)
-        {
-            const char* cluster0 = clusters.item(i);
-            if(cluster0 && !*cluster0)
-            {
-                return true;
-            }
-        }
-#else
         return true;
-#endif
     }
 
     return bFound;
@@ -1626,8 +1567,6 @@ bool FindInStringArray(StringArray& clusters, const char *cluster)
 void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, const char *name, const char *cluster, 
     const char *description,IEspDFUFileDetail& FileDetails)
 {
-    DBGLOG("CWsDfuEx::doGetFileDetails\n");
-
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(name, udesc);
     if(!df)
         throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",name);
@@ -1724,7 +1663,6 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
         {
             ForEach(*iter) 
             {
-                //printf("%s,%s\n",iter->query().queryLogicalName(),lname);
                 Owned<IEspDFULogicalFile> File = createDFULogicalFile("","");
                 File->setName(iter->queryName());
                 LogicalFiles.append(*File.getClear());
@@ -1951,8 +1889,6 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
 
 void CWsDfuEx::getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *dirname, IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& numFiles, int& numDirs)
 {
-    DBGLOG("CWsDfuEx::getLogicalFileAndDirectory\n");
-
     StringArray roxieClusterNames;
     IArrayOf<IEspTpCluster> roxieclusters;
     CTpWrapper dummy;
@@ -1988,15 +1924,11 @@ void CWsDfuEx::getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *di
                     pref.append(logicalName);
 
                 const char* owner=attr.queryProp("@owner");
-#if 0
-                char* clusterName=(char*)attr.queryProp("@group");   
-#else //Handling for multiple clusters
                 StringArray clusters;
                 if (getFileGroups(&attr,clusters)==0) 
                 {
                     clusters.append("");
                 }
-#endif
                 ForEachItemIn(i, clusters)
                 {
                     const char* clusterName = clusters.item(i);
@@ -2100,7 +2032,6 @@ bool CWsDfuEx::onDFUFileView(IEspContext &context, IEspDFUFileViewRequest &req, 
         Owned<IUserDescriptor> userdesc;
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuEx::onDFUFileView User=%s",username.str());
 
         if(username.length() > 0)
         {
@@ -2414,8 +2345,6 @@ bool CWsDfuEx::checkDescription(const char *description, const char *description
 
 bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc, IEspDFUQueryRequest & req, IEspDFUQueryResponse & resp)
 {
-    DBGLOG("CWsDfuEx::doLogicalFileSearch\n");
-
     double version = context.getClientVersion();
 
     IArrayOf<IEspDFULogicalFile> LogicalFiles;
@@ -2497,7 +2426,6 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
         {
             pagesize = 100;
         }
-//DBGLOG("pagesize=%d\n", pagesize);
 
         __int64 displayStartReq = 1;
         if (req.getPageStartFrom() > 0)
@@ -2598,27 +2526,6 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
                 if (!owner || stricmp(owner, req.getOwner()))
                     continue;
             }
-#if 0
-            char* clusterName = (char*)attr.queryProp("@group");      // ** TBD - Handling for multiple clusters?
-            if (clusterName)
-            {//special process for roxie cluster names
-                unsigned len = strlen(clusterName);
-                if (len > 8)
-                {
-                    char *pName = clusterName + len - 8; 
-                    if (!stricmp(pName, "__slaves"))
-                    {
-                        pName[0] = 0;//we did not specify slaves when copy/spray the file
-                    }
-                }
-            }
-
-        if (req.getClusterName() && *req.getClusterName()!=0)
-            {
-                if (!clusterName || stricmp(clusterName, req.getClusterName()))
-                    continue;
-            }
-#else
             StringArray clusters;
             StringArray clusters1;
             if (getFileGroups(&attr,clusters1)==0) 
@@ -2662,7 +2569,7 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
                     }
                 }
             }
-#endif
+
             const char* desc = attr.queryProp("@description");
             if(req.getDescription() && *req.getDescription())
             {
@@ -2804,7 +2711,7 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
                 {
                     File->setIsZipfile(true);
                 }
-                //File->setBrowseData(bKeyFile); //Bug: 39750 - All files should be viewable through ViewKeyFile function
+
                 if (numSubFiles > 1) //Bug 41379 - ViewKeyFile Cannot handle superfile with multiple subfiles
                     File->setBrowseData(false); 
                 else
@@ -2990,7 +2897,6 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
             resp.setBasicQuery(basicQuery.str());
         if (ParametersForPaging.length() > 0)
             resp.setParametersForPaging(ParametersForPaging.str());
-//DBGLOG("basicQuery=%s\n", basicQuery);
     }
 
     resp.setDFULogicalFiles(LogicalFiles);
@@ -3693,7 +3599,6 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                     if (dataNonKeyedColumns[19].length() > 0)
                         resp.setDFUDataNonKeyedColumns20(dataNonKeyedColumns[19]);
                 }
-                //resp.setColumnCount(columnCount);
                 resp.setRowCount(total);
             }
             
@@ -3929,8 +3834,6 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         bool bSchemaOnly=req.getSchemaOnly() ? req.getSchemaOnly() : false;
         bool bDisableUppercaseTranslation = req.getDisableUppercaseTranslation() ? req.getDisableUppercaseTranslation() : false; 
 
-#define HPCCBROWSER 1
-#ifdef HPCCBROWSER
         const char* filterBy = req.getFilterBy();
         const char* showColumns = req.getShowColumns();
 
@@ -3943,7 +3846,6 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         int iRet = GetIndexData(context, bSchemaOnly, logicalNameStr.str(), parentName, filterBy, start, count, read, total, msg, columnLabels, columnLabelsType, DataList, bDisableUppercaseTranslation);
         if (iRet > 0)
             resp.setMsgToDisplay("This search has timed out due to the restrictive filter. There may be more records.");
-        //GetIndexData(context, bSchemaOnly, logicalNameStr.str(), "roxie::thor_data400::key::bankruptcyv2::20090721::search::tmsid", filterBy, start, count, read, total, msg, columnLabels, columnLabelsType, DataList);
         resp.setResult(DataList.item(0).getData());
 
         unsigned int max_name_length = 3; //max length for name length
@@ -4036,238 +3938,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
             if (req.getCountForGoback())
                 resp.setCountForGoback(req.getCountForGoback());
         }
-#else
-        StringBuffer username;
-        context.getUserID(username);
-        double version = context.getClientVersion();
-        const char* passwd = context.queryPassword();
 
-        StringBuffer eclqueue, cluster;
-        Owned<IUserDescriptor> userdesc;
-        try
-        {
-            userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), passwd);
-            Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalNameStr.str(), userdesc);
-            if(df)
-            {
-                const char* wuid = df->queryProperties().queryProp("@workunit");
-                if (wuid && *wuid)
-                {
-                    CWUWrapper wu(wuid, context);
-                    if (wu)
-                    {   
-                        SCMStringBuffer eclqueue0, cluster0;
-                        eclqueue.append(wu->getQueue(eclqueue0).str());
-                        cluster.append(wu->getClusterName(cluster0).str());
-                    }
-                }
-            }
-        }
-        catch(...)
-        {
-            ;
-        }
-
-        Owned<IResultSetFactory> resultSetFactory;
-        if (context.querySecManager())
-            resultSetFactory.setown(getSecResultSetFactory(*context.querySecManager(), *context.queryUser()));
-        else
-            resultSetFactory.setown(getResultSetFactory(username, passwd));
-
-        Owned<INewResultSet> result;
-        if (eclqueue && *eclqueue && cluster && *cluster)
-        {
-            result.setown(resultSetFactory->createNewFileResultSet(logicalNameStr.str(), eclqueue, cluster));
-        }
-        else if (m_clusterName.length() > 0 && m_eclServerQueue.length() > 0)
-        {
-            result.setown(resultSetFactory->createNewFileResultSet(logicalNameStr.str(), m_eclServerQueue.str(), m_clusterName.str()));
-        }
-        else
-        {
-            result.setown(resultSetFactory->createNewFileResultSet(logicalNameStr.str(), NULL, NULL));
-        }
-        const IResultSetMetaData &meta = result->getMetaData();
-        unsigned columnCount = meta.getColumnCount();
-
-        StringArray filterByNames, filterByValues;
-        IArrayOf<IEspDFUDataColumn> dataColumns;
-        if (version > 1.04 && columnCount > 0)
-        {
-            int lenShowCols = 0, showCols[1024];
-            const char* showColumns = req.getShowColumns();
-            char *pShowColumns =  (char*) showColumns;
-            while (pShowColumns && *pShowColumns)
-            {
-                StringBuffer buf;
-                while (pShowColumns && isdigit(pShowColumns[0]))
-                {
-                    buf.append(pShowColumns[0]);
-                    pShowColumns++;
-                }
-                if (buf.length() > 0)
-                {
-                    showCols[lenShowCols] = atoi(buf.str());
-                    lenShowCols++;
-                }
-
-                if (!pShowColumns || !*pShowColumns)
-                    break;
-                pShowColumns++;
-            }
-
-            for(int col = 0; col < columnCount; col++)
-            {
-                Owned<IEspDFUDataColumn> item = createDFUDataColumn("","");
-
-                SCMStringBuffer scmbuf;
-                meta.getColumnLabel(scmbuf, col);
-                item->setColumnLabel(scmbuf.str()); 
-                if (!showColumns || !*showColumns)
-                {
-                    item->setColumnSize(1); //Show this column
-                    dataColumns.append(*item.getLink());
-                    continue;
-                }
-                else
-                {
-                    item->setColumnSize(0); //not show this column
-                }
-
-                for(int col1 = 0; col1 < lenShowCols; col1++)
-                {
-                    if (col == showCols[col1])
-                    {
-                        item->setColumnSize(1); //Show this column
-                        break;
-                    }
-                }
-                dataColumns.append(*item.getLink());
-            }
-
-            const char* filterBy = req.getFilterBy();
-            if (filterBy && *filterBy)
-            {
-                parseTwoStringArrays(filterBy, filterByNames, filterByValues);
-            }
-
-            if (req.getStartForGoback())
-                resp.setStartForGoback(req.getStartForGoback());
-            if (req.getCountForGoback())
-                resp.setCountForGoback(req.getCountForGoback());
-        }
-
-        StringBuffer filterByStr, filterByStr0;
-        unsigned int max_name_length = 3; //max length for name length
-        unsigned int max_value_length = 4; //max length for value length:
-        filterByStr0.appendf("%d%d", max_name_length, max_value_length);  
-        if (columnCount > 0 && filterByNames.length() > 0)
-        {
-            Owned<IFilteredResultSet> filter = result->createFiltered();
-            
-            for (int ii = 0; ii < filterByNames.length(); ii++)
-            {
-                const char* columnName = filterByNames.item(ii);
-                const char* columnValue = filterByValues.item(ii);
-                if (columnName && *columnName && columnValue && *columnValue)
-                {
-                    int col = 0;
-                    for(col = 0; col < columnCount; col++)
-                    {
-                        SCMStringBuffer scmbuf;
-                        meta.getColumnLabel(scmbuf, col);
-                        if (stricmp(scmbuf.str(), columnName) == 0)
-                        {
-                            filter->addFilter(col, columnValue);
-                            filterByStr.appendf("%s[%s]", columnName, columnValue);
-                            filterByStr0.appendf("%03d%04d%s%s", strlen(columnName), strlen(columnValue), columnName, columnValue);
-                    
-                            break;
-                        }
-                    }
-                    if (col == columnCount)
-                    {
-                        throw MakeStringException(0,"The filter %s not defined", columnName);
-                    }
-                }
-            }
-
-            result.setown(filter->create());
-        }
-
-        StringBuffer text;
-        const char* schemaName = "myschema";
-        Owned<IResultSetCursor> cursor = result->createCursor();
-
-        text.append("<XmlSchema name=\"").append(schemaName).append("\">");
-        const IResultSetMetaData & meta1 = cursor->queryResultSet()->getMetaData();
-        StringBufferAdaptor adaptor(text);
-        meta1.getXmlSchema(adaptor, false);
-        text.append("</XmlSchema>").newline();
-
-        text.append("<Dataset");
-        //if (name)
-        //  text.append(" name=\"").append(name).append("\" ");
-        text.append(" xmlSchema=\"").append(schemaName).append("\" ");
-        text.append(">").newline();
-
-        //__int64 total=0;
-        __int64 total=result->getNumRows();
-        __int64 read=0;
-        try
-        {
-            for(bool ok=cursor->absolute(start);ok;ok=cursor->next())
-            {
-                //total++;
-                //if(read < count)
-                {
-                    text.append(" ");
-                    StringBufferAdaptor adaptor2(text);
-                    cursor->getXmlRow(adaptor2);
-                    text.newline();
-
-                    read++;
-                }
-                if(read>=count)
-                    break;
-            }
-        }   
-        catch(IException* e)
-        {
-            if ((version < 1.08) || (e->errorCode() != FVERR_FilterTooRestrictive))
-                throw e;
-
-            e->Release();
-            resp.setMsgToDisplay("This search is timed out due to the restrictive filter. There may be more records.");
-        }
-
-        if (count > read)
-            count = read;
-
-        text.append("</Dataset>").newline();
-        ///DBGLOG("Dataset:%s", text.str());
-
-        MemoryBuffer buf;
-        struct MemoryBuffer2IStringVal : public CInterface, implements IStringVal
-        {
-             MemoryBuffer2IStringVal(MemoryBuffer & _buffer) : buffer(_buffer) {}
-             IMPLEMENT_IINTERFACE;
-
-             virtual const char * str() const { UNIMPLEMENTED;  }
-             virtual void set(const char *val) { buffer.append(strlen(val),val); }
-             virtual void clear() { } // clearing when appending does nothing
-             virtual void setLen(const char *val, unsigned length) { buffer.append(length, val); }
-             virtual unsigned length() const { return buffer.length(); };
-             MemoryBuffer & buffer;
-        } adaptor0(buf);
-
-        adaptor0.set(text.str());
-        buf.append(0);
-        resp.setResult(buf.toByteArray());
-#endif
-
-        //resp.setFilterBy(filterByStr.str()); 
         if (filterByStr.length() > 0)
         {
             const char* oldStr = "&";
@@ -4277,7 +3948,6 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         }
         if (version > 1.04)
         {
-            //resp.setFilterForGoBack(filterByStr0.str());
             if (filterByStr0.length() > 0)
             {
                 const char* oldStr = "&";
@@ -4293,11 +3963,8 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         {
             resp.setSchemaOnly(bSchemaOnly);
         }
-        //resp.setName(name.str());
         resp.setLogicalName(logicalNameStr.str());
         resp.setStart(start);
-        //if (requested > read)
-        //  requested = read;
         resp.setPageSize(requested);
         if (count > read)
         {
@@ -4340,16 +4007,10 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
 
 void CWsDfuEx::getRoxieClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress, int& port)
 {
-#if 0
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-    Owned<IConstEnvironment> environment = factory->openEnvironment();
-    Owned<IPropertyTree> pRoot = &environment->getPTree();
-#else
     CTpWrapper dummy;
     Owned<IPropertyTree> pRoot = dummy.getEnvironment("");
     if (!pRoot)
         throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO,"Failed to get environment information.");
-#endif
 
     StringBuffer xpath;
     xpath.appendf("Software/%s[@name='%s']", clusterType, clusterName);
@@ -4373,15 +4034,6 @@ void CWsDfuEx::getRoxieClusterConfig(char const * clusterType, char const * clus
         port = atoi(portStr);
     }
 
-#if 0
-    Owned<IConstMachineInfo> pMachine = environment->getMachine(computer);
-    if (pMachine)
-    {
-        SCMStringBuffer scmNetAddress;
-        pMachine->getNetAddress(scmNetAddress);
-        netAddress = scmNetAddress.str();
-    }
-#else
     xpath.clear().appendf("Hardware/Computer[@name=\"%s\"]", computer);
     IPropertyTree* pMachine = pRoot->queryPropTree( xpath.str() );
     if (pMachine)
@@ -4390,7 +4042,6 @@ void CWsDfuEx::getRoxieClusterConfig(char const * clusterType, char const * clus
         if (addr && *addr)
             netAddress.append(addr);
     }
-#endif
     
     return;
 }
@@ -4399,13 +4050,10 @@ void CWsDfuEx::getRoxieClusterConfig(char const * clusterType, char const * clus
 
 static const char* SCHEMANAME = "myschema";
 
-//void CWsDfuEx::setRootFilter(INewResultSet* result, const char* filterBy, IFilteredResultSet* filter)
 void CWsDfuEx::setRootFilter(INewResultSet* result, const char* filterBy, IResultSetFilter* filter, bool disableUppercaseTranslation)
 {
     if (!filterBy || !*filterBy || !result)
         return;
-
-    //Owned<IFilteredResultSet> filter = result->createFiltered();
 
     filter->clearFilters();
 
@@ -4450,9 +4098,6 @@ void CWsDfuEx::setRootFilter(INewResultSet* result, const char* filterBy, IResul
 
             if (!stricmp(scmbuf.str(), columnName))
             {
-                //filter->addFilter(col, columnValue);
-                //filterByStr.appendf("%s[%s]", columnName, columnValue);
-                //filterByStr0.appendf("%03d%04d%s%s", strlen(columnName), strlen(columnValue), columnName, columnValue);
                 if (hasSetTranslation)
                     filter->addNaturalFilter(col, strlen(columnValue), columnValue);
                 else
@@ -4463,7 +4108,6 @@ void CWsDfuEx::setRootFilter(INewResultSet* result, const char* filterBy, IResul
         }
     }
 
-    //result.setown(filter->create());
     return;
 }
 
@@ -4482,11 +4126,6 @@ void CWsDfuEx::getMappingColumns(IRelatedBrowseFile * file, bool isPrimary, Unsi
         cols.append(col);
     }
 
-#ifdef TESTDATASET
-    cols.kill();
-    cols.append(2);
-    cols.append(3);
-#endif
     return;
 }
 
@@ -4531,9 +4170,6 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
     if (schemaText2.length() < 1)
         return;
 
-//DBGLOG("First schema returns:%s", schemaText.str());
-//DBGLOG("Second schema returns:%s", schemaText2.str());
-
     Owned<IPropertyTree> schema = createPTreeFromXMLString(schemaText.str());
     Owned<IPropertyTree> schema2 = createPTreeFromXMLString(schemaText2.str());
     if (!schema || !schema2)
@@ -4571,11 +4207,6 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
     IPropertyTree*  rows = schema->queryBranch("xs:element[@name=\"Dataset\"]/xs:complexType/xs:sequence/xs:element[@name=\"Row\"]/xs:complexType/xs:sequence");
     if (!rows)
         return;
-
-//  StringBuffer schemaText4;
-//  toXML(schema, schemaText4);
-
-//DBGLOG("First schema returns:%s", schemaText4.str());
 
     //Find out labels used for column mapping
     columnsDisplay.kill();
@@ -4631,8 +4262,6 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
             }
         }
 
-#define RENAMESAMECOLUMN
-#ifdef RENAMESAMECOLUMN
         if (columnsDisplay.length() > 0)
         {
             for (unsigned i = 0; i < columnsDisplay.length(); i++)
@@ -4645,7 +4274,6 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
                 break;
             }
         }
-#endif
 
         if (!bAdd)
         {
@@ -4659,7 +4287,6 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
                 columnsDisplayType.append("Object");
             else
                 columnsDisplayType.append("Unknown");
-#ifdef RENAMESAMECOLUMN
             if (bRename)
             {
                 StringBuffer newName(name);
@@ -4670,12 +4297,9 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
             }
             else
             {
-#endif
-            columnsDisplay.append(name); //Display this column
-            rows->addPropTree(e.queryName(), LINK(&e));
-#ifdef RENAMESAMECOLUMN
+                columnsDisplay.append(name); //Display this column
+                rows->addPropTree(e.queryName(), LINK(&e));
             }
-#endif
         }
 
         col0++;
@@ -4685,7 +4309,6 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
     schemaText.clear();
     toXML(schema, schemaText);
 
-//DBGLOG("Merged schema returns:%s", schemaText.str());
     return;
 }
 
@@ -4703,10 +4326,8 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, int depth, IPropertyTreeIterat
             const char* label = e->queryName();
             if (label && *label)
             {
-#ifdef RENAMESAMECOLUMN
                 if (depth < 1)
                     columnsUsed.append(label);
-#endif
 
                 bool bHide = false;
                 if (columnsHide.length() > 0)
@@ -4722,7 +4343,6 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, int depth, IPropertyTreeIterat
                     }
                 }
 
-#ifdef RENAMESAMECOLUMN
                 if (!bHide && depth > 0 && columnsUsed.length() > 0)
                 {
                     for (unsigned i = 0 ; i < columnsUsed.length(); i++)
@@ -4737,7 +4357,7 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, int depth, IPropertyTreeIterat
                         break;
                     }
                 }
-#endif
+
                 if (!bHide)
                 {
                     StringBuffer dataRow;
@@ -4799,30 +4419,6 @@ void CWsDfuEx::browseRelatedFileSchema(IRelatedBrowseFile * file, const char* pa
             StringBufferAdaptor adaptor(schemaText);
             meta.getXmlSchema(adaptor, false);
 
-#ifdef TESTDATASET
-schemaText.clear();
-schemaText.append("<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\"");
-schemaText.append(" attributeFormDefault=\"unqualified\">");
-schemaText.append("<xs:element name=\"Dataset\"><xs:complexType><xs:sequence minOccurs=\"0\" maxOccurs=\"unbounded\">");
-schemaText.append("<xs:element name=\"Row\"><xs:complexType><xs:sequence>");
-schemaText.append("<xs:element name=\"state\" type=\"string2\"/>");
-schemaText.append("<xs:element name=\"rtype\" type=\"string2\"/>");
-schemaText.append("<xs:element name=\"id\" type=\"string20\"/>");
-schemaText.append("<xs:element name=\"seq\" type=\"xs:nonNegativeInteger\"/>");
-schemaText.append("<xs:element name=\"num\" type=\"xs:nonNegativeInteger\"/>");
-schemaText.append("<xs:element name=\"date\" type=\"string8\"/>");
-schemaText.append("<xs:element name=\"imglength\" type=\"xs:nonNegativeInteger\"/>");
-schemaText.append("<xs:element name=\"__filepos\" type=\"xs:nonNegativeInteger\"/>");
-schemaText.append("</xs:sequence></xs:complexType></xs:element>");
-schemaText.append("</xs:sequence></xs:complexType></xs:element>");
-schemaText.append("<xs:simpleType name=\"string2\"><xs:restriction base=\"xs:string\"><xs:maxLength value=\"2\"/>");
-schemaText.append("</xs:restriction></xs:simpleType>");
-schemaText.append("<xs:simpleType name=\"string20\"><xs:restriction base=\"xs:string\"><xs:maxLength value=\"20\"/>");
-schemaText.append("</xs:restriction></xs:simpleType>");
-schemaText.append("<xs:simpleType name=\"string8\"><xs:restriction base=\"xs:string\"><xs:maxLength value=\"8\"/>");
-schemaText.append("</xs:restriction></xs:simpleType>");
-schemaText.append("</xs:schema>");
-#endif
             readColumnsForDisplay(schemaText, columnsDisplay, columnsDisplayType);
         }
         else
@@ -4831,22 +4427,6 @@ schemaText.append("</xs:schema>");
             const IResultSetMetaData & meta = cursor->queryResultSet()->getMetaData();
             StringBufferAdaptor adaptor(schemaText0);
             meta.getXmlSchema(adaptor, false);
-#ifdef TESTDATASET
-schemaText0.clear();
-schemaText0.append("<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\"");
-schemaText0.append(" attributeFormDefault=\"unqualified\">");
-schemaText0.append("<xs:element name=\"Dataset\"><xs:complexType><xs:sequence minOccurs=\"0\" maxOccurs=\"unbounded\">");
-schemaText0.append("<xs:element name=\"Row\"><xs:complexType><xs:sequence>");
-schemaText0.append("<xs:element name=\"date_first_reported\" type=\"string12\"/>");
-schemaText0.append("<xs:element name=\"msa\" type=\"string8\"/>");
-schemaText0.append("<xs:element name=\"sid\" type=\"string20\"/>");
-schemaText0.append("<xs:element name=\"seq\" type=\"xs:nonNegativeInteger\"/>"); //not add
-schemaText0.append("</xs:sequence></xs:complexType></xs:element>");
-schemaText0.append("</xs:sequence></xs:complexType></xs:element>");
-schemaText0.append("<xs:simpleType name=\"string12\"><xs:restriction base=\"xs:string\"><xs:maxLength value=\"12\"/>");
-schemaText0.append("</xs:restriction></xs:simpleType>");
-schemaText0.append("</xs:schema>");
-#endif
             mergeSchema(file, schemaText, schemaText0, columnsDisplay, columnsDisplayType, columnsHide);
         }
 
@@ -4896,56 +4476,6 @@ int CWsDfuEx::browseRelatedFileDataSet(double version, IRelatedBrowseFile * file
                 StringBuffer text;
                 StringBufferAdaptor adaptor2(text);
                 cursor->getXmlRow(adaptor2);
-//DBGLOG("Data row returns:%s", text.str());
-
-#ifdef TESTDATASET
-text.clear();
-if (depth < 1)
-{
-    if (rows < 1)
-    {
-        text.append("<Row><state>AA</state><rtype>ab</rtype><id>abc</id><seq>12</seq></Row>");
-    }
-    else if (rows < 2)
-    {
-        text.append("<Row><state>BB</state><rtype>ba</rtype><id>abc</id><seq>13</seq></Row>");
-    }
-    else if (rows < 3)
-    {
-        text.append("<Row><state>CC</state><rtype>ca</rtype><id>bcd</id><seq>13</seq></Row>");
-    }
-    else
-    {
-        break;
-    }
-}
-else
-{
-    if (read < 1)
-    {
-        if (rows > 0)
-            break;
-        text.append("<Row><date_first_reported>20090511</date_first_reported><msa>6200</msa><sid>abc</sid><seq>12</seq></Row>");
-    }
-    else if (read < 2)
-    {
-        if (rows > 0)
-            break;
-        text.append("<Row><date_first_reported>20090512</date_first_reported><msa>6201</msa><sid>abc</sid><seq>13</seq></Row>");
-    }
-    else if (read < 3)
-    {
-        if (rows > 1)
-            break;
-        else if (rows > 0)
-            text.append("<Row><date_first_reported>20090514</date_first_reported><msa>6203</msa><sid>bcd</sid><seq>13</seq></Row>");
-        else
-            text.append("<Row><date_first_reported>20090513</date_first_reported><msa>6202</msa><sid>bcd</sid><seq>13</seq></Row>");
-    }
-}
-
-rows++;
-#endif
 
                 StringArray dataSetOutput0;
                 if (parentName && *parentName)
@@ -4983,7 +4513,6 @@ rows++;
                         if (text1.length() > 0)
                         {
                             mergeDataRow(text0, text, text1, columnsHide);
-    //DBGLOG("New row returns:%s", text0.str());
                         }
                         dataSetOutput.append(text0);
                     }
@@ -5084,7 +4613,6 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
         resultSetFactory.setown(getResultSetFactory(username, passwd));
 
     Owned<IViewFileWeb> web;
-    //Owned<INewResultSet> result;
     if (cluster && *cluster)
     {
         web.setown(createViewFileWeb(*resultSetFactory, cluster));
@@ -5143,10 +4671,8 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
     // Apply the filter to the root node
     if (filterBy && *filterBy)
     {
-        //Owned<IFilteredResultSet> filter = result->createFiltered();
         IResultSetFilter* filter = browser->queryRootFilter();
         setRootFilter(result, filterBy, filter, disableUppercaseTranslation);
-        ///result.setown(filter->create());
     }
 
     StringBuffer text, schemaText;

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -26,28 +26,9 @@
 #endif
 
 #include "ws_dfu_esp.ipp"
-
 #include "ws_dfuView.hpp"
-
 #include "fileview.hpp"
 #include "fvrelate.hpp"
-
-/*
-class CSpaceItem64 : public CInterface
-{
-public:
-    char Name[256];
-    char LargestFile[256];
-    char SmallestFile[256];
-    __int64 NumOfFilesInt;
-    __int64 NumOfFilesIntUnknown;
-    __int64 TotalSizeInt;
-    __int64 LargestSizeInt;
-    __int64 SmallestSizeInt;
-
-    IMPLEMENT_IINTERFACE;
-};*/
-
 
 class CWsDfuSoapBindingEx : public CWsDfuSoapBinding
 {
@@ -94,7 +75,6 @@ public:
 private:
     void getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *dirname, IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& numFiles, int& numDirs);
     bool doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc, IEspDFUQueryRequest & req, IEspDFUQueryResponse & resp);
-    //bool doLogicalFileSearch(IUserDescriptor* udesc, IEspDFUQueryRequest & req, IEspDFUQueryResponse & resp);
     void doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, const char *name,const char *cluster,
         const char *description,IEspDFUFileDetail& FileDetails);
     bool createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, unsigned& yearFrom, 
@@ -118,7 +98,6 @@ private:
     bool onDFUAction(IUserDescriptor* udesc, const char* LogicalFileName,const char* ClusterName,const char* ActionType, bool nodelete, StringBuffer& returnStr);
     bool checkFileContent(IEspContext &context, IUserDescriptor* udesc, const char * logicalName, const char * cluster);
     void getRoxieClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress, int& port);
-    //bool getRoxieQueriesForFile(const char* logicalName, const char* cluster, StringArray& roxieQueries);
     bool checkRoxieQueryFilesOnDelete(IEspDFUArrayActionRequest &req, StringArray& roxieQueries);
     bool DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &req, IEspDFUArrayActionResponse &resp);
 
@@ -146,7 +125,6 @@ private:
     StringBuffer user_;
     StringBuffer password_;
 };
-
 
 //helper functions
 inline const char * splitName(const char * name)

--- a/esp/services/ws_dfu/ws_dfuView.cpp
+++ b/esp/services/ws_dfu/ws_dfuView.cpp
@@ -20,9 +20,7 @@
 
 #include "ws_dfuService.hpp"
 
-
 unsigned CLogicalView::idgen_ = 0;
-
 
 CLogicalView *LVManager::createLogicalView(StringBuffer &token, const char * logicalFile, const char * cluster, unsigned rowsPerPage)
 {
@@ -105,21 +103,6 @@ CLogicalView *LVManager::queryLogicalView(const StringBuffer &strToken)
     return lv;
 }
 
-/*
-interface IResultSetMetaData : extends IInterface
-{
-    virtual int getColumnCount() const = 0;
-    virtual DisplayType getColumnDisplayType(int column) const = 0;
-    virtual IStringVal & getColumnLabel(IStringVal & s, int column) const = 0;
-    virtual IStringVal & getColumnEclType(IStringVal & s, int column) const = 0;
-    virtual IStringVal & getColumnXmlType(IStringVal & s, int column) const = 0;
-    virtual bool isSigned(int column) const = 0;
-    virtual bool isEBCDIC(int column) const = 0;
-    virtual bool isBigEndian(int column) const = 0;
-    virtual unsigned getColumnRawType(int column) const = 0;
-    virtual unsigned getColumnRawSize(int column) const = 0;
-};
-*/
 const char * CLogicalView::getXsd()
 {
     if (xsd_.length() == 0)
@@ -129,11 +112,7 @@ const char * CLogicalView::getXsd()
 
         IPropertyTree * schema = createPTree("xsd:schema", ipt_caseInsensitive);
         schema->setProp("@id", "DFUDataSet");
-//      schema->setProp("@targetNamespace", "http://tempuri.org/colTotals.xsd");
-//      schema->setProp("@elementFormDefault", "qualified");
-//      schema->setProp("@attributeFormDefault", "qualified");
         schema->setProp("@xmlns", "");
-//      schema->setProp("@xmlns:mstns", "http://tempuri.org/colTotals.xsd");
         schema->setProp("@xmlns:xsd", "http://www.w3.org/2001/XMLSchema");
         schema->setProp("@xmlns:msdata", "urn:schemas-microsoft-com:xml-msdata");
 
@@ -173,7 +152,7 @@ const char * CLogicalView::getXsd()
         schema->addPropTree("xsd:element", element);
         dataset->addPropTree("xsd:schema", schema);
 
-        toXML(schema, xsd_);//, false, false);
+        toXML(schema, xsd_);
     }
     return xsd_.str();
 }

--- a/esp/services/ws_dfu/ws_dfuXRefService.cpp
+++ b/esp/services/ws_dfu/ws_dfuXRefService.cpp
@@ -59,10 +59,7 @@ static void appendReplyMessage(StringBuffer &reply, const char *href,const char 
 void CWsDfuXRefEx::init(IPropertyTree *cfg, const char *process, const char *service)
 {
     
-    StringBuffer xpath;
-    
-    DBGLOG("Initializing %s service [process = %s]", service, process);
-    
+    StringBuffer xpath;   
     xpath.clear().appendf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/User", process, service);
     cfg->getProp(xpath.str(), user_);
 
@@ -87,7 +84,6 @@ bool CWsDfuXRefEx::onDFUXRefArrayAction(IEspContext &context, IEspDFUXRefArrayAc
     {
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefArrayAction User=%s",username.str());
         Owned<IUserDescriptor> userdesc;
         if(username.length() > 0)
         {
@@ -123,12 +119,8 @@ bool CWsDfuXRefEx::onDFUXRefArrayAction(IEspContext &context, IEspDFUXRefArrayAc
         StringBuffer returnStr,UserName;
         const char* ActionType = req.getAction();
 
-        DBGLOG("Running Xref Command %s for user %s",ActionType,context.getUserID(UserName).str());
-
         for(unsigned i = 0; i < req.getXRefFiles().length();i++)
         {
-            DBGLOG("CWsDfuXRefEx::onDFUXRefArrayAction %s file %s for User=%s", ActionType, req.getXRefFiles().item(i), username.str());
-
             StringBuffer errstr;
             if (strcmp("Delete" ,ActionType) == 0)
             {
@@ -187,7 +179,6 @@ bool CWsDfuXRefEx::onDFUXRefLostFiles(IEspContext &context, IEspDFUXRefLostFiles
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefLostFiles User=%s",username.str());
         if (!req.getCluster() || !*req.getCluster())
             throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT, "Cluster not defined.");
 
@@ -216,7 +207,6 @@ bool CWsDfuXRefEx::onDFUXRefFoundFiles(IEspContext &context, IEspDFUXRefFoundFil
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefFoundFiles User=%s",username.str());
 
         if (!req.getCluster() || !*req.getCluster())
             throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT, "Cluster not defined.");
@@ -244,7 +234,6 @@ bool CWsDfuXRefEx::onDFUXRefOrphanFiles(IEspContext &context, IEspDFUXRefOrphanF
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefOrphanFiles User=%s",username.str());
         if (!req.getCluster() || !*req.getCluster())
             throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT, "Cluster not defined.");
 
@@ -273,7 +262,6 @@ bool CWsDfuXRefEx::onDFUXRefMessages(IEspContext &context, IEspDFUXRefMessagesQu
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefMessages User=%s",username.str());
         if (!req.getCluster() || !*req.getCluster())
             throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT, "Cluster not defined.");
 
@@ -301,7 +289,6 @@ bool CWsDfuXRefEx::onDFUXRefCleanDirectories(IEspContext &context, IEspDFUXRefCl
         
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefDirectories User=%s",username.str());
         if (!req.getCluster() || !*req.getCluster())
             throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT, "Cluster not defined.");
 
@@ -311,7 +298,6 @@ bool CWsDfuXRefEx::onDFUXRefCleanDirectories(IEspContext &context, IEspDFUXRefCl
 
         StringBuffer buf;
         xRefNode->removeEmptyDirectories(buf);
-        DBGLOG("xRefNode->removeEmptyDirectories result=%s",buf.str());
         resp.setRedirectUrl(StringBuffer("/WsDFUXRef/DFUXRefDirectories?Cluster=").append(req.getCluster()));
     }
     catch(IException* e)
@@ -330,7 +316,6 @@ bool CWsDfuXRefEx::onDFUXRefDirectories(IEspContext &context, IEspDFUXRefDirecto
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefDirectories User=%s",username.str());
         if (!req.getCluster() || !*req.getCluster())
             throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT, "Cluster not defined.");
 
@@ -401,7 +386,6 @@ bool CWsDfuXRefEx::onDFUXRefBuild(IEspContext &context, IEspDFUXRefBuildRequest 
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefBuild User=%s",username.str());
         if (!req.getCluster() || !*req.getCluster())
             throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT, "Cluster not defined.");
 
@@ -439,7 +423,6 @@ bool CWsDfuXRefEx::onDFUXRefBuildCancel(IEspContext &context, IEspDFUXRefBuildCa
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefBuildCancel User=%s",username.str());
 
         m_XRefbuilder->Cancel();
         StringBuffer returnStr;
@@ -462,17 +445,13 @@ bool CWsDfuXRefEx::onDFUXRefList(IEspContext &context, IEspDFUXRefListRequest &r
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsDfuXRefEx::onDFUXRefList User=%s",username.str());
-
 
         //Firstly we need to get a list of the available Thor Cluster....
         IArrayOf<IEspTpCluster> clusters;
         CTpWrapper _topology;
         _topology.getClusterProcessList(eqThorCluster,clusters,false,true);
-        ///_topology.getClusterList(eqRoxieCluster,clusters,false,true);
 
         Owned<IPropertyTree> pXRefNodeTree = createPTree("XRefNodes");
-        //DBGLOG("CWsDfuXRefEx::onDFUXRefList1\n");
 
         for (unsigned x=0;x<=clusters.ordinality();x++)
         {
@@ -508,4 +487,3 @@ bool CWsDfuXRefEx::onDFUXRefList(IEspContext &context, IEspDFUXRefListRequest &r
     }
     return true;
 }
-

--- a/esp/services/ws_fileio/ws_fileioservice.cpp
+++ b/esp/services/ws_fileio/ws_fileioservice.cpp
@@ -26,7 +26,6 @@
 #include "windows.h"
 #endif
 
-///#define FILE_DESPRAY_URL "FileDesprayAccess"
 #define FILE_IO_URL     "FileIO"
 
 void CWsFileIOEx::init(IPropertyTree *cfg, const char *process, const char *service)
@@ -38,14 +37,7 @@ bool CWsFileIOEx::CheckServerAccess(const char* server, const char* relPath, Str
     if (!server || (server[0] == 0) || !relPath || (relPath[0] == 0))
         return false;
     Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-
-    Owned<IConstEnvironment> env;
-#if 0
-    env.setown(factory->openEnvironment());
-#else
-    env.setown(factory->openEnvironmentByFile());
-#endif
-
+    Owned<IConstEnvironment> env = factory->openEnvironmentByFile();
     Owned<IPropertyTree> pEnvRoot = &env->getPTree();
     IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
     IPropertyTree* pRoot = createPTreeFromXMLString("<Environment/>");
@@ -78,12 +70,7 @@ bool CWsFileIOEx::CheckServerAccess(const char* server, const char* relPath, Str
                         ipaddr.getIpText(ipStr);
                         if (ipStr.length() > 0)
                         {
-//#define MACHINE_IP "10.239.219.9"
-#ifdef MACHINE_IP
-                            sNetAddr.append(MACHINE_IP);
-#else
                             sNetAddr.append(ipStr.str());
-#endif
                         }
                     }
                     bool dropzoneFound = false;
@@ -103,9 +90,6 @@ bool CWsFileIOEx::CheckServerAccess(const char* server, const char* relPath, Str
 
                     char ch = '\\';
                     Owned<IConstMachineInfo> machine = env->getMachineByAddress(addr);
-                    //Owned<IConstEnvironment> env = factory->openEnvironment();
-                    //Owned<IConstMachineInfo> machine = getMachineByAddress(pEnvRoot, env, addr);
-
                     if (machine && (machine->getOS() == MachineOsLinux || machine->getOS() == MachineOsSolaris))
                     {
                         ch = '/';
@@ -370,5 +354,4 @@ bool CWsFileIOEx::onWriteFileData(IEspContext &context, IEspWriteFileDataRequest
 
     return true;
 }
-
 

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -195,11 +195,7 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
 IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, const char* dfuwuid)
 {
     Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-#if 0
-    Owned<IConstEnvironment> m_constEnv = factory->openEnvironment();
-#else
     Owned<IConstEnvironment> m_constEnv = factory->openEnvironmentByFile();
-#endif
     Owned<IPropertyTree> pEnvRoot = &m_constEnv->getPTree();
     IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
 
@@ -252,11 +248,7 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
                 ipaddr.getIpText(ipStr);
                 if (ipStr.length() > 0)
                 {
-#ifdef MACHINE_IP
-                    sNetAddr.append(MACHINE_IP);
-#else
                     sNetAddr.append(ipStr.str());
-#endif
                 }
             }
             pDropZone->addProp("@netAddress", sNetAddr.str());
@@ -279,7 +271,6 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
 
             if (machine)
             {
-                //int os = machine->getOS();
                 StringBuffer dir;
                 pDropZone->getProp("@directory", dir);
                 if (machine->getOS() == MachineOsLinux || machine->getOS() == MachineOsSolaris)
@@ -325,7 +316,6 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
 
                 ins++;
                 StringBuffer gname("hthor__");
-                //StringBuffer gname;
                 gname.append(name);
                 if (ins>1)
                     gname.append('_').append(ins);
@@ -388,24 +378,6 @@ void CFileSpraySoapBindingEx::downloadFile(IEspContext &context, CHttpRequest* r
         request->getParameter("Path", pathStr);
         request->getParameter("Name", nameStr);
         
-#if 0
-        StringArray files;
-        IProperties* params = request->queryParameters();
-        Owned<IPropertyIterator> iter = params->getIterator();
-        if (iter && iter->first())
-        {
-            while (iter->isValid())
-            {
-                const char *keyname=iter->getPropKey();
-                if (!keyname || strncmp(keyname, "Names", 5))
-                    continue;
-
-                files.append(params->queryProp(iter->getPropKey()));
-                iter->next();
-            }
-        }
-#endif
-
         if (netAddressStr.length() < 1)
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "Network address not specified.");
 
@@ -426,11 +398,7 @@ void CFileSpraySoapBindingEx::downloadFile(IEspContext &context, CHttpRequest* r
             pathStr.append( pathSep );
 
         StringBuffer logname;
-#ifdef MACHINE_IP
-        logname.appendf("//%s/%s/%s", MACHINE_IP, pathStr.str(), nameStr.str());
-#else
         logname.appendf("%c%s%c%s%s", pathSep, netAddressStr.str(), pathSep, pathStr.str(), nameStr.str());
-#endif
         logname.clear().appendf("%s%s", pathStr.str(), nameStr.str());
 
         StringBuffer headerStr("attachment;");

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -287,8 +287,6 @@ static void DeepAssign(IConstDFUWorkUnit *src, IEspDFUWorkunit &dest)
     IConstDFUfileSpec * file = src->querySource();
     if (file != NULL)
     {
-        //if (file->getTitle(tmp.clear()).length()!=0)
-        //  dest.setSourceTitle(tmp.str());
         StringBuffer lfn;
         file->getLogicalName(lfn);
         if (lfn.length() != 0)
@@ -930,13 +928,10 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
         unsigned numWUs = factory->numWorkUnitsFiltered(filters, filterbuf.bufferBase());
         Owned<IConstDFUWorkUnitIterator> itr = factory->getWorkUnitsSorted(sortorder, filters, filterbuf.bufferBase(), (int) displayFrom, (int) pagesize+1, req.getOwner(), &cachehint);
 
-        //unsigned actualCount = 0;
         itr->first();
         while(itr->isValid())
         {
             Owned<IConstDFUWorkUnit> wu = itr->get();
-            //actualCount++;
-
             Owned<IEspDFUWorkunit> resultWU = createDFUWorkunit("", "");
             resultWU->setID(wu->queryId());
             StringBuffer jobname, user, cluster;
@@ -2677,18 +2672,10 @@ int CFileSprayEx::doFileCheck(const char* mask, const char* netaddr, const char*
                     ipaddr.getIpText(ipStr);
                     if (ipStr.length() > 0)
                     {
-#ifdef MACHINE_IP
-                        sNetAddr.append(MACHINE_IP);
-#else
                         sNetAddr.append(ipStr.str());
-#endif
                     }
                 }
-#ifdef MACHINE_IP
-                if ((sNetAddr.length() > 0) && !stricmp(sNetAddr.str(), MACHINE_IP))
-#else
                 if ((sNetAddr.length() > 0) && !stricmp(sNetAddr.str(), netaddr))
-#endif
                 {
                     StringBuffer dir;
                     IPropertyTree* pDropZone = pSoftware->addPropTree("DropZone", &it->get());
@@ -2748,11 +2735,7 @@ bool CFileSprayEx::onFileList(IEspContext &context, IEspFileListRequest &req, IE
 
         RemoteFilename rfn;
         SocketEndpoint ep;
-#ifdef MACHINE_IP
-        ep.set(MACHINE_IP);
-#else
         ep.set(netaddr);
-#endif
         rfn.setPath(ep, sPath.str());
         Owned<IFile> f = createIFile(rfn);
         if(!f->isDirectory())
@@ -2916,11 +2899,7 @@ bool CFileSprayEx::getDropZoneFiles(IEspContext &context, const char* netaddr, c
 
     RemoteFilename rfn;
     SocketEndpoint ep;
-#ifdef MACHINE_IP
-    ep.set(MACHINE_IP);
-#else
     ep.set(netaddr);
-#endif
 
     rfn.setPath(ep, path);
     Owned<IFile> f = createIFile(rfn);
@@ -3014,11 +2993,7 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
                     ipaddr.getIpText(ipStr);
                     if (ipStr.length() > 0)
                     {
-#ifdef MACHINE_IP
-                        sNetAddr.append(MACHINE_IP);
-#else
                         sNetAddr.append(ipStr.str());
-#endif
                     }
                 }
 
@@ -3147,11 +3122,7 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
 
         RemoteFilename rfn;
         SocketEndpoint ep;
-#ifdef MACHINE_IP
-        ep.set(MACHINE_IP);
-#else
         ep.set(netAddress);
-#endif
 
         rfn.setPath(ep, sPath.str());
         Owned<IFile> f = createIFile(rfn);

--- a/esp/services/ws_machine/ws_machineServiceRexec.cpp
+++ b/esp/services/ws_machine/ws_machineServiceRexec.cpp
@@ -264,31 +264,30 @@ public:
       char   buffer[128];
       FILE   *fp;
 
-      /* Run the command so that it writes its output to a pipe. Open this
-       * pipe with read text attribute so that we can read it 
-       * like a text file. 
-       */
-        if (getEspLogLevel()>8)
+      // Run the command so that it writes its output to a pipe. Open this
+      // pipe with read text attribute so that we can read it 
+      // like a text file. 
+       
+        if (getEspLogLevel()>LogNormal)
         {
             DBGLOG("command_line=<%s>", command_line);
         }
-#ifdef CHECK_LINUX_COMMAND
-        return -1;
-#else
       if( (fp = popen( command_line, "r" )) == NULL )
          return -1;
 
-        /* Read pipe until end of file. End of file indicates that 
-       * the stream closed its standard out (probably meaning it 
-       * terminated).
-       */
+        // Read pipe until end of file. End of file indicates that 
+       // the stream closed its standard out (probably meaning it 
+       // terminated).
       while ( !feof(fp) )
          if ( fgets( buffer, 128, fp) )
             response.append( buffer );
 
-      /* Close pipe and print return value of CHKDSK. */
+      if (getEspLogLevel()>LogNormal)
+      {
+          DBGLOG("response=<%s>", response.str());
+      }
+      // Close pipe and print return value of CHKDSK. 
       return pclose( fp );
-#endif
    }
 };
 

--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
@@ -176,12 +176,7 @@ void CWsRoxieQueryEx::addToQueryStringFromInt(StringBuffer &queryString, const c
 void CWsRoxieQueryEx::getClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress, int& port)
 {
     Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-#if 0
-    Owned<IConstEnvironment> environment = factory->openEnvironment();
-#else
     Owned<IConstEnvironment> environment = factory->openEnvironmentByFile();
-#endif
-
     Owned<IPropertyTree> pRoot = &environment->getPTree();
 
     StringBuffer xpath;
@@ -211,10 +206,6 @@ void CWsRoxieQueryEx::getClusterConfig(char const * clusterType, char const * cl
         SCMStringBuffer scmNetAddress;
         pMachine->getNetAddress(scmNetAddress);
         netAddress = scmNetAddress.str();
-#ifdef MACHINE_IP
-        if (!strcmp(netAddress.str(), "."))
-            netAddress = MACHINE_IP;
-#endif
     }
     
     return;
@@ -229,7 +220,6 @@ bool CWsRoxieQueryEx::onRoxieQuerySearch(IEspContext &context, IEspRoxieQuerySea
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsRoxieQueryEx::onRoxieQuerySearch User=%s",username.str());
 
         CTpWrapper dummy;
         IArrayOf<IEspTpCluster> clusters;
@@ -435,7 +425,6 @@ bool CWsRoxieQueryEx::onRoxieQueryList(IEspContext &context, IEspRoxieQueryListR
 
         StringBuffer username;
         context.getUserID(username);
-        DBGLOG("CWsRoxieQueryEx::onRoxieQueryList User=%s",username.str());
 
         const char* sortBy = req.getSortby();
         bool descending = req.getDescending();
@@ -536,7 +525,6 @@ bool CWsRoxieQueryEx::onQueryDetails(IEspContext &context, IEspRoxieQueryDetails
 
         StringBuffer username, password;
         getUserInformation(context, username, password);
-        DBGLOG("CWsRoxieQueryEx::onQueryDetails User=%s",username.str());
 
         const char* queryID = req.getQueryID();
         const char* cluster = req.getCluster();

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -181,21 +181,15 @@ struct ArchivedWUsCacheElement: public CInterface, implements IInterface
 
     CDateTime m_timeCached;
     IArrayOf<IEspECLWorkunit> m_results;
-    //std::string m_data;
 };
 
 struct ArchivedWUsCache: public CInterface, implements IInterface
 {
     IMPLEMENT_IINTERFACE;
     
-    ArchivedWUsCache(size32_t _cacheSize=0): cacheSize(_cacheSize)
-    {
-    }
-
+    ArchivedWUsCache(size32_t _cacheSize=0): cacheSize(_cacheSize) {}
 
     ArchivedWUsCacheElement* lookup(IEspContext &context, const char* filter, const char* sashaUpdatedWhen, unsigned timeOutMin);
-     //void getQueryFileListFromTree(IPropertyTreeIterator* queries, const char* fileType, const char* cluster, 
-    //  IArrayOf<IEspRoxieDFULogicalFile>& queryFileList);
 
      void add(const char* filter, const char* sashaUpdatedWhen, bool hasNextPage, IArrayOf<IEspECLWorkunit>& wus);
 
@@ -361,11 +355,6 @@ private:
 
     void addSubFiles(IPropertyTreeIterator* f, IEspECLSourceFile* eclSuperFile, StringArray& fileNames);
     void openSaveFile(IEspContext &context, int opt, const char* filename, const char* origMimeType, MemoryBuffer& buf, IEspWULogFileResponse &resp);
-#if 0 //not use for now
-    void getSubFiles(IUserDescriptor* userdesc, const char *fileName, IEspECLSourceFile* eclSourceFile0);
-    bool checkFileInECLSourceFile(const char* file, IConstECLSourceFile& eclfile);
-    bool checkFileInECLSourceFiles(const char* file, IArrayOf<IEspECLSourceFile>& eclfiles);
-#endif
 
 private:
     StringBuffer m_GraphUpdateGvcXSLT;

--- a/esp/smc/SMCLib/LogicFileWrapper.cpp
+++ b/esp/smc/SMCLib/LogicFileWrapper.cpp
@@ -84,7 +84,6 @@ bool LogicFileWrapper::doDeleteFile(const char* LogicalFileName,const char *clus
             DBGLOG("%s", errorStr.str());
         }
         else {
-            PrintLog("Deleted Logical File: %s\n",LogicalFileName);
             returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>",LogicalFileName);
         }
 

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -34,8 +34,6 @@ const char* MSG_FAILED_GET_ENVIRONMENT_INFO = "Failed to get environment informa
 
 IPropertyTree* CTpWrapper::getEnvironment(const char* xpath)
 {
-    DBGLOG("CTpWrapper::getEnvironment()");
-
     Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
     Owned<IPropertyTree> root = &constEnv->getPTree();
@@ -73,13 +71,7 @@ bool CTpWrapper::getClusterLCR(const char* clusterType, const char* clusterName)
         return bLCR;
 
     Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
-    if (!envFactory)
-        throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
-    
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
-    if (!constEnv)
-        throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
-
     Owned<IPropertyTree> root = &constEnv->getPTree();
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
@@ -191,16 +183,7 @@ void CTpWrapper::fetchInstances(const char* ServiceType, IPropertyTree& service,
 
 void CTpWrapper::getTpDaliServers(IArrayOf<IConstTpDali>& list)
 {
-    DBGLOG("CTpWrapper::getTpDaliServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -246,16 +229,7 @@ void CTpWrapper::getTpDaliServers(IArrayOf<IConstTpDali>& list)
 
 void CTpWrapper::getTpEclServers(IArrayOf<IConstTpEclServer>& list)
 {
-    DBGLOG("CTpWrapper::getTpEclServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -291,16 +265,7 @@ void CTpWrapper::getTpEclServers(IArrayOf<IConstTpEclServer>& list)
 
 void CTpWrapper::getTpEclCCServers(IArrayOf<IConstTpEclServer>& list, const char* serverName)
 {
-    DBGLOG("CTpWrapper::getTpEclServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -340,16 +305,7 @@ void CTpWrapper::getTpEclCCServers(IArrayOf<IConstTpEclServer>& list, const char
 
 void CTpWrapper::getTpEclAgents(IArrayOf<IConstTpEclAgent>& list, const char* agentName)
 {
-    DBGLOG("CTpWrapper::getTpEclAgents()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -392,7 +348,6 @@ void CTpWrapper::getTpEclAgents(IArrayOf<IConstTpEclAgent>& list, const char* ag
 
 void CTpWrapper::getTpEclSchedulers(IArrayOf<IConstTpEclScheduler>& list, const char* serverName)
 {
-    DBGLOG("CTpWrapper::getTpEclSchedulers()");
     Owned<IPropertyTree> root = getEnvironment("Software");
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
@@ -433,16 +388,7 @@ void CTpWrapper::getTpEclSchedulers(IArrayOf<IConstTpEclScheduler>& list, const 
 
 void CTpWrapper::getTpEspServers(IArrayOf<IConstTpEspServer>& list)
 {
-    DBGLOG("CTpWrapper::getEspServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -505,16 +451,7 @@ void CTpWrapper::getTpEspServers(IArrayOf<IConstTpEspServer>& list)
 
 void CTpWrapper::getTpDfuServers(IArrayOf<IConstTpDfuServer>& list)
 {
-    DBGLOG("CTpWrapper::getTpDfuServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -552,16 +489,7 @@ void CTpWrapper::getTpDfuServers(IArrayOf<IConstTpDfuServer>& list)
 
 void CTpWrapper::getTpSashaServers(IArrayOf<IConstTpSashaServer>& list)
 {
-    DBGLOG("CTpWrapper::getSashaServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -596,16 +524,7 @@ void CTpWrapper::getTpSashaServers(IArrayOf<IConstTpSashaServer>& list)
 
 void CTpWrapper::getTpLdapServers(IArrayOf<IConstTpLdapServer>& list)
 {
-    DBGLOG("CTpWrapper::getTpLdapServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -656,27 +575,14 @@ void CTpWrapper::getTpLdapServers(IArrayOf<IConstTpLdapServer>& list)
 
 void CTpWrapper::getTpDropZones(IArrayOf<IConstTpDropZone>& list)
 {
-    DBGLOG("CTpWrapper::getTpDropZones()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
-    Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
-    if (!root)
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IConstEnvironment> env = factory->openEnvironmentByFile();
+    Owned<IPropertyTree> pEnvRoot = &env->getPTree();
+    IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
+    if (!pEnvSoftware)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-#if 0
-    Owned<IConstEnvironment> m_pConstEnvironment = factory->openEnvironment();
-#else
-    Owned<IConstEnvironment> m_pConstEnvironment = factory->openEnvironmentByFile();
-#endif
-
-    Owned<IPropertyTreeIterator> services= root->getElements(eqDropZone);
+    Owned<IPropertyTreeIterator> services= pEnvSoftware->getElements(eqDropZone);
     ForEach(*services)
     {
         IPropertyTree& serviceTree = services->query();
@@ -709,8 +615,9 @@ void CTpWrapper::getTpDropZones(IArrayOf<IConstTpDropZone>& list)
            if (directory && *directory)
               machine->setDirectory(directory);
 
-              Owned<IConstMachineInfo> pMachineInfo =  m_pConstEnvironment->getMachine(computerName.str());
-              machine->setOS(pMachineInfo->getOS());
+              Owned<IConstMachineInfo> pMachineInfo =  env->getMachine(computerName.str());
+              if (pMachineInfo.get())
+                machine->setOS(pMachineInfo->getOS());
 
            tpMachines.append(*machine.getLink());
         }
@@ -722,16 +629,7 @@ void CTpWrapper::getTpDropZones(IArrayOf<IConstTpDropZone>& list)
 
 void CTpWrapper::getTpFTSlaves(IArrayOf<IConstTpFTSlave>& list)
 {
-    DBGLOG("CTpWrapper::getTpFTSlaves()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -755,16 +653,7 @@ void CTpWrapper::getTpFTSlaves(IArrayOf<IConstTpFTSlave>& list)
 
 void CTpWrapper::getTpDkcSlaves(IArrayOf<IConstTpDkcSlave>& list)
 {
-    DBGLOG("CTpWrapper::getTpDkcSlaves()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -788,16 +677,7 @@ void CTpWrapper::getTpDkcSlaves(IArrayOf<IConstTpDkcSlave>& list)
 
 void CTpWrapper::getTpGenesisServers(IArrayOf<IConstTpGenesisServer>& list)
 {
-    DBGLOG("CTpWrapper::getTpGenesisServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -821,7 +701,6 @@ void CTpWrapper::getTpGenesisServers(IArrayOf<IConstTpGenesisServer>& list)
 
 void CTpWrapper::getTargetClusterList(IArrayOf<IEspTpLogicalCluster>& clusters, const char* clusterType, const char* clusterName)
 {
-    DBGLOG("CTpWrapper::getLogicalClusterList");
     Owned<IPropertyTree> root = getEnvironment("Software");
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
@@ -902,7 +781,7 @@ void CTpWrapper::queryTargetClusterProcess(double version, const char* processNa
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
     const char* queueName = NULL;
-    if (processName&&(stricmp(clusterType,eqThorCluster)==0)) 
+    if (processName&&(stricmp(clusterType,eqThorCluster)==0))
     {   
         // only for multi-thor
         // only list first thor cluster on queue
@@ -1147,165 +1026,155 @@ void CTpWrapper::getClusterProcessList(const char* ClusterType, IArrayOf<IEspTpC
 {
     try
     {
-#if 0
-        Owned<IRemoteConnection> conn = querySDS().connect("/Environment", myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-        if (conn)
-        {
-            IPropertyTree* root = conn->queryRoot();
-            IPropertyTree* pSoftware = root->queryPropTree("Software");
-            if (!pSoftware)
-                return;
-#else
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
-        Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
-        Owned<IPropertyTree> root = &constEnv->getPTree();
-        if (root)
-        {
-            IPropertyTree* pSoftware = root->queryPropTree("Software");
-#endif
-            if (!pSoftware)
-                throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IConstEnvironment> environment = factory->openEnvironmentByFile();
+        Owned<IPropertyTree> root = &environment->getPTree();
+        if (!root)
+            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
-            StringArray queuesdone;
-            StringArray groupsdone;
-            Owned<IPropertyTreeIterator> clusters= pSoftware->getElements(ClusterType);
-            if (clusters->first()) {
-                do {
-                    IPropertyTree &cluster = clusters->query();                 
-                    const char* name = cluster.queryProp("@name");
-                    if (!name||!*name)
-                        continue;
-                    const char* queueName = NULL;
-                    const char* groupName = NULL;
-                    if (name&&(stricmp(ClusterType,eqThorCluster)==0)) 
-                    {   
-                        // only for multi-thor
-                        // only list first thor cluster on queue
-                        queueName = cluster.queryProp("@queueName");
-                        if (!queueName||!*queueName)
-                            queueName = name;
-                        if (ignoreduplicatqueues) 
+        IPropertyTree* pSoftware = root->queryPropTree("Software");
+        if (!pSoftware)
+            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get software information.");
+
+        StringArray queuesdone;
+        StringArray groupsdone;
+        Owned<IPropertyTreeIterator> clusters= pSoftware->getElements(ClusterType);
+        if (clusters->first()) {
+            do {
+                IPropertyTree &cluster = clusters->query();
+                const char* name = cluster.queryProp("@name");
+                if (!name||!*name)
+                    continue;
+                const char* queueName = NULL;
+                const char* groupName = NULL;
+                if (name&&(stricmp(ClusterType,eqThorCluster)==0))
+                {
+                    // only for multi-thor
+                    // only list first thor cluster on queue
+                    queueName = cluster.queryProp("@queueName");
+                    if (!queueName||!*queueName)
+                        queueName = name;
+                    if (ignoreduplicatqueues)
+                    {
+                        bool done=false;
+                        ForEachItemIn(i,queuesdone)
                         {
-                            bool done=false;
-                            ForEachItemIn(i,queuesdone) 
+                            if (strcmp(queuesdone.item(i),queueName)==0)
                             {
-                                if (strcmp(queuesdone.item(i),queueName)==0) 
-                                {
-                                    done = true;
-                                    break;
-                                }
+                                done = true;
+                                break;
                             }
-                            if (done)
-                                continue;
-                            queuesdone.append(queueName);
                         }
-                        groupName = cluster.queryProp("@nodeGroup");
-                        if (!groupName||!*groupName)
-                            groupName = name;
-                        if (ignoreduplicategroups) 
+                        if (done)
+                            continue;
+                        queuesdone.append(queueName);
+                    }
+                    groupName = cluster.queryProp("@nodeGroup");
+                    if (!groupName||!*groupName)
+                        groupName = name;
+                    if (ignoreduplicategroups)
+                    {
+                        bool done=false;
+                        ForEachItemIn(i,groupsdone)
                         {
-                            bool done=false;
-                            ForEachItemIn(i,groupsdone) 
+                            if (strcmp(groupsdone.item(i),groupName)==0)
                             {
-                                if (strcmp(groupsdone.item(i),groupName)==0) 
-                                {
-                                    done = true;
-                                    break;
-                                }
+                                done = true;
+                                break;
                             }
-                            if (done)
-                                continue;
-                            groupsdone.append(groupName);
                         }
-
+                        if (done)
+                            continue;
+                        groupsdone.append(groupName);
                     }
 
-                    IEspTpCluster* clusterInfo = createTpCluster("","");                    
-                    clusterInfo->setName(name);
-                    if (queueName && *queueName)
-                        clusterInfo->setQueueName(queueName);
+                }
+
+                IEspTpCluster* clusterInfo = createTpCluster("","");
+                clusterInfo->setName(name);
+                if (queueName && *queueName)
+                    clusterInfo->setQueueName(queueName);
+                else
+                    clusterInfo->setQueueName(name);
+                clusterInfo->setDesc(name);
+                clusterInfo->setBuild( cluster.queryProp("@build") );
+
+                StringBuffer path("/Environment/Software");
+                StringBuffer tmpPath;
+                setAttPath(path, ClusterType, "name", name, tmpPath);
+
+                clusterInfo->setType(ClusterType);
+
+                StringBuffer tmpDir;
+                if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "run", ClusterType, name, tmpDir))
+                {
+                    clusterInfo->setDirectory(tmpDir.str());
+                }
+                else
+                {
+                    clusterInfo->setDirectory(cluster.queryProp("@directory"));
+                }
+
+                tmpDir.clear();
+                if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "log", ClusterType, name, tmpDir))
+                {
+                    clusterInfo->setLogDirectory( tmpDir.str() );
+                }
+                else
+                {
+                    const char* logDir = cluster.queryProp("@logDir");
+                    if (logDir)
+                        clusterInfo->setLogDirectory( logDir );
+                }
+
+                clusterInfo->setPath(tmpPath.str());
+
+                //this is defined in the Topology attribute for the Cluster.
+                StringBuffer prefix;
+                getPrefixName(name,prefix);
+                clusterInfo->setPrefix(prefix.str());
+
+                if(cluster.hasProp("@dataBuild"))
+                    clusterInfo->setDataModel(cluster.queryProp("@dataBuild"));
+
+                clusterList.append(*clusterInfo);
+
+                //find out OS
+                OS_TYPE os = OS_WINDOWS;
+                unsigned int clusterTypeLen = strlen(ClusterType);
+                const char* childType = NULL;
+                if (clusterTypeLen > 4)
+                    if (!strnicmp(ClusterType, "roxie", 4))
+                        childType = "RoxieServerProcess[1]";
+                    else if (!strnicmp(ClusterType, "thor", 4))
+                        childType = "ThorMasterProcess";
                     else
-                        clusterInfo->setQueueName(name);
-                    clusterInfo->setDesc(name);
-                    clusterInfo->setBuild( cluster.queryProp("@build") );
-
-                    StringBuffer path("/Environment/Software");
-                    StringBuffer tmpPath;
-                    setAttPath(path, ClusterType, "name", name, tmpPath);
-
-                    clusterInfo->setType(ClusterType);
-
-                    StringBuffer tmpDir;
-                    if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "run", ClusterType, name, tmpDir))
+                        childType = "HoleControlProcess";
+                if (childType)
+                {
+                    IPropertyTree* pChild = cluster.queryPropTree(childType);
+                    if (pChild)
                     {
-                        clusterInfo->setDirectory(tmpDir.str());
-                    }
-                    else
-                    {
-                        clusterInfo->setDirectory(cluster.queryProp("@directory"));
-                    }
-
-                    tmpDir.clear();
-                    if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "log", ClusterType, name, tmpDir))
-                    {
-                        clusterInfo->setLogDirectory( tmpDir.str() );
-                    }
-                    else
-                    {
-                        const char* logDir = cluster.queryProp("@logDir");
-                        if (logDir)
-                            clusterInfo->setLogDirectory( logDir );
-                    }
-
-                    clusterInfo->setPath(tmpPath.str());
-
-                    //this is defined in the Topology attribute for the Cluster.
-                    StringBuffer prefix;
-                    getPrefixName(name,prefix);
-                    clusterInfo->setPrefix(prefix.str());
-
-                    if(cluster.hasProp("@dataBuild"))
-                        clusterInfo->setDataModel(cluster.queryProp("@dataBuild"));
-
-                    clusterList.append(*clusterInfo);
-
-                    //find out OS
-                    OS_TYPE os = OS_WINDOWS;
-                    unsigned int clusterTypeLen = strlen(ClusterType);
-                    const char* childType = NULL;
-                    if (clusterTypeLen > 4)
-                        if (!strnicmp(ClusterType, "roxie", 4))
-                            childType = "RoxieServerProcess[1]";
-                        else if (!strnicmp(ClusterType, "thor", 4))
-                            childType = "ThorMasterProcess";
-                        else
-                            childType = "HoleControlProcess";
-                    if (childType)
-                    {
-                        IPropertyTree* pChild = cluster.queryPropTree(childType);
-                        if (pChild)
+                        const char* computer = pChild->queryProp("@computer");
+                        IPropertyTree* pHardware = root->queryPropTree("Hardware");
+                        if (computer && *computer && pHardware)
                         {
-                            const char* computer = pChild->queryProp("@computer");
-                            IPropertyTree* pHardware = root->queryPropTree("Hardware");
-                            if (computer && *computer && pHardware)
+                            StringBuffer xpath;
+                            xpath.appendf("Computer[@name='%s']/@computerType", computer);
+                            const char* computerType = pHardware->queryProp( xpath.str() );
+                            if (computerType && *computerType)
                             {
-                                StringBuffer xpath;
-                                xpath.appendf("Computer[@name='%s']/@computerType", computer);
-                                const char* computerType = pHardware->queryProp( xpath.str() );
-                                if (computerType && *computerType)
-                                {
-                                    xpath.clear().appendf("ComputerType[@name='%s']/@opSys", computerType);
-                                    const char* opSys = pHardware->queryProp( xpath.str() );
-                                    if (!stricmp(opSys, "linux") || !stricmp( opSys, "solaris"))
-                                        os = OS_LINUX;
-                                }
+                                xpath.clear().appendf("ComputerType[@name='%s']/@opSys", computerType);
+                                const char* opSys = pHardware->queryProp( xpath.str() );
+                                if (!stricmp(opSys, "linux") || !stricmp( opSys, "solaris"))
+                                    os = OS_LINUX;
                             }
                         }
                     }
-                    clusterInfo->setOS(os);
+                }
+                clusterInfo->setOS(os);
 
-                } while (clusters->next());
-            }
+            } while (clusters->next());
         }
     }
     catch(IException* e){   
@@ -1323,94 +1192,86 @@ void CTpWrapper::getHthorClusterList(IArrayOf<IEspTpCluster>& clusterList)
 {
     try
     {
-#if 0
-        Owned<IRemoteConnection> conn = querySDS().connect("/Environment", myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-        if (conn)
-        {
-            IPropertyTree* root = conn->queryRoot();
-            IPropertyTree* pSoftware = root->queryPropTree("Software");
-            if (!pSoftware)
-                return;
-#else
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
-        Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
-        Owned<IPropertyTree> root = &constEnv->getPTree();
-        if (root)
-        {
-            IPropertyTree* pSoftware = root->queryPropTree("Software");
-#endif
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IConstEnvironment> environment = factory->openEnvironmentByFile();
+        Owned<IPropertyTree> root = &environment->getPTree();
+        if (!root)
+            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
-            const char * ClusterType = "EclAgentProcess";
-            Owned<IPropertyTreeIterator> clusters(pSoftware->getElements(ClusterType));
-            ForEach(*clusters) 
+        IPropertyTree* pSoftware = root->queryPropTree("Software");
+        if (!pSoftware)
+            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get software information.");
+
+        const char * ClusterType = "EclAgentProcess";
+        Owned<IPropertyTreeIterator> clusters(pSoftware->getElements(ClusterType));
+        ForEach(*clusters)
+        {
+            IPropertyTree &cluster = clusters->query();
+            const char* name = cluster.queryProp("@name");
+            if (!name||!*name)
+                continue;
+            unsigned ins = 0;
+            Owned<IPropertyTreeIterator> insts = clusters->query().getElements("Instance");
+            ForEach(*insts)
             {
-                IPropertyTree &cluster = clusters->query();                 
-                const char* name = cluster.queryProp("@name");
-                if (!name||!*name)
-                    continue;
-                unsigned ins = 0;
-                Owned<IPropertyTreeIterator> insts = clusters->query().getElements("Instance");
-                ForEach(*insts) 
+                const char *na = insts->query().queryProp("@netAddress");
+                if (na&&*na)
                 {
-                    const char *na = insts->query().queryProp("@netAddress");
-                    if (na&&*na) 
+                    SocketEndpoint ep(na);
+                    if (!ep.isNull())
                     {
-                        SocketEndpoint ep(na);
-                        if (!ep.isNull()) 
+                        ins++;
+                        StringBuffer gname("hthor__");
+                        gname.append(name);
+                        if (ins>1)
+                            gname.append('_').append(ins);
+
+                        IEspTpCluster* clusterInfo = createTpCluster("","");
+
+                        clusterInfo->setName(gname.str());
+                        clusterInfo->setQueueName(name);
+                        clusterInfo->setDesc(cluster.queryProp("@build"));
+
+                        clusterInfo->setBuild( cluster.queryProp("@description") );
+
+                        StringBuffer path("/Environment/Software");
+                        StringBuffer tmpPath;
+                        setAttPath(path, ClusterType, "name", name, tmpPath);
+
+                        clusterInfo->setType(ClusterType);
+                        clusterInfo->setDirectory(insts->query().queryProp("@directory"));
+
+                        StringBuffer tmpDir;
+                        if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "run", ClusterType, name, tmpDir))
                         {
-                            ins++;
-                            StringBuffer gname("hthor__");
-                            gname.append(name);
-                            if (ins>1)
-                                gname.append('_').append(ins);
-
-                            IEspTpCluster* clusterInfo = createTpCluster("","");    
-                    
-                            clusterInfo->setName(gname.str());
-                            clusterInfo->setQueueName(name);
-                            clusterInfo->setDesc(cluster.queryProp("@build"));
-
-                            clusterInfo->setBuild( cluster.queryProp("@description") );
-
-                            StringBuffer path("/Environment/Software");
-                            StringBuffer tmpPath;
-                            setAttPath(path, ClusterType, "name", name, tmpPath);
-
-                            clusterInfo->setType(ClusterType);
-                            clusterInfo->setDirectory(insts->query().queryProp("@directory"));
-
-                            StringBuffer tmpDir;
-                            if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "run", ClusterType, name, tmpDir))
-                            {
-                                clusterInfo->setDirectory(tmpDir.str());
-                            }
-                            else
-                            {
-                                clusterInfo->setDirectory(insts->query().queryProp("@directory"));
-                            }
-
-                            clusterInfo->setPath(tmpPath.str());
-                            clusterList.append(*clusterInfo);
-
-                            //find out OS
-                            OS_TYPE os = OS_WINDOWS;
-                            const char* computer = insts->query().queryProp("@computer");
-                            IPropertyTree* pHardware = root->queryPropTree("Hardware");
-                            if (computer && *computer && pHardware)
-                            {
-                                StringBuffer xpath;
-                                xpath.appendf("Computer[@name='%s']/@computerType", computer);
-                                const char* computerType = pHardware->queryProp( xpath.str() );
-                                if (computerType && *computerType)
-                                {
-                                    xpath.clear().appendf("ComputerType[@name='%s']/@opSys", computerType);
-                                    const char* opSys = pHardware->queryProp( xpath.str() );
-                                    if (!stricmp(opSys, "linux") || !stricmp( opSys, "solaris"))
-                                        os = OS_LINUX;
-                                }
-                            }
-                            clusterInfo->setOS(os);
+                            clusterInfo->setDirectory(tmpDir.str());
                         }
+                        else
+                        {
+                            clusterInfo->setDirectory(insts->query().queryProp("@directory"));
+                        }
+
+                        clusterInfo->setPath(tmpPath.str());
+                        clusterList.append(*clusterInfo);
+
+                        //find out OS
+                        OS_TYPE os = OS_WINDOWS;
+                        const char* computer = insts->query().queryProp("@computer");
+                        IPropertyTree* pHardware = root->queryPropTree("Hardware");
+                        if (computer && *computer && pHardware)
+                        {
+                            StringBuffer xpath;
+                            xpath.appendf("Computer[@name='%s']/@computerType", computer);
+                            const char* computerType = pHardware->queryProp( xpath.str() );
+                            if (computerType && *computerType)
+                            {
+                                xpath.clear().appendf("ComputerType[@name='%s']/@opSys", computerType);
+                                const char* opSys = pHardware->queryProp( xpath.str() );
+                                if (!stricmp(opSys, "linux") || !stricmp( opSys, "solaris"))
+                                    os = OS_LINUX;
+                            }
+                        }
+                        clusterInfo->setOS(os);
                     }
                 }
             }
@@ -1454,67 +1315,6 @@ void CTpWrapper::getGroupList(IArrayOf<IEspTpGroup> &GroupList)
         WARNLOG("Unknown Exception caught within CTpWrapper::getGroupList");
     }
     StringBuffer cluster;
-}
-
-void CTpWrapper::resolveGroupInfo(const char* groupName,StringBuffer& Cluster, StringBuffer& ClusterPrefix)
-{
-    if(*groupName == 0)
-    {
-        DBGLOG("NULL PARAMETER groupName");
-        return;
-    }
-    //There is a big estimate here.... namely that one group can only be associated with one cluster.......
-    // if this changes then this code may be invalidated....
-    try
-    {
-#if 0
-        Owned<IRemoteConnection> conn = querySDS().connect("/Environment/Software/Topology", myProcessSession(), RTM_LOCK_READ|RTM_SUB, SDS_LOCK_TIMEOUT);
-        Owned<IPropertyTreeIterator> nodes=  conn->queryRoot()->getElements("//Cluster");
-        if (nodes->first()) {
-            do {
-
-                IPropertyTree &node = nodes->query();
-                if (ContainsProcessDefinition(node,groupName)==true)
-                {
-                    //the prefix info is contained within the parent
-                    ClusterPrefix.append(node.queryProp("@prefix"));
-                    Cluster.append(node.queryProp("@name"));
-                    break;
-                }
-            } while (nodes->next());
-        }
-#else
-        Owned<IPropertyTree> pTopology = getEnvironment("Software/Topology");
-        if (!pTopology)
-            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
-
-        Owned<IPropertyTreeIterator> nodes=  pTopology->getElements("//Cluster");
-        if (nodes->first()) 
-        {
-            do 
-            {
-
-                IPropertyTree &node = nodes->query();
-                if (ContainsProcessDefinition(node,groupName)==true)
-                {
-                    //the prefix info is contained within the parent
-                    ClusterPrefix.append(node.queryProp("@prefix"));
-                    Cluster.append(node.queryProp("@name"));
-                    break;
-                }
-            } while (nodes->next());
-        }
-#endif
-    }
-    catch(IException* e){   
-      StringBuffer msg;
-      e->errorMessage(msg);
-        WARNLOG("%s", msg.str());
-        e->Release();
-    }
-    catch(...){
-        WARNLOG("Unknown Exception caught within CTpWrapper::resolveGroupInfo");
-    }
 }
 
 StringBuffer& CTpWrapper::getPrefixName(const char* clusterName,StringBuffer& prefixName)
@@ -1576,13 +1376,6 @@ void CTpWrapper::getMachineList(const char* MachineType,
     try
     {
         //ParentPath=Path to parent node... normally a cluster
-#if 0
-        Owned<IRemoteConnection> conn = querySDS().connect(ParentPath, myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-      if (!conn)
-         throw MakeStringException(-1, "Specified path '%s' is invalid!", ParentPath);
-
-        IPropertyTree* root = conn->queryRoot();
-#else
         Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
         Owned<IPropertyTree> root0 = &constEnv->getPTree();
@@ -1596,7 +1389,7 @@ void CTpWrapper::getMachineList(const char* MachineType,
         IPropertyTree* root = root0->queryPropTree( xpath );
         if (!root)
             throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
-#endif
+
         Owned<IPropertyTreeIterator> machines= root->getElements(MachineType);
         const char* nodenametag = getNodeNameTag(MachineType);
         if (machines->first()) {
@@ -1656,10 +1449,6 @@ void CTpWrapper::getDropZoneList(const char* MachineType,
 {
     try
     {
-#if 0
-        Owned<IRemoteConnection> conn = querySDS().connect(ParentPath, myProcessSession(), RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
-        Owned<IPropertyTreeIterator> nodes=  conn->queryRoot()->getElements(eqDropZone);
-#else
         Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
         Owned<IPropertyTree> root0 = &constEnv->getPTree();
@@ -1675,7 +1464,6 @@ void CTpWrapper::getDropZoneList(const char* MachineType,
             throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
         Owned<IPropertyTreeIterator> nodes=  root->getElements(eqDropZone);
-#endif
         if (nodes->first()) {
             do {
 
@@ -1710,12 +1498,8 @@ void CTpWrapper::setMachineInfo(const char* name,const char* type,IEspTpMachine&
 {
     try{
         Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-#if 0
-        Owned<IConstEnvironment> m_pConstEnvironment = factory->openEnvironment();
-#else
-        Owned<IConstEnvironment> m_pConstEnvironment = factory->openEnvironmentByFile();
-#endif
-        Owned<IConstMachineInfo> pMachineInfo =  m_pConstEnvironment->getMachine(name);
+        Owned<IConstEnvironment> pEnvironment = factory->openEnvironmentByFile();
+        Owned<IConstMachineInfo> pMachineInfo =  pEnvironment->getMachine(name);
         if (pMachineInfo.get())
         {
             SCMStringBuffer ep;
@@ -1735,11 +1519,7 @@ void CTpWrapper::setMachineInfo(const char* name,const char* type,IEspTpMachine&
                 ipaddr.getIpText(ipStr);
                 if (ipStr.length() > 0)
                 {
-#ifdef MACHINE_IP
-                    machine.setNetaddress(MACHINE_IP);
-#else
                     machine.setNetaddress(ipStr.str());
-#endif
                     machine.setConfigNetaddress(".");
                 }
             }

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -159,7 +159,6 @@ public:
                         set<string>* pMachineNames=NULL);
     void getDropZoneList(const char* MachineType, const char* MachinePath, const char* Directory, IArrayOf<IEspTpMachine> &MachineList);
     void setMachineInfo(const char* name,const char* type,IEspTpMachine& machine);
-    void resolveGroupInfo(const char* groupName,StringBuffer& Cluster, StringBuffer& ClusterPrefix);
     void getMachineInfo(IEspTpMachine& machineInfo,IPropertyTree& machine,const char* ParentPath,const char* MachineType,const char* nodenametag);
     StringBuffer& getPrefixName(const char* clusterName,StringBuffer& prefixName);
 


### PR DESCRIPTION
This commit includes the code clean for the other C++ files of
ESP/ECLWatch services: (1) remove code lines which have been
commented out; (2) remove most of debug lines; (3) modify debug
log lines which should only be used at high log levels; (4)
Remove CTpWrapper::resolveGroupInfo() which is not used; (5)
Revise getTpDropZones(), getClusterProcessList() and
getHthorClusterList() in TpWrapper.cpp.

Reformatting will be the next step of the code clean for those
files.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
