### PR TITLE
Forbid adding superfiles to themselves

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1153,9 +1153,13 @@ FILESERVICES_API void FILESERVICES_CALL fslAddSuperFile(ICodeContext *ctx, const
         fsCreateSuperFile(ctx,lsuperfn,false,false);
         lookupSuperFile(ctx, lsuperfn, file, true, lsfn, false, false);
     }
-    IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
+    // Never add super file to itself
     StringBuffer lfn;
     constructLogicalName(ctx, _lfn, lfn);
+    if (stricmp(file->queryLogicalName(), lfn.str()) == 0) {
+        throw MakeStringException(0, "AddSuperFile: Adding super file %s to itself!", file->queryLogicalName());
+    }
+    IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
     if  (strict||addcontents) {
         Owned<IDistributedSuperFile> subfile;
         subfile.setown(transaction->lookupSuperFile(lfn.str()));

--- a/testing/ecl/key/superfile6.xml
+++ b/testing/ecl/key/superfile6.xml
@@ -1,0 +1,1 @@
+<Error><source>eclagent</source><code>0</code><message>System error: 0: AddSuperFile: Adding super file t6::superfile to itself!</message></Error>

--- a/testing/ecl/superfile6.ecl
+++ b/testing/ecl/superfile6.ecl
@@ -1,0 +1,47 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+import Std.File AS FileServices;
+// Super File added to itself test
+//noRoxie
+
+string fsuper := '~t6::superfile';
+string fsub := '~t6::subfile';
+ds := DATASET ([{'aaa'}, {'bbb'}, {'ccc'}, {'ddd'}], {string name});
+
+sequential (
+  FileServices.DeleteSuperFile (fsuper),
+  FileServices.DeleteLogicalFile (fsub),
+  output(FileServices.SuperFileExists (fsuper)),
+  output(FileServices.FileExists (fsub)),
+
+  // Creates a super with a sub and check
+  OUTPUT (ds, , fsub, OVERWRITE),
+  FileServices.CreateSuperfile (fsuper),
+  FileServices.AddSuperFile (fsuper, fsub),
+  output(FileServices.SuperFileExists (fsuper)),
+  output(FileServices.FileExists (fsub)),
+
+  // Tries to add the super to it, should fail
+  FileServices.AddSuperFile (fsuper, fsuper),
+
+  // Should still be there
+  output(FileServices.SuperFileExists (fsuper)),
+  output(FileServices.FileExists (fsub)),
+  output('done')
+)


### PR DESCRIPTION
As reported by Dustin Skaggs, we should not add a superfile to itself.

This patch assumes names are unique and uses it to avoid superfile lookup/creation in case we'll bail out anyway.

Test added to make sure we always fail in that case. All other regressions passing.
