### PR TITLE
FIX: gh-1080 Increates eclagent file handle limit

### DIFF
--- a/ecl/eclagent/start_eclagent
+++ b/ecl/eclagent/start_eclagent
@@ -18,5 +18,6 @@
 
 
 ulimit -c unlimited
+ulimit -n 8192
 export SENTINEL="eclagent.sentinel"
 nohup eclagent $* &


### PR DESCRIPTION
Some eclagent jobs that access a lot of file parts in parallel can hit
the 1024 open file handle limit, e.g. a job with a number of keyedjoins in a
subgraph. Increase this limit to 8K, inline with Thor nodes.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
