### PR TITLE
Log file name incorrect for standalone hthor

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3078,7 +3078,7 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
     {
         StringBuffer exeName;
         splitFilename(argv[0], NULL, NULL, &exeName, NULL);
-        openLogFile(logfilespec, exeName.toLowerCase());
+        openLogFile(logfilespec, exeName.append(".log"));
         PROGLOG("Logging to %s", logfilespec.str());
     }
 


### PR DESCRIPTION
Standalone programs compiled in hthor mode are generating a
log file name from the executable name, with directory and
extension stripped off, and lower cased. While this may work
ok in Windows (though it's less than ideal) it's liable to clash
with the name of the executable file itself in linux.

Change to add an extension of .log and preserve the case of the
original file.

I'm not convinced that we shoudl be generating a log file at all
by default in standalone programs but that's a separate issue.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
