### PR TITLE
gh-1995 Encrypt attributes of view type password

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -2265,6 +2265,7 @@ function promptVerifyPwd(category, params, attrName, oldValue, newValue, recordI
       var xmlArgs = "<XmlArgs><Setting category=\"" + category;
       xmlArgs += "\" params=\"" + params;
       xmlArgs += "\" attrName=\"" + attrName;
+      xmlArgs += "\" viewType=\"password";
       xmlArgs += "\" rowIndex=\"" + recordIndex;
       xmlArgs += "\" oldValue=\"" + escape(oldValue);
       xmlArgs += "\" newValue=\"" + escape(pwd) + "\"/></XmlArgs>";

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -929,6 +929,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
       const char* pszOldValue = pSetting->queryProp("@oldValue");
       const char* pszNewValue = pSetting->queryProp("@newValue");
       const char* pszOnChange = pSetting->queryProp("@onChange");
+      const char* pszViewType = pSetting->queryProp("@viewType");
 
       StringBuffer xpath;
       xpath.clear().appendf("%s[@name='%s']", pszCompType, pszCompName);
@@ -1293,8 +1294,7 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
         {
           xpath.clear().appendf("@%s", pszAttrName);
 
-          String strAttrName(pszAttrName);
-          if (strAttrName.toLowerCase()->endsWith("password"))
+          if (pszViewType && *pszViewType && !strcmp(pszViewType, "password"))
           {
             encrypt(encryptedText, pszNewValue);
             pszNewValue = encryptedText.str();


### PR DESCRIPTION
When encrypting attributes that were of the view type password, ConfigMgr was relying on attribute name rather than the view type. Hence some attributes like esp's passphrase were not encrypted causing issues at runtime. Fixed this by encrypting attribute values based on view type rather than attribute name.

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
