### PR TITLE
add ecl-queries copy command

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1205,6 +1205,7 @@ extern WORKUNIT_API IPropertyTree * resolveQueryAlias(IPropertyTree * queryRegis
 extern WORKUNIT_API IPropertyTree * getQueryRegistry(const char * wsEclId, bool readonly);
 extern WORKUNIT_API IPropertyTree * getQueryRegistryRoot();
 extern WORKUNIT_API void setQueryCommentForNamedQuery(IPropertyTree * queryRegistry, const char *id, const char *queryComment);
+extern WORKUNIT_API StringArray &getQuerySetTargetClusters(const char *queryset, StringArray &clusters);
 
 extern WORKUNIT_API void setQuerySuspendedState(IPropertyTree * queryRegistry, const char * name, bool suspend);
 
@@ -1212,7 +1213,7 @@ extern WORKUNIT_API IPropertyTree * addNamedPackageSet(IPropertyTree * packageRe
 extern WORKUNIT_API void removeNamedPackage(IPropertyTree * packageRegistry, const char * id);
 extern WORKUNIT_API IPropertyTree * getPackageSetRegistry(const char * wsEclId, bool readonly);
 
-extern WORKUNIT_API void addQueryToQuerySet(IWorkUnit *workunit, const char *querySetName, const char *queryName, IPropertyTree *packageInfo, WUQueryActivationOptions activateOption, StringBuffer &newQueryId);
+extern WORKUNIT_API void addQueryToQuerySet(IConstWorkUnit *workunit, const char *querySetName, const char *queryName, IPropertyTree *packageInfo, WUQueryActivationOptions activateOption, StringBuffer &newQueryId);
 extern WORKUNIT_API bool removeQuerySetAlias(const char *querySetName, const char *alias);
 extern WORKUNIT_API void addQuerySetAlias(const char *querySetName, const char *alias, const char *id);
 extern WORKUNIT_API void setSuspendQuerySetQuery(const char *querySetName, const char *id, bool suspend);

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -198,6 +198,7 @@ void EclCMDShell::usage()
            "   run         run the given ecl file, archive, dll, wuid, or query\n"
            "   activate    activate a published query\n"
            "   deactivate  deactivate the given query alias name\n"
+           "   queries     show or manipulate queries and querysets\n"
            "\nRun 'ecl help <command>' for more information on a specific command\n\n"
     );
 }

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -600,11 +600,18 @@ ESPrequest WULogFileRequest
     [min_ver("1.10")] string SlaveIP;
     [min_ver("1.32")] string IPAddress;
     [min_ver("1.32")] string Description;
+    [min_ver("1.36")] string QuerySet;
+    [min_ver("1.36")] string Query;
     string PlainText;
 };
 
 ESPresponse [exceptions_inline] WULogFileResponse
 {
+    [min_ver("1.36")] string Wuid;
+    [min_ver("1.36")] string QuerySet;
+    [min_ver("1.36")] string QueryName;
+    [min_ver("1.36")] string QueryId;
+    [min_ver("1.36")] string FileName;
     [http_content("application/octet-stream")] binary thefile;
 };
 
@@ -1209,8 +1216,22 @@ ESPresponse [exceptions_inline] WUQuerySetAliasActionResponse
     ESParray<ESPstruct QuerySetAliasActionResult, Result> Results;
 };
 
+ESPrequest WUQuerySetCopyQueryRequest
+{
+    string Source;
+    string Target;
+    string Cluster;
+    int Activate;
+    int Wait(10000);
+};
+
+ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
+{
+    string QueryId;
+};
+
 ESPservice [
-    version("1.35"), default_client_version("1.35"),
+    version("1.36"), default_client_version("1.36"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);
@@ -1273,6 +1294,7 @@ ESPservice [
     ESPmethod WUMultiQuerysetDetails(WUMultiQuerySetDetailsRequest, WUMultiQuerySetDetailsResponse);
     ESPmethod WUQuerysetQueryAction(WUQuerySetQueryActionRequest, WUQuerySetQueryActionResponse);
     ESPmethod WUQuerysetAliasAction(WUQuerySetAliasActionRequest, WUQuerySetAliasActionResponse);
+    ESPmethod WUQuerysetCopyQuery(WUQuerySetCopyQueryRequest, WUQuerySetCopyQueryResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/WUCopyLogicalFiles.xslt")] WUCopyLogicalFiles(WUCopyLogicalFilesRequest, WUCopyLogicalFilesResponse);
 };
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1595,14 +1595,14 @@ void WsWuInfo::getWorkunitArchiveQuery(MemoryBuffer& buf)
     buf.append(queryText.length(), queryText.str());
 }
 
-void WsWuInfo::getWorkunitDll(MemoryBuffer& buf)
+void WsWuInfo::getWorkunitDll(StringBuffer &dllname, MemoryBuffer& buf)
 {
     Owned<IConstWUQuery> query = cw->getQuery();
     if(!query)
         throw MakeStringException(ECLWATCH_QUERY_NOT_FOUND_FOR_WU,"No query for workunit %s.",wuid.str());
 
-    SCMStringBuffer dllname;
-    query->getQueryDllName(dllname);
+    StringBufferAdaptor isvName(dllname);
+    query->getQueryDllName(isvName);
     queryDllServer().getDll(dllname.str(), buf);
 }
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -169,7 +169,7 @@ public:
     void getWorkunitThorSlaveLog(const char *slaveip, MemoryBuffer& buf);
     void getWorkunitResTxt(MemoryBuffer& buf);
     void getWorkunitArchiveQuery(MemoryBuffer& buf);
-    void getWorkunitDll(MemoryBuffer& buf);
+    void getWorkunitDll(StringBuffer &name, MemoryBuffer& buf);
     void getWorkunitXml(const char* plainText, MemoryBuffer& buf);
     void getWorkunitCpp(const char* cppname, const char* description, const char* ipAddress, MemoryBuffer& buf);
     void getEventScheduleFlag(IEspECLWorkunit &info);

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -45,6 +45,7 @@ public:
     bool onWUMultiQuerysetDetails(IEspContext &context, IEspWUMultiQuerySetDetailsRequest &req, IEspWUMultiQuerySetDetailsResponse &resp);
     bool onWUQuerysetQueryAction(IEspContext &context, IEspWUQuerySetQueryActionRequest & req, IEspWUQuerySetQueryActionResponse & resp);
     bool onWUQuerysetAliasAction(IEspContext &context, IEspWUQuerySetAliasActionRequest &req, IEspWUQuerySetAliasActionResponse &resp);
+    bool onWUQuerysetCopyQuery(IEspContext &context, IEspWUQuerySetCopyQueryRequest &req, IEspWUQuerySetCopyQueryResponse &resp);
     bool onWUCopyLogicalFiles(IEspContext &context, IEspWUCopyLogicalFilesRequest &req, IEspWUCopyLogicalFilesResponse &resp);
 
     bool onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEspWUInfoResponse &resp);
@@ -101,7 +102,7 @@ public:
 
 private:
     unsigned awusCacheMinutes;
-
+    StringBuffer queryDirectory;
     Owned<DataCache> dataCache;
     Owned<ArchivedWuCache> archivedWuCache;
     WUSchedule m_sched;
@@ -145,5 +146,7 @@ public:
 private:
     bool batchWatchFeaturesOnly;
 };
+
+void deploySharedObject(IEspContext &context, StringBuffer &newWuid, const char *filename, const char *cluster, const char *name, const MemoryBuffer &obj, const char *dir, const char *xml=NULL);
 
 #endif


### PR DESCRIPTION
add ecl-queries copy command

Copies a query from one queryset to another.  Source queryset can be
from a remote environment.

Usage:

ecl queries copy &lt;from querypath> &lt;to queryset> [--activate]

 Options:
   &lt;from querypath>       path of query to copy
                                   format: [//ip:port/]queryset/query
   &lt;to queryset>          name of queryset to copy the query into
   -cl, --cluster         Local cluster to associate with remote workunit
   -A, --activate         Activate the new query
   --wait=&lt;ms>            Max time to wait in milliseconds
 Common Options:
   -v, --verbose          output additional tracing information
   -s, --server=&lt;ip>      ip of server running ecl services (eclwatch)
   --port=&lt;port>          ecl services port
   -u, --username=&lt;name>  username for accessing ecl services
   -pw, --password=&lt;pw>   password for accessing ecl services

Signed-off-by: Anthony Fishbeck &lt;Anthony.Fishbeck@lexisnexis.com>
