### PR TITLE
Remove unused variable for small case expressions

### DIFF
--- a/ecl/hqlcpp/hqlcppcase.cpp
+++ b/ecl/hqlcpp/hqlcppcase.cpp
@@ -283,11 +283,17 @@ void HqlCppCaseInfo::buildChop3Map(BuildCtx & ctx, const CHqlBoundTarget & targe
 
 void HqlCppCaseInfo::buildChop3Map(BuildCtx & ctx, const CHqlBoundTarget & target, CHqlBoundExpr & test)
 {
-    //need to hack it because there is no signed integer type
-    OwnedHqlExpr tempVar = ctx.getTempDeclare(indexType, NULL);
-
     translator.buildExprAssign(ctx, target, defaultValue);
-    buildChop3Map(ctx, target, test, tempVar, 0, getNumPairs());
+    if (getNumPairs() <= 2)
+    {
+        buildChop2Map(ctx, target, test, 0, getNumPairs());
+    }
+    else
+    {
+        //need to hack it because there is no signed integer type
+        OwnedHqlExpr tempVar = ctx.getTempDeclare(indexType, NULL);
+        buildChop3Map(ctx, target, test, tempVar, 0, getNumPairs());
+    }
 }
 
 void HqlCppCaseInfo::buildChop2Map(BuildCtx & ctx, const CHqlBoundTarget & target, CHqlBoundExpr & test, unsigned start, unsigned end)


### PR DESCRIPTION
CASE(string,k1=>v1,k2=>v2,v3) would generate a temporary variable which
was never used used.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
