### PR TITLE
FIX: 85258 Improve SSH deploy performance

### DIFF
--- a/deployment/deploy/DeploymentEngine.hpp
+++ b/deployment/deploy/DeploymentEngine.hpp
@@ -304,6 +304,7 @@ private:
     bool searchDeployMap(const char* fileName, const char* optionalFileExt) const;
     void getBackupDirName(const char* from, StringBuffer& to);
     bool checkSSHFileExists(const char* dir) const;
+    void setSSHVars(IPropertyTree& instance);
 
 protected:
    Owned<IThreadPool>      m_threadPool;


### PR DESCRIPTION
These changes are made in the deploy library(shared by ConfigMgr, 
ConfigGen and ConfigEnv) but affect ConfigEnv only.
1. Speed up the SSH deploy by replacing individual file copy via
   pscp (which se ems to be pretty slow) with Caching the files locally
   on the windows box (same as the caching done when multiple instances
   of a component are present) and copying the cached directory via pscp.
2. Fix the issue of handling pscp prompt to cache the server's host key
   into the windows registry. Previously this case was failing.
3. Set SSH flags based on individual instances rather than relying
   on previously set values
4. Fix reporting of deployed file sizes and count when using SSH deployment

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
