### PR TITLE
FIXES #850 Add new attribute defaultMemoryLimitMB to eclagent

### DIFF
--- a/initfiles/componentfiles/configxml/agentexec.xsl
+++ b/initfiles/componentfiles/configxml/agentexec.xsl
@@ -73,6 +73,10 @@
         </xsl:call-template>
       </xsl:attribute>
 
+      <xsl:attribute name="defaultMemoryLimitMB">
+        <xsl:value-of select="@defaultMemoryLimitMB"/>
+      </xsl:attribute>
+
       <xsl:attribute name="logDir">
         <xsl:call-template name="makeAbsolutePath">
           <xsl:with-param name="path" select="@logDir"/>

--- a/initfiles/componentfiles/configxml/eclagent_config.xsd.in
+++ b/initfiles/componentfiles/configxml/eclagent_config.xsd.in
@@ -175,6 +175,14 @@
       </xs:annotation>
     </xs:attribute>
 
+    <xs:attribute name="defaultMemoryLimitMB" type="nonNegativeInteger" use="optional" default="300">
+      <xs:annotation>
+        <xs:appinfo>
+          <tooltip>Default memory limit in MB for eclagent</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+
     <xs:attribute name="pluginDirectory" type="absolutePath" use="optional" default="${PLUGINS_PATH}/">
       <xs:annotation>
         <xs:appinfo>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -481,6 +481,7 @@
                    build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}"
                    buildSet="eclagent"
                    daliServers="mydali"
+                   defaultMemoryLimitMB="300"
                    description="EclAgent process"
                    name="myeclagent"
                    pluginDirectory="${PLUGINS_PATH}"


### PR DESCRIPTION
Also changed the xsl to copy out the new attribute and the default environment.xml file

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
