### PR TITLE
Fix access to context information from SUM/MAX

### DIFF
--- a/ecl/hqlcpp/hqlinline.cpp
+++ b/ecl/hqlcpp/hqlinline.cpp
@@ -630,8 +630,9 @@ GraphLocalisation queryActivityLocalisation(IHqlExpression * expr)
         if (!queryRealChild(expr, 3))
         {
             node_operator op = querySimpleAggregate(expr, false, false);
-            if (op != no_none)
+            if (op == no_existsgroup || op == no_countgroup)
                 return GraphNoAccess;
+            //Need to check if it accesses anything in the context!
         }
         break;
     }


### PR DESCRIPTION
The code generator was incorrectly marking SUM(ds, f(ds,context)) as
context independent.  This first fix ensures context is available.
(It should be improved to see if the context is needed - would help
other activities as well.)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
