### PR TITLE
ecl run should show failed workunit results

### DIFF
--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -550,14 +550,11 @@ public:
 
         StringBuffer respwuid(resp->getWuid());
         if (optVerbose && respwuid.length() && !streq(wuid.str(), respwuid.str()))
-            fprintf(stderr, "As %s\n", resp->getWuid());
+            fprintf(stdout, "As %s\n", respwuid.str());
         if (!streq(resp->getState(), "completed"))
-        {
-            fprintf(stderr, "%s\n", resp->getState());
-            return 1;
-        }
+            fprintf(stderr, "%s %s\n", respwuid.str(), resp->getState());
         if (resp->getResults())
-            fprintf(stdout, "%s", resp->getResults());
+            fprintf(stdout, "%s\n", resp->getResults());
 
         return 0;
     }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -991,13 +991,20 @@ bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWU
         resp.setState(cw->getStateDesc(stateDesc).str());
         resp.setWuid(wuid.str());
 
-        if (cw->getState()==WUStateCompleted)
+        switch (cw->getState())
         {
-            SCMStringBuffer result;
-            getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), result, false, ExceptionSeverityInformation);
-            resp.setResults(result.str());
+            case WUStateCompleted:
+            case WUStateFailed:
+            case WUStateUnknown:
+            {
+                SCMStringBuffer result;
+                getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), result, false, ExceptionSeverityInformation);
+                resp.setResults(result.str());
+                break;
+            }
+            default:
+                break;
         }
-
     }
     catch(IException* e)
     {


### PR DESCRIPTION
ecl run currently only shows the results for workunits that complete,
showing failed results would provide the user with error information.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
