### PR TITLE
More fixes from running cppcheck

### DIFF
--- a/common/fileview2/fvdisksource.cpp
+++ b/common/fileview2/fvdisksource.cpp
@@ -588,6 +588,7 @@ IndirectDiskDataSource::IndirectDiskDataSource(const char * _logicalName, IHqlEx
     username.set(_username);
     password.set(_password);
     extraFieldsSize = sizeof(offset_t) + sizeof(unsigned short);
+    totalSize = 0;
 }
 
 IndirectDiskDataSource::~IndirectDiskDataSource()

--- a/common/fileview2/fvrelate.ipp
+++ b/common/fileview2/fvrelate.ipp
@@ -31,7 +31,6 @@ typedef IArrayOf<ViewFile> ViewFileArray;
 typedef CIArrayOf<ViewRelation> ViewRelationArray;
 typedef CopyCIArrayOf<ViewFile> ViewFileCopyArray;
 typedef CopyCIArrayOf<ViewRelation> ViewRelationCopyArray;
-typedef ICopyArrayOf<IAtom> AtomArray;
 
 //---------------------------------------------------------------------------
 
@@ -330,7 +329,7 @@ interface IErDiagramBuilder
 class FILEVIEW_API ViewERdiagramVisitor : public IViewFileWebVisitor, public ISchemaBuilder
 {
 public:
-    ViewERdiagramVisitor(IErDiagramBuilder & _builder) : builder(_builder) {}
+    ViewERdiagramVisitor(IErDiagramBuilder & _builder) : builder(_builder) { activeFieldCount = 0; }
 
 // IViewFileWebVisitor
     virtual void visit(ViewFile * file);

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -2215,6 +2215,9 @@ void buildCursorIndex(unsigned & numElements, unsigned * & elements, CResultSetC
 
 CResultSetSortedCursor::CResultSetSortedCursor(const CResultSetMetaData & _meta, IExtendedNewResultSet * _resultSet, unsigned _column, bool _desc) : CResultSetCursor(_meta, _resultSet, false)
 {
+    numEntries = 0;
+    elements = NULL;
+    lastRow = 0;
     column = _column;
     desc = _desc;
     buildIndex();
@@ -2222,6 +2225,9 @@ CResultSetSortedCursor::CResultSetSortedCursor(const CResultSetMetaData & _meta,
 
 CResultSetSortedCursor::CResultSetSortedCursor(const CResultSetMetaData & _meta, IExtendedNewResultSet * _resultSet, unsigned _column, bool _desc, MemoryBuffer & buffer) : CResultSetCursor(_meta, _resultSet, false)
 { 
+    numEntries = 0;
+    elements = NULL;
+    lastRow = 0;
     column = _column;
     desc = _desc;
     buildIndex();
@@ -2670,7 +2676,6 @@ __int64 CFilteredResultSet::translateRow(__int64 row)
             nextPos = validPositions.tos()+1;
 
         MemoryBuffer tempBuffer;
-        unsigned numSkipped = 0;
         unsigned startTime = msTick();
         while (row >= validPositions.ordinality())
         {
@@ -2682,7 +2687,6 @@ __int64 CFilteredResultSet::translateRow(__int64 row)
             if (rowMatchesFilter((byte *)tempBuffer.toByteArray()))
             {
                 validPositions.append(nextPos);
-                numSkipped = 0;
             }
             else
             {

--- a/common/fileview2/fvresultset.ipp
+++ b/common/fileview2/fvresultset.ipp
@@ -183,7 +183,6 @@ protected:
     CResultSetMetaData  meta;
     Linked<IFvDataSource> dataSource;
     BoolArray mappedFields;
-    __int64 numRows;
     CriticalSection cs;
 };
 
@@ -193,7 +192,7 @@ class CColumnFilter : public CInterface
 public:
     CColumnFilter(unsigned _whichColumn, ITypeInfo * _type, bool _isMappedIndexField)
         : whichColumn(_whichColumn)
-    { type.set(_type); optimized = false; isMappedIndexField = _isMappedIndexField; }
+    { type.set(_type); optimized = false; isMappedIndexField = _isMappedIndexField; subLen = 0; }
 
     void addValue(unsigned lenText, const char * value);
 

--- a/common/fileview2/fvsource.cpp
+++ b/common/fileview2/fvsource.cpp
@@ -524,12 +524,14 @@ RowBlock::RowBlock(MemoryBuffer & _buffer, __int64 _start, __int64 _startOffset)
     buffer.swapWith(_buffer);
     start = _start;
     startOffset = _startOffset;
+    numRows = 0;
 }
 
 RowBlock::RowBlock(__int64 _start, __int64 _startOffset)
 {
     start = _start;
     startOffset = _startOffset;
+    numRows = 0;
 }
 
 void RowBlock::getNextStoredOffset(__int64 & row, offset_t & offset)

--- a/common/fileview2/fvtransform.cpp
+++ b/common/fileview2/fvtransform.cpp
@@ -140,7 +140,7 @@ void ViewFieldTransformer::transform(MemoryAttr & utfTarget, const MemoryAttr & 
     transform(lenTarget, target, lenSource, source);
 
     unsigned sizeTarget = rtlUtf8Size(lenTarget, target);
-    utfTarget.setOwn(lenTarget, target);
+    utfTarget.setOwn(sizeTarget, target);
 }
 
 
@@ -553,7 +553,13 @@ class MappingParser
 {
     enum { TokEof=256, TokId, TokInt, TokString };
 public:
-    MappingParser(const IResultSetMetaData & _fieldMeta, bool _datasetSelectorAllowed) : fieldMeta(_fieldMeta), datasetSelectorAllowed(_datasetSelectorAllowed) {}
+    MappingParser(const IResultSetMetaData & _fieldMeta, bool _datasetSelectorAllowed) : fieldMeta(_fieldMeta), datasetSelectorAllowed(_datasetSelectorAllowed)
+    {
+        tokenType = TokEof;
+        lenInput = 0;
+        input = NULL;
+        offset = 0;
+    }
 
     void parseColumnMappingList(FieldTransformInfoArray & results, unsigned len, const char * text);
 

--- a/common/fileview2/fvtransform.ipp
+++ b/common/fileview2/fvtransform.ipp
@@ -224,7 +224,6 @@ protected:
 
 //---------------------------------------------------------------------------
 
-typedef CIArrayOf<ViewFieldTransformer> ViewFieldTransformerArray;
 void translateValue(MemoryAttr & result, const MemoryAttr & value, const ViewFieldTransformerArray & transforms);
 
 bool containsFail(const ViewFieldTransformerArray & transforms);

--- a/common/fileview2/fvwugen.cpp
+++ b/common/fileview2/fvwugen.cpp
@@ -205,7 +205,6 @@ IHqlExpression * PositionTransformer::createTransformed(IHqlExpression * _expr)
             if (grouping && (grouping->getOperator() != no_attr))
                 fail();
             IHqlExpression * record = transformed->queryRecord();
-            unsigned max = record->numChildren();
             HqlExprArray fields;
             unwindChildren(fields, transformed->queryChild(1));
             ForEachChild(idx, record)

--- a/common/remote/rmtsmtp.cpp
+++ b/common/remote/rmtsmtp.cpp
@@ -28,7 +28,7 @@
 class CSMTPValidator
 {
 public:
-    CSMTPValidator() : scanlist(false) {}
+    CSMTPValidator() : scanlist(false), value(NULL), finger(NULL), label(NULL) {}
 
     void validateValue(char const * _value, char const * _label)
     {
@@ -360,7 +360,6 @@ private:
     char const * finger;
     char const * label;
     bool scanlist;
-    bool scanmore;
 };
 
 // escapes text for mail transfer, returns true if quoted-printable encoding was required
@@ -487,7 +486,7 @@ class CMailInfo
     static char const * senderHeader;
 public:
     CMailInfo(char const * _to, char const * _subject, char const * _mailServer, unsigned _port, char const * _sender, StringArray *_warnings) 
-        : subject(_subject), mailServer(_mailServer), port(_port), sender(_sender), lastAction("process initialization")
+        : subject(_subject), mailServer(_mailServer), port(_port), sender(_sender), lastAction("process initialization"), inlen(0)
     {
         warnings = _warnings;
         CSMTPValidator validator;

--- a/common/remote/rmtspawn.cpp
+++ b/common/remote/rmtspawn.cpp
@@ -252,6 +252,9 @@ ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoin
 
 CRemoteParentInfo::CRemoteParentInfo()
 {
+    replyTag = 0;
+    kind = SPAWNlast;
+    port = 0;
 }
 
 
@@ -311,7 +314,6 @@ bool CRemoteParentInfo::sendReply(unsigned version)
                         readBuffer(connect, buffer.clear());
                         buffer.read(connectVersion);
                         bool same = false;
-                        unsigned replyVersion = version;
                         IpAddress masterIP;
                         masterIP.ipdeserialize(buffer);
                         buffer.read(connectKind);
@@ -332,7 +334,6 @@ bool CRemoteParentInfo::sendReply(unsigned version)
                             if (connectKind != kind)
                             {
                                 LOG(MCdebugInfo(1000), unknownJob, "Connection for wrong slave kind (%u vs %u)- ignore", connectKind, kind);
-                                replyVersion = connectVersion;
                             }
                         }
 

--- a/common/remote/rmtssh.cpp
+++ b/common/remote/rmtssh.cpp
@@ -177,6 +177,7 @@ public:
         strict = false;
         verbose = false;
         dryrun = false;
+        useplink = false;
         replicationoffset = 0;
     }
 

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -1288,9 +1288,12 @@ public:
         // an extended difference iterator starts with 2 (for bwd compatibility)
         ep = _ep;
         curisdir = false;
+        curvalid = false;
         cursize = 0;
         curidx = (unsigned)-1;
         mask = 0;
+        numflags = 0;
+        flags = NULL;
     }
 
     bool appendBuf(MemoryBuffer &_buf)
@@ -3341,7 +3344,6 @@ public:
         msg.read(name->text).read(mode).read(share);  
         try {
             Owned<IFile> file = createIFile(name->text);
-            unsigned smode = 0;
             switch ((compatIFSHmode)share) {
             case compatIFSHnone:
                 file->setCreateFlags(S_IRUSR|S_IWUSR); 

--- a/common/roxiehelper/roxiehelper.cpp
+++ b/common/roxiehelper/roxiehelper.cpp
@@ -378,8 +378,6 @@ bool CRHLimitedCompareHelper::getGroup(OwnedRowArray &group, const void *left)
     }
     while (high-low>(int)atmost) 
     {
-        CRHRollingCacheElem *rl = cache->mid(low);
-        CRHRollingCacheElem *rh = cache->mid(high-1);
         int vl = iabs(cache->mid(low)->cmp);
         int vh = iabs(cache->mid(high-1)->cmp);
         int v;
@@ -852,7 +850,7 @@ void FlushingStringBuffer::append(unsigned len, const char *data)
     catch (IException *E)
     {
         logctx.logOperatorException(E, __FILE__, __LINE__, NULL);
-        throw E;
+        throw;
     }
 }
 

--- a/common/thorhelper/csvsplitter.cpp
+++ b/common/thorhelper/csvsplitter.cpp
@@ -34,6 +34,8 @@ CSVSplitter::CSVSplitter()
     data = NULL;
     numQuotes = 0;
     unquotedBuffer = NULL;
+    maxColumns = 0;
+    curUnquoted = NULL;
 }
 
 CSVSplitter::~CSVSplitter()
@@ -72,6 +74,7 @@ void CSVSplitter::reset()
     data = NULL;
     numQuotes = 0;
     unquotedBuffer = NULL;
+    maxCsvSize = 0;
 }
 
 void CSVSplitter::init(unsigned _maxColumns, ICsvParameters * csvInfo, const char * dfsQuotes, const char * dfsSeparators, const char * dfsTerminators)

--- a/common/thorhelper/thorcommon.cpp
+++ b/common/thorhelper/thorcommon.cpp
@@ -367,6 +367,8 @@ CStreamMerger::CStreamMerger(bool _pullConsumes)
     dedup = false;
     activeInputs = 0;
     pullConsumes = _pullConsumes;
+    numInputs = 0;
+    first = true;
 }
 
 CStreamMerger::~CStreamMerger()
@@ -1414,9 +1416,9 @@ public:
     void putRow(const void *row)
     {
         if (row) {
-            byte b = 0;
             serializer->serialize(*this,(const byte *)row);
             if (grouped) {
+                byte b = 0;
                 if (bufpos<ROW_WRITER_BUFFERSIZE) 
                     buf[bufpos++] = b;
                 else 
@@ -1538,7 +1540,6 @@ IExtRowWriter *createRowWriter(IFileIOStream *strm,IOutputRowSerializer *seriali
 class CDiskMerger : public CInterface, implements IDiskMerger
 {
     IArrayOf<IFile> tempfiles;
-    unsigned numstrms;
     IRowStream **strms;
     Linked<IRecordSize> irecsize;
     StringAttr tempnamebase;

--- a/common/thorhelper/thorcommon.ipp
+++ b/common/thorhelper/thorcommon.ipp
@@ -46,9 +46,9 @@ public:
     
 private: 
     /* these overloaded operators are the devil of memory leak. Use set, setown instead. */
-    inline OwnedConstRow(const OwnedConstRow & other)   { }
-    void operator = (void * _row)                { }
-    void operator = (const OwnedConstRow & other) { }
+    inline OwnedConstRow(const OwnedConstRow & other)   { row = NULL; }
+    void operator = (void * _row)                { row = NULL; }
+    void operator = (const OwnedConstRow & other) { row = NULL; }
 
     /* this causes -ve memory leak */
     void setown(const OwnedConstRow &other) {  }

--- a/common/thorhelper/thorparse.cpp
+++ b/common/thorhelper/thorparse.cpp
@@ -141,15 +141,6 @@ NlpMatchPath::~NlpMatchPath()
 void NlpMatchPath::init()
 {
     maxDepth = ids.ordinality();
-    unsigned firstUnbounded = maxDepth;
-    for (unsigned depth=0; depth < maxDepth; depth++)
-    {
-        if (indices.item(depth) == UNKNOWN_INSTANCE)
-        {
-            firstUnbounded = depth;
-            break;
-        }
-    }
     searchIndices = new unsigned[maxDepth];
 }
 
@@ -259,6 +250,7 @@ void CMatchedResultInfo::serialize(MemoryBuffer & out) const
 
 CMatchedResults::CMatchedResults(CMatchedResultInfo * _def)
 {
+    in = NULL;
     def = _def;
     unsigned num = def->matchResults.ordinality();
     matched = new IMatchedElement *[num];
@@ -358,8 +350,8 @@ void CMatchedResults::getMatchText(size32_t & outlen, char * & out, unsigned idx
 void CMatchedResults::getMatchUnicode(size32_t & outlen, UChar * & out, unsigned idx)
 {
     const IMatchedElement * cur = matched[idx];
-    const byte * start = matched[idx]->queryStartPtr(); 
-    size32_t size = (size32_t)(matched[idx]->queryEndPtr() - start);
+    const byte * start = cur->queryStartPtr();
+    size32_t size = (size32_t)(cur->queryEndPtr() - start);
 
     switch (def->inputFormat)
     {
@@ -383,8 +375,8 @@ void CMatchedResults::getMatchUnicode(size32_t & outlen, UChar * & out, unsigned
 void CMatchedResults::getMatchUtf8(size32_t & outlen, char * & out, unsigned idx)
 {
     const IMatchedElement * cur = matched[idx];
-    const byte * start = matched[idx]->queryStartPtr(); 
-    size32_t size = (size32_t)(matched[idx]->queryEndPtr() - start);
+    const byte * start = cur->queryStartPtr();
+    size32_t size = (size32_t)(cur->queryEndPtr() - start);
 
     switch (def->inputFormat)
     {
@@ -633,6 +625,10 @@ NlpAlgorithm::NlpAlgorithm(CMatchedResultInfo * _matched)
     chooseMax = false;
     chooseBest = false;
     singleChoicePerLine = false;
+    inputFormat = NlpAscii;
+    keepLimit = UINT_MAX;
+    atMostLimit = UINT_MAX;
+    charWidth = sizeof(char);
 }
 
 NlpAlgorithm::~NlpAlgorithm()

--- a/common/thorhelper/thorpipe.cpp
+++ b/common/thorhelper/thorpipe.cpp
@@ -157,6 +157,7 @@ public:
         : CBufferedReadRowStream(_rowAllocator), csvTransformer(_csvTransformer)
     {
         ICsvParameters * csvInfo = csvTransformer->queryCsvParameters();
+        //MORE: This value is never used.  Should it be asserting(headerLines == 0)
         unsigned int headerLines = csvInfo->queryHeaderLen();
         size32_t max = csvInfo->queryMaxSize();
 

--- a/common/thorhelper/thorrparse.cpp
+++ b/common/thorhelper/thorrparse.cpp
@@ -1159,7 +1159,6 @@ void RegexUtf8IPattern::toXMLattr(StringBuffer & out, RegexXmlState & state)
 
 inline bool RegexUtf8IPattern::doMatch(RegexState & state)
 {
-    const byte * start = state.cur;
     const byte * end = state.end;
 
     unsigned size = lower.length();

--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -104,7 +104,7 @@ public:
             return MakeStringExceptionDirect(e->errorCode(), text.str());
     }
 
-    Url()
+    Url() : port(0)
     {
     }
 
@@ -469,7 +469,7 @@ MODULE_EXIT()
 class ColumnProvider : public CInterface, public IColumnProvider
 {
 public:
-    ColumnProvider(unsigned _callLatencyMs) : callLatencyMs(_callLatencyMs) {}
+    ColumnProvider(unsigned _callLatencyMs) : callLatencyMs(_callLatencyMs), base(NULL) {}
     IMPLEMENT_IINTERFACE;
     virtual bool        getBool(const char * path) { return base->getBool(path); }
     virtual void        getData(size32_t len, void * text, const char * path) { base->getData(len, text, path); }
@@ -1751,7 +1751,7 @@ public:
                     {
                         StringBuffer s;
                         master->logctx.CTXLOG("%sCALL exiting: Roxie Abort : %s",master->wscType == STsoap ? "SOAP" : "HTTP",e->errorMessage(s).str());
-                        throw e;
+                        throw;
                     }
 
                     do 
@@ -1848,7 +1848,7 @@ public:
                 {
                     StringBuffer s;
                     master->logctx.CTXLOG("%sCALL exiting: Roxie Abort : %s",master->wscType == STsoap ? "SOAP" : "HTTP",e->errorMessage(s).str());
-                    throw e;
+                    throw;
                 }
 
                 // other IException ... retry up to maxRetries

--- a/common/thorhelper/thorstep.ipp
+++ b/common/thorhelper/thorstep.ipp
@@ -70,7 +70,18 @@ interface ISteppedJoinRowGenerator : public IInterface
 class THORHELPER_API CSteppingMeta : public CInterface, implements IInputSteppingMeta
 {
 public:
-    CSteppingMeta() { numFields = 0; fields = NULL; rangeCompare = NULL; distance = NULL; stepFlags = 0; priority = 0; distributed = false; }
+    CSteppingMeta()
+    {
+        numFields = 0;
+        fields = NULL;
+        rangeCompare = NULL;
+        distance = NULL;
+        stepFlags = 0;
+        priority = 0;
+        distributed = false;
+        postFiltered = false;
+        hadStepExtra = false;
+    }
 
     void intersect(IInputSteppingMeta * inputMeta);
     void init(ISteppingMeta * meta, bool _postFiltered)
@@ -301,7 +312,13 @@ protected:
 class THORHELPER_API CSteppedCandidateMerger : public CStreamMerger
 {
 public:
-    CSteppedCandidateMerger(unsigned _numEqualFields) : CStreamMerger(true) { numEqualFields = _numEqualFields; candidateRow = NULL; }
+    CSteppedCandidateMerger(unsigned _numEqualFields) : CStreamMerger(true)
+    {
+        numEqualFields = _numEqualFields;
+        candidateRow = NULL;
+        inputArray = NULL;
+        equalCompare = NULL;
+    }
     ~CSteppedCandidateMerger() { assertex(!candidateRow); }
 
     void init(IEngineRowAllocator * _allocator, ICompare * _equalCompare, ICompare * _mergeCompare, bool _dedup, IRangeCompare * _rangeCompare)
@@ -482,7 +499,7 @@ typedef CIArrayOf<CFilteredInputBuffer> CFilteredInputBufferArray;
 class THORHELPER_API CFilteredMerger : public CStreamMerger
 {
 public:
-    CFilteredMerger() : CStreamMerger(true) {}
+    CFilteredMerger() : CStreamMerger(true) { inputArray = NULL; rowAllocator = NULL; }
 
     void init(IEngineRowAllocator * _allocator, ICompare * _mergeCompare, bool _dedup, IRangeCompare * _rangeCompare)
     {

--- a/common/thorhelper/thorstep2.cpp
+++ b/common/thorhelper/thorstep2.cpp
@@ -239,6 +239,7 @@ CSteppedConjunctionOptimizer::CSteppedConjunctionOptimizer(IEngineRowAllocator *
     inputHasPostfilter = false;
     inputIsDistributed = false;
     eof = false;
+    maxOptimizeInput = 0;
 }
 
 CSteppedConjunctionOptimizer::~CSteppedConjunctionOptimizer()

--- a/common/thorhelper/thortalgo.ipp
+++ b/common/thorhelper/thortalgo.ipp
@@ -65,8 +65,8 @@ public:
 class THORHELPER_API TomitaMatchPath : public NlpMatchPath
 {
 public:
-    TomitaMatchPath(MemoryBuffer & in) : NlpMatchPath(in) {}
-    TomitaMatchPath(const UnsignedArray & _ids, const UnsignedArray & _indices) : NlpMatchPath(_ids, _indices) {}
+    TomitaMatchPath(MemoryBuffer & in) : NlpMatchPath(in) { choices = NULL; }
+    TomitaMatchPath(const UnsignedArray & _ids, const UnsignedArray & _indices) : NlpMatchPath(_ids, _indices) { choices = NULL; }
 
     IMatchedElement * getMatch(GrammarSymbol * top, PackedSymbolChoice & choice);
 

--- a/common/thorhelper/thortparse.ipp
+++ b/common/thorhelper/thortparse.ipp
@@ -136,8 +136,6 @@ protected:
     bool cachedIsNull;
 };
 
-typedef CIArrayOf<GrammarSymbol> GrammarSymbolArray;
-
 class PackedSymbol : public GrammarSymbol
 {
 public:

--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -1632,6 +1632,8 @@ class CXMLParse : public CInterface, implements IXMLParse
         {
             lastMatchKeptLevel = 0;
             lastMatchKeptNode = lastMatchKeptNodeParent = NULL;
+            maker = NULL;
+            utf8Translator = NULL;
         }
         ~CXMLMaker()
         {

--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -342,7 +342,6 @@ inline void outputEncodedXmlData(unsigned len, const void *_field, const char *f
 
 inline void outputEncoded64XmlData(unsigned len, const void *_field, const char *fieldname, StringBuffer &out)
 {
-    const unsigned char *field = (const unsigned char *) _field;
     if (fieldname)
         out.append('<').append(fieldname).append(" xsi:type=\"xsd:base64Binary\">");
     JBASE64_Encode(_field, len, out, false);

--- a/common/thorhelper/thorxmlwrite.hpp
+++ b/common/thorhelper/thorxmlwrite.hpp
@@ -145,7 +145,6 @@ public:
     void newline();
 protected:
     StringBuffer out;
-    bool csv;
 };
 
 class thorhelper_decl CommonFieldProcessor : public CInterface, implements IFieldProcessor

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -229,6 +229,7 @@ public:
         rootPath.append("/GraphProgress/").append(wuid).append('/').append(graphName).append('/');
         connected = connectedWrite = false;
         formatVersion = 0;
+        progress = NULL;
     }
     void connect()
     {
@@ -1802,7 +1803,6 @@ mapEnums sortFields[] =
 class asyncRemoveDllWorkItem: public CInterface, implements IWorkQueueItem // class only used in asyncRemoveDll
 {
     StringAttr name;
-    unsigned version;
     bool removeDlls;
     bool removeDirectory;
 public:
@@ -3328,7 +3328,6 @@ void CLocalWorkUnit::remoteCheckAccess(IUserDescriptor *user, bool writeaccess) 
                 perm = 0;
         }
     }
-    IDFS_Exception *e = NULL;
     if (!HASREADPERMISSION(perm)) {
         SCMStringBuffer wuid;
         getWuid(wuid);

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -314,7 +314,7 @@ void ClusterPartDiskMapSpec::setDefaultReplicateDir(const char *dir)
 }
 
 
-void ClusterPartDiskMapSpec::operator=(const ClusterPartDiskMapSpec &other)
+ClusterPartDiskMapSpec & ClusterPartDiskMapSpec::operator=(const ClusterPartDiskMapSpec &other)
 {
     replicateOffset = other.replicateOffset;
     defaultCopies = other.defaultCopies;
@@ -325,6 +325,7 @@ void ClusterPartDiskMapSpec::operator=(const ClusterPartDiskMapSpec &other)
     repeatedPart = other.repeatedPart;
     setDefaultBaseDir(other.defaultBaseDir);
     setDefaultReplicateDir(other.defaultReplicateDir);
+    return *this;
 }
 
 

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -79,7 +79,7 @@ public:
     void deserialize(MemoryBuffer &mb);
     unsigned numCopies(unsigned part,unsigned clusterwidth,unsigned filewidth);
 
-    void operator=(const ClusterPartDiskMapSpec &other);
+    ClusterPartDiskMapSpec & operator=(const ClusterPartDiskMapSpec &other);
 
 };
 

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -433,7 +433,6 @@ void codepageBlankFill(char const * codepage, char * out, unsigned len)
     }
     else
     {
-        UConverter * conv = queryRTLUnicodeConverter(codepage)->query();
         unsigned blanklen;
         char * blank;
         rtlUnicodeToCodepageX(blanklen, blank, 1, &unicodeSpace, codepage);
@@ -4373,7 +4372,6 @@ void rtlUtf8ToUnicode(unsigned outlen, UChar * out, unsigned inlen, char const *
 ECLRTL_API void rtlUtf8SubStrFT(unsigned tlen, char * tgt, unsigned slen, char const * src, unsigned from, unsigned to)
 {
     normalizeFromTo(from, to);
-    unsigned len = to - from;
     clipFromTo(from, to, slen);
 
     unsigned copylen = to - from;
@@ -4416,7 +4414,6 @@ ECLRTL_API void rtlUtf8SubStrFX(unsigned & tlen, char * & tgt, unsigned slen, ch
 ECLRTL_API void rtlUtf8ToLower(size32_t l, char * t, char const * locale)
 {
     //Convert to lower case, but only go via unicode routines if we have to...
-    const byte * buffer = (const byte *)t;
     for (unsigned i=0; i< l; i++)
     {
         byte next = *t;
@@ -4582,7 +4579,7 @@ public:
                 matched = boost::regex_search(_str + _from, _str + _len, subs, *regEx);
             }
         }
-        catch (std::runtime_error e)
+        catch (const std::runtime_error & e)
         {
             throw MakeStringException(0, "Error in regex search: %s (regex: %s)", e.what(), regEx->str().c_str());
         }
@@ -4648,7 +4645,7 @@ public:
             else
                 regEx.assign(_regExp, boost::regbase::perl | boost::regbase::icase);                
         }
-        catch(boost::bad_expression e)
+        catch(const boost::bad_expression & e)
         {
             StringBuffer msg;
             msg.append("Bad regular expression: ").append(e.what()).append(": ").append(_regExp);
@@ -4668,7 +4665,7 @@ public:
 //          tgt = boost::regex_merge(src, cre->regEx, fmt, boost::format_perl); //Algorithm regex_merge has been renamed regex_replace, existing code will continue to compile, but new code should use regex_replace instead.
             tgt = boost::regex_replace(src, regEx, fmt, boost::format_perl);
         }
-        catch(std::runtime_error e)
+        catch(const std::runtime_error & e)
         {
             throw MakeStringException(0, "Error in regex replace: %s (regex: %s)", e.what(), regEx.str().c_str());
         }
@@ -5274,7 +5271,6 @@ ECLRTL_API void xmlDecodeUStrX(size32_t & outLen, UChar * & out, size32_t inLen,
 
 ECLRTL_API void xmlEncodeStrX(size32_t & outLen, char * & out, size32_t inLen, const char * in, unsigned flags)
 {
-    unsigned encodeFlags = 0;
     StringBuffer temp;
     encodeXML(in, temp, flags, inLen, false);
     outLen = temp.length();

--- a/rtl/eclrtl/eclrtl_imp.hpp
+++ b/rtl/eclrtl/eclrtl_imp.hpp
@@ -55,7 +55,7 @@ public:
 private:
     //Force errors....
     inline rtlDataAttr(const rtlDataAttr &) {}
-    inline rtlDataAttr & operator = (const rtlDataAttr & other) { return *this; }
+    inline rtlDataAttr & operator = (const rtlDataAttr & other) { ptr = NULL; return *this; }
 
 protected:
     void * ptr;

--- a/rtl/eclrtl/eclrtl_imp.hpp
+++ b/rtl/eclrtl/eclrtl_imp.hpp
@@ -54,8 +54,8 @@ public:
 
 private:
     //Force errors....
-    inline rtlDataAttr(const rtlDataAttr &) {}
-    inline rtlDataAttr & operator = (const rtlDataAttr & other) { ptr = NULL; return *this; }
+    inline rtlDataAttr(const rtlDataAttr &);
+    inline rtlDataAttr & operator = (const rtlDataAttr & other);
 
 protected:
     void * ptr;

--- a/rtl/eclrtl/rtlds_imp.hpp
+++ b/rtl/eclrtl/rtlds_imp.hpp
@@ -160,7 +160,7 @@ protected:
 private:
     //Force errors....
     inline rtlRowAttr(const rtlRowAttr &) {}
-    inline rtlRowAttr & operator = (const rtlRowAttr & other) { return *this; }
+    inline rtlRowAttr & operator = (const rtlRowAttr & other) { row = NULL; return *this; }
 
 protected:
     byte * row;
@@ -194,7 +194,7 @@ protected:
 private:
     //Force errors....
     inline rtlRowsAttr(const rtlRowsAttr &) {}
-    inline rtlRowsAttr & operator = (const rtlRowsAttr & other) { return *this; }
+    inline rtlRowsAttr & operator = (const rtlRowsAttr & other) { count = 0; rows = NULL; return *this; }
 
 public:
     unsigned count;

--- a/rtl/eclrtl/rtlint.cpp
+++ b/rtl/eclrtl/rtlint.cpp
@@ -47,7 +47,7 @@ int rtlReadInt3(const void * data)                      { return (*(int *)data >
 __int64 rtlReadInt5(const void * data)                  { return (*(__int64 *)data >> 24); }
 __int64 rtlReadInt6(const void * data)                  { return (*(__int64 *)data >> 16); }
 __int64 rtlReadInt7(const void * data)                  { return (*(__int64 *)data >> 8); }
-unsigned rtlReadUInt3(const void * data)                { return (*(unsigned *)data >> 8; }
+unsigned rtlReadUInt3(const void * data)                { return (*(unsigned *)data >> 8); }
 unsigned __int64 rtlReadUInt5(const void * data)        { return (*(unsigned __int64 *)data >> 24); }
 unsigned __int64 rtlReadUInt6(const void * data)        { return (*(unsigned __int64 *)data >> 16); }
 unsigned __int64 rtlReadUInt7(const void * data)        { return (*(unsigned __int64 *)data >> 8); }

--- a/rtl/eclrtl/rtlqstr.cpp
+++ b/rtl/eclrtl/rtlqstr.cpp
@@ -109,7 +109,7 @@ static const char compressXlat[256] =
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-#define compressQChar(c) compressXlat[c]
+#define compressQChar(c) compressXlat[(byte)c]
 
 #else
 

--- a/rtl/eclrtl/rtlsize.cpp
+++ b/rtl/eclrtl/rtlsize.cpp
@@ -215,7 +215,7 @@ void IfBlockOffsetInfo::setValid(bool nowValid)
         }
         else
         {
-            unsigned offset = getOffset();
+            //unsigned offset = getOffset();
             //copy from offset to end of record to end of record.
             //create a default for this level (and possibly any child records).
             //child nodes need to notice that values have been created/destroyed

--- a/rtl/eclrtl/workflow.cpp
+++ b/rtl/eclrtl/workflow.cpp
@@ -485,7 +485,7 @@ private:
     class ListItemPtr : public CInterface, implements IRuntimeWorkflowItemIterator
     {
     public:
-        ListItemPtr(ListItem * _start) : start(_start) {}
+        ListItemPtr(ListItem * _start) : start(_start) { ptr = NULL; }
         IMPLEMENT_IINTERFACE;
         virtual bool         first() { ptr = start; return isValid(); }
         virtual bool         isValid() { return ptr != NULL; }
@@ -733,7 +733,7 @@ bool WorkflowMachine::executeItem(unsigned wfid, unsigned scheduledWfid)
         catch(WorkflowException * ce)
         {
             if(ce->queryType() == WorkflowException::ABORT)
-                throw ce;
+                throw;
             reportContingencyFailure("SUCCESS", ce);
             ce->Release();
         }
@@ -764,11 +764,11 @@ bool WorkflowMachine::doExecuteItemDependency(IRuntimeWorkflowItem & item, unsig
     catch(WorkflowException * e)
     {
         if(e->queryType() == WorkflowException::ABORT)
-            throw e;
+            throw;
         if(!attemptRetry(item, dep, scheduledWfid))
         {
             handleFailure(item, e, true);
-            throw e;
+            throw;
         }
         e->Release();
     }
@@ -784,11 +784,11 @@ void WorkflowMachine::doExecuteItem(IRuntimeWorkflowItem & item, unsigned schedu
     catch(WorkflowException * ein)
     {
         if(ein->queryType() == WorkflowException::ABORT)
-            throw ein;
+            throw;
         if(!attemptRetry(item, 0, scheduledWfid))
         {
             handleFailure(item, ein, true);
-            throw ein;
+            throw;
         }
         ein->Release();
     }
@@ -914,7 +914,7 @@ bool WorkflowMachine::attemptRetry(IRuntimeWorkflowItem & item, unsigned dep, un
         {
             okay = false;
             if(ce->queryType() == WorkflowException::ABORT)
-                throw ce;
+                throw;
             reportContingencyFailure("RECOVERY", ce);
             ce->Release();
         }
@@ -963,7 +963,7 @@ void WorkflowMachine::handleFailure(IRuntimeWorkflowItem & item, WorkflowExcepti
         catch(WorkflowException * ce)
         {
             if(ce->queryType() == WorkflowException::ABORT)
-                throw ce;
+                throw;
             reportContingencyFailure("FAILURE", ce);
             ce->Release();
         }

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -294,8 +294,10 @@ private:
 
 class NoQuickEditSection
 {
+#ifdef _WIN32
     DWORD savedmode;
     bool saved;
+#endif
 public:
     NoQuickEditSection()
     {

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -294,10 +294,8 @@ private:
 
 class NoQuickEditSection
 {
-#ifdef _WIN32
     DWORD savedmode;
     bool saved;
-#endif
 public:
     NoQuickEditSection()
     {

--- a/system/jlib/jsocket.hpp
+++ b/system/jlib/jsocket.hpp
@@ -104,9 +104,10 @@ public:
     size32_t getNetAddress(size32_t maxsz,void *dst) const;     // for internal use - returns 0 if address doesn't fit
     void setNetAddress(size32_t sz,const void *src);            // for internal use
 
-    inline void operator = ( const IpAddress &other )
+    inline IpAddress & operator = ( const IpAddress &other )
     {
         ipset(other);
+        return *this;
     }
 
 };
@@ -151,10 +152,11 @@ public:
     void getUrlStr(char * str, size32_t len) const;             // in form ip4:port or [ip6]:port
     StringBuffer &getUrlStr(StringBuffer &str) const;           // in form ip4:port or [ip6]:port
 
-    inline void operator = ( const SocketEndpoint &other )
+    inline SocketEndpoint & operator = ( const SocketEndpoint &other )
     {
         ipset(other);
         port = other.port;
+        return *this;
     }
 	bool operator == (const SocketEndpoint &other) const { return equals(other); }
 

--- a/system/jlib/jthread.hpp
+++ b/system/jlib/jthread.hpp
@@ -135,8 +135,8 @@ class CThreaded : public Thread
 {
     IThreaded *owner;
 public:
-    CThreaded(const char *name) : Thread(name) { }
-    void init(IThreaded *_owner) { owner = _owner; start(); }
+    inline CThreaded(const char *name) : Thread(name) { owner = NULL; }
+    inline void init(IThreaded *_owner) { owner = _owner; start(); }
     virtual int run() { owner->main(); return 1; }
 };
 


### PR DESCRIPTION
As well as cosmetic changes, there were two potential bugs.
- Dereferencing an array by a char in the qstring code
- Using a length instead of asize for a utf8 filter string (fileview)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
