### PR TITLE
Fix minor problem with AGGREGATE MERGE transform

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -5145,6 +5145,9 @@ void CHqlDataset::cacheParent()
                 normalized.setown(createInScopeSelectExpr(LINK(normalizedLeft), LINK(queryChild(1))));
 
             container = LINK(queryDatasetCursor(ds)->queryNormalizedSelector(false));
+#ifdef _DEBUG
+            assertex(!hasProperty(newAtom) || !isAlwaysActiveRow(ds));
+#endif
             break;
         }
     case no_if:
@@ -9843,6 +9846,9 @@ IHqlExpression *createDataset(node_operator op, HqlExprArray & parms)
         {
             IHqlExpression * field = &parms.item(1);
             datasetType = field->queryType();
+            //This can occur in very unusual situations...
+            if ((parms.ordinality() > 2) && isAlwaysActiveRow(&parms.item(0)))
+                removeProperty(parms, newAtom);
         }
         break;
     default:

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -1391,6 +1391,8 @@ IHqlExpression * NewHqlTransformer::createTransformed(IHqlExpression * expr)
                 children.replace(*LINK(ds.queryChild(0)), 0);
                 removeProperty(children, newAtom);
             }
+            if ((children.ordinality() > 2) && isAlwaysActiveRow(&ds))
+                removeProperty(children, newAtom);
         }
         else
             return createTransformedActiveSelect(expr);
@@ -2670,7 +2672,11 @@ IHqlExpression * MergingHqlTransformer::createTransformed(IHqlExpression * expr)
             bool same = optimizedTransformChildren(expr, children);
             popChildContext();
             if (!same)
+            {
+                if ((children.ordinality() > 2) && isAlwaysActiveRow(child))
+                    removeProperty(children, newAtom);
                 return expr->clone(children);
+            }
             return LINK(expr);
         }
     case childdataset_merge:


### PR DESCRIPTION
Field selections from the LEFT/RIGHT dataset could be marked as new,
leading to less optimal code (normalize instead of child dataset).

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
