### PR TITLE
Bug: #83964/83966 Add SKEW and THRESHOLD attributes

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -13361,6 +13361,22 @@ void unwindRealChildren(HqlExprArray & children, const IHqlExpression * expr, un
 }
 
 
+void unwindAttributes(HqlExprArray & children, const IHqlExpression * expr)
+{
+    unsigned max = expr->numChildren();
+    for (unsigned idx=0; idx < max; idx++)
+    {
+        IHqlExpression * child = expr->queryChild(idx);
+        if (child->isAttribute())
+        {
+            //Subsequent calls to ensure are quick no-ops
+            children.ensure(max - idx);
+            children.append(*LINK(child));
+        }
+    }
+}
+
+
 void unwindList(HqlExprArray &dst, IHqlExpression * expr, node_operator op)
 {
     while (expr->getOperator() == op)

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1356,6 +1356,7 @@ extern HQL_API void unwindChildren(HqlExprArray & children, const IHqlExpression
 extern HQL_API void unwindChildren(HqlExprArray & children, const IHqlExpression * expr, unsigned from, unsigned to);
 extern HQL_API void unwindChildren(HqlExprCopyArray & children, const IHqlExpression * expr, unsigned first=0);
 extern HQL_API void unwindRealChildren(HqlExprArray & children, const IHqlExpression * expr, unsigned first);
+extern HQL_API void unwindAttributes(HqlExprArray & children, const IHqlExpression * expr);
 extern HQL_API void unwindList(HqlExprArray &dst, IHqlExpression * expr, node_operator op);
 extern HQL_API void unwindCopyList(HqlExprCopyArray &dst, IHqlExpression * expr, node_operator op);
 extern HQL_API void unwindCommaCompound(HqlExprArray & target, IHqlExpression * expr);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -2665,6 +2665,11 @@ buildFlag
                             $$.setPosition($1);
                         }
     | skewAttribute
+    | THRESHOLD '(' expression ')'
+                        {
+                            parser->normalizeExpression($3, type_numeric, true);
+                            $$.setExpr(createAttribute(thresholdAtom, $3.getExpr()));
+                        }
     | FEW               {
                             $$.setExpr(createAttribute(fewAtom));
                             $$.setPosition($1);

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -5300,6 +5300,8 @@ IHqlExpression * HqlGram::processSortList(const attribute & errpos, node_operato
                     if (attr == manyAtom) ok = true;
                     if (attr == sortedAtom) ok = true;
                     if (attr == unsortedAtom) ok = true;
+                    if (attr == skewAtom) ok = true;
+                    if (attr == thresholdAtom) ok = true;
                     break;
                 case no_usertable:
                     if (attr == keyedAtom) ok = true;
@@ -5313,6 +5315,8 @@ IHqlExpression * HqlGram::processSortList(const attribute & errpos, node_operato
                     if (attr == manyAtom) ok = true;
                     if (attr == sortedAtom) ok = true;
                     if (attr == unsortedAtom) ok = true;
+                    if (attr == skewAtom) ok = true;
+                    if (attr == thresholdAtom) ok = true;
                     break;
                 case no_topn:
                     if (attr == bestAtom) ok = true;

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -4017,9 +4017,15 @@ IHqlExpression * appendOwnedOperandsF(IHqlExpression * expr, ...)
 }
 
 
+IHqlExpression * inheritAttribute(IHqlExpression * expr, IHqlExpression * donor, _ATOM name)
+{
+    return appendOwnedOperand(expr, LINK(donor->queryProperty(name)));
+}
 
 IHqlExpression * appendOwnedOperand(IHqlExpression * expr, IHqlExpression * ownedOperand)
 {
+    if (!ownedOperand)
+        return LINK(expr);
     HqlExprArray args;
     unwindChildren(args, expr);
     args.append(*ownedOperand);

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -143,6 +143,7 @@ extern HQL_API IHqlExpression * removeChildOp(IHqlExpression * expr, node_operat
 extern HQL_API IHqlExpression * appendOwnedOperand(IHqlExpression * expr, IHqlExpression * ownedOperand);
 extern HQL_API IHqlExpression * replaceOwnedProperty(IHqlExpression * expr, IHqlExpression * ownedProeprty);
 extern HQL_API IHqlExpression * appendOwnedOperandsF(IHqlExpression * expr, ...);
+extern HQL_API IHqlExpression * inheritAttribute(IHqlExpression * expr, IHqlExpression * donor, _ATOM name);
 extern HQL_API unsigned numRealChildren(IHqlExpression * expr);
 
 extern HQL_API IHqlExpression * createEvaluateOutputModule(HqlLookupContext & ctx, IHqlExpression * scopeExpr, IHqlExpression * ifaceExpr, bool expandCallsWhenBound, node_operator outputOp);

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -1831,14 +1831,8 @@ static IHqlExpression * normalizeIndexBuild(IHqlExpression * expr, bool sortInde
         if (sorted == dataset)
             return NULL;
 
-        IHqlExpression * skew = expr->queryProperty(skewAtom);
-        if (skew)
-        {
-            HqlExprArray args;
-            unwindChildren(args, sorted);
-            args.append(*LINK(skew));
-            sorted.setown(sorted->clone(args));
-        }
+        sorted.setown(inheritAttribute(sorted, expr, skewAtom));
+        sorted.setown(inheritAttribute(sorted, expr, thresholdAtom));
 
         HqlExprArray args;
         args.append(*LINK(sorted));
@@ -2264,6 +2258,8 @@ IHqlExpression * ThorHqlTransformer::normalizeGroup(IHqlExpression * expr)
     if (sorted == dataset)
         return removeProperty(expr, allAtom);
     sorted.setown(cloneInheritedAnnotations(expr, sorted));
+    sorted.setown(inheritAttribute(sorted, expr, skewAtom));
+    sorted.setown(inheritAttribute(sorted, expr, thresholdAtom));
 
     if (!isLocal)
     {
@@ -2993,12 +2989,14 @@ IHqlExpression * ThorHqlTransformer::normalizePrefetchAggregate(IHqlExpression *
 static IHqlExpression * convertAggregateGroupingToGroupedAggregate(IHqlExpression * expr, IHqlExpression* groupBy)
 {
     IHqlExpression * dataset = expr->queryChild(0);
-    IHqlExpression * localAttr = expr->queryProperty(localAtom);
-    IHqlExpression * sortedAttr = expr->queryProperty(sortedAtom);
-    IHqlExpression * unsortedAttr = expr->queryProperty(unsortedAtom);
 
-    IHqlExpression * attr = createComma(createAttribute(allAtom), LINK(localAttr), LINK(sortedAttr), LINK(unsortedAttr));
-    OwnedHqlExpr result = createDatasetF(no_group, LINK(dataset), LINK(groupBy), attr, NULL);
+    HqlExprArray groupArgs;
+    groupArgs.append(*LINK(dataset));
+    groupArgs.append(*LINK(groupBy));
+    groupArgs.append(*createAttribute(allAtom));
+    unwindChildren(groupArgs, expr, 4);
+    OwnedHqlExpr result = createDataset(no_group, groupArgs);
+
     result.setown(cloneInheritedAnnotations(expr, result));
 
     HqlExprArray args;
@@ -3207,13 +3205,15 @@ IHqlExpression * ThorHqlTransformer::normalizeTableToAggregate(IHqlExpression * 
     OwnedHqlExpr aggregateSelf = getSelf(aggregateRecord);
     replaceAssignSelector(aggregateAssigns, aggregateSelf);
     IHqlExpression * aggregateTransform = createValue(no_newtransform, makeTransformType(aggregateRecord->getType()), aggregateAssigns);
-    IHqlExpression * keyedAttr = expr->queryProperty(keyedAtom);
-    IHqlExpression * prefetchAttr = expr->queryProperty(prefetchAtom);
-    LinkedHqlExpr localAttr = expr->queryProperty(localAtom);
-    if (newGroupBy && !isGrouped(dataset) && isPartitionedForGroup(dataset, newGroupBy, true))
-        localAttr.setown(createLocalAttribute());
 
-    OwnedHqlExpr ret = createDataset(no_newaggregate, LINK(dataset), createComma(aggregateRecord, aggregateTransform, newGroupBy, createComma(LINK(keyedAttr), LINK(prefetchAttr), LINK(localAttr))));
+    HqlExprArray aggregateAttrs;
+    unwindAttributes(aggregateAttrs, expr);
+    removeProperty(aggregateAttrs, aggregateAtom);
+    removeProperty(aggregateAttrs, fewAtom);
+    if (!expr->hasProperty(localAtom) && newGroupBy && !isGrouped(dataset) && isPartitionedForGroup(dataset, newGroupBy, true))
+        aggregateAttrs.append(*createLocalAttribute());
+
+    OwnedHqlExpr ret = createDataset(no_newaggregate, LINK(dataset), createComma(aggregateRecord, aggregateTransform, newGroupBy, createComma(aggregateAttrs)));
     if (extraSelectNeeded)
         ret.setown(cloneInheritedAnnotations(expr, ret));
     else

--- a/ecl/regress/table7.ecl
+++ b/ecl/regress/table7.ecl
@@ -16,22 +16,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+#option ('importAllModules', true);
 
 namesRecord :=
             RECORD
-big_endian integer2     age := 25;
-integer2        age2 := 25;
-integer8        age8 := 25;
-real8           salary := 0;
-ebcdic string20 surname;
+string20        surname;
 string10        forename;
-unsigned8       filepos{virtual(fileposition)}
+integer2        age := 25;
             END;
 
 namesTable := dataset('x',namesRecord,FLAT);
-namesTable2 := dataset('xx.zzz',namesRecord,FLAT);
-nt2 := group(namesTable, age2);
 
-unsigned curVersion := 10;
-BUILDINDEX(nt2, { surname, forename, filepos }, 'name.idx', set('x','y'));
-BUILDINDEX(nt2, { age, age2, age8, filepos }, 'age.idx', dataset(namesTable2), skew(,2), threshold(3.1415), backup,set('version',curVersion), set(U'user',U'ghalliday'),set('system','local'));
+output(table(namesTable, { count(group); }, surname, many, threshold(3.1415),skew(1.2345,9.876)));


### PR DESCRIPTION
Add SKEW and THRESHOLD attributes to TABLE, and THRESHOLD attribute to
BUILD to provide more control of the sort that they might implicitly
create.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
