### PR TITLE
adding auto-configuration from environment.xml.

### DIFF
--- a/testing/ecl/runregress
+++ b/testing/ecl/runregress
@@ -53,6 +53,7 @@ GetOptions('help|?' => sub { pod2usage(-exitstatus => 0, -verbose => 2) },
            'listconfigs|lc' => \$options->{listconfigs},
            'describeonly' => \$options->{describeonly},
            'setup_generate|setup' => \$options->{setup_generate},
+           'generate_ini|ini=s' => \$options->{generate_ini},
            'suite|s=s' => \$options->{suite},
            'query=s' => \$options->{query},
            'variant=s' => \$options->{variant},
@@ -70,7 +71,7 @@ GetOptions('help|?' => sub { pod2usage(-exitstatus => 0, -verbose => 2) },
            'verbose' => \$options->{verbose},
            'config' => \$options->{configfile}) or pod2usage(-exitstatus => 2, -verbose => 1);
 
-if((@ARGV == 0) && !($options->{setup_generate} || $options->{listconfigs}))
+if((@ARGV == 0) && !($options->{setup_generate} || $options->{listconfigs} || $options->{generate_ini}))
 {
     print(STDERR "Missing argument (expected configuration name)\n");
     pod2usage(-exitstatus => 2, -verbose => 1);
@@ -86,6 +87,10 @@ my $engine = Regress::Engine->new($options);
 if($options->{listconfigs})
 {
     $engine->listconfigs();
+    exit(0);
+}
+if($options->{generate_ini})
+{
     exit(0);
 }
 $engine->init();
@@ -105,6 +110,10 @@ __END__
 =item B<-setup_generate>|B<-setup>|B<-se>
 
 Runs the setup queries rather than the test queries. May not be used with the options B<-class>, B<-query>, or B<-norun>.
+
+=item B<-generate_ini>|B<-ini>
+
+Builds the regress.ini file from the specified environment.xml file (created when HPCC builds). Needed to run -setup.
 
 =item B<-suite>|B<-s> I<suite>
 


### PR DESCRIPTION
adding auto-configuration from environment.xml. Lots of hard coded items, needs work.

I'm happy to re-work the parameters to get less hard-coded/better settings.

I've tested running with the ini file generated, well, lots of things fail, but fail the same way with Richard's ini file, so I'm guessing it's ok.

Usage is described in the docs (--help will give you):

ini file not found -> -generate_ini=environment.xml -> generate ini file and quit
then use -setup to configure the services.

-ini always overwrite the file (doesn't make sense to ask the user to remove the file first, I guess).
