### PR TITLE
Remove incorrect assert on nonempty in debug mode

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -2256,8 +2256,6 @@ unsigned getNumChildTables(IHqlExpression * dataset)
             assertex(num==2); 
         break;
     case childdataset_many_noscope:
-        assertex(num==2); 
-        break;
     case childdataset_many:
         break;
     case childdataset_if:


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
