### PR TITLE
Fix #354 Add missing include to processor.cpp

### DIFF
--- a/initfiles/processor.cpp
+++ b/initfiles/processor.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <iostream>
 #include <fstream>
+#include <cstdio>
 
 using namespace std;
 


### PR DESCRIPTION
G++ Strict compile would fail due to missing include of cstdio.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
