### PR TITLE
Ensure max/min graph timings always present

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -2463,6 +2463,8 @@ void CThorStats::processInfo()
 void CTimingInfo::getXGMML(IPropertyTree *node)
 {
     processInfo();
+    addAttribute(node, "timeMaxMs", max);
+    addAttribute(node, "timeMinMs", min);
     if (hi == lo)
     {
         removeAttribute(node, "timeMaxEndpoint");
@@ -2473,8 +2475,6 @@ void CTimingInfo::getXGMML(IPropertyTree *node)
     else
     {
         StringBuffer epStr;
-        addAttribute(node, "timeMaxMs", max);
-        addAttribute(node, "timeMinMs", min);
         addAttribute(node, "timeMaxEndpoint", querySlaveGroup().queryNode(maxNode).endpoint().getUrlStr(epStr).str());
         addAttribute(node, "timeMinEndpoint", querySlaveGroup().queryNode(minNode).endpoint().getUrlStr(epStr.clear()).str());
         addAttribute(node, "timeMaxSkew", hi);


### PR DESCRIPTION
Previously if the activity min and max timing were the same, it would not
bother storing the info. in the graph, in practice it's very
unlikely to be the same on a multi-node system, but on a 1 slave setup it
was always true, but the info is still interesting

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
