### PR TITLE
candidate-3.6.x -- gh-1376 ecl command line support for using eclserver

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -305,11 +305,26 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     if (iter.matchOption(optManifest, ECLOPT_MANIFEST) || iter.matchOption(optManifest, ECLOPT_MANIFEST_DASH))
         return EclCmdOptionMatch;
+    if (iter.matchOption(optAttribute, ECLOPT_ATTRIBUTE) || iter.matchOption(optAttribute, ECLOPT_ATTRIBUTE_S))
+        return EclCmdOptionMatch;
+    if (iter.matchFlag(optNoArchive, ECLOPT_ECL_ONLY) || iter.matchFlag(optNoArchive, ECLOPT_ECL_ONLY_S))
+        return EclCmdOptionMatch;
+
     return EclCmdCommon::matchCommandLineOption(iter, finalAttempt);
 }
 
 bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
 {
+    if (optObj.type == eclObjTypeUnknown && optAttribute.length())
+    {
+        optNoArchive = true;
+        optObj.type = eclObjSource;
+        optObj.value.set(optAttribute.get());
+        StringBuffer text(optAttribute.get());
+        text.append("();");
+        optObj.mb.append(text.str());
+    }
+
     return EclCmdCommon::finalizeOptions(globals);
 }
 

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -57,6 +57,11 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_ACTIVATE_INI "activateDefault"
 #define ECLOPT_ACTIVATE_ENV NULL
 
+#define ECLOPT_ATTRIBUTE "--attribute"
+#define ECLOPT_ATTRIBUTE_S "-at"
+#define ECLOPT_ECL_ONLY "--ecl-only"
+#define ECLOPT_ECL_ONLY_S "-EO"
+
 #define ECLOPT_WAIT "--wait"
 #define ECLOPT_WAIT_INI "waitTimeout"
 #define ECLOPT_WAIT_ENV "ECL_WAIT_TIMEOUT"
@@ -161,7 +166,7 @@ public:
 class EclCmdWithEclTarget : public EclCmdCommon
 {
 public:
-    EclCmdWithEclTarget()
+    EclCmdWithEclTarget() : optNoArchive(false)
     {
     }
     virtual eclCmdOptionMatchIndicator matchCommandLineOption(ArgvIterator &iter, bool finalAttempt=false);
@@ -171,6 +176,8 @@ public:
     {
         EclCmdCommon::usage();
         fprintf(stdout,
+            "   -at, --attribute       module.attribute in legacy code repository\n"
+            "   -EO, --ecl-only        send ecl text to hpcc without generating archive\n"
             " eclcc options:\n"
             "   -Ipath                 Add path to locations to search for ecl imports\n"
             "   -Lpath                 Add path to locations to search for system libraries\n"
@@ -182,6 +189,8 @@ public:
     StringBuffer optLibPath;
     StringBuffer optImpPath;
     StringAttr optManifest;
+    StringAttr optAttribute;
+    bool optNoArchive;
 };
 
 class EclCmdWithQueryTarget : public EclCmdCommon

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3241,7 +3241,7 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
 }
 
 
-void deployArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEspWUDeployWorkunitResponse & resp)
+void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEspWUDeployWorkunitResponse & resp)
 {
     const MemoryBuffer &obj = req.getObject();
 
@@ -3364,8 +3364,8 @@ bool CWsWorkunitsEx::onWUDeployWorkunit(IEspContext &context, IEspWUDeployWorkun
         if (!context.validateFeatureAccess(OWN_WU_ACCESS, SecAccess_Write, false))
             throw MakeStringException(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to create workunit. Permission denied.");
 
-        if (strieq(type, "archive"))
-            deployArchive(context, req, resp);
+        if (strieq(type, "archive")|| strieq(type, "ecl_text"))
+            deployEclOrArchive(context, req, resp);
         else if (strieq(type, "shared_object"))
             deploySharedObject(context, req, resp);
         else


### PR DESCRIPTION
ecl deploy, publish, and run should be able to refer to a module.attribute
or send ECL text without calling eclcc to create an archive.

2 new options have been added:

-at, --attribute  specify module.attribute in MySQL repository
-EO, --ecl-only   send ecl text to hpcc without generating archive

--attribute allows the direct publishing and running of repository
attributes.

--ecl-only supports running ecl text on eclserver, as well as
eclccserver if the ecl is self contained.

Fixes gh-1376

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
