### PR TITLE
Fix unused result on write warning

### DIFF
--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -1213,7 +1213,11 @@ int CDfuPlusHelper::savexml()
     }
     
     const MemoryBuffer& xmlmap = resp->getXmlmap();
-    write(ofile, xmlmap.toByteArray(), xmlmap.length());
+    ssize_t written = write(ofile, xmlmap.toByteArray(), xmlmap.length());
+    if (written < 0)
+        throw MakeStringException(-1, "can't write to file %s\n", dstxml);
+    if (written != xmlmap.length())
+        throw MakeStringException(-1, "truncated write to file %s\n", dstxml);
     close(ofile);
     return 0;
 }

--- a/roxie/roxieclient/roxieclient.cpp
+++ b/roxie/roxieclient/roxieclient.cpp
@@ -95,7 +95,13 @@ int CDataOutputCache::writeOutput()
             finger = strchr(obuf+9, '\0') + 1;
             len -= (finger-obuf);
         }
-        outputstream->writeBytes(finger, len);
+        try {
+            outputstream->writeBytes(finger, len);
+        }
+        catch (IException *e) {
+            delete mb;
+            throw;
+        }
 
 #ifdef DEBUG_ROXIECLIENT_
         DBGLOG("Written %d bytes to output %s", len, name.str());

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -3561,8 +3561,10 @@ class CSocketSelectThread: public Thread
 #ifdef _USE_PIPE_FOR_SELECT_TRIGGER
         CriticalBlock block(sect);
         char c = 0;
-        if(write(dummysock[1], &c, 1) != 1)
-            throwUnexpected();
+        if(write(dummysock[1], &c, 1) != 1) {
+            int err = ERRNO();
+            LOGERR(err,1,"Socket closed during trigger select");
+        }
 #else
         closedummy();
 #endif

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -3561,7 +3561,8 @@ class CSocketSelectThread: public Thread
 #ifdef _USE_PIPE_FOR_SELECT_TRIGGER
         CriticalBlock block(sect);
         char c = 0;
-        write(dummysock[1], &c, 1);
+        if(write(dummysock[1], &c, 1) != 1)
+            throwUnexpected();
 #else
         closedummy();
 #endif

--- a/system/jlib/jstream.cpp
+++ b/system/jlib/jstream.cpp
@@ -219,12 +219,14 @@ CFileOutputStream::CFileOutputStream(int _handle)
 
 void CFileOutputStream::writeByte(byte b)
 {
-    _write(handle, &b, 1);
+    if (_write(handle, &b, 1) != 1)
+        throwUnexpected();
 }
 
 void CFileOutputStream::writeBytes(const void *b, int len)
 {
-    _write(handle, b, len);
+    if (_write(handle, b, len) != len)
+        throwUnexpected();
 }
 
 extern jlib_decl IByteOutputStream *createOutputStream(int handle)

--- a/system/jlib/jstream.cpp
+++ b/system/jlib/jstream.cpp
@@ -220,13 +220,16 @@ CFileOutputStream::CFileOutputStream(int _handle)
 void CFileOutputStream::writeByte(byte b)
 {
     if (_write(handle, &b, 1) != 1)
-        throwUnexpected();
+        throw MakeStringException(-1, "Error while writing byte 0x%x\n", (unsigned)b);
 }
 
 void CFileOutputStream::writeBytes(const void *b, int len)
 {
-    if (_write(handle, b, len) != len)
-        throwUnexpected();
+    ssize_t written = _write(handle, b, len);
+    if (written < 0)
+        throw MakeStringException(-1, "Error while writing %d bytes\n", len);
+    if (written != len)
+        throw MakeStringException(-1, "Truncated (%d) while writing %d bytes\n", written, len);
 }
 
 extern jlib_decl IByteOutputStream *createOutputStream(int handle)

--- a/system/jlib/jstream.cpp
+++ b/system/jlib/jstream.cpp
@@ -229,7 +229,7 @@ void CFileOutputStream::writeBytes(const void *b, int len)
     if (written < 0)
         throw MakeStringException(-1, "Error while writing %d bytes\n", len);
     if (written != len)
-        throw MakeStringException(-1, "Truncated (%d) while writing %d bytes\n", written, len);
+        throw MakeStringException(-1, "Truncated (%d) while writing %d bytes\n", written, (int)len);
 }
 
 extern jlib_decl IByteOutputStream *createOutputStream(int handle)

--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -283,7 +283,11 @@ void indent(int indents)
 
 void out(const char *s,size_t l)
 {
-    write(gOutfile,s,(unsigned)l);
+    ssize_t written = write(gOutfile,s,(unsigned)l);
+    if (written < 0)
+        throw "Error while writing out";
+    if (written != l)
+        throw "Truncated write";
 }
 
 void outs(const char *s)


### PR DESCRIPTION
write returns the number of bytes written. If it's different than what's been asked for, the write was truncated. If it's -1, it failed altogether. On both occasions, this error is serious and needs a decent treatment.

On more shallow parts (dfuplus and hidlcomp), I've added a little more information, but on core places (jlib), differentiating them would probably cause more confusion than add.

No regressions detected.
