### PR TITLE
Fix inconsistent hash for debug library interface

### DIFF
--- a/ecl/hqlcpp/hqllib.cpp
+++ b/ecl/hqlcpp/hqllib.cpp
@@ -112,7 +112,7 @@ unsigned HqlCppLibrary::getHash(const HqlExprArray & values, unsigned crc) const
         crc = hashnc((const byte *)name, strlen(name), crc);
 
         ITypeInfo * type = cur.queryType();
-        type_t tc = type->getTypeCode();
+        byte tc = type->getTypeCode();
         switch (tc)
         {
         case type_record:


### PR DESCRIPTION
The hash which is used as the signiture for the library definitions,
and used to work out whether libraries are compatible was
inadvertantly dependent on release/debug since type_t has different
definitions for each.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
