### PR TITLE
Gh1993 Eclwatch crash, searching workunits by Ecl text

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1623,6 +1623,15 @@ void doWUQueryByXPath(IEspContext &context, IEspWUQueryRequest & req, IEspWUQuer
     if (!count)
         count=100;
 
+    if (wlist.getSize() < 1)
+    {
+        resp.setNumWUs(0);
+        return;
+    }
+
+    if (wlist.getSize() < count)
+        count = (int) wlist.getSize() - 1;
+
     WsWuSearch::iterator begin, end;
 
     if(notEmpty(req.getAfter()))
@@ -1657,11 +1666,10 @@ void doWUQueryByXPath(IEspContext &context, IEspWUQueryRequest & req, IEspWUQuer
     for(;begin!=end;begin++)
     {
         Owned<IEspECLWorkunit> info = createECLWorkunit("","");
-        WsWuInfo winfo(context, req.getWuid());
+        WsWuInfo winfo(context, begin->c_str());
         winfo.getCommon(*info, 0);
-        results.append(*info);
+        results.append(*info.getClear());
     }
-
     resp.setPageSize(abs(count));
     resp.setWorkunits(results);
 


### PR DESCRIPTION
Multiple problems are fixed here: when no WU matches
the search, the calculation based on page size causes
the crash; if number of matching WUs is less than page
size, the calculation based on page size also causes a
crash; we should use the WU id of matching WUs to get
WU information; Owned IEspECLWorkunit without
getClear() also causes a crash.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
