### PR TITLE
FIX gh-656 Workunits stuck in 'compiling' state

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3801,7 +3801,6 @@ class CEnvironmentClusterInfo: public CInterface, implements IConstWUClusterInfo
     StringAttr name;
     StringAttr serverQueue;
     StringAttr agentQueue;
-    StringAttr roxieQueue;
     StringAttr roxieProcess;
     StringAttr thorQueue;
     StringArray thorProcesses;
@@ -3849,9 +3848,12 @@ public:
         }
 
         if (agent)
+        {
+            assertex(!roxie);
             agentQueue.set(queue.clear().append(name).append(".agent"));
-        if (roxie)
-            roxieQueue.set(queue.clear().append(name).append(".roxie"));
+        }
+        else if (roxie)
+            agentQueue.set(queue.clear().append(name).append(".roxie"));
         // MORE - does this need to be conditional?
         serverQueue.set(queue.clear().append(name).append(".eclserver"));
     }
@@ -3868,11 +3870,6 @@ public:
     IStringVal & getAgentQueue(IStringVal & str) const
     {
         str.set(agentQueue);
-        return str;
-    }
-    IStringVal & getRoxieQueue(IStringVal & str) const
-    {
-        str.set(roxieQueue);
         return str;
     }
     virtual IStringVal & getServerQueue(IStringVal & str) const

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -537,7 +537,6 @@ interface IConstWUClusterInfo : extends IInterface
     virtual unsigned getSize() const = 0;
     virtual IStringVal & getPlatform(IStringVal & str) const = 0;
     virtual IStringVal & getAgentQueue(IStringVal & str) const = 0;
-    virtual IStringVal & getRoxieQueue(IStringVal & str) const = 0;
     virtual IStringVal & getServerQueue(IStringVal & str) const = 0;
     virtual IStringVal & getQuerySetName(IStringVal & str) const = 0;
     virtual IStringVal & getRoxieProcess(IStringVal & str) const = 0;

--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1868,8 +1868,6 @@ extern bool WORKUNIT_API runWorkUnit(const char *wuid, const char *cluster)
     SCMStringBuffer agentQueue;
     clusterInfo->getAgentQueue(agentQueue);
     if (!agentQueue.length())
-        clusterInfo->getRoxieQueue(agentQueue);
-    if (!agentQueue.length())
         return false;
 
     Owned<IJobQueue> queue = createJobQueue(agentQueue.str());

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -252,8 +252,7 @@ public:
             workunit.clear();
             return;
         }
-        SCMStringBuffer agentQueue, platform;
-        clusterInfo->getAgentQueue(agentQueue);
+        SCMStringBuffer platform;
         clusterInfo->getPlatform(platform);
         clusterInfo.clear();
         workunit->setState(WUStateCompiling);
@@ -261,11 +260,12 @@ public:
         bool ok = compile(wuid, platform.str(), clusterName.str());
         if (ok)
         {
+            workunit->setState(WUStateCompiled);
             if (isLibrary(workunit))
             {
                 workunit->setState(WUStateCompleted);
             }
-            else if (agentQueue.length() && workunit->getAction()==WUActionRun || workunit->getAction()==WUActionUnknown)  // Assume they meant run....
+            else if (workunit->getAction()==WUActionRun || workunit->getAction()==WUActionUnknown)  // Assume they meant run....
             {
                 workunit->schedule();
                 SCMStringBuffer dllBuff;
@@ -285,10 +285,11 @@ public:
                     }
                 }
                 else
+                {
+                    reportError("Failed to execute workunit (unknown DLL name)", 2);
                     workunit->setState(WUStateFailed);
+                }
             }
-            else if (workunit->getAction()==WUActionCompile)
-                workunit->setState(WUStateCompiled);
         }
         else if (workunit->getState() != WUStateAborted)
             workunit->setState(WUStateFailed);


### PR DESCRIPTION
Queries sumbitted to roxie via ecl ide were left in the 'compiling'
state. This was due to a combination of bugs:
1. eclccserver was only checking the agent queue, not the roxie queue
2. eclccserver was not setting the state to failed or compiled if agent
   queue was empty
3. If action was not specified, a separate bug meant that the agent queue
   check was accidentally bypassed and the submit then succeeded.

This patch ensures that eclccserver sets the state appropriately on all
paths, and eliminates the distinction between agent and roxie queues as
a given target cluster can only have one or the other.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
