### PR TITLE
Fix gh-222 - Tidy up spurious TRANSFERBLOCKSIZE

### DIFF
--- a/thorlcr/activities/msort/thgroupsortslave.cpp
+++ b/thorlcr/activities/msort/thgroupsortslave.cpp
@@ -28,8 +28,6 @@
 #include "thactivityutil.ipp"
 //#define TRACE_UNIQUE
 
-#define TRANSFERBLOCKSIZE 0x10000
-
 #include "jsort.hpp"
 #include "thactivityutil.ipp"
 

--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -197,8 +197,6 @@ bool VarElemArray::isNull(unsigned idx)
 }
 
 
-#define TRANSFERBLOCKSIZE 0x100000  // 1MB
-
 class CThorRowSortedLoader : public CSimpleInterface, implements IThorRowSortedLoader
 {
     IArrayOf<IRowStream> instrms;

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -55,11 +55,7 @@ inline void traceWait(const char *name,Semaphore &sem,unsigned interval=60*1000)
 
 
 
-#ifdef __64BIT__
-#define TRANSFERBLOCKSIZE 0x100000 // 1mb
-#else
-#define TRANSFERBLOCKSIZE 0x100000 // 64k
-#endif
+#define TRANSFERBLOCKSIZE 0x100000 // 1MB
 #define MINCOMPRESSEDROWSIZE 16
 #define MAXCOMPRESSEDROWSIZE  0x2000
 


### PR DESCRIPTION
TRANSFERBLOCKSIZE was changed from 64K to 1MB ages ago for 64bit, supposedly
left as 64K in 32bit, but perhaps due to a typo was also defined at that
time to 1MB.

Remove 32bit/64bit difference, 1MB should be fine for both.

Also remove a couple of other unused definitions of TRANSFERBLOCKSIZE

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
