### PR TITLE
Fixes gh-806 Optional default values not present in the environment are marked in different color

### DIFF
--- a/esp/files/scripts/configmgr/common.js
+++ b/esp/files/scripts/configmgr/common.js
@@ -342,3 +342,12 @@ function addUniqueToArray(arr, itm) {
     if (flag)
       arr[arr.length] = itm;
 }
+
+function isNotInEnv(notInEnvList, name)
+{
+  var tmp = ';@' + name + ';';
+  if (notInEnvList.indexOf(tmp) !== -1)
+    return true;
+  else
+    return false;
+}

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -3018,7 +3018,18 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
           const char* attrName = iAttr->queryName();
 
           if (!pSrcTree->hasProp(attrName))
+          {
             pSrcTree->addProp(attrName, iAttr->queryValue());
+
+            const char* prop = "@_notInEnv";
+            StringBuffer sbVal;
+
+            if (pSrcTree->hasProp(prop))
+              sbVal.append(pSrcTree->queryProp(prop));
+
+            pSrcTree->setProp(prop, sbVal.append(";").append(attrName).append(";").str());
+
+          }
         }
 
           //Add subelements that occur only once
@@ -3038,7 +3049,17 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
               const char* attrName = iAttrElem->queryName();
 
               if (!pSrcElem->hasProp(attrName))
+              {
                 pSrcElem->addProp(attrName, iAttrElem->queryValue());
+
+                const char* prop = "@_notInEnv";
+                StringBuffer sbVal;
+
+                if (pSrcElem->hasProp(prop))
+                  sbVal.append(pSrcElem->queryProp(prop));
+
+                pSrcElem->setProp(prop, sbVal.append(";").append(attrName).append(";").str());
+              }
             }
 
             Owned<IPropertyTreeIterator> iterSubElems = pElem->getElements("*");

--- a/esp/xslt/ui_configmgr.xslt
+++ b/esp/xslt/ui_configmgr.xslt
@@ -70,6 +70,8 @@
             <style type="text/css">
               /* custom styles for this example */
               .yui-skin-sam .yui-dt-liner { white-space:nowrap; }
+
+              .not_in_env  { color: #FF0000;}
             </style>
 
             <style type="text/css">
@@ -498,6 +500,7 @@
               <xsl:otherwise>
                 createRowArraysForComp('<xsl:value-of select="$Component"/>', rows);
                 var cN = '<xsl:value-of select="@name"/>';
+                var notInEnv = '<xsl:value-of select="@_notInEnv"/>';
                 var aS;
                 var tN;
                 <xsl:for-each select="@*">
@@ -525,6 +528,8 @@
                           i.value_onChange = aS.onChange;
                           i.value_onChangeMsg = aS.onChangeMsg;
                           i.params = "pcType=<xsl:value-of select="$Component"/>::pcName=" + cN;
+                          if (isNotInEnv(notInEnv, "<xsl:value-of select="name()"/>"))
+                            i._not_in_env = 1;
                           rows[tN][rows[tN].length] = i;
                         }
                       }


### PR DESCRIPTION
Optional default values not present in the environment are marked in red. A new context menu item has been added for these items to write them to environment. Note that the environment still needs to be saved after this action for it to be saved to the environment file. The tooltip has been updated to reflect that this value is not present in the environment.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
