### PR TITLE
Very rare race in roxie memory manager

### DIFF
--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -102,6 +102,10 @@ protected:
     }
 
 public:
+    inline bool isAlive() const
+    {
+        return atomic_read(&count) < DEAD_PSEUDO_COUNT;        //only safe if Link() is called first
+    }
 
     static void release(const void *ptr)
     {


### PR DESCRIPTION
The previous fix, while solving the race, would have increased the memory
footprint considerably.

This fixes the original race without changing the memory footprint. It's still
not a great bit of code though, and perhaps the upcoming refactor of this area
will address it further.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
