### PR TITLE
Remove CTempActiveTransaction

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -182,7 +182,7 @@ interface IDistributedFileTransaction: extends IInterface
     virtual void autoCommit()=0; // if transaction not active, commit straight away
     virtual void rollback()=0;
     virtual bool active()=0;
-    virtual bool setActive(bool on)=0; // returns old value (used internally)
+    virtual bool setCache(bool on)=0; // turns caching on/off, regardless of transaction's state
     virtual IDistributedFile *lookupFile(const char *lfn,unsigned timeout=INFINITE)=0;
     virtual IDistributedSuperFile *lookupSuperFile(const char *slfn,bool fixmissing=false,unsigned timeout=INFINITE)=0;
     virtual IUserDescriptor *queryUser()=0;


### PR DESCRIPTION
FileServices' lookup was temporarily activating the transaction
just to turn on the file caching. So far, it did not have side
effects, but some of the failed attempts to refactor the transactional
model in the DFS have hit this problem more than once. Adding a
cache option, if that's the only thing that is needed.

CDFile's detach had to be forced to loose the connection, and that
supports the idea that detach has to be an internal implementation
and probably factored out anyway, since it's no more than a glorified
removeEntry.
