### PR TITLE
gh-1918 - Fix dali backupComputer issue

### DIFF
--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -213,7 +213,6 @@ int main(int argc, char* argv[])
 
                     try
                     {
-                        recursiveCreateDirectory(mirrorPath);
                         StringBuffer backupURL;
                         if (mirrorPath.length()<=2 || !isPathSepChar(mirrorPath.charAt(0)) || !isPathSepChar(mirrorPath.charAt(1)))
                         { // local machine path, convert to url
@@ -231,6 +230,7 @@ int main(int argc, char* argv[])
                         }
                         else
                             backupURL.append(mirrorPath);
+                        recursiveCreateDirectory(backupURL.str());
                         addPathSepChar(backupURL);
                         serverConfig->setProp("SDS/@remoteBackupLocation", backupURL.str());
                         PROGLOG("Backup URL = %s", backupURL.str());


### PR DESCRIPTION
If the intermediate paths of the mirror path on the comupter specified by
backupComputer didn't exist. Dali would fail to create the dali backup
direcotry and cause dali to fail to start

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
