### PR TITLE
Fix gh-685 thorlib.group() gives internal error in eclagent

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1132,7 +1132,7 @@ extern WORKUNIT_API bool getWorkUnitCreateTime(const char *wuid,CDateTime &time)
 extern WORKUNIT_API bool restoreWorkUnit(const char *base,const char *wuid);
 extern WORKUNIT_API void clientShutdownWorkUnit();
 extern WORKUNIT_API IExtendedWUInterface * queryExtendedWU(IWorkUnit * wu);
-extern WORKUNIT_API unsigned getEnvironmentThorClusterNames(StringArray &clusternames, StringArray &groupnames, StringArray &qnames);
+extern WORKUNIT_API unsigned getEnvironmentThorClusterNames(StringArray &thorNames, StringArray &groupNames, StringArray &targetNames);
 extern WORKUNIT_API StringBuffer &formatGraphTimerLabel(StringBuffer &str, const char *graphName, unsigned subGraphNum=0, unsigned __int64 subId=0);
 extern WORKUNIT_API bool parseGraphTimerLabel(const char *label, StringBuffer &graphName, unsigned &subGraphNum, unsigned __int64  &subId);
 extern WORKUNIT_API void addExceptionToWorkunit(IWorkUnit * wu, WUExceptionSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column);


### PR DESCRIPTION
thorlib.group() (deprecated) is giving an internal error in eclagent. It's
deprecated because it is not always possible to give an unambiguous answer,
since there may be several thor clusters associated with a job with different
nodegroup names.

However, in the interests of harmony with legacy users, we should make the
effort to return an answer where an unambiguous one is available.

If all thors associated with the wu use the same nodegroup, or if there are
no thors associated, return an appropriate value. Otherwise, fail.

See also bugzilla ticket 89275

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
