### PR TITLE
Fix gh-687 Buuild error using gcc 4.6

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -111,7 +111,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
     set ( LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/libs" )
     if (${CMAKE_COMPILER_IS_GNUCXX})
       SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti -fPIC -fmessage-length=0 -Wformat -Wformat-security -Wformat-nonliteral -pthread")
-      SET (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --export-dynamic")
+      SET (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-export-dynamic")
       SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g -fno-default-inline -fno-inline-functions")
     endif ()
     # All of these are defined in platform.h too, but need to be defned before any system header is included


### PR DESCRIPTION
Use -Wl,-export-dynamic to pass the linker flag rather than --export-dynamic,
which (depending on who you believe) either worked by accident, or silently
failed to work at all, on pre-4.6 versions of gcc but gives an error on 4.6

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
