### PR TITLE
Protect against mismatched master and slave builds

### DIFF
--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -448,6 +448,7 @@ int main( int argc, char *argv[]  )
         Owned<IFile> iFile = createIFile("thor.xml");
         globals = iFile->exists() ? createPTree(*iFile, ipt_caseInsensitive) : createPTree("Thor", ipt_caseInsensitive);
     }
+    globals->setProp("@masterBuildTag", BUILD_TAG);
     char **pp = argv+1;
     while (*pp)
         loadCmdProp(globals, *pp++);

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -123,6 +123,18 @@ static bool RegisterSelf(SocketEndpoint &masterEp)
         globals->Release();
         globals = createPTree(msg);
         mergeCmdParams(globals); // cmd line 
+
+        const char *_masterBuildTag = globals->queryProp("@masterBuildTag");
+        const char *masterBuildTag = _masterBuildTag?_masterBuildTag:"no build tag";
+        PROGLOG("Master build: %s", masterBuildTag);
+#ifndef _DEBUG
+        if (!_masterBuildTag || 0 != strcmp(BUILD_TAG, _masterBuildTag))
+        {
+            StringBuffer errStr("Thor master/slave build mismatch, master = ");
+            replyError(errStr.append(masterBuildTag).append(", slave = ").append(BUILD_TAG).str());
+            return false;
+        }
+#endif
         msg.read((unsigned &)masterSlaveMpTag);
         msg.clear();
         msg.setReplyTag(MPTAG_THORREGISTRATION);


### PR DESCRIPTION
Compare the build tag of the master with the slaves and error if mismatch.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
