### PR TITLE
Revert the change that removed ftslave from environment

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -960,6 +960,17 @@
                          service="ecldirect"/>
    </Properties>
   </EspService>
+  <FTSlaveProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}"
+                  buildSet="ftslave"
+                  description="FTSlave process"
+                  name="myftslave"
+                  version="1">
+   <Instance computer="localhost"
+             directory="${RUNTIME_PATH}/myftslave"
+             name="s1"
+             netAddress="."
+             program="${EXEC_PATH}/ftslave"/>
+  </FTSlaveProcess>
   <PluginProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}"
                  buildSet="plugins_auditlib"
                  description="plugin process"

--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -1,9 +1,9 @@
 
 [Algorithm]
 max_comps_per_node=4
-do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver,ftslave
+do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver
 avoid_combo=dali-eclagent
-comps_on_all_nodes=dafilesrv
+comps_on_all_nodes=dafilesrv,ftslave
 topology_for_comps=thor,hthor,roxie
 do_not_gen_optional=dali,thor
 roxie_agent_redundancy=1,2,1


### PR DESCRIPTION
At present dfuserver uses environment to locate ftslave. Until we can
change that to use something more sensible, revert the change so that
dfu still works.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
