### PR TITLE
Always fold expressions trees after optimizing

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -5765,6 +5765,7 @@ IHqlExpression * foldHqlExpression(IHqlExpression * expr, ITemplateContext *temp
     case no_constant:
     case no_param:
     case no_variable:
+    case no_attr:
         return LINK(expr);
     case no_select:
         if (!expr->hasProperty(newAtom))

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -3814,7 +3814,11 @@ IHqlExpression * optimizeHqlExpression(IHqlExpression * expr, unsigned options)
     HqlExprArray args, newArgs;
     unwindCommaCompound(args, expr);
     optimizeHqlExpression(newArgs, args, options);
-    return createActionList(newArgs);
+    OwnedHqlExpr optimized = createActionList(newArgs);
+    //If the graph was optimized then it is highly likely there are now constant folding opportunities
+    if (expr != optimized)
+        return foldHqlExpression(optimized);
+    return optimized.getClear();
 }
 
 

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -2805,7 +2805,6 @@ ABoundActivity * HqlCppTranslator::doBuildActivityDiskRead(BuildCtx & ctx, IHqlE
         if (expr->getOperator() == no_table)
             transformed.setown(createDataset(no_compound_diskread, LINK(transformed)));
         OwnedHqlExpr optimized = optimizeHqlExpression(transformed, optFlags);
-        traceExpression("before disk optimize", transformed);
         traceExpression("after disk optimize", optimized);
         return doBuildActivityDiskRead(ctx, optimized);
     }
@@ -6310,7 +6309,6 @@ ABoundActivity * HqlCppTranslator::doBuildActivityIndexRead(BuildCtx & ctx, IHql
 {
     OwnedHqlExpr transformed = buildIndexFromPhysical(expr);
     OwnedHqlExpr optimized = optimizeHqlExpression(transformed, HOOfold);
-    optimized.setown(foldHqlExpression(optimized));
 
     IHqlExpression *tableExpr = queryPhysicalRootTable(optimized);
     //If the filter is false, then it may get reduced to a NULL operation!
@@ -6388,9 +6386,6 @@ ABoundActivity * HqlCppTranslator::doBuildActivityIndexNormalize(BuildCtx & ctx,
 {
     OwnedHqlExpr transformed = buildIndexFromPhysical(expr);
     OwnedHqlExpr optimized = optimizeHqlExpression(transformed, HOOfold);
-    optimized.setown(foldHqlExpression(optimized));
-    traceExpression("before physical", expr);
-    traceExpression("after physical", transformed);
     traceExpression("after optimize", optimized);
 
     IHqlExpression *tableExpr = queryPhysicalRootTable(optimized);
@@ -6559,7 +6554,6 @@ ABoundActivity * HqlCppTranslator::doBuildActivityIndexAggregate(BuildCtx & ctx,
 {
     OwnedHqlExpr transformed = buildIndexFromPhysical(expr);
     OwnedHqlExpr optimized = optimizeHqlExpression(transformed, getSourceAggregateOptimizeFlags());
-    optimized.setown(foldHqlExpression(optimized));
 
     IHqlExpression *tableExpr = queryPhysicalRootTable(optimized);
     if (!tableExpr)
@@ -6722,7 +6716,6 @@ ABoundActivity * HqlCppTranslator::doBuildActivityIndexGroupAggregate(BuildCtx &
 {
     OwnedHqlExpr transformed = buildIndexFromPhysical(expr);
     OwnedHqlExpr optimized = optimizeHqlExpression(transformed, getSourceAggregateOptimizeFlags());
-    optimized.setown(foldHqlExpression(optimized));
 
     IHqlExpression *tableExpr = queryPhysicalRootTable(optimized);
     if (!tableExpr)


### PR DESCRIPTION
Often folding no_select(no_createrow, som-field) will generate lots of
opportunities for constant folding.  This ensures trees that are
transformed are also folded.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
