### PR TITLE
Fix problem compiling files not in the include path

### DIFF
--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -821,7 +821,7 @@ IEclSourceCollection * createSingleDefinitionEclCollection(const char * attrName
     if (dot)
     {
         StringAttr module(attrName, dot-attrName);
-        return createSingleDefinitionEclCollection(module, attrName, contents);
+        return createSingleDefinitionEclCollection(module, dot+1, contents);
     }
     return createSingleDefinitionEclCollection("", attrName, contents);
 }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
