### PR TITLE
fixes gh-485 - Missing comma in lenny dependencies.

### DIFF
--- a/cmake_modules/dependencies/lenny.cmake
+++ b/cmake_modules/dependencies/lenny.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo openssh-client, openssh-server")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo, openssh-client, openssh-server, expect")


### PR DESCRIPTION
Corrected syntax error that was causing dpkg -i failures due to an invalid
dependency list.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
