### PR TITLE
ISSUE:1743 ConfigMgr crashes opening file w/o permission

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -5936,6 +5936,11 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite)
     if (modified && fileExists)
       saveEnvironment(NULL, NULL, err);
   }
+  catch (IErrnoException* e)
+  {
+    //Don't ignore file access exceptions
+    throw e;
+  }
   catch(IException* e)
   {
     //ignore any exceptions at this point like validation errors e.t.c


### PR DESCRIPTION
Add additional exception handling to catch
exceptions of type IErrnoException and pass
them up.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
