### PR TITLE
Fixes Bug 88478 Reset SSH variables for each operation so as not to be re

### DIFF
--- a/deployment/deploy/DeploymentEngine.cpp
+++ b/deployment/deploy/DeploymentEngine.cpp
@@ -294,6 +294,7 @@ void CDeploymentEngine::start()
         }//for
         
         m_curInstance = NULL;
+        clearSSHVars();
     }
 }
 
@@ -397,6 +398,7 @@ void CDeploymentEngine::stop()
             }
         }
         m_curInstance = NULL;
+        clearSSHVars();
     }
 }
 
@@ -474,6 +476,7 @@ void CDeploymentEngine::check()
         checkInstance(instance);
     }
     m_curInstance = NULL;
+    clearSSHVars();
 }
 
 //---------------------------------------------------------------------------
@@ -605,6 +608,7 @@ void CDeploymentEngine::beforeDeploy()
 
         EnvMachineOS os = m_envDepEngine.lookupMachineOS( m_instances.item(0) );
         m_curInstance = "Cache";
+        clearSSHVars();
         copyInstallFiles("Cache", -1, tempPath, os);
     }
     else
@@ -645,6 +649,7 @@ void CDeploymentEngine::_deploy(bool useTempDir)
         }
     }
     m_curInstance = NULL;
+    clearSSHVars();
     afterDeploy();
 }
 
@@ -655,6 +660,7 @@ void CDeploymentEngine::deployInstance(IPropertyTree& instanceNode, bool useTemp
 {
     StringAttr hostDir(getHostDir(instanceNode).str());
     StringAttr destDir(useTempDir ? getDeployDir(instanceNode).str() : hostDir.get());
+    ensurePath(destDir);
     
     const char* pszHostDir = hostDir.get();
     if (pszHostDir && *pszHostDir==PATHSEPCHAR && *(pszHostDir+1)==PATHSEPCHAR && m_envDepEngine.lookupMachineOS(instanceNode) != MachineOsLinux)
@@ -790,6 +796,7 @@ void CDeploymentEngine::backupDirs()
         }
     }
     m_curInstance = NULL;
+    clearSSHVars();
     m_pCallback->printStatus(STATUS_NORMAL, NULL, NULL, NULL);
 }
 
@@ -2673,4 +2680,11 @@ void CDeploymentEngine::setSSHVars(IPropertyTree& instance)
 
   if (depToFolder && *depToFolder)
     m_useSSHIfDefined = false;
+}
+
+void CDeploymentEngine::clearSSHVars()
+{
+  m_curSSHUser.clear();
+  m_curSSHKeyFile.clear();
+  m_curSSHKeyPassphrase.clear();
 }

--- a/deployment/deploy/DeploymentEngine.hpp
+++ b/deployment/deploy/DeploymentEngine.hpp
@@ -305,6 +305,7 @@ private:
     void getBackupDirName(const char* from, StringBuffer& to);
     bool checkSSHFileExists(const char* dir) const;
     void setSSHVars(IPropertyTree& instance);
+    void clearSSHVars();
 
 protected:
    Owned<IThreadPool>      m_threadPool;


### PR DESCRIPTION
Fixes Bug 88478 Reset SSH variables for each operation so as not to be reused
for other operations

When deployed via ConfigEnv, SSH variables were not being reset after each operation like deploy, backup,
start and stop, thereby causing unintended behavior.

Also, in the case of back up rename, added check to create the directory if
it does not exist.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
