### PR TITLE
Roxie memory leaks

### DIFF
--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -2724,6 +2724,7 @@ public:
                 }
                 else
                     DBGLOG("PING reply, garbled result");
+                ReleaseRoxieRow(answer);
             }
             else if (!anyActivity)
             {

--- a/roxie/udplib/udptrs.cpp
+++ b/roxie/udplib/udptrs.cpp
@@ -269,6 +269,10 @@ public:
                 }
                 retryData[slot] = buffer;
             }
+            else
+            {
+                ::Release(buffer);
+            }
         }
         return totalSent;
     }


### PR DESCRIPTION
Roxie leaks a DataMemoryBuffer per ping received when pingInterval is non-zero.
Also if udpRetryEnabled is false, all outboud packets are leaked (!).

This commit partially addresses gh-1358, but does NOT address the issue of ping
responses causing the retry queue to fill up. Until that is also fixed, it is
probably safest to keep pingInterval set at 0.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
