### PR TITLE
Fix problems with global optimizer

### DIFF
--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -1999,9 +1999,7 @@ IHqlExpression * CTreeOptimizer::createTransformed(IHqlExpression * expr)
 
     //Do this first, so that any references to a child dataset that changes are correctly updated, before proceeding any further.
     OwnedHqlExpr dft = defaultCreateTransformed(expr);
-#ifndef USE_MERGING_TRANSFORM
     updateOrphanedSelectors(dft, expr);
-#endif
 
     OwnedHqlExpr ret = doCreateTransformed(dft, expr);
     if (ret->queryBody() == expr->queryBody())

--- a/ecl/hql/hqlopt.ipp
+++ b/ecl/hql/hqlopt.ipp
@@ -24,30 +24,21 @@
 #include "hqlfold.ipp"
 #include "hqlutil.hpp"
 
-#define USE_MERGING_TRANSFORM
-#ifdef USE_MERGING_TRANSFORM
-#define OPTINFOBASE MergingTransformInfo
-#define OPTTRANSFORMBASE MergingHqlTransformer
-#else
-#define OPTINFOBASE NewTransformInfo
-#define OPTTRANSFORMBASE NewHqlTransformer
-#endif
-
 enum KeyCompType { SAME_KEY, PARTIAL_KEY, SUPER_KEY, DIFFERENT_KEY };
 
 typedef Owned<TableProjectMapper> OwnedMapper;
 
-class OptTransformInfo : public OPTINFOBASE
+class OptTransformInfo : public NewTransformInfo
 {
 public:
-    OptTransformInfo(IHqlExpression * _expr) : OPTINFOBASE(_expr) { useCount = 0; }
+    OptTransformInfo(IHqlExpression * _expr) : NewTransformInfo(_expr) { useCount = 0; }
 
 public:
     unsigned useCount;
 };
 
 class DedupInfoExtractor;
-class CTreeOptimizer : public OPTTRANSFORMBASE, public NullFolderMixin
+class CTreeOptimizer : public NewHqlTransformer, public NullFolderMixin
 {
     friend class ExpandMonitor;
 public:
@@ -133,7 +124,7 @@ protected:
     inline bool isAlwaysLocal() const { return (options & HOOalwayslocal) != 0; }
 
 protected:
-    typedef OPTTRANSFORMBASE PARENT;
+    typedef NewHqlTransformer PARENT;
     unsigned options;
     StringBuffer nodeText[2];
     HqlExprAttr noHoistAttr;


### PR DESCRIPTION
Previously the optimizer was based on a merging transformer - which
transforms each expression in the tree once for each context it is used
in.  This was because selectors can have ambiguous meanings depending
on the context they were used.

However the optimizer also relies on couning the number of active
references to each dataset, and if an expression is transformed more
than once those counts are no longer valid.  Instead this now
transforms and then calls updateOrphanedSelectors() to ensure the
expressions are only updated once.

That function required fixing to cope with sqnormidx2 and other
examples that implicitly access fields of the parent dataset
(a fairly unusual situation.)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
