### PR TITLE
Remove ThorCluster prop @slaves

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3856,7 +3856,10 @@ public:
             {
                 IPropertyTree &thor = thors.item(i);
                 thorProcesses.append(thor.queryProp("@name"));
-                unsigned ts = thor.getPropInt("@slaves");
+                unsigned nodes = thor.getCount("ThorSlaveProcess");
+                if (!nodes)
+                    throw MakeStringException(WUERR_MismatchClusterSize,"CEnvironmentClusterInfo: Thor cluster can not have 0 slave processes");
+                unsigned ts = nodes * thor.getPropInt("@slavesPerNode", 1);
                 if (clusterWidth && (ts!=clusterWidth)) 
                     throw MakeStringException(WUERR_MismatchClusterSize,"CEnvironmentClusterInfo: mismatched thor sizes in cluster");
                 clusterWidth = ts;

--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -1251,11 +1251,6 @@ void CConfigEnvHelper::UpdateThorAttributes(IPropertyTree* pParentNode)
 
     setAttribute(pParentNode, XML_ATTR_MULTISLAVES, multiSlaves ? "true" : "false");
     setAttribute(pParentNode, "@localThor", localThor ? "true" : "false");
-
-    StringBuffer sb;
-    int slavesPerNode = pParentNode->getPropInt("@slavesPerNode", 1);
-    sb.appendf("%d", nSlaves * slavesPerNode);
-    setAttribute(pParentNode, XML_ATTR_SLAVES, sb.str());
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Already absent from the xslt/xsd's, but still part of the environment xml
and generated by the wizard.
Remove from environment and calculate based on ThorSlaveProcess and
slavesPerNode.
Which avoids having to maintain (and potentially get wrong) number of slaves
in environment.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
