### PR TITLE
Add DISTRIBUTED flag to DATASET(N, trans(COUNTER))

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -2846,6 +2846,24 @@ expireAttr
                         }
     ;
 
+optDatasetFlags
+    :                   { $$.setNullExpr(); }
+    | ',' datasetFlags    { $$.inherit($2); }
+    ;
+
+datasetFlags
+    : datasetFlag
+    | datasetFlag ',' datasetFlags
+                        { $$.setExpr(createComma($1.getExpr(), $3.getExpr()), $1); }
+    ;
+
+datasetFlag
+    : DISTRIBUTED       {
+                            $$.setExpr(createExprAttribute(distributedAtom));
+                            $$.setPosition($1);
+                        }
+    ;
+
 optIndexFlags
     :                   { $$.setNullExpr(); $$.clearPosition(); }
     | ',' indexFlags    { $$.setExpr($2.getExpr()); $$.setPosition($1); }
@@ -8034,14 +8052,13 @@ simpleDataSet
                             $$.setExpr(createDataset(no_workunit_dataset, $8.getExpr(), arg));
                             $$.setPosition($1);
                         }
-    | DATASET '(' thorFilenameOrList ',' beginCounterScope transform endCounterScope ')'
+    | DATASET '(' thorFilenameOrList ',' beginCounterScope transform endCounterScope optDatasetFlags ')'
                         {
-                            // TODO: use DISTRIBUTED flag
                             parser->normalizeExpression($3, type_int, false);
                             IHqlExpression * counter = $7.getExpr();
                             if (counter)
                                 counter = createAttribute(_countProject_Atom, counter);
-                            $$.setExpr(createDataset(no_dataset_from_transform, $3.getExpr(), createComma($6.getExpr(), counter)));
+                            $$.setExpr(createDataset(no_dataset_from_transform, $3.getExpr(), createComma($6.getExpr(), counter, $8.getExpr())));
                             $$.setPosition($1);
                         }
     | ENTH '(' dataSet ',' expression optCommonAttrs ')'

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -1421,6 +1421,8 @@ public:
     ABoundActivity * doBuildActivityWorkunitRead(BuildCtx & ctx, IHqlExpression * expr);
     ABoundActivity * doBuildActivityXmlParse(BuildCtx & ctx, IHqlExpression * expr);
 
+    void doBuildTempTableFlags(BuildCtx & ctx, IHqlExpression * expr, bool isConstant);
+
     void doBuildXmlEncode(BuildCtx & ctx, const CHqlBoundTarget * tgt, IHqlExpression * expr, CHqlBoundExpr * result);
 
     IHqlExpression * doBuildOrderElement(BuildCtx & ctx, IHqlExpression * left, IHqlExpression * right);

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -15657,6 +15657,17 @@ void HqlCppTranslator::buildDatasetAssignXmlProject(BuildCtx & ctx, IHqlCppDatas
 //---------------------------------------------------------------------------
 //-- no_temptable [DATASET] --
 
+void HqlCppTranslator::doBuildTempTableFlags(BuildCtx & ctx, IHqlExpression * expr, bool isConstant)
+{
+    StringBuffer flags;
+    if (expr->hasProperty(distributedAtom))
+        flags.append("|TTFdistributed");
+    if (!isConstant)
+        flags.append("|TTFnoconstant");
+    if (flags.length())
+        doBuildUnsignedFunction(ctx, "getFlags", flags.str()+1);
+}
+
 ABoundActivity * HqlCppTranslator::doBuildActivityTempTable(BuildCtx & ctx, IHqlExpression * expr)
 {
     StringBuffer s;
@@ -15769,14 +15780,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityTempTable(BuildCtx & ctx, IHql
 
     doBuildUnsignedFunction(instance->startctx, "numRows", rowsExpr);
 
-    // unsigned getFlags()
-    StringBuffer flags;
-    if (expr->hasProperty(distributedAtom))
-        flags.append("|TTFdistributed");
-    if (!values->isConstant())
-        flags.append("|TTFnoconstant");
-    if (flags.length())
-        doBuildUnsignedFunction(instance->startctx, "getFlags", flags.str()+1);
+    doBuildTempTableFlags(instance->startctx, expr, values->isConstant());
 
     buildInstanceSuffix(instance);
 
@@ -15840,8 +15844,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCreateRow(BuildCtx & ctx, IHql
     buildAssign(funcctx, self, expr);
     buildReturnRecordSize(funcctx, selfCursor);
 
-    if (!valuesAreConstant)
-        doBuildBoolFunction(instance->startctx, "isConstant", false);
+    doBuildTempTableFlags(instance->startctx, expr, valuesAreConstant);
 
     buildInstanceSuffix(instance);
 
@@ -15917,14 +15920,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityInlineTable(BuildCtx & ctx, IH
     OwnedHqlExpr rowsExpr = getSizetConstant(maxRows);
     doBuildUnsignedFunction(instance->startctx, "numRows", rowsExpr);
 
-    // unsigned getFlags()
-    StringBuffer flags;
-    if (expr->hasProperty(distributedAtom))
-        flags.append("|TTFdistributed");
-    if (!values->isConstant())
-        flags.append("|TTFnoconstant");
-    if (flags.length())
-        doBuildUnsignedFunction(instance->startctx, "getFlags", flags.str()+1);
+    doBuildTempTableFlags(instance->startctx, expr, values->isConstant());
 
     buildInstanceSuffix(instance);
 
@@ -15958,14 +15954,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCountTransform(BuildCtx & ctx,
     // unsigned numRows() - count is guaranteed by lexer
     doBuildUnsignedFunction(instance->startctx, "numRows", count);
 
-    // unsigned getFlags()
-    StringBuffer flags;
-    if (expr->hasProperty(distributedAtom))
-        flags.append("|TTFdistributed");
-    if (!isConstantTransform(transform))
-        flags.append("|TTFnoconstant");
-    if (flags.length())
-        doBuildUnsignedFunction(instance->startctx, "getFlags", flags.str()+1);
+    doBuildTempTableFlags(instance->startctx, expr, isConstantTransform(transform));
 
     buildInstanceSuffix(instance);
 

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -15768,8 +15768,15 @@ ABoundActivity * HqlCppTranslator::doBuildActivityTempTable(BuildCtx & ctx, IHql
     }
 
     doBuildUnsignedFunction(instance->startctx, "numRows", rowsExpr);
+
+    // unsigned getFlags()
+    StringBuffer flags;
+    if (expr->hasProperty(distributedAtom))
+        flags.append("|TTFdistributed");
     if (!values->isConstant())
-        doBuildBoolFunction(instance->startctx, "isConstant", false);
+        flags.append("|TTFnoconstant");
+    if (flags.length())
+        doBuildUnsignedFunction(instance->startctx, "getFlags", flags.str()+1);
 
     buildInstanceSuffix(instance);
 
@@ -15910,8 +15917,14 @@ ABoundActivity * HqlCppTranslator::doBuildActivityInlineTable(BuildCtx & ctx, IH
     OwnedHqlExpr rowsExpr = getSizetConstant(maxRows);
     doBuildUnsignedFunction(instance->startctx, "numRows", rowsExpr);
 
+    // unsigned getFlags()
+    StringBuffer flags;
+    if (expr->hasProperty(distributedAtom))
+        flags.append("|TTFdistributed");
     if (!values->isConstant())
-        doBuildBoolFunction(instance->startctx, "isConstant", false);
+        flags.append("|TTFnoconstant");
+    if (flags.length())
+        doBuildUnsignedFunction(instance->startctx, "getFlags", flags.str()+1);
 
     buildInstanceSuffix(instance);
 
@@ -15945,9 +15958,14 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCountTransform(BuildCtx & ctx,
     // unsigned numRows() - count is guaranteed by lexer
     doBuildUnsignedFunction(instance->startctx, "numRows", count);
 
-    // bool isConstant() - default is true
+    // unsigned getFlags()
+    StringBuffer flags;
+    if (expr->hasProperty(distributedAtom))
+        flags.append("|TTFdistributed");
     if (!isConstantTransform(transform))
-        doBuildBoolFunction(instance->startctx, "isConstant", false);
+        flags.append("|TTFnoconstant");
+    if (flags.length())
+        doBuildUnsignedFunction(instance->startctx, "getFlags", flags.str()+1);
 
     buildInstanceSuffix(instance);
 

--- a/ecl/regress/dataset_transform.ecl
+++ b/ecl/regress/dataset_transform.ecl
@@ -49,3 +49,8 @@ output(ds50);
 output(true);
 ds5 := DATASET(C, t2());
 output(ds5);
+
+// distributed
+output(true);
+dsd := DATASET(10, t1(COUNTER), DISTRIBUTED);
+output(dsd);

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -956,6 +956,9 @@ enum ActivityInterfaceEnum
     TAIexternal_1,
     TAIpipethrougharg_2,
     TAIpipewritearg_2,
+    TAItemptablearg_2,
+
+//Should remain as last of all meaningful tags, but before aliases
     TAImax,
 
 //Only aliases follow - for interfaces implemented via typedefs
@@ -998,6 +1001,7 @@ interface IHThorArg : public IInterface
 
 typedef IHThorArg * (*EclHelperFactory)();
 
+//flags for thor disk access
 enum 
 {
 //General disk access flags
@@ -1042,7 +1046,7 @@ enum
     TDWupdatecrc        = 0x80000,      // has format crc
 };
 
-
+//flags for thor index read
 enum
 {
     TIRsorted           = 0x00000001,
@@ -1078,6 +1082,13 @@ enum
     TIWnooverwrite      = 0x0200,
     TIWupdatecrc        = 0x0400,
     TIWhaswidth         = 0x0800,
+};
+
+//flags for thor dataset/temp tables
+enum
+{
+    TTFnoconstant        = 0x0001,      // default flags is zero
+    TTFdistributed       = 0x0002,
 };
 
 struct IHThorIndexWriteArg : public IHThorArg
@@ -1400,9 +1411,20 @@ struct IHThorTempTableArg : public IHThorArg
 {
     virtual size32_t getRow(ARowBuilder & rowBuilder, unsigned row) = 0;
     virtual unsigned numRows() = 0;
-    virtual bool isConstant()                           { return true; }
+    virtual bool isConstant()                           { return true; }    // deprecate in favour of getFlags
     virtual size32_t getRowSingle(ARowBuilder & rowBuilder) = 0;            // only valid for TAKtemprow, could be called directly
 };
+
+/*
+ * New Temp table that allows flags to be set and retrieved on one
+ * single method. Future-proof and should merge with the interface
+ * above in the next major release.
+ */
+struct IHThorTempTableExtraArg : public IHThorTempTableArg
+{
+    virtual unsigned getFlags() = 0;
+};
+
 
 struct IHThorSampleArg : public IHThorArg
 {

--- a/rtl/include/eclhelper_base.hpp
+++ b/rtl/include/eclhelper_base.hpp
@@ -1299,7 +1299,7 @@ class CThorHashAggregateArg : public CThorArg, implements IHThorHashAggregateArg
     virtual size32_t mergeAggregate(ARowBuilder & rowBuilder, const void * src) { rtlFailUnexpected(); return 0; }
 };
 
-class CThorTempTableArg : public CThorArg, implements IHThorTempTableArg
+class CThorTempTableArg : public CThorArg, implements IHThorTempTableExtraArg
 {
 public:
     virtual void Link() const { RtlCInterface::Link(); }
@@ -1313,11 +1313,14 @@ public:
         case TAIarg:
         case TAItemptablearg_1:
             return static_cast<IHThorTempTableArg *>(this);
+        case TAItemptablearg_2:
+            return static_cast<IHThorTempTableExtraArg *>(this);
         }
         return NULL;
     }
 
-    virtual bool isConstant()                           { return true; }
+    virtual unsigned getFlags()                         { return 0; }
+    virtual bool isConstant()                           { return (getFlags() & TTFnoconstant) == 0; }
     virtual size32_t getRowSingle(ARowBuilder & rowBuilder) { return 0; }
 };
 

--- a/testing/ecl/dataset_transform.ecl
+++ b/testing/ecl/dataset_transform.ecl
@@ -1,0 +1,56 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+C := 5 : stored('C');
+
+r := record
+    unsigned i;
+end;
+
+r t1(unsigned value) := transform
+    SELF.i := value * 10;
+end;
+
+r t2() := transform
+    SELF.i := 10;
+end;
+
+// zero
+output(true);
+ds := DATASET(0, t1(COUNTER));
+output(ds);
+
+// plain
+output(true);
+ds10 := DATASET(10, t1(COUNTER));
+output(ds10);
+
+// expr
+output(true);
+ds50 := DATASET(5 * 10, t1(COUNTER));
+output(ds50);
+
+// variable
+output(true);
+ds5 := DATASET(C, t2());
+output(ds5);
+
+// distributed
+output(true);
+dsd := DATASET(10, t1(COUNTER), DISTRIBUTED);
+output(dsd);

--- a/testing/ecl/key/dataset_transform.xml
+++ b/testing/ecl/key/dataset_transform.xml
@@ -1,0 +1,100 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>true</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>true</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><i>0</i></Row>
+ <Row><i>10</i></Row>
+ <Row><i>20</i></Row>
+ <Row><i>30</i></Row>
+ <Row><i>40</i></Row>
+ <Row><i>50</i></Row>
+ <Row><i>60</i></Row>
+ <Row><i>70</i></Row>
+ <Row><i>80</i></Row>
+ <Row><i>90</i></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>true</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><i>0</i></Row>
+ <Row><i>10</i></Row>
+ <Row><i>20</i></Row>
+ <Row><i>30</i></Row>
+ <Row><i>40</i></Row>
+ <Row><i>50</i></Row>
+ <Row><i>60</i></Row>
+ <Row><i>70</i></Row>
+ <Row><i>80</i></Row>
+ <Row><i>90</i></Row>
+ <Row><i>100</i></Row>
+ <Row><i>110</i></Row>
+ <Row><i>120</i></Row>
+ <Row><i>130</i></Row>
+ <Row><i>140</i></Row>
+ <Row><i>150</i></Row>
+ <Row><i>160</i></Row>
+ <Row><i>170</i></Row>
+ <Row><i>180</i></Row>
+ <Row><i>190</i></Row>
+ <Row><i>200</i></Row>
+ <Row><i>210</i></Row>
+ <Row><i>220</i></Row>
+ <Row><i>230</i></Row>
+ <Row><i>240</i></Row>
+ <Row><i>250</i></Row>
+ <Row><i>260</i></Row>
+ <Row><i>270</i></Row>
+ <Row><i>280</i></Row>
+ <Row><i>290</i></Row>
+ <Row><i>300</i></Row>
+ <Row><i>310</i></Row>
+ <Row><i>320</i></Row>
+ <Row><i>330</i></Row>
+ <Row><i>340</i></Row>
+ <Row><i>350</i></Row>
+ <Row><i>360</i></Row>
+ <Row><i>370</i></Row>
+ <Row><i>380</i></Row>
+ <Row><i>390</i></Row>
+ <Row><i>400</i></Row>
+ <Row><i>410</i></Row>
+ <Row><i>420</i></Row>
+ <Row><i>430</i></Row>
+ <Row><i>440</i></Row>
+ <Row><i>450</i></Row>
+ <Row><i>460</i></Row>
+ <Row><i>470</i></Row>
+ <Row><i>480</i></Row>
+ <Row><i>490</i></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><Result_7>true</Result_7></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><i>10</i></Row>
+ <Row><i>10</i></Row>
+ <Row><i>10</i></Row>
+ <Row><i>10</i></Row>
+ <Row><i>10</i></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><Result_9>true</Result_9></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><i>0</i></Row>
+ <Row><i>10</i></Row>
+ <Row><i>20</i></Row>
+ <Row><i>30</i></Row>
+ <Row><i>40</i></Row>
+ <Row><i>50</i></Row>
+ <Row><i>60</i></Row>
+ <Row><i>70</i></Row>
+ <Row><i>80</i></Row>
+ <Row><i>90</i></Row>
+</Dataset>


### PR DESCRIPTION
This is patch is just adding the keyword and persisting
it in the object (via getFlags() function), but
it's not being used yet. We need to fix the limits of
getRow() to obey numRows() in the engine before coding
the distributed part.

The fix mentioned above is my next step. ECL regressions pass, both OSS and LN.
