### PR TITLE
WHEN fails if used in child graph

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -981,6 +981,7 @@ bool isGlobalActivity(CGraphElementBase &container)
         case TAKtopn:
         case TAKprocess:
         case TAKchildcount:
+        case TAKwhen:
             if (!container.queryLocalOrGrouped())
                 return true;
             break;


### PR DESCRIPTION
Thor refused to run WHEN in a child query, because it was marked as
a global activity, but WHEN(dataset, ..) can be executed in a child query
context

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
