### PR TITLE
gh1884 Only change existing jobname if caller is explicit its an update

### DIFF
--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -200,6 +200,9 @@ class EclccCompileThread : public CInterface, implements IPooledThread
                     Owned<ILocalWorkUnit> embeddedWU = createLocalWorkUnit();
                     embeddedWU->loadXML(wuXML);
                     queryExtendedWU(workunit)->copyWorkUnit(embeddedWU);
+                    SCMStringBuffer jobname;
+                    if (embeddedWU->getJobName(jobname).length()) //let ECL win naming job during initial compile
+                        workunit->setJobName(jobname.str());
                     Owned<IWUQuery> query = workunit->updateQuery();
                     query->setQueryText(eclQuery.s.str());
                 }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3379,14 +3379,11 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
 
     wu->setAction(WUActionCompile);
 
-    if (notEmpty(req.getName()))
-        wu->setJobName(req.getName());
-    else if (notEmpty(req.getFileName()))
-    {
-        StringBuffer name;
+    StringBuffer name(req.getName());
+    if (!name.trim().length() && notEmpty(req.getFileName()))
         splitFilename(req.getFileName(), NULL, NULL, &name, NULL);
+    if (name.length())
         wu->setJobName(name.str());
-    }
 
     if (req.getObject().length())
     {
@@ -3405,6 +3402,17 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
     WsWuInfo winfo(context, wuid.str());
     winfo.getCommon(resp.updateWorkunit(), WUINFO_All);
     winfo.getExceptions(resp.updateWorkunit(), WUINFO_All);
+
+    name.clear();
+    if (notEmpty(resp.updateWorkunit().getJobname()))
+        origValueChanged(req.getName(), resp.updateWorkunit().getJobname(), name, false);
+
+    if (name.length()) //non generated user specified name, so override #Workunit('name')
+    {
+        WorkunitUpdate wx(&winfo.cw->lock());
+        wx->setJobName(name.str());
+        resp.updateWorkunit().setJobname(name.str());
+    }
 
     AuditSystemAccess(context.queryUserId(), true, "Updated %s", wuid.str());
 }


### PR DESCRIPTION
When #Workunit is used to set the jobname, we should ignore the
calculated jobname being set.. but if a command line user explicitly sets
a name, it should be used.

Fixes gh-1884

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
