### PR TITLE
gh-1832 Fix Deleting a workunit should remove from queues

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -1960,6 +1960,7 @@ public:
         }
         else
             cw->cleanupAndDelete(true,true);
+        removeWorkUnitFromAllQueues(wuid); //known active workunits wouldn't make it this far
         return true;
     }
 

--- a/common/workunit/wujobq.hpp
+++ b/common/workunit/wujobq.hpp
@@ -139,6 +139,8 @@ extern WORKUNIT_API IJobQueue *createJobQueue(const char *name);
 
 extern bool WORKUNIT_API runWorkUnit(const char *wuid, const char *cluster);
 extern bool WORKUNIT_API runWorkUnit(const char *wuid);
+extern WORKUNIT_API StringBuffer & getQueuesContainingWorkUnit(const char *wuid, StringBuffer &queueList);
+extern WORKUNIT_API void removeWorkUnitFromAllQueues(const char *wuid);
 
 extern bool WORKUNIT_API switchWorkUnitQueue(IWorkUnit* wu, const char *cluster);
 


### PR DESCRIPTION
This addresses an external users issue.  This shouldn't happen unless
the workunit state is no longer active, but it is somehow stuck in
the queue.

To test, one can simulate the issue by stopping the cluster, queueing
a workunit, setting the state to failed, then deleting the workunit.

Fixes gh-1832.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
