### PR TITLE
Fixes #464 Display wizard dialog when user is done with Summary View

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -136,9 +136,9 @@ function invokeWizard() {
       }
       document.getElementById('top1').style.display = 'block';
       if( document.forms['treeForm'].wizops != '3')
-        getMessagePanel("Please select wizard to create an environment or select open environment to view environment summary.");
+        getMessagePanel("Please select wizard to create an environment or select open environment to view environment summary.").show();
       else
-        getMessagePanel("Please select wizard or open an environment to create/edit environment.");
+        getMessagePanel("Please select wizard or open an environment to create/edit environment.").show();
     }
   }
   var prevMode = document.forms['treeForm'].mode.value;
@@ -4154,7 +4154,7 @@ function summaryPageForAdvance() {
 
      var fileopened = window.location.href.split(/\?/g);
      if (fileopened.length <= 1)
-       getMessagePanel("Please select wizard or open an environment to create/edit environment.");
+       invokeWizard();
      
   };
 


### PR DESCRIPTION
As suggested in the issue, display wizard dialog when user presses ok button
in Summary View. The wizard dialog should be displayed only if no other file
is already open in the advanced mode. 

Since the message is not being displayed, the message not being displayed the second time around is not
an issue anymore. Bugzilla 81119 is similar to this issue, so marking that as a duplicate.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
