### PR TITLE
Fixes gh-651 Removed creation of directories in the start_slaves and start_slave script.

### DIFF
--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -25,11 +25,10 @@ if [ $# -lt 7 ]; then
   exit 1
 fi
 
-mkdir -p $instancedir
-cd $instancedir
-
 sudo /etc/init.d/hpcc-init -c $hpcc_compname setup 2>/dev/null 2>/dev/null
-. $instancedir/setvars
+
+cd $instancedir
+. ./setvars
 
 slaveproc="thorslave_$THORSLAVEPORT"
 if [ "$multislaves" = "true" ] || [ "$localthor" = "true" ]; then

--- a/initfiles/componentfiles/thor/start_slaves
+++ b/initfiles/componentfiles/thor/start_slaves
@@ -27,14 +27,14 @@ else
                 if [ "$slaveport" = "" ]; then
                     slaveport=$THORSLAVEPORT
                 fi
-                frunssh $ip "/bin/sh -c 'mkdir -p  $instancedir; cd $instancedir; mkdir -p $logdir; $deploydir/start_slave $deploydir $n $logpth $instancedir $slaveport $THORNAME $PATH_PRE&> $logdir/start_slave_$logpthtail.$n.log'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
+                frunssh $ip "/bin/sh -c '$deploydir/start_slave $deploydir $n $logpth $instancedir $slaveport $THORNAME $PATH_PRE&> $logdir/start_slave_$logpthtail.$n.log'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
                 let "n += 1";
             done
         else
             if [ -e $instancedir/thorgroup ]; then
                 mv $instancedir/thorgroup $instancedir/thorgroup.local
             fi
-            frunssh $instancedir/slaves "/bin/sh -c 'mkdir -p  $instancedir; cd $instancedir; mkdir -p $logdir; $deploydir/start_slave $deploydir %n $logpth $instancedir $THORSLAVEPORT $THORNAME $PATH_PRE &> $logdir/start_slave_$logpthtail.log'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
+            frunssh $instancedir/slaves "/bin/sh -c '$deploydir/start_slave $deploydir %n $logpth $instancedir $THORSLAVEPORT $THORNAME $PATH_PRE &> $logdir/start_slave_$logpthtail.log'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
         fi
 fi
 echo thorslaves started


### PR DESCRIPTION
Fixes gh-651 Removed creation of directories in the start_slaves and start_slave script.

Prior to this fix there was an issue when thormaster started on a clean multinode system due to the
instance dir not being created till the hpcc-init setup was called.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
