### PR TITLE
Fix ln-282 Update to correct eclserver log name

### DIFF
--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -1532,7 +1532,7 @@ bool CWsTopologyEx::onTpGetComponentFile(IEspContext &context,
             else if (!stricmp(compType, eqDfu))
                 fileName = "dfuserver.log";
             else if (!stricmp(compType, eqEclServer))
-                fileName = "ECLSERVER.log";
+                fileName = "eclserver.log";
             else if (!stricmp(compType, eqEclCCServer))
                 fileName = "eclccserver.log";
             else if (!stricmp(compType, eqEclScheduler))


### PR DESCRIPTION
The log file name for eclserver has been changed from
ECLSERVER.log to eclserver.log. ECLwatch should do the
same change for retrieving the log file.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
