### PR TITLE
Fix gh-452 - Cannot do multiple selection with shift button

### DIFF
--- a/esp/eclwatch/ws_XSLT/addto_superfile.xslt
+++ b/esp/eclwatch/ws_XSLT/addto_superfile.xslt
@@ -262,7 +262,7 @@
             </xsl:otherwise>
         </xsl:choose>   
         <td>
-        <input type="checkbox" name="names_i{position()}" value="{.}" onclick="return clicked(this)"/>
+        <input type="checkbox" name="names_i{position()}" value="{.}" onclick="return clicked(this, event)"/>
         </td>
         <td align="left">
                 <xsl:value-of select="."/>

--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -695,7 +695,7 @@
         <xsl:if test="FromRoxieCluster=1">
           <input type="hidden" id="{Name}@{ClusterName}"/>
         </xsl:if>
-        <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this)"/>
+        <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this, event)"/>
           <xsl:variable name="popup">return DFUFilePopup('<xsl:value-of select="$info_query"/>', '<xsl:value-of select="Name"/>', '<xsl:value-of select="ClusterName"/>', '<xsl:value-of select="Replicate"/>', '<xsl:value-of select="FromRoxieCluster"/>', '<xsl:value-of select="BrowseData"/>', '<xsl:value-of select="position()"/>')</xsl:variable>
           <xsl:variable name="oncontextmenu">
             <xsl:value-of select="$popup"/>

--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -405,7 +405,7 @@
             </xsl:otherwise>
         </xsl:choose>   
         <td>
-        <input type="checkbox" name="subfiles_i{position()}" value="{.}" onclick="return clicked(this)"/>
+        <input type="checkbox" name="subfiles_i{position()}" value="{.}" onclick="return clicked(this, event)"/>
         </td>
         <xsl:variable name="inf_query"><xsl:value-of select="."/>
         </xsl:variable>

--- a/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
@@ -350,7 +350,7 @@
             </xsl:attribute>
             <td>
                 <xsl:if test="isDirectory=0">
-                    <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this)"/>
+                    <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this, event)"/>
                     <xsl:variable name="popup">return DFUFilePopup('<xsl:value-of select="$info_query"/>', '<xsl:value-of select="Name"/>', '<xsl:value-of select="ClusterName"/>', '<xsl:value-of select="Replicate"/>', '<xsl:value-of select="FromRoxieCluster"/>', '<xsl:value-of select="BrowseData"/>', '<xsl:value-of select="position()"/>')</xsl:variable>
                     <xsl:attribute name="oncontextmenu"><xsl:value-of select="$popup"/></xsl:attribute>
           <img id="mn{position()}" class="menu1" src="/esp/files/img/menu1.png" onclick="{$popup}">&#160;</img>

--- a/esp/eclwatch/ws_XSLT/dfu_superedit.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_superedit.xslt
@@ -154,7 +154,7 @@
             </xsl:otherwise>
         </xsl:choose>   
         <td>
-        <input type="checkbox" name="subfiles_i{position()}" value="{.}" onclick="return clicked(this)"/>
+        <input type="checkbox" name="subfiles_i{position()}" value="{.}" onclick="return clicked(this, event)"/>
         </td>
         <td align="left">
         <xsl:value-of select="."/>

--- a/esp/eclwatch/ws_XSLT/dfu_viewdata.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_viewdata.xslt
@@ -204,7 +204,7 @@
                         return null;
                     }
 
-                    function menuHandler(cmd, skipCheckBoxUpdate)
+                    function menuHandler(cmd, skipCheckBoxUpdate, event)
                     {
                         var index = cmd.substring(5); //skip past "_col_"
                         var table     = document.forms['data'].all['dataset_table'];
@@ -220,7 +220,7 @@
                                 var id = 'ShowColumns_i' + (index - 1); //no checkbox exists for column 1 
                                 var checkbox = document.forms['control'].all[id];                      
                                 checkbox.checked = show;
-                                clicked(checkbox);
+                                clicked(checkbox, event);
                             }
                         }
                     }
@@ -361,13 +361,13 @@
          <xsl:choose>
             <xsl:when test="ColumnSize=1">
                <input type="checkbox" id="ShowColumns_i{$index}" name="ShowColumns_i{$index}" 
-                   value="" onclick="menuHandler('_col_{$index+1}', true);" checked = "0">
+                   value="" onclick="menuHandler('_col_{$index+1}', true, event);" checked = "0">
                  <xsl:value-of select="ColumnLabel"/>
                  </input>
             </xsl:when>
             <xsl:otherwise>
                <input type="checkbox" id="ShowColumns_i{$index}" name="ShowColumns_i{$index}" 
-                   value="" onclick="menuHandler('_col_{$index+1}', true);">
+                   value="" onclick="menuHandler('_col_{$index+1}', true, event);">
                  <xsl:value-of select="ColumnLabel"/>
                  </input>
             </xsl:otherwise>

--- a/esp/eclwatch/ws_XSLT/dfu_workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_workunits.xslt
@@ -389,7 +389,7 @@
                 </xsl:otherwise>
             </xsl:choose>    
             <td>
-                <input type="checkbox" name="wuids_i{position()}" value="{ID}" onclick="return clicked(this)"/>
+                <input type="checkbox" name="wuids_i{position()}" value="{ID}" onclick="return clicked(this, event)"/>
             </td>
             <td>
                 <xsl:if test="isProtected=1">

--- a/esp/eclwatch/ws_XSLT/machines.xslt
+++ b/esp/eclwatch/ws_XSLT/machines.xslt
@@ -309,7 +309,7 @@
             </xsl:variable>
             <td>
                 <xsl:if test="$ShowPreflightInfo">
-                    <input type="checkbox" name="Addresses_i{position()}" value="{Netaddress}|{ConfigNetaddress}:{Type}:{$clusterName}:{OS}:{translate(Directory, ':', '$')}" onclick="return clicked(this)">
+                    <input type="checkbox" name="Addresses_i{position()}" value="{Netaddress}|{ConfigNetaddress}:{Type}:{$clusterName}:{OS}:{translate(Directory, ':', '$')}" onclick="return clicked(this, event)">
                         <xsl:if test="not($SwapNode)">
                             <xsl:attribute name="checked">true</xsl:attribute>
                         </xsl:if>

--- a/esp/eclwatch/ws_XSLT/queryfilelistdone.xslt
+++ b/esp/eclwatch/ws_XSLT/queryfilelistdone.xslt
@@ -189,7 +189,7 @@
         </xsl:otherwise>
       </xsl:choose>
       <td>
-        <input type="checkbox" name="IDs_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this)"/>
+        <input type="checkbox" name="IDs_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this, event)"/>
         <xsl:variable name="popup">
           return QueryFilePopup('<xsl:value-of select="Name"/>', '<xsl:value-of select="ClusterName"/>', '<xsl:value-of select="Directory"/>', '<xsl:value-of select="Description"/>', '<xsl:value-of select="BrowseData"/>', '<xsl:value-of select="position()"/>')
         </xsl:variable>

--- a/esp/eclwatch/ws_XSLT/scheduledwus.xslt
+++ b/esp/eclwatch/ws_XSLT/scheduledwus.xslt
@@ -242,7 +242,7 @@
             </xsl:otherwise>
          </xsl:choose>   
          <td>
-            <input type="checkbox" name="Wuids_i{position()}" value="{Wuid}" onclick="return clicked(this)"/>
+            <input type="checkbox" name="Wuids_i{position()}" value="{Wuid}" onclick="return clicked(this, event)"/>
          </td>
          <td>
             <a href="javascript:go('/WsWorkunits/WUInfo?Wuid={Wuid}')">

--- a/esp/eclwatch/ws_XSLT/services.xslt
+++ b/esp/eclwatch/ws_XSLT/services.xslt
@@ -354,7 +354,7 @@
                     <td width="1%" valign="top">
                         <xsl:if test="$showCheckbox">
                             <input type="checkbox" name="Addresses_i{count(preceding::TpMachine)}" 
-                                value="{Netaddress}|{ConfigNetaddress}:{Type}:{$compName}:{OS}:{translate(Directory, ':', '$')}" onclick="return clicked(this)">
+                                value="{Netaddress}|{ConfigNetaddress}:{Type}:{$compName}:{OS}:{translate(Directory, ':', '$')}" onclick="return clicked(this, event)">
                                 <xsl:if test="$checked">
                                     <xsl:attribute name="checked">true</xsl:attribute>
                                 </xsl:if>

--- a/esp/eclwatch/ws_XSLT/topology.xslt
+++ b/esp/eclwatch/ws_XSLT/topology.xslt
@@ -210,7 +210,7 @@
         <!--we encode name, type, os and path for component - the service uses the name (first token)
         to look up component's address-->
         <input type="checkbox" name="Addresses_i{count(preceding::TpCluster)}" 
-        value="{Name}:{Type}:{Name}:{OS}:{translate(Directory, ':', '$')}:{$type3}MACHINES:{Path}" onclick="return clicked(this)">
+        value="{Name}:{Type}:{Name}:{OS}:{translate(Directory, ':', '$')}:{$type3}MACHINES:{Path}" onclick="return clicked(this, event)">
         </input>
       </td>
       <td width="45" nowrap="true">

--- a/esp/eclwatch/ws_XSLT/tplog.xslt
+++ b/esp/eclwatch/ws_XSLT/tplog.xslt
@@ -119,9 +119,11 @@
               }
             }
 
-            function onEditKeyUp()
+            function onEditKeyUp(e)
             {
-              if (window.event && window.event.keyCode == 13)
+              if (!e)
+                e = window.event;
+              if (e && e.keyCode == 13)
               {
                 onGetLog();
               }
@@ -493,7 +495,7 @@
                     <td><input type="radio" name="FilterRB" value="3" onclick="onRBChanged(3)"/>or last page (page <xsl:value-of select="$totalpages"/>)</td>
                   </tr>
                   <tr>
-                    <td><input type="radio" name="FilterRB" value="4" onclick="onRBChanged(4)"/>or go to page:<input id="PageNumber" size="5" type="text" value="{PageNumber+1}" style="text-align:right;" onKeyUp = "onEditKeyUp()"/> </td>
+                    <td><input type="radio" name="FilterRB" value="4" onclick="onRBChanged(4)"/>or go to page:<input id="PageNumber" size="5" type="text" value="{PageNumber+1}" style="text-align:right;" onKeyUp = "onEditKeyUp(event)"/> </td>
                   </tr>
                 </table>
               </td>
@@ -501,11 +503,11 @@
                 <table>
                   <tr>
                     <td><input type="radio" name="FilterRB" value="1" onclick="onRBChanged(1)"/></td>
-                    <td>or first:<input id="First" size="5" type="text" value="{FirstRows}" style="text-align:right;" onKeyUp = "onEditKeyUp()"/> rows</td>
+                    <td>or first:<input id="First" size="5" type="text" value="{FirstRows}" style="text-align:right;" onKeyUp = "onEditKeyUp(event)"/> rows</td>
                   </tr>
                   <tr>
                     <td><input type="radio" name="FilterRB" value="5" onclick="onRBChanged(5)"/></td>
-                    <td colspan="2">or last:<input id="Last" size="5" type="text" value="{LastRows}" style="text-align:right;" onKeyUp = "onEditKeyUp()"/> rows</td>
+                    <td colspan="2">or last:<input id="Last" size="5" type="text" value="{LastRows}" style="text-align:right;" onKeyUp = "onEditKeyUp(event)"/> rows</td>
                   </tr>
                 </table>
               </td>
@@ -515,23 +517,23 @@
                     <xsl:choose>
                       <xsl:when test="HasDate=1">
                         <td><input type="radio" name="FilterRB" value="6"  onclick="onRBChanged(6)"/>
-                        or date from:<input id="From" size="15" type="text" value="{StartDate}" onKeyUp = "onEditKeyUp()"/></td>
-                        <td colspan="4">to: <input id="To" size="15" type="text" value="{EndDate}" onKeyUp = "onEditKeyUp()"/> (mm/dd/yyyy hh:mm:ss)</td>
+                        or date from:<input id="From" size="15" type="text" value="{StartDate}" onKeyUp = "onEditKeyUp(event)"/></td>
+                        <td colspan="4">to: <input id="To" size="15" type="text" value="{EndDate}" onKeyUp = "onEditKeyUp(event)"/> (mm/dd/yyyy hh:mm:ss)</td>
                       </xsl:when>
                       <xsl:otherwise>
                         <td><input type="radio" name="FilterRB" value="6"  onclick="onRBChanged(6)" disabled="true"/>
-                        or date from:<input id="From" size="15" type="text" value="{StartDate}" onKeyUp = "onEditKeyUp()" disabled="true"/></td>
-                        <td colspan="4">to: <input id="To" size="15" type="text" value="{EndDate}" onKeyUp = "onEditKeyUp()" disabled="true"/> (mm/dd/yyyy hh:mm:ss)</td>
+                        or date from:<input id="From" size="15" type="text" value="{StartDate}" onKeyUp = "onEditKeyUp(event)" disabled="true"/></td>
+                        <td colspan="4">to: <input id="To" size="15" type="text" value="{EndDate}" onKeyUp = "onEditKeyUp(event)" disabled="true"/> (mm/dd/yyyy hh:mm:ss)</td>
                       </xsl:otherwise>
                     </xsl:choose>
                   </tr>
                   <tr>
                     <xsl:choose>
                       <xsl:when test="HasDate=1">
-                        <td><input type="radio" name="FilterRB" value="2" onclick="onRBChanged(2)"/> or last:<input id="Hour" size="5" type="text" value="{LastHours}"  onKeyUp = "onEditKeyUp()" style="text-align:right;"/> hours</td>
+                        <td><input type="radio" name="FilterRB" value="2" onclick="onRBChanged(2)"/> or last:<input id="Hour" size="5" type="text" value="{LastHours}"  onKeyUp = "onEditKeyUp(event)" style="text-align:right;"/> hours</td>
                       </xsl:when>
                       <xsl:otherwise>
-                        <td><input type="radio" name="FilterRB" value="2" onclick="onRBChanged(2)" disabled="true"/> or last:<input id="Hour" size="5" type="text" value="{LastHours}"  onKeyUp = "onEditKeyUp()" style="text-align:right;" disabled="true"/> hours</td>
+                        <td><input type="radio" name="FilterRB" value="2" onclick="onRBChanged(2)" disabled="true"/> or last:<input id="Hour" size="5" type="text" value="{LastHours}"  onKeyUp = "onEditKeyUp(event)" style="text-align:right;" disabled="true"/> hours</td>
                       </xsl:otherwise>
                     </xsl:choose>
                   </tr>

--- a/esp/eclwatch/ws_XSLT/workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/workunits.xslt
@@ -458,7 +458,7 @@
             </xsl:otherwise>
          </xsl:choose>   
          <td>
-            <input type="checkbox" name="Wuids_i{position()}" value="{Wuid}" onclick="clicked(this)"/>
+            <input type="checkbox" name="Wuids_i{position()}" value="{Wuid}" onclick="clicked(this, event)"/>
          </td>
          <td>
             <xsl:if test="Protected=1">

--- a/esp/eclwatch/ws_XSLT/xref_found.xslt
+++ b/esp/eclwatch/ws_XSLT/xref_found.xslt
@@ -116,7 +116,7 @@
                <xsl:attribute name="onmouseleave">this.bgColor = '#F0F0F0'</xsl:attribute>
             </xsl:otherwise>
          </xsl:choose>   
-        <td><input type="checkbox" name="XRefFiles_i{position()}" value="{Partmask}" onclick="clicked(this)"/></td>
+        <td><input type="checkbox" name="XRefFiles_i{position()}" value="{Partmask}" onclick="clicked(this, event)"/></td>
         <td align="left"><xsl:value-of select="Partmask"/> </td>
         <td><xsl:value-of select="Modified"/></td>
         <td><xsl:value-of select="Numparts"/></td>

--- a/esp/eclwatch/ws_XSLT/xref_lost.xslt
+++ b/esp/eclwatch/ws_XSLT/xref_lost.xslt
@@ -116,7 +116,7 @@
                </xsl:otherwise>
             </xsl:choose>   
         <td>
-           <input type="checkbox" name="XRefFiles_i{position()}" value="{Name}" onclick="clicked(this)"/>
+           <input type="checkbox" name="XRefFiles_i{position()}" value="{Name}" onclick="clicked(this, event)"/>
         </td>
         <td align="left"><xsl:value-of select="Name"/> </td>
         <td><xsl:value-of select="Modified"/></td>

--- a/esp/eclwatch/ws_XSLT/xref_orphan.xslt
+++ b/esp/eclwatch/ws_XSLT/xref_orphan.xslt
@@ -123,7 +123,7 @@
                <xsl:attribute name="onmouseleave">this.bgColor = '#F0F0F0'</xsl:attribute>
             </xsl:otherwise>
          </xsl:choose>   
-        <td><input type="checkbox" name="XRefFiles_i{position()}" value="{Partmask}" onclick="clicked(this)"/></td>     
+        <td><input type="checkbox" name="XRefFiles_i{position()}" value="{Partmask}" onclick="clicked(this, event)"/></td>
 
         <td align="left"><xsl:value-of select="Partmask"/> </td>
         <td><xsl:value-of select="Modified"/></td>

--- a/esp/files/scripts/multiselect.js
+++ b/esp/files/scripts/multiselect.js
@@ -96,7 +96,7 @@ function checkSelectAllCheckBoxes(check)
 }
 
 
-function clicked(o) {
+function clicked(o, event) {
    if (singleSelect && o.checked)
    {
       o.checked = false;
@@ -107,8 +107,11 @@ function clicked(o) {
    var cell = o.parentNode;
    var row = cell.parentNode;
    var rowNum = row.rowIndex;
-   
-   if (!singleSelect && window.event && window.event.shiftKey && lastClicked != -1 && lastClicked != rowNum)
+
+   if (!event)
+        event = window.event;
+
+   if (!singleSelect && event && event.shiftKey && lastClicked != -1 && lastClicked != rowNum)
    {
       rc = lastChecked == o.checked;
       if (lastClicked < rowNum)

--- a/esp/services/ws_machine/machines.xslt
+++ b/esp/services/ws_machine/machines.xslt
@@ -384,14 +384,14 @@
          </xsl:choose>   
          <td width="5">
            <!--xsl:if test="string(ComponentName)!='AgentExec'">
-               <input type="checkbox" name="Addresses_i{position()}" value="{Address}|{ConfigAddress}:{ProcessType}:{ComponentName}:{OS}:{translate(ComponentPath, ':', '$')}" onclick="return clicked(this)" checked="true"/>
+               <input type="checkbox" name="Addresses_i{position()}" value="{Address}|{ConfigAddress}:{ProcessType}:{ComponentName}:{OS}:{translate(ComponentPath, ':', '$')}" onclick="return clicked(this, event)" checked="true"/>
             </xsl:if-->
            <xsl:choose>
             <xsl:when test="string(ComponentName)='AgentExec'">
-               <input type="checkbox" name="Addresses_i{position()}" value="{Address}|{ConfigAddress}:EclAgentProcess:eclagent:{OS}:{translate(ComponentPath, ':', '$')}" onclick="return clicked(this)" checked="true"/>
+               <input type="checkbox" name="Addresses_i{position()}" value="{Address}|{ConfigAddress}:EclAgentProcess:eclagent:{OS}:{translate(ComponentPath, ':', '$')}" onclick="return clicked(this, event)" checked="true"/>
             </xsl:when>
             <xsl:otherwise>
-              <input type="checkbox" name="Addresses_i{position()}" value="{Address}|{ConfigAddress}:{ProcessType}:{ComponentName}:{OS}:{translate(ComponentPath, ':', '$')}" onclick="return clicked(this)" checked="true"/>
+              <input type="checkbox" name="Addresses_i{position()}" value="{Address}|{ConfigAddress}:{ProcessType}:{ComponentName}:{OS}:{translate(ComponentPath, ':', '$')}" onclick="return clicked(this, event)" checked="true"/>
             </xsl:otherwise>
            </xsl:choose>
          </td>


### PR DESCRIPTION
The problem happens when trying to select multiple logical files
or workunits on ECLWatch pages using Shift button. The code for
detecting Shift button is in multiselect.js which uses
window.event to detect Shift button. But, FireFox, Chrome, and
many other browsers do not have the window.event. Those browsers
store Shift button event inside 'event' object. This fix checks
'event' object first. If there is no 'event' object, the
window.event will be used, which is for IE.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
