### PR TITLE
swapSuper bypassing transaction and deadlocking

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1287,7 +1287,7 @@ public:
             ret = f->querySuperFile();
             if (ret)
                 return LINK(ret);
-        }   
+        }
         ret = queryDistributedFileDirectory().lookupSuperFile(name,udesc,this,fixmissing,timeout);
         if (!ret)
             return NULL;
@@ -1306,7 +1306,7 @@ public:
     bool setActive(bool on)
     {
         bool old = isactive;
-        isactive = false;
+        isactive = on;
         return old;
     }
 
@@ -5058,7 +5058,7 @@ public:
             // action is now owned by transaction so don't unlink or delete!
             return;
         }
-        Owned<IDistributedFile> sub = parent->lookup(subfile,udesc,false,transaction,defaultTimeout);  
+        Owned<IDistributedFile> sub = transaction ? transaction->lookupFile(subfile) : parent->lookup(subfile,udesc,false,NULL,defaultTimeout);
         if (!sub)
             throw MakeStringException(-1,"addSubFile(3): File %s cannot be found to add",subfile);
         bool lockreleased;
@@ -5367,16 +5367,17 @@ public:
         if (!file)
             return false;
         StringBuffer subname;
-        StringAttrArray subnames1;  // will be built reversed
-        StringAttrArray subnames2;  // will be built reversed
+        StringArray subnames1; // will be built reversed
+        StringArray subnames2; // will be built reversed
         unsigned pos = subfiles.ordinality();
         lockProperties(defaultTimeout);
         if (pos) {
             do {
                 pos--;
+                subfiles.item(pos).lockProperties(defaultTimeout);
                 unlinkSubFile(pos,transaction);
                 removeItem(pos,subname.clear());
-                subnames1.append(* new StringAttrItem(subname.str()));
+                subnames1.append(subname.str());
             } while (pos);
         }
         file->lockProperties(defaultTimeout);
@@ -5384,16 +5385,33 @@ public:
         if (pos) {
             do {
                 pos--;
+                file->subfiles.item(pos).lockProperties(defaultTimeout);
                 file->unlinkSubFile(pos,transaction);
                 file->removeItem(pos,subname.clear());
-                subnames2.append(* new StringAttrItem(subname.str()));
+                subnames2.append(subname.str());
             } while (pos);
         }
         ForEachItemInRev(i1,subnames1) {
-            file->addSubFile(subnames1.item(i1).text.get());
+            Owned<IDistributedFile> sub = transaction ? transaction->lookupFile(subnames1.item(i1)) : parent->lookup(subnames1.item(i1),udesc,false,NULL,defaultTimeout);
+            file->doAddSubFile(LINK(sub), false, NULL, transaction);
         }
         ForEachItemInRev(i2,subnames2) {
-            addSubFile(subnames2.item(i2).text.get());
+            Owned<IDistributedFile> sub = transaction ? transaction->lookupFile(subnames2.item(i2)) : parent->lookup(subnames2.item(i2),udesc,false,NULL,defaultTimeout);
+            doAddSubFile(LINK(sub), false, NULL, transaction);
+        }
+        pos = subfiles.ordinality();
+        if (pos) {
+            do {
+                pos--;
+                subfiles.item(pos).unlockProperties();
+            } while(pos);
+        }
+        pos = file->subfiles.ordinality();
+        if (pos) {
+            do {
+                pos--;
+                file->subfiles.item(pos).unlockProperties();
+            } while(pos);
         }
         file->setModified();
         file->updateFileAttrs();
@@ -8569,6 +8587,7 @@ void CDistributedFileDirectory::resolveForeignFiles(IPropertyTree *tree,const IN
 
 void CDistributedFileDirectory::linkSuperOwner(IDistributedFile &subfile,const char *superfile,bool link,IDistributedFileTransaction *transaction)
 {
+    subfile.lockProperties();
     IDistributedSuperFile *ssub = subfile.querySuperFile();
     if (ssub) {
         CDistributedSuperFile *cdsuper = QUERYINTERFACE(ssub,CDistributedSuperFile);
@@ -8578,6 +8597,7 @@ void CDistributedFileDirectory::linkSuperOwner(IDistributedFile &subfile,const c
         CDistributedFile *cdfile = QUERYINTERFACE(&subfile,CDistributedFile);
         cdfile->linkSuperOwner(superfile,link,transaction);
     }
+    subfile.unlockProperties();
 }
 
 int CDistributedFileDirectory::getFilePermissions(const char *lname,IUserDescriptor *user,unsigned auditflags)


### PR DESCRIPTION
This is a fix for gh-927

The swapsuper transaction commit phase, bypassed the transaction when
looking up the files it was adding back into the supers.
Therefore if those sub files were used elsewhere in the transaction,
and hence locked, swapsuper would stall.

There are a couple of other issues here, all related

1) swapSuper fix worked in transaction, but SuperOwner failed to be commited outside a transaction.
2) addSubFile could lockup, if processing a subfile already present in another 
3) AddSubFile(super1, super2, addcontents) -  would lockup trying to alter properties of a file it had locked

These are caused by same issue(s).

1) It's not supposed to commit anything unless it had a psueudo lock on the files properties (lockProperties())
In the past SuperOwner was bypassing that  - AND it was lucky to get away with, because it had a read lock, not a write lock as it would with all other changes, so it was lucky Dali is lenient to allow commits on non write locks. 
2) It wasn't consistently referencing the transaction to lookup files, which was causing it to lookup multiple times and keep multiple readlocks, which could lead to deadlock. A related issue was 3) - which whether inside or outside a user transaction needed to reference the same files/locks as it was altering.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
