### PR TITLE
Fix problem with missing toplevelkey indicator

### DIFF
--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -114,6 +114,7 @@ private:
 public:
     RemoteFilename          filename;
     RemoteFilename          mirrorFilename;
+    Linked<IPropertyTree>   properties;
     offset_t                offset;
     offset_t                size;               // expanded size
     offset_t                psize;              // physical (compressed) size


### PR DESCRIPTION
A dfu copy of an index from a remote dali would lost the indicator that
the last file part was the top level key, because the source is not a
distributed file.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
