### PR TITLE
Fixes #420 Remove quotes from Sentinel filenames

### DIFF
--- a/ecl/eclccserver/run_eclccserver.bat
+++ b/ecl/eclccserver/run_eclccserver.bat
@@ -15,7 +15,7 @@ rem
 rem     You should have received a copy of the GNU Affero General Public License
 rem     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 rem ############################################################################## */
-set SENTINEL="eclccserver.sentinel"
+set SENTINEL=eclccserver.sentinel
 :start
 start /wait eclccserver
 if exist %SENTINEL% (


### PR DESCRIPTION
Double quotes around sentinel filenames in the start/stop.bat files
are being passed on to the Windows CreateFile() api, which fails and
the components do not start.
Removed double quotes to eliminate the problem, and tested to ensure
specification of filespecs (including filespecs with embedded spaces)
works correctly

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
