### PR TITLE
Setup clusters per suite

### DIFF
--- a/testing/ecl/Regress/Engine.pm
+++ b/testing/ecl/Regress/Engine.pm
@@ -474,7 +474,6 @@ sub _check_ini_file($)
     my $ini = new Config::Simple(syntax=>'ini');
 
     # Test suites
-    my $clusters = '';
     my $xml_cl = $xml_sw->{Topology}->{Cluster};
     foreach my $name (keys %$xml_cl) {
         # Name and type are always present
@@ -487,6 +486,7 @@ sub _check_ini_file($)
         my %config = (
             'cluster' => $name,
             'type' => $type,
+            'setup_clusters' => $name
         );
         # roxieserver, only in Roxie
         if ($type eq 'roxie') {
@@ -503,8 +503,6 @@ sub _check_ini_file($)
                 }
             }
         }
-        # Append suite to list
-        $clusters .= $name.' ' unless ($type eq 'roxie');
 
         $ini->param(-block=>$name.'_suite', -value=> \%config);
     }
@@ -517,8 +515,7 @@ sub _check_ini_file($)
             'setup_file_location' => $fileloc,
             'os' => $os,
             'parallel_queries' => $parallel,
-            'purge' => $purge,
-            'setup_clusters' => $clusters,
+            'purge' => $purge
     });
 
     $ini->save($ini_file);


### PR DESCRIPTION
If the parameter is global, the regression suite will setup all
clusters for each suite, being not just redundant, but wrong. If
the parameter is per suite, each run will just run what's right
and necessary for each suite, without the need to tweek the
configuration file after setup.
