### PR TITLE
Fix set of string problems and move code to plugin

### DIFF
--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -7213,6 +7213,7 @@ bool ConstantRowCreator::processElement(IHqlExpression * expr, IHqlExpression * 
     }
 }
 
+
 bool ConstantRowCreator::processRecord(IHqlExpression * record, IHqlExpression * parentSelector)
 {
     ForEachChild(idx, record)
@@ -7365,4 +7366,15 @@ IHqlExpression * convertAttributeToQuery(IHqlExpression * expr, HqlLookupContext
             return transformed.getClear();
         query.set(transformed);
     }
+}
+
+bool isSetWithUnknownElementSize(ITypeInfo * type)
+{
+    switch (type->getTypeCode())
+    {
+    case type_set:
+    case type_array:
+        return isUnknownSize(type->queryChildType());
+    }
+    return false;
 }

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -619,6 +619,7 @@ extern HQL_API bool createConstantNullRow(MemoryBuffer & target, IHqlExpression 
 extern HQL_API IHqlExpression * createConstantRowExpr(IHqlExpression * transform);
 extern HQL_API IHqlExpression * createConstantNullRowExpr(IHqlExpression * record);
 extern HQL_API IHqlExpression * ensureOwned(IHqlExpression * expr);
+extern HQL_API bool isSetWithUnknownElementSize(ITypeInfo * type);
 
 //In hqlgram2.cpp
 extern HQL_API IPropertyTree * queryEnsureArchiveModule(IPropertyTree * archive, const char * name, IHqlScope * rScope);

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -1970,7 +1970,7 @@ extern HQLCPP_API IHqlExpression * getPointer(IHqlExpression * source);
 extern IHqlExpression * adjustIndexBaseToZero(IHqlExpression * index);
 extern IHqlExpression * adjustIndexBaseToOne(IHqlExpression * index);
 extern IHqlExpression * multiplyValue(IHqlExpression * expr, unsigned __int64 value);
-extern bool isComplexSet(ITypeInfo * type);
+extern bool isComplexSet(ITypeInfo * type, bool isConstant);
 extern bool isComplexSet(IHqlExpression * expr);
 extern bool isConstantSet(IHqlExpression * expr);
 

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -5032,7 +5032,7 @@ void HqlCppTranslator::buildSetResultInfo(BuildCtx & ctx, IHqlExpression * origi
         if (options.spotCSE)
             cseValue.setown(spotScalarCSE(cseValue));
 
-        if ((retType == type_set) && isComplexSet(resultType) && castValue->getOperator() == no_list && !isNullList(castValue))
+        if ((retType == type_set) && isComplexSet(resultType, false) && castValue->getOperator() == no_list && !isNullList(castValue))
         {
             CHqlBoundTarget tempTarget;
             createTempFor(ctx, resultType, tempTarget, typemod_none, FormatBlockedDataset);

--- a/ecl/hqlcpp/hqlstmt.cpp
+++ b/ecl/hqlcpp/hqlstmt.cpp
@@ -210,6 +210,7 @@ IHqlStmt * BuildCtx::addContinue()
 
 IHqlStmt * BuildCtx::addDeclare(IHqlExpression * name, IHqlExpression * value)
 {
+    assertex(name->getOperator() == no_variable);
     if (ignoreInput)
         return NULL;
     HqlStmt * next = new HqlStmt(declare_stmt, curStmts);
@@ -224,6 +225,7 @@ IHqlStmt * BuildCtx::addDeclare(IHqlExpression * name, IHqlExpression * value)
 
 IHqlStmt * BuildCtx::addDeclareExternal(IHqlExpression * name)
 {
+    assertex(name->getOperator() == no_variable);
     if (ignoreInput)
         return NULL;
     HqlStmt * next = new HqlStmt(external_stmt, curStmts);

--- a/ecllibrary/teststd/str/TestCombineWords.ecl
+++ b/ecllibrary/teststd/str/TestCombineWords.ecl
@@ -1,0 +1,16 @@
+/*##############################################################################
+## Copyright (c) 2011 HPCC Systems.  All rights reserved.
+############################################################################## */
+
+IMPORT Std.Str;
+
+EXPORT TestCombineWords := MODULE
+  EXPORT TestRuntime := MODULE
+    EXPORT Test01 := ASSERT(Str.CombineWords([],',') = '');
+    EXPORT Test02 := ASSERT(Str.CombineWords(['x'],',') = 'x');
+    EXPORT Test03 := ASSERT(Str.CombineWords(['x','y'],',') = 'x,y');
+    EXPORT Test04 := ASSERT(Str.CombineWords(['',''],',') = ',');
+    EXPORT Test05 := ASSERT(Str.CombineWords(['',''],'') = '');
+    EXPORT Test06 := ASSERT(Str.CombineWords(['abc','def','ghi'],'') = 'abcdefghi');
+  END;
+END;

--- a/ecllibrary/teststd/str/TestCountWords.ecl
+++ b/ecllibrary/teststd/str/TestCountWords.ecl
@@ -27,6 +27,9 @@ EXPORT TestCountWords := MODULE
     EXPORT Test18 := ASSERT(Str.CountWords('$$x$$', '$$') = 1);
     EXPORT Test19 := ASSERT(Str.CountWords('$$x$$y', '$$') = 2);
     EXPORT Test20 := ASSERT(Str.CountWords('$$x$$xy', '$$') = 2);
+    EXPORT Test21 := ASSERT(Str.CountWords('a,c,d', ',', TRUE) = 3);
+    EXPORT Test22 := ASSERT(Str.CountWords('a,,d', ',', TRUE) = 3);
+    EXPORT Test23 := ASSERT(Str.CountWords(',,,', ',', TRUE) = 4);
   END;
 
 END;

--- a/ecllibrary/teststd/str/TestSplitWords.ecl
+++ b/ecllibrary/teststd/str/TestSplitWords.ecl
@@ -7,26 +7,28 @@ IMPORT Std.Str;
 EXPORT TestSplitWords := MODULE
 
   EXPORT TestRuntime := MODULE
-    EXPORT Test01 := ASSERT(Str.SplitWords('', '') = global([]));
-    EXPORT Test02 := ASSERT(Str.SplitWords('x', '') = global(['x']));
-    EXPORT Test03 := ASSERT(Str.SplitWords('x', ' ') = global(['x']));
-    EXPORT Test04 := ASSERT(Str.SplitWords(' ', ' ') = global([]));
-    EXPORT Test05 := ASSERT(Str.SplitWords('  ', ' ') = global([]));
-    EXPORT Test06 := ASSERT(Str.SplitWords('x ', ' ') = global(['x']));
-    EXPORT Test07 := ASSERT(Str.SplitWords(' x', ' ') = global(['x']));
-    EXPORT Test08 := ASSERT(Str.SplitWords(' x ', ' ') = global(['x']));
-    EXPORT Test09 := ASSERT(Str.SplitWords(' abc def ', ' ') = global(['abc','def']));
-    EXPORT Test10 := ASSERT(Str.SplitWords(' abc   def ', ' ') = global(['abc','def']));
-    EXPORT Test11 := ASSERT(Str.SplitWords(' a b c   def ', ' ') = global(['a','b','c','def']));
-    EXPORT Test12 := ASSERT(Str.SplitWords(' abc   def', ' ') = global(['abc','def']));
-    EXPORT Test13 := ASSERT(Str.SplitWords('$', '$$') = global(['$']));
-    EXPORT Test14 := ASSERT(Str.SplitWords('$x', '$$') = global(['$x']));
-    EXPORT Test15 := ASSERT(Str.SplitWords('$$', '$$') = global([]));
-    EXPORT Test16 := ASSERT(Str.SplitWords('$$$', '$$') = global(['$']));
-    EXPORT Test17 := ASSERT(Str.SplitWords('$$$$', '$$') = global([]));
-    EXPORT Test18 := ASSERT(Str.SplitWords('$$x$$', '$$') = global(['x']));
-    EXPORT Test19 := ASSERT(Str.SplitWords('$$x$$y', '$$') = global(['x','y']));
-    EXPORT Test20 := ASSERT(Str.SplitWords('$$x$$xy', '$$') = global(['x','xy']));
+    EXPORT Test01 := ASSERT(Str.SplitWords('', '') = []);
+    EXPORT Test02 := ASSERT(Str.SplitWords('x', '') = ['x']);
+    EXPORT Test03 := ASSERT(Str.SplitWords('x', ' ') = ['x']);
+    EXPORT Test04 := ASSERT(Str.SplitWords(' ', ' ') = []);
+    EXPORT Test05 := ASSERT(Str.SplitWords('  ', ' ') = []);
+    EXPORT Test06 := ASSERT(Str.SplitWords('x ', ' ') = ['x']);
+    EXPORT Test07 := ASSERT(Str.SplitWords(' x', ' ') = ['x']);
+    EXPORT Test08 := ASSERT(Str.SplitWords(' x ', ' ') = ['x']);
+    EXPORT Test09 := ASSERT(Str.SplitWords(' abc def ', ' ') = ['abc','def']);
+    EXPORT Test10 := ASSERT(Str.SplitWords(' abc   def ', ' ') = ['abc','def']);
+    EXPORT Test11 := ASSERT(Str.SplitWords(' a b c   def ', ' ') = ['a','b','c','def']);
+    EXPORT Test12 := ASSERT(Str.SplitWords(' abc   def', ' ') = ['abc','def']);
+    EXPORT Test13 := ASSERT(Str.SplitWords('$', '$$') = ['$']);
+    EXPORT Test14 := ASSERT(Str.SplitWords('$x', '$$') = ['$x']);
+    EXPORT Test15 := ASSERT(Str.SplitWords('$$', '$$') = []);
+    EXPORT Test16 := ASSERT(Str.SplitWords('$$$', '$$') = ['$']);
+    EXPORT Test17 := ASSERT(Str.SplitWords('$$$$', '$$') = []);
+    EXPORT Test18 := ASSERT(Str.SplitWords('$$x$$', '$$') = ['x']);
+    EXPORT Test19 := ASSERT(Str.SplitWords('$$x$$y', '$$') = ['x','y']);
+    EXPORT Test20 := ASSERT(Str.SplitWords('$$x$$xy', '$$') = ['x','xy']);
+    EXPORT Test21 := ASSERT(Str.SplitWords('$$x$$xy', '$$', TRUE) = ['','x','xy']);
+    EXPORT Test22 := ASSERT(Str.SplitWords('$$$$', '$$',TRUE) = ['','','']);
   END;
 
 END;

--- a/plugins/stringlib/stringlib.hpp
+++ b/plugins/stringlib/stringlib.hpp
@@ -77,6 +77,9 @@ STRINGLIB_API unsigned STRINGLIB_CALL slEditDistanceV2(unsigned leftLen, const c
 STRINGLIB_API bool STRINGLIB_CALL slEditDistanceWithinRadiusV2(unsigned leftLen, const char * left, unsigned rightLen, const char * right, unsigned radius);
 STRINGLIB_API void STRINGLIB_CALL slStringGetNthWord(unsigned & tgtLen, char * & tgt, unsigned srcLen, const char * src, unsigned n);
 STRINGLIB_API unsigned STRINGLIB_CALL slStringWordCount(unsigned srcLen, const char * src);
+STRINGLIB_API unsigned STRINGLIB_CALL slCountWords(size32_t lenSrc, const char * src, size32_t lenSeparator, const char * separator, bool allowBlankItems);
+STRINGLIB_API void STRINGLIB_CALL slSplitWords(bool & __isAllResult, size32_t & __lenResult, void * & __result, size32_t lenSrc, const char * src, size32_t lenSeparator, const char * separator, bool allowBlankItems);
+STRINGLIB_API void STRINGLIB_CALL slCombineWords(size32_t & __lenResult, void * & __result, bool isAllSrc, size32_t lenSrc, const char * src, size32_t lenSeparator, const char * separator, bool allowBlankItems);
 }
 
 #endif


### PR DESCRIPTION
Move some of the inline C++ functions from std.str to the stringlib
plugin, so they can be constant folded and compiled once.

Also fixes various problems with inline sets of unknown length strings
which were revealed while writing test cases.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
