### PR TITLE
Roxiemem refactor - improve link and release

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -27526,6 +27526,8 @@ public:
 
         aborted = false;
         rowManager.setown(roxiemem::createRowManager(_memoryLimit, this, logctx, this, false));
+        //MORE: If checking heap required then should have
+        //rowManager.setown(createCheckingHeap(rowManager)) or something similar.
     }
 
     // interface IRoxieServerContext
@@ -28633,7 +28635,6 @@ public:
 
         // MORE some of these might be appropriate in wu case too?
         rowManager->setActivityTracking(context->getPropBool("_TraceMemory", false));
-        rowManager->setCheckingHeap(context->getPropInt("_CheckingHeap", defaultCheckingHeap));
         rowManager->setMemoryLimit((memsize_t) context->getPropInt64("_MemoryLimit", _factory->getMemoryLimit()));
         authToken.append(httpHelper.queryAuthToken());
         workflow.setown(_factory->createWorkflowMachine(false, logctx));

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -1972,6 +1972,33 @@ void DataBufferBottom::released()
     }
 }
 
+void DataBufferBottom::noteReleased(const void *ptr)
+{
+    HeapletBase * base = realBase(ptr);
+    if (base == this)
+        DataBufferBase::noteReleased(ptr);
+    else
+        base->noteReleased(ptr);
+}
+
+void DataBufferBottom::noteLinked(const void *ptr)
+{
+    HeapletBase * base = realBase(ptr);
+    if (base == this)
+        DataBufferBase::noteLinked(ptr);
+    else
+        base->noteLinked(ptr);
+}
+
+bool DataBufferBottom::_isShared(const void *ptr) const
+{
+    HeapletBase * base = realBase(ptr);
+    if (base == this)
+        return DataBufferBase::_isShared(ptr);
+    else
+        return base->_isShared(ptr);
+}
+
 size32_t DataBufferBottom::_capacity() const { throwUnexpected(); }
 void DataBufferBottom::_setDestructorFlag(const void *ptr) { throwUnexpected(); }
 

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -1621,7 +1621,7 @@ void * CNormalChunkingHeap::doAllocate(size32_t chunkSize, unsigned activityId)
 
 void DataBufferBase::noteReleased(const void *ptr)
 {
-    //The link counter is shared by all the rows that are contianed in this DataBuffer
+    //The link counter is shared by all the rows that are contained in this DataBuffer
     if (atomic_dec_and_test(&count))
         released();
 }

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -489,7 +489,7 @@ protected:
     }
 
 public:
-    BigHeapletBase(const IRowAllocatorCache *_allocatorCache) : HeapletBase(HEAP_ALIGNMENT_MASK)
+    BigHeapletBase(const IRowAllocatorCache *_allocatorCache)
     {
         next = NULL;
         allocatorCache = _allocatorCache;

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -33,10 +33,6 @@
  #define roxiemem_decl
 #endif
 
-#ifdef _DEBUG
-#define CHECKING_HEAP
-#endif
-
 #ifdef __64BIT__
 #define HEAP_ALIGNMENT_SIZE I64C(0x100000u)                     // 1 mb heaplets - may be too big?
 #else
@@ -54,8 +50,6 @@
 //================================================================================
 // Roxie heap
 
-#define EXTRA_DEBUG_INFO    2
-
 namespace roxiemem {
 
 interface IRowAllocatorCache
@@ -70,12 +64,10 @@ struct roxiemem_decl HeapletBase
     friend class DataBufferBottom;
 protected:
     atomic_t count;
-    unsigned flags;
 
     HeapletBase()
     {
         atomic_set(&count,1);  // Starts off active
-        flags = 0;
     }
 
     virtual ~HeapletBase()
@@ -169,10 +161,6 @@ public:
         return atomic_read(&count);
     }
 
-    inline void setFlag(unsigned flag)
-    {
-        flags |= flag;
-    }
 };
 
 extern roxiemem_decl unsigned DATA_ALIGNMENT_SIZE;  // Permissible values are 0x400 and 0x2000
@@ -373,7 +361,6 @@ interface IRowManager : extends IInterface
     virtual bool attachDataBuff(DataBuffer *dataBuff) = 0 ;
     virtual void noteDataBuffReleased(DataBuffer *dataBuff) = 0 ;
     virtual void setActivityTracking(bool val) = 0;
-    virtual void setCheckingHeap(int level) = 0;
     virtual void reportLeaks() = 0;
     virtual unsigned maxSimpleBlock() = 0;
     virtual void checkHeap() = 0;

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -69,13 +69,11 @@ struct roxiemem_decl HeapletBase
 {
     friend class DataBufferBottom;
 protected:
-    memsize_t mask;
     atomic_t count;
     unsigned flags;
 
-    HeapletBase(memsize_t _mask)
+    HeapletBase()
     {
-        mask = _mask;
         atomic_set(&count,1);  // Starts off active
         flags = 0;
     }
@@ -89,11 +87,6 @@ protected:
     virtual size32_t _capacity() const = 0;
     virtual void _setDestructorFlag(const void *ptr) = 0;
     virtual void noteLinked(const void *ptr) = 0;
-
-    inline HeapletBase *realBase(const void *ptr) const
-    {
-        return (HeapletBase *) ((memsize_t) ptr & mask);
-    }
 
     inline static HeapletBase *findBase(const void *ptr)
     {
@@ -199,11 +192,17 @@ protected:
     virtual void released() = 0;
     DataBufferBase *next;   // Used when chaining them together in rowMgr
     IRowManager *mgr;
-    DataBufferBase() : HeapletBase(DATA_ALIGNMENT_MASK)
+    DataBufferBase()
     {
         next = NULL;
         mgr = NULL;
     }
+    inline DataBufferBase *realBase(const void *ptr, memsize_t mask) const
+    {
+        return (DataBufferBase *) ((memsize_t) ptr & mask);
+    }
+    inline DataBufferBase *realBase(const void *ptr) const { return realBase(ptr, DATA_ALIGNMENT_MASK); }
+
 public:
     void Link() 
     { 

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -67,6 +67,7 @@ interface IRowAllocatorCache
 
 struct roxiemem_decl HeapletBase
 {
+    friend class DataBufferBottom;
 protected:
     memsize_t mask;
     atomic_t count;
@@ -89,14 +90,14 @@ protected:
     virtual void _setDestructorFlag(const void *ptr) = 0;
     virtual void noteLinked(const void *ptr) = 0;
 
+    inline HeapletBase *realBase(const void *ptr) const
+    {
+        return (HeapletBase *) ((memsize_t) ptr & mask);
+    }
+
     inline static HeapletBase *findBase(const void *ptr)
     {
-        HeapletBase *h = (HeapletBase *) ((memsize_t) ptr & HEAP_ALIGNMENT_MASK);
-        if (h->mask != HEAP_ALIGNMENT_MASK)
-        {
-            h = (HeapletBase *) ((memsize_t) ptr & h->mask);
-        }
-        return h;
+        return (HeapletBase *) ((memsize_t) ptr & HEAP_ALIGNMENT_MASK);
     }
 
 public:
@@ -249,8 +250,12 @@ private:
     CriticalSection crit;
 
     virtual void released();
+    virtual void noteReleased(const void *ptr);
+    virtual bool _isShared(const void *ptr) const;
     virtual size32_t _capacity() const;
     virtual void _setDestructorFlag(const void *ptr);
+    virtual void noteLinked(const void *ptr);
+
 public:
     DataBufferBottom(CDataBufferManager *_owner, DataBufferBottom *ownerFreeChain);
 

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -85,11 +85,11 @@ protected:
     }
 
     virtual void released() = 0;
-    virtual void noteReleased(const void *ptr) = 0;
+    virtual void noteReleased(const void *ptr);
     virtual bool _isShared(const void *ptr) const = 0;
     virtual size32_t _capacity() const = 0;
     virtual void _setDestructorFlag(const void *ptr) = 0;
-    virtual void noteLinked(const void *ptr) = 0;
+    virtual void noteLinked(const void *ptr);
 
     inline static HeapletBase *findBase(const void *ptr)
     {
@@ -112,10 +112,7 @@ public:
         if (ptr)
         {
             HeapletBase *h = findBase(ptr);
-            if (h->flags & NOTE_RELEASES)
-                h->noteReleased(ptr);
-            if (atomic_dec_and_test(&h->count))
-                h->released();
+            h->noteReleased(ptr);
         }
     }
 
@@ -178,9 +175,7 @@ public:
     static void link(const void *ptr)
     {
         HeapletBase *h = findBase(ptr);
-        if (h->flags & NOTE_RELEASES)
-            h->noteLinked(ptr);
-        atomic_inc(&h->count);
+        h->noteLinked(ptr);
     }
 
     inline unsigned queryCount() const
@@ -230,11 +225,9 @@ class roxiemem_decl DataBuffer : public DataBufferBase
     friend class CDataBufferManager;
 private:
     virtual void released();
-    virtual void noteReleased(const void *ptr);
     virtual bool _isShared(const void *ptr) const;
     virtual size32_t _capacity() const;
     virtual void _setDestructorFlag(const void *ptr);
-    virtual void noteLinked(const void *ptr);
 protected:
     DataBuffer()
     {
@@ -261,11 +254,9 @@ private:
     CriticalSection crit;
 
     virtual void released();
-    virtual void noteReleased(const void *ptr);
     virtual bool _isShared(const void *ptr) const;
     virtual size32_t _capacity() const;
     virtual void _setDestructorFlag(const void *ptr);
-    virtual void noteLinked(const void *ptr);
 public:
     DataBufferBottom(CDataBufferManager *_owner, DataBufferBottom *ownerFreeChain);
 

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -54,7 +54,6 @@
 //================================================================================
 // Roxie heap
 
-#define NOTE_RELEASES       1
 #define EXTRA_DEBUG_INFO    2
 
 namespace roxiemem {
@@ -120,9 +119,7 @@ public:
         if (ptr)
         {
             HeapletBase *h = findBase(ptr);
-            if (h->flags & NOTE_RELEASES)
-                return h->_isShared(ptr);
-            return atomic_read(&h->count)!= 2; // The heaplet itself has a usage count of 1
+            return h->_isShared(ptr);
         }
         // isShared(NULL) or isShared on an object that shares a link-count is an error
         throwUnexpected();
@@ -145,11 +142,7 @@ public:
         if (ptr)
         {
             HeapletBase *h = findBase(ptr);
-            //MORE: Should this test be debug only?
-            if (h->flags & NOTE_RELEASES)
-                h->_setDestructorFlag(ptr);
-            else
-                throwUnexpected();
+            h->_setDestructorFlag(ptr);
         }
     }
 
@@ -219,7 +212,7 @@ public:
 
     virtual void noteReleased(const void *ptr);
     virtual void noteLinked(const void *ptr);
-
+    virtual bool _isShared(const void *ptr) const;
 };
 
 
@@ -228,7 +221,6 @@ class roxiemem_decl DataBuffer : public DataBufferBase
     friend class CDataBufferManager;
 private:
     virtual void released();
-    virtual bool _isShared(const void *ptr) const;
     virtual size32_t _capacity() const;
     virtual void _setDestructorFlag(const void *ptr);
 protected:
@@ -257,7 +249,6 @@ private:
     CriticalSection crit;
 
     virtual void released();
-    virtual bool _isShared(const void *ptr) const;
     virtual size32_t _capacity() const;
     virtual void _setDestructorFlag(const void *ptr);
 public:

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -84,12 +84,11 @@ protected:
     {
     }
 
-    virtual void released() = 0;
-    virtual void noteReleased(const void *ptr);
+    virtual void noteReleased(const void *ptr) = 0;
     virtual bool _isShared(const void *ptr) const = 0;
     virtual size32_t _capacity() const = 0;
     virtual void _setDestructorFlag(const void *ptr) = 0;
-    virtual void noteLinked(const void *ptr);
+    virtual void noteLinked(const void *ptr) = 0;
 
     inline static HeapletBase *findBase(const void *ptr)
     {
@@ -203,6 +202,7 @@ class roxiemem_decl DataBufferBase : public HeapletBase
     friend class CChunkingRowManager;
     friend class DataBufferBottom;
 protected:
+    virtual void released() = 0;
     DataBufferBase *next;   // Used when chaining them together in rowMgr
     IRowManager *mgr;
     DataBufferBase() : HeapletBase(DATA_ALIGNMENT_MASK)
@@ -216,6 +216,9 @@ public:
         atomic_inc(&count); 
     }
     void Release();
+
+    virtual void noteReleased(const void *ptr);
+    virtual void noteLinked(const void *ptr);
 
 };
 


### PR DESCRIPTION
Since link and release normally call a virtual function when a row has
been allocated from a chunking heap, remove a conditional test and
always call a virtual.
It simplifies the code, removes a condition and allows link() to be more
efficient - not incrementing count each time.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
