### PR TITLE
Protect accidental use of OwnedMalloc method

### DIFF
--- a/system/jlib/jbuff.hpp
+++ b/system/jlib/jbuff.hpp
@@ -89,6 +89,7 @@ private:
         void * mem = clearMemory ? calloc(n, sizeof(CLASS)) : malloc(n * sizeof(CLASS));
         ptr = static_cast<CLASS *>(mem);
     }
+    void allocate(unsigned n, bool clearMemory = false);
     void operator = (CLASS * _ptr);
     void operator = (const OwnedMalloc<CLASS> & other);
     void set(CLASS * _ptr);


### PR DESCRIPTION
add a private allocate(unsigned..)  to avoid accidental use (as I did)
Although compiler spotted bool to int conversion and warned.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
