### PR TITLE
Fixes gh-369 - Assignment in test condition

### DIFF
--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -6242,15 +6242,16 @@ public:
     const CCachedFileIO *removeFile(const CCachedFileIO *io) 
     {
         CriticalBlock block(sect);
-        ForEachItemIn(oi,cache) {
-            if (io = cache.item(oi)) {
-                cache.replace(NULL,oi,true);    
+        ForEachItemIn(idx, cache)
+        {
+            if (io == cache.item(idx))
+            {
+                cache.replace(NULL, idx, true);
                 break;
             }
         }
         return io;
     }
-
 };
 
 


### PR DESCRIPTION
Fix an assignment that was intended to be a comparison in
CLazyFileIOCache::removeFile. As far as I can tell this would not cause
any issues in current usage of this function (we got lucky...).

Also reformatted the function to current coding standards and renamed
a confusing variable name.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
