### PR TITLE
Fix Preflight not work for Multinode thor slaves

### DIFF
--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -2141,7 +2141,7 @@ int Cws_machineEx::checkProcess(const char* type, const char* name, StringArray&
     return pos;
 }
 
-void Cws_machineEx::getThorMachineList(IConstEnvironment* constEnv, IPropertyTree* cluster, const char* machineName, const char* machineType, 
+void Cws_machineEx::getThorMachineList(IConstEnvironment* constEnv, IPropertyTree* cluster, const char* machineName, const char* machineType,
                                    const char* directory, StringArray& processAddresses)
 {
     if (!constEnv || !cluster)


### PR DESCRIPTION
In a multinode (2 slaves with 1 slave per node) system, the
preflight was showing certain thorslaves as down, when they
are not down. The problem was because incorrect slave number
was used to generate PID file names being given to preflight
script. The slave number should count per node group, not
per node (identified by its IP address). In this test
environment, the slave numbers are: 1 and 2. For the first
IP read from node group, the slave number is 1. 2 for the
second IP. Their PID files are: mythor_slave_1.pid and
mythor_slave_2.pid.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
