### PR TITLE
Allow manifest to specify which ecl file to compile and some options

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1178,7 +1178,9 @@ extern WORKUNIT_API IStringVal& createToken(const char *wuid, const char *user, 
 extern WORKUNIT_API void extractToken(const char *token, const char *wuid, IStringVal &user, IStringVal &password);
 extern WORKUNIT_API WUState getWorkUnitState(const char* state);
 extern WORKUNIT_API IWorkflowScheduleConnection * getWorkflowScheduleConnection(char const * wuid);
+extern WORKUNIT_API const char *skipLeadingXml(const char *text);
 extern WORKUNIT_API bool isArchiveQuery(const char * text);
+extern WORKUNIT_API bool isQueryManifest(const char * text);
 extern WORKUNIT_API IPropertyTree * resolveDefinitionInArchive(IPropertyTree * archive, const char * path);
 
 inline bool isLibrary(IConstWorkUnit * wu) { return wu->getApplicationValueInt("LibraryModule", "interfaceHash", 0) != 0; }

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -105,7 +105,8 @@ enum eclObjParameterType
     eclObjArchive = 0x02,
     eclObjSharedObject = 0x04,
     eclObjWuid = 0x08,
-    eclObjQuery = 0x10
+    eclObjQuery = 0x10,
+    eclObjManifest = 0x20
 };
 
 #define eclObjSourceOrArchive (eclObjSource|eclObjArchive)


### PR DESCRIPTION
Adding an ecl section to the manifest using the following syntax:

&lt;Manifest>
    &lt;Include filename="files/manifest.xml"/>
    &lt;ecl filename="pie.ecl" legacy="false" targetClusterType="roxie">
        &lt;IncludePath path="../../elc/mydefs"/>
        &lt;LibraryPath path="../../elc/libs"/>
    &lt;/ecl>
&lt;/Manifest>

Signed-off-by: Anthony Fishbeck &lt;Anthony.Fishbeck@lexisnexis.com>
