### PR TITLE
Fix problems with AGGREGATE on complex datasets

### DIFF
--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -664,6 +664,8 @@ void HqlCppTranslator::doBuildAssignAggregateLoop(BuildCtx & ctx, const CHqlBoun
             doBuildAssignAggregateLoop(ctx, target, expr, dataset->queryChild(1), doneFirstVar);
             return;
         }
+    case no_null:
+        return;
     }
 
     LinkedHqlExpr arg = expr->queryChild(1);

--- a/ecl/hqlcpp/hqlcset.cpp
+++ b/ecl/hqlcpp/hqlcset.cpp
@@ -1529,7 +1529,7 @@ void InlineDatasetBuilder::buildFinish(BuildCtx & ctx, CHqlBoundExpr & bound)
 void InlineDatasetBuilder::finishRow(BuildCtx & ctx, BoundRow * selfCursor)
 {
     CHqlBoundExpr bound;
-    translator.getRecordSize(ctx, selfCursor->queryDataset(), bound);
+    translator.getRecordSize(ctx, selfCursor->querySelector(), bound);
 
     if (translator.queryOptions().optimizeIncrement)
     {

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -1235,7 +1235,7 @@ void UpdateTransformBuilder::optimizeAssigns(IHqlExpression * expr, IHqlExpressi
                 IHqlExpression * source = match->queryChild(1);
                 OwnedHqlExpr previous = createSelectExpr(LINK(prevSelector), LINK(expr));
                 bool usesPrevious = (source != previous) && exprReferencesDataset(source, prevSelector);
-                bool retainAssign = !canRemoveLeadingAssigns || needToReassignAll || usesPrevious || (match->getOperator() != no_assign);
+                bool retainAssign = !canRemoveLeadingAssigns || needToReassignAll || usesPrevious || (match->getOperator() != no_assign) || isGraphDependent(source);
                 if (retainAssign)
                 {
                     IHqlExpression * target = match->queryChild(0);
@@ -1376,11 +1376,7 @@ public:
 
     IHqlExpression * ensureAliased(IHqlExpression * expr)
     {
-        LinkedHqlExpr value = expr;
-        if (expr->getOperator() == no_select)
-            value.setown(ensureOwned(value));
-
-        OwnedHqlExpr alias = createAlias(value, NULL);
+        OwnedHqlExpr alias = createAlias(expr, NULL);
         builder.ensureAlias(alias);
         return alias.getClear();
     }


### PR DESCRIPTION
There were several problems:
- MAX(IF(cond,NULL,ds), some-field) could generate an unknown dataset
- The wrong selector was used when builing a temporary set
- Assignments to child query results were lost from the transforms
- The generated code could incorrectly release a child row some some
  (unusual) situations.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
