### PR TITLE
EclWatch/Spray should displays local warning for user error

### DIFF
--- a/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
@@ -249,6 +249,16 @@
                 alert("Please specify a file in the Local Path field.");
                 return false;
               }
+              if ((method == 'SprayFixed') && (document.getElementById("sourceRecordSize").value == ''))
+              {
+                alert("Please specify a Record Length.");
+                return false;
+              }
+              if (document.getElementById("label").value == '')
+              {
+                alert("Please specify a name for destination file in the Destination Label field.");
+                return false;
+              }
               return true;
             }
       ]]></script>


### PR DESCRIPTION
This fix is based on issue #1630. Fill in a spray fixed dialog
and forget to include the record length. The existing code will
call the spray function which returns error for missing the
record length. A user has to re-fill the spray fixed dialog.
With this fix, new code will check the user input before calling
the spray function and show a warning if the record length field
(or other required field) is empty.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
