### PR TITLE
Remove casts that have no effect

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -2320,8 +2320,11 @@ IHqlExpression * foldConstantOperator(IHqlExpression * expr, unsigned foldOption
     case no_implicitcast:
         {
             IHqlExpression * child = expr->queryChild(0);
-            node_operator childOp = child->getOperator();
             ITypeInfo * exprType = expr->queryType();
+            if (exprType == child->queryType())
+                return LINK(child);
+
+            node_operator childOp = child->getOperator();
             switch (childOp)
             {
             case no_constant:


### PR DESCRIPTION
These are very occasionally generated when no_select are expanded.  If
they remain they can generate unnecessary temporaries.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
