### PR TITLE
DFS Property Lock Refactor

### DIFF
--- a/common/fileview2/fvdisksource.cpp
+++ b/common/fileview2/fvdisksource.cpp
@@ -212,7 +212,7 @@ bool DirectDiskDataSource::init()
     if (!df)
         return false;
 
-    IPropertyTree & properties = df->queryProperties();
+    IPropertyTree & properties = df->queryAttributes();
     const char * kind = properties.queryProp("@kind");
     bool isGrouped =properties.getPropBool("@grouped");
     if (kind && (stricmp(kind, "key") == 0))
@@ -334,7 +334,7 @@ enum { NONE, TERMINATOR };
 
 void CsvRecordSize::init(IDistributedFile * df)
 {
-    IPropertyTree * props = &df->queryProperties();
+    IPropertyTree * props = &df->queryAttributes();
     UtfReader::UtfFormat utfType = getFormat(props->queryProp("@format"));
     switch (utfType)
     {
@@ -410,7 +410,7 @@ DirectCsvDiskDataSource::DirectCsvDiskDataSource(IDistributedFile * _df, const c
     returnedRecordSize.set(&recordSizer);
     transformedMeta.set(returnedMeta);
     addFileposition();
-    IPropertyTree & properties = df->queryProperties();
+    IPropertyTree & properties = df->queryAttributes();
     if (properties.hasProp("@recordCount"))
         totalRows = properties.getPropInt64("@recordCount");
 }

--- a/common/fileview2/fvidxsource.cpp
+++ b/common/fileview2/fvidxsource.cpp
@@ -170,7 +170,7 @@ bool IndexDataSource::init()
     if (!tlk)
         return false;
 
-    IPropertyTree & properties = df->queryProperties();
+    IPropertyTree & properties = df->queryAttributes();
     //Need to assign the transformed record to meta
     if (!diskMeta)
         diskMeta.setown(new DataSourceMetaData(diskRecord, 0, true, false, tlk->keyedSize()));

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -107,7 +107,7 @@ IFvDataSource * createFileDataSource(IDistributedFile * df, const char * logical
     if (df->isCompressed(&blocked) && !blocked)
         throwError1(FVERR_CompressedFile, logicalName);
 
-    IPropertyTree & properties = df->queryProperties();
+    IPropertyTree & properties = df->queryAttributes();
     const char * format = properties.queryProp("@format");
     if (format && (stricmp(format,"csv")==0 || memicmp(format, "utf", 3) == 0))
     {

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2345,11 +2345,14 @@ public:
                 // Transactional logic, if any
                 switch(state) {
                 case TAS_SUCCESS:
-                    conn->commit(); break;
+                    conn->commit();
+                    break;
                 case TAS_FAILURE:
-                    conn->rollback(); break;
+                    conn->rollback();
+                    break;
                 case TAS_RETRY:
-                    conn->changeMode(RTM_NONE,defaultTimeout,true); return;
+                    conn->changeMode(RTM_NONE,defaultTimeout,true);
+                    return;
                 // TAS_NONE, do nothing
                 }
 #ifdef TRACE_LOCKS
@@ -5102,10 +5105,8 @@ private:
                 pos=findSubFileOrd(subfile);
                 if ((pos==NotFound)||(pos>=subfiles.ordinality()))
                     pos = findSubFile(subfile);
-                if (pos==NotFound) {
-                    unlockProperties();
+                if (pos==NotFound)
                     return false;
-                }
                 unlinkSubFile(pos,transaction);
                 removeItem(pos,subname.clear());
                 subnames.append(* new StringAttrItem(subname.str()));

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -980,7 +980,7 @@ class CDFAction: public CInterface
 protected:
     Linked<IDistributedFileTransaction> transaction;
     IArrayOf<IDistributedFile> lockedFiles;
-    TransActionState state;
+    DFTransactionState state;
     void addFile(IDistributedFile& file) {
         // derived's prepare must call this before locking
         lockedFiles.append(file);
@@ -1866,7 +1866,7 @@ public:
     unsigned getCRC();
     IPropertyTree &queryAttributes();
     bool lockProperties(unsigned timems);
-    void unlockProperties(TransActionState state);
+    void unlockProperties(DFTransactionState state);
     bool isHost(unsigned copy);
     offset_t getFileSize(bool allowphysical,bool forcephysical);
     offset_t getDiskSize();
@@ -2337,7 +2337,7 @@ public:
      *
      *  @deprecated : use DistributedFilePropertyLock instead, when possible
      */
-    void unlockProperties(TransActionState state=TAS_NONE)
+    void unlockProperties(DFTransactionState state=TAS_NONE)
     {
         savePartsAttr();
         if (--proplockcount==0) {
@@ -5713,7 +5713,7 @@ bool CDistributedFilePart::lockProperties(unsigned timeoutms)
 }
 
 // TODO: Create DistributedFilePropertyLock for parts
-void CDistributedFilePart::unlockProperties(TransActionState state=TAS_NONE)
+void CDistributedFilePart::unlockProperties(DFTransactionState state=TAS_NONE)
 {
     parent.unlockProperties(state);
 }

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -5705,12 +5705,14 @@ unsigned CDistributedFilePart::getPhysicalCrc()
     throw e;
 }
 
+// TODO: Create DistributedFilePropertyLock for parts
 bool CDistributedFilePart::lockProperties(unsigned timeoutms)
 {
     dirty = true;
     return parent.lockProperties(timeoutms);
 }
 
+// TODO: Create DistributedFilePropertyLock for parts
 void CDistributedFilePart::unlockProperties(TransActionState state=TAS_NONE)
 {
     parent.unlockProperties(state);

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -133,7 +133,7 @@ interface IDistributedFilePart: implements IInterface
 
     virtual IPropertyTree &queryProperties() = 0;                               // part properties
 
-    virtual IPropertyTree &lockProperties(unsigned timeoutms=INFINITE) = 0;                             // must be called before updating
+    virtual bool lockProperties(unsigned timeoutms=INFINITE) = 0;               // must be called before updating
     virtual void unlockProperties() = 0;                                        // must be called after updating
 
     virtual bool isHost(unsigned copy=0) = 0;                                   // file is located on this machine
@@ -219,7 +219,7 @@ interface IDistributedFile: extends IInterface
 
     virtual IPropertyTree &queryProperties() = 0;                               // DFile attributes (TODO: rename to getFileAttr)
 
-    virtual IPropertyTree &lockProperties(unsigned timeoutms=INFINITE) = 0;     // must be called before updating properties (will discard uncommitted changes)
+    virtual bool lockProperties(unsigned timeoutms=INFINITE) = 0;               // must be called before updating properties (will discard uncommitted changes)
     virtual void unlockProperties() = 0;                                        // must be called after updating properties
 
     virtual bool getModificationTime(CDateTime &dt) = 0;                        // get date and time last modified (returns false if not set)

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -110,6 +110,13 @@ enum GetFileClusterNamesType
 };
 
 
+enum TransActionState {
+    TAS_NONE,    // still working
+    TAS_RETRY,   // retry (din-phil problems)
+    TAS_SUCCESS, // committing
+    TAS_FAILURE  // rolling back
+};
+
 // ==DISTRIBUTED FILES===================================================================================================
 
 /**
@@ -134,7 +141,7 @@ interface IDistributedFilePart: implements IInterface
     virtual IPropertyTree &queryAttributes() = 0;                               // part attributes
 
     virtual bool lockProperties(unsigned timeoutms=INFINITE) = 0;               // must be called before updating
-    virtual void unlockProperties() = 0;                                        // must be called after updating
+    virtual void unlockProperties(TransActionState state=TAS_NONE) = 0;         // must be called after updating
 
     virtual bool isHost(unsigned copy=0) = 0;                                   // file is located on this machine
 
@@ -233,7 +240,7 @@ interface IDistributedFile: extends IInterface
     virtual IPropertyTree &queryAttributes() = 0;                               // DFile attributes
 
     virtual bool lockProperties(unsigned timeoutms=INFINITE) = 0;               // must be called before updating properties (will discard uncommitted changes)
-    virtual void unlockProperties() = 0;                                        // must be called after updating properties
+    virtual void unlockProperties(TransActionState state=TAS_NONE) = 0;         // must be called after updating properties
 
     virtual bool getModificationTime(CDateTime &dt) = 0;                        // get date and time last modified (returns false if not set)
     virtual void setModificationTime(const CDateTime &dt) = 0;                  // set date and time last modified
@@ -262,9 +269,6 @@ interface IDistributedFile: extends IInterface
     virtual bool isSubFile()=0;                                         // returns true if sub file of any SuperFile
     virtual IDistributedSuperFileIterator *getOwningSuperFiles(IDistributedFileTransaction *_transaction=NULL)=0;           // returns iterator for all parents
     virtual bool isCompressed(bool *blocked=NULL)=0;
-
-    virtual bool lockTransaction(unsigned timeout)=0;                           // internal use
-    virtual void unlockTransaction(bool _commit,bool _rollback)=0;              // internal use
 
     virtual StringBuffer &getClusterName(unsigned clusternum,StringBuffer &name) = 0;
     virtual unsigned getClusterNames(StringArray &clusters)=0;                  // returns ordinality

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -376,21 +376,7 @@ public:
         if (!unlocked)
             unlock();
     }
-    void commit()
-    {
-        file->unlockProperties(TAS_SUCCESS);
-        unlocked = true;
-    }
-    void rollback()
-    {
-        file->unlockProperties(TAS_FAILURE);
-        unlocked = true;
-    }
-    void retry()
-    {
-        file->unlockProperties(TAS_RETRY);
-        unlocked = true;
-    }
+    // MORE: Implement commit/rollback/retry as necessary
     void unlock()
     {
         file->unlockProperties(TAS_NONE);

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -110,7 +110,7 @@ enum GetFileClusterNamesType
 };
 
 
-enum TransActionState {
+enum DFTransactionState {
     TAS_NONE,    // still working
     TAS_RETRY,   // retry (din-phil problems)
     TAS_SUCCESS, // committing
@@ -141,7 +141,7 @@ interface IDistributedFilePart: implements IInterface
     virtual IPropertyTree &queryAttributes() = 0;                               // part attributes
 
     virtual bool lockProperties(unsigned timeoutms=INFINITE) = 0;               // must be called before updating
-    virtual void unlockProperties(TransActionState state=TAS_NONE) = 0;         // must be called after updating
+    virtual void unlockProperties(DFTransactionState state=TAS_NONE) = 0;         // must be called after updating
 
     virtual bool isHost(unsigned copy=0) = 0;                                   // file is located on this machine
 
@@ -227,7 +227,7 @@ interface IDistributedFile: extends IInterface
     virtual IPropertyTree &queryAttributes() = 0;                               // DFile attributes
 
     virtual bool lockProperties(unsigned timeoutms=INFINITE) = 0;               // must be called before updating properties (will discard uncommitted changes)
-    virtual void unlockProperties(TransActionState state=TAS_NONE) = 0;         // must be called after updating properties
+    virtual void unlockProperties(DFTransactionState state=TAS_NONE) = 0;         // must be called after updating properties
 
     virtual bool getModificationTime(CDateTime &dt) = 0;                        // get date and time last modified (returns false if not set)
     virtual void setModificationTime(const CDateTime &dt) = 0;                  // set date and time last modified

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -814,7 +814,7 @@ static int dfsverify(const char *name,CDateTime *cutoff)
             return 0;
     }
 
-    IPropertyTree &fileprops = file->queryProperties();
+    IPropertyTree &fileprops = file->queryAttributes();
     bool blocked;
     bool rowcompressed = file->isCompressed(&blocked)&&!blocked;
     CFileList list;
@@ -1344,7 +1344,7 @@ static offset_t getCompressedSize(IDistributedFile *file)
 {  // this should be parallel!  TBD
     if (!file)
         return (offset_t)-1;
-    offset_t ret = (offset_t)file->queryProperties().getPropInt64("@compressedSize",-1);
+    offset_t ret = (offset_t)file->queryAttributes().getPropInt64("@compressedSize",-1);
     if (ret==(offset_t)-1) {
         try {
             ret = 0;

--- a/dali/dalidiag/dalidiag.cpp
+++ b/dali/dalidiag/dalidiag.cpp
@@ -285,7 +285,7 @@ void partInfo(const char *name,unsigned copy)
             part.getFilename(fn,copy);
             StringBuffer buf;
             SocketEndpoint ep = fn.queryEndpoint();
-            printf("%3d %10"I64F"d %5s\n",partno,part.queryProperties().getPropInt64("@size", -1),fn.getRemotePath(buf).str());
+            printf("%3d %10"I64F"d %5s\n",partno,part.queryAttributes().getPropInt64("@size", -1),fn.getRemotePath(buf).str());
         }
     }
     else

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -77,7 +77,7 @@ static void addTestFile(const char *name,unsigned n)
     }
     Owned<IDistributedFile> dfile =  queryDistributedFileDirectory().createNew(fileDesc);
     dfile->lockProperties();
-    IPropertyTree &t = dfile->queryProperties();
+    IPropertyTree &t = dfile->queryAttributes();
     t.setProp("@owned","nigel");
     t.setPropInt("@recordSize",1);
     t.setProp("ECL","TESTECL();");
@@ -283,7 +283,7 @@ void Test_PartIter()
     Owned<IDistributedFilePartIterator> parts = file->getIterator();
     ForEach(*parts) {
         IDistributedFilePart & thisPart = parts->query(); 
-        IPropertyTree &partProps = thisPart.queryProperties();
+        IPropertyTree &partProps = thisPart.queryAttributes();
     }
     printf("time taken = %d\n",msTick()-start);
 }

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -76,12 +76,13 @@ static void addTestFile(const char *name,unsigned n)
         fileDesc->setPart(m,&group->queryNode(m), path.str(), pp);
     }
     Owned<IDistributedFile> dfile =  queryDistributedFileDirectory().createNew(fileDesc);
-    dfile->lockProperties();
-    IPropertyTree &t = dfile->queryAttributes();
-    t.setProp("@owned","nigel");
-    t.setPropInt("@recordSize",1);
-    t.setProp("ECL","TESTECL();");
-    dfile->unlockProperties();
+    {
+        DistributedFilePropertyLock lock(dfile);
+        IPropertyTree &t = lock.queryAttributes();
+        t.setProp("@owned","nigel");
+        t.setPropInt("@recordSize",1);
+        t.setProp("ECL","TESTECL();");
+    }
     dfile->attach(name);
 }
 

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -76,7 +76,8 @@ static void addTestFile(const char *name,unsigned n)
         fileDesc->setPart(m,&group->queryNode(m), path.str(), pp);
     }
     Owned<IDistributedFile> dfile =  queryDistributedFileDirectory().createNew(fileDesc);
-    IPropertyTree &t = dfile->lockProperties();
+    dfile->lockProperties();
+    IPropertyTree &t = dfile->queryProperties();
     t.setProp("@owned","nigel");
     t.setPropInt("@recordSize",1);
     t.setProp("ECL","TESTECL();");

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -857,7 +857,7 @@ public:
             else {
                 if (ctx.superoptions->getIfModified()&&
                     (ftree->hasProp("Attr/@fileCrc")&&ftree->getPropInt64("Attr/@size")&&
-                    ((unsigned)ftree->getPropInt64("Attr/@fileCrc")==(unsigned)dfile->queryProperties().getPropInt64("@fileCrc"))&&
+                    ((unsigned)ftree->getPropInt64("Attr/@fileCrc")==(unsigned)dfile->queryAttributes().getPropInt64("@fileCrc"))&&
                     (ftree->getPropInt64("Attr/@size")==dfile->getFileSize(false,false)))) {
                     PROGLOG("File copy of %s not done as file unchanged",srclfn);
                     return;
@@ -904,7 +904,7 @@ public:
             }
             if (newroxieprefix.length()) {
                 sfile->lockProperties();
-                sfile->queryProperties().setProp("@roxiePrefix",newroxieprefix.str());
+                sfile->queryAttributes().setProp("@roxiePrefix",newroxieprefix.str());
                 sfile->unlockProperties();
             }
 
@@ -1140,7 +1140,7 @@ public:
                               (cmd==DFUcmd_move)||(cmd==DFUcmd_rename)||((cmd==DFUcmd_copy)&&multiclusterinsert)));
                         if (!srcFile) 
                             throw MakeStringException(-1,"Source file %s could not be found",tmp.str());
-                        oldRoxiePrefix.set(srcFile->queryProperties().queryProp("@roxiePrefix"));
+                        oldRoxiePrefix.set(srcFile->queryAttributes().queryProp("@roxiePrefix"));
                         iskey = isFileKey(srcFile);
                         if (destination->getWrap()||(iskey&&(cmd==DFUcmd_copy)))    // keys default wrap for copy
                             destination->setNumPartsOverride(srcFile->numParts());

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -903,9 +903,8 @@ public:
                 sfile->addSubFile(subfiles.item(i));
             }
             if (newroxieprefix.length()) {
-                sfile->lockProperties();
-                sfile->queryAttributes().setProp("@roxiePrefix",newroxieprefix.str());
-                sfile->unlockProperties();
+                DistributedFilePropertyLock lock(sfile);
+                lock.queryAttributes().setProp("@roxiePrefix",newroxieprefix.str());
             }
 
         }

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -903,7 +903,8 @@ public:
                 sfile->addSubFile(subfiles.item(i));
             }
             if (newroxieprefix.length()) {
-                sfile->lockProperties().setProp("@roxiePrefix",newroxieprefix.str());
+                sfile->lockProperties();
+                sfile->queryProperties().setProp("@roxiePrefix",newroxieprefix.str());
                 sfile->unlockProperties();
             }
 

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -636,9 +636,8 @@ public:
                 sfile->addSubFile(subfiles.item(i));
             }
             if (!nameprefix.isEmpty()) {
-                sfile->lockProperties();
-                sfile->queryAttributes().setProp("@roxiePrefix",nameprefix.get());
-                sfile->unlockProperties();
+                DistributedFilePropertyLock lock(sfile);
+                lock.queryAttributes().setProp("@roxiePrefix",nameprefix.get());
             }
         }
         else {

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -636,7 +636,8 @@ public:
                 sfile->addSubFile(subfiles.item(i));
             }
             if (!nameprefix.isEmpty()) {
-                sfile->lockProperties().setProp("@roxiePrefix",nameprefix.get());
+                sfile->lockProperties();
+                sfile->queryProperties().setProp("@roxiePrefix",nameprefix.get());
                 sfile->unlockProperties();
             }
         }

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -637,7 +637,7 @@ public:
             }
             if (!nameprefix.isEmpty()) {
                 sfile->lockProperties();
-                sfile->queryProperties().setProp("@roxiePrefix",nameprefix.get());
+                sfile->queryAttributes().setProp("@roxiePrefix",nameprefix.get());
                 sfile->unlockProperties();
             }
         }
@@ -917,7 +917,7 @@ public:
                 dfile->detach();
             else {
                 if (ftree->hasProp("Attr/@fileCrc")&&ftree->getPropInt64("Attr/@size")&&
-                    ((unsigned)ftree->getPropInt64("Attr/@fileCrc")==(unsigned)dfile->queryProperties().getPropInt64("@fileCrc"))&&
+                    ((unsigned)ftree->getPropInt64("Attr/@fileCrc")==(unsigned)dfile->queryAttributes().getPropInt64("@fileCrc"))&&
                     (ftree->getPropInt64("Attr/@size")==dfile->getFileSize(false,false))) {
                     PROGLOG("File copy of %s not done as file unchanged",srclfn);
                     return;

--- a/dali/dfuXRefLib/dfuxreflib.cpp
+++ b/dali/dfuXRefLib/dfuxreflib.cpp
@@ -1787,7 +1787,7 @@ class CXRefManager: public CXRefManagerBase
                         name.toLowerCase();
                         CFileEntry *entry= filemap.find(name.str());
                         if (entry) {
-                            __int64 sz = part->queryProperties().getPropInt64("@size", -1);
+                            __int64 sz = part->queryAttributes().getPropInt64("@size", -1);
                             if (sz!=entry->size) {
                                 StringBuffer s1;
                                 entry->getLogicalName(s1);
@@ -1801,7 +1801,7 @@ class CXRefManager: public CXRefManagerBase
                         else 
                             total = -1;
                     }
-                    sz = file->queryProperties().getPropInt64("@size", -1);
+                    sz = file->queryAttributes().getPropInt64("@size", -1);
                     if (sz!=total) {
                         outf("SIZEFIX: Changing total size for %s from %"I64F"d to %"I64F"d\n",item.lname.get(),sz,total);
                         if (total!=-1)

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -188,7 +188,7 @@ void CDistributedFileSystem::physicalCopy(IPropertyTree * source, const char * t
 offset_t CDistributedFileSystem::getSize(IDistributedFile * file, bool forceget, bool dontsetattr)
 {
     //MORE: Should this be done on multiple threads??? (NH: probably)
-    offset_t totalSize = forceget?-1:file->queryProperties().getPropInt64("@size",-1);
+    offset_t totalSize = forceget?-1:file->queryAttributes().getPropInt64("@size",-1);
     if (totalSize == -1) {
         unsigned numParts = file->numParts();
         totalSize = 0;
@@ -206,7 +206,7 @@ offset_t CDistributedFileSystem::getSize(IDistributedFile * file, bool forceget,
         if (((totalSize != -1)||forceget) && !dontsetattr) // note forceget && !dontsetattr will reset attr if can't work out size
         {
             file->lockProperties();
-            file->queryProperties().setPropInt64("@size", totalSize);
+            file->queryAttributes().setPropInt64("@size", totalSize);
             file->unlockProperties();
         }
     }
@@ -272,7 +272,7 @@ offset_t CDistributedFileSystem::getSize(IDistributedFilePart * part, bool force
         if (((size != (offset_t)-1)||forceget) && !dontsetattr) // note forceget && !dontsetattr will reset attr if can't work out size
         {
             part->lockProperties();
-            part->queryProperties().setPropInt64("@size", size);
+            part->queryAttributes().setPropInt64("@size", size);
             part->unlockProperties();
         }
     }

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -205,9 +205,8 @@ offset_t CDistributedFileSystem::getSize(IDistributedFile * file, bool forceget,
         }
         if (((totalSize != -1)||forceget) && !dontsetattr) // note forceget && !dontsetattr will reset attr if can't work out size
         {
-            file->lockProperties();
-            file->queryAttributes().setPropInt64("@size", totalSize);
-            file->unlockProperties();
+            DistributedFilePropertyLock lock(file);
+            lock.queryAttributes().setPropInt64("@size", totalSize);
         }
     }
     //LOG(MCdebugInfo(1000), unknownJob, "DFS: getSize(%s)=%"I64F"d", file->queryLogicalName(), totalSize);
@@ -271,6 +270,7 @@ offset_t CDistributedFileSystem::getSize(IDistributedFilePart * part, bool force
         size = part->getFileSize(true,forceget);
         if (((size != (offset_t)-1)||forceget) && !dontsetattr) // note forceget && !dontsetattr will reset attr if can't work out size
         {
+            // TODO: Create DistributedFilePropertyLock for parts
             part->lockProperties();
             part->queryAttributes().setPropInt64("@size", size);
             part->unlockProperties();

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -205,8 +205,8 @@ offset_t CDistributedFileSystem::getSize(IDistributedFile * file, bool forceget,
         }
         if (((totalSize != -1)||forceget) && !dontsetattr) // note forceget && !dontsetattr will reset attr if can't work out size
         {
-            IPropertyTree &tree = file->lockProperties();
-            tree.setPropInt64("@size", totalSize);
+            file->lockProperties();
+            file->queryProperties().setPropInt64("@size", totalSize);
             file->unlockProperties();
         }
     }
@@ -271,8 +271,8 @@ offset_t CDistributedFileSystem::getSize(IDistributedFilePart * part, bool force
         size = part->getFileSize(true,forceget);
         if (((size != (offset_t)-1)||forceget) && !dontsetattr) // note forceget && !dontsetattr will reset attr if can't work out size
         {
-            IPropertyTree &tree = part->lockProperties();
-            tree.setPropInt64("@size", size);
+            part->lockProperties();
+            part->queryProperties().setPropInt64("@size", size);
             part->unlockProperties();
         }
     }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -1481,7 +1481,8 @@ void FileSprayer::analyseFileHeaders(bool setcurheadersize)
         tgtFormat.set(srcFormat);
         if (distributedTarget)
         {
-            IPropertyTree &curProps = distributedTarget->lockProperties();
+            distributedTarget->lockProperties();
+            IPropertyTree &curProps = distributedTarget->queryProperties();
             tgtFormat.save(&curProps);
             distributedTarget->unlockProperties();
         }
@@ -2427,7 +2428,8 @@ void FileSprayer::setTarget(IDistributedFile * target)
         tgtFormat.set(srcFormat);
         if (!unknownSourceFormat)
         {
-            IPropertyTree &curProps = target->lockProperties();
+            target->lockProperties();
+            IPropertyTree &curProps = target->queryProperties();
             tgtFormat.save(&curProps);
             target->unlockProperties();
         }
@@ -2758,7 +2760,8 @@ void FileSprayer::updateTargetProperties()
             if (idx+1 == partition.ordinality() || partition.item(idx+1).whichOutput != cur.whichOutput)
             {
                 Owned<IDistributedFilePart> curPart = distributedTarget->getPart(cur.whichOutput);
-                IPropertyTree& curProps = curPart->lockProperties();
+                curPart->lockProperties();
+                IPropertyTree& curProps = curPart->queryProperties();
                 if (calcCRC())
                 {
                     curProps.setPropInt(FAcrc, partCRC.get());
@@ -2827,7 +2830,8 @@ void FileSprayer::updateTargetProperties()
         if (failedParts.length())
             error.setown(MakeStringException(DFTERR_InputOutputCrcMismatch, "%s", failedParts.str()));
 
-        IPropertyTree &curProps = distributedTarget->lockProperties();
+        distributedTarget->lockProperties();
+        IPropertyTree &curProps = distributedTarget->queryProperties();
         if (calcCRC())
             curProps.setPropInt(FAcrc, totalCRC.get());
         curProps.setPropInt64(FAsize, totalLength);

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -140,9 +140,9 @@ void FilePartInfo::extractExtra(IDistributedFilePart &part)
     if (hasCRC)
         crc = _crc;
 
-    properties.set(&part.queryProperties());
-    if (part.queryProperties().hasProp("@modified"))
-        modifiedTime.setString(part.queryProperties().queryProp("@modified"));
+    properties.set(&part.queryAttributes());
+    if (part.queryAttributes().hasProp("@modified"))
+        modifiedTime.setString(part.queryAttributes().queryProp("@modified"));
 }
 
 void FilePartInfo::init()
@@ -1482,7 +1482,7 @@ void FileSprayer::analyseFileHeaders(bool setcurheadersize)
         if (distributedTarget)
         {
             distributedTarget->lockProperties();
-            IPropertyTree &curProps = distributedTarget->queryProperties();
+            IPropertyTree &curProps = distributedTarget->queryAttributes();
             tgtFormat.save(&curProps);
             distributedTarget->unlockProperties();
         }
@@ -2285,7 +2285,7 @@ void FileSprayer::setReplicate(bool _replicate)
 void FileSprayer::setSource(IDistributedFile * source)
 {
     distributedSource.set(source);
-    srcAttr.setown(createPTreeFromIPT(&source->queryProperties()));
+    srcAttr.setown(createPTreeFromIPT(&source->queryAttributes()));
     extractSourceFormat(srcAttr);
     unsigned numParts = source->numParts();
     for (unsigned idx=0; idx < numParts; idx++)
@@ -2421,7 +2421,7 @@ void FileSprayer::setTarget(IDistributedFile * target)
     distributedTarget.set(target);
     compressOutput = !encryptKey.isEmpty()||target->isCompressed();
 
-    if (tgtFormat.restore(&target->queryProperties()))
+    if (tgtFormat.restore(&target->queryAttributes()))
         unknownTargetFormat = false;
     else
     {
@@ -2429,7 +2429,7 @@ void FileSprayer::setTarget(IDistributedFile * target)
         if (!unknownSourceFormat)
         {
             target->lockProperties();
-            IPropertyTree &curProps = target->queryProperties();
+            IPropertyTree &curProps = target->queryAttributes();
             tgtFormat.save(&curProps);
             target->unlockProperties();
         }
@@ -2761,7 +2761,7 @@ void FileSprayer::updateTargetProperties()
             {
                 Owned<IDistributedFilePart> curPart = distributedTarget->getPart(cur.whichOutput);
                 curPart->lockProperties();
-                IPropertyTree& curProps = curPart->queryProperties();
+                IPropertyTree& curProps = curPart->queryAttributes();
                 if (calcCRC())
                 {
                     curProps.setPropInt(FAcrc, partCRC.get());
@@ -2831,7 +2831,7 @@ void FileSprayer::updateTargetProperties()
             error.setown(MakeStringException(DFTERR_InputOutputCrcMismatch, "%s", failedParts.str()));
 
         distributedTarget->lockProperties();
-        IPropertyTree &curProps = distributedTarget->queryProperties();
+        IPropertyTree &curProps = distributedTarget->queryAttributes();
         if (calcCRC())
             curProps.setPropInt(FAcrc, totalCRC.get());
         curProps.setPropInt64(FAsize, totalLength);

--- a/dali/regress/daregdfs.cpp
+++ b/dali/regress/daregdfs.cpp
@@ -586,7 +586,8 @@ void testDF1()
     fdesc->setPart(2,rfn,pt);
     dispFDesc(fdesc);
     Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
-    file->lockProperties().setProp("@testing","1");
+    file->lockProperties();
+    file->queryProperties().setProp("@testing","1");
     file->unlockProperties();
     file->attach("testing::propfile2");
 }

--- a/dali/regress/daregdfs.cpp
+++ b/dali/regress/daregdfs.cpp
@@ -586,9 +586,10 @@ void testDF1()
     fdesc->setPart(2,rfn,pt);
     dispFDesc(fdesc);
     Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
-    file->lockProperties();
-    file->queryAttributes().setProp("@testing","1");
-    file->unlockProperties();
+    {
+        DistributedFilePropertyLock lock(file);
+        lock.queryAttributes().setProp("@testing","1");
+    }
     file->attach("testing::propfile2");
 }
 

--- a/dali/regress/daregdfs.cpp
+++ b/dali/regress/daregdfs.cpp
@@ -137,7 +137,7 @@ void checkFilePart(IChecker *checker,IDistributedFilePart *part,bool blocked)
 #ifndef COMPAT
     checker->add("getPartDirectory",part->getPartDirectory(tmp.clear()).str());
 #endif
-    checker->add("queryProperties()",toXML(&part->queryProperties(),tmp.clear()).str());
+    checker->add("queryProperties()",toXML(&part->queryAttributes(),tmp.clear()).str());
     checker->add("isHost",part->isHost()?1:0);
     checker->add("getFileSize",part->getFileSize(false,false));
     CDateTime dt;
@@ -163,7 +163,7 @@ void checkFile(IChecker *checker,IDistributedFile *file)
     checker->add("queryDefaultDir",file->queryDefaultDir());
     if (np>1)
         checker->add("queryPartMask",file->queryPartMask());
-    checker->add("queryProperties()",toXML(&file->queryProperties(),tmp.clear()).str());
+    checker->add("queryProperties()",toXML(&file->queryAttributes(),tmp.clear()).str());
     CDateTime dt;
     if (file->getModificationTime(dt))
         dt.getString(tmp.clear());
@@ -587,7 +587,7 @@ void testDF1()
     dispFDesc(fdesc);
     Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
     file->lockProperties();
-    file->queryProperties().setProp("@testing","1");
+    file->queryAttributes().setProp("@testing","1");
     file->unlockProperties();
     file->attach("testing::propfile2");
 }

--- a/dali/regress/daregress.cpp
+++ b/dali/regress/daregress.cpp
@@ -300,7 +300,7 @@ static void test2()
             rfn.getRemotePath(s);
             crctot += crc32(s.str(),s.length(),0);
             np++;
-            totrows += (unsigned)(piter->query().getFileSize(false,false)/fiter->query().queryProperties().getPropInt("@recordSize",-1));
+            totrows += (unsigned)(piter->query().getFileSize(false,false)/fiter->query().queryAttributes().getPropInt("@recordSize",-1));
         }
     }
     piter.clear();
@@ -322,7 +322,7 @@ static void test2()
     crctot = 0;
     np = 0;
     totrows = 0;
-    size32_t srs = (size32_t)sfile->queryProperties().getPropInt("@recordSize",-1);
+    size32_t srs = (size32_t)sfile->queryAttributes().getPropInt("@recordSize",-1);
     if (srs!=17)
         ERROR1("Superfile does not match subfile row size %d",srs);
     piter.setown(sfile->getIterator()); 

--- a/dali/sasha/saverify.cpp
+++ b/dali/sasha/saverify.cpp
@@ -349,10 +349,9 @@ public:
             if (afor.ok) {
                 CDateTime dt;
                 dt.setNow();
-                file->lockProperties();
+                DistributedFilePropertyLock lock(file);
                 StringBuffer str;
-                file->queryAttributes().setProp("@verified",dt.getString(str).str());
-                file->unlockProperties();
+                lock.queryAttributes().setProp("@verified",dt.getString(str).str());
             }
             PROGLOG("VERIFY: file %s %s",name,afor.ok?"OK":"FAILED");
         }

--- a/dali/sasha/saverify.cpp
+++ b/dali/sasha/saverify.cpp
@@ -224,7 +224,7 @@ public:
         Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(name);
         if (!file)
             return;
-        IPropertyTree &fileprops = file->queryProperties();
+        IPropertyTree &fileprops = file->queryAttributes();
         bool blocked = false;
         if (file->isCompressed(&blocked)&&!blocked)
             return;
@@ -351,7 +351,7 @@ public:
                 dt.setNow();
                 file->lockProperties();
                 StringBuffer str;
-                file->queryProperties().setProp("@verified",dt.getString(str).str());
+                file->queryAttributes().setProp("@verified",dt.getString(str).str());
                 file->unlockProperties();
             }
             PROGLOG("VERIFY: file %s %s",name,afor.ok?"OK":"FAILED");

--- a/dali/sasha/saverify.cpp
+++ b/dali/sasha/saverify.cpp
@@ -349,9 +349,9 @@ public:
             if (afor.ok) {
                 CDateTime dt;
                 dt.setNow();
-                IPropertyTree &pt = file->lockProperties();
+                file->lockProperties();
                 StringBuffer str;
-                pt.setProp("@verified",dt.getString(str).str());
+                file->queryProperties().setProp("@verified",dt.getString(str).str());
                 file->unlockProperties();
             }
             PROGLOG("VERIFY: file %s %s",name,afor.ok?"OK":"FAILED");

--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -1504,7 +1504,7 @@ public:
                 error(lfn.get(),"could not set preferred cluster (set to %s)",tmpname.str());
                 continue;
             }
-            if (ignorelazylost&&(file->queryProperties().getPropInt("@lazy")!=0)) {
+            if (ignorelazylost&&(file->queryAttributes().getPropInt("@lazy")!=0)) {
                 warn(lfn.get(),"Lazy file ignored");
                 continue;
             }

--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -396,7 +396,7 @@ bool EclGraphElement::alreadyUpToDate(IAgentContext & agent)
         return (totalCRC <= pseudoCrc);
     }
 
-    IPropertyTree & cur = f->queryProperties();
+    IPropertyTree & cur = f->queryAttributes();
     if ((eclCRC != cur.getPropInt("@eclCRC")) || (totalCRC != cur.getPropInt64("@totalCRC")))
         return false;
     return true;

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -1005,7 +1005,7 @@ void CHThorIndexWriteActivity::execute()
         if (ldFile )
         {
             IDistributedFile * dFile = ldFile->queryDistributedFile();
-            fileSize = dFile ? dFile->queryProperties().getPropInt64("@size", 0) : ldFile->getPartFileSize(0);//MORE: is local part correct?
+            fileSize = dFile ? dFile->queryAttributes().getPropInt64("@size", 0) : ldFile->getPartFileSize(0);//MORE: is local part correct?
         }
     }
     unsigned int fileCrc = -1;
@@ -7538,7 +7538,7 @@ void CHThorDiskReadBaseActivity::resolve()
             IDistributedFile *dFile = ldFile->queryDistributedFile();
             if (dFile)  //only makes sense for distributed (non local) files
             {
-                persistent = dFile->queryProperties().getPropBool("@persistent");
+                persistent = dFile->queryAttributes().getPropBool("@persistent");
                 dfsParts.setown(dFile->getIterator());
                 if((helper.getFlags() & (TDXtemporary | TDXjobtemp)) == 0)
                     agent.logFileAccess(dFile, "HThor", "READ");
@@ -8439,7 +8439,7 @@ void CHThorCsvReadActivity::gatherInfo(IFileDescriptor * fd)
     IDistributedFile * dFile = ldFile?ldFile->queryDistributedFile():NULL;
     if (dFile)  //only makes sense for distributed (non local) files
     {
-        IPropertyTree & options = dFile->queryProperties();
+        IPropertyTree & options = dFile->queryAttributes();
         quotes = options.queryProp("@csvQuote");
         separators = options.queryProp("@csvSeparate");
         terminators = options.queryProp("@csvTerminate");

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -153,7 +153,7 @@ protected:
 
 static bool verifyFormatCrc(unsigned helperCrc, IDistributedFile * df, char const * super, bool isIndex, bool fail)
 {
-    IPropertyTree &props = df->queryProperties();
+    IPropertyTree &props = df->queryAttributes();
     if(props.hasProp("@formatCrc"))
     {
         unsigned dfsCrc = props.getPropInt("@formatCrc");

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -1928,8 +1928,8 @@ protected:
                     partsize = ifile->size();
                     if (partsize != -1)
                     {
-                        IPropertyTree &tree = part->lockProperties();
-                        tree.setPropInt64("@size", partsize);
+                        part->lockProperties();
+                        part->queryProperties().setPropInt64("@size", partsize);
                         part->unlockProperties();
                         break;
                     }

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -1928,6 +1928,7 @@ protected:
                     partsize = ifile->size();
                     if (partsize != -1)
                     {
+                        // TODO: Create DistributedFilePropertyLock for parts
                         part->lockProperties();
                         part->queryAttributes().setPropInt64("@size", partsize);
                         part->unlockProperties();

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -93,7 +93,7 @@ bool rltEnabled(IConstWorkUnit const * wu)
 
 IRecordLayoutTranslator * getRecordLayoutTranslator(IDefRecordMeta const * activityMeta, size32_t activityMetaSize, void const * activityMetaBuff, IDistributedFile * df, IRecordLayoutTranslatorCache * cache)
 {
-    IPropertyTree const & props = df->queryProperties();
+    IPropertyTree const & props = df->queryAttributes();
     MemoryBuffer diskMetaBuff;
     if(!props.getPropBin("_record_layout", diskMetaBuff))
 #ifdef IGNORE_FORMAT_CRC_MISMATCH_WHEN_NO_METADATA
@@ -379,7 +379,7 @@ CHThorIndexReadActivityBase::CHThorIndexReadActivityBase(IAgentContext &_agent, 
     : CHThorActivityBase(_agent, _activityId, _subgraphId, _arg, _kind), helper(_arg), df(LINK(_df)), activityRecordMetaBuff(NULL)
 {
     singlePart = false;
-    localSortKey = (df->queryProperties().hasProp("@local"));
+    localSortKey = (df->queryAttributes().hasProp("@local"));
     IDistributedSuperFile *super = df->querySuperFile();
     superCount = 1;
     superIndex = 0;
@@ -1809,7 +1809,7 @@ public:
                 unsigned __int64 thissize = ifile->size();
                 if (thissize != -1)
                 {
-                    IPropertyTree & props = part->queryProperties();
+                    IPropertyTree & props = part->queryAttributes();
                     unsigned __int64 expectedSize;
                     Owned<IExpander> eexp;
                     if (encryptionkey.length()!=0) {
@@ -1914,7 +1914,7 @@ public:
 protected:
     static offset_t getPartSize(IDistributedFilePart *part)
     {
-        offset_t partsize = part->queryProperties().getPropInt64("@size", -1);
+        offset_t partsize = part->queryAttributes().getPropInt64("@size", -1);
         if (partsize==-1)
         {
             MTIME_SECTION(timer, "Fetch remote file size");
@@ -1929,7 +1929,7 @@ protected:
                     if (partsize != -1)
                     {
                         part->lockProperties();
-                        part->queryProperties().setPropInt64("@size", partsize);
+                        part->queryAttributes().setPropInt64("@size", partsize);
                         part->unlockProperties();
                         break;
                     }
@@ -2453,7 +2453,7 @@ public:
         const char * terminators = NULL;
         if (dFile)
         {
-            IPropertyTree & options = dFile->queryProperties();
+            IPropertyTree & options = dFile->queryAttributes();
             quotes = options.queryProp("@csvQuote");
             separators = options.queryProp("@csvSeparate");
             terminators = options.queryProp("@csvTerminate");
@@ -3028,7 +3028,7 @@ class DistributedKeyLookupHandler : public CInterface, implements IThreadedExcep
 
     void addFile(IDistributedFile &f)
     {
-        if((f.numParts() == 1) || (f.queryProperties().hasProp("@local")))
+        if((f.numParts() == 1) || (f.queryAttributes().hasProp("@local")))
             throw MakeStringException(0, "Superfile %s contained mixed monolithic/local/noroot and regular distributed keys --- not supported", file->queryLogicalName());
         subSizes.append(parts.length());
         unsigned numParts = f.numParts()-1;
@@ -3188,7 +3188,7 @@ public:
 
     void addFile(IDistributedFile &f)
     {
-        if((f.numParts() != 1) && (!f.queryProperties().hasProp("@local")))
+        if((f.numParts() != 1) && (!f.queryAttributes().hasProp("@local")))
             throw MakeStringException(0, "Superfile %s contained mixed monolithic/local/noroot and regular distributed keys --- not supported", file->queryLogicalName());
         keyFiles.append(OLINK(f));
     }
@@ -3873,7 +3873,7 @@ public:
 
     static bool useMonolithic(IDistributedFile & f)
     {
-        return ((f.numParts() == 1) || (f.queryProperties().hasProp("@local")));
+        return ((f.numParts() == 1) || (f.queryAttributes().hasProp("@local")));
     }
 
     virtual void start()

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1503,11 +1503,11 @@ void CWsDfuEx::getDefFile(IUserDescriptor* udesc, const char* FileName,StringBuf
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(FileName, udesc);
     if(!df)
         throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",FileName);
-    if(!df->queryProperties().hasProp("ECL"))
+    if(!df->queryAttributes().hasProp("ECL"))
         throw MakeStringException(ECLWATCH_MISSING_PARAMS,"No record definition for file %s.",FileName);
 
     StringBuffer text;
-    text.append(df->queryProperties().queryProp("ECL"));
+    text.append(df->queryAttributes().queryProp("ECL"));
     
     MultiErrorReceiver errs;
     OwnedHqlExpr record = parseQuery(text.str(), &errs);
@@ -1541,7 +1541,7 @@ bool CWsDfuEx::checkFileContent(IEspContext &context, IUserDescriptor* udesc, co
     if (!cluster || !stricmp(cluster, ""))
     {
         char *eclCluster = NULL;
-        const char* wuid = df->queryProperties().queryProp("@workunit");
+        const char* wuid = df->queryAttributes().queryProp("@workunit");
         if (wuid && *wuid)
         {
             try
@@ -1571,7 +1571,7 @@ bool CWsDfuEx::checkFileContent(IEspContext &context, IUserDescriptor* udesc, co
     if (df->isCompressed(&blocked) && !blocked)
         return false;
 
-    IPropertyTree & properties = df->queryProperties();
+    IPropertyTree & properties = df->queryAttributes();
     const char * format = properties.queryProp("@format");
     if (format && (stricmp(format,"csv")==0 || memicmp(format, "utf", 3) == 0))
     {
@@ -1710,7 +1710,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
             throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",name);
     }
 
-    offset_t size=queryDistributedFileSystem().getSize(df), recordSize=df->queryProperties().getPropInt64("@recordSize",0);
+    offset_t size=queryDistributedFileSystem().getSize(df), recordSize=df->queryAttributes().getPropInt64("@recordSize",0);
 
     CDateTime dt;
     df->getModificationTime(dt);
@@ -1720,11 +1720,11 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     FileDetails.setDir(df->queryDefaultDir());
     FileDetails.setPathMask(df->queryPartMask());
 
-    StringBuffer strDesc = df->queryProperties().queryProp("@description");
+    StringBuffer strDesc = df->queryAttributes().queryProp("@description");
     if (description)
     {
         df->lockProperties();
-        df->queryProperties().setProp("@description",description);
+        df->queryAttributes().setProp("@description",description);
         df->unlockProperties();
         strDesc = description;
     }
@@ -1747,9 +1747,9 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     FileDetails.setRecordSize(tmpstr.str());
 
     tmpstr.clear();
-    if (df->queryProperties().hasProp("@recordCount"))
+    if (df->queryAttributes().hasProp("@recordCount"))
     {
-        comma c3(df->queryProperties().getPropInt64("@recordCount"));
+        comma c3(df->queryAttributes().getPropInt64("@recordCount"));
         tmpstr<<c3;
     }
     else if (recordSize)
@@ -1759,8 +1759,8 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     }
     FileDetails.setRecordCount(tmpstr.str());
 
-    FileDetails.setOwner(df->queryProperties().queryProp("@owner"));
-    FileDetails.setJobName(df->queryProperties().queryProp("@job"));
+    FileDetails.setOwner(df->queryAttributes().queryProp("@owner"));
+    FileDetails.setJobName(df->queryAttributes().queryProp("@job"));
 
     //#14280
     IDistributedSuperFile *sf = df->querySuperFile();
@@ -1785,7 +1785,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     }
     //#14280
 
-    FileDetails.setWuid(df->queryProperties().queryProp("@workunit"));
+    FileDetails.setWuid(df->queryAttributes().queryProp("@workunit"));
 
     //#17430
     {
@@ -1812,22 +1812,22 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
    //new (optional) attribute on a logical file (@persistent) 
    //indicates the ESP page that shows the details of a file.  It indicates 
    //whether the file was created with a PERSIST() ecl attribute.
-    FileDetails.setPersistent(df->queryProperties().queryProp("@persistent"));
+    FileDetails.setPersistent(df->queryAttributes().queryProp("@persistent"));
 
    //@format - what format the file is (if not fixed with)
-    FileDetails.setFormat(df->queryProperties().queryProp("@format"));
+    FileDetails.setFormat(df->queryAttributes().queryProp("@format"));
 
    //@maxRecordSize - what the maximum length of records is
-    FileDetails.setMaxRecordSize(df->queryProperties().queryProp("@maxRecordSize"));
+    FileDetails.setMaxRecordSize(df->queryAttributes().queryProp("@maxRecordSize"));
 
    //@csvSeparate - separators between fields for a CSV/utf file
-    FileDetails.setCsvSeparate(df->queryProperties().queryProp("@csvSeparate"));
+    FileDetails.setCsvSeparate(df->queryAttributes().queryProp("@csvSeparate"));
 
    //@csvQuote - character used to quote fields for a csv/utf file.
-    FileDetails.setCsvQuote(df->queryProperties().queryProp("@csvQuote"));
+    FileDetails.setCsvQuote(df->queryAttributes().queryProp("@csvQuote"));
 
    //@csvTerminate - characters used to terminate a record in a csv.utf file
-    FileDetails.setCsvTerminate(df->queryProperties().queryProp("@csvTerminate"));
+    FileDetails.setCsvTerminate(df->queryAttributes().queryProp("@csvTerminate"));
 
   
     //Time and date of the file
@@ -1837,8 +1837,8 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     dt.getTimeString(tmpstr);
     FileDetails.setModified(tmpstr.str());
 
-    if(df->queryProperties().hasProp("ECL"))
-        FileDetails.setEcl(df->queryProperties().queryProp("ECL"));
+    if(df->queryAttributes().hasProp("ECL"))
+        FileDetails.setEcl(df->queryAttributes().queryProp("ECL"));
 
     StringBuffer clusterStr;
     if ((!cluster || !*cluster) && clusters.ordinality())
@@ -1945,7 +1945,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
 
     if (version > 1.06)
     {
-        const char *wuid = df->queryProperties().queryProp("@workunit");
+        const char *wuid = df->queryAttributes().queryProp("@workunit");
         if (wuid && *wuid && (wuid[0]=='W'))
         {
             try
@@ -4106,7 +4106,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
             Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalNameStr.str(), userdesc);
             if(df)
             {
-                const char* wuid = df->queryProperties().queryProp("@workunit");
+                const char* wuid = df->queryAttributes().queryProp("@workunit");
                 if (wuid && *wuid)
                 {
                     CWUWrapper wu(wuid, context);
@@ -5115,7 +5115,7 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
                 }
             }
 
-            const char* wuid = df->queryProperties().queryProp("@workunit");
+            const char* wuid = df->queryAttributes().queryProp("@workunit");
             if (wuid && *wuid)
             {
                 CWUWrapper wu(wuid, context);

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1723,9 +1723,8 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     StringBuffer strDesc = df->queryAttributes().queryProp("@description");
     if (description)
     {
-        df->lockProperties();
-        df->queryAttributes().setProp("@description",description);
-        df->unlockProperties();
+        DistributedFilePropertyLock lock(df);
+        lock.queryAttributes().setProp("@description",description);
         strDesc = description;
     }
 

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1723,7 +1723,8 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     StringBuffer strDesc = df->queryProperties().queryProp("@description");
     if (description)
     {
-        df->lockProperties().setProp("@description",description); 
+        df->lockProperties();
+        df->queryProperties().setProp("@description",description);
         df->unlockProperties();
         strDesc = description;
     }

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -141,7 +141,7 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
                                 throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Could not find file %s.",sourceLogicalFile.str());
                             }
             
-                            const char *kind = df->queryProperties().queryProp("@kind");
+                            const char *kind = df->queryAttributes().queryProp("@kind");
                             if (kind && strcmp(kind,"key")==0)
                             {
                                 params->setProp("@compressflag", 0);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2578,7 +2578,7 @@ bool CFileSprayEx::onRename(IEspContext &context, IEspRename &req, IEspRenameRes
                 }
                 else
                 {
-                    const char *cluster = df->queryProperties().queryProp("@group");
+                    const char *cluster = df->queryAttributes().queryProp("@group");
                     if (cluster && *cluster)
                     {
                         wu->setClusterName(cluster);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -139,7 +139,7 @@ StringBuffer &getWuidFromLogicalFileName(IEspContext &context, const char *logic
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalName, userdesc);
     if (!df)
         throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",logicalName);
-    return wuid.append(df->queryProperties().queryProp("@workunit"));
+    return wuid.append(df->queryAttributes().queryProp("@workunit"));
 }
 
 void formatDuration(StringBuffer &s, unsigned ms)
@@ -1016,7 +1016,7 @@ bool shouldFileContentBeShown(IEspContext &context, const char * logicalName)
     if (df->isCompressed(&blocked) && !blocked)
         return false;
 
-    IPropertyTree & properties = df->queryProperties();
+    IPropertyTree & properties = df->queryAttributes();
     const char * format = properties.queryProp("@format");
     if (format && (stricmp(format,"csv")==0 || memicmp(format, "utf", 3) == 0))
     {
@@ -1201,7 +1201,7 @@ void WsWuInfo::getResult(IConstWUResult &r, IArrayOf<IEspECLResult>& results, un
                 userdesc->set(username.str(), context.queryPassword());
 
                 Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(filename.str(), userdesc);
-                if(df && df->queryProperties().hasProp("ECL"))
+                if(df && df->queryAttributes().hasProp("ECL"))
                     link.append(r.getResultSequence());
             }
             else

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1440,7 +1440,7 @@ FILESERVICES_API void FILESERVICES_CALL fsSetFileDescription(ICodeContext *ctx, 
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(lfn.str(),udesc);
     if (df) {
         df->lockProperties();
-        df->queryProperties().setProp("@description",value);
+        df->queryAttributes().setProp("@description",value);
         df->unlockProperties();
     }
     else
@@ -1456,7 +1456,7 @@ FILESERVICES_API char *  FILESERVICES_CALL fsGetFileDescription(ICodeContext *ct
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(lfn.str(),udesc);
     if (!df)
         throw MakeStringException(0, "GetFileDescription: Could not locate file %s", lfn.str());
-    const char * ret = df->queryProperties().queryProp("@description");
+    const char * ret = df->queryAttributes().queryProp("@description");
     if (ret)
         return CTXSTRDUP(parentCtx, ret);
     else
@@ -2070,7 +2070,7 @@ FILESERVICES_API char * FILESERVICES_CALL fsfGetLogicalFileAttribute(ICodeContex
             dt.getString(ret);
         }
         else if (strcmp(attrname,"protected")==0) {
-            IPropertyTree &attr = df->queryProperties();
+            IPropertyTree &attr = df->queryAttributes();
             Owned<IPropertyTreeIterator> piter = attr.getElements("Protect");
             ForEach(*piter) {
                 const char *name = piter->get().queryProp("@name");
@@ -2087,7 +2087,7 @@ FILESERVICES_API char * FILESERVICES_CALL fsfGetLogicalFileAttribute(ICodeContex
         else {
             StringBuffer xpath("@");
             xpath.append(attrname);
-            IPropertyTree &attr = df->queryProperties();
+            IPropertyTree &attr = df->queryAttributes();
             attr.getProp(xpath.str(),ret);
         }
     }

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1439,7 +1439,8 @@ FILESERVICES_API void FILESERVICES_CALL fsSetFileDescription(ICodeContext *ctx, 
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(lfn.str(),udesc);
     if (df) {
-        df->lockProperties().setProp("@description",value);
+        df->lockProperties();
+        df->queryProperties().setProp("@description",value);
         df->unlockProperties();
     }
     else

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1439,9 +1439,8 @@ FILESERVICES_API void FILESERVICES_CALL fsSetFileDescription(ICodeContext *ctx, 
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(lfn.str(),udesc);
     if (df) {
-        df->lockProperties();
-        df->queryAttributes().setProp("@description",value);
-        df->unlockProperties();
+        DistributedFilePropertyLock lock(df);
+        lock.queryAttributes().setProp("@description",value);
     }
     else
         throw MakeStringException(0, "SetFileDescription: Could not locate file %s", lfn.str());

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1861,7 +1861,7 @@ public:
                 addFile(dFile->queryLogicalName(), dFile->getFileDescriptor());
             bool tsSet = dFile->getModificationTime(fileTimeStamp);
             assertex(tsSet); // per Nigel, is always set
-            properties.set(&dFile->queryProperties());
+            properties.set(&dFile->queryAttributes());
         }
     }
     virtual void beforeDispose()
@@ -2295,7 +2295,7 @@ extern IResolvedFileCreator *createResolvedFile(const char *lfn)
 
 extern IResolvedFile *createResolvedFile(const char *lfn, IDistributedFile *dFile)
 {
-    const char *kind = dFile ? dFile->queryProperties().queryProp("@kind") : NULL;
+    const char *kind = dFile ? dFile->queryAttributes().queryProp("@kind") : NULL;
     return new CResolvedFile(lfn, dFile, kind && stricmp(kind, "key")==0 ? ROXIE_KEY : ROXIE_FILE);
 }
 

--- a/thorlcr/activities/diskread/thdiskread.cpp
+++ b/thorlcr/activities/diskread/thdiskread.cpp
@@ -168,9 +168,9 @@ public:
                 Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), helper->getFileName(), 0 != ((TDXtemporary|TDXjobtemp) & helper->getFlags()), 0 != (TDRoptional & helper->getFlags()));
                 if (file.get() && canMatch)
                 {
-                    if (0 != (TDRunfilteredcount & helper->getFlags()) && file->queryProperties().hasProp("@recordCount"))
+                    if (0 != (TDRunfilteredcount & helper->getFlags()) && file->queryAttributes().hasProp("@recordCount"))
                     {
-                        totalCount = (rowcount_t)file->queryProperties().getPropInt64("@recordCount");
+                        totalCount = (rowcount_t)file->queryAttributes().getPropInt64("@recordCount");
                         if (totalCount > stopAfter)
                             totalCount = stopAfter;
                         totalCountKnown = true;

--- a/thorlcr/activities/diskwrite/thdwslave.cpp
+++ b/thorlcr/activities/diskwrite/thdwslave.cpp
@@ -154,6 +154,6 @@ CActivityBase *createCsvWriteSlave(CGraphElementBase *container)
 #if 0
 void CsvWriteSlaveActivity::setFormat(IFileDescriptor * desc)
 {
-    desc->queryProperties().setProp("@format","csv");
+    desc->queryAttributes().setProp("@format","csv");
 }
 #endif

--- a/thorlcr/activities/fetch/thfetch.cpp
+++ b/thorlcr/activities/fetch/thfetch.cpp
@@ -102,7 +102,7 @@ public:
         if (fetchFile)
         {
             IHThorFetchArg *helper = (IHThorFetchArg *)queryHelper();
-            fetchFile->queryProperties().serialize(dst);
+            fetchFile->queryAttributes().serialize(dst);
         }
     }
 };

--- a/thorlcr/activities/indexread/thindexread.cpp
+++ b/thorlcr/activities/indexread/thindexread.cpp
@@ -98,14 +98,14 @@ protected:
                 unsigned _tlkCrc;
                 if (part->getCrc(_tlkCrc))
                     fileCrc = true;
-                else if (part->queryProperties().hasProp("@crc")) // NB: key "@crc" is not a crc on the file, but data within.
+                else if (part->queryAttributes().hasProp("@crc")) // NB: key "@crc" is not a crc on the file, but data within.
                 {
-                    _tlkCrc = part->queryProperties().getPropInt("@crc");
+                    _tlkCrc = part->queryAttributes().getPropInt("@crc");
                     rowCrc = true;
                 }
-                else if (part->queryProperties().hasProp("@tlkCrc")) // backward compat.
+                else if (part->queryAttributes().hasProp("@tlkCrc")) // backward compat.
                 {
-                    _tlkCrc = part->queryProperties().getPropInt("@tlkCrc");
+                    _tlkCrc = part->queryAttributes().getPropInt("@tlkCrc");
                     rowCrc = true;
                 }
                 else
@@ -196,7 +196,7 @@ public:
         if (index)
         {
             nofilter = 0 != (TIRnofilter & helper->getFlags());
-            if (index->queryProperties().getPropBool("@local"))
+            if (index->queryAttributes().getPropBool("@local"))
                 nofilter = true;
             else
             {

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -118,16 +118,16 @@ public:
             IDistributedFile *f = _f->querySuperFile();
             if (!f) f = _f;
             Owned<IDistributedFilePart> existingTlk = f->getPart(f->numParts()-1);
-            if (!existingTlk->queryProperties().hasProp("@kind") || 0 != stricmp("topLevelKey", existingTlk->queryProperties().queryProp("@kind")))
+            if (!existingTlk->queryAttributes().hasProp("@kind") || 0 != stricmp("topLevelKey", existingTlk->queryAttributes().queryProp("@kind")))
                 throw MakeActivityException(this, 0, "Cannot build new key '%s' based on non-distributed key '%s'", helper->getFileName(), helper->getDistributeIndexName());
             IPartDescriptor *tlkDesc = fileDesc->queryPart(fileDesc->numParts()-1);
             IPropertyTree &props = tlkDesc->queryProperties();
-            if (existingTlk->queryProperties().hasProp("@size"))
-                props.setPropInt64("@size", existingTlk->queryProperties().getPropInt64("@size"));
-            if (existingTlk->queryProperties().hasProp("@fileCrc"))
-                props.setPropInt64("@fileCrc", existingTlk->queryProperties().getPropInt64("@fileCrc"));
-            if (existingTlk->queryProperties().hasProp("@modified"))
-                props.setProp("@modified", existingTlk->queryProperties().queryProp("@modified"));
+            if (existingTlk->queryAttributes().hasProp("@size"))
+                props.setPropInt64("@size", existingTlk->queryAttributes().getPropInt64("@size"));
+            if (existingTlk->queryAttributes().hasProp("@fileCrc"))
+                props.setPropInt64("@fileCrc", existingTlk->queryAttributes().getPropInt64("@fileCrc"));
+            if (existingTlk->queryAttributes().hasProp("@modified"))
+                props.setProp("@modified", existingTlk->queryAttributes().queryProp("@modified"));
         }
         
         StringBuffer datasetName;
@@ -147,7 +147,7 @@ public:
 
             Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(datasetName.str(), container.queryJob().queryUserDescriptor());
             if (df)
-                fileSize = df->queryProperties().getPropInt64("@size", 0);
+                fileSize = df->queryAttributes().getPropInt64("@size", 0);
         }
 
         // Fill in some logical file properties here

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -181,7 +181,8 @@ public:
             e->Release();
         }
         // Add a new 'Patch' description to the secondary key.
-        IPropertyTree &fileProps = newIndexFile->lockProperties();
+        newIndexFile->lockProperties();
+        IPropertyTree &fileProps = newIndexFile->queryProperties();
         StringBuffer path("Patch[@name=\"");
         path.append(scopedName.str()).append("\"]");
         IPropertyTree *patch = fileProps.queryPropTree(path.str());

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -181,8 +181,8 @@ public:
             e->Release();
         }
         // Add a new 'Patch' description to the secondary key.
-        newIndexFile->lockProperties();
-        IPropertyTree &fileProps = newIndexFile->queryAttributes();
+        DistributedFilePropertyLock lock(newIndexFile);
+        IPropertyTree &fileProps = lock.queryAttributes();
         StringBuffer path("Patch[@name=\"");
         path.append(scopedName.str()).append("\"]");
         IPropertyTree *patch = fileProps.queryPropTree(path.str());
@@ -196,8 +196,6 @@ public:
         index->setProp("@name", originalIndexFile->queryLogicalName());
         if (originalIndexFile->getFileCheckSum(checkSum))
             index->setPropInt64("@checkSum", checkSum);
-
-        newIndexFile->unlockProperties();
     }
     void preStart(size32_t parentExtractSz, const byte *parentExtract)
     {

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -173,7 +173,7 @@ public:
             if (patchFile) {
                 __int64 fs = patchFile->getFileSize(true,false);
                 if (fs!=-1)
-                    patchFile->queryProperties().setPropInt64("@size",fs);
+                    patchFile->queryAttributes().setPropInt64("@size",fs);
             }
         }
         catch (IException *e) {
@@ -182,7 +182,7 @@ public:
         }
         // Add a new 'Patch' description to the secondary key.
         newIndexFile->lockProperties();
-        IPropertyTree &fileProps = newIndexFile->queryProperties();
+        IPropertyTree &fileProps = newIndexFile->queryAttributes();
         StringBuffer path("Patch[@name=\"");
         path.append(scopedName.str()).append("\"]");
         IPropertyTree *patch = fileProps.queryPropTree(path.str());

--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -89,7 +89,7 @@ public:
         if (indexFile)
         {
             unsigned numParts = 0;
-            localKey = indexFile->queryProperties().getPropBool("@local");
+            localKey = indexFile->queryAttributes().getPropBool("@local");
             checkFormatCrc(this, indexFile, helper->getIndexFormatCrc(), true);
             Owned<IFileDescriptor> indexFileDesc = indexFile->getFileDescriptor();
             IDistributedSuperFile *superIndex = indexFile->querySuperFile();
@@ -106,7 +106,7 @@ public:
                     IDistributedFile &f = iter->query();
                     unsigned np = f.numParts()-1;
                     IDistributedFilePart &part = f.queryPart(np);
-                    const char *kind = part.queryProperties().queryProp("@kind");
+                    const char *kind = part.queryAttributes().queryProp("@kind");
                     bool hasTlk = NULL != kind && 0 == stricmp("topLevelKey", kind); // if last part not tlk, then deemed local (might be singlePartKey)
                     if (first)
                     {
@@ -134,7 +134,7 @@ public:
                 numParts = indexFile->numParts();
                 if (numParts)
                 {
-                    const char *kind = indexFile->queryPart(indexFile->numParts()-1).queryProperties().queryProp("@kind");
+                    const char *kind = indexFile->queryPart(indexFile->numParts()-1).queryAttributes().queryProp("@kind");
                     keyHasTlk = NULL != kind && 0 == stricmp("topLevelKey", kind);
                     if (keyHasTlk)
                         --numParts;

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -491,7 +491,7 @@ bool CMasterGraphElement::checkUpdate()
         Owned<IDistributedFile> file = queryThorFileManager().lookup(queryJob(), filename, temporary, true);
         if (file)
         {
-            IPropertyTree &props = file->queryProperties();
+            IPropertyTree &props = file->queryAttributes();
             if ((eclCRC == props.getPropInt("@eclCRC")) && (totalCRC == props.getPropInt64("@totalCRC")))
             {
                 // so this needs pruning
@@ -1102,7 +1102,7 @@ public:
             else
             {
                 StringBuffer modifiedStr;
-                if (iDfsFile->queryProperties().getProp("@modified", modifiedStr))
+                if (iDfsFile->queryAttributes().getProp("@modified", modifiedStr))
                     hash = rtlHash64Data(modifiedStr.length(), modifiedStr.str(), hash);
                 // JCS->GH - what's the best thing to do here, if [for some reason] neither are available..
             }

--- a/thorlcr/master/thactivitymaster.cpp
+++ b/thorlcr/master/thactivitymaster.cpp
@@ -585,10 +585,10 @@ WUFileKind getDiskOutputKind(unsigned flags)
 
 void checkSuperFileOwnership(IDistributedFile &file)
 {
-    if (file.queryProperties().hasProp("SuperOwner"))
+    if (file.queryAttributes().hasProp("SuperOwner"))
     {
         StringBuffer owners;
-        Owned<IPropertyTreeIterator> iter = file.queryProperties().getElements("SuperOwner");
+        Owned<IPropertyTreeIterator> iter = file.queryAttributes().getElements("SuperOwner");
         if (iter->first())
         {
             loop
@@ -625,7 +625,7 @@ void checkFormatCrc(CActivityBase *activity, IDistributedFile *file, unsigned he
             else fileStr.append("File: ");
             fileStr.append(f->queryLogicalName());
             Owned<IThorException> e = MakeActivityException(activity, TE_FormatCrcMismatch, "%s: Layout does not match published layout. %s", kindStr.str(), fileStr.str());
-            if (index && !f->queryProperties().hasProp("_record_layout")) // Cannot verify if _true_ crc mismatch if soft layout missing anymore
+            if (index && !f->queryAttributes().hasProp("_record_layout")) // Cannot verify if _true_ crc mismatch if soft layout missing anymore
                 LOG(MCwarning, thorJob, e);
             else
             {

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -546,14 +546,14 @@ public:
             {
                 StringBuffer modTimeStr;
                 modTime.getString(modTimeStr);
-                file->queryProperties().setProp("@accessed", modTimeStr.str());
+                file->queryAttributes().setProp("@accessed", modTimeStr.str());
             }
         }
         if (publishedFile)
             publishedFile->set(file);
         __int64 fs = file->getFileSize(false,false);
         if (fs!=-1)
-            file->queryProperties().setPropInt64("@size",fs);
+            file->queryAttributes().setPropInt64("@size",fs);
         file->attach(scopedName.str(), NULL, job.queryUserDescriptor());
         unsigned c=0;
         for (; c<fileDesc.numClusters(); c++)
@@ -591,7 +591,7 @@ public:
         if (partno >= file->numParts())
             throw MakeThorException(TE_NoSuchPartForLogicalFile , "No such part number (%d) for logical file : %s", partno, scopedName.str());
         Owned<IDistributedFilePart> part = file->getPart(partno);
-        return part->queryProperties().getPropInt64("@offset");;
+        return part->queryAttributes().getPropInt64("@offset");;
     }
 
     void updateAccessTime(CJobBase &job, const char *logicalName)


### PR DESCRIPTION
This is a huge refactor of the property locking mechanism. The basic rationale is to simplify considerably the way locks are set/released so transactions, exception handling and lock context are clear and code is simple.

The main changes with this series of patches:
- Create `DistributedFilePropertyLock` object, that serves as a context-locking, avoiding multiple unlocks and complex exception handling. This object will lock on construction, unlock on destruction and keep the lock's state (reload, attrs) while alive. This object is in the header, since other systems are required to create them locally (no pointers to interfaces, or destruction won't happen automatically).
- Remove DFiles's `lockTransaction()` and `unlockTransaction`, since they were too similar to their property counterparts and added more confusion than solutions. CDFTransaction is now using properties directly.
- Rename DFile's `queryProperties()` to `queryAttributes()`, since that's what's being returned.
- `unlockProperties()` is now accepting the recently promoted global `DFTransactionState`, which removes the previous dichotomy when you could commit AND rollback at the same time.

There are still work to do, but this pull request shall make them **much** easier:
- Create `DistributedPartPropertyLock` (for file parts) or make part's lock/unlock use DFPL, whatever makes more sense.
- Finish replacement of all lock/unlock semantics to use DFPL, notably on:
  - SuperFile's `doSwapSuperFile`, that locks subfiles in different context blocks
  - SDSFix's `fixCompSize()`, that locks/unlocks across different iterations of the loop
- If possible/desirable, omit lock/unlock properties on IDFile's interface, and force the use of DFPL everywhere
- Use this simplified mechanism on SuperFile's sub-file actions:
  - Remove CWrappedTransaction from deletion, and implement `autocommit` on it
  - Implement `autocommit` on sub-file addition, moving remaining code to `doAddSubfile`
  - Implement `swapSubfiles` as sequence of add/removes
- Finally, implement `promoteSuperFiles` as a sequence of swaps within a transaction
