### PR TITLE
Re-enable FTSlaveProcess to avoid regressions

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -959,6 +959,17 @@
                          service="ecldirect"/>
    </Properties>
   </EspService>
+  <FTSlaveProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}"
+                  buildSet="ftslave"
+                  description="FTSlave process"
+                  name="myftslave"
+                  version="1">
+   <Instance computer="localhost"
+             directory="${RUNTIME_PATH}/myftslave"
+             name="s1"
+             netAddress="."
+             program="${EXEC_PATH}/ftslave"/>
+  </FTSlaveProcess>
   <PluginProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}"
                  buildSet="plugins_auditlib"
                  description="plugin process"


### PR DESCRIPTION
Not sure this is correct, or why it was done that way. But since this change got in, multiple EclWatch, eclplus and eclagent queries started failing when dealing with files.

Adding it back doesn't add new regressions, too.

Fixing #1053
