### PR TITLE
Set initial size for allocator to min not max

### DIFF
--- a/common/thorhelper/thorcommon.ipp
+++ b/common/thorhelper/thorcommon.ipp
@@ -86,11 +86,11 @@ public:
         if (_meta)
         {
             fixedSize = _meta->getFixedSize();
+            minSize = _meta->getMinRecordSize();
             if (fixedSize)
                 initialSize = fixedSize;
             else
-                initialSize = _meta->getRecordSize(NULL);
-            minSize = _meta->getMinRecordSize();
+                initialSize = minSize;
             metaFlags = meta->getMetaFlags();
         }
         else

--- a/common/thorhelper/thorcommon.ipp
+++ b/common/thorhelper/thorcommon.ipp
@@ -87,10 +87,7 @@ public:
         {
             fixedSize = _meta->getFixedSize();
             minSize = _meta->getMinRecordSize();
-            if (fixedSize)
-                initialSize = fixedSize;
-            else
-                initialSize = minSize;
+            initialSize = minSize;
             metaFlags = meta->getMetaFlags();
         }
         else

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -95,8 +95,10 @@ public:
         if (!rowset)
             rowset = createRowset(newRowCount);
         else
-            rowset = (byte * *)rowManager.resizeRow(rowset, (newRowCount-1) * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED);
-
+        {
+            size32_t capacity;
+            rowset = (byte * *)rowManager.resizeRow(rowset, (newRowCount-1) * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED, capacity);
+        }
         rowset[newRowCount-1] = (byte *)row;
         return rowset;
     }
@@ -106,8 +108,10 @@ public:
         if (!rowset)
             rowset = createRowset(newRowCount);
         else
-            rowset = (byte * *)rowManager.resizeRow(rowset, oldRowCount * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED);
-
+        {
+            size32_t capacity;
+            rowset = (byte * *)rowManager.resizeRow(rowset, oldRowCount * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED, capacity);
+        }
         //New rows (if any) aren't cleared....
         return rowset;
     }
@@ -147,8 +151,9 @@ public:
 
     virtual void * resizeRow(size32_t newSize, void * row, size32_t & size)
     {
-        void * ret = rowManager.resizeRow(row, size, newSize, allocatorId | ACTIVITY_FLAG_ISREGISTERED);
-        size = newSize;
+        size32_t capacity;
+        void * ret = rowManager.resizeRow(row, size, newSize, allocatorId | ACTIVITY_FLAG_ISREGISTERED, capacity);
+        size = capacity;
         return ret;
     }
 

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -245,8 +245,10 @@ public:
         if (!rowset)
             rowset = createRowset(newRowCount);
         else
-            rowset = (byte * *)rowManager.resizeRow(rowset, (newRowCount-1) * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED);
-
+        {
+            size32_t capacity;
+            rowset = (byte * *)rowManager.resizeRow(rowset, (newRowCount-1) * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED, capacity);
+        }
         rowset[newRowCount-1] = (byte *)row;
         return rowset;
     }
@@ -256,8 +258,10 @@ public:
         if (!rowset)
             rowset = createRowset(newRowCount);
         else
-            rowset = (byte * *)rowManager.resizeRow(rowset, oldRowCount * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED);
-
+        {
+            size32_t capacity;
+            rowset = (byte * *)rowManager.resizeRow(rowset, oldRowCount * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED, capacity);
+        }
         //New rows (if any) aren't cleared....
         return rowset;
     }
@@ -297,8 +301,9 @@ public:
 
     virtual void * resizeRow(size32_t newSize, void * row, size32_t & size)
     {
-        void * ret = rowManager.resizeRow(row, size, newSize, allocatorId | ACTIVITY_FLAG_ISREGISTERED);
-        size = newSize;
+        size32_t capacity;
+        void * ret = rowManager.resizeRow(row, size, newSize, allocatorId | ACTIVITY_FLAG_ISREGISTERED, capacity);
+        size = capacity;
         return ret;
     }
 

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -846,7 +846,7 @@ public:
         activityId = _activityId;
     }
 
-    virtual size32_t _capacity() const { return ((hugeSize + HEAP_ALIGNMENT_SIZE - 1) / HEAP_ALIGNMENT_SIZE) - offsetof(HugeHeaplet, data); }
+    virtual size32_t _capacity() const { return ((hugeSize + dataOffset() + HEAP_ALIGNMENT_SIZE - 1) & HEAP_ALIGNMENT_MASK) - dataOffset(); }
 
     virtual unsigned sizeInPages() 
     {
@@ -1318,7 +1318,7 @@ public:
         assertex(!HeapletBase::isShared(original));
         assertex(newsize >= oldsize);
         capacity = HeapletBase::capacity(original);
-        if (newsize==oldsize || newsize <= capacity)
+        if (newsize <= capacity)
             return original;
         else
         {

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -87,6 +87,7 @@ protected:
     virtual void released() = 0;
     virtual void noteReleased(const void *ptr) = 0;
     virtual bool _isShared(const void *ptr) const = 0;
+    virtual size32_t _capacity() const = 0;
     virtual void _setDestructorFlag(const void *ptr) = 0;
     virtual void noteLinked(const void *ptr) = 0;
 
@@ -124,6 +125,16 @@ public:
             return atomic_read(&h->count)!= 2; // The heaplet itself has a usage count of 1
         }
         // isShared(NULL) or isShared on an object that shares a link-count is an error
+        throwUnexpected();
+    }
+
+    static size32_t capacity(const void *ptr)
+    {
+        if (ptr)
+        {
+            HeapletBase *h = findBase(ptr);
+            return h->_capacity();
+        }
         throwUnexpected();
     }
 
@@ -214,6 +225,7 @@ private:
     virtual void released();
     virtual void noteReleased(const void *ptr);
     virtual bool _isShared(const void *ptr) const;
+    virtual size32_t _capacity() const;
     virtual void _setDestructorFlag(const void *ptr);
     virtual void noteLinked(const void *ptr);
 protected:
@@ -244,6 +256,7 @@ private:
     virtual void released();
     virtual void noteReleased(const void *ptr);
     virtual bool _isShared(const void *ptr) const;
+    virtual size32_t _capacity() const;
     virtual void _setDestructorFlag(const void *ptr);
     virtual void noteLinked(const void *ptr);
 public:
@@ -335,7 +348,7 @@ interface IRowManager : extends IInterface
 {
     virtual void *allocate(size32_t size, unsigned activityId=0) = 0;
     virtual void *clone(size32_t size, const void *source, unsigned activityId=0) = 0;
-    virtual void *resizeRow(void * original, unsigned oldsize, unsigned newsize, unsigned activityId=0) = 0;
+    virtual void *resizeRow(void * original, size32_t oldsize, size32_t newsize, unsigned activityId, size32_t &capacity) = 0;
     virtual void *finalizeRow(void *final, unsigned originalSize, unsigned finalSize, unsigned activityId) = 0;
     virtual void setMemoryLimit(memsize_t size) = 0;
     virtual unsigned allocated() = 0;


### PR DESCRIPTION
Change the initialSize in CachedOutputMetaData as used by allocators, to
the minimum record size not the maximum.
For a variable length record, which has a largish max, a low minimum and
which is frequently small in practice - pre-allocating max can cause the
memory
manager to fragment. Much better to allocate min and expand from there.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
