### PR TITLE
Fix gh-770 Makes publish command able to work directly on dlls and archive

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -216,12 +216,16 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
         queryName.set(req.getJobName());
     else
         cw->getJobName(queryName).str();
+    if (!queryName.length())
+        throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Query/Job name not defined for publishing workunit %s", req.getWuid());
 
     SCMStringBuffer cluster;
     if (notEmpty(req.getCluster()))
         cluster.set(req.getCluster());
     else
         cw->getClusterName(cluster);
+    if (!cluster.length())
+        throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Cluster name not defined for publishing workunit %s", req.getWuid());
 
     Owned <IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster.str());
 


### PR DESCRIPTION
Fix gh-770 Makes publish command able to work directly on dlls and archives

Simplifies the multiple steps required to compile, deploy,
and publish a query.

Usage:

ecl publish [--cluster=<cluster>] [--name=<name>] [--activate] <wuid>
ecl publish [--cluster=<cluster>] [--name=<name>] [--activate] <so|dll>
ecl publish --cluster=<cluster> --name=<name> [--activate] <archive>

   Options:
      <wuid>               workunit to publish
      <archive>            archive to publish
      <so|dll>             workunit dll or shared object to publish
      --cluster=<cluster>  cluster to publish workunit to
                           (defaults to cluster defined inside workunit)
      --name=<name>        query name to use for published workunit
      --activate           activates query when published
      --server=<ip>        ip of server running ecl services (eclwatch)
      --port=<port>        ecl services port
      --username=<name>    username for accessing ecl services
      --password=<pw>      password for accessing ecl services

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
