### PR TITLE
FIX #270 Add -g option to g++ compile step on debug build

### DIFF
--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -79,7 +79,7 @@ static const char * COMPILE_ONLY[] = { "/c", "-c" };
 
 static const char * CC_OPTION_CORE[] = { "", "-fvisibility=hidden -DUSE_VISIBILITY=1" };
 static const char * LINK_OPTION_CORE[] = { "/DLL /libpath:." , "" };
-static const char * CC_OPTION_DEBUG[] = { "/Zm500 /EHsc /GR /Zi /nologo /bigobj", "-fPIC -pipe -O0" };
+static const char * CC_OPTION_DEBUG[] = { "/Zm500 /EHsc /GR /Zi /nologo /bigobj", "-g -fPIC -pipe -O0" };
 
 static const char * DLL_LINK_OPTION_DEBUG[] = { "/BASE:" BASE_ADDRESS " /NOLOGO /LARGEADDRESSAWARE /INCREMENTAL:NO /DEBUG /DEBUGTYPE:CV", "-g -shared -L. -fPIC -pipe -O0" };
 static const char * EXE_LINK_OPTION_DEBUG[] = { "/BASE:" BASE_ADDRESS " /NOLOGO /LARGEADDRESSAWARE /INCREMENTAL:NO /DEBUG /DEBUGTYPE:CV", "-g -L. -Wl,-E -fPIC -pipe -O0" };


### PR DESCRIPTION
eclcc generated executables for Linux are not getting debug symbols
included, even though the debug command line option is set. Fix the
problem by adding -g to linux compile step

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
Rebased to merge into candidate-3.2.x for release in 3.2.2
