### PR TITLE
Fix problems with merged scope becoming inconsistent

### DIFF
--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -393,7 +393,6 @@ unsigned getOperatorMetaFlags(node_operator op)
     case no_xmlparse:
     case no_normalizegroup:
     case no_owned_ds:
-case no_unused53:
 
 //Multiple different kinds of values
     case no_select:
@@ -418,6 +417,8 @@ case no_unused53:
     case no_fieldmap:
     case no_template_context:
     case no_processing:
+    case no_merge_pending:
+    case no_merge_nomatch:
     case no_namedactual:
     case no_assertconstant:
 
@@ -610,7 +611,7 @@ case no_unused53:
     case no_unused20: case no_unused21: case no_unused22: case no_unused23: case no_unused24: case no_unused25: case no_unused26: case no_unused27: case no_unused28: case no_unused29:
     case no_unused30: case no_unused31: case no_unused32: case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38: case no_unused39:
     case no_unused40: case no_unused41: case no_unused42: case no_unused43: case no_unused44: case no_unused45: case no_unused46: case no_unused47: case no_unused48: case no_unused49:
-    case no_unused50: case no_unused52:
+    case no_unused52:
     case no_is_null:
     case no_position:
     case no_current_time:

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -120,6 +120,8 @@ static IHqlExpression * defaultSelectorSequenceExpr;
 static IHqlExpression * newSelectAttrExpr;
 static IHqlExpression * recursiveExpr;
 static IHqlExpression * processingMarker;
+static IHqlExpression * mergePendingMarker;
+static IHqlExpression * mergeNoMatchMarker;
 static IHqlExpression * nullIntValue[9][2];
 static CriticalSection * exprCacheCS;
 static CriticalSection * crcCS;
@@ -173,6 +175,8 @@ MODULE_INIT(INIT_PRIORITY_HQLINTERNAL)
     newSelectAttrExpr = createExprAttribute(newAtom);
     recursiveExpr = createAttribute(recursiveAtom);
     processingMarker = createValue(no_processing, makeNullType());
+    mergePendingMarker = createValue(no_merge_pending, makeNullType());
+    mergeNoMatchMarker = createValue(no_merge_nomatch, makeNullType());
     cachedNoBody = createValue(no_nobody, makeNullType());
     return true;
 }
@@ -184,6 +188,8 @@ MODULE_EXIT()
         ::Release(nullIntValue[i][1]);
     }
     cachedNoBody->Release();
+    mergeNoMatchMarker->Release();
+    mergePendingMarker->Release();
     processingMarker->Release();
     recursiveExpr->Release();
     newSelectAttrExpr->Release();
@@ -1058,6 +1064,8 @@ const char *getOpString(node_operator op)
     case no_uncommoned_comma: return ",";
     case no_nameof: return "__NAMEOF__";
     case no_processing: return "no_processing";
+    case no_merge_pending: return "no_merge_pending";
+    case no_merge_nomatch: return "no_merge_nomatch";
     case no_toxml: return "TOXML";
     case no_catchds: return "CATCH";
     case no_readspill: return "no_readspill";
@@ -1090,7 +1098,7 @@ const char *getOpString(node_operator op)
     case no_unused20: case no_unused21: case no_unused22: case no_unused23: case no_unused24: case no_unused25: case no_unused26: case no_unused27: case no_unused28: case no_unused29:
     case no_unused30: case no_unused31: case no_unused32: case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38: case no_unused39:
     case no_unused40: case no_unused41: case no_unused42: case no_unused43: case no_unused44: case no_unused45: case no_unused46: case no_unused47: case no_unused48: case no_unused49:
-    case no_unused50: case no_unused52: case no_unused53:
+    case no_unused52:
         return "unused";
     /* if fail, use "hqltest -internal" to find out why. */
     default: assertex(false); return "???";
@@ -7158,12 +7166,14 @@ IHqlExpression * CHqlMergedScope::lookupSymbol(_ATOM searchName, unsigned lookup
     if (resolved)
     {
         node_operator resolvedOp = resolved->getOperator();
-        if (resolvedOp == no_processing)
+        if (resolvedOp == no_merge_pending)
         {
             if (lookupFlags & LSFrequired)
                 throwRecursiveError(searchName);
             return NULL;
         }
+        if (resolvedOp == no_merge_nomatch)
+            return NULL;
         if (resolvedOp != no_nobody)
             return resolved;
     }
@@ -7173,7 +7183,7 @@ IHqlExpression * CHqlMergedScope::lookupSymbol(_ATOM searchName, unsigned lookup
             return NULL;
     }
 
-    OwnedHqlExpr recursionGuard = CHqlNamedSymbol::makeSymbol(searchName, NULL, LINK(processingMarker), true, false, 0);
+    OwnedHqlExpr recursionGuard = CHqlNamedSymbol::makeSymbol(searchName, NULL, LINK(mergePendingMarker), true, false, 0);
     defineSymbol(LINK(recursionGuard));
 
     OwnedHqlExpr previousMatch;
@@ -7228,6 +7238,7 @@ IHqlExpression * CHqlMergedScope::lookupSymbol(_ATOM searchName, unsigned lookup
         defineSymbol(LINK(previousMatch));
         return previousMatch.getClear();
     }
+    defineSymbol(CHqlNamedSymbol::makeSymbol(searchName, name, LINK(mergeNoMatchMarker), true, false, 0));
     return NULL;
 }
 
@@ -7259,14 +7270,17 @@ void CHqlMergedScope::ensureSymbolsDefined(HqlLookupContext & ctx)
             OwnedHqlExpr prev = symbols.getLinkedValue(curName);
             if (prev)
             {
-                if (canMergeDefinition(prev))
+                if ((prev->getOperator() != no_mergedscope) && (prev != &cur))
                 {
-                    //no_nobody means it need to be resolve - either because multiple matches, or because
-                    //a child scope hasn't resolved it yet.
-                    if (prev->getOperator() != no_nobody)
+                    if (canMergeDefinition(prev))
                     {
-                        CHqlNamedSymbol* newSymbol = CHqlNamedSymbol::makeSymbol(curName, name, NULL, true, false, 0);
-                        defineSymbol(newSymbol);
+                        //no_nobody means it need to be resolve - either because multiple matches, or because
+                        //a child scope hasn't resolved it yet.
+                        if (prev->getOperator() != no_nobody)
+                        {
+                            CHqlNamedSymbol* newSymbol = CHqlNamedSymbol::makeSymbol(curName, name, NULL, true, false, 0);
+                            defineSymbol(newSymbol);
+                        }
                     }
                 }
             }

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -390,7 +390,7 @@ enum _node_operator {
     no_unused47,
     no_unused48,
     no_unused49,
-    no_unused50,
+        no_merge_nomatch,
         no_nullptr,
         no_sizeof,
         no_offsetof, 
@@ -733,7 +733,7 @@ enum _node_operator {
         no_indirect,
         no_selectindirect,
         no_nohoist,                             //purely for debugging/test generation
-    no_unused53,
+        no_merge_pending,
         no_httpcall,
         no_getenv,
         no_last_op,


### PR DESCRIPTION
The legacy code causes all modules to be added to the current scope,
unfortunately a side-effect of that was that it was replacing a child
module it had already resolved leading to inconsistent symbols.
Recursive symbol markers were also left in place when no match was
found.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
