### PR TITLE
Fix gh-415 - problems for adding files to existing superfile

### DIFF
--- a/esp/eclwatch/ws_XSLT/addto_superfile.xslt
+++ b/esp/eclwatch/ws_XSLT/addto_superfile.xslt
@@ -171,12 +171,12 @@
       <body class="yui-skin-sam" onload="nof5();onLoad()">
             <h4>Add to Superfile</h4>
                 <form id="form1" method="POST" action="/WsDfu/AddtoSuperfile">
-                    <input type="hidden" name="ExistingFile" value="0"/>
+                    <input type="hidden" id="ExistingFile" name="ExistingFile" value="0"/>
                     <table>
                         <tr>
                             <td>Superfile Name:</td>
                             <td>
-                                <input type="text" id="Superfile" name="Superfile" size="25" onkeyup="validateInput()"/>
+                                <input type="text" id="Superfile" name="Superfile" size="25" onkeyup="validateInput()" oninput="validateInput()" onmouseout="validateInput()"/>
                             </td>
                         </tr>
                         <tr>
@@ -232,7 +232,6 @@
                         <tr>
                             <td colspan="2">
                                 <input type="submit" id="OK" value="OK" class="sbutton" onclick="return preSubmit(this)"/>
-                                <input type="button" class="sbutton" id="Cancel" value="Cancel" onclick="return onCancel()"/>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
Two problems: (1) the "OK" button is not enabled when a user
inputs the superfile name using mouse's copy/patse; (2) the
'Add to an existing superfile' flag is not sent to server for
Firefox and Chrome. To fix problem (1), both oninput attribute
and onmouseout attribute are added for the 'Superfile Name'
input field. The oninput attribute is for FF and Chrome. It
does not work for IE. I tested other attributes, such as
onchange, onpaste, onmouseup, and onmouseout. Only the last
one works. To fix problem (2), the id attribute is added for
the ExistingFile input.

I also removed the Cancel button since its function has been
included inside the "Go Back" button.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
