### PR TITLE
gh-1185 start_backupnode not working

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -831,3 +831,12 @@ is_root(){
     fi
 }
 
+is_user(){
+    USER=$1
+    if [ "$(id -u)" != "$(id -u ${USER})" ]; then
+        echo "This operation should be run as ${USER}"
+        exit
+    fi
+}
+
+

--- a/initfiles/componentfiles/thor/start_backupnode.in
+++ b/initfiles/componentfiles/thor/start_backupnode.in
@@ -20,6 +20,7 @@
 
 source  ${INSTALL_DIR}/etc/init.d/hpcc_common
 which_pidof
+set_environmentvars
 
 if [ $# -lt 1 ]; then
     echo usage: $0 thorinstance 
@@ -41,10 +42,20 @@ if [ -z "$PATH_PRE" ]; then
     PATH_PRE=`cat ${CONFIG_DIR}/environment.conf | sed -n "/\[DEFAULT\]/,/\[/p" | grep "^path=" | sed -e 's/^path=//'`/sbin/hpcc_setenv
 fi
 source ${PATH_PRE} ""
+is_user ${user}
 DEPLOY_DIR=${INSTALL_DIR}/bin
 ENVPATH=${CONFIG_DIR}/${ENV_XML_FILE}
 RUN_DIR=`cat ${HPCC_CONFIG} | sed -n "/\[DEFAULT\]/,/\[/p" | grep "^runtime=" | sed -e 's/^runtime=//'`
 INSTANCE_DIR=$RUN_DIR/$1
+
+if [ ! -e $INSTANCE_DIR ] ; then
+  # perhaps they gave a full path? 
+  if [ ! -e $1 ] ; then
+    echo Usage: $0 thor_cluster_name
+    exit 1
+  fi
+  INSTANCE_DIR=$1
+fi
 
 cd $INSTANCE_DIR
 
@@ -58,9 +69,6 @@ if [ ! -r $INSTANCE_DIR/slaves ]; then
     echo cannot read $INSTANCE_DIR/slaves 
     exit 1
 fi
-mkdir -p $BACKUPNODE_DATA
-rm -f $BACKUPNODE_DATA/*.ERR
-rm -f $BACKUPNODE_DATA/*.DAT
 . $INSTANCE_DIR/setvars
 
 BACKUPNODE_DATA=$BACKUPNODE_DATA/last_backup
@@ -70,8 +78,13 @@ else
  BACKUPNODE_REMOTEDATA=//$THORMASTER$BACKUPNODE_DATA
 fi
 
-echo ------------------------------
-echo scanning files from dali ...
+mkdir -p $BACKUPNODE_DATA
+rm -f $BACKUPNODE_DATA/*.ERR
+rm -f $BACKUPNODE_DATA/*.DAT
+
+echo Using backupnode directory $BACKUPNODE_DATA 
+echo Reading slaves file $INSTANCE_DIR/slaves 
+echo Scanning files from dali ...
 
 NODEGROUP=$THORPRIMARY
 if [ -z "$THORPRIMARY" ]; then
@@ -83,13 +96,13 @@ LOGDATE=`date +%m_%d_%Y_%H_%M_%S`
 LOGFILE="$LOGPATH/$LOGDATE".log
 mkdir -p `dirname $LOGFILE` 
 
-$DEPLOY_DIR/backupnode -O $DALISERVER $NODEGROUP $BACKUPNODE_DATA &>> $LOGFILE
+$DEPLOY_DIR/backupnode -O $DALISERVER $NODEGROUP $BACKUPNODE_DATA 2>&1 >> $LOGFILE
 if [ $? -ne 0 ]; then
   echo Backupnode failed - see $LOGFILE
   exit 1
 fi
 
-frunssh $INSTANCE_DIR/slaves "killall backupnode" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries -b &>> $LOGFILE
+frunssh $INSTANCE_DIR/slaves "killall backupnode" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries -b 2>&1 >> $LOGFILE
 frunssh $INSTANCE_DIR/slaves "/bin/sh -c 'mkdir -p `dirname $LOGPATH/${LOGDATE}_node%n.log`; mkdir -p $INSTANCE_DIR; $DEPLOY_DIR/backupnode -T -X $BACKUPNODE_REMOTEDATA $INSTANCE_DIR/slaves %n $2 > $LOGPATH/${LOGDATE}_node%n.log'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries -b 2>&1 >> $LOGFILE
 
 echo ------------------------------


### PR DESCRIPTION
Various issues with start_backupnode:
1. Poor error messages if full path given rather than cluster name
2. Does not check that it is running as appropriate user
3. Not creating last_backup directory before using it
4. Uses bash syntax that may not be available in all versions

Add better checking for incorrect usage, create the directories that
are needed, and use more standard syntax for stderr redirection.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
