### PR TITLE
gh-1476 - Fix regression in hashagg,local

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistrib.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistrib.cpp
@@ -288,7 +288,10 @@ CActivityBase *createHashJoinActivityMaster(CMasterGraphElement *container)
 
 CActivityBase *createHashAggregateActivityMaster(CMasterGraphElement *container)
 {
-    return new HashDistributeActivityMaster(DM_groupaggregate, container);      
+    if (container->queryLocalOrGrouped())
+        return new CMasterActivity(container);
+    else
+        return new HashDistributeActivityMaster(DM_groupaggregate, container);      
 }
 
 CActivityBase *createKeyedDistributeActivityMaster(CMasterGraphElement *container)


### PR DESCRIPTION
A change in gh-1104, caused hashagg,local to fail with a serialization error

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
