### PR TITLE
Allow dynamic resolution in Roxie

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -772,7 +772,8 @@ public:
         forceUnkeyed(_forceUnkeyed)
     {
         helper = (IHThorDiskReadBaseArg *) basehelper;
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0
+                || _aFactory->queryQueryFactory().queryPackage().dynamicFileResolution();
         isOpt = (helper->getFlags() & TDRoptional) != 0;
         diskSize.set(helper->queryDiskRecordSize());
         processed = 0;
@@ -916,7 +917,8 @@ public:
         : CSlaveActivityFactory(_graphNode, _subgraphId, _queryFactory, _helperFactory)
     {
         Owned<IHThorDiskReadBaseArg> helper = (IHThorDiskReadBaseArg *) helperFactory();
-        bool variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        bool variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0
+                                || _queryFactory.queryPackage().dynamicFileResolution();
         if (!variableFileName)
         {
             bool isOpt = (helper->getFlags() & TDRoptional) != 0;

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -518,6 +518,10 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                 runOnce = globals->getPropInt("port", 0) == 0;
             }
         }
+        // If standalone or workunit mode, tell root CRoxiePackage
+        // to resolve files dynamically
+        if (runOnce || standAloneDll)
+            topology->setPropBool("@dynamicFileResolution", true);
 
         traceLevel = topology->getPropInt("@traceLevel", runOnce ? 0 : 1);
         if (traceLevel > MAXTRACELEVEL)

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -19475,8 +19475,8 @@ public:
         isKeyed = false;
         stopAfter = I64C(0x7FFFFFFFFFFFFFFF);
         diskSize.set(helper.queryDiskRecordSize());
-        // MORE - This task do not take into accound the package's dynamicFileResolution property
-        variableFileName = (helper.getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName = (helper.getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0
+                || factory->queryQueryFactory().queryPackage().dynamicFileResolution();
         isOpt = (helper.getFlags() & TDRoptional) != 0;
     }
 

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -19475,6 +19475,7 @@ public:
         isKeyed = false;
         stopAfter = I64C(0x7FFFFFFFFFFFFFFF);
         diskSize.set(helper.queryDiskRecordSize());
+        // MORE - This task do not take into accound the package's dynamicFileResolution property
         variableFileName = (helper.getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         isOpt = (helper.getFlags() & TDRoptional) != 0;
     }
@@ -20487,7 +20488,8 @@ public:
         isLocal = _graphNode.getPropBool("att[@name='local']/@value");
         Owned<IHThorDiskReadBaseArg> helper = (IHThorDiskReadBaseArg *) helperFactory();
         sorted = (helper->getFlags() & TDRunsorted) == 0;
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0
+                || _queryFactory.queryPackage().dynamicFileResolution();
         maySkip = (helper->getFlags() & (TDRkeyedlimitskips|TDRkeyedlimitcreates|TDRlimitskips|TDRlimitcreates)) != 0;
         quotes = separators = terminators = NULL;
         if (!variableFileName)
@@ -22543,7 +22545,8 @@ public:
         : CRoxieServerActivityFactory(_id, _subgraphId, _queryFactory, _helperFactory, _kind)
     {
         Owned<IHThorCountFileArg> helper = (IHThorCountFileArg *) helperFactory();
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0
+                || _queryFactory.queryPackage().dynamicFileResolution();
         assertex(helper->queryRecordSize()->isFixedSize());
         if (!variableFileName)
         {
@@ -29864,7 +29867,7 @@ public:
         CriticalBlock b(daliUpdateCrit);
         if (!dynamicPackage)
         {
-            dynamicPackage.setown(createPackage(NULL));
+            dynamicPackage.setown(createPackage(topology));
         }
         return dynamicPackage->lookupFileName(filename, isOpt, true);
     }
@@ -29874,7 +29877,7 @@ public:
         CriticalBlock b(daliUpdateCrit);
         if (!dynamicPackage)
         {
-            dynamicPackage.setown(createPackage(NULL));
+            dynamicPackage.setown(createPackage(topology));
         }
         return dynamicPackage->createFileName(filename, overwrite, extend, clusters);
     }

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -522,6 +522,11 @@ public:
         return lookupElements(xpath.str(), "MemIndex");
     }
 
+    virtual bool dynamicFileResolution() const
+    {
+        return node->getPropBool("@dynamicFileResolution", false);
+    }
+
     virtual const IResolvedFile *lookupFileName(const char *_fileName, bool opt, bool cache) const
     {
         StringBuffer fileName;

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -71,6 +71,8 @@ interface IRoxiePackage : extends IInterface
     virtual const IResolvedFile *lookupFileName(const char *fileName, bool opt, bool cacheDaliResults) const = 0;
     // Lookup information in package to create new logical file name
     virtual IRoxieWriteHandler *createFileName(const char *fileName, bool overwrite, bool extend, const StringArray &clusters) const = 0;
+    // One-off queries should leave file resolution dynamically
+    virtual bool dynamicFileResolution() const = 0;
     // Lookup information in package about what in-memory indexes should be built for file
     virtual IPropertyTreeIterator *getInMemoryIndexInfo(const IPropertyTree &graphNode) const = 0;
     // Retrieve hash for the package


### PR DESCRIPTION
When running standalone or workunit queries (one-off),
allow Dali file resolution to happen dynamically. This avoids
the locks imposed by the forced cache in Roxie, when multiple
threads (master/slave) are trying to lock the same file
for reading/writing at different times (creation, deletion).

This pull request was tested in conjunction with (rebased at)
branch `roxie-local` (pull request #1797). Files are created successfully,
though I still see some exceptions being thrown on the static case:

```
 ERROR: assert(readPos+(sizeof(value))<=length()) failed - file: /home/rengolin/workspace/hpcc/src/system/jlib/jbuff.cpp, line 605
```

When trying to de-serialize the property tree on `CRoxieSlaveActivity::onCreate()`.

Is the property tree `topology` is a bit too big for a default parameter of a `CRoxiePackage`?
