### PR TITLE
Bug: 84908 Fix Warning log for EclWatch Activity page

### DIFF
--- a/esp/scm/ws_topology.ecm
+++ b/esp/scm/ws_topology.ecm
@@ -42,7 +42,7 @@ ESPStruct TpCluster
     string Directory;
     string LogDirectory;
     string Desc;
-    string Prefix;
+    [max_ver("1.16")] string Prefix;
     string Path;
     string DataModel;
     int    OS;
@@ -522,7 +522,7 @@ ESPresponse [exceptions_inline] TpGetComponentFileResponse
     [http_content("application/octet-stream")] binary FileContents;
 };
 
-ESPservice [noforms, version("1.16"), default_client_version("1.16"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsTopology
+ESPservice [noforms, version("1.17"), default_client_version("1.17"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsTopology
 {
     ESPuses ESPStruct TpBinding;
     ESPuses ESPstruct TpCluster;

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -947,11 +947,7 @@ void CTpWrapper::queryTargetClusterProcess(double version, const char* processNa
             clusterInfo->setLogDirectory( logDir );
     }
 
-    //this is defined in the Topology attribute for the Cluster.
-    StringBuffer prefix;
-    getPrefixName(processName,prefix);
-    clusterInfo->setPrefix(prefix.str());
-
+    clusterInfo->setPrefix("");
     if(pClusterTree->hasProp("@dataBuild"))
         clusterInfo->setDataModel(pClusterTree->queryProp("@dataBuild"));
 
@@ -1258,12 +1254,7 @@ void CTpWrapper::getClusterProcessList(const char* ClusterType, IArrayOf<IEspTpC
                     }
 
                     clusterInfo->setPath(tmpPath.str());
-
-                    //this is defined in the Topology attribute for the Cluster.
-                    StringBuffer prefix;
-                    getPrefixName(name,prefix);
-                    clusterInfo->setPrefix(prefix.str());
-
+                    clusterInfo->setPrefix("");
                     if(cluster.hasProp("@dataBuild"))
                         clusterInfo->setDataModel(cluster.queryProp("@dataBuild"));
 
@@ -1515,30 +1506,6 @@ void CTpWrapper::resolveGroupInfo(const char* groupName,StringBuffer& Cluster, S
     catch(...){
         WARNLOG("Unknown Exception caught within CTpWrapper::resolveGroupInfo");
     }
-}
-
-StringBuffer& CTpWrapper::getPrefixName(const char* clusterName,StringBuffer& prefixName)
-{
-    try
-    {
-        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(clusterName);
-        if (!clusterInfo)
-            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
-        StringBufferAdaptor adaptor(prefixName);
-        clusterInfo->getScope(adaptor);
-    }
-    catch(IException* e) 
-    {
-        StringBuffer msg;
-        e->errorMessage(msg);
-        WARNLOG("%s", msg.str());
-        e->Release();
-    }
-    catch(...)
-    {
-        WARNLOG("Unknown Exception caught within CTpWrapper::getPrefixName");
-    }
-    return prefixName;
 }
 
 bool CTpWrapper::ContainsProcessDefinition(IPropertyTree& clusterNode,const char* clusterName)

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -161,7 +161,6 @@ public:
     void setMachineInfo(const char* name,const char* type,IEspTpMachine& machine);
     void resolveGroupInfo(const char* groupName,StringBuffer& Cluster, StringBuffer& ClusterPrefix);
     void getMachineInfo(IEspTpMachine& machineInfo,IPropertyTree& machine,const char* ParentPath,const char* MachineType,const char* nodenametag);
-    StringBuffer& getPrefixName(const char* clusterName,StringBuffer& prefixName);
 
     void getTpDaliServers(IArrayOf<IConstTpDali>& list);
     void getTpEclServers(IArrayOf<IConstTpEclServer>& ServiceList);


### PR DESCRIPTION
The existing code tries to retrieve Prefix information for a physical
cluster using getPrefixName(). The getPrefixName() logs a warning if
the information cannot be found. But, the information does not exist
since the prefix is not associated with a physical cluster. The
warning should not be there. This fix removes getPrefixName() which
is used for retrieving the Prefix information for a physical cluster.
The prefix field of TpCluster is set to "".

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
