### PR TITLE
Bug: 84974 Add DFU File Rename to ECLWatch GUI

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -101,6 +101,9 @@
             function copyDFUFile() {
               document.location.href='/FileSpray/CopyInput?sourceLogicalName='+filename;
             }
+            function renameDFUFile() {
+              document.location.href='/FileSpray/RenameInput?sourceLogicalName='+filename;
+            }
             function desprayDFUFile()
             {
               document.location.href='/FileSpray/DesprayInput?sourceLogicalName='+filename;
@@ -116,76 +119,35 @@
             oMenu = new YAHOO.widget.Menu("logicalfilecontextmenu", {position: "dynamic", xy: xypos} );
             oMenu.clearContent();
 
+            oMenu.addItems([
+            { text: "Details", onclick: { fn: detailsDFUFile } },
+            { text: "Copy", onclick: { fn: copyDFUFile } },
+            { text: "Rename", onclick: { fn: renameDFUFile } }
+            ]);
+
+            if (browsedata != 0) {
+            oMenu.addItems([
+            { text: "View Data File", onclick: { fn: searchDFUData } }
+            ]);
+            }
+
+            if (replicate != 0) {
+            oMenu.addItems([
+            { text: "Replicate", onclick: { fn: replicateDFUFile } }
+            ]);
+            }
+
             if (roxiecluster != 0) {
-            if (browsedata != 0) {
-            if (replicate != 0) {
             oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
             { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
             ]);
             }
-            } else {
-            if (replicate != 0) {
+            else {
             oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
+            { text: "Despray", onclick: { fn: desprayDFUFile } }
             ]);
             }
-            }
-            } else {
-            if (browsedata != 0) {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            }
-            } else {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            }
-            }
-            }
+
             //showPopup(menu,(window.event ? window.event.screenX : 0),  (window.event ? window.event.screenY : 0));
             oMenu.render("dfulogicalfilemenu");
             oMenu.show();

--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -108,6 +108,11 @@
                                 document.location.href="/FileSpray/CopyInput?sourceLogicalName=" + filename;
                                 return true;
                             }
+                            else if (button == "Rename")
+                            {
+                                document.location.href="/FileSpray/RenameInput?sourceLogicalName=" + filename;
+                                return true;
+                            }
                             else if (button == "Despray")
                             {
                                 document.location.href="/FileSpray/DesprayInput?sourceLogicalName=" + filename;
@@ -328,10 +333,11 @@
                 <input type="submit" class="sbutton" id="deleteBtn" value="Delete" onclick="return confirm('Are you sure you want to delete '+'{Name}'+'?')"/>
             </form-->
             <br/><br/>
-            <input type="submit" class="sbutton" id="deleteBtn" value="Delete" onclick="submitaction('Delete','{Name}@{Cluster}')"/>
-            <input type="submit" class="sbutton" id="copyBtn" value="Copy" onclick="submitaction('Copy','{Name}')"/>
+            <input type="button" class="sbutton" id="deleteBtn" value="Delete" onclick="submitaction('Delete','{Name}@{Cluster}')"/>
+            <input type="button" class="sbutton" id="copyBtn" value="Copy" onclick="submitaction('Copy','{Name}')"/>
+            <input type="button" class="sbutton" id="renameBtn" value="Rename" onclick="submitaction('Rename','{Name}')"/>
             <xsl:if test="FromRoxieCluster=0">
-                <input type="submit" class="sbutton" id="desprayBtn" value="Despray" onclick="submitaction('Despray','{Name}')"/>
+                <input type="button" class="sbutton" id="desprayBtn" value="Despray" onclick="submitaction('Despray','{Name}')"/>
             </xsl:if>
         </body> 
         </xsl:otherwise>

--- a/esp/eclwatch/ws_XSLT/fs_renameForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_renameForm.xslt
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="html"/>
+    <xsl:param name="fullHtml" select="1"/>
+    <xsl:param name="includeFormTag" select="1"/>
+    <xsl:param name="method" select="'Rename'"/>
+    <xsl:param name="sourceLogicalName" select="''"/>
+    <xsl:template match="/Environment">
+    <xsl:choose>
+      <xsl:when test="ErrorMessage">
+        <h4>
+          <xsl:value-of select="$method"/> File: 
+          <xsl:value-of select="ErrorMessage"/>
+        </h4>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:choose>
+            <xsl:when test="$fullHtml">
+                <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+                    <head>
+                        <title>Spray / Despray result</title>
+            <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/fonts/fonts-min.css" />
+            <link rel="stylesheet" type="text/css" href="/esp/files/css/espdefault.css" />
+            <link rel="stylesheet" type="text/css" href="/esp/files/css/eclwatch.css" />
+            <script type="text/javascript" src="/esp/files/scripts/espdefault.js">&#160;</script>
+          </head>
+          <body class="yui-skin-sam" onload="nof5();onLoad()">
+                        <form method="POST" action="/FileSpray/{$method}">
+                            <xsl:call-template name="generateForm"/>
+                        </form>
+                    </body>
+                </html>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:choose>
+                    <xsl:when test="$includeFormTag">
+                        <form method="POST" action="/FileSpray/{$method}">
+                            <xsl:call-template name="generateForm"/>
+                        </form>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="generateForm"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+      </xsl:otherwise>
+    </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template name="generateForm">
+        <script type="text/javascript" language="javascript">
+            method = '<xsl:value-of select="$method"/>';
+            <![CDATA[
+                function onLoad()
+                {
+                    handleSubmitBtn();
+                }
+                
+                function handleSubmitBtn()
+                {
+                    sourceFile = document.getElementById('srcname').value;
+                    destFile = document.getElementById('dstname').value;
+                    sourceIn = document.getElementById('srcname').value == '';
+                    destIn = document.getElementById('dstname').value == '';
+                    if (sourceIn || destIn || (sourceFile == destFile))
+                        document.getElementById('submitBtn').disabled = true;
+                    else
+                        document.getElementById('submitBtn').disabled = false;
+                }
+            ]]>
+        </script>
+        <table name="table1">
+            <tr>
+                <th colspan="2">
+                    <h3>Rename File</h3>
+                </th>
+            </tr>
+            <tr>
+                <td height="10"/>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <b>Source</b>
+                </td>
+            </tr>
+            <xsl:variable name="origName">
+                <xsl:choose>
+                    <xsl:when test="$sourceLogicalName = ''">
+                        <xsl:value-of select="Software/DfuWorkunit/Source/OrigName"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$sourceLogicalName"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <tr>
+                <td>Logical File:</td>
+                <td>
+                    <xsl:choose>
+                        <xsl:when test="$origName=''">
+                            <input type="text" id="srcname" name="srcname" size="70" value="" onKeyUp="handleSubmitBtn()" onchange="handleSubmitBtn()"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$origName"/>
+                            <input type="hidden" id="srcname" name="srcname" value="{$origName}"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </td>
+            </tr>
+            <tr>
+                <td height="10"/>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <b>Destination</b>
+                </td>
+            </tr>
+            <tr>
+                <td>Logical File:</td>
+                <td>
+                    <input type="text" id="dstname" name="dstname" size="70" value="" onKeyUp="handleSubmitBtn()" onchange="handleSubmitBtn()"/>
+                </td>
+            </tr>
+                <tr>
+                    <td height="10"/>
+                </tr>
+            <tr>
+                <td>Overwrite:</td>
+                <td>
+                    <input type="checkbox" id="overwrite" name="overwrite"/>
+                </td>
+            </tr>
+        </table>
+        <xsl:if test="$fullHtml='1'">
+            <table>
+                <tr>
+                    <td/>
+                    <td>
+                        <input type="submit" id="submitBtn" name="submitBtn" value="Submit" disabled="true"/>
+                    </td>
+                </tr>
+            </table>
+        </xsl:if>
+    </xsl:template>
+</xsl:stylesheet>

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -78,6 +78,16 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
         methodbuf.append("Copy");
         bProcess = true;
     }
+    else if (stricmp(method, "RenameInput") == 0)
+    {
+        if (!context.validateFeatureAccess(FILE_SPRAY_URL, SecAccess_Write, false))
+            permission = false;
+
+        request->getParameter("sourceLogicalName", sourceLogicalFile);
+        xsltFileName.append("fs_renameForm.xslt");
+        methodbuf.append("Rename");
+        bProcess = true;
+    }
     else if (stricmp(method, "DownloadFile") == 0)
     {
         if (!context.validateFeatureAccess(FILE_SPRAY_URL, SecAccess_Full, false))

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2583,6 +2583,9 @@ bool CFileSprayEx::onRename(IEspContext &context, IEspRename &req, IEspRenameRes
         IDFUfileSpec *destination = wu->queryUpdateDestination();
         destination->setLogicalName(dstname);
 
+        IDFUoptions *options = wu->queryUpdateOptions();
+        options->setOverwrite(req.getOverwrite());
+
         resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());
         submitDFUWorkUnit(wu.getClear());
     }

--- a/install_directory/esp.install
+++ b/install_directory/esp.install
@@ -1585,6 +1585,9 @@ Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/esp/eclwatch/ws_XSLT/fs_desprayCopyF
 ### name=smc_xslt/fs_sprayForm.xslt
 Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt DESTINATION ${OSSDIR}/componentfiles/smc_xslt
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE )
+### name=smc_xslt/fs_renameForm.xslt
+Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/esp/eclwatch/ws_XSLT/fs_renameForm.xslt DESTINATION ${OSSDIR}/componentfiles/smc_xslt
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE )
 ### name=smc_xslt/graph.xslt
 Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/esp/eclwatch/ws_XSLT/graph.xslt DESTINATION ${OSSDIR}/componentfiles/smc_xslt
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE )


### PR DESCRIPTION
Existing WsFileService does have the "DFU File Rename" method. But,
no GUI is linked to that method. The fix adds: (1) a Rename dropdown
option for each logical file inside the Browse Logical Files page;
(2) a "Rename" button on the Logical File Details page. When the
Rename is selected, ECLWatch displays a Rename Input page based on
fs_renameForm.xslt. After destination file name is entered and
Submit button is clicked, the "DFU File Rename" method is called.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
