### PR TITLE
Fix deadlock stopping merge distribute

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -1338,7 +1338,10 @@ public:
         assertex(!donerecv[i]);
         if (self==i) {
             if (stopping)
+            {
+                selfdone.signal();
                 return (unsigned)-1;
+            }
             if (hasbuf[i]) {
                 bufs[i].swapWith(msg);
                 cBuf *cb = diskcached[i];
@@ -1425,6 +1428,7 @@ public:
     }
     void startTX()
     {
+        stopping = false;
         delete txthread;
         txthread = new cTxThread(*this);
         txthread->start();


### PR DESCRIPTION
If merge dist stopped early, it could deadlock, because it failed
to signal a pending semaphore
Also start didn't reset stopping flag which could cause problems if in child
queries

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
