### PR TITLE
Fix activity page not showing contents of eclccserver queue 3.6

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -549,7 +549,7 @@
                     <xsl:when test="count(//ThorClusters/ThorCluster) &gt; 0">
                         <xsl:for-each select="RoxieClusters/RoxieCluster">
                              <xsl:call-template name="show-queue">
-                                  <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='Roxie' and QueueName=current()/QueueName]"/>
+                                  <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='RoxieServer' and QueueName=current()/QueueName]"/>
                                   <xsl:with-param name="cluster" select="ClusterName"/>
                                   <xsl:with-param name="queue" select="QueueName"/>
                                   <xsl:with-param name="status" select="QueueStatus"/>
@@ -563,7 +563,7 @@
                     <xsl:otherwise>
                         <xsl:for-each select="RoxieClusters/RoxieCluster">
                              <xsl:call-template name="show-queue">
-                                  <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='Roxie' and QueueName=current()/QueueName]"/>
+                                  <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='RoxieServer' and QueueName=current()/QueueName]"/>
                                   <xsl:with-param name="cluster" select="ClusterName"/>
                                   <xsl:with-param name="queue" select="QueueName"/>
                                   <xsl:with-param name="status" select="QueueStatus"/>


### PR DESCRIPTION
Note that eclserver uses the same queue name, and this should work for that
as well.

Fixes LN issue 397: https://github.com/hpcc-systems/LN/issues/397

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
