### PR TITLE
Issue:174 Minor change to eclcc regress batch file

### DIFF
--- a/ecl/regress/r1.bat
+++ b/ecl/regress/r1.bat
@@ -20,4 +20,4 @@ rem ############################################################################
 setlocal enableextensions
 md %regresstgt% 2>nul
 call %~dp0\regress1 -m %*
-if EXIST %~dp0\rcompare.bat. call %~dp0\rcompare %*
+if EXIST %~dp0\rcompare.bat. call %~dp0\rcompare %~n1


### PR DESCRIPTION
Use the base name instead of the full pathname as the filter for the
regression comparison.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
