### PR TITLE
Increase default number of threads for xref

### DIFF
--- a/initfiles/componentfiles/configxml/sasha.xsd
+++ b/initfiles/componentfiles/configxml/sasha.xsd
@@ -408,6 +408,13 @@
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="xrefMaxScanThreads" type="xs:nonNegativeInteger" default="500">
+            <xs:annotation>
+                <xs:appinfo>
+                    <tooltip>maximum thread count for scanning directories</tooltip>
+                </xs:appinfo>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="xrefEclWatchProvider" type="xs:boolean" use="optional" default="true">
             <xs:annotation>
                 <xs:appinfo>

--- a/initfiles/componentfiles/configxml/sasha.xsl
+++ b/initfiles/componentfiles/configxml/sasha.xsl
@@ -193,6 +193,9 @@
                 <xsl:attribute name="cutoff">
                    <xsl:value-of select="@xrefCutoff"/>
                 </xsl:attribute>
+                <xsl:attribute name="maxScanThreads">
+                   <xsl:value-of select="@xrefMaxScanThreads"/>
+                </xsl:attribute>
                 <xsl:attribute name="eclwatchProvider">
                    <xsl:call-template name="outputBool">
                       <xsl:with-param name="val" select="@xrefEclWatchProvider"/>


### PR DESCRIPTION
Allow number of threads to scale to number of nodes,
with an upper default limit, that's configurable via config

Together with gh-352, will significantly increase throughput of xref on large clusters.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com

NB: Although this change could be taken without gh-
