### PR TITLE
FIX gh-377 Reports the correct line number at eof

### DIFF
--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -1064,6 +1064,12 @@ class HqlLex
             yyColumn += delta;
         }
 
+        inline void updateNewline()
+        {
+            yyColumn = 1;
+            ++yyLineNo;
+        }
+
         void pushText(const char *);
 
     protected:

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -263,7 +263,7 @@ xpathseq      ([^}\r\n])+
                             lexer->javaDocComment.clear().append(endpos-startpos-5, lexer->yyBuffer+startpos+3);
                     }
 <COMMENT>[^*\n]+    { updatepos1; }
-<COMMENT>\n         { updatepos1; lexer->yyColumn = 1; ++lexer->yyLineNo; }
+<COMMENT>\n         { updatepos1; lexer->updateNewline(); }
 <COMMENT>"*"        { updatepos1; }
 
 "*/"                { 
@@ -275,7 +275,7 @@ xpathseq      ([^}\r\n])+
 
 \r                  { updatepos1; }
 \n                  { 
-                        setupdatepos; lexer->yyColumn = 1; lexer->yyLineNo++; 
+                        setupdatepos; lexer->updateNewline();
                         
                         #if defined(TRACE_MACRO)
                             PrintLog("MACRO>> Newline occurs: now at %d:%d\n", lexer->yyLineNo, lexer->yyColumn);
@@ -285,7 +285,7 @@ xpathseq      ([^}\r\n])+
 {blank}+            { setupdatepos; }
 
 "//"                { setupdatepos; BEGIN(SLSL); }
-<SLSL>\n            { updatepos1; lexer->yyColumn = 1; lexer->yyLineNo++; BEGIN(0); } 
+<SLSL>\n            { updatepos1; lexer->updateNewline(); BEGIN(0); }
 <SLSL>[^\n]+        { updatepos1; }
 
 #ERROR              {
@@ -1519,7 +1519,7 @@ FUNCTIONMACRO|MACRO {
                         return CPPBODY;
                     }
 <CPP>[^\n]+         { updatepos1; }
-<CPP>\n             { updatepos1; lexer->yyColumn = 1; ++lexer->yyLineNo; }
+<CPP>\n             { updatepos1; lexer->updateNewline(); }
 
 "<)"                { setupdatepos; return(TYPE_RPAREN) ; }
 "(>"                { setupdatepos; return(TYPE_LPAREN) ; }

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -178,11 +178,10 @@ void HqlLex::init(IFileContents * _text)
     forLoop = NULL;
 
     size32_t len = _text->length();
-    yyBuffer = new char[len+3]; // Include room for \n , \0 and another \0 that we write beyond the end null while parsing
+    yyBuffer = new char[len+2]; // Include room for \0 and another \0 that we write beyond the end null while parsing
     memcpy(yyBuffer, text->getText(), len); 
-    yyBuffer[len] = '\n';
+    yyBuffer[len] = '\0';
     yyBuffer[len+1] = '\0';
-    yyBuffer[len+2] = '\0';
 
     yyLineNo = 1;
     yyPosition = 0;
@@ -191,7 +190,7 @@ void HqlLex::init(IFileContents * _text)
     lastToken = 0;
 
     eclyylex_init(&scanner);
-    eclyy_scan_buffer(yyBuffer, len+3, scanner);
+    eclyy_scan_buffer(yyBuffer, len+2, scanner);
 }
 
 ///////////////////////////////////////////////////
@@ -2121,6 +2120,7 @@ int HqlLex::yyLex(YYSTYPE & returnToken, bool lookup, const short * activeState)
             continue;
         if (ret == EOF)
         {
+            setTokenPosition(returnToken);
             if (inComment)
                 reportError(returnToken, ERR_COMMENT_UNENDED,"Comment is not terminated");
             else if (inCpp)

--- a/ecl/regress/issue377.ecl
+++ b/ecl/regress/issue377.ecl
@@ -1,0 +1,1 @@
+export issue377a := 'ggg'


### PR DESCRIPTION
Previously an implicit \n was added to the end of the source file,
which meant that any error at the end of the file reported the error
on the next (non-existant line number).  It also fixes a potential
problem where the position was not initialised for an EOF token.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
