### PR TITLE
Fix gh-109 - Publish csv attribute meta info

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -845,6 +845,20 @@ void CHThorCsvWriteActivity::execute()
 void CHThorCsvWriteActivity::setFormat(IFileDescriptor * desc)
 {
     // MORE - should call parent's setFormat too?
+    ICsvParameters * csvInfo = helper.queryCsvParameters();
+    StringBuffer separator;
+    const char *s = csvInfo->querySeparator(0);
+    while (*s)
+    {
+        if (',' == *s)
+            separator.append("\\,");
+        else
+            separator.append(*s);
+        ++s;
+    }
+    desc->queryProperties().setProp("@csvSeparate", separator.str());
+    desc->queryProperties().setProp("@csvQuote", csvInfo->queryQuote(0));
+    desc->queryProperties().setProp("@csvTerminate", csvInfo->queryTerminator(0));
     desc->queryProperties().setProp("@format","utf8n");
 }
 

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10785,7 +10785,23 @@ public:
     virtual void setFileProperties(IFileDescriptor *desc) const
     {
         CRoxieServerDiskWriteActivity::setFileProperties(desc);
-        desc->queryProperties().setProp("@format","utf8n");
+        IPropertyTree &props = desc->queryProperties();
+        props.setProp("@format","utf8n");
+
+        ICsvParameters *csvParameters = csvHelper.queryCsvParameters();
+        StringBuffer separator;
+        const char *s = csvParameters->querySeparator(0);
+        while (*s)
+        {
+            if (',' == *s)
+                separator.append("\\,");
+            else
+                separator.append(*s);
+            ++s;
+        }
+        props.setProp("@csvSeparate", separator.str());
+        props.setProp("@csvQuote", csvParameters->queryQuote(0));
+        props.setProp("@csvTerminate", csvParameters->queryTerminator(0));
     }
 
     virtual bool isOutputTransformed() const { return true; }

--- a/thorlcr/activities/diskwrite/thdiskwrite.cpp
+++ b/thorlcr/activities/diskwrite/thdiskwrite.cpp
@@ -58,16 +58,28 @@ class CsvWriteActivityMaster : public CWriteMasterBase
 {
 public:
     CsvWriteActivityMaster(CMasterGraphElement *info) : CWriteMasterBase(info) {}
-    void init()
-    {
-        CWriteMasterBase::init();
-        IPropertyTree &props = fileDesc->queryProperties();
-        props.setPropBool("@csv", true);
-    }
     void done()
     {
-        fileDesc->queryProperties().setProp("@format", "utf8n");
-        CWriteMasterBase::done();
+        IPropertyTree &props = fileDesc->queryProperties();
+        props.setPropBool("@csv", true);
+        props.setProp("@format", "utf8n");
+        IHThorCsvWriteArg *helper=(IHThorCsvWriteArg *)queryHelper();
+        ICsvParameters *csvParameters = helper->queryCsvParameters();
+        StringBuffer separator;
+        const char *s = csvParameters->querySeparator(0);
+        while (*s)
+        {
+            if (',' == *s)
+                separator.append("\\,");
+            else
+                separator.append(*s);
+            ++s;
+        }
+        props.setProp("@csvSeparate", separator.str());
+        props.setProp("@csvQuote", csvParameters->queryQuote(0));
+        props.setProp("@csvTerminate", csvParameters->queryTerminator(0));
+
+        CWriteMasterBase::done(); // will publish
     }
 };
 


### PR DESCRIPTION
Csv quote,separator and terminator information was not being published to
DFS. Consequently any non-default specifiers needed explicitly listing on
any subsequent csv read.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
