### PR TITLE
Add getCount(xpath) utility method to IPT

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -2415,7 +2415,16 @@ unsigned PTree::numChildren()
 {
     if (!checkChildren()) return 0;
     return children->numChildren();
-}   
+}
+
+unsigned PTree::getCount(const char *xpath)
+{
+    unsigned c=0;
+    Owned<IPropertyTreeIterator> iter = getElements(xpath);
+    ForEach(*iter)
+        ++c;
+    return c;
+}
 
 void getXPathMatchTree(IPropertyTree &parentContext, const char *xpath, IPropertyTree *&matchContainer)
 {

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -110,6 +110,7 @@ interface jlib_decl IPropertyTree : extends serializable
     virtual bool isCaseInsensitive() = 0;
     virtual bool IsShared() const = 0;
     virtual void localizeElements(const char *xpath, bool allTail=false) = 0;
+    virtual unsigned getCount(const char *xpath) = 0;
     
 private:
     void setProp(const char *, int); // dummy to catch accidental use of setProp when setPropInt() intended

--- a/system/jlib/jptree.ipp
+++ b/system/jlib/jptree.ipp
@@ -381,6 +381,7 @@ public:
     virtual unsigned numUniq() { return checkChildren()?children->count():0; }  
     virtual unsigned numChildren();
     virtual bool isCaseInsensitive() { return isnocase(); }
+    virtual unsigned getCount(const char *xpath);
 // serializable impl.
     virtual void serialize(MemoryBuffer &tgt);
     virtual void deserialize(MemoryBuffer &src);


### PR DESCRIPTION
Utility method to return count for given xpath.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
