### PR TITLE
Change the way depth and dependencies are calculated

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -3269,7 +3269,7 @@ void CHqlExpression::updateFlagsAfterOperands()
             infoFlags = (infoFlags &~HEFthrowds)|HEFthrowscalar;
         break;
     case no_select:
-        if (!hasProperty(newAtom))
+        if (!isNewSelector(this))
         {
             IHqlExpression * left = queryChild(0);
             node_operator lOp = left->getOperator();

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -1544,7 +1544,7 @@ ProjectExprKind ImplicitProjectTransformer::getProjectExprKind(IHqlExpression * 
         if (expr->isDataset())
             return PassThroughActivity;
         if (expr->isDatarow())
-            return ComplexNonActivity;
+            return PassThroughActivity;
         return NonActivity;
     case no_addfiles:
     case no_merge:


### PR DESCRIPTION
- Previously when resourcing the graphs the dependencies were expanded
  and inherited from the child graphs into the parent graph.  On very
  complex queries (e.g., 4000 subgraphs) this became prohibitively
  expensive.  The new code calculates depths and isDependency() on
  demand.
- Also fixes a minor issue where IF() on row was being marked as the
  wrong time in the implicit project code. (Could cause internal error)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
