### PR TITLE
Fix gh-1063 - Thor CHOOSESETS regression

### DIFF
--- a/testing/ecl/choosesets.ecl
+++ b/testing/ecl/choosesets.ecl
@@ -35,16 +35,17 @@ zperson := dataset([
         {'Liz','Zappa',12}
         ], zpr);
 
+sortedzperson := sort(zperson, surname, age);
 
-x := choosesets(zperson, surname='Halliday'=>2,forename='Liz'=>3,1,EXCLUSIVE);
+x := choosesets(sortedzperson, surname='Halliday'=>2,forename='Liz'=>3,1,EXCLUSIVE);
 output(x);
 
-y := choosesets(zperson, surname='Halliday'=>2,forename='Liz'=>3,1);
+y := choosesets(sortedzperson, surname='Halliday'=>2,forename='Liz'=>3,1);
 output(y);
 
-x1 := choosesets(zperson, surname='Halliday'=>2,forename='Liz'=>3,1,ENTH);
+x1 := choosesets(sortedzperson, surname='Halliday'=>2,forename='Liz'=>3,1,ENTH);
 output(x1);
 
-y1 := choosesets(zperson, surname='Halliday'=>2,forename='Liz'=>3,LAST);
+y1 := choosesets(sortedzperson, surname='Halliday'=>2,forename='Liz'=>3,LAST);
 output(y1);
 

--- a/testing/ecl/key/choosesets.xml
+++ b/testing/ecl/key/choosesets.xml
@@ -1,31 +1,31 @@
 <Dataset name='Result 1'>
- <Row><forename>Gavin               </forename><surname>Halliday            </surname><age>32</age></Row>
+ <Row><forename>Arther              </forename><surname>Dent                </surname><age>60</age></Row>
  <Row><forename>Jason               </forename><surname>Halliday            </surname><age>28</age></Row>
+ <Row><forename>Liz                 </forename><surname>Halliday            </surname><age>31</age></Row>
  <Row><forename>Liz                 </forename><surname>Malloy              </surname><age>28</age></Row>
  <Row><forename>Liz                 </forename><surname>Stevenson           </surname><age>32</age></Row>
- <Row><forename>James               </forename><surname>Mildew              </surname><age>46</age></Row>
  <Row><forename>Liz                 </forename><surname>Zappa               </surname><age>12</age></Row>
 </Dataset>
 <Dataset name='Result 2'>
- <Row><forename>Gavin               </forename><surname>Halliday            </surname><age>32</age></Row>
+ <Row><forename>Arther              </forename><surname>Dent                </surname><age>60</age></Row>
  <Row><forename>Jason               </forename><surname>Halliday            </surname><age>28</age></Row>
+ <Row><forename>Liz                 </forename><surname>Halliday            </surname><age>31</age></Row>
  <Row><forename>Liz                 </forename><surname>Malloy              </surname><age>28</age></Row>
  <Row><forename>Liz                 </forename><surname>Stevenson           </surname><age>32</age></Row>
- <Row><forename>James               </forename><surname>Mildew              </surname><age>46</age></Row>
- <Row><forename>Liz                 </forename><surname>Halliday            </surname><age>31</age></Row>
+ <Row><forename>Liz                 </forename><surname>Zappa               </surname><age>12</age></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><forename>Jason               </forename><surname>Halliday            </surname><age>28</age></Row>
- <Row><forename>Liz                 </forename><surname>Malloy              </surname><age>28</age></Row>
- <Row><forename>Liz                 </forename><surname>Stevenson           </surname><age>32</age></Row>
  <Row><forename>Liz                 </forename><surname>Halliday            </surname><age>31</age></Row>
+ <Row><forename>Gavin               </forename><surname>Halliday            </surname><age>32</age></Row>
+ <Row><forename>Liz                 </forename><surname>Malloy              </surname><age>28</age></Row>
  <Row><forename>Ronald              </forename><surname>Regan               </surname><age>84</age></Row>
+ <Row><forename>Liz                 </forename><surname>Stevenson           </surname><age>32</age></Row>
  <Row><forename>Liz                 </forename><surname>Zappa               </surname><age>12</age></Row>
 </Dataset>
 <Dataset name='Result 4'>
- <Row><forename>Jason               </forename><surname>Halliday            </surname><age>28</age></Row>
+ <Row><forename>Liz                 </forename><surname>Halliday            </surname><age>31</age></Row>
+ <Row><forename>Gavin               </forename><surname>Halliday            </surname><age>32</age></Row>
  <Row><forename>Liz                 </forename><surname>Malloy              </surname><age>28</age></Row>
  <Row><forename>Liz                 </forename><surname>Stevenson           </surname><age>32</age></Row>
- <Row><forename>Liz                 </forename><surname>Halliday            </surname><age>31</age></Row>
  <Row><forename>Liz                 </forename><surname>Zappa               </surname><age>12</age></Row>
 </Dataset>

--- a/thorlcr/activities/choosesets/thchoosesetsslave.cpp
+++ b/thorlcr/activities/choosesets/thchoosesetsslave.cpp
@@ -193,7 +193,7 @@ public:
         if (first) 
         {
             first = false;
-            if (!container.queryLocalOrGrouped() || firstNode())
+            if (container.queryLocalOrGrouped() || firstNode())
                 memset(tallies, 0, sizeof(unsigned)*numSets);
             else
                 getTallies();


### PR DESCRIPTION
On a global choosesets operation on a multi node system, Thor will produce
more matches than specified in the condition, unless the matches exist only
on one node.
Regression has existed since thorlcr.

The existing regression test did not expose it, because all records were on
one node. Have changed test to spread records.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
