### PR TITLE
Fix gh-622 set defaultCopies and ensureReplicate

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6488,7 +6488,7 @@ IDistributedFile *CDistributedFileDirectory::createExternal(const CDfsLogicalFil
         }
         fileDesc->setPart(i,rfn);
     }
-    fileDesc->queryPartDiskMapping(0).defaultCopies = 1;
+    fileDesc->queryPartDiskMapping(0).defaultCopies = DFD_NoCopies;
     IDistributedFile * ret = createNew(fileDesc,logicalname.get(),true);   // set modified
     if (ret&&moddtset) {
         ret->setModificationTime(moddt);    

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -274,6 +274,12 @@ void ClusterPartDiskMapSpec::ensureReplicate()
         defaultCopies = DFD_DefaultCopies;
 }
 
+bool ClusterPartDiskMapSpec::isReplicated() const
+{
+    // If defaultCopies is zero (deprecated/legacy), the default value for replicated is true
+    // Else, if it has any copy (>= 2), than it is replicated
+    return defaultCopies != DFD_NoCopies;
+}
 
 unsigned ClusterPartDiskMapSpec::numCopies(unsigned part,unsigned clusterwidth, unsigned filewidth)
 {

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -86,6 +86,7 @@ public:
 
     ClusterPartDiskMapSpec & operator=(const ClusterPartDiskMapSpec &other);
 
+    bool isReplicated() const;
 };
 
 #define CPDMSF_wrapToNextDrv    (0x01)      // whether should wrap to next drv

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -42,7 +42,11 @@ enum DFD_OS
     DFD_OSunix
 };
 
-
+enum DFD_Replicate
+{
+    DFD_NoCopies      = 1,
+    DFD_DefaultCopies = 2
+};
 
 // ==CLUSTER PART MAPPING ==============================================================================================
 
@@ -55,7 +59,7 @@ enum DFD_OS
 
 struct da_decl ClusterPartDiskMapSpec
 {
-    ClusterPartDiskMapSpec() { replicateOffset=1; defaultCopies=2; startDrv=0; maxDrvs=2; flags=0; interleave=0; repeatedPart=CPDMSRP_notRepeated; }
+    ClusterPartDiskMapSpec() { replicateOffset=1; defaultCopies=DFD_DefaultCopies; startDrv=0; maxDrvs=2; flags=0; interleave=0; repeatedPart=CPDMSRP_notRepeated; }
     int replicateOffset;    // offset to add to determine node
 public:
     byte defaultCopies;     // default number of copies (i.e. redundancy+1)
@@ -72,6 +76,7 @@ public:
     void setRepeatedCopies(unsigned partnum,bool onlyrepeats);
     void setDefaultBaseDir(const char *dir);
     void setDefaultReplicateDir(const char *dir);
+    void ensureReplicate();
     bool calcPartLocation (unsigned part, unsigned maxparts, unsigned copy, unsigned clusterWidth, unsigned &node, unsigned &drv);
     void toProp(IPropertyTree *tree);
     void fromProp(IPropertyTree *tree);
@@ -226,6 +231,7 @@ if endCluster is not called it will assume only one cluster and not replicated
 
     virtual StringBuffer &getClusterLabel(unsigned clusternum,StringBuffer &ret) = 0; // roxie label or node group name
 
+    virtual void ensureReplicate() = 0;                                             // make sure a file can be replicated
 };
 
 interface ISuperFileDescriptor: extends IFileDescriptor

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -1460,7 +1460,7 @@ void expandFileTree(IPropertyTree *file,bool expandnodes,const char *cluster)
             }
         }
         if (clusterinfo&&!file->hasProp("@replicated")) // legacy
-            file->setPropBool("@replicated",clusterinfo->queryPartDiskMapping().defaultCopies>DFD_NoCopies);
+            file->setPropBool("@replicated",clusterinfo->queryPartDiskMapping().isReplicated());
 
     }
 }

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -1460,7 +1460,7 @@ void expandFileTree(IPropertyTree *file,bool expandnodes,const char *cluster)
             }
         }
         if (clusterinfo&&!file->hasProp("@replicated")) // legacy
-            file->setPropBool("@replicated",clusterinfo->queryPartDiskMapping().defaultCopies>1);
+            file->setPropBool("@replicated",clusterinfo->queryPartDiskMapping().defaultCopies>DFD_NoCopies);
 
     }
 }
@@ -2905,7 +2905,7 @@ public:
         RemoteFilename rfn;
         getPartFilename(rfn,0,0);
         fileDesc->setPart(0,rfn);
-        fileDesc->queryPartDiskMapping(0).defaultCopies = 1;
+        fileDesc->queryPartDiskMapping(0).defaultCopies = DFD_DefaultCopies;
         return fileDesc.getClear();
     }
 

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1288,13 +1288,13 @@ public:
                         if (destination) {
                             if (destination->numClusters()==1) {
                                 destination->getClusterPartDiskMapSpec(0,mspec);  
-                                if (mspec.defaultCopies<2)          
+                                if (mspec.defaultCopies<DFD_DefaultCopies)
                                     needrep = false;
                             }
                         }
                         else if (multifdesc) {
                             if (multifdesc->numClusters()==1) {
-                                if (multifdesc->queryPartDiskMapping(0).defaultCopies<2) 
+                                if (multifdesc->queryPartDiskMapping(0).defaultCopies<DFD_DefaultCopies)
                                     needrep = false;
                             }
                         }
@@ -1455,6 +1455,7 @@ public:
                     }
                     setFileRepeatOptions(*srcFile,repcluster.str(),repeatlast,onlyrepeated);
                     Owned<IFileDescriptor> fdesc = srcFile->getFileDescriptor();
+                    fdesc->ensureReplicate();
                     fsys.replicate(fdesc.get(), mode, recovery, recoveryconn, filter, opttree, &feedback, &abortnotify, dfuwuid);
                     runningconn.clear();
                     if (!abortnotify.abortRequested()) {
@@ -1474,7 +1475,7 @@ public:
                         if (destination) {
                             if (destination->numClusters()==1) {
                                 destination->getClusterPartDiskMapSpec(0,mspec); 
-                                if (mspec.defaultCopies<2)   
+                                if (mspec.defaultCopies<DFD_DefaultCopies)
                                     needrep = false;
                             }
 #ifndef _DEBUG

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1288,13 +1288,13 @@ public:
                         if (destination) {
                             if (destination->numClusters()==1) {
                                 destination->getClusterPartDiskMapSpec(0,mspec);  
-                                if (mspec.defaultCopies<DFD_DefaultCopies)
+                                if (!mspec.isReplicated())
                                     needrep = false;
                             }
                         }
                         else if (multifdesc) {
                             if (multifdesc->numClusters()==1) {
-                                if (multifdesc->queryPartDiskMapping(0).defaultCopies<DFD_DefaultCopies)
+                                if (!multifdesc->queryPartDiskMapping(0).isReplicated())
                                     needrep = false;
                             }
                         }
@@ -1475,7 +1475,7 @@ public:
                         if (destination) {
                             if (destination->numClusters()==1) {
                                 destination->getClusterPartDiskMapSpec(0,mspec); 
-                                if (mspec.defaultCopies<DFD_DefaultCopies)
+                                if (!mspec.isReplicated())
                                     needrep = false;
                             }
 #ifndef _DEBUG

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -517,17 +517,17 @@ public:
         fdir = &queryDistributedFileDirectory();
         switch(_clustmap) {
         case DFUcpdm_c_replicated_by_d:
-            spec1.defaultCopies = 2;
+            spec1.defaultCopies = DFD_DefaultCopies;
             break;
         case DFUcpdm_c_only:
-            spec1.defaultCopies = 1;
+            spec1.defaultCopies = DFD_NoCopies;
             break;
         case DFUcpdm_d_only:
-            spec1.defaultCopies = 1;
+            spec1.defaultCopies = DFD_NoCopies;
             spec1.startDrv = 1;
             break;
         case DFUcpdm_c_then_d:
-            spec1.defaultCopies = 1;
+            spec1.defaultCopies = DFD_NoCopies;
             spec1.flags = CPDMSF_wrapToNextDrv;
             break;
         }

--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -1568,17 +1568,17 @@ public:
         ClusterPartDiskMapSpec spec;
         switch(val) {
         case DFUcpdm_c_replicated_by_d:
-            spec.defaultCopies = 2;
+            spec.defaultCopies = DFD_DefaultCopies;
             break;
         case DFUcpdm_c_only:
-            spec.defaultCopies = 1;
+            spec.defaultCopies = DFD_NoCopies;
             break;
         case DFUcpdm_d_only:
-            spec.defaultCopies = 1;
+            spec.defaultCopies = DFD_NoCopies;
             spec.startDrv = 1;
             break;
         case DFUcpdm_c_then_d:
-            spec.defaultCopies = 1;
+            spec.defaultCopies = DFD_NoCopies;
             spec.flags = CPDMSF_wrapToNextDrv;
             break;
         }

--- a/testing/ecl/key/persist_replicate.xml
+++ b/testing/ecl/key/persist_replicate.xml
@@ -1,0 +1,10 @@
+<Dataset name='Result 1'>
+ <Row><name>foo</name><city>london</city><phone>123456</phone></Row>
+ <Row><name>bar</name><city>cambridge</city><phone>321654</phone></Row>
+ <Row><name>baz</name><city>blackburn</city><phone>654321</phone></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><name>foo</name></Row>
+ <Row><name>bar</name></Row>
+ <Row><name>baz</name></Row>
+</Dataset>

--- a/testing/ecl/persist_replicate.ecl
+++ b/testing/ecl/persist_replicate.ecl
@@ -1,0 +1,47 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+import Std.File as Fileservices;
+//noRoxie
+
+// Following gh-622's recipe
+rec := RECORD
+    string name;
+    string city;
+    string phone;
+END;
+
+ds := DATASET([{'foo', 'london',    '123456'},
+               {'bar', 'cambridge', '321654'},
+               {'baz', 'blackburn', '654321'}], rec);
+OUTPUT(ds);
+
+small_rec := RECORD
+    string name;
+END;
+
+small_rec trans(rec r) := TRANSFORM
+    SELF.name  := r.name;
+END;
+
+// In Thor, this created a file that could not be replicated
+ds2 := PROJECT(ds, trans(LEFT)) : PERSIST('~temp::PersistReplicate');
+OUTPUT(ds2);
+
+// Now, replicate
+FileServices.Replicate('~temp::PersistReplicate');

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -449,7 +449,7 @@ public:
             ForEachItemIn(g, groups)
             {
                 ClusterPartDiskMapSpec mspec;
-                mspec.defaultCopies = replicate?2:1; // may be changed on publish to reflect always backed up on thor cluster
+                mspec.defaultCopies = replicate?DFD_DefaultCopies:DFD_NoCopies; // may be changed on publish to reflect always backed up on thor cluster
                 const char *groupname = groupNames.item(g);
                 if (groupname && *groupname)
                     desc->addCluster(groupname, &groups.item(g), mspec);
@@ -524,11 +524,7 @@ public:
         if (replicateOutputs && (!temporary || job.queryUseCheckpoints()))
         {
             // this potentially modifies fileDesc but I think OK at this point
-            for (unsigned clusterIdx = 0; clusterIdx<fileDesc.numClusters(); clusterIdx++) {
-                ClusterPartDiskMapSpec &mapspec = fileDesc.queryPartDiskMapping(clusterIdx);
-                if (mapspec.defaultCopies==1)
-                    mapspec.defaultCopies = 2;
-            }
+           fileDesc.ensureReplicate();
         }
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(&fileDesc);
         if (temporary && !job.queryUseCheckpoints())


### PR DESCRIPTION
Fixes the replicate bug on some files, especially when
run from Thor. This commit does not fix the underlying
issue, since that would require a big change in the naming
system (ie. recognizing types of files, ensuring net
address, filename, etc is always correct and reachable),
but that change is planned and will be done (See #654).
