### PR TITLE
Remove debug code from index.xslt

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -532,7 +532,7 @@
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <h3>
-                                            Existing Activity on Servers:<xsl:value-of select="SortBy"/>
+                                            Existing Activity on Servers:
                                         </h3>
                                     </xsl:otherwise>
                                 </xsl:choose>


### PR DESCRIPTION
The debug code was not cleaned and should be removed.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
