### PR TITLE
Report problems with invalid use of ROW(dataset)

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -3506,9 +3506,6 @@ switch (op)
     case no_lt:
         assertex(type->getTypeCode() == type_boolean);
         break;
-    case no_alias:
-        assertex(queryChild(0)->getOperator() != no_alias);
-        break;
     case no_funcdef:
         {
             assertex(type->getTypeCode() == type_function && queryChild(1) && queryChild(1)->getOperator() == no_sortlist);

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -2182,11 +2182,7 @@ void ActivityInstance::createGraphNode(IPropertyTree * defaultSubGraph, bool alw
     if (graphEclText.length() == 0)
         toECL(dataset->queryBody(), graphEclText, false, true);
 
-    if (graphEclText.length() > MAX_GRAPH_ECL_LENGTH)
-    {
-        graphEclText.setLength(MAX_GRAPH_ECL_LENGTH);
-        graphEclText.append("...");
-    }
+    elideString(graphEclText, MAX_GRAPH_ECL_LENGTH);
     if (strcmp(graphEclText.str(), "<>") != 0)
         addAttribute("ecl", graphEclText.str());
 
@@ -15815,11 +15811,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCreateRow(BuildCtx & ctx, IHql
     if (valueText.length())
     {
         StringBuffer graphLabel;
-        if (valueText.length() > MAX_ROW_VALUE_TEXT_LEN)
-        {
-            valueText.setLength(MAX_ROW_VALUE_TEXT_LEN);
-            valueText.append("...");
-        }
+        elideString(valueText, MAX_ROW_VALUE_TEXT_LEN);
         graphLabel.append(getActivityText(instance->kind)).append("\n{").append(valueText).append("}");
         instance->graphLabel.set(graphLabel.str());
     }

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -954,6 +954,7 @@ public:
 protected:
     void beginTableScope();
     void endTableScope(HqlExprArray & attrs, IHqlExpression * ds, IHqlExpression * newExpr);
+    void checkActiveRow(IHqlExpression * expr);
     IHqlExpression * transformSelect(IHqlExpression * expr);
 
     IHqlExpression * transformAmbiguous(IHqlExpression * expr, bool isActiveOk);

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -2092,3 +2092,13 @@ size32_t memcount(size32_t len, const char * str, char search)
     }
     return count;
 }
+
+StringBuffer & elideString(StringBuffer & s, unsigned maxLength)
+{
+    if (s.length() > maxLength)
+    {
+        s.setLength(maxLength);
+        s.append("...");
+    }
+    return s;
+}

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -377,6 +377,7 @@ extern jlib_decl bool clipStrToBool(size_t len, const char * text);
 extern jlib_decl bool clipStrToBool(const char * text);
 extern jlib_decl StringBuffer & ncnameEscape(char const * in, StringBuffer & out);
 extern jlib_decl StringBuffer & ncnameUnescape(char const * in, StringBuffer & out);
+extern jlib_decl StringBuffer & elideString(StringBuffer & s, unsigned maxLength);
 
 extern jlib_decl bool startsWith(const char* src, const char* dst);
 extern jlib_decl bool endsWith(const char* src, const char* dst);


### PR DESCRIPTION
- The argument to ROW(dataset) didn't check the dataset really was
  active.
- Without catching this error you may get strange internal errors which
  are hard to debug.
- The alias check could fail with some unusual user code using
  undocumented features.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
