### PR TITLE
GH-443 Typo in one of the refactored files

### DIFF
--- a/initfiles/sbin/CMakeLists.txt
+++ b/initfiles/sbin/CMakeLists.txt
@@ -40,5 +40,5 @@ FOREACH( oFILES
     ${CMAKE_CURRENT_BINARY_DIR}/regex.awk
     ${CMAKE_CURRENT_SOURCE_DIR}/alter_confs.sh
 )
-    install ( PROGRAMS ${oFILES} DESTINATION ${OSSDIR}/etc/init.d COMPONENT Runtime )
+    install ( PROGRAMS ${oFILES} DESTINATION ${OSSDIR}/sbin COMPONENT Runtime )
 ENDFOREACH ( oFILES )


### PR DESCRIPTION
Typo in one of the refactored files caused various script files
to be deployed to the wrong place.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
