### PR TITLE
Bug: 86235 Check user input in Local Path using dropzone path

### DIFF
--- a/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
@@ -77,6 +77,7 @@
             var sourceOS = 0;
             var pathSep;
             var prefix;
+            var dropzoneDirectory;
             function onChangeMachine(resetPath)
             {
               machineDropDown = document.forms[0].machine;
@@ -90,6 +91,7 @@
                
                sourceOS = linux == 'true' ? 1: 0;
          
+               dropzoneDirectory = directory;
                if ((dir0 != '') && (partmask0 != ''))
                {
                   if (sourceOS != 0)
@@ -104,7 +106,6 @@
                 if (!firsttime  || (val = 'undefined') || (document.forms[0].sourcePath.value.length <= 1) )
                 {
                   document.forms[0].sourcePath.value = directory;
-                  document.forms[0].sourcePathRoot.value = directory;
                   if (document.forms[0].sourcePathAndFile.value)
                     document.forms[0].sourcePath.value = document.forms[0].sourcePathAndFile.value;
                 }
@@ -204,9 +205,10 @@
 
             function beforeSubmit()
             {
-              if (document.getElementById("sourcePath").value == document.getElementById("sourcePathRoot").value)
+              if ((document.getElementById("sourcePath").value == '')
+                || (document.getElementById("sourcePath").value == dropzoneDirectory))
               {
-                alert("Please specify a file in the LocalPath.");
+                alert("Please specify a file in the Local Path field.");
                 return false;
               }
               return true;
@@ -265,12 +267,10 @@
               <input type="hidden" name="sourcePathAndFile" id="sourcePathAndFile" value=""/>
               <xsl:choose>
                 <xsl:when test="string-length($srcpath)">
-                  <input type="hidden" name="sourcePathRoot" id="sourcePathRoot" value="{$srcpath}/{$srcpartmask}"/>
                   <input type="text" name="sourcePath" id="sourcePath" value="{$srcpath}/{$srcpartmask}" size="70"
                     onchange="onChangeMachine(false)" onblur="onChangeMachine(false)"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <input type="hidden" name="sourcePathRoot" id="sourcePathRoot" value="/"/>
                   <input type="text" name="sourcePath" id="sourcePath" value="/" size="70"
                     onchange="onChangeMachine(false)" onblur="onChangeMachine(false)"/>
                 </xsl:otherwise>


### PR DESCRIPTION
When a file is sprayed, the Local Path field is pre-populated using
a dropzone directory. A user has to input a file under that directory
or select a file using the Choose File button. The existing code
verifies the file selection by comparing the Local Path field with
pre-populated value of the dropzone directory. If they are the same,
an error message will be shown. But, when the spray request comes from
a modified DFU WU, the Local Path field is pre-populated using the
full path of the file input by the user. The existing code does not
handle that. This fix changes the code to remember the value of the
dropzone directory and compare the Local Path field with the value of
dropzone directory.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
Rebased to Split-3.2 by Richard Chapman for application to 3.2.2
