### PR TITLE
Preflight should use new pid file name for multiSlaves

### DIFF
--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -2490,16 +2490,8 @@ void Cws_machineEx::getTargetClusterProcesses(StringArray& targetClusters, Strin
                                 dirStr.append(pClusterProcess->queryProp("@directory"));
 
                             getMachineList(constEnv, pClusterProcess, process, eqThorMasterProcess, dirStr.str(), processAddresses);
-                            if (pClusterProcess->getPropBool("@multiSlaves"))
-                            {
-                                getMachineList(constEnv, pClusterProcess, process, eqThorSlaveProcess, dirStr.str(), processAddresses);
-                                getMachineList(constEnv, pClusterProcess, process, eqThorSpareProcess, dirStr.str(), processAddresses);
-                            }
-                            else
-                            {
-                                getThorMachineList(constEnv, pClusterProcess, process, eqThorSlaveProcess, dirStr.str(), processAddresses);
-                                getThorMachineList(constEnv, pClusterProcess, process, eqThorSpareProcess, dirStr.str(), processAddresses);
-                            }
+                            getThorMachineList(constEnv, pClusterProcess, process, eqThorSlaveProcess, dirStr.str(), processAddresses);
+                            getThorMachineList(constEnv, pClusterProcess, process, eqThorSpareProcess, dirStr.str(), processAddresses);
                         }
                     }
                 }

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -1554,12 +1554,8 @@ void CTpWrapper::getMachineList(double clientVersion,
         if (!cluster)
             throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
+        //set this flag for legacy multi slave clusters because SwapNode made little sense in the old scheme
         multiSlaves = cluster->getPropBool("@multiSlaves");
-        if (multiSlaves)
-        {   //multiSlaves will be set to true for legacy multiSlaves environment
-            getMachineList(MachineType, ParentPath, Status, Directory, MachineList);
-            return;
-        }
 
         StringBuffer groupName;
         if (strieq(MachineType, eqThorSlaveProcess))


### PR DESCRIPTION
The multiSlaves flag is used by the existing Preflight code
to decide whether PID file names for multiSlaves contain
'_slaveNumber' or not. That caused problems when old version
of environment.xml is used because multiSlaves flag is set
inside the xml file. In this fix, the '_slaveNumber' is
always appended to the PID file names for thor slaves even
when the multiSlaves flag is set. The multiSlaves flag will
only be used for removing swapnode options for legacy system.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
