### PR TITLE
Adds functions to Str to convert to/from hex pairs

### DIFF
--- a/ecllibrary/std/Str.ecl
+++ b/ecllibrary/std/Str.ecl
@@ -424,4 +424,26 @@ EXPORT unsigned4 WordCount(string text) :=
 EXPORT string GetNthWord(string text, unsigned4 n) :=
     lib_stringlib.StringLib.StringGetNthWord(text, n);
 
+/*
+ * Converts the data value to a sequence of hex pairs.
+ *
+ * @param value         The data value that should be expanded as a sequence of hex pairs.
+ * @return              A string containg a sequence of hex pairs.
+ */
+
+EXPORT string ToHexPairs(data value) := lib_stringlib.StringLib.Data2String(value);
+
+/*
+ * Converts a string containing sequences of hex pairs to a data value.
+ *
+ * Embedded spaces are ignored, out of range characters are treated as '0', a trailing nibble
+ * at the end of the string is ignored.
+ *
+ *
+ * @param hex_pairs     The string containing the hex pairs to process.
+ * @return              A data value with each byte created from a pair of hex digits.
+ */
+
+EXPORT data FromHexPairs(string hex_pairs) := lib_stringlib.StringLib.String2Data(hex_pairs);
+
 END;

--- a/ecllibrary/teststd/str/TestFromHexPairs.ecl
+++ b/ecllibrary/teststd/str/TestFromHexPairs.ecl
@@ -1,0 +1,22 @@
+/*##############################################################################
+## Copyright (c) 2011 HPCC Systems.  All rights reserved.
+############################################################################## */
+
+IMPORT Std.Str;
+
+EXPORT TestFromHexPairs := MODULE
+
+  EXPORT TestConstant := MODULE
+    EXPORT Test01 := ASSERT(Str.FromHexPairs('')+D'X' = D'X', CONST);
+    EXPORT Test02 := ASSERT(Str.FromHexPairs('30313233')+D'X' = D'0123X', CONST);
+    EXPORT Test03 := ASSERT(Str.FromHexPairs('0001FF80')+D'X' = D'\000\001\377\200X', CONST);
+    EXPORT Test04 := ASSERT(Str.FromHexPairs('   00  01  FF 80   ')+D'X' = D'\000\001\377\200X', CONST);
+    EXPORT Test05 := ASSERT(Str.FromHexPairs('   XX  X1  FF 80   ')+D'X' = D'\000\001\377\200X', CONST);
+    EXPORT Test06 := ASSERT(Str.FromHexPairs('   XX  X1  ff 80   ')+D'X' = D'\000\001\377\200X', CONST);
+    EXPORT Test07 := ASSERT(Str.FromHexPairs('   XX  X1  ff 80   ')+D'X' = D'\000\001\377\200X', CONST);
+    EXPORT Test08 := ASSERT(Str.FromHexPairs('   @g  `1  ff 80   ')+D'X' = D'\000\001\377\200X', CONST);
+    EXPORT Test09 := ASSERT(Str.FromHexPairs('   @g  `1  ff 80 2')+D'X' = D'\000\001\377\200X', CONST);
+//    EXPORT Test10 := ASSERT(Str.FromHexPairs('   @g  `1  ff 80 2 ')+D'X' = D'\000\001\377\200X', CONST);  // undefined!
+  END;
+
+END;

--- a/ecllibrary/teststd/str/TestToHexPairs.ecl
+++ b/ecllibrary/teststd/str/TestToHexPairs.ecl
@@ -1,0 +1,15 @@
+/*##############################################################################
+## Copyright (c) 2011 HPCC Systems.  All rights reserved.
+############################################################################## */
+
+IMPORT Std.Str;
+
+EXPORT TestToHexPairs := MODULE
+
+  EXPORT TestConstant := MODULE
+    EXPORT Test01 := ASSERT(Str.ToHexPairs(D'')+'X' = 'X', CONST);
+    EXPORT Test02 := ASSERT(Str.ToHexPairs(D'0123')+'X' = '30313233X', CONST);
+    EXPORT Test03 := ASSERT(Str.ToHexPairs(D'\000\001\377\200')+'X' = '0001FF80X', CONST);
+  END;
+
+END;

--- a/install_directory/ecllibrary.install
+++ b/install_directory/ecllibrary.install
@@ -61,11 +61,13 @@ Install (
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestFind.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestFindCount.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestFindReplace.ecl
+    ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestFromHexPairs.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestGetNthWord.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestReverse.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestSplitWords.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestSubstituteExcluded.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestSubstituteIncluded.ecl
+    ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestToHexPairs.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestToLowerCase.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestToCapitalCase.ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/ecllibrary/teststd/str/TestToUpperCase.ecl


### PR DESCRIPTION
Adds a couple of functions to Std.Str to expose some other functions
in the stringlib plugin.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
