### PR TITLE
WIP hpccsystems/LN#253 Remove eclServer attribute in eclWatch

### DIFF
--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -56,14 +56,6 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="eclServer" type="eclCCServerType" use="optional">
-                <xs:annotation>
-                    <xs:appinfo>
-                        <tooltip>Name of the ECLCC server or job server where the jobs are dispatched</tooltip>
-                        <autogenforwizard>1</autogenforwizard>
-                    </xs:appinfo>
-                </xs:annotation>
-            </xs:attribute>
             <xs:attribute name="syntaxCheckQueue" type="xs:string" use="optional">
                 <xs:annotation>
                     <xs:appinfo>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -725,7 +725,6 @@
               buildSet="espsmc"
               description="ESP services for SMC"
               disableUppercaseTranslation="false"
-              eclServer="myeclccserver"
               enableSystemUseRewrite="false"
               excludePartitions="/,/dev*,/sys,/usr,/proc/*"
               monitorDaliFileServer="false"


### PR DESCRIPTION
Remove eclServer attribute in eclWatch in espsmc definition and the default environment.xml.in

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
