### PR TITLE
Fix gh-1047, replace invalid characters in query names when publishing queries

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -25,6 +25,7 @@
 #include "jptree.hpp"
 #include "jtime.ipp"
 #include "jencrypt.hpp"
+#include "junicode.hpp"
 #include "eclrtl.hpp"
 #include "deftype.hpp"
 #include <time.h>
@@ -8618,7 +8619,6 @@ extern WORKUNIT_API void addExceptionToWorkunit(IWorkUnit * wu, WUExceptionSever
     }
 }
 
-#define UTF8_BOM    "\357\273\277"
 
 extern WORKUNIT_API bool isArchiveQuery(const char * text)
 {
@@ -8938,8 +8938,8 @@ extern WORKUNIT_API IPropertyTree * getPackageSetRegistry(const char * wsEclId, 
 
 void addQueryToQuerySet(IWorkUnit *workunit, const char *querySetName, const char *queryName, IPropertyTree *packageInfo, WUQueryActivationOptions activateOption, StringBuffer &newQueryId)
 {
-    StringBuffer cleanQueryName(queryName);
-    cleanQueryName.replace(' ', '_');
+    StringBuffer cleanQueryName;
+    appendUtf8XmlName(cleanQueryName, strlen(queryName), queryName);
 
     SCMStringBuffer dllName;
     Owned<IConstWUQuery> q = workunit->getQuery();

--- a/system/jlib/junicode.hpp
+++ b/system/jlib/junicode.hpp
@@ -78,5 +78,16 @@ extern jlib_decl UTF32 readUtf8Character(unsigned len, const byte * & cur);
 extern jlib_decl size32_t readUtf8Size(const void * _data);
 extern jlib_decl UTF32 readUtf8Char(const void * _data);
 
+typedef MemoryBuffer & (*utfReplacementFunc)(MemoryBuffer & target, UTF32 match, UtfReader::UtfFormat type, const void * source, int len, bool start);
+extern jlib_decl bool replaceUtf(utfReplacementFunc func, MemoryBuffer & target, UtfReader::UtfFormat type, unsigned sourceLength, const void * source);
+extern jlib_decl bool appendUtfXmlName(MemoryBuffer & target, UtfReader::UtfFormat type, unsigned sourceLength, const void * source);
+
+inline StringBuffer &appendUtf8XmlName(StringBuffer & target, unsigned sourceLength, const void * source)
+{
+    MemoryBuffer mb;
+    appendUtfXmlName(mb, UtfReader::Utf8, sourceLength, source);
+    return target.append(mb.length(), mb.toByteArray());
+}
+
 
 #endif


### PR DESCRIPTION
Query names have to be valid xml tags in order to call them via soap.

Adds UTF based functions in junicode for creating names that should
be valid xml tags according to the W3C spec.  This takes a step
towards being more flexible in our unicode handling as well.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
