### PR TITLE
gh-372 Invalid include paths in CMake files

### DIFF
--- a/common/roxiecommlib/CMakeLists.txt
+++ b/common/roxiecommlib/CMakeLists.txt
@@ -39,7 +39,6 @@ include_directories (
          ./../../common/workunit 
          ./../../common/environment 
          ./../../roxie/ccd 
-         ./../../system/icu/include 
          ./../../common/fileview2 
          ./../../system/include 
          ./../../system/security/shared

--- a/common/roxiehelper/CMakeLists.txt
+++ b/common/roxiehelper/CMakeLists.txt
@@ -37,7 +37,6 @@ include_directories (            ./../../system/security/securesocket
          ./../workunit 
          ./../../system/jlib 
          ./../deftype 
-         ./../../system/icu/include 
          ./../../rtl/include
          ./../../system/mp 
          ./../../dali/base 

--- a/common/roxiemanager/CMakeLists.txt
+++ b/common/roxiemanager/CMakeLists.txt
@@ -51,7 +51,6 @@ include_directories (
          ./../../common/environment 
          ./../../roxie/roxie
          ./../../roxie/ccd
-         ./../../system/icu/include 
          ./../../common/fileview2 
          ./../../system/include 
          ./../../dali/base 

--- a/common/thorhelper/CMakeLists.txt
+++ b/common/thorhelper/CMakeLists.txt
@@ -67,7 +67,6 @@ include_directories (
          ./../workunit 
          ./../../system/jlib 
          ./../deftype 
-         ./../../system/icu/include 
          ./../../rtl/include 
     )
 

--- a/dali/dfu/dfuserver.cmake
+++ b/dali/dfu/dfuserver.cmake
@@ -43,7 +43,6 @@ include_directories (
          ./../base 
          ./../../system/include 
          ./../../system/jlib 
-         ./../../system/icu/include 
          ./../ft 
          ./../../common/environment 
          ./../../common/workunit 

--- a/dali/sasha/CMakeLists.txt
+++ b/dali/sasha/CMakeLists.txt
@@ -47,7 +47,6 @@ set (    SRCS
 include_directories ( 
          . 
          ${HPCC_SOURCE_DIR}/common/environment 
-         ${HPCC_SOURCE_DIR}/ft 
          ${HPCC_SOURCE_DIR}/common/workunit 
          ${HPCC_SOURCE_DIR}/common/dllserver 
          ${HPCC_SOURCE_DIR}/dali/base 

--- a/dali/treeview/CMakeLists.txt
+++ b/dali/treeview/CMakeLists.txt
@@ -39,7 +39,6 @@ if (WIN32)
 
     include_directories ( 
              ./../../system/mp 
-             ./../../common/ptree 
              ./../base 
              ./../../system/include 
              ./../../system/jlib 

--- a/deployment/deploy/CMakeLists.txt
+++ b/deployment/deploy/CMakeLists.txt
@@ -50,8 +50,6 @@ include_directories (
          ./../../system/mp 
          ./../../common/environment
          ./../../dali/base 
-         ./../../system/xalan/xml-xerces/c/src 
-         ./../../system/xalan/xml-xalan/c/src 
          ./../../system/security/securesocket 
     )
 

--- a/ecl/eclcc/CMakeLists.txt
+++ b/ecl/eclcc/CMakeLists.txt
@@ -35,14 +35,12 @@ include_directories (
          ${CMAKE_BINARY_DIR}/oss
          ./../../ecl/hqlcpp 
          ./../../common/workunit 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../ecl/hql 
          ./../../rtl/include 
          ./../../system/jlib 
          ./../../common/commonext 
-         ./../eclrepository 
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/ecl/hqlcpp/CMakeLists.txt
+++ b/ecl/hqlcpp/CMakeLists.txt
@@ -102,8 +102,6 @@ include_directories (
          ${CMAKE_BINARY_DIR}/oss
          ./../../common/remote 
          ./../../common/workunit 
-         ./../../system/icu/include 
-         ./../../ecl/scheduler 
          ./../../common/deftype 
          ./../../system/include 
          ./../../ecl/hql 

--- a/ecl/hthor/CMakeLists.txt
+++ b/ecl/hthor/CMakeLists.txt
@@ -50,9 +50,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/system/jhtree
          ${HPCC_SOURCE_DIR}/system/hrpc
          ${HPCC_SOURCE_DIR}/system/mp
-         ${HPCC_SOURCE_DIR}/common/ns
          ${HPCC_SOURCE_DIR}/common/workunit
-         ${HPCC_SOURCE_DIR}/system/icu/include
          ${HPCC_SOURCE_DIR}/common/deftype
          ${HPCC_SOURCE_DIR}/system/include
          ${HPCC_SOURCE_DIR}/dali/base

--- a/esp/clients/LoggingClient/CMakeLists.txt
+++ b/esp/clients/LoggingClient/CMakeLists.txt
@@ -45,12 +45,9 @@ include_directories (
          ./../../bindings/SOAP/Platform 
          ./../../../system/xmllib 
          ./../../../system/include 
-         ./../dataaccesslib 
-         ./../RemoteNSClient 
          ./../../clients 
          ./../../clients/LoggingClient 
          ./../../bindings 
-         ./../../bindings/SOAP/LoggingService 
          ./../../bindings/SOAP/xpp 
     )
 

--- a/esp/protocols/http/CMakeLists.txt
+++ b/esp/protocols/http/CMakeLists.txt
@@ -54,7 +54,6 @@ include_directories (
          ./../../../system/security/shared
          ./../../../system/security/securesocket 
          ./../../bindings 
-         ./../../../system/security/commonsecurity 
          ./../../bindings/SOAP/xpp 
          ./../../../system/xmllib 
          ./../../../system/jlib 

--- a/esp/scm/additional.cmake
+++ b/esp/scm/additional.cmake
@@ -56,4 +56,4 @@ foreach ( loop_var ${ESPSCM_SRCS} )
     set ( ESP_GENERATED_INCLUDES ${ESP_GENERATED_INCLUDES} ${ESPSCM_GENERATED_DIR}/${result}.esp ${ESPSCM_GENERATED_DIR}/${result}.hpp ${ESPSCM_GENERATED_DIR}/${result}.int ${ESPSCM_GENERATED_DIR}/${result}.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp.ipp ${ESPSCM_GENERATED_DIR}/${result}.xml )
 endforeach ( loop_var ${ESPSCM_SRCS} )
 
-include_directories ( ${ESPSCM_GENERATED_DIR} ${HPCC_SOURCE_DIR}/system/security/seclib)
+include_directories ( ${ESPSCM_GENERATED_DIR} )

--- a/esp/scm/espscm.cmake
+++ b/esp/scm/espscm.cmake
@@ -65,4 +65,4 @@ foreach ( loop_var ${ESPSCM_SRCS} )
     set ( ESP_GENERATED_INCLUDES ${ESP_GENERATED_INCLUDES} ${ESPSCM_GENERATED_DIR}/${result}.esp ${ESPSCM_GENERATED_DIR}/${result}.hpp ${ESPSCM_GENERATED_DIR}/${result}.int ${ESPSCM_GENERATED_DIR}/${result}.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp.ipp ${ESPSCM_GENERATED_DIR}/${result}.xml )
 endforeach ( loop_var ${ESPSCM_SRCS} )
 
-include_directories ( ${ESPSCM_GENERATED_DIR} ${HPCC_SOURCE_DIR}/system/security/seclib)
+include_directories ( ${ESPSCM_GENERATED_DIR} )

--- a/esp/scm/smcscm.cmake
+++ b/esp/scm/smcscm.cmake
@@ -60,4 +60,4 @@ foreach ( loop_var ${ESPSCM_SRCS} )
     set ( ESP_GENERATED_INCLUDES ${ESP_GENERATED_INCLUDES} ${ESPSCM_GENERATED_DIR}/${result}.esp ${ESPSCM_GENERATED_DIR}/${result}.hpp ${ESPSCM_GENERATED_DIR}/${result}.int ${ESPSCM_GENERATED_DIR}/${result}.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp.ipp ${ESPSCM_GENERATED_DIR}/${result}.xml )
 endforeach ( loop_var ${ESPSCM_SRCS} )
 
-include_directories ( ${ESPSCM_GENERATED_DIR} ${HPCC_SOURCE_DIR}/system/security/seclib)
+include_directories ( ${ESPSCM_GENERATED_DIR} )

--- a/esp/services/WsDeploy/CMakeLists.txt
+++ b/esp/services/WsDeploy/CMakeLists.txt
@@ -43,7 +43,6 @@ include_directories (
          ./../../../common/environment 
          ./../../services 
          ./../common 
-         ./../../../system/icu/include 
          ./../../../system/xmllib 
          ./../../../system/security/securesocket 
          ./../../../system/security/shared 

--- a/esp/services/ws_dfu/CMakeLists.txt
+++ b/esp/services/ws_dfu/CMakeLists.txt
@@ -48,10 +48,8 @@ include_directories (
          ./../../services 
          ./../../../dali/ft 
          ./../common 
-         ./../../../system/icu/include 
          ./../../../dali/dfuXRefLib 
          ./../../../system/xmllib 
-         ./../../../ecl/attrserver 
          ./../../../common/deftype 
          ./../../../ecl/hql 
          ./../../../system/security/securesocket 

--- a/esp/services/ws_fileio/CMakeLists.txt
+++ b/esp/services/ws_fileio/CMakeLists.txt
@@ -42,17 +42,14 @@ include_directories (
          ./../../services 
          ./../../../dali/ft 
          ./../common 
-         ./../../../system/icu/include 
          ./../../../system/xmllib 
          ./../../../esp/bindings/http/platform 
-         ./../../../ecl/attrserver 
          ./../../../system/security/securesocket 
          ./../../../system/security/shared 
          ./../../../system/include 
          ./../../../common/workunit 
          ./../../../common/remote 
          ./../../clients 
-         ./../../../roxie/roxieconfig 
          ./../../../esp/esplib 
          ./../../../dali/base 
          ./../../bindings/SOAP/scrubbed 

--- a/esp/services/ws_roxiequery/CMakeLists.txt
+++ b/esp/services/ws_roxiequery/CMakeLists.txt
@@ -38,7 +38,6 @@ set (    SRCS
     )
 
 include_directories ( 
-         ./../../../system/mysql 
          ./../../../dali/dfu 
          ./../../../system/mp 
          ./../../platform 
@@ -47,17 +46,14 @@ include_directories (
          ./../../services 
          ./../../../dali/ft 
          ./../common 
-         ./../../../system/icu/include 
          ./../../../system/xmllib 
          ./../../../esp/bindings/http/platform 
-         ./../../../ecl/attrserver 
          ./../../../system/security/securesocket 
          ./../../../system/security/shared 
          ./../../../system/include 
          ./../../../common/workunit 
          ./../../../common/remote 
          ./../../clients 
-         ./../../../roxie/roxieconfig 
          ./../../../esp/esplib 
          ./../../../dali/base 
          ./../../bindings/SOAP/scrubbed 
@@ -66,7 +62,6 @@ include_directories (
          ./../../../common/dllserver 
          ./../../bindings 
          ./../../smc/SMCLib 
-         ./../../../system/mysql/include 
          ./../../bindings/SOAP/xpp 
          ./../../../common/fileview2 
          ./../../../rtl/eclrtl 

--- a/esp/smc/SMCLib/CMakeLists.txt
+++ b/esp/smc/SMCLib/CMakeLists.txt
@@ -44,14 +44,12 @@ include_directories (
          ./../../../dali/ft 
          ./../../bindings/SOAP/Platform 
          ./../../../system/xmllib 
-         ./../../../ecl/attrserver 
          ./../../../system/security/securesocket 
          ./../../../system/security/shared
          ./../../../system/include 
          ./../../../common/workunit 
          ./../../../common/remote 
          ./../../clients 
-         ./../../services/fdleservice 
          ./../../../dali/base 
          ./../../clients/LoggingClient 
          ./../../bindings 

--- a/plugins/fileservices/CMakeLists.txt
+++ b/plugins/fileservices/CMakeLists.txt
@@ -39,11 +39,9 @@ include_directories (
          ./../../common/remote 
          ./../../system/jhtree 
          ./../../system/mp 
-         ./../../common/ns 
          ./../../common/workunit 
          ./../../esp/clients 
          ./../../dali/ft 
-         ./../../system/icu/include 
          ./../../system/security/shared 
          ./../../esp/bindings/SOAP/xpp 
          ./../../common/deftype 

--- a/plugins/unicodelib/CMakeLists.txt
+++ b/plugins/unicodelib/CMakeLists.txt
@@ -33,7 +33,6 @@ set (    SRCS
 include_directories ( 
          ./../../system/include 
          ./../../system/jlib 
-         ./../../system/icu/include 
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DUNICODELIB_EXPORTS )

--- a/plugins/workunitservices/CMakeLists.txt
+++ b/plugins/workunitservices/CMakeLists.txt
@@ -38,7 +38,6 @@ include_directories (
          ./../../dali/base 
          ./../../rtl/include 
          ./../../ecl/eclagent 
-         ./../../system/icu/include 
          ./../../common/thorhelper 
          ./../../common/deftype 
          ./../../rtl/eclrtl 

--- a/roxie/ccd/CMakeLists.txt
+++ b/roxie/ccd/CMakeLists.txt
@@ -58,13 +58,11 @@ include_directories (
          ./../../common/remote
          ./../../system/jhtree 
          ./../../system/mp 
-         ./../../common/ns 
          ./../../common/workunit 
          ./../../roxie/udplib 
          ./../../roxie/roxie 
          ./../../common/environment 
          ./../../ecl/hthor 
-         ./../../system/icu/include 
          ./../../rtl/nbcd 
          ./../../common/deftype 
          ./../../system/include 

--- a/thorlcr/activities/activitymasters_lcr.cmake
+++ b/thorlcr/activities/activitymasters_lcr.cmake
@@ -79,7 +79,6 @@ include_directories (
          ./../../common/workunit 
          ./../shared 
          ./../graph 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 

--- a/thorlcr/activities/activityslaves_lcr.cmake
+++ b/thorlcr/activities/activityslaves_lcr.cmake
@@ -96,7 +96,6 @@ include_directories (
          ./../shared 
          ./../graph 
          ./../activities/msort 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 

--- a/thorlcr/graph/graph_lcr.cmake
+++ b/thorlcr/graph/graph_lcr.cmake
@@ -44,7 +44,6 @@ include_directories (
          ./../thorcrc 
          ./../../common/workunit 
          ./../shared 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 

--- a/thorlcr/graph/graphmaster_lcr.cmake
+++ b/thorlcr/graph/graphmaster_lcr.cmake
@@ -39,12 +39,10 @@ include_directories (
          ./../../common/workunit 
          ./../shared 
          ./../graph 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 
          ./../../rtl/include 
-         /GZ 
          ./../../common/dllserver 
          ./../slave 
          ./../../system/jlib 

--- a/thorlcr/graph/graphslave_lcr.cmake
+++ b/thorlcr/graph/graphslave_lcr.cmake
@@ -36,7 +36,6 @@ include_directories (
          ./../thorcrc 
          ./../../common/workunit 
          ./../shared 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 

--- a/thorlcr/master/CMakeLists.txt
+++ b/thorlcr/master/CMakeLists.txt
@@ -41,7 +41,6 @@ include_directories (
          ./../shared 
          ./../graph 
          ./../../common/environment 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 

--- a/thorlcr/mfilemanager/CMakeLists.txt
+++ b/thorlcr/mfilemanager/CMakeLists.txt
@@ -40,7 +40,6 @@ include_directories (
          ./../graph 
          ./../../common/environment 
          ./../../dali/ft 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 

--- a/thorlcr/slave/CMakeLists.txt
+++ b/thorlcr/slave/CMakeLists.txt
@@ -42,7 +42,6 @@ include_directories (
          .
          ./../../common/environment 
          ./../../common/commonext
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 

--- a/thorlcr/thorcodectx/CMakeLists.txt
+++ b/thorlcr/thorcodectx/CMakeLists.txt
@@ -35,7 +35,6 @@ include_directories (
          ./../master 
          ./../../common/workunit 
          ./../graph 
-         ./../../system/icu/include 
          ./../../common/deftype 
          ./../../system/include 
          ./../../dali/base 

--- a/tools/combine/CMakeLists.txt
+++ b/tools/combine/CMakeLists.txt
@@ -34,7 +34,6 @@ include_directories (
          ./../../rtl/include 
          ./../../system/include 
          ./../../system/jlib 
-         ./../../system/icu/include 
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/tools/copyexp/CMakeLists.txt
+++ b/tools/copyexp/CMakeLists.txt
@@ -29,7 +29,6 @@ project( copyexp )
 set ( SRCS copyexp.cpp )
 
 include_directories ( 
-         ../../jlib.hpp 
          ./../../common/remote 
          ./../../system/mp 
          ./../../system/include 

--- a/tools/keydiff/keydiff.cmake
+++ b/tools/keydiff/keydiff.cmake
@@ -35,7 +35,6 @@ include_directories (
          ./../../rtl/include 
          ./../../system/include 
          ./../../system/jlib 
-         ./../../system/icu/include 
     )
 
 ADD_DEFINITIONS ( -DNO_SYBASE -D_CONSOLE )

--- a/tools/keydiff/keypatch.cmake
+++ b/tools/keydiff/keypatch.cmake
@@ -37,7 +37,6 @@ include_directories (
          ./../../rtl/include 
          ./../../system/include 
          ./../../system/jlib 
-         ./../../system/icu/include 
     )
 
 ADD_DEFINITIONS ( -DNO_SYBASE -D_CONSOLE )

--- a/tools/swapnode/CMakeLists.txt
+++ b/tools/swapnode/CMakeLists.txt
@@ -32,7 +32,6 @@ set (    SRCS
 include_directories ( 
          ./../../common/remote 
          ./../../system/mp 
-         ./../../common/ptree 
          ./../../system/include 
          ./../../dali/base 
          ./../../system/jlib 

--- a/tools/vkey/CMakeLists.txt
+++ b/tools/vkey/CMakeLists.txt
@@ -30,7 +30,6 @@ include_directories (
          ./../../system/include 
          ./../../rtl/include 
          ./../../rtl/eclrtl 
-         ./../../system/icu/include 
     )
 
 ADD_DEFINITIONS( -DMODULE_PRIORITY=1 -D_CONSOLE )

--- a/tools/xmlsize/CMakeLists.txt
+++ b/tools/xmlsize/CMakeLists.txt
@@ -36,7 +36,6 @@ include_directories (
          ./../../system/include 
          ./../../dali/base 
          ./../../system/jlib 
-         ./../../system/icu/include 
          ./../../common/workunit 
     )
 


### PR DESCRIPTION
Various cmake files refer to include paths that have been moved, deleted,
or never existed. Eclipse code analyser reports these as warnings.

Remove the unwanted entries from the CMake files.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
