### PR TITLE
gh-460 Generate meta information while parsing ecl

### DIFF
--- a/common/fileview2/fvwugen.cpp
+++ b/common/fileview2/fvwugen.cpp
@@ -56,14 +56,14 @@ IHqlExpression * addFilter(IHqlExpression * dataset, IHqlExpression * limitField
 {
     IHqlExpression * lower = createConstant(limitField->queryType()->castFrom(true, (__int64)0));
     lower = createValue(no_colon, lower, createValue(no_stored, createConstant(LOWER_LIMIT_ID)));
-    lower = createSymbol(createIdentifierAtom(LOWER_LIMIT_ID), lower->getType(), lower);
+    lower = createSymbol(createIdentifierAtom(LOWER_LIMIT_ID), lower, ob_private);
     dataset = createDataset(no_filter, LINK(dataset), createBoolExpr(no_ge, LINK(limitField), lower));
 
     IHqlExpression * upper = createConstant((int)DISKREAD_PAGE_SIZE);
     upper = createValue(no_colon, upper, createValue(no_stored, createConstant(RECORD_LIMIT_ID)));
-    upper = createSymbol(createIdentifierAtom(RECORD_LIMIT_ID), upper->getType(), upper);
+    upper = createSymbol(createIdentifierAtom(RECORD_LIMIT_ID), upper, ob_private);
     dataset = createDataset(no_choosen, dataset, upper);
-    dataset = createSymbol(createIdentifierAtom("_Filtered_"), dataset->getType(), dataset);
+    dataset = createSymbol(createIdentifierAtom("_Filtered_"), dataset, ob_private);
     return dataset;
 }
 
@@ -80,7 +80,7 @@ IHqlExpression * addSimplifyProject(IHqlExpression * dataset)
     if (!projectRecord)
         return LINK(dataset);
 
-    projectRecord = createSymbol(createIdentifierAtom("_TargetRecord_"), projectRecord->getType(), projectRecord);
+    projectRecord = createSymbol(createIdentifierAtom("_TargetRecord_"), projectRecord, ob_private);
     return createDataset(no_newusertable, LINK(dataset), createComma(projectRecord, getSimplifiedTransform(projectRecord, record, dataset)));
 }
 
@@ -89,7 +89,7 @@ IHqlExpression * addSimplifyProject(IHqlExpression * dataset)
 
 IHqlExpression * buildWorkUnitViewerEcl(IHqlExpression * record, const char * wuid, unsigned sequence, const char * name)
 {
-    OwnedHqlExpr newRecord = createSymbol(createIdentifierAtom("_SourceRecord_"), record->getType(), LINK(record));
+    OwnedHqlExpr newRecord = createSymbol(createIdentifierAtom("_SourceRecord_"), LINK(record), ob_private);
     IHqlExpression * arg = name ? createConstant(name) : createConstant((int)sequence);
     OwnedHqlExpr dataset = createDataset(no_workunit_dataset, newRecord.getLink(), createComma(createConstant(wuid), arg));
     OwnedHqlExpr projected = addSimplifyProject(dataset);
@@ -111,7 +111,7 @@ IHqlExpression * buildDiskFileViewerEcl(const char * logicalName, IHqlExpression
     fields.append(*reclen.getLink());
 
     OwnedHqlExpr newRecord = createRecord(fields);
-    newRecord.setown(createSymbol(createIdentifierAtom("_SourceRecord_"), newRecord->getType(), newRecord.getLink()));
+    newRecord.setown(createSymbol(createIdentifierAtom("_SourceRecord_"), newRecord.getLink(), ob_private));
 
     OwnedHqlExpr dataset = createNewDataset(createConstant(logicalName), newRecord.getLink(), createValue(no_thor), NULL, NULL, NULL);
     OwnedHqlExpr filtered = addFilter(dataset, filepos);

--- a/ecl/hql/CMakeLists.txt
+++ b/ecl/hql/CMakeLists.txt
@@ -31,6 +31,7 @@ set (   SRCS
         hqlatoms.cpp 
         hqlattr.cpp 
         hqlcollect.cpp
+        hqldesc.cpp
         hqldsparam.cpp 
         hqlerror.cpp 
         hqlesp.cpp 
@@ -63,6 +64,7 @@ set (   SRCS
         hqlatoms.hpp
         hqlattr.hpp
         hqlcollect.hpp
+        hqldesc.hpp
         hqlesp.hpp
         hqlexpr.hpp
         hqlfold.hpp

--- a/ecl/hql/hql.hpp
+++ b/ecl/hql/hql.hpp
@@ -71,6 +71,7 @@ typedef const char * user_t;
 enum object_type 
 {
 //Flags set on symbols
+    ob_private      = 0x0000,
     ob_exported     = 0x0001,
     ob_shared       = 0x0002,
     ob_import       = 0x0004,

--- a/ecl/hql/hqldesc.cpp
+++ b/ecl/hql/hqldesc.cpp
@@ -1,0 +1,76 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+#include "platform.h"
+
+#include "hql.hpp"
+#include "hqlexpr.hpp"
+#include "hqldesc.hpp"
+
+int compareSymbolsByPosition(IInterface * * pleft, IInterface * * pright)
+{
+    IHqlExpression * left = static_cast<IHqlExpression *>(*pleft);
+    IHqlExpression * right = static_cast<IHqlExpression *>(*pright);
+
+    int startLeft = left->getStartLine();
+    int startRight = right->getStartLine();
+    if (startLeft != startRight)
+        return startLeft < startRight ? -1 : +1;
+    return stricmp(left->queryName()->str(), right->queryName()->str());
+}
+
+void expandSymbolMeta(IPropertyTree * metaTree, IHqlExpression * expr)
+{
+    IPropertyTree * def = NULL;
+    if (isImport(expr))
+    {
+        def = metaTree->addPropTree("Import", createPTree("Import"));
+    }
+    else
+    {
+        def = metaTree->addPropTree("Definition", createPTree("Definition"));
+    }
+
+    if (def)
+    {
+        def->setProp("@name", expr->queryName()->str());
+        def->setPropInt("@line", expr->getStartLine());
+        if (expr->isExported())
+            def->setPropBool("@exported", true);
+        else if (isPublicSymbol(expr))
+            def->setPropBool("@shared", true);
+
+        if (expr->isScope() && !isImport(expr))
+        {
+            expandScopeSymbolsMeta(def, expr->queryScope());
+        }
+    }
+}
+
+
+void expandScopeSymbolsMeta(IPropertyTree * meta, IHqlScope * scope)
+{
+    if (!scope)
+        return;
+
+    HqlExprArray symbols;
+    scope->getSymbols(symbols);
+    symbols.sort(compareSymbolsByPosition);
+
+    ForEachItemIn(i, symbols)
+        expandSymbolMeta(meta, &symbols.item(i));
+}

--- a/ecl/hql/hqldesc.hpp
+++ b/ecl/hql/hqldesc.hpp
@@ -1,0 +1,25 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#ifndef HQLDESC_INCL
+#define HQLDESC_INCL
+
+void expandScopeSymbolsMeta(IPropertyTree * meta, IHqlScope * scope);
+
+
+#endif

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -942,7 +942,7 @@ macro
 #endif
 
                             //Use a named symbol to associate a line number/column
-                            expr = createSymbol(macroAtom, NULL, expr,
+                            expr = createSymbol(macroAtom, NULL, expr, NULL,
                                                 false, false, (object_type)0,
                                                 NULL, 0,
                                                 yylval.pos.lineno, yylval.pos.column);
@@ -958,7 +958,7 @@ macro
 #endif
 
                             //Use a named symbol to associate a line number/column
-                            expr = createSymbol(macroAtom, NULL, expr,
+                            expr = createSymbol(macroAtom, NULL, expr, NULL,
                                                 false, false, (object_type)0,
                                                 NULL, 0,
                                                 yylval.pos.lineno, yylval.pos.column);

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -401,11 +401,10 @@ void HqlLex::setMacroParam(const YYSTYPE & errpos, IHqlExpression* funcdef, Stri
 /* This is pushing a macro definition. */
 void HqlLex::pushMacro(IHqlExpression *expr)
 {
-    /* expr points to:
-        CHqlNamedSymbol
-        body  ----------------------->no_funcdef
-        body -> no_none                 0->body of macro
-                                        1->parameters
+    /* expr points to namedSymbol(no_funcdef):
+        child(0)-> no_macro = macro body
+        child(1) = parameters
+        child(2) = defaults for parameters
     */
 
     YYSTYPE nextToken;

--- a/ecl/hql/hqlrepository.cpp
+++ b/ecl/hql/hqlrepository.cpp
@@ -363,7 +363,7 @@ IHqlExpression * CNewEclRepository::createSymbol(IHqlRemoteScope * rScope, IEclS
     default:
         throwUnexpected();
     }
-    return CHqlNamedSymbol::makeSymbol(eclName, scope->queryName(), body.getClear(), NULL, true, true, symbolFlags, contents, 0);
+    return ::createSymbol(eclName, scope->queryName(), body.getClear(), NULL, true, true, symbolFlags, contents, 0, 0, 0);
 }
 
 

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -5495,7 +5495,7 @@ void LibraryInputMapper::mapRealToLogical(HqlExprArray & inputExprs, HqlExprArra
                 result = createValue(no_libraryinput, cur->getType(), seq);
         }
         
-        inputExprs.append(*createSymbol(cur->queryName(), result->getType(), result));
+        inputExprs.append(*createSymbol(cur->queryName(), result, ob_private));
     }
 
     IHqlExpression * formals = libraryInterface->queryChild(1);
@@ -5518,7 +5518,7 @@ IHqlExpression * LibraryInputMapper::mapRealToLogical(const HqlExprArray & input
             IHqlExpression * param = resolveParameter(createMangledName(expr, &cur));
             OwnedHqlExpr mapped = mapRealToLogical(inputExprs, param, libraryId);
 
-            OwnedHqlExpr named = createSymbol(cur.queryName(), mapped->getType(), LINK(mapped));
+            OwnedHqlExpr named = createSymbol(cur.queryName(), LINK(mapped), ob_private);
             newScope->defineSymbol(named.getClear());
         }
         return queryExpression(closeScope(newScope.getClear()));

--- a/ecl/hqlcpp/hqlregex.cpp
+++ b/ecl/hqlcpp/hqlregex.cpp
@@ -169,7 +169,7 @@ IHqlExpression * RegexIdAllocator::createKey(IHqlExpression * expr, _ATOM name)
         return NULL;
     IHqlExpression * body = expr->queryBody();
     if (name)
-        return createSymbol(name, body->getType(), LINK(body));
+        return createSymbol(name, LINK(body), ob_private);
     return LINK(body);
 }
 

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -10872,7 +10872,7 @@ IHqlExpression * HqlTreeNormalizer::createTransformedBody(IHqlExpression * expr)
                     _ATOM simpleName = simplifyUniqueAttributeName(name);
                     if (simpleName)
                         name = simpleName;
-                    return createSymbol(name, NULL, transformed.getClear());
+                    return createSymbol(name, transformed.getClear(), ob_private);
                 }
             }
             return transformed.getClear();


### PR DESCRIPTION
Some initial work towards producing meta output from the code generator
including some refactoring to clean up the visibility of
CHqlNamedSymbol to allow a lighter weight class to be used later on.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
