### PR TITLE
Fix gh-363 Invalid assignment for parentContextSz

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1975,11 +1975,11 @@ void CGraphBase::getLinkedResult(unsigned & count, byte * * & ret, unsigned id)
 }
 
 // IThorChildGraph impl.
-IEclGraphResults *CGraphBase::evaluate(unsigned parentExtractSz, const byte *parentExtract)
+IEclGraphResults *CGraphBase::evaluate(unsigned _parentExtractSz, const byte *parentExtract)
 {
     CriticalBlock block(evaluateCrit);
 
-    parentExtractSz = parentExtractSz;
+    parentExtractSz = _parentExtractSz;
     executeChild(parentExtractSz, parentExtract);
     //GH->JCS This needs to set up new results rather than returning a link, so helpers are thread safe
     return LINK(localResults);


### PR DESCRIPTION
parentContextSz isn't generally used, the parentContext pointer is
generally passed through, so the invalid size would not be problematic
The only potential exception to this, is a WHEN(dataset, ...) clause
within a child query, where the dependent subgraph is launched
asynchronously. If the activities in those dependent subgraphs use
the parentContext it is likely to fail/crash

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
