### PR TITLE
Protect against child query in master context

### DIFF
--- a/testing/ecl/loop2.ecl
+++ b/testing/ecl/loop2.ecl
@@ -19,6 +19,7 @@
 //Information derived from http://en.wikipedia.org/wiki/Template:HarryPotterFamilyTree
 //This example file alone licenced under licence http://creativecommons.org/licenses/by-sa/3.0/
 //nothor
+//nothorlcr
 
 potterRecord := RECORD
     unsigned id;

--- a/thorlcr/activities/thactivityutil.ipp
+++ b/thorlcr/activities/thactivityutil.ipp
@@ -122,14 +122,13 @@ IRowStream *createSequentialPartHandler(CPartHandler *partHandler, IArrayOf<IPar
             if (e) \
             { \
                 if (!e->queryActivityId()) \
-                { \
-                    e->setGraphId(container.queryOwner().queryGraphId()); \
-                    e->setActivityKind(container.getKind()); \
-                    e->setActivityId(container.queryId()); \
-                } \
+                    setExceptionActivityInfo(container, e); \
             } \
             else \
+            {  \
                 e = MakeActivityException(this, _e); \
+                _e->Release(); \
+            }  \
             if (!e->queryNotified()) \
             { \
                 fireException(e); \

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -2025,7 +2025,7 @@ void CMasterGraph::sendActivityInitData()
             rank_t sender;
             msg.clear();
             if (!job.queryJobComm().recv(msg, w+1, replyTag, &sender, LONGTIMEOUT))
-                throw MakeStringException(0, "Timeout receiving from slaves after graph sent");
+                throw MakeGraphException(this, 0, "Timeout receiving from slaves after graph sent");
 
             bool error;
             msg.read(error);
@@ -2064,6 +2064,12 @@ void CMasterGraph::serializeGraphInit(MemoryBuffer &mb)
         CMasterGraph &childGraph = (CMasterGraph &)childIter->query();
         childGraph.serializeGraphInit(mb);
     }
+}
+
+// IThorChildGraph impl.
+IEclGraphResults *CMasterGraph::evaluate(unsigned _parentExtractSz, const byte *parentExtract)
+{
+    throw MakeGraphException(this, 0, "Thor master does not support the execution of child queries");
 }
 
 void CMasterGraph::executeSubGraph(size32_t parentExtractSz, const byte *parentExtract)
@@ -2207,7 +2213,7 @@ void CMasterGraph::getFinalProgress()
     msg.append(job.queryKey());
     msg.append(queryGraphId());
     if (!job.queryJobComm().send(msg, RANK_ALL_OTHER, masterSlaveMpTag, LONGTIMEOUT))
-        throw MakeStringException(0, "Timeout sending to slaves");
+        throw MakeGraphException(this, 0, "Timeout sending to slaves");
 
     unsigned n=queryJob().querySlaves();
     while (n--)

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -79,6 +79,8 @@ public:
     virtual void abort(IException *e);
 // IExceptionHandler
     virtual bool fireException(IException *e);
+// IThorChildGraph impl.
+    virtual IEclGraphResults *evaluate(unsigned _parentExtractSz, const byte *parentExtract);
 };
 
 class CSlaveMessageHandler : public CInterface, implements IThreaded

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -526,6 +526,16 @@ IThorException *ThorWrapException(IException *e, const char *format, ...)
     return te;
 }
 
+IThorException *MakeGraphException(CGraphBase *graph, int code, const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    IThorException *e = _MakeThorException(MSGAUD_user, code, format, args);
+    e->setGraphId(graph->queryGraphId());
+    va_end(args);
+    return e;
+}
+
 StringBuffer &getLogDir(const char *prefix, const char *logdir, StringBuffer &logname) 
 {
     if (logdir && *logdir !='\0' && recursiveCreateDirectory(logdir))

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -278,6 +278,7 @@ extern graph_decl IThorException *MakeActivityException(CGraphElementBase *activ
 extern graph_decl IThorException *MakeActivityException(CGraphElementBase *activity, IException *e, const char *xtra=NULL, ...) __attribute__((format(printf, 3, 4)));
 extern graph_decl IThorException *MakeActivityWarning(CGraphElementBase *activity, int code, const char *_format, ...) __attribute__((format(printf, 3, 4)));
 extern graph_decl IThorException *MakeActivityWarning(CGraphElementBase *activity, IException *e, const char *format, ...) __attribute__((format(printf, 3, 4)));
+extern graph_decl IThorException *MakeGraphException(CGraphBase *graph, int code, const char *format, ...);
 extern graph_decl IThorException *MakeThorException(int code, const char *format, ...) __attribute__((format(printf, 2, 3)));
 extern graph_decl IThorException *MakeThorException(IException *e);
 extern graph_decl IThorException *MakeThorAudienceException(LogMsgAudience audience, int code, const char *format, ...) __attribute__((format(printf, 3, 4)));


### PR DESCRIPTION
Child queries should not be generated such that they are fired from helper
methods called in Thor Master. The only known way this can happen is via
NOHOIST. That resulted in an obscure crash, this change detects and gives a
sensible error and context.
Regression test loop2.ecl was an example that provoked this condition, which
has now been marked //nothorlcr

Also:
1) improved abort handling in sort
2) improved exception messages in some contexts
3) Fix a possible exception leak

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
