### PR TITLE
Fix gh-709 StandAlone data file location fix

### DIFF
--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -129,7 +129,7 @@ public:
     const CDfsLogicalFileName &multiItem(unsigned idx) const;
     const void resolveWild();  // only for multi
     IPropertyTree *createSuperTree() const;
-    void allowOsPath(bool set=true) { allowospath = true; } // allow local OS path to be specified
+    void allowOsPath(bool allow=true) { allowospath = allow; } // allow local OS path to be specified
 };
 
 // abstract class, define getCmdText to return tracing text of commands

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3233,19 +3233,12 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
             PrintLog("ECLAGENT build %s", BUILD_TAG);
             startLogMsgParentReceiver();    
             connectLogMsgManagerToDali();
-            StringBuffer datadir;
-            StringBuffer repdir;
 
-            const char * overrideBaseDirectory = "hthor";         // relative to UserDataDirectory in dali
-            const char * overrideReplicateDirectory = "hthor";    // relative to UserMirrorDirectory in dali
-            if (getConfigurationDirectory(agentTopology->queryPropTree("Directories"),"data","eclagent",agentTopology->queryProp("@name"),datadir))
-                overrideBaseDirectory = datadir.str();
-            if (getConfigurationDirectory(agentTopology->queryPropTree("Directories"),"mirror","eclagent",agentTopology->queryProp("@name"),repdir))
-                overrideReplicateDirectory = repdir.str();
-            if (overrideBaseDirectory&&*overrideBaseDirectory)
-                setBaseDirectory(overrideBaseDirectory, false);
-            if (overrideReplicateDirectory&&*overrideReplicateDirectory)
-                setBaseDirectory(overrideReplicateDirectory, true);
+            StringBuffer baseDir;
+            if (getConfigurationDirectory(agentTopology->queryPropTree("Directories"),"data","eclagent",agentTopology->queryProp("@name"),baseDir.clear()))
+                setBaseDirectory(baseDir.str(), false);
+            if (getConfigurationDirectory(agentTopology->queryPropTree("Directories"),"mirror","eclagent",agentTopology->queryProp("@name"),baseDir.clear()))
+                setBaseDirectory(baseDir.str(), true);
 
             if (standAloneWorkUnit)
             {


### PR DESCRIPTION
If running stand alone with a dali connection (config file not available),
the data directory defaults to /c$/thordata. This is incorrect as it
should be querying that location from dali.
Fix the problem by not setting default base to "hthor", therefore enabling
the conditional code in defdesc.cpp "loadDefaultBases" to query from dali.
Also, fixed a bug in dautils where allowospath(bool) was ignoring the flag
and always setting allow to true.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
