### PR TITLE
gh-1160 Fix compile issues with newer versions of zlib

### DIFF
--- a/system/security/zcrypt/ioapi.h
+++ b/system/security/zcrypt/ioapi.h
@@ -35,6 +35,10 @@
 extern "C" {
 #endif
 
+#ifndef OF
+#define OF(x) x
+#endif
+
 typedef voidpf (ZCALLBACK *open_file_func) OF((voidpf opaque, const char* filename, int mode));
 typedef uLong  (ZCALLBACK *read_file_func) OF((voidpf opaque, voidpf stream, void* buf, uLong size));
 typedef uLong  (ZCALLBACK *write_file_func) OF((voidpf opaque, voidpf stream, const void* buf, uLong size));


### PR DESCRIPTION
Newer versions of zlib headers (such as those found on latest
gentoo releases) are not defining the OF macro, causing compile
errors in zcrypt.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
