### PR TITLE
Change lockProperties API

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -133,7 +133,7 @@ interface IDistributedFilePart: implements IInterface
 
     virtual IPropertyTree &queryProperties() = 0;                               // part properties
 
-    virtual IPropertyTree &lockProperties(unsigned timeoutms=INFINITE) = 0;                             // must be called before updating
+    virtual bool lockProperties(unsigned timeoutms=INFINITE) = 0;               // must be called before updating
     virtual void unlockProperties() = 0;                                        // must be called after updating
 
     virtual bool isHost(unsigned copy=0) = 0;                                   // file is located on this machine
@@ -219,7 +219,7 @@ interface IDistributedFile: extends IInterface
 
     virtual IPropertyTree &queryProperties() = 0;                               // DFile attributes (TODO: rename to getFileAttr)
 
-    virtual IPropertyTree &lockProperties(unsigned timeoutms=INFINITE) = 0;     // must be called before updating properties (will discard uncommitted changes)
+    virtual bool lockProperties(unsigned timeoutms=INFINITE) = 0;               // must be called before updating properties (will discard uncommitted changes)
     virtual void unlockProperties() = 0;                                        // must be called after updating properties
 
     virtual bool getModificationTime(CDateTime &dt) = 0;                        // get date and time last modified (returns false if not set)

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -76,7 +76,8 @@ static void addTestFile(const char *name,unsigned n)
         fileDesc->setPart(m,&group->queryNode(m), path.str(), pp);
     }
     Owned<IDistributedFile> dfile =  queryDistributedFileDirectory().createNew(fileDesc);
-    IPropertyTree &t = dfile->lockProperties();
+    dfile->lockProperties();
+    IPropertyTree &t = dfile->queryProperties();
     t.setProp("@owned","nigel");
     t.setPropInt("@recordSize",1);
     t.setProp("ECL","TESTECL();");

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -903,7 +903,8 @@ public:
                 sfile->addSubFile(subfiles.item(i));
             }
             if (newroxieprefix.length()) {
-                sfile->lockProperties().setProp("@roxiePrefix",newroxieprefix.str());
+                sfile->lockProperties();
+                sfile->queryProperties().setProp("@roxiePrefix",newroxieprefix.str());
                 sfile->unlockProperties();
             }
 

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -636,7 +636,8 @@ public:
                 sfile->addSubFile(subfiles.item(i));
             }
             if (!nameprefix.isEmpty()) {
-                sfile->lockProperties().setProp("@roxiePrefix",nameprefix.get());
+                sfile->lockProperties();
+                sfile->queryProperties().setProp("@roxiePrefix",nameprefix.get());
                 sfile->unlockProperties();
             }
         }

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -205,8 +205,8 @@ offset_t CDistributedFileSystem::getSize(IDistributedFile * file, bool forceget,
         }
         if (((totalSize != -1)||forceget) && !dontsetattr) // note forceget && !dontsetattr will reset attr if can't work out size
         {
-            IPropertyTree &tree = file->lockProperties();
-            tree.setPropInt64("@size", totalSize);
+            file->lockProperties();
+            file->queryProperties().setPropInt64("@size", totalSize);
             file->unlockProperties();
         }
     }
@@ -271,8 +271,8 @@ offset_t CDistributedFileSystem::getSize(IDistributedFilePart * part, bool force
         size = part->getFileSize(true,forceget);
         if (((size != (offset_t)-1)||forceget) && !dontsetattr) // note forceget && !dontsetattr will reset attr if can't work out size
         {
-            IPropertyTree &tree = part->lockProperties();
-            tree.setPropInt64("@size", size);
+            part->lockProperties();
+            part->queryProperties().setPropInt64("@size", size);
             part->unlockProperties();
         }
     }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -1479,7 +1479,8 @@ void FileSprayer::analyseFileHeaders(bool setcurheadersize)
         tgtFormat.set(srcFormat);
         if (distributedTarget)
         {
-            IPropertyTree &curProps = distributedTarget->lockProperties();
+            distributedTarget->lockProperties();
+            IPropertyTree &curProps = distributedTarget->queryProperties();
             tgtFormat.save(&curProps);
             distributedTarget->unlockProperties();
         }
@@ -2425,7 +2426,8 @@ void FileSprayer::setTarget(IDistributedFile * target)
         tgtFormat.set(srcFormat);
         if (!unknownSourceFormat)
         {
-            IPropertyTree &curProps = target->lockProperties();
+            target->lockProperties();
+            IPropertyTree &curProps = target->queryProperties();
             tgtFormat.save(&curProps);
             target->unlockProperties();
         }
@@ -2756,7 +2758,8 @@ void FileSprayer::updateTargetProperties()
             if (idx+1 == partition.ordinality() || partition.item(idx+1).whichOutput != cur.whichOutput)
             {
                 Owned<IDistributedFilePart> curPart = distributedTarget->getPart(cur.whichOutput);
-                IPropertyTree& curProps = curPart->lockProperties();
+                curPart->lockProperties();
+                IPropertyTree& curProps = curPart->queryProperties();
                 if (calcCRC())
                 {
                     curProps.setPropInt(FAcrc, partCRC.get());
@@ -2821,7 +2824,8 @@ void FileSprayer::updateTargetProperties()
         if (failedParts.length())
             error.setown(MakeStringException(DFTERR_InputOutputCrcMismatch, "%s", failedParts.str()));
 
-        IPropertyTree &curProps = distributedTarget->lockProperties();
+        distributedTarget->lockProperties();
+        IPropertyTree &curProps = distributedTarget->queryProperties();
         if (calcCRC())
             curProps.setPropInt(FAcrc, totalCRC.get());
         curProps.setPropInt64(FAsize, totalLength);

--- a/dali/regress/daregdfs.cpp
+++ b/dali/regress/daregdfs.cpp
@@ -586,7 +586,8 @@ void testDF1()
     fdesc->setPart(2,rfn,pt);
     dispFDesc(fdesc);
     Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
-    file->lockProperties().setProp("@testing","1");
+    file->lockProperties();
+    file->queryProperties().setProp("@testing","1");
     file->unlockProperties();
     file->attach("testing::propfile2");
 }

--- a/dali/sasha/saverify.cpp
+++ b/dali/sasha/saverify.cpp
@@ -349,9 +349,9 @@ public:
             if (afor.ok) {
                 CDateTime dt;
                 dt.setNow();
-                IPropertyTree &pt = file->lockProperties();
+                file->lockProperties();
                 StringBuffer str;
-                pt.setProp("@verified",dt.getString(str).str());
+                file->queryProperties().setProp("@verified",dt.getString(str).str());
                 file->unlockProperties();
             }
             PROGLOG("VERIFY: file %s %s",name,afor.ok?"OK":"FAILED");

--- a/dali/sdsfix/sdsfix.cpp
+++ b/dali/sdsfix/sdsfix.cpp
@@ -1191,7 +1191,8 @@ void fixDates()
                                             locked = true;
                                             PROGLOG("Modifying %s",lfname.str());
                                         }
-                                        part->lockProperties().setProp("@modified",ptimestr.str());
+                                        part->lockProperties();
+                                        part->queryProperties().setProp("@modified",ptimestr.str());
                                         part->unlockProperties();
                                     }
                                     else {
@@ -3653,7 +3654,8 @@ void fixCompSize(const char *lfn,IDistributedFile *file, unsigned trials=0)
         const char *s2 = prop.queryProp("@compressedSize");
         if (s1&&s2&&(strcmp(s1,s2)==0)) {
             if (!locked) {
-                flockprop = &file->lockProperties();
+                file->lockProperties();
+                flockprop = &file->queryProperties();
                 locked = true;
             }
             RemoteFilename rfn;
@@ -3679,8 +3681,8 @@ void fixCompSize(const char *lfn,IDistributedFile *file, unsigned trials=0)
             }
             __int64 sz = fio->size();
             total += sz;
-            IPropertyTree &lockprop = part->lockProperties();
-            lockprop.setPropInt64("@size",sz);
+            part->lockProperties();
+            part->queryProperties().setPropInt64("@size",sz);
             part->unlockProperties();
             //PROGLOG("Changing %s to %"I64F"d",s1,sz);
             trials = 9999;
@@ -4062,7 +4064,8 @@ void makeTestFile(const char *lname,const char *cluster, offset_t fsize, size32_
         }
         fileio.clear();
         tot += psize;
-        IPropertyTree &props = part.lockProperties();
+        part.lockProperties();
+        IPropertyTree &props = part.queryProperties();
         props.setPropInt64("@size",psize);
         props.setPropInt64("@fileCrc", (unsigned long)fileCRC.get());
         CDateTime createTime, modifiedTime, accessedTime;

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -1928,8 +1928,8 @@ protected:
                     partsize = ifile->size();
                     if (partsize != -1)
                     {
-                        IPropertyTree &tree = part->lockProperties();
-                        tree.setPropInt64("@size", partsize);
+                        part->lockProperties();
+                        part->queryProperties().setPropInt64("@size", partsize);
                         part->unlockProperties();
                         break;
                     }

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1723,7 +1723,8 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     StringBuffer strDesc = df->queryProperties().queryProp("@description");
     if (description)
     {
-        df->lockProperties().setProp("@description",description); 
+        df->lockProperties();
+        df->queryProperties().setProp("@description",description);
         df->unlockProperties();
         strDesc = description;
     }

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1439,7 +1439,8 @@ FILESERVICES_API void FILESERVICES_CALL fsSetFileDescription(ICodeContext *ctx, 
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(lfn.str(),udesc);
     if (df) {
-        df->lockProperties().setProp("@description",value);
+        df->lockProperties();
+        df->queryProperties().setProp("@description",value);
         df->unlockProperties();
     }
     else

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -181,7 +181,8 @@ public:
             e->Release();
         }
         // Add a new 'Patch' description to the secondary key.
-        IPropertyTree &fileProps = newIndexFile->lockProperties();
+        newIndexFile->lockProperties();
+        IPropertyTree &fileProps = newIndexFile->queryProperties();
         StringBuffer path("Patch[@name=\"");
         path.append(scopedName.str()).append("\"]");
         IPropertyTree *patch = fileProps.queryPropTree(path.str());


### PR DESCRIPTION
lockProperties locks all properties in the connection, and not just
the Attr section, which is what was being returned. Now, the method
locks and return a boolean indicating if one needs to refresh its
data because the lock was not acquired clean. Using queryProperties
to get the properties after locking, to make it clear what's being
returned.

TODO: rename queryProperties to queryFileAttr (since that's what's
being returned), but this is a much bigger change (so better in a
separate patch), since there are other queryProperties around that
do different things.

It looks much bigger than it actually is.
