### PR TITLE
Make all checked_XXXX io functions public for consistency

### DIFF
--- a/system/jlib/jio.cpp
+++ b/system/jlib/jio.cpp
@@ -51,7 +51,7 @@ void setIORetryCount(unsigned _ioRetryCount) // non atomic, expected to be calle
     ioRetryCount = _ioRetryCount;
 }
 
-static inline offset_t checked_lseeki64( int handle, offset_t offset, int origin )
+extern jlib_decl offset_t checked_lseeki64( int handle, offset_t offset, int origin )
 {
     offset_t ret=_lseeki64(handle,offset,origin);
     if (ret==(offset_t)-1) 
@@ -179,7 +179,7 @@ extern jlib_decl size32_t checked_pread(int file, void *buffer, size32_t len, of
 #endif
 }
 
-static inline size32_t checked_write( int handle, const void *buffer, size32_t count )
+extern jlib_decl size32_t checked_write( int handle, const void *buffer, size32_t count )
 {
     int ret=_write(handle,buffer,count);
     if ((size32_t)ret != count)

--- a/system/jlib/jio.hpp
+++ b/system/jlib/jio.hpp
@@ -136,6 +136,8 @@ extern jlib_decl IRecordSize *createDeltaRecordSize(IRecordSize * size, int delt
 extern jlib_decl unsigned copySeq(IReadSeq *from,IWriteSeq *to,size32_t bufsize);
 
 extern jlib_decl void setIORetryCount(unsigned _ioRetryCount); // default 0 == off, retries if read op. fails
+extern jlib_decl offset_t checked_lseeki64(int handle, offset_t offset, int origin);
+extern jlib_decl size32_t checked_write(int handle, const void *buffer, size32_t count);
 extern jlib_decl size32_t checked_read(int file, void *buffer, size32_t len);
 extern jlib_decl size32_t checked_pread(int file, void *buffer, size32_t len, offset_t pos);
 


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
