### PR TITLE
Fix #245 Enable running of queries to roxie via eclplus

### DIFF
--- a/common/roxiemanager/roxiequerymanager.cpp
+++ b/common/roxiemanager/roxiequerymanager.cpp
@@ -203,12 +203,20 @@ public:
         return true;
     }
 
-    bool deployWorkunit(SCMStringBuffer &wuid,  SCMStringBuffer &roxieQueryName, IRoxieQueryProcessingInfo &processingInfo, const char *userId, WUQueryActivationOptions activateOption, bool allowNewRoxieOnDemandQuery, const char *querySetName, bool notifyRoxie, SCMStringBuffer &status, SCMStringBuffer &roxieDeployStatus)
+    bool deployWorkunit(SCMStringBuffer &wuid,  SCMStringBuffer &roxieQueryName, IRoxieQueryProcessingInfo &processingInfo, const char *userId, WUQueryActivationOptions activateOption, const char *querySetName, bool notifyRoxie, SCMStringBuffer &status, SCMStringBuffer &roxieDeployStatus)
     {
         if (!wuid.length())
             throw MakeStringException(ROXIEMANAGER_MISSING_ID, "Missing workunit id");
 
         Owned<IConstWorkUnit> workunit = getWorkUnit(wuid.str());
+        return publishWorkunit(workunit, roxieQueryName, processingInfo, userId, activateOption, querySetName, notifyRoxie, status, roxieDeployStatus);
+    }
+
+    bool publishWorkunit(IConstWorkUnit *workunit,  SCMStringBuffer &roxieQueryName, IRoxieQueryProcessingInfo &processingInfo, const char *userId, WUQueryActivationOptions activateOption, const char *querySetName, bool notifyRoxie, SCMStringBuffer &status, SCMStringBuffer &roxieDeployStatus)
+    {
+        if (!workunit)
+            throw MakeStringException(ROXIEMANAGER_MISSING_ID, "Missing workunit id");
+
         if (!roxieQueryName.length()) {
             SCMStringBuffer jobName;
             roxieQueryName.set(workunit->getJobName(jobName).str());

--- a/esp/scm/roxiemanagerscm.ecm
+++ b/esp/scm/roxiemanagerscm.ecm
@@ -135,7 +135,8 @@ SCMinterface IRoxieQueryManager(IInterface)
     bool deployQuery(SCMStringBuffer &wuid, SCMStringBuffer &roxieQueryName, IRoxieQueryCompileInfo &compileInfo,
                      IRoxieQueryProcessingInfo &processingInfo, const char *userId, WUQueryActivationOptions activateOption, bool allowNewRoxieOnDemandQuery, const char *targetClusterName, const char *querySetName, bool notifyRoxie, SCMStringBuffer &status, SCMStringBuffer &roxieDeployStatus);
 
-    bool deployWorkunit(SCMStringBuffer &wuid,  SCMStringBuffer &roxieQueryName, IRoxieQueryProcessingInfo &processingInfo, const char *userId, WUQueryActivationOptions activateOption, bool allowNewRoxieOnDemandQuery, const char *querySetName, bool notifyRoxie, SCMStringBuffer &status, SCMStringBuffer &roxieDeployStatus);
+    bool deployWorkunit(SCMStringBuffer &wuid,  SCMStringBuffer &roxieQueryName, IRoxieQueryProcessingInfo &processingInfo, const char *userId, WUQueryActivationOptions activateOption, const char *querySetName, bool notifyRoxie, SCMStringBuffer &status, SCMStringBuffer &roxieDeployStatus);
+    bool publishWorkunit(IConstWorkUnit *workunit,  SCMStringBuffer &roxieQueryName, IRoxieQueryProcessingInfo &processingInfo, const char *userId, WUQueryActivationOptions activateOption, const char *querySetName, bool notifyRoxie, SCMStringBuffer &status, SCMStringBuffer &roxieDeployStatus);
     
     bool publishFromQuerySet(SCMStringBuffer &name, SCMStringBuffer &roxieQueryName, IRoxieQueryProcessingInfo &processingInfo, const char *userId, WUQueryActivationOptions activateOption, const char *sourceQuerySetName, const char *targetQuerySetName, const char *sourceDaliIP, const char *queryComment, bool notifyRoxie, SCMStringBuffer &status, SCMStringBuffer &roxieDeployStatus);
     

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -473,6 +473,7 @@ ESPrequest WUSubmitRequest
     int    MaxRunTime;
     [min_ver("1.02")] int BlockTillFinishTimer(0);
     [min_ver("1.19")] bool SyntaxCheck(false);
+    bool NotifyCluster(false);
 };
 
 ESPresponse [exceptions_inline] WUSubmitResponse
@@ -965,7 +966,7 @@ ESPrequest WUDeployWorkunitRequest
     string Wuid;
     string JobName;
     int Activate;
-
+    bool NotifyCluster(false);
 };
 
 ESPresponse [exceptions_inline] WUDeployWorkunitResponse


### PR DESCRIPTION
Roxie queries run through eclplus need to be published to the roxie
and not run through agentexec (which would cause eclplus to hang
since the roxie workunit would never actually run / complete).

Eclplus will now compile a query, publish it to roxie, run it,
have the results stored in dali, and then delete the query from roxie (workunit will remain in dali)

Signed-off-by: Stuart Ort stuart.ort@lexisnexis.com
