### PR TITLE
Fix gh-1343 Add checkbox “No separator” to Spray csv input

### DIFF
--- a/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
@@ -181,7 +181,7 @@
                      if (method == 'SprayVariable')
                      {
                         disable = (document.getElementById('sourceMaxRecordSize') != null && document.getElementById('sourceMaxRecordSize').value == 0) || 
-                                      (document.getElementById('sourceCsvSeparate') != null && document.getElementById('sourceCsvSeparate').value  == '') ||
+                                      (document.getElementById('sourceCsvSeparator') != null && document.getElementById('sourceCsvSeparator').value  == '') ||
                                       (document.getElementById('sourceCsvTerminate') != null && document.getElementById('sourceCsvTerminate').value == '') ||
                                       (document.getElementById('sourceCsvQuote') != null && document.getElementById('sourceCsvQuote').value == '') ||
                                       (document.getElementById('sourceRowTag') != null && document.getElementById('sourceRowTag').value == '');
@@ -227,6 +227,18 @@
                 document.getElementById('sourceN').innerHTML = pathSep + pathSep + selected.value + prefix + path;
                 handleSubmitBtn();
               }
+            }
+
+            function setSourceCsvSeparator(noSeparatorCheckbox)
+            {
+                var separatorInputField = document.getElementById("sourceCsvSeparator");
+                if (separatorInputField == NaN)
+                    return;
+
+                if (noSeparatorCheckbox.checked)
+                    separatorInputField.disabled = true;
+                else
+                    separatorInputField.disabled = false;
             }
 
             function beforeSubmit()
@@ -457,7 +469,13 @@
                <tr>
                   <td>Separator:</td>
                   <td>
-                     <input type="text" id="sourceCsvSeparate" name="sourceCsvSeparate" size="6" value="{$sep}" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
+                     <input type="text" id="sourceCsvSeparator" name="sourceCsvSeparator" size="6" value="{$sep}" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
+                  </td>
+               </tr>
+               <tr>
+                  <td/>
+                  <td>
+                      <input type="checkbox" id="NoSourceCsvSeparator" name="NoSourceCsvSeparator" value="1" onclick="return setSourceCsvSeparator(this)">No Separator</input>
                   </td>
                </tr>
                <tr>

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -310,6 +310,7 @@ ESPrequest [nil_remove] SprayVariable
     
     int sourceMaxRecordSize;
     int sourceFormat;
+    bool   NoSourceCsvSeparator(false);
     string sourceCsvSeparate;
     string sourceCsvTerminate;
     string sourceCsvQuote;

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2004,8 +2004,13 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
         else
         {
             const char* cs = req.getSourceCsvSeparate();
-            if(cs == NULL || *cs == '\0')
+            if (req.getNoSourceCsvSeparator())
+            {
+                cs = "";
+            }
+            else if(cs == NULL || *cs == '\0')
                 cs = "\\,";
+
             const char* ct = req.getSourceCsvTerminate();
             if(ct == NULL || *ct == '\0')
                 ct = "\\n,\\r\\n";


### PR DESCRIPTION
When a user sprays a CSV file using EclWatch, the user should
be able to specify that there is no separator in the CSV file.
This fix adds a checkbox in Spray CSV input page to indicate
No Separator. When the checkbox is selected, the Separator
input field will be disabled.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
