### PR TITLE
Fix: #549 Commonize similar code into roxiehelper

### DIFF
--- a/common/roxiehelper/roxiehelper.cpp
+++ b/common/roxiehelper/roxiehelper.cpp
@@ -1317,3 +1317,57 @@ ROXIEHELPER_API IOrderedOutputSerializer * createOrderedOutputSerializer(FILE * 
 {
     return new COrderedOutputSerializer(_outFile);
 }
+
+//=====================================================================================================
+
+ROXIEHELPER_API StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, const char * wuid, unsigned int flags)
+{
+    out = in;
+    if (flags & (TDXtemporary | TDXjobtemp))
+        out.append("__").append(wuid);
+    return out;
+}
+
+ROXIEHELPER_API StringBuffer & mangleLocalTempFilename(StringBuffer & out, char const * in)
+{
+    char const * start = in;
+    while(true)
+    {
+        char const * end = strstr(start, "::");
+        if(end)
+        {
+            out.append(end-start, start).append("__scope__");
+            start = end + 2;
+        }
+        else
+        {
+            out.append(start);
+            break;
+        }
+    }
+    return out;
+}
+
+ROXIEHELPER_API StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fname, IConstWorkUnit * wu, bool resolveLocally)
+{
+    if (fname[0]=='~')
+        logicalName.append(fname+1);
+    else if (resolveLocally)
+    {
+        StringBuffer sb(fname);
+        sb.replaceString("::",PATHSEPSTR);
+        makeAbsolutePath(sb.str(), logicalName.clear());
+    }
+    else
+    {
+        SCMStringBuffer lfn;
+        if (wu)
+        {
+            wu->getScope(lfn);
+            if(lfn.length())
+                logicalName.append(lfn.s).append("::");
+        }
+        logicalName.append(fname);
+    }
+    return logicalName;
+}

--- a/common/roxiehelper/roxiehelper.hpp
+++ b/common/roxiehelper/roxiehelper.hpp
@@ -23,6 +23,7 @@
 #include "roxiehelper.ipp"
 #include "roxiemem.hpp"
 #include "mpbase.hpp"
+#include "workunit.hpp"
 
 #ifdef _WIN32
  #ifdef ROXIEHELPER_EXPORTS
@@ -208,5 +209,9 @@ private:
 };
 
 //==============================================================================================================
+
+ROXIEHELPER_API StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, const char * wuid, unsigned int flags);
+ROXIEHELPER_API StringBuffer & mangleLocalTempFilename(StringBuffer & out, char const * in);
+ROXIEHELPER_API StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fname, IConstWorkUnit * wu, bool resolveLocally);
 
 #endif // ROXIEHELPER_HPP

--- a/common/thorhelper/thorcommon.hpp
+++ b/common/thorhelper/thorcommon.hpp
@@ -265,6 +265,10 @@ public:
     {
         return ctx->getWuid();
     }
+    virtual const char *queryWuid()
+    {
+        return ctx->queryWuid();
+    }
     virtual void getExternalResultRaw(unsigned & tlen, void * & tgt, const char * wuid, const char * stepname, unsigned sequence, IXmlToRowTransformer * xmlTransformer, ICsvToRowTransformer * csvTransformer)
     {
         ctx->getExternalResultRaw(tlen, tgt, wuid, stepname, sequence, xmlTransformer, csvTransformer);

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1357,7 +1357,7 @@ bool EclAgent::expandLogicalName(StringBuffer & fullname, const char * logicalNa
 ILocalOrDistributedFile *EclAgent::resolveLFN(const char *fname, const char *errorTxt, bool optional, bool noteRead, bool isWrite, StringBuffer * expandedlfn)
 {
     StringBuffer lfn;
-    expandLogicalFilename(lfn, fname, *this);
+    expandLogicalFilename(lfn, fname, queryWorkUnit(), resolveFilesLocally);
     if (resolveFilesLocally && *fname != '~')
     {
         StringBuffer name;
@@ -1501,7 +1501,7 @@ __int64 EclAgent::countDiskFile(__int64 id, IHThorCountFileArg & arg)
     }
 
     StringBuffer mangled;
-    mangleHelperFileName(mangled, arg.getFileName(), *this, arg.getFlags());
+    mangleHelperFileName(mangled, arg.getFileName(), queryCodeContext()->queryWuid(), arg.getFlags());
     Owned<ILocalOrDistributedFile> ldFile = resolveLFN(mangled, "CountDisk", 0 != (arg.getFlags() & TDRoptional));
     if (ldFile) 
     {
@@ -2651,6 +2651,11 @@ void EclAgent::checkPersistMatches(const char * logicalName, unsigned eclCRC)
 char *EclAgent::getWuid()
 {
     return strdup(wuid);
+}
+
+const char *EclAgent::queryWuid()
+{
+    return wuid.get();
 }
 
 char * EclAgent::getDaliServers()

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -533,7 +533,7 @@ public:
     virtual char *resolveName(const char *in, char *out, unsigned outlen);
     virtual void logFileAccess(IDistributedFile * file, char const * component, char const * type);
     virtual IRecordLayoutTranslatorCache * queryRecordLayoutTranslatorCache() const { return rltCache; }
-    virtual ILocalOrDistributedFile  *resolveLFN(const char *logicalName, const char *errorTxt=NULL, bool optional=false, bool noteRead=true, bool write=false, StringBuffer * expandedlfn=NULL);//@@
+    virtual ILocalOrDistributedFile  *resolveLFN(const char *logicalName, const char *errorTxt=NULL, bool optional=false, bool noteRead=true, bool write=false, StringBuffer * expandedlfn=NULL);
 
     virtual void executeThorGraph(const char * graphName);
     virtual void executeGraph(const char * graphName, bool realThor, size32_t parentExtractSize, const void * parentExtract);
@@ -580,6 +580,7 @@ public:
     virtual unsigned __int64 getFileOffset(const char *logicalPart) { UNIMPLEMENTED; return 0; }
     virtual char *getOutputDir() { UNIMPLEMENTED; }
     virtual char *getWuid();
+    virtual const char *queryWuid();
     virtual IDistributedFileTransaction *querySuperFileTransaction();
     virtual unsigned getPriority() const { return 0; }
     virtual char *getPlatform() { return strdup(isStandAloneExe ? "standalone" : "hthor"); }

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -98,64 +98,6 @@ inline bool checkIsCompressed(unsigned int flags, size32_t fixedSize, bool group
 
 //=====================================================================================================
 
-StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, IAgentContext &agent, unsigned int flags)
-{
-    out = in;
-    if (flags & (TDXtemporary | TDXjobtemp))
-    {
-        char * wuid = agent.queryCodeContext()->getWuid();
-        out.append("__").append(wuid);
-        free(wuid);
-    }
-    return out;
-}
-
-
-StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fname, IAgentContext &agent)
-{
-    if (fname[0]=='~')
-        logicalName.append(fname+1);
-    else if (agent.queryResolveFilesLocally())
-        logicalName.append(fname);
-    else
-    {
-        SCMStringBuffer lfn;
-        agent.queryWorkUnit()->getScope(lfn);
-        if(lfn.length())
-            logicalName.append(lfn.s).append("::");
-        logicalName.append(fname);
-    }
-    if (agent.queryResolveFilesLocally())
-    {
-        StringBuffer sb(logicalName.str());
-        sb.replaceString("::",PATHSEPSTR);
-        makeAbsolutePath(sb.str(), logicalName.clear());
-    }
-    return logicalName;
-}
-
-StringBuffer & mangleLocalTempFilename(StringBuffer & out, char const * in)
-{
-    char const * start = in;
-    while(true)
-    {
-        char const * end = strstr(start, "::");
-        if(end)
-        {
-            out.append(end-start, start).append("__scope__");
-            start = end + 2;
-        }
-        else
-        {
-            out.append(start);
-            break;
-        }
-    }
-    return out;
-}
-
-//=====================================================================================================
-
 CRowBuffer::CRowBuffer(IRecordSize * _recsize, bool _grouped) : recsize(_recsize), grouped(_grouped)
 {
     fixsize = recsize->getFixedSize();
@@ -455,7 +397,7 @@ void CHThorDiskWriteActivity::done()
 
 void CHThorDiskWriteActivity::resolve()
 {
-    mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent, helper.getFlags());
+    mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent.queryCodeContext()->queryWuid(), helper.getFlags());
     assertex(mangledHelperFileName.str());
     if((helper.getFlags() & TDXtemporary) == 0)
     {
@@ -710,7 +652,7 @@ void CHThorDiskWriteActivity::publish()
     properties.setPropInt("@formatCrc", helper.getFormatCrc());
 
     StringBuffer lfn;
-    expandLogicalFilename(lfn, mangledHelperFileName.str(), agent);
+    expandLogicalFilename(lfn, mangledHelperFileName.str(), agent.queryWorkUnit(), agent.queryResolveFilesLocally());
     CDfsLogicalFileName logicalName;
     if (agent.queryResolveFilesLocally())
         logicalName.allowOsPath(true);
@@ -986,7 +928,7 @@ CHThorIndexWriteActivity::CHThorIndexWriteActivity(IAgentContext &_agent, unsign
 {
     incomplete = false;
     StringBuffer lfn;
-    expandLogicalFilename(lfn, helper.getFileName(), agent);
+    expandLogicalFilename(lfn, helper.getFileName(), agent.queryWorkUnit(), agent.queryResolveFilesLocally());
     if (!agent.queryResolveFilesLocally())
     {
         Owned<IDistributedFile> f = queryDistributedFileDirectory().lookup(lfn, agent.queryCodeContext()->queryUserDescriptor(), true);
@@ -1202,7 +1144,7 @@ void CHThorIndexWriteActivity::execute()
     if (!agent.queryResolveFilesLocally())
     {
         dfile.setown(queryDistributedFileDirectory().createNew(desc));
-        expandLogicalFilename(lfn, helper.getFileName(), agent);
+        expandLogicalFilename(lfn, helper.getFileName(), agent.queryWorkUnit(), agent.queryResolveFilesLocally());
         dfile->attach(lfn.str(),NULL, agent.queryCodeContext()->queryUserDescriptor());
         agent.logFileAccess(dfile, "HThor", "CREATED");
     }
@@ -7517,7 +7459,7 @@ void CHThorDiskReadBaseActivity::done()
 
 void CHThorDiskReadBaseActivity::resolve()
 {
-    mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent, helper.getFlags());
+    mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent.queryCodeContext()->queryWuid(), helper.getFlags());
     if (helper.getFlags() & TDXtemporary)
     {
         StringBuffer mangledFilename;

--- a/ecl/hthor/hthor.hpp
+++ b/ecl/hthor/hthor.hpp
@@ -86,8 +86,6 @@ struct IHThorActivity : implements IActivityBase
     virtual void setBoundGraph(IHThorBoundLoopGraph * graph) = 0;
 };
 
-extern HTHOR_API StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fname, IAgentContext &agent);
-
 extern HTHOR_API IHThorActivity *createDiskWriteActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorDiskWriteArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createIterateActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorIterateArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createGroupActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorGroupArg &arg, ThorActivityKind kind);
@@ -218,7 +216,5 @@ extern HTHOR_API IHThorException * makeHThorException(ThorActivityKind kind, uns
 
 extern HTHOR_API IEngineRowAllocator * createHThorRowAllocator(roxiemem::IRowManager & _rowManager, IOutputMetaData * _meta, unsigned _activityId, unsigned _allocatorId);
 extern HTHOR_API IRtlRowCallback * queryHThorRtlRowCallback();
-
-StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, IAgentContext &agent, unsigned int flags);
 
 #endif // HTHOR_INCL

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -489,6 +489,7 @@ public:
     // Not yet thought about these....
 
     virtual char *getWuid() { throwUnexpected(); } // caller frees return string.
+    virtual const char *queryWuid() { throwUnexpected(); }
     virtual void getExternalResultRaw(unsigned & tlen, void * & tgt, const char * wuid, const char * stepname, unsigned sequence, IXmlToRowTransformer * xmlTransformer, ICsvToRowTransformer * csvTransformer) { throwUnexpected(); }  // shouldn't really be here, but it broke thor.
     virtual char *getDaliServers() { throwUnexpected(); } // caller frees return string.
     virtual void executeGraph(const char * graphName, bool realThor, size32_t parentExtractSize, const void * parentExtract) { throwUnexpected(); }

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10467,45 +10467,8 @@ public:
     }
 };
 
-//==================================================================================
-
-extern StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fname, IConstWorkUnit * wu)
-{
-    if (fname[0]=='~')
-        logicalName.append(fname+1);
-    else
-    {
-        SCMStringBuffer lfn;
-        if (wu)
-            wu->getScope(lfn);
-        if(lfn.length())
-            logicalName.append(lfn.s).append("::");
-        logicalName.append(fname);
-    }
-    return logicalName;
-}
-
-StringBuffer & mangleLocalTempFilename(StringBuffer & out, char const * in)
-{
-    char const * start = in;
-    while(true)
-    {
-        char const * end = strstr(start, "::");
-        if(end)
-        {
-            out.append(end-start, start).append("__scope__");
-            start = end + 2;
-        }
-        else
-        {
-            out.append(start);
-            break;
-        }
-    }
-    return out;
-}
-
 //=====================================================================================================
+
 class CRoxieServerDiskWriteActivity : public CRoxieServerInternalSinkActivity
 {
 protected:
@@ -10577,7 +10540,7 @@ protected:
         assertex(rawLogicalName);
         if((helper.getFlags() & TDXtemporary) == 0)
         {
-            expandLogicalFilename(lfn, rawLogicalName, NULL); // MORE - should probably pass wu if we have one?
+            expandLogicalFilename(lfn, rawLogicalName, NULL, false); // MORE - should probably pass wu if we have one?
             CDfsLogicalFileName logicalName;
             if (!logicalName.setValidate(lfn.str()))
                 throw MakeStringException(99, "Cannot write %s, invalid logical name", lfn.str());
@@ -27730,6 +27693,7 @@ public:
     virtual void printResults(IXmlWriter *output, const char *name, unsigned sequence) { throwUnexpected(); }
 
     virtual char *getWuid() { throwUnexpected(); }
+    virtual const char *queryWuid() { throwUnexpected(); }
     virtual void getExternalResultRaw(unsigned & tlen, void * & tgt, const char * wuid, const char * stepname, unsigned sequence, IXmlToRowTransformer * xmlTransformer, ICsvToRowTransformer * csvTransformer) { throwUnexpected(); }
     virtual char *getDaliServers() { throwUnexpected(); } 
 
@@ -29741,6 +29705,7 @@ public:
         return strdup("roxie"); 
     }
     virtual char *getWuid() { throwUnexpected(); }
+    virtual const char *queryWuid() { throwUnexpected(); }
 
     // persist-related code - usage of persist should have been caught and rejected at codegen time
     virtual char * getExpandLogicalName(const char * logicalName) { throwUnexpected(); }

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -511,5 +511,4 @@ extern IRoxieServerActivityFactory *createRoxieServerPrefetchProjectActivityFact
 extern IRoxieServerActivityFactory *createRoxieServerStreamedIteratorActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerWhenActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 
-extern StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fname, IConstWorkUnit * wu);
 #endif

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -517,7 +517,7 @@ public:
     virtual const IResolvedFile *lookupFileName(const char *_fileName, bool opt, bool cache) const
     {
         StringBuffer fileName;
-        expandLogicalFilename(fileName, _fileName, NULL);   // MORE - if we have a wu, and we have not yet got rid of the concept of scope, we should use it here
+        expandLogicalFilename(fileName, _fileName, NULL, false);   // MORE - if we have a wu, and we have not yet got rid of the concept of scope, we should use it here
 
         const IResolvedFile *result = lookupFile(fileName, cache);
         if (!result)

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -560,6 +560,7 @@ interface ICodeContext : public IResourceContext
     virtual void getRowXML(size32_t & lenResult, char * & result, IOutputMetaData & info, const void * row, unsigned flags) = 0;
     virtual void addWuAssertFailure(unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column, bool isAbort) = 0;
     virtual const void * fromXml(IEngineRowAllocator * _rowAllocator, size32_t len, const char * utf8, IXmlToRowTransformer * xmlTransformer, bool stripWhitespace) = 0;
+    virtual const char *queryWuid() = 0;
 };
 
 

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -491,6 +491,7 @@ class graph_decl CGraphBase : public CInterface, implements ILocalGraph, impleme
         virtual UChar *getResultVarUnicode(const char * name, unsigned sequence) { return ctx->getResultVarUnicode(name, sequence); }
         virtual unsigned getResultHash(const char * name, unsigned sequence) { return ctx->getResultHash(name, sequence); }
         virtual char *getWuid() { return ctx->getWuid(); }
+        virtual const char *queryWuid() { return ctx->queryWuid(); }
         virtual void getExternalResultRaw(unsigned & tlen, void * & tgt, const char * wuid, const char * stepname, unsigned sequence, IXmlToRowTransformer * xmlTransformer, ICsvToRowTransformer * csvTransformer) { ctx->getExternalResultRaw(tlen, tgt, wuid, stepname, sequence, xmlTransformer, csvTransformer); }
         virtual char *getDaliServers() { return ctx->getDaliServers(); }
         virtual void executeGraph(const char * graphName, bool realThor, size32_t parentExtractSize, const void * parentExtract) { ctx->executeGraph(graphName, realThor, parentExtractSize, parentExtract); }

--- a/thorlcr/thorcodectx/thcodectx.cpp
+++ b/thorlcr/thorcodectx/thcodectx.cpp
@@ -43,6 +43,11 @@ char *CThorCodeContextBase::getWuid()
     return out.detach();
 }
 
+const char *CThorCodeContextBase::queryWuid()
+{
+    return job.queryWuid();
+}
+
 char *CThorCodeContextBase::getJobName()
 {
     throwUnexpected();

--- a/thorlcr/thorcodectx/thcodectx.hpp
+++ b/thorlcr/thorcodectx/thcodectx.hpp
@@ -84,6 +84,7 @@ public:
 // ICodeContext
     virtual const char *loadResource(unsigned id);
     virtual char *getWuid();
+    virtual const char *queryWuid();
     virtual char *getDaliServers();
 
     virtual char *getExpandLogicalName(const char * logicalName);


### PR DESCRIPTION
Several filename resolution/manipulation functions are (almost) the
same between roxie and hthor, and the Roxie ones did not consider stand
alone mode.
Removed them from roxie/hthor, and moved them into roxiehelper. Also
enhance to pass workunit into expandLogicalFilename for optional scope
resolution, and pass in resolveLocally flag to signal building of local
file system path. Modify roxie/hthor to call these modified common functions.
This is a step towards enhancing roxie to handle standAlone diskWrite
functionality, which is a step towards adding indexWrite ability (issue #491)

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
