### PR TITLE
Prevent compiler log files from clashing with eclcc

### DIFF
--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -454,7 +454,7 @@ bool CppCompiler::compileFile(IThreadPool * pool, const char * filename, Semapho
     StringBuffer expanded;
     expandRootDirectory(expanded, cmdline);
     StringBuffer logFile;
-    logFile.append(filename).append(".log");
+    logFile.append(filename).append(".log.tmp");
     logFiles.append(logFile);
 
     Owned<CCompilerThreadParam> parm;
@@ -497,7 +497,7 @@ bool CppCompiler::doLink()
     DWORD runcode = 0;
     if (verbose)
         PrintLog("%s", expanded.toCharArray());
-    StringBuffer logFile = StringBuffer(CORE_NAME).append("_link.log");
+    StringBuffer logFile = StringBuffer(CORE_NAME).append("_link.log.tmp");
     logFiles.append(logFile);
     bool ret = invoke_program(expanded.toCharArray(), runcode, true, logFile) && (runcode == 0);
     return ret;


### PR DESCRIPTION
Use a .tmp file extension on the log files generated by the compiler.
Otherwise it can clash with the name of the file used by eclcc for
logging.  (The files are subsequently read in and concatenated, so
are purely internal.)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
