### PR TITLE
ECL Command line support for ECL Text files

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -117,6 +117,7 @@ bool EclObjectParameter::isPEContent()
     unsigned long PESectStart = *((unsigned long *)(buffer + PE_OFFSET_LOCATION_IN_DOS_SECTION));
     if (mb.length()<PESectStart+3)
         return false;
+
     if (memcmp("PE", buffer + PESectStart, 2)!=0)
         return false;
     return true;
@@ -143,8 +144,10 @@ eclObjParameterType EclObjectParameter::finalizeContentType()
     else if (accept & eclObjSourceOrArchive)
     {
         ensureUtf8Content();
+        size32_t len = mb.length();
         mb.append((byte)0);
         type = isArchiveQuery(mb.toByteArray()) ? eclObjArchive : eclObjSource;
+        mb.setLength(len);
     }
     else
         mb.setLength(0);
@@ -208,19 +211,22 @@ const char *EclObjectParameter::queryTypeName()
     case eclObjWuid:
         return "WUID";
     case eclObjSource:
-        return "ECL File";
+        return "ECL Text";
     case eclObjArchive:
         return "ECL Archive";
     case eclObjSharedObject:
         return "ECL Shared Object";
     default:
-        return "Unknown";
+        return "Unknown Type";
     }
 }
 
 StringBuffer &EclObjectParameter::getDescription(StringBuffer &s)
 {
-    return s.append(queryTypeName()).append(' ').append(value.get());
+    return s.append(queryTypeName()).append(' ');
+    if (streq(value.sget(), "stdin"))
+        s.append("from ");
+    s.append(value.get());
 }
 
 eclCmdOptionMatchIndicator EclCmdCommon::matchCommandLineOption(ArgvIterator &iter, bool finalAttempt)
@@ -239,6 +245,9 @@ eclCmdOptionMatchIndicator EclCmdCommon::matchCommandLineOption(ArgvIterator &it
         return EclCmdOptionMatch;
     if (iter.matchOption(optPassword, ECLOPT_PASSWORD))
         return EclCmdOptionMatch;
+    if (iter.matchFlag(optVerbose, ECLOPT_VERBOSE) || iter.matchFlag(optVerbose, ECLOPT_VERBOSE_S))
+        return EclCmdOptionMatch;
+
     StringAttr tempArg;
     if (iter.matchOption(tempArg, "-brk"))
     {
@@ -263,4 +272,36 @@ bool EclCmdCommon::finalizeOptions(IProperties *globals)
     extractEclCmdOption(optUsername, globals, ECLOPT_USERNAME_ENV, ECLOPT_USERNAME_INI, NULL, NULL);
     extractEclCmdOption(optPassword, globals, ECLOPT_PASSWORD_ENV, ECLOPT_PASSWORD_INI, NULL, NULL);
     return true;
+}
+
+eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvIterator &iter, bool finalAttempt)
+{
+    const char *arg = iter.query();
+    if (streq(arg, "-"))
+    {
+        optObj.set("stdin");
+        return EclCmdOptionMatch;
+    }
+    if (*arg!='-')
+    {
+        if (optObj.value.length())
+        {
+            fprintf(stderr, "\nmultiple targets (%s and %s) not currently supported\n", optObj.value.sget(), arg);
+            return EclCmdOptionCompletion;
+        }
+        optObj.set(arg);
+        return EclCmdOptionMatch;
+    }
+    if (iter.matchPathFlag(optLibPath, ECLOPT_LIB_PATH_S))
+        return EclCmdOptionMatch;
+    if (iter.matchPathFlag(optImpPath, ECLOPT_IMP_PATH_S))
+        return EclCmdOptionMatch;
+    if (iter.matchOption(optManifest, ECLOPT_MANIFEST) || iter.matchOption(optManifest, ECLOPT_MANIFEST_DASH))
+        return EclCmdOptionMatch;
+    return EclCmdCommon::matchCommandLineOption(iter, finalAttempt);
+}
+
+bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
+{
+    return EclCmdCommon::finalizeOptions(globals);
 }

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -223,10 +223,10 @@ const char *EclObjectParameter::queryTypeName()
 
 StringBuffer &EclObjectParameter::getDescription(StringBuffer &s)
 {
-    return s.append(queryTypeName()).append(' ');
+    s.append(queryTypeName()).append(' ');
     if (streq(value.sget(), "stdin"))
         s.append("from ");
-    s.append(value.get());
+    return s.append(value.get());
 }
 
 eclCmdOptionMatchIndicator EclCmdCommon::matchCommandLineOption(ArgvIterator &iter, bool finalAttempt)

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -60,6 +60,14 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_QUERYSET "--queryset"
 #define ECLOPT_VERSION "--version"
 
+#define ECLOPT_LIB_PATH_S "-L"
+#define ECLOPT_IMP_PATH_S "-I"
+#define ECLOPT_MANIFEST "--manifest"
+#define ECLOPT_MANIFEST_DASH "-manifest"
+
+#define ECLOPT_VERBOSE "--verbose"
+#define ECLOPT_VERBOSE_S "-v"
+
 bool extractEclCmdOption(StringBuffer & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);
 bool extractEclCmdOption(StringAttr & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);
 bool extractEclCmdOption(bool & option, IProperties * globals, const char * envName, const char * propertyName, bool defval);
@@ -110,7 +118,7 @@ class EclCmdCommon : public CInterface, implements IEclCommand
 {
 public:
     IMPLEMENT_IINTERFACE;
-    EclCmdCommon()
+    EclCmdCommon() : optVerbose(false)
     {
     }
     virtual eclCmdOptionMatchIndicator matchCommandLineOption(ArgvIterator &iter, bool finalAttempt=false);
@@ -119,6 +127,7 @@ public:
     virtual void usage()
     {
         fprintf(stdout,
+            "      --verbose, -v        output additional tracing information\n"
             "      --server=<ip>        ip of server running ecl services (eclwatch)\n"
             "      --port=<port>        ecl services port\n"
             "      --username=<name>    username for accessing ecl services\n"
@@ -130,6 +139,33 @@ public:
     StringAttr optPort;
     StringAttr optUsername;
     StringAttr optPassword;
+    bool optVerbose;
+};
+
+class EclCmdWithEclTarget : public EclCmdCommon
+{
+public:
+    EclCmdWithEclTarget()
+    {
+    }
+    virtual eclCmdOptionMatchIndicator matchCommandLineOption(ArgvIterator &iter, bool finalAttempt=false);
+    virtual bool finalizeOptions(IProperties *globals);
+
+    virtual void usage()
+    {
+        EclCmdCommon::usage();
+        fprintf(stdout,
+            "   eclcc options:\n"
+            "      -Ipath               Add path to locations to search for ecl imports\n"
+            "      -Lpath               Add path to locations to search for system libraries\n"
+            "      -manifest            Specify path to manifest file\n"
+        );
+    }
+public:
+    EclObjectParameter optObj;
+    StringBuffer optLibPath;
+    StringBuffer optImpPath;
+    StringAttr optManifest;
 };
 
 #endif


### PR DESCRIPTION
Make ECL command line call out to eclcc to generate an archive when
the target content is ECL Text.

ECL text can now be deployed and published directly.

-I, -L, and -manifest options can be added as pass through options to eclcc.

Advanced eclcc options require eclcc to be called seperately.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
