### PR TITLE
Fix gh-1277 problems of Event Scheduler and deschedule

### DIFF
--- a/ecl/schedulectrl/scheduleread.cpp
+++ b/ecl/schedulectrl/scheduleread.cpp
@@ -404,7 +404,7 @@ private:
 
 IScheduleReader * getScheduleReader(char const * serverName, char const * eventName)
 {
-    if(eventName)
+    if(eventName && *eventName)
         return new CBranchScheduleReader(serverName, eventName, false, NULL);
     else
         return new CRootScheduleReader(serverName, false, NULL);
@@ -412,7 +412,7 @@ IScheduleReader * getScheduleReader(char const * serverName, char const * eventN
 
 IScheduleReader * getSubscribingScheduleReader(char const * serverName, IScheduleSubscriber * subscriber, char const * eventName)
 {
-    if(eventName)
+    if(eventName && *eventName)
         return new CBranchScheduleReader(serverName, eventName, true, subscriber);
     else
         return new CRootScheduleReader(serverName, true, subscriber);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -739,6 +739,38 @@ void WsWuInfo::getRoxieCluster(IEspECLWorkunit &info, unsigned flags)
     }
 }
 
+void WsWuInfo::getEventScheduleFlag(IEspECLWorkunit &info)
+{
+    info.setEventSchedule(0);
+    if (info.getState() && !stricmp(info.getState(), "wait"))
+    {
+        info.setEventSchedule(2); //Can deschedule
+    }
+    else
+    {
+        Owned<IConstWorkflowItemIterator> it = cw->getWorkflowItems();
+        if (it)
+        {
+            ForEach(*it)
+            {
+                IConstWorkflowItem *r = it->query();
+                if (!r)
+                    continue;
+
+                IWorkflowEvent *wfevent = r->getScheduleEvent();
+                if (!wfevent)
+                    continue;
+
+                if (!r->hasScheduleCount() || (r->queryScheduleCountRemaining() > 0))
+                {
+                    info.setEventSchedule(1); //Can reschedule
+                    break;
+                }
+            }
+        }
+    }
+}
+
 void WsWuInfo::getCommon(IEspECLWorkunit &info, unsigned flags)
 {
     SCMStringBuffer s;
@@ -762,6 +794,8 @@ void WsWuInfo::getCommon(IEspECLWorkunit &info, unsigned flags)
 
     if (cw->isPausing())
         info.setIsPausing(true);
+
+    getEventScheduleFlag(info);
 
     if (version > 1.27)
     {

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -172,6 +172,7 @@ public:
     void getWorkunitDll(MemoryBuffer& buf);
     void getWorkunitXml(const char* plainText, MemoryBuffer& buf);
     void getWorkunitCpp(const char* cppname, const char* description, const char* ipAddress, MemoryBuffer& buf);
+    void getEventScheduleFlag(IEspECLWorkunit &info);
 
 public:
     IEspContext &context;

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -392,6 +392,7 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
     wuActionTable.setValue("unprotect", ActionProtect);
     wuActionTable.setValue("restore", ActionRestore);
     wuActionTable.setValue("reschedule", ActionEventSchedule);
+    wuActionTable.setValue("deschedule", ActionEventDeschedule);
     wuActionTable.setValue("settofailed", ActionChangeState);
 
     awusCacheMinutes = AWUS_CACHE_MIN_DEFAULT;
@@ -2511,8 +2512,6 @@ bool CWsWorkunitsEx::onWUShowScheduled(IEspContext &context, IEspWUShowScheduled
         const char *eventName = req.getEventName();
 
         IArrayOf<IEspScheduledWU> results;
-        if(notEmpty(clusterName))
-            getScheduledWUs(context, clusterName, eventName, results);
         if(notEmpty(req.getPushEventName()))
             resp.setPushEventName(req.getPushEventName());
         if(notEmpty(req.getPushEventText()))
@@ -2535,9 +2534,12 @@ bool CWsWorkunitsEx::onWUShowScheduled(IEspContext &context, IEspWUShowScheduled
                 continue;
 
             if(isEmpty(clusterName))
-                getScheduledWUs(context, clusterName, eventName, results);
+                getScheduledWUs(context, iclusterName, eventName, results);
             else if (strieq(clusterName, iclusterName))
+            {
+                getScheduledWUs(context, clusterName, eventName, results);
                 resp.setClusterSelected(i+1);
+            }
 
             Owned<IEspServerInfo> server = createServerInfo("");
             server->setName(iclusterName);


### PR DESCRIPTION
This change fixes three problems related to EclWatch Event Scheduler
link and deschedule function. Problem #1: when Scheduler link on the
left side menu is clicked, Event Scheduled WUs do not show up. Two
bugs are found for this problem. In Scheduleread.cpp, if the Event
Name is an empty string, the CRootScheduleReader should be used. In
ws_workunit dll, a valid cluster name should be input to the
getScheduleWUs(). Problem #2: on Browse Workunits page, Deschedule
button is not activated when Scheduled WUs are selected. The problem
is caused by missing code for setting a WU flag. The flag is
used to indicate that the WU can be descheduled. Problem #3: when
Deschedule button on Workunit Details page is clicked, EclWatch shows
an error message: Invalid Action 'deschdule'. The problem is due to a
missing value: ActionEventDeschedule inside WU action table.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
