### PR TITLE
Generate meta for private symbols

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -764,7 +764,7 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
 
             gatherWarnings(ctx.errs, qquery);
 
-            if (qquery && !syntaxChecking)
+            if (qquery && !syntaxChecking && !optGenerateMeta)
                 qquery.setown(convertAttributeToQuery(qquery, ctx));
 
             if (instance.wu->getDebugValueBool("addTimingToWorkunit", true))

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -730,6 +730,14 @@ void HqlParseContext::noteFinishedParse(IHqlScope * scope)
         expandScopeSymbolsMeta(metaState.nesting.tos(), scope);
 }
 
+
+void HqlParseContext::notePrivateSymbols(IHqlScope * scope)
+{
+    if (metaState.gatherNow)
+        expandScopeSymbolsMeta(metaState.nesting.tos(), scope);
+}
+
+
 bool HqlParseContext::checkBeginMeta()
 {
     if (!metaTree)

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -893,6 +893,7 @@ public:
     void noteEndModule();
     void noteEndQuery();
     void noteFinishedParse(IHqlScope * scope);
+    void notePrivateSymbols(IHqlScope * scope);
     IPropertyTree * queryEnsureArchiveModule(const char * name, IHqlScope * scope);
 
     void setGatherMeta(const MetaOptions & options);
@@ -956,6 +957,7 @@ public:
     inline void noteEndQuery() { parseCtx.noteEndQuery(); }
     inline void noteFinishedParse(IHqlScope * scope) { parseCtx.noteFinishedParse(scope); }
     void noteExternalLookup(IHqlScope * parentScope, IHqlExpression * expr);
+    inline void notePrivateSymbols(IHqlScope * scope) { parseCtx.notePrivateSymbols(scope); }
 
     inline IEclRepository * queryRepository() const { return parseCtx.eclRepository; }
     inline bool queryExpandCallsWhenBound() const { return parseCtx.expandCallsWhenBound; }

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -8637,6 +8637,9 @@ void HqlGram::doDefineSymbol(DefineIdSt * defineid, IHqlExpression * _expr, IHql
             if (scopeExpr->getOperator() == no_virtualscope)
                 checkDerivedCompatible(name, scopeExpr, expr, isParametered, activeScope.activeParameters, idattr);
 
+            if (expectedAttribute && !insideNestedScope())
+                lookupCtx.notePrivateSymbols(activeScope.privateScope);
+
             //static int i = 0;
             //PrintLog("Kill private scope: %d at %s:%d because of %s", ++i, filename->str(), idattr.lineno, current_id->str());
             activeScope.newPrivateScope();


### PR DESCRIPTION
Temporary improvement to the meta generation to generation informaton
about private symbols in a definition, and don't bother converting
definitions to queries if only generating meta information.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
