### PR TITLE
gh-357 - Roxie not using the CSV separator info from dali

### DIFF
--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -111,6 +111,7 @@ interface IResolvedFile : extends ISimpleSuperFileEnquiry
     virtual const char *queryFileName() const = 0;
     virtual void setCache(const IRoxiePackage *cache) = 0;
     virtual bool isAlive() const = 0;
+    virtual const IPropertyTree *queryProperties() const = 0;
 };
 
 interface IResolvedFileCreator : extends IResolvedFile

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -19416,9 +19416,15 @@ class CRoxieServerCsvReadActivity : public CRoxieServerDiskReadBaseActivity
     unsigned maxDiskSize;
     CSVSplitter csvSplitter;    
     unsigned __int64 localOffset;
+    const char *quotes;
+    const char *separators;
+    const char *terminators;
 public:
-    CRoxieServerCsvReadActivity(const IRoxieServerActivityFactory *_factory, IProbeManager *_probeManager, const RemoteActivityId &_remoteId, unsigned _numParts, bool _isLocal, bool _sorted, bool _maySkip, IInMemoryIndexManager *_manager)
-        : CRoxieServerDiskReadBaseActivity(_factory, _probeManager, _remoteId, _numParts, _isLocal, _sorted, _maySkip, _manager)
+    CRoxieServerCsvReadActivity(const IRoxieServerActivityFactory *_factory, IProbeManager *_probeManager, const RemoteActivityId &_remoteId,
+                                unsigned _numParts, bool _isLocal, bool _sorted, bool _maySkip, IInMemoryIndexManager *_manager,
+                                const char *_quotes, const char *_separators, const char *_terminators)
+        : CRoxieServerDiskReadBaseActivity(_factory, _probeManager, _remoteId, _numParts, _isLocal, _sorted, _maySkip, _manager),
+          quotes(_quotes), separators(_separators), terminators(_terminators)
     {
         compoundHelper = NULL;
         readHelper = (IHThorCsvReadArg *)&helper;
@@ -19440,7 +19446,19 @@ public:
             if (headerLines && isLocal && reader->queryFilePart() != 1)
                 headerLines = 0;  // MORE - you could argue that if SINGLE not specified, should skip from all parts. But it would be painful since we have already concatenated and no-one else does...
             if (!eof)
-                csvSplitter.init(readHelper->getMaxColumns(), csvInfo, NULL, NULL, NULL); // MORE - could save some info about separators from dfs
+            {
+                if (varFileInfo)
+                {
+                    const IPropertyTree *options = varFileInfo->queryProperties();
+                    if (options)
+                    {
+                        quotes = options->queryProp("@csvQuote");
+                        separators = options->queryProp("@csvSeparate");
+                        terminators = options->queryProp("@csvTerminate");
+                    }
+                }
+                csvSplitter.init(readHelper->getMaxColumns(), csvInfo, quotes, separators, terminators);
+            }
         }
     }
 
@@ -19955,6 +19973,9 @@ public:
     Owned<IFileIOArray> files;
     Owned<IInMemoryIndexManager> manager;
     Owned<const IResolvedFile> datafile;
+    const char *quotes;
+    const char *separators;
+    const char *terminators;
 
     CRoxieServerDiskReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, const RemoteActivityId &_remoteId, IPropertyTree &_graphNode)
         : CRoxieServerActivityFactory(_id, _subgraphId, _queryFactory, _helperFactory, _kind), remoteId(_remoteId)
@@ -19964,6 +19985,7 @@ public:
         sorted = (helper->getFlags() & TDRunsorted) == 0;
         variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         maySkip = (helper->getFlags() & (TDRkeyedlimitskips|TDRkeyedlimitcreates|TDRlimitskips|TDRlimitcreates)) != 0;
+        quotes = separators = terminators = NULL;
         if (!variableFileName)
         {
             bool isOpt = (helper->getFlags() & TDRoptional) != 0;
@@ -19979,6 +20001,13 @@ public:
                     unsigned channel = isLocal ? queryFactory.queryChannel() : 0;
                     files.setown(datafile->getIFileIOArray(isOpt, channel));
                     manager.setown(datafile->getIndexManager(isOpt, channel, files, helper->queryDiskRecordSize(), _graphNode.getPropBool("att[@name=\"preload\"]/@value", false), _graphNode.getPropInt("att[@name=\"_preloadSize\"]/@value", 0)));
+                    const IPropertyTree *options = datafile->queryProperties();
+                    if (options)
+                    {
+                        quotes = options->queryProp("@csvQuote");
+                        separators = options->queryProp("@csvSeparate");
+                        terminators = options->queryProp("@csvTerminate");
+                    }
                 }
                 else
                     manager.setown(getEmptyIndexManager());
@@ -19992,7 +20021,8 @@ public:
         switch (kind)
         {
         case TAKcsvread:
-            return new CRoxieServerCsvReadActivity(this, _probeManager, remoteId, numParts, isLocal, sorted, maySkip, manager);
+            return new CRoxieServerCsvReadActivity(this, _probeManager, remoteId, numParts, isLocal, sorted, maySkip, manager,
+                                                   quotes, separators, terminators);
         case TAKxmlread:
             return new CRoxieServerXmlReadActivity(this, _probeManager, remoteId, numParts, isLocal, sorted, maySkip, manager);
         case TAKdiskread:


### PR DESCRIPTION
Roxie was not picking up the SEPARATOR, QUOTE and TERMINATOR
settings from dali when reading a CSV file.

Add a queryProperties method to the IResolvedFile interface,
and use it to track the properties from an IDistributedFile.
While the full IDistributedFile info is not serialized to slaves
in the delated resolution cases, the properties need to be.

Fixes gh-357. See also bugzilla issue 83402.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
