### PR TITLE
Small refactoring on queryProperties, lots of FIXMEs added

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2265,8 +2265,7 @@ public:
         return lockProperties(reload,timeoutms);
     }
 
-    // FIXME: This method is NOT locking the properties for exclusive access, just setting it
-    // to write mode on the first call. If concurrent access occur, there will be conflicts
+    // WARN: This method allows multiple access from the same instance to the same properties.
     // MORE: Shouldn't we return boolean and use queryProperties() outside of this method?
     IPropertyTree & lockProperties(bool &reload,unsigned timeoutms)
     {
@@ -2274,7 +2273,7 @@ public:
             timeoutms = defaultTimeout;
         reload = false;
         // this is a bit of a kludge for non-transactional superfile operations and other dining philosopher problems
-        CriticalBlock block (sect);
+        // WARN: This is not thread-safe
         if (proplockcount++==0) {
             attr.clear();
             if (conn) {
@@ -2306,7 +2305,7 @@ public:
     void unlockProperties()
     {
         savePartsAttr();
-        CriticalBlock block (sect);
+        // WARN: This is not thread-safe
         if (--proplockcount==0) {
             attr.clear();
             if (conn) {

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2791,14 +2791,14 @@ public:
                 }
             }
         }
-        // This is a new property tree, no concurrent access, just reload
-        reloadProperties();
+        lockProperties(defaultTimeout);         // only needed to load attr (no lock)
         shrinkFileTree(root);
         if (totalsize!=(offset_t)-1)
             attr->setPropInt64("@size", totalsize);
         if (useableCheckSum)
             attr->setPropInt64("@checkSum", checkSum);
         setModified();
+        unlockProperties();
 #ifdef EXTRA_LOGGING
         LOGPTREE("CDistributedFile.b root.2",root);
 #endif

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2239,12 +2239,18 @@ public:
         }
     }
 
-    IPropertyTree &queryProperties()
+    void reloadProperties()
     {
         CriticalBlock block (sect);
-        if (attr) 
-            return *attr;
-        loadAttr();
+        if (!attr)
+            loadAttr();
+    }
+
+    IPropertyTree &queryProperties()
+    {
+        // a bit redundant, but avoids unnecessary locking
+        if (!attr)
+            reloadProperties();
         return *attr;
     }
 
@@ -2366,7 +2372,7 @@ public:
                     ret = false;
                 }
             }
-            queryProperties(); // reloads attr
+            reloadProperties();
         }
         return ret;
     }
@@ -2787,7 +2793,7 @@ public:
             }
         }
         // This is a new property tree, no concurrent access, just reload
-        queryProperties();
+        reloadProperties();
         shrinkFileTree(root);
         if (totalsize!=(offset_t)-1)
             attr->setPropInt64("@size", totalsize);

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -217,7 +217,8 @@ interface IDistributedFile: extends IInterface
     virtual void attach(const char *logicalname,IDistributedFileTransaction *transaction=NULL,IUserDescriptor *user=NULL) = 0;                          // attach to name in DFS
     virtual void detach(IDistributedFileTransaction *transaction=NULL) = 0;                                                 // no longer attached to name in DFS
 
-    virtual IPropertyTree &queryProperties() = 0;                               // DFile properties
+    virtual IPropertyTree &queryProperties() = 0;                               // DFile properties (can call reload)
+    virtual void reloadProperties() = 0;                                       // DFile properties
 
     virtual IPropertyTree &lockProperties(unsigned timeoutms=INFINITE) = 0;     // must be called before updating
     virtual void unlockProperties() = 0;                                        // must be called after updating


### PR DESCRIPTION
Using queryProperties where it's due. I've added several FIXMEs,
TODOs and MOREs, outlining the plan on refactoring the locking
and unlocking of properties.
