### PR TITLE
Sasha deleting sentinel file when coalescing

### DIFF
--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -296,8 +296,12 @@ int main(int argc, const char* argv[])
     NoQuickEditSection x;
 #endif
 
-    Owned<IFile> sentinelFile = createSentinelTarget();
-    removeSentinelFile(sentinelFile);
+    Owned<IFile> sentinelFile;
+    if (!coalescer)
+    {
+        sentinelFile.setown(createSentinelTarget());
+        removeSentinelFile(sentinelFile);
+    }
 
     OwnedIFile ifile = createIFile("sashaconf.xml");
     serverConfig.setown(ifile->exists()?createPTreeFromXMLFile("sashaconf.xml"):createPTree());


### PR DESCRIPTION
Fix gh-598 - When sasha launched the child process to perform coalescing, it
inadvertently deleted the sentinel.
Which caused the init system to report stopped.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
