### PR TITLE
Spill reference count issue

### DIFF
--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -236,6 +236,7 @@ public:
     virtual void start()
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
+        CDiskReadSlaveActivityBase::start();
         out.setown(createSequentialPartHandler(partHandler, partDescs, false));
         dataLinkStart("CCsvReadSlaveActivity", container.queryId());
     }

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -440,6 +440,7 @@ public:
     virtual void start()
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
+        CDiskReadSlaveActivityRecord::start();
         out = createSequentialPartHandler(partHandler, partDescs, grouped); // **
         dataLinkStart("DISKREAD", container.queryId());
     }
@@ -595,6 +596,7 @@ public:
     virtual void start()
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
+        CDiskReadSlaveActivityRecord::start();
         out = createSequentialPartHandler(partHandler, partDescs, false);
         dataLinkStart("DISKNORMALIZE", container.queryId());
     }
@@ -718,6 +720,7 @@ public:
     virtual void start()
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
+        CDiskReadSlaveActivityRecord::start();
         eoi = false;
         dataLinkStart("DISKAGGREGATE", container.queryId());
     }
@@ -827,6 +830,7 @@ public:
     virtual void start()
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
+        CDiskReadSlaveActivityRecord::start();
         eoi = false;
         if (!helper->canMatchAny())
         {
@@ -940,6 +944,7 @@ public:
     virtual void start()
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
+        CDiskReadSlaveActivityRecord::start();
         gathered = eoi = false;
         localAggTable.setown(new CThorRowAggregator(*this, *helper, *helper, queryLargeMemSize()/10, container.queryOwnerId()==0));
         localAggTable->start(queryRowAllocator());

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -203,7 +203,7 @@ CDiskReadSlaveActivityBase::CDiskReadSlaveActivityBase(CGraphElementBase *_conta
 {
     helper = (IHThorDiskReadBaseArg *)queryHelper();
     crcCheckCompressed = 0 != container.queryJob().getWorkUnitValueInt("crcCheckCompressed", 0);
-    gotMeta = false;
+    markStart = gotMeta = false;
     checkFileCrc = !globals->getPropBool("Debug/@fileCrcDisabled");
 }
 
@@ -244,9 +244,14 @@ const char *CDiskReadSlaveActivityBase::queryLogicalFilename(unsigned index)
     return subfileLogicalFilenames.item(index);
 }
 
+void CDiskReadSlaveActivityBase::start()
+{
+    markStart = true;
+}
+
 void CDiskReadSlaveActivityBase::kill()
 {
-    if (actStarted && !abortSoon && 0 != (helper->getFlags() & TDXtemporary) && !container.queryJob().queryUseCheckpoints())
+    if (markStart && !abortSoon && 0 != (helper->getFlags() & TDXtemporary) && !container.queryJob().queryUseCheckpoints())
     {
         if (1 == partDescs.ordinality() && !partDescs.item(0).queryOwner().queryProperties().getPropBool("@pausefile"))
         {
@@ -258,6 +263,7 @@ void CDiskReadSlaveActivityBase::kill()
             container.queryTempHandler()->deregisterFile(locationName.str());
         }
     }
+    markStart = false;
     CSlaveActivity::kill();
 }
 

--- a/thorlcr/activities/thdiskbaseslave.ipp
+++ b/thorlcr/activities/thdiskbaseslave.ipp
@@ -81,7 +81,7 @@ protected:
     StringArray subfileLogicalFilenames;
     IArrayOf<IPartDescriptor> partDescs;
     IHThorDiskReadBaseArg *helper;
-    bool checkFileCrc, gotMeta, crcCheckCompressed;
+    bool checkFileCrc, gotMeta, crcCheckCompressed, markStart;
     ThorDataLinkMetaInfo cachedMetaInfo;
     Owned<CDiskPartHandlerBase> partHandler;
     Owned<IExpander> eexp;
@@ -91,6 +91,7 @@ public:
     const char *queryLogicalFilename(unsigned index);
     rowcount_t getHandlerProgress() { return partHandler.get()?partHandler->getProgress():0; }
     IRowInterfaces * queryDiskRowInterfaces();
+    void start();
 
     
 // IThorSlaveActivity

--- a/thorlcr/activities/xmlread/thxmlreadslave.cpp
+++ b/thorlcr/activities/xmlread/thxmlreadslave.cpp
@@ -201,6 +201,7 @@ public:
     virtual void start()
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
+        CDiskReadSlaveActivityBase::start();
         out = createSequentialPartHandler(partHandler, partDescs, false);
         dataLinkStart("XMLREAD", container.queryId());
     }


### PR DESCRIPTION
Spills pulled by reads depedendent on conditionals, were reducing the link
count whether executed or not.
This could lead to early deletion of the spill file and an probable error trying
to subsequently read it.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
