### PR TITLE
WIP #1475 Remove Protocol X tab on ESP process in ConfigMgr

### DIFF
--- a/initfiles/componentfiles/configxml/esp.xsd
+++ b/initfiles/componentfiles/configxml/esp.xsd
@@ -154,7 +154,6 @@
                                 <xs:restriction base="xs:string">
                                     <xs:enumeration value="http"/>
                                     <xs:enumeration value="https"/>
-                                    <xs:enumeration value="protocolx"/>
                                 </xs:restriction>
                             </xs:simpleType>
                         </xs:attribute>
@@ -432,63 +431,6 @@
                             <xs:annotation>
                                 <xs:appinfo>
                                     <tooltip>Set this to true to regenerate the private key, certificate and CSR.</tooltip>
-                                </xs:appinfo>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="ProtocolX" minOccurs="0">
-                    <xs:annotation>
-                        <xs:appinfo>
-                            <title>Protocol X</title>
-                        </xs:appinfo>
-                    </xs:annotation>
-                    <xs:complexType>
-                        <xs:attribute name="minTimeout" type="xs:string" use="optional" default="30">
-                            <xs:annotation>
-                                <xs:appinfo>
-                                    <title>Minimum Timeout</title>
-                                    <tooltip>The minimum user-specified transaction timeout in seconds</tooltip>
-                                </xs:appinfo>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="maxTimeout" type="xs:string" use="optional" default="36">
-                            <xs:annotation>
-                                <xs:appinfo>
-                                    <title>Maximum Timeout</title>
-                                    <tooltip>The maximum user-specified transaction timeout in seconds</tooltip>
-                                </xs:appinfo>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="defaultTimeout" type="xs:string" use="optional" default="21">
-                            <xs:annotation>
-                                <xs:appinfo>
-                                    <title>Default Timeout</title>
-                                    <tooltip>The default transaction timeout, in seconds, if not user-specified</tooltip>
-                                </xs:appinfo>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="idleTimeout" type="xs:string" use="optional" default="3600">
-                            <xs:annotation>
-                                <xs:appinfo>
-                                    <title>Idle Timeout</title>
-                                    <tooltip>When no traffic is seen for this many seconds, the connection is closed by the server</tooltip>
-                                </xs:appinfo>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="authTimeout" type="xs:string" use="optional" default="3">
-                            <xs:annotation>
-                                <xs:appinfo>
-                                    <title>Authentication Timeout</title>
-                                    <tooltip>Connection is refused if authentication takes longer than this (seconds)</tooltip>
-                                </xs:appinfo>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="threadCount" type="xs:string" use="optional" default="2">
-                            <xs:annotation>
-                                <xs:appinfo>
-                                    <title>Thread Count</title>
-                                    <tooltip>The maximum number of threads allocated to process transactions</tooltip>
                                 </xs:appinfo>
                             </xs:annotation>
                         </xs:attribute>

--- a/initfiles/componentfiles/configxml/esp.xsl
+++ b/initfiles/componentfiles/configxml/esp.xsl
@@ -161,17 +161,6 @@
                     </verify>
                 </EspProtocol>
             </xsl:if>
-            <!-- insert https protocol, if a certificate has been specified for it-->
-            <xsl:if test="EspBinding[@protocol='protocolx']">
-                <EspProtocol name="protocolx" type="protocolx_protocol">
-                    <xsl:attribute name="plugin">
-                       <xsl:call-template name="makeServicePluginName">
-                          <xsl:with-param name="plugin" select="'protocolx'"/>
-                       </xsl:call-template>
-                    </xsl:attribute>
-                    <xsl:copy-of select="ProtocolX/@*"/>
-                </EspProtocol>
-            </xsl:if>
             <xsl:variable name="importedServiceDefinitionFiles">
                 <xsl:call-template name="importServiceDefinitionFiles">
                     <xsl:with-param name="filesList" select="$serviceFilesList"/>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -664,12 +664,6 @@
              FQDN=""
              name="s1"
              netAddress="."/>
-   <ProtocolX authTimeout="3"
-              defaultTimeout="21"
-              idleTimeout="3600"
-              maxTimeout="36"
-              minTimeout="30"
-              threadCount="2"/>
   </EspProcess>
   <EspService allowNewRoxieOnDemandQuery="false"
               AWUsCacheTimeout="15"


### PR DESCRIPTION
Remove ProtocolX information from the relevant xsd and the environment files, so it does not show up in ConfigMgr

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
