### PR TITLE
Bug94798 Improve sort order tracking for keyed join

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -10103,15 +10103,6 @@ public:
         selSeq = ::queryProperty(_selectorSequence_Atom, params);
     }
 
-    inline bool isMatch(IHqlExpression * expr, node_operator op, IHqlExpression * side)
-    {
-        return (expr->getOperator() == op) &&
-            (expr->queryRecord()->queryBody() == side->queryRecord()->queryBody()) &&
-            (expr->queryChild(1) == selSeq);
-    }
-    inline bool isLeft(IHqlExpression * expr) { return isMatch(expr, no_left, left); }
-    inline bool isRight(IHqlExpression * expr) { return isMatch(expr, no_right, right); }
-
     IHqlExpression * mapEqualities(IHqlExpression * expr, IHqlExpression * cond)
     {
         if (cond->getOperator() == no_assertkeyed)
@@ -10138,6 +10129,17 @@ public:
         }
         return LINK(expr);
     }
+
+protected:
+    inline bool isMatch(IHqlExpression * expr, node_operator op, IHqlExpression * side)
+    {
+        return (expr->getOperator() == op) &&
+            (expr->queryRecord()->queryBody() == side->queryRecord()->queryBody()) &&
+            (expr->queryChild(1) == selSeq);
+    }
+    inline bool isLeft(IHqlExpression * expr) { return isMatch(expr, no_left, left); }
+    inline bool isRight(IHqlExpression * expr) { return isMatch(expr, no_right, right); }
+
 protected:
     IHqlExpression * left;
     IHqlExpression * right;

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1426,7 +1426,7 @@ extern HQL_API IHqlExpression *doInstantEclTransformations(IHqlExpression *qquer
 
 extern HQL_API unsigned getExpressionCRC(IHqlExpression * expr);
 extern HQL_API IHqlExpression * queryPropertyInList(_ATOM search, IHqlExpression * cur);
-extern HQL_API IHqlExpression * queryProperty(_ATOM search, HqlExprArray & exprs);
+extern HQL_API IHqlExpression * queryProperty(_ATOM search, const HqlExprArray & exprs);
 extern HQL_API IHqlExpression * queryAnnotation(IHqlExpression * expr, annotate_kind search);       // return first match
 extern HQL_API IHqlNamedAnnotation * queryNameAnnotation(IHqlExpression * expr);
 

--- a/ecl/hql/hqlmeta.cpp
+++ b/ecl/hql/hqlmeta.cpp
@@ -1326,3 +1326,17 @@ IHqlExpression * preserveTableInfo(IHqlExpression * newTable, IHqlExpression * o
     OwnedHqlExpr preserved = createPreserveTableInfo(newTable, original, loseDistribution, persistName);
     return optimizePreserveMeta(preserved);
 }
+
+bool hasUsefulMetaInformation(ITypeInfo * prev)
+{
+    IHqlExpression * distribution = queryDistribution(prev);
+    IHqlExpression * globalOrder = queryGlobalSortOrder(prev);
+    IHqlExpression * localOrder = queryLocalUngroupedSortOrder(prev);
+    IHqlExpression * grouping = queryGrouping(prev);
+    IHqlExpression * groupOrder = static_cast<IHqlExpression *>(prev->queryGroupSortInfo());
+    return (distribution && containsActiveDataset(distribution)) ||
+           (globalOrder && containsActiveDataset(globalOrder)) ||
+           (localOrder && containsActiveDataset(localOrder)) ||
+           (grouping && containsActiveDataset(grouping)) ||
+           (groupOrder && containsActiveDataset(groupOrder));
+}

--- a/ecl/hql/hqlmeta.hpp
+++ b/ecl/hql/hqlmeta.hpp
@@ -50,6 +50,7 @@ extern HQL_API ITypeInfo * getTypeUnknownDistribution(ITypeInfo * prev);
 extern HQL_API ITypeInfo * getTypeRemoveDistribution(ITypeInfo * prev);
 extern HQL_API ITypeInfo * getTypeRemoveActiveSort(ITypeInfo * prev);
 extern HQL_API ITypeInfo * getTypeRemoveAllSortOrders(ITypeInfo * prev);
+extern HQL_API bool hasUsefulMetaInformation(ITypeInfo * prev);
 
 //---------------------------------------------------------------------------------------------
 

--- a/ecl/regress/regress.bat
+++ b/ecl/regress/regress.bat
@@ -24,7 +24,7 @@ rd /s /q %regresstgt%
 md %regresstgt% 2>nul
 
 set flags=-P%regresstgt% -legacy -target=thorlcr -fforceGenerate -fdebugNlp=1 -fnoteRecordSizeInGraph -fregressionTest -b -m -S -shared -faddTimingToWorkunit=0 -fshowRecordCountInGraph
-set flags=%flags% %regressinclude%
+set flags=%flags% %regressinclude% -fshowMetaInGraph
 
 if NOT '%regressProcesses%'=='' goto multiway
 eclcc %flags% %* > out.log

--- a/ecl/regress/regress1.bat
+++ b/ecl/regress/regress1.bat
@@ -20,7 +20,7 @@ rem ############################################################################
 if '%regresstgt%'=='' goto novars
 
 set flags=-P%regresstgt% -legacy -target=thorlcr -fforceGenerate -fdebugNlp=1 -fnoteRecordSizeInGraph -fregressionTest -b -m -S -shared -faddTimingToWorkunit=0 -fshowRecordCountInGraph
-set flags=%flags% %regressinclude%
+set flags=%flags% %regressinclude% -fshowMetaInGraph
 
 md %regresstgt% 2>nul
 echo %* >> %regresstgt%\stdout.log


### PR DESCRIPTION
Improve tracking for JOIN(A,myKey,LEFT.x=RIGHT.x,TRANSFORM(RIGHT))
- If A was sorted by x then the result of the join is also sorted by x
  even through the transform value is RIGHT.x
  Can cause SORTS to be removed, or global->local (from distributions)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
