### PR TITLE
Fix gh-914, Ensure CSV headers skipped

### DIFF
--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -1901,7 +1901,12 @@ public:
 
     void setSubMapping(UnsignedArray &_subcounts, bool _interleaved)
     {
-        assertex(!"setSubMapping called from CFileDescriptor!");
+        UNIMPLEMENTED_X("setSubMapping called from CFileDescriptor!");
+    }
+
+    unsigned querySubFiles()
+    {
+        UNIMPLEMENTED_X("querySubFiles called from CFileDescriptor!");
     }
 };
 
@@ -1929,8 +1934,6 @@ public:
     {
         delete subfilecounts;
     }
-
-
 
     ISuperFileDescriptor *querySuperFileDescriptor()
     {
@@ -1976,7 +1979,6 @@ public:
             }
         }
         return false;
-
     }
 
     void setSubMapping(UnsignedArray &_subcounts, bool _interleaved)
@@ -1996,6 +1998,13 @@ public:
         }
     }
 
+    unsigned querySubFiles()
+    {
+        if (!subfilecounts)  // its a file!
+            return 1;
+        return subfilecounts->ordinality();
+    }
+
     void serializeSub(MemoryBuffer &mb)
     {
         if (subfilecounts) {
@@ -2008,7 +2017,6 @@ public:
             mb.append((unsigned)0);
         mb.append(interleaved);
     }
-
 };
 
 

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -233,7 +233,7 @@ interface ISuperFileDescriptor: extends IFileDescriptor
     // extension of IFileDescriptor for superfiles providing some part->file mapping
     virtual bool mapSubPart(unsigned superpartnum, unsigned &subfile, unsigned &subpartnum)=0;
     virtual void setSubMapping(UnsignedArray &subcounts, bool interleaved)=0;
-
+    virtual unsigned querySubFiles() = 0;
 };
 
 


### PR DESCRIPTION
It was assumed the csv header lines, existed on the 1st node, but they might
exist on any, and/or span nodes.
If a csv input has a header, it will now mean that the nodes must wait until
signalled by the previous node before proceeding. Once the header lines are
consumed, the consumer will signal all remaining nodes immediately.
Superfile with CSV's make this particularly nasty to deal with, as they may 
have headers that start or span different nodes to each other.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
