### PR TITLE
FIX: gh-1126 CRON incorrect handling of Sunday (day 7)

### DIFF
--- a/system/jlib/jtime.cpp
+++ b/system/jlib/jtime.cpp
@@ -886,8 +886,19 @@ static const char *parseCronItem(const char *s,UnsignedArray &a,unsigned first,u
                             if (isdigit(*s)) 
                                 s = getnum(s,inc,1,last);
                         }
-                        for (;n<=n2;n+=inc)
-                            a.bAdd(n,cmpval,added);
+                        if (n <= n2)
+                        {
+                            for (; n<=n2; n+=inc)
+                                a.bAdd(n,cmpval,added);
+                        }
+                        else
+                        {
+                            unsigned idx;
+                            for (idx=n; idx<=last; idx+=inc)
+                                a.bAdd(idx,cmpval,added);
+                            for (idx-=(last-first+1); idx<=n2; idx+=inc)
+                                a.bAdd(idx,cmpval,added);
+                        }
                     }
                     else
                         a.bAdd(n,cmpval,added);


### PR DESCRIPTION
Day Of Week can be specified in day range as 7 (ie "6-7" for Sat-Sun).
Parsing of that date converts it to 0 (0-7 for Sun-Sat). Unfortunately
the loop adding an event for each day in the range would never execute
because it would loop "for (6<=0)". Fix by checking min/max and using
that as sentinel

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
