### PR TITLE
Fix gh-652 Roxie dali caching

### DIFF
--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -341,6 +341,13 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="lockDali" type="xs:boolean" use="optional" default="false">
+        <xs:annotation>
+          <xs:appinfo>
+            <tooltip>If set, Roxie will use cached info from dali only, and will not connect to dali or refresh the cache.</tooltip>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="multicastBase" type="ipAddress" use="optional" default="239.1.1.1">
         <xs:annotation>
           <xs:appinfo>

--- a/roxie/ccd/ccddali.hpp
+++ b/roxie/ccd/ccddali.hpp
@@ -36,8 +36,9 @@ interface IDaliPackageWatcher : extends IInterface
 
 interface IRoxieDaliHelper : extends IInterface
 {
+    virtual void commitCache() = 0;
     virtual bool connected() const = 0;
-    virtual IDistributedFile *resolveLFN(const char *filename, bool writeAccess) = 0;
+    virtual IDistributedFile *resolveLFN(const char *filename, bool cacheIt, bool writeAccess) = 0;
     virtual IFileDescriptor *resolveCachedLFN(const char *filename) = 0;
     virtual IConstWorkUnit *attachWorkunit(const char *wuid, ILoadedDllEntry *source) = 0;
     virtual IPropertyTree *getQuerySet(const char *id) = 0;
@@ -46,6 +47,8 @@ interface IRoxieDaliHelper : extends IInterface
     virtual IDaliPackageWatcher *getPackageSetSubscription(const char *id, ISDSSubscription *notifier) = 0;
     virtual IPropertyTree *getPackageMap(const char *id) = 0;
     virtual IDaliPackageWatcher *getPackageMapSubscription(const char *id, ISDSSubscription *notifier) = 0;
+    virtual bool connect() = 0;
+    virtual void disconnect() = 0;
 };
 
 


### PR DESCRIPTION
Roxie needs to be able to save away sufficient information retrieved from dali so
that if can successfully start up even if dali is down.

The code to achieve this had a number of issues in it, notably related to when the
information was refreshed if roxie DID connect to dali, and how information fetched
from xpaths that contained filters was cached. This patch fixes those issues.

Also, add the ability to lock/unlock dali access. When locked, only the cached info
will be used.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
