### PR TITLE
Fix scope of transform on no_select.

### DIFF
--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -2744,7 +2744,7 @@ IHqlExpression * MergingHqlTransformer::createTransformed(IHqlExpression * expr)
     case no_select:
         if (!expr->hasProperty(newAtom))
             return createTransformedActiveSelect(expr);
-        break;
+        return NewHqlTransformer::createTransformed(expr);
     }
 
     switch (getChildDatasetType(expr))
@@ -2787,21 +2787,6 @@ IHqlExpression * MergingHqlTransformer::createTransformed(IHqlExpression * expr)
         }
     case childdataset_evaluate:
         throwUnexpected();
-        {
-            // I doubt this really works, but by the time any sensible transform is applied to the tree 
-            // evaluates will have been converted to projects instead
-            IHqlExpression * arg0 = expr->queryChild(0);
-            OwnedHqlExpr child = transform(arg0);
-
-            HqlExprArray children;
-            children.append(*LINK(child));
-            pushChildContext(arg0->queryNormalizedSelector(true), child->queryNormalizedSelector(true));
-            bool same = optimizedTransformChildren(expr, children);
-            popChildContext();
-            if (!same)
-                return expr->clone(children);
-            return LINK(expr);
-        }
     default:
         return NewHqlTransformer::createTransformed(expr);
     }


### PR DESCRIPTION
The MergingHqlTransformer was processing the lhs in a new scope, when
it shouldn't have been.  The change causes no differences on the
current regression suite, but was triggered by a new optimization.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
