### PR TITLE
Fixes #848 Wizard should not generate eclagent for Roxie Cluster Topology

### DIFF
--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -2499,11 +2499,13 @@ function onContextMenuBeforeShow(p_sType, p_aArgs) {
           {
             if (r.getData('name').indexOf('ThorCluster') == 0) {
               this.getItem(5).cfg.setProperty("disabled", true);
-              break;
             }
             else if (r.getData('name').indexOf('RoxieCluster') == 0) {
               this.getItem(4).cfg.setProperty("disabled", true);
-              break;
+              this.getItem(0).cfg.setProperty("disabled", true);
+            }
+            else if (r.getData('name').indexOf('EclAgent') == 0) {
+              this.getItem(5).cfg.setProperty("disabled", true);
             }
             else {
               var flag = false;

--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -10,6 +10,6 @@ roxie_dependencies=ws_roxieconfig
 roxie_agent_redundancy=1,2,1
 
 [Topology]
-roxie_topology=eclagent,eclccserver,eclscheduler
+roxie_topology=eclccserver,eclscheduler
 thor_topology=eclagent,eclccserver,eclscheduler
 hthor_topology=eclagent,eclccserver,eclscheduler


### PR DESCRIPTION
Fixes #848 Wizard should not generate eclagent for Roxie Cluster Topology

Disable the generation of eclagent for Topology Roxie Cluster via the
ConfigMgr Wizard and also disable the addition of EclAgent if Topology has
Roxie Cluster or the addition of the Roxie Cluster if Topology has EclAgent

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
