### PR TITLE
ISSUE:#1714 Restrict special chars from comp names

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -892,6 +892,13 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
     return true;
 }//onNavMenuEvent
 
+bool CWsDeployFileInfo::isAlphaNumeric(const char *pstr) const
+{
+  RegExpr expr("[A-Za-z0-9-_]+");
+
+  return (expr.find(pstr) && expr.findlen(0) == strlen(pstr));
+}
+
 bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest &req, IEspSaveSettingResponse &resp)
 {
   synchronized block(m_mutex);
@@ -1242,7 +1249,14 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
 
         //perform checks
         if (!strcmp(pszAttrName, "name"))
+        {
           ensureUniqueName(pEnvRoot, pComp, pszNewValue);
+
+          if (isAlphaNumeric(pszNewValue) == false)
+          {
+            throw MakeStringException(-1, "Invalid Character in name '%s'.", pszNewValue);
+          }
+        }
 
         //Store prev settings for use further down for esp service bindings
         const char* sPrevDefaultPort = NULL;

--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -259,6 +259,7 @@ public:
     virtual bool navMenuEvent(IEspContext &context, IEspNavMenuEventRequest &req, 
                                             IEspNavMenuEventResponse &resp);
     virtual bool displaySettings(IEspContext &context, IEspDisplaySettingsRequest &req, IEspDisplaySettingsResponse &resp);
+    virtual bool isAlphaNumeric(const char *pstr) const;
     virtual bool saveSetting(IEspContext &context, IEspSaveSettingRequest &req, IEspSaveSettingResponse &resp);
     virtual bool getBuildSetInfo(IEspContext &context, IEspGetBuildSetInfoRequest &req, IEspGetBuildSetInfoResponse &resp);
     virtual bool getDeployableComps(IEspContext &context, IEspGetDeployableCompsRequest &req, IEspGetDeployableCompsResponse &resp);

--- a/initfiles/componentfiles/configxml/validateAll.xsl
+++ b/initfiles/componentfiles/configxml/validateAll.xsl
@@ -29,6 +29,7 @@ xmlns:seisint="http://seisint.com" exclude-result-prefixes="seisint">
     <xsl:apply-templates select="Hardware/Computer"/>
     <xsl:apply-templates select="Software/ThorCluster"/>
     <xsl:apply-templates select="Software/Topology"/>
+    <xsl:apply-templates select="Software"/>
   </xsl:template>
 
   <xsl:template match="Environment/Software/*">
@@ -41,6 +42,12 @@ xmlns:seisint="http://seisint.com" exclude-result-prefixes="seisint">
         </xsl:call-template>        
       </xsl:if> 
     </xsl:for-each>
+    <xsl:variable select="@name" name="elem1"/>
+        <xsl:if test="(translate($elem1,'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_',''))" >
+      <xsl:call-template name="validationMessage">
+        <xsl:with-param name="msg" select=" concat('Invalid character[@name=' ,$elem1, ']') "/>
+      </xsl:call-template>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="Computer">


### PR DESCRIPTION
configgen will indicate and error when encountering
special characters in component names.

configmgr will pop-up an error when users attempt
to enter special characters in component name fields

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
