### PR TITLE
gh-1805 - Child query reading XML dataset failure

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -348,6 +348,7 @@ bool isDiskInput(ThorActivityKind kind)
     switch (kind)
     {
         case TAKcsvread:
+        case TAKxmlread:
         case TAKdiskread:
         case TAKdisknormalize:
         case TAKdiskaggregate:


### PR DESCRIPTION
When a child query read a xml dataset, Thor failed to create and serialize
the initialization meta information, resulting in a crash in the slave(s)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
