### PR TITLE
Fix segfault when activities stop before even starting

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -1235,7 +1235,7 @@ public:
                 ForEachItemIn(idx, dependencies)
                 {
                     if (dependencyControlIds.item(idx) == 0)
-                        dependencies.item(idx).stopSink(dependencyIndexes.item(idx));
+                        dependencies.item(idx).stopSink(dependencyIndexes.item(idx), aborting);
                 }
                 if (input)
                     input->stop(aborting);
@@ -1312,7 +1312,7 @@ public:
         throw MakeStringException(ROXIE_SINK, "Internal error: executeChild() requires a suitable sink");
     }
 
-    virtual void stopSink(unsigned idx)
+    virtual void stopSink(unsigned idx, bool abort)
     {
         throw MakeStringException(ROXIE_SINK, "Internal error: stopSink() requires a suitable sink");
     }
@@ -2170,7 +2170,7 @@ public:
         return NULL;
     }
 
-    virtual void stopSink(unsigned outputIdx)
+    virtual void stopSink(unsigned outputIdx, bool abort)
     {
         if (!stopped[outputIdx])
         {
@@ -2178,7 +2178,7 @@ public:
             for (unsigned s = 0; s < numOutputs; s++)
                 if (!stopped[s])
                     return;
-            stop(false); // all outputs stopped - stop parent.
+            stop(abort); // all outputs stopped - stop parent.
         }
     }
 

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -250,7 +250,7 @@ interface IRoxieServerActivity : extends IActivityBase
     virtual void executeChild(size32_t & retSize, void * & ret, unsigned parentExtractSize, const byte * parentExtract) = 0;
     virtual void serializeCreateStartContext(MemoryBuffer &out) = 0;
     virtual void serializeExtra(MemoryBuffer &out) = 0;
-    virtual void stopSink(unsigned idx) = 0;
+    virtual void stopSink(unsigned idx, bool abort) = 0;
 //Functions to support result streaming between parallel loop/graphloop/library implementations
     virtual IRoxieInput * querySelectOutput(unsigned id) = 0;
     virtual bool querySetStreamInput(unsigned id, IRoxieInput * _input) = 0;


### PR DESCRIPTION
Roxie activities stop on exception, and there is a difference between
abort stop and normal stop. One of the things it that an abort
stop can happen even before its related start took place, because
the exception handling stop chain has no idea how many starts took
place, so it just stops them all. One of the stops in this chain
didn't propagate the 'abort' flag, and stopping for real, expecting
a pointer to be valid, segfaulting.

Related to #886
