### PR TITLE
Fix gh-683 - Reduce length verify timeout

### DIFF
--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -230,7 +230,7 @@ void SashaMain()
                 PROGLOG("Sasha stopping");
                 break;
             }
-            else if (!verifyCovenConnection(5*60*1000)) {
+            else if (!verifyCovenConnection(30*1000)) {
                 PROGLOG("Dali stopped");
                 stopped = true;
             }


### PR DESCRIPTION
Sasha if idle periodically verified it's connection with Dali, with a very
long (5 mins) timeout. If Dali was down at the time Sasha was stopped and
Sasha was verifying the connection at this point, there was no way to cancel
it (as stuck re-connecting with this timeout in the MP layer).
See separate issue gh-773.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
