### PR TITLE
Some WUUpdate values not being set

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -418,7 +418,12 @@ static bool origValueChanged(const char *newValue, const char *origValue, String
         }
         return false;
     }
-    return (newValue || origValue);
+    if (newValue)
+    {
+        s.append(newValue).trim();
+        return true;
+    }
+    return (origValue!=NULL);
 }
 
 bool CWsWorkunitsEx::onWUUpdate(IEspContext &context, IEspWUUpdateRequest &req, IEspWUUpdateResponse &resp)


### PR DESCRIPTION
Fixes gh-710.  

Some field values not set when WsWorkunits::WUUpdate is called.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
