### PR TITLE
Fix ensure manifest object is valid before using

### DIFF
--- a/ecl/hqlcpp/hqlres.cpp
+++ b/ecl/hqlcpp/hqlres.cpp
@@ -182,7 +182,7 @@ void ResourceManager::addManifest(const char *filename)
     StringBuffer path;
     Owned<IPropertyTree> t = createPTree();
     t->setProp("@originalFilename", makeAbsolutePath(filename, path).str());
-    manifest->addPropTree("Include", t.getClear());
+    ensureManifestInfo()->addPropTree("Include", t.getClear());
     addManifestFile(filename);
 }
 


### PR DESCRIPTION
Not calling ensureManifestInfo() could cause a core.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
