### PR TITLE
WIP #174 Fix problems with count on temporary file

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1488,7 +1488,9 @@ __int64 EclAgent::countDiskFile(__int64 id, IHThorCountFileArg & arg)
         throw makeHThorException(TAKcountdisk, (unsigned)id, 0, e);
     }
 
-    Owned<ILocalOrDistributedFile> ldFile = resolveLFN(arg.getFileName(), "CountDisk", 0 != (arg.getFlags() & TDRoptional));
+    StringBuffer mangled;
+    mangleHelperFileName(mangled, arg.getFileName(), *this, arg.getFlags());
+    Owned<ILocalOrDistributedFile> ldFile = resolveLFN(mangled, "CountDisk", 0 != (arg.getFlags() & TDRoptional));
     if (ldFile) 
     {
         IRecordSize * rs = arg.queryRecordSize();

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -7608,6 +7608,11 @@ void HqlCppTranslator::doBuildExprCountFile(BuildCtx & ctx, IHqlExpression * _ex
     if (dataset->hasProperty(optAtom)) flags.append("|TDRoptional");
     if (!filename->isConstant()) flags.append("|TDXvarfilename");
     if (hasDynamicFilename(dataset)) flags.append("|TDXdynamicfilename");
+    if (dataset->hasProperty(_spill_Atom)) flags.append("|TDXtemporary");
+    if (dataset->hasProperty(jobTempAtom)) flags.append("|TDXjobtemp");
+    if (dataset->hasProperty(groupedAtom)) flags.append("|TDXgrouped");
+    if (dataset->hasProperty(__compressed__Atom)) flags.append("|TDXcompress");
+    if (dataset->hasProperty(_workflowPersist_Atom)) flags.append("|TDXupdateaccessed");
 
     if (flags.length())
         doBuildUnsignedFunction(instance->classctx, "getFlags", flags.str()+1);

--- a/ecl/hthor/hthor.hpp
+++ b/ecl/hthor/hthor.hpp
@@ -219,4 +219,6 @@ extern HTHOR_API IHThorException * makeHThorException(ThorActivityKind kind, uns
 extern HTHOR_API IEngineRowAllocator * createHThorRowAllocator(roxiemem::IRowManager & _rowManager, IOutputMetaData * _meta, unsigned _activityId, unsigned _allocatorId);
 extern HTHOR_API IRtlRowCallback * queryHThorRtlRowCallback();
 
+StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, IAgentContext &agent, unsigned int flags);
+
 #endif // HTHOR_INCL


### PR DESCRIPTION
Counts on temporary files have problems because the filename is
implicitly mangled with the wuid.  This wasn't being taken into
account.

Add code to output some more flags from the code generator, and code
in hthor to use those flags.

Note, this is likely to still require a similar fix in thor.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
