### PR TITLE
BUG:1494 Wizard shouldn't put dali and sasha on same node

### DIFF
--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -2,7 +2,7 @@
 [Algorithm]
 max_comps_per_node=4
 do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver
-avoid_combo=dali-eclagent
+avoid_combo=dali-eclagent,dali-sasha
 comps_on_all_nodes=dafilesrv,ftslave
 topology_for_comps=thor,hthor,roxie
 do_not_gen_optional=dali,thor
@@ -12,3 +12,4 @@ roxie_agent_redundancy=1,2,1
 roxie_topology=eclccserver,eclscheduler
 thor_topology=eclagent,eclccserver,eclscheduler
 hthor_topology=eclagent,eclccserver,eclscheduler
+


### PR DESCRIPTION
Modify genenvrules.conf to add dali-sasha to avoid_combo tag.  Prevent the
wizard from generating a configuration where dali and sasha are put on the
same node.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
