### PR TITLE
Fixes #1184 Add support for support nodes in envgen.

### DIFF
--- a/deployment/deployutils/wizardInputs.hpp
+++ b/deployment/deployutils/wizardInputs.hpp
@@ -93,13 +93,13 @@ public:
   void setWizardIPList(const StringArray ipArray);
   void setWizardRules();
   CInstDetails* getServerIPMap(const char* compName, const char* buildSetName,const IPropertyTree* pEnvTree, unsigned numOfNode = 1);
-  void applyOverlappingRules(const char* compName, const char* buildSetName);
+  void applyOverlappingRules(const char* compName, const char* buildSetName, unsigned startpos);
   count_t getNumOfInstForIP(StringBuffer ip);
   void generateSoftwareTree(IPropertyTree* pTree);
   void addInstanceToTree(IPropertyTree* pTree, StringBuffer attrName, const char* processName, const char* buildSetName, const char* instName);
   void getDefaultsForWizard(IPropertyTree* pTree);
   void addRoxieThorClusterToEnv(IPropertyTree* pNewEnvTree, CInstDetails* pInstDetails, const char* buildSetName, bool genRoxieOnDemand = false);
-  unsigned getCntForAlreadyAssignedIPS();
+  unsigned getCntForAlreadyAssignedIPS(const char* buildsetName);
   void addToCompIPMap(const char* buildSetName, const char* value, const char* compName);
   void getEspBindingInformation(IPropertyTree* pNewEnvTree);
   StringBuffer& getDbUser() { return m_dbuser;}
@@ -119,6 +119,7 @@ public:
 
 private:
   void addComponentToSoftware(IPropertyTree* pNewEnvTree, IPropertyTree* pBuildSet);
+  StringArray& getIpAddrMap(const char* buildsetName);
 
 private:
   typedef StringArray* StringArrayPtr;
@@ -133,6 +134,7 @@ private:
    MapStringToStringArray m_compForTopology; 
    GenOptional m_genOptForAllComps;
    MapStringToStringArray m_invalidServerCombo;
+   unsigned m_supportNodes;
    unsigned m_roxieNodes;
    unsigned m_thorNodes;
    unsigned m_thorSlavesPerNode;
@@ -141,6 +143,7 @@ private:
    bool m_roxieOnDemand;
    
    StringArray m_ipaddress;
+   StringArray m_ipaddressSupport;
    MapStringToMyClass<CInstDetails> m_compIpMap; 
    Owned<IPropertyTree> m_pXml;
    IPropertyTree* m_cfg;

--- a/deployment/envgen/main.cpp
+++ b/deployment/envgen/main.cpp
@@ -42,6 +42,11 @@ void usage()
   puts("          Allowed formats are ");
   puts("          X.X.X.X;");
   puts("          X.X.X.X-XXX;");
+  puts("   -supportnodes <number of support nodes>: Number of nodes to be used");
+  puts("           for non-Thor and non-Roxie components. If not specified or ");
+  puts("           specified as 0, thor and roxie nodes may overlap with support");
+  puts("           nodes. If an invalid value is provided, support nodes are ");
+  puts("           treated to be 0");
   puts("   -roxienodes <number of roxie nodes>: Number of nodes to be generated ");
   puts("          for roxie. If not specified or specified as 0, no roxie nodes");
   puts("          are generated");
@@ -70,7 +75,7 @@ int main(int argc, char** argv)
   const char* out_envname = NULL;
   const char* in_ipfilename;
   StringBuffer ipAddrs;
-  int roxieNodes=0, thorNodes=0, slavesPerNode=1;
+  int roxieNodes=0, thorNodes=0, slavesPerNode=1, supportNodes=0;
   bool roxieOnDemand = true;
   MapStringTo<StringBuffer> dirMap;
 
@@ -90,6 +95,11 @@ int main(int argc, char** argv)
     {
       i++;
       out_envname = argv[i++];
+    }
+    else if (stricmp(argv[i], "-supportnodes") == 0)
+    {
+      i++;
+      supportNodes = atoi(argv[i++]);
     }
     else if (stricmp(argv[i], "-roxienodes") == 0)
     {
@@ -173,7 +183,7 @@ int main(int argc, char** argv)
     const char* pServiceName = "WsDeploy_wsdeploy_esp";
     Owned<IPropertyTree> pCfg = createPTreeFromXMLFile(ENVGEN_PATH_TO_ESP_CONFIG);
 
-    optionsXml.appendf("<XmlArgs roxieNodes=\"%d\" thorNodes=\"%d\" slavesPerNode=\"%d\" roxieOnDemand=\"%s\" ipList=\"%s\"/>", roxieNodes,
+    optionsXml.appendf("<XmlArgs supportNodes=\"%d\" roxieNodes=\"%d\" thorNodes=\"%d\" slavesPerNode=\"%d\" roxieOnDemand=\"%s\" ipList=\"%s\"/>", supportNodes, roxieNodes,
       thorNodes, slavesPerNode, roxieOnDemand?"true":"false", ipAddrs.str());
 
     buildEnvFromWizard(optionsXml, pServiceName, pCfg, envXml, &dirMap);


### PR DESCRIPTION
If any valid number of support nodes are specified, all non-thor and non-roxie
nodes are assigned to the support nodes. Otherwise, environment is generated
as it is being done currently (i.e. thor/roxie and other components can be
assigned to the same node).

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
