### PR TITLE
Piperead was prevented from running in child graph

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1007,6 +1007,7 @@ bool isGlobalActivity(CGraphElementBase &container)
         case TAKchildif:
         case TAKcase:
         case TAKparse:
+        case TAKpiperead:
         case TAKxmlparse:
         case TAKjoinlight:
         case TAKselfjoinlight:


### PR DESCRIPTION
Piperead was unintionally marked as global act, which prevented it's
execution within child graphs

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
