### PR TITLE
BUG: #86144 Report an error if SKIP is used in ROW

### DIFF
--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -203,6 +203,7 @@
 #define HQLERR_OpArgDependsDataset              4180
 #define HQLERR_CouldNotDetermineMinSize         4181
 #define HQLERR_OutsideGroupAggregate            4182
+#define HQLERR_SkipInsideCreateRow              4183
 
 //Warnings....
 #define HQLWRN_PersistDataNotLikely             4500
@@ -477,6 +478,7 @@
 #define HQLERR_OpArgDependsDataset_Text         "%s: %s cannot be dependent on the dataset"
 #define HQLERR_CouldNotDetermineMinSize_Text    "Cannot determine the minimum size of the expression"
 #define HQLERR_OutsideGroupAggregate_Text       "%s used outside of a TABLE aggregation"
+#define HQLERR_SkipInsideCreateRow_Text         "SKIP inside a ROW(<transform>) not supported.  It is only allowed in a DATASET transform."
 
 //Warnings.
 #define HQLWRN_CannotRecreateDistribution_Text  "Cannot recreate the distribution for a persistent dataset"

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -1550,7 +1550,7 @@ public:
     ABoundActivity * doBuildActivityCombineGroup(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityCompoundSelectNew(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityConcat(BuildCtx & ctx, IHqlExpression * expr);
-    ABoundActivity * doBuildActivityCreateRow(BuildCtx & ctx, IHqlExpression * expr);
+    ABoundActivity * doBuildActivityCreateRow(BuildCtx & ctx, IHqlExpression * expr, bool isDataset);
     ABoundActivity * doBuildActivityXmlRead(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityDedup(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityDefineSideEffect(BuildCtx & ctx, IHqlExpression * expr);


### PR DESCRIPTION
The transform supplied to the ROW() function to create a row is not
allowed to include a SKIP.  (A ROW must always generate an output
row.)  Previously it could generate invalid code - accessing a row
that wasn't present.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
