### PR TITLE
Fix EclWatch and WsEcl pages using EXSLT node-sets not displaying correctly

### DIFF
--- a/esp/eclwatch/ws_XSLT/batchjobdispatch.xslt
+++ b/esp/eclwatch/ws_XSLT/batchjobdispatch.xslt
@@ -18,7 +18,6 @@
 -->
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-                              xmlns:xalan="http://xml.apache.org/xalan"
                               >
     <xsl:output method="html"/>
      <xsl:variable name="autorefreshtimer" select="/BatchJobDispatchResponse/AutoRefreshTimer"/>

--- a/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
+++ b/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
@@ -421,7 +421,7 @@
             <!--xsl:choose>
                <xsl:when test="$order!=''">
                   <xsl:apply-templates select="MachineInfoEx">
-                     <xsl:sort select="xalan:evaluate($order)"/>
+                     <xsl:sort select="dyn:evaluate($order)"/>
                   </xsl:apply-templates>
                </xsl:when>
                <xsl:otherwise>

--- a/esp/eclwatch/ws_XSLT/dfu_searchdata.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_searchdata.xslt
@@ -20,9 +20,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xmlns:xalan="http://xml.apache.org/xalan"
-  xmlns:msxsl="urn:schemas-microsoft-com:xslt"
-  exclude-result-prefixes="xalan">
+  xmlns:msxsl="urn:schemas-microsoft-com:xslt">
 
   <xsl:param name="showColumns" select="/DFUSearchDataResponse/ShowColumns"/>
     <xsl:param name="oldFile" select="/DFUSearchDataResponse/LogicalName"/>

--- a/esp/eclwatch/ws_XSLT/dfusearchresult.xslt
+++ b/esp/eclwatch/ws_XSLT/dfusearchresult.xslt
@@ -21,9 +21,8 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-    xmlns:xalan="http://xml.apache.org/xalan" 
-    xmlns:msxsl="urn:schemas-microsoft-com:xslt" 
-    exclude-result-prefixes="xalan">
+    xmlns:exsl="http://exslt.org/common"
+    xmlns:msxsl="urn:schemas-microsoft-com:xslt">
     
     <xsl:param name="showCount" select="1"/>
     <xsl:param name="showHeader" select="1"/>
@@ -81,9 +80,9 @@
                             </xsl:call-template>
                         </xsl:variable>
                         <xsl:choose>
-                            <xsl:when test="function-available('xalan:nodeset')">
+                            <xsl:when test="function-available('exsl:node-set')">
                                 <xsl:call-template name="show-row">
-                                    <xsl:with-param name="nodes" select="xalan:nodeset($nodes)"/>
+                                    <xsl:with-param name="nodes" select="exsl:node-set($nodes)"/>
                                     <xsl:with-param name="level" select="1"/>
                                 </xsl:call-template>
                             </xsl:when>
@@ -126,9 +125,9 @@
     ]]></xsl:text>
         <thead>
             <xsl:choose>
-                <xsl:when test="function-available('xalan:nodeset')">
+                <xsl:when test="function-available('exsl:node-set')">
                     <xsl:call-template name="show-header">
-                        <xsl:with-param name="headers" select="xalan:nodeset($headers)"/>
+                        <xsl:with-param name="headers" select="exsl:node-set($headers)"/>
                         <xsl:with-param name="showCount" select="$showCount"/>
                     </xsl:call-template>
                 </xsl:when>
@@ -308,9 +307,9 @@
             </xsl:variable>
             <xsl:variable name="newLevel">
                 <xsl:choose>
-                    <xsl:when test="function-available('xalan:nodeset')">
+                    <xsl:when test="function-available('exsl:node-set')">
                         <xsl:call-template name="getMaxLevel">
-                            <xsl:with-param name="nodes" select="xalan:nodeset($nodes)"/>
+                            <xsl:with-param name="nodes" select="exsl:node-set($nodes)"/>
                             <xsl:with-param name="level" select="$level"/>
                         </xsl:call-template>
                     </xsl:when>
@@ -342,8 +341,8 @@
                     </data>
                 </xsl:if>
                 <xsl:choose>
-                    <xsl:when test="function-available('xalan:nodeset')">
-                        <xsl:copy-of select="xalan:nodeset($nodes)/*"/>
+                    <xsl:when test="function-available('exsl:node-set')">
+                        <xsl:copy-of select="exsl:node-set($nodes)/*"/>
                     </xsl:when>
                     <xsl:when test="function-available('msxsl:node-set')">
                         <xsl:copy-of select="msxsl:node-set($nodes)/*"/>

--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -17,9 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-                              xmlns:xalan="http://xml.apache.org/xalan"
-                              >
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="html"/>
     <xsl:variable name="chaturl0" select="ActivityResponse/ChatURL"/>
     <xsl:template match="ActivityResponse">

--- a/esp/eclwatch/ws_XSLT/lib.xslt
+++ b/esp/eclwatch/ws_XSLT/lib.xslt
@@ -2,8 +2,6 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:xalan="http://xml.apache.org/xalan"
-    exclude-result-prefixes="xalan"
     >
 
 <!--

--- a/esp/eclwatch/ws_XSLT/machines.xslt
+++ b/esp/eclwatch/ws_XSLT/machines.xslt
@@ -18,7 +18,6 @@
 -->
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xalan="http://xml.apache.org/xalan"
                 >
     <xsl:output method="html"/>
     

--- a/esp/eclwatch/ws_XSLT/result.xslt
+++ b/esp/eclwatch/ws_XSLT/result.xslt
@@ -17,7 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xalan="http://xml.apache.org/xalan" exclude-result-prefixes="xalan">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xsl:import href="/esp/xslt/result_lib.xslt"/>
     <xsl:output method="html"/><!--change this to xml for stage1Only-->
     <xsl:param name="pageSize" select="/WUResultResponse/Requested"/>

--- a/esp/eclwatch/ws_XSLT/result_lib.xslt
+++ b/esp/eclwatch/ws_XSLT/result_lib.xslt
@@ -21,9 +21,9 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-    xmlns:xalan="http://xml.apache.org/xalan" 
+    xmlns:exsl="http://exslt.org/common" 
     xmlns:msxsl="urn:schemas-microsoft-com:xslt" 
-    exclude-result-prefixes="xalan">
+    exclude-result-prefixes="exsl">
     
     <xsl:param name="showCount" select="1"/>
     <xsl:param name="showHeader" select="1"/>
@@ -91,9 +91,9 @@
                             </xsl:call-template>
                         </xsl:variable>
                         <xsl:choose>
-                            <xsl:when test="function-available('xalan:nodeset')">
+                            <xsl:when test="function-available('exsl:node-set')">
                                 <xsl:call-template name="show-row">
-                                    <xsl:with-param name="nodes" select="xalan:nodeset($nodes)"/>
+                                    <xsl:with-param name="nodes" select="exsl:node-set($nodes)"/>
                                     <xsl:with-param name="level" select="1"/>
                                 </xsl:call-template>
                             </xsl:when>
@@ -127,9 +127,9 @@
         </xsl:variable>
         <thead>
             <xsl:choose>
-                <xsl:when test="function-available('xalan:nodeset')">
+                <xsl:when test="function-available('exsl:node-set')">
                     <xsl:call-template name="show-header">
-                        <xsl:with-param name="headers" select="xalan:nodeset($headers)"/>
+                        <xsl:with-param name="headers" select="exsl:node-set($headers)"/>
                         <xsl:with-param name="showCount" select="$showCount"/>
                     </xsl:call-template>
                 </xsl:when>
@@ -310,9 +310,9 @@
             </xsl:variable>
             <xsl:variable name="newLevel">
                 <xsl:choose>
-                    <xsl:when test="function-available('xalan:nodeset')">
+                    <xsl:when test="function-available('exsl:node-set')">
                         <xsl:call-template name="getMaxLevel">
-                            <xsl:with-param name="nodes" select="xalan:nodeset($nodes)"/>
+                            <xsl:with-param name="nodes" select="exsl:node-set($nodes)"/>
                             <xsl:with-param name="level" select="$level"/>
                         </xsl:call-template>
                     </xsl:when>
@@ -344,8 +344,8 @@
                     </data>
                 </xsl:if>
                 <xsl:choose>
-                    <xsl:when test="function-available('xalan:nodeset')">
-                        <xsl:copy-of select="xalan:nodeset($nodes)/*"/>
+                    <xsl:when test="function-available('exsl:node-set')">
+                        <xsl:copy-of select="exsl:node-set($nodes)/*"/>
                     </xsl:when>
                     <xsl:when test="function-available('msxsl:node-set')">
                         <xsl:copy-of select="msxsl:node-set($nodes)/*"/>

--- a/esp/eclwatch/ws_XSLT/result_lib1.xslt
+++ b/esp/eclwatch/ws_XSLT/result_lib1.xslt
@@ -20,10 +20,10 @@
 <xsl:stylesheet version="1.0" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-    xmlns:xalan="http://xml.apache.org/xalan" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:exsl="http://exslt.org/common"
     xmlns:msxsl="urn:schemas-microsoft-com:xslt" 
-    exclude-result-prefixes="xalan">
+    exclude-result-prefixes="exsl">
     
     <xsl:param name="showCount" select="1"/>
     <xsl:param name="showHeader" select="1"/>
@@ -81,9 +81,9 @@
                             </xsl:call-template>
                         </xsl:variable>
                         <xsl:choose>
-                            <xsl:when test="function-available('xalan:nodeset')">
+                            <xsl:when test="function-available('exsl:node-set')">
                                 <xsl:call-template name="show-row">
-                                    <xsl:with-param name="nodes" select="xalan:nodeset($nodes)"/>
+                                    <xsl:with-param name="nodes" select="exsl:node-set($nodes)"/>
                                     <xsl:with-param name="level" select="1"/>
                                 </xsl:call-template>
                             </xsl:when>
@@ -116,9 +116,9 @@
         </xsl:variable>
         <thead>
             <xsl:choose>
-                <xsl:when test="function-available('xalan:nodeset')">
+                <xsl:when test="function-available('exsl:node-set')">
                     <xsl:call-template name="show-header">
-                        <xsl:with-param name="headers" select="xalan:nodeset($headers)"/>
+                        <xsl:with-param name="headers" select="exsl:node-set($headers)"/>
                         <xsl:with-param name="showCount" select="$showCount"/>
                     </xsl:call-template>
                 </xsl:when>
@@ -281,9 +281,9 @@
             </xsl:variable>
             <xsl:variable name="newLevel">
                 <xsl:choose>
-                    <xsl:when test="function-available('xalan:nodeset')">
+                    <xsl:when test="function-available('exsl:node-set')">
                         <xsl:call-template name="getMaxLevel">
-                            <xsl:with-param name="nodes" select="xalan:nodeset($nodes)"/>
+                            <xsl:with-param name="nodes" select="exsl:node-set($nodes)"/>
                             <xsl:with-param name="level" select="$level"/>
                         </xsl:call-template>
                     </xsl:when>
@@ -315,8 +315,8 @@
                     </data>
                 </xsl:if>
                 <xsl:choose>
-                    <xsl:when test="function-available('xalan:nodeset')">
-                        <xsl:copy-of select="xalan:nodeset($nodes)/*"/>
+                    <xsl:when test="function-available('exsl:node-set')">
+                        <xsl:copy-of select="exsl:node-set($nodes)/*"/>
                     </xsl:when>
                     <xsl:when test="function-available('msxsl:node-set')">
                         <xsl:copy-of select="msxsl:node-set($nodes)/*"/>

--- a/esp/eclwatch/ws_XSLT/result_lib2.xslt
+++ b/esp/eclwatch/ws_XSLT/result_lib2.xslt
@@ -20,10 +20,10 @@
 <xsl:stylesheet version="1.0" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-    xmlns:xalan="http://xml.apache.org/xalan" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:exsl="http://exslt.org/common"
     xmlns:msxsl="urn:schemas-microsoft-com:xslt" 
-    exclude-result-prefixes="xalan">
+    exclude-result-prefixes="exsl">
     
     <xsl:param name="showCount" select="1"/>
     <xsl:param name="showHeader" select="1"/>
@@ -81,9 +81,9 @@
                             </xsl:call-template>
                         </xsl:variable>
                         <xsl:choose>
-                            <xsl:when test="function-available('xalan:nodeset')">
+                            <xsl:when test="function-available('exsl:node-set')">
                                 <xsl:call-template name="show-row">
-                                    <xsl:with-param name="nodes" select="xalan:nodeset($nodes)"/>
+                                    <xsl:with-param name="nodes" select="exsl:node-set($nodes)"/>
                                     <xsl:with-param name="level" select="1"/>
                                 </xsl:call-template>
                             </xsl:when>
@@ -131,9 +131,9 @@
         </colgroup>
         <thead>
             <xsl:choose>
-                <xsl:when test="function-available('xalan:nodeset')">
+                <xsl:when test="function-available('exsl:node-set')">
                     <xsl:call-template name="show-header">
-                        <xsl:with-param name="headers" select="xalan:nodeset($headers)"/>
+                        <xsl:with-param name="headers" select="exsl:node-set($headers)"/>
                         <xsl:with-param name="showCount" select="$showCount"/>
                     </xsl:call-template>
                 </xsl:when>
@@ -298,9 +298,9 @@
             </xsl:variable>
             <xsl:variable name="newLevel">
                 <xsl:choose>
-                    <xsl:when test="function-available('xalan:nodeset')">
+                    <xsl:when test="function-available('exsl:node-set')">
                         <xsl:call-template name="getMaxLevel">
-                            <xsl:with-param name="nodes" select="xalan:nodeset($nodes)"/>
+                            <xsl:with-param name="nodes" select="exsl:node-set($nodes)"/>
                             <xsl:with-param name="level" select="$level"/>
                         </xsl:call-template>
                     </xsl:when>
@@ -332,8 +332,8 @@
                     </data>
                 </xsl:if>
                 <xsl:choose>
-                    <xsl:when test="function-available('xalan:nodeset')">
-                        <xsl:copy-of select="xalan:nodeset($nodes)/*"/>
+                    <xsl:when test="function-available('exsl:node-set')">
+                        <xsl:copy-of select="exsl:node-set($nodes)/*"/>
                     </xsl:when>
                     <xsl:when test="function-available('msxsl:node-set')">
                         <xsl:copy-of select="msxsl:node-set($nodes)/*"/>

--- a/esp/eclwatch/ws_XSLT/resultxls.xslt
+++ b/esp/eclwatch/ws_XSLT/resultxls.xslt
@@ -21,8 +21,8 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:xalan="http://xml.apache.org/xalan"
-    exclude-result-prefixes="xalan"
+    xmlns:exsl="http://exslt.org/common"
+    exclude-result-prefixes="exsl"
     >
     <xsl:output method="html"/>
     <xsl:param name="attribute"/>
@@ -64,7 +64,7 @@
         </xsl:variable>
 
         <xsl:variable name="height">
-            <xsl:for-each select="xalan:nodeset($headers)/*/@height">
+            <xsl:for-each select="exsl:node-set($headers)/*/@height">
                 <xsl:sort data-type="number" order="descending"/>
                 <xsl:if test="position() = 1">
                     <xsl:value-of select="."/>
@@ -73,7 +73,7 @@
         </xsl:variable>
 
         <xsl:call-template name="show-header">
-            <xsl:with-param name="headers" select="xalan:nodeset($headers)" />
+            <xsl:with-param name="headers" select="exsl:node-set($headers)" />
             <xsl:with-param name="height" select="$height"/>
         </xsl:call-template>
 

--- a/esp/eclwatch/ws_XSLT/targetclusters.xslt
+++ b/esp/eclwatch/ws_XSLT/targetclusters.xslt
@@ -27,7 +27,6 @@
 ]>
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-                              xmlns:xalan="http://xml.apache.org/xalan"
                               >
   <xsl:output method="html"/>
 

--- a/esp/services/ws_machine/DhcpMethods.xslt
+++ b/esp/services/ws_machine/DhcpMethods.xslt
@@ -17,7 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xalan="http://xml.apache.org/xalan">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 <xsl:output method="text"/>
 
    <!--the methods SetDhcpInfo and MakeDhcp are not intended to generate any output unless 

--- a/esp/services/ws_machine/machines.xslt
+++ b/esp/services/ws_machine/machines.xslt
@@ -349,7 +349,7 @@
             <!--xsl:choose>
                <xsl:when test="$order!=''">
                   <xsl:apply-templates select="MachineInfoEx">
-                     <xsl:sort select="xalan:evaluate($order)"/>
+                     <xsl:sort select="dyn:evaluate($order)"/>
                   </xsl:apply-templates>
                </xsl:when>
                <xsl:otherwise>

--- a/initfiles/componentfiles/configxml/@temp/esp_service.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service.xsl
@@ -559,7 +559,7 @@ xmlns:seisint="http://seisint.com"  xmlns:set="http://exslt.org/sets" exclude-re
                 </xsl:if>
                 <xsl:variable name="pluginsNodes" select="$pluginsRoot/Plugins/Plugin/@destName"/>
                 <xsl:if test="not(function-available('set:distinct'))">
-                    <xsl:message terminate="yes">This XSL transformation can only be run by Apache's Xalan processor!</xsl:message>
+                    <xsl:message terminate="yes">This XSL transformation can only be run by an XSLT processor supporting exslt sets!</xsl:message>
                 </xsl:if>
                 <Plugins>
                     <xsl:attribute name="path"><xsl:value-of select="$eclServerNode/@pluginsPath"/></xsl:attribute>

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -275,7 +275,7 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
             </xsl:if>
             <xsl:variable name="pluginsNodes" select="$pluginsRoot/Plugins/Plugin/@destName"/>
             <xsl:if test="not(function-available('set:distinct'))">
-                <xsl:message terminate="yes">This XSL transformation can only be run by Apache's Xalan processor!</xsl:message>
+                <xsl:message terminate="yes">This XSL transformation can only be run by an XSLT processor supporting exslt sets!</xsl:message>
             </xsl:if>
             <Plugins>
                 <xsl:attribute name="path"><xsl:for-each select="set:distinct($pluginsNodes)"><xsl:if test="../@type != 'lib'"><xsl:choose><xsl:when test="$isLinuxInstance"><xsl:value-of select="translate(../@destPath, '\', '/')"/><xsl:value-of select="translate(., '\', '/')"/><xsl:text disable-output-escaping="yes">:</xsl:text></xsl:when><xsl:otherwise><xsl:value-of select="../@destPath"/><!--already has \ --><xsl:value-of select="."/><xsl:text disable-output-escaping="yes">;</xsl:text></xsl:otherwise></xsl:choose></xsl:if></xsl:for-each></xsl:attribute>


### PR DESCRIPTION
Fix gh-1194, Fix gh-1195, Fix gh-1201

Several EclWatch and WsEcl pages not displaying correctly because the XSLT stylesheets that were used to generate them referred to "Xalan:nodeset" instead of "exsl:node-set".  "exsl:node-set" is supported by both Xalan and libxslt.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
