### PR TITLE
Remove support for setting chunk sizes in roxiemem

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -31,7 +31,6 @@
 namespace roxiemem {
 
 #define USE_MADVISE_ON_FREE     // avoid linux swapping 'freed' pages to disk
-#define VARIABLE_CHUNKS
 #define TIMEOUT_CHECK_FREQUENCY_MILLISECONDS 10
 
 unsigned memTraceLevel = 1;
@@ -1081,9 +1080,6 @@ class CChunkingRowManager : public CInterface, implements IRowManager
     bool isUltraCheckingHeap;
     Owned<IActivityMemoryUsageMap> usageMap;
     const IRowAllocatorCache *allocatorCache;
-#ifdef VARIABLE_CHUNKS
-    UnsignedArray chunkLengths;
-#endif
     unsigned __int64 cyclesChecked;       // When we last checked timelimit
     unsigned __int64 cyclesCheckInterval; // How often we need to check timelimit
 
@@ -1131,15 +1127,6 @@ public:
         trackMemoryByActivity = false;
         isCheckingHeap = false;
         isUltraCheckingHeap = false;
-#endif
-#ifdef VARIABLE_CHUNKS
-        chunkLengths.append(32);
-        chunkLengths.append(64);
-        chunkLengths.append(128);
-        chunkLengths.append(256);
-        chunkLengths.append(512);
-        chunkLengths.append(1024);
-        chunkLengths.append(2048);
 #endif
         if (memTraceLevel >= 2)
             logctx.CTXLOG("RoxieMemMgr: CChunkingRowManager c-tor memLimit=%u pageLimit=%u rowMgr=%p", _memLimit, pageLimit, this);
@@ -1195,34 +1182,6 @@ public:
             dfinger = next;
         }
         logctx.Release();
-    }
-
-    static int compareUnsigned(unsigned *a, unsigned *b)
-    {
-        return (int) (*a - *b);
-    }
-
-    virtual void setChunkSizes(const UnsignedArray &sizes)
-    {
-#ifdef VARIABLE_CHUNKS
-        chunkLengths.kill();
-        ForEachItemIn(idx, sizes)
-        {
-            unsigned size = sizes.item(idx);
-            size += sizeof(atomic_t) + sizeof(unsigned);
-#ifdef CHECKING_HEAP
-            if (isCheckingHeap)
-                size += sizeof(unsigned); // for the magic number
-#endif
-            if (size <= FixedSizeHeaplet::maxHeapSize(isCheckingHeap)/20)
-            {
-                bool wasNew;
-                aindex_t added = chunkLengths.bAdd(size, compareUnsigned, wasNew);
-                if (!wasNew)
-                    chunkLengths.remove(added);  // Why is there no bAddUnique ?
-            }
-        }
-#endif
     }
 
     virtual void reportLeaks()
@@ -1330,50 +1289,21 @@ public:
             if (isCheckingHeap) 
                 size += sizeof(unsigned); // for the magic number
 #endif
-#ifdef VARIABLE_CHUNKS
-            // search the chunkLengths array to find the first one >= size
-            int a = 0;
-            int b = chunkLengths.length();
-            if (b)
-            {
-                // Classic binchop ...
-                while (a<b)
-                {
-                    int i = (a+b)/2;
-                    size32_t cl = chunkLengths.item(i);
-                    if (cl==size)
-                        return cl;  // good chance of an exact match since we tune the sizes to what we expect
-                    else if (cl < size)
-                        a = i+1;
-                    else
-                        b = i;
-                }
-                if (a < chunkLengths.length())
-                {
-                    size32_t cl = chunkLengths.item(a);
-                    assert(cl >= size);
-                    return cl;
-                }
-            }
-            else
-#endif
-            {
-                if (size<=32)
-                    return 32;
-                else if (size<=64)
-                    return 64;
-                else if (size<=128)
-                    return 128;
-                else if (size<=256)
-                    return 256;
-                else if (size<=512)
-                    return 512;
-                else if (size<=1024)
-                    return 1024;
-                else if (size<=2048)
-                    return 2048;
-            }
-            if (size <= FixedSizeHeaplet::maxHeapSize(isCheckingHeap)/20)
+            if (size<=32)
+                return 32;
+            else if (size<=64)
+                return 64;
+            else if (size<=128)
+                return 128;
+            else if (size<=256)
+                return 256;
+            else if (size<=512)
+                return 512;
+            else if (size<=1024)
+                return 1024;
+            else if (size<=2048)
+                return 2048;
+            else if (size <= FixedSizeHeaplet::maxHeapSize(isCheckingHeap)/20)
                 return (((size-1) / 4096)+1) * 4096;
             else
             {
@@ -1940,7 +1870,6 @@ public:
 class RoxieMemTests : public CppUnit::TestFixture  
 {
     CPPUNIT_TEST_SUITE( RoxieMemTests );
-        CPPUNIT_TEST(testBuckets);
         CPPUNIT_TEST(testHuge);
         CPPUNIT_TEST(testAll);
         CPPUNIT_TEST(testDatamanager);
@@ -2227,23 +2156,6 @@ protected:
         Owned<IRowManager> rm5 = createRowManager(0, NULL, logctx, NULL);
         rm5->allocate(4000, 0);
         rm5.clear();
-    }
-
-    void testBuckets()
-    {
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
-        UnsignedArray chunkSizes;
-        chunkSizes.append(10);
-        chunkSizes.append(20);
-        chunkSizes.append(30);
-        rm1->setChunkSizes(chunkSizes);
-        void *ptrs[50];
-        for (int i = 0; i < 50; i++)
-            ptrs[i] = rm1->allocate(i, 0);
-        ASSERT(rm1->pages()==4);
-        for (int i = 0; i < 50; i++)
-            ReleaseRoxieRow(ptrs[i]);
-        ASSERT(rm1->pages()==0);
     }
 
     void testFixed()

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -386,9 +386,6 @@ interface IRowManager : extends IInterface
     virtual void checkHeap() = 0;
     virtual IFixedRowHeap * createFixedRowHeap(size32_t fixedSize, unsigned activityId, RoxieHeapFlags flags) = 0;
     virtual IVariableRowHeap * createVariableRowHeap(unsigned activityId, RoxieHeapFlags flags) = 0;            // should this be passed the initial size?
-
-    // Set the chunk sizes to use. Note that these sizes are before adjusting for per-row overhead
-    virtual void setChunkSizes(const UnsignedArray &) = 0;
 };
 
 extern roxiemem_decl void setDataAlignmentSize(unsigned size);


### PR DESCRIPTION
The code to support configurable chunk sizes in RoxieMem was added
recently, and is not yet in use. As we have decided to take a different
approach that will give the same advantages as this but more efficiently,
the code can be removed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
