### PR TITLE
FIX gh-1932 Fixed poorly worded error message

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_adduser.xslt
+++ b/esp/eclwatch/ws_XSLT/access_adduser.xslt
@@ -47,7 +47,7 @@
             <xsl:when test="retcode=0">
             </xsl:when>
             <xsl:otherwise>
-            Error happened while adding user.
+            An error occurred while attempting to add user.
             </xsl:otherwise>
         </xsl:choose>
         <xsl:value-of select="retmsg"/>

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -4897,13 +4897,13 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                DBGLOG("can't add user %s, already exists", username);
-                throw MakeStringException(-1, "can't add user %s, already exists", username);
+                DBGLOG("Can't add user %s, already exists", username);
+                throw MakeStringException(-1, "Can't add user %s, already exists", username);
             }
             else
             {
-                DBGLOG("error addUser %s, ldap_add_ext_s error: %s", username, ldap_err2string( rc ));
-                throw MakeStringException(-1, "error addUser %s, ldap_add_ext_s error: %s", username, ldap_err2string( rc ));
+                DBGLOG("Error addUser %s, ldap_add_ext_s error: %s", username, ldap_err2string( rc ));
+                throw MakeStringException(-1, "Error addUser %s, ldap_add_ext_s error: %s", username, ldap_err2string( rc ));
             }
         }
 


### PR DESCRIPTION
Reworded from "Error happened while adding user." to "An error
occurred while attempting to add user." Also correct capitalization
problem in appended messages

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
