### PR TITLE
Fixes #592 Check file readonly attribute if the file exists

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -566,7 +566,7 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
           sbName.clear().append(req.getReqInfo().getUserId());
           context.getPeer(sbUserIp);
 
-          if (m_pFile->isReadOnly())
+          if (m_pFile.get() && m_pFile->isReadOnly())
           {
             xml.appendf("Write access to the Environment cannot be provided as %s is Read Only.", m_envFile.str());
             resp.setXmlArgs(xml.str());


### PR DESCRIPTION
When generating a new environment, check if file that we are writing
to is readonly after ensuring that the file object is valid.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
