### PR TITLE
Fixes gh-1718 Changed from awk with delim _ to bash expansions to

### DIFF
--- a/initfiles/bash/etc/init.d/dafilesrv.in
+++ b/initfiles/bash/etc/init.d/dafilesrv.in
@@ -86,7 +86,7 @@ COMPS=`${configgen_path}/configgen -env ${envfile} -ip "127.0.0.1" -list`
 
 comp.parser ${COMPS}
 for i in ${compArray[@]}; do
-    compName=`echo $i | awk -F"_" '{print $2}'`
+    compName=${i#*_}
     comp.getByName ${compName}
     compType=`echo $comp_return | cut -d ' ' -f 1 | cut -d '=' -f 2 `
     if strstr ${compType} "dafilesrv" ;

--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -140,7 +140,7 @@ compDafilesrv=''
 #Forming the component list from the configgen 
 
 for i in ${compArray[@]}; do
-    compName=`echo $i | awk -F"_" '{print $2}'`
+    compName=${i#*_}
     comp.getByName ${compName}
     componentType=`echo ${comp_return} | awk -F" " '{print $1}' | awk -F"=" '{print $2}'`
     if [ -z ${compName} ];


### PR DESCRIPTION
allow for component names with _ in them.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
