### PR TITLE
Fixes #1218 Add support for support nodes in ConfigMgr Wizard.

### DIFF
--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -264,10 +264,15 @@ CInstDetails* CWizardInputs::getServerIPMap(const char* compName, const char* bu
     if(m_compOnAllNodes.find(buildSetName) != NotFound)
       return instDetails;
     
-    if (m_ipaddress.ordinality() + m_supportNodes == 1 ||
-        (m_supportNodes == 1 && strcmp(buildSetName, "roxie") && strcmp(buildSetName, "thor" )))
+    if (m_ipaddress.ordinality() + m_supportNodes == 1)
     {
       instDetails = new CInstDetails(compName, m_ipaddress.item(0));
+      m_compIpMap.setValue(buildSetName,instDetails);
+      return instDetails;
+    }
+    else if (m_supportNodes == 1 && strcmp(buildSetName, "roxie") && strcmp(buildSetName, "thor" ))
+    {
+      instDetails = new CInstDetails(compName, m_ipaddressSupport.item(0));
       m_compIpMap.setValue(buildSetName,instDetails);
       return instDetails;
     }

--- a/deployment/deployutils/wizardInputs.hpp
+++ b/deployment/deployutils/wizardInputs.hpp
@@ -93,13 +93,13 @@ public:
   void setWizardIPList(const StringArray ipArray);
   void setWizardRules();
   CInstDetails* getServerIPMap(const char* compName, const char* buildSetName,const IPropertyTree* pEnvTree, unsigned numOfNode = 1);
-  void applyOverlappingRules(const char* compName, const char* buildSetName);
+  void applyOverlappingRules(const char* compName, const char* buildSetName, unsigned startpos);
   count_t getNumOfInstForIP(StringBuffer ip);
   void generateSoftwareTree(IPropertyTree* pTree);
   void addInstanceToTree(IPropertyTree* pTree, StringBuffer attrName, const char* processName, const char* buildSetName, const char* instName);
   void getDefaultsForWizard(IPropertyTree* pTree);
   void addRoxieThorClusterToEnv(IPropertyTree* pNewEnvTree, CInstDetails* pInstDetails, const char* buildSetName, bool genRoxieOnDemand = false);
-  unsigned getCntForAlreadyAssignedIPS();
+  unsigned getCntForAlreadyAssignedIPS(const char* buildsetName);
   void addToCompIPMap(const char* buildSetName, const char* value, const char* compName);
   void getEspBindingInformation(IPropertyTree* pNewEnvTree);
   StringBuffer& getDbUser() { return m_dbuser;}
@@ -119,6 +119,7 @@ public:
 
 private:
   void addComponentToSoftware(IPropertyTree* pNewEnvTree, IPropertyTree* pBuildSet);
+  StringArray& getIpAddrMap(const char* buildsetName);
 
 private:
   typedef StringArray* StringArrayPtr;
@@ -133,6 +134,7 @@ private:
    MapStringToStringArray m_compForTopology; 
    GenOptional m_genOptForAllComps;
    MapStringToStringArray m_invalidServerCombo;
+   unsigned m_supportNodes;
    unsigned m_roxieNodes;
    unsigned m_thorNodes;
    unsigned m_thorSlavesPerNode;
@@ -141,6 +143,7 @@ private:
    bool m_roxieOnDemand;
    
    StringArray m_ipaddress;
+   StringArray m_ipaddressSupport;
    MapStringToMyClass<CInstDetails> m_compIpMap; 
    Owned<IPropertyTree> m_pXml;
    IPropertyTree* m_cfg;

--- a/deployment/envgen/main.cpp
+++ b/deployment/envgen/main.cpp
@@ -42,6 +42,11 @@ void usage()
   puts("          Allowed formats are ");
   puts("          X.X.X.X;");
   puts("          X.X.X.X-XXX;");
+  puts("   -supportnodes <number of support nodes>: Number of nodes to be used");
+  puts("           for non-Thor and non-Roxie components. If not specified or ");
+  puts("           specified as 0, thor and roxie nodes may overlap with support");
+  puts("           nodes. If an invalid value is provided, support nodes are ");
+  puts("           treated to be 0");
   puts("   -roxienodes <number of roxie nodes>: Number of nodes to be generated ");
   puts("          for roxie. If not specified or specified as 0, no roxie nodes");
   puts("          are generated");
@@ -70,7 +75,7 @@ int main(int argc, char** argv)
   const char* out_envname = NULL;
   const char* in_ipfilename;
   StringBuffer ipAddrs;
-  int roxieNodes=0, thorNodes=0, slavesPerNode=1;
+  int roxieNodes=0, thorNodes=0, slavesPerNode=1, supportNodes=0;
   bool roxieOnDemand = true;
   MapStringTo<StringBuffer> dirMap;
 
@@ -90,6 +95,11 @@ int main(int argc, char** argv)
     {
       i++;
       out_envname = argv[i++];
+    }
+    else if (stricmp(argv[i], "-supportnodes") == 0)
+    {
+      i++;
+      supportNodes = atoi(argv[i++]);
     }
     else if (stricmp(argv[i], "-roxienodes") == 0)
     {
@@ -173,7 +183,7 @@ int main(int argc, char** argv)
     const char* pServiceName = "WsDeploy_wsdeploy_esp";
     Owned<IPropertyTree> pCfg = createPTreeFromXMLFile(ENVGEN_PATH_TO_ESP_CONFIG);
 
-    optionsXml.appendf("<XmlArgs roxieNodes=\"%d\" thorNodes=\"%d\" slavesPerNode=\"%d\" roxieOnDemand=\"%s\" ipList=\"%s\"/>", roxieNodes,
+    optionsXml.appendf("<XmlArgs supportNodes=\"%d\" roxieNodes=\"%d\" thorNodes=\"%d\" slavesPerNode=\"%d\" roxieOnDemand=\"%s\" ipList=\"%s\"/>", supportNodes, roxieNodes,
       thorNodes, slavesPerNode, roxieOnDemand?"true":"false", ipAddrs.str());
 
     buildEnvFromWizard(optionsXml, pServiceName, pCfg, envXml, &dirMap);

--- a/esp/files/configmgr.html
+++ b/esp/files/configmgr.html
@@ -391,6 +391,13 @@ body {
        background-position: -20px -60px; 
        background-color: transparent; 
      } 
+
+     @-moz-document url-prefix() {
+     .ff-only-align {
+        height: 38%;
+       }
+     }
+
     </style>
 </head>
 
@@ -535,34 +542,46 @@ You need to have Javascript enabled in order to use ConfigMgr. Please enable Jav
                 <table border="0" cellpadding="0" cellspacing="0" height="222px">
                   <tr>
                     <td>
-                      <label><br>Number of nodes for Roxie cluster<br>&nbsp;&nbsp;</label>
+                      <label>Number of support nodes&nbsp;&nbsp;</label>
                     </td>
                     <td>
+                      <div class="ff-only-align"/>
+                      <input id="node4Support" type="textbox" name="node4Support" style="width:33px" value="1" />&nbsp;
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <label>Number of nodes for Roxie cluster&nbsp;&nbsp;</label>
+                    </td>
+                    <td>
+                      <div class="ff-only-align"/>
                       <input id="node4RoxieServ" type="textbox" name="node4RoxieServ" style="width:33px"
                         value="1" />&nbsp;
                     </td>
                   </tr>
                   <tr>
                     <td>
-                      <label><br>Number of slave nodes for Thor cluster<br></label>
-                      <label style="font-weight:bold;font-weight:800">( A master node will be automatically added to the cluster )<br><br>
+                      <label>Number of slave nodes for Thor cluster</label><br/>
+                      <label style="font-weight:bold;font-weight:800">( A master node will be automatically added to the cluster )
                       </label>
                     </td>
                     <td>
+                      <div class="ff-only-align"/>
                       <input id="node4Thor" type="textbox" name="node4Thor" style="width: 33px" value="1" />&nbsp;
                     </td>
                     </tr>
                     <tr>
                      <td>
-                        <label id="slavePerNodelabel" onmouseover="showTooltipForButtons(event)"><br>Number of Thor slaves per node (default 1)<br></label><br>
+                       <label id="slavePerNodelabel" onmouseover="showTooltipForButtons(event)">Number of Thor slaves per node (default 1)</label>
                      </td>
                      <td>
+                       <div class="ff-only-align"/>
                        <input id="slavesPerNode" type="textbox" name="slavesPerNode" style="width: 33px" value="1" onmouseover="showTooltipForButtons(event)"/>&nbsp;
                      </td>
                   </tr>
                   <tr>
                      <td>
-                        <label id="roxieOnDemandLabel" onmouseover="showTooltipForButtons(event)"><br>Enable Roxie on demand<br></label><br>
+                        <label id="roxieOnDemandLabel" onmouseover="showTooltipForButtons(event)">Enable Roxie on demand</label>
                      </td>
                      <td>
                        <input id="roxieOnDemand" type="checkbox" name="roxieOnDemand" value="true" checked onmouseover="showTooltipForButtons(event)"/>&nbsp;

--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -3835,35 +3835,47 @@ populateNumberOfNode();
 
 function populateNumberOfNode(){
   var numberIPs = ipCount();
-  var defaultNodes =(parseInt(numberIPs) - 2 );
+  var defaultNodes = parseInt(numberIPs);
   
   if( parseInt(defaultNodes) <= 1){
-    document.getElementById('node4RoxieServ').value = "0";
     document.getElementById('node4Thor').value = "1";
+    document.getElementById('node4Support').value = "1";
   }
   else{
-    var node = (parseInt(defaultNodes) % 2 ) ;
-    if ( parseInt(node) !== 0 )
-      node = parseInt(defaultNodes) - 1 ;
-    else
-      node = defaultNodes ;
-    document.getElementById('node4RoxieServ').value = "0";
-    document.getElementById('node4Thor').value = node;
-   }    
+    var supportNodes = 7;
+
+    if ( defaultNodes > 1 && defaultNodes <= 10 )
+      supportNodes = 1;
+    else if ( defaultNodes > 10 && defaultNodes <= 20 )
+      supportNodes = 2;
+    else if ( defaultNodes > 20 && defaultNodes <= 50 )
+      supportNodes = 3;
+    else if ( defaultNodes > 50 && defaultNodes <= 100 )
+      supportNodes = 4;
+
+    document.getElementById('node4Support').value = supportNodes;
+    document.getElementById('node4Thor').value = defaultNodes - supportNodes == 1?1:defaultNodes - supportNodes - 1;
+  }
+
+  document.getElementById('node4RoxieServ').value = "0";
 }   
 
 function validateNumNodesDialog() {
-  if (!(isInteger(document.getElementById('node4Thor').value)) || !(isInteger(document.getElementById('node4RoxieServ').value)) || !(isInteger(document.getElementById('slavesPerNode').value)))
+  if (!(isInteger(document.getElementById('node4Thor').value)) ||
+      !(isInteger(document.getElementById('node4RoxieServ').value)) ||
+      !(isInteger(document.getElementById('slavesPerNode').value)) ||
+      !(isInteger(document.getElementById('node4Support').value)))
   {
     alert("Only Numeric entries allowed for number of nodes");
   }
   else
   {
     var numberIPs = parseInt(ipCount());
-    var roxieNodes = parseInt(document.getElementById('node4RoxieServ').value)
-    var thorNodes = parseInt(document.getElementById('node4Thor').value)
+    var roxieNodes = parseInt(document.getElementById('node4RoxieServ').value);
+    var thorNodes = parseInt(document.getElementById('node4Thor').value);
+    var supportNodes = parseInt(document.getElementById('node4Support').value);
 
-    if (roxieNodes <= numberIPs && thorNodes <= numberIPs) {
+    if (roxieNodes <= numberIPs && thorNodes <= numberIPs && supportNodes <= numberIPs) {
       if (thorNodes == numberIPs && numberIPs > 10) {
         if (!confirm("As the number of Thor slave nodes requested is equal to the number \
 of ip addresses given, there will be an overlap of Thor master node and a Thor \
@@ -3871,11 +3883,15 @@ slave node. This is not recommended in an environment with more than \
 10 nodes.\n\nDo you want to continue?"))
           return;
       }
+      else if (supportNodes == numberIPs && thorNodes + roxieNodes > 0){
+        alert("Number of support nodes cannot be equal to the number of IPs provided as nodes are required for thor/roxie.");
+        return;
+      }
 
       submitInformation();
     }
     else{
-      alert("Number of nodes should be less then number of IPs provided");
+      alert("Number of nodes should be less then number of IPs provided.");
     }   
   }
 }
@@ -3923,6 +3939,7 @@ function submitInformation() {
   //Before submitting collect all the information in XML format
   var roxieSrvNode = document.getElementById('node4RoxieServ').value ;
   var thorNode = document.getElementById('node4Thor').value ;
+  var supportNodes = document.getElementById('node4Support').value ;
   var iplist = document.getElementById('ipListText').value;
   var slavesPerNode = document.getElementById('slavesPerNode').value;
   var roxieOnDemand = document.getElementById('roxieOnDemand').checked;
@@ -3931,6 +3948,7 @@ function submitInformation() {
   xmlStr += "\" password=\"";
   xmlStr += "\" roxieNodes=\"" + roxieSrvNode;
   xmlStr += "\" thorNodes=\"" + thorNode;
+  xmlStr += "\" supportNodes=\"" + supportNodes;
   xmlStr += "\" slavesPerNode=\"" + slavesPerNode;
   xmlStr += "\" roxieOnDemand=\"" + roxieOnDemand;
   xmlStr += "\" ipList=\"" + iplist;


### PR DESCRIPTION
Added a new edit box for support nodes in the nodes screen of the Wizard.
Default number of support nodes are calculated based on table but user is free
to edit.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
