### PR TITLE
Allow max cores (for sort) to be configured

### DIFF
--- a/initfiles/componentfiles/configxml/thor.xsd.in
+++ b/initfiles/componentfiles/configxml/thor.xsd.in
@@ -526,6 +526,13 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="maxActivityCores" type="xs:nonNegativeInteger" use="optional" default="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <tooltip>Maximum number of cores to use per activity (only currently used by sorting activities). Default equals all available</tooltip>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="monitorDaliFileServer" type="xs:boolean" default="false">
         <xs:annotation>
           <xs:appinfo>

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2280,7 +2280,7 @@ public:
         Owned<IRowStream> reader = distributor->connect(inL,ihashL,icompareL);
         loaderL.setown(createThorRowSortedLoader(rows));
         bool isemptylhs;
-        strmL.setown(loaderL->load(reader,queryRowInterfaces(inL),icompareL,true,abortSoon,isemptylhs,"HASHJOIN(L)",true));
+        strmL.setown(loaderL->load(reader,queryRowInterfaces(inL),icompareL,true,abortSoon,isemptylhs,"HASHJOIN(L)",true,maxCores));
         reader.clear();
         stopInputL();
         distributor->disconnect(false);
@@ -2293,7 +2293,7 @@ public:
         distributor.setown(createHashDistributor(this, container.queryJob().queryJobComm(), mptag2, queryRowInterfaces(inR), abortSoon,false, this));
         reader.setown(distributor->connect(inR,ihashR,icompareR));
         bool isemptyrhs;
-        strmR.setown(loaderR->load(reader,queryRowInterfaces(inR),icompareR,false,abortSoon,isemptyrhs,"HASHJOIN(R)",true));
+        strmR.setown(loaderR->load(reader,queryRowInterfaces(inR),icompareR,false,abortSoon,isemptyrhs,"HASHJOIN(R)",true,maxCores));
         reader.clear();
         stopInputR();
         distributor->disconnect(false);

--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -446,7 +446,7 @@ public:
                 abortSoon,
                 isemptylhs,
                 tmpStr.append(activityName).append("(L)").str(),
-                true));
+                true,maxCores));
             stopInput1();
         }
         if (isemptylhs&&((helper->getJoinFlags()&JFrightouter)==0)) {
@@ -472,7 +472,7 @@ public:
                 abortSoon,
                 isemptyrhs,
                 tmpStr.append(activityName).append("(R)").str(),
-                true));
+                true,maxCores));
             stopInput2();
         }
     }

--- a/thorlcr/activities/msort/thgroupsortslave.cpp
+++ b/thorlcr/activities/msort/thgroupsortslave.cpp
@@ -112,7 +112,7 @@ public:
                     eof = true;
                     return NULL;
                 }
-                group.sort(*icompare,!unstable);   
+                group.sort(*icompare,!unstable,maxCores);
             }
             catch (IOutOfMemException *e)
             {
@@ -187,7 +187,7 @@ public:
         input = inputs.item(0);
         startInput(input);
         bool isempty;
-        out.setown(iloader->load(input,queryRowInterfaces(input), icompare,false,abortSoon,isempty,"LOCALSORT",!unstable));
+        out.setown(iloader->load(input,queryRowInterfaces(input), icompare,false,abortSoon,isempty,"LOCALSORT",!unstable,maxCores));
     }
     void stop()
     {

--- a/thorlcr/activities/selfjoin/thselfjoinslave.cpp
+++ b/thorlcr/activities/selfjoin/thselfjoinslave.cpp
@@ -67,7 +67,7 @@ private:
 #endif
         iloader.setown(createThorRowSortedLoader(rows));
         bool isempty;
-        IRowStream *rs = iloader->load(input,::queryRowInterfaces(input), compare, false, abortSoon, isempty, "SELFJOIN", !isUnstable());
+        IRowStream *rs = iloader->load(input,::queryRowInterfaces(input), compare, false, abortSoon, isempty, "SELFJOIN", !isUnstable(),maxCores);
         stopInput(input);
         input = NULL;
         return rs;

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2293,6 +2293,7 @@ void CJobBase::init()
 
     // global setting default on, can be overridden by #option
     timeActivities = 0 != getWorkUnitValueInt("timeActivities", globals->getPropBool("@timeActivities", true));
+    maxActivityCores = (unsigned)getWorkUnitValueInt("maxActivityCores", globals->getPropInt("@maxActivityCores", 0)); // NB: 0 means system decides
     pausing = false;
     resumed = false;
     setLCRrowCRCchecking(0 != getWorkUnitValueInt("THOR_ROWCRC", globals->getPropBool("@THOR_ROWCRC", 
@@ -2526,6 +2527,8 @@ CActivityBase::CActivityBase(CGraphElementBase *_container) : container(*_contai
     baseHelper.set(container.queryHelper());
     parentExtractSz = 0;
     parentExtract = NULL;
+    // NB: maxCores, currently only used to control # cores used by sorts
+    maxCores = container.queryXGMML().getPropInt("hint[@name=\"max_cores\"]/@value", container.queryJob().queryMaxDefaultActivityCores());
 }
 
 CActivityBase::~CActivityBase()

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -791,6 +791,7 @@ protected:
     Owned<IPropertyTree> xgmml;
     Owned<IGraphTempHandler> tmpHandler;
     bool timeActivities;
+    unsigned maxActivityCores;
     class CThorPluginCtx : public SimplePluginCtx
     {
     public:
@@ -881,6 +882,7 @@ public:
     ICommunicator &queryJobComm() const { return *jobComm; }
     IGroup &queryJobGroup() const { return *jobGroup; }
     const bool &queryTimeActivities() const { return timeActivities; }
+    unsigned queryMaxDefaultActivityCores() const { return maxActivityCores; }
     IGroup &querySlaveGroup() const { return *slaveGroup; }
     const rank_t &queryMyRank() const { return myrank; }
     mptag_t allocateMPTag();
@@ -925,6 +927,7 @@ protected:
     size32_t parentExtractSz;
     const byte *parentExtract;
     bool receiving, cancelledReceive;
+    unsigned maxCores; // NB: only used by acts that sort at the moment
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -940,6 +943,7 @@ public:
     void cancelReceiveMsg(const rank_t rank, const mptag_t mpTag);
     bool firstNode() { return 1 == container.queryJob().queryMyRank(); }
     bool lastNode() { return container.queryJob().querySlaves() == container.queryJob().queryMyRank(); }
+    unsigned queryMaxCores() const { return maxCores; }
 
 
     virtual void setInput(unsigned index, CActivityBase *inputActivity, unsigned inputOutIdx) { }

--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -83,9 +83,9 @@ bool VarElemArray::checksorted(ICompare *icmp)
 }
 
 
-void VarElemArray::sort(ICompare *icmp)
+void VarElemArray::sort(ICompare *icmp,unsigned maxcores)
 {
-    rows.sort(*icmp,true);
+    rows.sort(*icmp,true,maxcores);
 }
 
 size32_t VarElemArray::totalSize()
@@ -233,7 +233,7 @@ public:
         bool &abort, 
         bool &isempty,
         const char *tracename,
-        bool isstable)
+        bool isstable, unsigned maxcores)
     {
         overflowcount = 0;
         unsigned nrecs;
@@ -255,7 +255,7 @@ public:
             PROGLOG("rows loaded overflowed = %s",hasoverflowed?"true":"false");
 #endif
             if (nrecs&&icompare)
-                rows.sort(*icompare,isstable);
+                rows.sort(*icompare,isstable,maxcores);
             numrows += nrecs;
             totalsize += rows.totalSize();
             if (!hasoverflowed&&!alldisk) 

--- a/thorlcr/msort/tsorta.hpp
+++ b/thorlcr/msort/tsorta.hpp
@@ -56,7 +56,7 @@ public:
     unsigned ordinality();
     void transfer(VarElemArray &from);
     bool equal(ICompare *icmp,VarElemArray &to);
-    void sort(ICompare *icmp);
+    void sort(ICompare *icmp,unsigned maxcores);
     int compare(ICompare *icmp,unsigned i,unsigned j);
     int compare(ICompare *icmp,unsigned i,VarElemArray &other,unsigned j);
     bool isNull(unsigned idx);
@@ -83,7 +83,8 @@ interface IThorRowSortedLoader: extends IInterface
         bool &abort, 
         bool &isempty,
         const char *tracename,
-        bool isstable
+        bool isstable,
+        unsigned maxcores
     )=0;
     virtual bool hasOverflowed()=0;
     virtual rowcount_t numRows()=0;

--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -671,7 +671,7 @@ public:
         unsigned numsamples = sample.ordinality();
         size32_t ts=sample.totalSize();
         estrecsize = numsamples?(ts/numsamples):100;
-        sample.sort(icompare);
+        sample.sort(icompare,activity->queryMaxCores());
         VarElemArray mid(rowif,keyserializer);
         if (numsamples) { // could shuffle up empty nodes here
             for (unsigned i=0;i<numsplits;i++) {
@@ -1280,7 +1280,7 @@ public:
                     }
                     if (!partitioninfo->splitkeys.checksorted(icompare)) {
                         ActPrintLog(activity, "ERROR: Split keys out of order!");
-                        partitioninfo->splitkeys.sort(icompare);
+                        partitioninfo->splitkeys.sort(icompare,activity->queryMaxCores());
                     }
                 }
                 timer.stop("Calculating split map");

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -33,6 +33,7 @@
 #include "thbuf.hpp"
 #include "thcrc.hpp"
 #include "thmem.hpp"
+#include "thgraph.hpp"
 
 #define _TRACE
 
@@ -725,7 +726,7 @@ public:
         Owned<IRowStream> overflowstream;
         try {
             bool isempty;
-            overflowstream.setown(sortedloader->load(in,rowif,nosort?NULL:icompare,false,abort,isempty,"SORT",isstable));
+            overflowstream.setown(sortedloader->load(in,rowif,nosort?NULL:icompare,false,abort,isempty,"SORT",isstable,activity->queryMaxCores()));
             ActPrintLog(activity, "Local run sort(s) done");
         }
         catch (IException *e) {
@@ -1124,7 +1125,7 @@ public:
 #ifdef  _FULL_TRACE
             PROGLOG("MiniSort got %d rows %"I64F"d bytes",rowArray.ordinality(),(__int64)(rowArray.totalSize()));
 #endif
-            rowArray.sort(*icompare,isstable);
+            rowArray.sort(*icompare,isstable,activity->queryMaxCores());
             UnsignedArray points; 
             rowArray.partition(*icompare,numnodes,points);
 #ifdef  _FULL_TRACE

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -350,7 +350,7 @@ public:
         return sz>maxtotal;
     }
 
-    void sort(ICompare & compare, bool stable)
+    void sort(ICompare & compare, bool stable, unsigned maxcores)
     {
         unsigned n = ordinality();
         if (n>1) {
@@ -359,14 +359,14 @@ public:
                 MemoryAttr tmp;
                 void ** ptrs = (void **)tmp.allocate(n*sizeof(void *));
                 memcpy(ptrs,res,n*sizeof(void **));
-                parqsortvecstable(ptrs, n, compare, (void ***)res); // use res for index
+                parqsortvecstable(ptrs, n, compare, (void ***)res, maxcores); // use res for index
                 while (n--) {
                     *res = **((byte ***)res);
                     res++;
                 }
             }
             else 
-                parqsortvec((void **)res, n, compare);
+                parqsortvec((void **)res, n, compare, maxcores);
         }
     }
 


### PR DESCRIPTION
gh-1099 - Add thor configuration option 'maxActivityCores' to allow the max number of
cpu cores to be specified per activity. Currently only used by sorting
activities.  The default is all available cores.
The option is available as a HINT in ECL, as a #option and as
a thor configuration option. With precedence taken in that order.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
