### PR TITLE
Fix gh-153 LN preflight command should not specify EspUser

### DIFF
--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -39,7 +39,10 @@ struct CEnvironmentConfData
     StringBuffer m_runtimePath;
     StringBuffer m_lockPath;
     StringBuffer m_pidPath;
+    StringBuffer m_user;
 };
+
+static CEnvironmentConfData     environmentConfData;
 
 struct CField
 {
@@ -291,7 +294,6 @@ private:
     StringBuffer m_sTestStr1;
     StringBuffer m_sTestStr2;
 
-    bool m_useDefaultSSHUserID;
     bool m_useDefaultHPCCInit;
     bool m_useDefaultPIDFileName;
 
@@ -305,7 +307,6 @@ private:
     set<string>                  m_excludePartitions;
     set<string>                  m_excludePartitionPatterns;
     StringBuffer                 m_machineInfoFile;
-    CEnvironmentConfData     m_environmentConfData;
 };
 
 //---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Existing Preflight command specifies EspUser for EE. Discussed
with Philip, it should not specify EspUser so that it can use
the user name from environment.conf. If needed, the user name
can be set through configmgr. This fix removes the EspUser
related code.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
