### PR TITLE
Use _spawnvp instead of _execvp on windows for ecl command line for candidate-3.4

### DIFF
--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -36,7 +36,6 @@
 #ifdef _WIN32
 //TODO - move to or use existing jlib
 #include "process.h"
-#define _execvp execvp
 #endif
 
 int EclCMDShell::callExternal(ArgvIterator &iter)
@@ -51,7 +50,12 @@ int EclCMDShell::callExternal(ArgvIterator &iter)
     for (; !iter.done(); iter.next())
         argv[i++]=(char *)iter.query();
     argv[i]=NULL;
+//TODO - add common routine or use existing in jlib
+#ifdef _WIN32
+    if (_spawnvp(_P_WAIT, cmdstr.str(), argv)==-1)
+#else
     if (execvp(cmdstr.str(), argv)==-1)
+#endif
     {
         switch(errno)
         {


### PR DESCRIPTION
I've rebased this commit for candidate-3.4.x.  Should consider taking it since we will be shipping the windows ecl command line with ECL IDE.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
