### PR TITLE
gh-450 Add support for roxie listening on a queue

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3797,6 +3797,7 @@ class CEnvironmentClusterInfo: public CInterface, implements IConstWUClusterInfo
     StringAttr name;
     StringAttr serverQueue;
     StringAttr agentQueue;
+    StringAttr roxieQueue;
     StringAttr thorQueue;
     StringAttr prefix;
     StringAttr platform;
@@ -3841,6 +3842,8 @@ public:
 
         if (agent)
             agentQueue.set(queue.clear().append(name).append(".agent"));
+        if (roxie)
+            roxieQueue.set(queue.clear().append(name).append(".roxie"));
         // MORE - does this need to be conditional?
         serverQueue.set(queue.clear().append(name).append(".eclserver"));
     }
@@ -3857,6 +3860,11 @@ public:
     IStringVal & getAgentQueue(IStringVal & str) const
     {
         str.set(agentQueue);
+        return str;
+    }
+    IStringVal & getRoxieQueue(IStringVal & str) const
+    {
+        str.set(roxieQueue);
         return str;
     }
     virtual IStringVal & getServerQueue(IStringVal & str) const
@@ -3931,6 +3939,11 @@ extern WORKUNIT_API IStringVal &getEclSchedulerQueueNames(IStringVal &ret, const
 extern WORKUNIT_API IStringVal &getAgentQueueNames(IStringVal &ret, const char *process)
 {
     return getProcessQueueNames(ret, process, "EclAgentProcess", ".agent");
+}
+
+extern WORKUNIT_API IStringVal &getRoxieQueueNames(IStringVal &ret, const char *process)
+{
+    return getProcessQueueNames(ret, process, "RoxieCluster", ".roxie");
 }
 
 extern WORKUNIT_API IStringVal &getThorQueueNames(IStringVal &ret, const char *process)

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -558,6 +558,7 @@ interface IConstWUClusterInfo : extends IInterface
     virtual unsigned getSize() const = 0;
     virtual IStringVal & getPlatform(IStringVal & str) const = 0;
     virtual IStringVal & getAgentQueue(IStringVal & str) const = 0;
+    virtual IStringVal & getRoxieQueue(IStringVal & str) const = 0;
     virtual IStringVal & getServerQueue(IStringVal & str) const = 0;
     virtual IStringVal & getQuerySetName(IStringVal & str) const = 0;
 };
@@ -1135,6 +1136,7 @@ extern WORKUNIT_API IStringVal &getEclCCServerQueueNames(IStringVal &ret, const 
 extern WORKUNIT_API IStringVal &getEclServerQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getEclSchedulerQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getAgentQueueNames(IStringVal &ret, const char *process);
+extern WORKUNIT_API IStringVal &getRoxieQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getThorQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringIterator *getTargetClusters(const char *processType, const char *processName);
 extern WORKUNIT_API IConstWUClusterInfo* getTargetClusterInfo(const char *clustname);

--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1868,6 +1868,8 @@ extern bool WORKUNIT_API runWorkUnit(const char *wuid, const char *cluster)
     SCMStringBuffer agentQueue;
     clusterInfo->getAgentQueue(agentQueue);
     if (!agentQueue.length())
+        clusterInfo->getRoxieQueue(agentQueue);
+    if (!agentQueue.length())
         return false;
 
     Owned<IJobQueue> queue = createJobQueue(agentQueue.str());

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -610,6 +610,9 @@ void getFirstThorClusterName(StringBuffer& clusterName)
 
 bool isRoxieCluster(char const * targetClusterName)
 {
+#ifdef _TEST_ROXIE_QUEUE
+    return false;
+#else
     bool bReturn = false;
     IArrayOf<IEspTpLogicalCluster> roxieclusters;
     CTpWrapper wrapper;
@@ -625,6 +628,7 @@ bool isRoxieCluster(char const * targetClusterName)
         }
     }
     return bReturn;
+#endif
 }
 
 void formatDuration(StringBuffer &ret, unsigned ms)

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -86,6 +86,7 @@ extern unsigned myNodeIndex;
 // Status information returned in the activityId field of the header:
 // note - any of these also also set sequence top bit to ensure not regarded as dup.
 #define ROXIE_ACTIVITY_SPECIAL_FIRST    0x3ffffff0u
+#define ROXIE_UNLOAD 0x3ffffff6u
 #define ROXIE_DEBUGREQUEST 0x3ffffff7u
 #define ROXIE_DEBUGCALLBACK 0x3ffffff8u
 #define ROXIE_PING 0x3ffffff9u
@@ -958,6 +959,7 @@ class SlaveContextLogger : public StringContextLogger
     bool traceActivityTimes;
     bool debuggerActive;
     IpAddress ip;
+    StringAttr wuid;
 public:
     SlaveContextLogger();
     SlaveContextLogger(IRoxieQueryPacket *packet);
@@ -973,6 +975,10 @@ public:
     inline void requestAbort()
     {
         stats.requestAbort();
+    }
+    inline const char *queryWuid()
+    {
+        return wuid.get();
     }
 };
 #endif

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -291,7 +291,7 @@ public:
         Owned<IWorkUnitFactory> wuFactory = getWorkUnitFactory();
         Owned<IWorkUnit> w = wuFactory->updateWorkUnit(wuid);
         if (!w)
-            throw MakeStringException(ROXIE_DALI_ERROR, "Failed to open workunit %s", wuid);
+            return NULL;
         w->setAgentSession(myProcessSession());
         if (source)
         {
@@ -404,3 +404,12 @@ extern IDllServer &queryRoxieDllServer()
     return roxieDllServer;
 }
 
+extern void addWuException(IConstWorkUnit *workUnit, IException *E)
+{
+    StringBuffer message;
+    E->errorMessage(message);
+    unsigned code = E->errorCode();
+    OERRLOG("%d - %s", code, message.str());
+    WorkunitUpdate w(&workUnit->lock());
+    addExceptionToWorkunit(w, ExceptionSeverityError, "Roxie", code, message.str(), NULL, 0, 0);
+}

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -409,7 +409,7 @@ extern void addWuException(IConstWorkUnit *workUnit, IException *E)
     StringBuffer message;
     E->errorMessage(message);
     unsigned code = E->errorCode();
-    OERRLOG("%d - %s", code, message.str());
+    OERRLOG("%u - %s", code, message.str());
     WorkunitUpdate w(&workUnit->lock());
     addExceptionToWorkunit(w, ExceptionSeverityError, "Roxie", code, message.str(), NULL, 0, 0);
 }

--- a/roxie/ccd/ccddali.hpp
+++ b/roxie/ccd/ccddali.hpp
@@ -35,6 +35,8 @@ public:
     ~WorkunitUpdate() { if (get()) get()->commit(); }
 };
 
+extern void addWuException(IConstWorkUnit *workUnit, IException *E);
+
 interface IQuerySetWatcher : extends IInterface
 {
     virtual void unsubscribe() = 0;

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -105,7 +105,7 @@ public:
         if (goer == this)
             dllCache.remove(dllName);
     }
-    static const IQueryDll *getQueryDll(const char *dllName, bool isExe)
+    static const CQueryDll *getQueryDll(const char *dllName, bool isExe)
     {
         CriticalBlock b(dllCacheLock);
         CQueryDll *dll = LINK(dllCache.getValue(dllName));
@@ -117,6 +117,20 @@ public:
             assertex(dll != NULL);
             return new CQueryDll(dllName, dll.getClear());
         }
+    }
+    static const IQueryDll *getWorkUnitDll(const char *wuid)
+    {
+        Owned <IRoxieDaliHelper> daliHelper = connectToDali();
+        Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid, NULL);
+        if (wu)
+        {
+            SCMStringBuffer dllName;
+            Owned<IConstWUQuery> q = wu->getQuery();
+            q->getQueryDllName(dllName);
+            return getQueryDll(dllName.str(), false);
+        }
+        else
+            return NULL;
     }
     virtual HelperFactory *getFactory(const char *helperName) const
     {
@@ -134,7 +148,6 @@ public:
 CriticalSection CQueryDll::dllCacheLock;
 CopyMapStringToMyClass<CQueryDll> CQueryDll::dllCache;
 
-
 extern const IQueryDll *createQueryDll(const char *dllName)
 {
     return CQueryDll::getQueryDll(dllName, false);
@@ -144,6 +157,12 @@ extern const IQueryDll *createExeQueryDll(const char *exeName)
 {
     return CQueryDll::getQueryDll(exeName, true);
 }
+
+extern const IQueryDll *createWuQueryDll(const char *wuid)
+{
+    return CQueryDll::getWorkUnitDll(wuid);
+}
+
 
 //----------------------------------------------------------------------------------------------
 // Class CQueryFactory is the main implementation of IQueryFactory, combining a IQueryDll and a
@@ -781,7 +800,7 @@ public:
             timeLimit = (unsigned) stateInfo->getPropInt("@timeLimit", timeLimit);
             warnTimeLimit = (unsigned) stateInfo->getPropInt("@warnTimeLimit", warnTimeLimit);
         }
-        
+
         Owned<IConstWUGraphIterator> graphs = &wu->getGraphs(GraphTypeActivities);
         SCMStringBuffer graphNameStr;
         ForEach(*graphs)
@@ -1042,6 +1061,10 @@ public:
     {
         throwUnexpected();   // only implemented in derived server class
     }
+    virtual IRoxieServerContext *createContext(IConstWorkUnit *wu, const IRoxieContextLogger &_logctx) const
+    {
+        throwUnexpected();   // only implemented in derived server class
+    }
     virtual void noteQuery(time_t startTime, bool failed, unsigned elapsed, unsigned memused, unsigned slavesReplyLen, unsigned bytesOut)
     {
         throwUnexpected();   // only implemented in derived server class
@@ -1199,6 +1222,19 @@ public:
         return createRoxieServerContext(context, this, client, isXml, isRaw, isBlocked, httpHelper, trim, priority, _logctx, _poolEndpoint, _xmlReadFlags);
     }
 
+    virtual IRoxieServerContext *createContext(IConstWorkUnit *wu, const IRoxieContextLogger &_logctx) const
+    {
+        if (isSuspended)
+        {
+            StringBuffer err;
+            if (errorMessage.length())
+                err.appendf(" because %s", errorMessage.str());
+            throw MakeStringException(ROXIE_QUERY_SUSPENDED, "Query %s is suspended%s", id.get(), err.str());
+        }
+        checkOnceDone(_logctx);
+        return createWorkUnitServerContext(wu, this, _logctx);
+    }
+
     virtual WorkflowMachine *createWorkflowMachine(bool isOnce, const IRoxieContextLogger &logctx) const
     {
         IPropertyTree *workflow = queryWorkflowTree();
@@ -1216,7 +1252,7 @@ public:
     }
 };
 
-IQueryFactory *createRoxieServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo)
+IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo)
 {
     CriticalBlock b(CQueryFactory::queryCreateLock);
     hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo);
@@ -1229,6 +1265,14 @@ IQueryFactory *createRoxieServerQueryFactory(const char *id, const IQueryDll *dl
     Owned<CRoxieServerQueryFactory> newFactory = new CRoxieServerQueryFactory(id, dll, package, hashValue);
     newFactory->load(stateInfo);
     return newFactory.getClear();
+}
+
+extern IQueryFactory *createServerQueryFactoryFromWu(const char *wuid)
+{
+    Owned<const IQueryDll> dll = createWuQueryDll(wuid);
+    if (!dll)
+        return NULL;
+    return createServerQueryFactory(wuid, dll.getClear(), queryRootPackage(), NULL); // MORE - if use a constant for id might cache better?
 }
 
 //==============================================================================================================================================
@@ -1406,7 +1450,7 @@ class CSlaveQueryFactory : public CQueryFactory
     }
 
 public:
-    CSlaveQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, unsigned _channelNo) 
+    CSlaveQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, unsigned _channelNo)
         : CQueryFactory(_id, _dll, _package, _hashValue, _channelNo)
     {
     }
@@ -1418,7 +1462,7 @@ public:
 
     virtual ActivityArray *loadGraph(IPropertyTree &graph, const char *graphName)
     {
-        //MORE: common up with loadGraph for the Roxie server..
+        // MORE: common up with loadGraph for the Roxie server..
         bool isLibraryGraph = graph.getPropBool("@library");
         ActivityArray *activities = new ActivityArray(isLibraryGraph, false, isLibraryGraph);
         if (isLibraryGraph)
@@ -1469,6 +1513,14 @@ IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, con
     Owned<CSlaveQueryFactory> newFactory = new CSlaveQueryFactory(id, dll, package, hashValue, channel);
     newFactory->load(stateInfo);
     return newFactory.getClear();
+}
+
+extern IQueryFactory *createSlaveQueryFactoryFromWu(const char *wuid, unsigned channelNo)
+{
+    Owned<const IQueryDll> dll = createWuQueryDll(wuid);
+    if (!dll)
+        return NULL;
+    return createSlaveQueryFactory(wuid, dll.getClear(), queryRootPackage(), channelNo, NULL);  // MORE - if use a constant for id might cache better?
 }
 
 IRecordLayoutTranslator * createRecordLayoutTranslator(const char *logicalName, IDefRecordMeta const * diskMeta, IDefRecordMeta const * activityMeta)

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1211,26 +1211,14 @@ public:
 
     virtual IRoxieServerContext *createContext(IPropertyTree *context, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const IRoxieContextLogger &_logctx, const SocketEndpoint &_poolEndpoint, XmlReaderOptions _xmlReadFlags) const
     {
-        if (isSuspended)
-        {
-            StringBuffer err;
-            if (errorMessage.length())
-                err.appendf(" because %s", errorMessage.str());
-            throw MakeStringException(ROXIE_QUERY_SUSPENDED, "Query %s is suspended%s", id.get(), err.str());
-        }
+        checkSuspended();
         checkOnceDone(_logctx);
         return createRoxieServerContext(context, this, client, isXml, isRaw, isBlocked, httpHelper, trim, priority, _logctx, _poolEndpoint, _xmlReadFlags);
     }
 
     virtual IRoxieServerContext *createContext(IConstWorkUnit *wu, const IRoxieContextLogger &_logctx) const
     {
-        if (isSuspended)
-        {
-            StringBuffer err;
-            if (errorMessage.length())
-                err.appendf(" because %s", errorMessage.str());
-            throw MakeStringException(ROXIE_QUERY_SUSPENDED, "Query %s is suspended%s", id.get(), err.str());
-        }
+        checkSuspended();
         checkOnceDone(_logctx);
         return createWorkUnitServerContext(wu, this, _logctx);
     }
@@ -1250,6 +1238,19 @@ public:
     {
         return queryStats->getStats(from, to);
     }
+
+protected:
+    void checkSuspended() const
+    {
+        if (isSuspended)
+        {
+            StringBuffer err;
+            if (errorMessage.length())
+                err.appendf(" because %s", errorMessage.str());
+            throw MakeStringException(ROXIE_QUERY_SUSPENDED, "Query %s is suspended%s", id.get(), err.str());
+        }
+    }
+
 };
 
 IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo)

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -110,6 +110,7 @@ interface IQueryFactory : extends IInterface
     virtual bool getDebugValueBool(const char * propname, bool defVal) const = 0;
 
     virtual IRoxieServerContext *createContext(IPropertyTree *xml, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions xmlReadFlags) const = 0;
+    virtual IRoxieServerContext *createContext(IConstWorkUnit *wu, const IRoxieContextLogger &_logctx) const = 0;
     virtual void noteQuery(time_t startTime, bool failed, unsigned elapsed, unsigned memused, unsigned slavesReplyLen, unsigned bytesOut) = 0;
     virtual IPropertyTree *getQueryStats(time_t from, time_t to) = 0;
     virtual void getGraphNames(StringArray &ret) const = 0;
@@ -346,9 +347,11 @@ extern const IQueryDll *createQueryDll(const char *dllName);
 extern const IQueryDll *createExeQueryDll(const char *exeName);
 
 extern IRecordLayoutTranslator *createRecordLayoutTranslator(const char *logicalName, IDefRecordMeta const * diskMeta, IDefRecordMeta const * activityMeta);
-extern IQueryFactory *createRoxieServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo);
+extern IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo);
 extern IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, unsigned _channelNo, const IPropertyTree *stateInfo);
 extern IQueryFactory *getQueryFactory(hash64_t hashvalue, unsigned channel);
+extern IQueryFactory *createServerQueryFactoryFromWu(const char *wuid);
+extern IQueryFactory *createSlaveQueryFactoryFromWu(const char *wuid, unsigned channelNo);
 
 inline unsigned findParentId(IPropertyTree &node)
 {

--- a/roxie/ccd/ccdqueue.ipp
+++ b/roxie/ccd/ccdqueue.ipp
@@ -122,5 +122,6 @@ extern IPacketDiscarder *createPacketDiscarder();
 extern void startPingTimer();
 extern void stopPingTimer();
 extern void closeMulticastSockets();
+extern void sendUnloadMessage(hash64_t hash, const char *id, const IRoxieContextLogger &logctx);
 
 #endif

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -43,6 +43,7 @@
 
 #include "dafdesc.hpp"
 #include "dautils.hpp"
+#include "wujobq.hpp"
 
 namespace ccdserver_hqlhelper
 {
@@ -27812,7 +27813,10 @@ public:
 
     virtual IWorkUnit *updateWorkUnit() const
     {
-        throwUnexpected();
+        if (workUnit)
+            return &workUnit->lock();
+        else
+            return NULL;
     }
 };
 
@@ -28175,14 +28179,7 @@ protected:
     void addWuException(IException *E)
     {
         if (workUnit)
-        {
-            StringBuffer message;
-            E->errorMessage(message);
-            unsigned code = E->errorCode();
-            OERRLOG("%d - %s", code, message.str());
-            WorkunitUpdate w(&workUnit->lock());
-            addExceptionToWorkunit(w, ExceptionSeverityError, "Roxie", code, message.str(), NULL, 0, 0);
-        }
+            ::addWuException(workUnit, E);
     }
 
     void init()
@@ -28231,6 +28228,16 @@ public:
         context.setown(createPTree(ipt_caseInsensitive));
     }
 
+    CRoxieServerContext(IConstWorkUnit *_workUnit, const IQueryFactory *_factory, const IRoxieContextLogger &_logctx)
+        : CSlaveContext(_factory, _logctx, 0, 0, NULL, false, false), serverQueryFactory(_factory)
+    {
+        init();
+        workUnit.set(_workUnit);
+        rowManager->setMemoryLimit(serverQueryFactory->getMemoryLimit());
+        workflow.setown(_factory->createWorkflowMachine(false, logctx));
+        context.setown(createPTree(ipt_caseInsensitive));
+    }
+
     CRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, bool _isXml, bool _isRaw, bool _isBlocked, HttpHelper &httpHelper, bool _trim, unsigned _priority, const IRoxieContextLogger &_logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions _xmlReadFlags)
         : CSlaveContext(_factory, _logctx, 0, 0, NULL, false, false), serverQueryFactory(_factory)
     {
@@ -28257,6 +28264,8 @@ public:
             IRoxieDaliHelper *daliHelper = checkDaliConnection();
             assertex(daliHelper );
             workUnit.setown(daliHelper->attachWorkunit(wuid, _factory->queryDll())); 
+            if (!workUnit)
+                throw MakeStringException(ROXIE_DALI_ERROR, "Failed to open workunit %s", wuid);
             WorkunitUpdate wu(&workUnit->lock());
             debugRequested = workUnit->getDebugValueBool("Debug", false);
             if (debugRequested)
@@ -28482,6 +28491,8 @@ public:
     // interface ICodeContext
     virtual FlushingStringBuffer *queryResult(unsigned sequence)
     {
+        if (!client && workUnit)
+            return NULL;    // when outputting to workunit only, don't output anything to stdout
         CriticalBlock procedure(resultsCrit);
         while (!resultMap.isItem(sequence))
             resultMap.append(NULL);
@@ -29858,6 +29869,11 @@ IRoxieServerContext *createOnceServerContext(const IQueryFactory *factory, const
 {
     return new CRoxieServerContext(factory, _logctx);
 }
+
+IRoxieServerContext *createWorkUnitServerContext(IConstWorkUnit *wu, const IQueryFactory *factory, const IRoxieContextLogger &_logctx)
+{
+    return new CRoxieServerContext(wu, factory, _logctx);
+}
 //======================================================================================================================
 
 static void controlException(StringBuffer &response, IException *E, const IRoxieContextLogger &logctx)
@@ -30495,35 +30511,17 @@ public:
 
 //================================================================================================================
 
-class RoxieSocketListener : public Thread, implements IRoxieSocketListener, implements IThreadFactory
+class RoxieListener : public Thread, implements IRoxieListener, implements IThreadFactory
 {
-    unsigned port;
-    unsigned poolSize;
-    unsigned listenQueue;
-    bool running;
-    bool suspended;
-    Semaphore started;
-    Owned<ISocket> socket;
-    Owned<IThreadPool> pool;
-    SocketEndpoint ep;
-
-    unsigned threadsActive;
-    unsigned maxThreadsActive;
-    CriticalSection activeCrit;
-    friend class ActiveQueryLimiter;
-
 public:
     IMPLEMENT_IINTERFACE;
-    RoxieSocketListener(unsigned _port, unsigned _poolSize, unsigned _listenQueue, bool _suspended) : Thread("RoxieSocketListener")
+    RoxieListener(unsigned _poolSize, bool _suspended) : Thread("RoxieListener")
     {
-        port = _port;
         running = false;
         suspended = _suspended;
         poolSize = _poolSize;
-        listenQueue = _listenQueue;
         threadsActive = 0;
         maxThreadsActive = 0;
-        ep.set(port, queryHostIP());
     }
 
     virtual void start()
@@ -30540,49 +30538,11 @@ public:
         if (running)
         {
             running = false;
-            socket->cancel_accept();
             join();
             Release();
         }
         return pool->joinAll(false, timeout);
     }
-
-    virtual void stopListening()
-    {
-        // Not threadsafe, but we only call this when generating a core file... what's the worst that can happen?
-        try
-        {
-            DBGLOG("Closing listening socket %d", port);
-            socket.clear();
-            DBGLOG("Closed listening socket %d", port);
-        }
-        catch(...)
-        {
-        }
-    }
-
-    virtual int run()
-    {
-        DBGLOG("RoxieSocketListener (%d threads) listening to socket on port %d", poolSize, port);
-        socket.setown(ISocket::create(port, listenQueue));
-        running = true;
-        started.signal();
-        while (running)
-        {
-            ISocket *client = socket->accept(true);
-            if (client)
-            {
-                client->set_linger(-1);
-                pool->start(client);
-            }
-        }
-        DBGLOG("RoxieSocketListener closed query socket");
-        return 0;
-    }
-
-    virtual void runOnce(const char *query);
-
-    virtual IPooledThread *createNew();
 
     void reportBadQuery(const char *name, const IRoxieContextLogger &logctx)
     {
@@ -30590,7 +30550,10 @@ public:
         logctx.logOperatorException(NULL, NULL, 0, "Unknown query %s", name);
     }
 
-    CIArrayOf<AccessTableEntry> accessTable;
+    void checkWuAccess(bool isBlind)
+    {
+        // Could do some LDAP access checking here (via Dali?)
+    }
 
     void checkAccess(IpAddress &peer, const char *queryName, const char *queryText, bool isBlind)
     {
@@ -30624,16 +30587,6 @@ public:
         }
     }
 
-    virtual const SocketEndpoint &queryEndpoint() const
-    {
-        return ep;
-    }
-
-    virtual unsigned queryPort() const
-    {
-        return port;
-    }
-
     virtual bool suspend(bool suspendIt)
     {
         CriticalBlock b(activeCrit);
@@ -30657,21 +30610,167 @@ public:
         }
         info.append("</ACCESSINFO>\n");
     }
+
+protected:
+    unsigned poolSize;
+    bool running;
+    bool suspended;
+    Semaphore started;
+    Owned<IThreadPool> pool;
+
+    unsigned threadsActive;
+    unsigned maxThreadsActive;
+    CriticalSection activeCrit;
+    friend class ActiveQueryLimiter;
+
+private:
+    CIArrayOf<AccessTableEntry> accessTable;
+};
+
+class RoxieWorkUnitListener : public RoxieListener
+{
+public:
+    RoxieWorkUnitListener(unsigned _poolSize, bool _suspended)
+      : RoxieListener(_poolSize, _suspended)
+    {
+        SCMStringBuffer names;
+        getRoxieQueueNames(names, topology->queryProp("@name"));
+        queueNames.set(names.str());
+    }
+
+    virtual const SocketEndpoint& queryEndpoint() const
+    {
+        throwUnexpected(); // MORE get rid of this function altogether?
+    }
+
+    virtual unsigned int queryPort() const
+    {
+        return 0;
+    }
+
+    virtual void runOnce(const char*)
+    {
+        UNIMPLEMENTED;
+    }
+
+    virtual void stopListening()
+    {
+        // Nothing to do
+    }
+
+    virtual int run()
+    {
+        if (traceLevel)
+            DBGLOG("roxie: Waiting on queue(s) '%s'", queueNames.get());
+        running = true;
+        Owned<IJobQueue> queue = createJobQueue(queueNames.get());
+        queue->connect();
+        started.signal();
+        while (running)
+        {
+            Owned<IJobQueueItem> item = queue->dequeue(5000);
+            if (item.get())
+            {
+                if (traceLevel)
+                    PROGLOG("roxie: Dequeued workunit request '%s'", item->queryWUID());
+                pool->start((void *) item->queryWUID());
+            }
+        }
+        return 0;
+    }
+
+    virtual IPooledThread* createNew();
+private:
+    StringAttr queueNames;
+};
+
+class RoxieSocketListener : public RoxieListener
+{
+    unsigned port;
+    unsigned listenQueue;
+    Owned<ISocket> socket;
+    SocketEndpoint ep;
+
+public:
+    RoxieSocketListener(unsigned _port, unsigned _poolSize, unsigned _listenQueue, bool _suspended)
+      : RoxieListener(_poolSize, _suspended)
+    {
+        port = _port;
+        listenQueue = _listenQueue;
+        ep.set(port, queryHostIP());
+    }
+
+    virtual bool stop(unsigned timeout)
+    {
+        if (socket)
+        {
+            socket->cancel_accept();
+            socket.clear();
+        }
+        return RoxieListener::stop(timeout);
+    }
+
+    virtual void stopListening()
+    {
+        // Not threadsafe, but we only call this when generating a core file... what's the worst that can happen?
+        try
+        {
+            DBGLOG("Closing listening socket %d", port);
+            socket.clear();
+            DBGLOG("Closed listening socket %d", port);
+        }
+        catch(...)
+        {
+        }
+    }
+
+    virtual void runOnce(const char *query);
+
+    virtual int run()
+    {
+        DBGLOG("RoxieSocketListener (%d threads) listening to socket on port %d", poolSize, port);
+        socket.setown(ISocket::create(port, listenQueue));
+        running = true;
+        started.signal();
+        while (running)
+        {
+            ISocket *client = socket->accept(true);
+            if (client)
+            {
+                client->set_linger(-1);
+                pool->start(client);
+            }
+        }
+        DBGLOG("RoxieSocketListener closed query socket");
+        return 0;
+    }
+
+    virtual IPooledThread *createNew();
+
+    virtual const SocketEndpoint &queryEndpoint() const
+    {
+        return ep;
+    }
+
+    virtual unsigned queryPort() const
+    {
+        return port;
+    }
 };
 
 class ActiveQueryLimiter
 {
-    RoxieSocketListener *parent;
+    RoxieListener *parent;
 public:
     bool accepted;
-    ActiveQueryLimiter(RoxieSocketListener *_parent) : parent(_parent)
+    ActiveQueryLimiter(RoxieListener *_parent) : parent(_parent)
     {
         CriticalBlock b(parent->activeCrit);
         if (parent->suspended)
         {
             accepted = false;
             if (traceLevel > 1)
-                DBGLOG("Rejecting query since Roxie server pool %d is suspended ", parent->port);
+                DBGLOG("Rejecting query since Roxie server pool %d is suspended ", parent->queryPort());
         }
         else
         {
@@ -30680,7 +30779,7 @@ public:
             {
                 parent->maxThreadsActive = parent->threadsActive;
                 if (traceLevel > 1)
-                    DBGLOG("Maximum queries active %d of %d for pool %d", parent->threadsActive, parent->poolSize, parent->port);
+                    DBGLOG("Maximum queries active %d of %d for pool %d", parent->threadsActive, parent->poolSize, parent->queryPort());
             }
             if (!accepted && traceLevel > 5)
                 DBGLOG("Too many active queries (%d >= %d)", parent->threadsActive, parent->poolSize);
@@ -30695,14 +30794,40 @@ public:
     }
 };
 
-class RoxieSocketWorker : public CInterface, implements IPooledThread
+class RoxieQueryWorker : public CInterface, implements IPooledThread
 {
-    RoxieSocketListener *pool;
-    Owned<SafeSocket> client;
-    Owned<CDebugCommandHandler> debugCmdHandler;
+public:
+    IMPLEMENT_IINTERFACE;
+
+    RoxieQueryWorker(RoxieListener *_pool)
+    {
+        pool = _pool;
+        qstart = msTick();
+        time(&startTime);
+    }
+
+    //  interface IPooledThread
+    virtual void init(void *)
+    {
+        qstart = msTick();
+        time(&startTime);
+    }
+
+    virtual bool canReuse()
+    {
+        return true;
+    }
+
+    virtual bool stop()
+    {
+        ERRLOG("RoxieQueryWorker stopped with queries active");
+        return true;
+    }
+
+protected:
+    RoxieListener *pool;
     unsigned qstart;
     time_t startTime;
-    SocketEndpoint ep;
 
     inline RoxieQueryStats &getStats(unsigned priority)
     {
@@ -30727,23 +30852,178 @@ class RoxieSocketWorker : public CInterface, implements IPooledThread
         RoxieQueryStats &stats = getStats(priority);
         stats.noteQuery(failed, elapsedTime);
     }
+};
+
+/**
+ * RoxieWorkUnitWorker is the threadpool member that runs a query submitted as a
+ * workunit via a job queue. A temporary IQueryFactory object is created for the
+ * workunit and then executed.
+ *
+ * Currently this will only work correctly on a 1-way roxie or for queries where
+ * no slave activies are needed, since there is no mechanism for ensuring that
+ * the query is deployed on the slaves before any such activity runs.
+ *
+ * Possible approaches to address that limitation would be:
+ * 1. Use the cascade manager mechanism to send a control query to all slaves
+ *    before running the query, to ensure that they create slave query factories
+ *    for it. Use a similar query at the end to uninstall.
+ * 2. Create a mechanism for 'lazy' load of slave factories for a workunit, and
+ *    ensure that the wuid is passed with the slave requests.
+ *
+ * Approach 1 has the disadvantage of adding overhead that may not be needed as
+ * only a small number of slaves (if any) may actually end up being called.
+ *
+ * Approach 2 overcomes that problem but has a new one that there is no way to
+ * know when a query can be unloaded.
+ *
+ * A combination where the slave is warned to expect the query (and told to unload it)
+ * via option 1 but doesn't actually do the load until first needed might work...
+ *
+ **/
+
+class RoxieWorkUnitWorker : public RoxieQueryWorker
+{
+public:
+    RoxieWorkUnitWorker(RoxieListener *_pool)
+        : RoxieQueryWorker(_pool)
+    {
+    }
+
+    virtual void init(void *_r)
+    {
+        wuid.set((const char *) _r);
+        RoxieQueryWorker::init(_r);
+    }
+
+    virtual void main()
+    {
+        Owned <IRoxieDaliHelper> daliHelper = connectToDali();
+        Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid.get(), NULL);
+        if (!wu)
+            throw MakeStringException(ROXIE_DALI_ERROR, "Failed to open workunit %s", wuid.get());
+        Owned<IQueryFactory> queryFactory = createServerQueryFactoryFromWu(wuid.get());
+        Owned<StringContextLogger> logctx = new StringContextLogger(wuid.get());
+        doMain(wu, queryFactory, *logctx);
+        sendUnloadMessage(queryFactory->queryHash(), wuid.get(), *logctx);
+    }
+
+    void doMain(IConstWorkUnit *wu, IQueryFactory *queryFactory, StringContextLogger &logctx)
+    {
+        bool failed = true; // many paths to failure, only one to success...
+        unsigned memused = 0;
+        unsigned slavesReplyLen = 0;
+        unsigned priority = (unsigned) -2;
+        try
+        {
+            atomic_inc(&queryCount);
+
+            bool isBlind = wu->getDebugValueBool("blindLogging", false);
+            pool->checkWuAccess(isBlind);
+            isBlind = isBlind || blindLogging;
+            logctx.setBlind(isBlind);
+            ActiveQueryLimiter l(pool);
+            if (!l.accepted)
+            {
+                IException *e = MakeStringException(ROXIE_TOO_MANY_QUERIES, "Too many active queries");
+                if (trapTooManyActiveQueries)
+                    logctx.logOperatorException(e, __FILE__, __LINE__, NULL);
+                throw e;
+            }
+            priority = queryFactory->getPriority();
+            switch (priority)
+            {
+            case 0: loQueryStats.noteActive(); break;
+            case 1: hiQueryStats.noteActive(); break;
+            case 2: slaQueryStats.noteActive(); break;
+            }
+            Owned<IRoxieServerContext> ctx = queryFactory->createContext(wu, logctx);
+            try
+            {
+                ctx->process();
+                memused = ctx->getMemoryUsage();
+                slavesReplyLen = ctx->getSlavesReplyLen();
+                ctx->done(false);
+                failed = false;
+            }
+            catch(...)
+            {
+                memused = ctx->getMemoryUsage();
+                slavesReplyLen = ctx->getSlavesReplyLen();
+                ctx->done(true);
+                throw;
+            }
+        }
+        catch (WorkflowException *E)
+        {
+            reportException(wu, E, logctx);
+            E->Release();
+        }
+        catch (IException *E)
+        {
+            reportException(wu, E, logctx);
+            E->Release();
+        }
+#ifndef _DEBUG
+        catch(...)
+        {
+            IException *E = MakeStringException(ROXIE_INTERNAL_ERROR, "Unknown exception");
+            reportException(wu, E, logctx);
+            E->Release();
+        }
+#endif
+        unsigned elapsed = msTick() - qstart;
+        noteQuery(failed, elapsed, priority);
+        queryFactory->noteQuery(startTime, failed, elapsed, memused, slavesReplyLen, 0);
+        if (logctx.queryTraceLevel() > 2)
+            logctx.dumpStats();
+        if (logctx.queryTraceLevel() && (logctx.queryTraceLevel() > 2 || logFullQueries || logctx.intercept))
+            logctx.CTXLOG("COMPLETE: %s complete in %d msecs memory %d Mb priority %d slavesreply %d", wuid.get(), elapsed, memused, priority, slavesReplyLen);
+        logctx.flush(true, false);
+    }
+
+private:
+    void reportException(IConstWorkUnit *wu, IException *E, const IRoxieContextLogger &logctx)
+    {
+        logctx.CTXLOG("FAILED: %s", wuid.get());
+        StringBuffer error;
+        E->errorMessage(error);
+        logctx.CTXLOG("EXCEPTION: %s", error.str());
+        addWuException(wu, E);
+    }
+
+    StringAttr wuid;
+};
+
+class RoxieSocketWorker : public RoxieQueryWorker
+{
+    Owned<SafeSocket> client;
+    Owned<CDebugCommandHandler> debugCmdHandler;
+    SocketEndpoint ep;
 
 public:
-    IMPLEMENT_IINTERFACE;
-
-    RoxieSocketWorker(RoxieSocketListener *_pool, SocketEndpoint &_ep) : pool(_pool), ep(_ep)
+    RoxieSocketWorker(RoxieListener *_pool, SocketEndpoint &_ep)
+        : RoxieQueryWorker(_pool), ep(_ep)
     {
-        qstart = msTick();
-        time(&startTime);
     }
 
-    void init(void *_r)
+    //  interface IPooledThread
+    virtual void init(void *_r)
     {
         client.setown(new CSafeSocket((ISocket *) _r));
-        qstart = msTick();
-        time(&startTime);
+        RoxieQueryWorker::init(_r);
     }
 
+    virtual void main()
+    {
+        doMain("");
+    }
+
+    virtual void runOnce(const char *query)
+    {
+        doMain(query);
+    }
+
+private:
     static void sendHttpServerTooBusy(SafeSocket &client, const IRoxieContextLogger &logctx)
     {
         StringBuffer message;
@@ -30829,11 +31109,6 @@ public:
         }
         else
             throw MakeStringException(ROXIE_DATA_ERROR, "Malformed request");
-    }
-
-    void main()
-    {
-        doMain("");
     }
 
     void doMain(const char *runQuery)
@@ -31344,23 +31619,16 @@ readAnother:
 //#endif
         }
     }
-
-    bool canReuse()
-    {
-        return true;
-    }
-
-    bool stop()
-    {
-        ERRLOG("RoxieSocketWorker stopped with queries active");
-        return true; 
-    }
-
 };
 
 //=================================================================================
 
-IArrayOf<IRoxieSocketListener> socketListeners;
+IArrayOf<IRoxieListener> socketListeners;
+
+IPooledThread *RoxieWorkUnitListener::createNew()
+{
+    return new RoxieWorkUnitWorker(this);
+}
 
 IPooledThread *RoxieSocketListener::createNew()
 {
@@ -31370,25 +31638,32 @@ IPooledThread *RoxieSocketListener::createNew()
 void RoxieSocketListener::runOnce(const char *query)
 {
     Owned<RoxieSocketWorker> p = new RoxieSocketWorker(this, ep);
-    p->doMain(query);
+    p->runOnce(query);
 }
 
-IRoxieSocketListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended)
+IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended)
 {
     if (traceLevel)
         DBGLOG("Creating Roxie socket listener, pool size %d, listen queue %d%s", poolSize, listenQueue, suspended?" SUSPENDED":"");
     return new RoxieSocketListener(port, poolSize, listenQueue, suspended);
 }
 
-bool suspendRoxieSocketListener(unsigned port, bool suspended)
+IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended)
+{
+    if (traceLevel)
+        DBGLOG("Creating Roxie workunit listener, pool size %d%s", poolSize, suspended?" SUSPENDED":"");
+    return new RoxieWorkUnitListener(poolSize, suspended);
+}
+
+bool suspendRoxieListener(unsigned port, bool suspended)
 {
     ForEachItemIn(idx, socketListeners)
     {
-        IRoxieSocketListener &listener = socketListeners.item(idx);
+        IRoxieListener &listener = socketListeners.item(idx);
         if (listener.queryPort()==port)
             return listener.suspend(suspended);
     }
-    throw MakeStringException(ROXIE_INTERNAL_ERROR, "Unknown port %u specified in suspendRoxieSocketListener", port);
+    throw MakeStringException(ROXIE_INTERNAL_ERROR, "Unknown port %u specified in suspendRoxieListener", port);
 }
 
 //================================================================================================================================
@@ -31658,7 +31933,7 @@ protected:
         package.setown(createPackage(NULL));
         ctx.setown(createSlaveContext(NULL, logctx, 0, 50*1024*1024, NULL));
         queryDll.setown(createExeQueryDll("roxie"));
-        queryFactory.setown(createRoxieServerQueryFactory("test", queryDll.getLink(), *package, NULL));
+        queryFactory.setown(createServerQueryFactory("test", queryDll.getLink(), *package, NULL, 0));
         timer->reset();
     }
 

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -28,7 +28,7 @@
 #include "thorstep.hpp"
 
 interface IRoxieResourceManager;
-interface IRoxieSocketListener : extends IInterface
+interface IRoxieListener : extends IInterface
 {
     virtual void start() = 0;
     virtual bool stop(unsigned timeout) = 0;
@@ -74,9 +74,10 @@ interface IRoxieServerQueryPacket : public IInterface, public ILRUChain
     virtual void setDebugResponse(unsigned sequence, IRoxieQueryPacket *) = 0;
 };
 
-IRoxieSocketListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended);
-bool suspendRoxieSocketListener(unsigned port, bool suspended);
-extern IArrayOf<IRoxieSocketListener> socketListeners;
+IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended);
+IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended);
+bool suspendRoxieListener(unsigned port, bool suspended);
+extern IArrayOf<IRoxieListener> socketListeners;
 
 
 interface IRoxieInput;
@@ -335,7 +336,6 @@ interface IRoxieServerChildGraph : public IInterface
 
 extern void doDebugRequest(IRoxieQueryPacket *packet, const IRoxieContextLogger &logctx);
 interface IQueryFactory;
-interface IRoxieServerQueryFactory;
 interface ILoadedDllEntry;
 
 extern IActivityGraph *createActivityGraph(const char *graphName, unsigned id, ActivityArray &x, IRoxieServerActivity *parent, IProbeManager *probeManager, const IRoxieContextLogger &logctx);
@@ -344,6 +344,7 @@ extern IProbeManager *createDebugManager(IDebuggableContext *debugContext, const
 extern IRoxieSlaveContext *createSlaveContext(const IQueryFactory *factory, const SlaveContextLogger &logctx, unsigned timeLimit, memsize_t memoryLimit, IRoxieQueryPacket *packet);
 extern IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, const IQueryFactory *factory, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, unsigned priority, const IRoxieContextLogger &logctx, const SocketEndpoint &poolEndpoint, XmlReaderOptions xmlReadFlags);
 extern IRoxieServerContext *createOnceServerContext(const IQueryFactory *factory, const IRoxieContextLogger &_logctx);
+extern IRoxieServerContext *createWorkUnitServerContext(IConstWorkUnit *wu, const IQueryFactory *factory, const IRoxieContextLogger &logctx);
 extern WorkflowMachine *createRoxieWorkflowMachine(IPropertyTree *_workflowInfo, bool doOnce, const IRoxieContextLogger &_logctx);
 
 extern ruid_t getNextRuid();

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -52,9 +52,11 @@ interface IPackageMap : public IInterface
 {
     virtual void addPackage(const char *name, IRoxiePackage *package) = 0;
     virtual const IRoxiePackage *queryPackage(const char *name) const = 0;
-    virtual const IRoxiePackage *queryRootPackage() const = 0;
     virtual IPropertyTree *getQuerySets() const = 0;
+    virtual const char *queryPackageId() const = 0;
 };
+extern const IRoxiePackage &queryRootPackage();
+extern const IPackageMap &queryEmptyPackageMap();
 
 interface IRoxiePackage : extends IInterface 
 {
@@ -116,8 +118,16 @@ interface IRoxieDebugSessionManager : extends IInterface
     virtual IDebuggerContext *lookupDebuggerContext(const char *id) = 0;
 };
 
+interface IRoxieResourceManagerSet : extends IInterface
+{
+    virtual void load(const IPropertyTree *querySets, const IPackageMap &packages) = 0;
+};
+
 class GlobalResourceManager;
 
+extern IRoxieResourceManager *createServerManager();
+extern IRoxieResourceManager *createSlaveManager();
+extern IRoxieResourceManagerSet *createSlaveManagerSet();
 extern const IRoxieResourceManager *getRoxieServerManager();
 extern IRoxieDebugSessionManager *getRoxieDebugSessionManager();
 extern void selectPackage(const char * packageId);


### PR DESCRIPTION
To make Roxie-on-demand more efficient, and to make Roxie more like other
components and thus simplify the middleware, Roxie now has the ability to
listen for workunits on a job queue in the same way that hthor and thor do.

If a port value of 0 is specified for a roxie server to listen on, it will
create a threadpool that listens on a job queue rather than on a socket.
When workunits are added to the queue a temporary query factory is created,
executed, and destroyed.

Slaves will do a lazy create of the required IQueryFactory if a request is
received for a workunit that is not loaded. This is added to a cache so that
subsequent slave requests on the same channel are efficient. A broadcast
message at the end of the job allows the IQueryFactory to be removed from
the cache and released.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
