### PR TITLE
gh-1309 Additional fix for eclcc with output path

### DIFF
--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -453,8 +453,7 @@ bool CppCompiler::compileFile(IThreadPool * pool, const char * filename, Semapho
     }
     else
     {
-        if (targetDir.get())
-            cmdline.append(" -o ").append("\"").append(targetDir).append(filename).append('.').append(OBJECT_FILE_EXT[targetCompiler]).append("\"");
+        cmdline.append(" -o ").append("\"").append(targetDir).append(filename).append('.').append(OBJECT_FILE_EXT[targetCompiler]).append("\"");
     }
     
     StringBuffer expanded;


### PR DESCRIPTION
Previous fix was incomplete - target directory is not set by eclcc in such
cases so need to cope with case where source file name has a path in it.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
