### PR TITLE
Fix regression in remote dir iterator

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -1426,7 +1426,7 @@ public:
         bool ret = true;
         byte b=1;
         StringBuffer tmp;
-        if (first && iter->first() || iter->next()) {
+        if (first ? iter->first() : iter->next()) {
             loop {
                 mb.append(b);
                 bool isdir = iter->isDir();


### PR DESCRIPTION
error in logic was calling first() and next() when first() fails

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
