### PR TITLE
FIX: roxie/hthor to enforce indexWrite 32k limit

### DIFF
--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -505,7 +505,6 @@ class CHThorIndexWriteActivity : public CHThorActivityBase
     Owned<IFile> file;
     bool incomplete;
     offset_t sizeLimit;
-    size32_t maxDiskRecordSize;
 
     void close();
     void buildUserMetadata(Owned<IPropertyTree> & metadata);


### PR DESCRIPTION
Roxie and hthor indexWriteActivity should use a dynamic row buffer to
transform index rows, and should enforce a 32k maximum size for these
rows

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
