### PR TITLE
Fixes #581 Enable Roxie queues in ConfigMgr and Wizard

### DIFF
--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -253,7 +253,7 @@ bool CConfigEnvHelper::addRoxieServers(const char* xmlArg)
     xpath.clear().appendf("RoxieCluster[@name='%s']/"XML_TAG_ROXIE_FARM, pszRoxieCluster);
     pFarm = pParent->addPropTree(xpath.str(), createPTree());
     pFarm->addProp    (XML_ATTR_NAME,       sFarmName.str());
-    pFarm->addPropInt("@port",          9876);
+    pFarm->addPropInt("@port", pSrcTree->getPropInt("@port", 9876));
     pFarm->addProp    (XML_ATTR_DATADIRECTORY,  sDataDir.str());
     pFarm->addPropInt("@listenQueue", 200);
     pFarm->addPropInt("@numThreads",    30);

--- a/deployment/deployutils/wizardInputs.hpp
+++ b/deployment/deployutils/wizardInputs.hpp
@@ -98,7 +98,7 @@ public:
   void generateSoftwareTree(IPropertyTree* pTree);
   void addInstanceToTree(IPropertyTree* pTree, StringBuffer attrName, const char* processName, const char* buildSetName, const char* instName);
   void getDefaultsForWizard(IPropertyTree* pTree);
-  void addRoxieThorClusterToEnv(IPropertyTree* pNewEnvTree, CInstDetails* pInstDetails, const char* buildSetName);
+  void addRoxieThorClusterToEnv(IPropertyTree* pNewEnvTree, CInstDetails* pInstDetails, const char* buildSetName, bool genRoxieOnDemand = false);
   unsigned getCntForAlreadyAssignedIPS();
   void addToCompIPMap(const char* buildSetName, const char* value, const char* compName);
   void getEspBindingInformation(IPropertyTree* pNewEnvTree);
@@ -135,6 +135,7 @@ private:
    unsigned m_thorSlavesPerNode;
    unsigned m_roxieAgentRedChannels;
    unsigned m_roxieAgentRedOffset;
+   bool m_roxieOnDemand;
    
    StringArray m_ipaddress;
    MapStringToMyClass<CInstDetails> m_compIpMap; 

--- a/deployment/envgen/main.cpp
+++ b/deployment/envgen/main.cpp
@@ -50,7 +50,10 @@ void usage()
   puts("          If not specified or specified as 0, no thor nodes");
   puts("          are generated");
   puts("   -slavesPerNode <number of thor slaves per node>: Number of thor nodes ");
-  puts("          per slave. This feature is only available in Enterprise edition");
+  puts("          per slave.");
+  puts("   -roxieondemand <enable roxie on demand(1) or disable roxie on demand(any ");
+  puts("          other value)>: Enable roxie on demand by specifying 1 for flag. ");
+  puts("          Any other value will disable roxie on demand");
   puts("   -o <categoryname=newdirvalue>: overrides for any common directories");
   puts("          There can be multiple of the -o options. Each override should still");
   puts("          contain a [NAME] and either a [CATEGORY] or [INST]. ");
@@ -68,6 +71,7 @@ int main(int argc, char** argv)
   const char* in_ipfilename;
   StringBuffer ipAddrs;
   int roxieNodes=0, thorNodes=0, slavesPerNode=1;
+  bool roxieOnDemand = true;
   MapStringTo<StringBuffer> dirMap;
 
   int i = 1;
@@ -101,6 +105,13 @@ int main(int argc, char** argv)
     {
       i++;
       slavesPerNode = atoi(argv[i++]);
+    }
+    else if (stricmp(argv[i], "-roxieondemand") == 0)
+    {
+      i++;
+
+      if (atoi(argv[i++]) != 1)
+        roxieOnDemand = false;
     }
     else if (stricmp(argv[i], "-ip") == 0)
     {
@@ -162,8 +173,8 @@ int main(int argc, char** argv)
     const char* pServiceName = "WsDeploy_wsdeploy_esp";
     Owned<IPropertyTree> pCfg = createPTreeFromXMLFile(ENVGEN_PATH_TO_ESP_CONFIG);
 
-    optionsXml.appendf("<XmlArgs roxieNodes=\"%d\" thorNodes=\"%d\" slavesPerNode=\"%d\" ipList=\"%s\"/>", roxieNodes,
-                      thorNodes, slavesPerNode, ipAddrs.str());
+    optionsXml.appendf("<XmlArgs roxieNodes=\"%d\" thorNodes=\"%d\" slavesPerNode=\"%d\" roxieOnDemand=\"%s\" ipList=\"%s\"/>", roxieNodes,
+      thorNodes, slavesPerNode, roxieOnDemand?"true":"false", ipAddrs.str());
 
     buildEnvFromWizard(optionsXml, pServiceName, pCfg, envXml, &dirMap);
     if(envXml.length())

--- a/esp/files/configmgr.html
+++ b/esp/files/configmgr.html
@@ -516,7 +516,7 @@ You need to have Javascript enabled in order to use ConfigMgr. Please enable Jav
                         <label id="autoipId" onmouseover="showTooltipForButtons(event)"><input id="autoIP" type="radio" name="ipRadiobutton" disabled value="2" onmouseover="showTooltipForButtons(event)" onclick="if (this.checked) document.forms['treeForm'].ipMode.value='2';getIPAddrThrAutoGenScript();enableTextArea(false)" title="This operation is only supported in Enterprise Editions (or higher )."/>Auto
                           Discovery</label>
                       </fieldset>
-                      <textarea id="ipListText" name="ipListText" rows="5" cols="69" wrap onclick="if(document.forms['treeForm'].textClear.value !== 'true') clearTextArea();"
+                      <textarea id="ipListText" name="ipListText" rows="8" cols="69" wrap onclick="if(document.forms['treeForm'].textClear.value !== 'true') clearTextArea();"
                         onkeyup="addNewLine(event)" class="textAreaCSS">Sample: X.X.X.X; X.X.X.X - XXX;</textarea>
                         <!--onchange="document.forms['treeForm'].isChanged.value='true'" -->
                     </td>
@@ -551,17 +551,24 @@ You need to have Javascript enabled in order to use ConfigMgr. Please enable Jav
                     <td>
                       <input id="node4Thor" type="textbox" name="node4Thor" style="width: 33px" value="1" />&nbsp;
                     </td>
+                    </tr>
                     <tr>
                      <td>
-                        <label id="slavePerNodelabel" onmouseover="showTooltipForButtons(event)"><br>Number of Thor slaves per node (default 1):<br></label><br>
+                        <label id="slavePerNodelabel" onmouseover="showTooltipForButtons(event)"><br>Number of Thor slaves per node (default 1)<br></label><br>
                      </td>
                      <td>
                        <input id="slavesPerNode" type="textbox" name="slavesPerNode" style="width: 33px" value="1" onmouseover="showTooltipForButtons(event)"/>&nbsp;
                      </td>
                   </tr>
+                  <tr>
+                     <td>
+                        <label id="roxieOnDemandLabel" onmouseover="showTooltipForButtons(event)"><br>Enable Roxie on demand<br></label><br>
+                     </td>
+                     <td>
+                       <input id="roxieOnDemand" type="checkbox" name="roxieOnDemand" value="true" checked onmouseover="showTooltipForButtons(event)"/>&nbsp;
+                     </td>
                   </tr>
                 </table>
-                <br>
                 <!--[if IE]>
                 <br>
                 <![endif]-->

--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -3368,13 +3368,13 @@ if(top.document.displayModeDialog1)
       constraintoviewport:true,
       underlay: 'none',
       width: '500',
-      height: '500px'
+      height: '540px'
     });
     
     top.document.wizardpanel.renderEvent.subscribe(function() {
       if(!top.document.wizardpanel.layout){
         top.document.wizardpanel.layout = new YAHOO.widget.Layout('wizardLayout', {
-          height : 480,
+          height : 520,
           width: 475,
           units: [
            { position: 'top', height: 55, resize: false, body: 'wizardTop'},
@@ -3432,6 +3432,7 @@ function handleWizardScreen() {
     top.document.wizardDialog1 = new YAHOO.widget.Dialog('wizardIPAddressScreen', 
     {   
       width:((top.document.wizardpanel.layout.getUnitByPosition('center').get('width')) - 2),
+      height:((top.document.wizardpanel.layout.getUnitByPosition('center').get('height')) - 2),
       visible : true, 
       draggable : false,
       modal : false,
@@ -3802,6 +3803,7 @@ populateNumberOfNode();
     top.document.numNodesDialog = new YAHOO.widget.Dialog('wizardNumNodesPage', 
     {   
       width:((top.document.wizardpanel.layout.getUnitByPosition('center').get('width')) - 2),
+      height:((top.document.wizardpanel.layout.getUnitByPosition('center').get('height')) - 2),
       visible : true, 
       draggable : false,
       modal : false,
@@ -3923,12 +3925,14 @@ function submitInformation() {
   var thorNode = document.getElementById('node4Thor').value ;
   var iplist = document.getElementById('ipListText').value;
   var slavesPerNode = document.getElementById('slavesPerNode').value;
+  var roxieOnDemand = document.getElementById('roxieOnDemand').checked;
   
   var xmlStr = "<XmlArgs username=\"" ;
   xmlStr += "\" password=\"";
   xmlStr += "\" roxieNodes=\"" + roxieSrvNode;
   xmlStr += "\" thorNodes=\"" + thorNode;
   xmlStr += "\" slavesPerNode=\"" + slavesPerNode;
+  xmlStr += "\" roxieOnDemand=\"" + roxieOnDemand;
   xmlStr += "\" ipList=\"" + iplist;
   xmlStr += "\"/>";
 

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -1152,9 +1152,17 @@
                      port="9876"
                      requestArrayThreads="5">
     <RoxieServerProcess computer="localhost" name="farm1_s1"/>
-    <RoxieServerProcess computer="localhost" name="farm1_s1b"/>
    </RoxieFarmProcess>
-   <RoxieServerProcess 
+   <RoxieFarmProcess
+                      dataDirectory="${RUNTIME_PATH}/hpcc-data/roxie"
+                      listenQueue="200"
+                      name="farm2"
+                      numThreads="30"
+                      port="0"
+                      requestArrayThreads="5">
+      <RoxieServerProcess computer="localhost" name="farm2_s1"/>
+    </RoxieFarmProcess>
+    <RoxieServerProcess
                        computer="localhost"
                        dataDirectory="${RUNTIME_PATH}/hpcc-data/roxie"
                        listenQueue="200"
@@ -1166,7 +1174,8 @@
    <RoxieServerProcess 
                        computer="localhost"
                        dataDirectory="${RUNTIME_PATH}/hpcc-data/roxie"
-                       name="farm1_s1b"
+                       listenQueue="200"
+                       name="farm2_s1"
                        netAddress="."
                        numThreads="30"
                        port="0"


### PR DESCRIPTION
In ConfigMgr Wizard, added a new checkbox in the nodes page to enable
Roxie on Demand. In Advanced view, the feature can be enabled by
setting the roxie port to 0. Default environment.xml has been updated
to reflect the ConfigMgr changes.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
