### PR TITLE
Fix gh-1345 WU Result link not work for Chrome

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -283,7 +283,7 @@
 
            var downloadWnds = new Array();
          
-           function download(ParentElement, Link)
+           function getLink(ParentElement, Link)
            {
               ParentElement.disabled = true;
               for(var i=0;i<downloadWnds.length;i++)

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -1046,24 +1046,24 @@
      <xsl:choose>
        <xsl:when test="number(ShowFileContent) and string-length(Link)">
           <td>
-            <a href="javascript:void(0);" onclick="download(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResult?Wuid={$wuid}&amp;Sequence={Link}');return false;">
+            <a href="javascript:void(0);" onclick="getLink(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResult?Wuid={$wuid}&amp;Sequence={Link}');return false;">
               <xsl:value-of select="Value"/>
             </a>
           </td>
           <xsl:variable name="resultname" select="Name"/>
           <xsl:for-each select="/WUInfoResponse/ResultViews/View">
             <td>
-              <a href="javascript:void(0);" onclick="download(document.getElementById('ECL_Result_{$position}'), '/WsWorkunits/WUResultView?Wuid={$wuid}&amp;ResultName={$resultname}&amp;ViewName={.}');return false;"><xsl:value-of select="."/></a>
+              <a href="javascript:void(0);" onclick="getLink(document.getElementById('ECL_Result_{$position}'), '/WsWorkunits/WUResultView?Wuid={$wuid}&amp;ResultName={$resultname}&amp;ViewName={.}');return false;"><xsl:value-of select="."/></a>
             </td>
           </xsl:for-each>
           <td>
-            <a href="javascript:void(0);" onclick="download(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResultBin?Format=zip&amp;Wuid={$wuid}&amp;Sequence={Link}');return false;">.zip</a>
+            <a href="javascript:void(0);" onclick="getLink(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResultBin?Format=zip&amp;Wuid={$wuid}&amp;Sequence={Link}');return false;">.zip</a>
           </td>
           <td>
-            <a href="javascript:void(0);" onclick="download(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResultBin?Format=gzip&amp;Wuid={$wuid}&amp;Sequence={Link}');return false;">.gz</a>
+            <a href="javascript:void(0);" onclick="getLink(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResultBin?Format=gzip&amp;Wuid={$wuid}&amp;Sequence={Link}');return false;">.gz</a>
           </td>
           <td>
-            <a href="javascript:void(0);" onclick="download(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResultBin?Format=xls&amp;Wuid={$wuid}&amp;Sequence={Link}');return false;">.xls</a>
+            <a href="javascript:void(0);" onclick="getLink(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResultBin?Format=xls&amp;Wuid={$wuid}&amp;Sequence={Link}');return false;">.xls</a>
           </td>
           <td>
             <xsl:if test="string-length(FileName)">


### PR DESCRIPTION
In EclWatch WU Details page, the links inside the Results
section can be used to view or download the results. Those
links do work for IE and FireFox, but not for Chrome. It is
because the links use our javascript function called 'download'.
That function name makes Chrome confused since each <a> link
has an attribute called 'download'. This fix changes the
javascript function name and the problem is fixed.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
