### PR TITLE
ESP PW Days Until Expiration change

### DIFF
--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -165,7 +165,7 @@ bool Cws_accountEx::onMyAccount(IEspContext &context, IEspMyAccountRequest &req,
             else
             {
                 dt.getString(sb);
-                sb.replace('T', (char)0);
+                sb.replace('T', (char)' ');
             }
             resp.setPasswordExpiration(sb.str());
             resp.setPasswordDaysRemaining(user->getPasswordDaysRemaining());

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -114,17 +114,19 @@ public:
    {
        if (m_passwordExpiration.isNull())
            return -2;//-2 if never expires
+
        CDateTime expiry(m_passwordExpiration);
        expiry.setTime(0,0,0,0);
 
        CDateTime now;
        now.setNow();
-       now.setTime(0,0,0,0);
+       now.adjustTime(now.queryUtcToLocalDelta());
        if (expiry <= now)
            return -1;//-1 if already expired
+       now.setTime(23,59,59);
 
-       int numDays = -1;
-       while (expiry >= now)
+       int numDays = 0;
+       while (expiry > now)
        {
            ++numDays;
            now.adjustTime(24*60);


### PR DESCRIPTION
Current code to compute days until ESP password expires adds the number of
24 hour periods until expiration. This is non standard, so this change
computes it using the number of calendar days spanned (number of midnights
between now and expiration). Also, changed the ECLWatch password expiration
field to show time as well as password expiration date.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
@wangx
