### PR TITLE
Thor Status link broken due to missing xslt file

### DIFF
--- a/esp/eclwatch/ws_XSLT/CMakeLists.txt
+++ b/esp/eclwatch/ws_XSLT/CMakeLists.txt
@@ -106,6 +106,7 @@ FOREACH ( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/targetclusters.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/showresult.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/table.xslt
+    ${CMAKE_CURRENT_SOURCE_DIR}/thor_status.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/topology.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/tplog.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/tplogdisplay.xslt


### PR DESCRIPTION
From EclWatch/Thor Status page, clicks a link under name column and
the page shows nothing. That is because the thor_status.xslt is not
installed.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
