### PR TITLE
gh-1894 Change ESP default authentication to 'none'

### DIFF
--- a/initfiles/componentfiles/configxml/esp.xsd
+++ b/initfiles/componentfiles/configxml/esp.xsd
@@ -224,7 +224,7 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType>
-                        <xs:attribute name="method" use="optional" default="local">
+                        <xs:attribute name="method" use="optional" default="none">
                             <xs:annotation>
                                 <xs:appinfo>
                                     <autogenforwizard>1</autogenforwizard>


### PR DESCRIPTION
When using ConfigMgr Advanced mode to create an ESP, the default authentication should be set to 'none'.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
