### PR TITLE
FIXED: Bug81658  Add validation checks for mandatory settings

### DIFF
--- a/deployment/deploy/DeploymentEngine.cpp
+++ b/deployment/deploy/DeploymentEngine.cpp
@@ -52,7 +52,8 @@ CDeploymentEngine::CDeploymentEngine(IEnvDeploymentEngine& envDepEngine,
                                      m_startable(unknown),
                                      m_stoppable(unknown),
                                      m_createIni(createIni),
-                                     m_curInstance(NULL)
+                                     m_curInstance(NULL),
+                                     m_instanceCheck(true)
 {
     m_pCallback.set(&callback);
     m_installFiles.setDeploymentEngine(*this);
@@ -466,14 +467,17 @@ void CDeploymentEngine::check()
     if (m_instances.empty())
         throw MakeStringException(0, "Process %s has no instances defined.  Nothing to do!", m_name.get());
     
-    ForEachItemIn(idx, m_instances)
+    if (m_instanceCheck)
     {
-        checkAbort();
-        
-        IPropertyTree& instance = m_instances.item(idx);
-        m_curInstance = instance.queryProp("@name");
-        
-        checkInstance(instance);
+      ForEachItemIn(idx, m_instances)
+      {
+          checkAbort();
+
+          IPropertyTree& instance = m_instances.item(idx);
+          m_curInstance = instance.queryProp("@name");
+
+          checkInstance(instance);
+      }
     }
     m_curInstance = NULL;
     clearSSHVars();

--- a/deployment/deploy/DeploymentEngine.hpp
+++ b/deployment/deploy/DeploymentEngine.hpp
@@ -346,6 +346,7 @@ protected:
     bool       m_createIni;
     bool       m_abort;
     bool m_useSSHIfDefined;
+    bool m_instanceCheck;
 };
 
 

--- a/deployment/deploy/thorconfiggenengine.cpp
+++ b/deployment/deploy/thorconfiggenengine.cpp
@@ -38,6 +38,7 @@ CThorConfigGenEngine::CThorConfigGenEngine(IEnvDeploymentEngine& envDepEngine,
 //---------------------------------------------------------------------------
 void CThorConfigGenEngine::check()
 {
+   m_instanceCheck = false;
    CDeploymentEngine::check();
 
    const char* dali  = m_process.queryProp("@daliServers");

--- a/deployment/deployutils/deployutils.hpp
+++ b/deployment/deployutils/deployutils.hpp
@@ -83,5 +83,5 @@ extern DEPLOYUTILS_API void getSummary(const IPropertyTree* pEnvRoot, StringBuff
 extern DEPLOYUTILS_API void mergeAttributes(IPropertyTree* pTo, IPropertyTree* pFrom);
 extern DEPLOYUTILS_API void addEspBindingInformation(const char* xmlArg, IPropertyTree* pEnvRoot, StringBuffer& sbNewName, IConstEnvironment* pConstEnv);
 extern DEPLOYUTILS_API bool updateDirsWithConfSettings(IPropertyTree* pEnvRoot, IProperties* pParams, bool ovrLog = true, bool ovrRun = true);
-extern DEPLOYUTILS_API bool validateEnv(IConstEnvironment* pConstEnv);
+extern DEPLOYUTILS_API bool validateEnv(IConstEnvironment* pConstEnv, bool abortOnException = true);
 #endif

--- a/esp/files/configmgr.html
+++ b/esp/files/configmgr.html
@@ -612,6 +612,18 @@ You need to have Javascript enabled in order to use ConfigMgr. Please enable Jav
 <div class="ft sumpage" style="background-color:White;"></div>   
 </div>   
 
+<div id='validationErrPage' style="display:none;background-color:White;">
+  <div class="hd" style="background-color:White;">ConfigMgr - Validation errors/warnings</div>
+    <div class="bd" style="background-color:White"><p />
+       <div id='validationErrLayout' style="background-color:White;border:none">
+         <div id='validationErrLayoutTextArea' style="background-color:White;border:none">
+            <textarea id="validationErrs" name="validationErrs" rows="30" cols="80" readonly wrap></textarea>
+         </div>
+       </div>
+    </div>
+<div class="ft" style="background-color:White;"></div>
+</div>
+
 <div id="messagePanel" style="display:none;">
   <div class="bd"></div>
 </div>

--- a/esp/scm/WsDeploy.ecm
+++ b/esp/scm/WsDeploy.ecm
@@ -277,6 +277,20 @@ ESPresponse [exceptions_inline, encode(0)] HandleInstanceResponse
     string Status;
     string NewName;
     string Duplicates;
+    string ReqdCompNames;
+    string AddReqdComps;
+};
+
+ESPrequest AddReqdCompsRequest
+{
+    string XmlArgs;
+    ESPstruct WsDeployReqInfo ReqInfo;
+};
+
+ESPresponse [exceptions_inline, encode(0)] AddReqdCompsResponse
+{
+    string Status;
+    string Failures;
 };
 
 ESPrequest HandleEspServiceBindingsRequest
@@ -578,6 +592,8 @@ ESPservice [exceptions_inline("xslt/exceptions.xslt")] WsDeploy
         GetSubnetIPAddr(GetSubnetIPAddrRequest, GetSubnetIPAddrResponse);
     ESPmethod[description("To get the environment summary"), help("")]
             GetSummary(GetSummaryRequest, GetSummaryResponse);
+    ESPmethod[description("Add the required components on given ip addresses."), help("")]
+        AddReqdComps(AddReqdCompsRequest, AddReqdCompsResponse);
 };
 
 SCMexportdef(WsDeploy);

--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -288,6 +288,7 @@ public:
     virtual bool rollbackEnvironmentForCloud(IEspContext &context, IEspRollbackEnvironmentForCloudRequest &req, IEspRollbackEnvironmentForCloudResponse &resp);
     virtual bool notifyInitSystemSaveEnvForCloud(IEspContext &context, IEspNotifyInitSystemSaveEnvForCloudRequest &req, IEspNotifyInitSystemSaveEnvForCloudResponse &resp);
     virtual bool getSummary(IEspContext &context, IEspGetSummaryRequest &req, IEspGetSummaryResponse &resp);
+    virtual bool addReqdComps(IEspContext &context, IEspAddReqdCompsRequest &req, IEspAddReqdCompsResponse &resp);
     
     void environmentUpdated()
     {
@@ -325,9 +326,10 @@ private:
     void checkForRefresh(IEspContext &context, IConstWsDeployReqInfo *reqInfo, bool checkWriteAccess);
     IPropertyTree* getEnvTree(IEspContext &context, IConstWsDeployReqInfo *reqInfo);
     void activeUserNotResponding();
-    void saveEnvironment(IEspContext* pContext, IConstWsDeployReqInfo *reqInfo, bool saveAs = false);
+    void saveEnvironment(IEspContext* pContext, IConstWsDeployReqInfo *reqInfo, StringBuffer& errMsg, bool saveAs = false);
     void unlockEnvironment(IEspContext* pContext, IConstWsDeployReqInfo *reqInfo, const char* xmlarg, StringBuffer& sbMsg, bool saveEnv = false);
     void setEnvironment(IEspContext &context, IConstWsDeployReqInfo *reqInfo, const char* newEnv, const char* fnName, StringBuffer& sbBackup, bool validate = true, bool updateDali = true);
+    bool checkForRequiredComponents(IPropertyTree* pEnvRoot, const char* ip, StringBuffer& reqdCompNames, bool autoAdd=false);
   
     Owned<CSdsSubscription>   m_pSubscription;
     Owned<IConstEnvironment>  m_constEnvRdOnly;
@@ -720,6 +722,7 @@ public:
     virtual bool onRollbackEnvironmentForCloud(IEspContext &context, IEspRollbackEnvironmentForCloudRequest &req, IEspRollbackEnvironmentForCloudResponse &resp);
     virtual bool onNotifyInitSystemSaveEnvForCloud(IEspContext &context, IEspNotifyInitSystemSaveEnvForCloudRequest &req, IEspNotifyInitSystemSaveEnvForCloudResponse &resp);
     virtual bool onGetSummary(IEspContext &context, IEspGetSummaryRequest &req, IEspGetSummaryResponse &resp);
+    virtual bool onAddReqdComps(IEspContext &context, IEspAddReqdCompsRequest &req, IEspAddReqdCompsResponse &resp);
 
     void getNavigationData(IEspContext &context, IPropertyTree* pData);
     CWsDeployFileInfo* getFileInfo(const char* fileName, bool addIfNotFound=false, bool createFile = false);

--- a/initfiles/componentfiles/configxml/CMakeLists.txt
+++ b/initfiles/componentfiles/configxml/CMakeLists.txt
@@ -83,6 +83,7 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/roxievars_linux.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/sasha.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/eclcc.xsl
+    ${CMAKE_CURRENT_SOURCE_DIR}/validateAll.xsl
 )
     Install ( FILES ${iFILES} DESTINATION ${OSSDIR}/componentfiles/configxml COMPONENT Runtime)
 ENDFOREACH ( iFILES )

--- a/initfiles/componentfiles/configxml/validateAll.xsl
+++ b/initfiles/componentfiles/configxml/validateAll.xsl
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:space="default"
+xmlns:seisint="http://seisint.com" exclude-result-prefixes="seisint">
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:variable name="apos">'</xsl:variable>
+
+  <xsl:template match="/Environment">
+    <xsl:apply-templates select="Hardware/Computer"/>
+    <xsl:apply-templates select="Software/ThorCluster"/>
+  </xsl:template>
+
+  <xsl:template match="Computer">
+    <xsl:variable name="instanceIp" select="@netAddress"/>
+    <xsl:variable name="hasInstance" select="/Environment/DeployComponents/*/Instance[@netAddress=$instanceIp]"/>
+    <xsl:choose>
+      <xsl:when test="$hasInstance">
+        <xsl:variable name="dafileSrvNode" select="/Environment/DeployComponents/*[name()='DafilesrvProcess']/Instance[@netAddress=$instanceIp]"/>
+        <xsl:choose>
+          <xsl:when test="not($dafileSrvNode)">
+            <xsl:call-template name="validationMessage">
+              <xsl:with-param name="msg" select="concat('The computer ', $apos, $instanceIp, $apos, ' does not have a DafileSrvProcess Instance!')"/>
+            </xsl:call-template>
+          </xsl:when>
+        </xsl:choose>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="ThorCluster">
+    <xsl:variable name="thorMasterNode" select="./ThorMasterProcess[@computer]"/>
+    <xsl:choose>
+      <xsl:when test="$thorMasterNode">
+        <xsl:if test="string(@localThor) = 'true' and count(./ThorSlaveProcess[@computer!=$thorMasterNode/@computer]) > 0">
+          <xsl:call-template name="validationMessage">
+            <xsl:with-param name="msg" select="'Thor attribute localThor cannot be true when the master and slave processes are on different nodes!'"/>
+          </xsl:call-template>
+        </xsl:if>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="validationMessage">
+    <xsl:param name="type" select="'error'"/>
+    <xsl:param name="compType"/>
+    <xsl:param name="compName"/>
+    <xsl:param name="msg"/>
+    <!--ask deployment tool to display this validation error -->
+    <!--format is like: error:EspProcess:esp1:This is a message.-->
+    <xsl:variable name="encodedMsg" select="concat($type, ':', $compType, ':', $compName, ':', $msg)"/>
+    <xsl:choose>
+      <xsl:when test="function-available('seisint:validationMessage')">
+        <xsl:variable name="dummy" select="seisint:validationMessage($encodedMsg)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="message">
+          <xsl:with-param name="text" select="concat('Validation for ', $compType, ' named ', $compName, ': ', $msg)"/>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="message">
+    <xsl:param name="text"/>
+    <xsl:choose>
+      <xsl:when test="function-available('seisint:message')">
+        <xsl:variable name="dummy" select="seisint:message($text)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:message terminate="no">
+          <xsl:value-of select="$text"/>
+        </xsl:message>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -959,17 +959,6 @@
                          service="ecldirect"/>
    </Properties>
   </EspService>
-  <FTSlaveProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}"
-                  buildSet="ftslave"
-                  description="FTSlave process"
-                  name="myftslave"
-                  version="1">
-   <Instance computer="localhost"
-             directory="${RUNTIME_PATH}/myftslave"
-             name="s1"
-             netAddress="."
-             program="${EXEC_PATH}/ftslave"/>
-  </FTSlaveProcess>
   <PluginProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}"
                  buildSet="plugins_auditlib"
                  description="plugin process"

--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -1,9 +1,9 @@
 
 [Algorithm]
 max_comps_per_node=4
-do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver
+do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver,ftslave
 avoid_combo=dali-eclagent
-comps_on_all_nodes=dafilesrv,ftslave
+comps_on_all_nodes=dafilesrv
 topology_for_comps=thor,hthor,roxie
 do_not_gen_optional=dali,thor
 roxie_agent_redundancy=1,2,1


### PR DESCRIPTION
1. Validation errors/warnings will not prevent the users from saving/using the environment
2. When a new instance is added on a computer and a corresponding dafilesrv instance does not
   exist on that computer, user is prompted with a message that will add one for him. User can accept or decline.
3. If an instance of dafilesrv does not exist on any node that has other hpcc-system components
   it is flagged as an validation error
4. All validation errors/warnings are shown at the same time rather than one at a time
5. If localThor is set to true and all the thor slaves and the master are not on the same node,
   it is flagged as an validation error
6. FTSlave is started on demand and should not be generated via wizard nor should it be present in the default environment.xml

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
