### PR TITLE
gh1871 ldapsecurity link failure when USE_OPENLDAP=0

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -282,6 +282,8 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
         ELSE()
           message(FATAL_ERROR "OPENLDAP requested but package not found")
         ENDIF()
+      ELSE()
+        add_definitions (-D_NO_LDAP)
       ENDIF(USE_OPENLDAP)
 
       IF (USE_CPPUNIT)

--- a/dali/server/CMakeLists.txt
+++ b/dali/server/CMakeLists.txt
@@ -43,7 +43,6 @@ include_directories (
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
     )
-
 ADD_DEFINITIONS( -D_CONSOLE )
 
 if (WIN32)
@@ -58,10 +57,11 @@ add_executable ( daserver ${SRCS} )
 install ( TARGETS daserver DESTINATION ${OSSDIR}/bin)
 target_link_libraries ( daserver 
          jlib
-         LdapSecurity 
          mp 
          hrpc 
          remote 
          dalibase 
     )
-
+IF (USE_OPENLDAP)
+target_link_libraries ( daserver LdapSecurity )
+ENDIF(USE_OPENLDAP)

--- a/esp/services/CMakeLists.txt
+++ b/esp/services/CMakeLists.txt
@@ -17,7 +17,9 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 add_subdirectory (ecldirect)
-add_subdirectory (ws_access)
+IF (USE_OPENLDAP)
+    add_subdirectory (ws_access)
+ENDIF(USE_OPENLDAP)
 add_subdirectory (ws_account)
 add_subdirectory (ws_config)
 add_subdirectory (ws_dfu)

--- a/esp/services/ecldirect/CMakeLists.txt
+++ b/esp/services/ecldirect/CMakeLists.txt
@@ -61,7 +61,6 @@ target_link_libraries ( EclDirect
          jlib
          xmllib 
          esphttp 
-         LdapSecurity 
          mp 
          hrpc 
          remote 

--- a/esp/services/ws_account/CMakeLists.txt
+++ b/esp/services/ws_account/CMakeLists.txt
@@ -61,7 +61,8 @@ target_link_libraries ( ws_account
          jlib
          xmllib 
          esphttp 
-         LdapSecurity 
          securesocket 
     )
-
+IF (USE_OPENLDAP)
+target_link_libraries ( ws_account LdapSecurity )
+ENDIF(USE_OPENLDAP)

--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -17,7 +17,9 @@
 ############################################################################## */
 
 #include "ws_accountService.hpp"
+#ifdef _USE_OPENLDAP
 #include "ldapsecurity.ipp"
+#endif
 #include "exception_util.hpp"
 
 const int CUTOFF_MAJOR = 533;
@@ -29,6 +31,7 @@ void Cws_accountEx::init(IPropertyTree *cfg, const char *process, const char *se
 {
 }
 
+#ifdef _USE_OPENLDAP
 bool Cws_accountEx::onUpdateUser(IEspContext &context, IEspUpdateUserRequest & req, IEspUpdateUserResponse & resp)
 {
     try
@@ -160,6 +163,7 @@ bool Cws_accountEx::onWhoAmI(IEspContext &context, IEspWhoAmIRequest &req, IEspW
     }
     return true;
 }
+#endif
 
 bool Cws_accountEx::onVerifyUser(IEspContext &context, IEspVerifyUserRequest &req, IEspVerifyUserResponse &resp)
 {

--- a/esp/services/ws_account/ws_accountService.hpp
+++ b/esp/services/ws_account/ws_accountService.hpp
@@ -37,6 +37,7 @@ public:
 
     virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
     {
+#ifdef _USE_OPENLDAP
         bool isFF = false;
         StringBuffer browserUserAgent;
         context.getUseragent(browserUserAgent);
@@ -64,8 +65,10 @@ public:
                 ensureNavLink(*folder, "Relogin", "/Ws_Access/FirefoxNotSupport?form_", "Relogin", NULL, NULL, 0, true);//Force the menu to use this setting
             ensureNavLink(*folder, "Who Am I", "/Ws_Account/WhoAmI", "WhoAmI", NULL, NULL, 0, true);//Force the menu to use this setting
         }
+#endif
     }
 
+#ifdef _USE_OPENLDAP
     int onGetInstantQuery(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method)
     {
         if(!stricmp(method, "LogoutUser")||!stricmp(method, "LogoutUserRequest"))
@@ -138,6 +141,7 @@ public:
         else
             return Cws_accountSoapBinding::onGetInstantQuery(context, request, response, service, method);
     }
+#endif
 };
 
 class Cws_accountEx : public Cws_account
@@ -147,9 +151,15 @@ public:
 
     virtual void init(IPropertyTree *cfg, const char *process, const char *service);
 
+#ifdef _USE_OPENLDAP
     virtual bool onUpdateUser(IEspContext &context, IEspUpdateUserRequest &req, IEspUpdateUserResponse &resp);
     virtual bool onUpdateUserInput(IEspContext &context, IEspUpdateUserInputRequest &req, IEspUpdateUserInputResponse &resp);
     virtual bool onWhoAmI(IEspContext &context, IEspWhoAmIRequest &req, IEspWhoAmIResponse &resp);
+#else
+    virtual bool onUpdateUser(IEspContext &context, IEspUpdateUserRequest &req, IEspUpdateUserResponse &resp) {return true;};
+    virtual bool onUpdateUserInput(IEspContext &context, IEspUpdateUserInputRequest &req, IEspUpdateUserInputResponse &resp) {return true;};
+    virtual bool onWhoAmI(IEspContext &context, IEspWhoAmIRequest &req, IEspWhoAmIResponse &resp) {return true;};
+#endif
     virtual bool onVerifyUser(IEspContext &context, IEspVerifyUserRequest &req, IEspVerifyUserResponse &resp);
 };
 

--- a/esp/services/ws_dfu/CMakeLists.txt
+++ b/esp/services/ws_dfu/CMakeLists.txt
@@ -53,7 +53,6 @@ include_directories (
          ./../../../common/deftype 
          ./../../../ecl/hql 
          ./../../../system/security/securesocket 
-         ./../../../system/security/LdapSecurity 
          ./../../../system/security/shared 
          ./../../../system/include 
          ./../../../common/workunit 
@@ -92,7 +91,6 @@ target_link_libraries ( ws_dfu
          dalift 
          SMCLib 
          dfuXRefLib 
-         LdapSecurity 
          dfuwu 
          securesocket 
          roxiecommlib 

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -50,12 +50,9 @@
 #include "exception_util.hpp"
 
 #include "ws_dfuService.hpp"
-#include "ldapsecurity.hpp"
 
 #include "hqlerror.hpp"
 #include "eclrtl.hpp"
-
-///#define TESTDATASET 1
 
 #define     Action_Delete           "Delete"
 #define     Action_AddtoSuperfile   "Add To Superfile"

--- a/esp/services/ws_ecl/CMakeLists.txt
+++ b/esp/services/ws_ecl/CMakeLists.txt
@@ -66,7 +66,6 @@ target_link_libraries ( ws_ecl
          jlib
          xmllib 
          esphttp 
-         LdapSecurity 
          mp 
          hrpc 
          remote 

--- a/esp/services/ws_machine/CMakeLists.txt
+++ b/esp/services/ws_machine/CMakeLists.txt
@@ -65,7 +65,6 @@ target_link_libraries ( ws_machine
          roxiecommlib
          xmllib 
          esphttp 
-         LdapSecurity 
          mp 
          hrpc 
          remote 

--- a/esp/services/ws_smc/CMakeLists.txt
+++ b/esp/services/ws_smc/CMakeLists.txt
@@ -69,7 +69,6 @@ target_link_libraries ( ws_smc
          jlib
          xmllib 
          esphttp 
-         LdapSecurity 
          mp 
          hrpc 
          remote 
@@ -97,4 +96,7 @@ target_link_libraries ( ws_smc
          roxiemanager 
          ws_workunits 
     )
+IF (USE_OPENLDAP)
+target_link_libraries ( ws_smc LdapSecurity )
+ENDIF(USE_OPENLDAP)
 

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -18,7 +18,9 @@
 
 #pragma warning (disable : 4786)
 
+#ifdef _USE_OPENLDAP
 #include "ldapsecurity.ipp"
+#endif
 #include "ws_smcService.hpp"
 #include "wshelpers.hpp"
 
@@ -285,8 +287,12 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
 
         double version = context.getClientVersion();
 
+#ifdef _USE_OPENLDAP
         CLdapSecManager* secmgr = dynamic_cast<CLdapSecManager*>(context.querySecManager());
         if(req.getFromSubmitBtn() && secmgr && secmgr->isSuperUser(context.queryUser()))
+#else
+        if(req.getFromSubmitBtn())
+#endif
         {
             StringBuffer chatURLStr, bannerStr;
             const char* chatURL = req.getChatURL();
@@ -347,11 +353,14 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
 
         if (version > 1.05)
         {
+#ifdef _USE_OPENLDAP
             int UserPermission = -1;
             CLdapSecManager* secmgr = dynamic_cast<CLdapSecManager*>(context.querySecManager());
             if(secmgr && secmgr->isSuperUser(context.queryUser()))
                 UserPermission = 0;
-
+#else
+            int UserPermission = 0;
+#endif
             resp.setUserPermission(UserPermission);
             resp.setShowBanner(m_BannerAction);
             resp.setShowChatURL(m_EnableChatURL);
@@ -1138,10 +1147,11 @@ bool CWsSMCEx::onSetBanner(IEspContext &context, IEspSetBannerRequest &req, IEsp
 {
     try
     {
+#ifdef _USE_OPENLDAP
         CLdapSecManager* secmgr = dynamic_cast<CLdapSecManager*>(context.querySecManager());
         if(!secmgr || !secmgr->isSuperUser(context.queryUser()))
             throw MakeStringException(ECLWATCH_SUPER_USER_ACCESS_DENIED, "access denied, administrators only.");
-
+#endif
         StringBuffer chatURLStr, bannerStr;
         const char* chatURL = req.getChatURL();
         const char* banner = req.getBannerContent();

--- a/esp/services/ws_topology/CMakeLists.txt
+++ b/esp/services/ws_topology/CMakeLists.txt
@@ -77,7 +77,6 @@ target_link_libraries ( ws_topology
          deftype 
          workunit 
          SMCLib 
-         LdapSecurity 
          securesocket 
          swapnodelib
          )

--- a/esp/services/ws_workunits/CMakeLists.txt
+++ b/esp/services/ws_workunits/CMakeLists.txt
@@ -97,7 +97,6 @@ target_link_libraries ( ws_workunits
          schedulectrl
          roxiecommlib
          roxiemanager
-         LdapSecurity
          hql
          jhtree
          fileview2

--- a/system/security/CMakeLists.txt
+++ b/system/security/CMakeLists.txt
@@ -16,7 +16,9 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
+IF (USE_OPENLDAP)
 add_subdirectory (LdapSecurity)
+ENDIF(USE_OPENLDAP)
 add_subdirectory (securesocket)
 add_subdirectory (test)
 if (USE_ZLIB)

--- a/system/security/test/CMakeLists.txt
+++ b/system/security/test/CMakeLists.txt
@@ -16,5 +16,7 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
+IF (USE_OPENLDAP)
 add_subdirectory (ldapsecuritytest)
+ENDIF(USE_OPENLDAP)
 add_subdirectory (myssl)


### PR DESCRIPTION
Compiling EE under windows with ldap disabled fails to
link ldapsecurity.dll.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
