### PR TITLE
FIX #173 Ensure imported modules added to archive

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -6933,7 +6933,17 @@ IHqlExpression *CHqlRemoteScope::lookupSymbol(_ATOM searchName, unsigned lookupF
     if (!(lookupFlags & LSFignoreBase))
     {
         if (resolvedSym)
+        {
+            if (ctx.archive && resolvedSym->getOperator() == no_remotescope)
+            {
+                //Ensure the archive contains entries for each module - even if nothing is accessed from it
+                //It would be preferrable to only check once, but adds very little time anyway.
+                IHqlScope * scope = resolvedSym->queryScope();
+                queryEnsureArchiveModule(ctx.archive, scope->queryFullName(), scope);
+            }
+
             return resolvedSym.getClear();
+        }
     }
 
     OwnedHqlExpr ret = CHqlScope::lookupSymbol(searchName, LSFsharedOK|lookupFlags, ctx);


### PR DESCRIPTION
Previously a module  entry was only added to the archive if a
definition from it was used in the query.  This change ensures it
a blank entry will be created.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
