### PR TITLE
BUG:1596 configmgr - popup for password verify doesn't have focus

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -2236,7 +2236,7 @@ function refreshNavTree(paramds, paramdt, selRec) {
 
 function promptVerifyPwd(category, params, attrName, oldValue, newValue, recordIndex, callback) {
   var caller = this;
-
+  this.focus();
   var handleCancel = function() {
     this.hide();
     caller.promptPwdPanel.cfg.queueProperty("keylisteners", null);


### PR DESCRIPTION
Modify navtree.js to set focus to password verify pop-up.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
