### PR TITLE
Minor log improvement

### DIFF
--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -346,14 +346,14 @@ public:
     void stopInput1()
     {
         if (!in1stopped) {
-            stopInput(input1);
+            stopInput(input1, "(L)");
             in1stopped = true;
         }
     }
     void stopInput2()
     {
         if (!in2stopped) {
-            stopInput(input2);
+            stopInput(input2, "(R)");
             in2stopped = true;
         }
     }

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -161,7 +161,7 @@ void CSlaveActivity::startInput(IThorDataLink *itdl, const char *extra)
 
 void CSlaveActivity::stopInput(IThorDataLink *itdl, const char *extra)
 {
-    StringBuffer s("Stopping input for ");
+    StringBuffer s("Stopping input for");
     if (extra)
         s.append(" ").append(extra);
     ActPrintLog("%s", s.str());


### PR DESCRIPTION
Distinguish between left and right in join stop logging
And remove a spurious space

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
