### PR TITLE
Local result buffers too small

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -63,7 +63,7 @@ public:
     CThorGraphResult(IRowInterfaces *_rowIf, bool _local) : rowIf(_rowIf), local(_local)
     {
         init();
-        rowBuffer.setown(createOverflowableBuffer(rowIf, 1024));
+        rowBuffer.setown(createOverflowableBuffer(rowIf, LOCALRESULT_BUFFER_SIZE));
     }
 
 // IRowWriter

--- a/thorlcr/thorutil/thbufdef.hpp
+++ b/thorlcr/thorutil/thbufdef.hpp
@@ -55,6 +55,7 @@
 #define MERGE_TRANSFER_BUFFER_SIZE              (0x10000)               // 64K
 #define EXCESSIVE_PARALLEL_THRESHHOLD           (0x500000)              // 5MB
 #define LOOP_SMART_BUFFER_SIZE                  (0x100000*12)           // 12MB
+#define LOCALRESULT_BUFFER_SIZE                 (0x100000*10)           // 10MB
 
 
 


### PR DESCRIPTION
child/loop query result buffers spuriously way too small (1k), causing
them to spill to disk a lot

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
