### PR TITLE
Fix issue handling ipv4 .0 addresses

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -2668,7 +2668,7 @@ bool IpAddress::isLoopBack() const
 {
     if (::isIp4(netaddr)&&((netaddr[3] & 0x000000ff)==0x000007f))
         return true;
-    return (netaddr[3]==0)&&(netaddr[2]==0)&&(netaddr[1]==0)&&(netaddr[0]==1);
+    return (netaddr[3]==0x1000000)&&(netaddr[2]==0)&&(netaddr[1]==0)&&(netaddr[0]==0);
 }
 
 bool IpAddress::isLocal() const 
@@ -2678,30 +2678,6 @@ bool IpAddress::isLocal() const
     IpAddress ip(*this);
     return isInterfaceIp(ip, NULL);
 }
-
-
-bool IpAddress::isLinkLocal() const
-{
-    return (netaddr[0]&&0x3ff==0x3fa)&&(netaddr[2]==0);
-}
-
-
-bool IpAddress::isSiteLocal() const // depreciated
-{
-    if (::isIp4(netaddr)) {
-        switch (netaddr[3]&0xff) {
-        case 10:
-            return true;
-        case 192:
-            return ((netaddr[3]&0xff00)==0xc000);
-        case 172:
-            return ((netaddr[3]&0x0f00)==0x0100);
-        }
-        return false;
-    }
-    return (netaddr[0]&&0x3ff==0x3fb)&&(netaddr[2]==0);
-}
-
 
 bool IpAddress::ipequals(const IpAddress & other) const
 {
@@ -2713,7 +2689,6 @@ int  IpAddress::ipcompare(const IpAddress & other) const
 {
     return memcmp(&netaddr, &other.netaddr, sizeof(netaddr));
 }
-
 
 unsigned IpAddress::iphash(unsigned prev) const
 {
@@ -2964,7 +2939,7 @@ void IpAddress::ipdeserialize(MemoryBuffer & in)
     if (pfx!=IPV6_SERIALIZE_PREFIX) {
         netaddr[0] = 0;
         netaddr[1] = 0;
-        netaddr[2] = (pfx>0x1000000)?0xffff0000:0;  // catch null and loopback
+        netaddr[2] = (pfx == 0 || pfx == 0x1000000) ? 0 : 0xffff0000; // catch null and loopback
         netaddr[3] = pfx;
     }
     else 
@@ -3073,7 +3048,7 @@ void IpAddress::setNetAddress(size32_t sz,const void *src)
     }
     else if (!IP4only&&(sz==sizeof(netaddr))) { // IPv6
         memcpy(&netaddr,src,sz);
-        if ((netaddr[2]==0)&&(netaddr[3]>0x1000000)&&(netaddr[0]==0)&&(netaddr[1]==0))
+        if ((netaddr[2]==0)&&(netaddr[3]!=0)&&(netaddr[3]!=0x1000000)&&(netaddr[0]==0)&&(netaddr[1]==0))
             netaddr[2]=0xffff0000;  // use this form only
     }
     else

--- a/system/jlib/jsocket.hpp
+++ b/system/jlib/jsocket.hpp
@@ -90,8 +90,6 @@ public:
     bool isHost() const;                                // is primary host NIC ip
     bool isLoopBack() const;                            // is loopback (localhost: 127.0.0.1 or ::1)
     bool isLocal() const;                               // matches local interface 
-    bool isLinkLocal() const;
-    bool isSiteLocal() const; // depreciated
     bool isIp4() const;
     StringBuffer &getIpText(StringBuffer & out) const;
     void ipserialize(MemoryBuffer & out) const;         


### PR DESCRIPTION
An ip ending in .0 was wrongly detected as null or loopback device

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
