### PR TITLE
Fix gh-561 problem with transform return types

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -1146,9 +1146,7 @@ defineid
                             $$.setType(type.getClear());
                             $$.setPosition($1);
                         }
-// This really causes grief in trying to rationalise the grammar. In particular allowing dataset ids to be redefined in conditional assignments.
-// | scopedDatasetId knownOrUnknownId   - needs '(' dataset ')' removed as a production, or worse...  Revisit here
-    | DATASET_ID knownOrUnknownId 
+    | globalScopedDatasetId knownOrUnknownId
                         {
                             OwnedHqlExpr ds = $1.getExpr();
                             parser->beginDefineId($2.getName(), ds->queryType());
@@ -10084,7 +10082,7 @@ swapTopForLeft
     ;
 
 scopedDatasetId
-    : DATASET_ID
+    : globalScopedDatasetId
     | dotScope DATASET_ID leaveScope
                         {
                             IHqlExpression *e1 = $1.getExpr();
@@ -10097,11 +10095,6 @@ scopedDatasetId
                                 $$.setExpr(e2);
                             }
                         }
-    | moduleScopeDot DATASET_ID leaveScope
-                        {
-                            OwnedHqlExpr scope = $1.getExpr();
-                            $$.setExpr($2.getExpr());
-                        }
     | datasetFunction '('
                         {
                             parser->beginFunctionCall($1);
@@ -10109,6 +10102,15 @@ scopedDatasetId
     actualParameters ')'
                         {
                             $$.setExpr(parser->bindParameters($1, $4.getExpr()));
+                        }
+    ;
+
+globalScopedDatasetId
+    : DATASET_ID
+    | moduleScopeDot DATASET_ID leaveScope
+                        {
+                            OwnedHqlExpr scope = $1.getExpr();
+                            $$.setExpr($2.getExpr());
                         }
     ;
 

--- a/ecl/regress/issue561.ecl
+++ b/ecl/regress/issue561.ecl
@@ -16,4 +16,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
-export issue377a := 'ggg'
+a := module
+ export b := dataset([{'1'}], {string f});
+ end;
+
+a.b t(a.b L) := transform
+ self.f := L.f;
+ end;
+
+output(PROJECT(a.b, t(LEFT)));


### PR DESCRIPTION
Using a dataset from a module as the return type of a transform caused
a syntax error.  Modified the productions to allow it.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
