### PR TITLE
gh-478 Non-threadsafe directory scanning

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -1151,7 +1151,9 @@ public:
             processes.item(i1).active = false;
         DIR *dir = opendir("/proc");
         loop {
-            struct dirent *ent = readdir(dir);
+            struct dirent *ent;
+            struct dirent entryMem;
+            readdir_r(dir, &entrymem, &ent);
             if (!ent)
                 break;
             if ((ent->d_name[0]>='0')&&(ent->d_name[0]<='9')) {


### PR DESCRIPTION
In addition to the issue in CLinuxDirectoryIterator, there was also a call to
readdir in jdebug.cpp. It's unlikely to cause any issues in practice but
should be fixed.

Change jdebug.cpp to use readdir_r instead of readdir.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
