### PR TITLE
Ecl command line credential support

### DIFF
--- a/ecl/eclcmd/ecl.cpp
+++ b/ecl/eclcmd/ecl.cpp
@@ -38,7 +38,7 @@
 
 static int doMain(int argc, const char *argv[])
 {
-    EclCMDShell processor(argc, argv, createCoreEclCommand, BUILD_TAG);
+    EclCMDShell processor(argc, argv, createCoreEclCommand, BUILD_TAG, true);
     return processor.run();
 }
 

--- a/ecl/eclcmd/eclcmd.hpp
+++ b/ecl/eclcmd/eclcmd.hpp
@@ -24,8 +24,8 @@
 class EclCMDShell
 {
 public:
-    EclCMDShell(int argc, const char *argv[], EclCommandFactory _factory, const char *_version)
-        : args(argc, argv), factory(_factory), version(_version), optHelp(false)
+    EclCMDShell(int argc, const char *argv[], EclCommandFactory _factory, const char *_version, bool _runExternals=false)
+        : args(argc, argv), factory(_factory), version(_version), optHelp(false), runExternals(_runExternals)
     {
         splitFilename(argv[0], NULL, NULL, &name, NULL);
     }
@@ -33,6 +33,7 @@ public:
     bool parseCommandLineOptions(ArgvIterator &iter);
     void finalizeOptions(IProperties *globals);
     int processCMD(ArgvIterator &iter);
+    int callExternal(ArgvIterator &iter);
     int run();
 
     virtual void usage();
@@ -43,6 +44,7 @@ protected:
     EclCommandFactory factory;
     StringBuffer name;
     StringAttr cmd;
+    bool runExternals;
 
     StringAttr version;
 

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -29,13 +29,16 @@ bool extractOption(StringBuffer & option, IProperties * globals, const char * en
 {
     if (option.length())        // check if already specified via a command line option
         return true;
-    if (globals->getProp(propertyName, option))
+    if (propertyName && globals->getProp(propertyName, option))
         return true;
-    const char * env = getenv(envName);
-    if (env)
+    if (envName && *envName)
     {
-        option.append(env);
-        return true;
+        const char * env = getenv(envName);
+        if (env)
+        {
+            option.append(env);
+            return true;
+        }
     }
     if (defaultPrefix)
         option.append(defaultPrefix);

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -39,6 +39,14 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_PORT_INI "eclWatchPort"
 #define ECLOPT_PORT_ENV "ECL_WATCH_PORT"
 
+#define ECLOPT_USERNAME "--username"
+#define ECLOPT_USERNAME_INI "eclUserName"
+#define ECLOPT_USERNAME_ENV "ECL_USER_NAME"
+
+#define ECLOPT_PASSWORD "--password"
+#define ECLOPT_PASSWORD_INI "eclPassword"
+#define ECLOPT_PASSWORD_ENV "ECL_PASSWORD"
+
 #define ECLOPT_ACTIVATE "--activate"
 #define ECLOPT_ACTIVATE_INI "activateDefault"
 #define ECLOPT_ACTIVATE_ENV NULL
@@ -88,7 +96,11 @@ public:
     {
         if (iter.matchOption(optServer, ECLOPT_SERVER))
             return true;
-        else if (iter.matchOption(optPort, ECLOPT_PORT))
+        if (iter.matchOption(optPort, ECLOPT_PORT))
+            return true;
+        if (iter.matchOption(optUsername, ECLOPT_USERNAME))
+            return true;
+        if (iter.matchOption(optPassword, ECLOPT_PASSWORD))
             return true;
         return false;
     }
@@ -96,17 +108,23 @@ public:
     {
         extractOption(optServer, globals, ECLOPT_SERVER_ENV, ECLOPT_SERVER_INI, ".", NULL);
         extractOption(optPort, globals, ECLOPT_PORT_ENV, ECLOPT_PORT_INI, "8010", NULL);
+        extractOption(optUsername, globals, ECLOPT_USERNAME_ENV, ECLOPT_USERNAME_INI, NULL, NULL);
+        extractOption(optPassword, globals, ECLOPT_PASSWORD_ENV, ECLOPT_PASSWORD_INI, NULL, NULL);
     }
     virtual void usage()
     {
         fprintf(stdout,
             "      --server=<ip>        ip of server running ecl services (eclwatch)\n"
             "      --port=<port>        ecl services port\n"
+            "      --username=<name>    username for accessing ecl services\n"
+            "      --password=<pw>      password for accessing ecl services\n"
         );
     }
 public:
     StringAttr optServer;
     StringAttr optPort;
+    StringAttr optUsername;
+    StringAttr optPassword;
 };
 
 #endif

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -95,6 +95,8 @@ public:
             Owned<IClientWsWorkunits> client = createWsWorkunitsClient();
             VStringBuffer url("http://%s:%s/WsWorkunits", optServer.sget(), optPort.sget());
             client->addServiceUrl(url.str());
+            if (optUsername.length())
+                client->setUsernameToken(optUsername.get(), optPassword.sget(), NULL);
             Owned<IClientWUDeployWorkunitRequest> req = client->createWUDeployWorkunitRequest();
             switch (optObj.type)
             {
@@ -209,6 +211,8 @@ public:
         Owned<IClientWsWorkunits> client = createWsWorkunitsClient();
         VStringBuffer url("http://%s:%s/WsWorkunits", optServer.sget(), optPort.sget());
         client->addServiceUrl(url.str());
+        if (optUsername.length())
+            client->setUsernameToken(optUsername.get(), optPassword.sget(), NULL);
 
         Owned<IClientWUPublishWorkunitRequest> req = client->createWUPublishWorkunitRequest();
         req->setWuid(optWuid.get());


### PR DESCRIPTION
Might depend on HPCC-Systems 729

https://github.com/hpcc-systems/HPCC-Platform/pull/729

ecl command line user credential support

Provide a common mechanism for specifying the username and password to
eclwatch when using the ecl command line tool.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
