### PR TITLE
Hash Aggregrate failing in child query

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2545,7 +2545,8 @@ public:
         helper = static_cast <IHThorHashAggregateArg *> (queryHelper());
         appendOutputLinked(this);
 
-        mptag = container.queryJob().deserializeMPTag(data);
+        if (!container.queryLocal())
+            mptag = container.queryJob().deserializeMPTag(data);
         ActPrintLog("HASHAGGREGATE: init tags %d",(int)mptag);
     }
     void start()


### PR DESCRIPTION
A hash aggregate in a child query was trying to deserialize a mptag
that wasn't needed and not there, resulting in a deserialization error

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
