### PR TITLE
gh-510 Fix inefficiency in hthor/roxie diskWrite

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -727,19 +727,9 @@ void CHThorDiskWriteActivity::publish()
 
 void CHThorDiskWriteActivity::updateWorkUnitResult(unsigned __int64 reccount)
 {
-    WorkunitUpdate wu = agent.updateWorkUnit();
-    unsigned flags = helper.getFlags();
-    WUFileKind fileKind;
-    if (TDXtemporary & flags)
-        fileKind = WUFileTemporary;
-    else if(TDXjobtemp & flags)
-        fileKind = WUFileJobOwned;
-    else if(TDWowned & flags)
-        fileKind = WUFileOwned;
-    else
-        fileKind = WUFileStandard;
     if(lfn.length()) //this is required as long as temp files don't get a name which can be stored in the WU and automatically deleted by the WU
     {
+        WorkunitUpdate wu = agent.updateWorkUnit();
         StringArray clusters;
         if (clusterHandler)
             clusterHandler->getClusters(clusters);
@@ -749,8 +739,20 @@ void CHThorDiskWriteActivity::updateWorkUnitResult(unsigned __int64 reccount)
             wu->getClusterName(tgtCluster);
             clusters.append(tgtCluster.str());
         }
+        unsigned flags = helper.getFlags();
         if (!agent.queryResolveFilesLocally())
+        {
+            WUFileKind fileKind;
+            if (TDXtemporary & flags)
+                fileKind = WUFileTemporary;
+            else if(TDXjobtemp & flags)
+                fileKind = WUFileJobOwned;
+            else if(TDWowned & flags)
+                fileKind = WUFileOwned;
+            else
+                fileKind = WUFileStandard;
             wu->addFile(lfn.str(), &clusters, helper.getTempUsageCount(), fileKind, NULL);
+        }
         else if (TDXtemporary & flags)          
             agent.noteTemporaryFilespec(filename);//note for later deletion
         if (!(flags & TDXtemporary) && helper.getSequence() >= 0)

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10529,21 +10529,21 @@ protected:
     void updateWorkUnitResult(unsigned __int64 reccount)
     {
         // MORE - a lot of this is common with hthor
-        WorkunitUpdate wu = ctx->updateWorkUnit();
-        if (wu)
+        if(lfn.length()) //this is required as long as temp files don't get a name which can be stored in the WU and automatically deleted by the WU
         {
-            unsigned flags = helper.getFlags();
-            WUFileKind fileKind;
-            if (TDXtemporary & flags)
-                fileKind = WUFileTemporary;
-            else if(TDXjobtemp & flags)
-                fileKind = WUFileJobOwned;
-            else if(TDWowned & flags)
-                fileKind = WUFileOwned;
-            else
-                fileKind = WUFileStandard;
-            if(lfn.length()) //this is required as long as temp files don't get a name which can be stored in the WU and automatically deleted by the WU
+            WorkunitUpdate wu = ctx->updateWorkUnit();
+            if (wu)
             {
+                unsigned flags = helper.getFlags();
+                WUFileKind fileKind;
+                if (TDXtemporary & flags)
+                    fileKind = WUFileTemporary;
+                else if(TDXjobtemp & flags)
+                    fileKind = WUFileJobOwned;
+                else if(TDWowned & flags)
+                    fileKind = WUFileOwned;
+                else
+                    fileKind = WUFileStandard;
                 StringArray clusters;
                 if (clusterHandler)
                     clusterHandler->getClusters(clusters);


### PR DESCRIPTION
Code in both eclagent and Roxie diskWriteActivity::updateWorkUnitResult()
call the helper to set local fileKind variable even though it may not be
used (if an unnamed temp file). Move the code to only make the call and
assignment if needed.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
