### PR TITLE
Fixes #1441 Rename ConfigMgr esp instance name to create the logfiles in the appropriate directory

### DIFF
--- a/initfiles/etc/DIR_NAME/configmgr/esp.xml.in
+++ b/initfiles/etc/DIR_NAME/configmgr/esp.xml.in
@@ -20,7 +20,7 @@
 
 <Environment>
 <Software>
-<EspProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}" description="ESP server" componentfilesDir="${COMPONENTFILES_PATH}" enableSEHMapping="true" enableSNMP="false" formOptionsAccess="false" httpConfigAccess="true" logDir="${LOG_PATH}/configmgr" logLevel="1" logRequests="false" logResponses="false" maxBacklogQueueSize="200" maxConcurrentThreads="0" name="esp" perfReportDelay="60" computer="localhost" directory="${PID_PATH}/configmgr">
+<EspProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}" description="ESP server" componentfilesDir="${COMPONENTFILES_PATH}" enableSEHMapping="true" enableSNMP="false" formOptionsAccess="false" httpConfigAccess="true" logDir="${LOG_PATH}/configmgr" logLevel="1" logRequests="false" logResponses="false" maxBacklogQueueSize="200" maxConcurrentThreads="0" name="configmgr" perfReportDelay="60" computer="localhost" directory="${PID_PATH}/configmgr">
 <Environment/>
 <EspProtocol name="http" type="http_protocol" plugin="esphttp" maxRequestEntityLength="8000000"/>
 <EspService name="WsDeploy_wsdeploy_esp" type="WsDeploy" plugin="WsDeploy">


### PR DESCRIPTION
Renamed ConfigMgr esp instance name in esp.xml so log files will go into "configmgr" sub-directory under
the standard log directory for hpcc systems.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
