### PR TITLE
Package file resolution issues

### DIFF
--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -50,7 +50,10 @@ extern IFilePartMap *createFilePartMap(const char *fileName, IFileDescriptor &fd
 interface IRoxiePackage;
 interface IPackageMap : public IInterface
 {
+    // Lookup package using exact id
     virtual const IRoxiePackage *queryPackage(const char *name) const = 0;
+    // Lookup package using fuzzy id
+    virtual const IRoxiePackage *matchPackage(const char *name) const = 0;
     virtual const char *queryQuerySetId() const = 0;
     virtual const char *queryPackageId() const = 0;
     virtual bool isActive() const = 0;


### PR DESCRIPTION
A couple of issues in the package file code for resolving superfiles:
1. Negative memory leaks in two places
2. Using the query name as the package name doesn;t work very well with the
   standard alias scheme.

As well as fixing the mermory corruption issues, add a "queries=wildcardspec"
field to a package that allows it to specify  for what queries this package
should be used. These are checked in order, so queries=\* will replace the
previous 'default' package name.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
