### PR TITLE
Fix link errors when creating standalone executable

### DIFF
--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -294,7 +294,7 @@ void CppCompiler::addLibrary(const char * libName)
     {
         quote = "\"";
     }
-    linkerOptions.append(" ").append(USE_LIB_FLAG[targetCompiler]).append(quote).append(lname).append(USE_LIB_TAIL[targetCompiler]).append(quote);
+    linkerLibraries.append(" ").append(USE_LIB_FLAG[targetCompiler]).append(quote).append(lname).append(USE_LIB_TAIL[targetCompiler]).append(quote);
 }
 
 void CppCompiler::addLibraryPath(const char * libPath)
@@ -483,6 +483,8 @@ bool CppCompiler::doLink()
 
     ForEachItemIn(i0, allSources)
         cmdline.append(" ").append("\"").append(targetDir).append(allSources.item(i0)).append(".").append(OBJECT_FILE_EXT[targetCompiler]).append("\"");
+
+    cmdline.append(linkerLibraries);
 
     StringBuffer outName;
     outName.append(createDLL ? SharedObjectPrefix : NULL).append(CORE_NAME).append(createDLL ? SharedObjectExtension : ProcessExtension);

--- a/system/jlib/jcomp.ipp
+++ b/system/jlib/jcomp.ipp
@@ -67,6 +67,7 @@ protected:
     StringBuffer    compilerOptions;
     StringAttr      libraryOptions;
     StringBuffer    linkerOptions;
+    StringBuffer    linkerLibraries;
     StringAttr      sourceDir;
     StringAttr      targetDir;
     StringArray     allSources;


### PR DESCRIPTION
Modern g++ compilers such as that found on Ubuntu 11.10 require that
libraries are specified after the object files that might link them
on the command line.

We were generating a command line with the .o file at the end, so we
got link errors.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
