### PR TITLE
Remove unused port argument

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -5424,7 +5424,7 @@ void CLocalWorkUnit::deleteTempFiles(const char *graph, bool deleteOwned, bool d
         {
             const char *name = file.queryProp("@name");
             LOG(MCdebugProgress, unknownJob, "Removing workunit file %s from DFS", name);
-            queryDistributedFileDirectory().removePhysical(name, 0, NULL, NULL, queryUserDescriptor());
+            queryDistributedFileDirectory().removePhysical(name, NULL, NULL, queryUserDescriptor());
             toRemove.append(file);
         }
     }
@@ -5532,7 +5532,7 @@ void CLocalWorkUnit::releaseFile(const char *fileName)
             files->removeTree(file);
             if (!name.isEmpty()&&(1 == usageCount))
             {
-                if (queryDistributedFileDirectory().removePhysical(fileName, 0, NULL, NULL, queryUserDescriptor()))
+                if (queryDistributedFileDirectory().removePhysical(fileName, NULL, NULL, queryUserDescriptor()))
                     LOG(MCdebugProgress, unknownJob, "Removed (released) file %s from DFS", name.get());
             }
         }

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -238,7 +238,7 @@ interface IDistributedFile: extends IInterface
 
     virtual unsigned numCopies(unsigned partno) = 0;                            // number of copies
 
-    virtual bool removePhysicalPartFiles(unsigned short port=0,const char *cluster=NULL,IMultiException *exceptions=NULL) = 0;          // removes all physical part files
+    virtual bool removePhysicalPartFiles(const char *cluster=NULL,IMultiException *exceptions=NULL) = 0;          // removes all physical part files
                                                                                 // returns true if no major errors
 
     virtual bool existsPhysicalPartFiles(unsigned short port) = 0;              // returns true if physical patrs all exist (on primary OR secondary)
@@ -461,7 +461,7 @@ interface IDistributedFileDirectory: extends IInterface
     virtual IDFScopeIterator *getScopeIterator(const char *subscope=NULL,bool recursive=true,bool includeempty=false, IUserDescriptor *user=NULL)=0;
 
     virtual bool removeEntry(const char *name,IUserDescriptor *user=NULL) = 0;  // equivalent to lookup/detach/release
-    virtual bool removePhysical(const char *name,unsigned short port=0,const char *cluster=NULL,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                           // removes the physical parts as well as entry
+    virtual bool removePhysical(const char *name,const char *cluster=NULL,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                           // removes the physical parts as well as entry
     virtual bool renamePhysical(const char *oldname,const char *newname,unsigned short port=0,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                         // renames the physical parts as well as entry
     virtual void removeEmptyScope(const char *scope) = 0;   // does nothing if called on non-empty scope
     

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -243,7 +243,7 @@ interface IDistributedFile: extends IInterface
 
     virtual bool existsPhysicalPartFiles(unsigned short port) = 0;              // returns true if physical patrs all exist (on primary OR secondary)
 
-    virtual bool renamePhysicalPartFiles(const char *newlfn,const char *cluster=NULL,unsigned short port=0,IMultiException *exceptions=NULL,const char *newbasedir=NULL) = 0;           // renames all physical part files
+    virtual bool renamePhysicalPartFiles(const char *newlfn,const char *cluster=NULL,IMultiException *exceptions=NULL,const char *newbasedir=NULL) = 0;           // renames all physical part files
                                                                                 // returns true if no major errors
 
 
@@ -462,7 +462,7 @@ interface IDistributedFileDirectory: extends IInterface
 
     virtual bool removeEntry(const char *name,IUserDescriptor *user=NULL) = 0;  // equivalent to lookup/detach/release
     virtual bool removePhysical(const char *name,const char *cluster=NULL,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                           // removes the physical parts as well as entry
-    virtual bool renamePhysical(const char *oldname,const char *newname,unsigned short port=0,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                         // renames the physical parts as well as entry
+    virtual bool renamePhysical(const char *oldname,const char *newname,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                         // renames the physical parts as well as entry
     virtual void removeEmptyScope(const char *scope) = 0;   // does nothing if called on non-empty scope
     
 

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -863,7 +863,7 @@ public:
                     return;
                 }
                 dfile->detach();
-                dfile->removePhysicalPartFiles(0,NULL,NULL);
+                dfile->removePhysicalPartFiles(NULL,NULL);
             }
             dfile.clear();
         }
@@ -1224,7 +1224,7 @@ public:
                                     oldfile.clear();
                                     if (!options->getOverwrite())
                                         throw MakeStringException(-1,"Destination file %s already exists and overwrite not specified",tmp.str());
-                                    fdir.removePhysical(tmp.str(),0,NULL,NULL,userdesc);
+                                    fdir.removePhysical(tmp.str(),NULL,NULL,userdesc);
                                 }
                             }
                             StringBuffer jobname;
@@ -1385,7 +1385,7 @@ public:
                         if (options->getNoDelete())
                             fdir.removeEntry(tmp.str(),userdesc);
                         else
-                            fdir.removePhysical(tmp.str(),0,NULL,NULL,userdesc);
+                            fdir.removePhysical(tmp.str(),NULL,NULL,userdesc);
                         Audit("REMOVE",userdesc,tmp.clear(),NULL);
                         runningconn.clear();
                     }

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1423,7 +1423,7 @@ public:
                         newfile.clear();
                         StringBuffer fromname(srcName);
                         srcFile.clear();
-                        if (!queryDistributedFileDirectory().renamePhysical(fromname.str(),toname.str(),0,NULL,userdesc))
+                        if (!queryDistributedFileDirectory().renamePhysical(fromname.str(),toname.str(),NULL,userdesc))
                             throw MakeStringException(-1,"rename failed"); // could do with better error here
                         StringBuffer timetaken;
                         timetaken.appendf("%dms",msTick()-start);

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -613,7 +613,7 @@ public:
                 dfile->detach();
             else {
                 dfile->detach();
-                dfile->removePhysicalPartFiles(0,NULL,NULL);
+                dfile->removePhysicalPartFiles(NULL,NULL);
             }
             dfile.clear();
         }
@@ -689,7 +689,7 @@ public:
                 dfile->detach();
             else {
                 dfile->detach();
-                dfile->removePhysicalPartFiles(0,NULL,NULL);
+                dfile->removePhysicalPartFiles(NULL,NULL);
             }
             dfile.clear();
         }
@@ -893,7 +893,7 @@ public:
                     return;
                 }
                 dfile->detach();
-                dfile->removePhysicalPartFiles(0,NULL,NULL);
+                dfile->removePhysicalPartFiles(NULL,NULL);
             }
             dfile.clear();
         }

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -220,7 +220,7 @@ bool CDistributedFileSystem::remove(IDistributedFile * file,const char *cluster,
         cluster = NULL; // deleting the last cluster removes the file
         file->detach(); 
     }
-    return file->removePhysicalPartFiles(0,cluster,mexcept); // this is bit cavalier with errors - but better orphans than inconsistant DFS
+    return file->removePhysicalPartFiles(cluster,mexcept); // this is bit cavalier with errors - but better orphans than inconsistant DFS
 }
 
 bool CDistributedFileSystem::compress(IDistributedFile * file)

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -349,7 +349,7 @@ FILESERVICES_API void FILESERVICES_CALL fsDeleteLogicalFile(ICodeContext *ctx, c
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     StringBuffer uname;
     PrintLog("Deleting NS logical file %s for user %s", lfn.str(),udesc?udesc->getUserName(uname).str():"");
-    if (queryDistributedFileDirectory().removePhysical(lfn.str(),0,NULL,NULL,udesc))
+    if (queryDistributedFileDirectory().removePhysical(lfn.str(),NULL,NULL,udesc))
     {
         StringBuffer s("DeleteLogicalFile ('");         // ** TBD use removephysical (handles cluster)
         s.append(lfn).append("') done");

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -463,7 +463,7 @@ FILESERVICES_API void FILESERVICES_CALL fsRenameLogicalFile(ICodeContext *ctx, c
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     Owned<IMultiException> exceptions = MakeMultiException();
 
-    if (queryDistributedFileDirectory().renamePhysical(lfn.str(),nlfn.str(),0,exceptions,udesc)) {
+    if (queryDistributedFileDirectory().renamePhysical(lfn.str(),nlfn.str(),exceptions,udesc)) {
         StringBuffer s("RenameLogicalFile ('");
         s.append(lfn).append(", '").append(nlfn).append("') done");
         WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1594,7 +1594,7 @@ bool CJobMaster::go()
 
                 StringBuffer newName;
                 queryThorFileManager().addScope(*this, tmpName, newName, true, true);
-                verifyex(file->renamePhysicalPartFiles(newName.str(), NULL, 0, NULL, queryBaseDirectory()));
+                verifyex(file->renamePhysicalPartFiles(newName.str(), NULL, NULL, queryBaseDirectory()));
 
                 file->attach(newName);
 


### PR DESCRIPTION
The port argument, presumably to allow physical remove on a remote Dali, was unused
and will remain so, since we're going to change the name resolution to URI based. Even
while that doesn't happen, using that argument was ineffective and poor, probably
remaining of an old refactoring.
