### PR TITLE
gh-300 CResultSetCursor::getXmlText not respecting xpath

### DIFF
--- a/common/fileview2/fileview.hpp
+++ b/common/fileview2/fileview.hpp
@@ -157,6 +157,7 @@ interface IResultSetCursor : extends IInterface
     virtual IStringVal & getDisplayText(IStringVal & ret, int columnIndex) = 0;
     virtual IStringVal & getXml(IStringVal & ret, int columnIndex) = 0;
     virtual IStringVal & getXmlRow(IStringVal & ret) = 0;
+    virtual IStringVal & getXmlItem(IStringVal & ret) = 0;
     virtual __int64 getNumRows() const = 0;
 };
 

--- a/common/fileview2/fvdatasource.hpp
+++ b/common/fileview2/fvdatasource.hpp
@@ -49,6 +49,9 @@ interface IFvDataSourceMetaData : extends IInterface
     virtual unsigned numKeyedColumns() const = 0;
     
     inline bool isVirtual(unsigned column) const { return queryFieldFlags(column) == FVFFvirtual; }
+    virtual const char *queryXmlTag(unsigned column) const = 0;
+    virtual const char *queryXmlTag() const = 0;
+    virtual const IntArray &queryAttrList() = 0;
 };
 
 IFvDataSourceMetaData * deserializeDataSourceMeta(MemoryBuffer & in);

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -1508,12 +1508,12 @@ IStringVal & CResultSetCursor::getDisplayText(IStringVal &ret, int columnIndex)
 }
 
 
-void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex)
+void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex, const char *tag)
 {
     if (!isValid())
         return;
 
-    const char * name = meta.meta->queryName(columnIndex);
+    const char * name = (tag) ? tag : meta.meta->queryXmlTag(columnIndex);
     CResultSetColumnInfo & column = meta.columns.item(columnIndex);
     unsigned flags = column.flag;
     switch (flags)
@@ -1522,10 +1522,12 @@ void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex)
     case FVFFendif:
         return;
     case FVFFbeginrecord:
-        out.append("<").append(name).append(">");
+        if (name && *name)
+            out.append("<").append(name).append(">");
         return;
     case FVFFendrecord:
-        out.append("</").append(name).append(">");
+        if (name && *name)
+            out.append("</").append(name).append(">");
         return;
     }
 
@@ -1621,7 +1623,8 @@ void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex)
     case type_table:
     case type_groupedtable:
         {
-            out.append("<").append(name).append(">");
+            if (name && *name)
+                out.append("<").append(name).append(">");
             Owned<IResultSetCursor> childCursor = getChildren(columnIndex);
             
             ForEach(*childCursor)
@@ -1630,12 +1633,14 @@ void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex)
                 childCursor->getXmlRow(adaptor);
             }
 
-            out.append("</").append(name).append(">");
+            if (name && *name)
+                out.append("</").append(name).append(">");
             break;
         }
     case type_set:
         {
-            out.append("<").append(name).append(">");
+            if (name && *name)
+                out.append("<").append(name).append(">");
             if (getIsAll(columnIndex))
                 outputXmlSetAll(out);
             else
@@ -1644,16 +1649,132 @@ void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex)
                 
                 ForEach(*childCursor)
                 {
-                    out.append("<Item>");
                     StringBufferAdaptor adaptor(out);
-                    childCursor->getDisplayText(adaptor, 0);
-                    out.append("</Item>");
+                    childCursor->getXmlItem(adaptor);
                 }
             }
-
-            out.append("</").append(name).append(">");
+            if (name && *name)
+                out.append("</").append(name).append(">");
             break;
         }
+    default:
+        UNIMPLEMENTED;
+    }
+    rtlFree(resultStr);
+}
+
+void CResultSetCursor::getXmlAttrText(StringBuffer & out, int columnIndex, const char *tag)
+{
+    if (!isValid())
+        return;
+
+    const char * name = (tag) ? tag : meta.meta->queryXmlTag(columnIndex);
+    if (name && *name=='@')
+        name++;
+    CResultSetColumnInfo & column = meta.columns.item(columnIndex);
+    unsigned flags = column.flag;
+    switch (flags)
+    {
+    case FVFFbeginif:
+    case FVFFendif:
+    case FVFFbeginrecord:
+    case FVFFendrecord:
+        return;
+    }
+
+    const byte * cur = getColumn(columnIndex);
+    unsigned resultLen;
+    char * resultStr = NULL;
+
+    ITypeInfo & type = *column.type;
+    unsigned size = type.getSize();
+    unsigned len = UNKNOWN_LENGTH;
+    switch (type.getTypeCode())
+    {
+    case type_boolean:
+        outputXmlAttrBool((*((byte *)cur)) != 0, name, out);
+        break;
+    case type_int:
+        {
+            __int64 value = getIntFromInt(type, cur, isMappedIndexField(columnIndex));
+            if (type.isSigned())
+                outputXmlAttrInt((__int64) value, name, out);
+            else
+                outputXmlAttrUInt((unsigned __int64) value, name, out);
+            break;
+        }
+    case type_swapint:
+        {
+            __int64 value = getIntFromSwapInt(type, cur, isMappedIndexField(columnIndex));
+            if (type.isSigned())
+                outputXmlAttrInt((__int64) value, name, out);
+            else
+                outputXmlAttrUInt((unsigned __int64) value, name, out);
+            break;
+        }
+    case type_packedint:
+        {
+            if (type.isSigned())
+                outputXmlAttrInt(rtlGetPackedSigned(cur), name, out);
+            else
+                outputXmlAttrUInt(rtlGetPackedUnsigned(cur), name, out);
+            break;
+        }
+    case type_decimal:
+        if (type.isSigned())
+            outputXmlAttrDecimal(cur, size, type.getPrecision(), name, out);
+        else
+            outputXmlAttrUDecimal(cur, size, type.getPrecision(), name, out);
+        break;
+    case type_real:
+        if (size == 4)
+            outputXmlAttrReal(*(float *)cur, name, out);
+        else
+            outputXmlAttrReal(*(double *)cur, name, out);
+        break;
+    case type_qstring:
+        len = getLength(type, cur);
+        rtlQStrToStrX(resultLen, resultStr, len, (const char *)cur);
+        outputXmlAttrString(resultLen, resultStr, name, out);
+        break;
+    case type_data:
+        len = getLength(type, cur);
+        outputXmlAttrData(len, cur, name, out);
+        break;
+    case type_string:
+        len = getLength(type, cur);
+        if (meta.isEBCDIC(columnIndex))
+        {
+            rtlStrToEStrX(resultLen, resultStr, len, (const char *)cur);
+            outputXmlAttrString(resultLen, resultStr, name, out);
+        }
+        else
+            outputXmlAttrString(len, (const char *)cur, name, out);
+        break;
+    case type_unicode:
+        len = getLength(type, cur);
+        outputXmlAttrUnicode(len, (UChar const *)cur, name, out);
+        break;
+    case type_varstring:
+        if (meta.isEBCDIC(columnIndex))
+        {
+            rtlStrToEStrX(resultLen, resultStr, strlen((const char *)cur), (const char *)cur);
+            outputXmlAttrString(resultLen, resultStr, name, out);
+        }
+        else
+            outputXmlAttrString(strlen((const char *)cur), (const char *)cur, name, out);
+        break;
+    case type_varunicode:
+        outputXmlAttrUnicode(rtlUnicodeStrlen((UChar const *)cur), (UChar const *)cur, name, out);
+        break;
+    case type_utf8:
+        len = getLength(type, cur);
+        outputXmlAttrUtf8(len, (const char *)cur, name, out);
+        break;
+    case type_table:
+    case type_groupedtable:
+    case type_set:
+        break;
     default:
         UNIMPLEMENTED;
     }
@@ -1668,16 +1789,33 @@ IStringVal & CResultSetCursor::getXml(IStringVal &ret, int columnIndex)
     return ret;
 }
 
+IStringVal & CResultSetCursor::getXmlItem(IStringVal & ret)
+{
+    StringBuffer temp;
+    getXmlText(temp, 0, meta.meta->queryXmlTag());
+    ret.set(temp.str());
+    return ret;
+}
+
 //More efficient than above...
 IStringVal & CResultSetCursor::getXmlRow(IStringVal &ret)
 {
     StringBuffer temp;
-    temp.append("<Row>");
+    const char *rowtag = meta.meta->queryXmlTag();
+    if (rowtag && *rowtag)
+        temp.append('<').append(rowtag);
+    const IntArray &attributes = meta.meta->queryAttrList();
+    ForEachItemIn(ac, attributes)
+        getXmlAttrText(temp, attributes.item(ac));
+    temp.append('>');
     unsigned numColumns = meta.getColumnCount();
     unsigned ignoreNesting = 0;
     for (unsigned col = 0; col < numColumns; col++)
     {
         unsigned flags = meta.columns.item(col).flag;
+        const char *tag = meta.meta->queryXmlTag(col);
+        if (tag && *tag=='@')
+            continue;
         switch (flags)
         {
         case FVFFbeginif:
@@ -1710,7 +1848,8 @@ IStringVal & CResultSetCursor::getXmlRow(IStringVal &ret)
         }
     }
     assertex(ignoreNesting == 0);
-    temp.append("</Row>");
+    if (rowtag && *rowtag)
+        temp.append("</").append(rowtag).append('>');
     ret.set(temp.str());
     return ret;
 }
@@ -1956,6 +2095,10 @@ IStringVal & IndirectResultSetCursor::getXml(IStringVal & ret, int columnIndex)
 IStringVal & IndirectResultSetCursor::getXmlRow(IStringVal &ret)
 {
     return queryBase()->getXmlRow(ret);
+}
+IStringVal & IndirectResultSetCursor::getXmlItem(IStringVal &ret)
+{
+    return queryBase()->getXmlItem(ret);
 }
 void IndirectResultSetCursor::noteRelatedFileChanged()
 {

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -1522,12 +1522,10 @@ void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex, const cha
     case FVFFendif:
         return;
     case FVFFbeginrecord:
-        if (name && *name)
-            out.append("<").append(name).append(">");
+        appendXMLOpenTag(out, name);
         return;
     case FVFFendrecord:
-        if (name && *name)
-            out.append("</").append(name).append(">");
+        appendXMLCloseTag(out, name);
         return;
     }
 
@@ -1623,8 +1621,7 @@ void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex, const cha
     case type_table:
     case type_groupedtable:
         {
-            if (name && *name)
-                out.append("<").append(name).append(">");
+            appendXMLOpenTag(out, name);
             Owned<IResultSetCursor> childCursor = getChildren(columnIndex);
             
             ForEach(*childCursor)
@@ -1633,14 +1630,12 @@ void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex, const cha
                 childCursor->getXmlRow(adaptor);
             }
 
-            if (name && *name)
-                out.append("</").append(name).append(">");
+            appendXMLCloseTag(out, name);
             break;
         }
     case type_set:
         {
-            if (name && *name)
-                out.append("<").append(name).append(">");
+            appendXMLOpenTag(out, name);
             if (getIsAll(columnIndex))
                 outputXmlSetAll(out);
             else
@@ -1653,8 +1648,7 @@ void CResultSetCursor::getXmlText(StringBuffer & out, int columnIndex, const cha
                     childCursor->getXmlItem(adaptor);
                 }
             }
-            if (name && *name)
-                out.append("</").append(name).append(">");
+            appendXMLCloseTag(out, name);
             break;
         }
     default:
@@ -1803,11 +1797,13 @@ IStringVal & CResultSetCursor::getXmlRow(IStringVal &ret)
     StringBuffer temp;
     const char *rowtag = meta.meta->queryXmlTag();
     if (rowtag && *rowtag)
+    {
         temp.append('<').append(rowtag);
-    const IntArray &attributes = meta.meta->queryAttrList();
-    ForEachItemIn(ac, attributes)
-        getXmlAttrText(temp, attributes.item(ac));
-    temp.append('>');
+        const IntArray &attributes = meta.meta->queryAttrList();
+        ForEachItemIn(ac, attributes)
+            getXmlAttrText(temp, attributes.item(ac));
+        temp.append('>');
+    }
     unsigned numColumns = meta.getColumnCount();
     unsigned ignoreNesting = 0;
     for (unsigned col = 0; col < numColumns; col++)
@@ -1848,8 +1844,7 @@ IStringVal & CResultSetCursor::getXmlRow(IStringVal &ret)
         }
     }
     assertex(ignoreNesting == 0);
-    if (rowtag && *rowtag)
-        temp.append("</").append(rowtag).append('>');
+    appendXMLCloseTag(temp, rowtag);
     ret.set(temp.str());
     return ret;
 }

--- a/common/fileview2/fvresultset.ipp
+++ b/common/fileview2/fvresultset.ipp
@@ -368,6 +368,9 @@ public:
     virtual IStringVal & getDisplayText(IStringVal &ret, int columnIndex);
     virtual IStringVal & getXml(IStringVal & ret, int columnIndex);
     virtual IStringVal & getXmlRow(IStringVal &ret);
+    virtual IStringVal & getXmlItem(IStringVal & ret);
+
+
 
 //IResultSetCursor
     virtual void beginAccess();
@@ -381,7 +384,8 @@ protected:
     void init(IExtendedNewResultSet * _resultSet);
     bool isMappedIndexField(unsigned columnIndex) { return resultSet->isMappedIndexField(columnIndex); }
     const byte * getColumn(unsigned idx) const      { return (const byte *)curRowData.toByteArray() + offsets[idx]; }
-    void getXmlText(StringBuffer & out, int columnIndex);
+    void getXmlText(StringBuffer & out, int columnIndex, const char *tag=NULL);
+    void getXmlAttrText(StringBuffer & out, int columnIndex, const char *tag=NULL);
 
     virtual __int64 getCurRow() const;
     virtual __int64 translateRow(__int64 row) const;
@@ -436,6 +440,7 @@ public:
     virtual IStringVal & getDisplayText(IStringVal &ret, int columnIndex);
     virtual IStringVal & getXml(IStringVal & ret, int columnIndex);
     virtual IStringVal & getXmlRow(IStringVal &ret);
+    virtual IStringVal & getXmlItem(IStringVal &ret);
     virtual void noteRelatedFileChanged();
 
 protected:

--- a/common/fileview2/fvsource.ipp
+++ b/common/fileview2/fvsource.ipp
@@ -75,11 +75,12 @@ public:
     DataSourceMetaItem(unsigned flags, MemoryBuffer & in);
     virtual void serialize(MemoryBuffer & out) const;
     virtual DataSourceMetaData * queryChildMeta() { return NULL; }
+    bool isXmlAttribute(){return (tagname.length() && *tagname.get()=='@');}
 
 public:
     StringAttr  name;
     StringAttr  xpath;
-    StringBuffer tagname;
+    StringAttr tagname;
     OwnedITypeInfo type;
     byte           flags;
 };
@@ -136,6 +137,7 @@ protected:
 
 protected:
     CIArrayOf<DataSourceMetaItem> fields;
+    IntArray attributes;
     unsigned keyedSize;
     unsigned storedFixedSize;
     unsigned maxRecordSize;
@@ -144,11 +146,10 @@ protected:
     bool isStoredFixedWidth;
     bool randomIsOk;
     byte numFieldsToIgnore;
-    IntArray attributes;
-    bool attrset;
+    bool gatheredAttributes;
 
 public:
-    StringBuffer tagname;
+    StringAttr tagname;
 };
 
 

--- a/common/fileview2/fvsource.ipp
+++ b/common/fileview2/fvsource.ipp
@@ -75,7 +75,7 @@ public:
     DataSourceMetaItem(unsigned flags, MemoryBuffer & in);
     virtual void serialize(MemoryBuffer & out) const;
     virtual DataSourceMetaData * queryChildMeta() { return NULL; }
-    bool isXmlAttribute(){return (tagname.length() && *tagname.get()=='@');}
+    bool isXmlAttribute() const { return (tagname.length() && *tagname.get()=='@'); }
 
 public:
     StringAttr  name;
@@ -88,6 +88,7 @@ public:
 class DataSourceMetaData : public CInterface, implements IFvDataSourceMetaData, public IRecordSizeEx
 {
     friend class DataSourceSetItem;
+    friend class DataSourceDatasetItem;
 public:
     DataSourceMetaData(IHqlExpression * _record, byte _numFieldsToIgnore, bool _randomIsOk, bool _isGrouped, unsigned _keyedSize);
     DataSourceMetaData();           // for NULL implementation
@@ -147,8 +148,6 @@ protected:
     bool randomIsOk;
     byte numFieldsToIgnore;
     bool gatheredAttributes;
-
-public:
     StringAttr tagname;
 };
 

--- a/common/fileview2/fvsource.ipp
+++ b/common/fileview2/fvsource.ipp
@@ -79,6 +79,7 @@ public:
 public:
     StringAttr  name;
     StringAttr  xpath;
+    StringBuffer tagname;
     OwnedITypeInfo type;
     byte           flags;
 };
@@ -100,6 +101,10 @@ public:
     virtual bool supportsRandomSeek() const;
     virtual void serialize(MemoryBuffer & out) const;
     virtual unsigned queryFieldFlags(unsigned column) const;
+    virtual const char *queryXmlTag(unsigned column) const;
+    virtual const char *queryXmlTag() const;
+    virtual const IntArray &queryAttrList();
+
     virtual IFvDataSourceMetaData * queryChildMeta(unsigned column) const;
     virtual IFvDataSource * createChildDataSource(unsigned column, unsigned len, const void * data);
     virtual unsigned numKeyedColumns() const;
@@ -139,6 +144,11 @@ protected:
     bool isStoredFixedWidth;
     bool randomIsOk;
     byte numFieldsToIgnore;
+    IntArray attributes;
+    bool attrset;
+
+public:
+    StringBuffer tagname;
 };
 
 

--- a/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
+++ b/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
@@ -181,7 +181,7 @@ void WsEclWuInfo::getSchemaFromResult(StringBuffer &schema, IConstWUResult &res)
         
         Owned<IResultSetFactory> resultSetFactory(getResultSetFactory(username, password));
         Owned<IResultSetMetaData> meta = resultSetFactory->createResultSetMeta(&res);
-        meta->getXmlSchema(s, true);
+        meta->getXmlXPathSchema(s, true);
         const char *finger=schema.str();
         while (finger && strncmp(finger, "<xs:schema", 10))
             finger++;

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -362,12 +362,26 @@ inline const char *encodeUtf8XML(const char *x, StringBuffer &ret, unsigned flag
     return encodeXML(x, ret, flags, len, true);
 }
 
+inline StringBuffer & appendXMLOpenTag(StringBuffer &xml, const char *tag)
+{
+    if (tag && *tag)
+        xml.append('<').append(tag).append('>');
+    return xml;
+}
+
+inline StringBuffer & appendXMLCloseTag(StringBuffer &xml, const char *tag)
+{
+    if (tag && *tag)
+        xml.append("</").append(tag).append('>');
+    return xml;
+}
+
 inline StringBuffer &appendXMLTag(StringBuffer &xml, const char *tag, const char *value, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=true)
 {
-    xml.append('<').append(tag).append('>');
+    appendXMLOpenTag(xml, tag);
     if (value && *value)
         encodeXML(value, xml, flags, len, utf8);
-    return xml.append("</").append(tag).append('>');
+    return appendXMLCloseTag(xml, tag);
 }
 
 extern jlib_decl void decodeCppEscapeSequence(StringBuffer & out, const char * in, bool errorIfInvalid);


### PR DESCRIPTION
Getting XML from workunit did not conform to format specified by
XPATH specifiers in ECL.  Updated fileview2 to make use of the
XPATH information when building xml from results.

Fixes gh-300

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
