### PR TITLE
Add context sensitive help to EclWatch navigation menus

### DIFF
--- a/esp/services/ws_access/ws_accessService.hpp
+++ b/esp/services/ws_access/ws_accessService.hpp
@@ -61,10 +61,10 @@ public:
         if (m_portalURL.length() > 0)
             path.appendf("&EEPortal=%s", m_portalURL.str());
 
-        IPropertyTree *folder = ensureNavFolder(data, "Users/Permissions", "Permissions");
-        ensureNavLink(*folder, "Users", path.str(), "Users");
-        ensureNavLink(*folder, "Groups", path.str(), "Groups");
-        ensureNavLink(*folder, "Permissions", path.str(), "Permissions");
+        IPropertyTree *folder = ensureNavFolder(data, "Users/Permissions", NULL);
+        ensureNavLink(*folder, "Users", path.str(), "Manage Users and permissions");
+        ensureNavLink(*folder, "Groups", path.str(), "Manage Groups and permissions");
+        ensureNavLink(*folder, "Permissions", path.str(), "Manage Permissions");
     }
 
     int getQualifiedNames(IEspContext& ctx, MethodInfoArray & methods)

--- a/esp/services/ws_account/ws_accountService.hpp
+++ b/esp/services/ws_account/ws_accountService.hpp
@@ -43,15 +43,15 @@ public:
         if ((browserUserAgent.length() > 0) && strstr(browserUserAgent.str(), "Firefox"))
             isFF = true;
 
-        IPropertyTree *folder = ensureNavFolder(data, "My Account", "My Account");
+        IPropertyTree *folder = ensureNavFolder(data, "My Account", NULL);
         StringBuffer path = "/WsSMC/NotInCommunityEdition?form_";
         if (m_portalURL.length() > 0)
             path.appendf("&EEPortal=%s", m_portalURL.str());
 
-        ensureNavLink(*folder, "Change Password", path.str(), "Change Password");
+        ensureNavLink(*folder, "Change Password", path.str(), "Change Password for current account");
         if (!isFF)
-            ensureNavLink(*folder, "Relogin", path.str(), "Relogin");
-        ensureNavLink(*folder, "Who Am I", path.str(), "WhoAmI");
+            ensureNavLink(*folder, "Relogin", path.str(), "Log on using the same or different credential");
+        ensureNavLink(*folder, "Who Am I", path.str(), "Display the current user ");
     }
 };
 

--- a/esp/services/ws_fs/ws_fsBinding.hpp
+++ b/esp/services/ws_fs/ws_fsBinding.hpp
@@ -51,22 +51,22 @@ public:
         if (m_portalURL.length() > 0)
             path.appendf("&EEPortal=%s", m_portalURL.str());
 
-        IPropertyTree *folder0 = ensureNavFolder(data, "DFU Workunits", "DFU Workunits", NULL, false, 5);
-        ensureNavLink(*folder0, "Search", "/FileSpray/DFUWUSearch", "Search Workunits", NULL, NULL, 1);
-        ensureNavLink(*folder0, "Browse", "/FileSpray/GetDFUWorkunits", "Browse Workunits", NULL, NULL, 2);
-        IPropertyTree *folder = ensureNavFolder(data, "DFU Files", "DFU Files", NULL, false, 6);
-        ensureNavLink(*folder, "Upload/download File", "/FileSpray/DropZoneFiles", "Upload/download File", NULL, NULL, 1);
-        ensureNavLink(*folder, "View Data File", "/WsDfu/DFUGetDataColumns?ChooseFile=1", "View Data File", NULL, NULL, 2);
+        IPropertyTree *folder0 = ensureNavFolder(data, "DFU Workunits", NULL, NULL, false, 5);
+        ensureNavLink(*folder0, "Search", "/FileSpray/DFUWUSearch", "Search for DFU workunits ", NULL, NULL, 1);
+        ensureNavLink(*folder0, "Browse", "/FileSpray/GetDFUWorkunits", "Browse a list of DFU workunits", NULL, NULL, 2);
+        IPropertyTree *folder = ensureNavFolder(data, "DFU Files", NULL, NULL, false, 6);
+        ensureNavLink(*folder, "Upload/download File", "/FileSpray/DropZoneFiles", "Upload or download File from a Drop Zone in the environment", NULL, NULL, 1);
+        ensureNavLink(*folder, "View Data File", "/WsDfu/DFUGetDataColumns?ChooseFile=1", "Allows you to view the contents of a logical file", NULL, NULL, 2);
         ensureNavLink(*folder, "Search File Relationships", path.str(), "Search File Relationships", NULL, NULL, 3);
-        ensureNavLink(*folder, "Browse Space Usage", "/WsDfu/DFUSpace", "Browse Space Usage", NULL, NULL, 4);
-        ensureNavLink(*folder, "Search Logical Files", "/WsDfu/DFUSearch", "Search Logical Files", NULL, NULL, 5);
-        ensureNavLink(*folder, "Browse Logical Files", "/WsDfu/DFUQuery", "Browse Logical Files", NULL, NULL, 6);
-        ensureNavLink(*folder, "Browse Files by Scope", "/WsDfu/DFUFileView", "Browse Files by Scope", NULL, NULL, 7);
-        ensureNavLink(*folder, "Spray Fixed", "/FileSpray/SprayFixedInput", "Spray Fixed", NULL, NULL, 8);
-        ensureNavLink(*folder, "Spray CSV", "/FileSpray/SprayVariableInput?submethod=csv", "Spray CSV", NULL, NULL, 9);
-        ensureNavLink(*folder, "Spray XML", "/FileSpray/SprayVariableInput?submethod=xml", "Spray XML", NULL, NULL, 10);
-        ensureNavLink(*folder, "Remote Copy", "/FileSpray/CopyInput", "Remote Copy", NULL, NULL, 11);
-        ensureNavLink(*folder, "XRef", "/WsDFUXRef/DFUXRefList", "XRef", NULL, NULL, 12);
+        ensureNavLink(*folder, "Browse Space Usage", "/WsDfu/DFUSpace", "View details about Space Usage", NULL, NULL, 4);
+        ensureNavLink(*folder, "Search Logical Files", "/WsDfu/DFUSearch", "Search for Logical Files using a variety of search criteria", NULL, NULL, 5);
+        ensureNavLink(*folder, "Browse Logical Files", "/WsDfu/DFUQuery", "Browse a list of Logical Files", NULL, NULL, 6);
+        ensureNavLink(*folder, "Browse Files by Scope", "/WsDfu/DFUFileView", "Browse a list of Logical Files by Scope", NULL, NULL, 7);
+        ensureNavLink(*folder, "Spray Fixed", "/FileSpray/SprayFixedInput", "Spray a fixed width file", NULL, NULL, 8);
+        ensureNavLink(*folder, "Spray CSV", "/FileSpray/SprayVariableInput?submethod=csv", "Spray a comma separated value file", NULL, NULL, 9);
+        ensureNavLink(*folder, "Spray XML", "/FileSpray/SprayVariableInput?submethod=xml", "Spray an XML File", NULL, NULL, 10);
+        ensureNavLink(*folder, "Remote Copy", "/FileSpray/CopyInput", "Copy a Logical File from one environment to another", NULL, NULL, 11);
+        ensureNavLink(*folder, "XRef", "/WsDFUXRef/DFUXRefList", "View Xref result details or run the Xref utility", NULL, NULL, 12);
     }
 
     int onGetInstantQuery(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method);

--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
@@ -51,7 +51,7 @@ public:
 
     virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
     {
-        IPropertyTree *folder = ensureNavFolder(data, "Roxie Queries", "Roxie Queries", NULL, false, 7);
+        IPropertyTree *folder = ensureNavFolder(data, "Roxie Queries", NULL, NULL, false, 7);
         ensureNavLink(*folder, "Search Roxie Queries", "/WsRoxieQuery/RoxieQuerySearch", "Search Roxie Queries", NULL, NULL, 1);
 
         StringBuffer path = "/WsSMC/NotInCommunityEdition?form_";

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -90,12 +90,12 @@ public:
     {
         data.setProp("@appName", "EclWatch");
         data.setProp("@start_page", "/WsSMC/Activity");
-        IPropertyTree *folder = ensureNavFolder(data, "Clusters", "Clusters", NULL, false, 1);
-        ensureNavLink(*folder, "Activity", "/WsSMC/Activity", "View Activity", NULL, NULL, 1);
-        ensureNavLink(*folder, "Scheduler", "/WsWorkunits/WUShowScheduled", "Show Scheduled WUs", NULL, NULL, 2);
+        IPropertyTree *folder = ensureNavFolder(data, "Clusters", NULL, NULL, false, 1);
+        ensureNavLink(*folder, "Activity", "/WsSMC/Activity", "Display Activity on all target clusters in an environment", NULL, NULL, 1);
+        ensureNavLink(*folder, "Scheduler", "/WsWorkunits/WUShowScheduled", "Access the ECL Scheduler to view and manage scheduled workunits or events", NULL, NULL, 2);
 
-        IPropertyTree *folderTools = ensureNavFolder(data, "Resources", "HPCC Resources", NULL, false, 8);
-        ensureNavLink(*folderTools, "Browse", "/WsSMC/BrowseResources", "List HPCC Resources for Download", NULL, NULL, 1);
+        IPropertyTree *folderTools = ensureNavFolder(data, "Resources", NULL, NULL, false, 8);
+        ensureNavLink(*folderTools, "Browse", "/WsSMC/BrowseResources", "Browse a list of resources available for download, such as the ECL IDE, documentation, examples, etc. These are only available if optional packages are installed on the ESP Server.", NULL, NULL, 1);
     }
     virtual void getNavSettings(int &width, bool &resizable, bool &scroll)
     {

--- a/esp/services/ws_topology/ws_topologyService.hpp
+++ b/esp/services/ws_topology/ws_topologyService.hpp
@@ -50,10 +50,10 @@ public:
 
     virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
     {
-        IPropertyTree *folder = ensureNavFolder(data, "Topology", "Topology", NULL, false, 4);
-        ensureNavLink(*folder, "Target Clusters", "/WsTopology/TpTargetClusterQuery?Type=ROOT", "Target Clusters", NULL, NULL, 1);
-        ensureNavLink(*folder, "Cluster Processes", "/WsTopology/TpClusterQuery?Type=ROOT", "Cluster Processes", NULL, NULL, 2);
-        ensureNavLink(*folder, "System Servers", "/WsTopology/TpServiceQuery?Type=ALLSERVICES", "System Servers", NULL, NULL, 3);
+        IPropertyTree *folder = ensureNavFolder(data, "Topology", NULL, NULL, false, 4);
+        ensureNavLink(*folder, "Target Clusters", "/WsTopology/TpTargetClusterQuery?Type=ROOT", "View details about target clusters and optionally run preflight activities", NULL, NULL, 1);
+        ensureNavLink(*folder, "Cluster Processes", "/WsTopology/TpClusterQuery?Type=ROOT", "View details about clusters and optionally run preflight activities", NULL, NULL, 2);
+        ensureNavLink(*folder, "System Servers", "/WsTopology/TpServiceQuery?Type=ALLSERVICES", "View details about System Support Servers clusters and optionally run preflight activities", NULL, NULL, 3);
     }
 };
 

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -120,12 +120,12 @@ public:
     {
         if (!batchWatchFeaturesOnly)
         {
-            IPropertyTree *folder = ensureNavFolder(data, "ECL Workunits", "ECL Workunits", NULL, false, 2);
-            ensureNavLink(*folder, "Search", "/WsWorkunits/WUQuery?form_", "Search Workunits", NULL, NULL, 1);
-            ensureNavLink(*folder, "Browse", "/WsWorkunits/WUQuery", "Browse Workunits", NULL, NULL, 2);
+            IPropertyTree *folder = ensureNavFolder(data, "ECL Workunits", NULL, NULL, false, 2);
+            ensureNavLink(*folder, "Search Workunits", "/WsWorkunits/WUQuery?form_", "Search for ECL workunits", NULL, NULL, 1);
+            ensureNavLink(*folder, "Browse Workunits", "/WsWorkunits/WUQuery", "Browse a list of ECL workunits", NULL, NULL, 2);
 
-            IPropertyTree *folderQueryset = ensureNavFolder(data, "Query Sets", "Queryset Management", NULL, false, 3);
-            ensureNavLink(*folderQueryset, "Browse", "/WsWorkunits/WUQuerySets", "Browse Querysets");
+            IPropertyTree *folderQueryset = ensureNavFolder(data, "Query Sets", NULL, NULL, false, 3);
+            ensureNavLink(*folderQueryset, "Browse", "/WsWorkunits/WUQuerySets", "Browse Published Queries");
         }
     }
 

--- a/esp/xslt/nav.xsl
+++ b/esp/xslt/nav.xsl
@@ -86,7 +86,14 @@
                     </xsl:attribute>
                 </img>
                     <b>
-                        <xsl:value-of select="@name"/>
+                        <a>
+                            <xsl:if test="@tooltip">
+                                <xsl:attribute name="title">
+                                    <xsl:value-of select="@tooltip"/>
+                                </xsl:attribute>
+                            </xsl:if>
+                            <xsl:value-of select="@name"/>
+                        </a>
                     </b>
                     <xsl:if test="@showSchemaLinks">
                       <xsl:text disable-output-escaping="yes">&nbsp;</xsl:text>


### PR DESCRIPTION
One-sentence mouse-over popup is added for EclWatch menu items
on the left side navigation section. The existing tool tips for menu 
groups are removed because they are not useful. 

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
