### PR TITLE
BUG: 86651 Set permissions correctly when doing a SSH deploy via ConfigEn

### DIFF
--- a/deployment/deploy/DeployTask.cpp
+++ b/deployment/deploy/DeployTask.cpp
@@ -661,7 +661,7 @@ public:
              try
              {
                StringBuffer cmd;
-               cmd.clear().appendf("chmod 744 %s", destpath.str());
+               cmd.clear().appendf("chmod -R 744 %s", destpath.str());
                task->execSSHCmd(ip.str(), cmd, outbuf, errbuf);
              }
              catch(IException* e)


### PR DESCRIPTION
BUG: 86651 Set permissions correctly when doing a SSH deploy via ConfigEnv

Set permissions correctly when doing a SSH deploy via ConfigEnv. As copy is
being done recursively, add the -R flag to the chmod command to recursively
set the permissions.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
