### PR TITLE
New error message text to match arguments

### DIFF
--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -82,6 +82,7 @@
 #define DFTERR_PartitioningZeroSizedRowLink     8195
 #define DFTERR_CopyAborted                      8196
 #define DFTERR_WrongComputer                    8197
+#define DFTERR_OutputOffsetMismatchNoBlock      8198
 
 
 //---- Text for all errors (make it easy to internationalise) ---------------------------
@@ -134,6 +135,7 @@
 
 #define DFTERR_UnknownFormatType_Text           "INTERNAL: Save unknown format type"
 #define DFTERR_OutputOffsetMismatch_Text        "INTERNAL: Output offset does not match expected (%"I64F"d expected %"I64F"d) at %s of block %d"
+#define DFTERR_OutputOffsetMismatchNoBlock_Text "INTERNAL: Output offset does not match expected (%"I64F"d expected %"I64F"d) on deserialize"
 #define DFTERR_NoSolarisDir_Text                "Directory not yet supported for solaris"
 #define DFTERR_NoSolarisCopy_Text               "Copy not yet supported for solaris"
 #define DFTERR_ReplicateSameFormat_Text         "INTERNAL: Replicate cannot convert formats"

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -580,7 +580,7 @@ void TransferServer::deserializeAction(MemoryBuffer & msg, unsigned action)
         StringBuffer host, expected;
         queryHostIP().getIpText(host);
         ep.getIpText(expected);
-        throwError2(DFTERR_OutputOffsetMismatch, expected.str(), host.str());
+        throwError2(DFTERR_OutputOffsetMismatchNoBlock, I64_CAST expected.str(), I64_CAST host.str());
     }
 
     srcFormat.deserialize(msg);

--- a/system/include/platform.h
+++ b/system/include/platform.h
@@ -366,6 +366,7 @@ typedef int socklen_t;
 #define memicmp j_memicmp
 
 #define I64F          "ll"
+#define I64_CAST      (long long int)
 
 #ifndef stricmp
 #define stricmp   strcasecmp


### PR DESCRIPTION
To avoid warnings:

```
dali/ft/fttransform.cpp: In member function ‘void TransferServer::deserializeAction(MemoryBuffer&, unsigned int)’:
dali/ft/fttransform.cpp:583:1: warning: format ‘%lld’ expects type ‘long long int’, but argument 3 has type ‘const char*’
dali/ft/fttransform.cpp:583:1: warning: format ‘%lld’ expects type ‘long long int’, but argument 4 has type ‘const char*’
dali/ft/fttransform.cpp:583:1: warning: too few arguments for format
```
