### PR TITLE
gh-711 ws_workunts causing esp cores

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -58,6 +58,8 @@
 //#define    File_DLL "dll"
 //#define    File_ArchiveQuery "ArchiveQuery"
 
+namespace ws_workunits {
+
 SecAccessFlags chooseWuAccessFlagsByOwnership(const char *user, const char *owner, SecAccessFlags accessOwn, SecAccessFlags accessOthers)
 {
     return (isEmpty(owner) || (user && streq(user, owner))) ? accessOwn : accessOthers;
@@ -2291,4 +2293,6 @@ int WUSchedule::run()
     if (m_container)
         m_container->exitESP();
     return 0;
+}
+
 }

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -29,6 +29,7 @@
 #include <list>
 #include <vector>
 
+namespace ws_workunits {
 
 #define     OWN_WU_ACCESS      "OwnWorkunitsAccess"
 #define     OTHERS_WU_ACCESS   "OthersWorkunitsAccess"
@@ -319,4 +320,5 @@ public:
     }
 };
 
+}
 #endif


### PR DESCRIPTION
A class name clash between ws_workunits and ws_ecl was causing crashes in
esp at various points.

Add a namespace to ws_workunits to avoid the clash. We should be using namespaces
on all bew development and retrofitting to existing as time allows...

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
