### PR TITLE
Fix #223 Graphs for roxiequery need to show roxie graphs and stats.

### DIFF
--- a/esp/eclwatch/ws_XSLT/GvcGraph.xslt
+++ b/esp/eclwatch/ws_XSLT/GvcGraph.xslt
@@ -169,7 +169,7 @@
       {
           //var link = document.getElementById('StatsLink');
           //link.innerText = 'Loading Stats...';
-          var url = '/WsRoxieQuery/RoxieQueryProcessGraph?FileName=' + queryName + '/' + graphName + ".htm&ClusterName=" + cluster + "&Stats=1";
+          var url = '/WsRoxieQuery/RoxieQueryProcessGraph?Cluster=' + cluster + '&QueryId=' + queryName + '&GraphName=' + graphName;
           var wnd = window.open("about:blank", "_graphStats_", 
                                   "toolbar=0,location=0,directories=0,status=0,menubar=0," + 
                                   "scrollbars=1, resizable=1, width=640, height=480");

--- a/esp/files/scripts/graphgvc.js
+++ b/esp/files/scripts/graphgvc.js
@@ -1,18 +1,6 @@
 /*##############################################################################
-#    Copyright (C) 2011 HPCC Systems.
-#
-#    All rights reserved. This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+## Copyright © 2011 HPCC Systems.  All rights reserved.
     
 ############################################################################## */
 
@@ -266,7 +254,7 @@ function update_details() {
     showElement('findNodeBlock');
     showElement('autoSpan');
 
-    if (isrunning != '1' && forceFinalCountRefresh == false)
+    if (isrunning != '1')
     {
         hideElement('autoSpan');
         isrunningsave = '0';
@@ -471,21 +459,15 @@ function selectVertex(TargetVertex) {
     var FoundVertex = String(TargetVertex);
     pluginLHS().centerOnItem(pluginLHS().getItem(FoundVertex), true);
 }
-
-var forceFinalCountRefresh = true;
-
         
 function reloadGraph()
 {
-    if (isrunning == '1' || forceFinalCountRefresh)
+    if (isrunning == '1')
     {
       if (document.getElementById('auto').checked)
       {
           reloading = true;
           sendWuInfoRequest();
-          if (isrunning != '1') {
-              forceFinalCountRefresh = false;
-          }
       }
     }
 }
@@ -594,11 +576,11 @@ function loadXGMMLGraph(xgmmlResponse) {
             pluginLHS().setMessage("Performing Layout...");
             pluginLHS().startLayout("dot");
 
-            pluginLHS().centerOnItem(0, true); // scale to fit.
+            //pluginLHS().centerOnItem(0, true); // scale to fit.
 
         }
     }
-    if (isrunning == '1' || (isrunning != '1' && forceFinalCountRefresh)) {
+    if (isrunning == '1') {
         if (graphloaded != '1') {
             document.getElementById('auto').checked = true;
         }
@@ -804,32 +786,32 @@ function getEspAddressAndPort(Url)
 }
 
 function parseUri (str) {
-    var o   = parseUri.options,
-        m   = o.parser[o.strictMode ? "strict" : "loose"].exec(str),
-        uri = {},
-        i   = 14;
+	var	o   = parseUri.options,
+		m   = o.parser[o.strictMode ? "strict" : "loose"].exec(str),
+		uri = {},
+		i   = 14;
 
-    while (i--) uri[o.key[i]] = m[i] || "";
+	while (i--) uri[o.key[i]] = m[i] || "";
 
-    uri[o.q.name] = {};
-    uri[o.key[12]].replace(o.q.parser, function ($0, $1, $2) {
-        if ($1) uri[o.q.name][$1] = $2;
-    });
+	uri[o.q.name] = {};
+	uri[o.key[12]].replace(o.q.parser, function ($0, $1, $2) {
+		if ($1) uri[o.q.name][$1] = $2;
+	});
 
-    return uri;
+	return uri;
 };
 
 parseUri.options = {
-    strictMode: false,
-    key: ["source","protocol","authority","userInfo","user","password","host","port","relative","path","directory","file","query","anchor"],
-    q:   {
-        name:   "queryKey",
-        parser: /(?:^|&)([^&=]*)=?([^&]*)/g
-    },
-    parser: {
-        strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
-        loose:  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
-    }
+	strictMode: false,
+	key: ["source","protocol","authority","userInfo","user","password","host","port","relative","path","directory","file","query","anchor"],
+	q:   {
+		name:   "queryKey",
+		parser: /(?:^|&)([^&=]*)=?([^&]*)/g
+	},
+	parser: {
+		strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
+		loose:  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
+	}
 };
 
 function getUrlParam( Url, Param)
@@ -1088,7 +1070,7 @@ function getRoxieConfigRequestEnvelope(QueryName, GraphName)
 }
 
 function getWsRoxieQueryRequestEnvelope(QueryName, GraphName, Cluster) {
-    var RoxieQuerySOAPEnvelope = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsRoxieQuery"><soap:Body><RoxieQueryShowGVCGraphRequest><ClusterName>%Cluster%</ClusterName><QueryName>%QueryName%</QueryName><GraphName>%GraphName%</GraphName></RoxieQueryShowGVCGraphRequest></soap:Body></soap:Envelope>';
+    var RoxieQuerySOAPEnvelope = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsRoxieQuery"><soap:Body><ShowGVCGraphRequest><Cluster>%Cluster%</Cluster><QueryId>%QueryName%</QueryId><GraphName>%GraphName%</GraphName></ShowGVCGraphRequest></soap:Body></soap:Envelope>';
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%Cluster%', Cluster);
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%QueryName%', QueryName);
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%GraphName%', GraphName);
@@ -1114,23 +1096,23 @@ function getWuInfoRequestEnvelope(wuid)
 
 function showGraphStats()
 {
-    var link = document.getElementById('StatsLink');
-    link.innerHTML = 'Loading Stats...';
-    var baseUrl = '/ws_roxieconfig/ProcessGraph?FileName=' + queryName + '/' + graphName;
-    var url = baseUrl + '.htm&Stats=1';
-    var wnd = window.open("about:blank", "_graphStats_", 
-                            "toolbar=0,location=0,directories=0,status=0,menubar=0," + 
-                            "scrollbars=1, resizable=1, width=640, height=480");
-    link.innerHTML = 'Stats...';
-    if (wnd)
+	var link = document.getElementById('StatsLink');
+	link.innerHTML = 'Loading Stats...';
+	var baseUrl = '/ws_roxieconfig/ProcessGraph?FileName=' + queryName + '/' + graphName;
+	var url = baseUrl + '.htm&Stats=1';
+	var wnd = window.open("about:blank", "_graphStats_", 
+							"toolbar=0,location=0,directories=0,status=0,menubar=0," + 
+							"scrollbars=1, resizable=1, width=640, height=480");
+	link.innerHTML = 'Stats...';
+	if (wnd)
+	{
+		wnd.location = url;
+		wnd.focus();
+	}
+	else
     {
-        wnd.location = url;
-        wnd.focus();
-    }
-    else
-    {
-                alert(  "Popup window could not be opened!  " + 
-                            "Please disable any popup killer and try again.");
+		        alert(	"Popup window could not be opened!  " + 
+					        "Please disable any popup killer and try again.");
     }
 }
 

--- a/esp/scm/ws_roxiequery.ecm
+++ b/esp/scm/ws_roxiequery.ecm
@@ -131,6 +131,51 @@ RoxieQueryDetailsResponse
     ESParray<ESPStruct RoxieQueryAlias> Aliases;
 };
 
+ESPrequest GVCAjaxGraphRequest
+{
+    string Cluster;
+    string Name;
+    string GraphName;
+};
+
+ESPresponse [exceptions_inline, http_encode(0)] GVCAjaxGraphResponse
+{
+    string Cluster;
+    string Name;
+    string GraphName;
+    string GraphType;
+};
+
+ESPrequest ShowGVCGraphRequest
+{
+    string Cluster;
+    string QueryId;
+    string GraphName;
+};
+
+ESPresponse [exceptions_inline, http_encode(0)] ShowGVCGraphResponse
+{
+    string Cluster;
+    string QueryId;
+    string GraphName;
+    ESParray<string> GraphNames;
+    string TheGraph;
+};
+
+ESPrequest RoxieQueryProcessGraphRequest
+{
+	string Cluster;
+    string QueryId;
+    string GraphName;
+	bool   XmlGraph;
+	bool	 Stats;
+};
+
+ESPresponse  [encode(0), exceptions_inline] RoxieQueryProcessGraphResponse
+{
+    string theGraph;
+};
+
 
 //  ===========================================================================
 ESPservice [
@@ -144,6 +189,9 @@ ESPservice [
     ESPmethod [resp_xsl_default("/esp/xslt/roxiequery_search.xslt")] RoxieQuerySearch(RoxieQuerySearchRequest, RoxieQuerySearchResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/roxiequery.xslt")] RoxieQueryList(RoxieQueryListRequest, RoxieQueryListResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/roxiequerydetails.xslt")] QueryDetails(RoxieQueryDetailsRequest, RoxieQueryDetailsResponse);
+    ESPmethod [description("Stub for Ajax GVC Graph."), help(""), resp_xsl_default("/esp/xslt/GvcGraph.xslt")] GVCAjaxGraph(GVCAjaxGraphRequest, GVCAjaxGraphResponse);
+    ESPmethod [description("Show GVC graph for a Roxie query"), help(""), resp_xsl_default("/esp/xslt/RoxieGVCGraph.xslt")] ShowGVCGraph(ShowGVCGraphRequest, ShowGVCGraphResponse);
+	ESPmethod [resp_xsl_default("/esp/xslt/graphStats.xslt")] RoxieQueryProcessGraph(RoxieQueryProcessGraphRequest, RoxieQueryProcessGraphResponse);
 };
 
 SCMexportdef(WsRoxieQuery);

--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
@@ -47,6 +47,7 @@ const unsigned int  ROXIEQUERYASSOCIATEDNAME    = 9;
 const unsigned int  ROXIEQUERYHASALIASES            = 10;
 const unsigned int  ROXIEQUERYDEPLOYEDBY            = 11;
 const unsigned int  ROXIEQUERYUPDATEDBY         = 12;
+const unsigned int  ROXIEMANAGER_TIMEOUT        = 60000;
 
 static const char* FEATURE_URL="RoxieQueryAccess";
 static const char* ROXIE_CLUSTER="RoxieCluster";
@@ -290,7 +291,7 @@ bool CWsRoxieQueryEx::getAllRoxieQueries(IEspContext &context, const char* clust
     ep1.getUrlStr(currentDaliIp);
 
     LogLevel loglevel = getEspLogLevel(&context);
-    Owned<IRoxieQueryManager> queryManager = createRoxieQueryManager(ep, cluster, currentDaliIp, 60000, username.str(), password.str(), loglevel);
+    Owned<IRoxieQueryManager> queryManager = createRoxieQueryManager(ep, cluster, currentDaliIp, ROXIEMANAGER_TIMEOUT, username.str(), password.str(), loglevel);
     Owned<IPropertyTree> result = queryManager->retrieveQueryList("*", false, false, false, false, 0);
 
     Owned<IPropertyTreeIterator> queries = result->getElements("Query");
@@ -557,7 +558,7 @@ bool CWsRoxieQueryEx::onQueryDetails(IEspContext &context, IEspRoxieQueryDetails
         ep1.getUrlStr(currentDaliIp);
 
         LogLevel loglevel = getEspLogLevel(&context);
-        Owned<IRoxieQueryManager> queryManager = createRoxieQueryManager(ep, cluster, currentDaliIp, 60000, username.str(), password.str(), loglevel);
+        Owned<IRoxieQueryManager> queryManager = createRoxieQueryManager(ep, cluster, currentDaliIp, ROXIEMANAGER_TIMEOUT, username.str(), password.str(), loglevel);
         Owned<IPropertyTree> result = queryManager->retrieveQueryList(queryID, false, false, false, false, 0);
 
         if (result)
@@ -636,3 +637,179 @@ bool CWsRoxieQueryEx::onQueryDetails(IEspContext &context, IEspRoxieQueryDetails
     }
     return true;
 }
+
+bool CWsRoxieQueryEx::onGVCAjaxGraph(IEspContext &context, IEspGVCAjaxGraphRequest &req, IEspGVCAjaxGraphResponse &resp)
+{
+    resp.setCluster(req.getCluster());
+    resp.setName(req.getName());
+    resp.setGraphName(req.getGraphName());
+    resp.setGraphType("roxiequery");
+    return true;
+}
+bool CWsRoxieQueryEx::onShowGVCGraph(IEspContext &context, IEspShowGVCGraphRequest &req, IEspShowGVCGraphResponse &resp)
+    {
+        const char *queryName = req.getQueryId();
+        if (!queryName || !*queryName)
+            throw MakeStringException(0, "Missing Roxie query name!");
+
+        const char* cluster = req.getCluster();
+
+        int port;
+        StringBuffer netAddress;
+        SocketEndpoint ep;
+        getClusterConfig(ROXIE_CLUSTER, cluster, ROXIE_FARMERPROCESS1, netAddress, port);
+        ep.set(netAddress.str(), port);
+
+
+        StringArray graphNames;
+        enumerateGraphs(queryName, ep, graphNames);
+
+        char graphName[256];
+        if (req.getGraphName() && *req.getGraphName())
+        {
+            strcpy(graphName, req.getGraphName());
+        }
+        else if (graphNames.length() > 0)
+        {
+            StringBuffer graphName0 = graphNames.item(0);
+            strcpy(graphName, graphName0.str());
+        }
+        else
+        {
+            throw MakeStringException(0, "Graph not found!");
+        }
+
+        Owned<IPropertyTree> pXgmmlGraph = getXgmmlGraph(queryName, ep, graphName);
+
+        StringBuffer xml;
+        toXML(pXgmmlGraph, xml);
+
+        if (xml.length() > 0)
+        {
+            StringBuffer str;
+            encodeUtf8XML(xml.str(), str, 0);
+
+            StringBuffer xml1;
+            xml1.append("<Control>");
+            xml1.append("<Endpoint>");
+            xml1.append("<Query id=\"Gordon.Extractor.0\">");
+            xml1.appendf("<Graph id=\"%s\">", graphName);
+            xml1.append("<xgmml>");
+            xml1.append(str);
+            xml1.append("</xgmml>");
+            xml1.append("</Graph>");
+            xml1.append("</Query>");
+            xml1.append("</Endpoint>");
+            xml1.append("</Control>");
+
+            resp.setTheGraph(xml1);
+        }
+
+        if (graphName && *graphName)
+            resp.setGraphName( graphName );
+        resp.setQueryId( queryName );
+        resp.setGraphNames( graphNames );
+        return true;
+    }
+
+void CWsRoxieQueryEx::enumerateGraphs(const char *queryName, SocketEndpoint &ep, StringArray& graphNames)
+{
+
+    try
+    {
+
+        Owned<IRoxieCommunicationClient> roxieClient = createRoxieCommunicationClient(ep, ROXIEMANAGER_TIMEOUT);
+        Owned<IPropertyTree> result = roxieClient->retrieveQueryStats(queryName, "listGraphNames", NULL, false);
+        IPropertyTree* rootTree = result->queryPropTree("Endpoint/Query");
+
+        if (rootTree)
+        {
+            Owned<IPropertyTreeIterator> graphit = rootTree->getElements("Graph");
+            ForEach(*graphit)
+            {
+                const char* graphName = graphit->query().queryProp("@id");
+                graphNames.append( graphName );
+            }
+        }
+    }
+    catch (IException *e)
+    {
+        StringBuffer errmsg;
+        ERRLOG("Exception when enumerating graphs for %s: %s", queryName, e->errorMessage(errmsg).str());
+        throw e;
+    }
+    catch(...)
+    {
+        ERRLOG("Unknown exception when enumerating graphs for %s", queryName);
+        throw MakeStringException(-1, "Unknown exception while enumerating graphs for %s", queryName);
+    }
+}
+
+IPropertyTree* CWsRoxieQueryEx::getXgmmlGraph(const char *queryName, SocketEndpoint &ep, const char* graphName)
+{
+        
+    try
+    {
+        Owned<IRoxieCommunicationClient> roxieClient = createRoxieCommunicationClient(ep, ROXIEMANAGER_TIMEOUT);
+        Owned<IPropertyTree> result = roxieClient->retrieveQueryStats(queryName, "selectGraph", graphName, true);
+
+        StringBuffer xpath;
+        xpath   << "Endpoint/Query/Graph[@id='" 
+                << graphName
+                << "']/xgmml/graph";
+        IPropertyTree* pXgmmlGraph = result->queryPropTree(xpath.str());
+        if (!pXgmmlGraph)
+            throw MakeStringException(-1, "Graph not found!");
+        return LINK( pXgmmlGraph );
+    }
+    catch (IException *e)
+    {
+        StringBuffer errmsg;
+        ERRLOG("Exception when fetching graph %s for %s: %s", graphName, queryName, e->errorMessage(errmsg).str());
+        throw e;
+    }
+    catch(...)
+    {
+        ERRLOG("Unknown exception when fetching graph %s for %s", graphName, queryName);
+        throw MakeStringException(-1, "Unknown exception while generating graph %s for %s", graphName, queryName);
+    }
+}
+
+bool CWsRoxieQueryEx::onRoxieQueryProcessGraph(IEspContext &context, IEspRoxieQueryProcessGraphRequest &req, IEspRoxieQueryProcessGraphResponse &resp)
+{
+    const char* cluster = req.getCluster();
+    const char* graphName = req.getGraphName();
+    const char *queryName = req.getQueryId();
+    if (!queryName || !*queryName)
+        throw MakeStringException(0, "Missing Roxie query name!");
+
+	try
+	{
+		int port;
+		StringBuffer netAddress;
+		SocketEndpoint ep;
+		getClusterConfig(ROXIE_CLUSTER, cluster, ROXIE_FARMERPROCESS1, netAddress, port);
+		ep.set(netAddress.str(), port);
+		Owned<IRoxieCommunicationClient> roxieClient = createRoxieCommunicationClient(ep, ROXIEMANAGER_TIMEOUT);
+
+    	Owned<IPropertyTree> xgmml = getXgmmlGraph(queryName, ep, graphName);
+
+        StringBuffer x;
+
+        toXML(xgmml.get(), x);
+        resp.setTheGraph(x.str());
+	}
+    catch (IException *e)
+    {
+        StringBuffer errmsg;
+        ERRLOG("Exception when fetching graph stats %s for %s: %s", graphName, queryName, e->errorMessage(errmsg).str());
+        throw e;
+    }
+    catch(...)
+    {
+        ERRLOG("Unknown exception when fetching graph stats %s for %s", graphName, queryName);
+        throw MakeStringException(-1, "Unknown exception while generating graph %s for %s", graphName, queryName);
+    }
+	return true;
+}
+

--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
@@ -80,6 +80,9 @@ public:
     bool onRoxieQuerySearch(IEspContext &context, IEspRoxieQuerySearchRequest & req, IEspRoxieQuerySearchResponse & resp);
     bool onRoxieQueryList(IEspContext &context, IEspRoxieQueryListRequest &req, IEspRoxieQueryListResponse &resp);
     bool onQueryDetails(IEspContext &context, IEspRoxieQueryDetailsRequest & req, IEspRoxieQueryDetailsResponse & resp);
+    bool onGVCAjaxGraph(IEspContext &context, IEspGVCAjaxGraphRequest &req, IEspGVCAjaxGraphResponse &resp);
+    bool onShowGVCGraph(IEspContext &context, IEspShowGVCGraphRequest &req, IEspShowGVCGraphResponse &resp);
+    bool onRoxieQueryProcessGraph(IEspContext &context, IEspRoxieQueryProcessGraphRequest &req, IEspRoxieQueryProcessGraphResponse &resp);
 
 private:
     void addToQueryString(StringBuffer &queryString, const char *name, const char *value);
@@ -87,6 +90,8 @@ private:
     void getClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress, int& port);
 
     bool getAllRoxieQueries(IEspContext &context, const char* cluster, const char* suspended, const char* sortBy, bool descending, __int64 displayEnd, IArrayOf<IEspRoxieQuery>& RoxieQueryList, __int64& totalFiles);
+    IPropertyTree* getXgmmlGraph(const char *queryName, SocketEndpoint &ep, const char* graphName);
+    void enumerateGraphs(const char *queryName, SocketEndpoint &ep, StringArray& graphNames);
 };
 
 #endif //_ESPWIZ_WsRoxieQuery_HPP__


### PR DESCRIPTION
Returning code that had inadvertently been extracted from community.
The RoxieQueryProcessGraph esp method that returns the graphstats is
reworked and cleaned up to be more consistent with the ws_workunits
code that returns workunit graphs.

Signed-off-by: Jo Prichard jo.prichard@gmail.com
