### PR TITLE
Fix problem with COUNTER not tracked inside []

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -12672,9 +12672,12 @@ static bool exprContainsCounter(RecursionChecker & checker, IHqlExpression * exp
     case no_counter:
         return (expr == counter);
     case no_select:
-        if (expr->hasProperty(newAtom))
-            return exprContainsCounter(checker, expr->queryChild(0), counter);
-        return false;
+        {
+            IHqlExpression * ds = expr->queryChild(0);
+            if (expr->hasProperty(newAtom) || ((ds->getOperator() == no_select) && ds->isDatarow()) || (ds->getOperator() == no_selectnth))
+                return exprContainsCounter(checker, ds, counter);
+            return false;
+        }
     }
     ForEachChild(idx, expr)
         if (exprContainsCounter(checker, expr->queryChild(idx), counter))


### PR DESCRIPTION
- SELF.x := SomeDataset[COUNTER].y wasn't spotting that COUNTER was
  used in the expression because the function wasn't called on a
  normalized tree.  This change makes the test more lenient.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
