### PR TITLE
Add more ignore rules to ecl regress

### DIFF
--- a/ecl/regress/regress.sh
+++ b/ecl/regress/regress.sh
@@ -110,6 +110,8 @@ if [[ $compare_dir ]]; then
          -I $target_dir \
          -I '\d* ms' \
          -I 'at \/.*\(\d*\)$' \
+         -I '\d*s total time' \
+         -I 'hash=\"[0-9a-f]*"' \
          $quick $compare_dir $target_dir
 fi
 


### PR DESCRIPTION
These patterns were identified as benign while running
on LNtesting and are generic enough to be applied globally.
