### PR TITLE
Fix gh-695 Spill file fails creation

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -389,7 +389,7 @@ void CHThorDiskWriteActivity::done()
         uncompressedBytesWritten = outSeq->getPosition();
     updateWorkUnitResult(numRecords);
     close();
-    if((helper.getFlags() & TDXtemporary) == 0 && !agent.queryResolveFilesLocally())
+    if((helper.getFlags() & (TDXtemporary | TDXjobtemp) ) == 0 && !agent.queryResolveFilesLocally())
         publish();
     incomplete = false;
     if(clusterHandler)
@@ -401,7 +401,7 @@ void CHThorDiskWriteActivity::resolve()
 {
     mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent.queryWuid(), helper.getFlags());
     assertex(mangledHelperFileName.str());
-    if((helper.getFlags() & TDXtemporary) == 0)
+    if((helper.getFlags() & (TDXtemporary | TDXjobtemp)) == 0)
     {
         Owned<ILocalOrDistributedFile> f = agent.resolveLFN(mangledHelperFileName.str(),"Cannot write, invalid logical name",true,false,true,&lfn);
         if (f)


### PR DESCRIPTION
Spill files created via diskWriteActivity (as opposed to spillActivity)
have the TDXjobtemp flag set (as opposed to TDXtemporary). Because of
this the code incorrectly mangles the filename and leaves it in a form
(with ::) that cannot be created. Also might try to publish...
Fix the problem by checking both of these bits, when resolving filename
and before publishing.

@ghalliday

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
