### PR TITLE
Fold filenames to ensure they are consistent

### DIFF
--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -414,7 +414,7 @@ class GlobalFileTracker : public CInterface, public IHqlDelayedCodeGenerator
 public:
     GlobalFileTracker(IHqlExpression * _filename, IPropertyTree * _graphNode)
     {
-        filename.set(_filename);
+        filename.set(_filename->queryBody());
         graphNode.set(_graphNode);
         usageCount = 0;
     }

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -1718,7 +1718,7 @@ void HqlCppTranslator::finalizeTempRow(BuildCtx & ctx, BoundRow * row, BoundRow 
 
 bool GlobalFileTracker::checkMatch(IHqlExpression * searchFilename)
 {
-    if (searchFilename == filename.get())
+    if (searchFilename->queryBody() == filename.get())
     {
         usageCount++;
         return true;
@@ -9737,11 +9737,12 @@ void HqlCppTranslator::buildXmlWriteMembers(ActivityInstance * instance, IHqlExp
 ABoundActivity * HqlCppTranslator::doBuildActivityOutput(BuildCtx & ctx, IHqlExpression * expr, bool isRoot)
 {
     IHqlExpression * dataset  = expr->queryChild(0);
-    IHqlExpression * filename = queryRealChild(expr, 1);
+    IHqlExpression * rawFilename = queryRealChild(expr, 1);
 
-    if (!filename)
+    if (!rawFilename)
         return doBuildActivityOutputWorkunit(ctx, expr, isRoot);
 
+    OwnedHqlExpr filename = foldHqlExpression(rawFilename);
     IHqlExpression * program  = queryRealChild(expr, 2);
     IHqlExpression * csvAttr = expr->queryProperty(csvAtom);
     IHqlExpression * xmlAttr = expr->queryProperty(xmlAtom);

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -664,8 +664,9 @@ class SourceBuilder
 {
 public:
     SourceBuilder(HqlCppTranslator & _translator, IHqlExpression *_tableExpr, IHqlExpression *_nameExpr)
-        : tableExpr(_tableExpr), nameExpr(_nameExpr), translator(_translator)
+        : tableExpr(_tableExpr), translator(_translator)
     { 
+        nameExpr.setown(foldHqlExpression(_nameExpr));
         needDefaultTransform = true; 
         needToCallTransform = false; 
         isPreloaded = false;

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -4512,7 +4512,8 @@ IHqlExpression * GlobalAttributeInfo::queryFilename(IHqlExpression * value, ICon
             {
                 ITypeInfo * type = makeStringType(UNKNOWN_LENGTH, NULL, NULL);
 
-                cachedFilename.setown(createValue(no_concat, type, createConstant(prefix), cachedFilename.getClear()));
+                OwnedHqlExpr filename = createValue(no_concat, type, createConstant(prefix), cachedFilename.getClear());
+                cachedFilename.setown(foldHqlExpression(filename));
             }
         }
     }


### PR DESCRIPTION
- Otherwise very occasionlly the usage count could be wrong because the
  reads and writes weren't tied up correctly

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
