### PR TITLE
Minor code cleaup to avoid false positives from Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ externals/
 .project
 .svn/
 ln/
+.cproject

--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -466,7 +466,7 @@ void FileSystemEclCollection::processFilePath(const char * sourceSearchPath, boo
                 {
                     StringBuffer msg;
                     msg.appendf("Explicit source file %s not found", searchPattern.str());
-                    errs->reportWarning(10, msg.str());
+                    errs->reportWarning(10, msg.str(), NULL, 0, 0, 0);
                 }
                 else
                     printf("Explicit source file %s not found\n", searchPattern.str());

--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -284,7 +284,7 @@ void checkEclVersionCompatible(Owned<IErrorReceiver> & errors, const char * eclV
             {
                 StringBuffer msg;
                 msg.appendf("Mismatch in minor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
-                errors->reportWarning(HQLERR_VersionMismatch, msg.str(), NULL, 0, 0);
+                errors->reportWarning(HQLERR_VersionMismatch, msg.str(), NULL, 0, 0, 0);
             }
             else if (subminor != LANGUAGE_VERSION_MINOR)
             {

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -801,9 +801,9 @@ public:
 
 interface HQL_API IErrorReceiver : public IInterface
 {
-    virtual void reportError(int errNo, const char *msg, const char *filename=NULL, int lineno=0, int column=0, int pos=0) = 0;
+    virtual void reportError(int errNo, const char *msg, const char *filename, int lineno, int column, int pos) = 0;
     virtual void report(IECLError* err) = 0;
-    virtual void reportWarning(int warnNo, const char *msg, const char *filename=NULL, int lineno=0, int column=0, int pos=0) = 0;
+    virtual void reportWarning(int warnNo, const char *msg, const char *filename, int lineno, int column, int pos) = 0;
     virtual size32_t errCount() = 0;
     virtual size32_t warnCount() = 0;
 };

--- a/services/winremote/service/Service.c
+++ b/services/winremote/service/Service.c
@@ -22,6 +22,8 @@ FUNCTIONS:
 
 ---------------------------------------------------------------------------*/
 
+#ifdef _WIN32 // Just to shut up any code-checkers on linux side
+
 #include <windows.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -601,3 +603,4 @@ LPTSTR GetLastErrorText( LPTSTR lpszBuf, DWORD dwSize )
 
    return lpszBuf;
 }
+#endif

--- a/services/winremote/winremote.cpp
+++ b/services/winremote/winremote.cpp
@@ -16,6 +16,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+#ifdef _WIN32 // Just to shut up any code-checkers on linux side
+
 #pragma warning(disable:4786)
 
 #include "win32.hpp"
@@ -77,12 +79,6 @@ extern "C" WINREMOTE_API IRemoteOutput* queryStderr()
 {
     return &stdErr;
 }
-
-
-interface IErrorReceiver
-{
-    virtual void reportError(const char* machine,const char* error)=0;
-};
 
 class ServiceTask: public CInterface, implements ITask
 {
@@ -899,3 +895,4 @@ BOOL APIENTRY DllMain(HANDLE,DWORD,LPVOID)
 {
     return TRUE;
 }
+#endif

--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -1433,7 +1433,10 @@ CJHTreeNode *CKeyIndex::loadNode(char *nodeData, offset_t pos, bool needsCopy)
             ret.setown(new CJHTreeNode());
             break;
         case 1:
-            ret.setown(keyHdr->isVariable() ? new CJHVarTreeNode() : new CJHTreeNode());
+        	if (keyHdr->isVariable())
+        		ret.setown(new CJHVarTreeNode());
+        	else
+        		ret.setown(new CJHTreeNode());
             break;
         case 2:
             ret.setown(new CJHTreeBlobNode());

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -37,10 +37,10 @@ interface IMemoryMappedFile;
 class MemoryBuffer;
 class Semaphore;
 
-typedef enum { IFOcreate, IFOread, IFOwrite, IFOreadwrite, IFOcreaterw }                    IFOmode;    // modes for open
-typedef enum { IFSHnone, IFSHread=0x8, IFSHfull=0x10}                                       IFSHmode;   // sharing modes
-typedef enum { IFScurrent = FILE_CURRENT, IFSend = FILE_END, IFSbegin = FILE_BEGIN }        IFSmode;    // seek mode
-typedef enum { CFPcontinue, CFPcancel, CFPstop }                                            CFPmode;    // modes for ICopyFileProgress::onProgress return
+enum IFOmode { IFOcreate, IFOread, IFOwrite, IFOreadwrite, IFOcreaterw };    // modes for open
+enum IFSHmode { IFSHnone, IFSHread=0x8, IFSHfull=0x10};   // sharing modes
+enum IFSmode { IFScurrent = FILE_CURRENT, IFSend = FILE_END, IFSbegin = FILE_BEGIN };    // seek mode
+enum CFPmode { CFPcontinue, CFPcancel, CFPstop };    // modes for ICopyFileProgress::onProgress return
 
 class CDateTime;
 

--- a/system/jlib/jlzma.cpp
+++ b/system/jlib/jlzma.cpp
@@ -47,14 +47,12 @@ extern "C" {
 #endif
 
 
-static void *SzAlloc(void *p, size_t size) 
+static void *SzAlloc(void *, size_t size)
 { 
-    p = p; 
     return checked_malloc(size,-1);
 }
-static void SzFree(void *p, void *address) 
-{ 
-    p = p; 
+static void SzFree(void *, void *address)
+{
     free(address);
 }
 static ISzAlloc g_Alloc = { SzAlloc, SzFree };

--- a/system/lzma/LzmaEnc.c
+++ b/system/lzma/LzmaEnc.c
@@ -2092,13 +2092,11 @@ SRes LzmaEnc_MemPrepare(CLzmaEncHandle pp, const Byte *src, SizeT srcLen,
 
 void LzmaEnc_Finish(CLzmaEncHandle pp)
 {
-  #ifdef COMPRESS_MF_MT
+#ifdef COMPRESS_MF_MT
   CLzmaEnc *p = (CLzmaEnc *)pp;
   if (p->mtMode)
     MatchFinderMt_ReleaseStream(&p->matchFinderMt);
-  #else
-  pp = pp;
-  #endif
+#endif
 }
 
 typedef struct _CSeqOutStreamBuf


### PR DESCRIPTION
Eclipse Indigo code checker was unable to parse the (legal) c++ correctly
in a few places. Cleaning it up so that Eclipse didn't report false errors
also makes the code a little cleaner.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
