### PR TITLE
Fix gh-424 Roxie fails to load rest of queryset if any query fails

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -8773,6 +8773,8 @@ void addQueryToQuerySet(IWorkUnit *workunit, const char *querySetName, const cha
     SCMStringBuffer dllName;
     Owned<IConstWUQuery> q = workunit->getQuery();
     q->getQueryDllName(dllName);
+    if (!dllName.length())
+        throw MakeStringException(WUERR_InvalidDll, "Cannot deploy query - no associated dll.");
 
     SCMStringBuffer wuid;
     workunit->getWuid(wuid);

--- a/common/workunit/wuerror.hpp
+++ b/common/workunit/wuerror.hpp
@@ -47,5 +47,6 @@
 #define WUERR_ScheduleLockFailed                5021
 #define WUERR_PackageAlreadyExists              5022
 #define WUERR_MismatchClusterType               5023
+#define WUERR_InvalidDll                        5024
 
 #endif


### PR DESCRIPTION
If any query in a QuerySet fails to load, Roxie would not load the rest of
the QuerySet. The error reporting in such cases could also be improved.

The particular case that was causing trouble was a query with dllname="".
This should be reported better by Roxie and should never have been allowed
to be published by workunit.cpp

Add a try-catch block in Roxie to allow the remainder of the QuerySet to
process if any query or alias fails to load. Add code to workunit.cpp to
detect empty dllname when publishing a query.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
