### PR TITLE
gh-236 START-STOP-DAEMON environment variable needs renaming

### DIFF
--- a/initfiles/bash/etc/init.d/configmgr.in
+++ b/initfiles/bash/etc/init.d/configmgr.in
@@ -41,7 +41,7 @@ cleanup ()
     echo "Exiting configMgr"
     #stop configesp
     PIDPATH=${pid}/${compName}_init.pid
-    stopcmd="${START-STOP-DAEMON} -K -p $PIDPATH"
+    stopcmd="${START_STOP_DAEMON} -K -p $PIDPATH"
     eval $stopcmd 
     sleep 2
     killall -9 configesp >/dev/null 2>&1
@@ -203,7 +203,7 @@ cd ${runtime}/${compName}
 
 #start configesp
 EXEC_COMMAND="${exec_script_path}/init_configesp >> $logFile 2>&1"
-startcmd="${START-STOP-DAEMON} -S -p ${initPidFile} -c ${user}:${group} -d ${runtime}/${compName} -m -x ${EXEC_COMMAND} -b"
+startcmd="${START_STOP_DAEMON} -S -p ${initPidFile} -c ${user}:${group} -d ${runtime}/${compName} -m -x ${EXEC_COMMAND} -b"
 eval ${startcmd}
 started=$?
 

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -26,7 +26,7 @@
 ####
 
 ###<REPLACE>###
-START-STOP-DAEMON=${bin_path}/start-stop-daemon
+START_STOP_DAEMON=${INSTALL_DIR}/bin/start-stop-daemon
 
 which_service(){
     SERV=`type --path service`
@@ -447,7 +447,7 @@ startCmd() {
     fi
     
     EXEC_COMMAND="${bin_path}/init_${compType} "
-    startcmd="${START-STOP-DAEMON} -S -p ${pid}/${compName}_init.pid -c ${user}:${group} -d ${compPath} -m -x ${EXEC_COMMAND} -b  >>${logFile} 2>&1"
+    startcmd="${START_STOP_DAEMON} -S -p ${pid}/${compName}_init.pid -c ${user}:${group} -d ${compPath} -m -x ${EXEC_COMMAND} -b  >>${logFile} 2>&1"
 
     issueTime=`date`
     logCommand="COMMAND:: $startcmd  ::Issued at $issueTime "
@@ -542,7 +542,7 @@ stop_component() {
        return ${RCSTOP}
     fi
     
-    stopcmd="${START-STOP-DAEMON} -K -p ${PIDPATH} >> tmp.txt 2>&1"
+    stopcmd="${START_STOP_DAEMON} -K -p ${PIDPATH} >> tmp.txt 2>&1"
 
     if [ ${DEBUG} != "NO_DEBUG" ]; then
         echo "$stopcmd"

--- a/initfiles/bash/etc/init.d/init-functions
+++ b/initfiles/bash/etc/init.d/init-functions
@@ -101,12 +101,12 @@ killproc () {
     status=0
     if [ ! "$is_term_sig" = yes ]; then
         if [ -n "$sig" ]; then
-            ${START-STOP-DAEMON} --stop --signal "$sig" --quiet $name_param || status="$?"
+            ${START_STOP_DAEMON} --stop --signal "$sig" --quiet $name_param || status="$?"
         else
-            ${START-STOP-DAEMON} --stop --quiet $name_param || status="$?"
+            ${START_STOP_DAEMON} --stop --quiet $name_param || status="$?"
         fi
     else
-        ${START-STOP-DAEMON} --stop --quiet --oknodo $name_param || status="$?"
+        ${START_STOP_DAEMON} --stop --quiet --oknodo $name_param || status="$?"
     fi
     if [ "$status" = 1 ]; then
         if [ -n "$sig" ]; then


### PR DESCRIPTION
Fixes #236 - bash does not like - in an environment variable name.

Rename to use underscores in place of -. Also the code in hpcc-common to
set the variable was using the wrong path.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
