### PR TITLE
Fix gh-843 Thor Usage Graph show NaN%

### DIFF
--- a/esp/eclwatch/ws_XSLT/jobs_search.xslt
+++ b/esp/eclwatch/ws_XSLT/jobs_search.xslt
@@ -189,20 +189,21 @@
                     endDate=dt;
                 }
                 var src='';
-                //if (getGraph > 2)
-                //  src='/WsWorkunits/JobList?Cluster=';                
-                //else if (getGraph > 1)
-                //  src='/WsWorkunits/WUClusterJobSummaryXLS?Cluster=';
-                //else
-                //  src='/WsWorkunits/JobList?Type=Multi;Cluster=';
                 if (getGraph > 1)
-                    src='/WsWorkunits/JobQueue?Cluster=';                
-                else if (getGraph > 0)
-                    src='/WsWorkunits/JobList?Cluster=';                
+                {
+                    src='/WsWorkunits/JobQueue?Cluster=';
+                    var select=document.getElementById('TargetCluster');
+                    src+=select.value;
+                }
                 else
-                    src='/WsWorkunits/WUClusterJobSummaryXLS?Cluster=';
-                var select=document.getElementById('Cluster');
-                if(select.selectedIndex>=0) src+=select.options[select.selectedIndex].text;
+                {
+                    if (getGraph > 0)
+                        src='/WsWorkunits/JobList?Cluster=';
+                    else
+                        src='/WsWorkunits/WUClusterJobSummaryXLS?Cluster=';
+                    var select=document.getElementById('Cluster');
+                    if(select.selectedIndex>=0) src+=select.options[select.selectedIndex].text;
+                }
                 if(startDate) src+='&StartDate='+startDate;
                 if(endDate) src+='&EndDate='+endDate;
                 src+='&ShowAll=1';
@@ -215,7 +216,6 @@
                     reload_graph(src);
                 else
                     document.location.href=src;
-        
               return false;
          }
 
@@ -236,6 +236,7 @@
     <body class="yui-skin-sam" onload="nof5();onLoad()">
          Display workunits:<br/><br/>
          <form onsubmit="return submit_list()">
+         <input type="hidden" id="TargetCluster" name="TargetCluster" value="{TargetCluster}"/>
          <table>
             <tr>
                 <td>Cluster</td>

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -970,10 +970,11 @@ void streamJobListResponse(IEspContext &context, const char *cluster, const char
         appendQuoted(sb, job->getFinishedDate());
         appendQuoted(sb, job->getCluster());
         appendQuoted(sb, job->getState());
-        appendQuoted(sb, showall ? "1" : "0");
-        appendQuoted(sb, bbtime);
-        appendQuoted(sb, betime);
-        sb.append(")\r\n");
+        if (showall)
+            sb.append(",\'\',\'1\'");
+        else
+            sb.append(",\'\',\'0\'");
+        sb.append(',').append(bbtime).append(',').append(betime).append(")\r\n");
         if(++count>=50)
         {
             sb.append("</script>\r\n");
@@ -1014,10 +1015,12 @@ void streamJobListResponse(IEspContext &context, const char *cluster, const char
             appendQuoted(sb, finished.str());
             appendQuoted(sb, unfinishedClusters.item(idx3));
             appendQuoted(sb, "not finished");
-            appendQuoted(sb, showall ? "1" : "0");
-            appendQuoted(sb, bbtime);
-            appendQuoted(sb, betime);
-            sb.append(")\r\n");
+            if (showall)
+                sb.append(",\'\',\'1\'");
+            else
+                sb.append(",\'\',\'0\'");
+            sb.append(',').append(bbtime).append(',').append(betime).append(")\r\n");
+
             if(++count>=50)
             {
                 sb.append("</script>\r\n");

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3097,6 +3097,7 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
                         xml.append("<Cluster").append('>').append(thorInstances.item(i)).append("</Cluster>");
                     }
                 }
+                xml.append("<TargetCluster>").append(cluster).append("</TargetCluster>");
                 xml.append("</WUJobList>");
                 xslt.append(getCFD()).append("./smc_xslt/jobs_search.xslt");
                 response->addHeader("Expires", "0");


### PR DESCRIPTION
Using the latest code, I can see the Thor Usage Graph using
the Get Usage Graph button. But, some 'Business %' and
'non-Business %' show NaN%. One bug is found inside the new
code added recently and I fix it now.

Another change is this fix is to pass the target cluster name
to the Uasge page. When the Get Thor Queue button is clicked,
the target cluster name is used to retrieve the queue length
for that target cluster.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
