### PR TITLE
Fix potential aggregate child query issue

### DIFF
--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -32,6 +32,9 @@
 
 class AggregateSlaveBase : public CSlaveActivity, public CThorDataLink
 {
+protected:
+    bool hadElement;
+    IThorDataLink *input;
 public:
     AggregateSlaveBase(CGraphElementBase *_container) 
         : CSlaveActivity(_container), CThorDataLink(this)
@@ -111,14 +114,14 @@ public:
         if (!container.queryLocal())
             mpTag = container.queryJob().deserializeMPTag(data);
     }
+    void start()
+    {
+        hadElement = false;
+    }
     virtual void doStopInput()
     {
         stopInput(input);
     }
-
-protected:
-    bool hadElement;
-    IThorDataLink *input;
 };
 
 //
@@ -149,6 +152,7 @@ public:
     void start()
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
+        AggregateSlaveBase::start();
         eof = false;
         inputStopped = false;
         dataLinkStart("AGGREGATE", container.queryId());


### PR DESCRIPTION
Failing to reset a boolean (hadElement), could call
processNext instead of processFirst on next child query.
Or sendResult spuriously if no records on next run.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
