### PR TITLE
DiskGroupAggregate doesn't delete temp asap

### DIFF
--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -960,6 +960,7 @@ public:
 // IRowStream
     virtual void stop()
     {
+        partHandler.clear();
         dataLinkStop();
     }
     CATCH_NEXTROW()


### PR DESCRIPTION
A disk group aggregate reading a temp file, will not free the reader early
enough. As a consequence, if it's the last reader of the spill file, it will
try to delete it and may fail if the file system has the file locked.
The temp will still be deleted, but not until the end of all subgraph in the
graph.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
