### PR TITLE
fixes gh-544 Pause and PauseNow button not shown

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -109,7 +109,7 @@
                     return false;
                 }
 
-                function activePopup(isRoxie, type, queue,wuid,highpriority, PosId)
+                function activePopup(type, isRoxie, queue,wuid,highpriority, PosId)
                 {
                     isThor = 0;
                     if (isRoxie < 1)


### PR DESCRIPTION
When an ECL Workunit is running on Thor cluster and the 'LCR'
attribute is set on that cluster, the Pause button and PauseNow
button should be shown inside the drop-down menu on ECLWatch
Activity page. The buttons are not shown because incorrect order
of input parameters are used for the javascript function which
creates the drop-down menu. Now, the order is correct.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
