### PR TITLE
Fix build-break from xslt cache changes

### DIFF
--- a/common/roxiecommlib/CMakeLists.txt
+++ b/common/roxiecommlib/CMakeLists.txt
@@ -42,6 +42,7 @@ include_directories (
          ./../../common/fileview2 
          ./../../system/include 
          ./../../system/security/shared
+         ./../../system/xmllib
          ./../../dali/base 
          ./../../rtl/include 
          ./../../common/dllserver 

--- a/common/roxiemanager/CMakeLists.txt
+++ b/common/roxiemanager/CMakeLists.txt
@@ -56,6 +56,7 @@ include_directories (
          ./../../dali/base 
          ./../../rtl/include 
          ./../../common/dllserver 
+         ./../../system/xmllib
          ./../../esp/clients 
          ./../../esp/platform 
          ./../../esp/bindings 

--- a/esp/bindings/SOAP/Platform/soapmessage.hpp
+++ b/esp/bindings/SOAP/Platform/soapmessage.hpp
@@ -35,7 +35,7 @@
 
 #include <xpp/XmlPullParser.h>
 
-#include "../../../system/xmllib/xslprocessor.hpp"
+#include "xslprocessor.hpp"
 
 
 #define SOAP_OK           0

--- a/esp/bindings/bindutil.hpp
+++ b/esp/bindings/bindutil.hpp
@@ -22,7 +22,7 @@
 #include "jliball.hpp"
 #include "esp.hpp"
 
-#include "../../../system/xmllib/xslprocessor.hpp"
+#include "xslprocessor.hpp"
 
 #ifndef BINDUTIL_EXPORT
 #define BINDUTIL_EXPORT

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -30,7 +30,7 @@
 
 #include "bindutil.hpp"
 
-#include "../../../system/xmllib/xslprocessor.hpp"
+#include "xslprocessor.hpp"
 
 
 #define POST_METHOD "POST"

--- a/esp/clients/wsecl/CMakeLists.txt
+++ b/esp/clients/wsecl/CMakeLists.txt
@@ -34,6 +34,7 @@ set (    SRCS
 
 include_directories ( 
          ./../../../system/include 
+         ./../../../system/xmllib
          ./../../../system/security/shared 
          ./../../../system/security/securesocket 
          ./../../bindings 

--- a/esp/platform/espprotocol.hpp
+++ b/esp/platform/espprotocol.hpp
@@ -24,7 +24,7 @@
 
 //SCM Interfaces
 #include "esp.hpp"
-#include "../../../system/xmllib/xslprocessor.hpp"
+#include "xslprocessor.hpp"
 
 //STL
 #include <algorithm>

--- a/esp/services/ws_config/CMakeLists.txt
+++ b/esp/services/ws_config/CMakeLists.txt
@@ -42,6 +42,7 @@ include_directories (
          ./../../../system/security/securesocket 
          ./../../../system/security/shared 
          ./../../../system/include 
+         ./../../../system/xmllib
          ./../../../system/mp 
          ./../../../common/environment
          ./../../clients 

--- a/esp/services/ws_fs/CMakeLists.txt
+++ b/esp/services/ws_fs/CMakeLists.txt
@@ -51,6 +51,7 @@ include_directories (
          ./../../../system/security/securesocket 
          ./../../../system/security/shared 
          ./../../../system/include 
+         ./../../../system/xmllib
          ./../../clients 
          ./../../../esp/esplib 
          ./../../../dali/base 

--- a/system/xmllib/xslcache.cpp
+++ b/system/xmllib/xslcache.cpp
@@ -243,7 +243,7 @@ public:
             CXslEntry *entry = xslMap.mapToValue(&iter.query());
             if (entry->isExpired(m_cachetimeout))
             {
-                xslMap.removeExact(&iter.query());
+                xslMap.removeExact(& static_cast<MappingStringToIInterface &>(iter.query()));
                 return;
             }
             if (!oldest || entry->createTime < oldTime)
@@ -253,7 +253,7 @@ public:
             }
         }
         if (oldest)
-            xslMap.removeExact(oldest);
+            xslMap.removeExact(static_cast<MappingStringToIInterface *>(oldest));
     }
 
     void setCacheTimeout(int timeout)


### PR DESCRIPTION
xslt cache changes needed a cast to compile correctly. Also they showed up
(on my system at least) a lurking issue where xslprocessor.hpp was being
picked up via the wrong path because of some dodgy #include statements.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
