### PR TITLE
gh-443 more typos in refactored cmake files

### DIFF
--- a/initfiles/CMakeLists.txt
+++ b/initfiles/CMakeLists.txt
@@ -40,6 +40,7 @@ set(bash-vars "${CMAKE_BINARY_DIR}/bash-vars")
 
 ADD_SUBDIRECTORY(bash)
 ADD_SUBDIRECTORY(bin)
+ADD_SUBDIRECTORY(etc)
 ADD_SUBDIRECTORY(sbin)
 ADD_SUBDIRECTORY(componentfiles)
 

--- a/initfiles/etc/sshkey/CMakeLists.txt
+++ b/initfiles/etc/sshkey/CMakeLists.txt
@@ -15,6 +15,6 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
-Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/initfiles/etc/sshkey/.ssh.md5 DESTINATION ${OSSDIR}/etc/sshkey COMPONENT Runtime )
+Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/.ssh.md5 DESTINATION ${OSSDIR}/etc/sshkey COMPONENT Runtime )
 
 ADD_SUBDIRECTORY(.ssh)


### PR DESCRIPTION
The etc dir was not getting deployed leading to issues if installed on
a clean system. So much for testing before you release...

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
