### PR TITLE
IfNull regression

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -780,7 +780,8 @@ void CGraphElementBase::createActivity(size32_t parentExtractSz, const byte *par
                 else
                 {
                     onCreate();
-                    initActivity();
+                    if (!activity)
+                        factorySet(TAKnull);
                 }
                 break;
             default:


### PR DESCRIPTION
Regression introruced by gh-678.
If a CASE of IF statement evaluated to null, Thor threw an unexpected exception.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
