### PR TITLE
Fixes #1731 Set Thor slaves attribute to number of slaves times slavesPerNode

### DIFF
--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -1291,7 +1291,8 @@ void CConfigEnvHelper::UpdateThorAttributes(IPropertyTree* pParentNode)
     setAttribute(pParentNode, "@localThor", localThor ? "true" : "false");
 
     StringBuffer sb;
-    sb.appendf("%d", nSlaves);
+    int slavesPerNode = pParentNode->getPropInt("@slavesPerNode", 1);
+    sb.appendf("%d", nSlaves * slavesPerNode);
     setAttribute(pParentNode, XML_ATTR_SLAVES, sb.str());
 }
 


### PR DESCRIPTION
Set Thor slaves attribute to number of slaves times slavesPerNode.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
