### PR TITLE
Fix gh-1193 Graphs not displaying correctly in builds using libxslt

### DIFF
--- a/esp/eclwatch/ws_XSLT/GvcGraph.xslt
+++ b/esp/eclwatch/ws_XSLT/GvcGraph.xslt
@@ -19,11 +19,7 @@
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:include href="graph_gvc_common.xslt" />
-  <xsl:output
-  method="html"
-  version="4.0"
-  encoding="iso-8859-1" indent="yes"
-  omit-xml-declaration="yes"/>
+  <xsl:output method="html"/>
   <xsl:template match="GVCAjaxGraphResponse">
     <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
       <head>


### PR DESCRIPTION
Firefox does not display the graph at all, I.e. and chrome have
sizing issues.

LIBXSLT generates more html code based on the contents of the
xsl:output/ tag.  The extra generated HTML DOCTYPE delclaration
seemed to be causing the issue.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
