### PR TITLE
Promote Super-File refactor

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -9620,7 +9620,6 @@ void CDistributedFileDirectory::promoteSuperFiles(unsigned numsf,const char **sf
         assertex(dest.get());
         int common = hasCommonSubChildren(orig, dest);
         if (common != NotFound) {
-            transaction->rollback();
             throw MakeStringException(-1,"promoteSuperFiles: superfiles %s and %s share same subfile %s",
                     orig->queryLogicalName(), dest->queryLogicalName(), orig->querySubFile(common).queryLogicalName());
         }

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2463,16 +2463,8 @@ public:
             Owned<IPropertyTree> t = getNamedPropTree(root,"SuperOwner","@name",superfile,false);
             if (t && !link)
                 root->removeTree(t);
-            else if (link) {
-                if (t) {
-                    // Linking to same super-file it already belongs is OK
-                    StringBuffer buf;
-                    t->getProp("@name", buf);
-                    assertex(strcmp(buf.str(), superfile) == 0);
-                }
-                else
-                    t.setown(addNamedPropTree(root,"SuperOwner","@name",superfile));
-            }
+            else if (!t && link)
+                t.setown(addNamedPropTree(root,"SuperOwner","@name",superfile));
         }
         else 
             ERRLOG("linkSuperOwner - cannot link to %s (no connection in file)",superfile);

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -188,7 +188,7 @@ interface IDistributedFileTransaction: extends IInterface
     virtual IUserDescriptor *queryUser()=0;
     virtual bool addDelayedDelete(const char *lfn,bool remphys,IUserDescriptor *user)=0; // used internally to delay deletes untill commit 
     virtual void addAction(CDFAction *action)=0; // internal
-    virtual void addSuperFile(IDistributedSuperFile *sfile)=0; // TODO: avoid this being necessary
+    virtual void addFile(IDistributedFile *file)=0; // TODO: avoid this being necessary
     virtual void clearFiles()=0; // internal
 };
 

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1801,7 +1801,7 @@ FILESERVICES_API  char * FILESERVICES_CALL fsfPromoteSuperFileList(ICodeContext 
     UnsignedArray lfnofs;
     const char *s = (const char *)lsuperfns;
     // MORE - For now, we need a local transaction
-    CheckNotInTransaction(ctx, s);
+    CheckNotInTransaction(ctx, "PromoteSuperFile");
 
     while ((size32_t)(s-(const char *)lsuperfns)<lenLsuperfns) {
         constructLogicalName(wu,s,lfn.clear());

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1800,6 +1800,9 @@ FILESERVICES_API  char * FILESERVICES_CALL fsfPromoteSuperFileList(ICodeContext 
     StringBuffer lfn;
     UnsignedArray lfnofs;
     const char *s = (const char *)lsuperfns;
+    // MORE - For now, we need a local transaction
+    CheckNotInTransaction(ctx, s);
+
     while ((size32_t)(s-(const char *)lsuperfns)<lenLsuperfns) {
         constructLogicalName(wu,s,lfn.clear());
         lfnofs.append(mb.length());


### PR DESCRIPTION
This commit fixes issue #879 by using add/remove sub-file actions
instead of directly manipulating the property tree.

CLightWeightSuperFileConn can be reduced (preferably removed, but
there's still one other use), but that'll be for another patch.
