### PR TITLE
Compound filter group diskread could lose records

### DIFF
--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -262,7 +262,7 @@ public:
                                 if (!activity.grouped)
                                     break;
                                 if (!firstInGroup) {
-                                    firstInGroup = false;
+                                    firstInGroup = true;
                                     return NULL;
                                 }
                                 row = CDiskRecordPartHandler::prefetchRow();
@@ -288,7 +288,7 @@ public:
                                 if (!activity.grouped)
                                     break;
                                 if (!firstInGroup) {
-                                    firstInGroup = false;
+                                    firstInGroup = true;
                                     return NULL;
                                 }
                                 row.setown(CDiskRecordPartHandler::nextRow());


### PR DESCRIPTION
A bug in the end of group marker processing, could cause early termination
of diskread, if a group is filtered out entirely.

A similar bug on non-compount grouped disk read, but I think it could not be
hit - it would have required a empty to group to have been read from disk.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
