### PR TITLE
Switch special eclcc debug flags to use - not colon

### DIFF
--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -131,14 +131,14 @@ class EclccCompileThread : public CInterface, implements IPooledThread
             SCMStringBuffer debugStr, valueStr;
             debugValues->str(debugStr);
             workunit->getDebugValue(debugStr.str(), valueStr);
-            if (memicmp(debugStr.str(), "eclcc:", 6) == 0)
+            if (memicmp(debugStr.str(), "eclcc-", 6) == 0)
             {
-                //Allow eclcc:xx:1 so that multiple values can be passed through
+                //Allow eclcc-xx-<n> so that multiple values can be passed through for the same named debug symbol
                 const char * start = debugStr.str() + 6;
-                const char * colon = strchr(start, ':');
+                const char * dash = strchr(start, '-');
                 StringAttr optName;
-                if (colon)
-                    optName.set(start, colon-start);
+                if (dash)
+                    optName.set(start, dash-start);
                 else
                     optName.set(start);
 

--- a/ecl/eclplus/main.cpp
+++ b/ecl/eclplus/main.cpp
@@ -163,12 +163,12 @@ bool build_globals(int argc, const char *argv[], IProperties * globals)
             }
             else if (arg[1] == 'I')
             {
-                name.append("-feclcc:includeLibraryPath:").append(++eclccseq);
+                name.append("-feclcc-includeLibraryPath-").append(++eclccseq);
                 globals->setProp(name, arg+2);
             }
             else if (arg[1] == 'L')
             {
-                name.append("-feclcc:libraryPath:").append(++eclccseq);
+                name.append("-feclcc-libraryPath-").append(++eclccseq);
                 globals->setProp(name, arg+2);
             }
             else if (strcmp(arg, "-g") == 0)
@@ -177,7 +177,7 @@ bool build_globals(int argc, const char *argv[], IProperties * globals)
             }
             else if (strcmp(arg, "-legacy") == 0)
             {
-                globals->setProp("-feclcc:legacy", "1");
+                globals->setProp("-feclcc-legacy", "1");
             }
             else if (strcmp(arg, "-save-temps") == 0)
             {


### PR DESCRIPTION
Colon is used as a namespace separator, so use - instead to mangle
the eclcc options passed from eclplus.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
