### PR TITLE
gh-478 - CLinuxDirectoryIterator not threadsafe

### DIFF
--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -3364,10 +3364,11 @@ public:
     bool next()
     {
         loop {
+            struct dirent dirEntry;
             struct dirent *entry;
             loop {
                 gotst = false;
-                entry = readdir(handle);  // don't need _r here 
+                readdir_r(handle, &dirEntry, &entry);
                 // need better checking here?
                 if (!entry)
                     break;


### PR DESCRIPTION
CLinuxDirectoryIterator is using the non-threadsafe function readdir rather
than the threadsafe version readdir_r. This appears to be causing segfaults
in readdir64 when more than one thread does a directory lookup at the same
time.

Recent changes to xref mean that this is much more likely to occur in
dafilesrv than it was previously.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
