### PR TITLE
Clean old code for a false alarm on Roxie preflight

### DIFF
--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -294,8 +294,6 @@ private:
     StringBuffer m_sTestStr1;
     StringBuffer m_sTestStr2;
 
-    bool m_useDefaultHPCCInit;
-
     Owned<IPropertyTree>     m_monitorCfg;
     Owned<IPropertyTree>     m_processFilters;
     Owned<IThreadPool>       m_threadPool;

--- a/esp/services/ws_machine/ws_machineServiceRexec.cpp
+++ b/esp/services/ws_machine/ws_machineServiceRexec.cpp
@@ -690,7 +690,7 @@ bool Cws_machineEx::doStartStop(IEspContext &context, StringArray& addresses, ch
             resultsArray.append(*pResult.getLink());
 
             CStartStopThreadParam* pThreadReq;
-            pThreadReq = new CStartStopThreadParam(address, configAddress, bStop, m_useDefaultHPCCInit, this, context);
+            pThreadReq = new CStartStopThreadParam(address, configAddress, bStop, true, this, context);
             pThreadReq->setResultObject( pResult );
 
             if (userName && *userName)


### PR DESCRIPTION
A false alarm about ccd shows due to the old code about
not using HPCCInit porcess. We should always use HPCC process
now. This fix removes the old code.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
