### PR TITLE
Fixes gh-815 Show correct icon for publish dialog.

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -571,7 +571,7 @@
                         draggable: false,
                         close: true,
                         text: exceptionHtml,
-                        icon: YAHOO.widget.SimpleDialog.ICON_HELP,
+                        icon: (i > -1) ? YAHOO.widget.SimpleDialog.ICON_ALARM : YAHOO.widget.SimpleDialog.ICON_INFO,
                         constraintoviewport: true,
                         buttons: [ { text:"Ok", handler:handleOk, isDefault:true } ]
                       } );


### PR DESCRIPTION
Exceptions will show an alarm icon and everything else will have
the info icon.

Signed-off-by: Jo Prichard jo.prichard@lexisnexis.com
