### PR TITLE
Add support for local files in Roxie

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2187,7 +2187,16 @@ public:
         }
         else
         {
-            throwUnexpected();
+            try
+            {
+                Owned<IFile> file = createIFile(lfn.get());
+                file->remove();
+            }
+            catch (IException *e)
+            {
+                ERRLOG(-1, "Error removing file %s",lfn.get());
+                e->Release();
+            }
         }
     }
 };

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -543,19 +543,12 @@ public:
         StringBuffer fileName;
         expandLogicalFilename(fileName, _fileName, NULL, false);   // MORE - if we have a wu, and we have not yet got rid of the concept of scope, we should use it here
         // Dali filenames used locally
-        bool resolveFilesLocally = !daliHelper->connected();
-        if (resolveFilesLocally && *_fileName != '~')
+        bool disconnected = !daliHelper->connected();
+        if (disconnected && strstr(fileName,"::"))
         {
             StringBuffer name;
-            if (strstr(fileName,"::"))
-            {
-                bool wasDFS;
-                makeSinglePhysicalPartName(fileName, name, true, wasDFS, baseDataDirectory.str());
-            }
-            else
-            {
-                makeAbsolutePath(fileName.str(), name);
-            }
+            bool wasDFS;
+            makeSinglePhysicalPartName(fileName, name, true, wasDFS, baseDataDirectory.str());
             fileName.clear().append(name);
         }
         Owned<IResolvedFile> resolved = lookupFile(fileName, false, true);
@@ -569,9 +562,9 @@ public:
             resolved->remove();
             resolved.clear();
         }
-        Owned<ILocalOrDistributedFile> ldFile = createLocalOrDistributedFile(fileName, NULL, resolveFilesLocally, false, true); // MORE - is onlyDFS right?
+        Owned<ILocalOrDistributedFile> ldFile = createLocalOrDistributedFile(fileName, NULL, disconnected, false, true); // MORE - is onlyDFS right?
         if (!ldFile)
-            throw MakeStringException(ROXIE_FILE_ERROR, "Cannot write %s, %s file not found", fileName.str(), (resolveFilesLocally?"local":"DFS"));
+            throw MakeStringException(ROXIE_FILE_ERROR, "Cannot write %s, %s file not found", fileName.str(), (disconnected?"local":"DFS"));
 
         return createRoxieWriteHandler(daliHelper, ldFile.getClear(), clusters);
     }


### PR DESCRIPTION
Code stolen from EclAgent, makes sure Dali files can be
handled localy, if no Dali server is connected.

This pull request works only in conjunction with #1711. I'm posting this for review, just to make sure it's actually correct. It did work with example in #886, using local files and returning the correct results.

I've run `roxie` self tests.
