### PR TITLE
ISSUE:1881 ConfigMgr - notify user if component is not part of install

### DIFF
--- a/deployment/deploy/XMLTags.h
+++ b/deployment/deploy/XMLTags.h
@@ -28,6 +28,7 @@
 #define XML_TAG_PROGRAMS               "Programs"
 #define XML_TAG_DATA                   "Data"
 #define XML_TAG_ENVSETTINGS            "EnvSettings"
+#define XML_TAG_DIRECTORIES            "Directories"
 
 #define XML_TAG_ATTRIBUTESERVER        "AttributeServer"
 #define XML_TAG_ATTRSERVERINSTANCE     "AttrServerInstance"

--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -679,6 +679,21 @@ private:
     StringBuffer m_ip;
 };
 
+class CComponentBuildSetVerifier
+{
+public:
+
+  CComponentBuildSetVerifier();
+  virtual ~CComponentBuildSetVerifier();
+
+  void init(const String& build_file_name);
+
+  bool isInBuildSet(const char* comp_name) const;
+
+protected:
+  Owned<IPropertyTree> m_pDefBldSet;
+};
+
 class CWsDeployExCE : public CWsDeploy
 {
 public:
@@ -732,6 +747,7 @@ public:
     const char* getBackupDir() { return m_backupDir.str(); }
     const char* getProcessName() { return m_process.str(); }
     const char* getSourceDir() { return m_sourceDir.str(); }
+    CComponentBuildSetVerifier  m_bsVerifier;
 
 private:
   virtual void getWizOptions(StringBuffer& sb);


### PR DESCRIPTION
Add an informative exception notification message
when a component in the environment configuration
is not part of the buildset.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
