### PR TITLE
FIX gh-1331 - Check hthor mem limit setting on 32bit

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -2038,7 +2038,16 @@ void EclAgent::runProcess(IEclProcess *process)
     //Get memory limit. Workunit specified value takes precedence over config file
     int memLimitMB = globals->getPropInt("defaultMemoryLimitMB", DEFAULT_MEM_LIMIT);
     memLimitMB = queryWorkUnit()->getDebugValueInt("hthorMemoryLimit", memLimitMB);
-    roxiemem::setTotalMemoryLimit(memLimitMB * 1024 * 1024);
+#ifndef __64BIT__
+    if (memLimitMB > 4096)
+    {
+        StringBuffer errmsg;
+        errmsg.append("EclAgent (32 bit) specified memory limit (").append(memLimitMB).append("MB) greater than allowed limit (4096MB)");
+        fail(0, errmsg.str());
+    }
+#endif
+    memsize_t memLimitBytes = memLimitMB * 1024 * 1024;
+    roxiemem::setTotalMemoryLimit(memLimitBytes);
 
     if (debugContext)
         debugContext->checkBreakpoint(DebugStateReady, NULL, NULL);

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -2046,7 +2046,7 @@ void EclAgent::runProcess(IEclProcess *process)
         fail(0, errmsg.str());
     }
 #endif
-    memsize_t memLimitBytes = memLimitMB * 1024 * 1024;
+    memsize_t memLimitBytes = (memsize_t)memLimitMB * 1024 * 1024;
     roxiemem::setTotalMemoryLimit(memLimitBytes);
 
     if (debugContext)


### PR DESCRIPTION
HThor incorrectly computes environment 'defaultMemoryLimitMB' and WU
specified 'hthorMemoryLimit' settings in 32 bit build. Specifying, for
instance, 5000MB overflows and causes incorrect byte count to be computed.
Fix problem with conditionally compiled check to ensure specified value
is <= 4096MB in 32 bit build

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
