### PR TITLE
Add useradd/groupadd to esp files cmake file

### DIFF
--- a/esp/files/CMakeLists.txt
+++ b/esp/files/CMakeLists.txt
@@ -50,6 +50,8 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/transformDlg.html
     ${CMAKE_CURRENT_SOURCE_DIR}/esp_app_tree.html
     ${CMAKE_CURRENT_SOURCE_DIR}/esp_app.html
+    ${CMAKE_CURRENT_SOURCE_DIR}/useradd.html
+    ${CMAKE_CURRENT_SOURCE_DIR}/groupadd.html
 )
     Install( FILES ${iFILES} DESTINATION ${OSSDIR}/componentfiles/files COMPONENT Runtime )
 ENDFOREACH ( iFILES )


### PR DESCRIPTION
Add User function still does not work because of missing useradd html. To fix 
the problem, the entries of useradd.html and groupadd.html have to be added
into: /esp/files/CmakeLists.txt.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
