### PR TITLE
gh-1779 ecl command line does not support setting result limits

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -321,6 +321,11 @@ public:
             cmdLine.append(" -manifest ").append(cmd.optManifest.get());
         if (cmd.optObj.value.get())
             cmdLine.append(" ").append(streq(cmd.optObj.value.get(), "stdin") ? "- " : cmd.optObj.value.get());
+        if ((int)cmd.optResultLimit > 0)
+        {
+            cmdLine.append(" -fapplyInstantEclTransformations=1");
+            cmdLine.append(" -fapplyInstantEclTransformationsLimit=").append(cmd.optResultLimit);
+        }
     }
 
     bool eclcc(StringBuffer &out)
@@ -441,6 +446,8 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     if (iter.matchFlag(optNoArchive, ECLOPT_ECL_ONLY))
         return EclCmdOptionMatch;
+    if (iter.matchOption(optResultLimit, ECLOPT_RESULT_LIMIT))
+        return EclCmdOptionMatch;
 
     return EclCmdCommon::matchCommandLineOption(iter, finalAttempt);
 }
@@ -465,6 +472,9 @@ bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
         if (!conversion.process())
             return false;
     }
+    if (optResultLimit == (unsigned)-1)
+        extractEclCmdOption(optResultLimit, globals, ECLOPT_RESULT_LIMIT_ENV, ECLOPT_RESULT_LIMIT_INI, 100);
+
     return true;
 
 }

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -65,6 +65,10 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_WAIT_INI "waitTimeout"
 #define ECLOPT_WAIT_ENV "ECL_WAIT_TIMEOUT"
 
+#define ECLOPT_RESULT_LIMIT "--limit"
+#define ECLOPT_RESULT_LIMIT_INI "resultLimit"
+#define ECLOPT_RESULT_LIMIT_ENV "ECL_RESULT_LIMIT"
+
 #define ECLOPT_INPUT "--input"
 #define ECLOPT_INPUT_S "-in"
 
@@ -168,7 +172,7 @@ public:
 class EclCmdWithEclTarget : public EclCmdCommon
 {
 public:
-    EclCmdWithEclTarget() : optNoArchive(false)
+    EclCmdWithEclTarget() : optNoArchive(false), optResultLimit((unsigned)-1)
     {
     }
     virtual eclCmdOptionMatchIndicator matchCommandLineOption(ArgvIterator &iter, bool finalAttempt=false);
@@ -180,6 +184,7 @@ public:
         fprintf(stdout,
             "   --main=<definition>    definition to use from legacy ECL repository\n"
             "   --ecl-only             send ecl text to hpcc without generating archive\n"
+            "   --limit=<limit>        sets the result limit for the query, defaults to 100\n"
             " eclcc options:\n"
             "   -Ipath                 Add path to locations to search for ecl imports\n"
             "   -Lpath                 Add path to locations to search for system libraries\n"
@@ -192,6 +197,7 @@ public:
     StringBuffer optImpPath;
     StringAttr optManifest;
     StringAttr optAttributePath;
+    unsigned optResultLimit;
     bool optNoArchive;
 };
 

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -178,6 +178,8 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
         req->setCluster(cluster);
     req->setObject(cmd.optObj.mb);
     req->setFileName(cmd.optObj.value.sget());
+    if ((int)cmd.optResultLimit > 0)
+        req->setResultLimit(cmd.optResultLimit);
 
     Owned<IClientWUDeployWorkunitResponse> resp = client->WUDeployWorkunit(req);
     if (resp->getExceptions().ordinality())

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -285,7 +285,7 @@ ESPresponse [exceptions_inline] WUCreateResponse
     ESPstruct ECLWorkunit Workunit;
 };
 
-ESPrequest WUDeployWorkunitRequest
+ESPrequest [nil_remove] WUDeployWorkunitRequest
 {
     string Cluster;
     string Name;
@@ -293,6 +293,7 @@ ESPrequest WUDeployWorkunitRequest
     string ObjType;
     string FileName;
     binary Object;
+    int ResultLimit;
 };
 
 ESPresponse [exceptions_inline] WUDeployWorkunitResponse

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3300,6 +3300,8 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
         StringBuffer text(req.getObject().length(), req.getObject().toByteArray());
         wu.setQueryText(text.str());
     }
+    if (!req.getResultLimit_isNull())
+        wu->setResultLimit(req.getResultLimit());
 
     wu->commit();
     wu.clear();


### PR DESCRIPTION
Add --limit option to ecl command line to specify result limit. Default
is 100.

Fixes gh-1779.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
