### PR TITLE
gh-1307 Add ecl command line support for un-publishing

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -176,4 +176,22 @@ public:
     StringAttr optManifest;
 };
 
+class EclCmdWithQueryTarget : public EclCmdCommon
+{
+public:
+    EclCmdWithQueryTarget()
+    {
+    }
+    virtual eclCmdOptionMatchIndicator matchCommandLineOption(ArgvIterator &iter, bool finalAttempt=false);
+    virtual bool finalizeOptions(IProperties *globals);
+    virtual bool parseCommandLineOptions(ArgvIterator &iter);
+
+    virtual void usage()
+    {
+        EclCmdCommon::usage();
+    }
+public:
+    StringAttr optQuerySet;
+    StringAttr optQuery;
+};
 #endif

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -194,6 +194,7 @@ void EclCMDShell::usage()
            "Commonly used commands:\n"
            "   deploy      create a workunit from an ecl file, archive, or dll\n"
            "   publish     add a workunit to a query set\n"
+           "   unpublish   remove a query from a query set\n"
            "   run         run the given ecl file, archive, dll, wuid, or query\n"
            "   activate    activate a published query\n"
            "   deactivate  deactivate the given query alias name\n"


### PR DESCRIPTION
There is currently no way of removing queries from querysets from the
command line.

Add a new ecl unpublish command, and common up how queryset parameters
are handled.

ecl unpublish <queryset> <query>

Fixes gh-1307.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
