### PR TITLE
Add view definition to xml before calling xslt

### DIFF
--- a/common/wuwebview/wuweberror.hpp
+++ b/common/wuwebview/wuweberror.hpp
@@ -26,5 +26,6 @@
 #define WUWEBERR_WorkUnitNotFound               5500
 #define WUWEBERR_ManifestNotFound               5501
 #define WUWEBERR_ViewResourceNotFound           5502
+#define WUWEBERR_UnknownViewType                5503
 
 #endif


### PR DESCRIPTION
Allows customization parameters to be provided with a named view,
allowing greater reuse of predefined stylesheets.

For example, a single stylesheet could handle 2d and 3d charts:

&lt;Views>
&lt;Results type="XSLT" resource="mycharts" name="Custom View 3d">
    &lt;PieChart use3d="true" borderColor="blue"/>
    &lt;BarChart use3d="true" bold="true"/>
&lt;/Results>
&lt;Results type="XSLT" resource="mycharts" name="Custom View">
    &lt;PieChart use3d="false" borderColor="DarkGray"/>
    &lt;BarChart use3d="false" bold="false"/>
&lt;/Results>
&lt;/Views>

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
