### PR TITLE
Fix issues to do with usage and activity page

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3798,6 +3798,35 @@ public:
 
 };
 
+ClusterType getClusterType(const char * platform, ClusterType dft)
+{
+    if (stricmp(platform, "thor") == 0)
+        return ThorCluster;
+    if (stricmp(platform, "thorlcr") == 0)
+        return ThorLCRCluster;
+    if (stricmp(platform, "hthor") == 0)
+        return HThorCluster;
+    if (stricmp(platform, "roxie") == 0)
+        return RoxieCluster;
+    return dft;
+}
+
+const char *clusterTypeString(ClusterType clusterType)
+{
+    switch (clusterType)
+    {
+    case ThorCluster:
+        return "thor";
+    case ThorLCRCluster:
+        return "thorlcr";
+    case RoxieCluster:
+        return "roxie";
+    case HThorCluster:
+        return "hthor";
+    }
+    throwUnexpected();
+}
+
 class CEnvironmentClusterInfo: public CInterface, implements IConstWUClusterInfo
 {
     StringAttr name;
@@ -3807,7 +3836,7 @@ class CEnvironmentClusterInfo: public CInterface, implements IConstWUClusterInfo
     StringAttr thorQueue;
     StringArray thorProcesses;
     StringAttr prefix;
-    StringAttr platform;
+    ClusterType platform;
     StringAttr querySetName;
     unsigned clusterWidth;
 public:
@@ -3835,18 +3864,18 @@ public:
                 else if (lcr!=islcr)
                     throw MakeStringException(WUERR_MismatchThorType,"CEnvironmentClusterInfo: mismatched thor Legacy in cluster");
             }
-            platform.set(lcr ? "thorlcr" : "thor");
+            platform = lcr ? ThorLCRCluster : ThorCluster;
         }
         else if (roxie)
         {
             roxieProcess.set(roxie->queryProp("@name"));
             clusterWidth = roxie->getPropInt("@numChannels", 1);
-            platform.set("roxie");
+            platform = RoxieCluster;
         }
         else 
         {
             clusterWidth = 1;
-            platform.set("hthor");
+            platform = HThorCluster;
         }
 
         if (agent)
@@ -3888,10 +3917,9 @@ public:
     {
         return clusterWidth;
     }
-    virtual IStringVal & getPlatform(IStringVal & str) const
+    virtual const ClusterType getPlatform() const
     {
-        str.set(platform);
-        return str;
+        return platform;
     }
     IStringVal & getQuerySetName(IStringVal & str) const
     {

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3917,7 +3917,7 @@ public:
     {
         return clusterWidth;
     }
-    virtual const ClusterType getPlatform() const
+    virtual ClusterType getPlatform() const
     {
         return platform;
     }

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -543,7 +543,7 @@ interface IConstWUClusterInfo : extends IInterface
     virtual IStringVal & getScope(IStringVal & str) const = 0;
     virtual IStringVal & getThorQueue(IStringVal & str) const = 0;
     virtual unsigned getSize() const = 0;
-    virtual const ClusterType getPlatform() const = 0;
+    virtual ClusterType getPlatform() const = 0;
     virtual IStringVal & getAgentQueue(IStringVal & str) const = 0;
     virtual IStringVal & getServerQueue(IStringVal & str) const = 0;
     virtual IStringVal & getQuerySetName(IStringVal & str) const = 0;

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -530,6 +530,12 @@ interface IConstWUExceptionIterator : extends IScmIterator
     virtual IConstWUException & query() = 0;
 };
 
+enum ClusterType { NoCluster, ThorCluster, HThorCluster, RoxieCluster, ThorLCRCluster };
+
+extern WORKUNIT_API ClusterType getClusterType(const char * platform, ClusterType dft = NoCluster);
+extern WORKUNIT_API const char *clusterTypeString(ClusterType clusterType);
+inline bool isThorCluster(ClusterType type) { return (type == ThorCluster) || (type == ThorLCRCluster); }
+
 //! IClusterInfo
 interface IConstWUClusterInfo : extends IInterface
 {
@@ -537,7 +543,7 @@ interface IConstWUClusterInfo : extends IInterface
     virtual IStringVal & getScope(IStringVal & str) const = 0;
     virtual IStringVal & getThorQueue(IStringVal & str) const = 0;
     virtual unsigned getSize() const = 0;
-    virtual IStringVal & getPlatform(IStringVal & str) const = 0;
+    virtual const ClusterType getPlatform() const = 0;
     virtual IStringVal & getAgentQueue(IStringVal & str) const = 0;
     virtual IStringVal & getServerQueue(IStringVal & str) const = 0;
     virtual IStringVal & getQuerySetName(IStringVal & str) const = 0;

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -262,12 +262,11 @@ public:
             workunit.clear();
             return;
         }
-        SCMStringBuffer platform;
-        clusterInfo->getPlatform(platform);
+        ClusterType platform = clusterInfo->getPlatform();
         clusterInfo.clear();
         workunit->setState(WUStateCompiling);
         workunit->commit();
-        bool ok = compile(wuid, platform.str(), clusterName.str());
+        bool ok = compile(wuid, clusterTypeString(platform), clusterName.str());
         if (ok)
         {
             workunit->setState(WUStateCompiled);

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -164,19 +164,6 @@ IHqlExpression * DatasetReference::mapScalar(IHqlExpression * expr, IHqlExpressi
 
 //---------------------------------------------------------------------------
 
-extern ClusterType getClusterType(const char * platform, ClusterType dft)
-{
-    if (stricmp(platform, "thor") == 0)
-        return ThorCluster;
-    if (stricmp(platform, "thorlcr") == 0)
-        return ThorLCRCluster;
-    if (stricmp(platform, "hthor") == 0)
-        return HThorCluster;
-    if (stricmp(platform, "roxie") == 0)
-        return RoxieCluster;
-    return dft;
-}
-
 IHqlExpression * createVariable(ITypeInfo * type)
 {
     StringBuffer tempName;

--- a/ecl/hqlcpp/hqlcpp.hpp
+++ b/ecl/hqlcpp/hqlcpp.hpp
@@ -84,11 +84,6 @@ The following debug options are currently supported by the code generator:
 
 #define DEFAULT_conditionalStatements false
 
-enum ClusterType { NoCluster, ThorCluster, HThorCluster, RoxieCluster, ThorLCRCluster };
-
-extern HQLCPP_API ClusterType getClusterType(const char * platform, ClusterType dft = NoCluster);
-inline bool isThorCluster(ClusterType type) { return (type == ThorCluster) || (type == ThorLCRCluster); }
-
 #define STRING_RESOURCES
 
 #define CREATE_DEAULT_ROW_IF_NULL

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -399,11 +399,17 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 }
                 if (qname.length() > 0)
                 {
-                    serverID = runningQueueNames.find(qname);
-                    if (NotFound == serverID)
+                    StringArray qlist;
+                    CslToStringArray(qname.str(), qlist, true);
+                    ForEachItemIn(q, qlist)
                     {
-                        serverID = runningQueueNames.ordinality(); // i.e. last
-                        runningQueueNames.append(qname);
+                        const char *_qname = qlist.item(q);
+                        serverID = runningQueueNames.find(_qname);
+                        if (NotFound == serverID)
+                        {
+                            serverID = runningQueueNames.ordinality(); // i.e. last
+                            runningQueueNames.append(_qname);
+                        }
                     }
                 }
                 Owned<IPropertyTreeIterator> wuids(node.getElements("WorkUnit"));
@@ -485,9 +491,8 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 str.clear();
                 returnCluster->setClusterName(cluster.getName(str).str());
                 str.clear();
-                returnCluster->setQueueName(cluster.getThorQueue(str).str());
-                str.clear();
                 const char *queueName = cluster.getThorQueue(str).str();
+                returnCluster->setQueueName(queueName);
                 Owned<IJobQueue> queue = createJobQueue(queueName);
                 addQueuedWorkUnits(queueName, queue, aws, context, "ThorMaster", NULL);
 

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -481,7 +481,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
             if (cluster.getThorProcesses().ordinality())
             {
                 IEspThorCluster* returnCluster = new CThorCluster("","");
-                returnCluster->setThorLCR(0 == strcmp("thorlcr", cluster.getPlatform(str).str()) ? "withLCR" : "noLCR");
+                returnCluster->setThorLCR(ThorLCRCluster == cluster.getPlatform() ? "withLCR" : "noLCR");
                 str.clear();
                 returnCluster->setClusterName(cluster.getName(str).str());
                 str.clear();

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -1338,7 +1338,7 @@ void streamJobQueueListResponse(IEspContext &context, const char *cluster, const
             break;
 
         sb.append("parent.displayQueue(");
-        appendQuoted(sb, count);
+        appendQuoted(sb, count, true);
         appendQuoted(sb, tq.getDT());
         appendQuoted(sb, tq.getRunningWUs());
         appendQuoted(sb, tq.getQueuedWUs());

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -73,11 +73,8 @@ bool getClusterJobQueueXLS(StringBuffer &xml, const char* cluster, const char* s
     xml.append(">").newline();
 
     StringBuffer filter("ThorQueueMonitor");
-    if(notEmpty(cluster))
-    {
-        const char* queuename = getThorQueueName(cluster);
-        filter.appendf(",%s", notEmpty(queuename) ? queuename : cluster);
-    }
+    if (notEmpty(cluster))
+        filter.appendf(",%s", cluster);
 
     StringAttrArray lines;
     queryAuditLogs(fromTime, toTime, filter.str(), lines);
@@ -1294,10 +1291,7 @@ void streamJobQueueListResponse(IEspContext &context, const char *cluster, const
 
     StringBuffer filter("ThorQueueMonitor");
     if (notEmpty(cluster))
-    {
-        const char* queuename = getThorQueueName(cluster);
-        filter.appendf(",%s", notEmpty(queuename) ? queuename : cluster);
-    }
+        filter.appendf(",%s", cluster);
 
     StringAttrArray lines;
     queryAuditLogs(fromTime, toTime, filter.str(), lines);
@@ -1383,8 +1377,8 @@ int CWsWorkunitsSoapBindingEx::onGet(CHttpRequest* request, CHttpResponse* respo
 
     try
     {
-        StringBuffer path;
-        request->getPath(path);
+         StringBuffer path;
+         request->getPath(path);
 
          if(!strnicmp(path.str(), "/WsWorkunits/JobList", 20))
          {
@@ -1499,10 +1493,7 @@ bool CWsWorkunitsEx::onWUClusterJobQueueLOG(IEspContext &context,IEspWUClusterJo
         const char *cluster = req.getCluster();
         StringBuffer filter("ThorQueueMonitor");
         if (notEmpty(cluster))
-        {
-            const char* queuename = getThorQueueName(cluster);
-            filter.appendf(",%s", notEmpty(queuename) ? queuename : cluster);
-        }
+            filter.appendf(",%s", cluster);
 
         StringAttrArray lines;
         queryAuditLogs(fromTime, toTime, filter.str(), lines);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -302,7 +302,6 @@ public:
 };
 
 StringBuffer &getWuidFromLogicalFileName(IEspContext &context, const char *logicalName, StringBuffer &wuid);
-const char *getThorQueueName(const char *cluster);
 
 bool addToQueryString(StringBuffer &queryString, const char *name, const char *value, const char delim = '&');
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3081,24 +3081,20 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
             }
             else if (strieq(method,"WUJobList"))
             {
-                StringBuffer defcluster;
-                request->getParameter("Cluster",defcluster);
+                StringBuffer cluster;
+                request->getParameter("Cluster", cluster);
                 StringBuffer range;
                 request->getParameter("Range",range);
-
-                Owned<IPropertyTreeIterator> it = root->getElements("Software/ThorCluster");
+                Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
                 xml.append("<WUJobList>");
                 if (range.length())
                     appendXMLTag(xml, "Range", range.str());
-                ForEach (*it)
+                if (clusterInfo)
                 {
-                    const char *name = it->query().queryProp("@name");
-                    if (notEmpty(name))
+                    const StringArray &thorInstances = clusterInfo->getThorProcesses();
+                    ForEachItemIn(i, thorInstances)
                     {
-                        xml.append("<Cluster");
-                        if(strieq(name, defcluster.str()))
-                            xml.append(" selected=\"1\"");
-                        xml.append('>').append(name).append("</Cluster>");
+                        xml.append("<Cluster").append('>').append(thorInstances.item(i)).append("</Cluster>");
                     }
                 }
                 xml.append("</WUJobList>");


### PR DESCRIPTION
Various issues.
Clicking on a workunit where there was > thorinstance threw an ambiguity exception (though only seen in debug)
Some Cluster/queue confusion in usage.
Activity page with multiple target clusters sharing thor's failed to show correct info/status.
This relates to gh-781 and gh-747
