### PR TITLE
Update test to match new data comparison rules.

### DIFF
--- a/testing/ecl/stored.ecl
+++ b/testing/ecl/stored.ecl
@@ -58,7 +58,7 @@ output(vu2a);
 
 data20 d1 := x'123456' : stored('d1'); 
 data20 d1a := d1 : stored ('d1a'); 
-if (d1 != d1a OR d1 != x'123456', FAIL('d1 did not match'));
+if (d1 != d1a OR d1 != (data20)x'123456', FAIL('d1 did not match'));
 output(d1a);
 
 data d2 := x'123456' : stored('d2'); 


### PR DESCRIPTION
Values of type 'data' now  treat trailing zeros as significant.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
