### PR TITLE
ECL Command line enhancements

### DIFF
--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -59,8 +59,12 @@ public:
             const char *arg = iter.query();
             if (*arg!='-')
             {
+                if (optObj.value.length())
+                {
+                    fprintf(stderr, "\nmultiple targets (%s and %s) not currently supported\n", optObj.value.sget(), arg);
+                    return false;
+                }
                 optObj.set(arg);
-                break;
             }
             else if (EclCmdCommon::matchCommandLineOption(iter))
                 continue;
@@ -70,7 +74,12 @@ public:
                 continue;
             else if (iter.matchFlag(boolValue, ECLOPT_VERSION))
             {
-                fprintf(stdout, "\necl delploy version %s\n\n", BUILD_TAG);
+                fprintf(stdout, "%s\n", BUILD_TAG);
+                return false;
+            }
+            else
+            {
+                fprintf(stderr, "\n%s command not recognized\n", arg);
                 return false;
             }
         }
@@ -168,8 +177,12 @@ public:
             const char *arg = iter.query();
             if (*arg!='-')
             {
+                if (optWuid.length())
+                {
+                    fprintf(stderr, "\nmultiple targets (%s and %s) not currently supported\n", optWuid.sget(), arg);
+                    return false;
+                }
                 optWuid.set(arg);
-                break;
             }
             else if (EclCmdCommon::matchCommandLineOption(iter))
                 continue;
@@ -186,7 +199,12 @@ public:
             }
             else if (iter.matchFlag(boolValue, ECLOPT_VERSION))
             {
-                fprintf(stdout, "\necl publish version %s\n\n", BUILD_TAG);
+                fprintf(stdout, "%s\n", BUILD_TAG);
+                return false;
+            }
+            else
+            {
+                fprintf(stderr, "\n%s command not recognized\n", arg);
                 return false;
             }
         }

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -71,10 +71,12 @@ int EclCMDShell::processCMD(ArgvIterator &iter)
     Owned<IEclCommand> c = factory(cmd.get());
     if (!c)
     {
-        if (runExternals)
-            return callExternal(iter);
         if (cmd.length())
+        {
+            if (runExternals)
+                return callExternal(iter);
             fprintf(stderr, "ecl '%s' command not found\n", cmd.sget());
+        }
         usage();
         return 1;
     }
@@ -161,7 +163,7 @@ bool EclCMDShell::parseCommandLineOptions(ArgvIterator &iter)
         }
         else if (iter.matchFlag(boolValue, "--version"))
         {
-            fprintf(stdout, "\necl command line version %s\n\n", BUILD_TAG);
+            fprintf(stdout, "%s\n", BUILD_TAG);
             return false;
         }
     }


### PR DESCRIPTION
Fix gh-769 supports trailing command options

Fix gh-768 supports help without sub command

Fix gh-765 makes version information more concise

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
