### PR TITLE
gh-1997 Fix usability issues for User Permission view

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_accountpermissions.xslt
+++ b/esp/eclwatch/ws_XSLT/access_accountpermissions.xslt
@@ -212,17 +212,13 @@
     <body class="yui-skin-sam" onload="nof5();onLoad()">
             <h3>Permissions of <xsl:value-of select="AccountName"/></h3>
             <p/>
-            <xsl:choose>
-                <xsl:when test="not(Permissions/Permission[1])">
-                </xsl:when>
-                <xsl:otherwise>
-                    <!--xsl:apply-templates select="Permissions"/-->
-                    <xsl:apply-templates select="Permissions">
-                        <xsl:with-param name="AccountN" select="AccountName"/>
-                        <xsl:with-param name="AccountT" select="IsGroup"/>
-                    </xsl:apply-templates>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:if test="Permissions/Permission[1]">
+                <!--xsl:apply-templates select="Permissions"/-->
+                <xsl:apply-templates select="Permissions">
+                    <xsl:with-param name="AccountN" select="AccountName"/>
+                    <xsl:with-param name="AccountT" select="IsGroup"/>
+                </xsl:apply-templates>
+            </xsl:if>
             <xsl:if test="count(BasednNames/Item)">
                 <form method="POST" action="/ws_access/PermissionAddInput">
                     <input type="hidden" name="AccountName" value="{AccountName}"/>
@@ -235,13 +231,9 @@
                 </form>
             </xsl:if>
             <p/>
-            <xsl:choose>
-                <xsl:when test="not(GroupPermissions/GroupPermission[1])">
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:apply-templates select="GroupPermissions"/>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:if test="GroupPermissions/GroupPermission[1]">
+                <xsl:apply-templates select="GroupPermissions"/>
+            </xsl:if>
         </body>
         </html>
     </xsl:template>
@@ -267,17 +259,13 @@
             </a>
         </div>
         <span id ="{$groupDivId}" style="display:none; visibility:hidden;">
-            <xsl:choose>
-                <xsl:when test="not(Permissions/Permission[1])">
-                </xsl:when>
-                <xsl:otherwise>
-                    <!--xsl:apply-templates/-->
-                    <xsl:apply-templates select="Permissions">
-                        <xsl:with-param name="AccountN" select="GroupName"/>
-                        <xsl:with-param name="AccountT" select="1"/>
-                    </xsl:apply-templates>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:if test="Permissions/Permission[1]">
+                <!--xsl:apply-templates/-->
+                <xsl:apply-templates select="Permissions">
+                    <xsl:with-param name="AccountN" select="GroupName"/>
+                    <xsl:with-param name="AccountT" select="1"/>
+                </xsl:apply-templates>
+            </xsl:if>
             <xsl:if test="count(BasednNames/Item)">
                 <form method="POST" action="/ws_access/PermissionAddInput">
                     <input type="hidden" name="AccountName" value="{GroupName}"/>

--- a/esp/eclwatch/ws_XSLT/access_accountpermissions.xslt
+++ b/esp/eclwatch/ws_XSLT/access_accountpermissions.xslt
@@ -184,6 +184,27 @@
           return ret;
                 }
 
+                function toggleElement(ElementId)
+                {
+                    var obj = document.getElementById('group_div_' + ElementId);
+                    if (obj == null)
+                        return;
+                    explink = document.getElementById('explink_' + ElementId);
+                    if (obj.style.visibility == 'visible')
+                    {
+                        obj.style.display = 'none';
+                        obj.style.visibility = 'hidden';
+                        if (explink)
+                            explink.className = 'wusectionexpand';
+                    }
+                    else
+                    {
+                        obj.style.display = 'inline';
+                        obj.style.visibility = 'visible';
+                        if (explink)
+                            explink.className = 'wusectioncontract';
+                    }
+                }
                 var sortableTable = null;
             ]]></xsl:text>
             </script>
@@ -202,15 +223,17 @@
                     </xsl:apply-templates>
                 </xsl:otherwise>
             </xsl:choose>
-            <form method="POST" action="/ws_access/PermissionAddInput">
-                <input type="hidden" name="AccountName" value="{AccountName}"/>
-                <input type="hidden" name="AccountType" value="{IsGroup}"/>
-                <input type="hidden" name="prefix" value="{prefix}"/>
-                <select size="1" name="BasednName">
-                    <xsl:apply-templates select="BasednNames"/>
-                </select>
-                <input type="submit" class="sbutton" name="action" value="  Add  "/>
-            </form>
+            <xsl:if test="count(BasednNames/Item)">
+                <form method="POST" action="/ws_access/PermissionAddInput">
+                    <input type="hidden" name="AccountName" value="{AccountName}"/>
+                    <input type="hidden" name="AccountType" value="{IsGroup}"/>
+                    <input type="hidden" name="prefix" value="{prefix}"/>
+                    <select size="1" name="BasednName">
+                        <xsl:apply-templates select="BasednNames"/>
+                    </select>
+                    <input type="submit" class="sbutton" name="action" value="  Add  "/>
+                </form>
+            </xsl:if>
             <p/>
             <xsl:choose>
                 <xsl:when test="not(GroupPermissions/GroupPermission[1])">
@@ -230,29 +253,44 @@
     </xsl:template>
 
     <xsl:template match="GroupPermission">
-        <p/>
-        <h4>Inherited Permissions from Group: <xsl:value-of select="GroupName"/> (Changes inside this section will be applied to the whole group.)</h4>
-        <p/>
-        <xsl:choose>
-            <xsl:when test="not(Permissions/Permission[1])">
-            </xsl:when>
-            <xsl:otherwise>
-                <!--xsl:apply-templates/-->
-                <xsl:apply-templates select="Permissions">
-                    <xsl:with-param name="AccountN" select="GroupName"/>
-                    <xsl:with-param name="AccountT" select="1"/>
-                </xsl:apply-templates>
-            </xsl:otherwise>
-        </xsl:choose>
-        <form method="POST" action="/ws_access/PermissionAddInput">
-            <input type="hidden" name="AccountName" value="{GroupName}"/>
-            <input type="hidden" name="AccountType" value="1"/>
-            <input type="hidden" name="prefix" value="{prefix}"/>
-            <select size="1" name="BasednName">
-                <xsl:apply-templates select="/AccountPermissionsResponse/BasednNames"/>
-            </select>
-            <input type="submit" class="sbutton" name="action" value="  Add  "/>
-        </form>
+        <xsl:variable name="groupDivId">
+            <xsl:value-of select="concat('group_div_', GroupName)"/>
+        </xsl:variable>
+        <xsl:variable name="explinkId">
+            <xsl:value-of select="concat('explink_', GroupName)"/>
+        </xsl:variable>
+        <br/>
+        <div>
+            <a href="javascript:void(0)" onclick="toggleElement('{GroupName}');" id="{$explinkId}" class="wusectionexpand">
+                Inherited Permissions from Group: <xsl:value-of select="GroupName"/> (Changes inside this section will be applied to the whole group.)
+                <br/><br/>
+            </a>
+        </div>
+        <span id ="{$groupDivId}" style="display:none; visibility:hidden;">
+            <xsl:choose>
+                <xsl:when test="not(Permissions/Permission[1])">
+                </xsl:when>
+                <xsl:otherwise>
+                    <!--xsl:apply-templates/-->
+                    <xsl:apply-templates select="Permissions">
+                        <xsl:with-param name="AccountN" select="GroupName"/>
+                        <xsl:with-param name="AccountT" select="1"/>
+                    </xsl:apply-templates>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:if test="count(BasednNames/Item)">
+                <form method="POST" action="/ws_access/PermissionAddInput">
+                    <input type="hidden" name="AccountName" value="{GroupName}"/>
+                    <input type="hidden" name="AccountType" value="1"/>
+                    <input type="hidden" name="prefix" value="{prefix}"/>
+                    <select size="1" name="BasednName">
+                        <xsl:apply-templates select="BasednNames"/>
+                    </select>
+                    <input type="submit" class="sbutton" name="action" value="Add To This Group"/>
+                </form>
+            </xsl:if>
+            <br/>
+        </span>
     </xsl:template>
 
     <xsl:template match="Permissions">

--- a/esp/scm/ws_access.ecm
+++ b/esp/scm/ws_access.ecm
@@ -50,6 +50,7 @@ ESPstruct AccountPermission
 ESPstruct GroupAccountPermission
 {
     string GroupName;
+    [min_ver("1.06")] ESParray<string> BasednNames;
     ESParray<ESPstruct AccountPermission, Permission> Permissions;
 };
 
@@ -646,7 +647,7 @@ ESPresponse [nil_remove] UserAccountExportResponse
 };
 
 
-ESPservice [version("1.05"), default_client_version("1.05"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
+ESPservice [version("1.06"), default_client_version("1.06"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
 {
     ESPmethod [client_xslt("/esp/xslt/access_users.xslt")] Users(UserRequest, UserResponse);
     ESPmethod [client_xslt("/esp/xslt/access_useredit.xslt")] UserEdit(UserEditRequest, UserEditResponse);

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -3147,7 +3147,7 @@ bool Cws_accessEx::onAccountPermissions(IEspContext &context, IEspAccountPermiss
         }
 
         StringArray basednNames;
-        getBaseDNsForAddingPermssionToAccount(ldapsecmgr, NULL, username, 0, basednNames);
+        getBaseDNsForAddingPermssionToAccount(ldapsecmgr, NULL, username, bGroupAccount? 1:0, basednNames);
         if (basednNames.length() > 0)
         {
             resp.setBasednNames(basednNames);

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -2051,6 +2051,81 @@ bool Cws_accessEx::onPermissionsReset(IEspContext &context, IEspPermissionsReset
     return true;
 }
 
+//For every resources inside a baseDN, if there is no permission for this account, add the baseDN name to the basednNames list
+void Cws_accessEx::getBaseDNsForAddingPermssionToAccount(CLdapSecManager* secmgr, const char* prefix, const char* accountName, 
+                                           int accountType, StringArray& basednNames)
+{
+    if(secmgr == NULL)
+        throw MakeStringException(ECLWATCH_INVALID_SEC_MANAGER, MSG_SEC_MANAGER_IS_NULL);
+
+    ForEachItemIn(i, m_basedns)
+    {
+        IEspDnStruct* curbasedn = &(m_basedns.item(i));
+        const char *basednName = curbasedn->getName();
+        if (!basednName || !*basednName)
+            continue;
+
+        const char *basedn = curbasedn->getBasedn();
+        const char *rtypestr = curbasedn->getRtype();
+        if (!basedn || !*basedn || !rtypestr || !*rtypestr)
+            continue;
+
+        IArrayOf<ISecResource> resources;
+        SecResourceType rtype = str2type(rtypestr);
+        if(!secmgr->getResources(rtype, basedn, resources))
+            continue;
+
+        ForEachItemIn(j, resources)
+        {
+            ISecResource& r = resources.item(j);
+            const char* rname = r.getName();
+            if(!rname || !*rname)
+                continue;
+
+            if(prefix && *prefix)
+            {
+                int prefixlen = strlen(prefix);
+                if(strncmp(prefix, rname, prefixlen) == 0)
+                    rname += prefixlen;
+            }
+
+            StringBuffer namebuf(rname);
+            if((rtype == RT_MODULE) && !strieq(rname, "repository") && Utils::strncasecmp(rname, "repository.", 11) != 0)
+                namebuf.insert(0, "repository.");
+            if(prefix && *prefix)
+                namebuf.insert(0, prefix);
+
+            try
+            {
+                IArrayOf<CPermission> permissions;
+                secmgr->getPermissionsArray(basedn, rtype, namebuf.str(), permissions);
+
+                bool foundPermissionInThisAccount = false;
+                ForEachItemIn(k, permissions)
+                {
+                    CPermission& perm = permissions.item(k);
+                    if ((accountType == perm.getAccount_type()) && perm.getAccount_name() && streq(perm.getAccount_name(), accountName))
+                    {
+                        foundPermissionInThisAccount = true;
+                        break;
+                    }
+                }
+                if (!foundPermissionInThisAccount)
+                {
+                    basednNames.append(basednName);
+                    break;
+                }
+            }
+            catch(IException* e) //exception may be thrown when no permission for the resource
+            {
+                e->Release();
+                break;
+            }
+        }
+    }
+
+    return;
+}
 
 bool Cws_accessEx::permissionAddInputOnResource(IEspContext &context, IEspPermissionAddRequest &req, IEspPermissionAddResponse &resp)
 {
@@ -2803,31 +2878,43 @@ bool Cws_accessEx::onAccountPermissions(IEspContext &context, IEspAccountPermiss
             setBasedns(context);
         }
 
+        CLdapSecManager* ldapsecmgr = (CLdapSecManager*)secmgr;
         StringArray groupnames;
         if (version > 1.02 && !bGroupAccount && bIncludeGroup)
         {
-            CLdapSecManager* ldapsecmgr = (CLdapSecManager*)secmgr;
             ldapsecmgr->getGroups(username, groupnames);
         }
 
         groupnames.append("Authenticated Users");
         groupnames.append("everyone");
 
-        StringArray basednNames;
         IArrayOf<IEspAccountPermission> accountPermissions;
 
         bool bAuthUsersPerm = false;
         Owned<IEspGroupAccountPermission> grouppermission1 = createGroupAccountPermission();
         grouppermission1->setGroupName("Authenticated Users");
+        if (version > 1.05)
+        {
+            StringArray basednNames;
+            getBaseDNsForAddingPermssionToAccount(ldapsecmgr, NULL, "Authenticated Users", 1, basednNames);
+            if (basednNames.length() > 0)
+                grouppermission1->setBasednNames(basednNames);
+        }
         IArrayOf<IConstAccountPermission>& authUsersPermissions = grouppermission1->getPermissions();
 
         bool bEveryonePerm = false;
         Owned<IEspGroupAccountPermission> grouppermission2 = createGroupAccountPermission();
         grouppermission2->setGroupName("Everyone");
+        if (version > 1.05)
+        {
+            StringArray basednNames;
+            getBaseDNsForAddingPermssionToAccount(ldapsecmgr, NULL, "Everyone", 1, basednNames);
+            if (basednNames.length() > 0)
+                grouppermission2->setBasednNames(basednNames);
+        }
         IArrayOf<IConstAccountPermission>& everyonePermissions = grouppermission2->getPermissions();
 
         IArrayOf<IEspGroupAccountPermission> groupAccountPermissions;
-        CLdapSecManager* ldapsecmgr = (CLdapSecManager*)secmgr;
 
         StringBuffer moduleBasedn; //To be used by the Permission: codegenerator.cpp
         ForEachItemIn(y1, m_basedns)
@@ -2859,7 +2946,6 @@ bool Cws_accessEx::onAccountPermissions(IEspContext &context, IEspAccountPermiss
                 continue;
 
             SecResourceType rtype = str2type(aRtype);
-            basednNames.append(aName);
 
             IArrayOf<IEspResource> ResourceArray;
             //if(rtype == RT_FILE_SCOPE || rtype == RT_WORKUNIT_SCOPE)
@@ -3037,6 +3123,13 @@ bool Cws_accessEx::onAccountPermissions(IEspContext &context, IEspAccountPermiss
                                 {
                                     Owned<IEspGroupAccountPermission> grouppermission = createGroupAccountPermission();
                                     grouppermission->setGroupName(actname);
+                                    if (version > 1.05)
+                                    {
+                                        StringArray basednNames;
+                                        getBaseDNsForAddingPermssionToAccount(ldapsecmgr, NULL, actname, 1, basednNames);
+                                        if (basednNames.length() > 0)
+                                            grouppermission->setBasednNames(basednNames);
+                                    }
 
                                     IArrayOf<IConstAccountPermission>& g_permission = grouppermission->getPermissions();
                                     g_permission.append(*onepermission.getLink());
@@ -3053,6 +3146,8 @@ bool Cws_accessEx::onAccountPermissions(IEspContext &context, IEspAccountPermiss
             }
         }
 
+        StringArray basednNames;
+        getBaseDNsForAddingPermssionToAccount(ldapsecmgr, NULL, username, 0, basednNames);
         if (basednNames.length() > 0)
         {
             resp.setBasednNames(basednNames);

--- a/esp/services/ws_access/ws_accessService.hpp
+++ b/esp/services/ws_access/ws_accessService.hpp
@@ -83,6 +83,8 @@ class Cws_accessEx : public Cws_access
         const char* resourceName, ACT_TYPE accountType, const char* accountName,
         bool allow_access, bool allow_read, bool allow_write, bool allow_full,
         bool deny_access, bool deny_read, bool deny_write, bool deny_full);
+    void getBaseDNsForAddingPermssionToAccount(CLdapSecManager* secmgr, const char* prefix, const char* accountName, 
+        int accountType, StringArray& basednNames);
 
 public:
     IMPLEMENT_IINTERFACE;


### PR DESCRIPTION
Existing user permission page has two usability issues.
(1) multiple permission tables are displayed in one page
which makes the page difficult to read. (2) for each
permission table (permission group), there is an Add
button and a drop down list of resources which allows to 
add more permission to that group. The page shows the 
Add button and the reource list even though no more 
permission can be added for the resources. This fix only 
shows the first permission table and the expend links for 
other tables. This fix also filters out resources from the 
resource list if no more permission can be added for the
resources. If the resource list is empty, the Add button 
and the drop down list will not be displayed for that 
permission table.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
