### PR TITLE
Fixes Bug 88625 Change file permissions for files deployed using ConfigEn

### DIFF
--- a/deployment/deploy/DeployTask.cpp
+++ b/deployment/deploy/DeployTask.cpp
@@ -661,7 +661,7 @@ public:
              try
              {
                StringBuffer cmd;
-               cmd.clear().appendf("chmod -R 744 %s", destpath.str());
+               cmd.clear().appendf("chmod -R 755 %s", destpath.str());
                task->execSSHCmd(ip.str(), cmd, outbuf, errbuf);
              }
              catch(IException* e)


### PR DESCRIPTION
Fixes Bug 88625 Change file permissions for files deployed using ConfigEnv
SSH from "744" to "755"

As per the instruction in the bug description, changing the file permissions
for files deployed using ConfigEnv SSH from "744" to "755". Similar changes will be done in 702Series

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
