### PR TITLE
gh-1358 Roxie memory leaks

### DIFF
--- a/roxie/udplib/udptrs.cpp
+++ b/roxie/udplib/udptrs.cpp
@@ -210,13 +210,14 @@ public:
             DataBuffer *buffer = (DataBuffer *) toSend.item(idx);
             UdpPacketHeader *header = (UdpPacketHeader*) buffer->data;
             bool isRetry = (header->udpSequence != 0);
+            bool isPing = (header->ruid == RUID_PING);
             if (isRetry)
             {
                 if (checkTraceLevel(TRACE_RETRY_DATA, 1))
                     DBGLOG("UdpSender: Resending packet to destination node %u sequence %u", permit.destNodeIndex, header->udpSequence);
                 atomic_inc(&packetsRetried);
             }
-            else
+            else if (!isPing)
                 header->udpSequence = nextUdpSequence();
             unsigned length = header->length;
             if (bucket)
@@ -256,7 +257,7 @@ public:
             {
                 DBGLOG("UdpSender: write exception - unknown exception");
             }
-            if (!isRetry && maxRetryData)
+            if (!isRetry && !isPing && maxRetryData)
             {
                 unsigned slot = (retryDataIdx + retryDataCount) % maxRetryData;
                 if (retryDataCount < maxRetryData)


### PR DESCRIPTION
Complete the ping-related fixes - messages snet in response to ping
are not acknowledged and should not be saved in the retry buffer.

Fixes gh-1358.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
