### PR TITLE
Fix locality of activities within nested thor loops

### DIFF
--- a/ecl/hqlcpp/CMakeLists.txt
+++ b/ecl/hqlcpp/CMakeLists.txt
@@ -67,6 +67,7 @@ set (    SRCS
          hqlcpputil.hpp
          hqlecl.hpp
          hqlfunc.hpp
+         hqlinline.hpp
          hqlpopt.hpp
          hqlregex.hpp
          hqlres.hpp

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -550,7 +550,7 @@
 #define HQLERR_LibraryNoWorkunitRead_Text       "INTERNAL: Library '%s' shouldn't access work unit temporary '%s'"
 #define HQLERR_LibraryNoWorkunitWrite_Text      "INTERNAL: Library '%s' shouldn't create work unit temporary '%s'"
 #define HQLERR_GraphInputAccessedChild_Text     "INTERNAL: Attempting to access graph output directly from a child query"
-#define HQLERR_InconsisentLocalisation_Text     "INTERNAL: Inconsistent activity localisation (%d:%d)"
+#define HQLERR_InconsisentLocalisation_Text     "INTERNAL: Inconsistent activity localisation (child %d:graph %d)"
 #define HQLERR_NoParentExtract_Text             "INTERNAL: No active parent extract - activity has incorrect localisation?"
 #define HQLERR_InconsistentNaryInput_Text       "INTERNAL: Inputs to nary operation have inconsistent record structures"
 #define HQLERR_LinkedDatasetNoContext_Text      "INTERNAL: Linked child rows required without legal context available"

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -52,6 +52,7 @@
 #include "hqlpopt.hpp"
 #include "hqlcse.ipp"
 #include "thorplugin.hpp"
+#include "hqlinline.hpp"
 
 #ifdef _DEBUG
 //#define ADD_ASSIGNMENT_COMMENTS

--- a/ecl/hqlcpp/hqlhtcpp.ipp
+++ b/ecl/hqlcpp/hqlhtcpp.ipp
@@ -84,6 +84,7 @@ public:
 //===========================================================================
 
 //MORE: I should derive the following and ActivityInstance from a common base class
+class GlobalClassEvalContext;
 class GlobalClassBuilder
 {
 public:
@@ -119,7 +120,7 @@ class JoinKeyInfo;
 class ActivityInstance;
 class NlpParseContext;
 extern StringBuffer &expandLiteral(StringBuffer &s, const char *f);
-
+class ActivityEvalContext;
 class ActivityInstance : public HqlExprAssociation
 {
 public:
@@ -161,7 +162,7 @@ public:
     void processHints(IHqlExpression * hintAttr);
     void processSection(IHqlExpression * hintAttr);
 
-    BuildCtx &   onlyEvalOnceContext()              { return evalContext->onCreate.childctx; }
+    BuildCtx &   onlyEvalOnceContext();
     inline IPropertyTree * querySubgraphNode() { return subgraph ? subgraph->tree.get() : NULL; }
     inline void setImplementationClass(_ATOM name) { implementationClassName = name; }
     void setInternalSink(bool value);

--- a/ecl/hqlcpp/hqlinline.hpp
+++ b/ecl/hqlcpp/hqlinline.hpp
@@ -1,0 +1,265 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#ifndef __HQLINLINE_HPP_
+#define __HQLINLINE_HPP_
+
+class ActivityInstance;
+class SerializationRow;
+class EvalContext;
+
+// A parent extract represents the set of fields etc. which are used from the parent activity,
+// which are local to the point that the executeChildActivity() is called.  The type indicates
+// the reason it is being created.
+class ParentExtract : public HqlExprAssociation
+{
+public:
+    ParentExtract(HqlCppTranslator & _translator, PEtype _type, GraphLocalisation _localisation, EvalContext * _container=NULL);
+    ~ParentExtract();
+
+//HqlExprAssociation
+    virtual AssocKind getKind() { return AssocExtract; }
+
+    void beginCreateExtract(BuildCtx & buildctx, bool doDeclare);
+    void beginNestedExtract(BuildCtx & clonectx);
+    void beginReuseExtract();
+    void endCreateExtract(CHqlBoundExpr & boundExtract);
+    void endUseExtract(BuildCtx & ctx);
+    IHqlExpression * queryExtractName()             { return boundExtract.expr; }
+
+    bool canEvaluate(IHqlExpression * expr);
+    bool canSerializeFields() const { return buildctx != NULL; }
+    void associateCursors(BuildCtx & declarectx, BuildCtx & evalctx, GraphLocalisation childLocalisation);
+    void beginChildActivity(BuildCtx & declareCtx, BuildCtx & startCtx, GraphLocalisation childLocalisation, IHqlExpression * colocal, bool nested, bool ignoreSelf, ActivityInstance * activityRequiringCast);
+    void endChildActivity();
+
+    void addSerializedExpression(IHqlExpression * value, ITypeInfo * type);
+    void buildAssign(IHqlExpression * serializedTarget, IHqlExpression * originalValue);
+    AliasKind evaluateExpression(BuildCtx & ctx, IHqlExpression * value, CHqlBoundExpr & tgt, IHqlExpression * colocal, bool evaluateLocally);
+
+    void setAllowDestructor() { canDestroyExtract = true; }
+    inline GraphLocalisation queryLocalisation() { return localisation; }
+
+    bool requiresOnStart() const;
+    bool insideChildQuery() const;
+
+protected:
+    void ensureAccessible(BuildCtx & ctx, IHqlExpression * expr, const CHqlBoundExpr & bound, CHqlBoundExpr & tgt, IHqlExpression * colocal);
+    void gatherActiveRows(BuildCtx & ctx);
+
+protected:
+    HqlCppTranslator & translator;
+    EvalContext * container;
+    SerializationRow * serialization;           // fields that are serialized to the children
+    SerializationRow * childSerialization;      // same serialization, but as it is bound in the child.
+
+    CursorArray colocalBoundCursors;            // what rows/cursors are available at the point of executeChildGraph()
+    CursorArray nonlocalBoundCursors;           // what rows/cursors are available at the point of executeChildGraph()
+    GraphLocalisation localisation;             // what kind of localisation do ALL the children have?
+
+    CursorArray inheritedCursors;
+    CursorArray localCursors;       // does not include colocal
+    CursorArray cursorToBind;
+    CHqlBoundExpr boundBuilder;     // may have wrapper, or be a char[n]
+    CHqlBoundExpr boundExtract;     // always a reference to a row. for "extract"
+    Owned<BuildCtx> buildctx;       // may be null if nested extract
+    PEtype type;
+    bool canDestroyExtract;
+};
+
+
+class CtxCollection : public CInterface
+{
+public:
+    CtxCollection(BuildCtx & _declareCtx)   : clonectx(_declareCtx), childctx(_declareCtx), declarectx(_declareCtx) {}
+
+    void createFunctionStructure(HqlCppTranslator & translator, BuildCtx & ctx, bool canEvaluate, const char * serializeFunc);
+
+public:
+    BuildCtx clonectx;
+    BuildCtx childctx;      // child.onCreate() is called from here..
+    BuildCtx declarectx;
+
+    //following are always null for nested classes, always created for others.
+    Owned<BuildCtx> evalctx;
+    Owned<BuildCtx> serializectx;
+    Owned<BuildCtx> deserializectx;
+};
+
+
+//A potential location for an extract to be created...
+class EvalContext : public HqlExprAssociation
+{
+public:
+    EvalContext(HqlCppTranslator & _translator, ParentExtract * _parentExtract, EvalContext * _parent);
+
+    virtual AssocKind getKind() { return AssocExtractContext; }
+
+    virtual IHqlExpression * createGraphLookup(unique_id_t id, bool isChild);
+    virtual AliasKind evaluateExpression(BuildCtx & ctx, IHqlExpression * value, CHqlBoundExpr & tgt, bool evaluateLocally) = 0;
+    virtual bool isColocal()                                { return true; }
+    virtual ActivityInstance * queryActivity();
+    virtual bool isLibraryContext()                         { return false; }
+
+    virtual void tempCompatiablityEnsureSerialized(const CHqlBoundTarget & tgt) = 0;
+    virtual bool getInvariantMemberContext(BuildCtx * ctx, BuildCtx * * declarectx, BuildCtx * * initctx, bool isIndependentMaybeShared, bool invariantEachStart) { return false; }
+
+    void ensureContextAvailable()                           { ensureHelpersExist(); }
+    virtual bool evaluateInParent(BuildCtx & ctx, IHqlExpression * expr, bool hasOnStart);
+    bool hasParent()                                        { return parent != NULL; }
+    bool needToEvaluateLocally(BuildCtx & ctx, IHqlExpression * expr);
+
+public://only used by friends
+    virtual void callNestedHelpers(const char * memberName) = 0;
+    virtual void ensureHelpersExist() = 0;
+    virtual bool isRowInvariant(IHqlExpression * expr)      { return false; }
+
+    bool requiresOnStart() const;
+    bool insideChildQuery() const;
+
+protected:
+    Owned<ParentExtract> parentExtract;         // extract of the parent EvalContext
+    HqlCppTranslator & translator;
+    EvalContext * parent;
+    OwnedHqlExpr colocalMember;
+};
+
+class ClassEvalContext : public EvalContext
+{
+    friend class ActivityInstance;
+    friend class GlobalClassBuilder;
+public:
+    ClassEvalContext(HqlCppTranslator & _translator, ParentExtract * _parentExtract, EvalContext * _parent, BuildCtx & createctx, BuildCtx & startctx);
+
+    virtual AliasKind evaluateExpression(BuildCtx & ctx, IHqlExpression * value, CHqlBoundExpr & tgt, bool evaluateLocally);
+    virtual bool isRowInvariant(IHqlExpression * expr);
+
+    virtual void tempCompatiablityEnsureSerialized(const CHqlBoundTarget & tgt);
+    virtual bool getInvariantMemberContext(BuildCtx * ctx, BuildCtx * * declarectx, BuildCtx * * initctx, bool isIndependentMaybeShared, bool invariantEachStart);
+
+protected:
+    void cloneAliasInClass(CtxCollection & ctxs, const CHqlBoundExpr & bound, CHqlBoundExpr & tgt);
+    IHqlExpression * cloneExprInClass(CtxCollection & ctxs, IHqlExpression * expr);
+    void createMemberAlias(CtxCollection & ctxs, BuildCtx & ctx, IHqlExpression * value, CHqlBoundExpr & tgt);
+    void doCallNestedHelpers(const char * member, const char * acticity);
+    void ensureSerialized(CtxCollection & ctxs, const CHqlBoundTarget & tgt);
+
+protected:
+    CtxCollection onCreate;
+    CtxCollection onStart;
+};
+
+
+class GlobalClassEvalContext : public ClassEvalContext
+{
+public:
+    GlobalClassEvalContext(HqlCppTranslator & _translator, ParentExtract * _parentExtract, EvalContext * _parent, BuildCtx & createctx, BuildCtx & startctx);
+
+    virtual void callNestedHelpers(const char * memberName);
+    virtual IHqlExpression * createGraphLookup(unique_id_t id, bool isChild) { throwUnexpected(); }
+    virtual void ensureHelpersExist();
+    virtual bool isColocal()                                { return false; }
+};
+
+
+
+class ActivityEvalContext : public ClassEvalContext
+{
+    friend class ActivityInstance;
+public:
+    ActivityEvalContext(HqlCppTranslator & _translator, ActivityInstance * _activity, ParentExtract * _parentExtract, EvalContext * _parent, IHqlExpression * _colocal, BuildCtx & createctx, BuildCtx & startctx);
+
+    virtual void callNestedHelpers(const char * memberName);
+    virtual IHqlExpression * createGraphLookup(unique_id_t id, bool isChild);
+    virtual void ensureHelpersExist();
+    virtual bool isColocal()                                { return (colocalMember != NULL); }
+    virtual ActivityInstance * queryActivity();
+
+    void createMemberAlias(CtxCollection & ctxs, BuildCtx & ctx, IHqlExpression * value, CHqlBoundExpr & tgt);
+
+protected:
+    ActivityInstance * activity;
+};
+
+
+class NestedEvalContext : public ClassEvalContext
+{
+public:
+    NestedEvalContext(HqlCppTranslator & _translator, const char * _memberName, ParentExtract * _parentExtract, EvalContext * _parent, IHqlExpression * _colocal, BuildCtx & createctx, BuildCtx & startctx);
+
+    virtual void callNestedHelpers(const char * memberName);
+    virtual IHqlExpression * createGraphLookup(unique_id_t id, bool isChild);
+    virtual void ensureHelpersExist();
+
+    void initContext();
+    virtual bool evaluateInParent(BuildCtx & ctx, IHqlExpression * expr, bool hasOnStart);
+
+protected:
+    bool helpersExist;
+
+protected:
+    StringAttr memberName;
+};
+
+
+
+class MemberEvalContext : public EvalContext
+{
+public:
+    MemberEvalContext(HqlCppTranslator & _translator, ParentExtract * _parentExtract, EvalContext * _parent, BuildCtx & _ctx);
+
+    virtual void callNestedHelpers(const char * memberName);
+    virtual void ensureHelpersExist();
+    virtual bool isRowInvariant(IHqlExpression * expr);
+
+    virtual IHqlExpression * createGraphLookup(unique_id_t id, bool isChild);
+    virtual AliasKind evaluateExpression(BuildCtx & ctx, IHqlExpression * value, CHqlBoundExpr & tgt, bool evaluateLocally);
+
+    virtual bool getInvariantMemberContext(BuildCtx * ctx, BuildCtx * * declarectx, BuildCtx * * initctx, bool isIndependentMaybeShared, bool invariantEachStart);
+    virtual void tempCompatiablityEnsureSerialized(const CHqlBoundTarget & tgt);
+
+    void initContext();
+
+protected:
+    BuildCtx ctx;
+};
+
+class LibraryEvalContext : public EvalContext
+{
+public:
+    LibraryEvalContext(HqlCppTranslator & _translator);
+
+    virtual AliasKind evaluateExpression(BuildCtx & ctx, IHqlExpression * value, CHqlBoundExpr & tgt, bool evaluateLocally);
+    virtual bool isColocal()                                { return false; }
+    virtual bool isLibraryContext()                         { return true; }
+
+    virtual void tempCompatiablityEnsureSerialized(const CHqlBoundTarget & tgt);
+
+    void associateExpression(BuildCtx & ctx, IHqlExpression * value);
+    void ensureContextAvailable()                           { }
+
+public:
+    virtual void callNestedHelpers(const char * memberName)     {}
+    virtual void ensureHelpersExist()                           {}
+
+protected:
+    HqlExprArray values;
+    HqlExprArray bound;
+};
+
+#endif

--- a/ecl/hqlcpp/hqliter.cpp
+++ b/ecl/hqlcpp/hqliter.cpp
@@ -40,6 +40,7 @@
 #include "hqlutil.hpp"
 #include "hqlcse.ipp"
 #include "hqliter.ipp"
+#include "hqlinline.hpp"
 
 //===========================================================================
 

--- a/ecl/hqlcpp/hqllib.cpp
+++ b/ecl/hqlcpp/hqllib.cpp
@@ -38,6 +38,7 @@
 #include "hqllib.ipp"
 #include "hqlwcpp.hpp"
 #include "hqlttcpp.ipp"
+#include "hqlinline.hpp"
 
 static IHqlExpression * queryLibraryInputSequence(IHqlExpression * expr)
 {
@@ -478,7 +479,7 @@ void HqlCppTranslator::buildLibraryInstanceExtract(BuildCtx & ctx, HqlCppLibrary
 
     BuildCtx beforeBuilderCtx(subctx);
     beforeBuilderCtx.addGroup();
-    Owned<ParentExtract> extractBuilder = createExtractBuilder(subctx, GraphNonLocal, false);
+    Owned<ParentExtract> extractBuilder = createExtractBuilder(subctx, PETlibrary, GraphNonLocal, false);
 
     StringBuffer s;
     s.append("rtlRowBuilder & ");
@@ -629,7 +630,7 @@ void HqlCppTranslator::buildLibraryGraph(BuildCtx & ctx, IHqlExpression * expr, 
         libraryContext->associateExpression(initctx, &parameter);
     }
 
-    Owned<ParentExtract> extractBuilder = createExtractBuilder(initctx, GraphRemote, false);
+    Owned<ParentExtract> extractBuilder = createExtractBuilder(initctx, PETlibrary, GraphRemote, false);
     beginExtract(initctx, extractBuilder);
 
     BuildCtx evalctx(ctx);

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -4518,9 +4518,9 @@ IHqlExpression * resourceNewChildGraph(HqlCppTranslator & translator, HqlExprCop
     return doResourceGraph(translator, &activeRows, expr, targetClusterType, 0, graphIdExpr, numResults, true, true);
 }
 
-IHqlExpression * resourceLoopGraph(HqlCppTranslator & translator, HqlExprCopyArray & activeRows, IHqlExpression * expr, ClusterType targetClusterType, IHqlExpression * graphIdExpr, unsigned * numResults, bool insideChildGraph)
+IHqlExpression * resourceLoopGraph(HqlCppTranslator & translator, HqlExprCopyArray & activeRows, IHqlExpression * expr, ClusterType targetClusterType, IHqlExpression * graphIdExpr, unsigned * numResults, bool insideChildQuery)
 {
-    return doResourceGraph(translator, &activeRows, expr, targetClusterType, 0, graphIdExpr, numResults, insideChildGraph, true);
+    return doResourceGraph(translator, &activeRows, expr, targetClusterType, 0, graphIdExpr, numResults, insideChildQuery, true);
 }
 
 IHqlExpression * resourceRemoteGraph(HqlCppTranslator & translator, IHqlExpression * expr, ClusterType targetClusterType, unsigned clusterSize)

--- a/ecl/hqlcpp/hqlresource.hpp
+++ b/ecl/hqlcpp/hqlresource.hpp
@@ -24,7 +24,7 @@
 
 IHqlExpression * resourceThorGraph(HqlCppTranslator & translator, IHqlExpression * expr, ClusterType targetClusterType, unsigned clusterSize, IHqlExpression * graphIdExpr);
 IHqlExpression * resourceLibraryGraph(HqlCppTranslator & translator, IHqlExpression * expr, ClusterType targetClusterType, unsigned clusterSize, IHqlExpression * graphIdExpr, unsigned * numResults);
-IHqlExpression * resourceLoopGraph(HqlCppTranslator & translator, HqlExprCopyArray & activeRows, IHqlExpression * expr, ClusterType targetClusterType, IHqlExpression * graphIdExpr, unsigned * numResults, bool insideChildGraph);
+IHqlExpression * resourceLoopGraph(HqlCppTranslator & translator, HqlExprCopyArray & activeRows, IHqlExpression * expr, ClusterType targetClusterType, IHqlExpression * graphIdExpr, unsigned * numResults, bool insideChildQuery);
 IHqlExpression * resourceNewChildGraph(HqlCppTranslator & translator, HqlExprCopyArray & activeRows, IHqlExpression * expr, ClusterType targetClusterType, IHqlExpression * graphIdExpr, unsigned * numResults);
 IHqlExpression * resourceRemoteGraph(HqlCppTranslator & translator, IHqlExpression * expr, ClusterType targetClusterType, unsigned clusterSize);
 

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -47,6 +47,7 @@
 #include "hqlcse.ipp"
 #include "hqliter.ipp"
 #include "thorcommon.hpp"
+#include "hqlinline.hpp"
 
 //#define FLATTEN_DATASETS
 //#define HACK_TO_IGNORE_TABLE
@@ -2362,7 +2363,7 @@ void SourceBuilder::buildGroupAggregateTransformBody(BuildCtx & transformCtx, IH
     Owned<ParentExtract> extractBuilder;
     if (useExtract || (aggregate != mappedAggregate))
     {
-        extractBuilder.setown(translator.createExtractBuilder(transformCtx, GraphCoLocal, true));
+        extractBuilder.setown(translator.createExtractBuilder(transformCtx, PETcallback, GraphCoLocal, true));
         if (!translator.queryOptions().serializeRowsetInExtract)
             extractBuilder->setAllowDestructor();
         translator.beginExtract(transformCtx, extractBuilder);

--- a/ecl/hqlcpp/hqltcppc.cpp
+++ b/ecl/hqlcpp/hqltcppc.cpp
@@ -41,6 +41,7 @@
 #include "hqlccommon.hpp"
 #include "hqlpmap.hpp"
 #include "hqlutil.hpp"
+#include "hqlinline.hpp"
 
 #define LIMIT_FOR_GET       (NULL)
 


### PR DESCRIPTION
Activities within nested thor loops were incorrectly being marked as
colocal (i.e. able to access data from their parent activity).  This
fix also removes spurious code generated for grouped disk aggregate
callbacks.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
