### PR TITLE
FIX Implement Roxie IndexWriteActivity

### DIFF
--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -9547,9 +9547,6 @@ ABoundActivity * HqlCppTranslator::doBuildActivityOutputIndex(BuildCtx & ctx, IH
     IHqlExpression * record = dataset->queryRecord();
     IHqlDataset * baseTable = dataset->queryDataset()->queryRootTable();
 
-    if (targetRoxie() && options.checkRoxieRestrictions)
-        throwError1(HQLERR_NotSupportInRoxie, "BUILDINDEX");
-
     Owned<ABoundActivity> boundDataset = buildCachedActivity(ctx, dataset);
     Owned<ActivityInstance> instance = new ActivityInstance(*this, ctx, TAKindexwrite, expr, "IndexWrite");
     buildActivityFramework(instance, isRoot);

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -287,6 +287,8 @@ protected:
         case TAKxmlwrite:
         case TAKmemoryspillwrite:
             return createRoxieServerDiskWriteActivityFactory(id, subgraphId, *this, helperFactory, kind, isRootAction(node));
+        case TAKindexwrite:
+            return createRoxieServerIndexWriteActivityFactory(id, subgraphId, *this, helperFactory, kind, isRootAction(node));
         case TAKenth:
             return createRoxieServerEnthActivityFactory(id, subgraphId, *this, helperFactory, kind);
         case TAKfetch:
@@ -540,7 +542,6 @@ protected:
 
         // These are not required in Roxie for the time being - code generator should trap them
         case TAKdistribution:
-        case TAKindexwrite:
         case TAKchilddataset:
 
         default:

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -452,6 +452,7 @@ extern IRoxieServerActivityFactory *createRoxieServerHashAggregateActivityFactor
 extern IRoxieServerActivityFactory *createRoxieServerDegroupActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerSpillReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerDiskWriteActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, bool _isRoot);
+extern IRoxieServerActivityFactory *createRoxieServerIndexWriteActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, bool _isRoot);
 extern IRoxieServerActivityFactory *createRoxieServerJoinActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerDenormalizeActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerConcatActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);


### PR DESCRIPTION
Roxie currently does not support creating indices. Eliminate this
restriction by implementing the indexWriteActivity, and removing the code
in code generator that disallows this activity to be specified in ECL.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
