### PR TITLE
Fix build break from #1159

### DIFF
--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -275,7 +275,7 @@ public:
 
                         job->addSubGraph(*LINK(subGraph));
                         job->addDependencies(job->queryXGMML(), false);
-                        job->startGraph(*((CSlaveGraph *)subGraph.get()), *job, 0, NULL); // handoff to job to manage graph asynchronously from this msg
+                        job->startGraph(*((CSlaveGraph *)subGraph.get()), *job, true, 0, NULL); // handoff to job to manage graph asynchronously from this msg
 
                         msg.clear();
                         msg.append(false);


### PR DESCRIPTION
patch introduced a new parameter, called by a file in 3.4.x that was not changed in the patch and has has since changes in the master branch.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
