### PR TITLE
gh-1646 - Roxie groups only updated on new env.

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -8111,7 +8111,6 @@ public:
                     VStringBuffer xpath("Software/RoxieCluster[@name=\"%s\"]", cluster.queryProp("@name"));
                     oldCluster = oldEnvironment->queryPropTree(xpath.str());
                 }
-                force = true; // JCSMORE, roxie groups may only change on detected environment change in future?
                 constructGroup(cluster,NULL,oldCluster,grp_roxie,force,messages);
                 constructFarmGroup(clusters->query(),oldCluster,force,messages);
             }


### PR DESCRIPTION
Thor cluster groups are only updated if the environment is detected to be
different from both the old environment and the live group.
This was disabled for roxie cluster/groups, i.e. the loaded environment
always too precedence.

This change treates roxie cluster group updates in the same way as thor
cluster group updates.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
