### PR TITLE
gh-1099 - Detect process affinity and limit threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set ( HPCC_MAJOR 3 )
 set ( HPCC_MINOR 4 )
 set ( HPCC_POINT 2 )
 set ( HPCC_MATURITY "rc" )
-set ( HPCC_SEQUENCE 1 )
+set ( HPCC_SEQUENCE 2 )
 ###
 
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,8 @@ set(CMAKE_MODULE_PATH "${HPCC_SOURCE_DIR}/cmake_modules/")
 set ( HPCC_PROJECT "community" )
 set ( HPCC_MAJOR 3 )
 set ( HPCC_MINOR 4 )
-set ( HPCC_POINT 1 )
-set ( HPCC_MATURITY "closedown" )
+set ( HPCC_POINT 2 )
+set ( HPCC_MATURITY "rc" )
 set ( HPCC_SEQUENCE 1 )
 ###
 

--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1865,6 +1865,8 @@ IJobQueue *createJobQueue(const char *name)
 extern bool WORKUNIT_API runWorkUnit(const char *wuid, const char *cluster)
 {
     Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
+    if (!clusterInfo.get())
+        return false;
     SCMStringBuffer agentQueue;
     clusterInfo->getAgentQueue(agentQueue);
     if (!agentQueue.length())

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -869,15 +869,18 @@ bool WsWuInfo::getClusterInfo(IEspECLWorkunit &info, unsigned flags)
             throw MakeStringException(ECLWATCH_CANNOT_CONNECT_DALI,"Cannot connect to DALI server.");
 
         Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(clusterName.str());
-        ClusterType platform = clusterInfo->getPlatform();
-        if (isThorCluster(platform))
-        {
-            clusterTypeFlag=1;
-            if (version > 1.29)
-                info.setThorLCR(ThorLCRCluster == platform);
+        if (clusterInfo.get())
+        {//Set thor flag or roxie flag in order to display some options for thor or roxie
+            ClusterType platform = clusterInfo->getPlatform();
+            if (isThorCluster(platform))
+            {
+                clusterTypeFlag=1;
+                if (version > 1.29)
+                    info.setThorLCR(ThorLCRCluster == platform);
+            }
+            else if (RoxieCluster == platform)
+                clusterTypeFlag=2;
         }
-        else if (RoxieCluster == platform)
-            clusterTypeFlag=2;
         info.setClusterFlag(clusterTypeFlag);
     }
     return true;

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -1316,10 +1316,18 @@ public:
     {
         assertex(newsize);
         assertex(!HeapletBase::isShared(original));
-        assertex(newsize >= oldsize);
         capacity = HeapletBase::capacity(original);
         if (newsize <= capacity)
-            return original;
+        {
+            if (newsize >= oldsize || roundup(newsize) == roundup(oldsize))
+                return original;
+
+            void *ret = allocate(newsize, activityId);
+            memcpy(ret, original, newsize);
+            HeapletBase::release(original);
+            capacity = HeapletBase::capacity(ret);
+            return ret;
+        }
         else
         {
             void *ret = allocate(newsize, activityId);

--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -251,6 +251,7 @@ unsigned jlib_decl setAllocHook(bool on);  // bwd compat returns unsigned
 
 extern jlib_decl void getHardwareInfo(HardwareInfo &hdwInfo, const char *primDiskPath, const char *secDiskPath = NULL);
 extern jlib_decl void getCpuInfo(unsigned &numCPUs, unsigned &CPUSpeed);
+extern jlib_decl unsigned getAffinityCpus();
 extern jlib_decl void printProcMap(const char *fn, bool printbody, bool printsummary, StringBuffer *lnout, MemoryBuffer *mb, bool useprintf);
 extern jlib_decl void PrintMemoryReport(bool full=true);
 extern jlib_decl void printAllocationSummary();

--- a/system/jlib/jsort.cpp
+++ b/system/jlib/jsort.cpp
@@ -41,8 +41,7 @@ static bool sortParallel(unsigned &numcpus)
 {
     static unsigned numCPUs = 0;
     if (numCPUs==0) {
-        unsigned CPUSpeed;
-        getCpuInfo(numCPUs, CPUSpeed);
+        numCPUs = getAffinityCpus();
     }
     if ((numcpus==0)||(numcpus>numCPUs))
         numcpus = numCPUs;

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -1940,9 +1940,7 @@ IJoinHelper *createJoinHelper(IHThorJoinArg *helper, const char *activityName, a
     IJoinHelper *jhelper = new CJoinHelper(helper,activityName,TAKjoin,activityId,allocator);
     if (!parallelmatch||helper->getKeepLimit()||((helper->getJoinFlags()&JFslidingmatch)!=0)) // currently don't support betweenjoin or keep and multicore
         return jhelper;
-    unsigned numthreads;
-    unsigned CPUSpeed;
-    getCpuInfo(numthreads, CPUSpeed);
+    unsigned numthreads = getAffinityCpus();
     if (unsortedoutput)
         return new CMultiCoreUnorderedJoinHelper(numthreads,jhelper,helper,allocator,TAKjoin);
     return new CMultiCoreJoinHelper(numthreads,jhelper,helper,allocator,TAKjoin);
@@ -1960,9 +1958,7 @@ IJoinHelper *createSelfJoinHelper(IHThorJoinArg *helper, const char *activityNam
     IJoinHelper *jhelper = new SelfJoinHelper(helper,activityName,activityId,allocator);
     if (!parallelmatch||helper->getKeepLimit()||((helper->getJoinFlags()&JFslidingmatch)!=0)) // currently don't support betweenjoin or keep and multicore
         return jhelper;
-    unsigned numthreads;
-    unsigned CPUSpeed;
-    getCpuInfo(numthreads, CPUSpeed);
+    unsigned numthreads = getAffinityCpus();
     if (unsortedoutput)
         return new CMultiCoreUnorderedJoinHelper(numthreads,jhelper,helper,allocator,TAKselfjoin);
     return new CMultiCoreJoinHelper(numthreads,jhelper,helper,allocator,TAKselfjoin);

--- a/thorlcr/thorutil/mcorecache.cpp
+++ b/thorlcr/thorutil/mcorecache.cpp
@@ -327,8 +327,7 @@ IMultiCoreCache *createMultiCoreCache(IMultiCoreRowIntercept &wrapped, IRecordSi
 {
     static unsigned numCPUs = 0;
     if (numCPUs==0) {
-        unsigned CPUSpeed;
-        getCpuInfo(numCPUs, CPUSpeed);
+        numCPUs = getAffinityCpus();
     }
     if (numCPUs<=1)
         return new CPassThroughMultiCoreCache(wrapped,recsize);


### PR DESCRIPTION
Change the default number of threads used by e.g. sort to number of bound
cores, rather than total number of processes

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
