### PR TITLE
Correct code brought to attention by clang warnings

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -11267,8 +11267,8 @@ IHqlExpression * HqlTreeNormalizer::createTransformedBody(IHqlExpression * expr)
         {
             HqlExprArray children;
             bool same = transformChildren(expr, children);
-            IHqlExpression * denom = expr->queryChild(2);
-            if (!denom || (denom->isAttribute() && !expr->queryProperty(localAtom)))
+            IHqlExpression * denom = queryRealChild(expr, 2);
+            if (!denom && !expr->queryProperty(localAtom))
             {
                 children.add(*createValue(no_count, LINK(defaultIntegralType), LINK(&children.item(0))), 2);
                 same = false;


### PR DESCRIPTION
Previous code would have worked, but only by good fortune.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
