### PR TITLE
Fix issue with status page and shared thors

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3847,7 +3847,7 @@ public:
         StringBuffer queue;
         if (thors.ordinality())
         {
-            thorQueue.set(queue.clear().append(name).append(".thor"));
+            thorQueue.set(getClusterThorQueueName(queue.clear(), name));
             clusterWidth = 0;
             bool lcr = false;
             ForEachItemIn(i,thors) 
@@ -3881,12 +3881,12 @@ public:
         if (agent)
         {
             assertex(!roxie);
-            agentQueue.set(queue.clear().append(name).append(".agent"));
+            agentQueue.set(getClusterEclAgentQueueName(queue.clear(), name));
         }
         else if (roxie)
-            agentQueue.set(queue.clear().append(name).append(".roxie"));
+            agentQueue.set(getClusterRoxieQueueName(queue.clear(), name));
         // MORE - does this need to be conditional?
-        serverQueue.set(queue.clear().append(name).append(".eclserver"));
+        serverQueue.set(getClusterEclCCServerQueueName(queue.clear(), name));
     }
     IStringVal & getName(IStringVal & str) const
     {
@@ -3965,34 +3965,66 @@ IStringVal &getProcessQueueNames(IStringVal &ret, const char *process, const cha
     return ret;
 }
 
+#define ROXIE_QUEUE_EXT ".roxie"
+#define THOR_QUEUE_EXT ".thor"
+#define ECLCCSERVER_QUEUE_EXT ".eclserver"
+#define ECLSERVER_QUEUE_EXT ECLCCSERVER_QUEUE_EXT
+#define ECLSCHEDULER_QUEUE_EXT ".eclscheduler"
+#define ECLAGENT_QUEUE_EXT ".agent"
+
 extern WORKUNIT_API IStringVal &getEclCCServerQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "EclCCServerProcess", ".eclserver");
+    return getProcessQueueNames(ret, process, "EclCCServerProcess", ECLCCSERVER_QUEUE_EXT);
 }
 
 extern WORKUNIT_API IStringVal &getEclServerQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "EclServerProcess", ".eclserver"); // shares queue name with EclCCServer
+    return getProcessQueueNames(ret, process, "EclServerProcess", ECLSERVER_QUEUE_EXT); // shares queue name with EclCCServer
 }
 
 extern WORKUNIT_API IStringVal &getEclSchedulerQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "EclCCServerProcess", ".eclscheduler"); // Shares deployment/config with EclCCServer
+    return getProcessQueueNames(ret, process, "EclSchedulerProcess", ECLSCHEDULER_QUEUE_EXT); // Shares deployment/config with EclCCServer
 }
 
 extern WORKUNIT_API IStringVal &getAgentQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "EclAgentProcess", ".agent");
+    return getProcessQueueNames(ret, process, "EclAgentProcess", ECLAGENT_QUEUE_EXT);
 }
 
 extern WORKUNIT_API IStringVal &getRoxieQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "RoxieCluster", ".roxie");
+    return getProcessQueueNames(ret, process, "RoxieCluster", ROXIE_QUEUE_EXT);
 }
 
 extern WORKUNIT_API IStringVal &getThorQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "ThorCluster", ".thor");
+    return getProcessQueueNames(ret, process, "ThorCluster", THOR_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterThorQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(THOR_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterRoxieQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(ROXIE_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterEclCCServerQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(ECLCCSERVER_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterEclServerQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(ECLSERVER_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterEclAgentQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(ECLAGENT_QUEUE_EXT);
 }
 
 extern WORKUNIT_API IStringIterator *getTargetClusters(const char *processType, const char *processName)
@@ -4142,7 +4174,7 @@ unsigned getEnvironmentThorClusterNames(StringArray &thorNames, StringArray &gro
                     groupNames.append(groupName);
                     targetNames.append(targetName);
                     StringBuffer queueName(targetName);
-                    queueNames.append(queueName.append(".thor"));
+                    queueNames.append(queueName.append(THOR_QUEUE_EXT));
                 }
             }
         }

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1133,6 +1133,11 @@ extern WORKUNIT_API IStringVal &getEclSchedulerQueueNames(IStringVal &ret, const
 extern WORKUNIT_API IStringVal &getAgentQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getRoxieQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getThorQueueNames(IStringVal &ret, const char *process);
+extern WORKUNIT_API StringBuffer &getClusterThorQueueName(StringBuffer &ret, const char *cluster);
+extern WORKUNIT_API StringBuffer &getClusterRoxieQueueName(StringBuffer &ret, const char *cluster);
+extern WORKUNIT_API StringBuffer &getClusterEclCCServerQueueName(StringBuffer &ret, const char *cluster);
+extern WORKUNIT_API StringBuffer &getClusterEclServerQueueName(StringBuffer &ret, const char *cluster);
+extern WORKUNIT_API StringBuffer &getClusterEclAgentQueueName(StringBuffer &ret, const char *cluster);
 extern WORKUNIT_API IStringIterator *getTargetClusters(const char *processType, const char *processName);
 extern WORKUNIT_API IConstWUClusterInfo* getTargetClusterInfo(const char *clustname);
 typedef IArrayOf<IConstWUClusterInfo> CConstWUClusterInfoArray;

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -371,7 +371,6 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
         IArrayOf<IEspActiveWorkunit> aws;
         if (conn.get()) 
         {
-
             Owned<IPropertyTreeIterator> it(conn->queryRoot()->getElements("Server"));
             ForEach(*it) 
             {
@@ -423,9 +422,16 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                     {
                         IEspActiveWorkunit* wu=new CActiveWorkunitWrapper(context,wuid);
                         const char* servername = node.queryProp("@name");
+                        const char *cluster = node.queryProp("Cluster");
                         wu->setServer(servername);
                         wu->setInstance(instance.str());
-                        wu->setQueueName(qname.str());
+                        StringBuffer thorQueue;
+                        if (cluster) // backward compat check.
+                            getClusterThorQueueName(thorQueue, cluster);
+                        else
+                            thorQueue.append(qname);
+                        serverID = runningQueueNames.find(thorQueue.str());
+                        wu->setQueueName(thorQueue);
                         double version = context.getClientVersion();
                         if (version > 1.01)
                         {

--- a/thorlcr/graph/thgraphmaster.hpp
+++ b/thorlcr/graph/thgraphmaster.hpp
@@ -50,7 +50,7 @@ interface IJobManager : extends IInterface
 {
     virtual void stop() = 0;
     virtual void replyException(CJobMaster &job, IException *e) = 0;
-    virtual void setWuid(const char *wuid) = 0;
+    virtual void setWuid(const char *wuid, const char *cluster=NULL) = 0;
     virtual IDeMonServer *queryDeMonServer() = 0;
     virtual void fatal(IException *e) = 0;
     virtual void addCachedSo(const char *name) = 0;

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -705,7 +705,7 @@ int main( int argc, char *argv[]  )
         LOG(MCdebugProgress, thorJob, "Thor name = %s, queue = %s, nodeGroup = %s",thorname,queueName.str(),nodeGroup.str());
 
         serverStatus.queryProperties()->setProp("@thorname", thorname);
-        serverStatus.queryProperties()->setProp("@cluster", nodeGroup.str());
+        serverStatus.queryProperties()->setProp("@cluster", nodeGroup.str()); // JCSMORE rename
         serverStatus.queryProperties()->setProp("LogFile", logUrl.str()); // LogFile read by eclwatch (possibly)
         serverStatus.queryProperties()->setProp("@nodeGroup", nodeGroup.str());
         serverStatus.queryProperties()->setProp("@queue", queueName.str());


### PR DESCRIPTION
A shared thor, i.e. one that is in >1 cluster and listening to >1 queue
caused the activity page some confusion. Resulting in not displaying some
running jobs.
This is really a workaround until activiy page is restructued to more
acturately reflects the topology.
The workaround has Thor store the target cluster of workunit in the running
Status, which is then retreieved by the ws_smcService to tie up which target
the running workunit belongs to.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
