### PR TITLE
gh-717 Incorrect queuename in tracing + status

### DIFF
--- a/initfiles/componentfiles/configxml/thor.xsd.in
+++ b/initfiles/componentfiles/configxml/thor.xsd.in
@@ -364,15 +364,6 @@
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="pluginsPath" type="relativePath" default="${PLUGINS_PATH}/"/>
-      <xs:attribute name="queueName" type="xs:string" use="optional">
-        <xs:annotation>
-          <xs:appinfo>
-            <tooltip>Name of queue for this Thor. Leave blank if this Thor is not load balanced.</tooltip>
-            <autogenforwizard>1</autogenforwizard>
-            <autogendefaultvalue>$processname</autogendefaultvalue>
-          </xs:appinfo>
-        </xs:annotation>
-      </xs:attribute>
       <xs:attribute name="nodeGroup" type="xs:string" use="optional">
         <xs:annotation>
           <xs:appinfo>

--- a/initfiles/componentfiles/configxml/thor.xsl
+++ b/initfiles/componentfiles/configxml/thor.xsl
@@ -113,16 +113,6 @@
       <xsl:attribute name="slaves">
         <xsl:value-of select="count(ThorSlaveProcess)"/>
       </xsl:attribute>
-      <xsl:attribute name="queueName">
-        <xsl:choose>
-          <xsl:when test="string(@queueName) = ''">
-            <xsl:value-of select="@name"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="@queueName"/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:attribute>
       <xsl:attribute name="nodeGroup">
         <xsl:choose>
           <xsl:when test="string(@nodeGroup) = ''">

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -681,16 +681,18 @@ int main( int argc, char *argv[]  )
         return -1;
     }
     StringBuffer queueName;
+    SCMStringBuffer _queueNames;
+    const char *thorName = globals->queryProp("@name");
+    if (!thorName) thorName = "thor";
+    getThorQueueNames(_queueNames, thorName);
+    queueName.set(_queueNames.str());
+
     try {
         CSDSServerStatus &serverStatus = openThorServerStatus();
 
         Owned<CRegistryServer> registry = new CRegistryServer();
         StringBuffer thorEpStr;
         LOG(MCdebugProgress, thorJob, "ThorMaster version %d.%d, Started on %s", THOR_VERSION_MAJOR,THOR_VERSION_MINOR,thorEp.getUrlStr(thorEpStr).toCharArray());
-        if (!globals->getProp("@queueName", queueName)) 
-            queueName.append(thorname);
-        queueName.append(".thor");
-
 
         unsigned gmemsize = globals->getPropInt("@masterGlobalMemorySize"); // in MB
         if (gmemsize==0) {


### PR DESCRIPTION
A legacy 'queueName' property still existed in the config style sheets
for Thor and was still being used for some tracing and also in the
Status published to Dali - which would effect what eclwatch saw

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
