### PR TITLE
Fix windows build break caused by  missing mp_decl

### DIFF
--- a/system/mp/mpbase.hpp
+++ b/system/mp/mpbase.hpp
@@ -138,7 +138,7 @@ extern mp_decl IGroup *createIGroup(const char *endpointlist,unsigned short defp
 extern mp_decl IGroup *deserializeIGroup(MemoryBuffer &src); 
 
 extern mp_decl INode *queryNullNode(); 
-extern INode * queryMyNode();
+extern mp_decl INode * queryMyNode();
 extern mp_decl void initMyNode(unsigned short port);
 
 // Exceptions


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
