### PR TITLE
gh-1412 - fix some more swapnode related problems

### DIFF
--- a/initfiles/componentfiles/thor/run_thor
+++ b/initfiles/componentfiles/thor/run_thor
@@ -34,11 +34,21 @@ echo $$ > run_thor.lck
 
 export SENTINEL="thor.sentinel"
 while [ 1 ]; do
-    export logpth="$logdir/$logpthtail"
+    daliadmin $DALISERVER dfsgroup ${groupName} > slaves
+    errcode=$?
+    if [ 0 != ${errcode} ]; then
+    echo 'failed to lookup dali group for $groupName'
+        exit 1
+    fi
+    ## multislaves for bkwd compat. with old environments
+    if [ ${slavespernode} -gt 1 ] || [ "$localthor" = "true" ] || [ "$multislaves" = "true" ]; then
+        $deploydir/makethorgroup
+    fi
+
     $deploydir/start_slaves
 
-    echo thormaster cmd : $instancedir/thormaster_$THORMASTERPORT MASTER=$THORMASTER:$THORMASTERPORT logDir=$logpth SOCACHE_DIR=$instancedir/socache 
-    nohup $instancedir/thormaster_$THORMASTERPORT MASTER=$THORMASTER:$THORMASTERPORT logDir=$logpth SOCACHE_DIR=$instancedir/socache 2> /dev/null 1>/dev/null &
+    echo thormaster cmd : $instancedir/thormaster_$THORNAME MASTER=$THORMASTER:$THORMASTERPORT
+    nohup $instancedir/thormaster_$THORNAME MASTER=$THORMASTER:$THORMASTERPORT 2> /dev/null 1>/dev/null &
 
     thorpid=$!
     if [ "$thorpid" -ne "0" ]; then 
@@ -78,5 +88,4 @@ while [ 1 ]; do
         echo $SENTINEL 'has been removed or thormaster did not fully start - script stopping'
         exit 0
     fi
-    export logpthtail="`date +%m_%d_%Y_%H_%M_%S`"
 done

--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -39,12 +39,9 @@ fi
 
 mkdir -p $instancedir
 mkdir -p `dirname $logredirect`
-exec >$logredirect 2>&1
+exec >>$logredirect 2>&1
 
 cd $instancedir
-
-logpth=${logpth}_${slaveport}
-
 
 echo "slave init `date`"
 
@@ -69,7 +66,7 @@ echo $$ > $lckfile
 ulimit -c unlimited
 ulimit -n 8192
 
-slaveproc="thorslave_$slaveport"
+slaveproc="thorslave_${hpcc_compname}"
 ln -s -f `which $prog` $slaveproc
 
 echo "slave starting `date`"

--- a/initfiles/componentfiles/thor/start_slaves
+++ b/initfiles/componentfiles/thor/start_slaves
@@ -28,7 +28,7 @@ if [ "$localthor" = "true" ]; then
         if [ "$slaveport" = "" ]; then
             slaveport=$THORSLAVEPORT
         fi
-        $deploydir/start_slave thorslave${LCR} $THORMASTER:$THORMASTERPORT $logpth $instancedir $slaveport $THORNAME $PATH_PRE $logdir/start_slave_$logpthtail.$n.log
+        $deploydir/start_slave thorslave${LCR} $THORMASTER:$THORMASTERPORT $logdir $instancedir $slaveport $THORNAME $PATH_PRE $logdir/start_slave_$logpthtail.$n.log
         let "n += 1";
         done
 else
@@ -42,7 +42,7 @@ else
                     slaveport=$THORSLAVEPORT
                 fi
                 logredirect="$logdir/start_slave_$logpthtail.$n.log"
-                frunssh $ip "/bin/sh -c '$deploydir/start_slave thorslave${LCR} $THORMASTER:$THORMASTERPORT $logpth $instancedir $slaveport $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
+                frunssh $ip "/bin/sh -c '$deploydir/start_slave thorslave${LCR} $THORMASTER:$THORMASTERPORT $logdir $instancedir $slaveport $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
                 let "n += 1";
             done
         else
@@ -50,7 +50,7 @@ else
                 mv $instancedir/thorgroup $instancedir/thorgroup.local
             fi
             logredirect="$logdir/start_slave_$logpthtail.log"
-            frunssh $instancedir/slaves "/bin/sh -c '$deploydir/start_slave thorslave${LCR} $THORMASTER:$THORMASTERPORT $logpth $instancedir $THORSLAVEPORT $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
+            frunssh $instancedir/slaves "/bin/sh -c '$deploydir/start_slave thorslave${LCR} $THORMASTER:$THORMASTERPORT $logdir $instancedir $THORSLAVEPORT $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
         fi
 fi
 echo thorslaves started

--- a/initfiles/componentfiles/thor/start_thor
+++ b/initfiles/componentfiles/thor/start_thor
@@ -52,26 +52,11 @@ if [ `ulimit -n` -lt 8192 ]; then
 fi
 
 if [ ! -z ${THORPRIMARY} ]; then
-    groupName=${THORPRIMARY}
+    export groupName=${THORPRIMARY}
 else
-    groupName=${THORNAME}
+    export groupName=${THORNAME}
 fi
-daliadmin $DALISERVER dfsgroup ${groupName} > slaves
-errcode=$?
-if [ 0 != ${errcode} ]; then
-    echo 'failed to lookup dali group for $groupName'
-    exit 1
-fi
-
-ln -s -f $deploydir/thormaster${LCR} thormaster_$THORMASTERPORT
-
-if [ "$localthor" = "true" ]; then
-    ln -s -f $deploydir/thorslave${LCR} thorslave_$THORSLAVEPORT
-fi
-## multislaves for bkwd compat. with old environments
-if [ ${slavespernode} -gt 1 ] || [ "$localthor" = "true" ] || [ "$multislaves" = "true" ]; then
-    . $deploydir/makethorgroup
-fi
+ln -s -f $deploydir/thormaster${LCR} thormaster_$THORNAME
 
 ENV_DIR=`cat ${HPCC_CONFIG} | sed -n "/\[DEFAULT\]/,/\[/p" | grep "^configs=" | sed -e 's/^configs=//'`
 export logdir=`updtdalienv $ENV_DIR/environment.xml -d log thor $THORNAME`

--- a/initfiles/componentfiles/thor/stop_thor
+++ b/initfiles/componentfiles/thor/stop_thor
@@ -44,26 +44,28 @@ if [ "$#" -lt "2" ] || [ "$2" != "keep_sentinel" ]; then
     sleep 1
 fi
 
-while [ "`${PIDOF} thormaster_$THORMASTERPORT`" != "" ]
+masterproc="thormaster_$THORNAME"
+while [ "`${PIDOF} $masterproc`" != "" ]
 do
   echo --------------------------
   echo stopping thormaster $THORMASTER 
-  killall thormaster_$THORMASTERPORT
+  killall $masterproc
   sleep 8
-  killall -9 thormaster_$THORMASTERPORT
+  killall -9 $masterproc
   sleep 1
 done
 
 echo --------------------------
 echo stopping thor slaves 
 
+slaveproc="thorslave_$THORNAME"
 if [ "$localthor" = "true" ]; then
-    killall -9 thorslave_$THORSLAVEPORT
+    killall -9 $slaveproc
 else
     # use 20 threads
     # timeout of 60 seconds (in case slave busy)
     # hard kill (called after master down anyway so going to stall)
-    $deploydir/frunssh $instancedir/slaves "/bin/sh -c 'killall -9 thorslave_$THORSLAVEPORT'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1 | egrep -v "no process killed"
+    $deploydir/frunssh $instancedir/slaves "/bin/sh -c 'killall -9 $slaveproc'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1 | egrep -v "no process killed"
     echo slaves stopped
 fi
 


### PR DESCRIPTION
- regeneration of slaves/thorgroup was happening outside of script recycle
  loop, so autoswapnode didn't cause regenaration
- multislave process naming issue, causing failed stop(kill)
- weird problem with ports incrementing over time when recycling (because executing script inline)
- get rid of unused socache variable in scripts
- minor fix to log redirection paths

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
