### PR TITLE
Fixes #1218 Add support for support nodes in ConfigMgr Wizard.

### DIFF
--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -264,10 +264,15 @@ CInstDetails* CWizardInputs::getServerIPMap(const char* compName, const char* bu
     if(m_compOnAllNodes.find(buildSetName) != NotFound)
       return instDetails;
     
-    if (m_ipaddress.ordinality() + m_supportNodes == 1 ||
-        (m_supportNodes == 1 && strcmp(buildSetName, "roxie") && strcmp(buildSetName, "thor" )))
+    if (m_ipaddress.ordinality() + m_supportNodes == 1)
     {
       instDetails = new CInstDetails(compName, m_ipaddress.item(0));
+      m_compIpMap.setValue(buildSetName,instDetails);
+      return instDetails;
+    }
+    else if (m_supportNodes == 1 && strcmp(buildSetName, "roxie") && strcmp(buildSetName, "thor" ))
+    {
+      instDetails = new CInstDetails(compName, m_ipaddressSupport.item(0));
       m_compIpMap.setValue(buildSetName,instDetails);
       return instDetails;
     }

--- a/esp/files/configmgr.html
+++ b/esp/files/configmgr.html
@@ -391,6 +391,13 @@ body {
        background-position: -20px -60px; 
        background-color: transparent; 
      } 
+
+     @-moz-document url-prefix() {
+     .ff-only-align {
+        height: 38%;
+       }
+     }
+
     </style>
 </head>
 
@@ -535,34 +542,46 @@ You need to have Javascript enabled in order to use ConfigMgr. Please enable Jav
                 <table border="0" cellpadding="0" cellspacing="0" height="222px">
                   <tr>
                     <td>
-                      <label><br>Number of nodes for Roxie cluster<br>&nbsp;&nbsp;</label>
+                      <label>Number of support nodes&nbsp;&nbsp;</label>
                     </td>
                     <td>
+                      <div class="ff-only-align"/>
+                      <input id="node4Support" type="textbox" name="node4Support" style="width:33px" value="1" />&nbsp;
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <label>Number of nodes for Roxie cluster&nbsp;&nbsp;</label>
+                    </td>
+                    <td>
+                      <div class="ff-only-align"/>
                       <input id="node4RoxieServ" type="textbox" name="node4RoxieServ" style="width:33px"
                         value="1" />&nbsp;
                     </td>
                   </tr>
                   <tr>
                     <td>
-                      <label><br>Number of slave nodes for Thor cluster<br></label>
-                      <label style="font-weight:bold;font-weight:800">( A master node will be automatically added to the cluster )<br><br>
+                      <label>Number of slave nodes for Thor cluster</label><br/>
+                      <label style="font-weight:bold;font-weight:800">( A master node will be automatically added to the cluster )
                       </label>
                     </td>
                     <td>
+                      <div class="ff-only-align"/>
                       <input id="node4Thor" type="textbox" name="node4Thor" style="width: 33px" value="1" />&nbsp;
                     </td>
                     </tr>
                     <tr>
                      <td>
-                        <label id="slavePerNodelabel" onmouseover="showTooltipForButtons(event)"><br>Number of Thor slaves per node (default 1)<br></label><br>
+                       <label id="slavePerNodelabel" onmouseover="showTooltipForButtons(event)">Number of Thor slaves per node (default 1)</label>
                      </td>
                      <td>
+                       <div class="ff-only-align"/>
                        <input id="slavesPerNode" type="textbox" name="slavesPerNode" style="width: 33px" value="1" onmouseover="showTooltipForButtons(event)"/>&nbsp;
                      </td>
                   </tr>
                   <tr>
                      <td>
-                        <label id="roxieOnDemandLabel" onmouseover="showTooltipForButtons(event)"><br>Enable Roxie on demand<br></label><br>
+                        <label id="roxieOnDemandLabel" onmouseover="showTooltipForButtons(event)">Enable Roxie on demand</label>
                      </td>
                      <td>
                        <input id="roxieOnDemand" type="checkbox" name="roxieOnDemand" value="true" checked onmouseover="showTooltipForButtons(event)"/>&nbsp;

--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -3835,35 +3835,47 @@ populateNumberOfNode();
 
 function populateNumberOfNode(){
   var numberIPs = ipCount();
-  var defaultNodes =(parseInt(numberIPs) - 2 );
+  var defaultNodes = parseInt(numberIPs);
   
   if( parseInt(defaultNodes) <= 1){
-    document.getElementById('node4RoxieServ').value = "0";
     document.getElementById('node4Thor').value = "1";
+    document.getElementById('node4Support').value = "1";
   }
   else{
-    var node = (parseInt(defaultNodes) % 2 ) ;
-    if ( parseInt(node) !== 0 )
-      node = parseInt(defaultNodes) - 1 ;
-    else
-      node = defaultNodes ;
-    document.getElementById('node4RoxieServ').value = "0";
-    document.getElementById('node4Thor').value = node;
-   }    
+    var supportNodes = 7;
+
+    if ( defaultNodes > 1 && defaultNodes <= 10 )
+      supportNodes = 1;
+    else if ( defaultNodes > 10 && defaultNodes <= 20 )
+      supportNodes = 2;
+    else if ( defaultNodes > 20 && defaultNodes <= 50 )
+      supportNodes = 3;
+    else if ( defaultNodes > 50 && defaultNodes <= 100 )
+      supportNodes = 4;
+
+    document.getElementById('node4Support').value = supportNodes;
+    document.getElementById('node4Thor').value = defaultNodes - supportNodes == 1?1:defaultNodes - supportNodes - 1;
+  }
+
+  document.getElementById('node4RoxieServ').value = "0";
 }   
 
 function validateNumNodesDialog() {
-  if (!(isInteger(document.getElementById('node4Thor').value)) || !(isInteger(document.getElementById('node4RoxieServ').value)) || !(isInteger(document.getElementById('slavesPerNode').value)))
+  if (!(isInteger(document.getElementById('node4Thor').value)) ||
+      !(isInteger(document.getElementById('node4RoxieServ').value)) ||
+      !(isInteger(document.getElementById('slavesPerNode').value)) ||
+      !(isInteger(document.getElementById('node4Support').value)))
   {
     alert("Only Numeric entries allowed for number of nodes");
   }
   else
   {
     var numberIPs = parseInt(ipCount());
-    var roxieNodes = parseInt(document.getElementById('node4RoxieServ').value)
-    var thorNodes = parseInt(document.getElementById('node4Thor').value)
+    var roxieNodes = parseInt(document.getElementById('node4RoxieServ').value);
+    var thorNodes = parseInt(document.getElementById('node4Thor').value);
+    var supportNodes = parseInt(document.getElementById('node4Support').value);
 
-    if (roxieNodes <= numberIPs && thorNodes <= numberIPs) {
+    if (roxieNodes <= numberIPs && thorNodes <= numberIPs && supportNodes <= numberIPs) {
       if (thorNodes == numberIPs && numberIPs > 10) {
         if (!confirm("As the number of Thor slave nodes requested is equal to the number \
 of ip addresses given, there will be an overlap of Thor master node and a Thor \
@@ -3871,11 +3883,15 @@ slave node. This is not recommended in an environment with more than \
 10 nodes.\n\nDo you want to continue?"))
           return;
       }
+      else if (supportNodes == numberIPs && thorNodes + roxieNodes > 0){
+        alert("Number of support nodes cannot be equal to the number of IPs provided as nodes are required for thor/roxie.");
+        return;
+      }
 
       submitInformation();
     }
     else{
-      alert("Number of nodes should be less then number of IPs provided");
+      alert("Number of nodes should be less then number of IPs provided.");
     }   
   }
 }
@@ -3923,6 +3939,7 @@ function submitInformation() {
   //Before submitting collect all the information in XML format
   var roxieSrvNode = document.getElementById('node4RoxieServ').value ;
   var thorNode = document.getElementById('node4Thor').value ;
+  var supportNodes = document.getElementById('node4Support').value ;
   var iplist = document.getElementById('ipListText').value;
   var slavesPerNode = document.getElementById('slavesPerNode').value;
   var roxieOnDemand = document.getElementById('roxieOnDemand').checked;
@@ -3931,6 +3948,7 @@ function submitInformation() {
   xmlStr += "\" password=\"";
   xmlStr += "\" roxieNodes=\"" + roxieSrvNode;
   xmlStr += "\" thorNodes=\"" + thorNode;
+  xmlStr += "\" supportNodes=\"" + supportNodes;
   xmlStr += "\" slavesPerNode=\"" + slavesPerNode;
   xmlStr += "\" roxieOnDemand=\"" + roxieOnDemand;
   xmlStr += "\" ipList=\"" + iplist;


### PR DESCRIPTION
Added a new edit box for support nodes in the nodes screen of the Wizard.
Default number of support nodes are calculated based on table but user is free
to edit.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
