### PR TITLE
Fix gh-680 Get control:queries working again

### DIFF
--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -115,6 +115,7 @@ interface IRoxieQuerySetManager : extends IInterface
     virtual void resetQueryTimings(const char *queryName, const IRoxieContextLogger &logctx) = 0;
     virtual void resetAllQueryTimings() = 0;
     virtual void getActivityMetrics(StringBuffer &reply) const = 0;
+    virtual void getQueries(StringBuffer &reply) const = 0;
 };
 
 interface IRoxieDebugSessionManager : extends IInterface


### PR DESCRIPTION
control:queries roxie query was disabled during refactoring for roxie queue
support. While it's not used by any UI code it was a useful debugging tool
and I miss it.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
