### PR TITLE
Clean obvious false-positives from regressions

### DIFF
--- a/testing/ecl/hthor/key/graphrpn2bad.xml
+++ b/testing/ecl/hthor/key/graphrpn2bad.xml
@@ -1,2 +1,1 @@
-
 <Error><source>eclagent</source><code>99</code><message>System error: 99: Graph Result 4 accessed before it is created</message></Error>

--- a/testing/ecl/key/pipe9.xml
+++ b/testing/ecl/key/pipe9.xml
@@ -1,4 +1,3 @@
-Workunit W20110908-160647 submitted
 <Dataset name='Result 1'>
 </Dataset>
 <Dataset name='Result 2'>

--- a/testing/ecl/key/round.xml
+++ b/testing/ecl/key/round.xml
@@ -527,7 +527,7 @@
 </Result_132></Row>
 </Dataset>
 <Dataset name='Result 133'>
- <Row><Result_133>1.23456789018e-021 =
+ <Row><Result_133>1.23456789018e-21 =
 </Result_133></Row>
 </Dataset>
 <Dataset name='Result 134'>
@@ -547,11 +547,11 @@
 </Result_137></Row>
 </Dataset>
 <Dataset name='Result 138'>
- <Row><Result_138>   round(32) = 1.23456789018e-021
+ <Row><Result_138>   round(32) = 1.23456789018e-21
 </Result_138></Row>
 </Dataset>
 <Dataset name='Result 139'>
- <Row><Result_139>   round(100) = 1.23456789018e-021
+ <Row><Result_139>   round(100) = 1.23456789018e-21
 </Result_139></Row>
 </Dataset>
 <Dataset name='Result 140'>
@@ -1099,7 +1099,7 @@
 </Result_275></Row>
 </Dataset>
 <Dataset name='Result 276'>
- <Row><Result_276>1.234567890123457e+018 =
+ <Row><Result_276>1.234567890123457e+18 =
 </Result_276></Row>
 </Dataset>
 <Dataset name='Result 277'>
@@ -1107,31 +1107,31 @@
 </Result_277></Row>
 </Dataset>
 <Dataset name='Result 278'>
- <Row><Result_278>   round(0)  = 1.234567890123457e+018
+ <Row><Result_278>   round(0)  = 1.234567890123457e+18
 </Result_278></Row>
 </Dataset>
 <Dataset name='Result 279'>
- <Row><Result_279>   round(1)  = 1.234567890123457e+018
+ <Row><Result_279>   round(1)  = 1.234567890123457e+18
 </Result_279></Row>
 </Dataset>
 <Dataset name='Result 280'>
- <Row><Result_280>   round(10) = 1.234567890123457e+018
+ <Row><Result_280>   round(10) = 1.234567890123457e+18
 </Result_280></Row>
 </Dataset>
 <Dataset name='Result 281'>
- <Row><Result_281>   round(32) = 1.234567890123457e+018
+ <Row><Result_281>   round(32) = 1.234567890123457e+18
 </Result_281></Row>
 </Dataset>
 <Dataset name='Result 282'>
- <Row><Result_282>   round(100) = 1.234567890123457e+018
+ <Row><Result_282>   round(100) = 1.234567890123457e+18
 </Result_282></Row>
 </Dataset>
 <Dataset name='Result 283'>
- <Row><Result_283>   round(-1) = 1.234567890123457e+018
+ <Row><Result_283>   round(-1) = 1.234567890123457e+18
 </Result_283></Row>
 </Dataset>
 <Dataset name='Result 284'>
- <Row><Result_284>   round(-10) = 1.23456789e+018
+ <Row><Result_284>   round(-10) = 1.23456789e+18
 </Result_284></Row>
 </Dataset>
 <Dataset name='Result 285'>
@@ -1187,7 +1187,7 @@
 </Result_297></Row>
 </Dataset>
 <Dataset name='Result 298'>
- <Row><Result_298>1.234567890123457e-021 =
+ <Row><Result_298>1.234567890123457e-21 =
 </Result_298></Row>
 </Dataset>
 <Dataset name='Result 299'>
@@ -1207,11 +1207,11 @@
 </Result_302></Row>
 </Dataset>
 <Dataset name='Result 303'>
- <Row><Result_303>   round(32) = 1.23456789012e-021
+ <Row><Result_303>   round(32) = 1.23456789012e-21
 </Result_303></Row>
 </Dataset>
 <Dataset name='Result 304'>
- <Row><Result_304>   round(100) = 1.234567890123457e-021
+ <Row><Result_304>   round(100) = 1.234567890123457e-21
 </Result_304></Row>
 </Dataset>
 <Dataset name='Result 305'>
@@ -1275,7 +1275,7 @@
 </Result_319></Row>
 </Dataset>
 <Dataset name='Result 320'>
- <Row><Result_320>1.234567890123457e+033 =
+ <Row><Result_320>1.234567890123457e+33 =
 </Result_320></Row>
 </Dataset>
 <Dataset name='Result 321'>
@@ -1283,31 +1283,31 @@
 </Result_321></Row>
 </Dataset>
 <Dataset name='Result 322'>
- <Row><Result_322>   round(0)  = 1.234567890123457e+033
+ <Row><Result_322>   round(0)  = 1.234567890123457e+33
 </Result_322></Row>
 </Dataset>
 <Dataset name='Result 323'>
- <Row><Result_323>   round(1)  = 1.234567890123457e+033
+ <Row><Result_323>   round(1)  = 1.234567890123457e+33
 </Result_323></Row>
 </Dataset>
 <Dataset name='Result 324'>
- <Row><Result_324>   round(10) = 1.234567890123457e+033
+ <Row><Result_324>   round(10) = 1.234567890123457e+33
 </Result_324></Row>
 </Dataset>
 <Dataset name='Result 325'>
- <Row><Result_325>   round(32) = 1.234567890123457e+033
+ <Row><Result_325>   round(32) = 1.234567890123457e+33
 </Result_325></Row>
 </Dataset>
 <Dataset name='Result 326'>
- <Row><Result_326>   round(100) = 1.234567890123457e+033
+ <Row><Result_326>   round(100) = 1.234567890123457e+33
 </Result_326></Row>
 </Dataset>
 <Dataset name='Result 327'>
- <Row><Result_327>   round(-1) = 1.234567890123457e+033
+ <Row><Result_327>   round(-1) = 1.234567890123457e+33
 </Result_327></Row>
 </Dataset>
 <Dataset name='Result 328'>
- <Row><Result_328>   round(-10) = 1.234567890123457e+033
+ <Row><Result_328>   round(-10) = 1.234567890123457e+33
 </Result_328></Row>
 </Dataset>
 <Dataset name='Result 329'>
@@ -1535,75 +1535,75 @@
 </Result_384></Row>
 </Dataset>
 <Dataset name='Result 385'>
- <Row><Result_385>-18 -&gt; 1e+018
+ <Row><Result_385>-18 -&gt; 1e+18
 </Result_385></Row>
 </Dataset>
 <Dataset name='Result 386'>
- <Row><Result_386>-17 -&gt; 1.2e+018
+ <Row><Result_386>-17 -&gt; 1.2e+18
 </Result_386></Row>
 </Dataset>
 <Dataset name='Result 387'>
- <Row><Result_387>-16 -&gt; 1.23e+018
+ <Row><Result_387>-16 -&gt; 1.23e+18
 </Result_387></Row>
 </Dataset>
 <Dataset name='Result 388'>
- <Row><Result_388>-15 -&gt; 1.235e+018
+ <Row><Result_388>-15 -&gt; 1.235e+18
 </Result_388></Row>
 </Dataset>
 <Dataset name='Result 389'>
- <Row><Result_389>-14 -&gt; 1.2346e+018
+ <Row><Result_389>-14 -&gt; 1.2346e+18
 </Result_389></Row>
 </Dataset>
 <Dataset name='Result 390'>
- <Row><Result_390>-13 -&gt; 1.23457e+018
+ <Row><Result_390>-13 -&gt; 1.23457e+18
 </Result_390></Row>
 </Dataset>
 <Dataset name='Result 391'>
- <Row><Result_391>-12 -&gt; 1.234568e+018
+ <Row><Result_391>-12 -&gt; 1.234568e+18
 </Result_391></Row>
 </Dataset>
 <Dataset name='Result 392'>
- <Row><Result_392>-11 -&gt; 1.2345679e+018
+ <Row><Result_392>-11 -&gt; 1.2345679e+18
 </Result_392></Row>
 </Dataset>
 <Dataset name='Result 393'>
- <Row><Result_393>-10 -&gt; 1.23456789e+018
+ <Row><Result_393>-10 -&gt; 1.23456789e+18
 </Result_393></Row>
 </Dataset>
 <Dataset name='Result 394'>
- <Row><Result_394>-9 -&gt; 1.23456789e+018
+ <Row><Result_394>-9 -&gt; 1.23456789e+18
 </Result_394></Row>
 </Dataset>
 <Dataset name='Result 395'>
- <Row><Result_395>-8 -&gt; 1.2345678901e+018
+ <Row><Result_395>-8 -&gt; 1.2345678901e+18
 </Result_395></Row>
 </Dataset>
 <Dataset name='Result 396'>
- <Row><Result_396>-7 -&gt; 1.23456789012e+018
+ <Row><Result_396>-7 -&gt; 1.23456789012e+18
 </Result_396></Row>
 </Dataset>
 <Dataset name='Result 397'>
- <Row><Result_397>-6 -&gt; 1.234567890123e+018
+ <Row><Result_397>-6 -&gt; 1.234567890123e+18
 </Result_397></Row>
 </Dataset>
 <Dataset name='Result 398'>
- <Row><Result_398>-5 -&gt; 1.2345678901235e+018
+ <Row><Result_398>-5 -&gt; 1.2345678901235e+18
 </Result_398></Row>
 </Dataset>
 <Dataset name='Result 399'>
- <Row><Result_399>-4 -&gt; 1.23456789012346e+018
+ <Row><Result_399>-4 -&gt; 1.23456789012346e+18
 </Result_399></Row>
 </Dataset>
 <Dataset name='Result 400'>
- <Row><Result_400>-3 -&gt; 1.234567890123457e+018
+ <Row><Result_400>-3 -&gt; 1.234567890123457e+18
 </Result_400></Row>
 </Dataset>
 <Dataset name='Result 401'>
- <Row><Result_401>-2 -&gt; 1.234567890123457e+018
+ <Row><Result_401>-2 -&gt; 1.234567890123457e+18
 </Result_401></Row>
 </Dataset>
 <Dataset name='Result 402'>
- <Row><Result_402>-1 -&gt; 1.234567890123457e+018
+ <Row><Result_402>-1 -&gt; 1.234567890123457e+18
 </Result_402></Row>
 </Dataset>
 <Dataset name='Result 403'>
@@ -1615,274 +1615,274 @@
 </Result_404></Row>
 </Dataset>
 <Dataset name='Result 405'>
- <Row><Result_405>-68 -&gt; 1e+068
+ <Row><Result_405>-68 -&gt; 1e+68
 </Result_405></Row>
 </Dataset>
 <Dataset name='Result 406'>
- <Row><Result_406>-67 -&gt; 1.2e+068
+ <Row><Result_406>-67 -&gt; 1.2e+68
 </Result_406></Row>
 </Dataset>
 <Dataset name='Result 407'>
- <Row><Result_407>-66 -&gt; 1.23e+068
+ <Row><Result_407>-66 -&gt; 1.23e+68
 </Result_407></Row>
 </Dataset>
 <Dataset name='Result 408'>
- <Row><Result_408>-65 -&gt; 1.235e+068
+ <Row><Result_408>-65 -&gt; 1.235e+68
 </Result_408></Row>
 </Dataset>
 <Dataset name='Result 409'>
- <Row><Result_409>-64 -&gt; 1.2346e+068
+ <Row><Result_409>-64 -&gt; 1.2346e+68
 </Result_409></Row>
 </Dataset>
 <Dataset name='Result 410'>
- <Row><Result_410>-63 -&gt; 1.23457e+068
+ <Row><Result_410>-63 -&gt; 1.23457e+68
 </Result_410></Row>
 </Dataset>
 <Dataset name='Result 411'>
- <Row><Result_411>-62 -&gt; 1.234568e+068
+ <Row><Result_411>-62 -&gt; 1.234568e+68
 </Result_411></Row>
 </Dataset>
 <Dataset name='Result 412'>
- <Row><Result_412>-61 -&gt; 1.2345679e+068
+ <Row><Result_412>-61 -&gt; 1.2345679e+68
 </Result_412></Row>
 </Dataset>
 <Dataset name='Result 413'>
- <Row><Result_413>-60 -&gt; 1.23456789e+068
+ <Row><Result_413>-60 -&gt; 1.23456789e+68
 </Result_413></Row>
 </Dataset>
 <Dataset name='Result 414'>
- <Row><Result_414>-59 -&gt; 1.23456789e+068
+ <Row><Result_414>-59 -&gt; 1.23456789e+68
 </Result_414></Row>
 </Dataset>
 <Dataset name='Result 415'>
- <Row><Result_415>-58 -&gt; 1.2345678901e+068
+ <Row><Result_415>-58 -&gt; 1.2345678901e+68
 </Result_415></Row>
 </Dataset>
 <Dataset name='Result 416'>
- <Row><Result_416>-57 -&gt; 1.23456789012e+068
+ <Row><Result_416>-57 -&gt; 1.23456789012e+68
 </Result_416></Row>
 </Dataset>
 <Dataset name='Result 417'>
- <Row><Result_417>-56 -&gt; 1.234567890123e+068
+ <Row><Result_417>-56 -&gt; 1.234567890123e+68
 </Result_417></Row>
 </Dataset>
 <Dataset name='Result 418'>
- <Row><Result_418>-55 -&gt; 1.2345678901235e+068
+ <Row><Result_418>-55 -&gt; 1.2345678901235e+68
 </Result_418></Row>
 </Dataset>
 <Dataset name='Result 419'>
- <Row><Result_419>-54 -&gt; 1.23456789012346e+068
+ <Row><Result_419>-54 -&gt; 1.23456789012346e+68
 </Result_419></Row>
 </Dataset>
 <Dataset name='Result 420'>
- <Row><Result_420>-53 -&gt; 1.234567890123457e+068
+ <Row><Result_420>-53 -&gt; 1.234567890123457e+68
 </Result_420></Row>
 </Dataset>
 <Dataset name='Result 421'>
- <Row><Result_421>-52 -&gt; 1.234567890123457e+068
+ <Row><Result_421>-52 -&gt; 1.234567890123457e+68
 </Result_421></Row>
 </Dataset>
 <Dataset name='Result 422'>
- <Row><Result_422>-51 -&gt; 1.234567890123457e+068
+ <Row><Result_422>-51 -&gt; 1.234567890123457e+68
 </Result_422></Row>
 </Dataset>
 <Dataset name='Result 423'>
- <Row><Result_423>-50 -&gt; 1.234567890123457e+068
+ <Row><Result_423>-50 -&gt; 1.234567890123457e+68
 </Result_423></Row>
 </Dataset>
 <Dataset name='Result 424'>
- <Row><Result_424>-49 -&gt; 1.234567890123457e+068
+ <Row><Result_424>-49 -&gt; 1.234567890123457e+68
 </Result_424></Row>
 </Dataset>
 <Dataset name='Result 425'>
- <Row><Result_425>-48 -&gt; 1.234567890123457e+068
+ <Row><Result_425>-48 -&gt; 1.234567890123457e+68
 </Result_425></Row>
 </Dataset>
 <Dataset name='Result 426'>
- <Row><Result_426>-47 -&gt; 1.234567890123457e+068
+ <Row><Result_426>-47 -&gt; 1.234567890123457e+68
 </Result_426></Row>
 </Dataset>
 <Dataset name='Result 427'>
- <Row><Result_427>-46 -&gt; 1.234567890123457e+068
+ <Row><Result_427>-46 -&gt; 1.234567890123457e+68
 </Result_427></Row>
 </Dataset>
 <Dataset name='Result 428'>
- <Row><Result_428>-45 -&gt; 1.234567890123457e+068
+ <Row><Result_428>-45 -&gt; 1.234567890123457e+68
 </Result_428></Row>
 </Dataset>
 <Dataset name='Result 429'>
- <Row><Result_429>-44 -&gt; 1.234567890123457e+068
+ <Row><Result_429>-44 -&gt; 1.234567890123457e+68
 </Result_429></Row>
 </Dataset>
 <Dataset name='Result 430'>
- <Row><Result_430>-43 -&gt; 1.234567890123457e+068
+ <Row><Result_430>-43 -&gt; 1.234567890123457e+68
 </Result_430></Row>
 </Dataset>
 <Dataset name='Result 431'>
- <Row><Result_431>-42 -&gt; 1.234567890123457e+068
+ <Row><Result_431>-42 -&gt; 1.234567890123457e+68
 </Result_431></Row>
 </Dataset>
 <Dataset name='Result 432'>
- <Row><Result_432>-41 -&gt; 1.234567890123457e+068
+ <Row><Result_432>-41 -&gt; 1.234567890123457e+68
 </Result_432></Row>
 </Dataset>
 <Dataset name='Result 433'>
- <Row><Result_433>-40 -&gt; 1.234567890123457e+068
+ <Row><Result_433>-40 -&gt; 1.234567890123457e+68
 </Result_433></Row>
 </Dataset>
 <Dataset name='Result 434'>
- <Row><Result_434>-39 -&gt; 1.234567890123457e+068
+ <Row><Result_434>-39 -&gt; 1.234567890123457e+68
 </Result_434></Row>
 </Dataset>
 <Dataset name='Result 435'>
- <Row><Result_435>-38 -&gt; 1.234567890123457e+068
+ <Row><Result_435>-38 -&gt; 1.234567890123457e+68
 </Result_435></Row>
 </Dataset>
 <Dataset name='Result 436'>
- <Row><Result_436>-37 -&gt; 1.234567890123457e+068
+ <Row><Result_436>-37 -&gt; 1.234567890123457e+68
 </Result_436></Row>
 </Dataset>
 <Dataset name='Result 437'>
- <Row><Result_437>-36 -&gt; 1.234567890123457e+068
+ <Row><Result_437>-36 -&gt; 1.234567890123457e+68
 </Result_437></Row>
 </Dataset>
 <Dataset name='Result 438'>
- <Row><Result_438>-35 -&gt; 1.234567890123457e+068
+ <Row><Result_438>-35 -&gt; 1.234567890123457e+68
 </Result_438></Row>
 </Dataset>
 <Dataset name='Result 439'>
- <Row><Result_439>-34 -&gt; 1.234567890123457e+068
+ <Row><Result_439>-34 -&gt; 1.234567890123457e+68
 </Result_439></Row>
 </Dataset>
 <Dataset name='Result 440'>
- <Row><Result_440>-33 -&gt; 1.234567890123457e+068
+ <Row><Result_440>-33 -&gt; 1.234567890123457e+68
 </Result_440></Row>
 </Dataset>
 <Dataset name='Result 441'>
- <Row><Result_441>-32 -&gt; 1.234567890123457e+068
+ <Row><Result_441>-32 -&gt; 1.234567890123457e+68
 </Result_441></Row>
 </Dataset>
 <Dataset name='Result 442'>
- <Row><Result_442>-31 -&gt; 1.234567890123457e+068
+ <Row><Result_442>-31 -&gt; 1.234567890123457e+68
 </Result_442></Row>
 </Dataset>
 <Dataset name='Result 443'>
- <Row><Result_443>-30 -&gt; 1.234567890123457e+068
+ <Row><Result_443>-30 -&gt; 1.234567890123457e+68
 </Result_443></Row>
 </Dataset>
 <Dataset name='Result 444'>
- <Row><Result_444>-29 -&gt; 1.234567890123457e+068
+ <Row><Result_444>-29 -&gt; 1.234567890123457e+68
 </Result_444></Row>
 </Dataset>
 <Dataset name='Result 445'>
- <Row><Result_445>-28 -&gt; 1.234567890123457e+068
+ <Row><Result_445>-28 -&gt; 1.234567890123457e+68
 </Result_445></Row>
 </Dataset>
 <Dataset name='Result 446'>
- <Row><Result_446>-27 -&gt; 1.234567890123457e+068
+ <Row><Result_446>-27 -&gt; 1.234567890123457e+68
 </Result_446></Row>
 </Dataset>
 <Dataset name='Result 447'>
- <Row><Result_447>-26 -&gt; 1.234567890123457e+068
+ <Row><Result_447>-26 -&gt; 1.234567890123457e+68
 </Result_447></Row>
 </Dataset>
 <Dataset name='Result 448'>
- <Row><Result_448>-25 -&gt; 1.234567890123457e+068
+ <Row><Result_448>-25 -&gt; 1.234567890123457e+68
 </Result_448></Row>
 </Dataset>
 <Dataset name='Result 449'>
- <Row><Result_449>-24 -&gt; 1.234567890123457e+068
+ <Row><Result_449>-24 -&gt; 1.234567890123457e+68
 </Result_449></Row>
 </Dataset>
 <Dataset name='Result 450'>
- <Row><Result_450>-23 -&gt; 1.234567890123457e+068
+ <Row><Result_450>-23 -&gt; 1.234567890123457e+68
 </Result_450></Row>
 </Dataset>
 <Dataset name='Result 451'>
- <Row><Result_451>-22 -&gt; 1.234567890123457e+068
+ <Row><Result_451>-22 -&gt; 1.234567890123457e+68
 </Result_451></Row>
 </Dataset>
 <Dataset name='Result 452'>
- <Row><Result_452>-21 -&gt; 1.234567890123457e+068
+ <Row><Result_452>-21 -&gt; 1.234567890123457e+68
 </Result_452></Row>
 </Dataset>
 <Dataset name='Result 453'>
- <Row><Result_453>-20 -&gt; 1.234567890123457e+068
+ <Row><Result_453>-20 -&gt; 1.234567890123457e+68
 </Result_453></Row>
 </Dataset>
 <Dataset name='Result 454'>
- <Row><Result_454>-19 -&gt; 1.234567890123457e+068
+ <Row><Result_454>-19 -&gt; 1.234567890123457e+68
 </Result_454></Row>
 </Dataset>
 <Dataset name='Result 455'>
- <Row><Result_455>-18 -&gt; 1.234567890123457e+068
+ <Row><Result_455>-18 -&gt; 1.234567890123457e+68
 </Result_455></Row>
 </Dataset>
 <Dataset name='Result 456'>
- <Row><Result_456>-17 -&gt; 1.234567890123457e+068
+ <Row><Result_456>-17 -&gt; 1.234567890123457e+68
 </Result_456></Row>
 </Dataset>
 <Dataset name='Result 457'>
- <Row><Result_457>-16 -&gt; 1.234567890123457e+068
+ <Row><Result_457>-16 -&gt; 1.234567890123457e+68
 </Result_457></Row>
 </Dataset>
 <Dataset name='Result 458'>
- <Row><Result_458>-15 -&gt; 1.234567890123457e+068
+ <Row><Result_458>-15 -&gt; 1.234567890123457e+68
 </Result_458></Row>
 </Dataset>
 <Dataset name='Result 459'>
- <Row><Result_459>-14 -&gt; 1.234567890123457e+068
+ <Row><Result_459>-14 -&gt; 1.234567890123457e+68
 </Result_459></Row>
 </Dataset>
 <Dataset name='Result 460'>
- <Row><Result_460>-13 -&gt; 1.234567890123457e+068
+ <Row><Result_460>-13 -&gt; 1.234567890123457e+68
 </Result_460></Row>
 </Dataset>
 <Dataset name='Result 461'>
- <Row><Result_461>-12 -&gt; 1.234567890123457e+068
+ <Row><Result_461>-12 -&gt; 1.234567890123457e+68
 </Result_461></Row>
 </Dataset>
 <Dataset name='Result 462'>
- <Row><Result_462>-11 -&gt; 1.234567890123457e+068
+ <Row><Result_462>-11 -&gt; 1.234567890123457e+68
 </Result_462></Row>
 </Dataset>
 <Dataset name='Result 463'>
- <Row><Result_463>-10 -&gt; 1.234567890123457e+068
+ <Row><Result_463>-10 -&gt; 1.234567890123457e+68
 </Result_463></Row>
 </Dataset>
 <Dataset name='Result 464'>
- <Row><Result_464>-9 -&gt; 1.234567890123457e+068
+ <Row><Result_464>-9 -&gt; 1.234567890123457e+68
 </Result_464></Row>
 </Dataset>
 <Dataset name='Result 465'>
- <Row><Result_465>-8 -&gt; 1.234567890123457e+068
+ <Row><Result_465>-8 -&gt; 1.234567890123457e+68
 </Result_465></Row>
 </Dataset>
 <Dataset name='Result 466'>
- <Row><Result_466>-7 -&gt; 1.234567890123457e+068
+ <Row><Result_466>-7 -&gt; 1.234567890123457e+68
 </Result_466></Row>
 </Dataset>
 <Dataset name='Result 467'>
- <Row><Result_467>-6 -&gt; 1.234567890123457e+068
+ <Row><Result_467>-6 -&gt; 1.234567890123457e+68
 </Result_467></Row>
 </Dataset>
 <Dataset name='Result 468'>
- <Row><Result_468>-5 -&gt; 1.234567890123457e+068
+ <Row><Result_468>-5 -&gt; 1.234567890123457e+68
 </Result_468></Row>
 </Dataset>
 <Dataset name='Result 469'>
- <Row><Result_469>-4 -&gt; 1.234567890123457e+068
+ <Row><Result_469>-4 -&gt; 1.234567890123457e+68
 </Result_469></Row>
 </Dataset>
 <Dataset name='Result 470'>
- <Row><Result_470>-3 -&gt; 1.234567890123457e+068
+ <Row><Result_470>-3 -&gt; 1.234567890123457e+68
 </Result_470></Row>
 </Dataset>
 <Dataset name='Result 471'>
- <Row><Result_471>-2 -&gt; 1.234567890123457e+068
+ <Row><Result_471>-2 -&gt; 1.234567890123457e+68
 </Result_471></Row>
 </Dataset>
 <Dataset name='Result 472'>
- <Row><Result_472>-1 -&gt; 1.234567890123457e+068
+ <Row><Result_472>-1 -&gt; 1.234567890123457e+68
 </Result_472></Row>
 </Dataset>

--- a/testing/ecl/key/round2.xml
+++ b/testing/ecl/key/round2.xml
@@ -527,7 +527,7 @@
 </Result_132></Row>
 </Dataset>
 <Dataset name='Result 133'>
- <Row><Result_133>1.23456789018e-021 =
+ <Row><Result_133>1.23456789012e-21 =
 </Result_133></Row>
 </Dataset>
 <Dataset name='Result 134'>
@@ -547,11 +547,11 @@
 </Result_137></Row>
 </Dataset>
 <Dataset name='Result 138'>
- <Row><Result_138>   round(32) = 1.23456789018e-021
+ <Row><Result_138>   round(32) = 1.23456789012e-21
 </Result_138></Row>
 </Dataset>
 <Dataset name='Result 139'>
- <Row><Result_139>   round(100) = 1.23456789018e-021
+ <Row><Result_139>   round(100) = 1.23456789012e-21
 </Result_139></Row>
 </Dataset>
 <Dataset name='Result 140'>
@@ -1099,39 +1099,39 @@
 </Result_275></Row>
 </Dataset>
 <Dataset name='Result 276'>
- <Row><Result_276>1.234567890123457e+018 =
+ <Row><Result_276>1.234567890123457e+18 =
 </Result_276></Row>
 </Dataset>
 <Dataset name='Result 277'>
- <Row><Result_277>   round     = 1234567890123457024
+ <Row><Result_277>   round     = 1234567890123457280
 </Result_277></Row>
 </Dataset>
 <Dataset name='Result 278'>
- <Row><Result_278>   round(0)  = 1.234567890123457e+018
+ <Row><Result_278>   round(0)  = 1.234567890123457e+18
 </Result_278></Row>
 </Dataset>
 <Dataset name='Result 279'>
- <Row><Result_279>   round(1)  = 1.234567890123457e+018
+ <Row><Result_279>   round(1)  = 1.234567890123457e+18
 </Result_279></Row>
 </Dataset>
 <Dataset name='Result 280'>
- <Row><Result_280>   round(10) = 1.234567890123457e+018
+ <Row><Result_280>   round(10) = 1.234567890123457e+18
 </Result_280></Row>
 </Dataset>
 <Dataset name='Result 281'>
- <Row><Result_281>   round(32) = 1.234567890123457e+018
+ <Row><Result_281>   round(32) = 1.234567890123457e+18
 </Result_281></Row>
 </Dataset>
 <Dataset name='Result 282'>
- <Row><Result_282>   round(100) = 1.234567890123457e+018
+ <Row><Result_282>   round(100) = 1.234567890123457e+18
 </Result_282></Row>
 </Dataset>
 <Dataset name='Result 283'>
- <Row><Result_283>   round(-1) = 1.234567890123457e+018
+ <Row><Result_283>   round(-1) = 1.234567890123457e+18
 </Result_283></Row>
 </Dataset>
 <Dataset name='Result 284'>
- <Row><Result_284>   round(-10) = 1.23456789e+018
+ <Row><Result_284>   round(-10) = 1.23456789e+18
 </Result_284></Row>
 </Dataset>
 <Dataset name='Result 285'>
@@ -1187,7 +1187,7 @@
 </Result_297></Row>
 </Dataset>
 <Dataset name='Result 298'>
- <Row><Result_298>1.234567890123457e-021 =
+ <Row><Result_298>1.234567890123457e-21 =
 </Result_298></Row>
 </Dataset>
 <Dataset name='Result 299'>
@@ -1207,11 +1207,11 @@
 </Result_302></Row>
 </Dataset>
 <Dataset name='Result 303'>
- <Row><Result_303>   round(32) = 1.23456789012e-021
+ <Row><Result_303>   round(32) = 1.23456789012e-21
 </Result_303></Row>
 </Dataset>
 <Dataset name='Result 304'>
- <Row><Result_304>   round(100) = 1.234567890123457e-021
+ <Row><Result_304>   round(100) = 1.234567890123457e-21
 </Result_304></Row>
 </Dataset>
 <Dataset name='Result 305'>
@@ -1275,7 +1275,7 @@
 </Result_319></Row>
 </Dataset>
 <Dataset name='Result 320'>
- <Row><Result_320>1.234567890123457e+033 =
+ <Row><Result_320>1.234567890123457e+33 =
 </Result_320></Row>
 </Dataset>
 <Dataset name='Result 321'>
@@ -1283,31 +1283,31 @@
 </Result_321></Row>
 </Dataset>
 <Dataset name='Result 322'>
- <Row><Result_322>   round(0)  = 1.234567890123457e+033
+ <Row><Result_322>   round(0)  = 1.234567890123457e+33
 </Result_322></Row>
 </Dataset>
 <Dataset name='Result 323'>
- <Row><Result_323>   round(1)  = 1.234567890123457e+033
+ <Row><Result_323>   round(1)  = 1.234567890123457e+33
 </Result_323></Row>
 </Dataset>
 <Dataset name='Result 324'>
- <Row><Result_324>   round(10) = 1.234567890123457e+033
+ <Row><Result_324>   round(10) = 1.234567890123457e+33
 </Result_324></Row>
 </Dataset>
 <Dataset name='Result 325'>
- <Row><Result_325>   round(32) = 1.234567890123457e+033
+ <Row><Result_325>   round(32) = 1.234567890123457e+33
 </Result_325></Row>
 </Dataset>
 <Dataset name='Result 326'>
- <Row><Result_326>   round(100) = 1.234567890123457e+033
+ <Row><Result_326>   round(100) = 1.234567890123457e+33
 </Result_326></Row>
 </Dataset>
 <Dataset name='Result 327'>
- <Row><Result_327>   round(-1) = 1.234567890123457e+033
+ <Row><Result_327>   round(-1) = 1.234567890123457e+33
 </Result_327></Row>
 </Dataset>
 <Dataset name='Result 328'>
- <Row><Result_328>   round(-10) = 1.234567890123457e+033
+ <Row><Result_328>   round(-10) = 1.234567890123457e+33
 </Result_328></Row>
 </Dataset>
 <Dataset name='Result 329'>
@@ -1535,75 +1535,75 @@
 </Result_384></Row>
 </Dataset>
 <Dataset name='Result 385'>
- <Row><Result_385>-18 -&gt; 1e+018
+ <Row><Result_385>-18 -&gt; 1e+18
 </Result_385></Row>
 </Dataset>
 <Dataset name='Result 386'>
- <Row><Result_386>-17 -&gt; 1.2e+018
+ <Row><Result_386>-17 -&gt; 1.2e+18
 </Result_386></Row>
 </Dataset>
 <Dataset name='Result 387'>
- <Row><Result_387>-16 -&gt; 1.23e+018
+ <Row><Result_387>-16 -&gt; 1.23e+18
 </Result_387></Row>
 </Dataset>
 <Dataset name='Result 388'>
- <Row><Result_388>-15 -&gt; 1.235e+018
+ <Row><Result_388>-15 -&gt; 1.235e+18
 </Result_388></Row>
 </Dataset>
 <Dataset name='Result 389'>
- <Row><Result_389>-14 -&gt; 1.2346e+018
+ <Row><Result_389>-14 -&gt; 1.2346e+18
 </Result_389></Row>
 </Dataset>
 <Dataset name='Result 390'>
- <Row><Result_390>-13 -&gt; 1.23457e+018
+ <Row><Result_390>-13 -&gt; 1.23457e+18
 </Result_390></Row>
 </Dataset>
 <Dataset name='Result 391'>
- <Row><Result_391>-12 -&gt; 1.234568e+018
+ <Row><Result_391>-12 -&gt; 1.234568e+18
 </Result_391></Row>
 </Dataset>
 <Dataset name='Result 392'>
- <Row><Result_392>-11 -&gt; 1.2345679e+018
+ <Row><Result_392>-11 -&gt; 1.2345679e+18
 </Result_392></Row>
 </Dataset>
 <Dataset name='Result 393'>
- <Row><Result_393>-10 -&gt; 1.23456789e+018
+ <Row><Result_393>-10 -&gt; 1.23456789e+18
 </Result_393></Row>
 </Dataset>
 <Dataset name='Result 394'>
- <Row><Result_394>-9 -&gt; 1.23456789e+018
+ <Row><Result_394>-9 -&gt; 1.23456789e+18
 </Result_394></Row>
 </Dataset>
 <Dataset name='Result 395'>
- <Row><Result_395>-8 -&gt; 1.2345678901e+018
+ <Row><Result_395>-8 -&gt; 1.2345678901e+18
 </Result_395></Row>
 </Dataset>
 <Dataset name='Result 396'>
- <Row><Result_396>-7 -&gt; 1.23456789012e+018
+ <Row><Result_396>-7 -&gt; 1.23456789012e+18
 </Result_396></Row>
 </Dataset>
 <Dataset name='Result 397'>
- <Row><Result_397>-6 -&gt; 1.234567890123e+018
+ <Row><Result_397>-6 -&gt; 1.234567890123e+18
 </Result_397></Row>
 </Dataset>
 <Dataset name='Result 398'>
- <Row><Result_398>-5 -&gt; 1.2345678901235e+018
+ <Row><Result_398>-5 -&gt; 1.2345678901235e+18
 </Result_398></Row>
 </Dataset>
 <Dataset name='Result 399'>
- <Row><Result_399>-4 -&gt; 1.23456789012346e+018
+ <Row><Result_399>-4 -&gt; 1.23456789012346e+18
 </Result_399></Row>
 </Dataset>
 <Dataset name='Result 400'>
- <Row><Result_400>-3 -&gt; 1.234567890123457e+018
+ <Row><Result_400>-3 -&gt; 1.234567890123457e+18
 </Result_400></Row>
 </Dataset>
 <Dataset name='Result 401'>
- <Row><Result_401>-2 -&gt; 1.234567890123457e+018
+ <Row><Result_401>-2 -&gt; 1.234567890123457e+18
 </Result_401></Row>
 </Dataset>
 <Dataset name='Result 402'>
- <Row><Result_402>-1 -&gt; 1.234567890123457e+018
+ <Row><Result_402>-1 -&gt; 1.234567890123457e+18
 </Result_402></Row>
 </Dataset>
 <Dataset name='Result 403'>
@@ -1615,274 +1615,274 @@
 </Result_404></Row>
 </Dataset>
 <Dataset name='Result 405'>
- <Row><Result_405>-68 -&gt; 1e+068
+ <Row><Result_405>-68 -&gt; 1e+68
 </Result_405></Row>
 </Dataset>
 <Dataset name='Result 406'>
- <Row><Result_406>-67 -&gt; 1.2e+068
+ <Row><Result_406>-67 -&gt; 1.2e+68
 </Result_406></Row>
 </Dataset>
 <Dataset name='Result 407'>
- <Row><Result_407>-66 -&gt; 1.23e+068
+ <Row><Result_407>-66 -&gt; 1.23e+68
 </Result_407></Row>
 </Dataset>
 <Dataset name='Result 408'>
- <Row><Result_408>-65 -&gt; 1.235e+068
+ <Row><Result_408>-65 -&gt; 1.235e+68
 </Result_408></Row>
 </Dataset>
 <Dataset name='Result 409'>
- <Row><Result_409>-64 -&gt; 1.2346e+068
+ <Row><Result_409>-64 -&gt; 1.2346e+68
 </Result_409></Row>
 </Dataset>
 <Dataset name='Result 410'>
- <Row><Result_410>-63 -&gt; 1.23457e+068
+ <Row><Result_410>-63 -&gt; 1.23457e+68
 </Result_410></Row>
 </Dataset>
 <Dataset name='Result 411'>
- <Row><Result_411>-62 -&gt; 1.234568e+068
+ <Row><Result_411>-62 -&gt; 1.234568e+68
 </Result_411></Row>
 </Dataset>
 <Dataset name='Result 412'>
- <Row><Result_412>-61 -&gt; 1.2345679e+068
+ <Row><Result_412>-61 -&gt; 1.2345679e+68
 </Result_412></Row>
 </Dataset>
 <Dataset name='Result 413'>
- <Row><Result_413>-60 -&gt; 1.23456789e+068
+ <Row><Result_413>-60 -&gt; 1.23456789e+68
 </Result_413></Row>
 </Dataset>
 <Dataset name='Result 414'>
- <Row><Result_414>-59 -&gt; 1.23456789e+068
+ <Row><Result_414>-59 -&gt; 1.23456789e+68
 </Result_414></Row>
 </Dataset>
 <Dataset name='Result 415'>
- <Row><Result_415>-58 -&gt; 1.2345678901e+068
+ <Row><Result_415>-58 -&gt; 1.2345678901e+68
 </Result_415></Row>
 </Dataset>
 <Dataset name='Result 416'>
- <Row><Result_416>-57 -&gt; 1.23456789012e+068
+ <Row><Result_416>-57 -&gt; 1.23456789012e+68
 </Result_416></Row>
 </Dataset>
 <Dataset name='Result 417'>
- <Row><Result_417>-56 -&gt; 1.234567890123e+068
+ <Row><Result_417>-56 -&gt; 1.234567890123e+68
 </Result_417></Row>
 </Dataset>
 <Dataset name='Result 418'>
- <Row><Result_418>-55 -&gt; 1.2345678901235e+068
+ <Row><Result_418>-55 -&gt; 1.2345678901235e+68
 </Result_418></Row>
 </Dataset>
 <Dataset name='Result 419'>
- <Row><Result_419>-54 -&gt; 1.23456789012346e+068
+ <Row><Result_419>-54 -&gt; 1.23456789012346e+68
 </Result_419></Row>
 </Dataset>
 <Dataset name='Result 420'>
- <Row><Result_420>-53 -&gt; 1.234567890123457e+068
+ <Row><Result_420>-53 -&gt; 1.234567890123457e+68
 </Result_420></Row>
 </Dataset>
 <Dataset name='Result 421'>
- <Row><Result_421>-52 -&gt; 1.234567890123457e+068
+ <Row><Result_421>-52 -&gt; 1.234567890123457e+68
 </Result_421></Row>
 </Dataset>
 <Dataset name='Result 422'>
- <Row><Result_422>-51 -&gt; 1.234567890123457e+068
+ <Row><Result_422>-51 -&gt; 1.234567890123457e+68
 </Result_422></Row>
 </Dataset>
 <Dataset name='Result 423'>
- <Row><Result_423>-50 -&gt; 1.234567890123457e+068
+ <Row><Result_423>-50 -&gt; 1.234567890123457e+68
 </Result_423></Row>
 </Dataset>
 <Dataset name='Result 424'>
- <Row><Result_424>-49 -&gt; 1.234567890123457e+068
+ <Row><Result_424>-49 -&gt; 1.234567890123457e+68
 </Result_424></Row>
 </Dataset>
 <Dataset name='Result 425'>
- <Row><Result_425>-48 -&gt; 1.234567890123457e+068
+ <Row><Result_425>-48 -&gt; 1.234567890123457e+68
 </Result_425></Row>
 </Dataset>
 <Dataset name='Result 426'>
- <Row><Result_426>-47 -&gt; 1.234567890123457e+068
+ <Row><Result_426>-47 -&gt; 1.234567890123457e+68
 </Result_426></Row>
 </Dataset>
 <Dataset name='Result 427'>
- <Row><Result_427>-46 -&gt; 1.234567890123457e+068
+ <Row><Result_427>-46 -&gt; 1.234567890123457e+68
 </Result_427></Row>
 </Dataset>
 <Dataset name='Result 428'>
- <Row><Result_428>-45 -&gt; 1.234567890123457e+068
+ <Row><Result_428>-45 -&gt; 1.234567890123457e+68
 </Result_428></Row>
 </Dataset>
 <Dataset name='Result 429'>
- <Row><Result_429>-44 -&gt; 1.234567890123457e+068
+ <Row><Result_429>-44 -&gt; 1.234567890123457e+68
 </Result_429></Row>
 </Dataset>
 <Dataset name='Result 430'>
- <Row><Result_430>-43 -&gt; 1.234567890123457e+068
+ <Row><Result_430>-43 -&gt; 1.234567890123457e+68
 </Result_430></Row>
 </Dataset>
 <Dataset name='Result 431'>
- <Row><Result_431>-42 -&gt; 1.234567890123457e+068
+ <Row><Result_431>-42 -&gt; 1.234567890123457e+68
 </Result_431></Row>
 </Dataset>
 <Dataset name='Result 432'>
- <Row><Result_432>-41 -&gt; 1.234567890123457e+068
+ <Row><Result_432>-41 -&gt; 1.234567890123457e+68
 </Result_432></Row>
 </Dataset>
 <Dataset name='Result 433'>
- <Row><Result_433>-40 -&gt; 1.234567890123457e+068
+ <Row><Result_433>-40 -&gt; 1.234567890123457e+68
 </Result_433></Row>
 </Dataset>
 <Dataset name='Result 434'>
- <Row><Result_434>-39 -&gt; 1.234567890123457e+068
+ <Row><Result_434>-39 -&gt; 1.234567890123457e+68
 </Result_434></Row>
 </Dataset>
 <Dataset name='Result 435'>
- <Row><Result_435>-38 -&gt; 1.234567890123457e+068
+ <Row><Result_435>-38 -&gt; 1.234567890123457e+68
 </Result_435></Row>
 </Dataset>
 <Dataset name='Result 436'>
- <Row><Result_436>-37 -&gt; 1.234567890123457e+068
+ <Row><Result_436>-37 -&gt; 1.234567890123457e+68
 </Result_436></Row>
 </Dataset>
 <Dataset name='Result 437'>
- <Row><Result_437>-36 -&gt; 1.234567890123457e+068
+ <Row><Result_437>-36 -&gt; 1.234567890123457e+68
 </Result_437></Row>
 </Dataset>
 <Dataset name='Result 438'>
- <Row><Result_438>-35 -&gt; 1.234567890123457e+068
+ <Row><Result_438>-35 -&gt; 1.234567890123457e+68
 </Result_438></Row>
 </Dataset>
 <Dataset name='Result 439'>
- <Row><Result_439>-34 -&gt; 1.234567890123457e+068
+ <Row><Result_439>-34 -&gt; 1.234567890123457e+68
 </Result_439></Row>
 </Dataset>
 <Dataset name='Result 440'>
- <Row><Result_440>-33 -&gt; 1.234567890123457e+068
+ <Row><Result_440>-33 -&gt; 1.234567890123457e+68
 </Result_440></Row>
 </Dataset>
 <Dataset name='Result 441'>
- <Row><Result_441>-32 -&gt; 1.234567890123457e+068
+ <Row><Result_441>-32 -&gt; 1.234567890123457e+68
 </Result_441></Row>
 </Dataset>
 <Dataset name='Result 442'>
- <Row><Result_442>-31 -&gt; 1.234567890123457e+068
+ <Row><Result_442>-31 -&gt; 1.234567890123457e+68
 </Result_442></Row>
 </Dataset>
 <Dataset name='Result 443'>
- <Row><Result_443>-30 -&gt; 1.234567890123457e+068
+ <Row><Result_443>-30 -&gt; 1.234567890123457e+68
 </Result_443></Row>
 </Dataset>
 <Dataset name='Result 444'>
- <Row><Result_444>-29 -&gt; 1.234567890123457e+068
+ <Row><Result_444>-29 -&gt; 1.234567890123457e+68
 </Result_444></Row>
 </Dataset>
 <Dataset name='Result 445'>
- <Row><Result_445>-28 -&gt; 1.234567890123457e+068
+ <Row><Result_445>-28 -&gt; 1.234567890123457e+68
 </Result_445></Row>
 </Dataset>
 <Dataset name='Result 446'>
- <Row><Result_446>-27 -&gt; 1.234567890123457e+068
+ <Row><Result_446>-27 -&gt; 1.234567890123457e+68
 </Result_446></Row>
 </Dataset>
 <Dataset name='Result 447'>
- <Row><Result_447>-26 -&gt; 1.234567890123457e+068
+ <Row><Result_447>-26 -&gt; 1.234567890123457e+68
 </Result_447></Row>
 </Dataset>
 <Dataset name='Result 448'>
- <Row><Result_448>-25 -&gt; 1.234567890123457e+068
+ <Row><Result_448>-25 -&gt; 1.234567890123457e+68
 </Result_448></Row>
 </Dataset>
 <Dataset name='Result 449'>
- <Row><Result_449>-24 -&gt; 1.234567890123457e+068
+ <Row><Result_449>-24 -&gt; 1.234567890123457e+68
 </Result_449></Row>
 </Dataset>
 <Dataset name='Result 450'>
- <Row><Result_450>-23 -&gt; 1.234567890123457e+068
+ <Row><Result_450>-23 -&gt; 1.234567890123457e+68
 </Result_450></Row>
 </Dataset>
 <Dataset name='Result 451'>
- <Row><Result_451>-22 -&gt; 1.234567890123457e+068
+ <Row><Result_451>-22 -&gt; 1.234567890123457e+68
 </Result_451></Row>
 </Dataset>
 <Dataset name='Result 452'>
- <Row><Result_452>-21 -&gt; 1.234567890123457e+068
+ <Row><Result_452>-21 -&gt; 1.234567890123457e+68
 </Result_452></Row>
 </Dataset>
 <Dataset name='Result 453'>
- <Row><Result_453>-20 -&gt; 1.234567890123457e+068
+ <Row><Result_453>-20 -&gt; 1.234567890123457e+68
 </Result_453></Row>
 </Dataset>
 <Dataset name='Result 454'>
- <Row><Result_454>-19 -&gt; 1.234567890123457e+068
+ <Row><Result_454>-19 -&gt; 1.234567890123457e+68
 </Result_454></Row>
 </Dataset>
 <Dataset name='Result 455'>
- <Row><Result_455>-18 -&gt; 1.234567890123457e+068
+ <Row><Result_455>-18 -&gt; 1.234567890123457e+68
 </Result_455></Row>
 </Dataset>
 <Dataset name='Result 456'>
- <Row><Result_456>-17 -&gt; 1.234567890123457e+068
+ <Row><Result_456>-17 -&gt; 1.234567890123457e+68
 </Result_456></Row>
 </Dataset>
 <Dataset name='Result 457'>
- <Row><Result_457>-16 -&gt; 1.234567890123457e+068
+ <Row><Result_457>-16 -&gt; 1.234567890123457e+68
 </Result_457></Row>
 </Dataset>
 <Dataset name='Result 458'>
- <Row><Result_458>-15 -&gt; 1.234567890123457e+068
+ <Row><Result_458>-15 -&gt; 1.234567890123457e+68
 </Result_458></Row>
 </Dataset>
 <Dataset name='Result 459'>
- <Row><Result_459>-14 -&gt; 1.234567890123457e+068
+ <Row><Result_459>-14 -&gt; 1.234567890123457e+68
 </Result_459></Row>
 </Dataset>
 <Dataset name='Result 460'>
- <Row><Result_460>-13 -&gt; 1.234567890123457e+068
+ <Row><Result_460>-13 -&gt; 1.234567890123457e+68
 </Result_460></Row>
 </Dataset>
 <Dataset name='Result 461'>
- <Row><Result_461>-12 -&gt; 1.234567890123457e+068
+ <Row><Result_461>-12 -&gt; 1.234567890123457e+68
 </Result_461></Row>
 </Dataset>
 <Dataset name='Result 462'>
- <Row><Result_462>-11 -&gt; 1.234567890123457e+068
+ <Row><Result_462>-11 -&gt; 1.234567890123457e+68
 </Result_462></Row>
 </Dataset>
 <Dataset name='Result 463'>
- <Row><Result_463>-10 -&gt; 1.234567890123457e+068
+ <Row><Result_463>-10 -&gt; 1.234567890123457e+68
 </Result_463></Row>
 </Dataset>
 <Dataset name='Result 464'>
- <Row><Result_464>-9 -&gt; 1.234567890123457e+068
+ <Row><Result_464>-9 -&gt; 1.234567890123457e+68
 </Result_464></Row>
 </Dataset>
 <Dataset name='Result 465'>
- <Row><Result_465>-8 -&gt; 1.234567890123457e+068
+ <Row><Result_465>-8 -&gt; 1.234567890123457e+68
 </Result_465></Row>
 </Dataset>
 <Dataset name='Result 466'>
- <Row><Result_466>-7 -&gt; 1.234567890123457e+068
+ <Row><Result_466>-7 -&gt; 1.234567890123457e+68
 </Result_466></Row>
 </Dataset>
 <Dataset name='Result 467'>
- <Row><Result_467>-6 -&gt; 1.234567890123457e+068
+ <Row><Result_467>-6 -&gt; 1.234567890123457e+68
 </Result_467></Row>
 </Dataset>
 <Dataset name='Result 468'>
- <Row><Result_468>-5 -&gt; 1.234567890123457e+068
+ <Row><Result_468>-5 -&gt; 1.234567890123457e+68
 </Result_468></Row>
 </Dataset>
 <Dataset name='Result 469'>
- <Row><Result_469>-4 -&gt; 1.234567890123457e+068
+ <Row><Result_469>-4 -&gt; 1.234567890123457e+68
 </Result_469></Row>
 </Dataset>
 <Dataset name='Result 470'>
- <Row><Result_470>-3 -&gt; 1.234567890123457e+068
+ <Row><Result_470>-3 -&gt; 1.234567890123457e+68
 </Result_470></Row>
 </Dataset>
 <Dataset name='Result 471'>
- <Row><Result_471>-2 -&gt; 1.234567890123457e+068
+ <Row><Result_471>-2 -&gt; 1.234567890123457e+68
 </Result_471></Row>
 </Dataset>
 <Dataset name='Result 472'>
- <Row><Result_472>-1 -&gt; 1.234567890123457e+068
+ <Row><Result_472>-1 -&gt; 1.234567890123457e+68
 </Result_472></Row>
 </Dataset>

--- a/testing/ecl/key/stats.xml
+++ b/testing/ecl/key/stats.xml
@@ -8,10 +8,10 @@
  <Row><best_fit>bestFit: y=0.0 + 1.0x</best_fit></Row>
 </Dataset>
 <Dataset name='Result 4'>
- <Row><c>7</c><sx>17181700000.0</sx><sy>8860168000.0</sy><sxx>4.63897686502e+019</sxx><sxy>2.306781127058e+019</sxy><syy>1.2882340489264e+019</syy><varx>6.023992992122447e+017</varx><vary>2.38240947686204e+017</vary><varxy>1.886108238461221e+017</varxy><rc>0.49787</rc></Row>
+ <Row><c>7</c><sx>17181700000.0</sx><sy>8860168000.0</sy><sxx>4.63897686502e+19</sxx><sxy>2.306781127058e+19</sxy><syy>1.2882340489264e+19</syy><varx>6.023992992122447e+17</varx><vary>2.38240947686204e+17</vary><varxy>1.88610823846122e+17</varxy><rc>0.49787</rc></Row>
 </Dataset>
 <Dataset name='Result 5'>
- <Row><varx_check>6.023992992122447e+017</varx_check><vary_check>2.38240947686204e+017</vary_check><varxy_check>1.886108238461221e+017</varxy_check><rc_check>0.49787</rc_check></Row>
+ <Row><varx_check>6.023992992122447e+17</varx_check><vary_check>2.38240947686204e+17</vary_check><varxy_check>1.88610823846122e+17</varxy_check><rc_check>0.49787</rc_check></Row>
 </Dataset>
 <Dataset name='Result 6'>
  <Row><best_fit>bestFit: y=497227006.5405106 + 0.3130993414048916x</best_fit></Row>
@@ -23,5 +23,5 @@
  <Row><varx_check>2.916667</varx_check><vary_check>3.126389</vary_check><varxy_check>3.013601</varxy_check><rc_check>0.997978</rc_check></Row>
 </Dataset>
 <Dataset name='Result 9'>
- <Row><best_fit>bestFit: y=-0.09346578670619603 + 1.033234510487485x</best_fit></Row>
+ <Row><best_fit>bestFit: y=-0.09346578670619603 + 1.033234510487484x</best_fit></Row>
 </Dataset>

--- a/testing/ecl/key/stepjoin3.xml
+++ b/testing/ecl/key/stepjoin3.xml
@@ -5,7 +5,7 @@
  <Row><area>1</area><zone>4</zone><prob>0.196</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>1</zone><prob>0.027</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
  <Row><area>3</area><zone>4</zone><prob>0.008</prob></Row>
@@ -17,7 +17,7 @@
  <Row><area>1</area><zone>4</zone><prob>0.196</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>1</zone><prob>0.027</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
  <Row><area>3</area><zone>4</zone><prob>0.008</prob></Row>
@@ -27,7 +27,7 @@
  <Row><area>1</area><zone>4</zone><prob>0.196</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
 </Dataset>
 <Dataset name='j2inf'>
@@ -35,7 +35,7 @@
  <Row><area>1</area><zone>4</zone><prob>0.196</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
 </Dataset>
 <Dataset name='j1inf2'>
@@ -70,7 +70,7 @@
  <Row><area>1</area><zone>6</zone><prob>0.7</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>1</zone><prob>0.027</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
  <Row><area>3</area><zone>4</zone><prob>0.008</prob></Row>
@@ -85,7 +85,7 @@
  <Row><area>1</area><zone>6</zone><prob>0.7</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>1</zone><prob>0.027</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
  <Row><area>3</area><zone>4</zone><prob>0.008</prob></Row>
@@ -100,7 +100,7 @@
  <Row><area>1</area><zone>6</zone><prob>0.7</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>1</zone><prob>0.3</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
  <Row><area>3</area><zone>4</zone><prob>0.2</prob></Row>
@@ -115,7 +115,7 @@
  <Row><area>1</area><zone>6</zone><prob>0.7</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>1</zone><prob>0.3</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
  <Row><area>3</area><zone>4</zone><prob>0.2</prob></Row>
@@ -126,7 +126,7 @@
  <Row><area>1</area><zone>6</zone><prob>0.7</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
 </Dataset>
 <Dataset name='j2ous'>
@@ -135,6 +135,6 @@
  <Row><area>1</area><zone>6</zone><prob>0.7</prob></Row>
  <Row><area>2</area><zone>2</zone><prob>0.24</prob></Row>
  <Row><area>2</area><zone>3</zone><prob>0.144</prob></Row>
- <Row><area>2</area><zone>4</zone><prob>0.567</prob></Row>
+ <Row><area>2</area><zone>4</zone><prob>0.5669999999999999</prob></Row>
  <Row><area>3</area><zone>2</zone><prob>0.216</prob></Row>
 </Dataset>

--- a/testing/ecl/key/teststd.xml
+++ b/testing/ecl/key/teststd.xml
@@ -1,3 +1,9 @@
 <Dataset name='Result 1'>
- <Row><Result_1>Test std completed</Result_1></Row>
+ <Row><day>1000001</day><gregorian><year>2738</year><month>11</month><day>29</day></gregorian><julian><year>2738</year><month>11</month><day>8</day></julian></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><day>1000001</day><gregorian><year>2738</year><month>11</month><day>29</day></gregorian><julian><year>2738</year><month>11</month><day>8</day></julian></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>Test std completed</Result_3></Row>
 </Dataset>


### PR DESCRIPTION
This only reduces the number of false positives for the obvious ones. More patches are coming to fix them all.

@jakesmith please review, as this has to do with the integer/fp precision you were working on.
