### PR TITLE
WIP gh-850 hthor get mem limit from config file

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -2044,8 +2044,10 @@ void EclAgent::runProcess(IEclProcess *process)
     setHThorRowManager(rowManager.get());
     rtlSetReleaseRowHook(queryHThorRtlRowCallback());
 
-    int memLimit = queryWorkUnit()->getDebugValueInt("hthorMemoryLimit", DEFAULT_MEM_LIMIT); // value is limit in MB
-    roxiemem::setTotalMemoryLimit(memLimit * 1024 * 1024);
+    //Get memory limit. Workunit specified value takes precedence over config file
+    int memLimitMB = globals->getPropInt("defaultMemoryLimitMB", DEFAULT_MEM_LIMIT);
+    memLimitMB = queryWorkUnit()->getDebugValueInt("hthorMemoryLimit", memLimitMB);
+    roxiemem::setTotalMemoryLimit(memLimitMB * 1024 * 1024);
 
     if (debugContext)
         debugContext->checkBreakpoint(DebugStateReady, NULL, NULL);


### PR DESCRIPTION
Modify eclagent to get default memory limit from config file. Limits
specified in workunit take precedence over config file.

@richardkchapman please assign to @smeda for required config changes

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
