### PR TITLE
gh1719 Roxie regression suite assumes local server

### DIFF
--- a/testing/ecl/Regress/EclPublish.pm
+++ b/testing/ecl/Regress/EclPublish.pm
@@ -85,6 +85,7 @@ sub submit($$)
         my %vals = ('--username' => $self->{owner},
                     '--password' => $self->{password},
                     '--cluster' => $self->{cluster},
+                    '--server' => $self->{server},
                     '--name' => $basename
                    );
         my $args = ["run", "$run->{path}", map("$_=$vals{$_}", sort(keys(%vals)))];
@@ -101,6 +102,7 @@ sub submit($$)
             my %vals = ('--username' => $self->{owner},
                         '--password' => $self->{password},
                         '--cluster' => $self->{cluster},
+                        '--server' => $self->{server},
                         '--name' => $basename
                        );
             my $args = ["publish", "$run->{path}", "--activate", map("$_=$vals{$_}", sort(keys(%vals)))];


### PR DESCRIPTION
Pass the ECP service address from regress.ini  to ecl publish when
deploying test queries to Roxie.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
