### PR TITLE
Fix problems with hthor not caching allocators

### DIFF
--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -717,6 +717,8 @@ protected:
     IAgentContext & agent;
     Linked<IOutputMetaData> resultMeta;
     Linked<IOutputMetaData> counterMeta;
+    Owned<IEngineRowAllocator> inputAllocator;
+    Owned<IEngineRowAllocator> counterAllocator;
     unsigned activityId;
 };
 

--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -1812,7 +1812,9 @@ IHThorGraphResults * EclBoundLoopGraph::execute(void * counterRow, ConstPointerA
 {
     Owned<GraphResults> results = new GraphResults(3);
 
-    IHThorGraphResult * inputResult = results->createResult(1, agent.queryCodeContext()->getRowAllocator(resultMeta, activityId));
+    if (!inputAllocator)
+        inputAllocator.setown(agent.queryCodeContext()->getRowAllocator(resultMeta, activityId));
+    IHThorGraphResult * inputResult = results->createResult(1, LINK(inputAllocator));
     ForEachItemIn(i, rows)
         inputResult->addRowOwn(rows.item(i));
     rows.kill();
@@ -1820,7 +1822,9 @@ IHThorGraphResults * EclBoundLoopGraph::execute(void * counterRow, ConstPointerA
     if (counterRow)
     {
         counterMeta.setown(new EclCounterMeta);
-        IHThorGraphResult * counterResult = results->createResult(2, agent.queryCodeContext()->getRowAllocator(counterMeta, activityId));
+        if (!counterAllocator)
+            counterAllocator.setown(agent.queryCodeContext()->getRowAllocator(counterMeta, activityId));
+        IHThorGraphResult * counterResult = results->createResult(2, LINK(counterAllocator));
         counterResult->addRowOwn(counterRow);
     }
 
@@ -1835,7 +1839,9 @@ void EclBoundLoopGraph::execute(void * counterRow, IHThorGraphResults * graphLoo
     if (counterRow)
     {
         counterMeta.setown(new EclCounterMeta);
-        IHThorGraphResult * counterResult = results->createResult(0, agent.queryCodeContext()->getRowAllocator(counterMeta, activityId));
+        if (!counterAllocator)
+            counterAllocator.setown(agent.queryCodeContext()->getRowAllocator(counterMeta, activityId));
+        IHThorGraphResult * counterResult = results->createResult(0, LINK(counterAllocator));
         counterResult->addRowOwn(counterRow);
     }
 

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8742,7 +8742,7 @@ CHThorLocalResultWriteActivity::CHThorLocalResultWriteActivity(IAgentContext &_a
 
 void CHThorLocalResultWriteActivity::execute()
 {
-    IHThorGraphResult * result = graph->createResult(helper.querySequence(), agent.queryCodeContext()->getRowAllocator(input->queryOutputMeta(), activityId));
+    IHThorGraphResult * result = graph->createResult(helper.querySequence(), LINK(rowAllocator));
     loop
     {
         const void *nextrec = input->nextInGroup();
@@ -8771,7 +8771,7 @@ CHThorLocalResultSpillActivity::CHThorLocalResultSpillActivity(IAgentContext &_a
 void CHThorLocalResultSpillActivity::ready()
 {
     CHThorSimpleActivityBase::ready(); 
-    result = graph->createResult(helper.querySequence(), agent.queryCodeContext()->getRowAllocator(outputMeta.queryOriginal(), activityId));
+    result = graph->createResult(helper.querySequence(), LINK(rowAllocator));
     nullPending = false;
 }
 
@@ -9023,7 +9023,7 @@ CHThorGraphLoopResultWriteActivity::CHThorGraphLoopResultWriteActivity(IAgentCon
 
 void CHThorGraphLoopResultWriteActivity::execute()
 {
-    IHThorGraphResult * result = graph->createGraphLoopResult(agent.queryCodeContext()->getRowAllocator(input->queryOutputMeta(), activityId));
+    IHThorGraphResult * result = graph->createGraphLoopResult(LINK(rowAllocator));
     loop
     {
         const void *nextrec = input->nextInGroup();

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -2444,6 +2444,7 @@ public:
 
     CHThorLocalResultWriteActivity (IAgentContext &agent, unsigned _activityId, unsigned _subgraphId, IHThorLocalResultWriteArg &_arg, ThorActivityKind _kind, __int64 graphId);
     virtual void execute();
+    virtual bool needsAllocator() const { return true; }
 };
 
 
@@ -2568,6 +2569,7 @@ public:
 
     CHThorGraphLoopResultWriteActivity (IAgentContext &agent, unsigned _activityId, unsigned _subgraphId, IHThorGraphLoopResultWriteArg &_arg, ThorActivityKind _kind, __int64 graphId);
     virtual void execute();
+    virtual bool needsAllocator() const { return true; }
 };
 
 


### PR DESCRIPTION
Various pieces of code involved in loops were recreating an allocator
each time which lead to vast numbers of allocators being created.
With the new heap code it resulted in an O(n^2) clean up operation.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
