### PR TITLE
Fix numRows check in hthor/thor engine for temp table

### DIFF
--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -15982,8 +15982,6 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCountTransform(BuildCtx & ctx,
     BoundRow * selfCursor = bindSelf(funcctx, instance->dataset, "crSelf");
     IHqlExpression * self = selfCursor->querySelector();
     associateCounter(funcctx, counter, "row");
-    // FIXME: this should be fixed in the engine
-    funcctx.addQuoted("if (row == numRows()) return 0;");
     buildTransformBody(funcctx, transform, NULL, NULL, instance->dataset, self);
 
     // unsigned numRows() - count is guaranteed by lexer

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -5842,12 +5842,13 @@ void CHThorTempTableActivity::ready()
     CHThorSimpleActivityBase::ready();
     eof = false;
     curRow = 0;
+    numRows = helper.numRows();
 }
 
 
 const void *CHThorTempTableActivity::nextInGroup()
 {
-    if (!eof)
+    if (!eof && curRow < numRows)
     {
         RtlDynamicRowBuilder rowBuilder(rowAllocator);
         size32_t size = helper.getRow(rowBuilder, curRow++);

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -5840,7 +5840,6 @@ CHThorTempTableActivity::CHThorTempTableActivity(IAgentContext &_agent, unsigned
 void CHThorTempTableActivity::ready()
 {
     CHThorSimpleActivityBase::ready();
-    eof = false;
     curRow = 0;
     numRows = helper.numRows();
 }
@@ -5848,7 +5847,8 @@ void CHThorTempTableActivity::ready()
 
 const void *CHThorTempTableActivity::nextInGroup()
 {
-    if (!eof && curRow < numRows)
+    // Filtering empty rows, returns the next valid row
+    while (curRow < numRows)
     {
         RtlDynamicRowBuilder rowBuilder(rowAllocator);
         size32_t size = helper.getRow(rowBuilder, curRow++);
@@ -5858,7 +5858,6 @@ const void *CHThorTempTableActivity::nextInGroup()
             return rowBuilder.finalizeRowClear(size);
         }
     }
-    eof = true;
     return NULL;
 }
 

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -1495,6 +1495,7 @@ class CHThorTempTableActivity : public CHThorSimpleActivityBase
 {
     IHThorTempTableArg &helper;
     unsigned curRow;
+    unsigned numRows;
     bool eof;
 
 public:

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -1496,7 +1496,6 @@ class CHThorTempTableActivity : public CHThorSimpleActivityBase
     IHThorTempTableArg &helper;
     unsigned curRow;
     unsigned numRows;
-    bool eof;
 
 public:
     CHThorTempTableActivity(IAgentContext &agent, unsigned _activityId, unsigned _subgraphId, IHThorTempTableArg &_arg, ThorActivityKind _kind);

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -5293,7 +5293,6 @@ IRoxieServerActivityFactory *createRoxieServerDatasetResultActivityFactory(unsig
 class CRoxieServerTempTableActivity : public CRoxieServerActivity
 {
     IHThorTempTableArg &helper;
-    bool eof;
     unsigned curRow;
     unsigned numRows;
 
@@ -5301,13 +5300,11 @@ public:
     CRoxieServerTempTableActivity(const IRoxieServerActivityFactory *_factory, IProbeManager *_probeManager)
         : CRoxieServerActivity(_factory, _probeManager), helper((IHThorTempTableArg &) basehelper)
     {
-        eof = false;
         curRow = 0;
     }
 
     virtual void start(unsigned parentExtractSize, const byte *parentExtract, bool paused)
     {
-        eof = false;
         curRow = 0;
         CRoxieServerActivity::start(parentExtractSize, parentExtract, paused);
         numRows = helper.numRows();
@@ -5317,7 +5314,8 @@ public:
     virtual const void *nextInGroup()
     {
         ActivityTimer t(totalCycles, timeActivities, ctx->queryDebugContext());
-        if (!eof && curRow < numRows)
+        // Filtering empty rows, returns the next valid row
+        while (curRow < numRows)
         {
             RtlDynamicRowBuilder rowBuilder(rowAllocator);
             unsigned outSize = helper.getRow(rowBuilder, curRow++);
@@ -5327,7 +5325,6 @@ public:
                 return rowBuilder.finalizeRowClear(outSize);
             }
         }
-        eof = true;
         return NULL;
     }
 

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -5295,6 +5295,7 @@ class CRoxieServerTempTableActivity : public CRoxieServerActivity
     IHThorTempTableArg &helper;
     bool eof;
     unsigned curRow;
+    unsigned numRows;
 
 public:
     CRoxieServerTempTableActivity(const IRoxieServerActivityFactory *_factory, IProbeManager *_probeManager)
@@ -5309,13 +5310,14 @@ public:
         eof = false;
         curRow = 0;
         CRoxieServerActivity::start(parentExtractSize, parentExtract, paused);
+        numRows = helper.numRows();
     }
 
     virtual bool needsAllocator() const { return true; }
     virtual const void *nextInGroup()
     {
         ActivityTimer t(totalCycles, timeActivities, ctx->queryDebugContext());
-        if (!eof)
+        if (!eof && curRow < numRows)
         {
             RtlDynamicRowBuilder rowBuilder(rowAllocator);
             unsigned outSize = helper.getRow(rowBuilder, curRow++);

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -29,6 +29,7 @@ private:
     IHThorTempTableArg * helper;
     bool eof;
     unsigned currentRow;
+    unsigned numRows;
     size32_t maxrecsize;
     bool isLocal;
 public:
@@ -49,6 +50,7 @@ public:
         currentRow = 0;
         isLocal = container.queryOwnerId() && container.queryOwner().isLocalOnly();
         eof = isLocal ? false : !firstNode();
+        numRows = helper->numRows();
     }
     void stop()
     {
@@ -57,7 +59,7 @@ public:
     CATCH_NEXTROW()
     {
         ActivityTimer t(totalCycles, timeActivities, NULL);
-        if (eof || abortSoon)
+        if (eof || abortSoon || currentRow >= numRows)
             return NULL;
         RtlDynamicRowBuilder row(queryRowAllocator());
         size32_t sizeGot = helper->getRow(row, currentRow++);


### PR DESCRIPTION
Removes the necessity of the hack in `doBuildTempTableFlags` to check
whether the number of rows have been reached and return zero. Both Thor
and HThor engines know to not request another row if the maximum number
has been processed.
