### PR TITLE
Fix checkEclVersionCompatible checks subminor against wrong value

### DIFF
--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -286,7 +286,7 @@ void checkEclVersionCompatible(Shared<IErrorReceiver> & errors, const char * ecl
                 msg.appendf("Mismatch in minor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
                 errors->reportWarning(HQLERR_VersionMismatch, msg.str(), NULL, 0, 0, 0);
             }
-            else if (subminor != LANGUAGE_VERSION_MINOR)
+            else if (subminor != LANGUAGE_VERSION_SUB)
             {
                 //This adds the warning if any other warnings occur.
                 StringBuffer msg;


### PR DESCRIPTION
Checks subminor!=LANGUAGE_VERSION_MINOR rather than LANGUAGE_VERSION_SUB.

Fixes gh-1838.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
