### PR TITLE
WIP #1573 Remove Thor slaves and spares from configgen output

### DIFF
--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -342,7 +342,7 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
               isMaster = true;
               out.appendf("%s=%s;%s%c%s;%s\n", pComponent->queryProp("@name"), pComponent->queryProp("@buildSet"), out_dirname, PATHSEPCHAR, pComponent->queryProp("@name"),"master");
             }
-            else if (!strcmp(instName.toCharArray(), "ThorSlaveProcess") || !strcmp(instName.toCharArray(), "RoxieSlaveProcess"))
+            else if (!strcmp(instName.toCharArray(), "RoxieSlaveProcess"))
               sbChildren.appendf("%s=%s;%s%c%s;%s\n", pComponent->queryProp("@name"), pComponent->queryProp("@buildSet"), out_dirname, PATHSEPCHAR, pComponent->queryProp("@name"),"slave");
           }
 
@@ -372,6 +372,10 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
           ForEach(*itComp)
           {
             IPropertyTree* pInst = &itComp->query();
+
+            if (!strcmp(pInst->queryName(), "ThorSlaveProcess") || !strcmp(pInst->queryName(), "ThorSpareProcess"))
+              continue;
+
             netAddr.clear().append(pInst->queryProp("@netAddress"));
             port.clear().append(pInst->queryProp("@port"));
             


### PR DESCRIPTION
Remove Thor slaves and spares from configgen output when using the -list and -listall options.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
