### PR TITLE
Fix gh-640 Fix roxie diskWrite::resolve failure

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10561,13 +10561,8 @@ protected:
         }
         else
         {
-            if (ctx->queryWorkUnit())
-            {
-                // Not really sure if this code is wanted. What is the cluster name info in a workunit?
-                SCMStringBuffer cluster;
-                ctx->queryWorkUnit()->getClusterName(cluster);
-                clusters.append(cluster.str());
-            }
+            if (roxieName.length())
+                clusters.append(roxieName.str());
             else
                 clusters.append(".");
         }


### PR DESCRIPTION
In CRoxieServerDiskWriteActivity::resolve, a call is made to the workunit
to query the cluster name. The cluster name "roxie" from the workunit
does not resolve in subsequent calls in CRoxieWriteHandler to add the
cluster name.
Fix the problem by using the current cluster name, store in the
roxieName string variable. This allows the cluster to be resolved and
files to be created.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
