### PR TITLE
Fix regression from splitter-progress-fix

### DIFF
--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -231,7 +231,10 @@ class NSplitterSlaveActivity : public CSlaveActivity
         virtual void getMetaInfo(ThorDataLinkMetaInfo &info)
         {
             initMetaInfo(info);
-            input->getMetaInfo(info);
+            if (input)
+                input->getMetaInfo(info);
+            else
+                activity.inputs.item(0)->getMetaInfo(info);
         }
     };
 public:


### PR DESCRIPTION
Guard against getMetaInfo being called early in splitter.
Join for one does, probably it shouldn't.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
