### PR TITLE
Grouped HashAggregate deserialization error

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2554,7 +2554,7 @@ public:
         helper = static_cast <IHThorHashAggregateArg *> (queryHelper());
         appendOutputLinked(this);
 
-        if (!container.queryLocal())
+        if (!container.queryLocalOrGrouped())
             mptag = container.queryJob().deserializeMPTag(data);
         ActPrintLog("HASHAGGREGATE: init tags %d",(int)mptag);
     }


### PR DESCRIPTION
Exposed by change in gh-1476.
That stopped the unecessary seralization from master to slave for local or
grouped hash aggregragtes, but the slave was still trying to deserialize if
grouped.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
