### PR TITLE
Roxie query timing stats using uninitialized values

### DIFF
--- a/roxie/ccd/ccdsnmp.hpp
+++ b/roxie/ccd/ccdsnmp.hpp
@@ -38,6 +38,9 @@ public:
 public:
     RoxieQueryStats()
     {
+        count = 0;
+        failedCount = 0;
+        atomic_set(&active, 0);
         totalTime = 0;
         maxTime = 0;
         minTime = 0; 


### PR DESCRIPTION
Spotted by cppcheck - the values used for reporting counts of executed
queries are not properly initialized and therefore the reports are liable
to be wrong.

Add code to constructor to initialize the values.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
