### PR TITLE
Fix gh-612 Regression in roxie directory handling

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -181,7 +181,8 @@ private:
             cache->setPropTree(xpath, LINK(val));
         else
             cache->removeProp(xpath);
-        ensureDirectory(queryDirectory);
+        if (!recursiveCreateDirectory(queryDirectory))
+            throw MakeStringException(ROXIE_FILE_ERROR, "Unable to create directory %s", queryDirectory.str());
         StringBuffer cacheFileName(queryDirectory);
         cacheFileName.append(roxieStateName);
         saveXML(cacheFileName, cache);
@@ -441,7 +442,8 @@ public:
         Owned<IRoxieDaliHelper> daliHelper = connectToDali();
         if (!started)
         {
-            ensureDirectory(queryDirectory);
+            if (!recursiveCreateDirectory(queryDirectory))
+                throw MakeStringException(ROXIE_FILE_ERROR, "Unable to create directory %s", queryDirectory.str());
             initDllServer(queryDirectory);
             started = true;
         }

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2697,16 +2697,6 @@ extern IRoxieWriteHandler *createRoxieWriteHandler(IRoxieDaliHelper *_daliHelper
     return new CRoxieWriteHandler(_daliHelper, _dFile, _clusters);
 }
 
-extern void ensureDirectory(StringBuffer &dir)
-{
-    StringBuffer absolute;
-    if (!recursiveCreateDirectory(dir.str()))
-        throw MakeStringException(ROXIE_FILE_ERROR, "Unable to create directory %s", dir.str());
-    makeAbsolutePath(dir.str(), absolute);
-    dir.clear().append(absolute);
-    addPathSepChar(dir);
-}
-
 #ifdef _USE_CPPUNIT
 #include <cppunit/extensions/HelperMacros.h>
 

--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -145,6 +145,4 @@ extern IMemoryFile *createMemoryFile(const char *fileName);
 extern IDiffFileInfoCache *queryDiffFileInfoCache();
 extern void releaseDiffFileInfoCache();
 
-extern void ensureDirectory(StringBuffer &dir);
-
 #endif

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -462,7 +462,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         throw MakeStringException(ROXIE_INTERNAL_ERROR, "getcwd failed (%d)", errno);
 
     codeDirectory.set(currentDirectory);
-    ensureDirectory(codeDirectory);
+    addNonEmptyPathSepChar(codeDirectory);
     try
     {
         Owned<IProperties> globals = createProperties(true);
@@ -541,6 +541,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             if (!logDirectory.length())
                 logDirectory.append(codeDirectory).append("logs");
         }
+        addNonEmptyPathSepChar(logDirectory);
 
         StringBuffer initialFileName;
         if (globals->getPropBool("stdlog", traceLevel != 0) || topology->getPropBool("@forceStdLog", false))
@@ -573,7 +574,8 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             initialFileName.appendf("%s.log", (log[0] !='.') ? log.str() : (log.str()+1)); // make sure 'log' does not start with a '.'
 
             // build the base log file name using the logDir setting in the topology file
-            ensureDirectory(logDirectory);
+            if (!recursiveCreateDirectory(logDirectory))
+                throw MakeStringException(ROXIE_FILE_ERROR, "Unable to create directory %s", logDirectory.str());
             StringBuffer logBaseName(logDirectory.str());
             logBaseName.append("roxie");
 
@@ -832,6 +834,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             if (queryDirectory.length() == 0)
                 queryDirectory.append(codeDirectory).append("queries");
         }
+        addNonEmptyPathSepChar(queryDirectory);
 
         baseDataDirectory.append(topology->queryProp("@baseDataDir"));
         queryFileCache().start();


### PR DESCRIPTION
Previous commit 90e6e4cc52 broke some Roxie directory handling, which
relied on the calls to ensureDirectory to add the trailing path
separator to directory paths.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
