### PR TITLE
FIX Roxie not properly getting queryset name for packageset

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -2211,7 +2211,7 @@ private:
             if (packageId && *packageId)
             {
                 bool isActive = ps.getPropBool("@active", true);
-                const char *querySet = ps.queryProp("querySet");
+                const char *querySet = ps.queryProp("@querySet");
                 if (!querySet)
                     querySet = roxieName.str();
                 if (traceLevel)


### PR DESCRIPTION
Signed-off-by: Stuart Ort stuart.ort@lexisnexis.com
