### PR TITLE
Implementation of a persist thread (amended)

### DIFF
--- a/system/jlib/jthread.hpp
+++ b/system/jlib/jthread.hpp
@@ -151,10 +151,12 @@ class jlib_decl CThreadedPersistent : public CInterface
         CAThread(CThreadedPersistent &_owner, const char *name) : Thread(name), owner(_owner) { }
         virtual int run() { owner.main(); return 1; }
     } athread;
+    Owned<IException> exception;
     IThreaded *owner;
     Semaphore sem, joinSem;
     atomic_t state;
-    enum ThreadStates { s_stop, s_ready, s_running, s_joining };
+    bool halt;
+    enum ThreadStates { s_ready, s_running, s_joining };
 
     void main();
 public:


### PR DESCRIPTION
Separate stop state not really necessary, made slightly more complicated
Handle exceptions
Fire exceptions for invalid start in release also.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
