### PR TITLE
WIP #266 Fixes row invariant filters on csv files

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8471,7 +8471,13 @@ void CHThorCsvReadActivity::checkOpenNext()
     if (!opened)
     {
         agent.reportProgress(NULL);
-        open();
+        if (!helper.canMatchAny())
+        {
+            eofseen = true;
+            opened = true;
+        }
+        else
+            open();
     }
 
     loop


### PR DESCRIPTION
Fixes a bug with csv read in hthor, where the canMatchAny() was not
being tested before reading the disk file.  This meant row invariant
filters were ignored.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
