### PR TITLE
ESP should not log password

### DIFF
--- a/esp/bindings/SOAP/Platform/soapbind.cpp
+++ b/esp/bindings/SOAP/Platform/soapbind.cpp
@@ -164,8 +164,6 @@ int CHttpSoapBinding::HandleSoapRequest(CHttpRequest* request, CHttpResponse* re
     StringBuffer requeststr;
     request->getContent(requeststr);
     
-    if (log_level_>hsl_none)
-        DBGLOG("Received request, requestlen = %d request=\n%s", requeststr.length(), requeststr.str());
     if(requeststr.length() == 0)
         throw MakeStringException(-1, "Content read is empty");
 

--- a/esp/bindings/SOAP/client/soapclient.cpp
+++ b/esp/bindings/SOAP/client/soapclient.cpp
@@ -131,7 +131,6 @@ int CSoapClient::postRequest(const char* contenttype, const char* soapaction, IR
     if (getEspLogLevel(rpccall.queryContext())>LogNormal)
     {
         DBGLOG("Content type: %s", contenttypestr.str());
-        DBGLOG("Request content: %s", requeststr.str());
     }
 
     Owned<CSoapRequest> soap_request;

--- a/esp/bindings/http/client/httpclient.cpp
+++ b/esp/bindings/http/client/httpclient.cpp
@@ -640,9 +640,6 @@ int CHttpClient::postRequest(ISoapMessage &req, ISoapMessage& resp)
     httprequest->setContentType(HTTP_TYPE_TEXT_XML);
     httprequest->setContent(requeststr);
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("http request content = %s", requeststr);
-
 #ifdef COOKIE_HANDLING
     ForEachItemIn(x, m_request_cookies)
     {

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -609,13 +609,6 @@ int EspHttpBinding::onGet(CHttpRequest* request, CHttpResponse* response)
     if (level >= LogNormal)
         DBGLOG("EspHttpBinding::onGet");
     
-    if (level>=LogMax)
-    {
-        DBGLOG("Request Header:\n%s", request->queryHeader());
-        DBGLOG("Request Content:\n%s", request->queryContent());
-    }
-    
-    
     response->setVersion(HTTP_VERSION);
     response->addHeader("Expires", "0");
 

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -484,7 +484,7 @@ int CEspHttpServer::processRequest()
         DBGLOG("Unknown Exception - processing request");
         DBGLOG("METHOD: %s, PATH: %s, TYPE: %s, CONTENT-LENGTH: %d", m_request->queryMethod(), m_request->queryPath(), m_request->getContentType(content_type).str(), len);
         if (len)
-            DBGLOG("CONTENT: %s", (m_request->isTextMessage()) ? m_request->queryContent() : "#binary#");
+            m_request->logMessage(LOGCONTENT, "HTTP request content received:\n");
         return 0;
     }
 

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -68,6 +68,13 @@ private:
 
 IEspHttpException* createEspHttpException(int code, const char *_msg, const char* _httpstatus);
 
+enum MessageLogFlag
+{
+    LOGALL = 0,
+    LOGHEADERS = 1,
+    LOGCONTENT = 2
+};
+
 class CHttpMessage : public CInterface, implements IHttpMessage
 {
 protected:
@@ -134,6 +141,9 @@ public:
     unsigned getContentLength(){return m_content_length;}
     const char *queryContent(){return m_content.str();}
     const char *queryHeader() { return m_header.str(); }
+    void logSOAPMessage(const char* message, const char* prefix = NULL);
+    void logMessage(const char *message, const char *prefix = NULL, const char *find = NULL, const char *replace = NULL);
+    void logMessage(MessageLogFlag logFlag, const char *prefix = NULL);
 
     virtual StringBuffer& getContent(StringBuffer& content);
     virtual void setContent(const char* content);


### PR DESCRIPTION
The existing ESP logs contain user's password when ESP
LogLevel is higher than Normal. This fix filters out
the password from both HTTP requests and SOAP messages
before the messages are logged.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
