### PR TITLE
Fix gh-820 Exception when click XLS on Thor Usage

### DIFF
--- a/esp/files/joblist.js
+++ b/esp/files/joblist.js
@@ -425,7 +425,10 @@ function displayJob(wuid,graph,started,finished,cluster,state,source,showall,bbt
 
 function displayEnd(xls)
 {
-    displayProgress('<table><tr><td>Total: '+(totalWorkunits)+' graphs (<a href=\"/WsWorkunits/WUClusterJobXLS?' + xls +'\">xls</a>...<a href=\"/WsWorkunits/WUClusterJobSummaryXLS?' + xls +'\">summary</a>)</td></tr></table>');
+    if (totalWorkunits > 0)
+        displayProgress('<table><tr><td>Total: '+(totalWorkunits)+' graphs (<a href=\"/WsWorkunits/WUClusterJobXLS?' + xls +'\">xls</a>...<a href=\"/WsWorkunits/WUClusterJobSummaryXLS?' + xls +'\">summary</a>)</td></tr></table>');
+    else
+        displayProgress('<table><tr><td>Total: '+(totalWorkunits)+' graphs</td></tr></table>');
 }
 
 function displaySasha()

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -330,6 +330,8 @@ bool getClusterJobXLS(double version, StringBuffer &xml, const char* cluster, co
 
         jobList.append(*job.getClear());
     }
+    xml.append("</Dataset>").newline();
+
     return true;
 }
 
@@ -1544,7 +1546,6 @@ bool CWsWorkunitsEx::onWUClusterJobXLS(IEspContext &context, IEspWUClusterJobXLS
         StringBuffer xml("<WUResultExcel><Result>");
         getClusterJobXLS(context.getClientVersion(), xml, req.getCluster(), req.getStartDate(), req.getEndDate(), req.getShowAll(), req.getBusinessStartTime(), req.getBusinessEndTime());
         xml.append("</Result></WUResultExcel>");
-
         Owned<IProperties> params(createProperties());
         params->setProp("showCount",0);
 


### PR DESCRIPTION
The exception is because recent code change deleted the code
for </Dataset> by mistake. This fix adds the code back. I also
add the code to check WUs on the Thor Usage page. If no WUs,
the page should not show the xls and summery links.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
