### PR TITLE
Remove no_countfile from the code generator

### DIFF
--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -250,7 +250,6 @@ unsigned getOperatorMetaFlags(node_operator op)
     case no_within:
     case no_notwithin:
     case no_countcompare:
-    case no_countfile:
 
 //Selectors
     case no_left:
@@ -613,6 +612,7 @@ unsigned getOperatorMetaFlags(node_operator op)
     case no_unused30: case no_unused31: case no_unused32: case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38:
     case no_unused40: case no_unused41: case no_unused42: case no_unused43: case no_unused44: case no_unused45: case no_unused46: case no_unused47: case no_unused48: case no_unused49:
     case no_unused50: case no_unused52:
+    case no_unused80:
     case no_is_null:
     case no_position:
     case no_current_time:

--- a/ecl/hql/hqlattr.hpp
+++ b/ecl/hql/hqlattr.hpp
@@ -38,6 +38,7 @@ extern HQL_API bool maxRecordSizeCanBeDerived(IHqlExpression * record);
 extern HQL_API bool reducesRowSize(IHqlExpression * expr);
 extern HQL_API bool increasesRowSize(IHqlExpression * expr);
 extern HQL_API bool isVariableSizeRecord(IHqlExpression * record);
+inline bool isFixedSizeRecord(IHqlExpression * record) { return !isVariableSizeRecord(record); }
 
 extern HQL_API bool recordRequiresDestructor(IHqlExpression * expr);
 extern HQL_API bool recordRequiresSerialization(IHqlExpression * expr);

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -949,7 +949,6 @@ const char *getOpString(node_operator op)
     case no_comma: return ",";
     case no_compound: return ",";
     case no_count: case no_countlist: return "COUNT";
-    case no_countfile: return "COUNTFILE";
     case no_counter: return "COUNTER";
     case no_countgroup: return "COUNT";
     case no_distribution: return "DISTRIBUTION";
@@ -1698,7 +1697,6 @@ int getPrecedence(node_operator op)
     case no_filter:
     case no_limit:
     case no_catchds:
-    case no_countfile:
     case no_distribution:
     case NO_AGGREGATE:
     case no_keyedlimit:
@@ -1810,7 +1808,6 @@ childDatasetType getChildDatasetType(IHqlExpression * expr)
     case no_throughaggregate:
     case no_countcompare:
     case no_fieldmap:
-    case no_countfile:
     case NO_AGGREGATE:
     case no_output:
     case no_buildindex:
@@ -2068,7 +2065,6 @@ inline unsigned doGetNumChildTables(IHqlExpression * dataset)
     case no_aggregate:
     case no_usertable:
     case NO_AGGREGATE:
-    case no_countfile:
     case no_output:
     case no_buildindex:
     case no_distribution:
@@ -3253,8 +3249,6 @@ void CHqlExpression::updateFlagsAfterOperands()
         break;
     case NO_AGGREGATE:
         infoFlags2 |= HEF2containsNewDataset;
-        //fall through
-    case no_countfile:
         if (queryChild(0) && (queryChild(0)->getOperator() == no_null))
             infoFlags2 |= HEF2constant;
         // don't percolate aliases beyond their subqueries at the moment.
@@ -4190,7 +4184,6 @@ bool CHqlExpression::isAggregate()
     {
     case NO_AGGREGATE:
     case NO_AGGREGATEGROUP:
-    case no_countfile:
     case no_distribution:
 
 
@@ -4747,7 +4740,6 @@ void CHqlExpression::cacheTablesUsed()
                 addActiveTable(inScopeTables, this);
                 break;
             case NO_AGGREGATE:
-            case no_countfile:
             case no_createset:
                 {
 #ifdef GATHER_HIDDEN_SELECTORS

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -582,7 +582,7 @@ enum _node_operator {
         no_temprow,
         no_activerow,                   // no_activerow(dataset) - used to disambiguate rows that are in scope.
         no_catch,
-        no_countfile,
+    no_unused80,
         no_reference,
         no_callback,                    // only used by code generator to backpatch the source
         no_keyedlimit,

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4381,7 +4381,6 @@ IHqlExpression * CExprFolderTransformer::doFoldTransformed(IHqlExpression * unfo
             }
             break;
         }
-    case no_countfile:
     case no_within:
     case no_sum:
         {

--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -2817,11 +2817,6 @@ const char * HqltHql::getEclOpString(node_operator op)
         return "DISKREAD";
     case no_compound_indexread:
         return "INDEXREAD";
-    case no_countfile:
-        if (expandProcessed)
-            return ::getOpString(op);
-        else
-            return "COUNT";
     case no_keyedlimit:
         if (expandProcessed)
             return "KEYEDLIMIT";

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -3145,7 +3145,6 @@ void ScopedTransformer::analyseChildren(IHqlExpression * expr)
         }
         //fallthrough
     case NO_AGGREGATE:
-    case no_countfile:
     case no_buildindex:
     case no_apply:
     case no_distributer:
@@ -3524,7 +3523,6 @@ IHqlExpression * ScopedTransformer::createTransformed(IHqlExpression * expr)
         throwUnexpected();
     case NO_AGGREGATE:
     case no_joined:
-    case no_countfile:
     case no_buildindex:
     case no_apply:
     case no_distribution:

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -1491,7 +1491,6 @@ unsigned getNumActivityArguments(IHqlExpression * expr)
     case no_newkeyindex:
     case no_table:
     case no_preload:
-    case no_countfile:
     case no_allnodes:
     case no_thisnode:
     case no_keydiff:
@@ -4174,7 +4173,6 @@ void SplitDatasetAttributeTransformer::analyseExpr(IHqlExpression * expr)
         return;
     case NO_AGGREGATE:
     case no_createset:
-    case no_countfile:
     case no_colon:
     case no_globalscope:
     case no_nothor:

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1575,7 +1575,6 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.foldOptimized,"foldOptimized", false),
         DebugOption(options.globalFold,"globalFold", true),
         DebugOption(options.globalOptimize,"globalOptimize", false),
-        DebugOption(options.optimizeThorCounts,"optimizeThorCounts", true),
         DebugOption(options.applyInstantEclTransformations,"applyInstantEclTransformations", false),        // testing option
         DebugOption(options.calculateComplexity,"calculateComplexity", false),
         DebugOption(options.generateLogicalGraph,"generateLogicalGraph", false),
@@ -1626,7 +1625,6 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.optimizeDiskSource,"optimizeDiskSource", true),
         DebugOption(options.optimizeIndexSource,"optimizeIndexSource", true),
         DebugOption(options.optimizeChildSource,"optimizeChildSource", false),
-        DebugOption(options.createCountFile,"countFile", true),
         DebugOption(options.reportLocations,"reportLocations", true),
         DebugOption(options.debugGeneratedCpp,"debugGeneratedCpp", false),
         DebugOption(options.addFilesnamesToGraph,"addFilesnamesToGraph", true),
@@ -2773,9 +2771,6 @@ void HqlCppTranslator::buildExpr(BuildCtx & ctx, IHqlExpression * expr, CHqlBoun
     {
     case no_counter:
         doBuildExprCounter(ctx, expr, tgt);
-        return;
-    case no_countfile:
-        doBuildExprCountFile(ctx, expr, tgt);
         return;
     case no_evaluate:
         doBuildExprEvaluate(ctx, expr, tgt);

--- a/ecl/hqlcpp/hqlcpp.hpp
+++ b/ecl/hqlcpp/hqlcpp.hpp
@@ -67,7 +67,6 @@ The following debug options are currently supported by the code generator:
 "foldAssign"             true   - should transforms be constant folded?
 "foldGraph"              false  - fold expressions at the graph level if optimizeGraph is set.
 "foldOptimized"          false  - fold expressions when internal optimizer called.
-"optimizeThorCounts"     true   - convert count(diskfile) into optimized version.
 "peephole"               true   - peephole optimize memcpy/memsets etc.
 "spotCSE"                true   - Look for common sub-expressions in transforms/filters?
 "spotTopN"               true   - Convert choosen(sort()) into a topN activity.

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -559,7 +559,6 @@ struct HqlCppOptions
     bool                evaluateCoLocalRowInvariantInExtract;
     bool                allowInlineSpill;
     bool                spanMultipleCpp;
-    bool                createCountFile;
     bool                optimizeGlobalProjects;
     bool                optimizeResourcedProjects;
     byte                notifyOptimizedProjects;
@@ -626,7 +625,6 @@ struct HqlCppOptions
     bool                foldOptimized;
     bool                globalFold;
     bool                globalOptimize;
-    bool                optimizeThorCounts;
     bool                applyInstantEclTransformations;
     bool                calculateComplexity;
     bool                generateLogicalGraph;
@@ -1003,7 +1001,6 @@ public:
     void noteXpathUsed(const char * xpath);
     void noteXpathUsed(IHqlExpression * expr);
 
-    bool allowCountFile() { return options.createCountFile; }
     HqlCppOptions const & queryOptions() const { return options; }
     ITimeReporter * queryTimeReporter() const { return timeReporter; }
 
@@ -1238,7 +1235,6 @@ public:
     void doBuildExprCompare(BuildCtx & ctx, IHqlExpression * expr, CHqlBoundExpr & tgt);
     void doBuildExprCompareElement(BuildCtx & ctx, node_operator comp_op, IHqlExpression * lhs, IHqlExpression * rhs, CHqlBoundExpr & tgt);
     void doBuildExprCount(BuildCtx & ctx, IHqlExpression * expr, CHqlBoundExpr & tgt);
-    void doBuildExprCountFile(BuildCtx & ctx, IHqlExpression * expr, CHqlBoundExpr & tgt);
     void doBuildExprCounter(BuildCtx & ctx, IHqlExpression * expr, CHqlBoundExpr & tgt);
     void doBuildExprCppBody(BuildCtx & ctx, IHqlExpression * expr, CHqlBoundExpr * tgt);
     void doBuildExprDivide(BuildCtx & ctx, IHqlExpression * expr, CHqlBoundExpr & tgt);
@@ -1758,7 +1754,6 @@ protected:
     void processEmbeddedLibraries(HqlExprArray & exprs, HqlExprArray & internalLibraries, bool isLibrary);
     void pickBestEngine(WorkflowArray & array);
     void pickBestEngine(HqlExprArray & exprs);
-    void optimizeThorCounts(HqlExprArray & exprs);
     IHqlExpression * separateLibraries(IHqlExpression * query, HqlExprArray & internalLibraries);
 
     void doBuildSerialize(BuildCtx & ctx, _ATOM name, IHqlExpression * length, CHqlBoundExpr & bound, const char * bufferName);

--- a/ecl/hqlcpp/hqlcse.cpp
+++ b/ecl/hqlcpp/hqlcse.cpp
@@ -364,7 +364,6 @@ bool CseSpotter::containsPotentialCSE(IHqlExpression * expr)
     case no_activetable:
     case no_filepos:
     case no_file_logicalname:
-    case no_countfile:
     case no_matched:
     case no_matchtext:
     case no_matchunicode:
@@ -1245,7 +1244,6 @@ bool TableInvariantTransformer::isInvariant(IHqlExpression * expr)
     case no_workunit_dataset:
     case no_getresult:
     case no_getgraphresult:
-    case no_countfile:
         invariant = true;
         break;
     case no_select:

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -980,12 +980,6 @@ void ImplicitProjectTransformer::analyseExpr(IHqlExpression * expr)
                 {
                     switch (op)
                     {
-                    case no_countfile:
-                        //MORE: Is this the best way to handle this?
-                        allowActivity = false;
-                        Parent::analyseExpr(expr);
-                        allowActivity = true;
-                        return;
                     case NO_AGGREGATE:
                     case no_call:
                     case no_externalcall:
@@ -1202,7 +1196,6 @@ void ImplicitProjectTransformer::gatherFieldsUsed(IHqlExpression * expr, Implici
     /*
     The following can be handled using the default mechanism because we're not tracking newtables.
     case NO_AGGREGATE:
-    case no_countfile:
     case no_createset:
     */
     case no_table:
@@ -1572,7 +1565,6 @@ ProjectExprKind ImplicitProjectTransformer::getProjectExprKind(IHqlExpression * 
     case no_assignall:
         return NonActivity;
     case NO_AGGREGATE:
-//  case no_countfile:
     case no_createset:
         return SimpleActivity;
     case no_call:

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -2226,7 +2226,6 @@ protected:
                 break;
             }
         case no_sizeof:
-        case no_countfile:
         case no_allnodes:
         case no_nohoist:
             return;


### PR DESCRIPTION
This code is very old.  After comparing the results, I conclude
no_countfile is no longer worth generating - often better code is
generated by using the standard disk counting functions.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
