### PR TITLE
Issue 342: Fix order of operation for libxml xslprocessor include buffer

### DIFF
--- a/system/xmllib/xslprocessor.ipp
+++ b/system/xmllib/xslprocessor.ipp
@@ -133,7 +133,8 @@ public:
             }
             else
             {
-                MemBufInputSource* memsrc = new MemBufInputSource((const XMLByte*)buf.detach(), buf.length(), (const XMLCh*)NULL, false);
+                size32_t buflen = buf.length();
+                MemBufInputSource* memsrc = new MemBufInputSource((const XMLByte*)buf.detach(), buflen, (const XMLCh*)NULL, false);
                 memsrc->setCopyBufToStream(false);
                 inputsrc = memsrc;
             }


### PR DESCRIPTION
Issue 342: Fix order of operation for libxml xslprocessor include buffer handling

Order of evaluation can cause MemoryBuffer::detach to be called before
MemoryBuffer::length, ending up with a length of 0.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
