### PR TITLE
Fix possible deadlock regression in splitter

### DIFF
--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -235,6 +235,7 @@ class NSplitterSlaveActivity : public CSlaveActivity
                 input->getMetaInfo(info);
             else
                 activity.inputs.item(0)->getMetaInfo(info);
+            info.canStall = !activity.spill;
         }
     };
 public:
@@ -462,7 +463,6 @@ const void *CSplitterOutput::nextRow()
 
 void CSplitterOutput::getMetaInfo(ThorDataLinkMetaInfo &info)
 {
-    info.canStall = !activity.spill;
     CThorDataLink::calcMetaInfoSize(info, activity.inputs.item(0));
 }
 


### PR DESCRIPTION
canStall was being set too late, if an puller asked early, before
splitter was started, canStall was left unset, causing it to use
an non-spilling variety of lookahead further up the chain

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
