### PR TITLE
Better alignment for Name column in Browse Files by Scope

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
@@ -361,7 +361,7 @@
                     <img title="Compressed" border="0" src="/esp/files_/img/zip.gif" width="16" height="16"/>
                 </xsl:if>
             </td>
-            <td>
+            <td align="left">
                 <xsl:choose>
                     <xsl:when test="isDirectory=1">
                         <a title="Open folder..." href="{$href}">


### PR DESCRIPTION
This fix is based on issue #1631: The name column for the
browse files by scope page is centred when viewed with
chrome. This looks strange.

The default for <td> should be 'Left-aligns content'. For
some reason, Chrome does not follow the default. So, the
column has to be coded into 'Left-aligns content'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
