### PR TITLE
gh-443 Lost the permissions settiongs on the default ssh key

### DIFF
--- a/initfiles/etc/sshkey/.ssh/CMakeLists.txt
+++ b/initfiles/etc/sshkey/.ssh/CMakeLists.txt
@@ -17,8 +17,8 @@
 ################################################################################
 FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/authorized_keys
-    ${CMAKE_CURRENT_SOURCE_DIR}/id_rsa
     ${CMAKE_CURRENT_SOURCE_DIR}/id_rsa.pub
 )
     Install ( FILES ${iFILES} DESTINATION ${OSSDIR}/etc/sshkey/.ssh COMPONENT Runtime )
 ENDFOREACH ( iFILES )
+Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/id_rsa DESTINATION ${OSSDIR}/etc/sshkey/.ssh COMPONENT Runtime PERMISSIONS OWNER_READ OWNER_WRITE  )


### PR DESCRIPTION
The cmake refactoring lost the permissions on the default ssh key, resulting
in weird behaviour if it tries to use it (e.g. in preflight).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
