### PR TITLE
gh-1299 Roxie not setting workunit failed in all cases

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -31294,6 +31294,8 @@ private:
         E->errorMessage(error);
         logctx.CTXLOG("EXCEPTION: %s", error.str());
         addWuException(wu, E);
+        WorkunitUpdate w(&wu->lock());
+        w->setState(WUStateFailed);
     }
 
     StringAttr wuid;


### PR DESCRIPTION
Exceptions that occured before the execution context was created would
terminate workunit execution but not set the workunit state to failed,
leaving clients hanging indefinately.

Fixes gh-1299

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
