### PR TITLE
Fix bug in viewing unicode indexes

### DIFF
--- a/common/fileview2/fvidxsource.cpp
+++ b/common/fileview2/fvidxsource.cpp
@@ -416,6 +416,26 @@ bool IndexDataSource::addFilter(unsigned column, unsigned matchLen, unsigned siz
             }
             break;
         }
+    case type_unicode:
+        {
+            const char * inbuff = (const char *)data;
+            unsigned lenData = sizeData / sizeof(UChar);
+            unsigned lenField = cur.getStringLen();
+            if (matchLen != FullStringMatch)
+            {
+                unsigned lenLow, lenHigh;
+                rtlCreateUnicodeRangeLow(lenLow, tempLow.refustr(), lenField, matchLen, lenData, (const UChar *)inbuff);
+                rtlCreateUnicodeRangeHigh(lenHigh, tempHigh.refustr(), lenField, matchLen, lenData, (const UChar *)inbuff);
+                low = tempLow.getdata();
+                high = tempHigh.getdata();
+            }
+            else
+            {
+                rtlUnicodeToUnicode(lenField, (UChar *)temp, lenData, (const UChar *)data);
+                low = high = temp;
+            }
+            break;
+        }
     default:
         assertex(sizeData == curSize);
         break;

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -2448,6 +2448,7 @@ void CColumnFilter::addValue(unsigned sizeText, const char * text)
         }
     case type_unicode:
         {
+            if (lenText > subLen) lenText = subLen;
             UChar * target = (UChar *)next->allocate(lenText*2);
             rtlUtf8ToUnicode(lenText, target, lenText, text);
             break;


### PR DESCRIPTION
- Unicode comparison wasn't implemented in the fileview layer
  which meant  esp couldn't filter an index based on unicode.
- Unicode ranges also weren't passing the correct length

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
