### PR TITLE
Show queries suspended on a given cluster

### DIFF
--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -150,7 +150,7 @@ public:
         ForEachItemIn(idx, query.getClusters())
         {
             IConstClusterQueryState &state = query.getClusters().item(idx);
-            if (state.getSuspended())
+            if (strieq(state.getState(), "Suspended"))
             {
                 suspendedOnCluster = true;
                 break;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1078,7 +1078,7 @@ ESPresponse [exceptions_inline] WUQuerysetsResponse
 ESPStruct ClusterQueryState
 {
     string Cluster;
-    bool Suspended;
+    string State;
 };
 
 ESPStruct QuerySetQuery
@@ -1102,13 +1102,15 @@ ESPenum WUQuerySetFilterType : string
     ALL("All"),
     ID("Id"),
     NAME("Name"),
-    ALIAS("Alias")
+    ALIAS("Alias"),
+    STATUS("Status")
 };
 
 ESPrequest WUQuerySetDetailsRequest
 {
     string  QuerySetName;
     string  Filter;
+    string  ClusterName;
     ESPenum WUQuerySetFilterType FilterType("All");
 };
 
@@ -1117,6 +1119,10 @@ ESPresponse [exceptions_inline] WUQuerySetDetailsResponse
     string  QuerySetName;
     ESParray<ESPstruct QuerySetQuery> QuerysetQueries;
     ESParray<ESPstruct QuerySetAlias> QuerysetAliases;
+    [min_ver("1.37")] string  ClusterName;
+    [min_ver("1.37")] string  Filter;
+    [min_ver("1.37")] ESPenum WUQuerySetFilterType FilterType;
+    [min_ver("1.37")] ESParray<string> ClusterNames;
 };
 
 ESPrequest WUMultiQuerySetDetailsRequest
@@ -1233,7 +1239,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.36"), default_client_version("1.36"),
+    version("1.37"), default_client_version("1.37"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);


### PR DESCRIPTION
EclWatch lists queries in a queryset, and shows which are
globally suspended, but we should provide a way of seeing
the state of those queries on a specific cluster. This fix
displays a drop down list of clusters and a drop down list
of query status (Suspended, Available, Not Found, and All).
EclWatch shows query status on a given cluster when a user
selects a cluster from the drop down list.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
