### PR TITLE
gh-1460 Roxie should indicate suspended in control:queries

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -873,7 +873,11 @@ public:
         for (elems.first(); elems.isValid(); elems.next())
         {
             IMapping &cur = elems.query();
-            reply.appendf(" <Query id='%s'/>\n", queries.mapToValue(&cur)->queryQueryName());
+            IQueryFactory *query = queries.mapToValue(&cur);
+            reply.appendf(" <Query id='%s'", query->queryQueryName());
+            if (query->suspended())
+                reply.append(" suspended='1'");
+            reply.append("/>\n");
         }
         HashIterator aliasIterator(aliases);
         for (aliasIterator.first(); aliasIterator.isValid(); aliasIterator.next())


### PR DESCRIPTION
Roxie should indicate in the response to control:queries whether
a query is currently suspended or not.

Fixes gh-1460.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
