### PR TITLE
Minor fix to debugging cmd in dali

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -6437,7 +6437,7 @@ bool CCovenSDSManager::setSDSDebug(StringArray &params, StringBuffer &reply)
             reply.append("datalockHoldStack currently set to '").append(readWriteStackTracing?"on":"off").append("'");
             return false;
         }
-        readWriteStackTracing = (0 == stricmp("on", params.item(2)));
+        readWriteStackTracing = (0 == stricmp("on", params.item(1)));
 
         PROGLOG("datalock, held time stacks set to '%s'", readWriteStackTracing?"on":"off");
     }


### PR DESCRIPTION
Picking up the wrong parameter passed to debug command, resulted in
harmless stack trace. Cmd with bug can still be used by passing in a fake
1st param.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
