### PR TITLE
Refactor remote modules

### DIFF
--- a/common/fileview2/fvtransform.cpp
+++ b/common/fileview2/fvtransform.cpp
@@ -287,7 +287,8 @@ void ViewTransformerRegistry::addPlugins(const char * name)
     ThrowingErrorReceiver errors;
     dataServer.setown(createSourceFileEclRepository(&errors, name, NULL, NULL, 0));
     HqlScopeArray scopes;
-    HqlLookupContext ctx(NULL, &errors, NULL, dataServer);
+    HqlParseContext parseCtx(dataServer, NULL);
+    HqlLookupContext ctx(parseCtx, &errors);
     dataServer->getRootScopes(scopes, ctx);
     ForEachItemIn(i, scopes)
     {

--- a/ecl/hql/hqlesp.cpp
+++ b/ecl/hql/hqlesp.cpp
@@ -365,7 +365,7 @@ bool retrieveWebServicesInfo(IWorkUnit *workunit, HqlLookupContext & ctx)
     }
 
     //Names are currently stored case insensitively, we want the case sensitive variant.
-    OwnedHqlExpr s1 = ctx.eclRepository->lookupRootSymbol(createIdentifierAtom(moduleName.str()), LSFpublic, ctx);
+    OwnedHqlExpr s1 = ctx.queryRepository()->lookupRootSymbol(createIdentifierAtom(moduleName.str()), LSFpublic, ctx);
     if (s1 && s1->queryScope())
     {
         const char *caseSensitiveModuleName = s1->queryScope()->queryFullName();

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -898,35 +898,13 @@ public:
     virtual void deserialize(MemoryBuffer &) { UNIMPLEMENTED; }
 };
 
-class HQL_API CHqlObservedScope : public CHqlScope, implements IHqlRemoteScope
-{
-protected:
-    CriticalSection generalCS;
-    ICopyArrayOf<IHqlRemoteScopeObserver> observedItems;
-
-public:
-    CHqlObservedScope(node_operator _op, _ATOM _name, const char * _fullName) : CHqlScope(_op, _name, _fullName) {}
-    ~CHqlObservedScope();
-
-    IMPLEMENT_IINTERFACE_USING(CHqlScope)
-
-    virtual IHqlScope * queryScope()        { return this; }    // remove ambiguous call
-
-    virtual void invalidateParsed();
-
-    virtual void addObserver(IHqlRemoteScopeObserver & item) { observedItems.append(item); }
-    virtual void removeObserver(IHqlRemoteScopeObserver & item) { observedItems.zap(item); }
-
-protected:
-    void cleanupForwardReferences();
-};
-
-class HQL_API CHqlRemoteScope : public CHqlObservedScope
+class HQL_API CHqlRemoteScope : public CHqlScope, implements IHqlRemoteScope
 {
 protected:
     IEclRepository * ownerRepository;
     IProperties* props;
     Owned<IHqlScope> resolved;
+    CriticalSection generalCS;
     bool loadedAllSymbols;
 
 protected:
@@ -940,6 +918,9 @@ protected:
 public:
     CHqlRemoteScope(_ATOM _name, const char * _fullName, IEclRepository *_repository, IProperties* _props, IFileContents * _text, bool _lazy);
     ~CHqlRemoteScope();
+    IMPLEMENT_IINTERFACE_USING(CHqlScope)
+
+    virtual IHqlScope * queryScope()        { return this; }    // remove ambiguous call
 
 //interface IHqlExpression
     virtual IHqlExpression *clone(HqlExprArray &newkids);
@@ -1293,8 +1274,7 @@ class CHqlCachedBoundFunction : public CHqlExpression
 {
     friend class CHqlNamedSymbol;
 public:
-    CHqlCachedBoundFunction(IHqlExpression *func);
-    CHqlCachedBoundFunction(IHqlExpression *func, HqlExprArray &args);
+    CHqlCachedBoundFunction(IHqlExpression * func, bool _forceOutOfLineExpansion);
 
 public:
     LinkedHqlExpr bound;

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -350,25 +350,15 @@ typedef CIArrayOf<HqlExprArrayItem> HqlExprArrayArray;
 class HqlGramCtx : public CInterface
 {
 public:
-    HqlGramCtx() { lookupCtx = NULL; }
-    ~HqlGramCtx() { delete lookupCtx; }
+    HqlGramCtx(HqlLookupContext & _lookupCtx) : lookupCtx(_lookupCtx) {}
     bool hasAnyActiveParameters();
-    void cleanup()
-    {
-        defineScopes.kill();
-        defaultScopes.kill();
-        globalScope.clear();
-        imports.kill();
-        delete lookupCtx; 
-        lookupCtx = NULL;
-    }
 public:
     CIArrayOf<ActiveScopeInfo> defineScopes;
     IEclRepository *dataServer;
     HqlScopeArray defaultScopes;
     Owned<IHqlScope> globalScope;
     Linked<ISourcePath> sourcePath;
-    HqlLookupContext * lookupCtx;
+    HqlLookupContext lookupCtx;
     HqlExprArray imports;
 };
 

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -92,7 +92,7 @@ public:
        m_startLine(startLine), m_startCol(startCol) {}
     
     virtual IXmlScope* queryXmlScope()  { return m_xmlScope; }
-    virtual IEclRepository* queryDataServer()  { return m_lookupContext.eclRepository; }
+    virtual IEclRepository* queryDataServer()  { return m_lookupContext.queryRepository(); }
     
     // convenient functions
     virtual bool isInModule(const char* moduleName, const char* attrName) { return ::isInModule(m_lookupContext, moduleName,attrName); }
@@ -1314,7 +1314,7 @@ void HqlLex::doInModule(YYSTYPE & returnToken)
 
 static bool isInModule(HqlLookupContext & ctx, const char* moduleName, const char* attrName)
 {
-    if (!ctx.eclRepository)
+    if (!ctx.queryRepository())
         return false;
 
     try
@@ -1326,7 +1326,7 @@ static bool isInModule(HqlLookupContext & ctx, const char* moduleName, const cha
         const char* pAttr = attrName;
         while(*pAttr==' ') pAttr++;
 
-        OwnedHqlExpr match = ctx.eclRepository->lookupRootSymbol(createIdentifierAtom(pModule), LSFpublic, ctx);
+        OwnedHqlExpr match = ctx.queryRepository()->lookupRootSymbol(createIdentifierAtom(pModule), LSFpublic, ctx);
         IHqlScope * scope = match ? match->queryScope() : NULL;
         if (scope)
         {
@@ -1705,7 +1705,7 @@ IHqlExpression *HqlLex::parseECL(StringBuffer &curParam, IXmlScope *xmlScope, in
     Owned<IHqlScope> scope = new CHqlMultiParentScope(sharedAtom,yyParser->queryPrimaryScope(false),yyParser->queryPrimaryScope(true),yyParser->parseScope.get(),NULL); 
 //  scope->defineSymbol(yyParser->globalScope->queryName(), NULL, LINK(queryExpression(yyParser->globalScope)), false, false, ob_module);
 
-    HqlGramCtx parentContext;
+    HqlGramCtx parentContext(yyParser->lookupCtx);
     yyParser->saveContext(parentContext, false);
     Owned<IFileContents> contents = createFileContentsFromText(curParam, querySourcePath());
     HqlGram parser(parentContext, scope, contents, xmlScope); 

--- a/ecl/hql/hqlplugininfo.cpp
+++ b/ecl/hql/hqlplugininfo.cpp
@@ -39,7 +39,8 @@ IEclRepository * loadPlugins(const char * pluginPath, const char * libraryPath, 
 
 IPropertyTree * createPluginPropertyTree(IEclRepository * plugins, bool includeModuleText)
 {
-    HqlLookupContext ctx(NULL, NULL, NULL, plugins);
+    HqlParseContext parseCtx(plugins, NULL);
+    HqlLookupContext ctx(parseCtx, NULL);
     HqlScopeArray scopes;
     plugins->getRootScopes(scopes, ctx);
 
@@ -100,7 +101,8 @@ IPropertyTree * getPlugin(IPropertyTree * p, IEclRepository * plugins, const cha
 
     if(load && !plugin->getPropInt("@loaded",0))
     {
-        HqlLookupContext GHMOREctx(NULL, NULL,  NULL, plugins);
+        HqlParseContext parseCtx(plugins, NULL);
+        HqlLookupContext GHMOREctx(parseCtx, NULL);
         Owned<IHqlScope> resolved = getResolveDottedScope(modname, LSFpublic, GHMOREctx);
         if (resolved)
             exportSymbols(plugin, resolved, GHMOREctx);

--- a/ecl/hql/hqlremote.hpp
+++ b/ecl/hql/hqlremote.hpp
@@ -49,7 +49,7 @@ public:
 
 
 extern HQL_API IXmlEclRepository * createReplayRepository(IPropertyTree * xml);
-extern "C" HQL_API IEclRepository * attachLocalServer(IEclUser * user, IXmlEclRepository & repository, const char* cluster, const char * snapshot, bool sandbox4snapshot);
+extern "C" HQL_API IEclRepository * attachLocalServer(IEclUser * user, IXmlEclRepository & repository, const char * snapshot, bool sandbox4snapshot);
 extern "C" HQL_API IEclRepository * attachLoggingServer(IEclUser * user, IXmlEclRepository & repository, IWorkUnit* workunit, const char * snapshot, bool sandbox4snapshot);
 extern "C" HQL_API IEclRepository * createXmlDataServer(IPropertyTree * _xml, IEclRepository * defaultDataServer);
 

--- a/ecl/hql/hqlrepository.cpp
+++ b/ecl/hql/hqlrepository.cpp
@@ -76,7 +76,7 @@ IHqlExpression * getResolveAttributeFullPath(const char * attrname, unsigned loo
         }
         else
         {
-            resolved.setown(ctx.eclRepository->lookupRootSymbol(moduleName, lookupFlags, ctx));
+            resolved.setown(ctx.queryRepository()->lookupRootSymbol(moduleName, lookupFlags, ctx));
         }
 
         if (!resolved || !dot)
@@ -101,17 +101,18 @@ IHqlScope * getResolveDottedScope(const char * modname, unsigned lookupFlags, Hq
 }
 
 
-IHqlScope * createSyntaxCheckScope(IEclRepository & repository, const char * module, const char *attributes)
+IHqlScope * createSyntaxCheckScope(HqlParseContext & parseCtx, const char * module, const char *attributes)
 {
     //MORE: This doesn't currently work on child modules, and the list of attributes is overkill - a single item would be enough.
-    repository.checkCacheValid();
+    parseCtx.queryRepository()->checkCacheValid();
+
     //GHMORE: This whole function should really die.
-    HqlLookupContext GHMOREctx(NULL, NULL,  NULL, &repository);
-    Owned<IHqlScope> parent = getResolveDottedScope(module, LSFimport, GHMOREctx);
+    HqlLookupContext lookupCtx(parseCtx, NULL);
+    Owned<IHqlScope> parent = getResolveDottedScope(module, LSFimport, lookupCtx);
     if (!parent)
         return NULL;
 
-    return new CHqlSyntaxCheckScope(parent, &repository, attributes, true);
+    return new CHqlSyntaxCheckScope(parent, parseCtx.queryRepository(), attributes, true);
 }
 
 //-------------------------------------------------------------------------------------------------------------------
@@ -507,4 +508,3 @@ extern void getImplicitScopes(HqlScopeArray& implicitScopes, IEclRepository * re
             implicitScopes.append(OLINK(scope));
     }
 }
-

--- a/ecl/hql/hqlrepository.hpp
+++ b/ecl/hql/hqlrepository.hpp
@@ -141,11 +141,13 @@ private:
     unsigned traceMask;
 };
 
+class HqlParseContext;
+
 extern HQL_API IEclRepository *createSourceFileEclRepository(IErrorReceiver *err, const char * pluginPath, const char * constSourceSearchPath, const char * dynamicSourceSearchPath, unsigned traceMask);
 extern HQL_API IErrorReceiver *createFileErrorReceiver(FILE *f);
 extern HQL_API IHqlScope * getResolveDottedScope(const char * modname, unsigned lookupFlags, HqlLookupContext & ctx);
 extern HQL_API IHqlExpression * getResolveAttributeFullPath(const char * attrname, unsigned lookupFlags, HqlLookupContext & ctx);
-extern HQL_API IHqlScope * createSyntaxCheckScope(IEclRepository & repository, const char * module, const char *attributes);
+extern HQL_API IHqlScope * createSyntaxCheckScope(HqlParseContext & parseCtx, const char * module, const char *attributes);
 extern HQL_API IEclRepository * createCompoundRepositoryF(IEclRepository * repository, ...);
 extern HQL_API void getImplicitScopes(HqlScopeArray & implicitScopes, IEclRepository * repository, IHqlScope * scope, HqlLookupContext & ctx);
 

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -5516,7 +5516,7 @@ void LibraryInputMapper::mapLogicalToReal(HqlExprArray & mapped, IHqlExpression 
         HqlExprArray symbols;
         scope->getSymbols(symbols);
 
-        HqlLookupContext lookupCtx(NULL, NULL, NULL, NULL);
+        HqlDummyLookupContext lookupCtx(NULL);
         ForEachItemIn(i, symbols)
         {
             IHqlExpression & cur = symbols.item(i);


### PR DESCRIPTION
This refactors the way remote scopes are processed in several ways
- Removes the way forward modules hold references to thier containing
  scope.  This removes an unnecessary (and incorrect) dependency.
- Split a parse context and lookup context to ensure the list required
  by the forward change is shared.
- Include whether out of line functions are expanded in the bound
  function cache to prevent mis-matching previous instances (and
  failing to fold)
- Removed legacy unused cluster assoicated with a repository

This is work on the way to better encapsulation and implemention of
modules in abstract source trees.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
