### PR TITLE
Fix problem with constant folding inline tables

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -36,6 +36,8 @@
 #include "hqlfold.hpp"
 #include "hqlthql.hpp"
 
+//#define LOG_ALL_FOLDING
+
 //---------------------------------------------------------------------------
 // The following functions work purely on constant expressions - they do not attempt to process datasets.
 
@@ -5145,6 +5147,11 @@ IHqlExpression * CExprFolderTransformer::createTransformed(IHqlExpression * expr
 
     OwnedHqlExpr updated = (foldOptions & HFOpercolateconstants) ? percolateConstants(dft) : LINK(dft);
     OwnedHqlExpr transformed = doFoldTransformed(updated, expr);
+
+#ifdef LOG_ALL_FOLDING
+    if ((op != transformed->getOperator()) || (expr->numChildren() != transformed->numChildren()))
+        DBGLOG("Folding %s to %s", getOpString(updated->getOperator()), getOpString(transformed->getOperator()));
+#endif
 
 #ifdef _DEBUG
     if (expr->isConstant() && !transformed->queryValue())

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -39,7 +39,9 @@
 //#define LOG_ALL_FOLDING
 
 //---------------------------------------------------------------------------
-// The following functions work purely on constant expressions - they do not attempt to process datasets.
+// The following functions do not attempt to reorder datasets, e.g., filter(project)->project(filter).
+// Those changes can inadvertently cause common code to be lost.  Those optimizations are performed by
+// hqlopt which ensures it keeps track of the number of times a dataset expression is used.
 
 IHqlExpression * createNullValue(IHqlExpression * expr)
 {

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -265,7 +265,18 @@ unsigned activityHidesSelectorGetNumNonHidden(IHqlExpression * expr, IHqlExpress
         return 0;
     node_operator op = selector->getOperator();
     if ((op != no_left) && (op != no_right))
+    {
+        switch (getChildDatasetType(expr))
+        {
+        case childdataset_dataset:
+        case childdataset_datasetleft:
+        case childdataset_top_left_right:
+            if (expr->queryChild(0)->queryBody() == selector)
+                return 1;
+            break;
+        }
         return 0;
+    }
 
     switch (getChildDatasetType(expr))
     {

--- a/ecl/regress/klogermann21.ecl
+++ b/ecl/regress/klogermann21.ecl
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+rec := record
+   integer period;
+end;
+
+ds_base := dataset([{1},{2},{3}],rec);
+
+last_period := max(ds_base,period);
+output(last_period);
+output(ds_base);
+output(ds_base(period < last_period));


### PR DESCRIPTION
In unusual cicumstances (see associated example file klogermann21.ecl)
selectors were being replaced inside nested operators which were
applied to the same dataset.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
