### PR TITLE
Fix missing assignment causing WsEcl to not use configured VIP

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -231,7 +231,7 @@ bool CWsEclService::init(const char * name, const char * type, IPropertyTree * c
         StringBuffer list;
         const char *vip = NULL;
         if (vips)
-            vips->queryProp(xpath.clear().appendf("ProcessCluster[@name='%s']/@vip", name).str());
+            vip = vips->queryProp(xpath.clear().appendf("ProcessCluster[@name='%s']/@vip", name).str());
         if (vip && *vip)
         {
             list.append(vip);


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
