### PR TITLE
Fixes gh-365 - Invalid .deb file in debug build

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -136,7 +136,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   set(version ${majorver}.${minorver}.${point})
 
   IF ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-    set( stagever "${stagever}_Debug" )
+    set( stagever "${stagever}-Debug" )
   ENDIF ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 
   ###########################################################################


### PR DESCRIPTION
gpkg complains about the _ in the _debug suffix we added. Use -
instead.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com

@pschwartz please review
