### PR TITLE
WIP LN #172 Enable addition of EclServer to Topology

### DIFF
--- a/deployment/deployutils/deployutils.cpp
+++ b/deployment/deployutils/deployutils.cpp
@@ -1991,6 +1991,7 @@ bool generateHeaderForTopology(const IPropertyTree* pEnv, StringBuffer& sbDefn, 
   addTopologyType(jsStrBuf, pEnv, "", TAG_NAME, "", 1, 1, "", 1);
   addTopologyType(jsStrBuf, pEnv, "", TAG_BUILDSET, "", 1, 1, "", 1);
   addTopologyType(jsStrBuf, pEnv, XML_TAG_ECLCCSERVERPROCESS,  TAG_PROCESS, "", 0, 1, XML_TAG_SOFTWARE"/EclCCServerProcess", 4);
+  addTopologyType(jsStrBuf, pEnv, XML_TAG_ECLSERVERPROCESS,  TAG_PROCESS, "", 0, 1, XML_TAG_SOFTWARE"/EclServerProcess", 4);
   addTopologyType(jsStrBuf, pEnv, XML_TAG_ECLSCHEDULERPROCESS,  TAG_PROCESS, "", 0, 1, XML_TAG_SOFTWARE"/EclSchedulerProcess", 4);
   addTopologyType(jsStrBuf, pEnv, XML_TAG_ECLAGENTPROCESS,  TAG_PROCESS, "", 0, 1, XML_TAG_SOFTWARE"/EclAgentProcess", 4);
   addTopologyType(jsStrBuf, pEnv, XML_TAG_THORCLUSTER,  TAG_PROCESS, "", 0, 1, XML_TAG_SOFTWARE"/ThorCluster", 4);

--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -2388,12 +2388,16 @@ function onContextMenuBeforeShow(p_sType, p_aArgs) {
       "TopologyEclCCServer": [
                                 { text: "Delete", onclick: { fn: onMenuItemClickTopology} }
                             ],
+      "TopologyEclServer": [
+                                { text: "Delete", onclick: { fn: onMenuItemClickTopology} }
+                           ],
       "TopologyEclScheduler": [
                                 { text: "Delete", onclick: { fn: onMenuItemClickTopology} }
                             ],                            
       "TopologyCluster": [
                                { text: "Add EclAgent", onclick: { fn: onMenuItemClickTopology} },
                                { text: "Add EclCCServer", onclick: { fn: onMenuItemClickTopology} },
+                               { text: "Add EclServer", onclick: { fn: onMenuItemClickTopology} },
                                { text: "Add EclScheduler", onclick: { fn: onMenuItemClickTopology} },
                                { text: "Add Thor", onclick: { fn: onMenuItemClickTopology} },
                                { text: "Add Roxie", onclick: { fn: onMenuItemClickTopology} },
@@ -2449,6 +2453,8 @@ function onContextMenuBeforeShow(p_sType, p_aArgs) {
         parentName += "Cluster";
       else if (recName.indexOf("EclCCServer") === 0)
         parentName += "EclCCServer";
+      else if (recName.indexOf("EclServer") === 0)
+        parentName += "EclServer";
       else if (recName.indexOf("EclScheduler") === 0)
         parentName += "EclScheduler";  
       else if (recName.indexOf("ThorCluster") === 0)
@@ -2492,12 +2498,24 @@ function onContextMenuBeforeShow(p_sType, p_aArgs) {
           if (r.getData('parent') === record.getData('id'))
           {
             if (r.getData('name').indexOf('ThorCluster') == 0) {
-              this.getItem(4).cfg.setProperty("disabled", true);
+              this.getItem(5).cfg.setProperty("disabled", true);
               break;
             }
             else if (r.getData('name').indexOf('RoxieCluster') == 0) {
-              this.getItem(3).cfg.setProperty("disabled", true);
+              this.getItem(4).cfg.setProperty("disabled", true);
               break;
+            }
+            else {
+              var flag = false;
+
+              for (i = 0; i < top.document.navDT.navTreeData[0]["menuComps"].length; i++)
+                if (top.document.navDT.navTreeData[0]["menuComps"][i] === 'eclserver') {
+                  flag = true;
+                  break;
+                }
+
+              if (!flag)
+                this.getItem(2).cfg.setProperty("disabled", true);
             }
           }
         }

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -1663,7 +1663,8 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
 
         if (sbName)
         {
-          if (strstr(sbName, "EclCCServerProcess") == sbName || 
+          if (strstr(sbName, "EclCCServerProcess") == sbName ||
+              strstr(sbName, "EclServerProcess") == sbName ||
               strstr(sbName, "EclAgentProcess") == sbName ||
               strstr(sbName, "EclSchedulerProcess") == sbName)
           {
@@ -4523,7 +4524,8 @@ bool CWsDeployFileInfo::handleTopology(IEspContext &context, IEspHandleTopologyR
 
     if (sbName)
     {
-      if (strstr(sbName, "EclCCServerProcess") == sbName || 
+      if (strstr(sbName, "EclCCServerProcess") == sbName ||
+          strstr(sbName, "EclServerProcess") == sbName ||
           strstr(sbName, "EclAgentProcess") == sbName ||
           strstr(sbName, "EclSchedulerProcess") == sbName)
       {
@@ -4560,6 +4562,8 @@ bool CWsDeployFileInfo::handleTopology(IEspContext &context, IEspHandleTopologyR
 
     if (!strcmp(newType, "EclCCServer"))
       sbNewType.clear().append(XML_TAG_ECLCCSERVERPROCESS);
+    else if (!strcmp(newType, "EclServer"))
+      sbNewType.clear().append(XML_TAG_ECLSERVERPROCESS);
     else if (!strcmp(newType, "EclAgent"))
       sbNewType.clear().append(XML_TAG_ECLAGENTPROCESS);
     else if (!strcmp(newType, "EclScheduler"))
@@ -4571,7 +4575,8 @@ bool CWsDeployFileInfo::handleTopology(IEspContext &context, IEspHandleTopologyR
 
     IPropertyTree* pNode = createPTree(sbNewType.str());
 
-    if (!strcmp(sbNewType.str(), XML_TAG_ECLCCSERVERPROCESS) || 
+    if (!strcmp(sbNewType.str(), XML_TAG_ECLCCSERVERPROCESS) ||
+      !strcmp(sbNewType.str(), XML_TAG_ECLSERVERPROCESS) ||
       !strcmp(sbNewType.str(), XML_TAG_ECLAGENTPROCESS) ||
       !strcmp(sbNewType.str(), XML_TAG_ECLSCHEDULERPROCESS) ||
       !strcmp(sbNewType.str(), XML_TAG_THORCLUSTER) ||


### PR DESCRIPTION
Enable addition of EclServer to Topology, if EclServer is enabled in the
environment (i.e. if users can add EclServer to the environment). Otherwise
the "Add EclServer" menu item should be disabled.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
