### PR TITLE
Change name in xmlout temp file to avoid clashes

### DIFF
--- a/testing/ecl/xmlout2.ecl
+++ b/testing/ecl/xmlout2.ecl
@@ -58,8 +58,8 @@ namesTable := dataset([
         {'Halliday','Abigail','09876',654321,false,'','',false,[{'The cat in the hat','Suess'},{'Wolly the sheep',''}], ['Red','Yellow']}
         ], personRecord);
 
-output(namesTable,,'REGRESS::TEMP::output.xml',overwrite,xml(heading('','')));
+output(namesTable,,'REGRESS::TEMP::output2.xml',overwrite,xml(heading('','')));
 
-inf := dataset('REGRESS::TEMP::output.xml', { string text }, csv);
+inf := dataset('REGRESS::TEMP::output2.xml', { string text }, csv);
 output(inf);
 


### PR DESCRIPTION
Same thing as aggsq*.ecl, xmlout2.ecl should have a different name on temp files to avoid occasional crash when running with parallel queries.
