### PR TITLE
Meta information for a loop/graph was wrong

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -11044,8 +11044,6 @@ IHqlExpression *createDataset(node_operator op, HqlExprArray & parms)
     case no_newrow:
     case no_assert_ds:
     case no_spillgraphresult:
-    case no_loop:
-    case no_graphloop:
     case no_cluster:
     case no_forcenolocal:
     case no_thisnode:
@@ -11061,6 +11059,18 @@ IHqlExpression *createDataset(node_operator op, HqlExprArray & parms)
     case no_dataset_alias:
         type.set(datasetType);
         break;
+    case no_loop:
+        {
+            IHqlExpression & body = parms.item(4);
+            type.setown(getTypeIntersection(datasetType, body.queryChild(0)->queryType()));
+            break;
+        }
+    case no_graphloop:
+        {
+            IHqlExpression & body = parms.item(2);
+            type.setown(getTypeIntersection(datasetType, body.queryChild(0)->queryType()));
+            break;
+        }
     case no_serialize:
         type.setown(getSerializedForm(datasetType));
         break;


### PR DESCRIPTION
Meta information for a loop was based on the input dataset, instead of
the intersection of the input dataset and the result of the loop.
Could potentially cause some optimizations to occur (e.g., removing
sorts/making local) which weren't always valid.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
