### PR TITLE
Prefixjoin core

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -16665,7 +16665,6 @@ public:
                     else 
                     {
                         eof = true;
-                        input = (IRoxieInput*)dualcache->input();
                     }
                 }
                 


### PR DESCRIPTION
Prefix join code used to rely (unsuccessfully) on having reset the input
to point to a valid object before any calls that might crash because it
pointed to an invalid VMT (!)

This is no longer necessary, but missed removing one bit of the code to do
it. This would not cause any ill effect other than confusing future coders.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
