### PR TITLE
gh-351 - Support Visual Studio analyse tool

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -991,7 +991,7 @@ void CHqlBoundTarget::validate() const
             assertex(!length);
         }
         else if (isArrayRowset(queryType()))
-            assertex(count);
+            assertex(count != NULL);
         else
         {
             assertex(length || queryType()->getTypeCode() == type_varstring || queryType()->getTypeCode() == type_varunicode);
@@ -1895,7 +1895,7 @@ void HqlCppTranslator::checkPipeAllowed()
 IHqlExpression * HqlCppTranslator::bindFunctionCall(_ATOM name, HqlExprArray & args)
 {
     OwnedHqlExpr function = needFunction(name);
-    assertex(function);
+    assertex(function != NULL);
     return bindFunctionCall(function, args);
 }
 
@@ -5466,7 +5466,7 @@ void HqlCppTranslator::doBuildCall(BuildCtx & ctx, const CHqlBoundTarget * tgt, 
     if (expr->getOperator() == no_externalcall)
     {
         funcdef.set(expr->queryExternalDefinition());
-        assertex(funcdef);
+        assertex(funcdef != NULL);
         useFunction(funcdef);
     }
     else
@@ -5603,7 +5603,7 @@ void HqlCppTranslator::doBuildCall(BuildCtx & ctx, const CHqlBoundTarget * tgt, 
                     lenVar.setown(ctx.getTempDeclare(unsignedType, NULL));
                 else
                     lenVar.set(tgt->length);
-                assertex(tgt->isAll);
+                assertex(tgt->isAll != NULL);
                 isAll.set(tgt->isAll);
             }
             else

--- a/ecl/hqlcpp/hqlcset.cpp
+++ b/ecl/hqlcpp/hqlcset.cpp
@@ -515,7 +515,7 @@ BoundRow * InlineBlockDatasetCursor::buildSelect(BuildCtx & ctx, IHqlExpression 
 
 InlineLinkedDatasetCursor::InlineLinkedDatasetCursor(HqlCppTranslator & _translator, IHqlExpression * _ds, CHqlBoundExpr & _boundDs) : BaseDatasetCursor(_translator, _ds, &_boundDs)
 {
-    assertex(boundDs.count);
+    assertex(boundDs.count != NULL);
     assertex(isArrayRowset(boundDs.expr->queryType()));
 }
 
@@ -1469,13 +1469,13 @@ BoundRow * SingleRowTempDatasetBuilder::buildCreateRow(BuildCtx & ctx)
 
 void SingleRowTempDatasetBuilder::buildFinish(BuildCtx & ctx, const CHqlBoundTarget & target)
 {
-    assertex(cursor);
+    assertex(cursor != NULL);
 }
 
 
 void SingleRowTempDatasetBuilder::buildFinish(BuildCtx & ctx, CHqlBoundExpr & target)
 {
-    assertex(cursor);
+    assertex(cursor != NULL);
 }
 
 
@@ -1728,7 +1728,7 @@ void SetBuilder::buildFinish(BuildCtx & ctx, const CHqlBoundTarget & target)
 {
     if (target.isAll && (allVar != target.isAll))
     {
-        assertex(allVar);
+        assertex(allVar != NULL);
         ctx.addAssign(target.isAll, allVar);
     }
     datasetBuilder->buildFinish(ctx, target);

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -983,7 +983,7 @@ void TransformBuilder::buildTransform(BuildCtx & ctx, IHqlExpression * expr, IHq
 
             flush(ctx);
 
-            assertex(mapper);
+            assertex(mapper != NULL);
             OwnedHqlExpr test = replaceSelector(expr->queryChild(0), querySelfReference(), parentSelector);
             OwnedHqlExpr foldedTest = mapper->transformRoot(test);
             foldedTest.setown(foldHqlExpression(foldedTest));           // can only contain references to self, so don't need to worry about other datasets in scope being messed up.
@@ -10864,7 +10864,7 @@ void HqlCppTranslator::doBuildStmtOutput(BuildCtx & ctx, IHqlExpression * expr)
 
     LinkedHqlExpr seq = querySequence(expr);
     LinkedHqlExpr name = queryResultName(expr);
-    assertex(seq);
+    assertex(seq != NULL);
     int sequence = (int)getIntValue(seq, (int)ResultSequenceInternal);
     if (!seq)
         seq.setown(getSizetConstant(sequence));
@@ -14076,7 +14076,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityNormalizeLinkedChild(BuildCtx 
     CHqlBoundTarget boundActive;
     createTempFor(*declarectx, value->queryType(), childTarget, typemod_none, FormatLinkedDataset);
     boundChild.setFromTarget(childTarget);
-    assertex(boundChild.count);
+    assertex(boundChild.count != NULL);
 
     OwnedHqlExpr test;
     OwnedHqlExpr ret;

--- a/ecl/hqlcpp/hqlinline.cpp
+++ b/ecl/hqlcpp/hqlinline.cpp
@@ -1384,7 +1384,7 @@ void ClassEvalContext::createMemberAlias(CtxCollection & ctxs, BuildCtx & ctx, I
         return;
 
     //Should never be called for a nested class - that should be done in the context.
-    assertex(ctxs.evalctx);
+    assertex(ctxs.evalctx != NULL);
     translator.expandAliases(*ctxs.evalctx, value);
 
     CHqlBoundTarget tempTarget;

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -748,7 +748,7 @@ bool ComplexImplicitProjectInfo::safeToReorderInput()
 
 void ComplexImplicitProjectInfo::setMatchingOutput(ComplexImplicitProjectInfo * other)
 {
-    assertex(other->newOutputRecord);
+    assertex(other->newOutputRecord != NULL);
     outputFields.set(other->outputFields);
     newOutputRecord.set(other->newOutputRecord);
 }
@@ -1663,7 +1663,7 @@ void ImplicitProjectTransformer::calculateFieldsUsed(IHqlExpression * expr)
             extra->outputs.item(i1).notifyRequiredFields(extra);
 
         if (extra->outputFields.includeAll())
-            assertex(extra->newOutputRecord);       //extra->newOutputRecord.set(expr->queryRecord());
+            assertex(extra->newOutputRecord != NULL);       //extra->newOutputRecord.set(expr->queryRecord());
 
         //Ensure at least one field is required - otherwise meta goes wrong.  It really needs to be added here, rather than later,
         //otherwise the field tracking for iterate/rollup etc. go wrong.  Could possibly improve later if we added code to project the

--- a/ecl/hqlcpp/hqllib.cpp
+++ b/ecl/hqlcpp/hqllib.cpp
@@ -202,7 +202,7 @@ public:
                 _ATOM attrName = expr->queryChild(3)->queryName();
                 HqlDummyLookupContext dummyctx(NULL);
                 OwnedHqlExpr value = newModule->queryScope()->lookupSymbol(attrName, makeLookupFlags(true, expr->hasProperty(ignoreBaseAtom), false), dummyctx);
-                assertex(value);
+                assertex(value != NULL);
                 IHqlExpression * oldAttr = expr->queryChild(2);
                 if (oldAttr->isDataset() || oldAttr->isDatarow())
                     return value.getClear();

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -1191,7 +1191,7 @@ void SourceBuilder::buildTransformBody(BuildCtx & transformCtx, IHqlExpression *
 
 void SourceBuilder::buildTargetCursor(Owned<BoundRow> & tempRow, Owned<BoundRow> & rowBuilder, BuildCtx & ctx, IHqlExpression * expr)
 {
-    assertex(lastTransformer);
+    assertex(lastTransformer != NULL);
     if (expr == lastTransformer)
     {
         rowBuilder.set(rootSelfRow);

--- a/ecl/hqlcpp/hqltcppc.cpp
+++ b/ecl/hqlcpp/hqltcppc.cpp
@@ -186,7 +186,7 @@ IHqlExpression * SizeStruct::getSizeExpr(BoundRow * row)
         return createTranslated(bound->queryChild(1));
 #endif
 
-    assertex(self);
+    assertex(self != NULL);
     OwnedHqlExpr mapped = normalizeAdditions(varSize);
     OwnedHqlExpr total = row->bindToRow(mapped, self);
     if (!total)

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -4639,7 +4639,7 @@ public:
 
             Owned<IRoxieQueryPacket> indexPacket = createRoxiePacket(indexPacketData);
             Owned<ISlaveActivityFactory> indexActivityFactory = factory->queryQueryFactory().getSlaveActivityFactory(indexActivityId.activityId);
-            assertex(indexActivityFactory);
+            assertex(indexActivityFactory != NULL);
             rootIndexActivity.setown(indexActivityFactory->createActivity(logctx, indexPacket));
             rootIndex = rootIndexActivity->queryIndexReadActivity();
     

--- a/roxie/ccd/ccdkey.cpp
+++ b/roxie/ccd/ccdkey.cpp
@@ -796,7 +796,7 @@ public:
     virtual unsigned __int64 getFilePosition(const void *_ptr)
     {
         // MORE - could do with being faster than this!
-        assertex(curStream);
+        assertex(curStream != NULL);
         size32_t dummy;
         return thisFileStartPos + curStream->tell() + ((const char *)_ptr - (const char *)curStream->peek(1, dummy));
     }
@@ -804,7 +804,7 @@ public:
     virtual unsigned __int64 getLocalFilePosition(const void *_ptr)
     {
         // MORE - could do with being faster than this!
-        assertex(curStream);
+        assertex(curStream != NULL);
         size32_t dummy;
         return makeLocalFposOffset(thisPartIdx-1, curStream->tell() + (const char *)_ptr - (const char *)curStream->peek(1, dummy));
     }

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -114,7 +114,7 @@ public:
         else
         {
             Owned<ILoadedDllEntry> dll = isExe ? createExeDllEntry(dllName) : queryRoxieDllServer().loadDll(dllName, DllLocationDirectory);
-            assertex(dll);
+            assertex(dll != NULL);
             return new CQueryDll(dllName, dll.getClear());
         }
     }
@@ -1144,13 +1144,13 @@ public:
 
     virtual IDeserializedResultStore &queryOnceResultStore() const
     {
-        assertex(onceResultStore);
+        assertex(onceResultStore!= NULL);
         return *onceResultStore;
     }
 
     virtual IPropertyTree &queryOnceContext() const
     {
-        assertex(onceContext);
+        assertex(onceContext != NULL);
         return *onceContext;
     }
 

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -87,11 +87,6 @@ using roxiemem::OwnedRoxieRow;
 using roxiemem::OwnedConstRoxieRow;
 using roxiemem::IRowManager;
 
-#ifdef _PREFAST_
- #undef assertex
- #define assertex(p) ((p) ? ((void) 0) : (( (void) RaiseAssertException(#p, __FILE__, __LINE__), __analysis_assume(p))))
-#endif
-
 // There is a bug in VC6 implemetation of protected which prevents nested classes from accessing owner's data. It can be tricky to work around - hence...
 #if _MSC_VER==1200
 #define protected public
@@ -9000,7 +8995,7 @@ public:
     virtual const void *nextInGroup()
     {
         ActivityTimer t(totalCycles, timeActivities, ctx->queryDebugContext());
-        assertex(rows);
+        assertex(rows != NULL);
         const void * next = rows->nextRow();
         if (next)
             processed++;

--- a/system/jlib/jiface.hpp
+++ b/system/jlib/jiface.hpp
@@ -32,13 +32,18 @@ void jlib_decl RaiseAssertException(const char *assertion, const char *file, uns
 void jlib_decl RaiseAssertCore(const char *assertion, const char *file, unsigned line);
 
 #undef assert
+#undef assertex
 
-#if defined(_DEBUG)||defined(_TESTING)
-#define assertex(p) ((p) ? ((void) 0) : (( (void) RaiseAssertException(#p, __FILE__, __LINE__))))
-#define assert(p) ((p) ? ((void) 0) : (( (void) RaiseAssertCore(#p, __FILE__, __LINE__))))
+#ifdef _PREFAST_
+ #pragma warning (disable : 6244)   // generates too much noise at the moment
+ #define assertex(p) ((p) ? ((void) 0) : (( (void) RaiseAssertException(#p, __FILE__, __LINE__), __analysis_assume(p))))
+ #define assert(p) ((p) ? ((void) 0) : (( (void) RaiseAssertCore(#p, __FILE__, __LINE__), __analysis_assume(p))))
+#elif defined(_DEBUG)||defined(_TESTING)
+ #define assertex(p) ((p) ? ((void) 0) : (( (void) RaiseAssertException(#p, __FILE__, __LINE__))))
+ #define assert(p) ((p) ? ((void) 0) : (( (void) RaiseAssertCore(#p, __FILE__, __LINE__))))
 #else
-#define assertex(p)
-#define assert(p)
+ #define assertex(p)
+ #define assert(p)
 #endif
 
 #if defined(_DEBUG)||defined(_TESTING)


### PR DESCRIPTION
Fixes gh-351. Allow Visual Studio's analyse tool to understand the function
of assertex better, and thus reduce the false positives from the tool.

All cases of assertex(OwnedPtr) now get flagged as errors in analyze mode -
I have changed these to assertex(ownedptr != NULL) on a couple of projects but
not throughout.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
