### PR TITLE
Should indicate a 'diabled in this version' feature

### DIFF
--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1432,6 +1432,28 @@ int CWsSMCSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* request, 
             response->send();
             return 0;
         }
+        else if(stricmp(method,"DisabledInThisVersion")==0)
+        {
+            StringBuffer page;
+            page.append(
+                "<html>"
+                    "<head>"
+                        "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />"
+                        "<link rel=\"stylesheet\" type=\"text/css\" href=\"/esp/files/default.css\"/>"
+                        "<link rel=\"stylesheet\" type=\"text/css\" href=\"/esp/files/yui/build/fonts/fonts-min.css\" />"
+                        "<title>Disabled Feature in This Version</title>"
+                    "</head>"
+                    "<body>"
+                        "<h3 style=\"text-align:centre;\">Disabled Feature in This Version</h4>"
+                        "<p style=\"text-align:centre;\">This feature is disabled in this version. ");
+            page.append("</p></body>"
+                "</html>");
+
+            response->setContent(page.str());
+            response->setContentType("text/html");
+            response->send();
+            return 0;
+        }
     }
     catch(IException* e)
     {   


### PR DESCRIPTION
Fix gh-723: ECLWatch may need to show a page indicating a
'diabled in this version' feature. For example, right now, the
"Search Roxie Files" could be a 'diabled in this version' feature.
When the link "Search Roxie Files" is clicked, ECLWatch should
shows "This feature is disabled in this version". This fix adds
the message page into WsSMC, which may be used for other similar
features later.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
