### PR TITLE
Ordered Hash Aggregate broken in 64bit

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2458,7 +2458,7 @@ CThorRowAggregator *mergeLocalAggs(CActivityBase &activity, IHThorRowAggregator 
             virtual unsigned hash(const void *rowMeta)
             {
                 const void *row;
-                memcpy(&row, ((const byte *)rowMeta)+sizeof(size32_t), sizeof(size32_t));
+                memcpy(&row, ((const byte *)rowMeta)+sizeof(size32_t), sizeof(const void *));
                 return baseHash->hash(row);
             }
         } nodeCompare(helperExtra.queryHashElement());
@@ -2471,7 +2471,7 @@ CThorRowAggregator *mergeLocalAggs(CActivityBase &activity, IHThorRowAggregator 
                 break;
             readCount++;
             const void *row;
-            memcpy(&row, ((const byte *)rowMeta.get())+sizeof(size32_t), sizeof(size32_t));
+            memcpy(&row, ((const byte *)rowMeta.get())+sizeof(size32_t), sizeof(const void *));
             globalAggTable->mergeElement(row);
         }
     }


### PR DESCRIPTION
A couple of memcpy's that should have been copying a pointer size
were copying a size32_t instead, so the resulting pointer was invalid
if >32bits.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
