### PR TITLE
gh-1646 - Detect new environment cluster group changes

### DIFF
--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -1965,14 +1965,14 @@ bool CClientSDSManager::updateEnvironment(IPropertyTree *newEnv, bool forceGroup
         if (conn)
         {
             Owned<IPropertyTree> root = conn->getRoot();
-            Owned<IPropertyTree> child = root->getPropTree("Environment");
-            if (child.get())
+            Owned<IPropertyTree> oldEnvironment = root->getPropTree("Environment");
+            if (oldEnvironment.get())
             {
                 StringBuffer bakname;
                 Owned<IFileIO> io = createUniqueFile(NULL, "environment", "bak", bakname);
                 Owned<IFileIOStream> fstream = createBufferedIOStream(io);
-                toXML(child, *fstream);         // formatted (default)
-                root->removeTree(child);
+                toXML(oldEnvironment, *fstream);         // formatted (default)
+                root->removeTree(oldEnvironment);
             }
             root->addPropTree("Environment", LINK(newEnv));
             root.clear();

--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -1979,8 +1979,9 @@ bool CClientSDSManager::updateEnvironment(IPropertyTree *newEnv, bool forceGroup
             conn->commit();
             conn->close();
             StringBuffer messages;
-            if (!initClusterGroups(forceGroupUpdate, messages))
-                WARNLOG("CClientSDSManager::updateEnvironment: %s", messages.str());
+            initClusterGroups(forceGroupUpdate, messages, oldEnvironment);
+            if (messages.length())
+                PROGLOG("CClientSDSManager::updateEnvironment: %s", messages.str());
             PROGLOG("Environment and node groups updated");
         }
         return true;

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -610,7 +610,7 @@ interface IDaliServer;
 extern da_decl IDaliServer *createDaliDFSServer(IPropertyTree *config); // called for coven members
 
 // to initialize clustergroups after clusters change in the environment
-extern da_decl bool initClusterGroups(bool force, StringBuffer &response, unsigned timems=INFINITE);
+extern da_decl void initClusterGroups(bool force, StringBuffer &response, IPropertyTree *oldEnvironment, unsigned timems=INFINITE);
 extern da_decl bool resetClusterGroup(const char *clusterName, const char *type, bool spares, StringBuffer &response, unsigned timems=INFINITE);
 extern da_decl bool addClusterSpares(const char *clusterName, const char *type, SocketEndpointArray &eps, StringBuffer &response, unsigned timems=INFINITE);
 extern da_decl bool removeClusterSpares(const char *clusterName, const char *type, SocketEndpointArray &eps, StringBuffer &response, unsigned timems=INFINITE);

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -5800,6 +5800,13 @@ void CCovenSDSManager::loadStore(const char *storeName, const bool *abort)
             externalEnvironment = true;
         }
 
+        bool forceGroupUpdate = config.getPropBool("@forceGroupUpdate");
+        StringBuffer response;
+        initClusterGroups(forceGroupUpdate, response, oldEnvironment);
+        if (response.length())
+            PROGLOG("DFS group initialization : %s", response.str()); // should this be a syslog?
+
+
         UInt64Array refExts;
         PROGLOG("Scanning store for external references");
         Owned<IPropertyTreeIterator> rootIter = root->getElements("//*");
@@ -7866,7 +7873,7 @@ bool CCovenSDSManager::updateEnvironment(IPropertyTree *newEnv, bool forceGroupU
         conn->commit();
         conn->close();
         StringBuffer messages;
-        initClusterGroups(forceGroupUpdate, messages);
+        initClusterGroups(forceGroupUpdate, messages, oldEnvironment);
         response.append(messages);
         PROGLOG("Environment and node groups updated");
     }

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -267,6 +267,9 @@ static void import(const char *path,const char *src,bool add)
         Owned<IPropertyTree> child = root->getPropTree(tail);
         root->removeTree(child);
     }
+    Owned<IPropertyTree> oldEnvironment;
+    if (streq(path,"Environment"))
+        oldEnvironment.setown(createPTreeFromIPT(conn->queryRoot()));
     root->addPropTree(tail,LINK(branch));
     conn->commit();
     OUTLOG("Branch %s loaded from '%s'",path,src);
@@ -276,8 +279,9 @@ static void import(const char *path,const char *src,bool add)
     if (strcmp(path,"Environment")==0) {
         OUTLOG("Refreshing cluster groups from Environment");
         StringBuffer response;
-        if (!initClusterGroups(false, response))
-            WARNLOG("updating Environment via import path=%s, some groups clash and were not updated : %s", path, response.str());
+        initClusterGroups(false, response, oldEnvironment);
+        if (response.length())
+            PROGLOG("updating Environment via import path=%s : %s", path, response.str());
     }
 }
 

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -5357,12 +5357,14 @@ void CWsDeployFileInfo::saveEnvironment(IEspContext* pContext, IConstWsDeployReq
   }
   else
   {
+    // JAKESMITH->SMEDA - apparently this code is legacy and can be deleted, please do + clearup related code if any
     try
     {
       m_Environment->commit();
       StringBuffer response;
-      if (!initClusterGroups(false, response))
-        WARNLOG("CWsDeployFileInfo::saveEnvironment: some groups clash and were not updated : %s", response.str());
+      initClusterGroups(false, response, NULL);
+      if (response.length())
+        PROGLOG("CWsDeployFileInfo::saveEnvironment: %s", response.str());
     }
     catch (IException* e)
     {


### PR DESCRIPTION
Use old environment to detect configuration changes.
When constructing cluster groups, either at dali startup, or when a new
environment is loaded, e.g. via updtdalienv, compare old definition with new
and active groups.
The active groups are updated only if the new group definition mismatches the
old environment definition. i.e. no update will occur, if they already match
the active group, or they match the old environment definition.

This means, that a cluster environment change will be reflected when it's
deployed or updated, but prevents rollbacks of the active groups, during an
update or restart if the environment group hasn't changed, but the active
groups have diverged from old environment, e.g. due to swaps.
