### PR TITLE
Issue #216 Set Windows OS flag in upload/download function

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -3043,11 +3043,13 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
                     {
                         dir.replace('\\', '/');//replace all '\\' by '/'
                         aDropZone->setLinux("true");
+                        osStr = "1";
                     }
                     else
                     {
                         dir.replace('/', '\\');
                         dir.replace('$', ':');
+                        osStr = "0";
                     }
                 }
 
@@ -3059,10 +3061,6 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
                 {
                     netAddressStr = sNetAddr;
                     directoryStr = dir;
-                    if (machine->getOS() == MachineOsLinux || machine->getOS() == MachineOsSolaris)
-                    {
-                        osStr = "1";
-                    }
                 }
 
                 dropZoneList.append(*aDropZone.getClear());


### PR DESCRIPTION
The Upload/download menu link does not work for windows deployment.
The problem is caused by incorrect OS flag used for creating a
dropzone path.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
