### PR TITLE
gh-577 standalone ecl with -xml formatting issues

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -6663,18 +6663,18 @@ IStringVal& CLocalWUResult::getResultXml(IStringVal &str) const
     p->getPropBin("Value", raw);
     const char * name = p->queryProp("@name");
     if (name)
-        xml.appendf("<Dataset name=\"%s\">", name);
+        xml.appendf("<Dataset name=\'%s\'>\n", name);
     else
-        xml.append("<Dataset>");
+        xml.append("<Dataset>\n");
 
     unsigned __int64 numrows = getResultRowCount();
     while (numrows--)
     {
-        xml.append("<Row>");
+        xml.append(" <Row>");
         readRow(xml, raw, types, names);
-        xml.append("</Row>");
+        xml.append("</Row>\n");
     }
-    xml.append("</Dataset>");
+    xml.append("</Dataset>\n");
     str.set(xml.str());
     return str;
 }

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1188,19 +1188,26 @@ void EclAgent::setResultSet(const char * name, unsigned sequence, bool isAll, si
         else if (outputFmt == ofXML)
         {
             assertex(xform);
-            CommonXmlWriter xmlwrite(0);
-            xmlwrite.outputBeginNested("Dataset", false);
+            StringBuffer datasetName, resultName;
             if (name)
-                xmlwrite.outputString(strlen(name), name, "@name");
+            {
+                datasetName.append(name);
+                resultName.append(name);
+            }
             else
             {
-                StringBuffer resultName;
-                resultName.appendf("Result %d", sequence+1);
-                xmlwrite.outputString(resultName.length(), resultName.str(), "@name");
+                datasetName.appendf("Result %d", sequence+1);
+                resultName.appendf("Result_%d", sequence+1);
             }
+            CommonXmlWriter xmlwrite(0,1);
+            xmlwrite.outputBeginNested("Row", false);
+            xmlwrite.outputBeginNested(resultName.str(), false);
             xform->toXML(isAll, len, (const byte *)val, xmlwrite);
-            xmlwrite.outputEndNested("Dataset");
-            outputSerializer->printf(sequence, "%s", xmlwrite.str()); 
+            xmlwrite.outputEndNested(resultName.str());
+            xmlwrite.outputEndNested("Row");
+            outputSerializer->printf(sequence, "<Dataset name=\'%s'>\n%s</Dataset>\n",
+                    datasetName.str(),
+                    xmlwrite.str());
             outputSerializer->close(sequence, false);
         }
         else

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -791,7 +791,7 @@ void EclAgent::outputFormattedResult(const char * name, unsigned sequence, bool 
         }
     }
     if (close)
-        outputSerializer->close(sequence, outputFmt != ofRAW);
+        outputSerializer->close(sequence, false);
 }
 
 void EclAgent::setResultInt(const char * name, unsigned sequence, __int64 val)

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -5716,12 +5716,11 @@ void CHThorWorkUnitWriteActivity::execute()
         StringBuffer sb;
         const char *name = helper.queryName();
         if (name && *name)
-            sb.appendf("<Dataset name='%s'>", name);
+            sb.appendf("<Dataset name='%s'>\n", name);
         else
-            sb.appendf("<Dataset name='Result %d'>", seq+1);
+            sb.appendf("<Dataset name='Result %d'>\n", seq+1);
         agent.queryOutputSerializer()->fwrite(seq, (const void*)sb.str(), 1, sb.length());
     }
-    CommonXmlWriter xmlwrite(0,1);
     loop
     {
         if ((unsigned __int64)rows >= agent.queryStopAfter())
@@ -5766,11 +5765,11 @@ void CHThorWorkUnitWriteActivity::execute()
             }
             else if (agent.queryOutputFmt() == ofXML)
             {
+                CommonXmlWriter xmlwrite(0,1);
                 xmlwrite.outputBeginNested("Row", false);
                 helper.serializeXml((byte *) nextrec.get(), xmlwrite);
                 xmlwrite.outputEndNested("Row");
                 agent.queryOutputSerializer()->fwrite(seq, (const void*)xmlwrite.str(), 1, xmlwrite.length());
-                xmlwrite.clear();
             }
         }
         rows++;
@@ -5789,7 +5788,7 @@ void CHThorWorkUnitWriteActivity::execute()
         if (agent.queryOutputFmt() == ofXML)
         {
             StringBuffer sb;
-            sb.appendf("</Dataset>");
+            sb.appendf("</Dataset>\n");
             agent.queryOutputSerializer()->fwrite(seq, (const void*)sb.str(), 1, sb.length());
         }
         else if (agent.queryOutputFmt() != ofSTD)


### PR DESCRIPTION
Fix some anomolies in how xml is output from standalone ECL programs,
to make regression testing easier (and to make the output easier to
read).

Fixes gh-577

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
