### PR TITLE
Minor DFS refactoring

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1013,7 +1013,6 @@ public:
         assertex(_transaction);
         transaction.set(_transaction->baseTransaction()); // smacks of overkill
         transaction->addAction(this);
-        transaction->clearFiles();  // clean slate on open files (this is a bit arcane)
     }
     virtual ~CDFAction() {}
     virtual bool prepare()=0;  // should call lock
@@ -1226,8 +1225,6 @@ public:
                     break;
                 while (nlocked) // unlock for retry
                     actions.item(--nlocked).retry();
-                // This could be dangerous now that superfiles are in transactions
-                dflist.kill();
                 PROGLOG("CDistributedFileTransaction: Transaction pausing");
                 Sleep(SDS_TRANSACTION_RETRY/2+(getRandom()%SDS_TRANSACTION_RETRY)); 
             }
@@ -1383,6 +1380,7 @@ public:
         delayeddelete.kill();
     }
 
+    // MORE - remove this once CWrappedTransaction is gone
     IDistributedFileTransaction *baseTransaction() { return this; }
 };
 

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -978,6 +978,7 @@ static bool lookupSuperFile(ICodeContext *ctx, const char *lsuperfn, Owned<IDist
 {
     lsfn.clear();
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
+    assertex(transaction);
     constructLogicalName(ctx, lsuperfn, lsfn);
     if (!allowforeign) {
         CDfsLogicalFileName dlfn;
@@ -1014,7 +1015,8 @@ static bool lookupSuperFile(ICodeContext *ctx, const char *lsuperfn, Owned<IDist
 static ISimpleSuperFileEnquiry *getSimpleSuperFileEnquiry(ICodeContext *ctx, const char *lsuperfn)
 {
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
-    if (transaction&&transaction->active())
+    assertex(transaction);
+    if (transaction->active())
         return NULL;
     StringBuffer lsfn;
     constructLogicalName(ctx, lsuperfn, lsfn);
@@ -1024,7 +1026,8 @@ static ISimpleSuperFileEnquiry *getSimpleSuperFileEnquiry(ICodeContext *ctx, con
 static void CheckNotInTransaction(ICodeContext *ctx, const char *fn)
 {
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
-    if (transaction&&transaction->active()) {
+    assertex(transaction);
+    if (transaction->active()) {
         StringBuffer s("Operation not part of transaction : ");
         s.append(fn);
         WUmessage(ctx,ExceptionSeverityWarning,fn,s.str());
@@ -1034,6 +1037,7 @@ static void CheckNotInTransaction(ICodeContext *ctx, const char *fn)
 FILESERVICES_API void FILESERVICES_CALL fsCreateSuperFile(ICodeContext *ctx, const char *lsuperfn, bool sequentialparts, bool ifdoesnotexist)
 {
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
+    assertex(transaction);
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     StringBuffer lsfn;
     constructLogicalName(ctx, lsuperfn, lsfn);
@@ -1132,8 +1136,8 @@ FILESERVICES_API void FILESERVICES_CALL fsStartSuperFileTransaction(IGlobalCodeC
 FILESERVICES_API void FILESERVICES_CALL fslStartSuperFileTransaction(ICodeContext *ctx)
 {
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
-    if (transaction)
-        transaction->start();
+    assertex(transaction);
+    transaction->start();
     WUmessage(ctx,ExceptionSeverityInformation,NULL,"StartSuperFileTransaction");
 }
 
@@ -1160,6 +1164,7 @@ FILESERVICES_API void FILESERVICES_CALL fslAddSuperFile(ICodeContext *ctx, const
         throw MakeStringException(0, "AddSuperFile: Adding super file %s to itself!", file->queryLogicalName());
     }
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
+    assertex(transaction);
     if  (strict||addcontents) {
         Owned<IDistributedSuperFile> subfile;
         subfile.setown(transaction->lookupSuperFile(lfn.str()));
@@ -1180,7 +1185,7 @@ FILESERVICES_API void FILESERVICES_CALL fslAddSuperFile(ICodeContext *ctx, const
     if (addcontents)
         s.append(", addcontents");
     s.append(") ");
-    if (transaction&&transaction->active())
+    if (transaction->active())
         s.append("trans");
     else
         s.append("done");
@@ -1202,6 +1207,7 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveSuperFile(ICodeContext *ctx, co
         constructLogicalName(ctx, _lfn, lfn);
     lookupSuperFile(ctx, lsuperfn, file, true, lsfn, true, false);
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
+    assertex(transaction);
     file->removeSubFile(_lfn?lfn.str():NULL,del,del,remcontents,transaction);
     StringBuffer s;
     if (_lfn)
@@ -1216,7 +1222,7 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveSuperFile(ICodeContext *ctx, co
     if (remcontents)
         s.append(", remcontents");
     s.append(") ");
-    if (transaction&&transaction->active())
+    if (transaction->active())
         s.append("trans");
     else
         s.append("done");
@@ -1249,11 +1255,12 @@ FILESERVICES_API void FILESERVICES_CALL fslSwapSuperFile(ICodeContext *ctx, cons
     lookupSuperFile(ctx, lsuperfn2, file2, true,lsfn2,false,false);
 
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
+    assertex(transaction);
     file1->swapSuperFile(file2,transaction);
     StringBuffer s("SwapSuperFile ('");
     s.append(lsfn1).append("', '");
     s.append(lsfn2).append("') '");
-    if (transaction&&transaction->active())
+    if (transaction->active())
         s.append("trans");
     else
         s.append("done");
@@ -1283,7 +1290,8 @@ FILESERVICES_API void FILESERVICES_CALL fsFinishSuperFileTransaction(IGlobalCode
 FILESERVICES_API void FILESERVICES_CALL fslFinishSuperFileTransaction(ICodeContext *ctx, bool rollback)
 {
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
-    if (transaction) {
+    assertex(transaction);
+    if (transaction->active()) {
         if (rollback)
             transaction->rollback();
         else
@@ -1292,7 +1300,16 @@ FILESERVICES_API void FILESERVICES_CALL fslFinishSuperFileTransaction(ICodeConte
         if (rollback)
             s.append("rollback");
         else
+            s.append("commit");
+        WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    }
+    else {
+        StringBuffer s("Invalid FinishSuperFileTransaction ");
+        if (rollback)
+            s.append("rollback");
+        else
             s.append("done");
+        s.append(", transaction not active");
         WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
     }
 }

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1155,7 +1155,7 @@ FILESERVICES_API void FILESERVICES_CALL fslAddSuperFile(ICodeContext *ctx, const
     if (!lookupSuperFile(ctx, lsuperfn, file, strict, lsfn, false, false, addcontents)) {
         // auto create
         fsCreateSuperFile(ctx,lsuperfn,false,false);
-        lookupSuperFile(ctx, lsuperfn, file, true, lsfn, false, false);
+        lookupSuperFile(ctx, lsuperfn, file, true, lsfn, false, false, addcontents);
     }
     // Never add super file to itself
     StringBuffer lfn;


### PR DESCRIPTION
Four small changes into one:
- Consistent lookup cache request on add sub-file
- Assert on transactions, that are expected to always exist (even if inactive)
- Remove the bad `clearFiles()` on adding new actions or retries. That breaks `cCreateSuperFile` when inside user transactions
- Log error if trying to commit/rollback an inactive transaction (it's not an error, though)
