### PR TITLE
Fix gh-567 preserve legacy flag in archives

### DIFF
--- a/ecl/regress/legacy1.eclxml
+++ b/ecl/regress/legacy1.eclxml
@@ -1,0 +1,31 @@
+<Archive legacyMode="false">
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+ <Module name="common">
+  <Attribute name="m1">
+output('hello');
+export m1 := m2+10;
+  </Attribute>
+  <Attribute name="m2">
+export m2 := 20;
+  </Attribute>
+ </Module>
+ <Query>
+ output(common.m1);
+ </Query>
+</Archive>

--- a/ecl/regress/legacy2.eclxml
+++ b/ecl/regress/legacy2.eclxml
@@ -1,0 +1,31 @@
+<Archive legacyMode="true">
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+ <Module name="common">
+  <Attribute name="m1">
+output('hello');
+export m1 := m2+10;
+  </Attribute>
+  <Attribute name="m2">
+export m2 := 20;
+  </Attribute>
+ </Module>
+ <Query>
+ output(common.m1);
+ </Query>
+</Archive>


### PR DESCRIPTION
The legacy flag is now preserved in an archive, and interpreted when
compiling.  This fix also ensures an archive is still generated if
an error occurs.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
