### PR TITLE
g++ installed to wrong place

### DIFF
--- a/deploy/gcc3/bin/CMakeLists.txt
+++ b/deploy/gcc3/bin/CMakeLists.txt
@@ -16,4 +16,4 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
-Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/g++ DESTINATION ${OSSDIR}/componentfiles COMPONENT Runtime )
+Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/g++ DESTINATION ${OSSDIR}/componentfiles/cl/bin COMPONENT Runtime )


### PR DESCRIPTION
In order to be able to have eclcc or eclserver use the g++ script file
it needs to be installed to cl/bin.

It's not used by default, but can be handy for adding odd options or tracing.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
