### PR TITLE
Fix problem with extra splitters being created

### DIFF
--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -3657,7 +3657,7 @@ void EclResourcer::spotSharedInputs()
         ForEachItemIn(i2, curGraph.sinks)
         {
             ResourceGraphLink & cur = curGraph.sinks.item(i2);
-            IHqlExpression * curExpr = cur.sourceNode;
+            IHqlExpression * curExpr = cur.sourceNode->queryBody();
             if (!visited.contains(*curExpr))
             {
                 ResourcerInfo * info = queryResourceInfo(curExpr);


### PR DESCRIPTION
If an expression that is a spill point in a graph was refrenced with
and without an annotation, then its inputs could be counted twice
leading to splitters being introduced which weren't required.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
