### PR TITLE
Disallow assignment from pointer to owned/linked

### DIFF
--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1696,7 +1696,7 @@ void Cws_machineEx::enumerateRunningProcesses(CMachineInfoThreadParam* pParam,
               Owned<IEspSWRunInfo> info = static_cast<IEspSWRunInfo*>(new CSWRunInfo(""));
               info->setName(pszName);
             info->setInstances(1);
-                lptr = info.get();
+                lptr = info;
 
                 if (processMap)
                     processMap->insert(pair<string, Linked<IEspSWRunInfo> >(pszName, lptr));

--- a/system/jlib/jscm.hpp
+++ b/system/jlib/jscm.hpp
@@ -79,6 +79,7 @@ protected:
 
 private:
     inline void setown(const Shared<CLASS> &other); // illegal - going to cause a -ve leak
+    inline Shared<CLASS> & operator = (const CLASS * other);
 
 private:
     CLASS * ptr;
@@ -92,8 +93,11 @@ public:
     inline Owned()                              { }
     inline Owned(CLASS * _ptr) : Shared<CLASS>(_ptr)   { }
 
+    inline Shared<CLASS> & operator = (const Shared<CLASS> & other) { set(other.get()); return *this;  }
+
 private:
     inline Owned(const Shared<CLASS> & other); // Almost certainly a bug
+    inline Owned<CLASS> & operator = (const CLASS * other);
 };
 
 
@@ -104,6 +108,11 @@ public:
     inline Linked()                         { }
     inline Linked(CLASS * _ptr) : Shared<CLASS>(LINK(_ptr)) { }
     inline Linked(const Shared<CLASS> & other) : Shared<CLASS>(other) { }
+
+    inline Shared<CLASS> & operator = (const Shared<CLASS> & other) { set(other.get()); return *this;  }
+
+private:
+    inline Linked<CLASS> & operator = (const CLASS * other);
 };
 
 // IStringVal manages returning of arbitrary null-terminated string data between systems that may not share heap managers

--- a/system/security/shared/SecurityResourceList.hpp
+++ b/system/security/shared/SecurityResourceList.hpp
@@ -96,7 +96,7 @@ public:
         {   
             resource = new CSecurityResource(name);
             m_rlist.append(*resource);
-            m_rmap[name] = resource;
+            m_rmap[name].set(resource);
         }
         return resource;
     }
@@ -114,7 +114,7 @@ public:
         if(r == NULL)
         {
             m_rlist.append(*resource);
-            m_rmap[name] = resource;
+            m_rmap[name].set(resource);
         }
         else
             resource->Release();


### PR DESCRIPTION
The previous change to introduce a shared base class meant that
assignments from a pointer were allowed (by going via constructor
and copy constructor).  This fixes that issue.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
