### PR TITLE
getcwd warnings

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -5584,7 +5584,10 @@ CCovenSDSManager::CCovenSDSManager(ICoven &_coven, IPropertyTree &_config, const
     else
     {
         char cwd[1024];
-        GetCurrentDirectory(1024, cwd);
+        if (!GetCurrentDirectory(1024, cwd)) {
+            ERRLOG("CCovenSDSManager: Current directory path too big, setting local path to null");
+            cwd[0] = 0;
+        }
         rfn.setLocalPath(cwd);
     }
     unsigned keepLastN = config.getPropInt("@keepStores", DEFAULT_KEEP_LASTN_STORES);

--- a/dali/sasha/sacoalescer.cpp
+++ b/dali/sasha/sacoalescer.cpp
@@ -255,8 +255,10 @@ public:
                     StringBuffer cmd(sashaProgramName);
                     cmd.append(" coalesce");
                     char cwd[1024];
-                    GetCurrentDirectory(1024, cwd);
-                    PROGLOG("COALESCE: Running '%s' in '%s'",cmd.str(),cwd);
+                    if (GetCurrentDirectory(1024, cwd))
+                        PROGLOG("COALESCE: Running '%s' in '%s'",cmd.str(),cwd);
+                    else
+                        ERRLOG("COALESCE: Running '%s' in unknown current directory",cmd.str());
                     if (!invoke_program(cmd.str(), runcode, false, NULL, &h)) 
                         ERRLOG("Could not run saserver in coalesce mode");
                     else {

--- a/dali/sasha/salds.cpp
+++ b/dali/sasha/salds.cpp
@@ -30,7 +30,10 @@ class CLargeDataStore: public CInterface, implements ILargeDataStore
                 ldsrootdir=dataPath.str();
             if (!isAbsolutePath(ldsrootdir)) {
                 char cpath[_MAX_DIR];
-                getcwd(cpath, _MAX_DIR);
+                if (!GetCurrentDirectory(_MAX_DIR, cpath)){
+                    ERRLOG("CLargeDataStore::main: Current directory path too big, setting it to null");
+                    cpath[0] = 0;
+                }
                 basedir.append(cpath);
                 if (*ldsrootdir)
                     addPathSepChar(basedir);

--- a/dali/sasha/salds.cpp
+++ b/dali/sasha/salds.cpp
@@ -31,8 +31,8 @@ class CLargeDataStore: public CInterface, implements ILargeDataStore
             if (!isAbsolutePath(ldsrootdir)) {
                 char cpath[_MAX_DIR];
                 if (!GetCurrentDirectory(_MAX_DIR, cpath)){
-                    ERRLOG("CLargeDataStore::main: Current directory path too big, setting it to null");
-                    cpath[0] = 0;
+                    ERRLOG("CLargeDataStore::main: Current directory path too big, bailing out");
+                    throwUnexpected();
                 }
                 basedir.append(cpath);
                 if (*ldsrootdir)

--- a/dali/treeview/util.cpp
+++ b/dali/treeview/util.cpp
@@ -62,11 +62,6 @@ void putProfile(LPCSTR section, LPCSTR key, int value)
 
 LPCSTR getProfileStr(LPCSTR section, LPCSTR key)
 {
-    char cdir[256];
-    GetCurrentDirectory(256, cdir);
-
-
-
     static char buffer[256];
 
     DWORD b = GetPrivateProfileString(section, key, "0", buffer, sizeof(buffer), INIFILE);

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -617,8 +617,11 @@ typedef enum _cgi_resp_state
 
 int CEspHttpServer::onRunCGI(CHttpRequest* request, CHttpResponse* response, const char *path)
 {
-    char cwd[512]={0};
-    GetCurrentDirectory(512, cwd);
+    char cwd[1024];
+    if (!GetCurrentDirectory(1024, cwd)) {
+        ERRLOG("onRunCGI: Current directory path too big, setting local path to null");
+        cwd[0] = 0;
+    }
     StringBuffer docRoot(cwd);
     docRoot.append("/files");
     StringBuffer script(docRoot);

--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -606,8 +606,12 @@ public:
             // the path will be expanded (by xmllib's source resolver) to its full path, beginning with file://
             // on windows it looks like: file:///C:/playground/esp_lsb2/xslt/ui_overrides.xslt
             // on linux: file:///home/yma/playground/esp_lsb2/xslt/ui_overrides.xslt
+            // If current path not found, use root
             char dir[_MAX_PATH];
-            GetCurrentDirectory(sizeof(dir), dir);
+            if (!GetCurrentDirectory(sizeof(dir), dir)) {
+                ERRLOG("ESPxsltIncludeHandler::getInclude: Current directory path too big, setting local path to null");
+                dir[0] = 0;
+            }
 #ifdef _WIN32
             for(int i = 0; i < _MAX_PATH; i++)
             {

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -2959,7 +2959,10 @@ StringBuffer &createUNCFilename(const char * filename, StringBuffer &UNC, bool u
 
         if (*filename != '/')
         {
-            getcwd(buf, sizeof(buf));
+            if (!GetCurrentDirectory(sizeof(buf), buf)) {
+                ERRLOG("createUNCFilename: Current directory path too big, bailing out");
+                assertex(false);
+            }
             UNC.append(buf).append("/");
         }
         UNC.append(filename);
@@ -4305,7 +4308,10 @@ void RemoteFilename::setPath(const SocketEndpoint & _ep, const char * _filename)
         }
         if (isLocal()&&!isAbsolutePath(filename)) {
             char dir[_MAX_PATH];
-            GetCurrentDirectory(sizeof(dir), dir);
+            if (!GetCurrentDirectory(sizeof(dir), dir)) {
+                ERRLOG("RemoteFilename::setPath: Current directory path too big, bailing out");
+                assertex(false);
+            }
             if (*filename==PATHSEPCHAR) {
 #ifdef _WIN32
                 if (*dir && (dir[1]==':')) 

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -2961,7 +2961,7 @@ StringBuffer &createUNCFilename(const char * filename, StringBuffer &UNC, bool u
         {
             if (!GetCurrentDirectory(sizeof(buf), buf)) {
                 ERRLOG("createUNCFilename: Current directory path too big, bailing out");
-                assertex(false);
+                throwUnexpected();
             }
             UNC.append(buf).append("/");
         }
@@ -4310,7 +4310,7 @@ void RemoteFilename::setPath(const SocketEndpoint & _ep, const char * _filename)
             char dir[_MAX_PATH];
             if (!GetCurrentDirectory(sizeof(dir), dir)) {
                 ERRLOG("RemoteFilename::setPath: Current directory path too big, bailing out");
-                assertex(false);
+                throwUnexpected();
             }
             if (*filename==PATHSEPCHAR) {
 #ifdef _WIN32

--- a/system/xmllib/xalan_processor.ipp
+++ b/system/xmllib/xalan_processor.ipp
@@ -125,8 +125,11 @@ public:
                 StringBuffer path;
                 if(!isAbsolutePath((const char *)buf.toByteArray()))
                 {
-                    char baseurl[1025];
-                    GetCurrentDirectory(1024, baseurl);
+                    char baseurl[1024];
+                    if (!GetCurrentDirectory(1024, baseurl)) {
+                        ERRLOG("MemSourceResolver::resolveEntity: Current directory path too big, bailing out");
+                        assertex(false);
+                    }
                     path.append(URLPREFIX).append(baseurl).append(PATHSEPSTR);
                 }
                 path.append(buf.length(), buf.toByteArray());

--- a/system/xmllib/xalan_processor.ipp
+++ b/system/xmllib/xalan_processor.ipp
@@ -128,7 +128,7 @@ public:
                     char baseurl[1024];
                     if (!GetCurrentDirectory(1024, baseurl)) {
                         ERRLOG("MemSourceResolver::resolveEntity: Current directory path too big, bailing out");
-                        assertex(false);
+                        throwUnexpected();
                     }
                     path.append(URLPREFIX).append(baseurl).append(PATHSEPSTR);
                 }

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -631,7 +631,10 @@ int main( int argc, char *argv[]  )
         SetTempDir(tempdir,true);
 
         char thorPath[1024];
-        GetCurrentDirectory(1024, thorPath);
+        if (!GetCurrentDirectory(1024, thorPath)) {
+            ERRLOG("ThorMaster::main: Current directory path too big, setting it to null");
+            thorPath[0] = 0;
+        }
         unsigned l = strlen(thorPath);
         if (l) { thorPath[l] = PATHSEPCHAR; thorPath[l+1] = '\0'; }
         globals->setProp("@thorPath", thorPath);

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -195,7 +195,10 @@ public:
                             {
                                 StringBuffer msg("Failed to save dll, cwd = ");
                                 char buf[255];
-                                getcwd(buf, sizeof(buf));
+                                if (!GetCurrentDirectory(sizeof(buf), buf)) {
+                                    ERRLOG("CJobListener::main: Current directory path too big, setting it to null");
+                                    buf[0] = 0;
+                                }
                                 msg.append(buf).append(", path = ").append(soPath.str());
                                 EXCLOG(e, msg.str());
                                 e->Release();


### PR DESCRIPTION
Another round of warnings, not sure the best thing to do on most of them, just followed some basic guidelines.

Basically, `getcwd` returns NULL when it can't find the current path (what?) or the path is larger than `buffer` can accommodate (more plausible). 

We're clearly not hitting any of those cases, so this is more to clear the warnings than anything else, BUT, I'm asserting on some cases where it's impossible to continue (according to my blind guesses). Most of the time, having a NULL path is acceptable (local files, means remote) or fixable (try again, some other method).

I'll add a comment to each of the changes, making sense of them. Please let me know if my assumptions were wrong.
