### PR TITLE
Fix gh-767 ECL command line parmeter check and connect timeout

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -25,7 +25,7 @@
 #include "ws_workunits.hpp"
 #include "eclcmd_common.hpp"
 
-bool extractOption(StringBuffer & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix)
+bool extractEclCmdOption(StringBuffer & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix)
 {
     if (option.length())        // check if already specified via a command line option
         return true;
@@ -47,21 +47,29 @@ bool extractOption(StringBuffer & option, IProperties * globals, const char * en
     return false;
 }
 
-bool extractOption(StringAttr & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix)
+bool extractEclCmdOption(StringAttr & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix)
 {
     if (option)
         return true;
     StringBuffer temp;
-    bool ret = extractOption(temp, globals, envName, propertyName, defaultPrefix, defaultSuffix);
+    bool ret = extractEclCmdOption(temp, globals, envName, propertyName, defaultPrefix, defaultSuffix);
     option.set(temp.str());
     return ret;
 }
 
-bool extractOption(bool & option, IProperties * globals, const char * envName, const char * propertyName, bool defval)
+bool extractEclCmdOption(bool & option, IProperties * globals, const char * envName, const char * propertyName, bool defval)
 {
     StringBuffer temp;
-    bool ret = extractOption(temp, globals, envName, propertyName, defval ? "1" : "0", NULL);
+    bool ret = extractEclCmdOption(temp, globals, envName, propertyName, defval ? "1" : "0", NULL);
     option=(streq(temp.str(),"1")||strieq(temp.str(),"true"));
+    return ret;
+}
+
+bool extractEclCmdOption(unsigned & option, IProperties * globals, const char * envName, const char * propertyName, unsigned defval)
+{
+    StringBuffer temp;
+    bool ret = extractEclCmdOption(temp, globals, envName, propertyName, NULL, NULL);
+    option = (ret) ? strtoul(temp.str(), NULL, 10) : defval;
     return ret;
 }
 

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -110,14 +110,10 @@ public:
     }
     virtual bool finalizeOptions(IProperties *globals)
     {
-        extractEclCmdOption(optServer, globals, ECLOPT_SERVER_ENV, ECLOPT_SERVER_INI, ".", NULL);
-        extractEclCmdOption(optPort, globals, ECLOPT_PORT_ENV, ECLOPT_PORT_INI, "8010", NULL);
+        extractEclCmdOption(optServer, globals, ECLOPT_SERVER_ENV, ECLOPT_SERVER_INI, ECLOPT_SERVER_DEFAULT, NULL);
+        extractEclCmdOption(optPort, globals, ECLOPT_PORT_ENV, ECLOPT_PORT_INI, ECLOPT_PORT_DEFAULT, NULL);
         extractEclCmdOption(optUsername, globals, ECLOPT_USERNAME_ENV, ECLOPT_USERNAME_INI, NULL, NULL);
         extractEclCmdOption(optPassword, globals, ECLOPT_PASSWORD_ENV, ECLOPT_PASSWORD_INI, NULL, NULL);
-        if (optServer.isEmpty())
-            optServer.set(".");
-        if (optPort.isEmpty())
-            optPort.set("8010");
         return true;
     }
     virtual void usage()

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -24,7 +24,7 @@
 interface IEclCommand : extends IInterface
 {
     virtual bool parseCommandLineOptions(ArgvIterator &iter)=0;
-    virtual void finalizeOptions(IProperties *globals)=0;
+    virtual bool finalizeOptions(IProperties *globals)=0;
     virtual int processCMD()=0;
     virtual void usage()=0;
 };
@@ -34,10 +34,12 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_SERVER "--server"
 #define ECLOPT_SERVER_INI "eclWatchIP"
 #define ECLOPT_SERVER_ENV "ECL_WATCH_IP"
+#define ECLOPT_SERVER_DEFAULT "."
 
 #define ECLOPT_PORT "--port"
 #define ECLOPT_PORT_INI "eclWatchPort"
 #define ECLOPT_PORT_ENV "ECL_WATCH_PORT"
+#define ECLOPT_PORT_DEFAULT "8010"
 
 #define ECLOPT_USERNAME "--username"
 #define ECLOPT_USERNAME_INI "eclUserName"
@@ -57,9 +59,10 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_ACTIVATE "--activate"
 #define ECLOPT_VERSION "--version"
 
-bool extractOption(StringBuffer & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);
-bool extractOption(StringAttr & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);
-bool extractOption(bool & option, IProperties * globals, const char * envName, const char * propertyName, bool defval);
+bool extractEclCmdOption(StringBuffer & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);
+bool extractEclCmdOption(StringAttr & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);
+bool extractEclCmdOption(bool & option, IProperties * globals, const char * envName, const char * propertyName, bool defval);
+bool extractEclCmdOption(unsigned & option, IProperties * globals, const char * envName, const char * propertyName, unsigned defval);
 
 enum eclObjParameterType
 {
@@ -85,6 +88,7 @@ public:
     unsigned accept;
 };
 
+
 class EclCmdCommon : public CInterface, implements IEclCommand
 {
 public:
@@ -104,12 +108,17 @@ public:
             return true;
         return false;
     }
-    virtual void finalizeOptions(IProperties *globals)
+    virtual bool finalizeOptions(IProperties *globals)
     {
-        extractOption(optServer, globals, ECLOPT_SERVER_ENV, ECLOPT_SERVER_INI, ".", NULL);
-        extractOption(optPort, globals, ECLOPT_PORT_ENV, ECLOPT_PORT_INI, "8010", NULL);
-        extractOption(optUsername, globals, ECLOPT_USERNAME_ENV, ECLOPT_USERNAME_INI, NULL, NULL);
-        extractOption(optPassword, globals, ECLOPT_PASSWORD_ENV, ECLOPT_PASSWORD_INI, NULL, NULL);
+        extractEclCmdOption(optServer, globals, ECLOPT_SERVER_ENV, ECLOPT_SERVER_INI, ".", NULL);
+        extractEclCmdOption(optPort, globals, ECLOPT_PORT_ENV, ECLOPT_PORT_INI, "8010", NULL);
+        extractEclCmdOption(optUsername, globals, ECLOPT_USERNAME_ENV, ECLOPT_USERNAME_INI, NULL, NULL);
+        extractEclCmdOption(optPassword, globals, ECLOPT_PASSWORD_ENV, ECLOPT_PASSWORD_INI, NULL, NULL);
+        if (optServer.isEmpty())
+            optServer.set(".");
+        if (optPort.isEmpty())
+            optPort.set("8010");
+        return true;
     }
     virtual void usage()
     {

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -88,7 +88,8 @@ int EclCMDShell::processCMD(ArgvIterator &iter)
     if (!c->parseCommandLineOptions(iter))
         return 0;
 
-    c->finalizeOptions(globals);
+    if (!c->finalizeOptions(globals))
+        return 0;
 
     return c->processCMD();
 }

--- a/esp/bindings/http/client/httpclient.cpp
+++ b/esp/bindings/http/client/httpclient.cpp
@@ -39,7 +39,7 @@
      CHttpClient Implementation
 **************************************************************************/
 #define URL_MAX  512
-
+#define HTTP_CLIENT_DEFAULT_CONNECT_TIMEOUT 3000
 
 CHttpClientContext::CHttpClientContext()
 {
@@ -231,7 +231,7 @@ int CHttpClient::connect(StringBuffer& errmsg)
         if(m_timeout)
             m_socket = ISocket::connect_timeout(ep,m_timeout);
         else
-            m_socket = ISocket::connect(ep);
+            m_socket = ISocket::connect_timeout(ep, HTTP_CLIENT_DEFAULT_CONNECT_TIMEOUT);
 
         if(strcmp(m_protocol.get(), "HTTPS") == 0)
         {


### PR DESCRIPTION
Sets a more reasonable default connect timeout for http client.

Provides a model for consisently validating parameter combination for all
ecl command line commands.

Improves usage documentation for various parameter combinations.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
