### PR TITLE
Issue 267 rebased

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -617,17 +617,26 @@ ICodeContext *EclAgent::queryCodeContext()
 
 const char *EclAgent::queryTempfilePath()
 {
-    if (agentTempDir.isEmpty()) {
-#ifdef _WIN32
-        const char *ret = "C:\\hthortemp";
-#else
-        const char *ret = "/c$/hthortemp";
-#endif
+    if (agentTempDir.isEmpty())
+    {
         StringBuffer dir;
-        if (getConfigurationDirectory(agentTopology->queryPropTree("Directories"),"temp","eclagent",agentTopology->queryProp("@name"),dir))
-            ret = dir.str();
-        recursiveCreateDirectory(ret);
-        agentTempDir.set(ret);
+        if (!getConfigurationDirectory(agentTopology->queryPropTree("Directories"),"temp","eclagent",agentTopology->queryProp("@name"),dir))
+        {
+            dir.clear();
+#ifdef _WIN32
+            char path[_MAX_PATH+1];
+            DWORD len = GetEnvironmentVariable("TEMP",path,sizeof(path));
+            if (len)
+                dir.append(path);
+            else
+                dir.append("c:");
+            dir.append("\\HPCCSystems\\hthortemp");
+#else
+            dir.append("/tmp/HPCCSystems/hthortemp";
+#endif
+        }
+        recursiveCreateDirectory(dir.str());
+        agentTempDir.set(dir.str());
     }
     return agentTempDir.sget();
 }


### PR DESCRIPTION
Temp files are placed in a hard coded location, but should be in a branch
"HPCCSystems/hthortemp" under %TEMP% in Windows and /tmp in Linux.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
Rebased onto candidate-3.2.x for 3.2.2 release
