### PR TITLE
Add support for Include statements in manifest files

### DIFF
--- a/ecl/hqlcpp/hqlres.hpp
+++ b/ecl/hqlcpp/hqlres.hpp
@@ -36,7 +36,7 @@ public:
     void addManifestFromArchive(IPropertyTree *archive);
     void addWebServiceInfo(IPropertyTree *wsinfo);
     IPropertyTree *ensureManifestInfo(){if (!manifest) manifest.setown(createPTree("Manifest")); return manifest;}
-    bool getDuplicateResourceId(const char *srctype, const char *filename, int &id);
+    bool getDuplicateResourceId(const char *srctype, const char *respath, const char *filename, int &id);
     void finalize();
 
     unsigned count();
@@ -45,6 +45,8 @@ public:
     bool queryWriteText(StringBuffer & resTextName, const char * filename);
 private:
     void putbytes(int h, const void *b, unsigned len);
+    void addManifestFile(const char *filename);
+    void addManifestInclude(IPropertyTree &include, const char *dir);
 };
 
 #endif

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -4842,6 +4842,20 @@ IFile * createIFile(const RemoteFilename & filename)
     return createIFile(getLocalOrRemoteName(name,filename).str());
 }
 
+StringBuffer &makePathUniversal(const char *path, StringBuffer &out)
+{
+    if (!path||!*path)
+        return out;
+    if (path[1]==':')
+    {
+        out.append('/').append(*path);
+        path+=2;
+    }
+    for (; *path; path++)
+        out.append(isPathSepChar(*path) ? '/' : *path);
+    return out;
+}
+
 StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out)
 {
     if (isPathSepChar(relpath[0])&&(relpath[0]==relpath[1]))

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -539,6 +539,7 @@ inline bool isAbsolutePath(const char *path)
 extern jlib_decl StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out);
 extern jlib_decl StringBuffer &makeAbsolutePath(StringBuffer &relpath);
 extern jlib_decl StringBuffer &makeAbsolutePath(const char *relpath, const char *basedir, StringBuffer &out);
+extern jlib_decl StringBuffer &makePathUniversal(const char *path, StringBuffer &out);
 extern jlib_decl const char *splitRelativePath(const char *full,const char *basedir,StringBuffer &reldir); // removes basedir if matches, returns tail and relative dir
 extern jlib_decl const char *splitDirMultiTail(const char *multipath,StringBuffer &dir,StringBuffer &tail);
 extern jlib_decl StringBuffer &mergeDirMultiTail(const char *dir,const char *tail, StringBuffer &multipath);

--- a/system/xmllib/xalan_processor.cpp
+++ b/system/xmllib/xalan_processor.cpp
@@ -552,6 +552,13 @@ int CXslTransform::loadXslFromFile(const char *pszFileName, const char *cacheId)
     return 0;
 }
 
+int CXslTransform::loadXslFromEmbedded(const char *path, const char *cacheId)
+{
+    m_xslsource.setown(new CXslSource(m_sourceResolver?m_sourceResolver->getIncludeHandler():NULL, cacheId, path));
+
+    return 0;
+}
+
 int CXslTransform::setXslSource(const char *pszBuffer, unsigned int nSize, const char *cacheId, const char *rootpath)
 {
     assertex(cacheId && *cacheId);

--- a/system/xmllib/xalan_processor.ipp
+++ b/system/xmllib/xalan_processor.ipp
@@ -170,7 +170,7 @@ private:
 public:
     IMPLEMENT_IINTERFACE;
 
-    CXslSource(const char* fname, IIncludeHandler* handler, const char *cacheId=NULL) : m_XalanTransformer()
+    CXslSource(const char* fname, IIncludeHandler* handler, const char *cacheId) : m_XalanTransformer()
     {
         m_filename.set(fname);
         m_sourcetype = IO_TYPE_FILE;
@@ -179,6 +179,25 @@ public:
 
         if(handler)
             setIncludeHandler(handler);
+    }
+
+    CXslSource(IIncludeHandler* handler, const char *cacheId, const char *rootpath) : m_XalanTransformer()
+    {
+        if (!handler)
+            throw MakeStringException(-1, "xsl embedded include handler not set");
+        if (!rootpath || !*rootpath)
+            throw MakeStringException(-1, "xsl embedded resource path not set");
+        m_sourcetype = IO_TYPE_BUFFER;
+        m_CompiledStylesheet = NULL;
+        m_cacheId.set(cacheId);
+
+        MemoryBuffer mb;
+        bool pathOnly=false;
+        if (handler->getInclude(rootpath, mb, pathOnly) && mb.length())
+            m_xsltext.append(mb.length(), mb.toByteArray());
+
+        setIncludeHandler(handler);
+        m_rootpath.set(rootpath);
     }
 
     CXslSource(const char* buf, int len, IIncludeHandler* handler, const char *cacheId, const char *rootpath = NULL) : m_XalanTransformer()
@@ -510,6 +529,7 @@ public:
     virtual int setXmlSource(const char *pszFileName);
     virtual int setXmlSource(const char *pszBuffer, unsigned int nSize);
     virtual int loadXslFromFile(const char *pszFileName, const char *altCacheId=NULL);
+    virtual int loadXslFromEmbedded(const char *path, const char *cacheId);
     virtual int setXslSource(const char *pszBuffer, unsigned int nSize, const char *cacheId, const char *rootpath);
     virtual int setXslNoCache(const char *pszBuffer, unsigned int nSize, const char *rootpath);
     virtual int setResultTarget(char *pszBuffer, unsigned int nSize);

--- a/system/xmllib/xslprocessor.hpp
+++ b/system/xmllib/xslprocessor.hpp
@@ -56,6 +56,7 @@ public:
     virtual int setXslSource(const char *pszBuffer, unsigned int nSize, const char *cacheId, const char *rootpath) = 0;
     virtual int setXslNoCache(const char *pszBuffer, unsigned int nSize, const char *rootpath=NULL) = 0;
     virtual int loadXslFromFile(const char *pszFileName, const char *altCacheId=NULL) = 0;
+    virtual int loadXslFromEmbedded(const char *path, const char *cacheId) = 0;
 
     // setResultTarget - Specifies where the post transform data is to be placed
     // must be set before calling parameterless variety of transform


### PR DESCRIPTION
Will improve ability to organize and extend visualization files.

Precalculate a new universal path for resources in the finalized manifest
in order to support the include call back mechanisms for both libxslt
and xalan across various client and server combinations on
multiple operating systems.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
