### PR TITLE
Fix gh-907 Page Not Found error when ShowQuery for a file

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -110,7 +110,8 @@
             }
             function showRoxieQueries()
             {
-              document.location.href='/WsRoxieQuery/QueriesAction?Type=ListQueries&Cluster='+cluster+'&LogicalName='+filename;
+              //document.location.href='/WsRoxieQuery/QueriesAction?Type=ListQueries&Cluster='+cluster+'&LogicalName='+filename;
+              document.location.href='/WsSMC/DisabledInThisVersion?form_';
             }
             var xypos = YAHOO.util.Dom.getXY('mn' + PosId);
             if (oMenu) {


### PR DESCRIPTION
From ECLWatch Logical Files page, Page Not Found error shows
when selecting ShowQuery from the drop down menu for a logical
file. Since the ShowQuery will be supported later, this fix links
the ShowQuery menu to a message page: This feature is disabled
in this version.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
