### PR TITLE
EE-only executables do not have proper rpath settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,18 +108,6 @@ endif()
 include(${HPCC_SOURCE_DIR}/cmake_modules/optionDefaults.cmake)
 ###
 
-###
-## The following sets the install directories and names.
-###
-set ( OSSDIR "${DIR_NAME}" )
-set ( CPACK_INSTALL_PREFIX "${PREFIX}" )
-set ( CPACK_PACKAGING_INSTALL_PREFIX "${PREFIX}" )
-set ( CMAKE_INSTALL_PREFIX "${PREFIX}" )
-SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
-SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib")
-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 include(${HPCC_SOURCE_DIR}/cmake_modules/commonSetup.cmake)
 
 if ( CMAKE_SYSTEM MATCHES Linux )

--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -354,4 +354,16 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   endif(USE_MYSQL)
 
   ###########################################################################
+  ###
+  ## The following sets the install directories and names.
+  ###
+  set ( OSSDIR "${DIR_NAME}" )
+  set ( CPACK_INSTALL_PREFIX "${PREFIX}" )
+  set ( CPACK_PACKAGING_INSTALL_PREFIX "${PREFIX}" )
+  set ( CMAKE_INSTALL_PREFIX "${PREFIX}" )
+  SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+  SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
+  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib")
+  SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 endif ("${COMMONSETUP_DONE}" STREQUAL "")


### PR DESCRIPTION
The CMake rpath settings are only applied to the OSS components.
Move the rpath settings into the common cmake file.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
