### PR TITLE
Fixes some problems processing forward modules

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -6539,7 +6539,7 @@ IHqlExpression *CHqlScope::clone(HqlExprArray &newkids)
 {
     HqlExprArray syms;
     getSymbols(syms);
-    return queryExpression(clone(newkids, syms));
+    return clone(newkids, syms)->queryExpression();
 }
 
 IHqlExpression * createFunctionDefinition(_ATOM name, IHqlExpression * value, IHqlExpression * parameters, IHqlExpression * defaults, IHqlExpression * attrs)
@@ -7100,7 +7100,7 @@ IHqlExpression *CHqlLocalScope::clone(HqlExprArray &newkids)
 {
     HqlExprArray syms;
     getSymbols(syms);
-    return queryExpression(clone(newkids, syms));
+    return clone(newkids, syms)->queryExpression();
 }
 
 IHqlScope * CHqlLocalScope::clone(HqlExprArray & children, HqlExprArray & symbols)
@@ -7652,7 +7652,7 @@ IHqlExpression * CHqlVirtualScope::closeExpr()
     if (isVirtual && !isAbstract)
     {
         concrete.setown(deriveConcreteScope());
-        if (!containsInternalVirtual(queryExpression(concrete)))
+        if (!containsInternalVirtual(concrete->queryExpression()))
             infoFlags &= ~HEFinternalVirtual;
     }
 
@@ -7662,7 +7662,7 @@ IHqlExpression * CHqlVirtualScope::closeExpr()
 IHqlScope * CHqlVirtualScope::deriveConcreteScope()
 {
     Owned<IHqlScope> scope = createConcreteScope();
-    IHqlExpression * scopeExpr = queryExpression(scope);
+    IHqlExpression * scopeExpr = scope->queryExpression();
 
     ForEachChild(i, this)
         scopeExpr->addOperand(LINK(queryChild(i)));
@@ -7680,7 +7680,7 @@ IHqlScope * CHqlVirtualScope::deriveConcreteScope()
         }
     }
 
-    return queryExpression(scope.getClear())->closeExpr()->queryScope();
+    return scope.getClear()->queryExpression()->closeExpr()->queryScope();
 }
 
 
@@ -7773,7 +7773,7 @@ CHqlForwardScope::CHqlForwardScope(IHqlScope * _parentScope, HqlGramCtx * _paren
         infoFlags |= HEFunbound;
 
     resolved.setown(createVirtualScope(NULL, NULL));
-    IHqlExpression * resolvedScopeExpr = queryExpression(resolved);
+    IHqlExpression * resolvedScopeExpr = resolved->queryExpression();
     ForEachChild(i, this)
         resolvedScopeExpr->addOperand(LINK(queryChild(i)));
     resolvedAll = false;
@@ -8147,7 +8147,7 @@ StringBuffer &CHqlScopeParameter::toString(StringBuffer &ret)
 IHqlExpression * CHqlScopeParameter::lookupSymbol(_ATOM searchName, unsigned lookupFlags, HqlLookupContext & ctx)
 {
     if (searchName == _parameterScopeType_Atom)
-        return LINK(queryExpression(typeScope));
+        return LINK(typeScope->queryExpression());
     OwnedHqlExpr match = typeScope->lookupSymbol(searchName, lookupFlags, ctx);
     if (!match)
         return NULL;
@@ -14098,11 +14098,6 @@ IHqlExpression * queryExpression(IHqlDataset * ds)
 {
     if (!ds) return NULL;
     return QUERYINTERFACE(ds, IHqlExpression);
-}
-
-IHqlExpression * queryExpression(IHqlScope * scope)
-{
-    return QUERYINTERFACE(scope, IHqlExpression);
 }
 
 IHqlScope * queryScope(ITypeInfo * type)

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -965,6 +965,7 @@ inline unsigned makeLookupFlags(bool sharedOK, bool ignoreBase, bool required)
 //MORE: This should be split into a constant and creator interfaces
 interface IHqlScope : public IInterface
 {
+    virtual IHqlExpression * queryExpression() = 0;
     virtual IHqlExpression *lookupSymbol(_ATOM searchName, unsigned lookupFlags, HqlLookupContext & ctx) = 0;
 
     virtual void    getSymbols(HqlExprArray& exprs) const= 0;
@@ -1464,7 +1465,7 @@ extern HQL_API IHqlExpression * createNullDataset();
 extern HQL_API IHqlExpression * queryNullRecord();
 extern HQL_API IHqlExpression * queryExpression(ITypeInfo * t);
 extern HQL_API IHqlExpression * queryExpression(IHqlDataset * ds);
-extern HQL_API IHqlExpression * queryExpression(IHqlScope * scope);
+inline IHqlExpression * queryExpression(IHqlScope * scope) { return scope ? scope->queryExpression() : NULL; }
 extern HQL_API IHqlScope * queryScope(ITypeInfo * t);
 extern HQL_API IHqlRemoteScope * queryRemoteScope(IHqlScope * scope);
 extern HQL_API IHqlAlienTypeInfo * queryAlienType(ITypeInfo * t);
@@ -1593,6 +1594,7 @@ inline bool isAbstractDataset(IHqlExpression * expr)
 }
 
 extern HQL_API bool isPureVirtual(IHqlExpression * cur);
+inline bool isForwardScope(IHqlScope * scope) { return scope && (queryExpression(scope)->getOperator() == no_forwardscope); }
 
 extern HQL_API bool isContextDependent(IHqlExpression * expr, bool ignoreFailures = false, bool ignoreGraph = false);
 

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -792,6 +792,7 @@ public:
     virtual IHqlScope * queryConcreteScope() { return this; }
     virtual IHqlScope * queryResolvedScope(HqlLookupContext * context) { return this; }
 
+    virtual IHqlExpression * queryExpression() { return this; }
     virtual IHqlScope * queryScope() { return this; }
 
 protected:
@@ -826,6 +827,7 @@ public:
     virtual void sethash();
 
 //interface IHqlScope
+    virtual IHqlExpression * queryExpression() { return this; }
     virtual void defineSymbol(_ATOM name, _ATOM moduleName, IHqlExpression *value, bool isPublic, bool isShared, unsigned symbolFlags, IFileContents *, int bodystart, int lineno, int column);
     virtual void defineSymbol(_ATOM name, _ATOM moduleName, IHqlExpression *value, bool exported, bool shared, unsigned symbolFlags);
     virtual void defineSymbol(IHqlExpression * expr);

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -679,7 +679,7 @@ protected:
     IHqlExpression * createAssert(attribute & cond, attribute * msg, attribute & flags);
 
     void defineImport(const attribute & errpos, IHqlExpression * imported, _ATOM newName);
-    IHqlScope * resolveImportModule(const attribute & errpos, IHqlExpression * expr);
+    IHqlExpression * resolveImportModule(const attribute & errpos, IHqlExpression * expr);
 
     void setActiveAttrs(int activityToken, const TokenMap * attrs);
 
@@ -1181,47 +1181,6 @@ private:
 
 IHqlExpression *reparseTemplateFunction(IHqlExpression * funcdef, IHqlScope *scope, HqlLookupContext & ctx, bool hasFieldMap);
 extern HQL_API void resetLexerUniqueNames();        // to make regression suite consistent
-
-
-#ifdef _DEBUG
-#define PSEUDO_UNIMPLEMENTED
-//#define PSEUDO_UNIMPLEMENTED  UNIMPLEMENTED
-#else
-#define PSEUDO_UNIMPLEMENTED
-#endif
-class PseudoPatternScope : public CInterface, implements IHqlScope
-{
-public:
-    PseudoPatternScope(IHqlExpression * _patternList);
-    IMPLEMENT_IINTERFACE
-
-    virtual void defineSymbol(_ATOM name, _ATOM moduleName, IHqlExpression *value, bool isExported, bool isShared, unsigned flags, IFileContents *fc, int bodystart, int lineno, int column) { ::Release(value); PSEUDO_UNIMPLEMENTED; }
-    virtual void defineSymbol(_ATOM name, _ATOM moduleName, IHqlExpression *value, bool isExported, bool isShared, unsigned flags) { ::Release(value); PSEUDO_UNIMPLEMENTED; }
-    virtual void defineSymbol(IHqlExpression * value) { PSEUDO_UNIMPLEMENTED; ::Release(value); }
-    virtual IHqlExpression *lookupSymbol(_ATOM name, unsigned lookupFlags, HqlLookupContext & ctx);
-    virtual void removeSymbol(_ATOM name) { PSEUDO_UNIMPLEMENTED; }
-
-    virtual void    getSymbols(HqlExprArray& exprs) const { PSEUDO_UNIMPLEMENTED; }
-    virtual _ATOM   queryName() const { PSEUDO_UNIMPLEMENTED; return NULL; }
-    virtual const char * queryFullName() const { PSEUDO_UNIMPLEMENTED; return NULL; }
-    virtual ISourcePath * querySourcePath() const { PSEUDO_UNIMPLEMENTED; return NULL; }
-    virtual bool hasBaseClass(IHqlExpression * searchBase) { return false; }
-
-    virtual void ensureSymbolsDefined(HqlLookupContext & ctx) { }
-
-    virtual bool isImplicit() const { return false; }
-    virtual bool isPlugin() const { return false; }
-    virtual int getPropInt(_ATOM, int dft) const { PSEUDO_UNIMPLEMENTED; return dft; }
-    virtual bool getProp(_ATOM, StringBuffer &) const { PSEUDO_UNIMPLEMENTED; return false; }
-
-    virtual IHqlScope * clone(HqlExprArray & children, HqlExprArray & symbols) { throwUnexpected(); }
-    virtual IHqlScope * queryConcreteScope() { return this; }
-    virtual IHqlScope * queryResolvedScope(HqlLookupContext * context) { return this; }
-
-protected:
-    IHqlExpression * patternList;   // NB: Not linked.
-};
-
 extern HQL_API void testHqlInternals();
 
 #endif

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -1449,8 +1449,6 @@ FUNCTIONMACRO|MACRO {
                         //Need to process using an exclusive start condition unlike MACRO because many
                         //tokens in C++ aren't legal in ECL, so lexer->yyLex() will generate errors.
                         setupdatepos; 
-                        if (!lookup)
-                            return lookupIdentifierToken(returnToken, lexer, lookup, activeState, CUR_TOKEN_TEXT);
                         BEGIN(CPP);
                         lexer->inCpp = true;
                     }


### PR DESCRIPTION
Forward modules (still undocumented) didn't support beginc++
correctly, and a regression had lost access to local symbols.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
