### PR TITLE
gh1900 Roxie memory leaks not always properly cleaned up

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -1261,8 +1261,9 @@ public:
                 logctx.CTXLOG("RoxieMemMgr: Memory leak: %d records remain linked in active dataBuffer list - addr=%p rowMgr=%p", 
                         dfinger->queryCount()-1, dfinger, this);
             dfinger->next = NULL;
-            dfinger->mgr = NULL;
-            dfinger->Release();
+            dfinger->mgr = NULL; // Avoid calling back to noteDataBufferReleased, which would be unhelpful
+            atomic_set(&dfinger->count, 0);
+            dfinger->released();
             dfinger = next;
         }
         logctx.Release();


### PR DESCRIPTION
Activities that leak Roxie rows (should ever happen anyway) will not
have them automatically cleaned up at the end of the query if the rows
are returned from remote activities.

Rows from remote activities ARE properly released in normal circumstances,
and rows leaked in this way WILL be detected and reported (if memtrace level
set >2) but the leaks were not being corrected.

At least one activity that could leak large number of rows (lookupjoin - see
gh-1901) has been found - this fix would have made that error less fatal.

Fixes gh-1900

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
