### PR TITLE
Daregress refactoring/cleanup

### DIFF
--- a/dali/regress/daregress.cpp
+++ b/dali/regress/daregress.cpp
@@ -373,7 +373,7 @@ static void testDFS()
     for (i=0;i<100;i++) {
         Owned<IPropertyTree> pp = createPTree("Part");
         Owned<IFileDescriptor>fdesc = createFileDescriptor();
-        fdesc->setDefaultDir("thordata::regress");
+        fdesc->setDefaultDir("thordata/regress");
         n = 9;
         for (unsigned k=0;k<400;k++) {
             s.clear().append("192.168.").append(n/256).append('.').append(n%256);


### PR DESCRIPTION
Major refactoring on daregress suite, with a better
way of adding new tests and a simpler error report.
Also, added a transaction test to the list.

While refactoring, I cleaned up a bit of the code
and found three issues with the current implementation:
1. While creating a new superfile within a transaction,
   the pointer returned was the result of a dir-lookup,
   so in the case of active transactions, it'd be NULL.
   This bug is fixed with the current patch.
2. I managed to reduce the window to which a newly created
   superfile would be available in the filesystem, even before
   commit, by locking it straight after creation. There's
   still a tiny gap (heavy loaded systems might hit it) in
   between the two lines.
3. If adding the creation of the superfile inside the
   transaction, in the tests' conditions (which might not
   be correct), the sub files are not added. Since this
   works with FileServices, I'm guessing it's something wrong
   with the test, and not the DFS itself. Will create an issue
   on github to investigate.
