### PR TITLE
Fixes gh-779 Moved redirection of stdout to start_slave instead of in the frunssh call. 

### DIFF
--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -23,6 +23,7 @@ instancedir=$4
 slaveport=$5
 hpcc_compname=$6
 hpcc_setenv=$7
+logredirect=$8
 
 source ${hpcc_setenv}
 PID_NAME="$PID/${hpcc_compname}_slave.pid"
@@ -31,12 +32,14 @@ INSTALL_DIR=`dirname ${hpcc_setenv}`/..
 source  ${INSTALL_DIR}/etc/init.d/hpcc_common
 which_pidof
 
-if [ $# -lt 7 ]; then
-  echo usage: $0 thordeploydir slaveno logdir workingdir slaveport hpcc_compname hpcc_setenv
+if [ $# -lt 8 ]; then
+  echo usage: $0 thordeploydir slaveno logdir workingdir slaveport hpcc_compname hpcc_setenv logredirect
   exit 1
 fi
 
 sudo /etc/init.d/hpcc-init -c $hpcc_compname setup 2>/dev/null 2>/dev/null
+
+exec >$logredirect 2>&1
 
 cd $instancedir
 . ./setvars

--- a/initfiles/componentfiles/thor/start_slaves
+++ b/initfiles/componentfiles/thor/start_slaves
@@ -28,7 +28,7 @@ if [ "$localthor" = "true" ]; then
         if [ "$slaveport" = "" ]; then
             slaveport=$THORSLAVEPORT
         fi
-        $deploydir/start_slave $deploydir $n $logpth $instancedir $slaveport $THORNAME $PATH_PRE &> $logdir/start_slave_$logpthtail.$n.log
+        $deploydir/start_slave $deploydir $n $logpth $instancedir $slaveport $THORNAME $PATH_PRE $logdir/start_slave_$logpthtail.$n.log
         let "n += 1";
         done
 else
@@ -40,14 +40,16 @@ else
                 if [ "$slaveport" = "" ]; then
                     slaveport=$THORSLAVEPORT
                 fi
-                frunssh $ip "/bin/sh -c '$deploydir/start_slave $deploydir $n $logpth $instancedir $slaveport $THORNAME $PATH_PRE&> $logdir/start_slave_$logpthtail.$n.log'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
+                logredirect="$logdir/start_slave_$logpthtail.$n.log"
+                frunssh $ip "/bin/sh -c '$deploydir/start_slave $deploydir $n $logpth $instancedir $slaveport $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
                 let "n += 1";
             done
         else
             if [ -e $instancedir/thorgroup ]; then
                 mv $instancedir/thorgroup $instancedir/thorgroup.local
             fi
-            frunssh $instancedir/slaves "/bin/sh -c '$deploydir/start_slave $deploydir %n $logpth $instancedir $THORSLAVEPORT $THORNAME $PATH_PRE &> $logdir/start_slave_$logpthtail.log'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
+            logredirect="$logdir/start_slave_$logpthtail.log"
+            frunssh $instancedir/slaves "/bin/sh -c '$deploydir/start_slave $deploydir %n $logpth $instancedir $THORSLAVEPORT $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
         fi
 fi
 echo thorslaves started


### PR DESCRIPTION
Fixes gh-779 Moved redirection of stdout to start_slave instead of in the frunssh call.

Fixed typos in changes to start_slaves/start_slave.

Removed unneeded backgrounding.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
