### PR TITLE
Fix gh-803 User-Agent not set if no LDAP enabled

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -450,9 +450,6 @@ void EspHttpBinding::populateRequest(CHttpRequest *request)
 
     ctx->setSecManger(m_secmgr.getLink());
     ctx->setFeatureAuthMap(m_feature_authmap.getLink());
-    StringBuffer useragent;
-    request->getHeader("User-Agent", useragent);
-    ctx->setUseragent(useragent.str());
 
     StringBuffer userid, password,realm,peer;
     ctx->getUserID(userid);

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1517,6 +1517,10 @@ void CHttpRequest::updateContext()
             else
                 m_context->setClientVersion(0.0);
         }
+
+        StringBuffer useragent;
+        getHeader("User-Agent", useragent);
+        m_context->setUseragent(useragent.str());
     }
 }
 


### PR DESCRIPTION
ECLwatch does not display ReLogin menu correctly when no LDAP
is enabled. That is because that ECLWatch function depends on
ESP to provide browser information. The information is retrieved
from HTTP User-Agent header. The existing code reads the
User-Agent header inside an authentication related function
which is called if no LDAP is enabled. This fix moves the
User-Agent code out of the authentication function.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
