### PR TITLE
Fix gh-1663 Display component name for thorslaves

### DIFF
--- a/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
+++ b/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
@@ -371,12 +371,7 @@
          <thead>
             <tr bgcolor="#C0C0C0">
                <th>Location</th>
-               <th>
-                <xsl:choose>
-                                <xsl:when test="$clusterName=''">Component</xsl:when>
-                                <xsl:otherwise>Type</xsl:otherwise>
-                            </xsl:choose>
-               </th>
+               <th>Component</th>
                <xsl:choose>
                   <xsl:when test="../../../Columns/Item">
                      <xsl:for-each select="../../../Columns/Item[text()='Condition']">
@@ -457,9 +452,16 @@
          </td>
          <td>
             <xsl:value-of select="DisplayType"/>
-            <xsl:if test="$clusterName='' and string(ComponentName)!=''">
-                    <br/>
-                    <xsl:value-of select="concat('[', ComponentName, ']')"/>
+            <xsl:if test="string(ComponentName)!=''">
+                <br/>
+                <xsl:choose>
+                    <xsl:when test="ProcessType='ThorSlaveProcess'">
+                        <xsl:value-of select="concat('[', ComponentName, ', ', ProcessNumber, ']')"/>
+                    </xsl:when>
+                    <xsl:when test="ProcessType!='ThorMasterProcess' and ProcessType!='RoxieServerProcess'">
+                        <xsl:value-of select="concat('[', ComponentName, ']')"/>
+                    </xsl:when>
+                </xsl:choose>
             </xsl:if>
          </td>
          <xsl:choose>

--- a/esp/eclwatch/ws_XSLT/machines.xslt
+++ b/esp/eclwatch/ws_XSLT/machines.xslt
@@ -231,18 +231,18 @@
                                 <xsl:if test="TpMachine[2] and not($SwapNode)">
                                     <xsl:attribute name="id">selectAll1</xsl:attribute>
                                     <input type="checkbox" id="selectAll1" title="Select or deselect all machines" onclick="selectAll0(this)">
-                    <xsl:if test="not($SwapNode)">
-                      <xsl:attribute name="checked">true</xsl:attribute>
-                    </xsl:if>
-                  </input>
+                                        <xsl:if test="not($SwapNode)">
+                                            <xsl:attribute name="checked">true</xsl:attribute>
+                                        </xsl:if>
+                                    </input>
                                 </xsl:if>
                             </th>
                             <th align="center">Name</th>
-              <xsl:if test="/TpMachineQueryResponse/HasThorSpareProcess/text()='1' and /TpMachineQueryResponse/Type='THORMACHINES'">
-                  <th>Action</th>
-              </xsl:if>
-              <th>Net Address</th>
-                            <th>Type</th>
+                                <xsl:if test="/TpMachineQueryResponse/HasThorSpareProcess/text()='1' and /TpMachineQueryResponse/Type='THORMACHINES'">
+                                    <th>Action</th>
+                                </xsl:if>
+                            <th>Network Address</th>
+                            <th>Component</th>
                             <th>Domain</th>
                             <th>Platform</th>
                         </tr>
@@ -368,7 +368,10 @@
         <xsl:value-of select="Netaddress"/>
       </td>
       <td>
-                <xsl:value-of select="$displayType"/>
+            <xsl:value-of select="$displayType"/>
+            <xsl:if test="Type='ThorSlaveProcess'">
+                <br/><xsl:value-of select="concat('[', ProcessNumber, ']')"/>
+            </xsl:if>
             </td>
             <td>
                 <xsl:value-of select="Domain"/>

--- a/esp/eclwatch/ws_XSLT/targetclusters.xslt
+++ b/esp/eclwatch/ws_XSLT/targetclusters.xslt
@@ -292,7 +292,7 @@
             </tr>
       <tr>
         <td/>
-        <td colspan="6" align="left" style="padding-left=30px">
+        <td colspan="7" align="left" style="padding-left=30px">
           <span id="div_{$name}_{position()}" style="display:inline;visibility:visible">
                 <table class="blueline" border="2" frame="box" rules="groups">
                   <colgroup>
@@ -301,17 +301,17 @@
                     <col width="20%"/>
                     <col width="10%"/>
                     <col width="8%"/>
-                    <col width="15%"/>
                     <col width="25%"/>
+                    <col width="20%"/>
                   </colgroup>
                   <tr bgcolor="#C0C0C0">
                     <th/>
-                    <th>Name</th>
-                    <th>Type</th>
-                    <th>Computer</th>
-                    <th>Platform</th>
-                    <th>Network Address</th>
-                    <th>Directory</th>
+                    <th align="center">Name</th>
+                    <th align="center">Component</th>
+                    <th align="center">Computer</th>
+                    <th align="center">Platform</th>
+                    <th align="center">Network Address</th>
+                    <th align="center">Directory</th>
                   </tr>
 
                   <xsl:if test="count(TpClusters/TpCluster)">
@@ -415,12 +415,12 @@
                   <xsl:value-of select="Name"/>
                 </a>
               </td>
-              <td>
+              <td align="center">
                 <xsl:value-of select="$type4"/>
               </td>
               <td>
               </td>
-              <td>
+              <td align="center">
                 <xsl:choose>
                   <xsl:when test="OS=0">Windows</xsl:when>
                   <xsl:when test="OS=2">Linux</xsl:when>
@@ -466,14 +466,13 @@
                       <thead>
                         <tr>
                           <th align="center">Name</th>
-                          <th>Type</th>
+                          <th align="center">Component</th>
                           <xsl:if test="Type='ThorCluster' and HasThorSpareProcess/text()='1'">
                             <th>Action</th>
                           </xsl:if>
-                          <th>Net Address</th>
-                          <th>Domain</th>
-                          <th>Platform</th>
-                          <th>Log</th>
+                          <th align="center">Network Address</th>
+                          <th align="center">Domain</th>
+                          <th align="center">Platform</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -549,21 +548,21 @@
                 </tbody>
               </table>
             </td>
-            <td>
+            <td align="center">
               <xsl:value-of select="$type4"/>
             </td>
-            <td>
+            <td align="center">
               <xsl:value-of select="Name"/>
             </td>
-                <td>
-                  <xsl:choose>
-                    <xsl:when test="OS=0">Windows</xsl:when>
-                    <xsl:when test="OS=2">Linux</xsl:when>
-                    <xsl:when test="OS=1">Solaris</xsl:when>
-                    <xsl:otherwise>Unknown</xsl:otherwise>
-                  </xsl:choose>
-                </td>
-                <td>
+            <td align="center">
+              <xsl:choose>
+                <xsl:when test="OS=0">Windows</xsl:when>
+                <xsl:when test="OS=2">Linux</xsl:when>
+                <xsl:when test="OS=1">Solaris</xsl:when>
+                <xsl:otherwise>Unknown</xsl:otherwise>
+              </xsl:choose>
+            </td>
+            <td align="center">
               <xsl:value-of select="Netaddress"/>
               <xsl:if test="not(Port=0)">
                 :<xsl:value-of select="Port"/>
@@ -748,17 +747,17 @@
                   <table class="blueline" border="2" frame="box" rules="groups">
                     <thead>
                       <tr>
-                        <th>Component</th>
-                        <th>Dali Server</th>
+                        <th align="center">Component</th>
+                        <th align="center">Dali Server</th>
                         <!--th>WUQueueName</th-->
-                        <th>Configuration</th>
+                        <th align="center">Configuration</th>
                       </tr>
                     </thead>
                     <tbody>
                       <xsl:variable name="netAddress" select="Netaddress"/>
                       <tr>
-                        <td>AgentExec</td>
-                        <td>
+                        <td align="center">AgentExec</td>
+                        <td align="center">
                           <xsl:value-of select="../../DaliServer"/>
                         </td>
                         <td>
@@ -824,22 +823,25 @@
             <xsl:when test="Type='HoleControlProcess'">Hole Control</xsl:when>
             <xsl:when test="Type='HoleCollatorProcess'">Hole Collator</xsl:when>
             <xsl:when test="Type='HoleStandbyProcess'">Hole Standby</xsl:when>
-            <xsl:when test="Type='RoxieFarmerProcess'">Roxie Farmer</xsl:when>
-            <xsl:when test="Type='RoxieSlaveProcess'">Roxie Slave</xsl:when>
+            <xsl:when test="Type='RoxieServerProcess'">Roxie Server</xsl:when>
             <xsl:when test="Type='DropZone'">Drop Zone</xsl:when>
             <xsl:otherwise>
               <xsl:value-of select="Type"/>
             </xsl:otherwise>
           </xsl:choose>
         </xsl:variable>
-        <td>
+        <td align="center">
           <xsl:value-of select="Name"/>
         </td>
-      <td>
+      <td align="center">
         <xsl:value-of select="$displayType"/>
+          <xsl:if test="Type='ThorSlaveProcess'">
+              <br/>
+              <xsl:value-of select="concat('[', $clusterName, ', ', ProcessNumber, ']')"/>
+          </xsl:if>
       </td>
       <xsl:if test="$clusterType='ThorCluster' and ../../HasThorSpareProcess/text()='1'">
-          <td>
+          <td align="center">
             <xsl:if test="Type='ThorSlaveProcess'">
               <a href="/WsTopology/TpMachineQuery?Type=THORSPARENODES&amp;Cluster={$clusterName}&amp;OldIP={Netaddress}&amp;Path={../../Path}"
                 title="Swap node...">
@@ -847,51 +849,20 @@
               </a>
             </xsl:if>
           </td>
-        </xsl:if>
-        <td>
+      </xsl:if>
+      <td align="center">
           <xsl:value-of select="Netaddress"/>
-        </td>
-        <td>
+      </td>
+      <td align="center">
           <xsl:value-of select="Domain"/>
-        </td>
-        <td>
+      </td>
+      <td align="center">
           <xsl:choose>
             <xsl:when test="OS=0">Windows</xsl:when>
             <xsl:when test="OS=1">Solaris</xsl:when>
             <xsl:when test="OS=2">Linux</xsl:when>
             <xsl:otherwise>Unknown</xsl:otherwise>
           </xsl:choose>
-        </td>
-      <td>
-        <a style="padding-right:2" href="">
-          <xsl:variable name="url">
-            <xsl:text disable-output-escaping="yes">/WsTopology/TpGetComponentFile%3fFileType%3dlog%26NetAddress%3d</xsl:text>
-            <xsl:value-of select="concat(Netaddress, '%26CompType%3d', Type, '%26OsType%3d', OS, '%26Directory%3d')"/>
-          </xsl:variable>
-          <xsl:variable name="pageCaption">
-            <xsl:text disable-output-escaping="yes">esp_iframe_title=Log file for </xsl:text>
-            <xsl:value-of select="concat($displayType, ' [', Netaddress, '] of ')"/>
-            <!--xsl:variable name="clusterType" select="$clusterType"/-->
-            <xsl:text disable-output-escaping="yes"> cluster '</xsl:text>
-            <xsl:value-of select="$clusterName"/>
-            <xsl:text disable-output-escaping="yes">'</xsl:text>
-          </xsl:variable>
-          <xsl:attribute name="onclick">
-            <xsl:text disable-output-escaping="yes">return popup('</xsl:text>
-            <xsl:value-of select="Netaddress"/>
-            <xsl:text disable-output-escaping="yes">', '</xsl:text>
-            <xsl:value-of select="translate(../../LogDirectory, '\', '/')"/>
-            <xsl:text disable-output-escaping="yes">', '</xsl:text>
-            <xsl:value-of select="$url"/>
-            <xsl:text disable-output-escaping="yes">', "</xsl:text>
-            <xsl:value-of select="$pageCaption"/>
-            <xsl:text disable-output-escaping="yes">",</xsl:text>
-            <xsl:value-of select="OS"/>
-            <xsl:text disable-output-escaping="yes">);</xsl:text>
-          </xsl:attribute>
-          <img border="0" src="/esp/files_/img/base.gif" alt="View log file..." width="19" height="16"/>
-        </a>
-        <xsl:value-of select="../../LogDirectory"/>
       </td>
     </tr>
     </xsl:template>

--- a/esp/eclwatch/ws_XSLT/topology.xslt
+++ b/esp/eclwatch/ws_XSLT/topology.xslt
@@ -95,20 +95,16 @@
               <table class="sort-table" id="clustersTable">
                 <caption><h2 align="left">Clusters</h2></caption>
                 <colgroup>
-                  <col width="1%" align="center"/>
                   <col width="2%" align="center"/>
-                  <col width="18%" align="left"/>
-                  <col width="9%" align="left"/>
-                  <col width="10%" align="left"/>
-                  <col width="30%" align="left"/>
-                  <col width="30%" align="left"/>
+                  <col width="15%" align="left"/>
+                  <col width="19%" align="left"/>
+                  <col width="8%" align="left"/>
+                  <col width="28%" align="left"/>
+                  <col width="28%" align="left"/>
                 </colgroup>
                 <tr class="grey">
-                  <th id="selectAll1">
-                    <input type="checkbox" title="Select or deselect all clusters" onclick="selectAll(this.checked)"/>
-                  </th>
-                  <th colspan="2" align="left">Name</th>
-                  <th>Type</th>
+                  <th colspan="2">Name</th>
+                  <th>Component</th>
                   <th>Platform</th>
                   <th>Directory</th>
                   <th>Log Directory</th>
@@ -116,34 +112,6 @@
                 <xsl:apply-templates select="TpClusters/TpCluster">
                   <xsl:sort select="Name"/>
                 </xsl:apply-templates>
-              </table>
-              <table cellpadding="0" width="100%">
-                <tr>
-                  <th id="selectAll2" width="1%" style="padding-left:4px" align="left">
-                    <input type="checkbox" title="Select or deselect all clusters" onclick="selectAll(this.checked)"></input>
-                  </th>
-                  <th colspan="5" align="left">Select All / None</th>
-                </tr>
-                <tr>
-                  <td height="20"/>
-                </tr>
-                <xsl:if test="$enableSNMP != 0">
-                  <tr>
-                    <td><b>User Name: </b></td>
-                    <td><input type="text" id="submit3" name="submit3" size="20" value=""/></td>
-                  </tr>
-                  <tr>
-                    <td><b>Password: </b></td>
-                    <td><input type="password" id="submit4" name="submit4" size="20" value=""/></td>
-                  </tr>
-                  <tr>
-                    <td/>
-                    <td>
-                      <input type="submit" id="submit1" value="Start" onclick="return onSubmit(0)"/>
-                      <input type="submit" id="submit2" value="Stop" onclick="return onSubmit(1)"/>
-                    </td>
-                  </tr>
-                </xsl:if>
               </table>
             </xsl:when>
             <xsl:otherwise>
@@ -172,6 +140,13 @@
         </xsl:choose>
       </xsl:variable>
       <xsl:variable name="type3" select="translate($type2, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/>
+      <xsl:variable name="type4">
+        <xsl:choose>
+            <xsl:when test="Type='RoxieCluster'">Roxie Cluster Process</xsl:when>
+            <xsl:when test="Type='ThorCluster'">Thor Cluster Process</xsl:when>
+            <xsl:when test="Type='HoleCluster'">Hole Cluster Process</xsl:when>
+        </xsl:choose>
+      </xsl:variable>
       <xsl:variable name="absolutePath">
         <xsl:call-template name="makeAbsolutePath">
           <xsl:with-param name="path" select="Directory"/>
@@ -206,13 +181,6 @@
           </xsl:otherwise>
                 </xsl:choose>                                                       
             </xsl:variable>
-      <td>
-        <!--we encode name, type, os and path for component - the service uses the name (first token)
-        to look up component's address-->
-        <input type="checkbox" name="Addresses_i{count(preceding::TpCluster)}" 
-        value="{Name}:{Type}:{Name}:{OS}:{translate(Directory, ':', '$')}:{$type3}MACHINES:{Path}" onclick="return clicked(this, event)">
-        </input>
-      </td>
       <td width="45" nowrap="true">
         <xsl:variable name="href0">
           <xsl:text disable-output-escaping="yes">/esp/iframe?esp_iframe_title=Configuration file for </xsl:text>
@@ -228,7 +196,7 @@
         </a>
       </td>
       <td>
-        <xsl:value-of select="$type2"/>
+        <xsl:value-of select="$type4"/>
       </td>
       <td>
         <xsl:choose>

--- a/esp/services/ws_machine/machines.xslt
+++ b/esp/services/ws_machine/machines.xslt
@@ -299,12 +299,7 @@
                   </xsl:if>
                </th>
                <th>Location</th>
-               <th>
-                <xsl:choose>
-                                <xsl:when test="$clusterName=''">Component</xsl:when>
-                                <xsl:otherwise>Type</xsl:otherwise>
-                            </xsl:choose>
-               </th>
+               <th>Component</th>
                <xsl:choose>
                   <xsl:when test="../Columns/Item">
                      <xsl:for-each select="../Columns/Item[text()='Condition']">
@@ -408,9 +403,16 @@
          </td>
          <td>
             <xsl:value-of select="DisplayType"/>
-            <xsl:if test="$clusterName='' and string(ComponentName)!=''">
-                    <br/>
-                    <xsl:value-of select="concat('[', ComponentName, ']')"/>
+            <xsl:if test="string(ComponentName)!=''">
+               <br/>
+               <xsl:choose>
+                  <xsl:when test="ProcessType='ThorSlaveProcess'">
+                     <xsl:value-of select="concat('[', ProcessNumber, ']')"/>
+                  </xsl:when>
+                  <xsl:when test="ProcessType!='ThorMasterProcess' and ProcessType!='RoxieServerProcess'">
+                     <xsl:value-of select="concat('[', ComponentName, ']')"/>
+                  </xsl:when>
+               </xsl:choose>
             </xsl:if>
          </td>
          <xsl:choose>


### PR DESCRIPTION
For cluster processes, the existing EclWatch preflight page
only shows Process Type (Thor Master, Thor Slave, etc). This
fix displays the component names (mythor, myroxie, etc) with
the Process Type. For thor slaves, the component names will
be '$component_slave_$slavenumber' (mythor_slave_1,
mythor_slave_2, etc'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
