### PR TITLE
gh-2024 - Move thor base ports, to avoid clash

### DIFF
--- a/common/commonext/thorport.cpp
+++ b/common/commonext/thorport.cpp
@@ -36,7 +36,8 @@
 #include "portlist.h"
 #include "thorport.hpp"
 
-#define WATCHDOGINC        1
+#define MPPORT       0
+#define WATCHDOGPORT 1
 
 static CriticalSection *portallocsection;
 static IBitSet *portmap;
@@ -44,8 +45,8 @@ MODULE_INIT(INIT_PRIORITY_STANDARD)
 {
     portallocsection = new CriticalSection;
     portmap = createBitSet();
-    portmap->set(THOR_MP_INC, true);
-    portmap->set(WATCHDOGINC, true);
+    portmap->set(MPPORT, true);
+    portmap->set(WATCHDOGPORT, true);
     return true;
 }
 MODULE_EXIT()
@@ -74,9 +75,9 @@ unsigned short getExternalFixedPort(unsigned short masterBase, unsigned short ma
     if (!machineBase) machineBase = THOR_BASESLAVE_PORT;
     switch (category) {
     case TPORT_watchdog:
-        return machineBase+WATCHDOGINC;
+        return machineBase+WATCHDOGPORT;
     case TPORT_mp:
-        return machineBase+THOR_MP_INC; 
+        return machineBase+MPPORT; 
     }
     LOG(MCerror,unknownJob,"getFixedPort: Unknown Port Kind!");
     return 0;

--- a/initfiles/componentfiles/configxml/setvars_linux.xsl
+++ b/initfiles/componentfiles/configxml/setvars_linux.xsl
@@ -60,7 +60,7 @@ export THORMASTER=<xsl:call-template name="getNetAddress">
 export THORMASTERPORT=<xsl:value-of select="@masterport"/>
     </xsl:when>
     <xsl:otherwise>
-export THORMASTERPORT=6500
+export THORMASTERPORT=20000
     </xsl:otherwise>
 </xsl:choose>
 <xsl:choose>
@@ -68,7 +68,7 @@ export THORMASTERPORT=6500
 export THORSLAVEPORT=<xsl:value-of select="@slaveport"/>
     </xsl:when>
     <xsl:otherwise>
-export THORSLAVEPORT=6600
+export THORSLAVEPORT=20100
     </xsl:otherwise>
 </xsl:choose>
 <xsl:if test="string(@localThorPortInc) != ''">

--- a/system/include/portlist.h
+++ b/system/include/portlist.h
@@ -49,9 +49,6 @@
 #define SLAVE_CONNECT_PORT              6400 //..6439    [ uses numSlaveKinds * NUM_SLAVE_CONNECT_PORT ]
 #define NUM_SLAVE_CONNECT_PORT          20   // 20 for dfu, 20 for dkc
 
-#define THOR_BASE_PORT                  6500 //..6599
-#define THOR_BASESLAVE_PORT             6600 //..6999
-
 #define WUJOBQ_BASE_PORT                6700 // ..6999  // overlapped with Thor slaves
 #define WUJOBQ_PORT_NUM                 300
 
@@ -59,10 +56,7 @@
 #define DATA_TRANSFER_PORT              7080
 #define DAFILESRV_PORT                  7100 /// aka daliservix
 #define MP_BASE_PORT                    7101 //..7999 (for Dali too)
-
-#define THOR_MP_INC                     0
-#define THOR_MP_BASE_MASTER_PORT        (THOR_BASE_PORT+THOR_MP_INC)            // 7500+
-#define THOR_MP_BASE_SLAVE_PORT         (THOR_BASE_SLAVE_PORT+THOR_MP_INC)      // 7600+
+#define MP_PORT_RANGE                   400
 
 //ESP SERVICES
 //INSECURE
@@ -127,5 +121,8 @@
 #define WS_FACTS_SECURE_PORT            18999
 #define WS_MOXIE_SECURE_PORT            18999
 #define WS_DISTRIX_SECURE_PORT          18999
+
+#define THOR_BASE_PORT                  20000 //..~20099
+#define THOR_BASESLAVE_PORT             20100 //..~20199
 
 #endif

--- a/system/mp/mpcomm.cpp
+++ b/system/mp/mpcomm.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "platform.h"
+#include "portlist.h"
 #include "jlib.hpp"
 #include <limits.h>
 
@@ -58,10 +59,6 @@
 #define MP_PROTOCOL_VERSIONV6   0x202                   // extended for IPV6
 
 #define CANCELTIMEOUT       1000        // 1 sec
-
-#define MP_BASE_PORT    7101 //..7999 (for Dali too) -- Thor reserves 7500+
-#define MP_PORT_RANGE    400 //
-
 
 #define CONNECT_TIMEOUT         (5*60*1000) // 5 mins
 #define CONNECT_READ_TIMEOUT    (3*60*1000) // 3 min    

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -116,7 +116,6 @@ class CRegistryServer : public CSimpleInterface
                     return;
                 rank_t sender = queryClusterGroup().rank(senderNode);
                 SocketEndpoint ep = senderNode->endpoint();
-                ep.port -= THOR_MP_INC;
                 StringBuffer url;
                 ep.getUrlStr(url);
                 if (RANK_NULL == sender)
@@ -184,7 +183,6 @@ public:
     void registerNode(unsigned slave)
     {
         SocketEndpoint ep = queryClusterGroup().queryNode(slave).endpoint();
-        ep.port -= THOR_MP_INC;
         StringBuffer url;
         ep.getUrlStr(url);
         if (status->test(slave-1))
@@ -337,7 +335,6 @@ public:
             {
                 status->set(i, false);
                 SocketEndpoint ep = queryClusterGroup().queryNode(i+1).endpoint();
-                ep.port -= THOR_MP_INC;
                 if (watchdog)
                     watchdog->removeSlave(ep);
                 CMessageBuffer msg;

--- a/thorlcr/slave/slwatchdog.cpp
+++ b/thorlcr/slave/slwatchdog.cpp
@@ -55,7 +55,6 @@ public:
     CGraphProgressHandler() : threaded("CGraphProgressHandler")
     {
         self = queryMyNode()->endpoint();
-        self.port -= THOR_MP_INC;
         stopped = true;
 
         StringBuffer ipStr;

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -78,7 +78,6 @@ void mergeCmdParams(IPropertyTree *props)
 static void replyError(const char *errorMsg)
 {
     SocketEndpoint myEp = queryMyNode()->endpoint();
-    myEp.port -= THOR_MP_INC;
     StringBuffer str("Node '");
     myEp.getUrlStr(str);
     str.append("' exception: ").append(errorMsg);
@@ -114,7 +113,6 @@ static bool RegisterSelf(SocketEndpoint &masterEp)
         setClusterGroup(group);
 
         SocketEndpoint myEp = queryMyNode()->endpoint();
-        myEp.port -= THOR_MP_INC;
         if (RANK_NULL == group->rank(queryMyNode()))
         {
             replyError("Node not part of thorgroup");


### PR DESCRIPTION
Multislave configurations with eclagent on same box, could if unlucky use
clashing ports. The thor slave ports are fixed, but the agent dynamically
allocated ports between 6700-6999

Also, cleared up a few unused port definitions

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
