### PR TITLE
Ecl command line should default to not limiting results

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -466,7 +466,7 @@ bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
             return false;
     }
     if (optResultLimit == (unsigned)-1)
-        extractEclCmdOption(optResultLimit, globals, ECLOPT_RESULT_LIMIT_ENV, ECLOPT_RESULT_LIMIT_INI, 100);
+        extractEclCmdOption(optResultLimit, globals, ECLOPT_RESULT_LIMIT_ENV, ECLOPT_RESULT_LIMIT_INI, 0);
 
     return true;
 


### PR DESCRIPTION
Defaulting to 100 can cause issues with queries published to roxie,
and roxie regression testing... and I prefer to handle the --limit
command line option consistently in all cases.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
