### PR TITLE
Roxiemem chunk sort was backwards

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -1112,7 +1112,7 @@ public:
 
     static int compareUnsigned(unsigned *a, unsigned *b)
     {
-        return (int) (*b - *a);
+        return (int) (*a - *b);
     }
 
     virtual void setChunkSizes(const UnsignedArray &sizes)


### PR DESCRIPTION
The code added to support configurable chunk sizes was not working
correctly. This code is not yet in use.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
