### PR TITLE
FIX: gh-1549 HThor to warn on unsupported sort algo

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -3673,7 +3673,15 @@ void CHThorGroupSortActivity::createSorter()
         else
             sorter.setown(new CInsertionSorter(helper.queryCompare()));
     else
-        throw MakeStringException(0, "Requested sort algorithm %s which is not provided by hthor", algoname);
+    {
+        StringBuffer sb;
+        sb.appendf("Ignoring unsupported sort order algorithm '%s', using default", algoname);
+        agent.addWuException(sb.str(),0,ExceptionSeverityWarning,"hthor");
+        if((flags & TAFunstable) != 0)
+            sorter.setown(new CQuickSorter(helper.queryCompare()));
+        else
+            sorter.setown(new CHeapSorter(helper.queryCompare()));
+    }
 }
 
 void CHThorGroupSortActivity::getSorted()

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -7840,7 +7840,13 @@ public:
                     else if (stricmp(useAlgorithm, "insertionsort")==0)
                         sorter = new CInsertionSortAlgorithm(compare, &ctx->queryRowManager(), activityId);
                     else
-                        throw MakeStringException(ROXIE_UNKNOWN_ALGORITHM, "Invalid sort algorithm %s requested", useAlgorithm);
+                    {
+                        WARNLOG(ROXIE_UNKNOWN_ALGORITHM, "Ignoring unsupported sort order algorithm '%s', using default", useAlgorithm);
+                        if (sortFlags & TAFunstable)
+                            sorter = new CQuickSortAlgorithm(compare);
+                        else
+                            sorter = new CHeapSortAlgorithm(compare);
+                    }
                 }
                 else
                     sorter = new CHeapSortAlgorithm(compare); // shouldn't really happen but there was a vintage of codegen that did not set the flag when algorithm not specified...
@@ -7896,7 +7902,13 @@ public:
                     else if (stricmp(useAlgorithm, "insertionsort")==0)
                         sortAlgorithm = insertionSort;
                     else
-                        throw MakeStringException(ROXIE_UNKNOWN_ALGORITHM, "Invalid sort algorithm %s requested", useAlgorithm);
+                    {
+                        WARNLOG(ROXIE_UNKNOWN_ALGORITHM, "Ignoring unsupported sort order algorithm '%s', using default", useAlgorithm);
+                        if (sortFlags & TAFunstable)
+                            sortAlgorithm = quickSort;
+                        else
+                            sortAlgorithm = heapSort;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Change Roxie and HThor sort algorithm selection to create a warning,
and select the appropriate default algorithm, if ECL specified an
invalid algorithm

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
