### PR TITLE
Add ability to set the chunk sizes in roxiemem

### DIFF
--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -348,6 +348,8 @@ interface IRowManager : extends IInterface
     virtual void reportLeaks() = 0;
     virtual unsigned maxSimpleBlock() = 0;
     virtual void checkHeap() = 0;
+    // Set the chunk sizes to use. Note that these sizes are before adjusting for per-row overhead
+    virtual void setChunkSizes(const UnsignedArray &) = 0;
 };
 
 extern roxiemem_decl void setDataAlignmentSize(unsigned size);


### PR DESCRIPTION
If a query is using fixed-size rows, the mrmory manager can operate with a lot
less overhead by setting the chunk sizes more intelligently.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
