### PR TITLE
Change name in temp file to avoid clashes

### DIFF
--- a/testing/ecl/aggsq3.ecl
+++ b/testing/ecl/aggsq3.ecl
@@ -61,9 +61,9 @@ d := dataset([
             }
         ], houseRecord);
 
-output(d,,'houses2',overwrite);
+output(d,,'houses3',overwrite);
 
-houseTable2 := dataset('houses2', houseRecord, thor);
+houseTable2 := dataset('houses3', houseRecord, thor);
 
 output(table(houseTable2, { addr, numFamilies := count(dedup(occupants.extra, surname, all)); }));
 

--- a/testing/ecl/aggsq3seq.ecl
+++ b/testing/ecl/aggsq3seq.ecl
@@ -61,9 +61,9 @@ d := dataset([
             }
         ], houseRecord);
 
-output(d,,'houses2',overwrite);
+output(d,,'houses3s',overwrite);
 
-houseTable2 := dataset('houses2', houseRecord, thor);
+houseTable2 := dataset('houses3s', houseRecord, thor);
 
 p := table(houseTable2.occupants.extra(age != 0), { surname });
 

--- a/testing/ecl/aggsq4.ecl
+++ b/testing/ecl/aggsq4.ecl
@@ -57,9 +57,9 @@ d := dataset([
             }
         ], houseRecord);
 
-output(d,,'houses2',overwrite);
+output(d,,'houses4',overwrite);
 
-houseTable2 := dataset('houses2', houseRecord, thor);
+houseTable2 := dataset('houses4', houseRecord, thor);
 
 output(table(houseTable2, { addr, numFamilies := count(dedup(occupants.extra, surname, all)); }));
 

--- a/testing/ecl/aggsq4seq.ecl
+++ b/testing/ecl/aggsq4seq.ecl
@@ -57,9 +57,9 @@ d := dataset([
             }
         ], houseRecord);
 
-output(d,,'houses2',overwrite);
+output(d,,'houses4s',overwrite);
 
-houseTable2 := dataset('houses2', houseRecord, thor);
+houseTable2 := dataset('houses4s', houseRecord, thor);
 
 output(table(houseTable2, { addr, numFamilies := count(dedup(occupants.extra, surname, all)); }));
 


### PR DESCRIPTION
It seems aggsq[12] were following the same pattern, but [34] didn't. Just following the same style for local file names to avoid clashes.
