### PR TITLE
FIX #227 Thor sentinel file was not being created

### DIFF
--- a/initfiles/componentfiles/thor/run_thor
+++ b/initfiles/componentfiles/thor/run_thor
@@ -32,7 +32,7 @@ fi
 trap "rm -f run_thor.lck" exit
 echo $$ > run_thor.lck
 
-export sentinelfile="thor.sentinel"
+export SENTINEL="thor.sentinel"
 while [ 1 ]; do
     export logpthtail="`date +%m_%d_%Y_%H_%M_%S`"  
     export logpth="$logdir/$logpthtail"
@@ -54,8 +54,8 @@ while [ 1 ]; do
             exit 0
         fi
         echo master exited with errorcode = $errcode
-        if [ ! -e $sentinelfile ]; then
-            echo $sentinelfile 'has been removed (1) - script stopping'
+        if [ ! -e $SENTINEL ]; then
+            echo $SENTINEL 'has been removed (1) - script stopping'
             exit 0
         fi
 
@@ -65,8 +65,8 @@ while [ 1 ]; do
         echo failed to start thormaster$LCR, pausing for 30 seconds
         sleep 30
     fi
-    if [ ! -e $sentinelfile ]; then
-        echo $sentinelfile 'has been removed or thormaster did not fully start - script stopping'
+    if [ ! -e $SENTINEL ]; then
+        echo $SENTINEL 'has been removed or thormaster did not fully start - script stopping'
         exit 0
     fi
 done


### PR DESCRIPTION
Recent changes to sentinel file creation missed one file (because of
over-convoluted chain of files involved in thor startup, but that's
another bug). As a result thor would not automatically restart on
closedown.

Use the proper environment variable name so that thor will create the
sentinel file.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
