### PR TITLE
Fix gh-404 Custom XSL Cache entry identification and fix memory leaks

### DIFF
--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -372,7 +372,7 @@ void WuWebView::renderExpandedResults(const char *viewName, const StringBuffer &
     t->setIncludeHandler(this);
     StringBuffer cacheId(viewName);
     cacheId.append('@').append(dllname.str()); //using dllname, cloned workunits can share cache entry
-    t->setXslSource(xslt.str(), xslt.length(), rootpath.str(), cacheId.str());
+    t->setXslSource(xslt.str(), xslt.length(), cacheId.str(), rootpath.str());
     t->setXmlSource(expanded.str(), expanded.length());
     t->transform(out);
 }
@@ -413,7 +413,7 @@ void WuWebView::applyResultsXSLT(const char *filename, const char *xml, StringBu
     //mapped to resources and need to be distinguished in cache
     StringBuffer cacheId(filename);
     cacheId.append('@').append(dllname.str()); //cloned workunits have same dll and resources
-    t->setXslSource(filename, true, cacheId.str());
+    t->loadXslFromFile(filename, cacheId.str());
     t->setXmlSource(buffer.str(), buffer.length());
     t->transform(out);
 }

--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -184,6 +184,7 @@ class WuWebView : public CInterface,
 {
 public:
     IMPLEMENT_IINTERFACE;
+
     WuWebView(IConstWorkUnit &wu, const char *queryname, const char *wdir, bool mapEspDir) :
         manifestIncludePathsSet(false), dir(wdir), mapEspDirectories(mapEspDir)
     {
@@ -221,6 +222,7 @@ public:
     virtual bool getInclude(const char *includename, MemoryBuffer &includebuf, bool &pathOnly);
 
 protected:
+    SCMStringBuffer dllname;
     Owned<IConstWorkUnit> wu;
     Owned<ILoadedDllEntry> loadedDll;
     Owned<IPropertyTree> manifest;
@@ -368,7 +370,9 @@ void WuWebView::renderExpandedResults(const char *viewName, const StringBuffer &
         throw MakeStringException(WUWEBERR_ViewResourceNotFound, "Result view %s not found", viewName);
     Owned<IXslTransform> t = getXslProcessor()->createXslTransform();
     t->setIncludeHandler(this);
-    t->setXslSource(xslt.str(), xslt.length(), rootpath.str());
+    StringBuffer cacheId(viewName);
+    cacheId.append('@').append(dllname.str()); //using dllname, cloned workunits can share cache entry
+    t->setXslSource(xslt.str(), xslt.length(), rootpath.str(), cacheId.str());
     t->setXmlSource(expanded.str(), expanded.length());
     t->transform(out);
 }
@@ -405,7 +409,11 @@ void WuWebView::applyResultsXSLT(const char *filename, const char *xml, StringBu
 
     Owned<IXslTransform> t = getXslProcessor()->createXslTransform();
     t->setIncludeHandler(this);
-    t->setXslSource(filename);
+    //override default behavior using filename as cache identifier, there's a chance includes are
+    //mapped to resources and need to be distinguished in cache
+    StringBuffer cacheId(filename);
+    cacheId.append('@').append(dllname.str()); //cloned workunits have same dll and resources
+    t->setXslSource(filename, true, cacheId.str());
     t->setXmlSource(buffer.str(), buffer.length());
     t->transform(out);
 }
@@ -426,7 +434,6 @@ void WuWebView::load(IConstWorkUnit &cwu)
         name.s.replace(' ','_');
     }
     Owned<IConstWUQuery> q = wu->getQuery();
-    SCMStringBuffer dllname;
     q->getQueryDllName(dllname);
     loadedDll.setown(queryDllServer().loadDll(dllname.str(), DllLocationAnywhere));
 }

--- a/deployment/deploy/DeployTask.cpp
+++ b/deployment/deploy/DeployTask.cpp
@@ -356,7 +356,7 @@ public:
          if (m_instanceName.length())
            transform.setParameter("instance", StringBuffer("'").append(m_instanceName).append("'").str());
 
-         transform.setXslSource(xsl);
+         transform.loadXslFromFile(xsl);
          if (!m_dummy)
          {
            if(m_machineOS != MachineOsLinux)

--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -259,7 +259,7 @@ public:
         externalFunction.setown(m_transform->createExternalFunction("validationMessage", validationMessageFromXSLT));
         m_transform->setExternalFunction(SEISINT_NAMESPACE, externalFunction.get(), true);
         
-        m_transform->setXslSource("validateAll.xsl");
+        m_transform->loadXslFromFile("validateAll.xsl");
         m_transform->setUserData(this);
         
         try

--- a/deployment/deployutils/deployutils.cpp
+++ b/deployment/deployutils/deployutils.cpp
@@ -2905,15 +2905,14 @@ const char* expandXPath(StringBuffer& xpath, IPropertyTree* pNode, IPropertyTree
 
 bool xsltTransform(const StringBuffer& xml, const char* sheet, IProperties *params, StringBuffer& ret)
 {
-  StringBuffer xsl;
-  if (esp::readFile(sheet, xsl)<=0)
-    throw MakeStringException(-1, "Can not open stylesheet %s",sheet);
+  if (!checkFileExists(sheet))
+    throw MakeStringException(-1, "Could not find stylesheet %s",sheet);
 
   Owned<IXslProcessor> proc  = getXslProcessor();
   Owned<IXslTransform> trans = proc->createXslTransform();
 
   trans->setXmlSource(xml.str(), xml.length());
-  trans->setXslSource(xsl, xsl.length());
+  trans->loadXslFromFile(sheet);
 
   if (params)
   {

--- a/ecl/eclplus/formattypes.cpp
+++ b/ecl/eclplus/formattypes.cpp
@@ -217,7 +217,7 @@ void TextFormatType::printBody(FILE* fp, int len, char* txt)
     StringBuffer xmlbuf;
     xmlbuf.append("<Result>").append(len, txt).append("</Result>");
     transform->setXmlSource(xmlbuf.str(), xmlbuf.length());
-    transform->setXslSource(formatxsl, strlen(formatxsl));
+    transform->setXslNoCache(formatxsl, strlen(formatxsl));
     transform->setParameter("showHeader", displayNamesHeader()?"1":"0");
     transform->setParameter("showName", embedNames()?"1":"0");
     transform->setParameter("showRecordNumber", displayRecordNumber()?"1":"0");

--- a/esp/bindings/bindutil.cpp
+++ b/esp/bindings/bindutil.cpp
@@ -810,7 +810,7 @@ void xslTransformHelper(IXslProcessor *xslp, const char* xml, const char* xslFil
         if (!strnicmp(xslFile, "/esp/xslt/", 10))
             if (!checkFileExists(xslpath.append(getCFD()).append("smc_xslt/").append(xslFile+10).str()) && !checkFileExists(xslpath.append(getCFD()).append("xslt/").append(xslFile+10).str()))
                 return;
-        xform->setXslSource((xslpath.length()) ? xslpath.str() : xslFile);
+        xform->loadXslFromFile((xslpath.length()) ? xslpath.str() : xslFile);
         xform->setXmlSource(xml, strlen(xml)+1);
         if (params) xform->copyParameters(params);
         xform->transform(output.clear());

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1003,7 +1003,7 @@ int EspHttpBinding::onGetSoapBuilder(IEspContext &context, CHttpRequest* request
 
     IXslProcessor* xslp = getXmlLibXslProcessor();
     Owned<IXslTransform> xform = xslp->createXslTransform();
-    xform->setXslSource(StringBuffer(getCFD()).append("./xslt/soap_page.xsl").str());
+    xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/soap_page.xsl").str());
     xform->setXmlSource("<xml/>", 6);
 
     // params
@@ -1949,7 +1949,7 @@ int EspHttpBinding::onGetXForm(IEspContext &context, CHttpRequest* request, CHtt
         //DBGLOG("Schema: %s", schema.str());
 
         Owned<IXslTransform> xform = xslp->createXslTransform();
-        xform->setXslSource(StringBuffer(getCFD()).append("./xslt/gen_form.xsl").str());
+        xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/gen_form.xsl").str());
         xform->setXmlSource(schema.str(), schema.length()+1);
 
         // params
@@ -2393,7 +2393,7 @@ void EspHttpBinding::sortResponse(IEspContext& context, CHttpRequest* request, M
         IXslProcessor* xslp = getXmlLibXslProcessor();
 
         Owned<IXslTransform> xform = xslp->createXslTransform();
-        xform->setXslSource(StringBuffer(getCFD()).append("./xslt/dict_sort.xsl").str());   
+        xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/dict_sort.xsl").str());
 
         xform->setXmlSource(respXML,respXML.length());
         xform->transform(result);

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -137,7 +137,7 @@ const StringBuffer &CEspApplicationPort::getAppFrameHtml(time_t &modified, const
         xml.appendf("<EspApplicationFrame title=\"%s\" navWidth=\"%d\" navResize=\"%d\" navScroll=\"%d\" inner=\"%s\" params=\"%s\"/>", 
             getESPContainer()->getFrameTitle(), navWidth, navResize, navScroll, (inner&&*inner) ? encoded_inner.str() : "?main", params.str());
         Owned<IXslTransform> xform = xslp->createXslTransform();
-        xform->setXslSource(StringBuffer(getCFD()).append("./xslt/appframe.xsl").str());
+        xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/appframe.xsl").str());
         xform->setXmlSource(xml.str(), xml.length()+1);
         xform->transform( (needRefresh || embedded_url) ? html.clear() : appFrameHtml.clear());
     }
@@ -171,7 +171,7 @@ const StringBuffer &CEspApplicationPort::getTitleBarHtml(IEspContext& ctx, bool 
         else
         {
             Owned<IXslTransform> xform = xslp->createXslTransform();
-            xform->setXslSource(StringBuffer(getCFD()).append("./xslt/espheader.xsl").str());
+            xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/espheader.xsl").str());
             xform->setXmlSource(titleBarXml.str(), titleBarXml.length()+1);
             xform->transform(titleBarHtml.clear());
         }
@@ -211,7 +211,7 @@ const StringBuffer &CEspApplicationPort::getNavBarContent(IEspContext &context, 
                 xslsource.append(getCFD()).append("./xslt/nav.xsl");
                     
             }
-            xform->setXslSource(xslsource.str());
+            xform->loadXslFromFile(xslsource.str());
 
 
             xform->setXmlSource(xml.str(), xml.length()+1);

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1492,7 +1492,7 @@ void CWsDfuEx::xsltTransformer(const char* xsltPath,StringBuffer& source,StringB
 
     Owned<IXslTransform> xform = m_xsl->createXslTransform();
 
-    xform->setXslSource(xsltPath);
+    xform->loadXslFromFile(xsltPath);
     xform->setXmlSource(source.str(), source.length()+1);
     xform->transform(returnStr.clear());
 }

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -387,7 +387,7 @@ void CWsEclBinding::xsltTransform(const char* xml, unsigned int len, const char*
 
     StringBuffer xslpath(getCFD());
     xslpath.append(xslFileName);
-    trans->setXslSource(xslpath.str());
+    trans->loadXslFromFile(xslpath.str());
 
     if (params)
     {
@@ -858,7 +858,7 @@ int CWsEclBinding::getWsEclLinks(IEspContext &context, CHttpRequest* request, CH
 
     Owned<IXslProcessor> xslp = getXslProcessor();
     Owned<IXslTransform> xform = xslp->createXslTransform();
-    xform->setXslSource(StringBuffer(getCFD()).append("./xslt/wsecl3_links.xslt").str());
+    xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/wsecl3_links.xslt").str());
     xform->setXmlSource(xml.str(), xml.length());
 
     StringBuffer page;
@@ -1362,7 +1362,7 @@ int CWsEclBinding::getGenForm(IEspContext &context, CHttpRequest* request, CHttp
     Owned<IXslTransform> xform = xslp->createXslTransform();
 
     StringBuffer xslfile(getCFD());
-    xform->setXslSource(xslfile.append("./xslt/wsecl3_form.xsl").str());
+    xform->loadXslFromFile(xslfile.append("./xslt/wsecl3_form.xsl").str());
     xform->setXmlSource(formxml.str(), formxml.length()+1);
 
     // pass params to form (excluding form and __querystring)
@@ -1594,7 +1594,7 @@ int CWsEclBinding::getXmlTestForm(IEspContext &context, CHttpRequest* request, C
 
     Owned<IXslProcessor> xslp = getXslProcessor();
     Owned<IXslTransform> xform = xslp->createXslTransform();
-    xform->setXslSource(StringBuffer(getCFD()).append("./xslt/wsecl3_xmltest.xsl").str());
+    xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/wsecl3_xmltest.xsl").str());
 
     StringBuffer srcxml;
     srcxml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><srcxml><soapbody><![CDATA[");
@@ -1658,7 +1658,7 @@ int CWsEclBinding::getJsonTestForm(IEspContext &context, CHttpRequest* request, 
 
     Owned<IXslProcessor> xslp = getXslProcessor();
     Owned<IXslTransform> xform = xslp->createXslTransform();
-    xform->setXslSource(StringBuffer(getCFD()).append("./xslt/wsecl3_jsontest.xsl").str());
+    xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/wsecl3_jsontest.xsl").str());
 
     StringBuffer srcxml;
     srcxml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><srcxml><jsonreq><![CDATA[");

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -364,14 +364,14 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
 void CFileSpraySoapBindingEx::xsltTransform(const char* xml, const char* sheet, IProperties *params, StringBuffer& ret)
 {
     StringBuffer xsl;
-    if (esp::readFile(sheet,xsl)<=0)
+    if (!checkFileExists(sheet))
         throw MakeStringException(ECLWATCH_FILE_NOT_EXIST, "Cannot open stylesheet %s",sheet);
 
     Owned<IXslProcessor> proc  = getXslProcessor();
     Owned<IXslTransform> trans = proc->createXslTransform();
 
     trans->setXmlSource(xml, strlen(xml));
-    trans->setXslSource(xsl, xsl.length());
+    trans->loadXslFromFile(sheet);
 
     if (params)
     {

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -1712,16 +1712,14 @@ bool CWsTopologyEx::onTpGetComponentFile(IEspContext &context,
                 const char* plainText = req.getPlainText();
                 if (plainText && (!stricmp(plainText, "yes")))
                 {
-                    StringBuffer xslBuf, xmlBuf;
-                    if (esp::readFile("xslt/xmlformatter.xsl", xslBuf)<=0)
-                        throw MakeStringException(ECLWATCH_FILE_NOT_EXIST, "Cannot open stylesheet xmlformatter.xsl");
+                    if (!checkFileExists("xslt/xmlformatter.xsl"))
+                        throw MakeStringException(ECLWATCH_FILE_NOT_EXIST, "Could not find stylesheet xmlformatter.xsl");
 
                     Owned<IXslProcessor> proc  = getXslProcessor();
                     Owned<IXslTransform> trans = proc->createXslTransform();
 
-                    xmlBuf.append(buf.toByteArray(), 0, buf.length());
-                    trans->setXmlSource(xmlBuf.str(), xmlBuf.length());
-                    trans->setXslSource(xslBuf, xslBuf.length());
+                    trans->setXmlSource(pchBuf, buf.length());
+                    trans->loadXslFromFile("xslt/xmlformatter.xsl");
                     
                     StringBuffer htmlBuf;
                     trans->transform(htmlBuf);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2171,12 +2171,12 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
 void CWsWorkunitsEx::xsltTransform(const char* xml,const char* sheet,IProperties *params,StringBuffer& ret)
 {
     StringBuffer xsl;
-    if(readFile(sheet,xsl)<=0)
-        throw MakeStringException(ECLWATCH_FILE_NOT_EXIST, "Cannot load stylesheet %s.",sheet);
+    if(!checkFileExists(sheet))
+        throw MakeStringException(ECLWATCH_FILE_NOT_EXIST, "Could not find stylesheet %s.",sheet);
     Owned<IXslProcessor> proc = getXslProcessor();
     Owned<IXslTransform> trans = proc->createXslTransform();
     trans->setXmlSource(xml, strlen(xml));
-    trans->setXslSource(xsl, xsl.length());
+    trans->loadXslFromFile(sheet);
     if (params)
     {
         Owned<IPropertyIterator> it = params->getIterator();

--- a/system/xmllib/xslcache.cpp
+++ b/system/xmllib/xslcache.cpp
@@ -21,12 +21,9 @@
 class CXslIncludeSignature : public CInterface, implements IInterface
 {
 private:
-    IO_Type m_type;
-    StringBuffer m_path;
-
-    int m_size;
-    unsigned long m_modtime;
-    unsigned long m_crc;
+    StringBuffer filePath;
+    offset_t fileSize;
+    time_t fileTime;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -35,48 +32,30 @@ public:
     {
         if(!path || !*path)
             throw MakeStringException(-1, "CXslIncludeSignature : path can't be emtpy");
-
-        m_path.append(path);
-
-        m_type = IO_TYPE_FILE;
+        filePath.append(path);
         Owned<IFile> f = createIFile(path);
         if(f)
         {
             CDateTime modtime;
             f->getTime(NULL, &modtime, NULL);
-            m_modtime = modtime.getSimple();
-            m_size = f->size();
+            fileTime = modtime.getSimple();
+            fileSize = f->size();
         }
         else
         {
-            m_size = 0;
-            m_modtime = 0;
+            fileSize = 0;
+            fileTime = 0;
         }
-    }
-
-    CXslIncludeSignature(const char* path, MemoryBuffer& buf)
-    {
-        if(!path || !*path)
-            throw MakeStringException(-1, "CXslIncludeSignature : path can't be emtpy");
-
-        m_type = IO_TYPE_BUFFER;
-        m_size = buf.length();
-        m_crc = ~crc32(buf.toByteArray(), m_size, ~0);
     }
 
     bool operator==(CXslIncludeSignature& incl)
     {
-        if(m_type != incl.m_type)
-            return false;
-        if(m_type == IO_TYPE_FILE)
-            return (strcmp(m_path.str(), incl.m_path.str()) == 0) && (m_size == incl.m_size) && (m_modtime == incl.m_modtime);
-        else
-            return (m_size == incl.m_size) && (m_crc == incl.m_crc);
+        return (strieq(filePath.str(), incl.filePath.str())) && (fileSize == incl.fileSize) && (fileTime == incl.fileTime);
     }
 
     const char* getPath()
     {
-        return m_path.str();
+        return filePath.str();
     }
 };
 
@@ -106,11 +85,9 @@ public:
     {
         ForEachItemIn(x, m_signatures)
         {
-            CXslIncludeSignature* inc1p = &m_signatures.item(x);
-            if(!inc1p)
-                return true;
-            CXslIncludeSignature inc2(inc1p->getPath());
-            if(!(*inc1p == inc2))
+            CXslIncludeSignature &compiled = m_signatures.item(x);
+            CXslIncludeSignature current(compiled.getPath());
+            if(!(compiled == current))
                 return true;
         }
         return false;
@@ -119,65 +96,39 @@ public:
 
 class CXslEntry : public CInterface, implements IInterface
 {
-private:
+public:
     Owned<IXslBuffer> m_buffer;
-    StringBuffer  m_fname;
-    int m_size;
-    unsigned long m_timestamp;
-    unsigned long m_crc; 
-    unsigned long m_modtime;
-    IO_Type m_type;
-    StringArray*  m_includepaths;
+    offset_t m_size;
+    time_t createTime;
+    time_t fileModTime;
     Owned<CXslIncludeCompare> m_includecomp;
-    StringBuffer m_cacheId;
-
+    StringAttr m_cacheId;
 public:
     IMPLEMENT_IINTERFACE;
 
     CXslEntry(IXslBuffer* buffer)
     {
+        assertex(buffer);
         m_size = 0;
-        m_modtime = 0;
-        m_crc = 0;
-        m_timestamp = 0;
-        setBuffer(buffer);
-    }
+        fileModTime = 0;
+        time(&createTime);
 
-    void setBuffer(IXslBuffer* buffer)
-    {
-        if(buffer)
+        m_buffer.set(buffer);
+        m_cacheId.set(buffer->getCacheId());
+
+        if(m_buffer->getType() == IO_TYPE_FILE)
         {
-            time_t t;
-            time(&t);
-            m_timestamp = t;
-        
-            m_includepaths = &buffer->getIncludes();
-            m_buffer.set(buffer);
-            m_type = buffer->getType();
-            m_cacheId.clear().append(buffer->getCacheId());
-
-            if(m_type == IO_TYPE_FILE)
+            Owned<IFile> f = createIFile(buffer->getFileName());
+            if(f)
             {
-                m_fname.clear().append(buffer->getFileName());
-                if (!m_cacheId.length())
-                   m_cacheId.append(m_fname);
-                Owned<IFile> f = createIFile(m_fname.str());
-                if(f)
-                {
-                    CDateTime modtime;
-                    f->getTime(NULL, &modtime, NULL);
-                    m_modtime = modtime.getSimple();
-                    m_size = f->size();
-                }
-            }
-            else 
-            {
-                m_size = buffer->getLen();
-                m_crc = ~crc32(buffer->getBuf(), m_size, ~0);
+                CDateTime modtime;
+                f->getTime(NULL, &modtime, NULL);
+                fileModTime = modtime.getSimple();
+                m_size = f->size();
             }
         }
         else
-            throw MakeStringException(-1, "can't create CXslEntry with a NULL input");
+            m_size = buffer->getLen();
     }
 
     IXslBuffer* getBuffer()
@@ -185,55 +136,39 @@ public:
         return m_buffer.get();
     }
 
+    bool isExpired(int cacheTimeout)
+    {
+        if (cacheTimeout==-1)
+            return false;
+        time_t t;
+        time(&t);
+        if(t > createTime + cacheTimeout)
+            return true;
+        return false;
+    }
+
     bool match(CXslEntry* entry)
     {
         if(!entry)
             return false;
-
-        if(m_type != entry->m_type)
+        if(m_buffer->getType() != entry->m_buffer->getType())
             return false;
-        if (m_cacheId.length())
-            return (entry->m_cacheId.length()) && (streq(m_cacheId.str(), entry->m_cacheId.str()));
-        else
-            return (m_size == entry->m_size) && (m_crc == entry->m_crc);
+        if (!m_cacheId.length())
+            return false;
+        return (entry->m_cacheId.length()) && (streq(m_cacheId.sget(), entry->m_cacheId.sget()));
     }
 
     bool equal(CXslEntry* entry, bool matched)
     {
         if(!entry)
             return false;
-
         if(!matched && !match(entry))
             return false;
-
-        if (m_type == IO_TYPE_FILE && !((m_modtime == entry->m_modtime) && (m_size == entry->m_size)))
+        if (m_buffer->getType() == IO_TYPE_FILE && (fileModTime != entry->fileModTime || m_size != entry->m_size))
             return false;
-
         if(m_includecomp.get() && m_includecomp->hasChanged())
             return false;
-
         return true;
-    }
-
-    unsigned long getCacheIdHash()
-    {
-        unsigned long keyhash = 5381;
-        for(int i = 0; i < m_cacheId.length(); i++)
-            keyhash = ((keyhash << 5) + keyhash) + m_cacheId.charAt(i);
-        return keyhash;
-    }
-
-    unsigned long getKeyHash()
-    {
-        if (m_cacheId.length())
-            return getCacheIdHash();
-        else
-            return (m_size + m_crc)*127;
-    }
-
-    unsigned long getTimestamp()
-    {
-        return m_timestamp;
     }
 
     void compile()
@@ -241,10 +176,8 @@ public:
         if(m_buffer.get())
         {
             m_buffer->compile();
-            if(m_includepaths && m_includepaths->length() > 0)
-            {
-                m_includecomp.setown(new CXslIncludeCompare(*m_includepaths));
-            }
+            if(m_buffer->getIncludes().length())
+                m_includecomp.setown(new CXslIncludeCompare(m_buffer->getIncludes()));
         }
     }
 };
@@ -254,7 +187,7 @@ public:
 class CXslCache : public CInterface, implements IXslCache
 {
 private:
-    CXslEntry* m_cache[XSLTCACHESIZE];
+    MapStringToMyClass<CXslEntry> xslMap;
     Mutex m_mutex;
     int m_cachetimeout;
 
@@ -264,77 +197,59 @@ public:
     CXslCache()
     {
         m_cachetimeout = XSLT_DEFAULT_CACHETIMEOUT;
-
-        for(int i = 0; i < XSLTCACHESIZE; i++)
-            m_cache[i] = NULL;
     }
 
     virtual ~CXslCache()
     {
-        for(int i = 0; i < XSLTCACHESIZE; i++)
-        {
-            if(m_cache[i] != NULL)
-                m_cache[i]->Release();;
-        }
     }
 
     IXslBuffer* getCompiledXsl(IXslBuffer* xslbuffer, bool replace)
     {
         if(!xslbuffer)
             return NULL;
-        
+
         synchronized block(m_mutex);
-        Owned<CXslEntry> newentry = new CXslEntry(xslbuffer);
 
-        int start = (newentry->getKeyHash()) % XSLTCACHESIZE;
-        int ind = start;
-        int oldest = start;
-        do
+        Owned<CXslEntry> newEntry = new CXslEntry(xslbuffer);
+        const char *cacheId = newEntry->m_cacheId.get();
+        if (cacheId && *cacheId)
         {
-            CXslEntry* oneentry = m_cache[ind];
-            if(!oneentry)
-                break;
-
-            time_t t;
-            time(&t);
-            if(m_cachetimeout != -1 && (t >= oneentry->getTimestamp() + m_cachetimeout))
+            CXslEntry* cacheEntry = xslMap.getValue(cacheId);
+            if (cacheEntry)
             {
-                oneentry->Release();
-                m_cache[ind] = NULL;
-                break;
-            }
-
-            if(oneentry->match(newentry.get()))
-            {
-                if(replace || !oneentry->equal(newentry, true))
-                {
-                    oneentry->Release();
-                    m_cache[ind] = NULL;
-                    break;
-                }
+                if(!replace && !cacheEntry->isExpired(m_cachetimeout) && cacheEntry->equal(newEntry, false))
+                    return cacheEntry->getBuffer();
                 else
-                    return oneentry->getBuffer();
+                    xslMap.remove(cacheId);
             }
-
-            if(oneentry->getTimestamp() < m_cache[oldest]->getTimestamp())
-                oldest = ind;
-
-            ind = (ind + 1) % XSLTCACHESIZE;
         }
-        while(ind != start);
-
-        newentry->compile();
-        if(m_cache[ind] == NULL)
-            m_cache[ind] = newentry.getLink();
-        else
+        newEntry->compile();
+        if (cacheId && *cacheId)
         {
-            DBGLOG("XSLT cache is full, replacing oldest entry at index %d", oldest);
-            if(m_cache[oldest] != NULL)
-                m_cache[oldest]->Release();
-            m_cache[oldest] = newentry.getLink();
+            if (xslMap.count()>=XSLTCACHESIZE)
+                freeOneCacheEntry();
+            xslMap.setValue(cacheId, newEntry.get());
         }
-
         return xslbuffer;
+    }
+
+    void freeOneCacheEntry()
+    {
+        CXslEntry *oldest = NULL;
+        HashIterator iter(xslMap);
+        for (iter.first(); iter.isValid(); iter.next())
+        {
+            CXslEntry *entry = xslMap.mapToValue(&iter.query());
+            if (entry->isExpired(m_cachetimeout))
+            {
+                xslMap.remove(dynamic_cast<MappingStringToIInterface*>(&iter.query()));
+                return;
+            }
+            if (!oldest || entry->createTime < oldest->createTime)
+                oldest=entry;
+        }
+        if (oldest)
+            xslMap.remove(oldest->m_cacheId.sget());
     }
 
     void setCacheTimeout(int timeout)

--- a/system/xmllib/xslcache.hpp
+++ b/system/xmllib/xslcache.hpp
@@ -34,19 +34,20 @@ enum IO_Type
 interface IXslBuffer : public IInterface
 {
 public:
-    virtual void compile(bool recompile) = 0;
+    virtual void compile() = 0;
     virtual bool isCompiled() const = 0;
     virtual IO_Type getType() = 0;
     virtual const char* getFileName() = 0;
     virtual char* getBuf() = 0;
     virtual int getLen() = 0;
     virtual StringArray& getIncludes() = 0;
+    virtual const char *getCacheId()=0;
 };
 
 interface IXslCache : public IInterface
 {
 public:
-    virtual IXslBuffer* getCompiledXsl(IXslBuffer* xslbuffer, bool recompile) = 0;
+    virtual IXslBuffer* getCompiledXsl(IXslBuffer* xslbuffer, bool replace) = 0;
     virtual void setCacheTimeout(int timeout) = 0;
 };
 

--- a/system/xmllib/xslprocessor.cpp
+++ b/system/xmllib/xslprocessor.cpp
@@ -545,16 +545,24 @@ int CXslTransform::setXmlSource(const char *pszBuffer, unsigned int nSize)
     return theResult;
 }
 
-int CXslTransform::setXslSource(const char *pszFileName, const char *cacheId)
+int CXslTransform::loadXslFromFile(const char *pszFileName, const char *cacheId)
 {
     m_xslsource.setown(new CXslSource(pszFileName, m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL, cacheId));
 
     return 0;
 }
 
-int CXslTransform::setXslSource(const char *pszBuffer, unsigned int nSize, const char *rootpath, const char *cacheId)
+int CXslTransform::setXslSource(const char *pszBuffer, unsigned int nSize, const char *cacheId, const char *rootpath)
 {
-    m_xslsource.setown(new CXslSource(pszBuffer, nSize, m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL, rootpath, cacheId));
+    assertex(cacheId && *cacheId);
+    m_xslsource.setown(new CXslSource(pszBuffer, nSize, m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL, cacheId, rootpath));
+
+    return 0;
+}
+
+int CXslTransform::setXslNoCache(const char *pszBuffer, unsigned int nSize, const char *rootpath)
+{
+    m_xslsource.setown(new CXslSource(pszBuffer, nSize, m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL, NULL, rootpath));
 
     return 0;
 }

--- a/system/xmllib/xslprocessor.cpp
+++ b/system/xmllib/xslprocessor.cpp
@@ -326,6 +326,9 @@ CXslTransform::~CXslTransform()
     if(m_sourceResolver != NULL)
         delete m_sourceResolver;
 
+    if (m_xslsource)
+        m_xslsource->clearIncludeHandler();
+
     if(m_ParsedSource)
     {
         m_XalanTransformer.destroyParsedSource(m_ParsedSource);
@@ -349,8 +352,7 @@ int CXslTransform::transform(StringBuffer &target)
 
 
     XalanCompiledStylesheet* pCompiledStylesheet = NULL;
-    const bool bReloadStylesheet = false;
-    pCompiledStylesheet = m_xslsource->getStylesheet(bReloadStylesheet);
+    pCompiledStylesheet = m_xslsource->getStylesheet();
 
     if (!pCompiledStylesheet)
     {
@@ -395,8 +397,7 @@ int CXslTransform::transform()
         throw MakeStringException(2, "[XSLT target file/buffer not set]");
 
     XalanCompiledStylesheet* pCompiledStylesheet = NULL;
-    const bool bReloadStylesheet = false;
-    pCompiledStylesheet = m_xslsource->getStylesheet(bReloadStylesheet);
+    pCompiledStylesheet = m_xslsource->getStylesheet();
 
     if (!pCompiledStylesheet)
     {
@@ -436,8 +437,7 @@ int CXslTransform::transform(ISocket* targetSocket)
         throw MakeStringException(2, "[XSL stylesheet not set]");
 
     XalanCompiledStylesheet* pCompiledStylesheet = NULL;
-    const bool bReloadStylesheet = false;
-    pCompiledStylesheet = m_xslsource->getStylesheet(bReloadStylesheet);
+    pCompiledStylesheet = m_xslsource->getStylesheet();
 
     if (!pCompiledStylesheet)
     {
@@ -545,16 +545,16 @@ int CXslTransform::setXmlSource(const char *pszBuffer, unsigned int nSize)
     return theResult;
 }
 
-int CXslTransform::setXslSource(const char *pszFileName)
+int CXslTransform::setXslSource(const char *pszFileName, const char *cacheId)
 {
-    m_xslsource.setown(new CXslSource(pszFileName, m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL));
+    m_xslsource.setown(new CXslSource(pszFileName, m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL, cacheId));
 
     return 0;
 }
 
-int CXslTransform::setXslSource(const char *pszBuffer, unsigned int nSize, const char *rootpath)
+int CXslTransform::setXslSource(const char *pszBuffer, unsigned int nSize, const char *rootpath, const char *cacheId)
 {
-    m_xslsource.setown(new CXslSource(pszBuffer, nSize, m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL, rootpath));
+    m_xslsource.setown(new CXslSource(pszBuffer, nSize, m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL, rootpath, cacheId));
 
     return 0;
 }

--- a/system/xmllib/xslprocessor.hpp
+++ b/system/xmllib/xslprocessor.hpp
@@ -52,8 +52,8 @@ public:
  
     // setXslSource - specifies the source of the XSLT "script" to use
     //
-    virtual int setXslSource(const char *pszFileName) = 0;
-    virtual int setXslSource(const char *pszBuffer, unsigned int nSize, const char *rootpath=NULL) = 0;
+    virtual int setXslSource(const char *pszFileName, const char *cacheId=NULL) = 0;
+    virtual int setXslSource(const char *pszBuffer, unsigned int nSize, const char *rootpath=NULL, const char *cacheId=NULL) = 0;
  
     // setResultTarget - Specifies where the post transform data is to be placed
     // must be set before calling parameterless variety of transform

--- a/system/xmllib/xslprocessor.hpp
+++ b/system/xmllib/xslprocessor.hpp
@@ -52,9 +52,10 @@ public:
  
     // setXslSource - specifies the source of the XSLT "script" to use
     //
-    virtual int setXslSource(const char *pszFileName, const char *cacheId=NULL) = 0;
-    virtual int setXslSource(const char *pszBuffer, unsigned int nSize, const char *rootpath=NULL, const char *cacheId=NULL) = 0;
- 
+    virtual int setXslSource(const char *pszBuffer, unsigned int nSize, const char *cacheId, const char *rootpath) = 0;
+    virtual int setXslNoCache(const char *pszBuffer, unsigned int nSize, const char *rootpath=NULL) = 0;
+    virtual int loadXslFromFile(const char *pszFileName, const char *altCacheId=NULL) = 0;
+
     // setResultTarget - Specifies where the post transform data is to be placed
     // must be set before calling parameterless variety of transform
     virtual int setResultTarget(const char *pszFileName) = 0; 

--- a/system/xmllib/xslprocessor.ipp
+++ b/system/xmllib/xslprocessor.ipp
@@ -175,7 +175,7 @@ public:
         m_filename.set(fname);
         m_sourcetype = IO_TYPE_FILE;
         m_CompiledStylesheet = NULL;
-        m_cacheId.set(cacheId);
+        m_cacheId.set(cacheId ? cacheId : fname);
 
         if(handler)
             setIncludeHandler(handler);

--- a/system/xmllib/xslprocessor.ipp
+++ b/system/xmllib/xslprocessor.ipp
@@ -181,7 +181,7 @@ public:
             setIncludeHandler(handler);
     }
 
-    CXslSource(const char* buf, int len, IIncludeHandler* handler, const char *rootpath = NULL, const char *cacheId=NULL) : m_XalanTransformer()
+    CXslSource(const char* buf, int len, IIncludeHandler* handler, const char *cacheId, const char *rootpath = NULL) : m_XalanTransformer()
     {
         m_xsltext.append(len, buf);
         m_sourcetype = IO_TYPE_BUFFER;
@@ -509,8 +509,9 @@ public:
 
     virtual int setXmlSource(const char *pszFileName);
     virtual int setXmlSource(const char *pszBuffer, unsigned int nSize);
-    virtual int setXslSource(const char *pszFileName, const char *cacheId=NULL);
-    virtual int setXslSource(const char *pszBuffer, unsigned int nSize, const char *rootpath, const char *cacheId=NULL);
+    virtual int loadXslFromFile(const char *pszFileName, const char *altCacheId=NULL);
+    virtual int setXslSource(const char *pszBuffer, unsigned int nSize, const char *cacheId, const char *rootpath);
+    virtual int setXslNoCache(const char *pszBuffer, unsigned int nSize, const char *rootpath);
     virtual int setResultTarget(char *pszBuffer, unsigned int nSize);
     virtual int setResultTarget(const char *pszFileName);
     virtual int closeResultTarget();

--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -5453,7 +5453,7 @@ void EspServInfo::write_esp_binding_ipp()
             "\t\t\tif (!strnicmp(xslFile, \"/esp/xslt/\", 10))\n"
             "\t\t\t\tif (!checkFileExists(xslpath.append(getCFD()).append(\"smc_xslt/\").append(xslFile+10).str()) && !checkFileExists(xslpath.append(getCFD()).append(\"xslt/\").append(xslFile+10).str()))\n"
             "\t\t\t\t\treturn;\n"
-            "\t\t\txform->setXslSource((xslpath.length()) ? xslpath.str() : xslFile);\n"
+            "\t\t\txform->loadXslFromFile((xslpath.length()) ? xslpath.str() : xslFile);\n"
             "\t\t\txform->setXmlSource(xml, strlen(xml)+1);\n"
             "\t\t\tif (params) xform->copyParameters(params);\n"
             "\t\t\txform->transform(output.clear());\n"


### PR DESCRIPTION
Provide a customizable way of uniquely identifying compiled xslt
cache entries.  In the case of Workunit resource based XSLT stylesheets
use a combination of the view name and the workunit dll name.  Using the
dllname rather then the wuid allows cloned workunits to share the same
cache entry.

Remove the unused and complicated xsl cache entry "recompile" option which
required the object providing the Include handler to remain instantiated
while the entry was in cache.

Also, fix XMLLIB memory leaks when calling XSLT include handlers when includes
were not file based.  Loading includes from workunit resources was
the only place currently exercising this code path.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
