### PR TITLE
Fixes #423 Allow ConfigMgr to open readonly files without crashing

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -15,7 +15,7 @@
     allowRollup: true,
     onSuccess: function() {
       var invokeWiz = true;
-    
+
       YAHOO.util.Event.onContentReady("envctrls", function() {
         function fnce() {
           var oPushButton3 = new YAHOO.widget.Button("validatebutton", { onclick: { fn: validateEnvironment} });
@@ -29,10 +29,10 @@
 
         versionOperation(fnce, fnce);
       });
-      
+
       top.document.startWait = function(doc) { top.document.body.style.cursor = "wait"; if (doc) doc.body.style.cursor = "wait"; }
       top.document.stopWait = function(doc) { top.document.body.style.cursor = "auto"; if (doc) doc.body.style.cursor = "auto"; }
-        
+
       if (top.window.location.search.length > 0) {
         var filename = top.window.location.search.split(/=/g);
         document.forms['treeForm'].sourcefile.value = decodeURI(filename[1]);
@@ -40,7 +40,11 @@
       }
       document.getElementById('top1').style.display = 'none';
       getWaitDlg().show();
-      var params = "queryType=customType::params=environment,laststarted,lastsaved,defenvfile,username,wizops";
+      var params = "queryType=customType::params=environment,laststarted,defenvfile,username,wizops";
+
+      if (!invokeWiz)
+        params += ",lastsaved";
+
       YAHOO.util.Connect.asyncRequest('POST', '/WsDeploy/GetValue', {
         success: function(o) {
           getWaitDlg().hide();
@@ -77,6 +81,13 @@
               else
                 handleAdvance();
             }
+          }
+          else if (o.responseText.indexOf("<html") === 0) {
+            var temp = o.responseText.split(/td align=\"left\">/g);
+            var temp1 = temp[1].split(/<\/td>/g);
+            alert(temp1[0]);
+            var loc = window.location.href.split(/\?/g);
+            var newwin = top.open(loc[0], "_self");
           }
         },
         failure: function(o) {
@@ -4263,7 +4274,7 @@ function populateSummaryDetails(linkFlag, sumDataTable)
    },
       scope: this
    },
-   getFileName(true, !linkFlag)  + 'PrepareLinkFlag=' + true);
+   getFileName(true, true)  + 'PrepareLinkFlag=' + true);
 }
 
 


### PR DESCRIPTION
Allow ConfigMgr to open readonly files without crashing. If the
file is readonly and user tries to acquire write access, display an
error message that file is readonlt. Also, alert the user if the file
being opened is corrupt (invalid xml etc.).

As a side effect, these changes have also fixed #403

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
Rebased to 3.2-split by RKC
