### PR TITLE
EclAgent through pipe behaving erratically

### DIFF
--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -531,11 +531,14 @@ class PipeWriter : public CInterface
 {
 public:
     PipeWriter(IPipeWriteOwner * _owner, IPipeProcess * _pipe, bool _syncsAtStart, bool _syncs, bool _recreate) 
-        : owner(_owner), pipe(_pipe), syncsAtStart(_syncsAtStart), syncs(_syncs), recreate(_recreate) {}
+        : owner(_owner), pipe(_pipe), syncsAtStart(_syncsAtStart), syncs(_syncs), recreate(_recreate)
+    {
+        reccount = 0; started = false; finished = false; aborted = false;
+    }
     void ready() { reccount = 0; started = false; finished = false; aborted = false; }
     void run();
     void abort();
-    bool sync() { readyForWrite.signal(); readyForRead.wait(); return !finished; }
+    void sync();
     unsigned __int64 queryRecCount() const { return reccount; }
 
 private:

--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -1450,7 +1450,21 @@ static unsigned dowaitpid(HANDLE pid, int mode)
         int stat=-1;
         int ret = waitpid(pid, &stat, mode);
         if (ret>0) 
-            return WIFSIGNALED(stat)?254:WEXITSTATUS(stat);
+        {
+            if (WIFEXITED(stat))
+                return WEXITSTATUS(stat);
+            else if (WIFSIGNALED(stat))
+            {
+                ERRLOG("Program was terminated by signal %u", (unsigned) WTERMSIG(stat));
+                if (WTERMSIG(stat)==SIGPIPE)
+                    return 0;
+                return 254;
+            }
+            else
+            {
+                return 254;
+            }
+        }
         if (ret==0)
             break;
         int err = errno;


### PR DESCRIPTION
Fixes gh-269. Due to a race condition between the reading and writing threads
at either side of the through PIPE activity, erratic results could be returned.
These would include spurious reports of pipe program failing with error code
254, or incomplete results.

This patch corrects the race condition, and also improves the error reporting
when a child process is terminated by SIGPIPE.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
