### PR TITLE
Superfile resolution from packages may core

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2137,7 +2137,7 @@ public:
             fileType = sub->fileType;
         ForEachItemIn(idx, sub->subFiles)
         {
-            addFile(sub->subNames.item(idx), sub->subFiles.item(idx));
+            addFile(sub->subNames.item(idx), LINK(sub->subFiles.item(idx)));
         }
     }
     virtual void addSubFile(IFileDescriptor *_sub)


### PR DESCRIPTION
When resolving superfiles using package file, a -ve memory leak will cause roxie
to crash if there is more than one subfile.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
