### PR TITLE
Remove useless attribute object

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -217,11 +217,10 @@ interface IDistributedFile: extends IInterface
     virtual void attach(const char *logicalname,IDistributedFileTransaction *transaction=NULL,IUserDescriptor *user=NULL) = 0;                          // attach to name in DFS
     virtual void detach(IDistributedFileTransaction *transaction=NULL) = 0;                                                 // no longer attached to name in DFS
 
-    virtual IPropertyTree &queryProperties() = 0;                               // DFile properties (can call reload)
-    virtual void reloadProperties() = 0;                                       // DFile properties
+    virtual IPropertyTree &queryProperties() = 0;                               // DFile attributes (TODO: rename to getFileAttr)
 
-    virtual IPropertyTree &lockProperties(unsigned timeoutms=INFINITE) = 0;     // must be called before updating
-    virtual void unlockProperties() = 0;                                        // must be called after updating
+    virtual IPropertyTree &lockProperties(unsigned timeoutms=INFINITE) = 0;     // must be called before updating properties (will discard uncommitted changes)
+    virtual void unlockProperties() = 0;                                        // must be called after updating properties
 
     virtual bool getModificationTime(CDateTime &dt) = 0;                        // get date and time last modified (returns false if not set)
     virtual void setModificationTime(const CDateTime &dt) = 0;                  // set date and time last modified


### PR DESCRIPTION
The attr Owned pointer to properties's Attr section of a file
had no effect on the properties' lock/unlock and changes, and
was increasing the complexity of the transaction mechanism
unnecessarily.

All regressions pass.
