### PR TITLE
BUG:1493 configmgr - Updating node name does not update dali backup

### DIFF
--- a/deployment/deploy/XMLTags.h
+++ b/deployment/deploy/XMLTags.h
@@ -83,6 +83,7 @@
 
 #define XML_ATTR_AGENTPORT             "@agentPort"
 #define XML_ATTR_ATTRSERVER            "@attrServer"
+#define XML_ATTR_BACKUPCOMPUTER        "@backupComputer"
 #define XML_ATTR_BLOBDIRECTORY         "@blobDirectory"
 #define XML_ATTR_BLOBNAME              "@blobName"
 #define XML_ATTR_BREAKOUTLIMIT         "@breakoutLimit"

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -1840,7 +1840,10 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
         if (!strcmp(pszAttrName, "name"))
         {
           if (!strcmp(pszSubType, XML_TAG_COMPUTER))
+          {
             UpdateRefAttributes(pEnvRoot, XML_TAG_SOFTWARE"//*", XML_ATTR_COMPUTER, pszOldValue, pszNewValue);
+            UpdateRefAttributes(pEnvRoot, XML_TAG_SOFTWARE"/"XML_TAG_DALISERVERPROCESS, XML_ATTR_BACKUPCOMPUTER, pszOldValue, pszNewValue);
+          }
           else if (!strcmp(pszSubType, XML_TAG_DOMAIN))
             UpdateRefAttributes(pEnvRoot, XML_TAG_HARDWARE"/"XML_TAG_COMPUTER, XML_ATTR_DOMAIN, pszOldValue, pszNewValue);
           else if (!strcmp(pszSubType, XML_TAG_SWITCH))


### PR DESCRIPTION
Add logic to update Dali Server-Backup-backupComputer when modifying Hardware-Computers-name.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
