### PR TITLE
Guard against no spares on manual swap

### DIFF
--- a/tools/swapnode/swapnodelib.cpp
+++ b/tools/swapnode/swapnodelib.cpp
@@ -527,14 +527,16 @@ public:
             return false;
         // check to see if it was a spare and remove
         SocketEndpoint spareEp(newip);
-        rank_t r = spareGroup->rank(spareEp);
-        if (RANK_NULL != r)
+        if (spareGroup)
         {
-            PROGLOG("Removing spare : %s", newip);
-            spareGroup.setown(spareGroup->remove(r));
-            queryNamedGroupStore().add(spareGroupName, spareGroup); // NB: replace
+            rank_t r = spareGroup->rank(spareEp);
+            if (RANK_NULL != r)
+            {
+                PROGLOG("Removing spare : %s", newip);
+                spareGroup.setown(spareGroup->remove(r));
+                queryNamedGroupStore().add(spareGroupName, spareGroup); // NB: replace
+            }
         }
-
         info.clear();
 
         PROGLOG("SwapNode finished");


### PR DESCRIPTION
Manual swap permits a node to be swapped in that isn't listed as a spare.
But if there are no spares at all, the check to remove from spare list
caused fault

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
