### PR TITLE
Various changes to improve meta output

### DIFF
--- a/ecl/hql/hqldesc.cpp
+++ b/ecl/hql/hqldesc.cpp
@@ -21,6 +21,43 @@
 #include "hqlexpr.hpp"
 #include "hqldesc.hpp"
 
+void getFullName(StringBuffer & name, IHqlExpression * expr)
+{
+    IHqlScope * scope = expr->queryScope();
+    if (scope)
+    {
+        name.append(scope->queryFullName());
+    }
+    else
+    {
+        const char * module = expr->queryFullModuleName()->str();
+        if (module && *module)
+            name.append(module).append(".");
+        name.append(expr->queryName());
+    }
+}
+
+void setFullNameProp(IPropertyTree * tree, const char * prop, const char * module, const char * def)
+{
+    if (module && *module)
+    {
+        StringBuffer s;
+        s.append(module).append('.').append(def);
+        tree->setProp(prop, s.str());
+    }
+    else
+        tree->setProp(prop, def);
+}
+
+void setFullNameProp(IPropertyTree * tree, const char * prop, IHqlExpression * expr)
+{
+    IHqlScope * scope = expr->queryScope();
+    if (scope)
+        tree->setProp(prop, scope->queryFullName());
+    else
+        setFullNameProp(tree, prop, expr->queryFullModuleName()->str(), expr->queryName()->str());
+}
+
 int compareSymbolsByPosition(IInterface * * pleft, IInterface * * pright)
 {
     IHqlExpression * left = static_cast<IHqlExpression *>(*pleft);
@@ -33,12 +70,20 @@ int compareSymbolsByPosition(IInterface * * pleft, IInterface * * pright)
     return stricmp(left->queryName()->str(), right->queryName()->str());
 }
 
+static void setNonZeroPropInt(IPropertyTree * tree, const char * path, int value)
+{
+    if (value)
+        tree->setPropInt(path, value);
+}
+
 void expandSymbolMeta(IPropertyTree * metaTree, IHqlExpression * expr)
 {
     IPropertyTree * def = NULL;
     if (isImport(expr))
     {
         def = metaTree->addPropTree("Import", createPTree("Import"));
+        IHqlExpression * original = expr->queryBody(true);
+        setFullNameProp(def, "@ref", original);
     }
     else
     {
@@ -47,12 +92,20 @@ void expandSymbolMeta(IPropertyTree * metaTree, IHqlExpression * expr)
 
     if (def)
     {
+        IHqlNamedAnnotation * symbol = queryNameAnnotation(expr);
         def->setProp("@name", expr->queryName()->str());
         def->setPropInt("@line", expr->getStartLine());
         if (expr->isExported())
             def->setPropBool("@exported", true);
         else if (isPublicSymbol(expr))
             def->setPropBool("@shared", true);
+
+        if (symbol)
+        {
+            setNonZeroPropInt(def, "@start", symbol->getStartPos());
+            setNonZeroPropInt(def, "@body", symbol->getBodyPos());
+            setNonZeroPropInt(def, "@end", symbol->getEndPos());
+        }
 
         if (expr->isScope() && !isImport(expr))
         {

--- a/ecl/hql/hqldesc.hpp
+++ b/ecl/hql/hqldesc.hpp
@@ -21,5 +21,9 @@
 
 void expandScopeSymbolsMeta(IPropertyTree * meta, IHqlScope * scope);
 
+extern void getFullName(StringBuffer & name, IHqlExpression * expr);
+extern void setFullNameProp(IPropertyTree * tree, const char * prop, const char * module, const char * def);
+extern void setFullNameProp(IPropertyTree * tree, const char * prop, IHqlExpression * expr);
+
 
 #endif

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -6219,7 +6219,7 @@ IHqlExpression * CHqlNamedSymbol::cloneSymbol(_ATOM optname, IHqlExpression * op
 
 IFileContents * CHqlNamedSymbol::getBodyContents()
 {
-    return createFileContentsSubset(text, bodypos, text->length()-bodypos);
+    return createFileContentsSubset(text, bodypos, endpos-bodypos);
 }
 
 IFileContents * CHqlNamedSymbol::queryDefinitionText() const

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -891,7 +891,6 @@ public:
     void noteEndAttribute();
     void noteEndQuery();
     void noteFinishedParse(IHqlScope * scope);
-    inline void noteImport(IHqlExpression * expr, _ATOM name, int position) { if (metaState.gatherNow) addImport(expr, name, position); }
     IPropertyTree * queryEnsureArchiveModule(const char * name, IHqlScope * scope);
 
     void setGatherMeta(const MetaOptions & options);
@@ -912,7 +911,6 @@ public:
     bool ignoreUnknownImport;
 
 private:
-    void addImport(IHqlExpression * expr, _ATOM name, int position);
     bool checkBeginMeta();
     bool checkEndMeta();
     void finishMeta();
@@ -954,7 +952,6 @@ public:
     inline void noteEndQuery() { parseCtx.noteEndQuery(); }
     inline void noteFinishedParse(IHqlScope * scope) { parseCtx.noteFinishedParse(scope); }
     void noteExternalLookup(IHqlScope * parentScope, IHqlExpression * expr);
-    inline void noteImport(IHqlExpression * expr, _ATOM name, int position) { parseCtx.noteImport(expr, name, position); }
 
     inline IEclRepository * queryRepository() const { return parseCtx.eclRepository; }
     inline bool queryExpandCallsWhenBound() const { return parseCtx.expandCallsWhenBound; }
@@ -1173,6 +1170,9 @@ interface IHqlNamedAnnotation : public IHqlAnnotation
     virtual int getStartLine() const = 0;
     virtual int getStartColumn() const = 0;
     virtual void setRepositoryFlags(unsigned _flags) = 0;  // To preserve flags like ob_locked, ob_sandbox, etc.
+    virtual int getStartPos() const = 0;
+    virtual int getBodyPos() const = 0;
+    virtual int getEndPos() const = 0;
 };
 
 

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -887,8 +887,10 @@ public:
 
     void addForwardReference(IHqlScope * owner, IHasUnlinkedOwnerReference * child);
     void noteBeginAttribute(IHqlScope * scope, IFileContents * contents, _ATOM name);
+    void noteBeginModule(IHqlScope * scope, IFileContents * contents);
     void noteBeginQuery(IHqlScope * scope, IFileContents * contents);
     void noteEndAttribute();
+    void noteEndModule();
     void noteEndQuery();
     void noteFinishedParse(IHqlScope * scope);
     IPropertyTree * queryEnsureArchiveModule(const char * name, IHqlScope * scope);
@@ -947,8 +949,10 @@ public:
 
     void createDependencyEntry(IHqlScope * scope, _ATOM name);
     void noteBeginAttribute(IHqlScope * scope, IFileContents * contents, _ATOM name);
+    void noteBeginModule(IHqlScope * scope, IFileContents * contents);
     void noteBeginQuery(IHqlScope * scope, IFileContents * contents);
     inline void noteEndAttribute() { parseCtx.noteEndAttribute(); }
+    inline void noteEndModule() { parseCtx.noteEndAttribute(); }
     inline void noteEndQuery() { parseCtx.noteEndQuery(); }
     inline void noteFinishedParse(IHqlScope * scope) { parseCtx.noteFinishedParse(scope); }
     void noteExternalLookup(IHqlScope * parentScope, IHqlExpression * expr);
@@ -1363,6 +1367,7 @@ extern HQL_API IHqlExpression * normalizeListCasts(IHqlExpression * expr);
 extern HQL_API IHqlExpression * simplifyFixedLengthList(IHqlExpression * expr);
 extern HQL_API IHqlExpression * getCastExpr(IHqlExpression * expr, ITypeInfo * type);
 
+extern HQL_API void parseModule(IHqlScope *scope, IFileContents * contents, HqlLookupContext & ctx, IXmlScope *xmlScope, bool loadImplicit);
 extern HQL_API IHqlExpression *parseQuery(IHqlScope *scope, IFileContents * contents, 
                                           HqlLookupContext & ctx, IXmlScope *xmlScope, bool loadImplicit);
 extern HQL_API IHqlExpression *parseQuery(const char *in, IErrorReceiver * errs);

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -429,6 +429,9 @@ public:
     virtual IHqlExpression * cloneSymbol(_ATOM optname, IHqlExpression * optnewbody, IHqlExpression * optnewfuncdef, HqlExprArray * optargs);
     virtual int getStartLine() const { return 0; }
     virtual int getStartColumn() const { return 0; }
+    virtual int getStartPos() const { return 0; }
+    virtual int getBodyPos() const { return 0; }
+    virtual int getEndPos() const { return 0; }
 
 protected:
     CHqlSimpleSymbol(_ATOM _name, _ATOM _module, IHqlExpression *_expr, IHqlExpression *_funcdef, unsigned _obFlags);
@@ -438,7 +441,7 @@ class HQL_API CHqlNamedSymbol: public CHqlSymbolAnnotation
 {
 public:
     static CHqlNamedSymbol *makeSymbol(_ATOM _name, _ATOM _module, IHqlExpression *_expr, bool _exported, bool _shared, unsigned _flags);
-    static CHqlNamedSymbol *makeSymbol(_ATOM _name, _ATOM _module, IHqlExpression *_expr, IHqlExpression *_funcdef, bool _exported, bool _shared, unsigned _flags, IFileContents *_text, int _bodystart, int lineno, int column);
+    static CHqlNamedSymbol *makeSymbol(_ATOM _name, _ATOM _module, IHqlExpression *_expr, IHqlExpression *_funcdef, bool _exported, bool _shared, unsigned _flags, IFileContents *_text, int lineno, int column, int _startpos, int _bodypos, int _endpos);
 
     virtual ISourcePath * querySourcePath() const;
     
@@ -446,6 +449,9 @@ public:
     virtual IFileContents * queryDefinitionText() const;
     virtual int  getStartLine() const { return startLine; }
     virtual int  getStartColumn() const { return startColumn; }
+    virtual int getStartPos() const { return startpos; }
+    virtual int getBodyPos() const { return bodypos; }
+    virtual int getEndPos() const { return endpos; }
 
 //interface IHqlNamedAnnotation
     virtual IFileContents * getBodyContents();
@@ -453,11 +459,13 @@ public:
 
 protected:
     CHqlNamedSymbol(_ATOM _name, _ATOM _module, IHqlExpression *_expr, bool _exported, bool _shared, unsigned _obFlags);
-    CHqlNamedSymbol(_ATOM _name, _ATOM _module, IHqlExpression *_expr, IHqlExpression *_funcdef, bool _exported, bool _shared, unsigned _flags, IFileContents *_text, int _bodystart, int _startLine, int _startColumn);
+    CHqlNamedSymbol(_ATOM _name, _ATOM _module, IHqlExpression *_expr, IHqlExpression *_funcdef, bool _exported, bool _shared, unsigned _flags, IFileContents *_text, int _startLine, int _startColumn, int _startpos, int _bodypos, int _endpos);
 
 protected:
     Linked<IFileContents> text;
-    int bodystart;
+    int startpos;
+    int bodypos;
+    int endpos;
     int startLine;
     unsigned short startColumn;
 };

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -374,7 +374,7 @@ class HqlGram : public CInterface, implements IErrorReceiver
     friend int eclyyparse(HqlGram * parser);
 
 public:
-    HqlGram(HqlGramCtx &parent, IHqlScope * containerScope, IFileContents * text, IXmlScope *xmlScope);
+    HqlGram(HqlGramCtx &parent, IHqlScope * containerScope, IFileContents * text, IXmlScope *xmlScope, bool _parseConstantText);
     HqlGram(IHqlScope * _globalScope, IHqlScope * _containerScope, IFileContents * text, HqlLookupContext & _ctx, IXmlScope *xmlScope, bool _hasFieldMap, bool loadImplicit);
     virtual ~HqlGram();
     IMPLEMENT_IINTERFACE
@@ -811,6 +811,7 @@ protected:
     bool associateWarnings;
     bool legacyEclSemantics;
     bool isQuery;
+    bool parseConstantText;
     unsigned m_maxErrorsAllowed;
 
     IECLErrorArray pendingWarnings;

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -2302,7 +2302,7 @@ void HqlGram::addField(const attribute &errpos, _ATOM name, ITypeInfo *_type, IH
         reportError(ERR_BAD_FIELD_SIZE, errpos, "Field %s is too large", name->str());
 
     OwnedHqlExpr newField = createField(name, fieldType.getClear(), value, attrs);
-    OwnedHqlExpr annotated = createLocationAnnotation(newField, errpos.pos);
+    OwnedHqlExpr annotated = createLocationAnnotation(LINK(newField), errpos.pos);
     addToActiveRecord(LINK(newField));
 }
 

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -8711,8 +8711,7 @@ void HqlGram::defineSymbolInScope(IHqlScope * scope, DefineIdSt * defineid, IHql
     if (doc)
         expr = createJavadocAnnotation(expr, LINK(doc));
 
-    Owned<IFileContents> contents = createFileContentsSubset(lexObject->query_FileContents(), lastpos, semiColonPos+1-lastpos);
-    scope->defineSymbol(defineid->id, moduleName, expr, (defineid->scope & EXPORT_FLAG) != 0, (defineid->scope & SHARED_FLAG) != 0, symbolFlags, contents, idattr.pos.lineno, idattr.pos.column, idattr.pos.position, assignPos+2-lastpos, semiColonPos+1-lastpos);
+    scope->defineSymbol(defineid->id, moduleName, expr, (defineid->scope & EXPORT_FLAG) != 0, (defineid->scope & SHARED_FLAG) != 0, symbolFlags, lexObject->query_FileContents(), idattr.pos.lineno, idattr.pos.column, idattr.pos.position, assignPos+2, semiColonPos+1);
 }
 
 

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -273,6 +273,7 @@ void HqlGram::gatherActiveParameters(HqlExprCopyArray & target)
 HqlGram::HqlGram(IHqlScope * _globalScope, IHqlScope * _containerScope, IFileContents * _text, HqlLookupContext & _ctx, IXmlScope *xmlScope, bool _hasFieldMap, bool loadImplicit)
 : lookupCtx(_ctx)
 {
+    parseConstantText = false;
     init(_globalScope, _containerScope);
     fieldMapUsed = _hasFieldMap;
     if (!lookupCtx.functionCache)
@@ -293,7 +294,7 @@ HqlGram::HqlGram(IHqlScope * _globalScope, IHqlScope * _containerScope, IFileCon
     }
 }
 
-HqlGram::HqlGram(HqlGramCtx & parent, IHqlScope * _containerScope, IFileContents * _text, IXmlScope *xmlScope)
+HqlGram::HqlGram(HqlGramCtx & parent, IHqlScope * _containerScope, IFileContents * _text, IXmlScope *xmlScope, bool _parseConstantText)
 : lookupCtx(parent.lookupCtx)
 {
     //This is used for parsing a constant expression inside the preprocessor
@@ -315,6 +316,7 @@ HqlGram::HqlGram(HqlGramCtx & parent, IHqlScope * _containerScope, IFileContents
     //Clone parseScope
     lexObject = new HqlLex(this, _text, xmlScope, NULL);
     forceResult = true;
+    parseConstantText = _parseConstantText;
 }
 
 void HqlGram::saveContext(HqlGramCtx & ctx, bool cloneScopes)
@@ -8710,7 +8712,7 @@ void HqlGram::defineSymbolInScope(IHqlScope * scope, DefineIdSt * defineid, IHql
         expr = createJavadocAnnotation(expr, LINK(doc));
 
     Owned<IFileContents> contents = createFileContentsSubset(lexObject->query_FileContents(), lastpos, semiColonPos+1-lastpos);
-    scope->defineSymbol(defineid->id, moduleName, expr, (defineid->scope & EXPORT_FLAG) != 0, (defineid->scope & SHARED_FLAG) != 0, symbolFlags, contents, idattr.pos.lineno, idattr.pos.column, 0, assignPos+2-lastpos, semiColonPos+1-lastpos);
+    scope->defineSymbol(defineid->id, moduleName, expr, (defineid->scope & EXPORT_FLAG) != 0, (defineid->scope & SHARED_FLAG) != 0, symbolFlags, contents, idattr.pos.lineno, idattr.pos.column, idattr.pos.position, assignPos+2-lastpos, semiColonPos+1-lastpos);
 }
 
 
@@ -9737,8 +9739,7 @@ void HqlGram::defineImport(const attribute & errpos, IHqlExpression * imported, 
         reportWarning(ERR_ID_REDEFINE, errpos.pos, "import hides previously defined identifier");
     }
 
-    parseScope->defineSymbol(newName, NULL, LINK(imported), false, false, ob_import);
-    lookupCtx.noteImport(imported, newName, errpos.pos.position);
+    parseScope->defineSymbol(newName, NULL, LINK(imported), false, false, ob_import, NULL, errpos.pos.lineno, errpos.pos.column, errpos.pos.position, 0, errpos.pos.position);
 }
 
 
@@ -11026,7 +11027,7 @@ bool parseForwardModuleMember(HqlGramCtx & _parent, IHqlScope *scope, IHqlExpres
 {
     //The attribute will be added to the current scope as a side-effect of parsing the attribute.
     IFileContents * contents = forwardSymbol->queryDefinitionText();
-    HqlGram parser(_parent, scope, contents, NULL); 
+    HqlGram parser(_parent, scope, contents, NULL, false);
     parser.setExpectedAttribute(forwardSymbol->queryName());
     parser.setAssociateWarnings(true);
     parser.getLexer()->set_yyLineNo(forwardSymbol->getStartLine());
@@ -11156,7 +11157,8 @@ IHqlExpression *HqlGram::doParse()
         return NULL;
 
     lookupCtx.noteFinishedParse(defineScopes.tos().privateScope);
-    lookupCtx.noteFinishedParse(parseScope);
+    if (!parseConstantText)
+        lookupCtx.noteFinishedParse(parseScope);
     if (parsingTemplateAttribute)
     {
         if (parseResults.ordinality() == 0)

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -1700,14 +1700,13 @@ IHqlExpression *HqlLex::parseECL(StringBuffer &curParam, IXmlScope *xmlScope, in
 #ifdef TIMING_DEBUG
     MTIME_SECTION(timer, "HqlLex::parseConstExpression");
 #endif
-    //  Use a ECL reserved word as the scope name to avoid name conflicts with these defined localscope.
+    //  Use an ECL reserved word as the scope name to avoid name conflicts with these defined localscope.
     Owned<IHqlScope> scope = new CHqlMultiParentScope(sharedAtom,yyParser->queryPrimaryScope(false),yyParser->queryPrimaryScope(true),yyParser->parseScope.get(),NULL); 
-//  scope->defineSymbol(yyParser->globalScope->queryName(), NULL, LINK(queryExpression(yyParser->globalScope)), false, false, ob_module);
 
     HqlGramCtx parentContext(yyParser->lookupCtx);
     yyParser->saveContext(parentContext, false);
     Owned<IFileContents> contents = createFileContentsFromText(curParam, querySourcePath());
-    HqlGram parser(parentContext, scope, contents, xmlScope); 
+    HqlGram parser(parentContext, scope, contents, xmlScope, true);
     parser.getLexer()->set_yyLineNo(startLine);
     parser.getLexer()->set_yyColumn(startCol);
     return parser.yyParse(false, false);

--- a/ecl/regress/module2.ecl
+++ b/ecl/regress/module2.ecl
@@ -25,8 +25,8 @@ customerNames := module
     integer2        age := 25;
                 END;
 
-    output('customer file used by user <x>');
-    export File := dataset('x',Layout,FLAT);
+    o := output('customer file used by user <x>');
+    export File := WHEN(dataset('x',Layout,FLAT), o);
 end;
 
 


### PR DESCRIPTION
Some provisional work to generate meta information while compiling
an ECL program.  This implementation is far from complete, and the next
version is likely to be implemented rather differently.  However this
does provide some useful functionality for the eclipse plugin, so worth
releasing.
