### PR TITLE
Fix jstring long long + ellipsis object

### DIFF
--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -357,7 +357,7 @@ public:
             if (asz < minRemaining) {
 #ifdef _DEBUG
                 StringBuffer msg("CThorRowArray isFull(), ThorMemoryManager remaining() : ");
-                PROGLOG("%s", msg.append(asz));
+                PROGLOG("%s", msg.append((unsigned __int64)asz).str());
 #endif
                 return true;
             }


### PR DESCRIPTION
This is in addition to Gavin's fix on jmalloc, plus there was an
error on operator const char \* not being called on my compiler
(thus, not being POD) and breaking ellipsis constraints.
