### PR TITLE
gh-644 Change button names to avoid misleading

### DIFF
--- a/esp/eclwatch/ws_XSLT/tplog.xslt
+++ b/esp/eclwatch/ws_XSLT/tplog.xslt
@@ -548,8 +548,8 @@
             </tr>
             <tr>
               <td colspan="4">
-                <input type="button" id="GetLog" class="sbutton"  size="40" value="Submit" onClick="return onGetLog(0)"/>
-                <input type="button" id="GetLogR" class="sbutton"  size="40" value="Reversely" onClick="return onGetLog(-1)"/>
+                <input type="button" id="GetLog" class="sbutton"  size="40" value="EarliestFirst" onClick="return onGetLog(0)"/>
+                <input type="button" id="GetLogR" class="sbutton"  size="40" value="LatestFirst" onClick="return onGetLog(-1)"/>
                 <input type="button" id="PrevPage" class="sbutton"  size="40" value="PrevPage" onClick="return onGetLog(1)"/>
                 <input type="button" id="NextPage" class="sbutton"  size="40" value="NextPage" onClick="return onGetLog(2)"/>
                 <input type="button" id="Download" class="sbutton"  size="40" value="Download" onClick="return onDownload(0)"/>


### PR DESCRIPTION
In ECLWatch View Log page, people have been confused by the name
of the Submit button and Reversely button. The Submit button
shows the log lines in the order of the earliest first. The
Reversely button displays most recent line first. This fix
changes the Submit button to be EarliestFirst button. Also
change the Reversely button to be LatestFirst button.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
