### PR TITLE
Turn off parallel subgraph handling if 1

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1507,6 +1507,7 @@ bool CJobMaster::go()
 
     Owned<IConstWUGraphProgress> graphProgress = getGraphProgress();
     bool allDone = true;
+    unsigned concurrentSubGraphs = (unsigned)getWorkUnitValueInt("concurrentSubGraphs", globals->getPropInt("@concurrentSubGraphs", 1));
     try
     {
         ClearTempDirs();
@@ -1530,7 +1531,7 @@ bool CJobMaster::go()
             if (aborted) break;
             CMasterGraph &graph = toRun.item(g);
             if (graph.isSink())
-                graph.execute(0, NULL, true, true);
+                graph.execute(0, NULL, true, concurrentSubGraphs>1);
             if (queryPausing()) break;
         }
         graphExecutor->wait();


### PR DESCRIPTION
If concurrentSubGraphs is set to 1 (the default) disable the sub graph
executor and handle synchronously.
It's a sensible change regardless, and the feature is experimental only at
this stage, there are still issues handling and blocking on the
dependencies when enabled.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
