### PR TITLE
Fix h-642 ensure correct file is compiled

### DIFF
--- a/ecl/hql/hql.hpp
+++ b/ecl/hql/hql.hpp
@@ -176,7 +176,6 @@ interface IFileContents;
 interface IEclRepository: public IInterface
 {
     virtual IHqlScope * queryRootScope() = 0;
-    virtual void checkCacheValid() = 0;
 };
 
 //MORE: Make this more private

--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -797,7 +797,7 @@ extern HQL_API IEclSourceCollection * createArchiveEclCollection(IPropertyTree *
 
 //---------------------------------------------------------------------------------------
 
-extern HQL_API IEclSourceCollection * createSingleDefinitionEclCollection(const char * moduleName, const char * attrName, const char * text)
+IEclSourceCollection * createSingleDefinitionEclCollection(const char * moduleName, const char * attrName, IFileContents * contents)
 {
     //Create an archive with a single module/
     Owned<IPropertyTree> archive = createPTree("Archive");
@@ -805,8 +805,25 @@ extern HQL_API IEclSourceCollection * createSingleDefinitionEclCollection(const 
     module->setProp("@name", moduleName);
     IPropertyTree * attr = module->addPropTree("Attribute", createPTree("Attribute"));
     attr->setProp("@name", attrName);
-    attr->setProp("", text);
+    const char * filename = contents->querySourcePath()->str();
+    if (filename)
+        attr->setProp("@sourcePath", filename);
+
+    StringBuffer temp;
+    temp.append(contents->length(), contents->getText());
+    attr->setProp("", temp.str());
     return createArchiveEclCollection(archive);
+}
+
+IEclSourceCollection * createSingleDefinitionEclCollection(const char * attrName, IFileContents * contents)
+{
+    const char * dot = strrchr(attrName, '.');
+    if (dot)
+    {
+        StringAttr module(attrName, dot-attrName);
+        return createSingleDefinitionEclCollection(module, attrName, contents);
+    }
+    return createSingleDefinitionEclCollection("", attrName, contents);
 }
 
 //---------------------------------------------------------------------------------------

--- a/ecl/hql/hqlcollect.hpp
+++ b/ecl/hql/hqlcollect.hpp
@@ -80,7 +80,8 @@ enum EclSourceCollectionFlags {
 
 extern HQL_API IEclSourceCollection * createFileSystemEclCollection(IErrorReceiver *errs, const char * path, unsigned flags, unsigned trace);
 extern HQL_API IEclSourceCollection * createArchiveEclCollection(IPropertyTree * tree);
-extern HQL_API IEclSourceCollection * createSingleDefinitionEclCollection(const char * moduleName, const char * attrName, const char * text);
+extern HQL_API IEclSourceCollection * createSingleDefinitionEclCollection(const char * moduleName, const char * attrName, IFileContents * contents);
+extern HQL_API IEclSourceCollection * createSingleDefinitionEclCollection(const char * attrName, IFileContents * contents);
 extern HQL_API IEclSourceCollection * createRemoteXmlEclCollection(IEclUser * user, IXmlEclRepository & repository, const char * snapshot, bool useSandbox);
 
 extern HQL_API IXmlEclRepository * createArchiveXmlEclRepository(IPropertyTree * archive);

--- a/ecl/hql/hqlrepository.hpp
+++ b/ecl/hql/hqlrepository.hpp
@@ -25,12 +25,13 @@
 typedef IArrayOf<IEclRepository> EclRepositoryArray;
 
 extern HQL_API IEclRepository * createNewSourceFileEclRepository(IErrorReceiver *err, const char * pluginPath, unsigned flags, unsigned traceMask);
-extern HQL_API IEclRepository * createSingleDefinitionEclRepository(const char * moduleName, const char * attrName, const char * text);
+extern HQL_API IEclRepository * createSingleDefinitionEclRepository(const char * moduleName, const char * attrName, IFileContents * contents);
 
 extern HQL_API IEclRepository * createCompoundRepositoryF(IEclRepository * repository, ...);
 extern HQL_API IEclRepository * createCompoundRepository(EclRepositoryArray & repositories);
-extern HQL_API IEclRepository * createRepository(IEclSourceCollection * source);
+extern HQL_API IEclRepository * createRepository(IEclSourceCollection * source, const char * rootScopeFullName = NULL);
 extern HQL_API IEclRepository * createRepository(EclSourceCollectionArray & sources);
+extern HQL_API IEclRepository * createNestedRepository(_ATOM name, IEclRepository * root);
 
 extern HQL_API void getRootScopes(HqlScopeArray & rootScopes, IHqlScope * scope, HqlLookupContext & ctx);
 extern HQL_API void getRootScopes(HqlScopeArray & rootScopes, IEclRepository * repository, HqlLookupContext & ctx);


### PR DESCRIPTION
Ensure the correct file is compiled - even if it clashes with a
different file that would be dound using in the include directories.

Also
- Use full path names for batch mode (not sure why it didn't before)
- Fix problems with symbols in the directory of a file not on the
  include path clashing with the global modules.
- Ensure filenames are retrieved from singleDefinitionEclCollections.
- Remove unused checkCacheValiad() code (only called on collections).

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
