### PR TITLE
Fixes gh-817 Graph not found error.

### DIFF
--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
@@ -660,8 +660,6 @@ bool CWsRoxieQueryEx::onShowGVCGraph(IEspContext &context, IEspShowGVCGraphReque
         getClusterConfig(ROXIE_CLUSTER, cluster, ROXIE_FARMERPROCESS1, netAddress, port);
         ep.set(netAddress.str(), port);
 
-        ep.set("10.239.219.15", port); // jo remove
-
         StringArray graphNames;
         enumerateGraphs(queryName, ep, graphNames);
 


### PR DESCRIPTION
Remove offending line of code that was redirecting the endpoint.

Signed-off-by: Jo Prichard jo.prichard@lexisnexis.com
