### PR TITLE
Add url option to list ESP service test forms

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1747,7 +1747,7 @@ int EspHttpBinding::onGetIndex(IEspContext &context, CHttpRequest* request,  CHt
         MethodInfoArray methods;
         getQualifiedNames(context, methods);
 
-        if (supportGeneratedForms())
+        if (supportGeneratedForms() || request->queryParameters()->hasProp("list_forms"))
         {
             page.appendContent(new CHtmlText("The following operations are supported:<br/>"));
 


### PR DESCRIPTION
Provides a way to simplify testing the HTTP Post handling of
multiple ESP methods in a given service.

Accessible by adding the "list_forms" parameter to the base servie URL:
http://IP:Port/WsWorkunits?list_forms

Additional parameters should be forwarded to the selected methods:
http://IP:Port/WsWorkunits?list_forms&my_feature=1

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
