### PR TITLE
Pipethrough,REPEAT could deadlock on write failure

### DIFF
--- a/thorlcr/activities/piperead/thprslave.cpp
+++ b/thorlcr/activities/piperead/thprslave.cpp
@@ -294,6 +294,10 @@ public:
         Thread::join();
         return exc.getClear();
     }
+    IException * checkError()
+    {
+        return exc.getClear();
+    }
 
 protected:
     CPipeThroughSlaveActivity &     activity;
@@ -383,6 +387,9 @@ public:
             if (recreate && firstRead)
             {
                 pipeOpened.wait();
+                Owned<IException> wrexc = pipeWriter->checkError();
+                if (wrexc)
+                    throw wrexc.getClear();
                 if (inputExhausted)
                 {
                     eof = true;
@@ -534,6 +541,8 @@ int PipeWriterThread::run()
             e->Release();
         else
             exc.setown(e);
+        if (activity.recreate)
+            activity.pipeOpened.signal();
     }
     return ret;
 }


### PR DESCRIPTION
If an exception occurs when writing to the pipe process in a PIPE,REPEAT
the exception is not picked up by the reading act. and is left hanging
waiting for the next instance of the pipe to run

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
