### PR TITLE
Fix gh-831 g++ script needs to be executable

### DIFF
--- a/deploy/gcc3/bin/CMakeLists.txt
+++ b/deploy/gcc3/bin/CMakeLists.txt
@@ -16,4 +16,4 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
-Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/g++ DESTINATION ${OSSDIR}/componentfiles/cl/bin COMPONENT Runtime )
+Install ( PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/g++ DESTINATION ${OSSDIR}/componentfiles/cl/bin COMPONENT Runtime )


### PR DESCRIPTION
We supply a script file g++ that can be used to redirect the compiler used by eclcc,
but it's not marked as executable in the rpm.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
