### PR TITLE
Fixes #1520 Check for null object before accessing it

### DIFF
--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -3456,7 +3456,7 @@ function updateParams(record, attrName, oldValue, newValue, updateAttr, prevVal,
           }
           record.setData(subrec, sub);
         }
-        else {
+        else if (sub){
           var sparams = sub.params;
           var newsparams = updateParams(null, attrName, oldValue, newValue, updateAttr, prevVal, updateVal, sparams);
           if (newsparams.length > 0)


### PR DESCRIPTION
This is not related to the thor changes but a side effect of the fix for #806 which had to do with displaying optional attributes not present in the environment. In this case, slavesPerNode is a required attribute, which
caused a variable evaluate to null. Added a check for null object before accessing it.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
