### PR TITLE
Fixes #1117 Fix naming inconsistency when generating dropzone directory using wizard

### DIFF
--- a/initfiles/componentfiles/configxml/dropzone.xsd.in
+++ b/initfiles/componentfiles/configxml/dropzone.xsd.in
@@ -127,7 +127,7 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="directory" type="absolutePath" use="optional" default="${EXEC_PREFIX}/lib/${DIR_NAME}/dropzone">
+            <xs:attribute name="directory" type="absolutePath" use="optional" default="${EXEC_PREFIX}/lib/${DIR_NAME}/mydropzone">
                 <xs:annotation>
                     <xs:appinfo>
                         <tooltip>The directory where the drop zone is located.</tooltip>


### PR DESCRIPTION
When using the wizard, the dropzone directory is now same as the value in the default environment.xml

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
