### PR TITLE
Fix #223 Graphs for roxiequery need to show roxie graphs and stats.

### DIFF
--- a/esp/eclwatch/ws_XSLT/GvcGraph.xslt
+++ b/esp/eclwatch/ws_XSLT/GvcGraph.xslt
@@ -169,7 +169,7 @@
       {
           //var link = document.getElementById('StatsLink');
           //link.innerText = 'Loading Stats...';
-          var url = '/WsRoxieQuery/RoxieQueryProcessGraph?FileName=' + queryName + '/' + graphName + ".htm&ClusterName=" + cluster + "&Stats=1";
+          var url = '/WsRoxieQuery/RoxieQueryProcessGraph?Cluster=' + cluster + '&QueryId=' + queryName + '&GraphName=' + graphName;
           var wnd = window.open("about:blank", "_graphStats_", 
                                   "toolbar=0,location=0,directories=0,status=0,menubar=0," + 
                                   "scrollbars=1, resizable=1, width=640, height=480");

--- a/esp/files/scripts/graphgvc.js
+++ b/esp/files/scripts/graphgvc.js
@@ -593,9 +593,6 @@ function loadXGMMLGraph(xgmmlResponse) {
             pluginLHS().loadXGMML(xgmmldecoded);
             pluginLHS().setMessage("Performing Layout...");
             pluginLHS().startLayout("dot");
-
-            pluginLHS().centerOnItem(0, true); // scale to fit.
-
         }
     }
     if (isrunning == '1' || (isrunning != '1' && forceFinalCountRefresh)) {
@@ -917,6 +914,8 @@ function getGraph(Url) {
     if (Url.toLowerCase().indexOf('ws_roxieconfig') > -1)
     {
       isRoxieGraph = true;
+      forceFinalCountRefresh = false;
+      hideElement('autoSpan');
       getRoxieConfigDetails(Url);
       requestEnvelope = getRoxieConfigRequestEnvelope(wuid, graphName);
       requestSourceUrl = espAddressAndPort + '/ws_roxieconfig/ShowGVCGraph';
@@ -926,6 +925,8 @@ function getGraph(Url) {
 
     if (Url.toLowerCase().indexOf('wsroxiequery') > -1) {
         isWsRoxieQueryGraph = true;
+        forceFinalCountRefresh = false;
+        hideElement('autoSpan');
         getWsRoxieQueryDetails(Url);
         requestEnvelope = getWsRoxieQueryRequestEnvelope(wuid, graphName, cluster);
         requestSourceUrl = espAddressAndPort + '/WsRoxieQuery/ShowGVCGraph';
@@ -1088,7 +1089,7 @@ function getRoxieConfigRequestEnvelope(QueryName, GraphName)
 }
 
 function getWsRoxieQueryRequestEnvelope(QueryName, GraphName, Cluster) {
-    var RoxieQuerySOAPEnvelope = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsRoxieQuery"><soap:Body><RoxieQueryShowGVCGraphRequest><ClusterName>%Cluster%</ClusterName><QueryName>%QueryName%</QueryName><GraphName>%GraphName%</GraphName></RoxieQueryShowGVCGraphRequest></soap:Body></soap:Envelope>';
+    var RoxieQuerySOAPEnvelope = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsRoxieQuery"><soap:Body><ShowGVCGraphRequest><Cluster>%Cluster%</Cluster><QueryId>%QueryName%</QueryId><GraphName>%GraphName%</GraphName></ShowGVCGraphRequest></soap:Body></soap:Envelope>';
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%Cluster%', Cluster);
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%QueryName%', QueryName);
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%GraphName%', GraphName);

--- a/esp/scm/ws_roxiequery.ecm
+++ b/esp/scm/ws_roxiequery.ecm
@@ -131,6 +131,51 @@ RoxieQueryDetailsResponse
     ESParray<ESPStruct RoxieQueryAlias> Aliases;
 };
 
+ESPrequest GVCAjaxGraphRequest
+{
+    string Cluster;
+    string Name;
+    string GraphName;
+};
+
+ESPresponse [exceptions_inline, http_encode(0)] GVCAjaxGraphResponse
+{
+    string Cluster;
+    string Name;
+    string GraphName;
+    string GraphType;
+};
+
+ESPrequest ShowGVCGraphRequest
+{
+    string Cluster;
+    string QueryId;
+    string GraphName;
+};
+
+ESPresponse [exceptions_inline, http_encode(0)] ShowGVCGraphResponse
+{
+    string Cluster;
+    string QueryId;
+    string GraphName;
+    ESParray<string> GraphNames;
+    string TheGraph;
+};
+
+ESPrequest RoxieQueryProcessGraphRequest
+{
+    string  Cluster;
+    string  QueryId;
+    string  GraphName;
+    bool    XmlGraph;
+    bool    Stats;
+};
+
+ESPresponse  [encode(0), exceptions_inline] RoxieQueryProcessGraphResponse
+{
+    string theGraph;
+};
+
 
 //  ===========================================================================
 ESPservice [
@@ -144,6 +189,9 @@ ESPservice [
     ESPmethod [resp_xsl_default("/esp/xslt/roxiequery_search.xslt")] RoxieQuerySearch(RoxieQuerySearchRequest, RoxieQuerySearchResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/roxiequery.xslt")] RoxieQueryList(RoxieQueryListRequest, RoxieQueryListResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/roxiequerydetails.xslt")] QueryDetails(RoxieQueryDetailsRequest, RoxieQueryDetailsResponse);
+    ESPmethod [description("Stub for Ajax GVC Graph."), help(""), resp_xsl_default("/esp/xslt/GvcGraph.xslt")] GVCAjaxGraph(GVCAjaxGraphRequest, GVCAjaxGraphResponse);
+    ESPmethod [description("Show GVC graph for a Roxie query"), help(""), resp_xsl_default("/esp/xslt/RoxieGVCGraph.xslt")] ShowGVCGraph(ShowGVCGraphRequest, ShowGVCGraphResponse);
+    ESPmethod [resp_xsl_default("/esp/xslt/graphStats.xslt")] RoxieQueryProcessGraph(RoxieQueryProcessGraphRequest, RoxieQueryProcessGraphResponse);
 };
 
 SCMexportdef(WsRoxieQuery);

--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
@@ -80,6 +80,9 @@ public:
     bool onRoxieQuerySearch(IEspContext &context, IEspRoxieQuerySearchRequest & req, IEspRoxieQuerySearchResponse & resp);
     bool onRoxieQueryList(IEspContext &context, IEspRoxieQueryListRequest &req, IEspRoxieQueryListResponse &resp);
     bool onQueryDetails(IEspContext &context, IEspRoxieQueryDetailsRequest & req, IEspRoxieQueryDetailsResponse & resp);
+    bool onGVCAjaxGraph(IEspContext &context, IEspGVCAjaxGraphRequest &req, IEspGVCAjaxGraphResponse &resp);
+    bool onShowGVCGraph(IEspContext &context, IEspShowGVCGraphRequest &req, IEspShowGVCGraphResponse &resp);
+    bool onRoxieQueryProcessGraph(IEspContext &context, IEspRoxieQueryProcessGraphRequest &req, IEspRoxieQueryProcessGraphResponse &resp);
 
 private:
     void addToQueryString(StringBuffer &queryString, const char *name, const char *value);
@@ -87,6 +90,8 @@ private:
     void getClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress, int& port);
 
     bool getAllRoxieQueries(IEspContext &context, const char* cluster, const char* suspended, const char* sortBy, bool descending, __int64 displayEnd, IArrayOf<IEspRoxieQuery>& RoxieQueryList, __int64& totalFiles);
+    IPropertyTree* getXgmmlGraph(const char *queryName, SocketEndpoint &ep, const char* graphName);
+    void enumerateGraphs(const char *queryName, SocketEndpoint &ep, StringArray& graphNames);
 };
 
 #endif //_ESPWIZ_WsRoxieQuery_HPP__


### PR DESCRIPTION
Returning code that had inadvertently been extracted from community.
The RoxieQueryProcessGraph esp method that returns the graphstats is
reworked and cleaned up to be more consistent with the ws_workunits
code that returns workunit graphs.

Turned off running graph refreshes for roxiegraphs.

Signed-off-by: Jo Prichard jo.prichard@lexisnexis.com
