### PR TITLE
Fix gh-666 Release roxie file lock before deleting

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6607,6 +6607,7 @@ IDistributedFile *CDistributedFileDirectory::dolookup(const CDfsLogicalFileName 
                                 break;
                         }
                     }
+                    fcl.remove();
                     return new CDistributedFile(this,fcl.detach(),*logicalname,user);  // found
                 }
                 // now super file


### PR DESCRIPTION
When Roxie diskWriteActivity tries to delete an existing file before
OVERWRITing it, it needs to release the file lock.
Fix this problem be releasing before creation of new CDistributedFile,
which will relock the file.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
