### PR TITLE
Show correct node information for external node

### DIFF
--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -1616,6 +1616,11 @@ void CTpWrapper::getMachineList(const char* clusterName,
                     machineInfo.setDomain(pDomain->getName(sName).str());
                 }
             }
+            else
+            {
+                machineInfo.setName("external");
+                machineInfo.setOS(MachineOsUnknown);
+            }
 
             MachineList.append(machineInfo);
         }


### PR DESCRIPTION
On EclWatch, external node is not shown correctly now on
the node list of thor cluster. This fix shows the node name
to be 'external' and the platform to be 'Unknown'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
