### PR TITLE
Silent printf warning

### DIFF
--- a/system/jlib/jexcept.hpp
+++ b/system/jlib/jexcept.hpp
@@ -98,7 +98,8 @@ IException jlib_decl *MakeStringExceptionDirect(int code,const char *why);
 IException jlib_decl *MakeStringException(MessageAudience aud,int code,const char *why, ...) __attribute__((format(printf, 3, 4)));
 IException jlib_decl *MakeStringExceptionVA(MessageAudience aud,int code,const char *why, va_list args);
 IException jlib_decl *MakeStringExceptionDirect(MessageAudience aud,int code,const char *why);
-void jlib_decl ThrowStringException(int code,const char *format, ...) __attribute__((format(printf, 2, 3)));
+
+void jlib_decl ThrowStringException(int code,const char *format, ...) __attribute__((format(printf, 2, 0)));
 
 interface jlib_thrown_decl IOSException: extends IException{};
 IOSException jlib_decl *MakeOsException(int code);


### PR DESCRIPTION
Macro `ThrowStringException` is used by other macros that build printf-like functions with varied number of arguments. The attribute is meant to check the format, but since there are more than one, the check only pass in one of them. The zero tells GCC to only check the format string, not the arguments themselves, so it's not completely removing all checks.

Another way to fix this warning would be to implement `ThrowStringExceptionN` for N between nil and 4, but that throws away the benefit of using variadic arguments in the first place. I don't feel particularly strong about this patch, either way is fine.

The warnings were:

```
/home/rengolin/workspace/hpcc/src/dali/ft/fttransform.cpp: In member function ‘void TransferServer::deserializeAction(MemoryBuffer&, unsigned int)’:
/home/rengolin/workspace/hpcc/src/dali/ft/fttransform.cpp:583:1: warning: format ‘%lld’ expects type ‘long long int’, but argument 3 has type ‘const char*’
/home/rengolin/workspace/hpcc/src/dali/ft/fttransform.cpp:583:1: warning: format ‘%lld’ expects type ‘long long int’, but argument 4 has type ‘const char*’
/home/rengolin/workspace/hpcc/src/dali/ft/fttransform.cpp:583:1: warning: too few arguments for format
```
