### PR TITLE
Improve implicit field projection for count/exists

### DIFF
--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -218,6 +218,7 @@ _ATOM noBoundCheckAtom;
 _ATOM noCaseAtom;
 _ATOM _noHoist_Atom;
 _ATOM noLocalAtom;
+_ATOM _nonEmpty_Atom;
 _ATOM noOverwriteAtom;
 _ATOM _normalized_Atom;
 _ATOM noRootAtom;
@@ -597,6 +598,7 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKEATOM(noCase);
     MAKESYSATOM(noHoist);
     MAKEATOM(noLocal);
+    MAKESYSATOM(nonEmpty);
     MAKEATOM(noOverwrite);
     MAKESYSATOM(normalized);
     MAKEATOM(noRoot);

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -222,6 +222,7 @@ extern HQL_API _ATOM noBoundCheckAtom;
 extern HQL_API _ATOM noCaseAtom;
 extern HQL_API _ATOM _noHoist_Atom;
 extern HQL_API _ATOM noLocalAtom;
+extern HQL_API _ATOM _nonEmpty_Atom;
 extern HQL_API _ATOM noOverwriteAtom;
 extern HQL_API _ATOM _normalized_Atom;
 extern HQL_API _ATOM noRootAtom;

--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -1162,6 +1162,13 @@ static IHqlExpression * evaluateRecordAttrSize(IHqlExpression * expr)
         }
     }
 
+    if ((maximumSize == 0) && expr->hasProperty(_nonEmpty_Atom))
+    {
+        expectedSize = 1;
+        minimumSize = 1;
+        maximumSize = 1;
+    }
+
     if (maximumSize || !maximumSizeExpr)
     {
         OwnedHqlExpr maxExpr = getSizetConstant(truncMaxlength(maximumSize));

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1534,6 +1534,7 @@ extern HQL_API bool isSimpleCountExistsAggregate(IHqlExpression * aggregateExpr,
 extern HQL_API bool isKeyedCountAggregate(IHqlExpression * aggregate);
 extern HQL_API IHqlExpression * createNullDataset();
 extern HQL_API IHqlExpression * queryNullRecord();
+extern HQL_API IHqlExpression * queryNullRowRecord();
 extern HQL_API IHqlExpression * queryExpression(ITypeInfo * t);
 extern HQL_API IHqlExpression * queryExpression(IHqlDataset * ds);
 inline IHqlExpression * queryExpression(IHqlScope * scope) { return scope ? scope->queryExpression() : NULL; }
@@ -1607,7 +1608,7 @@ inline IHqlExpression * queryDistribution(IHqlExpression * expr)    { return que
 inline IHqlExpression * queryGlobalSortOrder(IHqlExpression * expr) { return queryGlobalSortOrder(expr->queryType()); }
 inline IHqlExpression * queryLocalUngroupedSortOrder(IHqlExpression * expr) { return queryLocalUngroupedSortOrder(expr->queryType()); }
 inline IHqlExpression * queryGroupSortOrder(IHqlExpression * expr)  { return queryGroupSortOrder(expr->queryType()); }
-inline bool isGrouped(ITypeInfo * type)                     { return type->queryGroupInfo() != NULL; }
+inline bool isGrouped(ITypeInfo * type)                     { return type && type->queryGroupInfo() != NULL; }
 inline bool isGrouped(IHqlExpression * expr)                { return isGrouped(expr->queryType()); }
 
 inline IFunctionTypeExtra * queryFunctionTypeExtra(ITypeInfo * type)    { return static_cast<IFunctionTypeExtra *>(queryUnqualifiedType(type)->queryModifierExtra()); }
@@ -1664,6 +1665,12 @@ inline bool isAbstractDataset(IHqlExpression * expr)
 { 
     IHqlExpression * record = expr->queryRecord();
     return record && record->hasProperty(abstractAtom);
+}
+inline IHqlExpression * queryRecord(IHqlExpression * expr)
+{
+    if (!expr)
+        return NULL;
+    return expr->queryRecord();
 }
 
 extern HQL_API bool isPureVirtual(IHqlExpression * cur);

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -576,6 +576,8 @@ IHqlExpression * CTreeOptimizer::optimizeAggregateDataset(IHqlExpression * trans
             if (ds->hasProperty(prefetchAtom))
                 break;
 
+            //MORE: If the record is empty then either remove the project if no SKIP, or convert the SKIP to a filter
+
             //Don't remove projects for the moment because they can make counts of disk reads much less
             //efficient.  Delete the following lines once we have a count-diskread activity
             if (!isScalarAggregate && !(options & (HOOcompoundproject|HOOinsidecompound)) && !ds->hasProperty(_countProject_Atom) )

--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -1084,7 +1084,7 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
             ForEachChild(i2, expr)
             {
                 IHqlExpression *child = queryChild(expr, i2);
-                if (child->getOperator() == no_record)
+                if (child && child->getOperator() == no_record)
                 {
                     s.append("(");
                     if (isEclAlias(child) || !m_recurse)

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -63,6 +63,7 @@ extern HQL_API IHqlExpression * createIf(IHqlExpression * cond, IHqlExpression *
 
 extern HQL_API void gatherIndexBuildSortOrder(HqlExprArray & sorts, IHqlExpression * expr, bool sortIndexPayload);
 extern HQL_API bool recordContainsBlobs(IHqlExpression * record);
+inline bool recordIsEmpty(IHqlExpression * record) { return queryLastField(record) == NULL; }
 extern HQL_API IHqlExpression * queryVirtualFileposField(IHqlExpression * record);
 
 extern HQL_API IHqlExpression * flattenListOwn(IHqlExpression * list);

--- a/ecl/hqlcpp/hqlckey.cpp
+++ b/ecl/hqlcpp/hqlckey.cpp
@@ -409,8 +409,7 @@ void KeyedJoinInfo::buildExtractFetchFields(BuildCtx & ctx)
     }
 
     //virtual IOutputMetaData * queryFetchInputRecordSize() = 0;
-    OwnedHqlExpr null = createValue(no_null, makeVoidType());
-    translator.buildMetaMember(ctx, fileAccessDataset.get() ? fileAccessDataset.get() : null.get(), "queryFetchInputRecordSize");
+    translator.buildMetaMember(ctx, fileAccessDataset, false, "queryFetchInputRecordSize");
 }
 
 
@@ -430,7 +429,7 @@ void KeyedJoinInfo::buildExtractIndexReadFields(BuildCtx & ctx)
     }
 
     //virtual IOutputMetaData * queryIndexReadInputRecordSize() = 0;
-    translator.buildMetaMember(ctx, keyAccessDataset, "queryIndexReadInputRecordSize");
+    translator.buildMetaMember(ctx, keyAccessDataset, isGrouped(keyAccessDataset), "queryIndexReadInputRecordSize");    //->false
 }
 
 
@@ -465,7 +464,7 @@ void KeyedJoinInfo::buildExtractJoinFields(ActivityInstance & instance)
     }
 
     //virtual IOutputMetaData * queryJoinFieldsRecordSize() = 0;
-    translator.buildMetaMember(instance.classctx, extractJoinFieldsRecord, "queryJoinFieldsRecordSize");
+    translator.buildMetaMember(instance.classctx, extractJoinFieldsRecord, false, "queryJoinFieldsRecordSize");
 }
 
 void KeyedJoinInfo::buildFetchMatch(BuildCtx & ctx)
@@ -1136,7 +1135,7 @@ void HqlCppTranslator::buildKeyedJoinExtra(ActivityInstance & instance, IHqlExpr
 {
     //virtual IOutputMetaData * queryDiskRecordSize() = 0;  // Excluding fpos and sequence
     if (info->isFullJoin())
-        buildMetaMember(instance.classctx, info->queryRawRhs(), "queryDiskRecordSize");
+        buildMetaMember(instance.classctx, info->queryRawRhs(), false, "queryDiskRecordSize");
 
     //virtual unsigned __int64 extractPosition(const void * _right) = 0;  // Gets file position value from rhs row
     if (info->isFullJoin())
@@ -1194,7 +1193,7 @@ void HqlCppTranslator::buildKeyJoinIndexReadHelper(ActivityInstance & instance, 
     buildFilenameFunction(instance, instance.startctx, "getIndexFileName", info->queryKeyFilename(), hasDynamicFilename(info->queryKey()));
 
     //virtual IOutputMetaData * queryIndexRecordSize() = 0; //Excluding fpos and sequence
-    buildMetaMember(instance.classctx, info->queryRawKey(), "queryIndexRecordSize");
+    buildMetaMember(instance.classctx, info->queryRawKey(), false, "queryIndexRecordSize");
 
     //virtual void createSegmentMonitors(IIndexReadContext *ctx, const void *lhs) = 0;
     info->buildMonitors(instance.startctx);
@@ -1436,7 +1435,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityKeyedDistribute(BuildCtx & ctx
     buildFilenameFunction(*instance, instance->startctx, "getIndexFileName", keyFilename, dynamic);
 
     //virtual IOutputMetaData * queryIndexRecordSize() = 0; //Excluding fpos and sequence
-    buildMetaMember(instance->classctx, info.queryRawKey(), "queryIndexRecordSize");
+    buildMetaMember(instance->classctx, info.queryRawKey(), false, "queryIndexRecordSize");
 
     //virtual void createSegmentMonitors(IIndexReadContext *ctx, const void *lhs) = 0;
     info.buildMonitors(instance->startctx);

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -1608,7 +1608,7 @@ public:
 
     void buildSetXmlSerializer(StringBuffer & helper, ITypeInfo * valueType);
 
-    void buildMetaMember(BuildCtx & ctx, IHqlExpression * datasetOrRecord, const char * name);
+    void buildMetaMember(BuildCtx & ctx, IHqlExpression * datasetOrRecord, bool isGrouped, const char * name);
     void buildMetaSerializerClass(BuildCtx & ctx, IHqlExpression * record, const char * serializerName);
     void buildMetaDeserializerClass(BuildCtx & ctx, IHqlExpression * record, const char * deserializerName);
     bool buildMetaPrefetcherClass(BuildCtx & ctx, IHqlExpression * record, const char * prefetcherName);

--- a/ecl/hqlcpp/hqlhtcpp.ipp
+++ b/ecl/hqlcpp/hqlhtcpp.ipp
@@ -40,20 +40,23 @@ class MetaInstance
 {
 public:
     //Shouldn't really need to pass translator, but it provides a place to have a per-query unique id. Anything else seems even messier.
-    MetaInstance()  { dataset = NULL; }
-    MetaInstance(HqlCppTranslator & translator, IHqlExpression * _dataset);
-    IHqlExpression * queryRecord();
-    void setDataset(HqlCppTranslator & translator, IHqlExpression * _dataset);
+    MetaInstance()  { record = NULL; grouped = false; }
+    MetaInstance(HqlCppTranslator & translator, IHqlExpression * _record, bool _isGrouped);
+    bool isGrouped() const { return grouped; }
+    IHqlExpression * queryRecord() const { return record; }
+    void setMeta(HqlCppTranslator & translator, IHqlExpression * _record, bool _isGrouped);
     IHqlExpression * getMetaUniqueKey()     { return searchKey.getLink(); }
     const char * queryInstanceObject()      { return instanceObject ? instanceObject : instanceName; }
 
 public:
-    IHqlExpression * dataset;
-    HqlExprAttr      searchKey;
     StringAttr       metaName;
     StringAttr       instanceName;
     StringAttr       metaFactoryName;
     StringAttr       instanceObject;
+private:
+    HqlExprAttr      searchKey;
+    IHqlExpression * record;
+    bool grouped;
 };
 
 //===========================================================================

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -498,55 +498,6 @@ int ComplexImplicitProjectInfo::docompare(const void * l,const void * r) const
 }
 
 
-void ComplexImplicitProjectInfo::ensureOutputNotEmpty()
-{
-    if (outputInfo && (outputFields.ordinality() == 0))
-    {
-        //MORE: Sometimes this can pull in other data from upstream activities - should pick one that is already required if
-        //there are any.  e.g., count(ds(x=0)) should pick field x.
-#if 1
-        IHqlExpression * best = &outputInfo->outputFields.item(0);
-#else
-        //Looks good, but in first field is more often used by something else. so disable...
-        //choose the smallest field at a fixed offset
-        IHqlExpression * best = NULL;
-        unsigned bestSize = UNKNOWN_LENGTH;
-        ForEachItemIn(i, outputInfo->outputFields)
-        {
-            IHqlExpression & cur = outputInfo->outputFields.item(i);
-            ITypeInfo * curType = cur.queryType();
-            type_t tc = curType->getTypeCode();
-            //try not to select record fields - they tend to have 0 length size
-            size32_t curSize = (tc == type_row) ? UNKNOWN_LENGTH-1 : curType->getSize();
-            if (!best)
-            {
-                best = &cur;
-                bestSize = curSize;
-            }
-            else if (bestSize > curSize)
-            {
-                switch (tc)
-                {
-                case type_bitfield:
-                case type_alien:
-                case type_row:
-                    //avoid these if at all possible....
-                    break;
-                default:
-                    best = &cur;
-                    bestSize = curSize;
-                    break;
-                }
-            }
-            if (curSize == UNKNOWN_LENGTH)
-                break;
-        }
-#endif
-
-        outputFields.append(OLINK(*best));
-    }
-}
-
 void ComplexImplicitProjectInfo::finalizeOutputRecord()
 {
     //MORE: Create them in the same order as the original record + don't change if numOutputFields = numOriginalOutputFields
@@ -563,9 +514,10 @@ void ComplexImplicitProjectInfo::finalizeOutputRecord()
             }
 
             outputFields.sort(*outputInfo);
-            assertex(outputFields.ordinality() != 0);
-
             outputFields.getFields(recordFields);
+
+            if (recordFields.ordinality() == 0)
+                recordFields.append(*createAttribute(_nonEmpty_Atom));
 
             //Ensure that maxSize is set on the new record - if necessary
             OwnedHqlExpr newRecord = createRecord(recordFields);
@@ -1428,6 +1380,7 @@ ProjectExprKind ImplicitProjectTransformer::getProjectExprKind(IHqlExpression * 
     case no_newparse:
     case no_newxmlparse:
     case no_createrow:
+    case no_rollupgroup:
         return CreateRecordActivity;
     case no_inlinetable:
         return CreateRecordSourceActivity;
@@ -1530,7 +1483,6 @@ ProjectExprKind ImplicitProjectTransformer::getProjectExprKind(IHqlExpression * 
         //MORE: Rethink these later:
     case no_combine:
     case no_combinegroup:
-    case no_rollupgroup:
     case no_regroup:
     case no_loop:
     case no_graphloop:
@@ -1674,11 +1626,6 @@ void ImplicitProjectTransformer::calculateFieldsUsed(IHqlExpression * expr)
 
         if (extra->outputFields.includeAll())
             assertex(extra->newOutputRecord != NULL);       //extra->newOutputRecord.set(expr->queryRecord());
-
-        //Ensure at least one field is required - otherwise meta goes wrong.  It really needs to be added here, rather than later,
-        //otherwise the field tracking for iterate/rollup etc. go wrong.  Could possibly improve later if we added code to project the
-        //dataset in front of a iterate/rollup
-        extra->ensureOutputNotEmpty();
     }
 
     switch (extra->activityKind())

--- a/ecl/hqlcpp/hqliproj.ipp
+++ b/ecl/hqlcpp/hqliproj.ipp
@@ -226,7 +226,6 @@ public:
     void addAllOutputs();
     bool addOutputField(IHqlExpression * field);
     IHqlExpression * createOutputProject(IHqlExpression * ds);
-    void ensureOutputNotEmpty();
     void finalizeOutputRecord();
     void inheritRequiredFields(UsedFieldSet * requiredList);
     bool safeToReorderInput();

--- a/ecl/hqlcpp/hqllib.cpp
+++ b/ecl/hqlcpp/hqllib.cpp
@@ -587,7 +587,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityLibraryInstance(BuildCtx & ctx
         IHqlExpression & cur = library->outputs.item(iout);
         OwnedHqlExpr dataset = moduleScope->lookupSymbol(cur.queryName(), LSFpublic, dummyCtx);
         assertex(dataset && dataset->queryRecord());
-        MetaInstance meta(*this, dataset);
+        MetaInstance meta(*this, dataset->queryRecord(), isGrouped(dataset));
         buildMetaInfo(meta);
         switchctx.addQuoted(s.clear().append("case ").append(iout).append(": return &").append(meta.queryInstanceObject()).append(";"));
     }

--- a/ecl/hqlcpp/hqlnlp.cpp
+++ b/ecl/hqlcpp/hqlnlp.cpp
@@ -292,8 +292,7 @@ void NlpParseContext::buildProductions(HqlCppTranslator & translator, BuildCtx &
         ForEachItemIn(i, productions)
         {
             IHqlExpression & cur = productions.item(i);
-            OwnedHqlExpr dataset = createDataset(no_anon, LINK(cur.queryChild(1)->queryRecord()));
-            MetaInstance meta(translator, dataset);
+            MetaInstance meta(translator, cur.queryChild(1)->queryRecord(), false);
             translator.buildMetaInfo(meta);
 
             s.clear().append("case ").append(getIntValue(cur.queryChild(0)));

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -1869,10 +1869,10 @@ ABoundActivity * SourceBuilder::buildActivity(BuildCtx & ctx, IHqlExpression * e
             if (fieldInfo.hasVirtualsOrDeserialize())
             {
                 OwnedHqlExpr diskTable = createDataset(no_anon, LINK(physicalRecord));
-                translator.buildMetaMember(instance->classctx, diskTable, "queryDiskRecordSize");
+                translator.buildMetaMember(instance->classctx, diskTable, false, "queryDiskRecordSize");
             }
             else
-                translator.buildMetaMember(instance->classctx, tableExpr, "queryDiskRecordSize");
+                translator.buildMetaMember(instance->classctx, tableExpr, isGrouped(tableExpr), "queryDiskRecordSize");
 
         }
     }
@@ -6807,7 +6807,7 @@ void HqlCppTranslator::buildXmlReadTransform(IHqlExpression * dataset, StringBuf
 
     classctx.addQuoted("ICodeContext * ctx;");
     classctx.addQuoted("unsigned activityId;");
-    buildMetaMember(classctx, dataset, "queryRecordSize");
+    buildMetaMember(classctx, dataset, false, "queryRecordSize");
 
     transformClass->setIncomplete(false);
 
@@ -6894,7 +6894,7 @@ void HqlCppTranslator::buildCsvReadTransformer(IHqlExpression * dataset, StringB
     unsigned maxColumns = buildCsvReadTransform(classctx, dataset, false, optCsvAttr);
     doBuildUnsignedFunction(classctx, "getMaxColumns", maxColumns);
 
-    buildMetaMember(classctx, dataset, "queryRecordSize");
+    buildMetaMember(classctx, dataset, false, "queryRecordSize");
     buildCsvParameters(classctx, optCsvAttr, NULL, true);
 
     transformClass->setIncomplete(false);
@@ -6935,7 +6935,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityXmlRead(BuildCtx & ctx, IHqlEx
 
     doBuildVarStringFunction(instance->classctx, "queryIteratorPath", queryRealChild(mode, 0));
 
-    buildMetaMember(instance->classctx, tableExpr, "queryDiskRecordSize");  // A lie, but I don't care....
+    buildMetaMember(instance->classctx, tableExpr, false, "queryDiskRecordSize");  // A lie, but I don't care....
 
     //virtual unsigned getFlags() = 0;
     StringBuffer flags;
@@ -7075,8 +7075,7 @@ void FetchBuilder::buildMembers(IHqlExpression * expr)
         translator.buildRecordSerializeExtract(funcctx, memoryRhsRecord);
 
         StringBuffer s;
-        OwnedHqlExpr serializedRhs = createDataset(no_anon, LINK(serializedRhsRecord));
-        MetaInstance meta(translator, serializedRhs);
+        MetaInstance meta(translator, serializedRhsRecord, false);
         translator.buildMetaInfo(meta);
         instance->classctx.addQuoted(s.clear().append("virtual IOutputMetaData * queryExtractedSize() { return &").append(meta.queryInstanceObject()).append("; }"));
     }

--- a/ecl/hqlcpp/hqlstep.cpp
+++ b/ecl/hqlcpp/hqlstep.cpp
@@ -945,7 +945,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityNWayMergeJoin(BuildCtx & ctx, 
 
     //virtual IOutputMetaData * queryInputMeta()
     {
-        MetaInstance inputmeta(*this, dataset);
+        MetaInstance inputmeta(*this, dataset->queryRecord(), isGrouped(dataset));
         buildMetaInfo(inputmeta);
 
         StringBuffer s;

--- a/ecl/hqlcpp/hqltcppc.ipp
+++ b/ecl/hqlcpp/hqltcppc.ipp
@@ -45,6 +45,7 @@ public:
     unsigned getFixedSize() const                           { return fixedSize; }
     unsigned getMinimumSize()   const                       { return fixedSize+varMinSize; }
     IHqlExpression * getSizeExpr(BoundRow * cursor);
+    bool isEmpty() const                                    { return fixedSize == 0 && varSize == NULL; }
     bool isFixedSize() const                                { return varSize == NULL; }
     bool isWorthCommoning() const;
     IHqlExpression * queryVarSize() const                   { return varSize; }
@@ -188,7 +189,7 @@ public:
     virtual unsigned getTotalFixedSize();
     virtual unsigned getTotalMinimumSize();
     virtual bool isConditional();
-    virtual bool isFixedSize()              { return fixedSize; }
+    virtual bool isFixedSize()              { return fixedSize && !isDynamic; }
 
     void addTrailingFixed(SizeStruct & size, CMemberInfo * cur);
     void subLeadingFixed(SizeStruct & size, CMemberInfo * cur);
@@ -198,6 +199,7 @@ public:
 public:
     void addChild(CMemberInfo * child);
     void setFixedSize(bool _fixed)          { fixedSize = _fixed; }
+    void setDynamic()                       { isDynamic = true; }
 
 protected:
     virtual void registerChild(CMemberInfo * child);
@@ -208,6 +210,7 @@ protected:
 protected:
     CMemberInfoArray    children;
     bool                fixedSize;
+    bool                isDynamic;
 };
 
 

--- a/rtl/include/eclhelper_base.hpp
+++ b/rtl/include/eclhelper_base.hpp
@@ -3030,6 +3030,7 @@ class CThorLibraryCallArg : public CThorArg, implements IHThorLibraryCallArg
     virtual void Link() const { RtlCInterface::Link(); }
     virtual bool Release() const { return RtlCInterface::Release(); }
     virtual void onCreate(ICodeContext * _ctx, IHThorArg *, MemoryBuffer * in) { ctx = _ctx; }
+    virtual IOutputMetaData * queryOutputMeta()             { return NULL; }
 
     virtual IInterface * selectInterface(ActivityInterfaceEnum which)
     {


### PR DESCRIPTION
- Previously the output record from an activity was required to have at least one
  field, which meant that exists/count arbitrarily "used" the first field.  With
  this change that no longer happens - often reducing the number of fields used.

A record can have a _nonEmpty_ attribute associated with it to ensure
it has a non-zero size (to differenitate it from a skipped row).  The
transform clears the byte (to make memory consitant and ensure spilt
files compress properly).

Serialize/Deserialize use the default classes so they will still work.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
