### PR TITLE
Add EclDirect to EclWatch

### DIFF
--- a/esp/eclwatch/ws_XSLT/CMakeLists.txt
+++ b/esp/eclwatch/ws_XSLT/CMakeLists.txt
@@ -100,6 +100,7 @@ FOREACH ( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/roxiequerydetails.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/roxiequerygraph.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/roxiequerygvcgraph.xslt
+    ${CMAKE_CURRENT_SOURCE_DIR}/run_ecl.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/scheduledwus.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/services.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/clusterprocesses.xslt

--- a/esp/eclwatch/ws_XSLT/run_ecl.xslt
+++ b/esp/eclwatch/ws_XSLT/run_ecl.xslt
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="html"/>
+    <xsl:template match="RunEclEx">
+        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+            <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+                <title>Run Ecl form</title>
+                <script language="JavaScript1.2">
+                    <xsl:text disable-output-escaping="yes"><![CDATA[
+                    function hideOption(obj) {
+                        var option_span = document.getElementById("option_span");
+                        if (option_span.style.display=='block'){
+                            option_span.style.display='none';
+                            obj.value='options >>';
+                        } else {
+                            option_span.style.display='block';
+                            obj.value='<< options';
+                        }
+                    }
+                    ]]></xsl:text>
+                </script>
+            </head>
+            <body>
+                <xsl:apply-templates/>
+            </body>
+        </html>
+    </xsl:template>
+
+    <xsl:template match="EclWatchRunEcl">
+        <h4>Submit ECL text for execution:</h4>
+        <form method="POST" action="/EclDirect/RunEclEx">
+            <table cellSpacing="0" cellPadding="0" width="90%" border="0">
+                <tbody>
+                    <tr>
+                        <td valign="top"><b>ECL Text: </b></td>
+                        <td>
+                            <textarea name="eclText" rows="20" cols="80" ></textarea>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><b>Cluster: </b></td>
+                        <td>
+                            <select name="cluster" >
+                                <option value="default" selected="1" >default</option>
+                                <xsl:for-each select="Cluster">
+                                    <option>
+                                        <xsl:value-of select="."/>
+                                    </option>
+                                </xsl:for-each>
+                            </select>
+                        </td>
+                    </tr>
+                    <xsl:if test="UseEclRepository='Yes'">
+                        <tr>
+                            <td>
+                                <b>Repository Label </b>
+                            </td>
+                            <td valign="top" rowspan="2">
+                                <input type="text" name="snapshot"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <b>(Legacy): </b>
+                            </td>
+                        </tr>
+                    </xsl:if>
+                    <tr>
+                        <td>
+                            <b>Output: </b>
+                        </td>
+                        <td>
+                            <select name="outputFormat" >
+                                <option value="TABLE" selected="1">Table</option>
+                                <option value="XML" >XML</option>
+                                <option value="EXTENDEDXML" >Extended XML</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td/>
+                        <td>
+                            <input type="checkbox" name="limitResults" checked="1" value="1"/> Limit Result Count to 100.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td/>
+                        <td>
+                            <input type="submit" value="Submit" name="S1" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </form>
+    </xsl:template>
+
+    <xsl:template match="RunEcl">
+        <p align="center" />
+        <table cellSpacing="0" cellPadding="1" width="90%" bgColor="#4775FF" border="0">
+            <tbody>
+                <tr align="middle" bgColor="#4775FF">
+                    <td height="23">
+                        <p align="left">
+                            <font color="#efefef">
+                                <b><xsl:value-of select="ServiceQName"/> [Version <xsl:value-of select="ClientVersion"/>]</b>
+                            </font>
+                        </p>
+                    </td>
+                </tr>
+                <tr bgColor="#CBE5FF">
+                    <td height="3">
+                        <p align="left">
+                            <b>&gt; <xsl:value-of select="MethodQName"/></b>
+                        </p>
+                    </td>
+                </tr>
+                <tr bgColor="#666666">
+                    <table cellSpacing="0" width="90%" bgColor="#efefef" border="0">
+                        <tbody>
+                            <tr>
+                                <td vAlign="center" align="left">
+                                    <p align="left">
+                                        <br/>Submit ECL text for execution.
+                                    </p>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </tr>
+                <tr bgColor="#666666">
+                    <table cellSpacing="0" width="90%" bgColor="#efefef" border="0">
+                        <tbody>
+                            <tr>
+                                <td vAlign="center" align="left">
+                                    <form method="POST" action="/EclDirect/RunEcl">
+                                        <p align="left">
+                                            <b>ECL Text: </b>
+                                            <br/>
+                                            <textarea name="eclText" rows="20" cols="80" ></textarea>
+                                            <br/>
+                                            <input type='button' value='options >>' onclick="hideOption(this);"/>
+                                            <span id="option_span" style="display:none">
+                                                <br/>
+                                                <b>Cluster: </b><br/>
+                                                <select name="cluster" >
+                                                    <option value="default" selected="1" >default</option>
+                                                    <xsl:for-each select="Cluster">
+                                                        <option>
+                                                            <xsl:value-of select="."/>
+                                                        </option>
+                                                    </xsl:for-each>
+                                                </select>
+                                                <br/>
+                                                <br/>
+                                                <b>Repository Label (Legacy): </b>
+                                                <br/>
+                                                <input type="text" name="snapshot"/>
+                                                <br/>
+                                                <br/>
+                                                <input type="checkbox" name="limitResults" checked="1" value="1"> Limit Result Count to 100.</input>
+                                                <br/>
+                                                <input type="checkbox" name="rawxml_" > Output Xml?</input>
+                                            </span>
+                                            <br/><input type="submit" value="Submit" name="S1" />
+                                        </p>
+                                    </form>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </tr>
+            </tbody>
+        </table>
+    </xsl:template>
+
+    <xsl:template match="*|@*|text()"/>
+</xsl:stylesheet>

--- a/esp/scm/ecldirect.ecm
+++ b/esp/scm/ecldirect.ecm
@@ -32,10 +32,26 @@ ESPresponse [http_encode(0)] RunEclResponse
     EspResultSet results;
 };
 
+ESPrequest RunEclExRequest
+{
+    string eclText;
+    string cluster;
+    string snapshot;
+    boolean limitResults;
+    string outputFormat;
+};
+
+
+ESPresponse [http_encode(0)] RunEclExResponse
+{
+    string results;
+};
+
 
 ESPservice EclDirect
 {
     ESPmethod RunEcl(RunEclRequest, RunEclResponse);
+    ESPmethod RunEclEx(RunEclExRequest, RunEclExResponse);
 };
 
 

--- a/esp/services/ecldirect/CMakeLists.txt
+++ b/esp/services/ecldirect/CMakeLists.txt
@@ -45,6 +45,7 @@ include_directories (
          ./../../../system/include 
          ./../../../common/environment 
          ./../../../common/workunit 
+         ./../../../common/wuwebview
          ./../../clients 
          ./../../../common/fileview2 
          ./../../../dali/base 
@@ -72,6 +73,7 @@ target_link_libraries ( EclDirect
          eclrtl 
          deftype 
          workunit 
+         wuwebview
          jhtree 
          hql 
          fileview2 

--- a/esp/services/ecldirect/EclDirectBinding.hpp
+++ b/esp/services/ecldirect/EclDirectBinding.hpp
@@ -31,6 +31,7 @@ class CEclDirectSoapBindingEx : public CEclDirectSoapBinding
 private:
     StringArray m_clusterNames;
     StringArray m_eclQueueNames;
+    bool        m_useEclRepository;
 
 public:
     CEclDirectSoapBindingEx()
@@ -43,18 +44,23 @@ public:
         initFromEnv();
     }
 
+    virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
+    {
+        IPropertyTree *folder = ensureNavFolder(data, "ECL", "Run Ecl code and review Ecl workunits", NULL, false, 2);
+        ensureNavLink(*folder, "Run Ecl", "/EclDirect/RunEclEx?form_", "Submit ECL text for execution", NULL, NULL, 3);
+    }
+
     int onGetXForm(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method)
     {
         return onGetForm(context, request, response, service, method);
     }
 
+    virtual int onGet(CHttpRequest* request, CHttpResponse* response);
+
     void initFromEnv();
 
     int onGetForm(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *serv, const char *method);
 
-    int getMethodHtmlForm(IEspContext &context, CHttpRequest* request, const char *serv, const char *method, StringBuffer &form, bool bIncludeFormTag);
-
-    virtual int getMethodDescription(IEspContext &context, const char *serv, const char *method, StringBuffer &page);
     virtual int getMethodHelp(IEspContext &context, const char *serv, const char *method, StringBuffer &page);
 
     //overide the default behavior when the basic service method url is accessed (http://host:port/EclDirect/RunEcl)

--- a/esp/services/ecldirect/EclDirectService.hpp
+++ b/esp/services/ecldirect/EclDirectService.hpp
@@ -37,6 +37,7 @@ public:
     virtual void init(IPropertyTree *cfg, const char *process, const char *service);
 
     bool onRunEcl(IEspContext &context, IEspRunEclRequest &req, IEspRunEclResponse &resp);
+    bool onRunEclEx(IEspContext &context, IEspRunEclExRequest &req, IEspRunEclExResponse &resp);
 };
 
 #endif //_ESPWIZ_EclDirect_HPP__

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -120,9 +120,9 @@ public:
     {
         if (!batchWatchFeaturesOnly)
         {
-            IPropertyTree *folder = ensureNavFolder(data, "ECL Workunits", "ECL Workunits", NULL, false, 2);
-            ensureNavLink(*folder, "Search", "/WsWorkunits/WUQuery?form_", "Search Workunits", NULL, NULL, 1);
-            ensureNavLink(*folder, "Browse", "/WsWorkunits/WUQuery", "Browse Workunits", NULL, NULL, 2);
+            IPropertyTree *folder = ensureNavFolder(data, "ECL", "Run Ecl code and review Ecl workunits", NULL, false, 2);
+            ensureNavLink(*folder, "Search Workunits", "/WsWorkunits/WUQuery?form_", "Search Workunits", NULL, NULL, 1);
+            ensureNavLink(*folder, "Browse Workunits", "/WsWorkunits/WUQuery", "Browse Workunits", NULL, NULL, 2);
 
             IPropertyTree *folderQueryset = ensureNavFolder(data, "Query Sets", "Queryset Management", NULL, false, 3);
             ensureNavLink(*folderQueryset, "Browse", "/WsWorkunits/WUQuerySets", "Browse Querysets");

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -400,9 +400,9 @@
              processName="EspService"
              schema="esp_service_ecldirect.xsd">
     <Properties bindingType="EclDirectSoapBinding"
-                defaultPort="8008"
+                defaultPort="8010"
                 defaultResourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
-                defaultSecurePort="18008"
+                defaultSecurePort="18010"
                 plugin="ecldirect"
                 type="ecldirect">
      <Authenticate access="Read"
@@ -675,7 +675,7 @@
    <EspBinding defaultForPort="true"
                defaultServiceVersion=""
                name="ecldirect"
-               port="8008"
+               port="8010"
                protocol="http"
                resourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
                service="ecldirect"
@@ -944,9 +944,9 @@
               description="ESP service for running raw ECL queries"
               name="ecldirect">
    <Properties bindingType="EclDirectSoapBinding"
-               defaultPort="8008"
+               defaultPort="8010"
                defaultResourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
-               defaultSecurePort="18008"
+               defaultSecurePort="18010"
                plugin="ecldirect"
                type="ecldirect">
     <Authenticate access="Read"


### PR DESCRIPTION
This fix adds a Run Ecl menu under Ecl (Workunits) menu section
inside EclWatch. The menu is linked with EclDirect RunEclEx
method. The RunEclEx is an enhanced version of the existing
RunEcl method. After the menu is selected, a Run Ecl input form is
displayed. A user may type in Ecl code, specify a cluster if
needed, and run the Ecl code. The results of the Ecl code execution
will be displayed in XMl format or table format.

The port of EclDirect service is moved from 8008 to 8010. In
EclWatch navigation panel, the 'ECL Workunits' menu section
is renamed as 'ECL'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
