### PR TITLE
bug: #84683 Fixes SEH with very large data values

### DIFF
--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -1641,6 +1641,8 @@ void HqlCppWriter::generateStmtDeclare(IHqlStmt * declare)
             else
                 indent().append("rtlRowsAttr ").append(targetName);
         }
+        else if (typeSize != UNKNOWN_LENGTH)
+            indent().append("rtlFixedSizeDataAttr<").append(typeSize).append("> ").append(targetName);
         else
             indent().append("rtlDataAttr ").append(targetName);
     }

--- a/ecl/regress/bug84683.ecl
+++ b/ecl/regress/bug84683.ecl
@@ -1,0 +1,49 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+// Works:
+
+// le := {DATA val {MAXLENGTH(99999)}};
+// DATA99999 arraye  := x'00';
+// dse := DATASET([{arraye}], le);
+
+// datadse := DATASET('~temp::dataarrayein', le, THOR);
+// DATA99999 arraye1  := datadse[1].val;
+
+// dse1 := DATASET([{arraye1}], le);
+
+
+// SEQUENTIAL(output(dse, , '~temp::dataarrayein', OVERWRITE)
+// , output(dse1, , '~temp::dataarraye1', OVERWRITE)
+// );
+
+// Throws a segfault:
+
+le := {DATA val {MAXLENGTH(100000)}};
+DATA100000 arraye  := x'00';
+dse := DATASET([{arraye}], le);
+
+datadse := DATASET('~temp::dataarrayein', le, THOR);
+DATA100000 arraye1  := datadse[1].val;
+
+dse1 := DATASET([{arraye1}], le);
+
+SEQUENTIAL(
+output(dse, , '~temp::dataarrayein', OVERWRITE)
+, output(dse1, , '~temp::dataarraye1', OVERWRITE)
+);

--- a/ecl/regress/bug84683a.ecl
+++ b/ecl/regress/bug84683a.ecl
@@ -1,0 +1,23 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+DATA arraye  := x'00' : independent;
+
+dse1 := DATASET([{(data100000)arraye}], { data100000 x });
+
+output(dse1);

--- a/rtl/eclrtl/eclrtl_imp.hpp
+++ b/rtl/eclrtl/eclrtl_imp.hpp
@@ -61,6 +61,13 @@ protected:
     void * ptr;
 };
 
+template <size32_t SIZE>
+class rtlFixedSizeDataAttr : public rtlDataAttr
+{
+public:
+    inline rtlFixedSizeDataAttr() : rtlDataAttr(SIZE) {}
+};
+
 class ECLRTL_API rtlRowBuilder : public rtlDataAttr
 {
 public:


### PR DESCRIPTION
If a _fixed length_ string or data value was larger than 100k the
temporary was created in a different way.  Unfortunately the memory
was never allocated which caused the program to crash.
Many instances of large fields would work as expected.

Uses a template class to avoid problems passing parameters to
constructors for class members.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
