### PR TITLE
Remove transaction from linkSuperOwner

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -376,12 +376,17 @@ public:
         if (!unlocked)
             unlock();
     }
-    // MORE: Implement commit/rollback/retry as necessary
     void unlock()
     {
         file->unlockProperties(TAS_NONE);
         unlocked = true;
     }
+    void commit()
+    {
+        file->unlockProperties(TAS_SUCCESS);
+        unlocked = true;
+    }
+    // MORE: Implement rollback when necessary
     IPropertyTree &queryAttributes()
     {
         return file->queryAttributes();


### PR DESCRIPTION
linkSuperOwner was (badly) using transaction to know if it could commit the changes or not. Thius logic is already imposed by the PropertyLock introduced recently, so we can remove the need to pass the additional parameter.

Also, removed linkSuperOwner from CDFDirectory, which was unnecessary and unused.

All regressions pass.
