### PR TITLE
Improve skew warning/error messages

### DIFF
--- a/system/jlib/jbuff.hpp
+++ b/system/jlib/jbuff.hpp
@@ -63,6 +63,7 @@ template <class CLASS> class OwnedMalloc
 public:
     inline OwnedMalloc()                        { ptr = NULL; }
     inline OwnedMalloc(CLASS * _ptr)            { ptr = _ptr; }
+    explicit inline OwnedMalloc(unsigned n, bool clearMemory = false) { doAllocate(n, clearMemory); }
     inline ~OwnedMalloc()                       { free(ptr); }
 
     inline CLASS * operator -> () const         { return ptr; }
@@ -77,13 +78,17 @@ public:
     inline void allocateN(unsigned n, bool clearMemory = false)
     {
         clear();
-        void * mem = clearMemory ? calloc(n, sizeof(CLASS)) : malloc(n * sizeof(CLASS));
-        ptr = static_cast<CLASS *>(mem);
+        doAllocate(n, clearMemory);
     }
 
 private:
     inline OwnedMalloc(const OwnedMalloc<CLASS> & other);
 
+    inline void doAllocate(unsigned n, bool clearMemory = false)
+    {
+        void * mem = clearMemory ? calloc(n, sizeof(CLASS)) : malloc(n * sizeof(CLASS));
+        ptr = static_cast<CLASS *>(mem);
+    }
     void operator = (CLASS * _ptr);
     void operator = (const OwnedMalloc<CLASS> & other);
     void set(CLASS * _ptr);

--- a/thorlcr/msort/tsortm.hpp
+++ b/thorlcr/msort/tsortm.hpp
@@ -41,7 +41,7 @@ public:
                             const char *cosortfilenames,
                             IRowInterfaces *auxrowif
                         )=0;
-    virtual bool Sort(unsigned __int64 threshold, double skewWarning, double skewError, size32_t deviance, bool canoptimizenullcolumns, bool usepartitionrow, bool betweensort, unsigned minisortthresholdmb)=0;
+    virtual void Sort(unsigned __int64 threshold, double skewWarning, double skewError, size32_t deviance, bool canoptimizenullcolumns, bool usepartitionrow, bool betweensort, unsigned minisortthresholdmb)=0;
     virtual bool MiniSort(rowcount_t totalrows)=0;
     virtual void SortDone()=0;
 };

--- a/thorlcr/shared/thexception.hpp
+++ b/thorlcr/shared/thexception.hpp
@@ -155,7 +155,8 @@
 #define TE_NotSorted                            TE_Base + 131
 #define TE_LargeAggregateTable                  TE_Base + 132
 #define TE_SkewWarning                          TE_Base + 133
-#define TE_Final                                TE_Base + 134       // keep this last
+#define TE_SkewError                            TE_Base + 134
+#define TE_Final                                TE_Base + 135       // keep this last
 #define ISTHOREXCEPTION(n) (n > TE_Base && n < TE_Final)
 
 #endif


### PR DESCRIPTION
The skew messages in a global join were particularly confusing,
if the skew was detected on the co-sort.

Also fixed 1 minor leak (in thormaster) per global sort and some other
potential ones.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
