### PR TITLE
Fix #87 Added creation of Full Name with useradd and usermod.

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -763,7 +763,7 @@ add_user(){
         then
             printf "Adding %s to group %s ..." "${USER}" "${GROUP}"
             CURRGROUPS=`id -nG ${USER} | tr ' ' ','`
-            usermod -G ${CURRGROUPS},${GROUP} ${USER}
+            usermod -G ${CURRGROUPS},${GROUP} -c "${USER} Runtime User" ${USER}
             if [ $? -eq 0 ];
             then
                 log_success_msg
@@ -773,7 +773,7 @@ add_user(){
             fi
         else
             printf "Adding %s to system ..." "${USER}"
-            useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} ${USER}
+            useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
             passwd -d ${USER} 1>/dev/null 2>&1
             if [ $? -eq 0 ];
             then
@@ -797,7 +797,7 @@ add_user(){
         then
             printf "Adding %s to group %s ..." "${USER}" "${GROUP}"
             CURRGROUPS=`id -nG ${USER} | tr ' ' ','`
-            usermod -G ${CURRGROUPS},${GROUP} ${USER}
+            usermod -G ${CURRGROUPS},${GROUP} -c "${USER} Runtime User" ${USER}
             if [ $? -eq 0 ];
             then
                 log_success_msg
@@ -807,7 +807,7 @@ add_user(){
             fi
         else
             printf "Adding %s to system ..." "${USER}"
-            useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} ${USER}
+            useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
             passwd -d ${USER} 1>/dev/null 2>&1
             if [ $? -eq 0 ];
             then


### PR DESCRIPTION
Previously a Full Name was not being created for the hpcc user.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
