### PR TITLE
Replacing TAKtemptable for TAKinlinetable

### DIFF
--- a/ecl/hql/hql.hpp
+++ b/ecl/hql/hql.hpp
@@ -50,7 +50,7 @@ Relevant changes include
 
 #define LANGUAGE_VERSION_MAJOR      3
 #define LANGUAGE_VERSION_MINOR      6
-#define LANGUAGE_VERSION_SUB        0
+#define LANGUAGE_VERSION_SUB        1
 
 #define LANGUAGE_VERSION   estringify(LANGUAGE_VERSION_MAJOR) "." estringify(LANGUAGE_VERSION_MINOR) "." estringify(LANGUAGE_VERSION_SUB)
 

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -5832,6 +5832,11 @@ void CHThorRemoteResultActivity::execute()
 
 //=====================================================================================================
 
+/*
+ * Deprecated in 3.8, this class is being kept for backward compatibility,
+ * since now the code generator is using InlineTables (below) for all
+ * temporary tables and rows.
+ */
 CHThorTempTableActivity::CHThorTempTableActivity(IAgentContext &_agent, unsigned _activityId, unsigned _subgraphId, IHThorTempTableArg &_arg, ThorActivityKind _kind) :
                  CHThorSimpleActivityBase(_agent, _activityId, _subgraphId, _arg, _kind), helper(_arg)
 {

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -5216,6 +5216,11 @@ IRoxieServerActivityFactory *createRoxieServerDatasetResultActivityFactory(unsig
 
 //=================================================================================
 
+/*
+ * Deprecated in 3.8, this class is being kept for backward compatibility,
+ * since now the code generator is using InlineTables (below) for all
+ * temporary tables and rows.
+ */
 class CRoxieServerTempTableActivity : public CRoxieServerActivity
 {
     IHThorTempTableArg &helper;
@@ -5287,14 +5292,6 @@ IRoxieServerActivityFactory *createRoxieServerTempTableActivityFactory(unsigned 
 
 //=================================================================================
 
-/*
- * This class differ from TempTable (above) by having 64-bit number of rows
- * and, in Thor, it's able to run distributed in the cluster. We, therefore,
- * need to keep consistency and implement it here, too.
- *
- * Some optimisations [ex. NORMALIZE(ds) -> DATASET(COUNT)] will make use of
- * this class, so you can't use TempTables.
- */
 class CRoxieServerInlineTableActivity : public CRoxieServerActivity
 {
     IHThorInlineTableArg &helper;

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -31,7 +31,7 @@ It should only contain pure interface definitions or inline functions.
 
 //Should be incremented whenever the virtuals in the context or a helper are changed, so
 //that a work unit can't be rerun.  Try as hard as possible to retain compatibility.
-#define ACTIVITY_INTERFACE_VERSION      138
+#define ACTIVITY_INTERFACE_VERSION      139
 #define MIN_ACTIVITY_INTERFACE_VERSION  138             //minimum value that is compatible with current interface - without using selectInterface
 
 typedef unsigned char byte;

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -1408,26 +1408,26 @@ struct IHThorHashAggregateArg : public IHThorAggregateArg, public IHThorHashAggr
     COMMON_NEWTHOR_FUNCTIONS
 };
 
+/*
+ * This class has been deprecated in 3.8 in favour of IHThorInlineTableArg.
+ * CThorTempRowArg also now derives from IHThorInlineTableArg.
+ *
+ * As of 3.8, only old code will implement this interface.
+ */
 struct IHThorTempTableArg : public IHThorArg
 {
     virtual size32_t getRow(ARowBuilder & rowBuilder, unsigned row) = 0;
     virtual unsigned numRows() = 0;
-    virtual bool isConstant()                           { return true; }    // deprecate in favour of getFlags
-    virtual size32_t getRowSingle(ARowBuilder & rowBuilder) = 0;            // only valid for TAKtemprow, could be called directly
+    virtual bool isConstant()                           { return true; }    // deprecated in favour of getFlags
+    virtual size32_t getRowSingle(ARowBuilder & rowBuilder) = 0;            // deprecated, TempRow derives from InlineTable
 };
 
-/*
- * New Temp table that allows flags to be set and retrieved on one
- * single method. Future-proof and should merge with the interface
- * above in the next major release.
- */
 struct IHThorInlineTableArg : public IHThorArg
 {
     virtual size32_t getRow(ARowBuilder & rowBuilder, __uint64 row) = 0;
     virtual __uint64 numRows() = 0;
     virtual unsigned getFlags() = 0;
 };
-
 
 struct IHThorSampleArg : public IHThorArg
 {

--- a/rtl/include/eclhelper_base.hpp
+++ b/rtl/include/eclhelper_base.hpp
@@ -1343,10 +1343,9 @@ public:
     virtual unsigned getFlags()                         { return 0; }
 };
 
-class CThorTempRowArg : public CThorTempTableArg
+class CThorTempRowArg : public CThorInlineTableArg
 {
-    virtual size32_t getRow(ARowBuilder & rowBuilder, unsigned row) { if (row) return 0; return getRowSingle(rowBuilder); }
-    virtual unsigned numRows()                          { return 1; }
+    virtual __uint64 numRows()                          { return 1; }
 };
 
 class CThorSampleArg : public CThorArg, implements IHThorSampleArg

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -23,6 +23,11 @@
 #include "thorport.hpp"
 #include "thactivityutil.ipp"
 
+/*
+ * Deprecated in 3.8, this class is being kept for backward compatibility,
+ * since now the code generator is using InlineTables (below) for all
+ * temporary tables and rows.
+ */
 class CTempTableSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
 private:


### PR DESCRIPTION
Code generation now creating inline tables (rather than
temp tables), including temp rows, since numRows() is
being used by the engine to limit size.

Added some deprecated comments, so we can easily find
and remove all deprecated code in the next major release.
