### PR TITLE
Fix gh-1775 - Splitter, child recs issue

### DIFF
--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -1514,7 +1514,11 @@ class CSharedWriteAheadDisk : public CSharedWriteAheadBase
     }
     virtual size32_t rowSize(const void *row)
     {
-        return serializeMeta->getRecordSize(row)+1; // space on disk, +1 = eog marker
+        if (meta == serializeMeta)
+            return meta->getRecordSize(row)+1; // space on disk, +1 = eog marker
+        CSizingSerializer ssz;
+        serializer->serialize(ssz,(const byte *)row);
+        return ssz.size()+1; // space on disk, +1 = eog marker
     }
 public:
     CSharedWriteAheadDisk(CActivityBase *activity, const char *spillName, unsigned outputCount, IRowInterfaces *rowIf, IDiskUsage *_iDiskUsage) : CSharedWriteAheadBase(activity, outputCount, rowIf),


### PR DESCRIPTION
A splitter that spilt to disk, was likely to fail if the input dataset it
was dealing with had child records.
It was using the wrong meta info to calculate the sizes of the records it
was accumulating before flushing to disk

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
