### PR TITLE
Default linuxYield option to false

### DIFF
--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -1214,10 +1214,10 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="linuxYield" type="xs:boolean" use="optional" default="true">
+    <xs:attribute name="linuxYield" type="xs:boolean" use="optional" default="false">
       <xs:annotation>
         <xs:appinfo>
-          <tooltip>option to yield in some tight loops.</tooltip>
+          <tooltip>Yield to scheduler in some tight loops. May help latency on uniprocessor machines</tooltip>
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -1063,7 +1063,7 @@
                 keyedJoinStable="true"
                 lazyOpen="true"
                 leafCacheMem="50"
-                linuxYield="true"
+                linuxYield="false"
                 localFilesExpire="-1"
                 localSlave="true"
                 logFullQueries="false"

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -632,7 +632,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         blindLogging = topology->getPropBool("@blindLogging", false);
         if (!blindLogging)
             logExcessiveSeeks = true;
-        linuxYield = topology->getPropBool("@linuxYield", true);
+        linuxYield = topology->getPropBool("@linuxYield", false);
         traceSmartStepping = topology->getPropBool("@traceSmartStepping", false);
         useMemoryMappedIndexes = topology->getPropBool("@useMemoryMappedIndexes", false);
         traceJHtreeAllocations = topology->getPropBool("@traceJHtreeAllocations", false);


### PR DESCRIPTION
Roxie's linuxYield option (added a LONG time ago to help reduce latency
on uniprocessor boxes by ensuring that the threads reading data from
slaves were not starved out by tight loops in other queries) has a
major impact on the performance of the memory manager if set.

On today's typical hardware (and typical Roxie usage) it is much more
appropriate to default this option off.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
