### PR TITLE
gh-533/531 Fix wrong display format in Results window

### DIFF
--- a/esp/eclwatch/ws_XSLT/result.xslt
+++ b/esp/eclwatch/ws_XSLT/result.xslt
@@ -23,7 +23,6 @@
     <xsl:param name="pageSize" select="/WUResultResponse/Requested"/>
     <xsl:param name="rowStart" select="/WUResultResponse/Start"/>
     <xsl:param name="rowCount" select="/WUResultResponse/Count"/>
-  <xsl:param name="format" select="/WUResultResponse/Format"/>
     
     <xsl:variable name="debug" select="0"/>
     <xsl:variable name="stage1Only" select="0"/><!--for debugging: produce intermediate nodeset only-->
@@ -66,7 +65,7 @@
                 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
                 <title>Result <xsl:value-of select="Name"/>
                 </title>
-        <xsl:if test="$format='xls'">
+        <xsl:if test="(string-length(Format) &lt; 1) or (Format != 'xls')">
         <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/fonts/fonts-min.css" />
         <link rel="stylesheet" type="text/css" href="/esp/files/css/espdefault.css" />
         <link rel="stylesheet" type="text/css" href="/esp/files/css/eclwatch.css" />


### PR DESCRIPTION
Right now, ECLWatch results window displays values centred
vertically rather than top justified. The text and values are
displayed in a serif font rather than sans serif font. The
results become very difficult to read. That is because web
style files are not loaded by an incorrect 'if condition'.
Those style files should be included unless the web page is
used to build Excel output. The fix checks whether the output
format is 'xls' or not. If not, the style files will be linked.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
