### PR TITLE
REGRESSSION: typo in code to ensure full reading could core

### DIFF
--- a/system/jlib/jio.cpp
+++ b/system/jlib/jio.cpp
@@ -67,8 +67,8 @@ extern jlib_decl size32_t checked_read(int file, void *buffer, size32_t len)
     unsigned __int64 startCycles = get_cycles_now();
     loop
     {
-        size_t readNow = _read(file, buffer, len);
-        if (readNow == (size32_t)-1)
+        ssize_t readNow = _read(file, buffer, len);
+        if (readNow == (ssize_t)-1)
         {
             switch (errno)
             {
@@ -141,8 +141,8 @@ extern jlib_decl size32_t checked_pread(int file, void *buffer, size32_t len, of
     unsigned __int64 startCycles = get_cycles_now();
     loop
     {
-        size_t readNow = ::pread(file, buffer, len, pos);
-        if (readNow == (size32_t)-1)
+        ssize_t readNow = ::pread(file, buffer, len, pos);
+        if (readNow == (ssize_t)-1)
         {
             switch (errno)
             {


### PR DESCRIPTION
A typo in the code for ensureing that read/pread read the full amount even
when interrupted by signals could result in a heap corruption, as the byte
before the buffer might get overwritten.

Code was checking a 64-bit unsigned -1 value against a 32-bit one, and thus
comparing 0xffffffffffffffff versus 0x00000000ffffffff and not getting a match

In fact neither type was right - the return value is ssize_t (which is signed)

Fixes gh-254 (again). No builds containing this bug were released externally.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
