### PR TITLE
gh-506 Fix incorrect source indentation

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10694,10 +10694,10 @@ protected:
             modifiedTime.getString(timestr);
             if(timestr.length())
                 attrs->setProp("@modified", timestr.str());
-                if(clusterHandler)
-                    clusterHandler->setDescriptorParts(desc, base.str(), attrs);
-                else
-                    desc->setPart(0, queryMyNode(), base.str(), attrs);
+            if(clusterHandler)
+                clusterHandler->setDescriptorParts(desc, base.str(), attrs);
+            else
+                desc->setPart(0, queryMyNode(), base.str(), attrs);
 
             // properties of the logical file
             IPropertyTree & properties = desc->queryProperties();


### PR DESCRIPTION
In ccdserver.cpp, class CRoxieServerDiskWriteActivity::publish(),
fix the following misleading indentation error

```
if(timestr.length())
    attrs->setProp("@modified", timestr.str());
    if(clusterHandler)
        clusterHandler->setDescriptorParts(desc, base.str(), attrs);
    else
        desc->setPart(0, queryMyNode(), base.str(), attrs);
```

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
