### PR TITLE
Command line should default jobname when deploying ecl file or archive

### DIFF
--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -354,11 +354,6 @@ public:
                 fprintf(stderr, "\nCluster must be specified when publishing ECL Text or Archive\n");
                 return false;
             }
-            if (optName.isEmpty())
-            {
-                fprintf(stderr, "\nQuery name must be specified when publishing an ECL Text or Archive\n");
-                return false;
-            }
         }
         return true;
     }
@@ -477,12 +472,7 @@ public:
         {
             if (optCluster.isEmpty())
             {
-                fprintf(stderr, "\nCluster must be specified when publishing ECL Text or Archive\n");
-                return false;
-            }
-            if (optName.isEmpty())
-            {
-                fprintf(stderr, "\nQuery name must be specified when publishing an ECL Text or Archive\n");
+                fprintf(stderr, "\nCluster must be specified when running ECL Text or Archive\n");
                 return false;
             }
         }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3256,7 +3256,11 @@ void deployArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEsp
     if (notEmpty(req.getName()))
         wu->setJobName(req.getName());
     else if (notEmpty(req.getFileName()))
-        wu->setJobName(req.getFileName());
+    {
+        StringBuffer name;
+        splitFilename(req.getFileName(), NULL, NULL, &name, NULL);
+        wu->setJobName(name.str());
+    }
 
     Owned<IWUQuery> query=wu->updateQuery();
     StringBuffer text(obj.length(), obj.toByteArray());

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3255,6 +3255,8 @@ void deployArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEsp
 
     if (notEmpty(req.getName()))
         wu->setJobName(req.getName());
+    else if (notEmpty(req.getFileName()))
+        wu->setJobName(req.getFileName());
 
     Owned<IWUQuery> query=wu->updateQuery();
     StringBuffer text(obj.length(), obj.toByteArray());
@@ -3327,8 +3329,6 @@ void deploySharedObject(IEspContext &context, IEspWUDeployWorkunitRequest & req,
         Owned<ILocalWorkUnit> embeddedWU = createLocalWorkUnit();
         embeddedWU->loadXML(wuXML);
         queryExtendedWU(wu)->copyWorkUnit(embeddedWU);
-        //Owned<IWUQuery> query = workunit->updateQuery();
-        //query->setQueryText(eclQuery.s.str());
     }
 
     StringBuffer dllurl;


### PR DESCRIPTION
If no job name is provided, use the ecl or archive filename.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
