### PR TITLE
FIX gh-337 - ECLAgent incorrectly checks overrideBaseDirectory

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3188,7 +3188,7 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
                 overrideReplicateDirectory = repdir.str();
             if (overrideBaseDirectory&&*overrideBaseDirectory)
                 setBaseDirectory(overrideBaseDirectory, false);
-            if (overrideReplicateDirectory&&*overrideBaseDirectory)
+            if (overrideReplicateDirectory&&*overrideReplicateDirectory)
                 setBaseDirectory(overrideReplicateDirectory, true);
 
             if (standAloneWorkUnit)


### PR DESCRIPTION
When checking to see if it should set the overrideReplicateDirectory,
eclagent tests the wrong variable
        if (overrideReplicateDirectory&&_overrideBaseDirectory)
            setBaseDirectory(overrideReplicateDirectory, true);
should be
        if (overrideReplicateDirectory&&_overrideReplicateDirectory)
            setBaseDirectory(overrideReplicateDirectory, true);

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
