### PR TITLE
gh-1901 Lookup join leaking rows on failure

### DIFF
--- a/testing/ecl/roxie/key/lookupfail.xml
+++ b/testing/ecl/roxie/key/lookupfail.xml
@@ -1,0 +1,3 @@
+<Dataset name='Result 1'>
+ <Row><f>Success</f></Row>
+</Dataset>

--- a/testing/ecl/roxie/lookupfail.ecl
+++ b/testing/ecl/roxie/lookupfail.ecl
@@ -1,0 +1,11 @@
+d := dataset([{'bad'},{'worse'}], {string f});
+
+d success := transform
+  self.f := 'Success';
+end;
+
+l := NOFOLD(LIMIT(NOFOLD(d), 1));
+
+j := JOIN(d,l,LEFT.f=right.f);
+
+CATCH(j,ONFAIL(success));


### PR DESCRIPTION
Roxie lookup join activity will leak rows if its input throws an
exception while gathering the RHS. Normally any such leak will be
mopped up at the end of the query (though see also gh-1900 for a
situation where they are not.

Fixes gh-1901

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
