### PR TITLE
Fix #355 Added missing STL header includes.

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -34,6 +34,8 @@
 #include <stdexcept>
 #endif
 
+#include <new>
+
 #define CONTENT_LENGTH "Content-Length: "
 
 unsigned soapTraceLevel = 1;

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -51,10 +51,13 @@
 #include "roxiehelper.hpp"
 #include "jlzw.hpp"
 
+#include <new>
+
 #ifdef _USE_CPPUNIT
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
 #endif
+
 
 //#define LEAK_FILE         "c:\\leaks.txt"
 

--- a/esp/services/ws_ecl/ws_ecl_json.cpp
+++ b/esp/services/ws_ecl/ws_ecl_json.cpp
@@ -7,6 +7,7 @@
 //#include <locale.h>
 
 #include <vector>
+#include <clocale>
 
 #include "JSON_parser.h"
 

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -36,6 +36,8 @@
 
 #include "slave.ipp"
 
+#include <new>
+
 #define FATAL_ACTJOIN_TIMEOUT (5*60*1000)
 
 activityslaves_decl CGraphElementBase *createSlaveContainer(IPropertyTree &xgmml, CGraphBase &owner, CGraphBase *resultsGraph);


### PR DESCRIPTION
G++ Strict builds would fail due to missing includes of STL new and clocale.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
