### PR TITLE
Issue 339: WuWebView should strip namespaces to simplify XSLT code

### DIFF
--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -125,7 +125,7 @@ public:
 
     virtual void newAttribute(const char *name, const char *value)
     {
-        if (datasetLevel)
+        if (datasetLevel && !streq(name, "@xmlns"))
             buffer.append(' ').append(name+1).append("=\"").append(value).append('\"');
     }
     virtual void beginNodeContent(const char *tag)


### PR DESCRIPTION
Writing xslt that respects namespaces can be complex.

Strip namespaces in WuWebView when possible to make it easier for users to write
custom xslt code.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
