### PR TITLE
Fix problem submitting macros as queries.

### DIFF
--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -415,6 +415,7 @@
 #define HQLERR_CannotSubmitFunction 2385
 #define HQLERR_CannotSubmitModule   2386
 #define ERR_COUNTER_NOT_COUNT       2387
+#define HQLERR_CannotSubmitMacroX   2385
 
 #define ERR_ASSERTION_FAILS         100000
 

--- a/ecl/regress/macro12.eclxml
+++ b/ecl/regress/macro12.eclxml
@@ -1,0 +1,27 @@
+<Archive>
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+ <Module name="myModule">
+  <Attribute name="myAttr">
+      EXPORT myAttr := MACRO
+      'Hello world'
+      ENDMACRO;
+    </Attribute>
+  </Module>
+ <Query attributePath="myModule.myAttr"/>
+</Archive>

--- a/ecl/regress/macro13.eclxml
+++ b/ecl/regress/macro13.eclxml
@@ -1,0 +1,27 @@
+<Archive>
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+ <Module name="myModule">
+  <Attribute name="myAttr">
+      EXPORT myAttr() := MACRO
+      'Hello world'
+      ENDMACRO;
+    </Attribute>
+  </Module>
+ <Query attributePath="myModule.myAttr"/>
+</Archive>

--- a/ecl/regress/macro14.eclxml
+++ b/ecl/regress/macro14.eclxml
@@ -1,0 +1,28 @@
+<Archive>
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+ <Module name="myModule">
+  <Attribute name="myAttr">
+      //MACRO with parameters - even if the values are defaulted is not currently supported
+      EXPORT myAttr(name = 'unknown') := MACRO
+      'Hello world' + #TEXT(name)
+      ENDMACRO;
+    </Attribute>
+  </Module>
+ <Query attributePath="myModule.myAttr"/>
+</Archive>

--- a/ecl/regress/macro15.eclxml
+++ b/ecl/regress/macro15.eclxml
@@ -1,0 +1,30 @@
+<Archive>
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+ <Module name="myModule">
+  <Attribute name="myAttr">
+  EXPORT myAttr() := MACRO
+      hello := 'hello';
+      sp := ' ';
+      world := 'world';
+      hello + sp + world
+  ENDMACRO;
+    </Attribute>
+  </Module>
+ <Query attributePath="myModule.myAttr"/>
+</Archive>

--- a/ecl/regress/macro16.eclxml
+++ b/ecl/regress/macro16.eclxml
@@ -1,0 +1,36 @@
+<Archive legacyMode="1">
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+ <Module name="myModule">
+  <Attribute name="myAttr">
+  EXPORT myAttr() := MACRO
+      hello := 'hello';
+      sp := ' ';
+      world := 'world';
+      //Check that legacy mode means that modules are imported by default.
+      hello + sp + otherModule.myAttr
+  ENDMACRO;
+    </Attribute>
+  </Module>
+    <Module name="otherModule">
+        <Attribute name="myAttr">
+            EXPORT myAttr := 'world';
+        </Attribute>
+    </Module>
+    <Query attributePath="myModule.myAttr"/>
+</Archive>

--- a/ecl/regress/macro17.eclxml
+++ b/ecl/regress/macro17.eclxml
@@ -1,0 +1,36 @@
+<Archive legacyMode="1">
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+ <Module name="myModule">
+  <Attribute name="myAttr">
+  EXPORT myAttr() := MACRO
+      hello := 'hello';
+      sp := ' ';
+      world := 'world';
+      //Check that legacy mode means that modules are imported by default.
+      hello + sp + otherModule.myAttr;
+  ENDMACRO;
+    </Attribute>
+  </Module>
+    <Module name="otherModule">
+        <Attribute name="myAttr">
+            EXPORT myAttr := 'world';
+        </Attribute>
+    </Module>
+    <Query attributePath="myModule.myAttr"/>
+</Archive>


### PR DESCRIPTION
- Previously it was only supported in legacy mode.  There isn't a good
  reason for that restriction.
- Simple macros and macros that didn't end in ';' might have had problems

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
