### PR TITLE
gh-743 ECLWatch not show Thor Queue Graph

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -1344,7 +1344,7 @@ void streamJobQueueListResponse(IEspContext &context, const char *cluster, const
             break;
 
         sb.append("parent.displayQueue(");
-        appendQuoted(sb, count);
+        appendQuoted(sb, count, true);
         appendQuoted(sb, tq.getDT());
         appendQuoted(sb, tq.getRunningWUs());
         appendQuoted(sb, tq.getQueuedWUs());


### PR DESCRIPTION
On the Activity page, select the Usage link from a thor cluster
drop done menu. Then, click the Get Thor Queue button. ECLwatch
should show a graph. But, right now, it shows 'No data found'
even though there were workunit activities.

I found three problems. 1. The thor DaAudit log does not contain
correct information about workunits which run on the thor cluster.
Recent changes for getEnvironmentThorClusterNames() fixed a part
of this problem. When saqmon.cpp writes the audit log, it retrieves
workunit data using thor.thor from 'Status/Servers/Server'. But, the
queue name currently in 'Status/Servers/Server' is 'mythor.thor'.
So, Workunit running on the thor queue cannot be found. 2. ECLWatch
uses the wrong queue name 'mythor' to filter the audit log lines
which use 'thor'. 3. A small mistake is introduced by recent
changes on ws_workunits. When the streamJobQueueListResponse()
sends the queue data to Javascript, it adds an extra ','.

This change should fix the problem 2 and 3. The problem 1 will not
be fixed here since Jake will check whether the queue name
'mythor.thor' should be used or not (gh-717).

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
