### PR TITLE
FIX: #225 Fix ConfigMgr Wizard to allow overlap of thor master and slave

### DIFF
--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -551,7 +551,11 @@ void CWizardInputs::generateSoftwareTree(IPropertyTree* pNewEnvTree)
             if(!strcmp(buildSetName, "roxie"))
               numOfIpNeeded = m_roxieNodes;
             else if(!strcmp(buildSetName, "thor"))
-              numOfIpNeeded = m_thorNodes + 1;
+            {
+              numOfIpNeeded = m_thorNodes;
+              if (m_thorNodes < m_ipaddress.ordinality())
+                numOfIpNeeded += 1;
+            }
                     
             CInstDetails* pInstDetail = getServerIPMap(sbNewName.str(), buildSetName, pNewEnvTree, numOfIpNeeded);
                     
@@ -814,7 +818,7 @@ void CWizardInputs::addRoxieThorClusterToEnv(IPropertyTree* pNewEnvTree, CInstDe
 
       //Now add Slave 
       xml.clear().appendf("<ThorData type=\"Slave\" name=\"%s\" validateComputers=\"false\" slavesPerNode=\"%d\" skipExisting=\"false\" >", compName.str(), m_thorSlavesPerNode);
-      unsigned numOfNodes = ipAssignedToComp.ordinality() == 1 ? 0 : 1;
+      unsigned numOfNodes = ipAssignedToComp.ordinality() == 1 || m_thorNodes == m_ipaddress.ordinality()? 0 : 1;
 
       for( ; numOfNodes < ipAssignedToComp.ordinality() ; numOfNodes++)
       {

--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -3847,10 +3847,18 @@ function validateNumNodesDialog() {
   else
   {
     var numberIPs = parseInt(ipCount());
-    var roxieNode = parseInt(document.getElementById('node4RoxieServ').value)
-    var thorNode = parseInt(document.getElementById('node4Thor').value)
-       
-    if ( roxieNode <= numberIPs && thorNode <= numberIPs ) {
+    var roxieNodes = parseInt(document.getElementById('node4RoxieServ').value)
+    var thorNodes = parseInt(document.getElementById('node4Thor').value)
+
+    if (roxieNodes <= numberIPs && thorNodes <= numberIPs) {
+      if (thorNodes == numberIPs && numberIPs > 10) {
+        if (!confirm("As the number of Thor slave nodes requested is equal to the number \
+of ip addresses given, there will be an overlap of Thor master node and a Thor \
+slave node. This is not recommended in an environment with more than \
+10 nodes.\n\nDo you want to continue?"))
+          return;
+      }
+
       submitInformation();
     }
     else{


### PR DESCRIPTION
Fix ConfigMgr Wizard to allow overlap of thor master and slave node. A
prompt will be displayed if the number of ip addresses entered is more than
10 and user specifies the same number of thor slaves as the number of ip
addresses.

The message of the prompt is as follows

"As the number of Thor slave nodes requested is equal to the number
of ip addresses given, there will be an overlap of Thor master node
and a Thor slave node. This is not recommended in an environment
with more than 10 nodes.

Do you want to continue?"

If the user answers yes to this question, environment is generated.
Otherwise, user is given a chance to edit the number of thor slave nodes.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
