### PR TITLE
WIP: Add spill support to Roxie Sort Activity

### DIFF
--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -37,6 +37,7 @@
 #include <sys/vfs.h>
 #include <sys/mman.h>
 #include <sys/sendfile.h>
+#include <stdlib.h>
 #endif
 
 #include "time.h"
@@ -6372,4 +6373,29 @@ jlib_decl StringBuffer & appendCurrentDirectory(StringBuffer & target, bool blan
         throw MakeStringException(JLIBERR_InternalError, "getcwd failed (%d)", errno);
     }
     return target.append(temp);
+}
+
+jlib_decl StringBuffer &queryTempfilePath(StringBuffer & target, const char * component, IPropertyTree * pTree)
+{
+    StringBuffer dir;
+    if (pTree)
+        getConfigurationDirectory(pTree->queryPropTree("Directories"),"temp",component,pTree->queryProp("@name"),dir);
+    if (!dir.length())
+    {
+#ifdef _WIN32
+        char path[_MAX_PATH+1];
+        if(GetTempPath(sizeof(path),path))
+            dir.append(path);
+        else
+            dir.append("c:\\");
+        dir.append("\\HPCCSystems\\").append(component);
+#else
+        dir.append(getenv("TMPDIR"));
+        if (!dir.length())
+            dir.append("/tmp/HPCCSystems");
+        dir.append(PATHSEPSTR).append(component);
+#endif
+    }
+    recursiveCreateDirectory(dir.str());
+    return target.set(dir);
 }

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -605,5 +605,6 @@ extern jlib_decl IFile * createSentinelTarget();
 extern jlib_decl void writeSentinelFile(IFile * file);
 extern jlib_decl void removeSentinelFile(IFile * file);
 extern jlib_decl StringBuffer & appendCurrentDirectory(StringBuffer & target, bool blankIfFails);
+extern jlib_decl StringBuffer &queryTempfilePath(StringBuffer & target, const char * component, IPropertyTree * pTree);
 
 #endif


### PR DESCRIPTION
Currently Roxie sort activity will error out if the memory limit is
exceeded.  This change improves roxie to behave more like Thor and eclagent,
by spilling records to disk during a large sort and reading/merging them
back in as they are consumed.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
