### PR TITLE
Fix gh-1283 EclWatch Config button not display esp.xml

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1102,18 +1102,11 @@ int EspHttpBinding::onGetConfig(IEspContext &context, CHttpRequest* request, CHt
     if (m_viewConfig || (user && (user->getStatus()==SecUserStatus_Inhouse)))
     {
         ESPLOG(LogNormal, "Get config file: %s", m_configFile.get());
-        StringBuffer mimetype;
-        MemoryBuffer content;
-        httpContentFromFile(m_configFile, mimetype, content);
 
-        response->setContent(content.length(), content.toByteArray());
-
-        StringBuffer plainText;
-        request->getParameter("PlainText", plainText);
-        if ((plainText.length() > 0) && (!stricmp(plainText.str(), "yes")))
-            response->setContentType(HTTP_TYPE_TEXT_PLAIN);
-        else
-            response->setContentType("text/xml; charset=UTF-8");
+        StringBuffer content;
+        xmlContentFromFile(m_configFile, "/esp/xslt/xmlformatter.xsl", content);
+        response->setContent(content.str());
+        response->setContentType("text/xml; charset=UTF-8");
         response->setStatus(HTTP_STATUS_OK);
         response->send();
         return 0;

--- a/esp/bindings/http/platform/httptransport.hpp
+++ b/esp/bindings/http/platform/httptransport.hpp
@@ -97,6 +97,7 @@
 #endif
 
 bool httpContentFromFile(const char *filepath, StringBuffer &mimetype, MemoryBuffer &fileContents);
+bool xmlContentFromFile(const char *filepath, const char *stylesheet, StringBuffer &fileContents);
 
 
 #endif


### PR DESCRIPTION
The problem happens on FireFox. The esp.xml is sent to the
browser. The browser does not display the esp.xml correctly
because XML style sheet is not specified for the esp.xml.
This fix creates a new function which allows an XML style sheet
to be specified before the file is sent to the browser. The fix
also removes the code for displaying in plain text format as an
option because the configuration file is an xml file.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
