### PR TITLE
Resolve bottleneck on directory operations

### DIFF
--- a/system/jlib/jsocket.hpp
+++ b/system/jlib/jsocket.hpp
@@ -156,6 +156,7 @@ public:
         ipset(other);
         port = other.port;
     }
+	bool operator == (const SocketEndpoint &other) const { return equals(other); }
 
     unsigned hash(unsigned prev) const;
     


### PR DESCRIPTION
Directory serialization introduced ~10 months back, introduced a critical
section, that caused all directory operations from a given client to be
serialized. This made XREF intollerably slow.
Plus, there were a few bugs in the directory serialization which meant it
was never used and would have failed (loop indefinetely) if had been.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
