### PR TITLE
Obvious typo in WrappedTransaction

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1344,7 +1344,7 @@ public:
         if (owner&&(strcmp(lfn,owner->queryLogicalName())==0))
             return LINK(owner);
         if (chain)
-            chain-> lookupFile(lfn,timeout);
+            return chain->lookupFile(lfn,timeout);
         return queryDistributedFileDirectory().lookup(lfn,udesc,false,NULL,timeout);
     }
     IDistributedSuperFile *lookupSuperFile(const char *slfn,bool fixmissing=false,unsigned timeout=INFINITE)


### PR DESCRIPTION
Wrapped transaction should always chain down the requests, if possible. This was not happening.

The call was caching locally, but grabbing from the file system in the end. That didn't trigger any problem in the tests, since all our subfile deletions were of unmodified files, thus identical in the transaction and the file system.
