### PR TITLE
Initial work on implicit alias creation.

### DIFF
--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -218,6 +218,7 @@ _ATOM noCaseAtom;
 _ATOM _noHoist_Atom;
 _ATOM noLocalAtom;
 _ATOM noOverwriteAtom;
+_ATOM _normalized_Atom;
 _ATOM noRootAtom;
 _ATOM noScanAtom;
 _ATOM noSortAtom;
@@ -594,6 +595,7 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKESYSATOM(noHoist);
     MAKEATOM(noLocal);
     MAKEATOM(noOverwrite);
+    MAKESYSATOM(normalized);
     MAKEATOM(noRoot);
     MAKEATOM(noScan);
     MAKEATOM(noSort);

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -222,6 +222,7 @@ extern HQL_API _ATOM noCaseAtom;
 extern HQL_API _ATOM _noHoist_Atom;
 extern HQL_API _ATOM noLocalAtom;
 extern HQL_API _ATOM noOverwriteAtom;
+extern HQL_API _ATOM _normalized_Atom;
 extern HQL_API _ATOM noRootAtom;
 extern HQL_API _ATOM noScanAtom;
 extern HQL_API _ATOM noSortAtom;

--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -538,7 +538,7 @@ unsigned getOperatorMetaFlags(node_operator op)
     case no_notify:
     case no_setgraphresult:
     case no_extractresult:
-    case no_updatestate:
+    case no_unused81:
     case no_definesideeffect:
 
 // Scopes etc.
@@ -1918,6 +1918,7 @@ bool isTrivialDataset(IHqlExpression * expr)
         case no_distributed:
         case no_grouped:
         case no_preservemeta:
+        case no_dataset_alias:
         case no_filter:
             expr = expr->queryChild(0);
             break;

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4909,14 +4909,14 @@ IHqlExpression * CExprFolderTransformer::percolateConstants(IHqlExpression * exp
             {
             case childdataset_none: 
             case childdataset_nway_left_right:
-            case childdataset_addfiles:
-            case childdataset_merge:
+            case childdataset_many_noscope:
+            case childdataset_many:
             case childdataset_if:
             case childdataset_case:
             case childdataset_map:
             case childdataset_evaluate:
-            case childdataset_dataset_noscope: 
                 break;
+            case childdataset_dataset_noscope:
             case childdataset_dataset:
                 updated.setown(percolateConstants(updated, child, no_none));
                 break;
@@ -5553,6 +5553,8 @@ HqlConstantPercolator * CExprFolderTransformer::gatherConstants(IHqlExpression *
         break;
 
     default:
+        if (expr->isAction())
+            break;
         DBGLOG("Missing entry: %s", getOpString(expr->getOperator()));
         if (expr->isDatarow())
         {

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -7776,6 +7776,10 @@ simpleDataSet
                             $$.setExpr(createDataset(no_newusertable, $3.getExpr(), createComma(LINK(tform->queryRecord()), ensureTransformType(tform, no_newtransform))));
                             $$.setPosition($1);
                         }
+    | TABLE '(' startTopFilter ')' endTopFilter
+                        {
+                            $$.setExpr(createDataset(no_dataset_alias, $3.getExpr(), ::createUniqueId()), $1);
+                        }
     | FETCH '(' startLeftSeqFilter ',' startRightFilterUpdateSeq ',' expression ',' transform optCommonAttrs ')' endRightFilter endLeftFilter endSelectorSequence
                         {
                             parser->normalizeExpression($7, type_int, false);
@@ -8014,20 +8018,20 @@ simpleDataSet
                             $$.setExpr(createDataset(no_workunit_dataset, $8.getExpr(), arg));
                             $$.setPosition($1);
                         }
-    | ENTH '(' startTopFilter ',' expression optCommonAttrs ')' endTopFilter
+    | ENTH '(' dataSet ',' expression optCommonAttrs ')'
                         {
                             parser->normalizeExpression($5, type_numeric, false);
                             $$.setExpr(createDataset(no_enth, $3.getExpr(), createComma($5.getExpr(), $6.getExpr())));
                             $$.setPosition($1);
                         }
-    | ENTH '(' startTopFilter ',' expression ',' expression optCommonAttrs ')' endTopFilter
+    | ENTH '(' dataSet ',' expression ',' expression optCommonAttrs ')'
                         {
                             parser->normalizeExpression($5, type_numeric, false);
                             parser->normalizeExpression($7, type_numeric, false);
                             $$.setExpr(createDataset(no_enth, $3.getExpr(), createComma($5.getExpr(), $7.getExpr(), $8.getExpr())));
                             $$.setPosition($1);
                         }
-    | ENTH '(' startTopFilter ',' expression ',' expression ',' expression optCommonAttrs ')' endTopFilter
+    | ENTH '(' dataSet ',' expression ',' expression ',' expression optCommonAttrs ')'
                         {
                             parser->normalizeExpression($5, type_numeric, false);
                             parser->normalizeExpression($7, type_numeric, false);
@@ -8064,7 +8068,7 @@ simpleDataSet
                             $$.setExpr(createDataset(no_pipe, $3.getExpr(), createComma($5.getExpr(), $7.getExpr(), LINK(attrs))));
                             $$.setPosition($1);
                         }
-    | PRELOAD '(' startTopFilter optConstExpression ')' endTopFilter
+    | PRELOAD '(' dataSet optConstExpression ')'
                         {
                             $$.setExpr(createDataset(no_preload, $3.getExpr(), $4.getExpr()));
                             $$.setPosition($1);

--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -526,10 +526,34 @@ public:
     using NewHqlTransformer::setSelectorMapping;
 };
 
+class HQL_API HqlMapDatasetTransformer : public NewHqlTransformer
+{
+public:
+    HqlMapDatasetTransformer();
+
+    virtual IHqlExpression * createTransformed(IHqlExpression * expr)
+    {
+        IHqlExpression * body = expr->queryBody(true);
+        if (expr == body)
+        {
+            OwnedHqlExpr transformed = NewHqlTransformer::createTransformed(expr);
+            updateOrphanedSelectors(transformed, expr);
+            return transformed.getClear();
+        }
+        OwnedHqlExpr transformed = transform(body);
+        return expr->cloneAnnotation(transformed);
+    }
+
+    using NewHqlTransformer::setMapping;
+    using NewHqlTransformer::setSelectorMapping;
+};
+
 class HQL_API HqlMapSelectorTransformer : public HqlMapTransformer
 {
 public:
     HqlMapSelectorTransformer(IHqlExpression * oldValue, IHqlExpression * newValue);
+
+    virtual IHqlExpression * createTransformed(IHqlExpression * expr);
 
 protected:
     OwnedHqlExpr oldSelector;
@@ -672,6 +696,7 @@ public:
 
 
 extern HQL_API IHqlExpression * replaceExpression(IHqlExpression * expr, IHqlExpression * original, IHqlExpression * replacement);
+extern HQL_API IHqlExpression * replaceDataset(IHqlExpression * expr, IHqlExpression * original, IHqlExpression * replacement);
 
 
 //------------------------------------------------------------------------

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -625,6 +625,9 @@ extern HQL_API IHqlExpression * ensureOwned(IHqlExpression * expr);
 extern HQL_API bool isSetWithUnknownElementSize(ITypeInfo * type);
 extern HQL_API IHqlExpression * replaceParameters(IHqlExpression * body, IHqlExpression * oldParams, IHqlExpression * newParams);
 
+extern HQL_API IHqlExpression * normalizeDatasetAlias(IHqlExpression * expr);
+extern HQL_API IHqlExpression * normalizeAnyDatasetAliases(IHqlExpression * expr);
+
 //In hqlgram2.cpp
 extern HQL_API IPropertyTree * queryEnsureArchiveModule(IPropertyTree * archive, const char * name, IHqlScope * rScope);
 extern HQL_API IPropertyTree * queryArchiveAttribute(IPropertyTree * module, const char * name);

--- a/ecl/hqlcpp/hqlcatom.cpp
+++ b/ecl/hqlcpp/hqlcatom.cpp
@@ -416,7 +416,6 @@ _ATOM newWorkUnitReadArgAtom;
 _ATOM newWorkUnitWriteArgAtom;
 _ATOM _noAccess_Atom;
 _ATOM _noReplicate_Atom;
-_ATOM _normalized_Atom;
 _ATOM noSetAtom;
 _ATOM _noVirtual_Atom;
 _ATOM numResultsAtom;
@@ -1119,7 +1118,6 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM-1)
     MAKEATOM(newWorkUnitWriteArg);
     MAKESYSATOM(noAccess);
     MAKESYSATOM(noReplicate);
-    MAKESYSATOM(normalized);
     MAKEATOM(noSet);
     MAKESYSATOM(noVirtual);
     MAKEATOM(numResults);

--- a/ecl/hqlcpp/hqlcatom.hpp
+++ b/ecl/hqlcpp/hqlcatom.hpp
@@ -416,7 +416,6 @@ extern _ATOM newWorkUnitReadArgAtom;
 extern _ATOM newWorkUnitWriteArgAtom;
 extern _ATOM _noAccess_Atom;
 extern _ATOM _noReplicate_Atom;
-extern _ATOM _normalized_Atom;
 extern _ATOM noSetAtom;
 extern _ATOM _noVirtual_Atom;
 extern _ATOM numResultsAtom;

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1671,6 +1671,9 @@ void HqlCppTranslator::cacheOptions()
         // The following works 99% of the time, but disabled due to potential problems with the ambiguity of LEFT
         //possibly causing filters on nested records to be incorrectly removed.
         DebugOption(options.optimizeNestedConditional,"optimizeNestedConditional", false),
+        DebugOption(options.createImplicitAliases,"createImplicitAliases", false),
+        DebugOption(options.combineSiblingGraphs,"combineSiblingGraphs", true),
+        DebugOption(options.optimizeSharedGraphInputs,"optimizeSharedGraphInputs", true),
     };
 
     //get options values from workunit

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -700,6 +700,9 @@ struct HqlCppOptions
     bool                standAloneExe;
     bool                enableCompoundCsvRead;
     bool                optimizeNestedConditional;
+    bool                createImplicitAliases;
+    bool                combineSiblingGraphs;
+    bool                optimizeSharedGraphInputs;
 };
 
 //Any information gathered while processing the query should be moved into here, rather than cluttering up the translator class

--- a/ecl/hqlcpp/hqlcpputil.cpp
+++ b/ecl/hqlcpp/hqlcpputil.cpp
@@ -215,14 +215,6 @@ bool storePointerInArray(ITypeInfo * type)
     return type->isReference() && isTypePassedByAddress(type); 
 }
 
-//Convert no_dataset_alias(expr, uid) to expr'
-IHqlExpression * normalizeDatasetAlias(IHqlExpression * expr)
-{
-    IHqlExpression * uid = expr->queryProperty(_uid_Atom);
-    assertex(uid);
-    return appendOwnedOperand(expr->queryChild(0), LINK(uid));
-}
-
 //---------------------------------------------------------------------------
 
 bool isSelectSortedTop(IHqlExpression * selectExpr)

--- a/ecl/hqlcpp/hqlcpputil.hpp
+++ b/ecl/hqlcpp/hqlcpputil.hpp
@@ -46,7 +46,6 @@ extern IHqlExpression * addMemberSelector(IHqlExpression * expr, IHqlExpression 
 extern IHqlExpression * addExpressionModifier(IHqlExpression * expr, typemod_t modifier, IInterface * extra=NULL);
 extern void expandFieldNames(StringBuffer & out, IHqlExpression * record, const char * sep, IHqlExpression * formatFunc);
 extern IHqlExpression * ensurePositiveOrZeroInt64(IHqlExpression * expr);
-extern IHqlExpression * normalizeDatasetAlias(IHqlExpression * expr);
 
 extern void getOutputLibraryName(SCMStringBuffer & libraryName, IConstWorkUnit * wu);
 extern bool canCreateTemporary(IHqlExpression * expr);

--- a/ecl/hqlcpp/hqlcse.cpp
+++ b/ecl/hqlcpp/hqlcse.cpp
@@ -543,6 +543,7 @@ bool CseSpotter::checkPotentialCSE(IHqlExpression * expr, CseSpotterInfo * extra
     case no_xmlproject:
     case no_datasetfromrow:
     case no_preservemeta:
+    case no_dataset_alias:
     case no_workunit_dataset:
     case no_left:
     case no_right:

--- a/ecl/hqlcpp/hqlinline.cpp
+++ b/ecl/hqlcpp/hqlinline.cpp
@@ -262,6 +262,7 @@ static unsigned calcInlineFlags(BuildCtx * ctx, IHqlExpression * expr)
     case no_alias_scope:
     case no_serialize:
     case no_deserialize:
+    case no_dataset_alias:
         return getInlineFlags(ctx, expr->queryChild(0));
     case no_forcegraph:
         return 0;

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -326,6 +326,7 @@ static node_operator queryCompoundOp(IHqlExpression * expr)
         return no_compound_diskread;
     case no_newkeyindex:
         return no_compound_indexread;
+    case no_dataset_alias:
     case no_preservemeta:
         return queryCompoundOp(expr->queryChild(0));
     }
@@ -625,8 +626,8 @@ void ComplexImplicitProjectInfo::trace()
     switch (childDatasetType)
     {
     case childdataset_none: 
-    case childdataset_addfiles:
-    case childdataset_merge:
+    case childdataset_many_noscope:
+    case childdataset_many:
     case childdataset_if:
     case childdataset_case:
     case childdataset_map:
@@ -1225,7 +1226,7 @@ void ImplicitProjectTransformer::gatherFieldsUsed(IHqlExpression * expr, Implici
             switch (getChildDatasetType(expr))
             {
             case childdataset_none: 
-            case childdataset_addfiles:
+            case childdataset_many_noscope:
             case childdataset_if:
             case childdataset_case:
             case childdataset_map:
@@ -1233,7 +1234,7 @@ void ImplicitProjectTransformer::gatherFieldsUsed(IHqlExpression * expr, Implici
                 inheritActiveFields(expr, extra, 0, max);
                 //None of these have any scoped arguments, so no need to remove them
                 break;
-            case childdataset_merge:
+            case childdataset_many:
                 {
                     unsigned firstAttr = getNumChildTables(expr);
                     inheritActiveFields(expr, extra, firstAttr, max);
@@ -1583,10 +1584,9 @@ ProjectExprKind ImplicitProjectTransformer::getProjectExprKind(IHqlExpression * 
     case no_writespill:
         return ActionSinkActivity;
     case no_preservemeta:
+    case no_dataset_alias:
         if (getProjectExprKind(expr->queryChild(0)) == CompoundableActivity)
             return CompoundableActivity;
-        return PassThroughActivity;
-    case no_dataset_alias:
         return PassThroughActivity;
     }
 
@@ -2643,8 +2643,8 @@ IHqlExpression * ImplicitProjectTransformer::updateSelectors(IHqlExpression * ne
     switch (getChildDatasetType(newExpr))
     {
     case childdataset_none: 
-    case childdataset_addfiles:
-    case childdataset_merge:
+    case childdataset_many_noscope:
+    case childdataset_many:
     case childdataset_if:
     case childdataset_case:
     case childdataset_map:

--- a/ecl/hqlcpp/hqliter.cpp
+++ b/ecl/hqlcpp/hqliter.cpp
@@ -100,6 +100,7 @@ bool canBuildSequenceInline(IHqlExpression * expr)
         case no_compound_selectnew:
         case no_compound_inline:
         case no_alias_scope:
+        case no_dataset_alias:
             expr = expr->queryChild(0);
             break;
         default:

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -196,6 +196,7 @@ bool isSimpleSource(IHqlExpression * expr)
         case no_sectioninput:
         case no_nofold:
         case no_nohoist:
+        case no_dataset_alias:
             break;
         default:
             return false;
@@ -950,6 +951,7 @@ void SourceBuilder::analyse(IHqlExpression * expr)
     case no_sectioninput:
     case no_nofold:
     case no_nohoist:
+    case no_dataset_alias:
         break;
     case no_preload:
         isPreloaded = true;
@@ -5902,6 +5904,7 @@ void MonitorExtractor::extractAllFilters(IHqlExpression * dataset)
         case no_stepped:
         case no_grouped:
         case no_alias_scope:
+        case no_dataset_alias:
             break;
         default:
             UNIMPLEMENTED;
@@ -7200,4 +7203,3 @@ ABoundActivity * HqlCppTranslator::doBuildActivityFetch(BuildCtx & ctx, IHqlExpr
     throwError1(HQLERR_FetchNotSupportMode, getOpString(kind));
     return NULL;
 }
-

--- a/ecl/regress/sqfilt6.ecl
+++ b/ecl/regress/sqfilt6.ecl
@@ -36,4 +36,7 @@ books_2 := table(books);
 
 //people with a book worth more than the rest of their books.
 //Iterate books twice, and ensure that the two cursors are separately accessed.
-output(sqHousePersonBookDs.persons, { exists(books(price > sum(books_2(id != books.id), price))); });
+validBooks := nofold(books(max(id*7,99) != 0));
+validBooks2 := table(validBooks);
+
+output(sqHousePersonBookDs.persons, { exists(validBooks(price > sum(validBooks2(id != books.id), price))); });


### PR DESCRIPTION
- USE TABLE(dataset) to introduce a dataset alias
- Fix problems with using dataset aliases in various contexts (e.g,
  inline aggregates)
- Fix the implicit alias creator to generate much better code.
  - the option is currently defaulted off
- IF(cond, ds(x), table(ds)(y)) now optimized to
  table(ds)(if(cond, x, y));
  (generating same code as if implicit aliases are disabled)

Some related changes
- Clean up the childdataset types
- Improve generation of splitters inside subgraphs

Previously a disk read of a spill file would often be duplicated
inside a subgraph that read it, and sibling subgraphs which read the
same spill files were not combined.  This change ensures a splitter
is now generated in those situations.

A splitter is only added if it would be balanced - otherwise the
potential spill in the splitter would outweigh any benefit.
- Splitters of splitter are now combined into a single splitter.  (Also
  improves existing queries.)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
