### PR TITLE
Add support for unsigned integral constants

### DIFF
--- a/common/deftype/defvalue.cpp
+++ b/common/deftype/defvalue.cpp
@@ -1657,7 +1657,13 @@ const char *IntValue::generateCPP(StringBuffer &s, CompilerType compiler)
         break;
     case Vs6CppCompiler:
         if (val && (type->getSize() > sizeof(unsigned)))
+        {
+            if (!type->isSigned())
+                s.append("U");
             s.append("i64");
+        }
+        else if (!type->isSigned() && ((unsigned __int64)val > INT_MAX))
+            s.append("U");
         break;
     default:
         throwUnexpected();

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -1103,6 +1103,7 @@ class HqlLex
         IHqlExpression * parseECL(StringBuffer &curParam, IXmlScope *xmlScope, int startLine, int startCol);
         void setMacroParam(const YYSTYPE & errpos, IHqlExpression* funcdef, StringBuffer& curParam, _ATOM argumentName, unsigned& parmno,IProperties *macroParms);
         unsigned getTypeSize(unsigned lengthTypeName);
+        static IHqlExpression * createIntegerConstant(__int64 value, bool isSigned);
 
         void doPreprocessorLookup(const YYSTYPE & errpos, bool stringify, int extra);
         void doApply(YYSTYPE & returnToken);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -3049,9 +3049,10 @@ outputFlag
                                 parser->normalizeExpression($1, type_string, false);
                             $$.inherit($1);
                         }
-    | FIRST '(' INTEGER_CONST ')'
+    | FIRST '(' constExpression ')'
                         {
-                            $$.setExpr(createAttribute(firstAtom, createConstant($3.getInt())));
+                            parser->normalizeExpression($3, type_int, false);
+                            $$.setExpr(createAttribute(firstAtom, $3.getExpr()));
                             $$.setPosition($1);
                         }
     | THOR              {
@@ -3281,9 +3282,10 @@ outputWuFlag
                             $$.setExpr(createAttribute(allAtom));
                             $$.setPosition($1);
                         }
-    | FIRST '(' INTEGER_CONST ')'
+    | FIRST '(' constExpression ')'
                         {
-                            $$.setExpr(createAttribute(firstAtom, createConstant($3.getInt())));
+                            parser->normalizeExpression($3, type_int, true);
+                            $$.setExpr(createAttribute(firstAtom, $3.getExpr()));
                             $$.setPosition($1);
                         }
     | THOR              {
@@ -10884,9 +10886,7 @@ caseActionItem
 
 const
     : stringConstExpr
-    | INTEGER_CONST     {
-                            $$.setExpr(createConstant(createIntValue($1.getInt(), LINK(parser->defaultIntegralType))), $1);
-                        }
+    | INTEGER_CONST
     | DATA_CONST
     | REAL_CONST
     | UNICODE_CONST
@@ -11185,12 +11185,13 @@ pattern0
                         }
     | pattern0 '*' INTEGER_CONST
                         {
+                            parser->normalizeExpression($3, type_int, true);
                             parser->checkPattern($1, true);
                             if ($1.queryExpr()->queryRecord())
                                 parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use * on a rule with associated an row");
 
                             IHqlExpression * pattern = $1.getExpr();
-                            IHqlExpression * count = createConstant($3.getInt());
+                            IHqlExpression * count = $3.getExpr();
                             $$.setExpr(createValue(no_pat_repeat, parser->getCompoundRuleType(pattern), pattern, count, LINK(count)));
                         }
     | '(' pattern ')'   {   $$.setExpr($2.getExpr()); }
@@ -11601,9 +11602,7 @@ featureId
 
 featureValue
     : featureCompound
-    | stringConstExpr
-    | INTEGER_CONST             
-                        {   $$.setExpr(createConstant($1.getInt())); }
+    | constExpression
     ;
 
 featureValueList

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -1994,7 +1994,7 @@ void HqlGram::checkFoldConstant(attribute & attr)
 
 IHqlExpression * HqlGram::checkConstant(const attribute & errpos, IHqlExpression * expr)
 {
-    if (expr->isConstant())
+    if (expr->isConstant() || (expr->getOperator() == no_assertconstant))
         return LINK(expr);
 
     return createValue(no_assertconstant, expr->getType(), LINK(expr), createLocationAttr(errpos));

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -560,7 +560,7 @@ xpathseq      ([^}\r\n])+
                     }
 __LINE__            {
                         setupdatepos; 
-                        returnToken.setInt(lexer->yyLineNo);
+                        returnToken.setExpr(createIntegerConstant(lexer->yyLineNo, false));
                         return (INTEGER_CONST);
                     }
 #REGION[^\n]*       { 
@@ -955,17 +955,17 @@ __ECL_VERSION__     {
                     }
 __ECL_VERSION_MAJOR__ {
                         setupdatepos; 
-                        returnToken.setInt(LANGUAGE_VERSION_MAJOR);
+                        returnToken.setExpr(createIntegerConstant(LANGUAGE_VERSION_MAJOR, false));
                         return (INTEGER_CONST);
                     }
 __ECL_VERSION_MINOR__ {
                         setupdatepos; 
-                        returnToken.setInt(LANGUAGE_VERSION_MINOR);
+                        returnToken.setExpr(createIntegerConstant(LANGUAGE_VERSION_MINOR, false));
                         return (INTEGER_CONST);
                     }
 __ECL_VERSION_SUBMINOR__ {
                         setupdatepos; 
-                        returnToken.setInt(LANGUAGE_VERSION_SUB);
+                        returnToken.setExpr(createIntegerConstant(LANGUAGE_VERSION_SUB, false));
                         return (INTEGER_CONST);
                     }
 __OS__              { 
@@ -1516,11 +1516,41 @@ FUNCTIONMACRO|MACRO {
 "<?>"               { setupdatepos; return(FIELD_REF) ; }
 "<??>"              { setupdatepos; return(FIELDS_REF) ; }
 
-0(x|X){hexdigit}+   { setupdatepos; returnToken.setInt(str2int64(CUR_TOKEN_LENGTH-2,(const char *)CUR_TOKEN_TEXT+2, 16)); return(INTEGER_CONST);}
-{digit}{hexdigit}*(x|X) { setupdatepos; returnToken.setInt(str2int64(CUR_TOKEN_LENGTH-1,(const char *)CUR_TOKEN_TEXT, 16)); return(INTEGER_CONST);}
-0(b|B){bindigit}+   { setupdatepos; returnToken.setInt(str2int64(CUR_TOKEN_LENGTH-2,(const char *)CUR_TOKEN_TEXT+2, 2)); return(INTEGER_CONST);}
-{bindigit}+(b|B)    { setupdatepos; returnToken.setInt(str2int64(CUR_TOKEN_LENGTH-1,(const char *)CUR_TOKEN_TEXT, 2)); return(INTEGER_CONST);}
-{digit}+            { setupdatepos; returnToken.setInt(str2int64(CUR_TOKEN_LENGTH, (const char *)CUR_TOKEN_TEXT, 10)); return(INTEGER_CONST);}
+0x{hexdigit}+U?     {
+                        setupdatepos;
+                        bool isSigned = toupper(CUR_TOKEN_TEXT[CUR_TOKEN_LENGTH-1]) != 'U';
+                        unsigned len = isSigned ? CUR_TOKEN_LENGTH-2 : CUR_TOKEN_LENGTH-3;
+                        returnToken.setExpr(createIntegerConstant(str2int64(len,(const char *)CUR_TOKEN_TEXT+2, 16), isSigned));
+                        return(INTEGER_CONST);
+                    }
+{digit}{hexdigit}*XU? {
+                        setupdatepos;
+                        bool isSigned = toupper(CUR_TOKEN_TEXT[CUR_TOKEN_LENGTH-1]) != 'U';
+                        unsigned len = isSigned ? CUR_TOKEN_LENGTH-1 : CUR_TOKEN_LENGTH-2;
+                        returnToken.setExpr(createIntegerConstant(str2int64(len,(const char *)CUR_TOKEN_TEXT, 16), isSigned));
+                        return(INTEGER_CONST);
+                    }
+0b{bindigit}+U?     {
+                        setupdatepos;
+                        bool isSigned = toupper(CUR_TOKEN_TEXT[CUR_TOKEN_LENGTH-1]) != 'U';
+                        unsigned len = isSigned ? CUR_TOKEN_LENGTH-2 : CUR_TOKEN_LENGTH-3;
+                        returnToken.setExpr(createIntegerConstant(str2int64(len,(const char *)CUR_TOKEN_TEXT+2, 2), isSigned));
+                        return(INTEGER_CONST);
+                    }
+{bindigit}+BU?      {
+                        setupdatepos;
+                        bool isSigned = toupper(CUR_TOKEN_TEXT[CUR_TOKEN_LENGTH-1]) != 'U';
+                        unsigned len = isSigned ? CUR_TOKEN_LENGTH-1 : CUR_TOKEN_LENGTH-2;
+                        returnToken.setExpr(createIntegerConstant(str2int64(len,(const char *)CUR_TOKEN_TEXT, 2), isSigned));
+                        return(INTEGER_CONST);
+                    }
+{digit}+U?          {
+                        setupdatepos;
+                        bool isSigned = toupper(CUR_TOKEN_TEXT[CUR_TOKEN_LENGTH-1]) != 'U';
+                        unsigned len = isSigned ? CUR_TOKEN_LENGTH : CUR_TOKEN_LENGTH-1;
+                        returnToken.setExpr(createIntegerConstant(str2int64(len, (const char *)CUR_TOKEN_TEXT, 10), isSigned));
+                        return(INTEGER_CONST);
+                    }
 {digit}+(d|D)       { 
                         setupdatepos;
                         unsigned digits = CUR_TOKEN_LENGTH-1;

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -298,6 +298,10 @@ void HqlLex::hex2str(char * target, const char * digits, unsigned len)
   }
 } 
 
+IHqlExpression * HqlLex::createIntegerConstant(__int64 value, bool isSigned)
+{
+    return createConstant(createIntValue(value, makeIntType(8, isSigned)));
+}
 
 void HqlLex::pushText(const char *s, int startLineNo, int startColumn)
 {

--- a/ecl/regress/unsigned1.ecl
+++ b/ecl/regress/unsigned1.ecl
@@ -1,0 +1,29 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+100U=100;
+100u=100;
+0b100U=4;
+0x100U=256;
+100BU=100b;
+100XU=256;
+100xu=100x;
+
+0xFFFFFFFFFFFFFFFFU % 6U;
+nofold(0xFFFFFFFFFFFFFFFFU) % 6U;
+nofold(0x7FFFFFFFFFFFFFFFU) % 6U;


### PR DESCRIPTION
Allow U as a suffix to a number to inidicate it should be an unsigned number
E.g., 123U 0xFFFFU 0b010101110101U

Also fixed potential problem that windows code was also not adding
unsigned suffixes on generated literal constants.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
