### PR TITLE
Fix gh-1232 Ecl WU Details crashed when cluster not found

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -869,15 +869,18 @@ bool WsWuInfo::getClusterInfo(IEspECLWorkunit &info, unsigned flags)
             throw MakeStringException(ECLWATCH_CANNOT_CONNECT_DALI,"Cannot connect to DALI server.");
 
         Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(clusterName.str());
-        ClusterType platform = clusterInfo->getPlatform();
-        if (isThorCluster(platform))
-        {
-            clusterTypeFlag=1;
-            if (version > 1.29)
-                info.setThorLCR(ThorLCRCluster == platform);
+        if (clusterInfo.get())
+        {//Set thor flag or roxie flag in order to display some options for thor or roxie
+            ClusterType platform = clusterInfo->getPlatform();
+            if (isThorCluster(platform))
+            {
+                clusterTypeFlag=1;
+                if (version > 1.29)
+                    info.setThorLCR(ThorLCRCluster == platform);
+            }
+            else if (RoxieCluster == platform)
+                clusterTypeFlag=2;
         }
-        else if (RoxieCluster == platform)
-            clusterTypeFlag=2;
         info.setClusterFlag(clusterTypeFlag);
     }
     return true;


### PR DESCRIPTION
This problem happened when a user tried to view Ecl WU Details
page. If, for some reason, the cluster name for that WU was not
in environment settings, the WU Details page crashed. This fix
changes the code to avoid the crash.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
