### PR TITLE
Fix gh-622 don't force defaultCopies

### DIFF
--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -2132,7 +2132,7 @@ IFileDescriptor *createFileDescriptor(const char *lname,IGroup *grp,IPropertyTre
         res->setPart(i,rfn,NULL);
     }
     ClusterPartDiskMapSpec map; // use defaults
-    map.defaultCopies = 1;
+//    map.defaultCopies = 1; // WARN: removed due to gh-622
     res->endCluster(map);
     return res;
 }


### PR DESCRIPTION
I don't know why it was forcing `defaultCopies` to 1, since it's initialized as 2 irrespective of where the file comes from. There is no comment, nor explanation, and since all regressions pass (and bug #622 is fixed), I'm tempted to leave it commented out with a note.
