### PR TITLE
FIX: gh-739 WHEN6 regression suite failure

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -592,6 +592,14 @@ bool EclGraphElement::prepare(IAgentContext & agent, const byte * parentExtract,
                     return branches.item(whichBranch).prepare(agent, parentExtract, checkDependencies);
                 return true;
             }
+        case TAKwhen_action:
+            {
+                ForEachItemIn(i, dependentOn)
+                {
+                    dependentOn.item(i).execute(parentExtract);
+                }
+                break;
+            }
         case TAKfilter:
         case TAKfiltergroup:
         case TAKfilterproject:

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -165,9 +165,7 @@ void CHThorActivityBase::setInput(unsigned index, IHThorInput *_input)
 
 IHThorInput *CHThorActivityBase::queryOutput(unsigned index)
 {
-    agent.fail(255, "internal logic error: CHThorActivityBase::queryOutput");
-    // never returns....
-    return NULL;
+    return this;
 }
 
 void CHThorActivityBase::ready()

--- a/testing/ecl/key/when6.xml
+++ b/testing/ecl/key/when6.xml
@@ -1,15 +1,15 @@
 <Dataset name='Result 1'>
- <Row><c>1</c></Row>
- <Row><c>1</c></Row>
- <Row><c>1</c></Row>
-</Dataset>
-<Dataset name='Result 2'>
  <Row><s>3</s></Row>
  <Row><s>1</s></Row>
  <Row><s>9</s></Row>
 </Dataset>
-<Dataset name='Result 3'>
+<Dataset name='Result 2'>
  <Row><f1>1</f1></Row>
  <Row><f1>9</f1></Row>
  <Row><f1>3</f1></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><c>1</c></Row>
+ <Row><c>1</c></Row>
+ <Row><c>1</c></Row>
 </Dataset>


### PR DESCRIPTION
Fix "internal logic error" by allowing call to queryOutput on a sink
activity. Also, fix problem where dependant graphs are not executed
on a TAKwhen_action.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
