### PR TITLE
Fix build errors under windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,9 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 include(${HPCC_SOURCE_DIR}/cmake_modules/commonSetup.cmake)
 
-add_subdirectory (initfiles)
+if ( CMAKE_SYSTEM MATCHES Linux )
+    add_subdirectory (initfiles)
+endif ()
 add_subdirectory (tools)
 add_subdirectory (common)
 add_subdirectory (dali)


### PR DESCRIPTION
The generation and packaging of the init system is all irrelevant to non-Linux
builds (we may at some point need replacements for Windows, BSD, OSX etc, but
they should most likely go in their own subdirectories).

Disable the initfiles section of the build for non-linux systems.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
