### PR TITLE
Use _spawnvp instead of _execvp on windows for ecl command line for candidate-3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,8 @@ set(CMAKE_MODULE_PATH "${HPCC_SOURCE_DIR}/cmake_modules/")
 set ( HPCC_PROJECT "community" )
 set ( HPCC_MAJOR 3 )
 set ( HPCC_MINOR 4 )
-set ( HPCC_POINT 0 )
-set ( HPCC_MATURITY "rc" )
+set ( HPCC_POINT 1 )
+set ( HPCC_MATURITY "closedown" )
 set ( HPCC_SEQUENCE 1 )
 ###
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ set(CMAKE_MODULE_PATH "${HPCC_SOURCE_DIR}/cmake_modules/")
 ###
 set ( HPCC_PROJECT "community" )
 set ( HPCC_MAJOR 3 )
-set ( HPCC_MINOR 3 )
+set ( HPCC_MINOR 4 )
 set ( HPCC_POINT 0 )
-set ( HPCC_MATURITY "trunk" )
+set ( HPCC_MATURITY "rc" )
 set ( HPCC_SEQUENCE 1 )
 ###
 

--- a/cmake_modules/dependencies/lenny.cmake
+++ b/cmake_modules/dependencies/lenny.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo, openssh-client, openssh-server, expect, sysvconfig")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo, openssh-client, openssh-server, expect, sysvconfig, psmisc")

--- a/cmake_modules/dependencies/lenny.cmake
+++ b/cmake_modules/dependencies/lenny.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo, openssh-client, openssh-server, expect, sysvconfig, psmisc")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo, openssh-client, openssh-server, expect")

--- a/cmake_modules/dependencies/oneiric.cmake
+++ b/cmake_modules/dependencies/oneiric.cmake
@@ -1,0 +1,1 @@
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.46.1, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect")

--- a/common/deftype/defvalue.cpp
+++ b/common/deftype/defvalue.cpp
@@ -1167,8 +1167,7 @@ IValue * createUtf8Value(size32_t len, const char * text, ITypeInfo * type)
         return createUtf8Value(text, type);
 
     rtlDataAttr buff(nlen * 4);
-    unsigned bufflen = 0;
-    rtlUtf8SubStrFT(bufflen, buff.getstr(), len, text, 1, nlen);
+    rtlUtf8SubStrFT(nlen, buff.getstr(), len, text, 1, nlen);
     return new Utf8Value(buff.getstr(), type);
 }
 

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3847,7 +3847,7 @@ public:
         StringBuffer queue;
         if (thors.ordinality())
         {
-            thorQueue.set(queue.clear().append(name).append(".thor"));
+            thorQueue.set(getClusterThorQueueName(queue.clear(), name));
             clusterWidth = 0;
             bool lcr = false;
             ForEachItemIn(i,thors) 
@@ -3881,12 +3881,12 @@ public:
         if (agent)
         {
             assertex(!roxie);
-            agentQueue.set(queue.clear().append(name).append(".agent"));
+            agentQueue.set(getClusterEclAgentQueueName(queue.clear(), name));
         }
         else if (roxie)
-            agentQueue.set(queue.clear().append(name).append(".roxie"));
+            agentQueue.set(getClusterRoxieQueueName(queue.clear(), name));
         // MORE - does this need to be conditional?
-        serverQueue.set(queue.clear().append(name).append(".eclserver"));
+        serverQueue.set(getClusterEclCCServerQueueName(queue.clear(), name));
     }
     IStringVal & getName(IStringVal & str) const
     {
@@ -3965,34 +3965,66 @@ IStringVal &getProcessQueueNames(IStringVal &ret, const char *process, const cha
     return ret;
 }
 
+#define ROXIE_QUEUE_EXT ".roxie"
+#define THOR_QUEUE_EXT ".thor"
+#define ECLCCSERVER_QUEUE_EXT ".eclserver"
+#define ECLSERVER_QUEUE_EXT ECLCCSERVER_QUEUE_EXT
+#define ECLSCHEDULER_QUEUE_EXT ".eclscheduler"
+#define ECLAGENT_QUEUE_EXT ".agent"
+
 extern WORKUNIT_API IStringVal &getEclCCServerQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "EclCCServerProcess", ".eclserver");
+    return getProcessQueueNames(ret, process, "EclCCServerProcess", ECLCCSERVER_QUEUE_EXT);
 }
 
 extern WORKUNIT_API IStringVal &getEclServerQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "EclServerProcess", ".eclserver"); // shares queue name with EclCCServer
+    return getProcessQueueNames(ret, process, "EclServerProcess", ECLSERVER_QUEUE_EXT); // shares queue name with EclCCServer
 }
 
 extern WORKUNIT_API IStringVal &getEclSchedulerQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "EclCCServerProcess", ".eclscheduler"); // Shares deployment/config with EclCCServer
+    return getProcessQueueNames(ret, process, "EclSchedulerProcess", ECLSCHEDULER_QUEUE_EXT); // Shares deployment/config with EclCCServer
 }
 
 extern WORKUNIT_API IStringVal &getAgentQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "EclAgentProcess", ".agent");
+    return getProcessQueueNames(ret, process, "EclAgentProcess", ECLAGENT_QUEUE_EXT);
 }
 
 extern WORKUNIT_API IStringVal &getRoxieQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "RoxieCluster", ".roxie");
+    return getProcessQueueNames(ret, process, "RoxieCluster", ROXIE_QUEUE_EXT);
 }
 
 extern WORKUNIT_API IStringVal &getThorQueueNames(IStringVal &ret, const char *process)
 {
-    return getProcessQueueNames(ret, process, "ThorCluster", ".thor");
+    return getProcessQueueNames(ret, process, "ThorCluster", THOR_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterThorQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(THOR_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterRoxieQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(ROXIE_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterEclCCServerQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(ECLCCSERVER_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterEclServerQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(ECLSERVER_QUEUE_EXT);
+}
+
+extern WORKUNIT_API StringBuffer &getClusterEclAgentQueueName(StringBuffer &ret, const char *cluster)
+{
+    return ret.append(cluster).append(ECLAGENT_QUEUE_EXT);
 }
 
 extern WORKUNIT_API IStringIterator *getTargetClusters(const char *processType, const char *processName)
@@ -4142,7 +4174,7 @@ unsigned getEnvironmentThorClusterNames(StringArray &thorNames, StringArray &gro
                     groupNames.append(groupName);
                     targetNames.append(targetName);
                     StringBuffer queueName(targetName);
-                    queueNames.append(queueName.append(".thor"));
+                    queueNames.append(queueName.append(THOR_QUEUE_EXT));
                 }
             }
         }

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1133,6 +1133,11 @@ extern WORKUNIT_API IStringVal &getEclSchedulerQueueNames(IStringVal &ret, const
 extern WORKUNIT_API IStringVal &getAgentQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getRoxieQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getThorQueueNames(IStringVal &ret, const char *process);
+extern WORKUNIT_API StringBuffer &getClusterThorQueueName(StringBuffer &ret, const char *cluster);
+extern WORKUNIT_API StringBuffer &getClusterRoxieQueueName(StringBuffer &ret, const char *cluster);
+extern WORKUNIT_API StringBuffer &getClusterEclCCServerQueueName(StringBuffer &ret, const char *cluster);
+extern WORKUNIT_API StringBuffer &getClusterEclServerQueueName(StringBuffer &ret, const char *cluster);
+extern WORKUNIT_API StringBuffer &getClusterEclAgentQueueName(StringBuffer &ret, const char *cluster);
 extern WORKUNIT_API IStringIterator *getTargetClusters(const char *processType, const char *processName);
 extern WORKUNIT_API IConstWUClusterInfo* getTargetClusterInfo(const char *clustname);
 typedef IArrayOf<IConstWUClusterInfo> CConstWUClusterInfoArray;

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -933,7 +933,7 @@ void EclCC::processFile(EclCompileInstance & instance)
         {
             //Ensure that $ is valid for any file submitted - even if it isn't in the include direcotories
             //Disable this for the moment when running the regression suite.
-            if (!optBatchMode && !withinRepository && !inputFromStdIn)
+            if (!optBatchMode && !withinRepository && !inputFromStdIn && !optLegacy)
             {
                 //Associate the contents of the directory with an internal module called _local_directory_
                 //(If it was root it might override existing root symbols).  $ is the only public way to get at the symbol

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -833,7 +833,8 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
     instance.legacyMode = archiveTree->getPropBool("@legacyMode", instance.legacyMode);
 
     //Some old archives contained imports, but no definitions of the module.  This option is to allow them to compile.
-    instance.ignoreUnknownImport = archiveTree->getPropBool("@ignoreUnknownImport", false);
+    //It shouldn't be needed for new archives in non-legacy mode. (But neither should it cause any harm.)
+    instance.ignoreUnknownImport = archiveTree->getPropBool("@ignoreUnknownImport", true);
 
     instance.eclVersion.set(archiveTree->queryProp("@eclVersion"));
     checkEclVersionCompatible(instance.errs, instance.eclVersion);

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -36,7 +36,6 @@
 #ifdef _WIN32
 //TODO - move to or use existing jlib
 #include "process.h"
-#define _execvp execvp
 #endif
 
 int EclCMDShell::callExternal(ArgvIterator &iter)
@@ -51,7 +50,12 @@ int EclCMDShell::callExternal(ArgvIterator &iter)
     for (; !iter.done(); iter.next())
         argv[i++]=(char *)iter.query();
     argv[i]=NULL;
+//TODO - add common routine or use existing in jlib
+#ifdef _WIN32
+    if (_spawnvp(_P_WAIT, cmdstr.str(), argv)==-1)
+#else
     if (execvp(cmdstr.str(), argv)==-1)
+#endif
     {
         switch(errno)
         {

--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -821,7 +821,7 @@ IEclSourceCollection * createSingleDefinitionEclCollection(const char * attrName
     if (dot)
     {
         StringAttr module(attrName, dot-attrName);
-        return createSingleDefinitionEclCollection(module, attrName, contents);
+        return createSingleDefinitionEclCollection(module, dot+1, contents);
     }
     return createSingleDefinitionEclCollection("", attrName, contents);
 }

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1163,12 +1163,12 @@ bool HqlCppInstance::useFunction(IHqlExpression * func)
     if (pluginAttr)
     {
         StringBuffer plugin, version;
-        pluginAttr->queryChild(0)->queryValue()->getStringValue(plugin);
-        pluginAttr->queryChild(1)->queryValue()->getStringValue(version);
+        getStringValue(plugin, pluginAttr->queryChild(0));
+        getStringValue(version, pluginAttr->queryChild(1));
         addPlugin(plugin.str(), version.str(), false);
         if (!libname.length())
         {
-            pluginAttr->queryChild(0)->queryValue()->getStringValue(libname);
+            getStringValue(libname, pluginAttr->queryChild(0));
             getFullFileName(libname, true);
         }
     }

--- a/ecl/regress/modules/testplugins/lib_stringlib.ecllib
+++ b/ecl/regress/modules/testplugins/lib_stringlib.ecllib
@@ -1,0 +1,60 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+EXPORT StringLib := SERVICE : PLUGIN('stringlib.dll','STRINGLIB 1.1.14')
+  string StringFilterOut(const string src, const string _within) : c, pure,entrypoint='slStringFilterOut';
+  string StringFilter(const string src, const string _within) : c, pure,entrypoint='slStringFilter';
+  string StringSubstituteOut(const string src, const string _within, const string _newchar) : c, pure,entrypoint='slStringSubsOut';
+  string StringSubstitute(const string src, const string _within, const string _newchar) : c, pure,entrypoint='slStringSubs';
+  string StringRepad(const string src, unsigned4 size) : c, pure,entrypoint='slStringRepad';
+  unsigned integer4 StringFind(const string src, const string tofind, unsigned4 instance ) : c, pure,entrypoint='slStringFind';
+  unsigned integer4 StringUnboundedUnsafeFind(const string src, const string tofind ) : c, pure,entrypoint='slStringFind2';
+  unsigned integer4 StringFindCount(const string src, const string tofind) : c, pure,entrypoint='slStringFindCount';
+  unsigned integer4 EbcdicStringFind(const ebcdic string src, const ebcdic string tofind , unsigned4 instance ) : c,pure,entrypoint='slStringFind';
+  unsigned integer4 EbcdicStringUnboundedUnsafeFind(const ebcdic string src, const ebcdic string tofind ) : c,pure,entrypoint='slStringFind2';
+  string StringExtract(const string src, unsigned4 instance) : c,pure,entrypoint='slStringExtract';
+  string8 GetDateYYYYMMDD() : c,once,entrypoint='slGetDateYYYYMMDD2';
+  varstring GetBuildInfo() : c,once,entrypoint='slGetBuildInfo';
+  string Data2String(const data src) : c,pure,entrypoint='slData2String';
+  data String2Data(const string src) : c,pure,entrypoint='slString2Data';
+  string StringToLowerCase(const string src) : c,pure,entrypoint='slStringToLowerCase';
+  string StringToUpperCase(const string src) : c,pure,entrypoint='slStringToUpperCase';
+  string StringToProperCase(const string src) : c,pure,entrypoint='slStringToProperCase';
+  string StringToCapitalCase(const string src) : c,pure,entrypoint='slStringToCapitalCase';
+  string StringToTitleCase(const string src) : c,pure,entrypoint='slStringToTitleCase';
+  integer4 StringCompareIgnoreCase(const string src1, string src2) : c,pure,entrypoint='slStringCompareIgnoreCase';
+  string StringReverse(const string src) : c,pure,entrypoint='slStringReverse';
+  string StringFindReplace(const string src, const string stok, const string rtok) : c,pure,entrypoint='slStringFindReplace';
+  string StringCleanSpaces(const string src) : c,pure,entrypoint='slStringCleanSpaces';
+  boolean StringWildMatch(const string src, const string _pattern, boolean _noCase) : c, pure,entrypoint='slStringWildMatch';
+  boolean StringWildExactMatch(const string src, const string _pattern, boolean _noCase) : c, pure,entrypoint='slStringWildExactMatch';
+  boolean StringContains(const string src, const string _pattern, boolean _noCase) : c, pure,entrypoint='slStringContains';
+  string StringExtractMultiple(const string src, unsigned8 mask) : c,pure,entrypoint='slStringExtractMultiple';
+  unsigned integer4 EditDistance(const string l, const string r) : c, pure,entrypoint='slEditDistance';
+  boolean EditDistanceWithinRadius(const string l, const string r, unsigned4 radius) : c,pure,entrypoint='slEditDistanceWithinRadius';
+  unsigned integer4 EditDistanceV2(const string l, const string r) : c, pure,entrypoint='slEditDistanceV2';
+  boolean EditDistanceWithinRadiusV2(const string l, const string r, unsigned4 radius) : c,pure,entrypoint='slEditDistanceWithinRadiusV2';
+  string StringGetNthWord(const string src, unsigned4 n) : c, pure,entrypoint='slStringGetNthWord';
+  unsigned4 StringWordCount(const string src) : c, pure,entrypoint='slStringWordCount';
+  unsigned4 CountWords(const string src, const string _separator, BOOLEAN allow_blanks) : c, pure,entrypoint='slCountWords';
+  SET OF STRING SplitWords(const string src, const string _separator, BOOLEAN allow_blanks) : c, pure,entrypoint='slSplitWords';
+  STRING CombineWords(set of string src, const string _separator) : c, pure,entrypoint='slCombineWords';
+  UNSIGNED4 StringToDate(const string src, const varstring format) : c, pure,entrypoint='slStringToDate';
+  UNSIGNED4 MatchDate(const string src, set of varstring formats) : c, pure,entrypoint='slMatchDate';
+  STRING FormatDate(UNSIGNED4 date, const varstring format) : c, pure,entrypoint='slFormatDate';
+END;

--- a/ecl/regress/stringlib1a.ecl
+++ b/ecl/regress/stringlib1a.ecl
@@ -1,0 +1,32 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+StringLib := SERVICE : PLUGIN('unknown\\stringlib.dll','STRINGLIB 1.1.14')
+  string8 GetDateYYYYMMDD() : c,once,entrypoint='slGetDateYYYYMMDD2';
+END;
+
+zzz := StringLib;
+
+loadxml('<AA><BB>1</BB><CC>2</CC></AA>');
+
+#DECLARE (y)
+
+#SET (y, zzz.GetDateYYYYMMDD()[1..4])
+
+%'y'%;
+(string10)zzz.GetDateYYYYMMDD();

--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -110,7 +110,8 @@
             }
             function showRoxieQueries()
             {
-              document.location.href='/WsRoxieQuery/QueriesAction?Type=ListQueries&Cluster='+cluster+'&LogicalName='+filename;
+              //document.location.href='/WsRoxieQuery/QueriesAction?Type=ListQueries&Cluster='+cluster+'&LogicalName='+filename;
+              document.location.href='/WsSMC/DisabledInThisVersion?form_';
             }
             var xypos = YAHOO.util.Dom.getXY('mn' + PosId);
             if (oMenu) {

--- a/esp/files/joblist.js
+++ b/esp/files/joblist.js
@@ -425,7 +425,10 @@ function displayJob(wuid,graph,started,finished,cluster,state,source,showall,bbt
 
 function displayEnd(xls)
 {
-    displayProgress('<table><tr><td>Total: '+(totalWorkunits)+' graphs (<a href=\"/WsWorkunits/WUClusterJobXLS?' + xls +'\">xls</a>...<a href=\"/WsWorkunits/WUClusterJobSummaryXLS?' + xls +'\">summary</a>)</td></tr></table>');
+    if (totalWorkunits > 0)
+        displayProgress('<table><tr><td>Total: '+(totalWorkunits)+' graphs (<a href=\"/WsWorkunits/WUClusterJobXLS?' + xls +'\">xls</a>...<a href=\"/WsWorkunits/WUClusterJobSummaryXLS?' + xls +'\">summary</a>)</td></tr></table>');
+    else
+        displayProgress('<table><tr><td>Total: '+(totalWorkunits)+' graphs</td></tr></table>');
 }
 
 function displaySasha()

--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -2499,11 +2499,13 @@ function onContextMenuBeforeShow(p_sType, p_aArgs) {
           {
             if (r.getData('name').indexOf('ThorCluster') == 0) {
               this.getItem(5).cfg.setProperty("disabled", true);
-              break;
             }
             else if (r.getData('name').indexOf('RoxieCluster') == 0) {
               this.getItem(4).cfg.setProperty("disabled", true);
-              break;
+              this.getItem(0).cfg.setProperty("disabled", true);
+            }
+            else if (r.getData('name').indexOf('EclAgent') == 0) {
+              this.getItem(5).cfg.setProperty("disabled", true);
             }
             else {
               var flag = false;

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -371,7 +371,6 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
         IArrayOf<IEspActiveWorkunit> aws;
         if (conn.get()) 
         {
-
             Owned<IPropertyTreeIterator> it(conn->queryRoot()->getElements("Server"));
             ForEach(*it) 
             {
@@ -423,9 +422,16 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                     {
                         IEspActiveWorkunit* wu=new CActiveWorkunitWrapper(context,wuid);
                         const char* servername = node.queryProp("@name");
+                        const char *cluster = node.queryProp("Cluster");
                         wu->setServer(servername);
                         wu->setInstance(instance.str());
-                        wu->setQueueName(qname.str());
+                        StringBuffer thorQueue;
+                        if (cluster) // backward compat check.
+                            getClusterThorQueueName(thorQueue, cluster);
+                        else
+                            thorQueue.append(qname);
+                        serverID = runningQueueNames.find(thorQueue.str());
+                        wu->setQueueName(thorQueue);
                         double version = context.getClientVersion();
                         if (version > 1.01)
                         {

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -330,6 +330,8 @@ bool getClusterJobXLS(double version, StringBuffer &xml, const char* cluster, co
 
         jobList.append(*job.getClear());
     }
+    xml.append("</Dataset>").newline();
+
     return true;
 }
 
@@ -1544,7 +1546,6 @@ bool CWsWorkunitsEx::onWUClusterJobXLS(IEspContext &context, IEspWUClusterJobXLS
         StringBuffer xml("<WUResultExcel><Result>");
         getClusterJobXLS(context.getClientVersion(), xml, req.getCluster(), req.getStartDate(), req.getEndDate(), req.getShowAll(), req.getBusinessStartTime(), req.getBusinessEndTime());
         xml.append("</Result></WUResultExcel>");
-
         Owned<IProperties> params(createProperties());
         params->setProp("showCount",0);
 

--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -285,13 +285,13 @@ fi
 if [ ! -z "${compDafilesrv}" ];then
     case "$1" in
         start)
-            ${SERV} dafilesrv status 1>/dev/null 2>/dev/null
+            /etc/init.d/dafilesrv status 1>/dev/null 2>/dev/null
             if [ $? -ne 0 ];then
-              ${SERV} dafilesrv $1 2>/dev/null
+              /etc/init.d/dafilesrv $1 2>/dev/null
             fi
             ;;
         status|setup)
-            ${SERV} dafilesrv ${1} 2>/dev/null
+            /etc/init.d/dafilesrv ${1} 2>/dev/null
             ;;
         stop|restart)
             ;;

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -389,7 +389,7 @@ createRuntime() {
 }
 
 start_dafilesrv() {
-   ${SERV} dafilesrv status 1>/dev/null 2>/dev/null
+   /etc/init.d/dafilesrv status 1>/dev/null 2>/dev/null
    if [ $? -ne 0 ];then
       #Dafilesrv is not running so start it , before starting cleanup the lock and pid file.
        if [ ${DEBUG} != "NO_DEBUG" ]; then
@@ -402,7 +402,7 @@ start_dafilesrv() {
       fi
 
       noStatusCheck=1
-      ${SERV} dafilesrv setup 1>/dev/null 2>/dev/null
+      /etc/init.d/dafilesrv setup 1>/dev/null 2>/dev/null
       startCmd ${compName} ${noStatusCheck}
       return $?
    else 
@@ -630,15 +630,15 @@ start_component() {
 
 restart_component() {
     if strstr "${compType}" "dafilesrv" ;then
-       ${SERV} dafilesrv status 1>/dev/null 2>/dev/null
+       /etc/init.d/dafilesrv status 1>/dev/null 2>/dev/null
        if [ $? -eq 0 ];then
-         ${SERV} dafilesrv stop 2>/dev/null
+         /etc/init.d/dafilesrv stop 2>/dev/null
        else
            echo "Component $compName was not running. Will start it now for you ...."
            removePid ${PIDPATH}
            unlock ${LOCKPATH}
        fi
-         ${SERV} dafilesrv start 2>/dev/null
+         /etc/init.d/dafilesrv start 2>/dev/null
     else
        check_status ${PIDPATH} ${LOCKPATH} ${COMPPIDPATH} 0
        RCRESTART=$?

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -775,8 +775,8 @@ add_user(){
             fi
         else
             printf "Adding %s to system ..." "${USER}"
-            useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
-            passwd -d ${USER} 1>/dev/null 2>&1
+            useradd -s ${SHELL} -r -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
+            passwd -l ${USER} 1>/dev/null 2>&1
             if [ $? -eq 0 ];
             then
                 log_success_msg
@@ -809,8 +809,8 @@ add_user(){
             fi
         else
             printf "Adding %s to system ..." "${USER}"
-            useradd -s ${SHELL} -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
-            passwd -d ${USER} 1>/dev/null 2>&1
+            useradd -s ${SHELL} -r -m -d ${HOMEPATH} -g ${GROUP} -c "${USER} Runtime User" ${USER}
+            passwd -l ${USER} 1>/dev/null 2>&1
             if [ $? -eq 0 ];
             then
                 log_success_msg

--- a/initfiles/componentfiles/configxml/buildsetCC.xml.in
+++ b/initfiles/componentfiles/configxml/buildsetCC.xml.in
@@ -211,10 +211,10 @@
         <Process name="ftslave"/>
        </ProcessFilter>
        <ProcessFilter name="RoxieServerProcess">
-        <Process name="ccd"/>
+        <Process name="roxie"/>
        </ProcessFilter>
        <ProcessFilter name="RoxieSlaveProcess">
-        <Process name="ccd"/>
+        <Process name="roxie"/>
        </ProcessFilter>
        <ProcessFilter name="SchedulerProcess">
         <Process name="scheduler"/>
@@ -240,13 +240,13 @@
         <Process name="daserver"/>
        </ProcessFilter>
        <ProcessFilter multipleInstances="true" name="DfuServerProcess">
-        <Process name="."/>
+        <Process name="dfuserver"/>
        </ProcessFilter>
        <ProcessFilter multipleInstances="true" name="EclCCServerProcess">
-        <Process name="."/>
+        <Process name="eclccserver"/>
        </ProcessFilter>
        <ProcessFilter multipleInstances="true" name="EspProcess">
-        <Process name="."/>
+        <Process name="esp"/>
         <Process name="dafilesrv" remove="true"/>
        </ProcessFilter>
        <ProcessFilter name="FTSlaveProcess">
@@ -258,10 +258,10 @@
         <Process name="dhcpd"/>
        </ProcessFilter>
        <ProcessFilter name="RoxieServerProcess">
-        <Process name="ccd"/>
+        <Process name="roxie"/>
        </ProcessFilter>
        <ProcessFilter name="RoxieSlaveProcess">
-        <Process name="ccd"/>
+        <Process name="roxie"/>
        </ProcessFilter>
        <ProcessFilter name="SchedulerProcess">
         <Process name="scheduler"/>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -233,13 +233,13 @@
         <Process name="daserver"/>
        </ProcessFilter>
        <ProcessFilter multipleInstances="true" name="DfuServerProcess">
-        <Process name="."/>
+        <Process name="dfuserver"/>
        </ProcessFilter>
        <ProcessFilter multipleInstances="true" name="EclCCServerProcess">
-        <Process name="."/>
+        <Process name="eclccserver"/>
        </ProcessFilter>
        <ProcessFilter multipleInstances="true" name="EspProcess">
-        <Process name="."/>
+        <Process name="esp"/>
         <Process name="dafilesrv" remove="true"/>
        </ProcessFilter>
        <ProcessFilter name="FTSlaveProcess">

--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -10,6 +10,6 @@ roxie_dependencies=ws_roxieconfig
 roxie_agent_redundancy=1,2,1
 
 [Topology]
-roxie_topology=eclagent,eclccserver,eclscheduler
+roxie_topology=eclccserver,eclscheduler
 thor_topology=eclagent,eclccserver,eclscheduler
 hthor_topology=eclagent,eclccserver,eclscheduler

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -2572,23 +2572,22 @@ const char * GetCachedHostName()
     if (!cachehostname.get())
     {
 #ifndef _WIN32
-        StringBuffer ifs;
         IpAddress ip;
         if (EnvConfPath.length() == 0)
             EnvConfPath.append(CONFIG_DIR).append(PATHSEPSTR).append("environment.conf");
         Owned<IProperties> conf = createProperties(EnvConfPath.str(), true);
-        if (conf->getProp("interface", ifs) && ifs.length())
+
+        StringBuffer ifs;
+        conf->getProp("interface", ifs);
+        if (getInterfaceIp(ip, ifs.str()))
         {
-            if (getInterfaceIp(ip, ifs.str()))
+            StringBuffer ips;
+            ip.getIpText(ips);
+            if (ips.length())
             {
-                StringBuffer ips;
-                ip.getIpText(ips);
-                if (ips.length())
-                {
-                    cachehostname.set(ips.str());
-                    cachehostip.ipset(ip);
-                    return cachehostname.get();
-                }
+                cachehostname.set(ips.str());
+                cachehostip.ipset(ip);
+                return cachehostname.get();
             }
         }
 #endif

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2235,20 +2235,22 @@ public:
                     break;
                 }
                 if (job.queryPausing()) return; // pending graphs will re-run on resubmission
-                assertex(running.ordinality() <= limit);
                 bool added = false;
-                while (toRun.ordinality())
+                if (running.ordinality() < limit)
                 {
-                    Linked<CGraphExecutorGraphInfo> graphInfo = &toRun.item(0);
-                    toRun.remove(0);
-                    running.append(*LINK(graphInfo));
-                    CGraphBase *subGraph = graphInfo->subGraph;
-                    PROGLOG("Wait: Launching graph thread for graphId=%"GIDPF"d", subGraph->queryGraphId());
-                    added = true;
-                    PooledThreadHandle h = graphPool->start(graphInfo.getClear());
-                    subGraph->poolThreadHandle = h;
-                    if (running.ordinality() >= limit)
-                        break;
+                    while (toRun.ordinality())
+                    {
+                        Linked<CGraphExecutorGraphInfo> graphInfo = &toRun.item(0);
+                        toRun.remove(0);
+                        running.append(*LINK(graphInfo));
+                        CGraphBase *subGraph = graphInfo->subGraph;
+                        PROGLOG("Wait: Launching graph thread for graphId=%"GIDPF"d", subGraph->queryGraphId());
+                        added = true;
+                        PooledThreadHandle h = graphPool->start(graphInfo.getClear());
+                        subGraph->poolThreadHandle = h;
+                        if (running.ordinality() >= limit)
+                            break;
+                    }
                 }
                 if (!added)
                     Sleep(1000); // still more to come

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -780,7 +780,8 @@ void CGraphElementBase::createActivity(size32_t parentExtractSz, const byte *par
                 else
                 {
                     onCreate();
-                    initActivity();
+                    if (!activity)
+                        factorySet(TAKnull);
                 }
                 break;
             default:

--- a/thorlcr/graph/thgraphmaster.hpp
+++ b/thorlcr/graph/thgraphmaster.hpp
@@ -50,7 +50,7 @@ interface IJobManager : extends IInterface
 {
     virtual void stop() = 0;
     virtual void replyException(CJobMaster &job, IException *e) = 0;
-    virtual void setWuid(const char *wuid) = 0;
+    virtual void setWuid(const char *wuid, const char *cluster=NULL) = 0;
     virtual IDeMonServer *queryDeMonServer() = 0;
     virtual void fatal(IException *e) = 0;
     virtual void addCachedSo(const char *name) = 0;

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -705,7 +705,7 @@ int main( int argc, char *argv[]  )
         LOG(MCdebugProgress, thorJob, "Thor name = %s, queue = %s, nodeGroup = %s",thorname,queueName.str(),nodeGroup.str());
 
         serverStatus.queryProperties()->setProp("@thorname", thorname);
-        serverStatus.queryProperties()->setProp("@cluster", nodeGroup.str());
+        serverStatus.queryProperties()->setProp("@cluster", nodeGroup.str()); // JCSMORE rename
         serverStatus.queryProperties()->setProp("LogFile", logUrl.str()); // LogFile read by eclwatch (possibly)
         serverStatus.queryProperties()->setProp("@nodeGroup", nodeGroup.str());
         serverStatus.queryProperties()->setProp("@queue", queueName.str());

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -258,10 +258,10 @@ public:
                         CJobSlave *job = jobs.find(jobKey.get());
                         if (!job)
                             throw MakeStringException(0, "Job not found: %s", jobKey.get());
-                        PROGLOG("GraphInit: %s", jobKey.get());
                         Owned<IPropertyTree> graphNode = createPTree(msg);
                         Owned<CSlaveGraph> subGraph = (CSlaveGraph *)job->createGraph();
                         subGraph->createFromXGMML(graphNode, NULL, NULL, NULL);
+                        PROGLOG("GraphInit: %s, graphId=%"GIDPF"d", jobKey.get(), subGraph->queryGraphId());
                         subGraph->setExecuteReplyTag(subGraph->queryJob().deserializeMPTag(msg));
                         unsigned len;
                         msg.read(len);


### PR DESCRIPTION
I've rebased this commit to candidate-3.4.x, should consider taking it since we will be shipping the windows ecl command line with the ECL IDE.
