### PR TITLE
Modify configmr to prevent dupe Clusters names

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -1610,6 +1610,13 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
       const char* rowIndex = pSetting->queryProp("@rowIndex");
       const char* pszOldValue = pSetting->queryProp("@oldValue");
       const char* pszNewValue = pSetting->queryProp("@newValue");
+            
+      StringBuffer xpath_key;
+      xpath_key.appendf("%s/%s/%s[%s='%s']", XML_TAG_SOFTWARE, XML_TAG_TOPOLOGY, XML_TAG_CLUSTER, XML_ATTR_NAME, pszNewValue);
+      //Check to see if the cluster name is already in use
+      IPropertyTree* pEnvCluster = pEnvRoot->queryPropTree(xpath_key);
+      if (pEnvCluster != NULL)
+        throw MakeStringException(-1, "Cluster - %s is already in use. Please enter a unique name for the Cluster.", pszNewValue);      
 
       StringBuffer buf("Topology");
 

--- a/initfiles/componentfiles/configxml/validateAll.xsl
+++ b/initfiles/componentfiles/configxml/validateAll.xsl
@@ -28,6 +28,19 @@ xmlns:seisint="http://seisint.com" exclude-result-prefixes="seisint">
   <xsl:template match="/Environment">
     <xsl:apply-templates select="Hardware/Computer"/>
     <xsl:apply-templates select="Software/ThorCluster"/>
+    <xsl:apply-templates select="Software/Topology"/>
+  </xsl:template>
+
+  <xsl:template match="Environment/Software/*">
+    <xsl:for-each select="descendant-or-self::*[name()='Cluster']">
+    <xsl:variable select="@name" name="elem"/>
+      <xsl:if test= "count(preceding-sibling::*[@name=$elem]) = 0 and count(following-sibling::*[@name=$elem]) &gt; 0">
+        <xsl:variable select="count(following-sibling::*[@name=$elem])+1" name="numOccurrences"/>
+        <xsl:call-template name="validationMessage">
+            <xsl:with-param name="msg" select="concat('/Environment/Software/Topology/Cluster[@name=',$elem,']',' occurs ', $numOccurrences, ' times. Max occurrence must be 1.')"/>
+        </xsl:call-template>        
+      </xsl:if> 
+    </xsl:for-each>
   </xsl:template>
 
   <xsl:template match="Computer">


### PR DESCRIPTION
configgen will indicate an error when validating XML with
duplicately named Topology Clusters.

configmgr will indicate an error when attempting
to use the same cluster name.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
