### PR TITLE
gh-254 Code assumes read() will read full requested amount

### DIFF
--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -597,7 +597,6 @@ extern jlib_decl bool containsFileWildcard(const char * path);
 extern jlib_decl bool isDirectory(const char * path);
 
 extern jlib_decl IFileIOCache* createFileIOCache(unsigned max);
-extern jlib_decl void setIORetryCount(unsigned _ioRetryCount); // default 0 == off, retries if read op. fails, linux only
 extern jlib_decl IFile * createSentinelTarget();
 extern jlib_decl void writeSentinelFile(IFile * file);
 extern jlib_decl void removeSentinelFile(IFile * file);

--- a/system/jlib/jio.hpp
+++ b/system/jlib/jio.hpp
@@ -135,11 +135,9 @@ extern jlib_decl IRecordSize *createDeltaRecordSize(IRecordSize * size, int delt
 
 extern jlib_decl unsigned copySeq(IReadSeq *from,IWriteSeq *to,size32_t bufsize);
 
-//atomic read/write - used with _open 
-// avoids the need to seek separately
-
-extern jlib_decl size32_t atomicRead(int fildes, void *buf, size32_t nbyte, offset_t offset);
-extern jlib_decl size32_t atomicWrite(int fildes, const void *buf, size32_t nbyte, offset_t offset);
+extern jlib_decl void setIORetryCount(unsigned _ioRetryCount); // default 0 == off, retries if read op. fails
+extern jlib_decl size32_t checked_read(int file, void *buffer, size32_t len);
+extern jlib_decl size32_t checked_pread(int file, void *buffer, size32_t len, offset_t pos);
 
 class CachedRecordSize
 {

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -2192,10 +2192,10 @@ StringBuffer jlib_decl passwordInput(const char* prompt, StringBuffer& passwd)
     set_term.c_lflag &= ~(ECHO|ECHOE|ECHOK|ECHONL);
     tcsetattr(termfd, TCSAFLUSH, &set_term);
     char c = EOF;
-    int rd = _read(termfd,&c,1);
+    int rd = ::read(termfd,&c,1);
     while ((rd==1)&&(c!='\r')&&(c!='\n')&&(c!=EOF)) {
         passwd.append(c);
-        rd = _read(termfd,&c,1);
+        rd = ::read(termfd,&c,1);
     }
     int err = (rd<0)?errno:0;
     tcsetattr(termfd, TCSAFLUSH, &saved_term);


### PR DESCRIPTION
Various code in jlib was assuming that read() and pread() would never
return less than the requested amount except at end-of-file. The Posix
standard states that they may do so if a signal is received during the
read operation after some data has been retrieved. Testing on Lustre
suggests that this ican sometimes happen. We previously had code in to
handle cases where calls to pread() were interrupted before data had
been read, but they would not help all cases.

The calls to ::read / ::pread were not as well isolated as they should
have been (and there were also calls to _read to confuse the issue).

Refactor the code to common up calls to ::read as much as possible, and
add logic to retry interrupted reads.
read full requested amount.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
