### PR TITLE
Remove unused transaction from attach/detach

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -3145,7 +3145,7 @@ public:
         return new CDistributedFilePartIterator(queryParts(),filter);
     }
 
-    void rename(const char *_logicalname,IDistributedFileTransaction *transaction,IUserDescriptor *user)
+    void rename(const char *_logicalname,IUserDescriptor *user)
     {
         StringBuffer prevname;
         Owned<IFileRelationshipIterator> reliter;
@@ -3160,9 +3160,9 @@ public:
                 EXCLOG(e,"CDistributedFileDirectory::rename");
                 e->Release();
             }
-            detach(transaction);
+            detach();
         }
-        attach(_logicalname,transaction,user);
+        attach(_logicalname,user);
         if (prevname.length()) {
             DistributedFilePropertyLock lock(this);
             IPropertyTree &pt = queryAttributes();
@@ -3199,9 +3199,8 @@ public:
         return (!logicalName.isSet());
     }
 
-    void attach(const char *_logicalname,IDistributedFileTransaction *transaction,IUserDescriptor *user)
+    void attach(const char *_logicalname,IUserDescriptor *user)
     {
-        assertex(!transaction); 
         CriticalBlock block (sect);
         assertex(isAnon()); // already attached!
         logicalName.set(_logicalname);
@@ -3228,9 +3227,8 @@ public:
 #endif
     }
 
-    void detach(IDistributedFileTransaction *transaction)
+    void detach()
     {
-        assertex(!transaction); 
         assert(proplockcount == 0 && "CDistributedFile detach: Some properties are still locked");
         CriticalBlock block (sect);
         assertex(!isAnon()); // not attached!
@@ -4615,7 +4613,7 @@ public:
         return ret;
     }
 
-    void rename(const char *_logicalname,IDistributedFileTransaction *transaction,IUserDescriptor *user)
+    void rename(const char *_logicalname,IUserDescriptor *user)
     {
         StringBuffer prevname;
         Owned<IFileRelationshipIterator> reliter;
@@ -4630,9 +4628,9 @@ public:
                 EXCLOG(e,"CDistributedFileDirectory::rename");
                 e->Release();
             }
-            detach(transaction);
+            detach();
         }
-        attach(_logicalname,transaction,user);
+        attach(_logicalname,user);
         if (reliter.get()) {
             // add back any relationships with new name
             parent->renameFileRelationships(prevname.str(),_logicalname,reliter);
@@ -4679,11 +4677,10 @@ public:
 
 
 
-    void attach(const char *_logicalname,IDistributedFileTransaction *transaction,IUserDescriptor *user)
+    void attach(const char *_logicalname,IUserDescriptor *user)
     {
         // I don't think this ever gets called on superfiles
         WARNLOG("attach called on superfile! (%s)",_logicalname);
-        assertex(!transaction); 
         CriticalBlock block (sect);
         assertex(isAnon()); // already attached!
         StringBuffer tail;
@@ -4697,7 +4694,7 @@ public:
         root.setown(conn->getRoot());
     }
 
-    void detach(IDistributedFileTransaction *transaction)
+    void detach()
     {   
         // will need more thought but this gives limited support for anon
         CriticalBlock block (sect);
@@ -7012,7 +7009,7 @@ bool CDistributedFileDirectory::renamePhysical(const char *oldname,const char *n
         fixDates(newfile,port);
     }
     else
-        file->rename(newname,NULL,user);
+        file->rename(newname,user);
     return true;
 }
 

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -213,7 +213,7 @@ interface IDistributedFile: extends IInterface
 
     virtual IDistributedFilePartIterator *getIterator(IDFPartFilter *filter=NULL) = 0;
 
-    virtual void rename(const char *logicalname,IDistributedFileTransaction *transaction=NULL,IUserDescriptor *user=NULL) = 0;                          // simple rename (no file copy)
+    virtual void rename(const char *logicalname,IUserDescriptor *user=NULL) = 0;// simple rename (no file copy)
 
     virtual IFileDescriptor *getFileDescriptor(const char *clustername=NULL) = 0;   // get file descriptor used for file system access
                                                                                 // if clustername specified makes filedesc for only that cluster
@@ -221,8 +221,8 @@ interface IDistributedFile: extends IInterface
     virtual const char *queryDefaultDir() = 0;                                  // default directory (note primary dir)
     virtual const char *queryPartMask() = 0;                                    // default part name mask
 
-    virtual void attach(const char *logicalname,IDistributedFileTransaction *transaction=NULL,IUserDescriptor *user=NULL) = 0;                          // attach to name in DFS
-    virtual void detach(IDistributedFileTransaction *transaction=NULL) = 0;                                                 // no longer attached to name in DFS
+    virtual void attach(const char *logicalname,IUserDescriptor *user=NULL) = 0;// attach to name in DFS
+    virtual void detach() = 0;                                                  // no longer attached to name in DFS
 
     virtual IPropertyTree &queryAttributes() = 0;                               // DFile attributes
 

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1334,7 +1334,7 @@ public:
                                 if (needrep) 
                                     replicating = true;
                                 else
-                                    dstFile->attach(dstName.get(),NULL, userdesc);
+                                    dstFile->attach(dstName.get(), userdesc);
                                 Audit("COPYDIFF",userdesc,srcName.get(),dstName.get());
                             }
                         }
@@ -1344,7 +1344,7 @@ public:
                                 if (needrep) 
                                     replicating = true;
                                 else
-                                    dstFile->attach(dstName.get(),NULL, userdesc);
+                                    dstFile->attach(dstName.get(), userdesc);
                                 Audit("COPY",userdesc,srcName.get(),dstName.get());
                             }
                         }
@@ -1369,7 +1369,7 @@ public:
                                 if (needrep) 
                                     replicating = true;
                                 else
-                                    dstFile->attach(dstName.get(),NULL,userdesc);
+                                    dstFile->attach(dstName.get(),userdesc);
                                 Audit("COPY",userdesc,srcFile?srcFile->queryLogicalName():NULL,dstName.get());
                             }
                         }
@@ -1400,7 +1400,7 @@ public:
                     fsys.move(srcFile,dstFile,recovery, recoveryconn, filter, opttree, &feedback, &abortnotify, dfuwuid);
                     runningconn.clear();
                     if (!abortnotify.abortRequested()) {
-                        dstFile->attach(dstName.get(),NULL,userdesc);
+                        dstFile->attach(dstName.get(),userdesc);
                         Audit("MOVE",userdesc,srcFile?srcFile->queryLogicalName():NULL,dstName.get());
                     }
                 }
@@ -1492,7 +1492,7 @@ public:
                             if (needrep) 
                                 replicating = true;
                             else
-                                dstFile->attach(dstName.get(),NULL, userdesc);
+                                dstFile->attach(dstName.get(), userdesc);
                             Audit("IMPORT",userdesc,dstName.get(),NULL);
                         }
                         runningconn.clear();
@@ -1513,7 +1513,7 @@ public:
                 break;
             case DFUcmd_add:
                 {
-                    dstFile->attach(dstName.get(),NULL,userdesc);
+                    dstFile->attach(dstName.get(),userdesc);
                     Audit("ADD",userdesc,dstName.get(),NULL);
                 }
                 break;
@@ -1590,7 +1590,7 @@ public:
                             }
                             else {
                                 //dstFile->queryPartDiskMapping(0).maxCopies = 2;           // dont think this is right ** TBD
-                                dstFile->attach(dstName.get(),NULL,userdesc);
+                                dstFile->attach(dstName.get(),userdesc);
                             }
                             progress->setDone(NULL,0,true);
                             Audit("REPLICATE",userdesc,dstName.get(),NULL);

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -459,7 +459,7 @@ class CFileCloner
         }
 
         Owned<IDistributedFile> dstfile = fdir->createNew(dstfdesc);
-        dstfile->attach(destfilename,NULL,userdesc);
+        dstfile->attach(destfilename,userdesc);
 
 
 
@@ -847,7 +847,7 @@ public:
         Owned<IFileDescriptor> fdesc = deserializeFileDescriptorTree(t,&queryNamedGroupStore(),0);
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc,true);
         if (file)
-            file->attach(lfn,NULL,user);
+            file->attach(lfn,user);
     }
 
     void addFileRemote(const char *lfn,SocketEndpoint &srcdali,const char *srclfn,IUserDescriptor *srcuser=NULL,IUserDescriptor *user=NULL)
@@ -863,7 +863,7 @@ public:
         }
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
         if (file)
-            file->attach(lfn,NULL,user);
+            file->attach(lfn,user);
     }
 
 

--- a/dali/dfuXRefLib/XRefFilesNode.cpp
+++ b/dali/dfuXRefLib/XRefFilesNode.cpp
@@ -380,7 +380,7 @@ bool CXRefFilesNode::AttachPhysical(const char* _Partmask,IUserDescriptor* udesc
     }
 
     Owned<IDistributedFile> dFile = queryDistributedFileDirectory().createNew(fileDesc);
-    dFile->attach(logicalName.toCharArray(),NULL,udesc);
+    dFile->attach(logicalName.toCharArray(),udesc);
 
     if (!RemoveTreeNode(_Partmask)) {                   
         ERRLOG("Removing XRef Branch %s",_Partmask);

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -2838,7 +2838,7 @@ char *EclAgent::getFilePart(const char *lfn, bool create)
         desc->setDefaultDir(dir.str());
         desc->setPart(0, queryMyNode(), base.str(), NULL);
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(desc);
-        file->attach(full_lfn.str(),NULL,queryUserDescriptor());
+        file->attach(full_lfn.str(),queryUserDescriptor());
         return physical.detach();
     }
     else

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -673,7 +673,7 @@ void CHThorDiskWriteActivity::publish()
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(desc);
         if((helper.getFlags() & TDWpersist) && file->getModificationTime(modifiedTime))
             file->setAccessedTime(modifiedTime);
-        file->attach(logicalName.get(), NULL, agent.queryCodeContext()->queryUserDescriptor());
+        file->attach(logicalName.get(), agent.queryCodeContext()->queryUserDescriptor());
         agent.logFileAccess(file, "HThor", "CREATED");
     }
 }
@@ -1177,7 +1177,7 @@ void CHThorIndexWriteActivity::execute()
     {
         dfile.setown(queryDistributedFileDirectory().createNew(desc));
         expandLogicalFilename(lfn, helper.getFileName(), agent.queryWorkUnit(), agent.queryResolveFilesLocally());
-        dfile->attach(lfn.str(),NULL, agent.queryCodeContext()->queryUserDescriptor());
+        dfile->attach(lfn.str(),agent.queryCodeContext()->queryUserDescriptor());
         agent.logFileAccess(dfile, "HThor", "CREATED");
     }
     else

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2670,7 +2670,7 @@ private:
 
             Owned<IDistributedFile> publishFile = queryDistributedFileDirectory().createNew(desc); // MORE - we'll create this earlier if we change the locking paradigm
             publishFile->setAccessedTime(modifiedTime);
-            publishFile->attach(dFile->queryLogicalName(), NULL, activity ? activity->queryUserDescriptor() : NULL);
+            publishFile->attach(dFile->queryLogicalName(), activity ? activity->queryUserDescriptor() : NULL);
             // MORE should probably write to the roxielocalstate too in case Dali is down next time I look...
         }
     }

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -550,7 +550,7 @@ public:
         __int64 fs = file->getFileSize(false,false);
         if (fs!=-1)
             file->queryAttributes().setPropInt64("@size",fs);
-        file->attach(scopedName.str(), NULL, job.queryUserDescriptor());
+        file->attach(scopedName.str(), job.queryUserDescriptor());
         unsigned c=0;
         for (; c<fileDesc.numClusters(); c++)
         {


### PR DESCRIPTION
The transaction parameter is set, only for the sake of asserting
on its existence, but the parameter is never passed (all calls
pass NULL). If, in the future, a check is needed, it should be
done in the caller, rather than here.
