### PR TITLE
Hashdistribute not handling grouped input

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -160,9 +160,14 @@ public:
         PtrElem *ret = (PtrElem *)fsallocator.alloc();
         ret->setNext(NULL);
         const void *row = in.nextRow();
-        if (!row) {
-            fsallocator.dealloc(ret);
-            return NULL;
+        if (!row)
+        {
+            row = in.nextRow();
+            if (!row)
+            {
+                fsallocator.dealloc(ret);
+                return NULL;
+            }
         }
         ret->setRow(row);
         return ret;


### PR DESCRIPTION
Reasonably rare I think, but if the input activity feeding a HD is providing
grouped output, hash distribute failed to notice the group markers and
instead considered them end of input.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
