### PR TITLE
Use _spawnvp instead of _execvp on windows for ecl command line

### DIFF
--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -34,9 +34,7 @@
 //=========================================================================================
 
 #ifdef _WIN32
-//TODO - move to or use existing jlib
 #include "process.h"
-#define _execvp execvp
 #endif
 
 int EclCMDShell::callExternal(ArgvIterator &iter)
@@ -51,7 +49,12 @@ int EclCMDShell::callExternal(ArgvIterator &iter)
     for (; !iter.done(); iter.next())
         argv[i++]=iter.query();
     argv[i]=NULL;
+//TODO - add common routine or use existing in jlib
+#ifdef _WIN32
+    if (_spawnvp(_P_WAIT, cmdstr.str(), const_cast<char **>(argv))==-1)
+#else
     if (execvp(cmdstr.str(), const_cast<char **>(argv))==-1)
+#endif
     {
         switch(errno)
         {


### PR DESCRIPTION
Even microsoft's example for the exec functions seem to have issues
on windows.  After returning the command shell seems to be in the proper
state but the prompt doesn't appear until after the next action.

Its quite confusing for the user.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
