### PR TITLE
Fix gh-509 prototype for out of line functions

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -8139,7 +8139,6 @@ void CHqlParameter::sethash()
 
 IHqlExpression *CHqlParameter::clone(HqlExprArray &newkids)
 {
-    throwUnexpected();
     return makeParameter(name, idx, LINK(type), newkids);
 }
 

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -5456,6 +5456,43 @@ void HqlCppTranslator::normalizeBoundExpr(BuildCtx & ctx, CHqlBoundExpr & bound)
     bound.expr.setown(convertWrapperToPointer(bound.expr));
 }
 
+
+static IHqlExpression * mapInternalFunctionParameters(IHqlExpression * expr)
+{
+    switch (expr->getOperator())
+    {
+    case no_sortlist:
+        {
+            HqlExprArray args;
+            ForEachChild(i, expr)
+                args.append(*mapInternalFunctionParameters(expr->queryChild(i)));
+            return cloneOrLink(expr, args);
+        }
+    case no_param:
+        {
+            ITypeInfo * type = expr->queryType();
+            //String parameters need to be passed as c++ const string parameters
+            switch (type->getTypeCode())
+            {
+            case type_string:
+            case type_varstring:
+            case type_data:
+            case type_qstring:
+            case type_unicode:
+            case type_utf8:
+            case type_varunicode:
+                if (!expr->hasProperty(constAtom))
+                    return appendOwnedOperand(expr, createAttribute(constAtom));
+                break;
+            }
+            break;
+        }
+    }
+
+    return LINK(expr);
+}
+
+
 IHqlExpression * HqlCppTranslator::doBuildInternalFunction(IHqlExpression * funcdef)
 {
     unsigned match = internalFunctions.find(*funcdef);
@@ -5474,7 +5511,7 @@ IHqlExpression * HqlCppTranslator::doBuildInternalFunction(IHqlExpression * func
     HqlExprArray funcdefArgs;
     ITypeInfo * returnType = funcdef->queryType()->queryChildType();
     funcdefArgs.append(*createExternalReference(funcdef->queryName(), LINK(returnType), attrs));
-    funcdefArgs.append(*LINK(queryFunctionParameters(funcdef)));
+    funcdefArgs.append(*mapInternalFunctionParameters(queryFunctionParameters(funcdef)));
     unwindChildren(funcdefArgs, funcdef, 1);
     OwnedHqlExpr externalFuncdef = funcdef->clone(funcdefArgs);
 


### PR DESCRIPTION
String (input) parameters to functions generated from ecl expressions
need to take const char \* parameters otherwise passing constant
strings reports errors on strict compilers

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
