### PR TITLE
Increase the ecl language version to 3.6.0

### DIFF
--- a/ecl/hql/hql.hpp
+++ b/ecl/hql/hql.hpp
@@ -49,7 +49,7 @@ Relevant changes include
 */
 
 #define LANGUAGE_VERSION_MAJOR      3
-#define LANGUAGE_VERSION_MINOR      0
+#define LANGUAGE_VERSION_MINOR      6
 #define LANGUAGE_VERSION_SUB        0
 
 #define LANGUAGE_VERSION   estringify(LANGUAGE_VERSION_MAJOR) "." estringify(LANGUAGE_VERSION_MINOR) "." estringify(LANGUAGE_VERSION_SUB)


### PR DESCRIPTION
- Changes in std.str which called new functions in stringlib plugin
  mean that compiles from new versions may not be compatible with
  old remote servers.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
