### PR TITLE
Potential for splitter deadlock or crash

### DIFF
--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -1022,7 +1022,7 @@ protected:
         {
             if (queryCOutput(o).currentChunkNum < lsf)
             {
-                lsf = queryCOutput(o).currentChunkNum ; 
+                lsf = queryCOutput(o).currentChunkNum; 
                 lsfOutput = o;
             }
             if (++o == outputCount)
@@ -1078,8 +1078,11 @@ protected:
 #ifdef TRACE_WRITEAHEAD
             ActPrintLog(activity, "Input %d stopped. Caught up", output);
 #endif
+            queryCOutput(output).currentChunkNum = (unsigned)-1;
+            lowestOutput = getLowest();
         }
-        queryCOutput(output).currentChunkNum = (unsigned)-1;
+        else
+            queryCOutput(output).currentChunkNum = (unsigned)-1;
     }
     void stopAll()
     {


### PR DESCRIPTION
If one of the arms pulling from a splitter was stopped and it wasn't the
first output, two problems could occur:
1) If the splitter was an in-memory type (balanced), the splitter could
deadlock, if the write ahead thread gets too far ahead of remaining readers.
2) If one of the arms gets out of sync with the others (very likely, unless
pulling slowly), then an assert or null dereference will be hit

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
