### PR TITLE
Default filesbasedn setting

### DIFF
--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -502,7 +502,14 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
         
         <EspService name="{$serviceName}" type="{$serviceType}" plugin="{$servicePlugin}">
             <xsl:variable name="ldapservername" select="$bindingNode/../Authentication/@ldapServer"/>
-            <Files basedn="{../DaliServerProcess/@filesBasedn}"/>
+            <xsl:choose>
+                <xsl:when test="string(@filesBasedn) != ''">
+                    <Files basedn="{@filesBasedn}"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <Files basedn="ou=Files,ou=ecl"/>
+                </xsl:otherwise>
+            </xsl:choose>
             <Resources>
                 <xsl:for-each select="../EspProcess[Authentication/@ldapServer=$ldapservername]/EspBinding">
                     <Binding name="{@name}" service="{@service}" port="{@port}" basedn="{@resourcesBasedn}" workunitsBasedn="{@workunitsBasedn}"/>

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -63,6 +63,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="filesBasedn" type="xs:string" use="optional" default="ou=Files,ou=ecl">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>base location for ldap file scopes</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="pluginsPath" type="relativePath" use="optional" default="${PLUGINS_PATH}">
                 <xs:annotation>
                     <xs:appinfo>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -683,6 +683,7 @@
               name="EclWatch"
               pluginsPath="${PLUGINS_PATH}"
               syntaxCheckQueue=""
+              filesBasedn="ou=Files,ou=ecl"
               viewTimeout="1000"
               warnIfCpuLoadOver="95"
               warnIfFreeMemoryUnder="5"


### PR DESCRIPTION
This fix was added to EE. Now, it should be CE also.
Existing code for generating the esp.xml sets the value of
filesbasedn based on dali setting. The filesbasedn was not set
in the esp.xml because it was not set in dali setting (dali
does not use filesbasedn, but ESP uses it). ESP should be able
to set the filesbasedn without dali setting. This fix in
esp_service_WsSMC.xsl sets the default value (the same value
as that in dali.xsd) if filesbasedn is not set. The fix in
environment.xml.in allows a user to set filesbasedn using
environment.xml.in. The fix in espsmcservice.xsd.in allows a
user to set filesbasedn using configmgr.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
