### PR TITLE
Potential keyed join deadlock

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -987,7 +987,8 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                 threaded.join();
                 if (stopPending) // stop groups in progress
                 {
-                    requestProcessor->stop();
+                    if (aborted) // don't stop request processor unless aborting, other nodes may depend on it's reply.
+                        requestProcessor->stop();
                     resultProcessor->stop();
                 }
             }


### PR DESCRIPTION
A previous change in gh-416, could lead to deadlock in full keyed joins,
that were stopped (e.g. via choosen) quickly.
The fetch handlers request thread was cancelled on stop, but needed to
remain listening until other nodes had done, so that it could acknowledge
stop

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
