### PR TITLE
Fix gh-1161, detect low allocator memory

### DIFF
--- a/system/jlib/jmalloc.hpp
+++ b/system/jlib/jmalloc.hpp
@@ -31,6 +31,7 @@ interface IAllocator: extends IInterface
     virtual size32_t usableSize(const void *)=0;  
     virtual memsize_t totalAllocated()=0;   // amount allocated from OS
     virtual memsize_t totalMax()=0;         // total that can be allocated from OS
+    virtual memsize_t totalRemaining()=0;   // maximum remaining
     virtual void checkPtrValid(const void * ptr)=0;   // for debugging only
     virtual void logMemLeaks(bool logdata)=0; 
     virtual void * allocMem2(size32_t sz, size32_t &usablesz)=0;               // returns size actually allocated 

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -723,7 +723,7 @@ public:
         icompare = _icompare;
         icollate = _icollate?_icollate:_icompare;
         icollateupper = _icollateupper?_icollateupper:icollate;
-        
+
         Linked<IThorRowSortedLoader> sortedloader;
         sortedloader.setown(createThorRowSortedLoader(rowArray));
         Owned<IRowStream> overflowstream;

--- a/thorlcr/thorutil/thalloc.cpp
+++ b/thorlcr/thorutil/thalloc.cpp
@@ -217,11 +217,7 @@ public:
 
     virtual memsize_t remaining()
     {   
-        memsize_t a = allocator->totalAllocated();
-        memsize_t t = allocator->totalMax();
-        if (a<t)
-            return t-a;
-        return 0;
+        return allocator->totalRemaining();
     }
 
     virtual void reportLeaks()

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1186,6 +1186,7 @@ size32_t CThorRowAllocatorCache::subSize(unsigned cacheId, const void *row) cons
         }
         virtual void visitRowset(size32_t count, byte * * rows)
         {
+            size += thorRowMemoryFootprint(rows);
             while (count--) {
                 size += thorRowMemoryFootprint(*rows);
                 rows++;


### PR DESCRIPTION
Detect low allocator memory when checking if row arrays are full, tested
during sort/join gather->spill cycle.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
