### PR TITLE
Fixes #848 Wizard should not generate eclagent for Roxie Cluster

### DIFF
--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -2497,6 +2497,7 @@ function onContextMenuBeforeShow(p_sType, p_aArgs) {
             }
             else if (r.getData('name').indexOf('RoxieCluster') == 0) {
               this.getItem(3).cfg.setProperty("disabled", true);
+              this.getItem(0).cfg.setProperty("disabled", true);
               break;
             }
           }

--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -10,6 +10,6 @@ roxie_dependencies=ws_roxieconfig
 roxie_agent_redundancy=1,2,1
 
 [Topology]
-roxie_topology=eclagent,eclccserver,eclscheduler
+roxie_topology=eclccserver,eclscheduler
 thor_topology=eclagent,eclccserver,eclscheduler
 hthor_topology=eclagent,eclccserver,eclscheduler


### PR DESCRIPTION
Disable the generation of eclagent for Topology Roxie Cluster via the ConfigMgr
Wizard and also disable the "Add EclAgent" menu item for Topology/Roxie Cluster

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
