### PR TITLE
Removes parameter from compare in eclcc regress batch file

### DIFF
--- a/ecl/regress/regress.bat
+++ b/ecl/regress/regress.bat
@@ -49,7 +49,7 @@ sort %regresstgt%\_batch_.tmp > %regresstgt%\_batch_.log
 del %regresstgt%\_batch_.tmp
 
 :compare
-if EXIST %~dp0\rcompare.bat. call %~dp0\rcompare %*
+if EXIST %~dp0\rcompare.bat. call %~dp0\rcompare
 goto done;
 
 :novars


### PR DESCRIPTION
%\* was incorrectly being passed to the compare batch file creating
an invalid filter.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
