### PR TITLE
Fix possible deadlock regression in splitter

### DIFF
--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -219,7 +219,11 @@ protected: friend class SplitterOutput;
             input->start();
         }
         virtual bool isGrouped() { return activity.inputs.item(0)->isGrouped(); }
-        virtual void getMetaInfo(ThorDataLinkMetaInfo &info) { activity.inputs.item(0)->getMetaInfo(info); }
+        virtual void getMetaInfo(ThorDataLinkMetaInfo &info)
+        {
+            activity.inputs.item(0)->getMetaInfo(info);
+            info.canStall = !activity.spill;
+        }
     };
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);


### PR DESCRIPTION
canStall was being set too late, if an puller asked early, before
splitter was started, canStall was left unset, causing it to use
an non-spilling variety of lookahead further up the chain

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
