### PR TITLE
Fix graph prepare threading issue

### DIFF
--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -812,7 +812,7 @@ friend class CGraphElementBase;
 
 interface IGraphExecutor : extends IInterface
 {
-    virtual void add(CGraphBase *subGraph, IGraphCallback &callback, size32_t parentExtractSz, const byte *parentExtract) = 0;
+    virtual void add(CGraphBase *subGraph, IGraphCallback &callback, bool checkDependencies, size32_t parentExtractSz, const byte *parentExtract) = 0;
     virtual IThreadPool &queryGraphPool() = 0 ;
     virtual void wait() = 0;
 };
@@ -884,7 +884,7 @@ public:
     virtual IGraphTempHandler *createTempHandler() = 0;
     virtual CGraphBase *createGraph() = 0;
     void joinGraph(CGraphBase &graph);
-    void startGraph(CGraphBase &graph, IGraphCallback &callback, size32_t parentExtractSize, const byte *parentExtract);
+    void startGraph(CGraphBase &graph, IGraphCallback &callback, bool checkDependencies, size32_t parentExtractSize, const byte *parentExtract);
 
     void addDependencies(IPropertyTree *xgmml, bool failIfMissing=true);
     void addSubGraph(CGraphBase &graph)


### PR DESCRIPTION
Sub graphs executed by the graph executor thread could overlap the main
dependency walking thread, resulting in the same graph being prepared on two
different threads. Normally this went unoticed, but could cause problems if
a conditional was being followed and being reevaluated at the same time.
Also fix a related, exposed issues - if an OUTPUT,UPDATE was part of a set
of subgraphs and the last one to execute and already up to date, then the
graph executor would wait indefinetely for it to finish

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
