### PR TITLE
Fix minor issue with local sort order tracking

### DIFF
--- a/ecl/hql/hqlmeta.cpp
+++ b/ecl/hql/hqlmeta.cpp
@@ -446,7 +446,10 @@ IHqlExpression * getLocalSortOrder(ITypeInfo * type)
     else
         components.pop();
     if (components.ordinality())
+    {
+        removeDuplicates(components);
         return createValue(no_sortlist, makeSortListType(NULL), components);
+    }
     return NULL;
 }
 


### PR DESCRIPTION
Duplicate sort elements weren't deduped if a group was sorted by some
of the grouping criteria.  Could potentially cause codegenerator to
not thing something was already sorted when it was.  Saw no examples
in existing archived queries though.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
