### PR TITLE
Optimize DEDUP(ds, LEFT.x = RIGHT.x) in thor

### DIFF
--- a/ecl/regress/dedup2.ecl
+++ b/ecl/regress/dedup2.ecl
@@ -34,6 +34,6 @@ input3 := group(deduped3);
 
 deduped4 := dedup(input3,age,surname,ALL);
 
-deduped5 := dedup(deduped4,age,LEFT.surname = RIGHT.surname);
+deduped5 := dedup(deduped4,age,LEFT.surname = RIGHT.surname+nofold(''));
 
 output(deduped5,,'out.d00');


### PR DESCRIPTION
It is now treated the same way as DEDUP(ds, x) - which generates a
group followed by a dedup, which tends to be much more efficient in
thor.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
