### PR TITLE
Implement DISTRIBUTED DATASET(COUNT) in Thor

### DIFF
--- a/common/commonext/commonext.cpp
+++ b/common/commonext/commonext.cpp
@@ -60,6 +60,7 @@ MODULE_INIT(INIT_PRIORITY_STANDARD)
     kindArray[TAKfunnel] = "funnel";
     kindArray[TAKapply] = "apply";
     kindArray[TAKtemptable] = "temptable";
+    kindArray[TAKinlinetable] = "inlinetable";
     kindArray[TAKtemprow] = "temprow";
     kindArray[TAKhashdistribute] = "hashdistribute";
     kindArray[TAKhashdedup] = "hashdedup";

--- a/common/thorhelper/thorcommon.cpp
+++ b/common/thorhelper/thorcommon.cpp
@@ -625,6 +625,7 @@ extern const char * getActivityText(ThorActivityKind kind)
     case TAKfunnel:                 return "Funnel";
     case TAKapply:                  return "Apply";
     case TAKtemptable:              return "Inline Dataset";
+    case TAKinlinetable:            return "Inline Dataset";
     case TAKtemprow:                return "Inline Row";
     case TAKhashdistribute:         return "Hash Distribute";
     case TAKhashdedup:              return "Hash Dedup";
@@ -779,6 +780,7 @@ extern bool isActivitySource(ThorActivityKind kind)
     {
     case TAKpiperead:
     case TAKtemptable:
+    case TAKinlinetable:
     case TAKtemprow:
     case TAKworkunitread:
     case TAKnull:

--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -106,6 +106,8 @@ static IHThorActivity * createActivity(IAgentContext & agent, unsigned activityI
     case TAKtemptable:
     case TAKtemprow:
         return createTempTableActivity(agent, activityId, subgraphId, (IHThorTempTableArg &)arg, kind);
+    case TAKinlinetable:
+        return createInlineTableActivity(agent, activityId, subgraphId, (IHThorInlineTableArg &)arg, kind);
     case TAKnormalize:
         return createNormalizeActivity(agent, activityId, subgraphId, (IHThorNormalizeArg &)arg, kind);
     case TAKnormalizechild:

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -15988,13 +15988,13 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCountTransform(BuildCtx & ctx,
     IHqlExpression * counter = queryPropertyChild(expr, _countProject_Atom, 0);
 
     // Overriding IHThorTempTableArg
-    Owned<ActivityInstance> instance = new ActivityInstance(*this, ctx, TAKtemptable, expr,"TempTable");
+    Owned<ActivityInstance> instance = new ActivityInstance(*this, ctx, TAKinlinetable, expr,"InlineTable");
     buildActivityFramework(instance);
     buildInstancePrefix(instance);
 
     // size32_t getRow()
     BuildCtx funcctx(instance->startctx);
-    funcctx.addQuotedCompound("virtual size32_t getRow(ARowBuilder & crSelf, unsigned row)");
+    funcctx.addQuotedCompound("virtual size32_t getRow(ARowBuilder & crSelf, __uint64 row)");
     ensureRowAllocated(funcctx, "crSelf");
     BoundRow * selfCursor = bindSelf(funcctx, instance->dataset, "crSelf");
     IHqlExpression * self = selfCursor->querySelector();
@@ -16002,7 +16002,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCountTransform(BuildCtx & ctx,
     buildTransformBody(funcctx, transform, NULL, NULL, instance->dataset, self);
 
     // unsigned numRows() - count is guaranteed by lexer
-    doBuildUnsignedFunction(instance->startctx, "numRows", count);
+    doBuildUnsigned64Function(instance->startctx, "numRows", count);
 
     doBuildTempTableFlags(instance->startctx, expr, isConstantTransform(transform));
 

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -5873,8 +5873,6 @@ void CHThorInlineTableActivity::ready()
     CHThorSimpleActivityBase::ready();
     curRow = 0;
     numRows = helper.numRows();
-    if (helper.getFlags() & TTFdistributed != 0)
-        WARNLOG("HThor does not support distributed inline tables, using master");
 }
 
 

--- a/ecl/hthor/hthor.hpp
+++ b/ecl/hthor/hthor.hpp
@@ -108,6 +108,7 @@ extern HTHOR_API IHThorActivity *createWorkUnitWriteActivity(IAgentContext &, un
 extern HTHOR_API IHThorActivity *createFirstNActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorFirstNArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createCountActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorCountArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createTempTableActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorTempTableArg &arg, ThorActivityKind kind);
+extern HTHOR_API IHThorActivity *createInlineTableActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorInlineTableArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createConcatActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorFunnelArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createApplyActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorApplyArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createSampleActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorSampleArg &arg, ThorActivityKind kind);

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -1508,6 +1508,22 @@ public:
 };
 
 
+class CHThorInlineTableActivity : public CHThorSimpleActivityBase
+{
+    IHThorInlineTableArg &helper;
+    __uint64 curRow;
+    __uint64 numRows;
+
+public:
+    CHThorInlineTableActivity(IAgentContext &agent, unsigned _activityId, unsigned _subgraphId, IHThorInlineTableArg &_arg, ThorActivityKind _kind);
+
+    virtual void ready();
+    virtual bool needsAllocator() const { return true; }
+
+    //interface IHThorInput
+    virtual const void *nextInGroup();
+};
+
 class CHThorNullActivity : public CHThorSimpleActivityBase
 {
     IHThorArg &helper;

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -1507,7 +1507,14 @@ public:
     virtual const void *nextInGroup();
 };
 
-
+/*
+ * This class differ from TempTable (above) by having 64-bit number of rows
+ * and, in Thor, it's able to run distributed in the cluster. We, therefore,
+ * need to keep consistency and implement it here, too.
+ *
+ * Some optimisations [ex. NORMALIZE(ds) -> DATASET(COUNT)] will make use of
+ * this class, so you can't use TempTables.
+ */
 class CHThorInlineTableActivity : public CHThorSimpleActivityBase
 {
     IHThorInlineTableArg &helper;

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -444,6 +444,8 @@ protected:
         case TAKtemptable:
         case TAKtemprow:
             return createRoxieServerTempTableActivityFactory(id, subgraphId, *this, helperFactory, kind);
+        case TAKinlinetable:
+            return createRoxieServerInlineTableActivityFactory(id, subgraphId, *this, helperFactory, kind);
         case TAKthroughaggregate:
             throwUnexpected(); // Concept of through aggregates has been proven not to work in Roxie - codegen should not be creating them any more.
         case TAKtopn:

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -5287,6 +5287,14 @@ IRoxieServerActivityFactory *createRoxieServerTempTableActivityFactory(unsigned 
 
 //=================================================================================
 
+/*
+ * This class differ from TempTable (above) by having 64-bit number of rows
+ * and, in Thor, it's able to run distributed in the cluster. We, therefore,
+ * need to keep consistency and implement it here, too.
+ *
+ * Some optimisations [ex. NORMALIZE(ds) -> DATASET(COUNT)] will make use of
+ * this class, so you can't use TempTables.
+ */
 class CRoxieServerInlineTableActivity : public CRoxieServerActivity
 {
     IHThorInlineTableArg &helper;
@@ -5304,8 +5312,6 @@ public:
         curRow = 0;
         CRoxieServerActivity::start(parentExtractSize, parentExtract, paused);
         numRows = helper.numRows();
-        if (helper.getFlags() & TTFdistributed != 0)
-            CTXLOG("Roxie does not support distributed inline tables, using master");
     }
 
     virtual bool needsAllocator() const { return true; }

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -424,6 +424,7 @@ extern IRoxieServerActivityFactory *createRoxieServerNewChildGroupAggregateActiv
 extern IRoxieServerActivityFactory *createRoxieServerNewChildThroughNormalizeActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerDatasetResultActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, bool _isRoot);
 extern IRoxieServerActivityFactory *createRoxieServerTempTableActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
+extern IRoxieServerActivityFactory *createRoxieServerInlineTableActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerWorkUnitReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerLocalResultReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, unsigned graphId);
 extern IRoxieServerActivityFactory *createRoxieServerLocalResultStreamReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -809,7 +809,7 @@ enum ThorActivityKind
     TAKhashdistributemerge,
     TAKselfjoinlight,
     TAKhttp_rowdataset,     // a source activity
-        TAKunused3,
+    TAKinlinetable,
     TAKcountdisk,
     TAKstreamediterator,
     TAKexternalsource,
@@ -956,7 +956,7 @@ enum ActivityInterfaceEnum
     TAIexternal_1,
     TAIpipethrougharg_2,
     TAIpipewritearg_2,
-    TAItemptablearg_2,
+    TAIinlinetablearg_1,
     TAIshuffleextra_1,
 
 //Should remain as last of all meaningful tags, but before aliases
@@ -1421,8 +1421,10 @@ struct IHThorTempTableArg : public IHThorArg
  * single method. Future-proof and should merge with the interface
  * above in the next major release.
  */
-struct IHThorTempTableExtraArg : public IHThorTempTableArg
+struct IHThorInlineTableArg : public IHThorArg
 {
+    virtual size32_t getRow(ARowBuilder & rowBuilder, __uint64 row) = 0;
+    virtual __uint64 numRows() = 0;
     virtual unsigned getFlags() = 0;
 };
 

--- a/rtl/include/eclhelper_base.hpp
+++ b/rtl/include/eclhelper_base.hpp
@@ -1299,7 +1299,7 @@ class CThorHashAggregateArg : public CThorArg, implements IHThorHashAggregateArg
     virtual size32_t mergeAggregate(ARowBuilder & rowBuilder, const void * src) { rtlFailUnexpected(); return 0; }
 };
 
-class CThorTempTableArg : public CThorArg, implements IHThorTempTableExtraArg
+class CThorTempTableArg : public CThorArg, implements IHThorTempTableArg
 {
 public:
     virtual void Link() const { RtlCInterface::Link(); }
@@ -1313,14 +1313,34 @@ public:
         case TAIarg:
         case TAItemptablearg_1:
             return static_cast<IHThorTempTableArg *>(this);
-        case TAItemptablearg_2:
-            return static_cast<IHThorTempTableExtraArg *>(this);
         }
         return NULL;
     }
 
     virtual unsigned getFlags()                         { return 0; }
     virtual bool isConstant()                           { return (getFlags() & TTFnoconstant) == 0; }
+    virtual size32_t getRowSingle(ARowBuilder & rowBuilder) { return 0; }
+};
+
+class CThorInlineTableArg : public CThorArg, implements IHThorInlineTableArg
+{
+public:
+    virtual void Link() const { RtlCInterface::Link(); }
+    virtual bool Release() const { return RtlCInterface::Release(); }
+    virtual void onCreate(ICodeContext * _ctx, IHThorArg *, MemoryBuffer * in) { ctx = _ctx; }
+
+    virtual IInterface * selectInterface(ActivityInterfaceEnum which)
+    {
+        switch (which)
+        {
+        case TAIarg:
+        case TAIinlinetablearg_1:
+            return static_cast<IHThorInlineTableArg *>(this);
+        }
+        return NULL;
+    }
+
+    virtual unsigned getFlags()                         { return 0; }
     virtual size32_t getRowSingle(ARowBuilder & rowBuilder) { return 0; }
 };
 

--- a/rtl/include/eclhelper_base.hpp
+++ b/rtl/include/eclhelper_base.hpp
@@ -1341,7 +1341,6 @@ public:
     }
 
     virtual unsigned getFlags()                         { return 0; }
-    virtual size32_t getRowSingle(ARowBuilder & rowBuilder) { return 0; }
 };
 
 class CThorTempRowArg : public CThorTempTableArg

--- a/testing/ecl/dataset_transform.ecl
+++ b/testing/ecl/dataset_transform.ecl
@@ -31,26 +31,26 @@ r t2() := transform
 end;
 
 // zero
-output(true);
+output('Zero Rows');
 ds := DATASET(0, t1(COUNTER));
 output(ds);
 
 // plain
-output(true);
+output('Constant, 10');
 ds10 := DATASET(10, t1(COUNTER));
 output(ds10);
 
 // expr
-output(true);
+output('Constant expression, 50');
 ds50 := DATASET(5 * 10, t1(COUNTER));
 output(ds50);
 
 // variable
-output(true);
+output('Variable 5, row constant');
 ds5 := DATASET(C, t2());
 output(ds5);
 
 // distributed
-output(true);
+output('Distributed 10');
 dsd := DATASET(10, t1(COUNTER), DISTRIBUTED);
 output(dsd);

--- a/testing/ecl/key/dataset_transform.xml
+++ b/testing/ecl/key/dataset_transform.xml
@@ -1,10 +1,10 @@
 <Dataset name='Result 1'>
- <Row><Result_1>true</Result_1></Row>
+ <Row><Result_1>Zero Rows</Result_1></Row>
 </Dataset>
 <Dataset name='Result 2'>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><Result_3>true</Result_3></Row>
+ <Row><Result_3>Constant, 10</Result_3></Row>
 </Dataset>
 <Dataset name='Result 4'>
  <Row><i>0</i></Row>
@@ -19,7 +19,7 @@
  <Row><i>90</i></Row>
 </Dataset>
 <Dataset name='Result 5'>
- <Row><Result_5>true</Result_5></Row>
+ <Row><Result_5>Constant expression, 50</Result_5></Row>
 </Dataset>
 <Dataset name='Result 6'>
  <Row><i>0</i></Row>
@@ -74,7 +74,7 @@
  <Row><i>490</i></Row>
 </Dataset>
 <Dataset name='Result 7'>
- <Row><Result_7>true</Result_7></Row>
+ <Row><Result_7>Variable 5, row constant</Result_7></Row>
 </Dataset>
 <Dataset name='Result 8'>
  <Row><i>10</i></Row>
@@ -84,7 +84,7 @@
  <Row><i>10</i></Row>
 </Dataset>
 <Dataset name='Result 9'>
- <Row><Result_9>true</Result_9></Row>
+ <Row><Result_9>Distributed 10</Result_9></Row>
 </Dataset>
 <Dataset name='Result 10'>
  <Row><i>0</i></Row>

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -107,7 +107,6 @@ private:
     __uint64 startRow;
     __uint64 currentRow;
     __uint64 maxRow;
-    bool empty;
 
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
@@ -135,14 +134,15 @@ public:
             ActPrintLog("InlineSLAVE: numRows = %"I64F"d, nodes = %"I64F
                         "d, nodeid = %"I64F"d, start = %"I64F"d, max = %"I64F"d",
                         numRows, nodes, nodeid, startRow, maxRow);
-            empty = false;
         }
         else
         {
             startRow = 0;
-            maxRow = numRows;
             // when not distributed, only first node compute, unless local
-            empty = isLocal ? false : !firstNode();
+            if (firstNode() || isLocal)
+                maxRow = numRows;
+            else
+                maxRow = 0;
         }
         currentRow = startRow;
     }
@@ -153,7 +153,7 @@ public:
     CATCH_NEXTROW()
     {
         ActivityTimer t(totalCycles, timeActivities, NULL);
-        if (empty || abortSoon)
+        if (abortSoon)
             return NULL;
         while (currentRow < maxRow) {
             RtlDynamicRowBuilder row(queryRowAllocator());

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -124,7 +124,9 @@ public:
         ActivityTimer s(totalCycles, timeActivities, NULL);
         dataLinkStart("InlineTABLE", container.queryId());
         __uint64 numRows = helper->numRows();
-        if (helper->getFlags() & TTFdistributed != 0)
+        // local when generated from a child query (the range is per node, don't split)
+        bool isLocal = container.queryOwnerId() && container.queryOwner().isLocalOnly();
+        if (!isLocal && (helper->getFlags() & TTFdistributed != 0))
         {
             __uint64 nodes = container.queryCodeContext()->getNodes();
             __uint64 nodeid = container.queryCodeContext()->getNodeNum();
@@ -139,7 +141,8 @@ public:
         {
             startRow = 0;
             maxRow = numRows;
-            empty = !firstNode();
+            // when not distributed, only first node compute, unless local
+            empty = isLocal ? false : !firstNode();
         }
         currentRow = startRow;
     }

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -107,6 +107,8 @@ private:
     __uint64 startRow;
     __uint64 currentRow;
     __uint64 maxRow;
+    bool empty;
+
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
@@ -131,11 +133,13 @@ public:
             ActPrintLog("InlineSLAVE: numRows = %"I64F"d, nodes = %"I64F
                         "d, nodeid = %"I64F"d, start = %"I64F"d, max = %"I64F"d",
                         numRows, nodes, nodeid, startRow, maxRow);
+            empty = false;
         }
         else
         {
             startRow = 0;
             maxRow = numRows;
+            empty = !firstNode();
         }
         currentRow = startRow;
     }
@@ -146,7 +150,7 @@ public:
     CATCH_NEXTROW()
     {
         ActivityTimer t(totalCycles, timeActivities, NULL);
-        if (abortSoon)
+        if (empty || abortSoon)
             return NULL;
         while (currentRow < maxRow) {
             RtlDynamicRowBuilder row(queryRowAllocator());

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -90,3 +90,85 @@ CActivityBase *createTempTableSlave(CGraphElementBase *container)
 {
     return new CTempTableSlaveActivity(container);
 }
+
+/*
+ * This class is essentially a temp table, but this could be used for creating massive
+ * test tables and will also be used when optimising NORMALISE(ds, count) to
+ * DATASET(count, transform), so could end up consuming a lot of rows.
+ *
+ * It also uses an extended version of the helper (to get distributed flag), and it was
+ * simple enough to clone. Should be simpler to deprecate the old 32bit temp table
+ * in the future, too.
+ */
+class CInlineTableSlaveActivity : public CSlaveActivity, public CThorDataLink
+{
+private:
+    IHThorInlineTableArg * helper;
+    __uint64 startRow;
+    __uint64 currentRow;
+    __uint64 maxRow;
+public:
+    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+
+    CInlineTableSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container), CThorDataLink(this) { }
+    virtual bool isGrouped() { return false; }
+    void init(MemoryBuffer &data, MemoryBuffer &slaveData)
+    {
+        appendOutputLinked(this);
+        helper = static_cast <IHThorInlineTableArg *> (queryHelper());
+    }
+    void start()
+    {
+        ActivityTimer s(totalCycles, timeActivities, NULL);
+        dataLinkStart("InlineTABLE", container.queryId());
+        __uint64 numRows = helper->numRows();
+        if (helper->getFlags() & TTFdistributed != 0)
+        {
+            __uint64 nodes = container.queryCodeContext()->getNodes();
+            __uint64 nodeid = container.queryCodeContext()->getNodeNum();
+            startRow = (nodeid * numRows) / nodes;
+            maxRow = ((nodeid + 1) * numRows) / nodes;
+            ActPrintLog("InlineSLAVE: numRows = %"I64F"d, nodes = %"I64F
+                        "d, nodeid = %"I64F"d, start = %"I64F"d, max = %"I64F"d",
+                        numRows, nodes, nodeid, startRow, maxRow);
+        }
+        else
+        {
+            startRow = 0;
+            maxRow = numRows;
+        }
+        currentRow = startRow;
+    }
+    void stop()
+    {
+        dataLinkStop();
+    }
+    CATCH_NEXTROW()
+    {
+        ActivityTimer t(totalCycles, timeActivities, NULL);
+        if (abortSoon)
+            return NULL;
+        while (currentRow < maxRow) {
+            RtlDynamicRowBuilder row(queryRowAllocator());
+            size32_t sizeGot = helper->getRow(row, currentRow++);
+            if (sizeGot)
+            {
+                dataLinkIncrement();
+                return row.finalizeRowClear(sizeGot);
+            }
+        }
+        return NULL;
+    }
+    void getMetaInfo(ThorDataLinkMetaInfo &info)
+    {
+        initMetaInfo(info);
+        info.isSource = true;
+        info.unknownRowsOutput = false;
+        info.totalRowsMin = info.totalRowsMax = maxRow - startRow;
+    }
+};
+
+CActivityBase *createInlineTableSlave(CGraphElementBase *container)
+{
+    return new CInlineTableSlaveActivity(container);
+}

--- a/thorlcr/activities/temptable/thtmptableslave.ipp
+++ b/thorlcr/activities/temptable/thtmptableslave.ipp
@@ -30,5 +30,7 @@
 activityslaves_decl CActivityBase *createTempTableSlave(CGraphElementBase *container);
 
 
+activityslaves_decl CActivityBase *createInlineTableSlave(CGraphElementBase *container);
+
 
 #endif

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -998,6 +998,7 @@ bool isGlobalActivity(CGraphElementBase &container)
         case TAKworkunitread:
         case TAKchilddataset:
         case TAKtemptable:
+        case TAKinlinetable:
         case TAKtemprow:
         case TAKnull:
         case TAKemptyaction:

--- a/thorlcr/master/thactivitymaster.cpp
+++ b/thorlcr/master/thactivitymaster.cpp
@@ -123,6 +123,7 @@ public:
             case TAKnormalizelinkedchild:
             case TAKgroup:
             case TAKtemptable:
+            case TAKinlinetable:
             case TAKtemprow:
             case TAKpull:
             case TAKnull:

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -462,6 +462,9 @@ public:
             case TAKtemprow:
                 ret = createTempTableSlave(this);
                 break;
+            case TAKinlinetable:
+                ret = createInlineTableSlave(this);
+                break;
             case TAKkeyeddistribute:
                 ret = createIndexDistributeSlave(this);
                 break;


### PR DESCRIPTION
Adding inline table activity (TAKinlinetable) with
64-bit integers for rows and distributed logic.
Similar implementtions in Roxie and HThor, but
without distributed behaviour. This is now the
default for DATASET(COUNT) construct.

Tested on Thor clusters with up to 9 nodes. Changed
the test to print strings as headers, rather than
boolean separators.
