### PR TITLE
Improve cse inside nodes that can't create temps

### DIFF
--- a/ecl/hqlcpp/hqlcse.cpp
+++ b/ecl/hqlcpp/hqlcse.cpp
@@ -241,11 +241,32 @@ void CseSpotter::analyseExpr(IHqlExpression * expr)
         extra->alreadyAliased = true;
     }
 
+    switch (op)
+    {
+    case no_assign:
+    case no_transform:
+    case no_newtransform:
+    case no_range:
+    case no_rangefrom:
+        if (expr->isConstant())
+            return;
+        break;
+    case no_constant:
+        return;
+    }
+
     if (extra->numRefs++ != 0)
     {
-        if (!spottedCandidate && extra->worthAliasing() && (op != no_alias))
+        if (op == no_alias)
+            return;
+        if (!spottedCandidate && extra->worthAliasing())
             spottedCandidate = true;
-        //if (canCreateTemporary(expr))
+        if (canCreateTemporary(expr))
+            return;
+
+        //Ugly! This is here as a temporary hack to stop branches of maps being commoned up and always
+        //evaluated.  The alias spotting and generation really needs to take conditionality into account....
+        if (op == no_mapto)
             return;
     }
 


### PR DESCRIPTION
If you have a cse within a node that can't have a temporary created
for it e.g., str[1..f()] and other[1..f()].  The no_range is common
but doesn't correspond to an expression that can be generated.  With
this fix f() is spotted as a cse.

Has a dramatic effect on a small subset of the archived queries.  A
prerequisite for another change that is comming up.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
