### PR TITLE
Xref change holding reference could crash

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -1479,7 +1479,7 @@ class CCritTable;
 class CEndpointCS : public CriticalSection, public CInterface
 {
     CCritTable &table;
-    const SocketEndpoint &ep;
+    const SocketEndpoint ep;
 public:
     CEndpointCS(CCritTable &_table, const SocketEndpoint &_ep) : table(_table), ep(_ep) { }
     const void *queryFindParam() const { return &ep; }


### PR DESCRIPTION
The gh-352 change, unintentionally introduced a reference to the endpoint
when should have been a copy, consequently those endpoints could become
invalid and sequently cause a core on access. This would tend to happen
when a client already had a few previous connections to a dafilesrv,
but where the original connection (CRemoteFile) had been destroyed along
with it's endpoint.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
