### PR TITLE
Tidy up thors array and iterator definitions

### DIFF
--- a/dali/base/dacsds.ipp
+++ b/dali/base/dacsds.ipp
@@ -103,10 +103,10 @@ public:
     inline bool queryConnected() { return connected; }
     inline void setConnected(bool _connected) { connected = _connected; }
     inline void setOrphaned() { orphaned = true; }
-    inline const bool queryServerIter() const { return serverIter; }
-    inline const bool queryServerIterAvailable() const { return serverIterAvailable; }
-    inline const bool queryServerGetIdsAvailable() const { return serverGetIdsAvailable; }
-    inline const bool queryUseAppendOpt() const { return useAppendOpt; }
+    inline bool queryServerIter() const { return serverIter; }
+    inline bool queryServerIterAvailable() const { return serverIterAvailable; }
+    inline bool queryServerGetIdsAvailable() const { return serverGetIdsAvailable; }
+    inline bool queryUseAppendOpt() const { return useAppendOpt; }
 
     void getDetails(MemoryBuffer &mb);
     void clearCommitChanges();

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -375,7 +375,7 @@ public:
         CriticalBlock b(crit);
         return LINK(_queryElem(id));
     }
-    const unsigned maxElements() const { return nextId; } // actual is nextId - however many in free chain
+    unsigned maxElements() const { return nextId; } // actual is nextId - however many in free chain
 };
 
 ////////////////

--- a/thorlcr/slave/slwatchdog.cpp
+++ b/thorlcr/slave/slwatchdog.cpp
@@ -32,7 +32,7 @@
 class CGraphProgressHandler : public CSimpleInterface, implements ISlaveWatchdog, implements IThreaded
 {
     CriticalSection crit;
-    CIArrayOf<CGraphBase> activeGraphs;
+    CGraphArray activeGraphs;
     bool stopped, progressEnabled;
     Owned<ISocket> sock;
     CThreaded threaded;

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -811,8 +811,8 @@ public:
         chunk = _chunk;
         rows.clear();
     }
-    inline const unsigned queryChunk() { return chunk; }
-    inline const unsigned getRowCount() const { return rows.ordinality(); }
+    inline unsigned queryChunk() const { return chunk; }
+    inline unsigned getRowCount() const { return rows.ordinality(); }
     inline void addRow(const void *row) { rows.append(row); }
     inline const void *getRow(unsigned r)
     {

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -289,7 +289,7 @@ public:
     const char *queryOrigin() { return origin; }
     const char *queryMessage() { return msg; }
     WUExceptionSeverity querySeverity() { return severity; }
-    const bool queryNotified() const { return notified; }
+    bool queryNotified() const { return notified; }
     MemoryBuffer &queryData() { return data; }
     void setNotified() { notified = true; }
     void setActivityId(activity_id _id) { id = _id; }
@@ -856,7 +856,7 @@ void setClusterGroup(IGroup *group)
     dfsGroup = createIGroup(nodes.ordinality(), nodes.getArray());
     clusterComm = createCommunicator(clusterGroup);
 }
-const bool clusterInitialized() { return NULL != clusterComm; }
+bool clusterInitialized() { return NULL != clusterComm; }
 ICommunicator &queryClusterComm() { return *clusterComm; }
 IGroup &queryClusterGroup() { return *clusterGroup; }
 IGroup &querySlaveGroup() { return *slaveGroup; }

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -188,7 +188,7 @@ interface IThorException : extends IException
     virtual const char *queryOrigin() = 0;
     virtual WUExceptionSeverity querySeverity() = 0;
     virtual const char *queryMessage() = 0;
-    virtual const bool queryNotified() const = 0;
+    virtual bool queryNotified() const = 0;
     virtual MemoryBuffer &queryData() = 0;
     virtual void setNotified() = 0;
     virtual void setAction(ThorExceptionAction _action) = 0;
@@ -309,7 +309,7 @@ extern graph_decl memsize_t queryLargeMemSize();
 extern graph_decl StringBuffer &getCompoundQueryName(StringBuffer &compoundName, const char *queryName, unsigned version);
 
 extern graph_decl void setClusterGroup(IGroup *group);
-extern graph_decl const bool clusterInitialized();
+extern graph_decl bool clusterInitialized();
 extern graph_decl ICommunicator &queryClusterComm();
 extern graph_decl IGroup &queryClusterGroup();
 extern graph_decl IGroup &querySlaveGroup();


### PR DESCRIPTION
Use consistent class or typedef definitions for graph and activity iterators
Also remove a few pointless const's on return values of simple
non-reference types

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
