### PR TITLE
Fix #455 Fully qualify logfile name in eclcc msg

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -497,7 +497,13 @@ ICppCompiler * EclCC::createCompiler(const char * coreName)
 void EclCC::reportCompileErrors(IErrorReceiver *errs, const char * processName)
 {
     StringBuffer failText;
-    failText.appendf("Compile/Link failed for %s (see '%s' for details)",processName,optLogfile.get() ? optLogfile.get() : "log file");
+    StringBuffer absCCLogName;
+    if (optLogfile.get())
+        createUNCFilename(optLogfile.get(), absCCLogName, false);
+    else
+        absCCLogName = "log file";
+
+    failText.appendf("Compile/Link failed for %s (see '%s' for details)",processName,absCCLogName.str());
     errs->reportError(ERR_INTERNALEXCEPTION, failText.toCharArray(), processName, 0, 0, 0);
     try
     {


### PR DESCRIPTION
When presented with the eclcc message "see eclcc.txt for details",
users have not idea where to locate that file, especially when
submitting to a remote cluster.
Modify eclcc to build fully qualified UNC filespec in the form
"see '\172.16.48.132\c$\eclcc\eclcc.log' for details"

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
