### PR TITLE
gh-439 hpcc user should be a system account

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -775,8 +775,8 @@ add_user(){
             fi
         else
             printf "Adding %s to system ..." "${USER}"
-            useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
-            passwd -d ${USER} 1>/dev/null 2>&1
+            useradd -s ${SHELL} -r -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
+            passwd -l ${USER} 1>/dev/null 2>&1
             if [ $? -eq 0 ];
             then
                 log_success_msg
@@ -809,8 +809,8 @@ add_user(){
             fi
         else
             printf "Adding %s to system ..." "${USER}"
-            useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
-            passwd -d ${USER} 1>/dev/null 2>&1
+            useradd -s ${SHELL} -r -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
+            passwd -l ${USER} 1>/dev/null 2>&1
             if [ $? -eq 0 ];
             then
                 log_success_msg


### PR DESCRIPTION
The hpcc user should be a sustem account, and should have a locked password.
useradd -r is part of the LSB spec and should be ok on all distros we support
(was added to debian in 2006 and RH before that).

Without this fix desktop users can log in to the hpcc account without any
authentication.

Fixes gh-439.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
