### PR TITLE
gh-450 Issues in roxie queue support

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -30703,10 +30703,7 @@ public:
     virtual bool stop(unsigned timeout)
     {
         if (socket)
-        {
             socket->cancel_accept();
-            socket.clear();
-        }
         return RoxieListener::stop(timeout);
     }
 

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -908,11 +908,6 @@ private:
     CRoxieSlaveResourceManager **managers;
 };
 
-IRoxieResourceManagerSet *createSlaveManagerSet()
-{
-    return new CRoxieSlaveResourceManagerSet(numChannels);
-}
-
 //===============================================================================================================
 
 class CRoxieDebugSessionManager : public CInterface, implements IRoxieDebugSessionManager
@@ -1978,7 +1973,7 @@ public:
         Owned<IRoxieResourceManager> newServerManager = createServerManager();
         newServerManager->load(newQuerySets, *packages);
         newSlaveManagers->load(newQuerySets, *packages);
-        reloadQueryManagers(newSlaveManagers, newServerManager.getClear());
+        reloadQueryManagers(newSlaveManagers.getClear(), newServerManager.getClear());
     }
 
 protected:

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -127,7 +127,6 @@ class GlobalResourceManager;
 
 extern IRoxieResourceManager *createServerManager();
 extern IRoxieResourceManager *createSlaveManager();
-extern IRoxieResourceManagerSet *createSlaveManagerSet();
 extern const IRoxieResourceManager *getRoxieServerManager();
 extern IRoxieDebugSessionManager *getRoxieDebugSessionManager();
 extern void selectPackage(const char * packageId);


### PR DESCRIPTION
A couple if issues introduced by the previous refactoring.
1. Negative memory leak on the slaveManagerSet
2. Crash on closedown because of race condition between releasing
   socket and setting running to false.

Also delete a function I had added that ended up unused.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
