### PR TITLE
Assume local files when no Dali

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -790,7 +790,11 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         }
         addNonEmptyPathSepChar(queryDirectory);
 
-        baseDataDirectory.append(topology->queryProp("@baseDataDir"));
+        // if no Dali, files are local
+        if (fileNameServiceDali.length() == 0)
+            baseDataDirectory.append("./"); // Path separator will be replaced, if necessary
+        else
+            baseDataDirectory.append(topology->queryProp("@baseDataDir"));
         queryFileCache().start();
 
 #ifdef _WIN32


### PR DESCRIPTION
When Dali is not specified, files should be looked up on
local directory, as HThor does. Fixes copying issue of #886,
but write to file is still impaired.

Roxie selftest and regressions ok.
