### PR TITLE
Overflow partition bug

### DIFF
--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -1234,20 +1234,24 @@ public:
 #ifdef USE_SAMPLE_PARTITIONING
         bool usesampling = true;        
 #endif
+        bool useAux = false; // JCSMORE using existing partioning and auxillary rowIf (only used if overflow)
         loop {
             OwnedMalloc<rowmap_t> splitMap, splitMapUpper;
             CTimer timer;
             if (numnodes>1) {
                 timer.start();
                 if (cosortfilenames) {
+                    useAux = true;
                     CalcExtPartition();
                     canoptimizenullcolumns = false;
                 }
                 if (usepartitionrow) {
+                    useAux = true;
                     CalcPreviousPartition();
                     canoptimizenullcolumns = false;
                 }
                 if (partitioninfo->IsOK()) {
+                    useAux = true;
                     splitMap.setown(UsePartitionInfo(*partitioninfo, betweensort));
                     if (betweensort) {
                         splitMapUpper.setown(UsePartitionInfo(*partitioninfo, false));
@@ -1329,7 +1333,7 @@ public:
                     for (i=0;i<numnodes;i++) {
                         CSortNode &slave = slaves.item(i);
                         if (slave.overflow) 
-                            slave.OverflowAdjustMapStart(numnodes,splitMap+i*numnodes,mbsk.length(),(const byte *)mbsk.bufferBase(),CMPFN_COLLATE);
+                            slave.OverflowAdjustMapStart(numnodes,splitMap+i*numnodes,mbsk.length(),(const byte *)mbsk.bufferBase(),CMPFN_COLLATE,useAux);
                     }
                     for (i=0;i<numnodes;i++) {
                         CSortNode &slave = slaves.item(i);
@@ -1340,7 +1344,7 @@ public:
                         for (i=0;i<numnodes;i++) {
                             CSortNode &slave = slaves.item(i);
                             if (slave.overflow) 
-                                slave.OverflowAdjustMapStart(numnodes,splitMapUpper+i*numnodes,mbsk.length(),(const byte *)mbsk.bufferBase(),CMPFN_UPPER);
+                                slave.OverflowAdjustMapStart(numnodes,splitMapUpper+i*numnodes,mbsk.length(),(const byte *)mbsk.bufferBase(),CMPFN_UPPER,useAux);
                         }
                         for (i=0;i<numnodes;i++) {
                             CSortNode &slave = slaves.item(i);

--- a/thorlcr/msort/tsortmp.cpp
+++ b/thorlcr/msort/tsortmp.cpp
@@ -207,12 +207,12 @@ void SortSlaveMP::MultiBinChopStop(unsigned num,rowmap_t *pos)
     mb.read(num*sizeof(rowmap_t),pos);
 }
 
-void SortSlaveMP::OverflowAdjustMapStart( unsigned mapsize,rowmap_t *map,size32_t keybuffsize,const byte *keybuff, byte cmpfn) /* async */
+void SortSlaveMP::OverflowAdjustMapStart( unsigned mapsize,rowmap_t *map,size32_t keybuffsize,const byte *keybuff, byte cmpfn,bool useaux) /* async */
 {
     CMessageBuffer mb;
     mb.append((byte)FN_OverflowAdjustMapStart);
     mb.append(mapsize).append(mapsize*sizeof(rowmap_t),map);
-    serializeblk(mb,keybuffsize,keybuff).append(cmpfn);
+    serializeblk(mb,keybuffsize,keybuff).append(cmpfn).append(useaux);
     sendRecv(mb);
 
 }
@@ -477,7 +477,9 @@ bool SortSlaveMP::marshall(ISortSlaveMP &slave, ICommunicator* comm, mptag_t tag
                 deserializeblk(mb,keybuffsize,keybuff);
                 byte cmpfn;
                 mb.read(cmpfn);
-                slave.OverflowAdjustMapStart(mapsize,(rowmap_t *)map,keybuffsize,(const byte *)keybuff,cmpfn);
+                bool useaux;
+                mb.read(useaux);
+                slave.OverflowAdjustMapStart(mapsize,(rowmap_t *)map,keybuffsize,(const byte *)keybuff,cmpfn,useaux);
                 free(keybuff);
             }
             break;

--- a/thorlcr/msort/tsortmp.hpp
+++ b/thorlcr/msort/tsortmp.hpp
@@ -25,7 +25,7 @@ interface ISortSlaveMP
     virtual void MultiBinChop(size32_t keybuffsize,const byte *keybuff, unsigned num,rowmap_t *pos,byte cmpfn,bool useaux)=0;
     virtual void MultiBinChopStart(size32_t keybuffsize,const byte *keybuff, byte cmpfn)=0; /* async */
     virtual void MultiBinChopStop(unsigned num,rowmap_t *pos)=0;
-    virtual void OverflowAdjustMapStart( unsigned mapsize,rowmap_t *map,size32_t keybuffsize,const byte *keybuff, byte cmpfn)=0; /* async */
+    virtual void OverflowAdjustMapStart( unsigned mapsize,rowmap_t *map,size32_t keybuffsize,const byte *keybuff, byte cmpfn, bool useaux)=0; /* async */
     virtual rowmap_t OverflowAdjustMapStop( unsigned mapsize, rowmap_t *map)=0;
     virtual void MultiMerge(unsigned mapsize,rowmap_t *map,unsigned num,SocketEndpoint* endpoints)=0; /* async */
     virtual void MultiMergeBetween(unsigned mapsize,rowmap_t *map,rowmap_t *mapupper,unsigned num,SocketEndpoint* endpoints)=0; /* async */
@@ -62,7 +62,7 @@ public:
     void MultiBinChop(size32_t keybuffsize,const byte *keybuff, unsigned num,rowmap_t *pos,byte cmpfn,bool useaux);
     void MultiBinChopStart(size32_t keybuffsize,const byte *keybuff, byte cmpfn); /* async */
     void MultiBinChopStop(unsigned num,rowmap_t *pos);
-    void OverflowAdjustMapStart( unsigned mapsize,rowmap_t *map,size32_t keybuffsize,const byte *keybuff, byte cmpfn); /* async */
+    void OverflowAdjustMapStart( unsigned mapsize,rowmap_t *map,size32_t keybuffsize,const byte *keybuff, byte cmpfn,bool useaux); /* async */
     rowmap_t OverflowAdjustMapStop( unsigned mapsize, rowmap_t *map);
     void MultiMerge(unsigned mapsize,rowmap_t *map,unsigned num,SocketEndpoint* endpoints); /* async */
     void MultiMergeBetween(unsigned mapsize,rowmap_t *map,rowmap_t *mapupper,unsigned num,SocketEndpoint* endpoints); /* async */

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -623,7 +623,7 @@ public:
 
 
     void OverflowAdjustMapStart(unsigned mapsize, rowmap_t * map,
-                               size32_t keybufsize, const byte * keybuf, byte cmpfn)
+                               size32_t keybufsize, const byte * keybuf, byte cmpfn, bool useaux)
     {
         assertex(overflowfile);
         overflowmap = (rowmap_t *)malloc(mapsize*sizeof(rowmap_t));
@@ -636,7 +636,7 @@ public:
         for (i=0;i<mapsize;i++)
             ActPrintLog(activity, "%"RMF"d ",overflowmap[i]);
 #endif
-        VarElemArray keys(rowif,NULL);
+        VarElemArray keys(useaux?auxrowif:rowif,NULL);
         keys.deserialize(keybuf,keybufsize,false);
         for (i=0;i<mapsize-1;i++)
             AdjustOverflow(overflowmap[i],keys.item(i),cmpfn);


### PR DESCRIPTION
When the RHS of a join overflows, the partitioning code would crash, unless
the RHS had the same meta as the LHS.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
