### PR TITLE
Roxie core in self-join with prefix match optimization

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -16430,6 +16430,7 @@ class CRoxieServerSelfJoinActivity : public CRoxieServerActivity
     Owned<IEngineRowAllocator> defaultAllocator;
     Owned<IRHLimitedCompareHelper> limitedhelper;
     Owned<CRHDualCache> dualcache;
+    IInputBase *input; // Hiding the one in the base class - note this is an IInputBase not an IRoxieInput
 
     bool fillGroup()
     {
@@ -16623,8 +16624,8 @@ public:
         if ((helper.getJoinFlags() & JFlimitedprefixjoin) && helper.getJoinLimit()) 
         {   //limited match join (s[1..n])
             dualcache.setown(new CRHDualCache());
-            dualcache->init(input);
-            setInput(0, (IRoxieInput *)dualcache->queryOut1());
+            dualcache->init(CRoxieServerActivity::input);
+            input = dualcache->queryOut1();
             failingOuterAtmost = false;
             matchedLeft = false;
             leftIndex = 0;
@@ -16633,13 +16634,13 @@ public:
             limitedhelper.setown(createRHLimitedCompareHelper());
             limitedhelper->init( helper.getJoinLimit(), dualcache->queryOut2(), collate, helper.queryPrefixCompare() );
         }
+        else
+            input = CRoxieServerActivity::input;
     }
 
     virtual void reset()
     {
         group.clear();
-        if (limitedhelper)
-            input = (IRoxieInput*)dualcache->input();
         CRoxieServerActivity::reset();
         defaultLeft.clear();
         defaultRight.clear();


### PR DESCRIPTION
The prefixjoin.ecl test case in regression suite cores if executed
with a choosen on the output datasets, as prefixed selfjoin was
not correctly handling the case where not all data was pulled.

Code was casting a pointer to a more derived type incorrectly, then
attempting to avoid the resulting issues by copying a valid pointer
back in before any virtual calls that migth crash were made. Yuk!

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
