### PR TITLE
Protect LOOP maxIterations from going negative

### DIFF
--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -215,6 +215,7 @@ public:
         eof = false;
         helper->createParentExtract(extractBuilder);
         maxIterations = helper->numIterations();
+        if ((int)maxIterations < 0) maxIterations = 0;
         loopPending.setown(createOverflowableBuffer(this, LOOP_SMART_BUFFER_SIZE));
         loopPendingCount = 0;
         finishedLooping = ((container.getKind() == TAKloopcount) && (maxIterations == 0));


### PR DESCRIPTION
The loop count is passed to the engines as an unsigned, without protecting
against a (int)loopcount<0, it caused Thor execute the loop repeatedly
(well upto 2^32-1 times)
