### PR TITLE
NWaySelect late initialization causing crash

### DIFF
--- a/thorlcr/activities/funnel/thfunnelslave.cpp
+++ b/thorlcr/activities/funnel/thfunnelslave.cpp
@@ -850,6 +850,7 @@ public:
     CNWaySelectActivity(CGraphElementBase *_container) : CSlaveActivity(_container), CThorDataLink(this), CThorSteppable(this)
     {
         helper = (IHThorNWaySelectArg *)queryHelper();
+        selectedInput = NULL;
     }
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
     {
@@ -934,6 +935,8 @@ public:
         initMetaInfo(info);
         if (selectedInput)
             calcMetaInfoSize(info, selectedInput);
+        else if (!started())
+            info.canStall = true; // unkwown if !started
     }
     virtual bool isGrouped() { return selectedInput ? selectedInput->isGrouped() : false; }
 // steppable


### PR DESCRIPTION
The member variable selectedInput was uninitialized until the activity
was started. If the input meta info was queried before the activity was
started, it would cause a crash

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
