### PR TITLE
gh-1683 assertex(diff >= 0) failing in global smart stepping

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -21087,8 +21087,7 @@ public:
                     else
                         nextSeek = (byte *) seeks->querySeek(i)+seekGEOffset;
                     int diff = memcmp(nextSeek, lastSeek, seekLen);
-                    assertex(diff >= 0);
-                    if (diff)
+                    if (diff > 0)
                     {
                         serialized++;
                         out.append(seekLen, nextSeek);


### PR DESCRIPTION
The assert appears to be triggereing because sometimes the seek value
passed in is greater than one of the queued seek values. We did not
see this assert in 702 builds because diff was (incorrectly) declared
as unsigned. When that was fixed this lurking bug was revealed.

By removing the assert and skipping any such records instead, we will
return the same answers as 702 series. However the underlying cause of the
low queued seek value (which should have been skipped) is still under
investigation so will leave the issue open for now.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
