### PR TITLE
Fixes #692 Fix if condition for New and New Range to act on "Computer" ty

### DIFF
--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -2926,7 +2926,7 @@ function onMenuItemClickHandleComputer(p_sType, p_aArgs, p_oValue) {
   if (menuItemName === "New" || menuItemName === "New Range...")
     oper = "New";
 
-  if (menuItemName === "New Range..." || menuItemName === "New") {
+  if (parentName === "Computers" && ( menuItemName === "New Range..." || menuItemName === "New")) {
     for (i = 0; i < recSet.getLength(); i++) {
       var arr = recSet.getRecord(i).getData('domain_extra');
       if (YAHOO.lang.isArray(arr))


### PR DESCRIPTION
Fixes #692 Fix if condition for New and New Range to act on "Computer" type only.

This is a side effect of the fix for bugzilla bug 81208. New and New range
for Computer acts differently from the New for the other types but all
types were being handled by that piece of code causing the menu item not
to work. Fixed the if condition to act on Computer type only.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
