### PR TITLE
Fix graph executor, needs to block if running

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2218,7 +2218,7 @@ public:
         else
         {
             CriticalBlock b(crit);
-            if (NotFound != seen.find(subGraph->queryGraphId()))
+            if (seen.contains(subGraph->queryGraphId()))
                 return; // already queued;
             seen.append(subGraph->queryGraphId());
         }
@@ -2242,8 +2242,8 @@ public:
             if (dependenciesDone)
                 subGraph->dependentSubGraphs.kill(); // none to track anymore
         }
-        CriticalBlock b(crit);
         Owned<CGraphExecutorGraphInfo> graphInfo = new CGraphExecutorGraphInfo(*this, subGraph, callback, parentExtract, parentExtractSz);
+        CriticalBlock b(crit);
         if (0 == subGraph->dependentSubGraphs.ordinality())
         {
             if (running.ordinality()<limit)

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2195,7 +2195,8 @@ public:
     virtual void add(CGraphBase *subGraph, IGraphCallback &callback, bool checkDependencies, size32_t parentExtractSz, const byte *parentExtract)
     {
         bool alreadyRunning;
-        { CriticalBlock b(crit);
+        {
+            CriticalBlock b(crit);
             if (job.queryPausing())
                 return;
             if (subGraph->isComplete())


### PR DESCRIPTION
Previous fix for a race condition in the graph executor (gh-1159) avoided
the race, by preparing inside the executor, but meant the prepare could occur
too early, if a dependency was in flight.
If traversing another sink graph and executing dependencies, the graph
executor needs to block and wait if a dependent graph is already running.
Otherwise prepare() may attempt to use something created by the
dependencies, e.g. a global in a conditinal branch of the graph.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
