### PR TITLE
Fixes gh-368 - Assignment in test condition in wujobq

### DIFF
--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1693,8 +1693,9 @@ public:
                 ret = &it.queryTree();
                 break;
             }
-            else if (idx=(unsigned)-1)
+            else if (idx==(unsigned)-1)  // -1 means return last
                 ret = &it.queryTree();
+            i++;
         }
         if (ret)
             return new CJobQueueItem(ret);


### PR DESCRIPTION
Not clear what the symptoms of this would be - I don't know how/when the
code reaches this branch rather than the qdata-based one.

Fix the incorrect assigment and also a missing increment of i, which
together would have meant that requesting any item other than the head
would have returned the last item rather than the one requested.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
