### PR TITLE
FIXES hpcc-systems/LN#255 Add check for references to @MySQL

### DIFF
--- a/deployment/deployutils/deployutils.cpp
+++ b/deployment/deployutils/deployutils.cpp
@@ -2623,6 +2623,7 @@ bool checkComponentReferences(const IPropertyTree* pEnv, IPropertyTree* pNode, c
     xpathArray.append("*");
     attribs.append("@mySql");
     attribs.append("@MySql");
+    attribs.append("@MySQL");
     attribs.append("@database");
   }
   else if (!strcmp(szProcess, XML_TAG_PLUGINPROCESS))


### PR DESCRIPTION
Checking for references to @MySQL to prevent deletion of mysqlserver component

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
