### PR TITLE
gh-1367 Fix ecl run formatting

### DIFF
--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -3361,7 +3361,7 @@ extern "C" FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSet
 
     text.append("<Dataset");
     if (name)
-        text.append(" name=\"").append(name).append("\" ");
+        text.append(" name='").append(name).append('\'');
     if (schemaName) 
         text.append(" xmlSchema=\"").append(schemaName).append("\" ");
     text.append(">").newline();

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -68,6 +68,8 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_INPUT "--input"
 #define ECLOPT_INPUT_S "-in"
 
+#define ECLOPT_NOROOT "--noroot"
+
 #define ECLOPT_WUID "--wuid"
 #define ECLOPT_WUID_S "-wu"
 #define ECLOPT_CLUSTER "--cluster"

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -432,7 +432,7 @@ private:
 class EclCmdRun : public EclCmdWithEclTarget
 {
 public:
-    EclCmdRun() : optWaitTime((unsigned)-1)
+    EclCmdRun() : optWaitTime((unsigned)-1), optNoRoot(false)
     {
         optObj.accept = eclObjWuid | eclObjArchive | eclObjSharedObject | eclObjWuid | eclObjQuery;
     }
@@ -455,6 +455,8 @@ public:
             if (iter.matchOption(optInput, ECLOPT_INPUT)||iter.matchOption(optInput, ECLOPT_INPUT_S))
                 continue;
             if (iter.matchOption(optWaitTime, ECLOPT_WAIT))
+                continue;
+            if (iter.matchFlag(optNoRoot, ECLOPT_NOROOT))
                 continue;
             if (EclCmdWithEclTarget::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
@@ -506,6 +508,7 @@ public:
 
         Owned<IClientWURunRequest> req = client->createWURunRequest();
         req->setCloneWorkunit(true);
+        req->setNoRootTag(optNoRoot);
 
         StringBuffer wuid;
         StringBuffer queryset;
@@ -588,6 +591,7 @@ private:
     StringAttr optName;
     StringAttr optInput;
     unsigned optWaitTime;
+    bool optNoRoot;
 };
 
 class EclCmdActivate : public EclCmdWithQueryTarget

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -490,6 +490,7 @@ ESPrequest WURunRequest
     string Cluster;
     int Wait(-1);
     [rows(15)] string Input;
+    bool NoRootTag(0);
 };
 
 ESPresponse [exceptions_inline] WURunResponse

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1019,7 +1019,7 @@ bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWU
             case WUStateUnknown:
             {
                 SCMStringBuffer result;
-                getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), result, false, ExceptionSeverityInformation);
+                getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), result, false, ExceptionSeverityInformation, req.getNoRootTag());
                 resp.setResults(result.str());
                 break;
             }


### PR DESCRIPTION
"ecl run --noroot" should now match "eclplus format=xml".

Fixes gh-1367.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
