### PR TITLE
Minor join tracing fix

### DIFF
--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -233,7 +233,7 @@ public:
     virtual bool startAsync() { return true; }
     virtual void onInputFinished(rowcount_t count)
     {
-        ActPrintLog("JOIN: RHS input finished, %"RCPF"d rows read", count);
+        ActPrintLog("JOIN: %s input finished, %"RCPF"d rows read", rightpartition?"LHS":"RHS", count);
     }
 
     void doDataLinkStart(bool denorm)


### PR DESCRIPTION
Global join was tracing wrong side had finished reading input, if
right partitioned

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
