### PR TITLE
Clean up issues highlighted by running cppcheck

### DIFF
--- a/common/deftype/defvalue.cpp
+++ b/common/deftype/defvalue.cpp
@@ -302,7 +302,6 @@ IValue *VarStringValue::castTo(ITypeInfo *t)
     if (tc == type_any)
         return LINK(this);
 
-    int osize = val.length();
     return doCastTo(val.length(), (const char *)val.get(), t);
 }
 
@@ -1463,7 +1462,6 @@ IValue *CharValue::castTo(ITypeInfo *t)
     if (tc == type_any)
         return LINK(this);
 
-    int nsize = t->getSize();
     switch (tc)
     {
     case type_boolean:
@@ -1605,8 +1603,7 @@ const void * IntValue::queryValue() const
 void IntValue::toMem(void *target)
 {
     int size = type->getSize();
-    unsigned __int64 temp = val;
-    byte * data = getAddressValue();
+    const byte * data = getAddressValue();
     
     if (type->isSwappedEndian())
         _cpyrevn(target, data, size);
@@ -1709,7 +1706,6 @@ void IntValue::deserialize(MemoryBuffer &src)
 int PackedIntValue::compare(IValue *_to)
 {
     assertThrow(_to->queryType()==type);
-    PackedIntValue *to = (PackedIntValue *) _to;
     unsigned __int64 val = value->getIntValue();
     unsigned __int64 toVal = _to->getIntValue();
     if (val == toVal)
@@ -1899,7 +1895,6 @@ IValue *RealValue::castTo(ITypeInfo *t)
     if (tc == type_any)
         return LINK(this);
 
-    int nsize = t->getSize();
     switch (tc)
     {
     case type_real:
@@ -2260,7 +2255,6 @@ IValue *BoolValue::castTo(ITypeInfo *t)
     if (tc == type_any)
         return LINK(this);
 
-    int nsize = t->getSize();
     switch (tc)
     {
     case type_string:
@@ -2552,7 +2546,7 @@ IValue * divideValues(IValue * left, IValue * right)
     {
         double lv = left->getRealValue();
         double rv = right->getRealValue();
-        double res = rv ? left->getRealValue() / rv : 0;
+        double res = rv ? lv / rv : 0;
         return createRealValue(res, pnt);
     }
     case type_decimal:

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -889,7 +889,6 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
         HqlExprArray functionCache;
         HqlLookupContext ctx(instance.archive, errs, &functionCache, repository);
 
-        unsigned time = msTick();
         Owned<IFileContents> contents = createFileContentsFromText(queryText, sourcePath);
 
         if (withinRepository)

--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -1522,7 +1522,7 @@ static IHqlExpression * evaluateAttrAligned(IHqlExpression * expr)
     }
     if (optimizeFieldOrder(result, reorder))
         same = false;
-    OwnedHqlExpr newRecord = expr->clone(result);
+    OwnedHqlExpr newRecord = same ? LINK(expr) : expr->clone(result);
     if (expr == newRecord)
         return meta.addAttribute(expr, queryAlignedAttr());
     meta.addAttribute(newRecord, queryAlignedAttr());

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -12855,7 +12855,6 @@ static bool removeVirtualAttributes(HqlExprArray & fields, IHqlExpression * cur,
         {
             ITypeInfo * type = cur->queryType();
             Linked<ITypeInfo> targetType = type;
-            IHqlExpression * attrs = NULL;
             switch (type->getTypeCode())
             {
             case type_groupedtable:
@@ -13267,7 +13266,7 @@ static void getSimplifiedAssigns(HqlExprArray & assigns, IHqlExpression * tgt, I
                 IHqlExpression * srcRecord = src->queryRecord();
                 OwnedHqlExpr seq = createSelectorSequence();
                 OwnedHqlExpr srcSelector = createSelector(no_left, srcSelect, seq);
-                OwnedHqlExpr transform = getSimplifiedTransform(tgt->queryRecord(), src->queryRecord(), srcSelector);
+                OwnedHqlExpr transform = getSimplifiedTransform(tgt->queryRecord(), srcRecord, srcSelector);
                 OwnedHqlExpr project = createDataset(no_hqlproject, LINK(srcSelect), createComma(LINK(transform), LINK(seq)));
                 assigns.append(*createAssign(LINK(tgtSelect), LINK(project)));
             }

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4765,7 +4765,6 @@ static IHqlExpression * stripDedupConditions(IHqlExpression * update, IHqlExpres
     for (unsigned i=max-1; i != 0; i--)
     {
         IHqlExpression * cur = &args.item(i);
-        IHqlExpression * curOriginal = original->queryChild(i);
         LinkedHqlExpr mapped;
         switch (cur->getOperator())
         {

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -7212,8 +7212,6 @@ void HqlGram::checkGrouping(const attribute & errpos, IHqlExpression * dataset, 
     if (!groups) return;
     assertex(record->getOperator()==no_record);
 
-    IHqlDataset *table = dataset->queryDataset()->queryTable();
-
     //match should be by structure!!
     HqlExprArray parms1;
     HqlExprArray parms;
@@ -7299,7 +7297,6 @@ void HqlGram::checkProjectedFields(IHqlExpression * e, attribute & errpos)
                     if (hadVariableAggregate)
                         reportError(ERR_AGG_FIELD_AFTER_VAR, errpos, "Field %s: Fields cannot follow a variable length aggregate in the record", name ? name->str() : "");
 
-                    IHqlExpression * cond = NULL;
                     if (value->isGroupAggregateFunction())
                         hadVariableAggregate = true;
                 }
@@ -7643,7 +7640,6 @@ void HqlGram::ensureDataset(attribute & attr)
 }
 void HqlGram::expandPayload(HqlExprArray & fields, IHqlExpression * payload, IHqlSimpleScope * scope, ITypeInfo * & lastFieldType, const attribute & errpos)
 {
-    unsigned oldFields = fields.ordinality();
     ForEachChild(i2, payload)
     {
         IHqlExpression * cur = payload->queryChild(i2);
@@ -8496,7 +8492,6 @@ void HqlGram::checkDerivedCompatible(_ATOM name, IHqlExpression * scope, IHqlExp
 
 bool HqlGram::okToAddSideEffects(IHqlExpression * expr)
 {
-    bool ok = true;
     switch (expr->getOperator())
     {
     case no_transform:
@@ -8616,7 +8611,6 @@ void HqlGram::doDefineSymbol(DefineIdSt * defineid, IHqlExpression * _expr, IHql
         }
         else
         {
-            int startpos = idattr.pos.position;
             defineSymbolInScope(activeScope.privateScope, defineid, expr.getClear(), failure, idattr, assignPos, semiColonPos, isParametered, activeScope.activeParameters, activeScope.createDefaults());
         }
     }
@@ -9371,7 +9365,6 @@ static IHqlExpression * createSingleValueTransform(IHqlExpression * record, IHql
 IHqlExpression * HqlGram::createIffDataset(IHqlExpression * record, IHqlExpression * value)
 {
     IHqlExpression * field = record->queryChild(0);
-    IHqlExpression * datasetToProject = NULL;
     if (value->getOperator() == no_select)
     {
         IHqlExpression * lhs = value->queryChild(0);

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -3174,9 +3174,7 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
                     if (childKeyed && !transformKeyed)
                         break;
 
-                    IHqlExpression * curRecord = transformed->queryChild(1);
                     IHqlExpression * grandchild = child->queryChild(0);
-
                     OwnedMapper mapper = getMapper(child);
 
                     HqlExprArray args;

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -81,7 +81,6 @@ public:
 class CTemplateContext : public CInterface, implements ITemplateContext
 {
     IXmlScope* m_xmlScope;
-    IEclRepository* m_dataServer;
     int m_startLine,m_startCol;
     HqlLookupContext & m_lookupContext;
 

--- a/ecl/hql/hqlpmap.hpp
+++ b/ecl/hql/hqlpmap.hpp
@@ -33,7 +33,7 @@ class TableProjectMapper;
 class HQL_API NewProjectMapper2 : public CInterface
 {
 public:
-    NewProjectMapper2() { ignoreMissingFields = false; }
+    NewProjectMapper2() { ignoreMissingFields = false; mapping = NULL; matchedAll = true; expandCallback = NULL; }
 
     //if newDataset is NULL, the mapping stored in the transform is returned unchanged (useful for seeing if filters can move over joins)
     IHqlExpression * expandFields(IHqlExpression * expr, IHqlExpression * oldDataset, IHqlExpression * newDataset, IHqlExpression * mapperParent, IExpandCallback * _expandCallback = NULL);

--- a/ecl/hql/hqlremote.cpp
+++ b/ecl/hql/hqlremote.cpp
@@ -384,7 +384,6 @@ void RemoteXmlEclRepository::checkCacheValid()
     {
         IPropertyTree & cur = it->query();
         Owned<IHqlRemoteScope> rScope = createModule(&cur);
-        unsigned flags = cur.getPropInt("@flags", 0);
         timestamp_t timestamp = (timestamp_t)cur.getPropInt64("@timestamp"); 
         if (timestamp > cachestamp)
             cachestamp = timestamp;

--- a/ecl/hql/hqlstack.cpp
+++ b/ecl/hql/hqlstack.cpp
@@ -37,6 +37,7 @@ FuncCallStack::FuncCallStack(int size) {
     sp = 0;
     tos = size;
     stackbuf = (char*) malloc(tos);
+    numToFree = 0;
 #ifdef __64BIT__
     numFpRegs = 0;
     for (unsigned i=0;i<MAXFPREGS;i++)

--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -1084,7 +1084,6 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
         }
         case no_rowvalue:
         {
-            unsigned kids = expr->numChildren();
             s.append("{");
             childrenToECL(expr, s, inType, false, 0);
             s.append("}");
@@ -2074,7 +2073,6 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
         case no_newaggregate:
         case no_newusertable:
         {
-            unsigned kids = expr->numChildren();
             s.append(getEclOpString(no));
             s.append('(');
             assertex(child0);
@@ -2615,7 +2613,6 @@ void HqltHql::defaultToECL(IHqlExpression *expr, StringBuffer &s, bool inType)
 void HqltHql::defaultChildrenToECL(IHqlExpression *expr, StringBuffer &s, bool inType)
 {
     // standard function-style operators
-    unsigned kids = expr->numChildren();
     IHqlExpression * child0 = expr->queryChild(0);
     if (child0)
     {
@@ -2702,7 +2699,7 @@ StringBuffer &HqltHql::getTypeString(ITypeInfo * i, StringBuffer &s)
             {
                 IHqlExpression * e = &(visited->item(idx));
                 IHqlExpression * extra = static_cast<IHqlExpression *>(e->queryTransformExtra());
-                if(e && e->queryChild(1) && extra)
+                if(e->queryChild(1) && extra)
                 {
                     if(expr->queryType() == e->queryChild(1)->queryType())
                     {

--- a/ecl/hqlcpp/hqlckey.cpp
+++ b/ecl/hqlcpp/hqlckey.cpp
@@ -727,7 +727,6 @@ IHqlExpression * KeyedJoinInfo::optimizeTransfer(HqlExprArray & fields, HqlExprA
         break;
     }
 
-    unsigned max = filter->numChildren();
     HqlExprArray children;
     ForEachChild(i, filter)
     {

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -598,9 +598,6 @@ public:
     virtual void ensureHelpersExist();
     virtual bool insideQueryDepth(unsigned depth)           { return false; }
     virtual bool isColocal()                                { return false; }
-
-protected:
-    ActivityInstance * activity;
 };
 
 
@@ -947,7 +944,12 @@ struct EvaluateCompareInfo
 {
 public:
     EvaluateCompareInfo(node_operator _op) { actionIfDiffer = null_stmt; op = _op; isBoolEquality = false; hasDefault = true; alwaysReturns = false; }
-    EvaluateCompareInfo(const EvaluateCompareInfo & info) { target.set(info.target); actionIfDiffer = info.actionIfDiffer; op = info.op; isBoolEquality = info.isBoolEquality; }
+    EvaluateCompareInfo(const EvaluateCompareInfo & info)
+    {
+        target.set(info.target); actionIfDiffer = info.actionIfDiffer; op = info.op; isBoolEquality = info.isBoolEquality;
+        alwaysReturns = false;
+        hasDefault = true;
+    }
 
     bool isEqualityCompare() const { return op == no_eq; }
     IHqlExpression * getEqualityReturnValue() { return isBoolEquality ? createConstant(false) : createIntConstant(1); }

--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -431,7 +431,6 @@ IReferenceSelector * HqlCppTranslator::buildNewRow(BuildCtx & ctx, IHqlExpressio
         {
             IHqlExpression * seqAttr = expr->queryProperty(sequenceAtom);
             IHqlExpression * nameAttr = expr->queryProperty(namedAtom);
-            IHqlExpression * seq = queryPropertyChild(expr, sequenceAtom, 0);
             IHqlExpression * record = expr->queryRecord();
             OwnedHqlExpr serializedRecord = getSerializedForm(record);
 
@@ -475,7 +474,9 @@ IReferenceSelector * HqlCppTranslator::buildNewRow(BuildCtx & ctx, IHqlExpressio
         return buildNewRow(ctx, expr->queryChild(1));
     case no_select:
         {
+#ifdef _DEBUG
             IHqlExpression * field = expr->queryChild(1);
+#endif
             Owned<IReferenceSelector> selector;
             if (expr->hasProperty(newAtom))
                 selector.setown(buildNewRow(ctx, expr->queryChild(0)));
@@ -2473,8 +2474,6 @@ void HqlCppTranslator::buildDatasetAssignTempTable(BuildCtx & ctx, IHqlCppDatase
         return;
 
     IHqlExpression * record = expr->queryChild(1);
-    IHqlExpression * defaults = expr->queryChild(2);
-
     OwnedHqlExpr rowsExpr;
     if (values->queryType()->getTypeCode() == type_set)
     {
@@ -3429,7 +3428,6 @@ void HqlCppTranslator::doBuildRowAssignAggregateNext(BuildCtx & ctx, IReferenceS
 void HqlCppTranslator::doBuildRowAssignAggregate(BuildCtx & ctx, IReferenceSelector * target, IHqlExpression * expr)
 {
     IHqlExpression * dataset = expr->queryChild(0);
-    IHqlExpression * tgtRecord = expr->queryChild(1);
     IHqlExpression * transform = expr->queryChild(2);
     unsigned numAggregates = transform->numChildren();
 
@@ -4050,7 +4048,6 @@ IReferenceSelector * HqlCppTranslator::buildDatasetIndex(BuildCtx & ctx, IHqlExp
 #endif
 
     IHqlExpression * dataset = expr->queryChild(0);
-    IHqlExpression * index = expr->queryChild(1);
 
     //Special cases:
     //i) selecting row [1] from something that only has a single row
@@ -4481,7 +4478,6 @@ ABoundActivity * HqlCppTranslator::doBuildActivityForceLocal(BuildCtx & ctx, IHq
 void HqlCppTranslator::doBuildStmtApply(BuildCtx & ctx, IHqlExpression * expr)
 {
     IHqlExpression * dataset = expr->queryChild(0);
-    IHqlExpression * action = expr->queryChild(1);
     IHqlExpression * start = expr->queryProperty(beforeAtom);
     IHqlExpression * end = expr->queryProperty(afterAtom);
 

--- a/ecl/hqlcpp/hqlcset.cpp
+++ b/ecl/hqlcpp/hqlcset.cpp
@@ -1370,6 +1370,7 @@ void DatasetBuilderBase::finishRow(BuildCtx & ctx, BoundRow * selfCursor)
 
 BlockedDatasetBuilder::BlockedDatasetBuilder(HqlCppTranslator & _translator, IHqlExpression * _record) : DatasetBuilderBase(_translator, _record, false)
 {
+    forceLength = false;
 }
 
 void BlockedDatasetBuilder::buildDeclare(BuildCtx & ctx)
@@ -1857,8 +1858,7 @@ void HqlCppTranslator::buildSetAssign(BuildCtx & ctx, IHqlCppSetBuilder * builde
     case no_list:
         {
             unsigned max = expr->numChildren();
-            if (((max >= 0) && (max < 3)) || 
-                isComplexSet(expr) || !isConstantSet(expr))
+            if ((max < 3) || isComplexSet(expr) || !isConstantSet(expr))
             {
                 for (unsigned i=0; i < max; i++)
                 {

--- a/ecl/hqlcpp/hqlgraph.cpp
+++ b/ecl/hqlcpp/hqlgraph.cpp
@@ -150,6 +150,8 @@ LogicalGraphCreator::LogicalGraphCreator(IWorkUnit * _wu)
     includeModuleInText = wu->getDebugValueBool("logicalGraphIncludeModule", true);
     displayJavadoc = wu->getDebugValueBool("logicalGraphDisplayJavadoc", true);
     displayJavadocParameters = wu->getDebugValueBool("logicalGraphDisplayJavadocParameters", false);
+    rootGraphId = 0;
+    subGraphId = 0;
 }
 
 LogicalGraphCreator::~LogicalGraphCreator()
@@ -483,7 +485,6 @@ bool LogicalGraphCreator::gatherGraphActivities(IHqlExpression * expr, HqlExprAr
         return false;
 
     //if no_select with new then create a child graph
-    ITypeInfo * type = expr->queryType();
     node_operator op = expr->getOperator();
     switch (op)
     {

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -2748,10 +2748,10 @@ void DatasetSelector::modifyOp(BuildCtx & ctx, IHqlExpression * expr, node_opera
         break;
 #ifdef _THE_FOLLOWING_ARENT_YET_IMPLEMENTED_BUT_WOULD_BE_USEFUL
     case no_assign_concat:
-        result.setown(createValue(no_concat, path->getType(), LINK(sourceValue), LINK(expr));
+        result.setown(createValue(no_concat, path->getType(), LINK(sourceValue), LINK(expr)));
         break;
     case no_assign_add:
-        result.setown(createValue(no_add, path->getType(), LINK(sourceValue), LINK(expr));
+        result.setown(createValue(no_add, path->getType(), LINK(sourceValue), LINK(expr)));
         break;
 #endif
     default:

--- a/ecl/hqlcpp/hqlinline.cpp
+++ b/ecl/hqlcpp/hqlinline.cpp
@@ -1061,7 +1061,6 @@ void ParentExtract::gatherActiveRows(BuildCtx & ctx)
     //and remove else
     if (localisation == GraphCoLocal || localisation == GraphCoNonLocal)
     {
-        unsigned extractIndex = 0;
         OwnedHqlExpr colocal = createQuoted("colocal", makeVoidType());
         ForEachItemInRev(i, activeRows)
         {

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -1824,7 +1824,6 @@ void ImplicitProjectTransformer::calculateFieldsUsed(IHqlExpression * expr)
             else if (op == no_merge)
             {
                 //Ensure all the fields used by the sort order are preserved in the input streams
-                IHqlExpression * selector = expr->queryChild(0)->queryNormalizedSelector();
                 IHqlExpression * order = expr->queryProperty(sortedAtom);
                 assertex(order);
                 ForEachChild(i, order)
@@ -2080,7 +2079,6 @@ void ImplicitProjectTransformer::createFilteredAssigns(HqlExprArray & assigns, I
             {
                 IHqlExpression * lhs = cur->queryChild(0);
                 IHqlExpression * field = lhs->queryChild(1);
-                IHqlExpression * oldSelf = lhs->queryChild(0);
                 if (fields.contains(*field))
                 {
                     IHqlExpression * newLhs = createSelectExpr(LINK(newSelf), LINK(field));

--- a/ecl/hqlcpp/hqliproj.ipp
+++ b/ecl/hqlcpp/hqliproj.ipp
@@ -321,7 +321,6 @@ protected:
     HqlCppTranslator &  translator;
     HqlExprArray activities;
     ClusterType targetClusterType;
-    unsigned activityDepth;
     ImplicitProjectOptions options;
     bool allowActivity;
 };

--- a/ecl/hqlcpp/hqlregex.cpp
+++ b/ecl/hqlcpp/hqlregex.cpp
@@ -237,7 +237,7 @@ protected:
 class SymbolArrayIterator
 {
 public:
-    SymbolArrayIterator(SymbolArray & _table) : table(_table) {}
+    SymbolArrayIterator(SymbolArray & _table) : table(_table) { cur = 0; }
     inline bool first() 
     { 
         cur = 0; return table.symbols.isItem(cur);
@@ -594,7 +594,6 @@ void HqlRegexExpr::calcDfaScore()
         }
         else if (!expr->hasProperty(minimalAtom))
         {
-            unsigned min = getRepeatMin();
             unsigned max = getRepeatMax();
             unsigned namedDfaScore = queryNamed()->getDfaScore();
             if (max <= options.dfaRepeatMax)
@@ -1414,7 +1413,6 @@ void HqlRegexExpr::generateRegex(GenerateRegexCtx & ctx)
                     created.setown(new RegexValidateUtf8AsUniPattern(stripSeparator, idx));
                 else
                     created.setown(new RegexValidateUtf8AsAscPattern(stripSeparator, idx));
-                break;
                 break;
             case NlpAscii:
                 if (validatorKind != ValidateIsUnicode)

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -73,7 +73,7 @@ void getResources(IHqlExpression * expr, CResources & resources, const CResource
         resources.setLightweight();
         return;
     }
-    ITypeInfo * type = expr->queryType();
+
     bool isLocal = isLocalActivity(expr);
     bool isGrouped = isGroupedActivity(expr);
     switch (expr->getOperator())
@@ -3588,7 +3588,6 @@ bool EclResourcer::queryMergeGraphLink(ResourceGraphLink & link)
         //1) if context the source graph is being merged into is unconditional, then it is ok [ could have conditional and unconditional paths to same graph]
         //2) if context is conditional, then we don't really want to do it unless the conditions on all sinks are identical, and the only links occur between these two graphs.
         //   (situation occurs with spill fed into two branches of a join).
-        ResourcerInfo * thisSinkInfo = queryResourceInfo(link.sinkNode);
         bool isConditionalInSinkGraph = false;
         bool accessedFromManyGraphs = false;
         ForEachItemIn(i, sinks)

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -333,7 +333,6 @@ protected:
 
 IHqlExpression * createTableWithoutVirtuals(VirtualFieldsInfo & info, IHqlExpression * tableExpr)
 {
-    IHqlExpression * name = tableExpr->queryChild(0);
     IHqlExpression * record = tableExpr->queryChild(1);
     OwnedHqlExpr diskRecord = info.createPhysicalRecord();
     //Clone the annotations to improve the regenerated text in the graph
@@ -3882,9 +3881,6 @@ void MonitorExtractor::buildKeySegmentInExpr(BuildMonitorState & buildState, Key
 
     if (values->getOperator() != no_list)
     {
-        ITypeInfo * eclFieldType = lhs->queryType()->queryPromotedType();
-        ITypeInfo * elementType = values->queryType()->queryChildType();
-
         //iterate through the set
         BuildCtx subctx(ctx);
         CHqlBoundExpr boundCurElement;
@@ -4638,14 +4634,11 @@ void MonitorExtractor::buildKeySegment(BuildMonitorState & buildState, BuildCtx 
 void MonitorExtractor::buildArbitaryKeySegment(BuildMonitorState & buildState, BuildCtx & ctx, unsigned curSize, IHqlExpression * condition)
 {
     IHqlExpression * left = condition->queryChild(0);
-    IHqlExpression * right = condition->queryChild(1);
     node_operator op = condition->getOperator();
 
     StringBuffer createMonitorText;
     OwnedHqlExpr field = createField(unknownAtom, getExpandedFieldType(left->queryType(), NULL), NULL);
     OwnedHqlExpr pseudoSelector = createSelectExpr(getActiveTableSelector(), LINK(field));
-    bool done = false;
-    KeyedKind keyedKind = KeyedExtend;
 
     KeySelectorInfo selectorInfo(KeyedExtend, left, pseudoSelector, buildState.curOffset, curSize, false, true);
     BuildCtx subctx(ctx);
@@ -4711,7 +4704,6 @@ void MonitorExtractor::spotSegmentCSE(BuildCtx & ctx)
 void MonitorExtractor::buildSegments(BuildCtx & ctx, const char * listName, bool _ignoreUnkeyed)
 {
     translator.useInclude("rtlkey.hpp");
-    IHqlExpression *record = tableExpr->queryChild(1);
     ignoreUnkeyed = _ignoreUnkeyed;
 
     if (translator.queryOptions().spotCSE)
@@ -6618,7 +6610,6 @@ protected:
     }
 
 protected:
-    bool optimizeCount;
     bool transformAccessesCallback;
 };
 

--- a/ecl/hqlcpp/hqlstmt.cpp
+++ b/ecl/hqlcpp/hqlstmt.cpp
@@ -942,7 +942,6 @@ HqlStmts::HqlStmts(HqlStmt * _owner)    : owner(_owner)
 void HqlStmts::appendStmt(HqlStmt & stmt)
 {
     unsigned newPrio = stmt.queryPriority();
-    unsigned left = 0;
     unsigned right = ordinality();
 
     if (right == 0)
@@ -963,6 +962,7 @@ void HqlStmts::appendStmt(HqlStmt & stmt)
     }
     else
     {
+        unsigned left = 0;
         while (right - left >= 2)
         {
             unsigned mid = (left + right - 1) / 2;
@@ -1762,7 +1762,6 @@ void PeepHoleOptimizer::optimize(HqlStmts & stmts)
                 while (j < max)
                 {
                     IHqlStmt & next = stmts.item(j);
-                    bool merged = false;
                     if (!nextMatch.extractIsSpecial(next, memsetOnly, peepholeOptions))
                         break;
                     if (!prevMatch.queryCombine(nextMatch, memsetOnly, combineStringLimit))
@@ -1806,6 +1805,7 @@ AssociationIterator::AssociationIterator(BuildCtx & ctx)
 {
     rootStmts = ctx.curStmts;
     curStmts = NULL;
+    curIdx = 0;
 }
 
 

--- a/ecl/hqlcpp/hqltcppc.cpp
+++ b/ecl/hqlcpp/hqltcppc.cpp
@@ -1004,7 +1004,6 @@ void CContainerInfo::subLeadingFixed(SizeStruct & size, CMemberInfo * cur)
     if (container)
         container->subLeadingFixed(size, this);
 
-    unsigned max = children.ordinality();
     unsigned match = children.find(*cur);
     for (unsigned i=0; i < match; i++)
         size.addFixed((unsigned)-(int)children.item(i).getTotalFixedSize());

--- a/ecl/hqlcpp/hqltcppc2.cpp
+++ b/ecl/hqlcpp/hqltcppc2.cpp
@@ -718,8 +718,6 @@ bool CChildLinkedDatasetColumnInfo::modifyColumn(HqlCppTranslator & translator, 
     boundTarget.count.setown(convertAddressToValue(addressSize, sizetType));
     boundTarget.expr.setown(convertAddressToValue(addressData, queryType()));
 
-    IHqlExpression * record = column->queryRecord();
-    
     HqlExprArray args;
     args.append(*LINK(value));
     OwnedHqlExpr call = translator.bindFunctionCall(appendRowsToRowsetAtom, args, resultType);
@@ -745,7 +743,6 @@ void CChildLinkedDatasetColumnInfo::setColumn(HqlCppTranslator & translator, Bui
     boundTarget.count.setown(convertAddressToValue(addressSize, sizetType));
     boundTarget.expr.setown(convertAddressToValue(addressData, queryType()));
 
-    IHqlExpression * record = column->queryRecord();
     if (value->getOperator() == no_null)
         value.setown(createNullExpr(resultType));
     

--- a/ecl/hqlcpp/hqltomita.cpp
+++ b/ecl/hqlcpp/hqltomita.cpp
@@ -824,7 +824,6 @@ void TomRule::setProductionIds(HqlExprArray & productionMappings, unsigned & id)
                 {
                     //Check there is only a single input symbol which has an associated record
                     TomRule * defaultRule = NULL;
-                    unsigned defaultIndex = NotFound;
                     for (unsigned i=0;;i++)
                     {
                         TomStep * curStep = cur.queryStep(i);
@@ -837,7 +836,6 @@ void TomRule::setProductionIds(HqlExprArray & productionMappings, unsigned & id)
                             if (defaultRule)
                                 throwError(HQLERR_ExpectedTransformManyInputs);
                             defaultRule = curRule;
-                            defaultIndex = i;
                         }
                     }
                     if (!defaultRule || !recordTypesMatch(defaultRule->queryRecord(), record))

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -1018,6 +1018,7 @@ static HqlTransformerInfo ThorScalarTransformerInfo("ThorScalarTransformer");
 ThorScalarTransformer::ThorScalarTransformer(const HqlCppOptions & _options) : HoistingHqlTransformer(ThorScalarTransformerInfo, HTFnoteconditionalactions), options(_options)
 {
     isConditionalDepth = 0;
+    seenCandidate = false;
 }
 
 
@@ -4511,7 +4512,7 @@ IHqlExpression * GlobalAttributeInfo::queryFilename(IHqlExpression * value, ICon
             {
                 if (persistOp == no_stored)
                     prefix.append("spill::stored");
-                else if (persistOp = no_checkpoint)
+                else if (persistOp == no_checkpoint)
                     prefix.append("spill::checkpoint");
             }
             if (persistOp == no_once)

--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -88,6 +88,7 @@ bool isTypePassedByAddress(ITypeInfo * type)
 CppWriterTemplate::CppWriterTemplate()
 {
     text = NULL;
+    len = 0;
 }
 
 CppWriterTemplate::~CppWriterTemplate()


### PR DESCRIPTION
Removes various unused variables, initialised some uninitialised
variables, and clean up a couple of other potential issues.
As far as I can tell, none of the problems caused any ill effects in
practice.
Includes fix for gh-370

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
