### PR TITLE
gh-1430 SOAP Namespace missing trailing '/'

### DIFF
--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -49,8 +49,8 @@ public:
             buffer.append("<?xml-stylesheet type=\"text/xsl\" href=\"/esp/xslt/xmlformatter.xsl\"?>");
         if (flags & WWV_ADD_SOAP)
             buffer.append(
-                "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope\""
-                  " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding\">"
+                "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\""
+                  " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">"
                     " <soap:Body>"
             );
         if (flags & WWV_ADD_RESPONSE_TAG)

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -850,8 +850,8 @@ void EspHttpBinding::getSoapMessage(StringBuffer& soapmsg, IEspContext& ctx, CHt
     StringBuffer ns;
     soapmsg.appendf(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope\""
-          " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding\""
+        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\""
+          " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\""
           " xmlns=\"%s\">"
         " <soap:Body>%s </soap:Body></soap:Envelope>",
         generateNamespace(ctx, request, serv, method, ns).str(), filtered.str()
@@ -964,8 +964,8 @@ void EspHttpBinding::getSoapMessage(StringBuffer& soapmsg, IEspContext& ctx, CHt
     
     soapmsg.appendf(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope\""
-            " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding\""
+        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\""
+            " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\""
             " xmlns=\"urn:hpccsystems:ws:");
     if (serv && *serv)
         soapmsg.appendLower(strlen(serv), serv);
@@ -1258,19 +1258,6 @@ bool EspHttpBinding::getSchema(StringBuffer& schema, IEspContext &ctx, CHttpRequ
     
 
     schema.append(
-//      "<xsd:import namespace=\"http://schemas.xmlsoap.org/soap/encoding/\" schemaLocation=\"http://schemas.xmlsoap.org/soap/encoding/\"/>\n"
-/*      "<xsd:complexType name=\"EspStringArray\">"
-            "<xsd:sequence>"
-                "<xsd:element name=\"Item\" type=\"xsd:string\"  minOccurs=\"0\" maxOccurs=\"unbounded\" />"
-            "</xsd:sequence>"
-        "</xsd:complexType>\n"
-        "<xsd:complexType name=\"EspIntArray\">"
-            "<xsd:sequence>"
-                "<xsd:element name=\"Item\" type=\"xsd:int\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>"
-            "</xsd:sequence>"
-        "</xsd:complexType>\n"
-*/
-        // EspException type
         "<xsd:complexType name=\"EspException\">"
             "<xsd:all>"
                 "<xsd:element name=\"Code\" type=\"xsd:string\"  minOccurs=\"0\"/>"

--- a/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
@@ -79,7 +79,7 @@
                       }
                   };
 
-                  var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsWorkunits"><soap:Body>' + getQueryActions(Action) + '</soap:Body></soap:Envelope>';
+                  var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/WsWorkunits"><soap:Body>' + getQueryActions(Action) + '</soap:Body></soap:Envelope>';
 
                   YAHOO.util.Connect.initHeader("SOAPAction", "/WsWorkunits/WUQuerysetQueryAction?");
                   YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
@@ -123,7 +123,7 @@
                       }
                   };
 
-                  var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body>' + getAliasActions(Action) + '</soap:Body></soap:Envelope>';
+                  var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body>' + getAliasActions(Action) + '</soap:Body></soap:Envelope>';
 
                   YAHOO.util.Connect.initHeader("SOAPAction", "/WsWorkunits/WUQuerysetActionAliases?");
                   YAHOO.util.Connect.initHeader("Content-Type", "text/xml");

--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -607,7 +607,7 @@
 
         /*
         <?xml version="1.0" encoding="utf-8"?>
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsWorkunits">
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/WsWorkunits">
  <soap:Body>
   <WUPublishWorkunitRequest>
    <Wuid>W20110125-150953</Wuid>

--- a/esp/files/scripts/graphgvc.js
+++ b/esp/files/scripts/graphgvc.js
@@ -1090,14 +1090,14 @@ function sendWuInfoRequest() {
 
 function getRoxieConfigRequestEnvelope(QueryName, GraphName)
 {
-    var RoxieConfigSOAPEnvelope = '<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ShowGVCGraphRequest><QueryId>%QueryName%</QueryId><GraphName>%GraphName%</GraphName></ShowGVCGraphRequest></soap:Body></soap:Envelope>';
+    var RoxieConfigSOAPEnvelope = '<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ShowGVCGraphRequest><QueryId>%QueryName%</QueryId><GraphName>%GraphName%</GraphName></ShowGVCGraphRequest></soap:Body></soap:Envelope>';
     RoxieConfigSOAPEnvelope = RoxieConfigSOAPEnvelope.replace('%QueryName%', QueryName);
     RoxieConfigSOAPEnvelope = RoxieConfigSOAPEnvelope.replace('%GraphName%', GraphName);
     return RoxieConfigSOAPEnvelope;
 }
 
 function getWsRoxieQueryRequestEnvelope(QueryName, GraphName, Cluster) {
-    var RoxieQuerySOAPEnvelope = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsRoxieQuery"><soap:Body><ShowGVCGraphRequest><Cluster>%Cluster%</Cluster><QueryId>%QueryName%</QueryId><GraphName>%GraphName%</GraphName></ShowGVCGraphRequest></soap:Body></soap:Envelope>';
+    var RoxieQuerySOAPEnvelope = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/WsRoxieQuery"><soap:Body><ShowGVCGraphRequest><Cluster>%Cluster%</Cluster><QueryId>%QueryName%</QueryId><GraphName>%GraphName%</GraphName></ShowGVCGraphRequest></soap:Body></soap:Envelope>';
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%Cluster%', Cluster);
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%QueryName%', QueryName);
     RoxieQuerySOAPEnvelope = RoxieQuerySOAPEnvelope.replace('%GraphName%', GraphName);
@@ -1106,7 +1106,7 @@ function getWsRoxieQueryRequestEnvelope(QueryName, GraphName, Cluster) {
 
 function getWsWorkunitsRequestEnvelope(wuid, GraphName, SubGraphId)
 {
-    var WsworkunitsSOAPEnvelope = '<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsWorkunits"><soap:Body><WUGetGraphRequest><Wuid>%wuid%</Wuid><GraphName>%GraphName%</GraphName><SubGraphId>%SubGraphId%</SubGraphId></WUGetGraphRequest></soap:Body></soap:Envelope>';
+    var WsworkunitsSOAPEnvelope = '<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/WsWorkunits"><soap:Body><WUGetGraphRequest><Wuid>%wuid%</Wuid><GraphName>%GraphName%</GraphName><SubGraphId>%SubGraphId%</SubGraphId></WUGetGraphRequest></soap:Body></soap:Envelope>';
     WsworkunitsSOAPEnvelope = WsworkunitsSOAPEnvelope.replace('%wuid%', wuid);
     WsworkunitsSOAPEnvelope = WsworkunitsSOAPEnvelope.replace('%GraphName%', GraphName);
     WsworkunitsSOAPEnvelope = WsworkunitsSOAPEnvelope.replace('%SubGraphId%', SubGraphId);
@@ -1115,7 +1115,7 @@ function getWsWorkunitsRequestEnvelope(wuid, GraphName, SubGraphId)
 
 function getWuInfoRequestEnvelope(wuid)
 {
-    var WuInfoSOAPEnvelope = '<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/WsWorkunits"><soap:Body><WUInfoRequest><Wuid>%wuid%</Wuid><Type></Type><IncludeExceptions>0</IncludeExceptions><IncludeGraphs>1</IncludeGraphs><IncludeSourceFiles>0</IncludeSourceFiles><IncludeResults>0</IncludeResults><IncludeVariables>0</IncludeVariables><IncludeTimers>0</IncludeTimers><IncludeDebugValues>0</IncludeDebugValues><IncludeApplicationValues>0</IncludeApplicationValues><IncludeWorkflows>0</IncludeWorkflows><SuppressResultSchemas>1</SuppressResultSchemas></WUInfoRequest></soap:Body></soap:Envelope>';
+    var WuInfoSOAPEnvelope = '<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/WsWorkunits"><soap:Body><WUInfoRequest><Wuid>%wuid%</Wuid><Type></Type><IncludeExceptions>0</IncludeExceptions><IncludeGraphs>1</IncludeGraphs><IncludeSourceFiles>0</IncludeSourceFiles><IncludeResults>0</IncludeResults><IncludeVariables>0</IncludeVariables><IncludeTimers>0</IncludeTimers><IncludeDebugValues>0</IncludeDebugValues><IncludeApplicationValues>0</IncludeApplicationValues><IncludeWorkflows>0</IncludeWorkflows><SuppressResultSchemas>1</SuppressResultSchemas></WUInfoRequest></soap:Body></soap:Envelope>';
     WuInfoSOAPEnvelope = WuInfoSOAPEnvelope.replace('%wuid%', wuid);
     return WuInfoSOAPEnvelope;
 }

--- a/esp/files/scripts/ws_roxieconfig.js
+++ b/esp/files/scripts/ws_roxieconfig.js
@@ -534,7 +534,7 @@ function loadQueries(QueryType, Resize) {
     createQueryDataTable(QueryType);
     dt_Queries.showTableMessage(dt_Queries.get("MSG_LOADING"), dt_Queries.CLASS_LOADING);
     
-    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><' + QueryType + '><excludeAliasNames>0</excludeAliasNames><excludeQueryNames>0</excludeQueryNames><excludeLibraryNames>0</excludeLibraryNames><excludeDataOnlyNames>1</excludeDataOnlyNames></' + QueryType + '></soap:Body></soap:Envelope>';
+    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><' + QueryType + '><excludeAliasNames>0</excludeAliasNames><excludeQueryNames>0</excludeQueryNames><excludeLibraryNames>0</excludeLibraryNames><excludeDataOnlyNames>1</excludeDataOnlyNames></' + QueryType + '></soap:Body></soap:Envelope>';
 
     YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/" + QueryType + "?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
@@ -679,7 +679,7 @@ function loadAliases(QueryName, ElementId, QueryPage, Resize) {
     createAliasDataTable(ElementId);
     dt_Aliases.showTableMessage(dt_Aliases.get("MSG_LOADING"), dt_Aliases.CLASS_LOADING);
         
-    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListDeployedAliasesRequest><QueryId>' + QueryName + '</QueryId></ListDeployedAliasesRequest></soap:Body></soap:Envelope>';
+    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListDeployedAliasesRequest><QueryId>' + QueryName + '</QueryId></ListDeployedAliasesRequest></soap:Body></soap:Envelope>';
     YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/ListDeployedAliases?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
     YAHOO.util.Connect._use_default_post_header = false;
@@ -854,7 +854,7 @@ function loadDataFiles(QueryName, ElementId, RowsPerPage, QueryPage, Resize)
     dt_IndexFiles.showTableMessage(dt_IndexFiles.get("MSG_LOADING"), dt_IndexFiles.CLASS_LOADING);
     dt_DataFiles.showTableMessage(dt_DataFiles.get("MSG_LOADING"), dt_DataFiles.CLASS_LOADING);
         
-    var postBody = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListFilesUsedByQueryRequest><QueryId>' + QueryName + '</QueryId><excludeSuperFileNames>1</excludeSuperFileNames><excludeDataFileNames>0</excludeDataFileNames></ListFilesUsedByQueryRequest></soap:Body></soap:Envelope>';
+    var postBody = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListFilesUsedByQueryRequest><QueryId>' + QueryName + '</QueryId><excludeSuperFileNames>1</excludeSuperFileNames><excludeDataFileNames>0</excludeDataFileNames></ListFilesUsedByQueryRequest></soap:Body></soap:Envelope>';
     YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/ListFilesUsedByQuery?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
     YAHOO.util.Connect._use_default_post_header = false;
@@ -967,7 +967,7 @@ function loadSuperFiles(QueryName, ElementId, RowsPerPage, QueryPage, Resize)
     createSuperFilesDataTable();
     dt_SuperFiles.showTableMessage(dt_SuperFiles.get("MSG_LOADING"), dt_SuperFiles.CLASS_LOADING);
         
-    var postBody = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListFilesUsedByQueryRequest><QueryId>' + QueryName + '</QueryId><excludeSuperFileNames>0</excludeSuperFileNames><excludeDataFileNames>1</excludeDataFileNames></ListFilesUsedByQueryRequest></soap:Body></soap:Envelope>';
+    var postBody = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListFilesUsedByQueryRequest><QueryId>' + QueryName + '</QueryId><excludeSuperFileNames>0</excludeSuperFileNames><excludeDataFileNames>1</excludeDataFileNames></ListFilesUsedByQueryRequest></soap:Body></soap:Envelope>';
     YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/ListFilesUsedByQuery?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
     YAHOO.util.Connect._use_default_post_header = false;
@@ -1305,7 +1305,7 @@ function doDeleteAliases() {
     }
 
     document.getElementById('ActionProgress').innerHTML = '<img src="/esp/files/img/loading.gif" style="height:18px;" />';
-    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body>' + getSelectedAliases() + '</soap:Body></soap:Envelope>';
+    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body>' + getSelectedAliases() + '</soap:Body></soap:Envelope>';
     
     YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/RemoveAliases?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
@@ -1372,7 +1372,7 @@ function loadQueriesUsingLibrary(LibraryName, ElementId)
     };
     
     document.getElementById(ElementId).innerHTML = '<img src="/esp/files/img/loading.gif" style="height:18px;" />';
-    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListQueriesUsingLibraryRequest><LibraryName>' + LibraryName + '</LibraryName></ListQueriesUsingLibraryRequest></soap:Body></soap:Envelope>';
+    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListQueriesUsingLibraryRequest><LibraryName>' + LibraryName + '</LibraryName></ListQueriesUsingLibraryRequest></soap:Body></soap:Envelope>';
     YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/ListQueriesUsingLibrary?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
     YAHOO.util.Connect._use_default_post_header = false;
@@ -1434,7 +1434,7 @@ function modifyQueries(Operation, ElementId)
     }
 
     document.getElementById('ActionProgress').innerHTML = '<img src="/esp/files/img/loading.gif" style="height:18px;" />';
-    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body>' + getSelectedQueries(Operation) + '</soap:Body></soap:Envelope>';
+    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body>' + getSelectedQueries(Operation) + '</soap:Body></soap:Envelope>';
     YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/ModifyQueries?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
     YAHOO.util.Connect._use_default_post_header = false;
@@ -1591,7 +1591,7 @@ function actionQueries(Activate) {
     } 
     
     document.getElementById('ActionProgress').innerHTML = '<img src="/esp/files/img/loading.gif" style="height:18px;" />';
-    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body>' + getActionQueries(Activate) + '</soap:Body></soap:Envelope>';
+    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body>' + getActionQueries(Activate) + '</soap:Body></soap:Envelope>';
     YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/AddAliasesToQueries?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
     YAHOO.util.Connect._use_default_post_header = false;
@@ -1722,7 +1722,7 @@ function listQueriesUsingFile(SourceDt) {
         var rec = SourceDt.getRecord(rows[0]);
         var FileName = rec.getData('Name');
         document.getElementById('ActionProgress').innerHTML = '<img src="/esp/files/img/loading.gif" style="height:18px;" />';
-        var postBody = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListQueriesUsingFileRequest><fileName>' + FileName + '</fileName></ListQueriesUsingFileRequest></soap:Body></soap:Envelope>';
+        var postBody = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><ListQueriesUsingFileRequest><fileName>' + FileName + '</fileName></ListQueriesUsingFileRequest></soap:Body></soap:Envelope>';
         YAHOO.util.Connect.initHeader("SOAPAction", "ws_roxieconfig/ListQueriesUsingFile?ver_=" + WS_ROXIECONFIG_VER);
         YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
         YAHOO.util.Connect._use_default_post_header = false;

--- a/esp/files/scripts/ws_roxieconfig_deploytab.js
+++ b/esp/files/scripts/ws_roxieconfig_deploytab.js
@@ -148,7 +148,7 @@ function loadPendingDeployments(ElementId, Resize) {
     createDeploymentDataTable(ElementId);
     dtDeploy.showTableMessage(dtDeploy.get("MSG_LOADING"), dtDeploy.CLASS_LOADING);
 
-    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><RoxieWUQueryRequest><Cluster></Cluster><TargetClusterType>roxie</TargetClusterType><Owner/><Jobname/></RoxieWUQueryRequest></soap:Body></soap:Envelope>';
+    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><RoxieWUQueryRequest><Cluster></Cluster><TargetClusterType>roxie</TargetClusterType><Owner/><Jobname/></RoxieWUQueryRequest></soap:Body></soap:Envelope>';
     YAHOO.util.Connect.initHeader("SOAPAction", "/ws_roxieconfig/RoxieWUQuery?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
     YAHOO.util.Connect._use_default_post_header = false;
@@ -236,7 +236,7 @@ function deployWorkunit(Workunit, JobName, Activate) {
         }
     };
 
-    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><RoxieDeployWorkunit><Wuid>' + Workunit + '</Wuid><QueryName>' + JobName + '</QueryName><Options><Activate>' + Activate + '</Activate><NotifyRoxie>' + notifyRoxie + '</NotifyRoxie></Options></RoxieDeployWorkunit></soap:Body></soap:Envelope>';
+    var postBody = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns="http://webservices.seisint.com/ws_roxieconfig"><soap:Body><RoxieDeployWorkunit><Wuid>' + Workunit + '</Wuid><QueryName>' + JobName + '</QueryName><Options><Activate>' + Activate + '</Activate><NotifyRoxie>' + notifyRoxie + '</NotifyRoxie></Options></RoxieDeployWorkunit></soap:Body></soap:Envelope>';
     YAHOO.util.Connect.initHeader("SOAPAction", "/ws_roxieconfig/DeployWorkunit?ver_=" + WS_ROXIECONFIG_VER);
     YAHOO.util.Connect.initHeader("Content-Type", "text/xml");
     YAHOO.util.Connect._use_default_post_header = false;

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -1588,8 +1588,8 @@ void CWsEclBinding::getSoapMessage(StringBuffer& soapmsg, IEspContext &context, 
 {
     soapmsg.append(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope\""
-          " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding\">"
+        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\""
+          " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">"
             " <soap:Body>"
         );
 
@@ -2501,8 +2501,8 @@ void CWsEclBinding::handleHttpPost(CHttpRequest *request, CHttpResponse *respons
         StringBuffer soapfromjson;
         soapfromjson.append(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-            "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope\""
-              " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding\">"
+            "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\""
+              " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">"
                 " <soap:Body>"
             );
         createPTreeFromJsonString(content.str(), false, soapfromjson, "Request");

--- a/esp/tools/soapplus/EspLogDeserializer.cpp
+++ b/esp/tools/soapplus/EspLogDeserializer.cpp
@@ -482,8 +482,8 @@ bool loadEspLog(const char* logFileName, HttpClient& httpClient, HttpStat& httpS
             if (bProcess)
             {
                 xml.insert( 0, "<?xml version='1.0' encoding='UTF-8'?>\n"
-                            "<soap:Envelope xmlns:soap='http://schemas.xmlsoap.org/soap/envelope' \n"
-                            "  xmlns:SOAP-ENC='http://schemas.xmlsoap.org/soap/encoding' \n"
+                            "<soap:Envelope xmlns:soap='http://schemas.xmlsoap.org/soap/envelope/' \n"
+                            "  xmlns:SOAP-ENC='http://schemas.xmlsoap.org/soap/encoding/' \n"
                             "  xmlns='urn:hpccsystems:ws:wsaccurint'>\n  <soap:Body>\n");
                 xml.append("  </soap:Body>\n</soap:Envelope>\n");
 

--- a/esp/tools/soapplus/http.cpp
+++ b/esp/tools/soapplus/http.cpp
@@ -1748,7 +1748,7 @@ int SimpleServer::start()
 
             if(m_response.length() == 0)
             {
-                const char* resp_body = "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding\"><soap:Body></soap:Body></soap:Envelope>";
+                const char* resp_body = "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\"><soap:Body></soap:Body></soap:Envelope>";
                 m_response.append("HTTP/1.1 200 OK\r\n");
                 m_response.append("Content-Type: text/xml; charset=UTF-8\r\n");
                 m_response.appendf("Content-Length: %d\r\n", (int) strlen(resp_body));

--- a/esp/xslt/soap_page.xsl
+++ b/esp/xslt/soap_page.xsl
@@ -676,8 +676,8 @@ function inputReturnMethod()
       }
       
       var head = '<?xml version="1.0" encoding="UTF-8"?>'
-             + '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope"'
-             + ' xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding"'
+             + '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"'
+             + ' xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"'
              + ' xmlns="http://webservices.seisint.com/' + gServiceName + '">'
              + ' <soap:Body><'
              + gMethodName + 'Request>';

--- a/esp/xslt/sso_create_session.xslt
+++ b/esp/xslt/sso_create_session.xslt
@@ -21,7 +21,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:sa="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:sp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xa="urn:xform_assertion">
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>
     <xsl:template match="/">
-        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope" xmlns="urn:LNSSO">
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns="urn:LNSSO">
             <soap:Body>
                     <CreateSSOSessionRequest>
                         <ClientIP><xsl:value-of select="/xa:XForm_Assertion/xa:Context/xa:ClientIP"/></ClientIP>

--- a/esp/xslt/wsecl3_jsontest.xsl
+++ b/esp/xslt/wsecl3_jsontest.xsl
@@ -541,8 +541,8 @@ function inputReturnMethod()
       }
       
       var head = '<?xml version="1.0" encoding="UTF-8"?>'
-             + '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope"'
-             + ' xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding"'
+             + '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"'
+             + ' xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"'
              + ' xmlns="urn:LNHPCC:' + gServiceName + '">'
              + ' <soap:Body><'
              + gMethodName + 'Request>';

--- a/esp/xslt/wsecl3_result.xslt
+++ b/esp/xslt/wsecl3_result.xslt
@@ -3,7 +3,7 @@
 
 ## Copyright (c) 2011 HPCC Systems.  All rights reserved.
 -->
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <xsl:output method="html"/>
     <xsl:param name="url" select="'unknown'"/>
     <xsl:param name="rowStart" select="0"/>

--- a/esp/xslt/wsecl3_xmltest.xsl
+++ b/esp/xslt/wsecl3_xmltest.xsl
@@ -678,8 +678,8 @@ function inputReturnMethod()
       }
       
       var head = '<?xml version="1.0" encoding="UTF-8"?>'
-             + '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope"'
-             + ' xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding"'
+             + '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"'
+             + ' xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"'
              + ' xmlns="urn:hpccsystems:ecl:' + gServiceName + '">'
              + ' <soap:Body><'
              + gMethodName + 'Request>';


### PR DESCRIPTION
Missing '/' causes SOAP responses to not be interoperable with some client libraries.

Changing some places that have no affect on interoperability, but these
get cut and pasted quite a bit so don't want to leave any incorrect examples.

Fixes gh-1430

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
