### PR TITLE
Roxie internal error when no dali connected

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -2193,13 +2193,15 @@ private:
     {
         // Called from reload inside critical block
         unsubscribe();
-        // We want tokill the old packages, but not until we have created the new ones (i.e. at the end of this function)
+        // We want to kill the old packages, but not until we have created the new ones (i.e. at the end of this function)
         // So that the query/dll caching will work for anything that is not affected by the changes
         CIArrayOf<CRoxieQueryPackageManager> oldQueryPackages;
         appendArray(oldQueryPackages, allQueryPackages);
         allQueryPackages.kill();
 
-        notifiers.append(*daliHelper->getPackageSetSubscription(roxieName, this));
+        Owned<IDaliPackageWatcher> notifier = daliHelper->getPackageSetSubscription(roxieName, this);
+        if (notifier)
+            notifiers.append(*notifier.getClear());
         Owned<IPropertyTree> packageTree = daliHelper->getPackageSet(roxieName);
         Owned<IPropertyTreeIterator> packageMaps = packageTree->getElements("PackageMap");
         ForEach(*packageMaps)


### PR DESCRIPTION
Roxie fails an assert if started without a dali connection. This
patch checks for a NULL notifier before trying to add it to the
notifier list.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
