### PR TITLE
Cleans up a  few minor issues in the source code

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4056,6 +4056,7 @@ public:
     }
     void inheritMapping(const HqlConstantPercolator * other)
     {
+        assertex(other);
         if (other->self)
         {
             assertex(!self || self == other->self);
@@ -4069,6 +4070,7 @@ public:
     }
     void intersectMapping(const HqlConstantPercolator * other)
     {
+        assertex(other);
         ForEachItemInRev(i, targets)
         {
             unsigned match = other->targets.find(targets.item(i));

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -1067,15 +1067,17 @@ void HqlLex::doTrace(YYSTYPE & returnToken)
             ;
     }
     curParam.append(')');
-    IValue *value = parseConstExpression(returnToken, curParam, queryTopXmlScope(),startLine-1,startCol);
+    Owned<IValue> value = parseConstExpression(returnToken, curParam, queryTopXmlScope(),startLine-1,startCol);
     if (value)
     {
         StringBuffer buf;
         value->getStringValue(buf);
         FILE *trace = fopen("hql.log", "at");
-        fwrite(buf.str(),buf.length(),1,trace);
-        fclose(trace);
-        value->Release();
+        if (trace)
+        {
+            fwrite(buf.str(),buf.length(),1,trace);
+            fclose(trace);
+        }
     }
 }
 
@@ -1083,7 +1085,7 @@ void HqlLex::doFor(YYSTYPE & returnToken, bool doAll)
 {
     //MTIME_SECTION(timer, "HqlLex::doFor")
 
-    int startLine = -1, startCol;
+    int startLine = -1, startCol = 0;
     StringBuffer forwhat;
     forwhat.appendf("#FOR(%d,%d)",returnToken.pos.lineno,returnToken.pos.column);
 
@@ -1153,7 +1155,7 @@ void HqlLex::doFor(YYSTYPE & returnToken, bool doAll)
 
 void HqlLex::doLoop(YYSTYPE & returnToken)
 {
-    int startLine = -1, startCol;
+    int startLine = -1, startCol = 0;
     StringBuffer forwhat;
     forwhat.appendf("#LOOP(%d,%d)",returnToken.pos.lineno,returnToken.pos.column);
     

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -4786,9 +4786,9 @@ void HqlCppTranslator::doBuildFilterToTarget(BuildCtx & ctx, const CHqlBoundTarg
         BuildCtx subctx(ctx);
         if (outer != 0)
             subctx.addFilter(test);
-        buildExprAssign(subctx, isOk, queryBoolExpr(false ^ invert));
+        buildExprAssign(subctx, isOk, queryBoolExpr(invert));       // if(!invert,false,true) => invert
         doBuildFilterNextAndRange(subctx, curIndex, MAX_NESTED_CASES, conds);
-        buildExprAssign(subctx, isOk, queryBoolExpr(true ^ invert));
+        buildExprAssign(subctx, isOk, queryBoolExpr(!invert));      // if(!invert,true,false) => !invert
     }
 }
 
@@ -8177,6 +8177,8 @@ void HqlCppTranslator::doBuildAssignCompareElement(BuildCtx & ctx, EvaluateCompa
     }
 
     OwnedHqlExpr safeReleaseOp = op;
+    assertex(op);
+
     BuildCtx subctx(ctx);
     if (info.isEqualityCompare() && (info.actionIfDiffer == return_stmt))
     {


### PR DESCRIPTION
The only change that should have any effect is the guard against
trace being null (if the fopen failed). Only affects #TRACE (rarely
used.)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
