### PR TITLE
gh-1160 Compile errors with glibc 2.14

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -48,7 +48,7 @@
 
 //===========================================================================
 #ifdef _DEBUG
-//#define _USE_MALLOC_HOOK  
+// #define _USE_MALLOC_HOOK  // Only enable if you need it - slow!
 #else
 #undef _USE_MALLOC_HOOK // don't define for release - not threadsafe
 #endif
@@ -3058,6 +3058,8 @@ void jlib_decl jlib_init_hook()
 {
 }
 
+#endif
+
 class UserMetricMsgHandler : public CInterface, implements ILogMsgHandler, implements IUserMetric
 {
     mutable unsigned __int64 counter;
@@ -3107,7 +3109,3 @@ jlib_decl IUserMetric *createUserMetric(const char *name, const char *matchStrin
 {
     return new UserMetricMsgHandler(name, matchString);
 }
-
-#endif
-
-

--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -243,10 +243,14 @@ unsigned jlib_decl getLatestCPUUsage();
 __int64 jlib_decl getTotalMem();
 unsigned jlib_decl setAllocHook(bool on);  // bwd compat returns unsigned
 
-#ifdef __linux__
-#define USE_JLIB_ALLOC_HOOK extern void jlib_decl jlib_init_hook(); void (*__malloc_initialize_hook) (void) = jlib_init_hook;       
+#if defined(__GLIBC) && !defined(_DEBUG)
+ #if __GLIBC_PREREQ(2, 14)
+  #define USE_JLIB_ALLOC_HOOK extern void jlib_decl jlib_init_hook(); void (* volatile __malloc_initialize_hook) (void) = jlib_init_hook;
+ #else
+  #define USE_JLIB_ALLOC_HOOK extern void jlib_decl jlib_init_hook(); void (* __malloc_initialize_hook) (void) = jlib_init_hook;
+ #endif
 #else
-#define USE_JLIB_ALLOC_HOOK
+ #define USE_JLIB_ALLOC_HOOK
 #endif
 
 extern jlib_decl void getHardwareInfo(HardwareInfo &hdwInfo, const char *primDiskPath, const char *secDiskPath = NULL);


### PR DESCRIPTION
In glibc 2.14 the definition of __malloc_init_hook has changed, so
we need to change the code in jdebug that uses it to match.

While testing, I also discovered some code that was incorrectly inside
the #else clause and thus prevented the system from compiling when full
memory hooks were in use.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
