### PR TITLE
FIX: All components to use new logging creator

### DIFF
--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -2795,7 +2795,8 @@ int main(int argc, char* argv[])
     try {
         StringBuffer cmd;
         splitFilename(argv[0], NULL, NULL, &cmd, NULL);
-        openLogFile(cmd.toLowerCase().append(".log").str());
+        StringBuffer lf;
+        openLogFile(lf, cmd.toLowerCase().append(".log").str());
 
 #if defined(TEST_MEMTHREADS)
         printf("start...\n");

--- a/dali/datest/dfuwutest.cpp
+++ b/dali/datest/dfuwutest.cpp
@@ -952,7 +952,8 @@ int main(int argc, char* argv[])
 
         StringBuffer cmd;
         splitFilename(argv[0], NULL, NULL, &cmd, NULL);
-        openLogFile(cmd.toLowerCase().append(".log").str());
+        StringBuffer lf;
+        openLogFile(lf, cmd.toLowerCase().append(".log").str());
         PROGLOG("DFUWUTEST Starting");
         SocketEndpoint ep;
         SocketEndpointArray epa;

--- a/dali/daunittest/daunittest.cpp
+++ b/dali/daunittest/daunittest.cpp
@@ -104,7 +104,8 @@ int main( int argc, char **argv )
     try {
         StringBuffer cmd;
         splitFilename(argv[0], NULL, NULL, &cmd, NULL);
-        openLogFile(cmd.toLowerCase().append(".log").str());
+        StringBuffer lf;
+        openLogFile(lf, cmd.toLowerCase().append(".log").str());
         if (argc<2) {
             usage();
             return 1;

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -143,7 +143,7 @@ int main(int argc, const char *argv[])
         removeSentinelFile(sentinelFile);
         Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(globals, "dfuserver");
         lf->setMaxDetail(1000);
-        lf->beginLogging();
+        fileMsgHandler = lf->beginLogging();
     }
     StringBuffer ftslogdir;
     if (getConfigurationDirectory(globals->queryPropTree("Directories"),"log","ftslave",globals->queryProp("@name"),ftslogdir)) // NB instance deliberately dfuserver's

--- a/dali/regress/daregress.cpp
+++ b/dali/regress/daregress.cpp
@@ -668,7 +668,8 @@ int main(int argc, char* argv[])
     try {
         StringBuffer cmd;
         splitFilename(argv[0], NULL, NULL, &cmd, NULL);
-        openLogFile(cmd.toLowerCase().append(".log").str());
+        StringBuffer lf;
+        openLogFile(lf, cmd.toLowerCase().append(".log").str());
         if (argc<2) {
             usage();
             return 1;

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -69,12 +69,10 @@ MODULE_EXIT()
     delete stopServerCrit;
 }
 
-ILogMsgHandler * fileMsgHandler;
-
 #define DEFAULT_PERF_REPORT_DELAY 60
 #define DEFAULT_MOUNT_POINT "/mnt/dalimirror/"
 
-void setMsgLevel(unsigned level)
+void setMsgLevel(ILogMsgHandler * fileMsgHandler, unsigned level)
 {
     ILogMsgFilter *filter = getSwitchLogMsgFilterOwn(getComponentLogMsgFilter(3), getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, level, true), getDefaultLogMsgFilter());
     queryLogMsgManager()->changeMonitorFilter(queryStderrLogMsgHandler(), filter);
@@ -170,11 +168,12 @@ int main(int argc, char* argv[])
         if (confIFile->exists())
             serverConfig.setown(createPTreeFromXMLFile(DALICONF));
 
+        ILogMsgHandler * fileMsgHandler;
         {
             Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(serverConfig, "dali");
             lf->setLogDirSubdir("server");//add to tail of config log dir
             lf->setName("DaServer");//override default filename
-            lf->beginLogging();
+            fileMsgHandler = lf->beginLogging();
         }
 
         DBGLOG("Build %s", BUILD_TAG);
@@ -356,7 +355,7 @@ int main(int argc, char* argv[])
         }
         unsigned short myport = epa.item(myrank).port;
         startMPServer(myport,true);
-        setMsgLevel(serverConfig->getPropInt("SDS/@msgLevel", 100));
+        setMsgLevel(fileMsgHandler, serverConfig->getPropInt("SDS/@msgLevel", 100));
         startLogMsgChildReceiver(); 
         startLogMsgParentReceiver();
 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3062,8 +3062,8 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
     if (!standAloneExe)
     {
         Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(agentTopology, "eclagent");
-        lf->setCreateAliasFile(false);
         lf->setMsgFields(MSGFIELD_timeDate | MSGFIELD_msgID | MSGFIELD_process | MSGFIELD_thread | MSGFIELD_code);
+        lf->setCreateAliasFile(false);
         lf->beginLogging();
         PROGLOG("Logging to %s", lf->queryLogFileSpec());
         logfilespec.set(lf->queryLogFileSpec());
@@ -3072,14 +3072,8 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
     {
         StringBuffer exeName;
         splitFilename(argv[0], NULL, NULL, &exeName, NULL);
-
-        Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(".", exeName.toLowerCase());//log to "cwd/exename.log"
-        lf->setLocal(true);
-        lf->setRolling(false);
-        lf->setMsgFields(MSGFIELD_timeDate | MSGFIELD_msgID | MSGFIELD_process | MSGFIELD_thread | MSGFIELD_code);
-        lf->beginLogging();
-        PROGLOG("Logging to %s", lf->queryLogFileSpec());
-        logfilespec.set(lf->queryLogFileSpec());
+        openLogFile(logfilespec, exeName.toLowerCase());
+        PROGLOG("Logging to %s", logfilespec.str());
     }
 
     if (wuXML && wuXML->length())

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -376,9 +376,10 @@ void EclCC::loadOptions()
     {
         if (optLogfile.length())
         {
-            openLogFile(optLogfile, optLogDetail, false);
+            StringBuffer lf;
+            openLogFile(lf, optLogfile, optLogDetail, false);
             if (logVerbose)
-                fprintf(stdout, "Logging to '%s'\n",optLogfile.get());
+                fprintf(stdout, "Logging to '%s'\n",lf.str());
         }
     }
 

--- a/services/runagent/frunssh.cpp
+++ b/services/runagent/frunssh.cpp
@@ -53,16 +53,11 @@ int main( int argc, char *argv[] )
     try  {
         StringBuffer logname;
         splitFilename(argv[0], NULL, NULL, &logname, NULL);
-        StringBuffer logdir;
-        if (getConfigurationDirectory(NULL,"log","frunssh",logname.str(),logdir)) {
-            recursiveCreateDirectory(logdir.str());
-            StringBuffer tmp(logname);
-            addPathSepChar(logname.clear().append(logdir)).append(tmp);
-        }
-        addFileTimestamp(logname, true);
-        logname.append(".log");
-        appendLogFile(logname.str(),0,false);
-        queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_prefix);
+
+        Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator("frunssh");
+        lf->setCreateAliasFile(false);
+        lf->setMsgFields(MSGFIELD_prefix);
+        lf->beginLogging();
 
         Owned<IFRunSSH> runssh = createFRunSSH();
         runssh->init(argc,argv);

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -4858,6 +4858,14 @@ StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out)
     return out.append(path);
 }
 
+StringBuffer &makeAbsolutePath(StringBuffer &relpath)
+{
+    StringBuffer out;
+    makeAbsolutePath(relpath.str(),out);
+    relpath.swapWith(out);
+    return relpath;
+}
+
 StringBuffer &makeAbsolutePath(const char *relpath, const char *basedir, StringBuffer &out)
 {
     StringBuffer combined;

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -535,6 +535,7 @@ inline bool isAbsolutePath(const char *path)
 
 
 extern jlib_decl StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out);
+extern jlib_decl StringBuffer &makeAbsolutePath(StringBuffer &relpath);
 extern jlib_decl StringBuffer &makeAbsolutePath(const char *relpath, const char *basedir, StringBuffer &out);
 extern jlib_decl const char *splitRelativePath(const char *full,const char *basedir,StringBuffer &reldir); // removes basedir if matches, returns tail and relative dir
 extern jlib_decl const char *splitDirMultiTail(const char *multipath,StringBuffer &dir,StringBuffer &tail);

--- a/system/jlib/jlog.hpp
+++ b/system/jlib/jlog.hpp
@@ -1014,6 +1014,7 @@ interface IComponentLogFileCreator : extends IInterface
     virtual void setAliasName(const char * _aliasName) = 0; //alias file name, overrides default of component name
     virtual void setLogDirSubdir(const char * _subdir) = 0; //subdir be appended to config log dir (eg "server" or "audit")
     virtual void setRolling(const bool _rolls) = 0;         //daily rollover to new file
+    virtual void setCompleteFilespec(const char * _fs) = 0; //Full filespec (path/fn.ext), overrides everything else
 
     //ILogMsgHandler fields
     virtual void setAppend(const bool _append) = 0;         //append to existing logfile
@@ -1031,10 +1032,10 @@ interface IComponentLogFileCreator : extends IInterface
     virtual const char * queryLogFileSpec() = 0;    //Full log filespec
     virtual const char * queryAliasFileSpec() = 0;  //Full alias filespec, if created
 
-    virtual bool beginLogging() = 0;    //begin logging to specified file(s)
+    virtual ILogMsgHandler * beginLogging() = 0;    //begin logging to specified file(s)
 };
 
 extern jlib_decl IComponentLogFileCreator * createComponentLogFileCreator(IPropertyTree * _properties, const char *_component);
 extern jlib_decl IComponentLogFileCreator * createComponentLogFileCreator(const char *_logDir, const char *_component);
-
+extern jlib_decl IComponentLogFileCreator * createComponentLogFileCreator(const char *_component);
 #endif

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -58,9 +58,9 @@ public:
 };
 jlib_decl ILogIntercept* interceptLog(ILogIntercept *intercept); // for custom tracing
 
-jlib_decl void openLogFile(const char *filename, unsigned detail = 0, bool enterQueueMode = true);
-jlib_decl void appendLogFile(const char *filename, unsigned detail = 0, bool enterQueueMode = true);
-jlib_decl ILogMsgHandler * queryLegacyLogMsgHandler();
+//Use openLogFile() to create/append a simple, local component logfile, providing a filename(or filespec).
+//Typically used to create a non rolling, local logfile in cwd, using default logfile contents
+jlib_decl void openLogFile(StringBuffer & resolvedFS, const char *filename, unsigned detail = 0, bool enterQueueMode = true, bool append = false);
 
 #ifndef DISABLE_PRINTLOG
 jlib_decl void PrintLogDirect(const char *msg);

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -2236,25 +2236,20 @@ StringBuffer & fillConfigurationDirectoryEntry(const char *dir,const char *name,
 
 IPropertyTree *getHPCCenvironment(const char *confloc)
 {
-    
-    if (!confloc)
+    StringBuffer configFileSpec(confloc);
+    if (!configFileSpec.length())
 #ifdef _WIN32 
         return NULL;
 #else
-    {
-        StringBuffer EnvConfPath(CONFIG_DIR);
-        EnvConfPath.append(PATHSEPSTR).append("environment.conf");
-
-        confloc = EnvConfPath.str();
-    }
+        configFileSpec.set(CONFIG_DIR).append(PATHSEPSTR).append("environment.conf");
 #endif  
-    Owned<IProperties> props = createProperties(confloc);
+    Owned<IProperties> props = createProperties(configFileSpec.str());
     if (props) {
         StringBuffer envfile;
         if (props->getProp("environment",envfile)&&envfile.length()) {
             if (!isAbsolutePath(envfile.str())) {
                 StringBuffer tail(envfile);
-                splitDirTail(confloc,envfile.clear());
+                splitDirTail(configFileSpec.str(),envfile.clear());
                 addPathSepChar(envfile).append(tail);
             }
             Owned<IFile> file = createIFile(envfile.str());

--- a/system/mp/test/mptest.cpp
+++ b/system/mp/test/mptest.cpp
@@ -505,7 +505,8 @@ int main(int argc, char* argv[])
 #endif
     try {
         EnableSEHtoExceptionMapping();
-        openLogFile("c:\\mptest.log");
+        StringBuffer lf;
+        openLogFile(lf, "c:\\mptest.log");
         PrintLog("MPTEST Starting");
 
 #ifndef MYMACHINES

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -495,7 +495,7 @@ int main( int argc, char *argv[]  )
             lf->setCreateAliasFile(false);
             lf->setMsgFields(MSGFIELD_timeDate | MSGFIELD_msgID | MSGFIELD_process | MSGFIELD_thread | MSGFIELD_code);
             lf->beginLogging();
-            createUNCFilename(lf->queryAliasFileSpec(), logUrl, false);
+            createUNCFilename(lf->queryLogFileSpec(), logUrl, false);
         }
         LOG(MCdebugProgress, thorJob, "Opened log file %s", logUrl.toCharArray());
         LOG(MCdebugProgress, thorJob, "Build %s", BUILD_TAG);

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -210,7 +210,7 @@ void startSlaveLog()
     lf->beginLogging();
 
     StringBuffer url;
-    createUNCFilename(lf->queryAliasFileSpec(), url);//use alias name
+    createUNCFilename(lf->queryLogFileSpec(), url);
 
     LOG(MCdebugProgress, thorJob, "Opened log file %s", url.toCharArray());
     LOG(MCdebugProgress, thorJob, "Build %s", BUILD_TAG);

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -575,8 +575,9 @@ void SetLogName(const char *prefix, const char *logdir, const char *thorname, bo
     logname.append(timeStamp);
 #endif
     logname.append(".log");
-    openLogFile(logname.toCharArray());
-    PrintLog("Opened log file %s", logname.toCharArray());
+    StringBuffer lf;
+    openLogFile(lf, logname.toCharArray());
+    PrintLog("Opened log file %s", lf.str());
     PrintLog("Build %s", BUILD_TAG);
 }
 #endif

--- a/tools/dumpkey/dumpkey.cpp
+++ b/tools/dumpkey/dumpkey.cpp
@@ -88,7 +88,8 @@ int main(int argc, const char **argv)
     {
         StringBuffer logname("dumpkey.");
         logname.append(GetCachedHostName()).append(".");
-        openLogFile(logname.append("log").str());
+        StringBuffer lf;
+        openLogFile(lf, logname.append("log").str());
         
         Owned <IKeyIndex> index;
         const char * keyName = globals->queryProp("keyfile");

--- a/tools/swapnode/swapnode.cpp
+++ b/tools/swapnode/swapnode.cpp
@@ -1180,7 +1180,8 @@ int main(int argc,char** argv)
             splitFilename(argv[0], NULL, NULL, &logname, NULL);
             addFileTimestamp(logname, true);
             logname.append(".log");
-            appendLogFile(logname.str(),0,false);
+            StringBuffer lf;
+            openLogFile(lf, logname.str(),0,false,true);
             queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_prefix);
             if (options&&options->getPropBool("@enableSysLog",true))
                 UseSysLogForOperatorMessages();


### PR DESCRIPTION
Convert all of HPCC-Platform to use new component logfile creator.
Fixed a bug in jutil getHPCCenvironment() setting ptr to out of scope
StringBuffer (EnvConfPath).

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
