### PR TITLE
Fixes Bug84019 When using wizard, assign esp to the the first ip

### DIFF
--- a/deployment/deployutils/wizardInputs.hpp
+++ b/deployment/deployutils/wizardInputs.hpp
@@ -112,10 +112,13 @@ public:
   void checkAndAddDependComponent(const char* key);
   unsigned getNumOfNodes(const char* compName);
   void setTopologyParam();
-        
+
  IMPLEMENT_IINTERFACE;
   bool generateEnvironment(StringBuffer& envXml);
   IPropertyTree* createEnvironment();
+
+private:
+  void addComponentToSoftware(IPropertyTree* pNewEnvTree, IPropertyTree* pBuildSet);
 
 private:
   typedef StringArray* StringArrayPtr;


### PR DESCRIPTION
When using wizard to generate a new environment, assigning ESP to the
first node by generating the esp component before the other components.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
