### PR TITLE
Roxie reload core

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -587,7 +587,6 @@ class CPackageMap : public CInterface, implements IPackageMap
     MapStringToMyClass<IRoxiePackage> packages;
     StringAttr packageId;
     StringAttr querySetId;
-    Owned<IPropertyTree> querySets;
     bool active;
     StringArray wildMatches, wildIds;
 public:


### PR DESCRIPTION
A race condition between the control:reload query sent by ecl publish,
and the automatic reload triggered by the dali subscription, can cause
Roxie to core if the notify call is in progress when the QuerySet manager
is destroyed by the control:reload

Add a critical section so that a we never unsubscribe when a notify is
in flight.

Also deleted an unused member variable. Fixes gh-1865

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
