### PR TITLE
Non-reentrant spinlock inefficient

### DIFF
--- a/system/jlib/jmutex.hpp
+++ b/system/jlib/jmutex.hpp
@@ -384,22 +384,19 @@ class jlib_decl NonReentrantSpinLock
 public:
     inline NonReentrantSpinLock()       
     {
-        __sync_synchronize();
         owner.tid = 0;
         atomic_set(&value, 0); 
     }
     inline void enter()       
     { 
-        __sync_synchronize();
         ThreadId self = GetCurrentThreadId(); 
         assertex(self!=owner.tid); // check for reentrancy
-        while (atomic_xchg(1,&value))
+        while (!atomic_cas(&value,1,0))
             ThreadYield();
         owner.tid = self;
     }
     inline void leave()
     { 
-        __sync_synchronize();
         assertex(GetCurrentThreadId()==owner.tid); // check for spurious leave
         owner.tid = 0;
         atomic_set(&value, 0); 
@@ -414,18 +411,15 @@ class jlib_decl  NonReentrantSpinLock
 public:
     inline NonReentrantSpinLock()       
     {   
-        __sync_synchronize();
         atomic_set(&value, 0); 
     }
     inline void enter()       
     { 
-        __sync_synchronize();
-        while (atomic_xchg(1,&value))
+        while (!atomic_cas(&value,1,0))
             ThreadYield();
     }
     inline void leave()
     { 
-        __sync_synchronize();
         atomic_set(&value, 0); 
     }
 };


### PR DESCRIPTION
The non-reentrant spinlock is supposed to be faster than the general-purpose
SpinLock class (but only suitable for uses where no thread attempts to use
a lock it already owns). Unfortunately it seems that it was slower.

The addition of __sync_synchronize calls was necessary to fix a bug when
using __sync_xchg (which is not considered to be a full barrier), but
they are NOT needed when using __sync_compare_and_swap which therefore
ends up faster.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
