### PR TITLE
datastream should be build and packaged independent from the platform

### DIFF
--- a/plugins/datastream/CMakeLists.txt
+++ b/plugins/datastream/CMakeLists.txt
@@ -1,2 +1,147 @@
-project (datastream)
+project (hpccsystems-datastream)
+cmake_minimum_required (VERSION 2.6)
+
+set ( HPCC_DATASTREAM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set ( HPCC_SOURCE_DIR ${HPCC_DATASTREAM_SOURCE_DIR}/../../)
+
+set ( CMAKE_MODULE_PATH "${HPCC_SOURCE_DIR}/cmake_modules")
+set ( EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin" )
+set ( PRODUCT_PREFIX "hpccsystems" )
+
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib")
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+#include(${HPCC_SOURCE_DIR}/cmake_modules/optionDefaults.cmake)
+
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
+    set ( CMAKE_BUILD_TYPE "Release" )
+elseif (NOT "${CMAKE_BUILD_TYPE}" MATCHES "Debug|Release")
+    message (FATAL_ERROR "Unknown build type $ENV{CMAKE_BUILD_TYPE}")
+endif ()
+message ("-- Making ${CMAKE_BUILD_TYPE} system")
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+   set ( ARCH64BIT 1 )
+else ()
+   set ( ARCH64BIT 0 )
+endif ()
+message ("-- 64bit architecture is ${ARCH64BIT}")
+
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG -DDEBUG")
+
+###
+## Version Information keep in synch with top level hpcc versioning
+###
+set ( HPCC_PROJECT "community" )
+set ( HPCC_MAJOR 3 )
+set ( HPCC_MINOR 6 )
+set ( HPCC_POINT 2 )
+set ( HPCC_MATURITY "rc" )
+set ( HPCC_SEQUENCE 3 )
+###
+
+include(${HPCC_SOURCE_DIR}/cmake_modules/optionDefaults.cmake)
+include(${HPCC_SOURCE_DIR}/cmake_modules/commonSetup.cmake)
+
+set ( CPACK_PACKAGE_CONTACT "HPCCSystems <ossdevelopment@lexisnexis.com>" )
+set ( CPACK_SOURCE_GENERATOR TGZ )
+set ( CPACK_RPM_PACKAGE_VERSION "${projname}" )
+
+if ( ${ARCH64BIT} EQUAL 1 )
+    set ( CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
+else( ${ARCH64BIT} EQUAL 1 )
+    set ( CPACK_RPM_PACKAGE_ARCHITECTURE "i386")
+endif ( ${ARCH64BIT} EQUAL 1 )
+
+set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CPACK_RPM_PACKAGE_ARCHITECTURE}")
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    set(CPACK_STRIP_FILES TRUE)
+endif()
+
+set ( CPACK_INSTALL_CMAKE_PROJECTS "${CMAKE_CURRENT_BINARY_DIR};hdfsstream;ALL;/")
+
+if ( CMAKE_SYSTEM MATCHES Linux )
+    EXECUTE_PROCESS (
+                COMMAND ${HPCC_SOURCE_DIR}/cmake_modules/distrocheck.sh
+                    OUTPUT_VARIABLE packageManagement
+                        ERROR_VARIABLE  packageManagement
+                )
+    EXECUTE_PROCESS (
+                COMMAND ${HPCC_SOURCE_DIR}/cmake_modules/getpackagerevisionarch.sh
+                    OUTPUT_VARIABLE packageRevisionArch
+                        ERROR_VARIABLE  packageRevisionArch
+                )
+    EXECUTE_PROCESS (
+                COMMAND ${HPCC_SOURCE_DIR}/cmake_modules/getpackagerevisionarch.sh --noarch
+                    OUTPUT_VARIABLE packageRevision
+                        ERROR_VARIABLE  packageRevision
+                )
+
+    message ( "-- Auto Detecting Packaging type")
+    message ( "-- distro uses ${packageManagement}, revision is ${packageRevisionArch}" )
+
+if ( ${packageManagement} STREQUAL "DEB" )
+        set(CPACK_PACKAGE_FILE_NAME     "${CMAKE_PROJECT_NAME}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}${packageRevisionArch}")
+    elseif ( ${packageManagement} STREQUAL "RPM" )
+        set(CPACK_PACKAGE_FILE_NAME     "${CMAKE_PROJECT_NAME}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}.${packageRevisionArch}")
+        else()
+        set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}${CPACK_SYSTEM_NAME}")
+    endif ()
+endif ( CMAKE_SYSTEM MATCHES Linux )
+
+MESSAGE ("-- Current release version is ${CPACK_PACKAGE_FILE_NAME}")
+
+set( CPACK_SOURCE_GENERATOR TGZ )
+
+###
+## CPack commands in this section require cpack 2.8.1 to function.
+## When using cpack 2.8.1, the command "make package" will create
+## an RPM.
+###
+
+if (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.1")
+    if ( CMAKE_SYSTEM MATCHES Linux )
+        if ( ${packageManagement} STREQUAL "DEB" )
+            if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.2")
+                message("WARNING: CMAKE 2.8.2  would not build DEB package")
+            else ()
+                set ( CPACK_GENERATOR "${packageManagement}" )
+                message("-- Will build DEB package")
+                ###
+                ## CPack instruction required for Debian
+                ###
+                message ("-- Packing BASH installation files")
+                set ( CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/initfiles/bash/sbin/deb/postinst;${CMAKE_CURRENT_BINARY_DIR}/initfiles/sbin/prerm;${CMAKE_CURRENT_BINARY_DIR}/initfiles/bash/sbin/deb/postrm" )
+            endif ()
+
+        elseif ( ${packageManagement} STREQUAL "RPM" )
+            set ( CPACK_GENERATOR "${packageManagement}" )
+            ###
+            ## CPack instruction required for RPM
+            ###
+            message("-- Will build RPM package")
+            message ("-- Packing BASH installation files")
+            set ( CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/initfiles/bash/sbin/deb/postinst" )
+
+            set ( CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/initfiles/sbin/prerm" )
+            set ( CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/initfiles/bash/sbin/deb/postrm" )
+                else()
+            message("WARNING: Unsupported package ${packageManagement}.")
+        endif ()
+
+    endif ( CMAKE_SYSTEM MATCHES Linux )
+    if ( EXISTS ${HPCC_SOURCE_DIR}/cmake_modules/dependencies/${packageRevision}.cmake )
+        include( ${HPCC_SOURCE_DIR}/cmake_modules/dependencies/${packageRevision}.cmake )
+    else()
+        message("-- WARNING: DEPENDENCY FILE FOR ${packageRevision} NOT FOUND, Using deps template.")
+        include( ${HPCC_SOURCE_DIR}/cmake_modules/dependencies/template.cmake )
+    endif()
+else()
+    message("WARNING: CMAKE 2.8.1 or later required to create RPMs from this project")
+endif()
+
 add_subdirectory (hdfsstream)
+
+INCLUDE(CPack)

--- a/plugins/datastream/hdfsstream/CMakeLists.txt
+++ b/plugins/datastream/hdfsstream/CMakeLists.txt
@@ -2,6 +2,7 @@ project(hdfsstream)
 
 option(USE_HDFSSTREAM "Configure use of hdstream plugin" OFF)
 if ( USE_HDFSSTREAM )
+add_subdirectory (ecl)
 	option(HADOOP_PATH "Set the Hadoop path.")
 	if( NOT HADOOP_PATH )
 		set(HADOOP_PATH "/usr/local/hadoop")
@@ -28,10 +29,11 @@ if ( USE_HDFSSTREAM )
 
 	add_executable( hdfsstream ${SRC} )
 
-#	Install ( TARGETS hdfsstream DESTINATION ${DIR_NAME}/bin COMPONENT Runtime)
-#	Install ( PROGRAMS hdfspipe DESTINATION ${DIR_NAME}/bin COMPONENT Runtime )
-#	Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/hdfsstreamconfig DESTINATION ${CONFIG_DIR}/rpmnew COMPONENT Runtime )
-#	Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/hdfsstreamconfig DESTINATION ${DIR_NAME}/bin COMPONENT Runtime )
+	set ( INSTALLDIR "${OSSDIR}/bin")
+	Install ( TARGETS hdfsstream DESTINATION ${INSTALLDIR} COMPONENT Runtime)
+	Install ( PROGRAMS hdfspipe DESTINATION ${INSTALLDIR} COMPONENT Runtime )
+	Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/hdfsstreamconfig DESTINATION ${INSTALLDIR} COMPONENT Runtime )
+
 	target_link_libraries ( hdfsstream
 					${JAVA_JVM_LIBRARY}
 					${LIBHDFS_LIBRARIES})

--- a/plugins/datastream/hdfsstream/ecl/CMakeLists.txt
+++ b/plugins/datastream/hdfsstream/ecl/CMakeLists.txt
@@ -1,0 +1,1 @@
+Install ( FILES HDFSPipe.ecl DESTINATION "${OSSDIR}/share/My Files/DataStream" COMPONENT Runtime )

--- a/plugins/datastream/hdfsstream/hdfspipe
+++ b/plugins/datastream/hdfsstream/hdfspipe
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source hadoopConfig
+source hdfsstreamconfig 
 
 CLASSPATH=$CLASSPATH:$HADOOP_LOCATION/conf
 
@@ -13,16 +13,32 @@ for f in $HADOOP_LOCATION/lib/*.jar ; do
 done
 
 export CLASSPATH=$CLASSPATH
+
 PID=$$
 
-LOG=/tmp/HPCC-HadoopStream.log.$PID
+idfound=0;
+nodeid=0;
 
-echo "Script starting"  		>> $LOG
-echo "Running as user: $USER" 	>> $LOG
-echo "Running mode: $run_mode" 	>> $LOG
-echo "Incoming params: ${@}" 	>> $LOG
+for p in $*;
+ do
+#   echo "[$p]" >> $LOG;
+   if [ "$idfound" = "1" ];
+   then
+        nodeid=$p;
+        idfound=0;
+   elif [ "$p" = "-nodeid" ];
+   then
+	idfound=1;
+   fi
+done;
 
-HPCCTMPFILE=/tmp/HPCCTMPFILE;
+LOG=/tmp/HPCC-HadoopStream.log.$nodeid.$PID
+
+echo "Script starting"		>> $LOG
+echo "Running as user: $USER"   >> $LOG
+echo "Running mode: $run_mode"  >> $LOG
+echo "Incoming params: ${@}"    >> $LOG
+echo "nodeid: $nodeid" 		>> $LOG
 
 if [ "$1" = "" ];
 then
@@ -36,6 +52,8 @@ then
 	/opt/HPCCSystems/bin/hdfsstream  "${@}" 2>> $LOG;
 elif [ $1 = "-so" ];
 then
+
+	HPCCTMPFILE=/tmp/HPCCTMPFILE_$nodeid;
 	if [ -f $HPCCTMPFILE ]
 	then
 		rm "$HPCCTMPFILE" 			2>> $LOG
@@ -51,12 +69,12 @@ then
 
 	echo "calling hdfsstream..." 		>> $LOG
 
-	/opt/HPCCSystems/bin/hdfsstream "${@}" 	2>> $LOG
+	/opt/HPCCSystems/bin/hdfsstream "${@}" -pipepath $HPCCTMPFILE  	2>> $LOG
 
 	echo "write exited with: $?" 			>> $LOG
 elif [ $1 = "-sop" ];
 then
-	pipepath=/tmp/HPCCPIPE;
+	pipepath=/tmp/HPCCPIPE_$nodeid;
 	mkfifo $pipepath 2> /tmp/HPCC-FIFO.err.$PID;
 	chmod 666 $pipepath 2> /tmp/HPCC-FIFO.err.$PID;
 
@@ -68,7 +86,7 @@ then
 	else
 		echo "  WARNING (hdfsstream mkfifo) error registered in file: /tmp/HPCC-FIFO.err.$PID " >> $LOG
 	fi
-	/opt/HPCCSystems/bin/hdfsstream  "${@}" 	2>> $LOG &
+	/opt/HPCCSystems/bin/hdfsstream  "${@}" -pipepath $pipepath	2>> $LOG &
 	echo "redirecting stdin to named pipe ... " 	>> $LOG
 	cat < /dev/stdin > "$pipepath"			2>> $LOG
 


### PR DESCRIPTION
The CMAKE process does not currently allow buiding multiple packages,
until that feature is introduced to cmake, datastream will have its own
cmake process which generates an install package following the same
naming and versioning standards as the platform.
This forces a seperate set of version cmake vars which have to be kept
in synch with the toplevel vars.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
