### PR TITLE
fix gh-1075 remove unhelp warning on MERGE grouped

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -7482,8 +7482,6 @@ simpleDataSet
                             bool isLocal = queryPropertyInList(localAtom, $5.queryExpr()) != NULL;
                             parser->checkMergeInputSorted($3, isLocal);
                             OwnedHqlExpr ds = $3.getExpr();
-                            if (isGrouped(ds))
-                                parser->reportWarning(WRN_GROUPINGIGNORED, $3.pos, "MERGE applied to a grouped dataset - was this intended?");
 
                             HqlExprArray args, orderedArgs;
                             args.append(*LINK(ds));


### PR DESCRIPTION
Previously the code generator reported a warning if the input to a
MERGE oepration was grouped.  This isn't very helpful - since it is
legal and I can't imagine an alternative expected behaviour if the
input were grouped.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
