### PR TITLE
gh-587 WsDfu should use scope to check user's file access

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -136,6 +136,7 @@ private:
     int GetIndexData(IEspContext &context, bool bSchemaOnly, const char* indexName, const char* parentName, const char* filterBy, __int64 start, 
                                         __int64& count, __int64& read, __int64& total, StringBuffer& message, StringArray& columnLabels, 
                                         StringArray& columnLabelsType, IArrayOf<IEspDFUData>& DataList, bool webDisableUppercaseTranslation);
+    bool getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, int& permission);
 
 private:
     bool         m_disableUppercaseTranslation;


### PR DESCRIPTION
WsDfu displays file access permission inside the Logical File
Details page. Existing WsDfu code checks the permission using the
logical file name as the input. In LDAPSecurity dll, the input and
the permission are cached to save time for the same input. Since
the file permissions are file scope based, WsDfu should use the
file scope as the input to check the permission for a better
performance. This fix changes the input from logical file name to
file scope. In addition, the code for the file permission check is
moved to a new function "getUserFilePermission" in order to
improve code readability.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
