### PR TITLE
jptree serialization format change means reads from old dali fails

### DIFF
--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -163,7 +163,7 @@ interface IPTreeNodeCreator : extends IInterface
 };
 
 // NB ipt_ext5 - used by SDS
-enum ipt_flags { ipt_none=0x00, ipt_caseInsensitive=0x01, ipt_ordered=0x02, ipt_binary=0x04, ipt_ext1=0x08, ipt_ext2=16, ipt_ext3=32, ipt_ext4=64, ipt_ext5=128 };
+enum ipt_flags { ipt_none=0x00, ipt_caseInsensitive=0x01, ipt_binary=0x02, ipt_ordered=0x04, ipt_ext1=0x08, ipt_ext2=16, ipt_ext3=32, ipt_ext4=64, ipt_ext5=128 };
 jlib_decl IPTreeMaker *createPTreeMaker(byte flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
 jlib_decl IPTreeMaker *createRootLessPTreeMaker(byte flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
 jlib_decl IXMLReader *createXMLStreamReader(ISimpleReadStream &stream, IPTreeNotifyEvent &iEvent, XmlReaderOptions xmlReaderOptions=xr_ignoreWhiteSpace, size32_t bufSize=0);


### PR DESCRIPTION
Fixes gh-246 - jptree serialization format change means reads from old dali
fails. The change that Jake made to jptree to introduce the ordered tree
flag causes serialization issues when talking to a dali that saved data
using the previous flag values.

This change restores the binary flag to its previous value, and uses a
previously unused value for the new ordered flag. Dali information saved by
systems between the previous change and now may be invalidated, but this
should only affect developer-built private systems as the change has
never been released in any official build.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
