### PR TITLE
Fix: searching logical files: hthor cluster not available

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4220,6 +4220,41 @@ unsigned getEnvironmentHThorClusterNames(StringArray &eclAgentNames, StringArray
     return eclAgentNames.ordinality();
 }
 
+unsigned getEnvironmentRoxieClusterNames(StringArray &roxieNames, StringArray &groupNames, StringArray &targetNames, StringArray &queueNames)
+{
+    Owned<IRemoteConnection> conn = querySDS().connect("Environment", myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
+    if (!conn)
+        return 0;
+    Owned<IPropertyTreeIterator> allTargets = conn->queryRoot()->getElements("Software/Topology/Cluster");
+    ForEach(*allTargets)
+    {
+        IPropertyTree &target = allTargets->query();
+        const char *targetName = target.queryProp("@name");
+        if (targetName && *targetName)
+        {
+            Owned<IPropertyTreeIterator> roxieClusters = target.getElements("RoxieCluster");
+            ForEach(*roxieClusters)
+            {
+                const char *roxieName = roxieClusters->query().queryProp("@process");
+                VStringBuffer query("Software/RoxieCluster[@name=\"%s\"]",roxieName);
+                IPropertyTree *roxieCluster = conn->queryRoot()->queryPropTree(query.str());
+                if (roxieCluster)
+                {
+                    const char *groupName = roxieCluster->queryProp("@nodeGroup");
+                    if (!groupName||!*groupName)
+                        groupName = roxieName;
+                    roxieNames.append(roxieName);
+                    groupNames.append(groupName);
+                    targetNames.append(targetName);
+                    StringBuffer queueName(targetName);
+                    queueNames.append(queueName.append(ROXIE_QUEUE_EXT));
+                }
+            }
+        }
+    }
+    return roxieNames.ordinality();
+}
+
 
 IStringVal& CLocalWorkUnit::getScope(IStringVal &str) const 
 {

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1149,6 +1149,7 @@ extern WORKUNIT_API void clientShutdownWorkUnit();
 extern WORKUNIT_API IExtendedWUInterface * queryExtendedWU(IWorkUnit * wu);
 extern WORKUNIT_API unsigned getEnvironmentThorClusterNames(StringArray &thorNames, StringArray &groupNames, StringArray &targetNames, StringArray &queueNames);
 extern WORKUNIT_API unsigned getEnvironmentHThorClusterNames(StringArray &eclAgentNames, StringArray &groupNames, StringArray &targetNames);
+extern WORKUNIT_API unsigned getEnvironmentRoxieClusterNames(StringArray &roxieNames, StringArray &groupNames, StringArray &targetNames, StringArray &queueNames);
 extern WORKUNIT_API StringBuffer &formatGraphTimerLabel(StringBuffer &str, const char *graphName, unsigned subGraphNum=0, unsigned __int64 subId=0);
 extern WORKUNIT_API bool parseGraphTimerLabel(const char *label, StringBuffer &graphName, unsigned &subGraphNum, unsigned __int64  &subId);
 extern WORKUNIT_API void addExceptionToWorkunit(IWorkUnit * wu, WUExceptionSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column);

--- a/esp/eclwatch/ws_XSLT/fs_desprayCopyForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_desprayCopyForm.xslt
@@ -619,13 +619,11 @@
                                             <xsl:value-of select="@name"/>
                                         </option>
                                     </xsl:for-each>
-                                    <xsl:for-each select="Software/EclAgentProcess/Instance">
+                                    <xsl:for-each select="Software/EclAgentProcess">
                                         <option>
-                                            <xsl:attribute name="title"><xsl:text>T</xsl:text><xsl:value-of select="../@name"/></xsl:attribute>
+                                            <xsl:attribute name="title"><xsl:text>T</xsl:text><xsl:value-of select="@name"/></xsl:attribute>
                                             <xsl:attribute name="value"><xsl:value-of select="@netAddress"/></xsl:attribute>
-                                            <xsl:value-of select="../@name"/>
-                                            <xsl:text> </xsl:text>
-                                            <xsl:value-of select="@netAddress"/>
+                                            <xsl:value-of select="@name"/>
                                         </option>
                                     </xsl:for-each>
                                 </optgroup>

--- a/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
@@ -135,7 +135,7 @@
                 var obj = document.getElementById('replicate');
                 var groups = document.getElementById("destGroup");
                 var selected = groups.options[groups.selectedIndex];
-                if (selected.title == 'false')
+                if (selected.title == '0')
                 {
                     row.style.display = 'none';
                     row.style.visibility = 'hidden';
@@ -506,23 +506,23 @@
                             <xsl:value-of select="@replicateOutputs"/>
                         </xsl:attribute>
                         <xsl:attribute name="value">
-                            <xsl:value-of select="@name"/>
+                            <xsl:value-of select="@gname"/>
                         </xsl:attribute>
-                        <xsl:variable name="curgrp" select="@name"/>
+                        <xsl:variable name="curgrp" select="@tname"/>
                         <xsl:if test="$grp = $curgrp">
                            <xsl:attribute name="selected"/>
                         </xsl:if>
-                        <xsl:value-of select="@name"/>
+                        <xsl:value-of select="@tname"/>
                      </option>
                   </xsl:for-each>
-                  <xsl:for-each select="Software/EclAgentProcess/Instance">
+                  <xsl:for-each select="Software/EclAgentProcess">
                      <option>
                          <!--The 'title' attribute is used to pass the replicate flag to onChangeDestGroup(). Since
                         hthor never replicates, the 'title' attribute is set to be false and the onChangeDestGroup()
                         will hide the "Replicate" checkbox and set the "Replicate" option to false. -->
-                        <xsl:attribute name="title">false</xsl:attribute>
+                        <xsl:attribute name="title">0</xsl:attribute>
                         <xsl:attribute name="value"><xsl:value-of select="@gname"/><xsl:text> </xsl:text><xsl:value-of select="@netAddress"/></xsl:attribute>
-                        <xsl:value-of select="@gname"/><xsl:text> </xsl:text><xsl:value-of select="@netAddress"/>
+                        <xsl:value-of select="@tname"/>
                      </option>
                   </xsl:for-each>
                </select>

--- a/esp/services/ws_fs/CMakeLists.txt
+++ b/esp/services/ws_fs/CMakeLists.txt
@@ -59,6 +59,7 @@ include_directories (
          ./../../smc/SMCLib 
          ./../../bindings/SOAP/xpp 
          ./../../../common/remote 
+         ./../../../common/workunit
     )
 
 ADD_DEFINITIONS( -D_USRDLL )

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -200,5 +200,24 @@ private:
     Owned<IRemoteConnection> conn;
 };
 
+//helper functions
+//Map a name from originalNames to the name in newNames. If not found, return the original name.
+inline char* mapName(const char* originalName, StringArray& originalNames, StringArray& newNames)
+{
+    char* newName = (char*) originalName;
+    ForEachItemIn(x,originalNames)
+    {
+        const char* name = originalNames.item(x);
+        if (strieq(originalName, name))
+        {
+            newName = (char*) newNames.item(x);
+            break;
+        }
+    }
+
+    return newName;
+}
+
+
 #endif //_ESPWIZ_TpWrapper_HPP__
 


### PR DESCRIPTION
The problem in issue ln-129 is that ECLwatch should not show
hthor__myeclagent as the name for hthor. The hthor__myeclagent
is the name of the group associated with 'hthor' target
cluster. The group name is used for Spray and it should not be
presented to the user in ECLwatch. Based on Jake's suggestion,
this fix replaces the group names using target cluster names.
The changes include: (1) display target cluster names (such as
thor, roxie, hthor) in three Spray forms; (2) after a target
cluster name is selected, the queue name associated with the
target cluster is used to call a spray function; (3) display
target cluster names inside the Searching Logical File form;
(4) after a target cluster name is selected, the group name
associated with the target cluster is used to Searching
Logical File; (5) for each logical file inside the results of
Searching (and Browse) Logical File, replace the group name
with the target cluster name; (6) In the Logical File Details
page, replace the group name with the target cluster name.
(7) for searching (and displaying) DFU workunit(s), existing
code does switch from target cluster name to the group name
when retrieving and switch it back for display, if the cluster
is a thor cluster or a roxie cluster. This fix implements the
same logical for hthor cluster.

In addition, the new code uses the workunit lib methods (such
as getEnvironmentThorClusterNames(), etc) to retrieve the
names of target clusters. A new workunit lib method is added:
getEnvironmentRoxieClusterNames().

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
