### PR TITLE
gh-1728 Add ecl queries support for showing suspended given cluster

### DIFF
--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -146,17 +146,33 @@ public:
     {
         const char *queryid = query.getId();
         bool isActive = queryMap.isActive(queryid);
+        bool suspendedOnCluster = false;
+        ForEachItemIn(idx, query.getClusters())
+        {
+            IConstClusterQueryState &state = query.getClusters().item(idx);
+            if (state.getSuspended())
+            {
+                suspendedOnCluster = true;
+                break;
+            }
+        }
+
         if (flags)
         {
             if (isActive && !(flags & QUERYLIST_SHOW_ACTIVE))
                 return;
             if (query.getSuspended() && !(flags & QUERYLIST_SHOW_SUSPENDED))
                 return;
+            if (suspendedOnCluster && !(flags & QUERYLIST_SHOW_CLUSTER_SUSPENDED))
+                return;
             if (!isActive && !query.getSuspended() &&  !(flags & QUERYLIST_SHOW_UNFLAGGED))
                 return;
         }
-        VStringBuffer line("  %c%c  ", query.getSuspended() ? 'S' : ' ', isActive ? 'A' : ' ');
-        line.append(queryid);
+        StringBuffer line(" ");
+        line.append(suspendedOnCluster ? 'X' : ' ');
+        line.append(query.getSuspended() ? 'S' : ' ');
+        line.append(isActive ? 'A' : ' ');
+        line.append(' ').append(queryid);
         if (isActive)
         {
             Owned<IPropertyTreeIterator> activeNames = queryMap.getActiveNames(queryid);


### PR DESCRIPTION
When ecl queries is given a roxie cluster to run against it will mark
queries suspended on that cluster with an X (S is used to indicate
suspended within the queryset).

ecl queries list --cluster=roxie

results in:

QuerySet: myroxie

Flags Query Id                     [Active Name(s)]

---

   A  chart_views_query.1          [chart_views_query]
 XSA  json_demo.1                  [json_demo]

Fixes gh-1728.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
