### PR TITLE
Thor tmpfile threading

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1949,6 +1949,7 @@ void CGraphTempHandler::registerFile(const char *name, graph_id graphId, unsigne
 {
     assertex(temp);
     LOG(MCdebugProgress, thorJob, "registerTmpFile name=%s, usageCount=%d", name, usageCount);
+    CriticalBlock b(crit);
     if (tmpFiles.find(name))
         throw MakeThorException(TE_FileAlreadyUsedAsTempFile, "File already used as temp file (%s)", name);
     tmpFiles.replace(* new CFileUsageEntry(name, graphId, fileKind, usageCount));
@@ -1957,6 +1958,7 @@ void CGraphTempHandler::registerFile(const char *name, graph_id graphId, unsigne
 void CGraphTempHandler::deregisterFile(const char *name, bool kept)
 {
     LOG(MCdebugProgress, thorJob, "deregisterTmpFile name=%s", name);
+    CriticalBlock b(crit);
     CFileUsageEntry *fileUsage = tmpFiles.find(name);
     if (!fileUsage)
         throw MakeThorException(TE_FileNotFound, "File not found (%s) deregistering tmp file", name);
@@ -1978,6 +1980,7 @@ void CGraphTempHandler::deregisterFile(const char *name, bool kept)
 
 void CGraphTempHandler::clearTemps()
 {
+    CriticalBlock b(crit);
     Owned<IFileUsageIterator> iter = getIterator();
     ForEach(*iter)
     {

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -378,6 +378,7 @@ class graph_decl CGraphTempHandler : public CInterface, implements IGraphTempHan
 protected:
     CFileUsageTable tmpFiles;
     CJobBase &job;
+    mutable CriticalSection crit;
 public:
     IMPLEMENT_IINTERFACE;
 


### PR DESCRIPTION
Access to CGraphTempHandler is not threadsafe, and may core if there
are enough temp files registered in a job to cause the hash table to
be expanded (it's possible, though a lot less likely, to see issues even
with fewer temp files).

Add a CritSec to protect access to the hash table.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
