### PR TITLE
gh1888 Fix ecl run error output

### DIFF
--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -219,7 +219,7 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
                 errorCount++;
         }
         if (errorCount || warningCount)
-            fprintf(stderr, "%d error, %d warning\n\n", errorCount, warningCount);
+            fprintf(stderr, "%d error(s), %d warning(s)\n\n", errorCount, warningCount);
 
         return isCompiled;
     }


### PR DESCRIPTION
Errors should include line/col/filename information formatted
similarly to the way eclcc outputs errors.

Fixes gh-1888

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
