### PR TITLE
Fix whitespace mismatch in sizeof.ecl test

### DIFF
--- a/testing/ecl/key/sizeof.xml
+++ b/testing/ecl/key/sizeof.xml
@@ -1,11 +1,11 @@
 <Dataset name='Result 1'>
- <Row><Result_1>------ SIZEOF BOOLEAN           </Result_1></Row>
+ <Row><Result_1>------ SIZEOF BOOLEAN</Result_1></Row>
 </Dataset>
 <Dataset name='Result 2'>
  <Row><Result_2>1</Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><Result_3>------ SIZEOF INTEGERn      </Result_3></Row>
+ <Row><Result_3>------ SIZEOF INTEGERn</Result_3></Row>
 </Dataset>
 <Dataset name='Result 4'>
  <Row><Result_4>8</Result_4></Row>
@@ -35,7 +35,7 @@
  <Row><Result_12>8</Result_12></Row>
 </Dataset>
 <Dataset name='Result 13'>
- <Row><Result_13>------ SIZEOF UNSIGNED INTEGERn    </Result_13></Row>
+ <Row><Result_13>------ SIZEOF UNSIGNED INTEGERn</Result_13></Row>
 </Dataset>
 <Dataset name='Result 14'>
  <Row><Result_14>8</Result_14></Row>
@@ -65,7 +65,7 @@
  <Row><Result_22>8</Result_22></Row>
 </Dataset>
 <Dataset name='Result 23'>
- <Row><Result_23>------ SIZEOF REALn            </Result_23></Row>
+ <Row><Result_23>------ SIZEOF REALn</Result_23></Row>
 </Dataset>
 <Dataset name='Result 24'>
  <Row><Result_24>8</Result_24></Row>
@@ -77,7 +77,7 @@
  <Row><Result_26>8</Result_26></Row>
 </Dataset>
 <Dataset name='Result 27'>
- <Row><Result_27>------ SIZEOF DECIMAL 1..9     </Result_27></Row>
+ <Row><Result_27>------ SIZEOF DECIMAL 1..9</Result_27></Row>
 </Dataset>
 <Dataset name='Result 28'>
  <Row><Result_28>1</Result_28></Row>
@@ -107,7 +107,7 @@
  <Row><Result_36>5</Result_36></Row>
 </Dataset>
 <Dataset name='Result 37'>
- <Row><Result_37>------ SIZEOF QSTRING Variable length, 1, &amp; 120    </Result_37></Row>
+ <Row><Result_37>------ SIZEOF QSTRING Variable length, 1, &amp; 120</Result_37></Row>
 </Dataset>
 <Dataset name='Result 38'>
  <Row><Result_38>1</Result_38></Row>
@@ -131,7 +131,7 @@
  <Row><Result_44>0</Result_44></Row>
 </Dataset>
 <Dataset name='Result 45'>
- <Row><Result_45>------ SIZEOF DATASET          </Result_45></Row>
+ <Row><Result_45>------ SIZEOF DATASET</Result_45></Row>
 </Dataset>
 <Dataset name='Result 46'>
  <Row><Result_46>2</Result_46></Row>

--- a/testing/ecl/sizeof.ecl
+++ b/testing/ecl/sizeof.ecl
@@ -18,7 +18,7 @@
 
 BOOLEAN b   := TRUE;
 
-output('------ SIZEOF BOOLEAN           ');
+output('------ SIZEOF BOOLEAN');
 output(SIZEOF(b));
 
 INTEGER  i  := 0;
@@ -31,7 +31,7 @@ INTEGER6 i6 := 0;
 INTEGER7 i7 := 0;
 INTEGER8 i8 := 0;
 
-output('------ SIZEOF INTEGERn      ');
+output('------ SIZEOF INTEGERn');
 output(SIZEOF(i));
 output(SIZEOF(i1));
 output(SIZEOF(i2));
@@ -52,7 +52,7 @@ UNSIGNED INTEGER6  ui6  := 0;
 UNSIGNED INTEGER7  ui7  := 0;
 UNSIGNED INTEGER8  ui8  := 0;
 
-output('------ SIZEOF UNSIGNED INTEGERn ');
+output('------ SIZEOF UNSIGNED INTEGERn');
 output(SIZEOF(ui));
 output(SIZEOF(ui1));
 output(SIZEOF(ui2));
@@ -67,7 +67,7 @@ REAL  r  := 0.0;
 REAL4 r4     := 0.0;
 REAL8 r8     := 0.0;
 
-output('------ SIZEOF REALn         ');
+output('------ SIZEOF REALn');
 output(SIZEOF(r));
 output(SIZEOF(r4));
 output(SIZEOF(r8));
@@ -82,7 +82,7 @@ DECIMAL7_2 d7_2 := 0;
 DECIMAL8_2 d8_2 := 0;
 DECIMAL9_2 d9_2 := 0;
 
-output('------ SIZEOF DECIMAL 1..9      ');
+output('------ SIZEOF DECIMAL 1..9');
 
 output(SIZEOF(d1));
 output(SIZEOF(d2_2));
@@ -94,7 +94,7 @@ output(SIZEOF(d7_2));
 output(SIZEOF(d8_2));
 output(SIZEOF(d9_2));
 
-output('------ SIZEOF QSTRING Variable length, 1, & 120 ');
+output('------ SIZEOF QSTRING Variable length, 1, & 120');
 
 QSTRING1    qs1 := 'S';
 QSTRING120  qs120   := 'Seisint';
@@ -109,7 +109,7 @@ output(LENGTH('abc' + '123'));
 output(SIZEOF(''));
 output(LENGTH(''));
 
-output('------ SIZEOF DATASET          ');
+output('------ SIZEOF DATASET');
 
 SomeRecord  := RECORD
     STRING1 Value1;


### PR DESCRIPTION
Remove spurious trailing spaces in test output tracing, which didn't match in test vs key

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
