### PR TITLE
Fix gh-1166 use extern "C" for dynamically loaded functions in xmllib

### DIFF
--- a/system/xmllib/xmlvalidator.hpp
+++ b/system/xmllib/xmlvalidator.hpp
@@ -49,7 +49,7 @@ interface XMLLIB_API IXmlDomParser : public IInterface
 };
 
 
-XMLLIB_API IXmlDomParser* getXmlDomParser();
+extern "C" XMLLIB_API IXmlDomParser* getXmlDomParser();
 
 
 #endif

--- a/system/xmllib/xslprocessor.hpp
+++ b/system/xmllib/xslprocessor.hpp
@@ -125,6 +125,6 @@ interface XMLLIB_API IXslProcessor : public IInterface
     virtual int getCacheTimeout() = 0;
 };
 
-XMLLIB_API IXslProcessor* getXslProcessor();
+extern "C" XMLLIB_API IXslProcessor* getXslProcessor();
 
 #endif


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
