### PR TITLE
DATASET (N, transform(COUNTER))

### DIFF
--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -605,8 +605,9 @@ unsigned getOperatorMetaFlags(node_operator op)
     case no_bound_type:
     case no_mix:
     case no_persist_check:
+    case no_dataset_from_transform:
 
-    case no_unused1: case no_unused2: case no_unused3: case no_unused4: case no_unused5: case no_unused6:
+    case no_unused2: case no_unused3: case no_unused4: case no_unused5: case no_unused6:
     case no_unused13: case no_unused14: case no_unused15: case no_unused17: case no_unused18: case no_unused19:
     case no_unused20: case no_unused21: case no_unused22: case no_unused23: case no_unused24: case no_unused25: case no_unused26: case no_unused27: case no_unused28: case no_unused29:
     case no_unused30: case no_unused31: case no_unused32: case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38:
@@ -2596,6 +2597,16 @@ IHqlExpression * calcRowInformation(IHqlExpression * expr)
                     minValue++;
             }
             info.setRange(minValue, maxValue);
+            break;
+        }
+    case no_dataset_from_transform:
+        {
+            // only if the count is a constant value
+            IHqlExpression * count = expr->queryChild(0);
+            IValue * value = count->queryValue();
+            if (value)
+                info.setN(value->getIntValue());
+            // leave it be, if it's a constant expression or a variable
             break;
         }
     case no_null:

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -1075,6 +1075,7 @@ const char *getOpString(node_operator op)
     case no_transformebcdic: return "EBCDIC";
     case no_transformascii: return "ASCII";
     case no_hqlproject: return "PROJECT";
+    case no_dataset_from_transform: return "DATASET";
     case no_newtransform: return "NEWTRANSFORM";
     case no_transform: return "TRANSFORM";
     case no_attr: return "no_attr";
@@ -1424,7 +1425,7 @@ const char *getOpString(node_operator op)
     case no_debug_option_value: return "__DEBUG__";
     case no_dataset_alias: return "TABLE";
 
-    case no_unused1: case no_unused2: case no_unused3: case no_unused4: case no_unused5: case no_unused6:
+    case no_unused2: case no_unused3: case no_unused4: case no_unused5: case no_unused6:
     case no_unused13: case no_unused14: case no_unused15: case no_unused17: case no_unused18: case no_unused19:
     case no_unused20: case no_unused21: case no_unused22: case no_unused23: case no_unused24: case no_unused25: case no_unused26: case no_unused27: case no_unused28: case no_unused29:
     case no_unused30: case no_unused31: case no_unused32: case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38:
@@ -1772,6 +1773,7 @@ childDatasetType getChildDatasetType(IHqlExpression * expr)
     case no_definesideeffect:
     case no_callsideeffect:
     case no_fromxml:
+    case no_dataset_from_transform:
         return childdataset_none;
     case no_group:
     case no_grouped:
@@ -2167,6 +2169,7 @@ inline unsigned doGetNumChildTables(IHqlExpression * dataset)
     case no_definesideeffect:
     case no_callsideeffect:
     case no_fromxml:
+    case no_dataset_from_transform:
         return 0;
     case no_delayedselect:
     case no_libraryselect:
@@ -2477,6 +2480,7 @@ bool definesColumnList(IHqlExpression * dataset)
     case no_normalizegroup:
     case no_cogroup:
     case no_dataset_alias:
+    case no_dataset_from_transform:
         return true;
     case no_select:
     case no_field:
@@ -2574,6 +2578,7 @@ IHqlExpression * queryNewColumnProvider(IHqlExpression * expr)
     case no_transformebcdic:
     case no_transformascii:
     case no_hqlproject:
+    case no_dataset_from_transform:
     case no_keyindex:
     case no_projectrow:
     case no_iterate:
@@ -10321,6 +10326,7 @@ IHqlExpression *createDataset(node_operator op, HqlExprArray & parms)
         assertex(parms.ordinality()>1);     // should have a count or a length
         break;
     case no_inlinetable:
+    case no_dataset_from_transform:
     case no_xmlproject:
     case no_temptable:
     case no_id2blob:

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -352,7 +352,7 @@ enum _node_operator {
     no_unused22,
     no_unused23,
     no_unused24,
-    no_unused1,   
+        no_dataset_from_transform,
     no_unused2,
         no_unknown,
     no_unused3,

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -3532,6 +3532,10 @@ IHqlExpression * NullFolderMixin::foldNullDataset(IHqlExpression * expr)
         if (expr->queryChild(0)->numChildren() == 0)
             return replaceWithNull(expr);
         break;
+    case no_dataset_from_transform:
+        if (isZero(expr->queryChild(0)))
+            return replaceWithNull(expr);
+        break;
     case no_temptable:
         {
             IHqlExpression * values = expr->queryChild(0);
@@ -5336,6 +5340,7 @@ HqlConstantPercolator * CExprFolderTransformer::gatherConstants(IHqlExpression *
     case no_nwayjoin:
     case no_projectrow:
     case no_createrow:
+    case no_dataset_from_transform:
         {
             IHqlExpression * transform = queryNewColumnProvider(expr);
             exprMapping.setown(HqlConstantPercolator::extractConstantMapping(transform));

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -1330,6 +1330,7 @@ public:
     ABoundActivity * doBuildActivityCombineGroup(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityCompoundSelectNew(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityConcat(BuildCtx & ctx, IHqlExpression * expr);
+    ABoundActivity * doBuildActivityCountTransform(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityCreateRow(BuildCtx & ctx, IHqlExpression * expr, bool isDataset);
     ABoundActivity * doBuildActivityXmlRead(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityDedup(BuildCtx & ctx, IHqlExpression * expr);

--- a/ecl/regress/dataset_transform.ecl
+++ b/ecl/regress/dataset_transform.ecl
@@ -1,0 +1,51 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+C := 5 : stored('C');
+
+r := record
+    unsigned i;
+end;
+
+r t1(unsigned value) := transform
+    SELF.i := value * 10;
+end;
+
+r t2() := transform
+    SELF.i := 10;
+end;
+
+// zero
+output(true);
+ds := DATASET(0, t1(COUNTER));
+output(ds);
+
+// plain
+output(true);
+ds10 := DATASET(10, t1(COUNTER));
+output(ds10);
+
+// expr
+output(true);
+ds50 := DATASET(5 * 10, t1(COUNTER));
+output(ds50);
+
+// variable
+output(true);
+ds5 := DATASET(C, t2());
+output(ds5);

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -636,6 +636,7 @@ interface ICsvToRowTransformer : public IInterface
 
 
 
+// Activity index: Class name = s/TAK(.*)/IHThor$1Arg/, with $1 using camel case
 enum ThorActivityKind
 {   
     //This list cannot be reordered - unless all workunits are invalidated...


### PR DESCRIPTION
First steps to implement an ECL construct. Node type
enum element added in place of an unused one and implemented in switch/
case blocks as needed (trial and error).

Several corrections by Gavin, now it's producing expected results for
a very limited set of use-cases.
