### PR TITLE
Bug: 85010 Fix "Disk full" error while getting system topology

### DIFF
--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -47,16 +47,6 @@ IPropertyTree* CTpWrapper::getEnvironment(const char* xpath)
         }
         else
         {
-            StringBuffer buf;
-            toXML(root, buf);
-            if (buf.length() > 0)
-            {
-                Owned<IFile> f = createIFile("new_config.xml");
-                Owned<IFileIO> fio = f->open(IFOcreaterw);
-                if (fio.get())
-                    fio->write(0, buf.length(), buf.str());
-            }
-
             IPropertyTree* pSubTree = root->queryPropTree( xpath );
             if (pSubTree)
                 return LINK(pSubTree);


### PR DESCRIPTION
A "CFileIO::write, Disk full" error occurs when ECLWatch tries to
create and display a system topology (clusters or servers) page.
The write() should not be called when the page is created and
displayed. The problem is caused by a group of debug code. This
fix removes the debug code.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
