### PR TITLE
FIX Convert remaining component to use logfile creator

### DIFF
--- a/dali/base/daclient.cpp
+++ b/dali/base/daclient.cpp
@@ -38,7 +38,6 @@ extern void stopClientProcess();
 static bool restoreSEH=false;
 static bool daliClientIsActive = false;
 static INode * daliClientLoggingParent = 0;
-static ILogMsgHandler * fileMsgHandler = 0;
 
 static IArrayOf<IDaliClientShutdown> shutdownHooks;
 MODULE_INIT(INIT_PRIORITY_STANDARD)

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -2127,7 +2127,7 @@ int main(int argc, char* argv[])
         usage(argv[0]);
         return -1;
     }
-    Owned<ILogMsgHandler> fileMsgHandler;
+
     try {
         StringBuffer logname;
         StringBuffer aliasname;

--- a/dali/dfu/dfurun.hpp
+++ b/dali/dfu/dfurun.hpp
@@ -37,7 +37,5 @@ interface IDFUengine: extends IInterface
 IDFUengine *createDFUengine();
 void stopDFUserver(const char *qname);
 
-extern ILogMsgHandler * fileMsgHandler;
-
 #endif
 

--- a/dali/dfuxref/dfuxrefmain.cpp
+++ b/dali/dfuxref/dfuxrefmain.cpp
@@ -48,13 +48,16 @@ int main(int argc, char* argv[])
     InitModuleObjects();
     EnableSEHtoExceptionMapping();
     setNodeCaching(true);
-    StringBuffer logName("dfuxref");
-    StringBuffer aliasLogName(logName);
-    aliasLogName.append(".log");
 
-    ILogMsgHandler *fileMsgHandler = getRollingFileLogMsgHandler(logName.str(), ".log", MSGFIELD_STANDARD, false, true, NULL, aliasLogName.str());
-    queryLogMsgManager()->addMonitorOwn(fileMsgHandler, getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, TopDetail));
+    {
+        Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator("dfuxref");
+        lf->setAppend(false);
+        lf->setMaxDetail(TopDetail);
+        lf->setMsgFields(MSGFIELD_STANDARD);
+        lf->beginLogging();
+    }
     queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_prefix);
+
     StringBuffer cmdline;
     unsigned i;
     for (i=0;i<(unsigned)argc;i++)

--- a/dali/fuse/dafuse.cpp
+++ b/dali/fuse/dafuse.cpp
@@ -1038,15 +1038,19 @@ int main(int argc, char *_argv[])
     Owned<IProperties> prop = createProperties("dafuse.ini",true);
     if (!parseParams(argc,argv,prop))
         return 1;
-    StringBuffer logName;
-    StringBuffer aliasLogName;
-    if (!prop->getProp("LOGFILE", logName)) {
-        logName.append("dafuse");
-        aliasLogName.append("dafuse.log");
+
+    {
+        StringBuffer logName;
+        if (!prop->getProp("LOGFILE", logName))
+            logName.set(dafuse);
+
+        Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(logName.str());
+        lf->setMsgFields(MSGFIELD_STANDARD);
+        lf->setAppend(false);
+        ls->setMaxDetail(TopDetail);
+        lf->beginLogging();
     }
 
-    ILogMsgHandler *fileMsgHandler = getRollingFileLogMsgHandler(logName.str(), ".log", MSGFIELD_STANDARD, false, true, NULL, aliasLogName.length()?aliasLogName.str():NULL);
-    queryLogMsgManager()->addMonitorOwn(fileMsgHandler, getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, TopDetail));
     StringBuffer daliServer;
     if (!prop->getProp("DALISERVER", daliServer)) {
         ERRLOG("DALISERVER setting not found in dafuse.ini");

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -51,7 +51,6 @@ extern void LDStest();
 
 Owned<IPropertyTree> serverConfig;
 static IArrayOf<ISashaServer> servers;
-static ILogMsgHandler * fileMsgHandler=NULL;
 static CSDSServerStatus * SashaServerStatus=NULL;
 static atomic_t StopSuspendCount = ATOMIC_INIT(0);
 static bool stopped = false;
@@ -61,15 +60,6 @@ const char *sashaProgramName;
 
 CSuspendAutoStop::CSuspendAutoStop() { atomic_inc(&StopSuspendCount); }
 CSuspendAutoStop::~CSuspendAutoStop() { atomic_dec(&StopSuspendCount); }
-
-void setMsgLevel(unsigned level)
-{
-    if (!fileMsgHandler)
-        return;
-    ILogMsgFilter *filter = getSwitchLogMsgFilterOwn(getComponentLogMsgFilter(3), getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, level, true), getDefaultLogMsgFilter());
-    queryLogMsgManager()->changeMonitorFilter(queryStderrLogMsgHandler(), filter);
-    queryLogMsgManager()->changeMonitorFilterOwn(fileMsgHandler, filter);
-}
 
 static void AddServers()
 {

--- a/dali/sdsfix/sdsfix.cpp
+++ b/dali/sdsfix/sdsfix.cpp
@@ -5869,15 +5869,15 @@ int main(int argc, char* argv[])
     }
     bool done = false;
     try {
-
-        //testSetPath();
-        StringBuffer logName("sdsfix");
-        if (myport)
-            logName.append('_').append(myport);
-        StringBuffer aliasLogName(logName);
-        aliasLogName.append(".log");
-        ILogMsgHandler *fileMsgHandler = getRollingFileLogMsgHandler(logName.str(), ".log", MSGFIELD_STANDARD, false, true, NULL, aliasLogName.str());
-        queryLogMsgManager()->addMonitorOwn(fileMsgHandler, getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, TopDetail));
+        {
+            StringBuffer logName("sdsfix");
+            if (myport)
+                logName.append('_').append(myport);
+            Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator("sdsfix");
+            lf->setName(logName.str());//override default filename
+            lf->setMaxDetail(TopDetail);
+            lf->beginLogging();
+        }
         queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_prefix);
 
         if ((argc==2) && (stricmp(argv[1],"coalesce")==0))

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -423,7 +423,6 @@ extern unsigned defaultFetchPreload;
 extern unsigned defaultFullKeyedJoinPreload;
 extern unsigned defaultKeyedJoinPreload;
 extern unsigned defaultPrefetchProjectPreload;
-extern ILogMsgHandler * logFileHandler;
 
 extern StringBuffer logDirectory;
 extern StringBuffer pluginDirectory;

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -127,7 +127,6 @@ unsigned defaultFullKeyedJoinPreload = 0;
 unsigned defaultKeyedJoinPreload = 0;
 unsigned dafilesrvLookupTimeout = 10000;
 
-ILogMsgHandler * logFileHandler;
 unsigned logQueueLen;
 unsigned logQueueDrop;
 bool useLogQueue;

--- a/roxie/udplib/uttest.cpp
+++ b/roxie/udplib/uttest.cpp
@@ -599,9 +599,17 @@ int main(int argc, char * argv[] )
         usage();
     strdup("Make sure leak checking is working");
     queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_time | MSGFIELD_thread | MSGFIELD_prefix);
-    ILogMsgFilter * filter = getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, TopDetail, false);
-    ILogMsgHandler * logFileHandler = getFileLogMsgHandler("UDPTRANSPORT.LOG", NULL, MSGFIELD_STANDARD, false, false, true);
-    queryLogMsgManager()->addMonitorOwn(logFileHandler, filter);
+
+    {
+        Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator("UDPTRANSPORT");
+        lf->setCreateAliasFile(false);
+        lf->setRolling(false);
+        lf->setAppend(false);
+        lf->setMaxDetail(TopDetail);
+        lf->setMsgFields(MSGFIELD_STANDARD);
+        lf->beginLogging();
+    }
+
     StringBuffer cmdline;
     int c;
     for (c = 0; c < argc; c++) {

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -891,7 +891,7 @@ void FileLogMsgHandlerXML::addToPTree(IPropertyTree * tree) const
     tree->addPropTree("handler", handlerTree);
 }
 
-// FileLogMsgHandler
+// RollingFileLogMsgHandler
 
 RollingFileLogMsgHandler::RollingFileLogMsgHandler(const char * _filebase, const char * _fileextn, unsigned _fields, bool _append, bool _flushes, const char *initialName, const char *_alias, bool daily) : messageFields(_fields), filebase(_filebase), fileextn(_fileextn), append(_append), flushes(_flushes), handle(0), alias(_alias)
 {
@@ -2690,9 +2690,9 @@ public:
     void setLocal(const bool _local)               { local = _local; }
 
     //query methods (not valid until logging started)
-    const char * queryLogDir()          { return logDir.str(); }
-    const char * queryLogFileSpec()     { return expandedLogSpec.str(); }
-    const char * queryAliasFileSpec()   { return aliasFileSpec.str(); }
+    const char * queryLogDir() const        { return logDir.str(); }
+    const char * queryLogFileSpec() const   { return expandedLogSpec.str(); }
+    const char * queryAliasFileSpec() const { return aliasFileSpec.str(); }
 
     ILogMsgHandler * beginLogging()
     {

--- a/system/jlib/jlog.hpp
+++ b/system/jlib/jlog.hpp
@@ -1005,7 +1005,7 @@ extern jlib_decl const IContextLogger &queryDummyContextLogger();
 
 interface IComponentLogFileCreator : extends IInterface
 {
-    //set methods
+    //IComponentLogFileCreator set methods
     virtual void setExtension(const char * _ext) = 0;       //log filename extension (eg ".log")
     virtual void setPrefix(const char * _prefix) = 0;       //filename prefix (eg "master")
     virtual void setName(const char * _name) = 0;           //log filename, overrides default of component name (without extension)
@@ -1028,9 +1028,9 @@ interface IComponentLogFileCreator : extends IInterface
     virtual void setLocal(const bool _local) = 0;                   //local logging
 
     //query methods (not valid until logging started)
-    virtual const char * queryLogDir() = 0;         //Location of component logfile
-    virtual const char * queryLogFileSpec() = 0;    //Full log filespec
-    virtual const char * queryAliasFileSpec() = 0;  //Full alias filespec, if created
+    virtual const char * queryLogDir() const = 0;           //Location of component logfile
+    virtual const char * queryLogFileSpec() const = 0;      //Full log filespec
+    virtual const char * queryAliasFileSpec() const = 0;    //Full alias filespec, if created
 
     virtual ILogMsgHandler * beginLogging() = 0;    //begin logging to specified file(s)
 };


### PR DESCRIPTION
Several utilities are still using the old interface to add logfile
monitors. Converted these over to use new interface, removed some
dead code and some unused variables.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
