### PR TITLE
Simplify addSuper

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1188,6 +1188,13 @@ public:
         setUserDescriptor(udesc,user);
         isactive = false;
     }
+    ~CDistributedFileTransaction()
+    {
+        // New files should be removed automatically if not committed
+        // MORE - refactor cCreateSuperFileAction to avoid this
+        if (isactive)
+            rollback();
+    }
     void addAction(CDFAction *action)
     {
         actions.append(*action);

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -727,9 +727,8 @@ public:
                 else
                     superfile->addSubFile(subfiles[i],false,NULL,false,transaction);
             }
+            transaction->commit();
         }
-        // MORE - Previous behaviour would keep new super-file even if no subs were added, do we change this?
-        transaction->commit();
     }
 
 

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -708,41 +708,28 @@ public:
 
     void addSuper(const char *superfname, unsigned numtoadd, const char **subfiles, const char *before,IUserDescriptor *user)
     {
-        Owned<IDistributedSuperFile> superfile = queryDistributedFileDirectory().lookupSuperFile(superfname,user);
+        Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
+        transaction->start();
+        Owned<IDistributedSuperFile> superfile = queryDistributedFileDirectory().lookupSuperFile(superfname,user,transaction);
         bool newfile = false;
         if (!superfile) {
-            superfile.setown(queryDistributedFileDirectory().createSuperFile(superfname,true,false,user));
+            superfile.setown(queryDistributedFileDirectory().createSuperFile(superfname,true,false,user,transaction));
             newfile = true;
         }
-        try {
-            if (numtoadd) {
-                unsigned i;
-                for (i=0;i<numtoadd;i++)
-                    if (superfile->querySubFileNamed(subfiles[i]))
-                        throwError1(DFUERR_DSuperFileContainsSub, subfiles[i]);
-                Owned<IDistributedFileTransaction> transaction;
-                if (numtoadd>1) {
-                    transaction.setown(createDistributedFileTransaction(user));
-                    transaction->start();
-                }
-                //StringBuffer before;
-                for (i=0;i<numtoadd;i++) {
-                    if (before&&*before)
-                        superfile->addSubFile(subfiles[i],true,(stricmp(before,"*")==0)?NULL:before,false,transaction);
-                    else
-                        superfile->addSubFile(subfiles[i],false,NULL,false,transaction);
-                }
-                if (transaction.get()) {
-                    superfile.clear(); // superfile must not be active when transactiion committed
-                    transaction->commit();
-                }
+        if (numtoadd) {
+            unsigned i;
+            for (i=0;i<numtoadd;i++)
+                if (superfile->querySubFileNamed(subfiles[i]))
+                    throwError1(DFUERR_DSuperFileContainsSub, subfiles[i]);
+            for (i=0;i<numtoadd;i++) {
+                if (before&&*before)
+                    superfile->addSubFile(subfiles[i],true,(stricmp(before,"*")==0)?NULL:before,false,transaction);
+                else
+                    superfile->addSubFile(subfiles[i],false,NULL,false,transaction);
             }
-        } catch (IException *) {
-            // TODO: DFS transaction could take care of it
-            if (newfile)
-                queryDistributedFileDirectory().removeEntry(superfname,user);
-            throw;
         }
+        // MORE - Previous behaviour would keep new super-file even if no subs were added, do we change this?
+        transaction->commit();
     }
 
 


### PR DESCRIPTION
Using new features of transactions (create file) to simplify addSuper code. We might
want to not keep new super-files (added on aut-create) if there are no
sub-files to add. Just left it to match previous behaviour.
