### PR TITLE
Minor disk grouping issues

### DIFF
--- a/thorlcr/activities/diskread/thdiskread.cpp
+++ b/thorlcr/activities/diskread/thdiskread.cpp
@@ -48,16 +48,16 @@ public:
                 size32_t rSz = fileDesc->queryProperties().getPropInt("@recordSize");
                 if (isGrouped)
                     rSz--; // eog byte not to be included in this test.
-                if (rSz != recordSize-> getMinRecordSize())
+                if (rSz != recordSize->getMinRecordSize())
                     throw MakeThorException(TE_RecordSizeMismatch, "Published record size %d for file %s, does not match coded record size %d", rSz, helper->getFileName(), recordSize->getMinRecordSize());
             }
             if (!fileDesc->isCompressed() && (TDXcompress & helper->getFlags()))
             {
                 size32_t rSz = recordSize->getMinRecordSize();
-                if(codeGenGrouped) rSz++;
+                if (isGrouped) rSz++;
                 if (rSz >= MIN_ROWCOMPRESS_RECSIZE)
                 {
-                    Owned<IException> e = MakeActivityWarning(&container, TE_CompressionMismatch, "Ignoring compression attribute on file '%s', which is not published as compressed", helper->getFileName());
+                    Owned<IException> e = MakeActivityWarning(&container, TE_CompressionMismatch, "Ignoring compression attribute on file '%s', which is not published as compressed in DFS", helper->getFileName());
                     container.queryJob().fireException(e);
                 }
             }

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -368,7 +368,6 @@ public:
         helper = (IHThorDiskReadArg *)queryHelper();
         unsorted = 0 != (TDRunsorted & helper->getFlags());
         grouped = 0 != (TDXgrouped & helper->getFlags());
-        if (isFixedDiskWidth && grouped) diskRowMinSz++;
         needTransform = segMonitors.length() || helper->needTransform();
         out = NULL;
         countSent = false;
@@ -396,6 +395,7 @@ public:
             if (dfsGrouped != grouped) // NB: will already have warned in master->wuid.
                 ActPrintLog("Dfsgrouping vs codegen grouping differ, DFS grouping takes precedence. DfsGrouping=%s", dfsGrouped?"true":"false");
             grouped = dfsGrouped;
+            if (isFixedDiskWidth && grouped) diskRowMinSz++;
         }
         if (grouped)
         {


### PR DESCRIPTION
1) Not taking into account the extra byte on grouped inputs, when decideing to
issue warning after detecting non-compressed file, being read by codegen
flagged compressed marker.
2) If an diskread was not marked grouped by codegen, but was in DFS (e.g. a
persist file), then a spurious error about mismatched record sizes could
ensure.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
