### PR TITLE
Fix #88 Changed sudoers prefix to HPCC from OSS.

### DIFF
--- a/initfiles/sbin/add_conf_settings.sh.in
+++ b/initfiles/sbin/add_conf_settings.sh.in
@@ -27,10 +27,10 @@ PREFIX_PATH=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^path 
 
 source $PREFIX_PATH/sbin/alter_confs.sh
 
-alter_file /etc/sudoers "^Cmnd_Alias OSS_|^${USER_NAME} ALL =|^Defaults\:${USER_NAME} !requiretty" <<-%EOF
-Cmnd_Alias OSS_DAFILESRV = /etc/init.d/dafilesrv
-Cmnd_Alias OSS_HPCCINIT = /etc/init.d/hpcc-init
-${USER_NAME} ALL = NOPASSWD: OSS_DAFILESRV, OSS_HPCCINIT
+alter_file /etc/sudoers "^Cmnd_Alias HPCC_|^${USER_NAME} ALL =|^Defaults\:${USER_NAME} !requiretty" <<-%EOF
+Cmnd_Alias HPCC_DAFILESRV = /etc/init.d/dafilesrv
+Cmnd_Alias HPCC_HPCCINIT = /etc/init.d/hpcc-init
+${USER_NAME} ALL = NOPASSWD: HPCC_DAFILESRV, HPCC_HPCCINIT
 Defaults:${USER_NAME} !requiretty
 %EOF
 

--- a/initfiles/sbin/rm_conf_settings.sh.in
+++ b/initfiles/sbin/rm_conf_settings.sh.in
@@ -27,7 +27,7 @@ PREFIX_PATH=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^path=
 
 source $PREFIX_PATH/sbin/alter_confs.sh
 
-alter_file /etc/sudoers "^Cmnd_Alias OSS_|^${USER_NAME} ALL =" < /dev/null
+alter_file /etc/sudoers "^Cmnd_Alias HPCC_|^${USER_NAME} ALL =" < /dev/null
 
 alter_file /etc/security/limits.conf "^${USER_NAME}" < /dev/null
 


### PR DESCRIPTION
The sudoers prefix for hpcc-init and dafilesrv were set to OSS instead of HPCC.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
