### PR TITLE
Fix: #547 agentexec to register correctly with dali

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -51,6 +51,7 @@ const char *queryRoleName(DaliClientRole role)
     case DCR_HoleServer: return "HoleServer";
     case DCR_EclServer: return "EclServer";
     case DCR_EclAgent: return "EclAgent";
+    case DCR_AgentExec: return "AgentExec";
     case DCR_DaliServer:return "DaliServer";
     case DCR_SashaServer: return "SashaServer";
     case DCR_Util: return "Util";

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -39,7 +39,7 @@ typedef DALI_UID SecurityToken;  // currently use 0
 #define FIXED_HT_SIZE 4096 // elements
 #define FIXED_KEY_SIZE 24
 
-enum DaliClientRole // if changed must update map in StringDCRoleMap
+enum DaliClientRole // if changed must update queryRoleName()
 {
     DCR_Unknown,
     DCR_Private,
@@ -64,6 +64,7 @@ enum DaliClientRole // if changed must update map in StringDCRoleMap
     DCR_RoxySlave,
     DCR_Other,
     DCR_BackupGen,
+    DCR_AgentExec,
     DCR_Max
 };
 

--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -126,7 +126,7 @@ int CEclAgentExecutionServer::run()
     try
     {
         Owned<IGroup> serverGroup = createIGroup(daliServers, DALI_SERVER_PORT);
-        initClientProcess(serverGroup, DCR_EclServer);
+        initClientProcess(serverGroup, DCR_AgentExec);
         getAgentQueueNames(queueNames, agentName);
         queue.setown(createJobQueue(queueNames.str()));
         queue->connect();


### PR DESCRIPTION
AgentExec is using the wrong ID to register with dali, making it
appear in eclwatch as "EclServer"
Add a new #define (and matching display string) for agentexec, and
specify it in the connect request.
This was found in the 0702_40 line and is being checked in using
bugzilla 87764

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
