### PR TITLE
Add eclipse project files to gitignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 externals/
+.project
 .svn/
 ln/


### PR DESCRIPTION
This makes testing the ECL eclipse plugin easier (for example for the test
suite).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
