### PR TITLE
Temporary fix for dfuserver crash

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -985,7 +985,7 @@ public:
             return DFUstate_unknown;
         }
         StringBuffer logname;
-        if (fileMsgHandler->getLogName(logname)) 
+        if (fileMsgHandler && fileMsgHandler->getLogName(logname))
             wu->setDebugValue("dfulog", logname.str(), true);
         IConstDFUfileSpec *source = wu->querySource();
         IConstDFUfileSpec *destination = wu->queryDestination();


### PR DESCRIPTION
Regression caused by recent changes to the logging.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
