### PR TITLE
Remove default memory setting values from thor.xsd

### DIFF
--- a/initfiles/componentfiles/configxml/thor.xsd.in
+++ b/initfiles/componentfiles/configxml/thor.xsd.in
@@ -347,7 +347,7 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="globalMemorySize" type="xs:nonNegativeInteger" use="optional" default="2048">
+      <xs:attribute name="globalMemorySize" type="xs:nonNegativeInteger" use="optional">
         <xs:annotation>
           <xs:appinfo>
             <tooltip>Memory (in MB) to use for Link Counted Rows</tooltip>
@@ -512,7 +512,7 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="largeMemSize" type="xs:nonNegativeInteger" use="optional" default="1400">
+      <xs:attribute name="largeMemSize" type="xs:nonNegativeInteger" use="optional">
         <xs:annotation>
           <xs:appinfo>
             <tooltip>Memory available to thor for heavyweith operations (MB)</tooltip>


### PR DESCRIPTION
default for globalMemorySize is now unset, which means unbound
default for largeMemSize is 75% of globalMemorySize if set, or 75% of 2GB
(will become 75% of RAM / slavesPerNode shortly)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
