### PR TITLE
gh-1099 - Detect process affinity and limit threads

### DIFF
--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -255,6 +255,7 @@ unsigned jlib_decl setAllocHook(bool on);  // bwd compat returns unsigned
 
 extern jlib_decl void getHardwareInfo(HardwareInfo &hdwInfo, const char *primDiskPath, const char *secDiskPath = NULL);
 extern jlib_decl void getCpuInfo(unsigned &numCPUs, unsigned &CPUSpeed);
+extern jlib_decl unsigned getAffinityCpus();
 extern jlib_decl void printProcMap(const char *fn, bool printbody, bool printsummary, StringBuffer *lnout, MemoryBuffer *mb, bool useprintf);
 extern jlib_decl void PrintMemoryReport(bool full=true);
 extern jlib_decl void printAllocationSummary();

--- a/system/jlib/jsort.cpp
+++ b/system/jlib/jsort.cpp
@@ -41,8 +41,7 @@ static bool sortParallel(unsigned &numcpus)
 {
     static unsigned numCPUs = 0;
     if (numCPUs==0) {
-        unsigned CPUSpeed;
-        getCpuInfo(numCPUs, CPUSpeed);
+        numCPUs = getAffinityCpus();
     }
     if ((numcpus==0)||(numcpus>numCPUs))
         numcpus = numCPUs;

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -1940,9 +1940,7 @@ IJoinHelper *createJoinHelper(IHThorJoinArg *helper, const char *activityName, a
     IJoinHelper *jhelper = new CJoinHelper(helper,activityName,TAKjoin,activityId,allocator);
     if (!parallelmatch||helper->getKeepLimit()||((helper->getJoinFlags()&JFslidingmatch)!=0)) // currently don't support betweenjoin or keep and multicore
         return jhelper;
-    unsigned numthreads;
-    unsigned CPUSpeed;
-    getCpuInfo(numthreads, CPUSpeed);
+    unsigned numthreads = getAffinityCpus();
     if (unsortedoutput)
         return new CMultiCoreUnorderedJoinHelper(numthreads,jhelper,helper,allocator,TAKjoin);
     return new CMultiCoreJoinHelper(numthreads,jhelper,helper,allocator,TAKjoin);
@@ -1960,9 +1958,7 @@ IJoinHelper *createSelfJoinHelper(IHThorJoinArg *helper, const char *activityNam
     IJoinHelper *jhelper = new SelfJoinHelper(helper,activityName,activityId,allocator);
     if (!parallelmatch||helper->getKeepLimit()||((helper->getJoinFlags()&JFslidingmatch)!=0)) // currently don't support betweenjoin or keep and multicore
         return jhelper;
-    unsigned numthreads;
-    unsigned CPUSpeed;
-    getCpuInfo(numthreads, CPUSpeed);
+    unsigned numthreads = getAffinityCpus();
     if (unsortedoutput)
         return new CMultiCoreUnorderedJoinHelper(numthreads,jhelper,helper,allocator,TAKselfjoin);
     return new CMultiCoreJoinHelper(numthreads,jhelper,helper,allocator,TAKselfjoin);

--- a/thorlcr/thorutil/mcorecache.cpp
+++ b/thorlcr/thorutil/mcorecache.cpp
@@ -327,8 +327,7 @@ IMultiCoreCache *createMultiCoreCache(IMultiCoreRowIntercept &wrapped, IRecordSi
 {
     static unsigned numCPUs = 0;
     if (numCPUs==0) {
-        unsigned CPUSpeed;
-        getCpuInfo(numCPUs, CPUSpeed);
+        numCPUs = getAffinityCpus();
     }
     if (numCPUs<=1)
         return new CPassThroughMultiCoreCache(wrapped,recsize);


### PR DESCRIPTION
Change the default number of threads used by e.g. sort to number of bound
cores, rather than total number of processes

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
