### PR TITLE
Include options from dfu superfile copy to contents

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -781,7 +781,22 @@ public:
             options->setNoSplit(ctx.superoptions->getNoSplit());
             options->setOverwrite(ctx.superoptions->getOverwrite());
             options->setReplicate(ctx.superoptions->getReplicate());
+            options->setNoRecover(ctx.superoptions->getNoRecover());
+            options->setIfNewer(ctx.superoptions->getIfNewer());
+            options->setIfModified(ctx.superoptions->getIfModified());
+            options->setCrcCheck(ctx.superoptions->getCrcCheck());
+            options->setmaxConnections(ctx.superoptions->getmaxConnections());
+            options->setPush(ctx.superoptions->getPush());
+            options->setRetry(ctx.superoptions->getRetry());
+            options->setCrc(ctx.superoptions->getCrc());
+            options->setThrottle(ctx.superoptions->getThrottle());
+            options->setTransferBufferSize(ctx.superoptions->getTransferBufferSize());
+            options->setVerify(ctx.superoptions->getVerify());
+            StringBuffer slave;
+            if (ctx.superoptions->getSlavePathOverride(slave))
+                options->setSlavePathOverride(slave);
             options->setSubfileCopy(true);
+
             wu->queryUpdateProgress()->setState(DFUstate_queued); // well, good as
             // should be no need for overwrite
             wuid.set(wu->queryId());


### PR DESCRIPTION
When copying a superfile, the following options were not set on the
copies of the child files:
NoRecover, IfNewer, IfModified, CrcCheck, maxConnections
Push, Retry, Crc, Throttle, TransferBufferSize, Verify

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
