### PR TITLE
Fix uncompressed size for compressed CSV and XML's

### DIFF
--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -369,6 +369,7 @@ void CDiskWriteSlaveActivityBase::close()
         }
         else if (outraw) {
             outraw->flush();
+            uncompressedBytesWritten = outraw->tell();
             outraw.clear();
         }
         if (!rfsQueryParallel && dlfn.isExternal() && (container.queryJob().queryMyRank() != container.queryJob().querySlaves()))


### PR DESCRIPTION
Compressed csv/xml files were not correctly setting the size attribute, as a
side effect, this resulted in eclwatch not being able to inspect the records
in the result of these compressed files

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
