### PR TITLE
Fix problem with import all on legacy queries

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -933,7 +933,7 @@ void EclCC::processFile(EclCompileInstance & instance)
         {
             //Ensure that $ is valid for any file submitted - even if it isn't in the include direcotories
             //Disable this for the moment when running the regression suite.
-            if (!optBatchMode && !withinRepository && !inputFromStdIn)
+            if (!optBatchMode && !withinRepository && !inputFromStdIn && !optLegacy)
             {
                 //Associate the contents of the directory with an internal module called _local_directory_
                 //(If it was root it might override existing root symbols).  $ is the only public way to get at the symbol


### PR DESCRIPTION
The code to perform an import all for the main query was being disabled
by the recent fixes to $ handling in files not in the include path.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
