### PR TITLE
gh-1684 Redirection intended for eclwatch messing up requests for xml

### DIFF
--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -407,5 +407,9 @@ public:
     void setTimeOut(unsigned int timeout);
 };
 
+inline bool canRedirect(CHttpRequest &req)
+{
+    return !req.queryParameters()->hasProp("rawxml_");
+}
 
 #endif

--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -6076,7 +6076,7 @@ void EspServInfo::write_esp_binding()
             }
             
             
-            outs("\t\t\tif (esp_response->getRedirectUrl() && *esp_response->getRedirectUrl())\n");
+            outs("\t\t\tif (canRedirect(*request) && esp_response->getRedirectUrl() && *esp_response->getRedirectUrl())\n");
             outs("\t\t\t{\n");
             outs("\t\t\t\tresponse->redirect(*request, esp_response->getRedirectUrl());\n");
             outs("\t\t\t}\n");
@@ -6143,7 +6143,7 @@ void EspServInfo::write_esp_binding()
     indentReset(2);
     indentOuts("if (esp_response.get())\n");
     indentOuts("{\n");
-    indentOuts(1,"if (esp_response->getRedirectUrl() && *esp_response->getRedirectUrl())\n");
+    indentOuts(1,"if (canRedirect(*request) && esp_response->getRedirectUrl() && *esp_response->getRedirectUrl())\n");
     indentOuts(1,"response->redirect(*request, esp_response->getRedirectUrl());\n");
     indentOuts(-1,"else\n");
     indentOuts("{\n");


### PR DESCRIPTION
The "rawxml_" url parameter avoids xslt transformation of the content,
but should also avoid HTTP redirection.

Fixes gh-1684

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
