### PR TITLE
gh-1895 Set the componentfilesDir attribute in esp to the cmake generated default path

### DIFF
--- a/initfiles/componentfiles/configxml/CMakeLists.txt
+++ b/initfiles/componentfiles/configxml/CMakeLists.txt
@@ -18,6 +18,7 @@
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/dropzone.xsd.in ${CMAKE_CURRENT_BINARY_DIR}/dropzone.xsd)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/eclagent_config.xsd.in ${CMAKE_CURRENT_BINARY_DIR}/eclagent_config.xsd)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/eclagent_config.xsd.in ${CMAKE_CURRENT_BINARY_DIR}/eclagent_config.xsd)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/esp.xsd.in ${CMAKE_CURRENT_BINARY_DIR}/esp.xsd)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/espsmcservice.xsd.in ${CMAKE_CURRENT_BINARY_DIR}/espsmcservice.xsd)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/ftslave_linux.xsd.in ${CMAKE_CURRENT_BINARY_DIR}/ftslave_linux.xsd)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/roxie.xsd.in ${CMAKE_CURRENT_BINARY_DIR}/roxie.xsd)
@@ -31,6 +32,7 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_BINARY_DIR}/dropzone.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/eclagent_config.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/eclagent_config.xsd
+    ${CMAKE_CURRENT_BINARY_DIR}/esp.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/espsmcservice.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/ftslave_linux.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/roxie.xsd
@@ -54,7 +56,6 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/esp_service_ecldirect.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/esp_service_wsecl.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/esp_service_wsecl2.xsd
-    ${CMAKE_CURRENT_SOURCE_DIR}/esp.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/ftslave.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/GABConfig.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/generic.xsd

--- a/initfiles/componentfiles/configxml/esp.xsd.in
+++ b/initfiles/componentfiles/configxml/esp.xsd.in
@@ -141,7 +141,7 @@
                                     <colIndex>2</colIndex>
                                 </xs:appinfo>
                             </xs:annotation>
-                        </xs:attribute>              
+                        </xs:attribute>
                         <xs:attribute name="protocol" use="optional" default="http">
                             <xs:annotation>
                                 <xs:appinfo>
@@ -161,7 +161,7 @@
                             <xs:annotation>
                                 <xs:appinfo>
                                     <tooltip>Network port to install this service</tooltip>
-                                    <colIndex>4</colIndex>                  
+                                    <colIndex>4</colIndex>
                                 </xs:appinfo>
                             </xs:annotation>
                         </xs:attribute>
@@ -671,7 +671,7 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute-->
-            <xs:attribute name="componentfilesDir" type="xs:string" use="optional" default=".">
+            <xs:attribute name="componentfilesDir" type="xs:string" use="optional" default="${COMPONENTFILES_PATH}">
                 <xs:annotation>
                     <xs:appinfo>
                         <autogenforwizard>1</autogenforwizard>


### PR DESCRIPTION
Set the componentfilesDir attribute in esp to the cmake generated default path which resolves to /opt/HPCCSystems/componentfiles

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
