### PR TITLE
Fix gh-666 Roxie locks up when trying to overwrite a file

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2164,8 +2164,10 @@ public:
     {
         return properties;
     }
-    virtual void remove() const
+    virtual void remove()
     {
+        subFiles.kill();
+        properties.clear();
         if (dFile)
         {
             dFile->detach();

--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -113,7 +113,7 @@ interface IResolvedFile : extends ISimpleSuperFileEnquiry
     virtual bool isAlive() const = 0;
     virtual const IPropertyTree *queryProperties() const = 0;
 
-    virtual void remove() const = 0;
+    virtual void remove() = 0;
 };
 
 interface IResolvedFileCreator : extends IResolvedFile


### PR DESCRIPTION
The recent refactoring of Roxie file write code is locking up when
trying to delete an existing logical file (when ,OVERWRITE specified),
as detach() is called while a lock is still held on the file because
of the properties.

Add a clear() of properties field in CResolvedFile::remove to ensure
that the detach can succeed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
