### PR TITLE
Fix gh-1002 - csv in child query issue

### DIFF
--- a/thorlcr/master/thactivitymaster.hpp
+++ b/thorlcr/master/thactivitymaster.hpp
@@ -63,7 +63,14 @@ public:
     }
     unsigned queryParts() { return partToNode.ordinality(); }
     unsigned queryNumMaps() { return maps.ordinality(); }
-    unsigned queryMapWidth(unsigned map) { return maps.isItem(map)?maps.item(map).ordinality():0; }
+    unsigned queryMapWidth(unsigned map)
+    {
+        if (local)
+            map = 0;
+        if (!maps.isItem(map))
+            return 0;
+        return maps.item(map).ordinality();
+    }
     void serializeFileOffsetMap(MemoryBuffer &mb);
     void getParts(unsigned i, IArrayOf<IPartDescriptor> &parts);
     void serializeMap(unsigned map, MemoryBuffer &mb, IGetSlaveData *extra=NULL);


### PR DESCRIPTION
A csv read within a local child query was only reading data on the 1st thor
node. Due to a bug in the part mapping/serialization, only the 1st node was
sent the part meta data

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
