### PR TITLE
Remove iterators dead methods

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1983,13 +1983,6 @@ public:
         return list.item(index);
     }
 
-    IDistributedFilePart & get()
-    {
-        IDistributedFilePart &ret = list.item(index);
-        ret.Link();
-        return ret;
-    }
-
     CDistributedFilePartArray &queryParts()
     {
         return list;
@@ -2092,12 +2085,6 @@ public:
         if (!cur.get())
             throw  MakeStringException(-1,"superFileIter: invalid super-file on query at %s", queryName());
 
-        return *cur;
-    }
-
-    IDistributedSuperFile & get()
-    {
-        cur->Link();
         return *cur;
     }
 


### PR DESCRIPTION
get() methods are identical in semantics to their base methods in IIteratorOf<>, so redundant.

This is not to say that they're not being used within this context, as they are, but helps remove duplication of code. The refactoring of merging get() with query() could prove more work than it seems, so it'll be left for another day.

All regressions passed.
