### PR TITLE
Fix gh-1198, Check return from getTargetClusterInfo to prevent core

### DIFF
--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1865,6 +1865,8 @@ IJobQueue *createJobQueue(const char *name)
 extern bool WORKUNIT_API runWorkUnit(const char *wuid, const char *cluster)
 {
     Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
+    if (!clusterInfo.get())
+        return false;
     SCMStringBuffer agentQueue;
     clusterInfo->getAgentQueue(agentQueue);
     if (!agentQueue.length())


### PR DESCRIPTION
Fix gh-1198, Check return from getTargetClusterInfo to prevent core in workunit.dll

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
