### PR TITLE
Ensures slaves file exists - backupnode/stop thor

### DIFF
--- a/initfiles/componentfiles/thor/start_backupnode.in
+++ b/initfiles/componentfiles/thor/start_backupnode.in
@@ -65,11 +65,19 @@ if [ -z "$BACKUPNODE_DATA" ]; then
     echo cannot determine backupnode directory 
     exit 1
 fi
-if [ ! -r $INSTANCE_DIR/slaves ]; then
-    echo cannot read $INSTANCE_DIR/slaves 
+. $INSTANCE_DIR/setvars
+
+if [ ! -z ${THORPRIMARY} ]; then
+    groupName=${THORPRIMARY}
+else
+    groupName=${THORNAME}
+fi
+daliadmin $DALISERVER dfsgroup ${groupName} > $INSTANCE_DIR/slaves
+errcode=$?
+if [ 0 != ${errcode} ]; then
+    echo 'failed to lookup dali group for $groupName'
     exit 1
 fi
-. $INSTANCE_DIR/setvars
 
 BACKUPNODE_DATA=$BACKUPNODE_DATA/last_backup
 if [ "$localthor" == "true" ]; then

--- a/initfiles/componentfiles/thor/stop_thor
+++ b/initfiles/componentfiles/thor/stop_thor
@@ -63,7 +63,20 @@ else
     # use 20 threads
     # timeout of 60 seconds (in case slave busy)
     # hard kill (called after master down anyway so going to stall)
-    $deploydir/frunssh $instancedir/slaves "/bin/sh -c 'killall -9 thorslave_$THORSLAVEPORT'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1 | egrep -v "no process killed"
+    if [ ! -r $instancedir/slaves ]; then
+        if [ ! -z ${THORPRIMARY} ]; then
+            groupName=${THORPRIMARY}
+        else
+            groupName=${THORNAME}
+        fi
+        daliadmin $DALISERVER dfsgroup ${groupName} > $instancedir/slaves
+        errcode=$?
+        if [ 0 != ${errcode} ]; then
+            echo 'failed to lookup dali group for $groupName'
+            exit 1
+        fi
+    fi
+    $deploydir/frunssh $instancedir/slaves "/bin/sh -c 'killall -9 $slaveproc'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1 | egrep -v "no process killed"
     echo slaves stopped
 fi
 


### PR DESCRIPTION
If Thor's ever been started then slaves should exist,
but guard against and regenerate.

In case of stop, only generate if missing, which means that stop will used
any current list, that may have been updated in the interim.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
