### PR TITLE
Updated ecljdbc creation

### DIFF
--- a/plugins/dbconnectors/CMakeLists.txt
+++ b/plugins/dbconnectors/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 2.8)
+project (hpccsystems-dbconnectors)
+add_subdirectory (ecljdbc)

--- a/plugins/dbconnectors/ecljdbc/CMakeLists.txt
+++ b/plugins/dbconnectors/ecljdbc/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8)
+project(ecljdbc Java)
+option(USE_ECLJDBC "Configure use of DB Connectors")
+if ( USE_ECLJDBC )
+	add_subdirectory (src/main/java/com/hpccsystems/ecljdbc)
+
+        find_package(JNI REQUIRED)
+        find_package(Java REQUIRED)
+
+        include_directories (
+                                        ${CMAKE_BINARY_DIR}
+                                        ${CMAKE_BINARY_DIR}/oss
+                                        ${JNI_INCLUDE_DIRS}
+                                        ${JAVA_INCLUDE_PATH}
+                                        ${JAVA_INCLUDE_PATH2}
+                                        )
+
+        set ( INSTALLDIR "${OSSDIR}/bin")
+
+endif( USE_ECLJDBC)

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/CMakeLists.txt
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 2.8)
+
+#configure_file("EclVersionTracker.java.in" "EclVersionTracker.java")
+
+###
+## Version Information keep in synch with top level hpcc versioning
+###
+set ( HPCC_PROJECT "community" )
+set ( HPCC_MAJOR 3 )
+set ( HPCC_MINOR 6 )
+set ( HPCC_POINT 2 )
+set ( HPCC_MATURITY "rc" )
+set ( HPCC_SEQUENCE 3 )
+###
+
+set ( HPCC_ECLJDBC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set ( HPCC_SOURCE_DIR ${HPCC_DATASTREAM_SOURCE_DIR}/../../../../../../../../../..)
+
+set ( CMAKE_MODULE_PATH "${HPCC_SOURCE_DIR}/cmake_modules")
+set ( EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin" )
+set ( PRODUCT_PREFIX "hpccsystems" )
+
+#include(${HPCC_SOURCE_DIR}/cmake_modules/optionDefaults.cmake)
+#include(${HPCC_SOURCE_DIR}/cmake_modules/commonSetup.cmake)
+
+SET (CLASS_DIR "class")
+#SET (JAR_DIR "jar")
+FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CLASS_DIR})
+#FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${JAR_DIR})
+#SET (JAR_FILE ecljdbc.jar)
+SET (JAR_FILE "${PRODUCT_PREFIX}-ecljdbc_${HPCC_PROJECT}-${HPCC_MAJOR}.${HPCC_MINOR}.${HPCC_POINT}.jar")
+SET (JAVA_FILES
+EclDatabaseMetaData.java EclQuery.java SqlExpression.java DFUFile.java EclDriver.java EclResultSet.java SqlOperator.java EclColumn.java EclEngine.java EclResultSetMetadata.java SqlParser.java EclColumnMetaData.java EclPreparedStatement.java EclStatement.java SqlWhereClause.java EclConnection.java EclQueries.java SqlColumn.java Utils.java 
+#EclDatabaseMetaData.java EclQuery.java SqlExpression.java DFUFile.java EclDriver.java EclResultSet.java SqlOperator.java EclColumn.java EclEngine.java EclResultSetMetadata.java SqlParser.java EclColumnMetaData.java EclPreparedStatement.java EclStatement.java SqlWhereClause.java EclConnection.java EclQueries.java SqlColumn.java Utils.java ${CMAKE_CURRENT_BINARY_DIR}/EclVersionTracker.java
+)
+
+# compile all .java files with javac to .class
+ADD_CUSTOM_COMMAND(
+OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${JAVA_FILES}.class
+COMMAND ${CMAKE_Java_COMPILER}
+#ARGS -d ${CMAKE_CURRENT_SOURCE_DIR}/${CLASS_DIR}
+ARGS -d ${CMAKE_CURRENT_BINARY_DIR}/${CLASS_DIR}
+${CMAKE_CURRENT_SOURCE_DIR}/*.java
+)
+
+# build .jar file from .class files
+ADD_CUSTOM_COMMAND(
+OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${JAR_FILE}
+DEPENDS
+${CMAKE_CURRENT_BINARY_DIR}/${JAVA_FILES}.class
+COMMAND ${CMAKE_COMMAND}
+ARGS -E chdir ${CMAKE_CURRENT_BINARY_DIR}/${CLASS_DIR}
+#${CMAKE_Java_ARCHIVE} -cfv ${JAR_DIR}/${JAR_FILE} ${CLASS_DIR}/com/hpccsystems/ecljdbc
+${CMAKE_Java_ARCHIVE} -cfv ${CMAKE_CURRENT_BINARY_DIR}/${JAR_FILE} com/hpccsystems/ecljdbc
+)
+
+# the target
+ADD_CUSTOM_TARGET(
+${JAR_FILE}
+ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${JAR_FILE})

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/DFUFile.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/DFUFile.java
@@ -1,0 +1,771 @@
+package com.hpccsystems.ecljdbc;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.StringTokenizer;
+
+public class DFUFile
+{
+	private String Prefix;
+	private String ClusterName;
+	private String Directory;
+	private String Description;
+	private int Parts;
+	private String FullyQualifiedName;
+	private String FileName;
+	private String Owner;
+	private long TotalSize;
+	private long RecordCount;
+	private String Modified;
+	private long LongSize;
+	private long LongRecordCount;
+	private boolean isSuperFile;
+	private boolean isZipFile;
+	private boolean isDirectory;
+	private int Replicate;
+	private int IntSize;
+	private int IntRecordCount;
+	private boolean FromRoxieCluster;
+	private boolean BrowseData;
+	private boolean IsKeyFile;
+	private Properties Fields;
+	private String Format;
+	private String CsvSeparate;
+	private String CsvTerminate;
+	private String CsvQuote;
+	private String Ecl;
+	private Properties KeyedColumns;
+	private Properties NonKeyedColumns;
+	private List<String> relatedIndexes;
+	private String IdxFilePosField;
+	private boolean HasPayLoad;
+
+	private final static String RELATEDINDEXKEYWORD = "XDBC:RelIndexes";
+	private final static String IDXFILEPOSFIELDTAG = "XDBC:PosField";
+
+	public DFUFile(String prefix, String clusterName, String filename) {
+		super();
+		Prefix = prefix;
+		ClusterName = clusterName;
+		FileName = filename;
+		FullyQualifiedName = filename;
+
+		Directory = null;
+		Description = null;
+		Parts = -1;
+		Owner = null;
+		TotalSize = -1;
+		RecordCount = -1;
+		Modified = null;
+		LongSize = -1;
+		LongRecordCount = -1;
+		isSuperFile = false;
+		isZipFile = false;
+		isDirectory = false;
+		Replicate = -1;
+		IntSize = -1;
+		IntRecordCount = -1;
+		FromRoxieCluster = false;
+		BrowseData = false;
+		IsKeyFile = false;
+		Format = "FLAT";
+		CsvSeparate = null;
+		CsvTerminate = null;
+		CsvQuote = null;
+		Ecl = null;
+		Fields = new Properties();
+		KeyedColumns = new Properties();
+		NonKeyedColumns = new Properties();
+		relatedIndexes = null;
+		IdxFilePosField = null;
+		HasPayLoad = false;
+	}
+
+	public DFUFile(String prefix, String clusterName, String directory,
+			String description, int parts, String filename, String fullyqualifiedname, String owner,
+			long totalSize, long recordCount, String modified, long longSize,
+			long longRecordCount, boolean isSuperFile, boolean isZipFile,
+			boolean isDirectory, int replicate, int intSize,
+			int intRecordCount, boolean fromRoxieCluster, boolean browseData,
+			boolean isKeyFile, String format, String csvseparate, String csvterminate, String csvquote, String ecl)
+	{
+		Prefix = prefix;
+		ClusterName = clusterName;
+		Directory = directory;
+		Description = description;
+		Parts = parts;
+		FileName = filename;
+		FullyQualifiedName = fullyqualifiedname;
+		Owner = owner;
+		TotalSize = totalSize;
+		RecordCount = recordCount;
+		Modified = modified;
+		LongSize = longSize;
+		LongRecordCount = longRecordCount;
+		this.isSuperFile = isSuperFile;
+		this.isZipFile = isZipFile;
+		this.isDirectory = isDirectory;
+		Replicate = replicate;
+		IntSize = intSize;
+		IntRecordCount = intRecordCount;
+		FromRoxieCluster = fromRoxieCluster;
+		BrowseData = browseData;
+		IsKeyFile = isKeyFile;
+		Fields = new Properties();
+		Format = format;
+		CsvSeparate = csvseparate;
+		CsvTerminate = csvterminate;
+		CsvQuote = csvquote;
+		KeyedColumns = new Properties();
+		NonKeyedColumns = new Properties();
+
+		if (ecl != null && ecl.length()>0)
+		{
+			Ecl = ecl;
+			setFileRecDef(ecl);
+		}
+		relatedIndexes = null;
+		IdxFilePosField = null;
+		HasPayLoad = false;
+	}
+
+	public DFUFile()
+	{
+		Prefix = null;
+		ClusterName = null;
+		Directory = null;
+		Description = null;
+		Parts = -1;
+		FullyQualifiedName = null;
+		FileName = null;
+		Owner = null;
+		TotalSize = -1;
+		RecordCount = -1;
+		Modified = null;
+		LongSize = -1;
+		LongRecordCount = -1;
+		this.isSuperFile = false;
+		this.isZipFile = false;
+		this.isDirectory = false;
+		Replicate = -1;
+		IntSize = -1;
+		IntRecordCount = -1;
+		FromRoxieCluster = false;
+		BrowseData = false;
+		IsKeyFile = false;
+		Fields = new Properties();
+		Format = "FLAT";
+		CsvSeparate = null;
+		CsvTerminate = null;
+		CsvQuote = null;
+		Ecl = null;
+		KeyedColumns = new Properties();
+		NonKeyedColumns = new Properties();
+		relatedIndexes = null;
+		IdxFilePosField = null;
+		HasPayLoad = false;
+	}
+
+	public String getFileName() {
+		return FileName;
+	}
+
+	public void setFileName(String fileName) {
+		FileName = fileName;
+	}
+	public String getPrefix() {
+		return Prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		Prefix = prefix;
+	}
+
+	public String getClusterName() {
+		return ClusterName;
+	}
+
+	public void setClusterName(String clusterName) {
+		ClusterName = clusterName;
+	}
+
+	public String getDirectory() {
+		return Directory;
+	}
+
+	public void setDirectory(String directory) {
+		Directory = directory;
+	}
+
+	public String getDescription() {
+		return Description;
+	}
+
+	public void setDescription(String description)
+	{
+		Description = description;
+
+		if (description.contains(RELATEDINDEXKEYWORD))
+			setRelatedIndexes(description.substring(description.indexOf(RELATEDINDEXKEYWORD)));
+
+		if (description.contains(IDXFILEPOSFIELDTAG))
+			setIdxFilePosField(description.substring(description.indexOf(IDXFILEPOSFIELDTAG)));
+	}
+
+	private void setIdxFilePosField(String str)
+	{
+		IdxFilePosField = str.substring(IDXFILEPOSFIELDTAG.length()+1+1, str.indexOf(']'));
+	}
+
+	public String getIdxFilePosField()
+	{
+		return IdxFilePosField != null ? IdxFilePosField : getLastNonKeyedNumericField();
+	}
+
+	public boolean hasValidIdxFilePosField()
+	{
+		String tmp = getIdxFilePosField();
+		return tmp != null && tmp.length() > 0 ? true : false;
+	}
+
+	private String getLastNonKeyedNumericField()
+	{
+		//TODO get numeric field
+		return (String)NonKeyedColumns.get(NonKeyedColumns.size());
+	}
+
+	private void setRelatedIndexes(String str)
+	{
+		String indexes = str.substring(RELATEDINDEXKEYWORD.length()+1+1, str.indexOf(']'));
+		StringTokenizer indexeToks = new StringTokenizer(indexes,";");
+
+		while (indexeToks.hasMoreTokens())
+		{
+			addRelatedIndex(indexeToks.nextToken().trim());
+		}
+	}
+
+	public int getParts() {
+		return Parts;
+	}
+
+	public void setParts(int parts) {
+		Parts = parts;
+	}
+
+	public String getFullyQualifiedName() {
+		return FullyQualifiedName;
+	}
+
+	public void setFullyQualifiedName(String name) {
+		FullyQualifiedName = name;
+	}
+
+	public String getOwner() {
+		return Owner;
+	}
+
+	public void setOwner(String owner) {
+		Owner = owner;
+	}
+
+	public long getTotalSize() {
+		return TotalSize;
+	}
+
+	public void setTotalSize(long totalSize) {
+		TotalSize = totalSize;
+	}
+
+	public long getRecordCount() {
+		return RecordCount;
+	}
+
+	public void setRecordCount(long recordCount) {
+		RecordCount = recordCount;
+	}
+
+	public String getModified() {
+		return Modified;
+	}
+
+	public void setModified(String modified) {
+		Modified = modified;
+	}
+
+	public long getLongSize() {
+		return LongSize;
+	}
+
+	public void setLongSize(long longSize) {
+		LongSize = longSize;
+	}
+
+	public long getLongRecordCount() {
+		return LongRecordCount;
+	}
+
+	public void setLongRecordCount(long longRecordCount) {
+		LongRecordCount = longRecordCount;
+	}
+
+	public boolean isSuperFile() {
+		return isSuperFile;
+	}
+
+	public void setSuperFile(boolean isSuperFile) {
+		this.isSuperFile = isSuperFile;
+	}
+
+	public boolean isZipFile() {
+		return isZipFile;
+	}
+
+	public void setZipFile(boolean isZipFile) {
+		this.isZipFile = isZipFile;
+	}
+
+	public boolean isDirectory() {
+		return isDirectory;
+	}
+
+	public void setDirectory(boolean isDirectory) {
+		this.isDirectory = isDirectory;
+	}
+
+	public int getReplicate() {
+		return Replicate;
+	}
+
+	public void setReplicate(int replicate) {
+		Replicate = replicate;
+	}
+
+	public int getIntSize() {
+		return IntSize;
+	}
+
+	public void setIntSize(int intSize) {
+		IntSize = intSize;
+	}
+
+	public int getIntRecordCount() {
+		return IntRecordCount;
+	}
+
+	public void setIntRecordCount(int intRecordCount) {
+		IntRecordCount = intRecordCount;
+	}
+
+	public boolean isFromRoxieCluster() {
+		return FromRoxieCluster;
+	}
+
+	public void setFromRoxieCluster(boolean fromRoxieCluster) {
+		FromRoxieCluster = fromRoxieCluster;
+	}
+
+	public boolean isBrowseData() {
+		return BrowseData;
+	}
+
+	public void setBrowseData(boolean browseData) {
+		BrowseData = browseData;
+	}
+
+	public boolean isKeyFile() {
+		return IsKeyFile;
+	}
+
+	public void setIsKeyFile(boolean isKeyFile) {
+		IsKeyFile = isKeyFile;
+	}
+
+	public void setFileFields(String eclString)
+	{
+		//Ecl = "filerecstruct := RECORD ";
+		Ecl = "";
+		if (eclString != null && eclString.length()>0)
+		{
+			try
+			{
+				StringTokenizer comatokens = null;
+				//ECL RECORD can be defined as { type name,...,type name}; or RECORD type name;...;type name;END;
+				//TODO we should handle nested file types
+				if (eclString.toUpperCase().contains("RECORD"))
+				{
+					String tmp = eclString.substring(eclString.indexOf("RECORD")+6, eclString.indexOf("END"));
+					comatokens = new StringTokenizer(tmp, ";");
+
+				}
+				else if (eclString.contains("{"))
+				{
+					String tmp = eclString.substring(eclString.indexOf('{')+1, eclString.indexOf('}'));
+					comatokens = new StringTokenizer(tmp, ",");
+
+				}
+
+				if (comatokens != null)
+				{
+					int index = 0;
+					while (comatokens.hasMoreTokens())
+					{
+						StringTokenizer spacetokens = new StringTokenizer(comatokens.nextToken()," \n");
+						if(spacetokens.hasMoreTokens())
+						{
+							String type = spacetokens.nextToken();
+							String name = spacetokens.nextToken();
+							EclColumnMetaData columnmeta = new EclColumnMetaData(name, index, EclDatabaseMetaData.convertECLtype2SQLtype(type.toUpperCase()));
+							columnmeta.setEclType(type);
+							//columnmeta.setTableName(this.FileName);
+							columnmeta.setTableName(this.FullyQualifiedName);
+
+							Ecl += type + " " + name + "; ";
+							//Fields.add(columnmeta);
+							Fields.put(name.toUpperCase(), columnmeta);
+						}
+						index++;
+					}
+				}
+			}
+			catch (Exception e)
+			{
+				System.out.println("Invalid ECL Record definition found in " + this.getFullyQualifiedName() + " details.");
+				return;
+			}
+			/*finally
+			{
+				Ecl += "END; ";
+			}*/
+		}
+	}
+
+	public Enumeration<Object> getAllFields()
+	{
+		return Fields.elements();
+	}
+
+	public Properties getAllFieldsProps()
+	{
+		return Fields;
+	}
+	public boolean containsField(String fieldName)
+	{
+		return Fields.containsKey(fieldName.toUpperCase());
+	}
+
+	public EclColumnMetaData getFieldMetaData(String fieldName)
+	{
+		return (EclColumnMetaData) Fields.get(fieldName.toUpperCase());
+	}
+
+	public String[] getAllTableFieldsStringArray()
+	{
+		String [] fields = new String [Fields.size()];
+		Enumeration<Object> it = Fields.elements();
+		while(it.hasMoreElements())
+		{
+			EclColumnMetaData col = ((EclColumnMetaData)it.nextElement());
+			fields[col.getIndex()] = col.getColumnName();
+		}
+		return fields;
+	}
+
+
+	public String getFormat() {
+		return Format;
+	}
+
+	public String getCsvSeparate() {
+		return CsvSeparate;
+	}
+
+	public String getCsvTerminate() {
+		return CsvTerminate;
+	}
+
+	public void setFormat(String format)
+	{
+		if (format != null && format.length()>0)
+		{
+			if (format.equalsIgnoreCase("THOR") || format.equalsIgnoreCase("CSV") || format.equalsIgnoreCase("XML"))
+			{
+				Format = format;
+				return;
+			}
+		}
+		//TODO Default = FLAT... is this safe to assume???
+		Format = "FLAT";
+	}
+
+	public void setCsvSeparate(String csvSeparate)
+	{
+		CsvSeparate = csvSeparate;
+	}
+
+	public void setCsvTerminate(String csvTerminate)
+	{
+		CsvTerminate = csvTerminate;
+	}
+
+	public void setCsvQuote(String csvQuote)
+	{
+		CsvQuote = csvQuote;
+	}
+
+	public String getCsvQuote()
+	{
+		return CsvQuote;
+	}
+
+	public boolean hasFileRecDef()
+	{
+		return Ecl == null || Ecl.length() <= 0 ? false : true;
+	}
+
+	public String getFileRecDef(String structname)
+	{
+		return Ecl == null ? null : structname + " := RECORD " + Ecl + "END; ";
+	}
+
+	public void setFileRecDef(String ecl) {
+		if (ecl != null && ecl.length()>0)
+			setFileFields(ecl);
+	}
+
+	public EclColumnMetaData getCompatibleField(String keyName, String keyType) {
+		//EclColumnMetaData field = (EclColumnMetaData) Fields.get(keyName.toUpperCase());
+		//want to match up name and type, for now just check name.
+		return (EclColumnMetaData) Fields.get(keyName.toUpperCase());
+	}
+
+	public void  setKeyedColumns (Properties KeyFields)
+	{
+		KeyedColumns = KeyFields;
+	}
+
+	public void  setNonKeyedColumns (Properties NonKeyFields)
+	{
+		NonKeyedColumns = NonKeyFields;
+		if (NonKeyFields != null && NonKeyFields.size()>0)
+			HasPayLoad = true;
+	}
+
+	public void  addKeyedColumnInOrder(String KeyLabel)
+	{
+		KeyedColumns.put(KeyedColumns.size()+1, KeyLabel);
+	}
+
+	public void  addKeyedColumn (int KeyIndex, String KeyLabel)
+	{
+		if (!KeyedColumns.containsKey(KeyIndex))
+			KeyedColumns.put(KeyIndex, KeyLabel);
+	}
+
+	public void  addNonKeyedColumnInOrder(String KeyLabel)
+	{
+		if (KeyLabel.startsWith("__internal_fpos__"))
+		{
+			//IndexPositionField = KeyLabel;
+			return;
+		}
+		NonKeyedColumns.put(NonKeyedColumns.size()+1, KeyLabel);
+	}
+
+	public void  addNonKeyedColumn (int NonKeyIndex, String NonKeyLabel)
+	{
+		if (!NonKeyedColumns.containsKey(NonKeyIndex))
+		{
+			NonKeyedColumns.put(NonKeyIndex, NonKeyLabel);
+			HasPayLoad = true;
+		}
+	}
+
+	public boolean hasPayLoad()
+	{
+		return HasPayLoad;
+	}
+
+	public Properties getKeyedColumns()
+	{
+		return KeyedColumns;
+	}
+
+	public Properties getNonKeyedColumns()
+	{
+		return NonKeyedColumns;
+	}
+
+	public int getNonKeyColumnIndex(String ColumnName)
+	{
+		int cols = NonKeyedColumns.size();
+		for (int i = 1; i <= cols; i++)
+		{
+			if(NonKeyedColumns.get(i).equals(ColumnName))
+				return i;
+		}
+
+		return -1;
+	}
+
+	public int getKeyColumnIndex(String ColumnName)
+	{
+		int cols = KeyedColumns.size();
+		for (int i = 1; i <= cols; i++)
+		{
+			if(KeyedColumns.get(i).equals(ColumnName))
+				return i;
+		}
+		return -1;
+	}
+
+	public void addRelatedIndex(String IndexName)
+	{
+		if (relatedIndexes == null)
+			relatedIndexes = new ArrayList<String>();
+
+		relatedIndexes.add(IndexName);
+	}
+
+	public void setRelatedIndexes(List<String> indexes)
+	{
+		relatedIndexes = indexes;
+	}
+
+	public boolean isRelatedIndex(String indexname)
+	{
+		if (relatedIndexes != null)
+			return relatedIndexes.contains(indexname);
+		return false;
+	}
+
+	public Iterator<String> getRelatedIndexes()
+	{
+		return relatedIndexes == null ? null : relatedIndexes.iterator();
+	}
+
+	public String[] getRelatedIndexesAsArray()
+	{
+		String [] indexes = new String [relatedIndexes.size()];
+		for (int i = 0; i < indexes.length; i++)
+		{
+			indexes[i] = relatedIndexes.get(i);
+		}
+		return indexes;
+	}
+
+	public List<String> getRelatedIndexesList()
+	{
+		return relatedIndexes;
+	}
+
+	public int getRelatedIndexesCount()
+	{
+		return relatedIndexes == null ? 0 : relatedIndexes.size();
+	}
+
+	public Object getFileRecDefwithIndexpos(EclColumnMetaData fieldMetaData, String structname)
+	{
+		if(fieldMetaData != null)
+			//return "filerecstruct := RECORD " + Ecl + fieldMetaData.getEclType() + " " + fieldMetaData.getColumnName() + " {virtual(fileposition)}; END; ";
+			return structname + " := RECORD " + Ecl + fieldMetaData.getEclType() + " " + fieldMetaData.getColumnName() + " {virtual(fileposition)}; END; ";
+
+		return structname + " := RECORD " + Ecl +  " END; "; //might need to throw exception instead
+	}
+
+	public String getKeyedFieldsAsDelmitedString(char c, String prefixtoappend)
+	{
+		StringBuilder fields = new StringBuilder();
+		int colscount = KeyedColumns.size();
+
+		for (int i = 1; i <= colscount; i++)
+		{
+			if (prefixtoappend != null)
+				fields.append(prefixtoappend).append('.');
+			fields.append(KeyedColumns.get(i));
+			if (i < colscount)
+				fields.append(c).append(" ");
+		}
+		return fields.toString();
+	}
+
+	public String getNonKeyedFieldsAsDelmitedString(char c, String prefixtoappend)
+	{
+		StringBuilder fields = new StringBuilder();
+		int colscount = NonKeyedColumns.size();
+
+		for (int i = 1; i <= colscount; i++)
+		{
+			if (prefixtoappend != null)
+				fields.append(prefixtoappend).append('.');
+			fields.append(NonKeyedColumns.get(i));
+			if (i < colscount)
+				fields.append(c).append(" ");
+		}
+		return fields.toString();
+	}
+	public String getAllFieldsAsDelimitedString(char c)
+	{
+		String [] cols = getAllTableFieldsStringArray();
+		StringBuilder fields = new StringBuilder();
+		if (cols.length <= 0)
+		{
+			for (int index = 0; index < cols.length; index++ )
+			{
+				fields.append(cols[index]);
+
+				if (index < cols.length-1)
+					fields.append(c).append(" ");
+			}
+		}
+
+		return fields.toString();
+	}
+
+	public String getIndexNameByIndex(int i)
+	{
+		return relatedIndexes.get(i);
+	}
+
+	public boolean hasRelatedIndexes()
+	{
+		return relatedIndexes == null || relatedIndexes.size() <= 0 ? false : true;
+	}
+
+	public boolean containsField(EclColumnMetaData fieldMetaData, boolean verifyEclType)
+	{
+		String fieldName = fieldMetaData.getColumnName().toUpperCase();
+		if (Fields.containsKey(fieldName))
+			if (!verifyEclType || ((EclColumnMetaData)Fields.get(fieldName)).getEclType().equals(fieldMetaData.getEclType()))
+				return true;
+		return false;
+	}
+
+	public boolean containsAllFieldsNames(String[] columnNames)
+	{
+		if(columnNames != null)
+		{
+			for (int i = 0; i < columnNames.length; i++)
+			{
+				if(!this.containsField(columnNames[i]))
+					return false;
+			}
+			return true;
+		}
+
+		return false;
+	}
+
+	public int getNonKeyedColumnsCount()
+	{
+		return NonKeyedColumns == null ? 0 : NonKeyedColumns.size();
+	}
+
+	public boolean containsField(EclColumnMetaData column)
+	{
+		return this.containsField(column.getColumnName());
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclColumn.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclColumn.java
@@ -1,0 +1,26 @@
+package com.hpccsystems.ecljdbc;
+
+/**
+ * @author ChalaAX
+ */
+public class EclColumn
+{
+    private String name;
+    private String value;
+
+    public EclColumn(String name, String value)
+    {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getValue()
+    {
+        return value;
+    }
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclColumnMetaData.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclColumnMetaData.java
@@ -1,0 +1,263 @@
+package com.hpccsystems.ecljdbc;
+
+import java.util.List;
+
+/**
+ * @author rpastrana
+ */
+
+public class EclColumnMetaData {
+	private String columnName;
+	private int index;
+	private int sqlType;
+
+	private String eclType;
+	private String tableName;
+	private int columnSize;
+	private int decimalDigits;
+	private int radix;
+	private String nullable;
+	private String remarks;
+	private String columnDefault;
+	// private Properties restrictions;
+	private int paramType;
+	private String javaClassName;
+	private String constantValue;
+	private int columnType;
+	private String alias;
+	private List<EclColumnMetaData> funccols;
+
+
+	final static int COLUMN_TYPE_DATA 		= 1;
+	final static int COLUMN_TYPE_CONSTANT 	= 2;
+	final static int COLUMN_TYPE_FNCTION	= 3;
+
+	public EclColumnMetaData(String columnName, int index, int sqlType,	String constant, String eclType)
+	{
+		constantValue = constant;
+		this.columnName = columnName;
+		this.index = index;
+		this.sqlType = sqlType;
+		this.paramType = EclDatabaseMetaData.procedureColumnUnknown;
+		javaClassName = EclDatabaseMetaData.convertSQLtype2JavaClassName(this.sqlType);
+		this.eclType = eclType;
+		columnType = COLUMN_TYPE_CONSTANT;
+		funccols = null;
+		alias = null;
+	}
+
+	public EclColumnMetaData(String columnName, int index, int sqlType)
+	{
+		this.columnName = columnName;
+		this.index = index;
+		this.sqlType = sqlType;
+		this.paramType = EclDatabaseMetaData.procedureColumnUnknown;
+		javaClassName = EclDatabaseMetaData.convertSQLtype2JavaClassName(this.sqlType);
+		constantValue = null;
+		columnType = COLUMN_TYPE_DATA;
+		funccols = null;
+		alias = null;
+	}
+
+	public EclColumnMetaData(String columnName, int index, List<EclColumnMetaData> columns )
+	{
+		this.columnName = columnName;
+		this.index = index;
+		this.sqlType = java.sql.Types.OTHER;
+		this.paramType = EclDatabaseMetaData.procedureColumnUnknown;
+		javaClassName = EclDatabaseMetaData.convertSQLtype2JavaClassName(this.sqlType);
+		constantValue = null;
+		columnType = COLUMN_TYPE_FNCTION;
+		funccols = columns;
+		alias = null;
+	}
+
+	public void setConstantValue(String value)
+	{
+		constantValue = value;
+	}
+
+	public boolean isConstant()
+	{
+		return constantValue == null ? false : true;
+	}
+
+	public String getConstantValue()
+	{
+		return constantValue;
+	}
+
+	public int getSQLType()
+	{
+		return sqlType;
+	}
+
+	public void setSQLType(int type)
+	{
+		this.sqlType = type;
+	}
+
+	public String getColumnName()
+	{
+		return columnName;
+	}
+
+	public void setColumnName(String columnName)
+	{
+		this.columnName = columnName;
+	}
+
+	public int getIndex()
+	{
+		return index;
+	}
+
+	public void setIndex(int index)
+	{
+		this.index = index;
+	}
+
+	public int getParamType()
+	{
+		return paramType;
+	}
+
+	public void setParamType(int paramType)
+	{
+		this.paramType = paramType;
+	}
+
+	// public Properties getRestrictions() {
+	// return restrictions;
+	// }
+	//
+	// public void addRestriction(String restriction, String value)
+	// {
+	// if (restrictions == null)
+	// restrictions = new Properties();
+	//
+	// this.restrictions.put(restriction, value);
+	// }
+	//
+	// public String getRestrictionStringValue(String restriction)
+	// {
+	// return (String)this.restrictions.get(restriction);
+	// }
+
+	public int getSqlType()
+	{
+		return sqlType;
+	}
+
+	public String getEclType()
+	{
+		return eclType;
+	}
+
+	public void setEclType(String eclType)
+	{
+		this.eclType = eclType;
+		this.sqlType = EclDatabaseMetaData.convertECLtype2SQLtype(eclType.toUpperCase());
+	}
+
+	public String getTableName()
+	{
+		return tableName;
+	}
+
+	public void setTableName(String tableName)
+	{
+		this.tableName = tableName;
+	}
+
+	public int getColumnSize()
+	{
+		return columnSize;
+	}
+
+	public void setColumnSize(int columnSize)
+	{
+		this.columnSize = columnSize;
+	}
+
+	public int getDecimalDigits()
+	{
+		return decimalDigits;
+	}
+
+	public void setDecimalDigits(int decimalDigits)
+	{
+		this.decimalDigits = decimalDigits;
+	}
+
+	public int getRadix()
+	{
+		return radix;
+	}
+
+	public void setRadix(int radix)
+	{
+		this.radix = radix;
+	}
+
+	public String getNullable()
+	{
+		return nullable;
+	}
+
+	public void setNullable(String nullable)
+	{
+		this.nullable = nullable;
+	}
+
+	public String getRemarks()
+	{
+		return remarks;
+	}
+
+	public void setRemarks(String remarks)
+	{
+		this.remarks = remarks;
+	}
+
+	public String getColumnDefault()
+	{
+		return columnDefault;
+	}
+
+	public void setColumnDefault(String columnDefault)
+	{
+		this.columnDefault = columnDefault;
+	}
+
+	public String getJavaClassName()
+	{
+		return javaClassName;
+	}
+
+	public int getColumnType() {
+		return columnType;
+	}
+
+	public void setColumnType(int columnType) {
+		this.columnType = columnType;
+	}
+
+	public List<EclColumnMetaData> getFunccols() {
+		return funccols;
+	}
+
+	public String getAlias() {
+		return alias;
+	}
+
+	public void setAlias(String alias) {
+		this.alias = alias;
+	}
+
+	@Override
+	public String toString()
+	{
+		return "Name: " + this.columnName + " SQL Type: " + sqlType	+ " ECL Type: " + eclType;
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclConnection.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclConnection.java
@@ -1,0 +1,368 @@
+package com.hpccsystems.ecljdbc;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ *
+ * @author rpastrana
+ */
+
+public class EclConnection implements Connection {
+    private boolean closed;
+    private EclDatabaseMetaData metadata;
+    private Properties props;
+    private String serverAddress;
+    private String cluster;
+    private Properties clientInfo;
+
+    public EclConnection(Properties props)
+    {
+       closed = false;
+
+       this.serverAddress = props.getProperty("ServerAddress","localhost");
+       this.cluster = props.getProperty("Cluster","myroxie");
+       this.props = props;
+
+       if (!this.props.containsKey("WsECLWatchPort"))
+    	   this.props.setProperty("WsECLWatchPort", "8010");
+
+       if (!this.props.containsKey("WsECLPort"))
+    	   this.props.setProperty("WsECLPort", "8002");
+
+       //TODO soon wsecldirect will be part of wseclwatch
+       //I will continue to support this property but, by
+       //default we should use the wseclwatch port
+       if (!this.props.containsKey("WsECLDirectPort"))
+    	   this.props.setProperty("WsECLDirectPort", "8008");
+
+       if (!this.props.containsKey("username"))
+    	   this.props.setProperty("username", "");
+
+       if (!this.props.containsKey("password"))
+    	   this.props.setProperty("password", "");
+
+       if (!this.props.containsKey("EclLimit"))
+    	   this.props.setProperty("EclLimit", "100");
+
+       //basicAuth
+       String userPassword = this.props.getProperty("username") + ":" + props.getProperty("password");
+       //String basicAuth = "Basic " + new String(new Base64().encode(userPassword.getBytes()));
+
+       String basicAuth = "Basic " + Utils.Base64Encode(userPassword.getBytes(), false);
+
+       //System.out.println(Utils.Base64Decode(Utils.Base64Encode(userPassword.getBytes(), false).getBytes()));
+       this.props.put("BasicAuth", basicAuth);
+       metadata = new EclDatabaseMetaData(props);
+
+       //TODO not doing anything w/ this yet, just exposing it to comply w/ API definition...
+       clientInfo = new Properties();
+
+       System.out.println("EclConnection initialized - server: " + this.serverAddress + " cluster: " + this.cluster);
+
+    }
+
+    public Properties getProperties()
+    {
+    	return props;
+    }
+
+    public String getProperty(String propname)
+    {
+    	return props.getProperty(propname, "");
+    }
+    public String getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(String cluster) {
+        this.cluster = cluster;
+    }
+
+    public String getServerAddress() {
+        return serverAddress;
+    }
+
+    public void setServerAddress(String serverAddress) {
+        this.serverAddress = serverAddress;
+    }
+
+    public EclDatabaseMetaData getDatabaseMetaData() {
+        return metadata;
+    }
+
+    public void setMetadata(EclDatabaseMetaData metadata) {
+        this.metadata = metadata;
+    }
+
+
+    public Statement createStatement() throws SQLException {
+    	System.out.println("##Statement EclConnection::createStatement()##");
+        return new EclPreparedStatement(this, null);
+    }
+
+
+    public PreparedStatement prepareStatement(String query) throws SQLException {
+    	System.out.println("##PreparedStatement EclConnection::createStatement("+ query +")##");
+        return new EclPreparedStatement(this, query);
+    }
+
+
+    public CallableStatement prepareCall(String sql) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: prepareCall(string sql) Not supported yet.");
+    }
+
+
+    public String nativeSQL(String sql) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: nativeSQL(string sql) Not supported yet.");
+    }
+
+
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: setAutoCommit(boolean autoCommit) Not supported yet.");
+    }
+
+
+    public boolean getAutoCommit() throws SQLException {
+        return true;
+    }
+
+
+    public void commit() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: commit Not supported yet.");
+    }
+
+
+    public void rollback() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: rollback Not supported yet.");
+    }
+
+
+    public void close() throws SQLException {
+        closed = true;
+    }
+
+
+    public boolean isClosed() throws SQLException {
+        return closed;
+    }
+
+
+    public DatabaseMetaData getMetaData() throws SQLException {
+        return metadata;
+    }
+
+
+    public void setReadOnly(boolean readOnly) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: setReadOnly Not supported yet.");
+    }
+
+
+    public boolean isReadOnly() throws SQLException {
+        return true;
+    }
+
+
+    public void setCatalog(String catalog) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: setCatalog Not supported yet.");
+    }
+
+
+    public String getCatalog() throws SQLException
+    {
+    //    throw new UnsupportedOperationException("EclConnection: getCatalog Not supported yet.");
+    	return "myroxie";
+    }
+
+
+    public void setTransactionIsolation(int level) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: settransactionisolation Not supported yet.");
+    }
+
+
+    public int getTransactionIsolation() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: getTransactionIsolation Not supported yet.");
+    }
+
+
+    public SQLWarning getWarnings() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: getWarnings Not supported yet.");
+    }
+
+
+    public void clearWarnings() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: clearWarnings Not supported yet.");
+    }
+
+
+    public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+    	System.out.println("##Statement EclConnection::createStatement(resulttype, resultsetcon)##");
+        return new EclPreparedStatement(this, null);
+    }
+
+
+    public PreparedStatement prepareStatement(String query, int resultSetType, int resultSetConcurrency) throws SQLException {
+    	System.out.println("##EclConnection::createStatement("+ query +", resultsetype, resultsetcon)##");
+        return new EclPreparedStatement(this, query);
+    }
+
+
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: prepareCall(String sql, int resultSetType, int resultSetConcurrency) Not supported yet.");
+    }
+
+
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: getTypeMap Not supported yet.");
+    }
+
+
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: setTypeMap Not supported yet.");
+    }
+
+
+    public void setHoldability(int holdability) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: setHoldability Not supported yet.");
+    }
+
+
+    public int getHoldability() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: getHoldability Not supported yet.");
+    }
+
+
+    public Savepoint setSavepoint() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: setSavepoint Not supported yet.");
+    }
+
+
+    public Savepoint setSavepoint(String name) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: setSavepoint Not supported yet.");
+    }
+
+
+    public void rollback(Savepoint savepoint) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: rollback Not supported yet.");
+    }
+
+
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: releaseSavepoint Not supported yet.");
+    }
+
+
+    public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: createStatement Not supported yet.");
+    }
+
+
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) Not supported yet.");
+    }
+
+
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) Not supported yet.");
+    }
+
+
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: prepareStatement(String sql, int autoGeneratedKeys) Not supported yet.");
+    }
+
+
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: prepareStatement(String sql, int[] columnIndexes) Not supported yet.");
+    }
+
+
+    public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection:  prepareStatement(String sql, String[] columnNames) Not supported yet.");
+    }
+
+
+    public Clob createClob() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: createClob Not supported yet.");
+    }
+
+
+    public Blob createBlob() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: createBlob Not supported yet.");
+    }
+
+
+    public NClob createNClob() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: createNClob Not supported yet.");
+    }
+
+
+    public SQLXML createSQLXML() throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: createSQLXML Not supported yet.");
+    }
+
+
+    public boolean isValid(int timeout) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: isValid Not supported yet.");
+    }
+
+
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+    	System.out.println("ECLCONNECTION SETCLIENTINFO");
+    	clientInfo.put(name, value);
+    }
+
+
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+    	System.out.println("ECLCONNECTION SETCLIENTINFO");
+    	clientInfo = properties;
+    }
+
+
+    public String getClientInfo(String name) throws SQLException {
+    	System.out.println("ECLCONNECTION GETCLIENTINFO");
+    	return (String)clientInfo.getProperty(name);
+    }
+
+
+    public Properties getClientInfo() throws SQLException {
+    	System.out.println("ECLCONNECTION GETCLIENTINFO");
+    	return clientInfo;
+    }
+
+
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: createArrayOf(String typeName, Object[] elements) Not supported yet.");
+    }
+
+
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: createStruct(String typeName, Object[] attributes)Not supported yet.");
+    }
+
+
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: unwrap(Class<T> iface) Not supported yet.");
+    }
+
+
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new UnsupportedOperationException("EclConnection: isWrapperFor(Class<?> iface) sNot supported yet.");
+    }
+
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDatabaseMetaData.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDatabaseMetaData.java
@@ -1,0 +1,2587 @@
+package com.hpccsystems.ecljdbc;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.RowIdLifetime;
+import java.sql.SQLException;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+
+/**
+ *
+ * @author  rpastrana
+ */
+
+public class EclDatabaseMetaData implements DatabaseMetaData {
+
+	//private Properties eclQueryAliases;
+	private EclQueries eclqueries;
+	private Properties dfufiles;
+	private static Map<Integer, String> SQLFieldMapping;
+
+	public static final short JDBCVerMajor = 0;
+	public static final short JDBCVerMinor = 1;
+
+	private static String HPCCBuildVersionFull = "";
+	@SuppressWarnings("unused")
+	private static String HPCCBuildType = "";
+	private static short HPCCBuildMajor = 0;
+	private static float HPCCBuildMinor = 0;
+
+	private boolean isMetaDataCached;
+	private String serverAddress;
+	private String cluster;
+	private String wseclwatchport;
+	private String wseclport;
+	private String basicAuth;
+	private String UserName;
+
+	public EclDatabaseMetaData(Properties props)
+	{
+		super();
+		this.serverAddress = props.getProperty("ServerAddress","localhost");
+		this.cluster = props.getProperty("Cluster","myroxie");
+		this.wseclwatchport  = props.getProperty("WsECLWatchPort"); ;
+		this.wseclport = props.getProperty("WsECLPort");
+		this.UserName = props.getProperty("username");
+		//this.defaultDB =  props.getProperty("DefaultDB");
+		this.basicAuth = props.getProperty("BasicAuth");
+
+		System.out.println("EclDatabaseMetaData ServerAddress: " + serverAddress + " Cluster: " + cluster + " eclwatch: " + wseclwatchport + " ecl: " + wseclport);
+
+		dfufiles = new Properties();
+		//eclQueryAliases = new Properties();
+		eclqueries = new EclQueries(this.cluster);
+		SQLFieldMapping = new HashMap<Integer, String>();
+
+		System.out.println("EclDatabaseMetaData initialized");
+
+		if (!isMetaDataCached())
+			setMetaDataCached(CacheMetaData());
+
+		setSQLTypeNames();
+	}
+
+	private static void setSQLTypeNames()
+	{
+		//TODO
+		//might want to just hardcode this list rather than creating at runtime...
+		if (SQLFieldMapping.isEmpty())
+		{
+			Field[] fields = java.sql.Types.class.getFields();
+
+			for (int i = 0; i < fields.length; i++) {
+				try
+				{
+					String name = fields[i].getName();
+					Integer value = (Integer) fields[i].get(null);
+					SQLFieldMapping.put(value, name);
+				}
+				catch (IllegalAccessException e) {}
+			}
+		}
+	}
+
+	public static String getFieldName(Integer type)
+	{
+		if (SQLFieldMapping.isEmpty())
+			setSQLTypeNames();
+
+		return SQLFieldMapping.get(type);
+	}
+
+	public int getProcFieldType(String eclqueryname, String eclresultset, String fieldName)
+	{
+		try
+		{
+			EclQuery query = (EclQuery)eclqueries.getQuery(eclqueryname);
+			if (query != null && query.containsField(eclresultset, fieldName))
+				return query.getFieldMetaData(fieldName).getSqlType();
+			return java.sql.Types.NULL;
+		}
+		catch (NumberFormatException e)
+		{
+			return java.sql.Types.NULL;
+		}
+	}
+	public int getTableFieldType(String hpccfilename, String fieldName)
+	{
+		try
+		{
+			DFUFile file = (DFUFile)dfufiles.get(hpccfilename);
+			if (file != null && file.containsField(fieldName))
+				return file.getFieldMetaData(fieldName).getSqlType();
+			return java.sql.Types.NULL;
+		}
+		catch (NumberFormatException e)
+		{
+			return java.sql.Types.NULL;
+		}
+	}
+
+	public boolean isMetaDataCached() {
+		return isMetaDataCached;
+	}
+
+	public void setMetaDataCached(boolean isMetaDataCached) {
+		this.isMetaDataCached = isMetaDataCached;
+	}
+
+	private boolean CacheMetaData()
+	{
+		boolean isSuccess = true;
+		if (serverAddress == null || cluster == null)
+			return false;
+
+		getHPCCInfo();
+
+		try
+		{
+			String urlString = "http://" + serverAddress + ":" + wseclwatchport + "/WsDfu/DFUQuery?rawxml_";
+
+			URL dfuLogicalFilesURL;
+			dfuLogicalFilesURL = new URL(urlString);
+
+			HttpURLConnection dfulogfilesConn = (HttpURLConnection)dfuLogicalFilesURL.openConnection();
+			dfulogfilesConn.setInstanceFollowRedirects(false);
+			System.out.println("Setting auth: " + basicAuth);
+			dfulogfilesConn.setRequestProperty("Authorization", basicAuth);
+			dfulogfilesConn.setRequestMethod("GET");
+			dfulogfilesConn.setDoOutput(true);
+			dfulogfilesConn.setDoInput(true);
+
+			InputStream xml = dfulogfilesConn.getInputStream();
+
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			DocumentBuilder db = dbf.newDocumentBuilder();
+			Document dom = db.parse(xml);
+
+			NodeList querySetList = dom.getElementsByTagName("DFULogicalFiles");
+
+			if (querySetList.getLength() > 0)
+			{
+				NumberFormat format = NumberFormat.getInstance(Locale.US);
+
+				NodeList queryList = querySetList.item(0).getChildNodes();
+				for (int i = 0; i < queryList.getLength(); i++)
+				{
+					Node currentNode = queryList.item(i);
+					if (currentNode.getNodeName().equals("DFULogicalFile"))
+					{
+						NodeList querysetquerychildren = currentNode.getChildNodes();
+
+						DFUFile file = new DFUFile();
+						for (int j = 0; j < querysetquerychildren.getLength(); j++)
+						{
+							if (!querysetquerychildren.item(j).getTextContent().equals(""))
+							{
+								String NodeName = querysetquerychildren.item(j).getNodeName();
+								if (NodeName.equals("Prefix"))
+								{
+									file.setPrefix(querysetquerychildren.item(j).getTextContent());
+								}
+								else if (NodeName.equals("ClusterName"))
+								{
+									file.setClusterName(querysetquerychildren.item(j).getTextContent());
+								}
+								else if (NodeName.equals("Directory"))
+								{
+									file.setDirectory(querysetquerychildren.item(j).getTextContent());
+								}
+								//else if (NodeName.equals("Description"))
+								//{
+								//	file.setDescription((querysetquerychildren.item(j).getTextContent()));
+								//}
+								else if (NodeName.equals("Parts"))
+								{
+									file.setParts((Integer.parseInt(querysetquerychildren.item(j).getTextContent())));
+								}
+								else if (NodeName.equals("Name"))
+								{
+									file.setFullyQualifiedName(querysetquerychildren.item(j).getTextContent());
+								}
+								else if (NodeName.equals("Owner"))
+								{
+									file.setOwner(querysetquerychildren.item(j).getTextContent());
+								}
+								else if (NodeName.equals("Totalsize"))
+								{
+									file.setTotalSize(format.parse(querysetquerychildren.item(j).getTextContent()).longValue());
+								}
+								else if (NodeName.equals("RecordCount"))
+								{
+									file.setRecordCount(format.parse(querysetquerychildren.item(j).getTextContent()).longValue());
+								}
+								else if (NodeName.equals("Modified"))
+								{
+									file.setModified(querysetquerychildren.item(j).getTextContent());
+								}
+								else if (NodeName.equals("LongSize"))
+								{
+									file.setLongSize(format.parse(querysetquerychildren.item(j).getTextContent()).longValue());
+								}
+								else if (NodeName.equals("LongRecordCount"))
+								{
+									file.setLongRecordCount(Long.parseLong(querysetquerychildren.item(j).getTextContent()));
+								}
+								else if (NodeName.equals("isSuperfile"))
+								{
+									file.setSuperFile(querysetquerychildren.item(j).getTextContent().equals("1"));
+								}
+								else if (NodeName.equals("isZipfile"))
+								{
+									file.setZipFile(querysetquerychildren.item(j).getTextContent().equals("1"));
+								}
+								else if (NodeName.equals("isDirectory"))
+								{
+									file.setDirectory(querysetquerychildren.item(j).getTextContent());
+								}
+								else if (NodeName.equals("Replicate"))
+								{
+									file.setReplicate(Integer.parseInt(querysetquerychildren.item(j).getTextContent()));
+								}
+								else if (NodeName.equals("IntSize"))
+								{
+									file.setIntSize(Integer.parseInt(querysetquerychildren.item(j).getTextContent()));
+								}
+								else if (NodeName.equals("IntRecordCount"))
+								{
+									file.setIntRecordCount(Integer.parseInt(querysetquerychildren.item(j).getTextContent()));
+								}
+								else if (NodeName.equals("FromRoxieCluster"))
+								{
+									file.setFromRoxieCluster(querysetquerychildren.item(j).getTextContent().equals("1"));
+								}
+								else if (NodeName.equals("BrowseData"))
+								{
+									file.setBrowseData(querysetquerychildren.item(j).getTextContent().equals("1"));
+								}
+								else if (NodeName.equals("IsKeyFile"))
+								{
+									file.setIsKeyFile(querysetquerychildren.item(j).getTextContent().equals("1"));
+								}
+								else
+									System.out.println("Unknow QuerySetElement found: " + NodeName);
+							}
+
+						}
+
+						if (file.getFullyQualifiedName().length() > 0 && file.getClusterName()!=null)
+						{
+							String filedetailUrl = "http://" + serverAddress + ":" + wseclwatchport +
+									"/WsDfu/DFUInfo?Name=" +
+									URLEncoder.encode(file.getFullyQualifiedName(), "UTF-8") +
+									"&Cluster=" +
+									file.getClusterName() +
+									"&rawxml_";
+
+							//now request the schema for each roxy query
+							URL queryschema = new URL(filedetailUrl);
+							HttpURLConnection queryschemaconnection = (HttpURLConnection)queryschema.openConnection();
+							queryschemaconnection.setInstanceFollowRedirects(false);
+							queryschemaconnection.setRequestProperty("Authorization", basicAuth);
+							queryschemaconnection.setRequestMethod("GET");
+							queryschemaconnection.setDoOutput(true);
+							queryschemaconnection.setDoInput(true);
+
+							InputStream schema = queryschemaconnection.getInputStream();
+							Document dom2 = db.parse(schema);
+
+							Element docElement = dom2.getDocumentElement();
+
+							// Get all pertinent detail info regarding this file (files are being treated as DB tables)
+							registerFileDetails(docElement, file);
+
+
+							//we might need more info if this file is actually an index:
+							if(file.isKeyFile())
+							{
+								String openfiledetailUrl = "http://" + serverAddress + ":" + wseclwatchport +
+										"/WsDfu/DFUSearchData?OpenLogicalName=" +
+										URLEncoder.encode(file.getFullyQualifiedName(), "UTF-8") +
+										"&Cluster=" +
+										file.getClusterName() +
+										"&RoxieSelections=0"+
+										"&rawxml_";
+
+								//now request the schema for each roxy query
+								URL queryfiledata = new URL(openfiledetailUrl);
+								HttpURLConnection queryfiledataconnection = (HttpURLConnection)queryfiledata.openConnection();
+								queryfiledataconnection.setInstanceFollowRedirects(false);
+								queryfiledataconnection.setRequestProperty("Authorization", basicAuth);
+								queryfiledataconnection.setRequestMethod("GET");
+								queryfiledataconnection.setDoOutput(true);
+								queryfiledataconnection.setDoInput(true);
+
+								InputStream filesearchinfo = queryfiledataconnection.getInputStream();
+								Document dom3 = db.parse(filesearchinfo);
+
+								Element docElement2 = dom3.getDocumentElement();
+
+								//NodeList keyfiledetail = docElement2.getElementsByTagName("DFUSearchDataResponse");
+								NodeList keyfiledetail = docElement2.getChildNodes();
+								if (keyfiledetail.getLength()>0)
+								{
+									//NodeList resultslist = keyfiledetail.item(0).getChildNodes(); //ECLResult nodes
+									for (int k = 0; k< keyfiledetail.getLength(); k++)
+									{
+										Node currentnode = keyfiledetail.item(k);
+										if(currentnode.getNodeName().startsWith("DFUDataKeyedColumns"))
+										{
+											NodeList keyedColumns = currentnode.getChildNodes();
+											for (int fieldindex = 0 ; fieldindex < keyedColumns.getLength(); fieldindex++)
+											{
+												Node KeyedColumn = keyedColumns.item(fieldindex);
+												NodeList KeyedColumnFields = KeyedColumn.getChildNodes();
+												for (int q = 0; q < KeyedColumnFields.getLength(); q++)
+												{
+													Node keyedcolumnfield = KeyedColumnFields.item(q);
+													if (keyedcolumnfield.getNodeName().equals("ColumnLabel"))
+													{
+														//file.addKeyedColumn(fieldindex+1,keyedcolumnfield.getTextContent());
+														file.addKeyedColumnInOrder(keyedcolumnfield.getTextContent());
+														break;
+													}
+													/*currently not interested in any other field, if we need
+													 * other field values, remove above break;
+													 */
+												}
+
+											}
+										}
+										else if(currentnode.getNodeName().startsWith("DFUDataNonKeyedColumns"))
+										{
+											NodeList nonKeyedColumns = currentnode.getChildNodes();
+
+											//Properties nonkeyedcolumns = new Properties();
+											for (int fieldindex = 0 ; fieldindex < nonKeyedColumns.getLength(); fieldindex++)
+											{
+												Node nonKeyedColumn = nonKeyedColumns.item(fieldindex);
+												NodeList nonKeyedColumnFields = nonKeyedColumn.getChildNodes();
+												for (int q = 0; q < nonKeyedColumnFields.getLength(); q++)
+												{
+													Node nonkeyedcolumnfield = nonKeyedColumnFields.item(q);
+													if (nonkeyedcolumnfield.getNodeName().equals("ColumnLabel"))
+													{
+														//file.addNonKeyedColumn(fieldindex+1, nonkeyedcolumnfield.getTextContent());
+														file.addNonKeyedColumnInOrder(nonkeyedcolumnfield.getTextContent());
+														break;
+													}
+													//currently not interested in any other field, if we need
+													 // other field values, remove above break;
+												}
+											}
+										}
+									}
+								}
+							}
+
+							// Add this file name to files structure
+							dfufiles.put(file.getFullyQualifiedName(), file);
+						}
+						else
+							System.out.println("Found DFU file but could not determine name and/or cluster");
+					}
+				}
+			}
+			else
+				System.out.println("No DFU files found, check server address and ECL watch port");
+		}
+		catch (MalformedURLException e)
+		{
+			isSuccess = false;
+			e.printStackTrace();
+		}
+		catch (IOException e)
+		{
+			isSuccess = false;
+			e.printStackTrace();
+		}
+		catch (ParserConfigurationException e)
+		{
+			isSuccess = false;
+			e.printStackTrace();
+		}
+		catch (SAXException e)
+		{
+			isSuccess = false;
+			e.printStackTrace();
+		}
+		catch (ParseException e)
+		{
+			isSuccess = false;
+			e.printStackTrace();
+		}
+
+		try
+		{
+			String urlString = "http://" + serverAddress + ":" + wseclwatchport + "/WsWorkunits/WUQuerysetDetails?QuerySetName=" + cluster + "&rawxml_";
+
+			URL querysetURL;
+			querysetURL = new URL(urlString);
+
+			HttpURLConnection querysetconnection = (HttpURLConnection)querysetURL.openConnection();
+			querysetconnection.setInstanceFollowRedirects(false);
+			querysetconnection.setRequestProperty("Authorization", basicAuth);
+			querysetconnection.setRequestMethod("GET");
+			querysetconnection.setDoOutput(true);
+			querysetconnection.setDoInput(true);
+
+			InputStream xml = querysetconnection.getInputStream();
+
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			DocumentBuilder db = dbf.newDocumentBuilder();
+			Document dom = db.parse(xml);
+
+			NodeList querySetList = dom.getElementsByTagName("QuerysetQueries");
+
+			if (querySetList.getLength() > 0)
+			{
+				NodeList queryList = querySetList.item(0).getChildNodes();
+				for (int i = 0; i < queryList.getLength(); i++)
+				{
+					Node currentNode = queryList.item(i);
+					if (currentNode.getNodeName().equals("QuerySetQuery"))
+					{
+						NodeList querysetquerychildren = currentNode.getChildNodes();
+
+						EclQuery query = new EclQuery();
+						for (int j = 0; j < querysetquerychildren.getLength(); j++)
+						{
+							String NodeName = querysetquerychildren.item(j).getNodeName();
+							if (NodeName.equals("Id"))
+							{
+								query.setID(querysetquerychildren.item(j).getTextContent());
+							}
+							else if (NodeName.equals("Name"))
+							{
+								query.setName(querysetquerychildren.item(j).getTextContent());
+							}
+							else if (NodeName.equals("Wuid"))
+							{
+								query.setWUID(querysetquerychildren.item(j).getTextContent());
+							}
+							else if (NodeName.equals("Dll"))
+							{
+								query.setDLL(querysetquerychildren.item(j).getTextContent());
+							}
+							else if (NodeName.equals("Suspended"))
+							{
+								query.setSuspended(Boolean.parseBoolean(querysetquerychildren.item(j).getTextContent()));
+							}
+							else
+								System.out.println("Unknow QuerySetElement found: " + NodeName);
+
+						}
+						//for each QuerySetQuery found above, get all schema related info:
+						String queryinfourl = "http://" + serverAddress + ":" + wseclwatchport +
+								"/WsWorkunits/WUInfo/WUInfoRequest?Wuid=" +
+								query.getWUID() +
+								"&IncludeExceptions=0" +
+								"&IncludeGraphs=0" +
+								"&IncludeSourceFiles=0" +
+								"&IncludeTimers=0" +
+								"&IncludeDebugValues=0" +
+								"&IncludeApplicationValues=0" +
+								"&IncludeWorkflows=0" +
+								"&IncludeHelpers=0" +
+								"&rawxml_";
+
+						//now request the schema for each roxy query
+						URL queryschema = new URL(queryinfourl);
+						HttpURLConnection queryschemaconnection = (HttpURLConnection)queryschema.openConnection();
+						queryschemaconnection.setInstanceFollowRedirects(false);
+						queryschemaconnection.setRequestProperty("Authorization", basicAuth);
+						queryschemaconnection.setRequestMethod("GET");
+						queryschemaconnection.setDoOutput(true);
+						queryschemaconnection.setDoInput(true);
+
+						InputStream schema = queryschemaconnection.getInputStream();
+						try
+						{
+							Document dom2 = db.parse(schema);
+
+							Element docElement = dom2.getDocumentElement();
+
+							// 	Get all pertinent info regarding this query (analogous to SQL DB)
+							registerSchemaElements(docElement, query);
+
+							// Add this query name to queries structure
+							eclqueries.put(query.getName(),query);
+						}
+						catch (SAXException e)
+						{
+							System.out.println("Could not retreive Query info for: " + query.getName() + "(" + query.getWUID() +")");
+						}
+						catch (Exception e)
+						{
+							System.out.println("Could not retreive Query info for: " + query.getName() + "(" + query.getWUID() +")");
+						}
+					}
+				}
+			}
+			else
+				System.out.println("No ECL queries found, check server address, ECL cluster, and ECL watch port");
+		}
+		catch (IOException e)
+		{
+			isSuccess = false;
+			e.printStackTrace();
+		}
+		catch (SAXException e)
+		{
+			isSuccess = false;
+			e.printStackTrace();
+		}
+		catch (ParserConfigurationException e)
+		{
+			isSuccess = false;
+			e.printStackTrace();
+		}
+
+		System.out.println("Tables found: ");
+		Enumeration<Object> em = dfufiles.elements();
+		while (em.hasMoreElements())
+		{
+			 DFUFile file = (DFUFile)em.nextElement();
+			System.out.println("\t" + file.getClusterName() + "." +file.getFileName() +"("+ file.getFullyQualifiedName()+")");
+		}
+
+		System.out.println("Stored Procedures found: ");
+		Enumeration<Object> em1 = eclqueries.getQueries();
+		while (em1.hasMoreElements()) {
+			EclQuery query = (EclQuery) em1.nextElement();
+			System.out.println("\t" + query.getName() + "#" + query.getDefaultTableName());
+		}
+
+		if (!isSuccess)
+			System.out.println("Could not query DB metadata check server address, cluster name, wsecl, and wseclwatch ports");
+		return isSuccess;
+	}
+
+	private int registerFileDetails(Element node, DFUFile file) {
+
+		NodeList fileDetail = node.getElementsByTagName("FileDetail");
+		if (fileDetail.getLength()>0)
+		{
+			NodeList resultslist = fileDetail.item(0).getChildNodes(); //ECLResult nodes
+			for (int i = 0; i < resultslist.getLength(); i++)
+			{
+				Node currentfiledetail = resultslist.item(i);
+
+				if (currentfiledetail.getNodeName().equals("Ecl"))
+				{
+					//file.setFileFields(currentfiledetail.getTextContent());
+					file.setFileRecDef(currentfiledetail.getTextContent());
+				}
+				else if (currentfiledetail.getNodeName().equals("Filename"))
+				{
+					file.setFileName(currentfiledetail.getTextContent());
+				}
+				else if (currentfiledetail.getNodeName().equals("Format"))
+				{
+					file.setFormat(currentfiledetail.getTextContent());
+				}
+				else if (currentfiledetail.getNodeName().equals("CsvSeparate"))
+				{
+					file.setCsvSeparate(currentfiledetail.getTextContent());
+				}
+				else if (currentfiledetail.getNodeName().equals("CsvQuote"))
+				{
+					file.setCsvQuote(currentfiledetail.getTextContent());
+				}
+				else if (currentfiledetail.getNodeName().equals("CsvTerminate"))
+				{
+					file.setCsvTerminate(currentfiledetail.getTextContent());
+				}
+				else if (currentfiledetail.getNodeName().equals("Description"))
+				{
+					file.setDescription(currentfiledetail.getTextContent());
+				}
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Translates a data type from an integer (java.sql.Types value) to a string
+	 * that represents the corresponding class.
+	 *
+	 * @param type
+	 *            The java.sql.Types value to convert to a string
+	 *            representation.
+	 * @return The class name that corresponds to the given java.sql.Types
+	 *         value, or "java.lang.Object" if the type has no known mapping.
+	 */
+	public static String convertSQLtype2JavaClassName(int type)
+	{
+		String result = "java.lang.Object";
+
+		switch (type)
+		{
+			case java.sql.Types.CHAR:
+			case java.sql.Types.VARCHAR:
+			case java.sql.Types.LONGVARCHAR:
+				result = "java.lang.String";
+				break;
+			case java.sql.Types.NUMERIC:
+			case java.sql.Types.DECIMAL:
+				result = "java.math.BigDecimal";
+				break;
+			case java.sql.Types.BIT:
+				result = "java.lang.Boolean";
+				break;
+			case java.sql.Types.TINYINT:
+				result = "java.lang.Byte";
+				break;
+			case java.sql.Types.SMALLINT:
+				result = "java.lang.Short";
+				break;
+			case java.sql.Types.INTEGER:
+				result = "java.lang.Integer";
+				break;
+			case java.sql.Types.BIGINT:
+				result = "java.lang.Long";
+				break;
+			case java.sql.Types.REAL:
+				result = "java.lang.Real";
+				break;
+			case java.sql.Types.FLOAT:
+			case java.sql.Types.DOUBLE:
+				result = "java.lang.Double";
+				break;
+			case java.sql.Types.BINARY:
+			case java.sql.Types.VARBINARY:
+			case java.sql.Types.LONGVARBINARY:
+				result = "java.lang.Byte[]";
+				break;
+			case java.sql.Types.DATE:
+				result = "java.sql.Date";
+				break;
+			case java.sql.Types.TIME:
+				result = "java.sql.Time";
+				break;
+			case java.sql.Types.TIMESTAMP:
+				result = "java.sql.Timestamp";
+				break;
+		}
+		return result;
+	}
+
+	private static int convertECLtypeCode2SQLtype(int ecltypecode)
+	{
+		int type = java.sql.Types.OTHER;
+
+		if (ecltypecode == EclTypes.ECLTypeboolean.ordinal())
+			type = java.sql.Types.BOOLEAN;
+		else if (ecltypecode == EclTypes.ECLTypearray.ordinal())
+			type = java.sql.Types.ARRAY;
+		else if (ecltypecode == EclTypes.ECLTypeblob.ordinal())
+			type = java.sql.Types.BLOB;
+		else if (ecltypecode == EclTypes.ECLTypechar.ordinal())
+			type = java.sql.Types.CHAR;
+		else if (ecltypecode == EclTypes.ECLTypedate.ordinal())
+			type = java.sql.Types.DATE;
+		else if (ecltypecode == EclTypes.ECLTypedecimal.ordinal())
+			type = java.sql.Types.DECIMAL;
+		else if (ecltypecode ==  EclTypes.ECLTypeint.ordinal())
+			type = java.sql.Types.INTEGER;
+		else if (ecltypecode == EclTypes.ECLTypenull.ordinal())
+			type = java.sql.Types.NULL;
+		else if (ecltypecode == EclTypes.ECLTypenumeric.ordinal())
+			type = java.sql.Types.NUMERIC;
+		else if (ecltypecode == EclTypes.ECLTypepackedint.ordinal())
+			type = java.sql.Types.INTEGER;
+		else if (ecltypecode == EclTypes.ECLTypepointer.ordinal())
+			type = java.sql.Types.REF;
+		else if (ecltypecode == EclTypes.ECLTypeqstring.ordinal())
+			type = java.sql.Types.VARCHAR;
+		else if (ecltypecode == EclTypes.ECLTypereal.ordinal())
+			type = java.sql.Types.REAL;
+		else if (ecltypecode == EclTypes.ECLTypestring.ordinal())
+			type = java.sql.Types.VARCHAR;
+		else if (ecltypecode == EclTypes.ECLTypeunsigned.ordinal())
+			type = java.sql.Types.NUMERIC;
+		else if (ecltypecode == EclTypes.ECLTypevarstring.ordinal())
+			type = java.sql.Types.VARCHAR;
+		/*else if (ecltypecode == EclTypes.ECLTyperecord.ordinal():
+		case EclTypes.ECLTyperow.ordinal():
+		case EclTypes.ECLTyperule.ordinal():
+		case EclTypes.ECLTypescalar.ordinal():
+		case EclTypes.ECLTypescope.ordinal():
+		case EclTypes.ECLTypeset.ordinal():
+		case EclTypes.ECLTypesortlist.ordinal():
+		case EclTypes.ECLTypestringorunicode.ordinal():
+		case EclTypes.ECLTypeswapint.ordinal():
+		case EclTypes.ECLTypetable.ordinal():
+		case EclTypes.ECLTypetoken.ordinal():
+		case EclTypes.ECLTypetransform.ordinal():
+		case EclTypes.ECLTypeunicode.ordinal():
+		case EclTypes.ECLTypeunused1.ordinal():
+		case EclTypes.ECLTypeunused2.ordinal():
+		case EclTypes.ECLTypeunused3.ordinal():
+		case EclTypes.ECLTypeunused4.ordinal():
+		case EclTypes.ECLTypeunused5.ordinal():
+		case EclTypes.ECLTypeutf8.ordinal():
+		case EclTypes.ECLTypevarunicode.ordinal():
+		case EclTypes.ECLTypevoid.ordinal():
+		case EclTypes.ECLTypeebcdic.ordinal():
+		case EclTypes.ECLTypeenumerated.ordinal():
+		case EclTypes.ECLTypeevent.ordinal():
+		case EclTypes.ECLTypefeature.ordinal():
+		case EclTypes.ECLTypefunction.ordinal():
+		case EclTypes.ECLTypegroupedtable.ordinal():
+		case EclTypes.ECLTypeifblock.ordinal():
+		case EclTypes.ECLTypemodifier.ordinal():
+		case EclTypes.ECLTypepattern.ordinal():
+		case EclTypes.ECLTypealien.ordinal():
+		case EclTypes.ECLTypeany.ordinal():
+		case EclTypes.ECLTypebitfield.ordinal():
+		case EclTypes.ECLTypeclass.ordinal():
+		case EclTypes.ECLTypedata.ordinal():
+		default:
+			break;*/
+		return type;
+	}
+
+	public static int convertECLtype2SQLtype(String ecltype)
+	{
+		int type = java.sql.Types.OTHER;
+		String postfix = ecltype.substring(ecltype.lastIndexOf(':')+1);
+		/*Simple types*/
+		//if (postfix.startsWith("STRING"))
+		if (postfix.contains("STRING"))
+			type = java.sql.Types.VARCHAR;
+		else if (postfix.startsWith("FLOAT"))
+			type = java.sql.Types.FLOAT;
+		else if (postfix.startsWith("DOUBLE"))
+			type = java.sql.Types.DOUBLE;
+		//else if (postfix.endsWith("DECIMAL"))
+		else if (postfix.startsWith("DECIMAL"))
+			type = java.sql.Types.DECIMAL;
+		//else if (postfix.endsWith("INTEGER"))
+		else if (postfix.startsWith("INTEGER"))
+			type = java.sql.Types.INTEGER;
+		//nonNegativeInteger
+		//else if (ecltype.endsWith("NONNEGATIVEINTEGER"))
+		//	type = java.sql.Types.??
+		//positiveInteger
+		//nonPositiveInteger
+		//negativeInteger
+		else if (postfix.startsWith("LONG"))
+			type = java.sql.Types.NUMERIC;
+		//unsignedLong
+		else if (postfix.startsWith("INT"))
+			type = java.sql.Types.INTEGER;
+		//unsignedInt
+		else if (postfix.startsWith("SHORT"))
+			type = java.sql.Types.SMALLINT;
+		//unsignedShort
+		//else if (ecltype.endsWith("BYTE"))
+		//	type = java.sql.Types.;
+		else if (postfix.startsWith("UNSIGNED"))
+			type = java.sql.Types.NUMERIC;
+		/*XML primitive types*/
+		else if (postfix.startsWith("DATETIME"))
+			type = java.sql.Types.TIMESTAMP;
+		else if (postfix.startsWith("TIME"))
+			type = java.sql.Types.TIME;
+		else if (postfix.startsWith("DATE"))
+			type = java.sql.Types.DATE;
+		else if (postfix.startsWith("GDAY"))
+			type = java.sql.Types.DATE;
+		else if (postfix.startsWith("GMONTH"))
+			type = java.sql.Types.DATE;
+		else if (postfix.startsWith("GYEAR"))
+			type = java.sql.Types.DATE;
+		else if (postfix.startsWith("GYEARMONTH"))
+			type = java.sql.Types.DATE;
+		else if (postfix.startsWith("GMONTHDAY"))
+			type = java.sql.Types.DATE;
+		else if (postfix.startsWith("DURATION"))
+			type = java.sql.Types.VARCHAR;
+
+		return type;
+	}
+
+	public static int registerSchemaElements(Element node, EclQuery query)
+	{
+		NodeList results = node.getElementsByTagName("Results");
+		if (results.getLength()>0)
+		{
+			NodeList resultslist = results.item(0).getChildNodes(); //ECLResult nodes
+			for (int i = 0; i < resultslist.getLength(); i++)
+			{
+				Node currentresult = resultslist.item(i);
+				NodeList resultprops = currentresult.getChildNodes();
+				String tablename = "";
+				for (int j = 0; j < resultprops.getLength(); j++)
+				{
+					Node currentresultprop = resultprops.item(j);
+					if (currentresultprop.getNodeName().equals("Name"))
+					{
+						tablename = currentresultprop.getTextContent();
+						query.addResultDataset(tablename);
+					}
+					else if (currentresultprop.getNodeName().equals("ECLSchemas"))
+					{
+						NodeList schemaitems = currentresultprop.getChildNodes(); //ECLSchemaItem
+						String columname = "";
+						String columntype = "";
+						for (int x = 0; x < schemaitems.getLength(); x++)
+						{
+							NodeList schemaitemfields = schemaitems.item(x).getChildNodes();
+
+							for (int y = 0; y < schemaitemfields.getLength(); y++)
+							{
+								Node elem = schemaitemfields.item(y);
+								if (elem.getNodeName().equals("ColumnName"))
+									columname = elem.getTextContent();
+								else if (elem.getNodeName().equals("ColumnType"))
+									columntype = elem.getTextContent();
+								//System.out.println(schemaitemfields.item(y).getNodeName() + ": " + schemaitemfields.item(y).getTextContent());
+							}
+							EclColumnMetaData elemmeta = new EclColumnMetaData(columname.toUpperCase(), 0, convertECLtype2SQLtype(columntype.toUpperCase()));
+							elemmeta.setTableName(tablename);
+							elemmeta.setParamType(procedureColumnOut);
+							try {
+								query.addResultElement(elemmeta);
+							} catch (Exception e) {
+								System.out.println("Could not add dataset element: " + tablename + ":"+ elemmeta.getColumnName());
+							}
+						}
+
+					}
+				}
+			}
+		}
+
+		NodeList variables = node.getElementsByTagName("Variables");
+		if (variables.getLength()>0)
+		{
+			NodeList resultslist = variables.item(0).getChildNodes(); //ECLResult nodes
+			for (int i = 0; i < resultslist.getLength(); i++)
+			{
+				Node currentresult = resultslist.item(i);
+				NodeList resultprops = currentresult.getChildNodes();
+				String inParam = "";
+				for (int j = 0; j < resultprops.getLength(); j++)
+				{
+					Node currentresultprop = resultprops.item(j);
+					/*if (currentresultprop.getNodeName().equals("Name"))
+					{
+						inParam = currentresultprop.getTextContent();
+						query.addResultDataset(inParam);
+					}
+					else*/
+					if (currentresultprop.getNodeName().equals("ECLSchemas"))
+					{
+						NodeList schemaitems = currentresultprop.getChildNodes(); //ECLSchemaItem
+						String columname = "";
+						String columntype = "";
+						for (int x = 0; x < schemaitems.getLength(); x++)
+						{
+							NodeList schemaitemfields = schemaitems.item(x).getChildNodes();
+
+							for (int y = 0; y < schemaitemfields.getLength(); y++)
+							{
+								Node elem = schemaitemfields.item(y);
+								if (elem.getNodeName().equals("ColumnName"))
+									columname = elem.getTextContent();
+								else if (elem.getNodeName().equals("ColumnType"))
+									columntype = elem.getTextContent();
+								//System.out.println(schemaitemfields.item(y).getNodeName() + ": " + schemaitemfields.item(y).getTextContent());
+							}
+							EclColumnMetaData elemmeta = new EclColumnMetaData(columname, i+1, convertECLtype2SQLtype(columntype.toUpperCase()));
+							elemmeta.setTableName(query.getName());
+							elemmeta.setParamType(procedureColumnIn);
+							try {
+								query.addResultElement(elemmeta);
+							} catch (Exception e) {
+								System.out.println("Could not add dataset element: " + inParam + ":"+ elemmeta.getColumnName());
+							}
+						}
+
+					}
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	@Override
+	public boolean allProceduresAreCallable() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean allTablesAreSelectable() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public String getURL() throws SQLException
+	{
+		return "http://www.hpccsystems.com";
+	}
+
+	@Override
+	public String getUserName() throws SQLException {
+		return UserName;
+	}
+
+	@Override
+	public boolean isReadOnly() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean nullsAreSortedHigh() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean nullsAreSortedLow() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean nullsAreSortedAtStart() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean nullsAreSortedAtEnd() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public String getDatabaseProductName() throws SQLException {
+		return "HPCC - Version " +  HPCCBuildVersionFull;
+	}
+
+	@Override
+	public String getDatabaseProductVersion() throws SQLException {
+		return HPCCBuildVersionFull;
+	}
+
+	@Override
+	public String getDriverName() throws SQLException {
+		return "HPCC ECLJDBC Driver";
+	}
+
+	@Override
+	public String getDriverVersion() throws SQLException
+	{
+		return EclDriver.ECLJDBCMajorVersion + "." + EclDriver.ECLJDBCMinorVersion + "." + EclDriver.ECLJDBCPatchVersion ;
+
+	}
+
+	@Override
+	public int getDriverMajorVersion()
+	{
+		return EclDriver.ECLJDBCMajorVersion;
+	}
+
+	@Override
+	public int getDriverMinorVersion()
+	{
+		return EclDriver.ECLJDBCMinorVersion;
+	}
+
+	@Override
+	public boolean usesLocalFiles() throws SQLException
+	{
+		return false;
+	}
+
+	@Override
+	public boolean usesLocalFilePerTable() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsMixedCaseIdentifiers() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean storesUpperCaseIdentifiers() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean storesLowerCaseIdentifiers() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean storesMixedCaseIdentifiers() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsMixedCaseQuotedIdentifiers() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean storesUpperCaseQuotedIdentifiers() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean storesLowerCaseQuotedIdentifiers() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean storesMixedCaseQuotedIdentifiers() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public String getIdentifierQuoteString() throws SQLException {
+		return "";
+	}
+
+	@Override
+	public String getSQLKeywords() throws SQLException {
+		return "select from where AND call";
+	}
+
+	@Override
+	public String getNumericFunctions() throws SQLException {
+		return "";
+	}
+
+	@Override
+	public String getStringFunctions() throws SQLException {
+		return "";
+	}
+
+	@Override
+	public String getSystemFunctions() throws SQLException {
+		return "";
+	}
+
+	@Override
+	public String getTimeDateFunctions() throws SQLException {
+		return "";
+	}
+
+	@Override
+	public String getSearchStringEscape() throws SQLException {
+		return "";
+	}
+
+	@Override
+	public String getExtraNameCharacters() throws SQLException {
+		return "";
+	}
+
+	@Override
+	public boolean supportsAlterTableWithAddColumn() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsAlterTableWithDropColumn() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsColumnAliasing() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean nullPlusNonNullIsNull() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsConvert() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsConvert(int fromType, int toType)
+			throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsTableCorrelationNames() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsDifferentTableCorrelationNames() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsExpressionsInOrderBy() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsOrderByUnrelated() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsGroupBy() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsGroupByUnrelated() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsGroupByBeyondSelect() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsLikeEscapeClause() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsMultipleResultSets() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsMultipleTransactions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsNonNullableColumns() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsMinimumSQLGrammar() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsCoreSQLGrammar() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsExtendedSQLGrammar() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsANSI92EntryLevelSQL() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsANSI92IntermediateSQL() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsANSI92FullSQL() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsIntegrityEnhancementFacility() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsOuterJoins() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsFullOuterJoins() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsLimitedOuterJoins() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public String getSchemaTerm() throws SQLException
+	{
+		//Arjuna: this will be the cluster name for now
+		//throw new UnsupportedOperationException("yNot supported yet.");
+		return "schema";
+	}
+
+	@Override
+	public String getProcedureTerm() throws SQLException
+	{
+		return "NULL";
+	}
+
+	@Override
+	public String getCatalogTerm() throws SQLException
+	{
+		//this will be the cluster name for now
+		return "NULL";
+	}
+
+	@Override
+	public boolean isCatalogAtStart() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public String getCatalogSeparator() throws SQLException {
+		return "NULL";
+	}
+
+	@Override
+	public boolean supportsSchemasInDataManipulation() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSchemasInProcedureCalls() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSchemasInTableDefinitions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSchemasInIndexDefinitions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSchemasInPrivilegeDefinitions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsCatalogsInDataManipulation() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsCatalogsInProcedureCalls() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsCatalogsInTableDefinitions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsCatalogsInIndexDefinitions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsCatalogsInPrivilegeDefinitions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsPositionedDelete() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsPositionedUpdate() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSelectForUpdate() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsStoredProcedures() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsSubqueriesInComparisons() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSubqueriesInExists() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSubqueriesInIns() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsSubqueriesInQuantifieds() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsCorrelatedSubqueries() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsUnion() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsUnionAll() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsOpenCursorsAcrossCommit() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsOpenCursorsAcrossRollback() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsOpenStatementsAcrossCommit() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsOpenStatementsAcrossRollback() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public int getMaxBinaryLiteralLength() throws SQLException {
+		return 1024;
+	}
+
+	@Override
+	public int getMaxCharLiteralLength() throws SQLException {
+		return 1024;
+	}
+
+	@Override
+	public int getMaxColumnNameLength() throws SQLException {
+		return 256;
+	}
+
+	@Override
+	public int getMaxColumnsInGroupBy() throws SQLException {
+		return 4;
+	}
+
+	@Override
+	public int getMaxColumnsInIndex() throws SQLException {
+		return 4;
+	}
+
+	@Override
+	public int getMaxColumnsInOrderBy() throws SQLException {
+		return 4;
+	}
+
+	@Override
+	public int getMaxColumnsInSelect() throws SQLException {
+		return 16;
+	}
+
+	@Override
+	public int getMaxColumnsInTable() throws SQLException {
+		return 128;
+	}
+
+	@Override
+	public int getMaxConnections() throws SQLException {
+		return 1024;
+	}
+
+	@Override
+	public int getMaxCursorNameLength() throws SQLException {
+		return 50000;
+	}
+
+	@Override
+	public int getMaxIndexLength() throws SQLException {
+		return 256;
+	}
+
+	@Override
+	public int getMaxSchemaNameLength() throws SQLException {
+		return 256;
+	}
+
+	@Override
+	public int getMaxProcedureNameLength() throws SQLException {
+		return 256;
+	}
+
+	@Override
+	public int getMaxCatalogNameLength() throws SQLException {
+		return 256;
+	}
+
+	@Override
+	public int getMaxRowSize() throws SQLException {
+		return 10000;
+	}
+
+	@Override
+	public boolean doesMaxRowSizeIncludeBlobs() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public int getMaxStatementLength() throws SQLException {
+		return 200;
+	}
+
+	@Override
+	public int getMaxStatements() throws SQLException {
+		return 100;
+	}
+
+	@Override
+	public int getMaxTableNameLength() throws SQLException {
+		return 100;
+	}
+
+	@Override
+	public int getMaxTablesInSelect() throws SQLException {
+		return 1;
+	}
+
+	@Override
+	public int getMaxUserNameLength() throws SQLException {
+		return 20;
+		//This is an LDAP limitation, in the future the ESP will expose a query for this value
+	}
+
+	@Override
+	public int getDefaultTransactionIsolation() throws SQLException {
+		return java.sql.Connection.TRANSACTION_NONE;
+	}
+
+	@Override
+	public boolean supportsTransactions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsDataDefinitionAndDataManipulationTransactions() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsDataManipulationTransactionsOnly() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean dataDefinitionCausesTransactionCommit() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean dataDefinitionIgnoredInTransactions() throws SQLException {
+		return true;
+	}
+
+	@Override
+	public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern) throws SQLException
+	{
+		List<List> procedures = new ArrayList<List>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		if (!isMetaDataCached())
+			CacheMetaData();
+
+		System.out.println("ECLDATABASEMETADATA GETPROCS catalog: " + catalog +", schemaPattern: " + schemaPattern + ", procedureNamePattern: " + procedureNamePattern);
+
+		metacols.add(new EclColumnMetaData("PROCEDURE_CAT", 1, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PROCEDURE_SCHEM", 2, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PROCEDURE_NAME", 3, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("R1", 4, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("R2", 5, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("R6", 6, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("REMARKS", 7, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PROCEDURE_TYPE", 8, java.sql.Types.SMALLINT));
+
+		Enumeration<Object> queries = eclqueries.getQueries();
+		while (queries.hasMoreElements())
+		{
+			EclQuery query = (EclQuery) queries.nextElement();
+			String queryname = query.getName();
+
+				//if(!wildproceduresearch && !procedureNamePattern.equalsIgnoreCase(queryname))
+				//	continue;
+
+				ArrayList rowValues = new ArrayList();
+				procedures.add(rowValues);
+				rowValues.add("");
+				rowValues.add("");
+				rowValues.add(queryname);
+				rowValues.add("");
+				rowValues.add("");
+				rowValues.add("");
+				rowValues.add("");
+				rowValues.add(procedureResultUnknown);
+
+				System.out.println("founc proc: " + queryname);
+		}
+
+		return new EclResultSet(procedures, metacols, "Procedures");
+	}
+
+	@Override
+	public ResultSet getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern) throws SQLException
+	{
+		System.out.println("ECLDATABASEMETADATA getProcedureColumns catalog: " + catalog +", schemaPattern: " + schemaPattern + ", procedureNamePattern: " + procedureNamePattern + " columnanmepat: " +columnNamePattern);
+
+		List<List> procedurecols = new ArrayList<List>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		if (!isMetaDataCached())
+			CacheMetaData();
+
+		System.out.println("ECLDATABASEMETADATA GETPROCS catalog: " + catalog +", schemaPattern: " + schemaPattern + ", procedureNamePattern: " + procedureNamePattern);
+
+		boolean wildprocsearch = procedureNamePattern == null || procedureNamePattern.length()==0 || procedureNamePattern.contains("*") || procedureNamePattern.contains("%");
+		boolean wildcolumnsearch = columnNamePattern == null || columnNamePattern.length()==0 || columnNamePattern.contains("*") || columnNamePattern.contains("%");
+
+		metacols.add(new EclColumnMetaData("PROCEDURE_CAT", 1, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PROCEDURE_SCHEM",2, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PROCEDURE_NAME",3, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("COLUMN_NAME", 	4, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("COLUMN_TYPE", 	5, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("DATA_TYPE", 	6, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("TYPE_NAME", 	7, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PRECISION", 	8, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("LENGTH", 		9, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("SCALE", 		10, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("RADIX",			11, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("NULLABLE", 		12, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("REMARKS", 		13, java.sql.Types.VARCHAR));
+
+		int coltype = java.sql.Types.NULL;
+
+		Enumeration<Object> queries = eclqueries.getQueries();
+		while(queries.hasMoreElements())
+		{
+			EclQuery query = (EclQuery)queries.nextElement();
+			String eclqueryname = query.getName();
+			if(!wildprocsearch && !procedureNamePattern.equalsIgnoreCase(eclqueryname))
+				continue;
+
+			String tablename = query.getDefaultTableName();
+
+			Iterator<EclColumnMetaData> e = query.getAllFields().iterator();
+			int index = 1;
+			while (e.hasNext())
+			{
+				EclColumnMetaData col = (EclColumnMetaData)e.next();
+				String fieldname = col.getColumnName();
+				if(!wildcolumnsearch && !columnNamePattern.equalsIgnoreCase(fieldname))
+					continue;
+
+				coltype = getProcFieldType(eclqueryname,tablename, fieldname);
+
+				System.out.println("Proc col Found: "  + eclqueryname+"#"+tablename+"."+fieldname + " of type: " + coltype + "("+convertSQLtype2JavaClassName(coltype)+")");
+
+				ArrayList rowValues = new ArrayList();
+				procedurecols.add(rowValues);
+
+				/* 1*/rowValues.add(catalog);
+				/* 2*/rowValues.add(schemaPattern);
+				/* 3*/rowValues.add(query.getName());
+				/* 4*/rowValues.add(fieldname);
+				/* 5*/rowValues.add(col.getParamType());
+				/* 6*/rowValues.add(coltype);
+				/* 7*/rowValues.add(convertSQLtype2JavaClassName(coltype));
+				/* 8*/rowValues.add(0);
+				/* 9*/rowValues.add(0);
+				/*10*/rowValues.add(0);
+				/*11*/rowValues.add(1);
+				/*12*/rowValues.add(procedureNoNulls);
+				/*13*/rowValues.add("");
+
+				if(!wildcolumnsearch)
+					break;
+
+				index++;
+			}
+			if(!wildprocsearch)
+				break;
+		}
+		return new EclResultSet(procedurecols, metacols, "ProcedureColumns");
+	}
+
+	@Override
+	public ResultSet getTables(String catalog, String schemaPattern,
+			String tableNamePattern, String[] types) throws SQLException {
+		/*
+		 * TABLE_CAT String => table catalog (may be null) TABLE_SCHEM String =>
+		 * table schema (may be null) TABLE_NAME String => table name TABLE_TYPE
+		 * String => table type. Typical types are "TABLE", "VIEW",
+		 * "SYSTEM TABLE", "GLOBAL TEMPORARY", "LOCAL TEMPORARY", "ALIAS",
+		 * "SYNONYM". REMARKS String => explanatory comment on the table
+		 * TYPE_CAT String => the types catalog (may be null) TYPE_SCHEM String
+		 * => the types schema (may be null) TYPE_NAME String => type name (may
+		 * be null) SELF_REFERENCING_COL_NAME String => name of the designated
+		 * "identifier" column of a typed table (may be null) REF_GENERATION
+		 * String => specifies how values in SELF_REFERENCING_COL_NAME are
+		 * created. Values are "SYSTEM", "USER", "DERIVED". (may be null)
+		 */
+
+		if (!isMetaDataCached())
+			CacheMetaData();
+
+		System.out.println("ECLDATABASEMETADATA GETTABLES catalog: " + catalog +", schemaPattern: " + schemaPattern + ", tableNamePattern: " + tableNamePattern);
+
+		//boolean wilddbsearch = schemaPattern == null || schemaPattern.length()==0 || schemaPattern.contains("*");
+		boolean wildtablesearch = tableNamePattern == null || tableNamePattern.length()==0 || tableNamePattern.contains("*") || tableNamePattern.contains("%");
+
+		List<List<String>> tables = new ArrayList<List<String>>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		metacols.add(new EclColumnMetaData("TABLE_CAT", 1, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TABLE_SCHEM", 2, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TABLE_NAME", 3, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TABLE_TYPE", 4, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("REMARKS", 5, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TYPE_CAT", 6, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TABLE_CAT", 7, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TYPE_SCHEM", 8, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TYPE_NAME", 9, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("SELF_REFERENCING_COL_NAME", 10, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("REF_GENERATION", 11, java.sql.Types.VARCHAR));
+
+		Enumeration<Object> files = dfufiles.elements();
+		while (files.hasMoreElements())
+		{
+			DFUFile file = (DFUFile) files.nextElement();
+			//String filename = file.getFileName();
+			String filename = file.getFullyQualifiedName();
+
+			if(!wildtablesearch && !tableNamePattern.equalsIgnoreCase(filename))
+				continue;
+			System.out.println("Found table: " + filename);
+			ArrayList<String> rowValues = new ArrayList<String>();
+			tables.add(rowValues);
+			rowValues.add(file.getClusterName());
+			rowValues.add(filename);
+			rowValues.add(filename);
+			rowValues.add("TABLE");
+			rowValues.add(file.getDescription() + (!file.hasFileRecDef() ? "**HPCC FILE DOESNOT CONTAIN ECL RECORD LAYOUT**" : "") + (file.hasRelatedIndexes() ? "Has " + file.getRelatedIndexesCount() + " related Indexes": "") +(file.isKeyFile() ? "-Keyed File " : "") + (file.isSuperFile() ? "-SuperFile " : "") + (file.isFromRoxieCluster() ? "-FromRoxieCluster" : ""));
+			rowValues.add("null");
+			rowValues.add("null");
+			rowValues.add("null");
+			rowValues.add("null");
+			rowValues.add("null");
+
+			if(!wildtablesearch)
+				break;
+		}
+		return new EclResultSet(tables, metacols, "Tables");
+	}
+
+	@Override
+	public ResultSet getSchemas() throws SQLException
+	{
+		if (!isMetaDataCached())
+			CacheMetaData();
+
+		System.out.println("ECLDATABASEMETADATA GETSCHEMAS");
+
+		List<List<String>> tables = new ArrayList<List<String>>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		metacols.add(new EclColumnMetaData("TABLE_SCHEM", 1, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TABLE_CATALOG", 2, java.sql.Types.VARCHAR));
+
+		Enumeration<Object> files = dfufiles.elements();
+		while (files.hasMoreElements())
+		{
+			DFUFile file = (DFUFile)files.nextElement();
+			String tablename = file.getFileName();
+
+			ArrayList<String> rowValues = new ArrayList<String>();
+			tables.add(rowValues);
+			rowValues.add(tablename);
+			rowValues.add("Catalog");
+
+		}
+		return new EclResultSet(tables, metacols, "Schemas");
+	}
+
+	@Override
+	public ResultSet getCatalogs() throws SQLException {
+		System.out.println("ECLDATABASEMETADATA getCatalogs");
+
+		List<List<String>> catalogs = new ArrayList<List<String>>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		metacols.add(new EclColumnMetaData("TABLE_CAT", 1, java.sql.Types.VARCHAR));
+
+		ArrayList<String> rowValues = new ArrayList<String>();
+		catalogs.add(rowValues);
+		rowValues.add("");
+
+		return new EclResultSet(catalogs, metacols, "Catalogs");
+	}
+
+	@Override
+	public ResultSet getTableTypes() throws SQLException
+	{
+		System.out.println("ECLDATABASEMETADATA getTableTypes");
+
+		List<List<String>> tabletypes = new ArrayList<List<String>>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		metacols.add(new EclColumnMetaData("TABLE_TYPE", 1, java.sql.Types.VARCHAR));
+
+		ArrayList<String> rowValues = new ArrayList<String>();
+		tabletypes.add(rowValues);
+		rowValues.add("TABLE");
+
+		return new EclResultSet(tabletypes, metacols, "TableTypes");
+	}
+
+	public String [] getAllTableFields(String dbname, String tablename)
+	{
+		DFUFile file = (DFUFile)dfufiles.get(tablename);
+		if (file != null)
+			return file.getAllTableFieldsStringArray();
+
+		return null;
+	}
+
+	@Override
+	public ResultSet getColumns(String catalog, String schemaPattern,
+			String tableNamePattern, String columnNamePattern)	throws SQLException
+	{
+		System.out.println("ECLDATABASEMETADATA GETCOLUMNS catalog: " + catalog +", schemaPattern: " + schemaPattern + ", tableNamePattern: " + tableNamePattern + ", columnNamePattern: " + columnNamePattern);
+
+		boolean wildtablesearch = tableNamePattern == null || tableNamePattern.length()==0 || tableNamePattern.contains("*") || tableNamePattern.contains("%");
+		boolean wildfieldsearch = columnNamePattern == null || columnNamePattern.length()==0 || columnNamePattern.contains("*") || columnNamePattern.contains("%");
+
+		List<List<String>> columns = new ArrayList<List<String>>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		metacols.add(new EclColumnMetaData("TABLE_CAT", 		1, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TABLE_SCHEM", 		2, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("TABLE_NAME", 		3, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("COLUMN_NAME", 		4, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("DATA_TYPE", 		5, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("TYPE_NAME", 		6, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("COLUMN_SIZE", 		7, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("BUFFER_LENGTH", 	8, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("DECIMAL_DIGITS", 	9, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("NUM_PREC_RADIX", 	10, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("NULLABLE", 			11, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("REMARKS", 			12, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("COLUMN_DEF", 		13, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("SQL_DATA_TYPE", 	14, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("SQL_DATETIME_SUB", 	15, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("CHAR_OCTET_LENGTH", 16, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("ORDINAL_POSITION", 	17, java.sql.Types.INTEGER));
+		metacols.add(new EclColumnMetaData("IS_NULLABLE", 		18, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("SCOPE_CATLOG", 		19, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("SCOPE_SCHEMA", 		20, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("SCOPE_TABLE", 		21, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("SOURCE_DATA_TYPE", 	22, java.sql.Types.SMALLINT));
+
+		int coltype = java.sql.Types.NULL;
+
+		Enumeration<Object> files = dfufiles.elements();
+		while(files.hasMoreElements())
+		{
+			DFUFile file = (DFUFile)files.nextElement();
+			//String filename = file.getFileName();
+			String filename = file.getFullyQualifiedName();
+			if(!wildtablesearch && !tableNamePattern.equalsIgnoreCase(filename))
+				continue;
+
+			Enumeration<Object> e = file.getAllFields();
+			while (e.hasMoreElements())
+			{
+				EclColumnMetaData field = (EclColumnMetaData)e.nextElement();
+				String fieldname = field.getColumnName();
+				if(!wildfieldsearch && !columnNamePattern.equalsIgnoreCase(fieldname))
+					continue;
+
+				coltype = field.getSqlType();
+				System.out.println("Table col found: "  + filename+"."+fieldname + " of type: " + coltype + "("+convertSQLtype2JavaClassName(coltype)+")");
+
+				ArrayList rowValues = new ArrayList();
+				columns.add(rowValues);
+
+				/* 1*/rowValues.add(catalog);
+				/* 2*/rowValues.add(schemaPattern);
+				/* 3*/rowValues.add(file.getFullyQualifiedName());
+				/* 4*/rowValues.add(fieldname);
+				/* 5*/rowValues.add(coltype);
+				/* 6*/rowValues.add(convertSQLtype2JavaClassName(coltype));
+				/* 7*/rowValues.add(0);
+				/* 8*/rowValues.add("null");
+				/* 9*/rowValues.add(0);
+				/*10*/rowValues.add(0);
+				/*11*/rowValues.add(1);
+				/*12*/rowValues.add(file.isKeyFile() && file.getIdxFilePosField() != null && file.getIdxFilePosField().equals(fieldname) ? "File Position Field" : "");
+				/*13*/rowValues.add("");
+				/*14*/rowValues.add(0);//unused
+				/*15*/rowValues.add(0);
+				/*16*/rowValues.add(0);
+				/*17*/rowValues.add(field.getIndex()); //need to get index
+				/*18*/rowValues.add("YES");
+				/*19*/rowValues.add(coltype == java.sql.Types.REF ? null : "");
+				/*20*/rowValues.add(coltype == java.sql.Types.REF ? null : "");
+				/*21*/rowValues.add(coltype == java.sql.Types.REF ? null : "");
+				/*22*/rowValues.add(coltype == java.sql.Types.REF ? null : "");
+
+				if(!wildfieldsearch)
+					break;
+			}
+			if(!wildtablesearch)
+				break;
+		}
+		return new EclResultSet(columns, metacols, tableNamePattern);
+	}
+
+	@Override
+	public ResultSet getColumnPrivileges(String catalog, String schema,	String table, String columnNamePattern) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData:  getColumnPrivileges Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getTablePrivileges Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getBestRowIdentifier(String catalog, String schema,
+			String table, int scope, boolean nullable) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getBestRowIdentifier Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getVersionColumns(String catalog, String schema, String table) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getVersionColumns Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getPrimaryKeys Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getImportedKeys(String catalog, String schema, String table) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getImportedKeys Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getExportedKeys(String catalog, String schema, String table) throws SQLException
+	{
+		System.out.println("ECLDATABASEMETADATA getExportedKeys catalog: " + catalog +", schema: " + schema + ", table: " + table);
+
+		List<List<String>> exportedkeys = new ArrayList<List<String>>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		metacols.add(new EclColumnMetaData("PKTABLE_CAT", 		1, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PKTABLE_SCHEM", 	2, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PKTABLE_NAME", 		3, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PKCOLUMN_NAME", 	4, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("FKTABLE_CAT", 		5, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("FKTABLE_SCHEM", 	6, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("FKTABLE_NAME", 		7, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("FKCOLUMN_NAME", 	8, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("KEY_SEQ", 			9, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("UPDATE_RULE", 		10, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("DELETE_RULE", 		11, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("FK_NAME", 			12, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("PK_NAME", 			13, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("DEFERRABILITY", 	14, java.sql.Types.SMALLINT));
+
+		DFUFile file = getDFUFile(table);
+//		if(file != null && file.getFileName().length()>0 && file.isKeyFile())
+//		{
+//			Enumeration<Object> e = file.getKeyedColumns().elements();
+//			while (e.hasMoreElements())
+//			{
+//				String fieldname = (String)e.nextElement();
+//
+//				ArrayList rowValues = new ArrayList();
+//				exportedkeys.add(rowValues);
+//
+//				/* 1*/rowValues.add(catalog);
+//				/* 2*/rowValues.add(schema);
+//				/* 3*/rowValues.add(file.getFullyQualifiedName());
+//				/* 4*/rowValues.add(fieldname);
+//				/* 5*/rowValues.add("null");
+//				/* 6*/rowValues.add("null");
+//				/* 7*/rowValues.add("");
+//				/* 8*/rowValues.add(fieldname);
+//				/* 9*/rowValues.add(file.getKeyColumnIndex(fieldname));
+//				/*10*/rowValues.add(importedKeyRestrict);
+//				/*11*/rowValues.add(importedKeyRestrict);
+//				/*12*/rowValues.add(0);
+//				/*13*/rowValues.add(0);
+//				/*14*/rowValues.add(importedKeyNotDeferrable);
+//			}
+//		}
+		return new EclResultSet(exportedkeys, metacols, "ExportedKeys");
+	}
+
+	@Override
+	public ResultSet getCrossReference(String parentCatalog,
+			String parentSchema, String parentTable, String foreignCatalog,
+			String foreignSchema, String foreignTable) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getCrossReference Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getTypeInfo() throws SQLException
+	{
+
+		System.out.println("ECLDATABASEMETADATA GETTYPEINFO");
+
+		List<List<String>> types = new ArrayList<List<String>>();
+		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+		metacols.add(new EclColumnMetaData("TYPE_NAME", 		1, java.sql.Types.VARCHAR));
+		metacols.add(new EclColumnMetaData("DATA_TYPE", 		2, java.sql.Types.INTEGER));//SQL data type from java.sql.Types
+		metacols.add(new EclColumnMetaData("PRECISION", 		3, java.sql.Types.INTEGER));//maximum precision
+		metacols.add(new EclColumnMetaData("LITERAL_PREFIX", 	4, java.sql.Types.VARCHAR));//prefix used to quote a literal (may be null)
+		metacols.add(new EclColumnMetaData("LITERAL_SUFFIX", 	5, java.sql.Types.VARCHAR));//suffix used to quote a literal (may be null)
+		metacols.add(new EclColumnMetaData("CREATE_PARAMS", 	6, java.sql.Types.VARCHAR));//parameters used in creating the type (may be null)
+		metacols.add(new EclColumnMetaData("NULLABLE", 			7, java.sql.Types.SMALLINT));//can you use NULL for this type.	    typeNoNulls - does not allow NULL values	    typeNullable - allows NULL values	    typeNullableUnknown - nullability unknown
+		metacols.add(new EclColumnMetaData("CASE_SENSITIVE", 	8, java.sql.Types.BOOLEAN));
+		metacols.add(new EclColumnMetaData("SEARCHABLE", 		9, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("UNSIGNED_ATTRIBUTE",10, java.sql.Types.BOOLEAN));
+		metacols.add(new EclColumnMetaData("FIXED_PREC_SCALE", 	11, java.sql.Types.BOOLEAN));//can it be a money value
+		metacols.add(new EclColumnMetaData("AUTO_INCREMENT", 	12, java.sql.Types.BOOLEAN));//can it be used for an auto-increment value
+		metacols.add(new EclColumnMetaData("LOCAL_TYPE_NAME", 	13, java.sql.Types.VARCHAR));//localized version of type name (may be null)
+		metacols.add(new EclColumnMetaData("MINIMUM_SCALE", 	14, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("MAXIMUM_SCALE", 	15, java.sql.Types.SMALLINT));
+		metacols.add(new EclColumnMetaData("SQL_DATA_TYPE", 	16, java.sql.Types.INTEGER));//unused
+		metacols.add(new EclColumnMetaData("SQL_DATETIME_SUB", 	17, java.sql.Types.INTEGER));//unused
+		metacols.add(new EclColumnMetaData("NUM_PREC_RADIX", 	18, java.sql.Types.INTEGER));//unused
+
+		for(EclTypes ecltype : EclTypes.values())
+		{
+			ArrayList rowValues = new ArrayList();
+			types.add(rowValues);
+
+			/* 1*/rowValues.add(String.valueOf(ecltype));
+			/* 2*/rowValues.add(convertECLtypeCode2SQLtype(ecltype.ordinal()));
+			/* 3*/rowValues.add(0);
+			/* 4*/rowValues.add(null);
+			/* 5*/rowValues.add(null);
+			/* 6*/rowValues.add(null);
+			/* 7*/rowValues.add(typeNullableUnknown);
+			/* 8*/rowValues.add(false);
+			/* 9*/rowValues.add(typePredNone);
+			/*10*/rowValues.add(false);
+			/*11*/rowValues.add(false);
+			/*12*/rowValues.add(false);
+			/*13*/rowValues.add(convertSQLtype2JavaClassName(convertECLtypeCode2SQLtype(ecltype.ordinal())));
+			/*14*/rowValues.add(0);
+			/*15*/rowValues.add(0);
+			/*16*/rowValues.add(0);
+			/*17*/rowValues.add(0);
+			/*18*/rowValues.add(0);
+		}
+
+		return new EclResultSet(types, metacols, "Types");
+	}
+
+	@Override
+	public ResultSet getIndexInfo(String catalog, String schema, String table,
+			boolean unique, boolean approximate) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: Not  supported yet.");
+	}
+
+	@Override
+	public boolean supportsResultSetType(int type) throws SQLException {
+		return true;
+	}
+
+	@Override
+	public boolean supportsResultSetConcurrency(int type, int concurrency)	throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean ownUpdatesAreVisible(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean ownDeletesAreVisible(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean ownInsertsAreVisible(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean othersUpdatesAreVisible(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean othersDeletesAreVisible(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean othersInsertsAreVisible(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean updatesAreDetected(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean deletesAreDetected(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean insertsAreDetected(int type) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public boolean supportsBatchUpdates() throws SQLException {
+		return false;
+	}
+
+	@Override
+	public ResultSet getUDTs(String catalog, String schemaPattern,
+			String typeNamePattern, int[] types) throws SQLException {
+		/*
+				TYPE_CAT String => the type's catalog (may be null)
+	    	    TYPE_SCHEM String => type's schema (may be null)
+	    	    TYPE_NAME String => type name
+	    	    CLASS_NAME String => Java class name
+	    	    DATA_TYPE int => type value defined in java.sql.Types. One of JAVA_OBJECT, STRUCT, or DISTINCT
+	    	    REMARKS String => explanatory comment on the type
+	    	    BASE_TYPE short => type code of the source type of a DISTINCT type or the type that implements the user-generated reference type of the SELF_REFERENCING_COLUMN of a structured type as defined in java.sql.Types (null if DATA_TYPE is not DISTINCT or not STRUCT with REFERENCE_GENERATION = USER_DEFINED)
+
+	    	Note: If the driver does not support UDTs, an empty result set is returned.*/
+	    	System.out.println("ECLDATABASEMETADATA GETTYPEINFO");
+
+	    		List<List<String>> udts = new ArrayList<List<String>>();
+	    		ArrayList<EclColumnMetaData> metacols = new ArrayList<EclColumnMetaData>();
+
+	    		metacols.add(new EclColumnMetaData("TYPE_CAT", 		1, java.sql.Types.VARCHAR)); //the type's catalog (may be null)
+	    		metacols.add(new EclColumnMetaData("TYPE_SCHEM", 	2, java.sql.Types.VARCHAR)); //type's schema (may be null)
+	    		metacols.add(new EclColumnMetaData("TYPE_NAME", 	3, java.sql.Types.VARCHAR)); //type name
+	    		metacols.add(new EclColumnMetaData("CLASS_NAME", 	4, java.sql.Types.VARCHAR)); //Java class name
+	    		metacols.add(new EclColumnMetaData("DATA_TYPE", 	5, java.sql.Types.INTEGER)); //type value defined in java.sql.Types. One of JAVA_OBJECT, STRUCT, or DISTINCT
+	    		metacols.add(new EclColumnMetaData("REMARKS", 		6, java.sql.Types.VARCHAR)); //explanatory comment on the type
+	    		metacols.add(new EclColumnMetaData("BASE_TYPE", 	7, java.sql.Types.SMALLINT)); //
+
+	    		/*for(EclTypes ecltype : EclTypes.values())
+	    		{
+	    			ArrayList rowValues = new ArrayList();
+	    			udts.add(rowValues);
+
+	    			rowValues.add(String.valueOf(ecltype));
+	    			rowValues.add(convertECLtypeCode2SQLtype(ecltype.ordinal()));
+	    			rowValues.add(0);
+	    			rowValues.add(null);
+	    			rowValues.add(null);
+	    			rowValues.add(null);
+	    			rowValues.add(typeNullableUnknown);
+	    		}*/
+
+	    		return new EclResultSet(udts, metacols, "UDTs");
+
+	}
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getConnection Not  supported yet.");
+	}
+
+	@Override
+	public boolean supportsSavepoints() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: supportsSavepoints Not  supported yet.");
+	}
+
+	@Override
+	public boolean supportsNamedParameters() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: supportsNamedParameters Not  supported yet.");
+	}
+
+	@Override
+	public boolean supportsMultipleOpenResults() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: supportsMultipleOpenResults Not  supported yet.");
+	}
+
+	@Override
+	public boolean supportsGetGeneratedKeys() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: supportsGetGeneratedKeysNot  supported yet.");
+	}
+
+	@Override
+	public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getSuperTypes Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getSuperTables Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getAttributes Not  supported yet.");
+	}
+
+	@Override
+	public boolean supportsResultSetHoldability(int holdability) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: supportsResultSetHoldability(int holdability) Not  supported yet.");
+	}
+
+	@Override
+	public int getResultSetHoldability() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getResultSetHoldability Not  supported yet.");
+	}
+
+	@Override
+	public int getDatabaseMajorVersion() throws SQLException
+	{
+		return HPCCBuildMajor;
+	}
+
+	@Override
+	public int getDatabaseMinorVersion() throws SQLException {
+		return (int)HPCCBuildMinor;
+	}
+
+	private boolean getHPCCInfo()
+	{
+		if (serverAddress == null || cluster == null)
+			return false;
+
+		String urlString = "http://" + serverAddress + ":"+wseclwatchport+"/WsSMC/Activity?rawxml_";
+
+		URL querysetURL;
+
+		try
+		{
+			querysetURL = new URL(urlString);
+
+			HttpURLConnection querysetconnection = (HttpURLConnection)querysetURL.openConnection();
+			querysetconnection.setInstanceFollowRedirects(false);
+			querysetconnection.setRequestProperty("Authorization", basicAuth);
+			querysetconnection.setRequestMethod("GET");
+			querysetconnection.setDoOutput(true);
+			querysetconnection.setDoInput(true);
+
+			InputStream xml = querysetconnection.getInputStream();
+
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			DocumentBuilder db = dbf.newDocumentBuilder();
+			Document dom = db.parse(xml);
+
+
+			NodeList activityList = dom.getElementsByTagName("ActivityResponse");
+			if (activityList.getLength() > 0)
+			{
+				NodeList queryList = activityList.item(0).getChildNodes();
+				for (int i = 0; i < queryList.getLength(); i++)
+				{
+					Node currentNode = queryList.item(i);
+
+					/*Get build block*/
+					if (currentNode.getNodeName().equals("Build"))
+					{
+						Node buildNode = currentNode.getFirstChild();
+
+						if (buildNode != null && buildNode.getNodeType() == Node.TEXT_NODE)
+							HPCCBuildVersionFull = buildNode.getTextContent();
+
+						parseVersionString();
+
+						break;
+					}
+					/*Get whatever other element block
+					 *
+					 * else if (currentNode.getNodeName().equals("RoxieClusters"))
+					 * REMOVE THE ABOVE BREAK!!!!!
+					 *
+					 */
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	private void parseVersionString()
+	{
+		try
+		{
+			HPCCBuildType = HPCCBuildVersionFull.substring(0, HPCCBuildVersionFull.lastIndexOf('_'));
+
+			//String numeric = HPCCBuildVersionFull.substring(HPCCBuildVersionFull.lastIndexOf('_')+1, HPCCBuildVersionFull.indexOf('-'));
+			String numeric = HPCCBuildVersionFull.substring(HPCCBuildVersionFull.indexOf('_')+1, HPCCBuildVersionFull.indexOf('-'));
+
+			HPCCBuildMajor = Short.parseShort(numeric.substring(0, numeric.indexOf('.')));
+			HPCCBuildMinor = Float.parseFloat(numeric.substring(numeric.indexOf('.')+1));
+		}
+		catch (Exception e)
+		{
+			System.out.println("Error parsing HPCC version: " + e.getMessage());
+		}
+	}
+
+	@Override
+	public int getJDBCMajorVersion() throws SQLException {
+		return JDBCVerMajor;
+	}
+
+	@Override
+	public int getJDBCMinorVersion() throws SQLException {
+		return JDBCVerMinor;
+	}
+
+	@Override
+	public int getSQLStateType() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getSQLStateType Not  supported yet.");
+	}
+
+	@Override
+	public boolean locatorsUpdateCopy() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: locatorsUpdateCopy Not  supported yet.");
+	}
+
+	@Override
+	public boolean supportsStatementPooling() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: supportsStatementPooling Not  supported yet.");
+	}
+
+	@Override
+	public RowIdLifetime getRowIdLifetime() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getRowIdLifetime Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getSchemas Not supported yet.");
+	}
+
+	@Override
+	public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData:  supportsStoredFunctionsUsingCallSyntax Not supported yet.");
+	}
+
+	@Override
+	public boolean autoCommitFailureClosesAllResultSets() throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: autoCommitFailureClosesAllResultSets Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getClientInfoProperties() throws SQLException
+	{
+		//System.out.println("EclDBMetaData: getClientInfoProperties");
+		throw new UnsupportedOperationException("EclDBMetaData: getClientInfoProperties Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getFunctions(String catalog, String schemaPattern,	String functionNamePattern) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getFunctions(String catalog, String schemaPattern, String functionNamePattern) Not  supported yet.");
+	}
+
+	@Override
+	public ResultSet getFunctionColumns(String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern)	throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: getFunctionColumns(String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern) Not  supported yet.");
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> iface) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: unwrap(Class<T> iface) Not  supported yet.");
+	}
+
+	@Override
+	public boolean isWrapperFor(Class<?> iface) throws SQLException {
+		throw new UnsupportedOperationException("EclDBMetaData: isWrapperFor(Class<?> iface) Not  supported yet.");
+	}
+
+	public String getBasicAuth()
+	{
+		return basicAuth;
+	}
+	public enum EclTypes
+	{
+		ECLTypeboolean(0),
+		ECLTypeint(1),
+		ECLTypereal(2),
+		ECLTypedecimal(3),
+		ECLTypestring(4),
+		ECLTypeunused1(5),
+		ECLTypedate(6),
+		ECLTypeunused2(7),
+		ECLTypeunused3(8),
+		ECLTypebitfield(9),
+		ECLTypeunused4(10),
+		ECLTypechar(11),
+		ECLTypeenumerated(12),
+		ECLTyperecord(13),
+		ECLTypevarstring(14),
+		ECLTypeblob(15),
+		ECLTypedata(16),
+		ECLTypepointer(17),
+		ECLTypeclass(18),
+		ECLTypearray(19),
+		ECLTypetable(20),
+		ECLTypeset(21),
+		ECLTyperow(22),
+		ECLTypegroupedtable(23),
+		ECLTypevoid(24),
+		ECLTypealien(25),
+		ECLTypeswapint(26),
+		ECLTypepackedint(28),
+		ECLTypeunused5(29),
+		ECLTypeqstring(30),
+		ECLTypeunicode(31),
+		ECLTypeany(32),
+		ECLTypevarunicode(33),
+		ECLTypepattern(34),
+		ECLTyperule(35),
+		ECLTypetoken(36),
+		ECLTypefeature(37),
+		ECLTypeevent(38),
+		ECLTypenull(39),
+		ECLTypescope(40),
+		ECLTypeutf8(41),
+		ECLTypetransform(42),
+		ECLTypeifblock(43), // not a real type -but used for the rtlfield serialization
+		ECLTypefunction(44),
+		ECLTypesortlist(45),
+		ECLTypemodifier(0xff), // used by getKind()
+		ECLTypeunsigned(0x100),// combined with some of the above, when returning summary type information. Not returned by getTypeCode()
+		ECLTypeebcdic(0x200),// combined with some of the above, when returning summary type information. Not returned by getTypeCode()
+		//Some pseudo types - never actually created
+		ECLTypestringorunicode(0xfc),// any string/unicode variant
+		ECLTypenumeric(0xfd),
+		ECLTypescalar(0xfe);
+
+	    EclTypes(int eclcode)  {}
+
+	 /*   public String getTypeName()
+	    {
+	    	switch(this.ordinal())
+			{
+				case EclTypes.ECLTypeboolean:
+				case java.sql.Types.VARCHAR:
+				case java.sql.Types.LONGVARCHAR:
+					result = "java.lang.String";
+					break;
+				case java.sql.Types.NUMERIC:
+				case java.sql.Types.DECIMAL:
+					result = "java.math.BigDecimal";
+					break;
+				case java.sql.Types.BIT:
+					result = "java.lang.Boolean";
+					break;
+				case java.sql.Types.TINYINT:
+					result = "java.lang.Byte";
+					break;
+				case java.sql.Types.SMALLINT:
+					result = "java.lang.Short";
+					break;
+				case java.sql.Types.INTEGER:
+					result = "java.lang.Integer";
+					break;
+				case java.sql.Types.BIGINT:
+					result = "java.lang.Long";
+					break;
+				case java.sql.Types.REAL:
+					result = "java.lang.Real";
+					break;
+				case java.sql.Types.FLOAT:
+				case java.sql.Types.DOUBLE:
+					result = "java.lang.Double";
+					break;
+				case java.sql.Types.BINARY:
+				case java.sql.Types.VARBINARY:
+				case java.sql.Types.LONGVARBINARY:
+					result = "java.lang.Byte[]";
+					break;
+				case java.sql.Types.DATE:
+					result = "java.sql.Date";
+					break;
+				case java.sql.Types.TIME:
+					result = "java.sql.Time";
+					break;
+				case java.sql.Types.TIMESTAMP:
+					result = "java.sql.Timestamp";
+					break;
+	    	}
+	    	return "";
+	    }*/
+
+	}
+
+	/*public String findAlias(String name)
+	{
+		return eclQueryAliases.getProperty(name, null);
+	}*/
+
+	public String getdefaultECLQueryResultDatasetName(String clustername,	String eclqueryname)
+	{
+		EclQuery query = eclqueries.getQuery(eclqueryname);
+		return query == null ? "" : query.getDefaultTableName();
+	}
+
+	public boolean tableExists(String clustername, String eclqueryname)
+	{
+		return dfufiles.containsKey(eclqueryname);
+	}
+
+	public boolean eclQueryExists(String clustername, String eclqueryname)
+	{
+		return eclqueries.getQuery(eclqueryname) == null ? false : true;
+	}
+
+	public boolean allFieldsExist(String clustername, String eclqueryname, String[] columnNames)
+	{
+		EclQuery query = eclqueries.getQuery(eclqueryname);
+		if(query != null  && columnNames != null)
+		{
+			for (int i = 0; i < columnNames.length; i++)
+			{
+				if(!query.containsField(columnNames[i]))
+					return false;
+			}
+			return true;
+		}
+
+		return false;
+	}
+
+	public boolean allDFUFileFieldsExist(String clustername, String dfufilename, String[] columnNames)
+	{
+		DFUFile file = (DFUFile)dfufiles.get(dfufilename);
+
+		if(file != null  && columnNames != null)
+		{
+			for (int i = 0; i < columnNames.length; i++)
+			{
+				if(!file.containsField(columnNames[i]))
+					return false;
+			}
+			return true;
+		}
+
+		return false;
+	}
+
+	public ArrayList<EclColumnMetaData> getStoredProcOutColumns(String cluster, String eclqueryname)
+	{
+		EclQuery query = eclqueries.getQuery(eclqueryname);
+		if(query != null)
+		{
+			return query.getAllNonInFields();
+		}
+		return null;
+	}
+
+	public ArrayList<EclColumnMetaData> getStoredProcInColumns(String cluster, String eclqueryname)
+	{
+		EclQuery query = eclqueries.getQuery(eclqueryname);
+		if(query != null)
+		{
+			return query.getAllInFields();
+		}
+		return null;
+
+	}
+
+	public EclColumnMetaData getTableColumn(String hpccfilename, String fieldName)
+	{
+		try
+		{
+			DFUFile file = (DFUFile)dfufiles.get(hpccfilename);
+			if (file != null && file.containsField(fieldName))
+				return file.getFieldMetaData(fieldName);
+			return null;
+		}
+		catch (NumberFormatException e)
+		{
+			return null;
+		}
+	}
+
+	public DFUFile getDFUFile(String hpccfilename)
+	{
+		return (DFUFile)dfufiles.get(hpccfilename);
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDriver.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDriver.java
@@ -1,0 +1,318 @@
+package com.hpccsystems.ecljdbc;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.PreparedStatement;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.StringTokenizer;
+
+public class EclDriver implements Driver
+{
+	static
+	{
+		try
+		{
+			EclDriver driver = new EclDriver();
+			DriverManager.registerDriver(driver);
+			System.out.println("EclDriver initialized");
+		}
+		catch (SQLException ex)
+		{
+			ex.printStackTrace();
+		}
+	}
+
+	static final int ECLJDBCMajorVersion = 0;
+	static final int ECLJDBCMinorVersion = 1;
+	static final int ECLJDBCPatchVersion = 0;
+
+	public EclDriver()
+	{
+	}
+
+
+	public Connection connect(String url, Properties info) throws SQLException
+	{
+		String serverAddress = info.getProperty("ServerAddress");
+		String cluster = info.getProperty("Cluster");
+
+		try
+		{
+			StringTokenizer urltokens = new StringTokenizer(url,";");
+			while (urltokens.hasMoreTokens())
+			{
+				String token = urltokens.nextToken();
+				if (token.contains("="))
+				{
+					StringTokenizer keyvalues = new StringTokenizer(token, "=");
+					while (keyvalues.hasMoreTokens())
+					{
+						String key = keyvalues.nextToken();
+						String value = keyvalues.nextToken();
+						if (!info.containsKey(key))
+							info.put(key, value);
+					}
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			System.out.println("Issue parsing URL! \"" + url +"\"" );
+		}
+
+
+		System.out.println("EclDriver::connect" + serverAddress + ":" + cluster);
+		return new EclConnection(info);
+	}
+
+
+	public boolean acceptsURL(String url) throws SQLException {
+		return true;
+	}
+
+
+	public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException
+	{
+		DriverPropertyInfo[] infoArray = new DriverPropertyInfo[1];
+		infoArray[0] = new DriverPropertyInfo("ip", "IP Address");
+		return infoArray;
+	}
+
+
+	public int getMajorVersion()
+	{
+		System.out.println("ECLDRIVER GETMAJORVERSION");
+		return ECLJDBCMajorVersion;
+	}
+
+
+	public int getMinorVersion() {
+		System.out.println("ECLDRIVER GETMINORVERSION");
+		return ECLJDBCMinorVersion;
+	}
+
+
+	public boolean jdbcCompliant() {
+		return true;
+	}
+
+	public static void main(String[] args) {
+		EclDriver d = new EclDriver();
+		EclConnection conn;
+		try
+		{
+			Properties info = new Properties();
+			info.put("ServerAddress", "192.168.124.128"); //Mine
+			//info.put("ServerAddress", "10.239.20.80"); //clo
+			//info.put("ServerAddress", "10.239.219.10"); //fishbeck
+			//info.put("ServerAddress", "172.25.237.145"); //arjuna
+
+			info.put("Cluster", "thor"); //analagous to DB server instance
+			info.put("DefaultQuery", "fetchpeoplebyzipservice"); //analagous to default DB name
+			info.put("WsECLWatchPort", "8010");
+			//info.put("EclLimit", "100");
+			info.put("WsECLPort", "8002");
+			info.put("WsECLDirectPort", "8008");
+			info.put("username", "_rpastrana");
+			info.put("password", "ch@ng3m3");
+
+			//conn = (EclConnection) d.connect("url:jdbc:ecl;ServerAddress=192.168.124.128;Cluster=myroxie",info);
+			//conn = (EclConnection) d.connect("url:jdbc:ecl;ServerAddress=10.239.20.80;Cluster=thor;EclLimit=8",info);
+			conn = (EclConnection) d.connect("url:jdbc:ecl;ServerAddress=10.239.219.10;Cluster=thor;EclLimit=8",info);
+
+
+			//PreparedStatement p = conn.prepareStatement("SELECT 2");
+			//PreparedStatement p = conn.prepareStatement("select  * from thor::full_test_distributed_index where lname = BRYANT , fname = whoknows group by zips order by birth_month DESC");
+			//PreparedStatement p = conn.prepareStatement("select  * from thor::full_test_distributed_index where lname = BRYANT AND fname = SILVA ");
+
+			//PreparedStatement p = conn.prepareStatement("select  x, 'firstname', 1  from tutorial::rp::tutorialperson where  firstname >= ? and firstname >= ? limit 1000");
+			//PreparedStatement p = conn.prepareStatement("select  count(*) from tutorial::rp::tutorialperson where  firstname = 'A' or firstname = 'Z' limit 1000");
+			//PreparedStatement p = conn.prepareStatement("select  firstname from tutorial::rp::tutorialperson where  middlename =' ' ");
+			//PreparedStatement p = conn.prepareStatement("select  * from tutorial::rp::tutorialperson where zip = ? and  middlename>='W'    city='DELRAY BEACH' limit 1000" );
+			//PreparedStatement p = conn.prepareStatement("select * from tutorial::rp::tutorialperson where firstname = 'MARICHELLE'  order by lastname ASC, firstname DESC limit 1000");
+			//PreparedStatement p = conn.prepareStatement("select count(*) from tutorial::rp::tutorialperson");
+			//PreparedStatement p = conn.prepareStatement("select tutorial::rp::peoplebyzipindex.zip from \n tutorial::rp::peoplebyzipindex order by zip");
+			//PreparedStatement p = conn.prepareStatement("select zip, count( * ) from tutorial::rp::tutorialperson  group by zip");
+			//PreparedStatement p = conn.prepareStatement("select city, zip, count(*) from tutorial::rp::tutorialperson where zip ='33445' limit 1000");
+			//PreparedStatement p = conn.prepareStatement("select city from tutorial::rp::tutorialperson USE INDEX(tutorial::rp::peoplebyzipindex2) where zip = ? ");
+			//PreparedStatement p = conn.prepareStatement("select count(*) from tutorial::rp::tutorialperson USE INDEX(0) where zip > ?");
+			//PreparedStatement p = conn.prepareStatement("select count(city)  from tutorial::rp::tutorialperson where zip = '33445'");//where zip = '33445'");
+			//PreparedStatement p = conn.prepareStatement("select * from enron::final where tos = 'randy.young@enron.com' limit 1000");
+			PreparedStatement p = conn.prepareStatement("select count(*), zip from tutorial::rp::tutorialperson ");
+
+
+
+			//PreparedStatement p = conn.prepareStatement("select tbl.* from progguide::exampledata::peopleaccts tbl");
+			//PreparedStatement p = conn.prepareStatement("select firstname, lastname, middlename, city, street, state, zip from tutorial::rp::tutorialperson where firstname = VIMA LIMIT 1000");
+		//PreparedStatement p = conn.prepareStatement("select tbl.* from progguide::exampledata::people tbl");
+
+			//PreparedStatement p = conn.prepareStatement("select * from certification::full_test_distributed limit 100");
+			//PreparedStatement p = conn.prepareStatement("select * from certification::full_test_distributed where birth_state = FL LIMIT 1000");
+			//PreparedStatement p = conn.prepareStatement("select * from customer::customer");
+			//PreparedStatement p = conn.prepareStatement("select count(*) from tutorial::rp::tutorialperson");
+			//PreparedStatement p = conn.prepareStatement("select * from tutorial::rp::tutorialperson");
+
+
+			//PreparedStatement p = conn.prepareStatement("select tbl.* from .::xdbcsample tbl");
+
+			//PreparedStatement p = conn.prepareStatement("select tbl.* from fetchpeoplebyzipservice tbl where zipvalue=33445  order by fname DESC group by zip limit 10");
+			//PreparedStatement p = conn.prepareStatement("select tbl.* from fetchpeoplebyzipservice tbl where zipvalue=33445 group by zip, fname order by fname DESC, lname, zip ASC limit 10");
+			//PreparedStatement p = conn.prepareStatement("call fetchpeoplebyzipservice(?)");
+			//PreparedStatement p = conn.prepareStatement("select tbl.* from bestdemo tbl ");
+			//PreparedStatement p = conn.prepareStatement("select * fname from fetchpeoplebyzipservice");
+
+
+			//PreparedStatement p = conn.prepareStatement("select * from 'Result 1' where zipvalue=33445");
+
+			//PreparedStatement p = conn.prepareStatement("select * from Timeline_Total_Property_Sales");
+			//PreparedStatement p = conn.prepareStatement("select * from motiondemo");
+
+			p.clearParameters();
+			p.setObject(1, "'33445'");
+			//p.setObject(1, "'A'");
+			//p.setObject(2, "'D'");
+			EclResultSet qrs = (EclResultSet)((EclPreparedStatement)p).executeQuery();
+
+			ResultSetMetaData meta = qrs.getMetaData();
+			System.out.println();
+
+			for (int i = 1; i <= meta.getColumnCount(); i++)
+			{
+				System.out.print("[*****" + meta.getColumnName(i) + "******]");
+			}
+			System.out.println();
+			for (int i = 1; i <= meta.getColumnCount(); i++)
+			{
+				System.out.print("[*****" + EclDatabaseMetaData.convertSQLtype2JavaClassName(meta.getColumnType(i)) + "******]");
+			}
+
+			while (qrs.next())
+			{
+				System.out.println();
+				for (int i = 1; i <= meta.getColumnCount(); i++)
+				{
+					System.out.print("[ " + qrs.getObject(i) + " ]");
+				}
+			}
+
+			System.out.println("\nTotal Records found: " + qrs.getRowCount());
+
+//			p.clearParameters();
+//			//p.setObject(1, "'33445'");
+//			p.setObject(1, "'ROBERT'");
+//			p.setObject(2, "'LO'");
+//			qrs = (EclResultSet)((EclPreparedStatement)p).executeQuery();
+//
+//
+//			for (int i = 1; i <= meta.getColumnCount(); i++)
+//			{
+//				System.out.print("[*****" + meta.getColumnName(i) + "******]");
+//			}
+//
+//			while (qrs.next())
+//			{
+//				System.out.println();
+//				for (int i = 1; i <= meta.getColumnCount(); i++)
+//				{
+//					System.out.print("[ " + qrs.getObject(i) + " ]");
+//				}
+//			}
+//
+//			System.out.println("\nTotal Records found: " + qrs.getRowCount());
+
+			//String tabname = meta.getTableName(1);
+			//int count = meta.getColumnCount();
+			//String label = meta.getColumnLabel(2);
+			//String typename = meta.getColumnTypeName(1);
+
+			//System.out.println("Table name: " + tabname + "tablecolumncount: " + count);
+			/* while (qrs.next())
+			 {
+				 String fnvalue = qrs.getString("firstname");
+				 String lnvalue = qrs.getString("lastname");
+				 //String fnvalue = qrs.getString(1);
+				 //String lnvalue = qrs.getString(2);
+				 System.out.println("name: " + fnvalue + " " + lnvalue);
+			 }*/
+
+			//String hpccname = conn.getMetaData().getDatabaseProductVersion();
+			//int major = conn.getMetaData().getDatabaseMajorVersion();
+			//int minor = conn.getMetaData().getDatabaseMinorVersion();
+
+			//System.out.println("Connected to : " + hpccname +" version:" + major +"."+ minor);
+			//ECLDATABASEMETADATA GETCOLUMNS catalog: myroxie, schemaPattern: null, tableNameP
+			//attern: tutorial::rp::tutorialperson, columnNamePattern: null
+			// ResultSet columns = conn.getMetaData().getColumns("myroxie", null,"tutorial::rp::tutorialperson", null);
+
+			/*ResultSet typeinfo = conn.getMetaData().getTypeInfo();
+			 while (typeinfo.next())
+			 {
+				 System.out.print("col 1: " + typeinfo.getObject(1) + "\t");
+				 System.out.print("col 2: " + typeinfo.getObject(2) + "\t");
+				 System.out.print("col 3: " + typeinfo.getObject(3) + "\t");
+				 System.out.print("col 4: " + typeinfo.getObject(4) + "\t");
+				 System.out.print("col 5: " + typeinfo.getObject(5) + "\t");
+				 System.out.print("col 6: " + typeinfo.getObject(6) + "\t");
+				 System.out.print("col 7: " + typeinfo.getObject(7) + "\t");
+				 System.out.print("col 8: " + typeinfo.getObject(8) + "\t");
+
+					System.out.println("   " + typeinfo.getString("TYPE_NAME")+"("+typeinfo.getString("LOCAL_TYPE_NAME") + ")");
+			}*/
+
+			/*ResultSet columns = conn.getMetaData().getColumns(null, "",	"", "%");
+
+			 while (columns.next())
+			 {
+				 columns.getMetaData().getColumnType(1);
+				 columns.getMetaData().getColumnTypeName(1);
+				 System.out.print("col 1: " + columns.getObject(1) + "\t");
+				 System.out.print("col 2: " + columns.getObject(2) + "\t");
+				 System.out.print("col 3: " + columns.getObject(3) + "\t");
+				 System.out.print("col 4: " + columns.getObject(4) + "\t");
+				 System.out.print("col 5: " + columns.getObject(5) + "\t");
+				 System.out.print("col 6: " + columns.getObject(6) + "\t");
+				 System.out.print("col 7: " + columns.getObject(7) + "\t");
+				 System.out.print("col 8: " + columns.getObject(8) + "\t");
+
+					System.out.println("   " + columns.getString("TABLE_NAME")+"."+columns.getString("COLUMN_NAME")	+ "(" + columns.getString("TYPE_CAT") +")");
+			}
+			*/
+
+			//ECLDATABASEMETADATA GETTABLES catalog: myroxie, schemaPattern: null, tableNamePattern: %
+			//ResultSet tables = conn.getMetaData().getTables(null,null,null,	new String[] {""});
+			//ResultSet tables = conn.getMetaData().getTables("myroxie", null, "%",new String[] {""} );
+
+			//System.out.println("Tables found: ");
+			//while (tables.next()) {
+			//	System.out.println("   " + tables.getString("TABLE_NAME") + " Remarks: \'" + tables.getString("REMARKS")+"\'");
+		//	}
+
+
+			/*
+			ResultSet procs = conn.getMetaData().getProcedures(null, null, null);
+
+			System.out.println("procs found: ");
+			while (procs.next()) {
+				System.out.println("   " + procs.getString("PROCEDURE_NAME"));
+			}
+			*/
+			/*
+			ResultSet proccols = conn.getMetaData().getProcedureColumns(null, null, null, null);
+
+			System.out.println("procs cols found: ");
+			while (proccols.next()) {
+				System.out.println("   " + proccols.getString("COLUMN_NAME"));
+			}
+			*/
+			//getProcedureColumns catalog: null, schemaPattern: null, procedureNamePattern: fetchpeoplebyzipservice columnanmepat: null
+
+		}
+		catch (SQLException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclEngine.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclEngine.java
@@ -1,0 +1,932 @@
+package com.hpccsystems.ecljdbc;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.Socket;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.net.UnknownHostException;
+import java.sql.SQLWarning;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Vector;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class EclEngine
+{
+
+	private  		String		urlString;
+	private final 	String 		basicAuth;
+	private 	 	String 		eclqueryname;
+	private final 	String 		datasetname;
+	private 		NodeList 	resultschema;
+	private final 	Properties 	props;
+	private 		ArrayList<SQLWarning> warnings;
+	private 		SqlParser 	parser;
+	private			EclDatabaseMetaData dbMetadata;
+	private 		String 		indexToUseName;
+	private 		HashMap<String, String> 	eclEnteties;
+
+	public EclEngine(String eclqueryname, String datasetname, Properties props)
+	{
+		this.props = props;
+		this.datasetname = datasetname;
+		this.eclqueryname = eclqueryname;
+		basicAuth = props.getProperty("BasicAuth");
+		resultschema = null;
+		eclEnteties = new HashMap<String, String>();
+	}
+
+	public EclEngine(SqlParser parser, EclDatabaseMetaData dbmetadata, Properties props, String indextouse)
+	{
+		this.props = props;
+		this.dbMetadata = dbmetadata;
+		this.parser = parser;
+		basicAuth = props.getProperty("BasicAuth");
+		this.indexToUseName = indextouse;
+		datasetname = null;
+		resultschema = null;
+		eclqueryname = null;
+		eclEnteties = new HashMap<String, String>();
+	}
+
+	public ArrayList executeSelectConstant(String eclstring)
+	{
+		try
+		{
+			urlString = "http://" + props.getProperty("ServerAddress") + ":" + props.getProperty("WsECLDirectPort") + "/EclDirect/RunEcl?Submit&eclText=";
+			urlString +=  URLEncoder.encode(eclstring, "UTF-8");
+
+			System.out.println("WSECL:executeSelect: " + urlString);
+
+			// Send data
+			long startTime = System.currentTimeMillis();
+
+			URL url = new URL(urlString);
+			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+			conn.setInstanceFollowRedirects(false);
+			conn.setRequestProperty("Authorization", basicAuth);
+			conn.setRequestMethod("GET");
+			conn.setDoOutput(true);
+			conn.setDoInput(true);
+
+			return parse(conn.getInputStream(),startTime);
+		}
+		catch (Exception e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	public  ArrayList execute() throws Exception
+	{
+		int sqlreqtype = parser.getSqlType();
+
+		List<EclColumnMetaData> expectedretcolumns = new ArrayList();
+		ArrayList<EclColumnMetaData> storeProcInParams = new ArrayList();
+		String hpccfilename = "";
+		String indexposfield = null;
+		StringBuilder keyedandwild = new StringBuilder();
+		DFUFile indexfiletouse = null;
+		StringBuilder eclcode = new StringBuilder("");
+		int totalparamcount = 0;
+		boolean isPayloadIndex = false;
+
+		switch (sqlreqtype)
+		{
+			case SqlParser.SQL_TYPE_SELECT:
+			{
+				hpccfilename = Utils.handleQuotedString(parser.getTableName());
+				if(!dbMetadata.tableExists("", hpccfilename))
+					throw new Exception("Invalid table found: " + hpccfilename);
+
+				DFUFile dfufile = dbMetadata.getDFUFile(hpccfilename);
+
+				//in future this might need to be a container of dfufile(s)
+				parser.verifySelectColumns(dfufile);
+
+				expectedretcolumns = parser.getSelectColumns();
+				totalparamcount = parser.getWhereClauseExpressionsCount();
+
+				if (indexToUseName != null)
+				{
+					indexfiletouse = dbMetadata.getDFUFile(indexToUseName);
+					indexposfield = indexfiletouse.getIdxFilePosField();
+
+					isPayloadIndex = processIndex(indexfiletouse, keyedandwild);
+
+					eclEnteties.put("KEYEDWILD", keyedandwild.toString());
+					if (isPayloadIndex)
+						eclEnteties.put("PAYLOADINDEX", "true");
+				}
+
+				eclEnteties.put("PARAMCOUNT", Integer.toString(totalparamcount));
+
+				if(dfufile.hasFileRecDef())
+				{
+					if (indexfiletouse != null && indexposfield != null)
+						eclcode.append(dfufile.getFileRecDefwithIndexpos(indexfiletouse.getFieldMetaData(indexposfield), "filerecstruct"));
+					else
+						eclcode.append(dfufile.getFileRecDef("filerecstruct"));
+				}
+				else
+					throw new Exception("Target HPCC file ("+hpccfilename+") does not contain ECL record definition");
+
+				if(!dfufile.isKeyFile())
+					eclcode.append("fileds := DATASET(\'~").append(dfufile.getFullyQualifiedName()).append("\', filerecstruct,").append(dfufile.getFormat()).append("); ");
+				else
+				{
+					eclcode.append("fileds := INDEX( ");
+					eclcode.append('{');
+					eclcode.append(dfufile.getKeyedFieldsAsDelmitedString(',', "filerecstruct"));
+					eclcode.append("},{");
+					eclcode.append(dfufile.getNonKeyedFieldsAsDelmitedString(',', "filerecstruct"));
+					eclcode.append("},");
+					eclcode.append("\'~").append(dfufile.getFullyQualifiedName()).append("\');");
+				}
+
+				StringBuilder selectstruct = new StringBuilder(" selectstruct:=RECORD ");
+				String datasource = indexToUseName == null || isPayloadIndex ? "fileds" : "fetchedds";
+
+				//boolean usescalar = expectedretcolumns.size() == 1;
+				for (int i = 0; i < expectedretcolumns.size(); i++)
+				{
+					EclColumnMetaData col = expectedretcolumns.get(i);
+					if (col.getColumnType() == EclColumnMetaData.COLUMN_TYPE_CONSTANT)
+					{
+						selectstruct.append(col.getEclType()).append(" ").append(col.getColumnName()).append(" := ").append(col.getConstantValue()).append("; ");
+						if (i == 0 && expectedretcolumns.size() == 1)
+							eclEnteties.put("SCALAROUTNAME", col.getColumnName());
+					}
+
+					else if (col.getColumnType() == EclColumnMetaData.COLUMN_TYPE_FNCTION)
+					{
+						if (col.getColumnName().equalsIgnoreCase("COUNT"))
+						{
+							eclEnteties.put("COUNTFN", "TRUE");
+							selectstruct.append("countout := ");
+							if (parser.hasGroupByColumns())
+							{
+								selectstruct.append(col.getColumnName().toUpperCase()).append("( GROUP");
+								List<EclColumnMetaData> funccols = col.getFunccols();
+
+								if (funccols.size() > 0)
+								{
+									String paramname = funccols.get(0).getColumnName();
+									if (!paramname.equals("*") && funccols.get(0).getColumnType() != EclColumnMetaData.COLUMN_TYPE_CONSTANT)
+									{
+										selectstruct.append(", ");
+										selectstruct.append(datasource);
+										selectstruct.append(".");
+										selectstruct.append(paramname);
+										selectstruct.append("<> \'\'");
+										//if (eclEnteties.size() > 0)
+										//	addFilterClause(selectstruct, eclEnteties);
+									}
+								}
+								selectstruct.append(" );");
+							}
+							else
+							{
+								selectstruct.append(" scalarout;");
+								if (expectedretcolumns.size() == 1)
+									eclEnteties.put("SCALAROUTNAME", col.getColumnName());
+							}
+
+							col.setSQLType(java.sql.Types.NUMERIC);
+						}
+						else if (col.getColumnName().equalsIgnoreCase("MAX"))
+						{
+							eclEnteties.put("MAXFN", "TRUE");
+							selectstruct.append("maxout :=  ");
+
+							if (parser.hasGroupByColumns())
+							{
+								selectstruct.append("MAX( GROUP ");
+							}
+							else
+							{
+								selectstruct.append("MAX( ").append(datasource);
+								if (eclEnteties.size() > 0)
+									addFilterClause(selectstruct, eclEnteties);
+							}
+
+							List<EclColumnMetaData> funccols = col.getFunccols();
+							if (funccols.size() > 0)
+							{
+								String paramname = funccols.get(0).getColumnName();
+								eclEnteties.put("FNCOLS", paramname);
+								if (!paramname.equals("*") && funccols.get(0).getColumnType() != EclColumnMetaData.COLUMN_TYPE_CONSTANT)
+								{
+									selectstruct.append(", ");
+									selectstruct.append(datasource);
+									selectstruct.append(".");
+									selectstruct.append(paramname);
+								}
+							}
+							selectstruct.append(" );");
+
+							/*
+							if (parser.hasGroupByColumns())
+							{
+								selectstruct.append(col.getColumnName().toUpperCase()).append("( GROUP");
+								List<EclColumnMetaData> funccols = col.getFunccols();
+
+								if (funccols.size() > 0)
+								{
+									String paramname = funccols.get(0).getColumnName();
+									eclEnteties.put("FNCOLS", paramname);
+									if (!paramname.equals("*") && funccols.get(0).getColumnType() != EclColumnMetaData.COLUMN_TYPE_CONSTANT)
+									{
+										selectstruct.append(", ");
+										selectstruct.append(datasource);
+										selectstruct.append(".");
+										selectstruct.append(paramname);
+									}
+								}
+								selectstruct.append(" );");
+							}
+							else
+							{
+								selectstruct.append(" totalmax;");
+								//if (expectedretcolumns.size() == 1)
+								//	eclEnteties.put("SCALAROUTNAME", col.getColumnName());
+							}
+							*/
+							/*
+
+							selectstruct.append(col.getColumnName().toUpperCase()).append(" ( ");
+							if (parser.hasGroupByColumns())
+								selectstruct.append("GROUP");
+							else
+								selectstruct.append(datasource);
+
+							List<EclColumnMetaData> funccols = col.getFunccols();
+
+							if (funccols.size() > 0)
+							{
+								String paramname = funccols.get(0).getColumnName();
+								if (!paramname.equals("*") && funccols.get(0).getColumnType() != EclColumnMetaData.COLUMN_TYPE_CONSTANT)
+								{
+									selectstruct.append(", ");
+									selectstruct.append(datasource);
+									selectstruct.append(".");
+									selectstruct.append(paramname);
+								}
+							}
+							selectstruct.append(" );");*/
+						}
+					}
+					else
+						selectstruct.append(col.getEclType()).append(" ").append(col.getColumnName()).append(" := ").append(datasource).append(".").append(col.getColumnName()).append("; ");
+
+					//if (i == 0 && expectedretcolumns.size() == 1 &&  col.getColumnType() != EclColumnMetaData.COLUMN_TYPE_DATA )
+					//	eclEnteties.put("SCALAROUTNAME", col.getColumnName());
+				}
+				selectstruct.append("END; ");
+
+				eclEnteties.put("SELECTSTRUCT", selectstruct.toString());
+
+				if(parser.hasOrderByColumns())
+					eclEnteties.put("ORDERBY",parser.getOrderByString());
+				if (parser.hasGroupByColumns())
+					eclEnteties.put("GROUPBY",parser.getGroupByString());
+				if (parser.hasLimitBy())
+					eclEnteties.put("LIMIT",Integer.toString(parser.getLimit()));
+
+				return executeSelect(eclcode.toString(), eclEnteties, indexfiletouse);
+			}
+			case SqlParser.SQL_TYPE_SELECTCONST:
+			{
+				System.out.println("Processing test_query...");
+				//ArrayList<EclColumnMetaData> columns = new ArrayList();
+				eclcode.append("selectstruct:=RECORD ");
+				expectedretcolumns = parser.getSelectColumns();
+				//defaultEclQueryReturnDatasetName = "ConstECLQueryResult";
+				StringBuilder ecloutput = new StringBuilder(" OUTPUT(DATASET([{ ");
+				for (int i = 1;  i <= expectedretcolumns.size(); i++)
+				{
+					EclColumnMetaData col = expectedretcolumns.get(i-1);
+					eclcode.append(col.getEclType()).append(" ").append(col.getColumnName()).append("; ");
+					ecloutput.append(col.getConstantValue());
+					if (i < expectedretcolumns.size())
+						ecloutput.append(", ");
+				}
+				ecloutput.append("}],selectstruct), NAMED(\'");
+				//ecloutput.append(defaultEclQueryReturnDatasetName);
+				ecloutput.append("ConstECLQueryResult");
+				ecloutput.append("\'));");
+
+				eclcode.append(" END; ");
+				eclcode.append(ecloutput.toString());
+
+				return executeSelectConstant(eclcode.toString());
+			}
+			case SqlParser.SQL_TYPE_CALL:
+			{
+				eclqueryname = Utils.handleQuotedString(parser.getStoredProcName());
+				if(!dbMetadata.eclQueryExists("", eclqueryname))
+					throw new Exception("Invalid store procedure found");
+
+				return executeCall(null);
+			}
+			default:
+
+				break;
+		}
+
+		return null;
+	}
+
+	public boolean processIndex(DFUFile indexfiletouse, StringBuilder keyedandwild)
+	{
+		boolean isPayloadIndex = containsPayload(indexfiletouse.getAllFieldsProps(), parser.getSelectColumns().iterator());
+
+		Vector<String> keyed = new Vector<String>();
+		Vector<String> wild = new Vector<String>();
+
+		//Create keyed and wild string
+		Properties keyedcols = indexfiletouse.getKeyedColumns();
+		for (int i = 1; i <= keyedcols.size(); i++)
+		{
+			String keyedcolname = (String)keyedcols.get(i);
+			if(parser.whereClauseContainsKey(keyedcolname))
+				keyed.add(" " + parser.getExpressionFromName(keyedcolname).toString() + " ");
+			else if (keyed.isEmpty())
+				wild.add(" " + keyedcolname + " ");
+		}
+
+		if(isPayloadIndex)
+		{
+			if (keyed.size()>0)
+			{
+				keyedandwild.append("KEYED( ");
+				for (int i = 0 ; i < keyed.size(); i++)
+				{
+					keyedandwild.append(keyed.get(i));
+					if (i < keyed.size()-1)
+						keyedandwild.append(" AND ");
+				}
+				keyedandwild.append(" )");
+			}
+			if (wild.size()>0)
+			{
+				//TODO should I bother making sure there's a KEYED entry ?
+				for (int i = 0 ; i < wild.size(); i++)
+				{
+					keyedandwild.append(" and WILD( ");
+					keyedandwild.append(wild.get(i));
+					keyedandwild.append(" )");
+				}
+			}
+
+			keyedandwild.append(" and (").append(parser.getWhereClauseString()).append(" )");
+		}
+		else //non-payload just AND the keyed expressions
+		{
+			keyedandwild.append("( ");
+			keyedandwild.append(parser.getWhereClauseString());
+			keyedandwild.append(" )");
+		}
+
+		return isPayloadIndex;
+	}
+
+	private boolean containsPayload(Properties indexfields,	Iterator<EclColumnMetaData> selectcolsit)
+	{
+		while(selectcolsit.hasNext())
+		{
+			EclColumnMetaData currentselectcol = selectcolsit.next();
+			String colname = currentselectcol.getColumnName();
+			int type = currentselectcol.getColumnType();
+			if (type == EclColumnMetaData.COLUMN_TYPE_DATA && !indexfields.containsKey(colname.toUpperCase()))
+				return false;
+			else if (type == EclColumnMetaData.COLUMN_TYPE_FNCTION && !containsPayload(indexfields, currentselectcol.getFunccols().iterator()))
+				return false;
+		}
+		return true;
+	}
+
+	public ArrayList executeSelect(String eclcode, HashMap parameters, DFUFile indexfile)
+	{
+		int responseCode = -1;
+		try
+		{
+			urlString = "http://" + props.getProperty("ServerAddress") + ":" + props.getProperty("WsECLDirectPort") + "/EclDirect/RunEcl?Submit"; 			//&eclText=
+
+			StringBuilder sb = new StringBuilder("&eclText=");
+			sb.append(eclcode);
+
+			if (indexfile == null) //no indexfile read...
+			{
+				if (!parameters.containsKey("GROUPBY"))
+				{
+					if (parameters.containsKey("COUNTFN"))
+					{
+						sb.append("scalarout := COUNT(fileds");
+						if (parameters.size() > 0)
+							addFilterClause(sb, parameters);
+						sb.append(");");
+					}
+
+					if (parameters.containsKey("MAXFN"))
+					{
+						sb.append("scalarout := MAX(fileds");
+						if (parameters.size() > 0)
+							addFilterClause(sb, parameters);
+
+						sb.append(" , fileds.");
+						sb.append(parameters.get("FNCOLS"));
+						sb.append(");");
+					}
+				}
+
+				if (parameters.containsKey("SCALAROUTNAME"))
+				{
+					sb.append("OUTPUT(scalarout ,NAMED(\'");
+					sb.append(parameters.get("SCALAROUTNAME"));
+					sb.append("\'));");
+				}
+				else
+				{
+					sb.append(parameters.get("SELECTSTRUCT"));
+					sb.append("OUTPUT(CHOOSEN(");
+
+					if (parameters.containsKey("ORDERBY"))
+						sb.append("SORT( ");
+
+					sb.append("TABLE(fileds");
+
+					if (parameters.size() > 0)
+						addFilterClause(sb, parameters);
+
+					sb.append(", selectstruct");
+					if (parameters.containsKey("GROUPBY"))
+					{
+						sb.append(",");
+						sb.append(parameters.get("GROUPBY"));
+					}
+
+					sb.append(")");
+
+					if (parameters.containsKey("ORDERBY"))
+					{
+						sb.append(",");
+						sb.append(parameters.get("ORDERBY"));
+						sb.append(")");
+					}
+				}
+			}
+			else // use index
+			{
+				sb.append("IDX := INDEX(fileds, {")
+				.append(indexfile.getKeyedFieldsAsDelmitedString(',', null))
+				.append("}");
+
+				if(indexfile.getNonKeyedColumnsCount()>0)
+					sb.append(",{ ").append(indexfile.getNonKeyedFieldsAsDelmitedString(',', null)).append(" }");
+
+				sb.append(",\'~").append(indexfile.getFullyQualifiedName()).append("\');");
+
+				if( parameters.containsKey("PAYLOADINDEX"))
+				{
+					sb.append(" OUTPUT(CHOOSEN(");
+					if (parameters.containsKey("ORDERBY"))
+						sb.append("SORT( ");
+
+					sb.append("IDX(")
+					.append(parameters.get("KEYEDWILD"))
+					.append(")");
+					if (parameters.containsKey("ORDERBY"))
+					{
+						sb.append(",");
+						sb.append(parameters.get("ORDERBY"));
+						sb.append(")");
+					}
+				}
+				else
+				{
+					sb.append("fetchedds := FETCH(fileds, IDX( ");
+
+					sb.append(parameters.get("KEYEDWILD"));
+					sb.append("), RIGHT.");
+					sb.append(indexfile.getIdxFilePosField()).append(");");
+
+
+					if (!parameters.containsKey("GROUPBY"))
+					{
+						if (parameters.containsKey("COUNTFN"))
+							sb.append("scalarout := COUNT(fetchedds);");
+						if (parameters.containsKey("MAXFN"))
+							sb.append("scalarout := MAX(fetchedds, fileds.zip);");
+					}
+
+					if (parameters.containsKey("SCALAROUTNAME"))
+					{
+						sb.append("OUTPUT(scalarout ,NAMED(\'");
+						sb.append(parameters.get("SCALAROUTNAME"));
+						sb.append("\'));");
+					}
+					else
+					{
+
+					sb.append(parameters.get("SELECTSTRUCT"));
+
+					sb.append(" IDXTABLE := TABLE(fetchedds , selectstruct ");
+
+					if (parameters.containsKey("GROUPBY"))
+					{
+						sb.append(", ");
+						sb.append(parameters.get("GROUPBY"));
+					}
+
+					sb.append("); ");
+
+					sb.append(" OUTPUT(CHOOSEN(");
+					sb.append(" IDXTABLE ");
+					}
+
+					/*{
+						sb.append(" OUTPUT(CHOOSEN(");
+						if (parameters.containsKey("ORDERBY"))
+							sb.append("SORT( ");
+
+						sb.append("fetchedds");
+						if (parameters.size() > 0)
+							addFilterClause(sb, parameters);
+
+						if (parameters.containsKey("ORDERBY"))
+						{
+							sb.append(",");
+							sb.append(parameters.get("ORDERBY"));
+							sb.append(")");
+						}
+					}*/
+				}
+			}
+
+			if (!parameters.containsKey("SCALAROUTNAME"))
+			{
+				sb.append(",");
+				if (parameters.containsKey("LIMIT"))
+					sb.append(parameters.get("LIMIT"));
+				else
+					sb.append( props.getProperty("EclLimit"));
+				sb.append("),NAMED(\'ECLJDBCSelectOutput\'));");
+			}
+
+			System.out.println("WSECL:executeSelect: " + urlString + sb.toString());
+
+			// Send data
+			long startTime = System.currentTimeMillis();
+
+			URL url = new URL(urlString);
+			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+			conn.setInstanceFollowRedirects(false);
+			conn.setRequestProperty("Authorization", basicAuth);
+			conn.setRequestMethod("GET");
+			conn.setDoOutput(true);
+			conn.setDoInput(true);
+
+			OutputStreamWriter wr = new OutputStreamWriter(	conn.getOutputStream());
+			wr.write(sb.toString());
+			wr.flush();
+
+			responseCode = conn.getResponseCode();
+
+			return parse(conn.getInputStream(),startTime);
+		}
+		catch (Exception e)
+		{
+			if (responseCode != 200)
+			{
+				throw new RuntimeException("HTTP Connection Response code: " + responseCode + " verify access to WsECLDirect", e);
+			}
+			else
+				throw new RuntimeException(e);
+		}
+	}
+
+	private void addFilterClause(StringBuilder sb, HashMap parameters)
+	{
+		String whereclause = parser.getWhereClauseString();
+		if (whereclause != null && whereclause.length() > 0)
+		{
+			sb.append("( ");
+			sb.append(whereclause);
+			sb.append(" )");
+		}
+	}
+
+	public ArrayList executeCall(Map parameters)
+	{
+		try
+		{
+			urlString = "http://" + props.getProperty("ServerAddress") + ":" + props.getProperty("WsECLPort") + "/WsEcl/submit/query/" + props.getProperty("Cluster") + "/" + eclqueryname + "/expanded";
+			System.out.println("WSECL:executeCall: " + urlString);
+
+			// Construct data
+			StringBuilder sb = new StringBuilder();
+			sb.append(URLEncoder.encode("submit_type_=xml", "UTF-8"));
+			sb.append("&").append(URLEncoder.encode("S1=Submit", "UTF-8"));
+
+			ArrayList<EclColumnMetaData> storeProcInParams = dbMetadata.getStoredProcInColumns("",eclqueryname);
+			String[] procInParamValues = parser.getStoredProcInParamVals();
+
+			for (int i = 0; i < procInParamValues.length; i++)
+			{
+				String key = storeProcInParams.get(i).getColumnName();
+				{
+					sb.append("&").append(key).append("=").append(procInParamValues[i]);
+				}
+			}
+
+			//if (parameters.size() > 0)
+			//{
+			//	for (Object key : parameters.keySet())
+			//	{
+			//		Object value = parameters.get(key);
+			//		sb.append("&").append(key).append("=").append(value);
+			//	}
+			//}
+
+			long startTime = System.currentTimeMillis();
+			// Send data
+			URL url = new URL(urlString);
+			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+			conn.setInstanceFollowRedirects(false);
+			conn.setRequestProperty("Authorization", basicAuth);
+			conn.setRequestMethod("GET");
+			conn.setDoOutput(true);
+			conn.setDoInput(true);
+
+			OutputStreamWriter wr = new OutputStreamWriter(	conn.getOutputStream());
+			wr.write(sb.toString());
+			wr.flush();
+
+			System.out.println("WsEcl Execute: " + urlString + " : " + sb.toString());
+
+			// Get the response
+			return parse(conn.getInputStream(), startTime);
+		}
+		catch (Exception e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	public ArrayList parse(InputStream xml, long startTime) throws Exception
+	{
+		ArrayList results = null;
+
+		try
+		{
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			DocumentBuilder db = dbf.newDocumentBuilder();
+
+			Document dom = db.parse(xml);
+
+			long elapsedTime = System.currentTimeMillis() - startTime;
+		    System.out.println("Total elapsed http request/response time in milliseconds: " + elapsedTime);
+
+
+			Element docElement = dom.getDocumentElement();
+
+			NodeList dsList = docElement.getElementsByTagName("Dataset");
+
+			if (dsList != null && dsList.getLength() > 0)
+			{ // The dataset element is encapsulated within a Result element
+
+				//need to fetch appropriate resulst dataset ie map eclqueryname to dataset name
+				ArrayList dsArray = new ArrayList();
+
+				results = dsArray;
+
+				for (int i = 0; i < dsList.getLength(); i++)
+				{
+					Element ds = (Element) dsList.item(i);
+					String currentdatsetname = ds.getAttribute("name");
+					if (datasetname == null || datasetname.length() == 0 || currentdatsetname.equalsIgnoreCase(datasetname))
+					{
+						NodeList rowList = ds.getElementsByTagName("Row");
+
+						if (rowList != null && rowList.getLength() > 0)
+						{
+
+							ArrayList rowArray = new ArrayList();
+
+							dsArray.add(rowArray);
+
+							for (int j = 0; j < rowList.getLength(); j++)
+							{
+								Element row = (Element) rowList.item(j);
+
+								NodeList columnList = row.getChildNodes();
+
+								ArrayList columnsArray = new ArrayList();
+								rowArray.add(columnsArray);
+
+								for (int k = 0; k < columnList.getLength(); k++)
+								{
+									columnsArray.add(new EclColumn(columnList.item(k).getNodeName(), columnList.item(k).getTextContent()));
+								}
+							}
+						}
+						break;
+					}
+
+				}
+			}
+			else if (docElement.getElementsByTagName("Exception").getLength()>0)
+			{
+				Exception xmlexception = new Exception();
+				NodeList exceptionlist = docElement.getElementsByTagName("Exception");
+				//for (int i = 0; i < exceptionlist.getLength(); i++)
+				//{
+				if (exceptionlist.getLength()>0)
+				{
+					Exception resexception = null;
+					NodeList currexceptionelements = exceptionlist.item(0).getChildNodes();
+
+					for (int j = 0; j < currexceptionelements.getLength(); j++)
+					{
+						Node exceptionelement = currexceptionelements.item(j);
+						if (exceptionelement.getNodeName().equals("Message"))
+						{
+							resexception = new Exception("ECLJDBC error in response: \'" + exceptionelement.getTextContent()+"\'");
+						}
+					}
+					if (dsList == null || dsList.getLength() <= 0)
+						throw resexception;
+				}
+			}
+			else
+			{
+				// The root element is itself the Dataset element
+				if (dsList.getLength() == 0)
+				{
+					ArrayList dsArray = new ArrayList();
+					results = dsArray;
+					NodeList rowList = docElement.getElementsByTagName("Row");
+
+					if (rowList != null && rowList.getLength() > 0)
+					{
+						ArrayList rowArray = new ArrayList();
+						dsArray.add(rowArray);
+
+						for (int j = 0; j < rowList.getLength(); j++)
+						{
+							Element row = (Element) rowList.item(j);
+							NodeList columnList = row.getChildNodes();
+
+							ArrayList columnsArray = new ArrayList();
+							rowArray.add(columnsArray);
+
+							for (int k = 0; k < columnList.getLength(); k++)
+							{
+								columnsArray.add(new EclColumn(columnList.item(k).getNodeName(), columnList.item(k).getTextContent()));
+							}
+						}
+					}
+				}
+			}
+
+			/*not being used right not
+			 *
+			 * setResultschema( docElement.getElementsByTagName("XmlSchema"));
+			 */
+
+			System.out.println("Parsing results...");
+			Iterator itr = results.iterator();
+			System.out.println("Results datsets found: " + results.size());
+			while (itr.hasNext())
+			{
+				ArrayList rows = (ArrayList) itr.next();
+				System.out.println("Results rows found: " + rows.size());
+				Iterator itr2 = rows.iterator();
+				while (itr2.hasNext())
+				{
+					ArrayList cols = (ArrayList) itr2.next();
+					Iterator itr3 = cols.iterator();
+					while (itr3.hasNext())
+					{
+						EclColumn element = (EclColumn) itr3.next();
+					}
+				}
+			}
+			System.out.println("Finished Parsing results.");
+		}
+		catch (Exception e)
+		{
+			throw new Exception("Invalid response received, verify serveraddress and cluster name and HPCC query/file name:\n" +e.getMessage() );
+		}
+
+		return results;
+	}
+
+	public String convertInputStreamToString(InputStream ists)	throws IOException
+	{
+		if (ists != null)
+		{
+			StringBuilder sb = new StringBuilder();
+			String line;
+
+			try
+			{
+				BufferedReader r1 = new BufferedReader(new InputStreamReader(ists, "UTF-8"));
+				while ((line = r1.readLine()) != null)
+				{
+					sb.append(line).append("\n");
+				}
+			}
+			finally
+			{
+				ists.close();
+			}
+			return sb.toString();
+		}
+		else
+		{
+			return "";
+		}
+	}
+
+	public boolean hasResultSchema()
+	{
+		return (this.resultschema != null && this.resultschema.getLength() > 0);
+	}
+
+	public void setResultschema(NodeList resultschema)
+	{
+		this.resultschema = resultschema;
+
+		if (this.resultschema != null && this.resultschema.getLength() > 0)
+		{
+			System.out.println("contains resultschema");
+		}
+	}
+
+	public NodeList getResultschema()
+	{
+		return resultschema;
+	}
+
+
+	public static void main(String[] args)
+	{
+		// WsEcl wsEcl = new WsEcl("localhost", "myroxie", "person_query.1");
+		//WsEcl wsEcl = new WsEcl("192.168.92.130", "myroxie",
+
+		Properties info = new Properties();
+		// info.put("ServerAddress",
+		// "192.168.92.130:8002/WsEcl/definitions/query");
+		//info.put("ServerAddress", "192.168.124.128");
+		info.put("ServerAddress", "10.239.20.80");
+
+		info.put("Cluster", "myroxie");
+		info.put("WsECLWatchPort", "8010");
+		info.put("WsECLPort", "8002");
+		info.put("username", "_rpastrana");
+		info.put("password", "ch@ng3m3");
+
+		EclEngine wsEcl = new EclEngine("fetchpeoplebyzipservice.2","" ,info);
+		// http://192.168.56.102:8002/
+		HashMap params = new HashMap();
+		params.put("zipvalue", "30005");
+		ArrayList dataset = wsEcl.executeCall(params);
+
+		Iterator itr = dataset.iterator();
+		while (itr.hasNext())
+		{
+			ArrayList rows = (ArrayList) itr.next();
+			Iterator itr2 = rows.iterator();
+			while (itr2.hasNext())
+			{
+				ArrayList cols = (ArrayList) itr2.next();
+				Iterator itr3 = cols.iterator();
+				while (itr3.hasNext())
+				{
+					EclColumn element = (EclColumn) itr3.next();
+					System.out.print(element.getName() + " : "	+ element.getValue());
+				}
+			}
+		}
+		System.out.println();
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclPreparedStatement.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclPreparedStatement.java
@@ -1,0 +1,580 @@
+package com.hpccsystems.ecljdbc;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+/**
+ *
+ * @author rpastrana
+ */
+public class EclPreparedStatement implements PreparedStatement {
+    private boolean closed = false;
+    private int maxRows = 100;
+    private String query;
+    private Connection connection;
+    private HashMap<Integer, Object> parameters = new HashMap<Integer, Object>();
+    private ArrayList<SQLWarning> warnings;
+    private String indexToUse;
+
+    private EclResultSet result;
+
+    public EclPreparedStatement(Connection connection, String query)
+    {
+    	System.out.println("#####ECLPreparedStatement::ECLPreparedStatement: " + query + "###");
+        this.query = query;
+        this.connection = connection;
+        warnings = new ArrayList<SQLWarning>();
+        indexToUse = null;
+    }
+
+    public boolean isIndexSet()
+    {
+    	return indexToUse == null ? false : true;
+    }
+
+    public void setIndexToUse(String indexfilename)
+    {
+    	indexToUse = indexfilename;
+    }
+
+    public String getIndexToUse()
+    {
+    	return indexToUse;
+    }
+
+
+    public ResultSet executeQuery() throws SQLException
+    {
+    	System.out.println("#####ECLPreparedStatement::executeQuery: " + query + "###");
+    	return new EclResultSet(this, query, parameters);
+    }
+
+
+    public int executeUpdate() throws SQLException
+    {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT: executeUpdate Not supported yet.");
+    }
+
+
+    public void setNull(int parameterIndex, int sqlType) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), sqlType);
+    }
+
+
+    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setByte(int parameterIndex, byte x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setShort(int parameterIndex, short x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setInt(int parameterIndex, int x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setLong(int parameterIndex, long x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setFloat(int parameterIndex, float x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setDouble(int parameterIndex, double x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setString(int parameterIndex, String x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setDate(int parameterIndex, Date x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setTime(int parameterIndex, Time x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT: setAsciiStream Not supported yet.");
+    }
+
+
+    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT: setUnicodeStream Not supported yet.");
+    }
+
+
+    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT: setBinaryStream Not supported yet.");
+    }
+
+
+    public void clearParameters() throws SQLException {
+        parameters.clear();
+    }
+
+
+    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+    	System.out.println("ECLPrepStamt::setObject Parameter Index = " + parameterIndex + ", Object = " + x + ", targetSqlType = " + targetSqlType);
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setObject(int parameterIndex, Object x) throws SQLException {
+        System.out.println("ECLPrepStamt::setObject Parameter Index = " + parameterIndex + ", Object = " + x);
+        parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public boolean execute() throws SQLException
+    {
+    	result = new EclResultSet(this, query, parameters);
+    	System.out.println("ECLPreparedStatement: execute rowcount: " + result.getRowCount());
+    	return result.getRowCount() > 0 ? true : false;
+    }
+
+
+    public void addBatch() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT: addBatch Not supported yet.");
+    }
+
+
+    public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setCharacterStream Not supported yet.");
+    }
+
+
+    public void setRef(int parameterIndex, Ref x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setBlob(int parameterIndex, Blob x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setClob(int parameterIndex, Clob x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setArray(int parameterIndex, Array x) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public ResultSetMetaData getMetaData() throws SQLException
+    {
+    	System.out.println("ECLPreparedStatement: getMetaData");
+    	return result.getMetaData();
+    }
+
+
+    public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setDate Not supported yet.");
+    }
+
+
+    public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setTime Not supported yet.");
+    }
+
+
+    public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setTimestamp Not supported yet.");
+    }
+
+
+    public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setNull Not supported yet.");
+    }
+
+
+    public void setURL(int parameterIndex, URL x) throws SQLException
+    {
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public ParameterMetaData getParameterMetaData() throws SQLException
+    {
+    	System.out.println("ECLPREPSTATEMENT getParameterMetaData");
+    	throw new UnsupportedOperationException("ECLPREPSTATEMNT:getParameterMetaData Not supported yet.");
+    }
+
+
+    public void setRowId(int parameterIndex, RowId x) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setRowId Not supported yet.");
+    }
+
+
+    public void setNString(int parameterIndex, String value) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), value);
+    }
+
+
+    public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setNCharacterStream Not supported yet.");
+    }
+
+
+    public void setNClob(int parameterIndex, NClob value) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), value);
+    }
+
+
+    public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setClob Not supported yet.");
+    }
+
+
+    public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setBlob Not supported yet.");
+    }
+
+
+    public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setNClob Not supported yet.");
+    }
+
+
+    public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+    	parameters.put(new Integer(parameterIndex), xmlObject);
+    }
+
+
+    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
+    	System.out.println("ECLPrepStamt::setObject Parameter Index = " + parameterIndex + ", Object = " + x + ", targetSqlType = " + targetSqlType + ", scaleOrLength = " + scaleOrLength );
+    	parameters.put(new Integer(parameterIndex), x);
+    }
+
+
+    public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setAsciiStream Not supported yet.");
+    }
+
+
+    public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setBinaryStream Not supported yet.");
+    }
+
+
+    public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setCharacterStream Not supported yet.");
+    }
+
+
+    public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setAsciiStream Not supported yet.");
+    }
+
+
+    public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setBinaryStream Not supported yet.");
+    }
+
+
+    public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setCharacterStream Not supported yet.");
+    }
+
+
+    public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setNCharacterStream Not supported yet.");
+    }
+
+
+    public void setClob(int parameterIndex, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setClob Not supported yet.");
+    }
+
+
+    public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setBlob Not supported yet.");
+    }
+
+
+    public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setNClob Not supported yet.");
+    }
+
+
+    public ResultSet executeQuery(String query) throws SQLException
+    {
+    	System.out.println("ECLPreparedStatement: executeQuery(" + query +")");
+    	result = new EclResultSet(this, query, parameters);
+    	System.out.println("ECLPreparedStatement: executeQuery returned " + result.getRowCount() + " rows, and " + result.getMetaData().getColumnCount() + " columns");
+    	System.out.println("results object id: " + (Object)result.hashCode());
+
+        return result;
+    }
+
+
+    public int executeUpdate(String sql) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:executeUpdate Not supported yet.");
+    }
+
+
+    public void close() throws SQLException
+    {
+        connection.close();
+        query = "";
+        result = null;
+        closed = true;
+    }
+
+
+    public int getMaxFieldSize() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT: getMaxFieldSizeNot supported yet.");
+    }
+
+
+    public void setMaxFieldSize(int max) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setMaxFieldSize Not supported yet.");
+    }
+
+
+    public int getMaxRows() throws SQLException {
+        return maxRows;
+    }
+
+
+    public void setMaxRows(int max) throws SQLException {
+        maxRows = max;
+    }
+
+
+    public void setEscapeProcessing(boolean enable) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setEscapeProcessing Not supported yet.");
+    }
+
+
+    public int getQueryTimeout() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:getQueryTimeout Not supported yet.");
+    }
+
+
+    public void setQueryTimeout(int seconds) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setQueryTimeout Not supported yet.");
+    }
+
+
+    public void cancel() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:cancel Not supported yet.");
+    }
+
+
+    public SQLWarning getWarnings() throws SQLException {
+        return (warnings.size()<=0) ? null : warnings.get(1);
+    }
+
+
+    public void clearWarnings() throws SQLException {
+        warnings.clear();
+    }
+
+
+    public void setCursorName(String name) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setCursorName Not supported yet.");
+    }
+
+
+    public boolean execute(String sql) throws SQLException {
+        //throw new UnsupportedOperationException("ECLPREPSTATEMNT:execute Not supported yet.");
+    	System.out.println("ECLPREPSTMT execute(" + sql +")");
+    	query = sql;
+    	result = new EclResultSet(this, query, parameters);
+    	System.out.println("ECLPreparedStatement: execute rowcount: " + result.getRowCount());
+    	return result.getRowCount() > 0 ? true : false;
+    }
+
+
+    public ResultSet getResultSet() throws SQLException {
+        return result;
+    }
+
+
+    public int getUpdateCount() throws SQLException {
+    	return 0;
+    }
+
+
+    public boolean getMoreResults() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:getMoreResults Not supported yet.");
+    }
+
+
+    public void setFetchDirection(int direction) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setFetchDirection Not supported yet.");
+    }
+
+
+    public int getFetchDirection() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:getFetchDirection Not supported yet.");
+    }
+
+
+    public void setFetchSize(int rows) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setFetchSize Not supported yet.");
+    }
+
+
+    public int getFetchSize() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:getFetchSize Not supported yet.");
+    }
+
+
+    public int getResultSetConcurrency() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:getResultSetConcurrency Not supported yet.");
+    }
+
+
+    public int getResultSetType() throws SQLException {
+        return ResultSet.TYPE_FORWARD_ONLY;
+    }
+
+
+    public void addBatch(String sql) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:addBatch Not supported yet.");
+    }
+
+
+    public void clearBatch() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:clearBatch Not supported yet.");
+    }
+
+
+    public int[] executeBatch() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:executeBatch Not supported yet.");
+    }
+
+
+    public Connection getConnection() throws SQLException {
+        return connection;
+    }
+
+
+    public boolean getMoreResults(int current) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:getMoreResults Not supported yet.");
+    }
+
+
+    public ResultSet getGeneratedKeys() throws SQLException {
+        return null;
+    }
+
+
+    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:executeUpdate Not supported yet.");
+    }
+
+
+    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:executeUpdate Not supported yet.");
+    }
+
+
+    public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:executeUpdate Not supported yet.");
+    }
+
+
+    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:execute(String sql, int autoGeneratedKeys) Not supported yet.");
+    }
+
+
+    public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:execute(String sql, int[] columnIndexes) Not supported yet.");
+    }
+
+
+    public boolean execute(String sql, String[] columnNames) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:execute(String sql, String[] columnNames) Not supported yet.");
+    }
+
+
+    public int getResultSetHoldability() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:getResultSetHoldability Not supported yet.");
+    }
+
+
+    public boolean isClosed() throws SQLException {
+        return closed;
+    }
+
+
+    public void setPoolable(boolean poolable) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:setPoolable Not supported yet.");
+    }
+
+
+    public boolean isPoolable() throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:isPoolable Not supported yet.");
+    }
+
+
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:unwrap Not supported yet.");
+    }
+
+
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new UnsupportedOperationException("ECLPREPSTATEMNT:isWrapperFor Not supported yet.");
+    }
+
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclQueries.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclQueries.java
@@ -1,0 +1,35 @@
+package com.hpccsystems.ecljdbc;
+
+import java.util.Enumeration;
+import java.util.Properties;
+
+public class EclQueries {
+
+	private Properties queries;
+	private String clusterName;
+
+	public EclQueries(String cluster)
+	{
+		clusterName = cluster;
+		queries = new Properties();
+	}
+
+	public void put(String name, EclQuery query)
+	{
+		queries.put(name, query);
+	}
+
+	public String getClusterName()
+	{
+		return clusterName;
+	}
+	public Enumeration<Object> getQueries()
+	{
+		return queries.elements();
+	}
+
+	public EclQuery getQuery(String eclqueryname)
+	{
+		return (EclQuery)queries.get(eclqueryname);
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclQuery.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclQuery.java
@@ -1,0 +1,253 @@
+package com.hpccsystems.ecljdbc;
+
+import java.sql.DatabaseMetaData;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class EclQuery
+{
+	private String ID;
+	private String Name;
+	private String WUID;
+	private String DLL;
+	private String Alias;
+
+	private boolean Suspended;
+	private List<String> ResultDatasets;
+	private List<EclColumnMetaData> schema;
+	private String defaulttable;
+	private List<EclColumnMetaData> defaultfields;
+
+	private final static String DEFAULTDATASETNAME = "BIOUTPUT";
+
+	public EclQuery()
+	{
+		ID = "";
+		Name = "";
+		WUID = "";
+		Suspended = false;
+		Alias = "";
+		ResultDatasets = new ArrayList<String>();
+		schema = new ArrayList<EclColumnMetaData>();
+		defaulttable = null;
+		defaultfields = new ArrayList<EclColumnMetaData>();;
+	}
+
+	public String getAlias() {
+		return Alias;
+	}
+
+	public void setAlias(String alias) {
+		Alias = alias;
+	}
+
+	public String [] getAllTableFieldsStringArray(String tablename)
+	{
+		//ArrayList<String> fields = new ArrayList<String>();
+
+		//Iterator<EclColumnMetaData> it = schema.iterator();
+		String fields [] = new String [defaultfields.size()];
+		int i = 0;
+		Iterator<EclColumnMetaData> it = defaultfields.iterator();
+		while (it.hasNext())
+		{
+			EclColumnMetaData field = (EclColumnMetaData)it.next();
+			//if (field.getTableName().equals(tablename))
+				//fields.add(field.getColumnName());
+				fields[i++] = field.getColumnName();
+		}
+
+
+	    /*String f [] = new String [fields.size()];
+	    for (String string : fields)
+	    {
+	    	f[i++] = string;
+		}*/
+
+		return fields;
+	}
+
+	public void addResultElement(EclColumnMetaData elem) throws Exception
+	{
+		if (defaulttable != null)
+		{
+			if (elem.getTableName().equalsIgnoreCase(defaulttable) || elem.getParamType() == DatabaseMetaData.procedureColumnIn)
+			{
+				defaultfields.add(elem);
+			}
+
+			schema.add(elem);
+		}
+		else
+			throw new Exception("Cannot add Result Elements before adding Result Dataset");
+
+	}
+
+	public void addResultDataset(String ds)
+	{
+		if (defaulttable == null || ds.equalsIgnoreCase(DEFAULTDATASETNAME))
+		{
+			defaulttable = ds;
+			defaultfields.clear();
+		}
+		ResultDatasets.add(ds);
+	}
+
+	/*Doesn't make since if we're mapping one ECL query to one DB table*/
+	public List<String> getAllTables()
+	{
+		return ResultDatasets;
+	}
+
+
+	public List<EclColumnMetaData> getAllFields()
+	{
+		return defaultfields;
+	}
+
+	public String getID()
+	{
+		return ID;
+	}
+
+	public void setID(String iD)
+	{
+		ID = iD;
+	}
+
+	public String getName() {
+		return Name;
+	}
+
+	public void setName(String name) {
+		Name = name;
+	}
+
+	public String getWUID() {
+		return WUID;
+	}
+
+	public void setWUID(String wUID) {
+		WUID = wUID;
+	}
+
+	public String getDLL() {
+		return DLL;
+	}
+
+	public void setDLL(String dLL) {
+		DLL = dLL;
+	}
+
+	public boolean isSuspended() {
+		return Suspended;
+	}
+
+	public void setSuspended(boolean suspended) {
+		Suspended = suspended;
+	}
+
+	@Override
+	public String toString()
+	{
+		String tmp = Name + " " + WUID;
+
+		tmp += "tables: {";
+		Iterator<String> iterator = ResultDatasets.iterator();
+		while (iterator.hasNext()) {
+			tmp += " " + iterator.next();
+		}
+
+		tmp += "}";
+
+		tmp += "elements: {";
+		Iterator<EclColumnMetaData> iterator2 = schema.iterator();
+		while (iterator2.hasNext()) {
+			tmp += " " + iterator2.next();
+		}
+
+		tmp += "}";
+
+		return tmp;
+	}
+
+	public boolean containsField(String tablename, String fieldname)
+	{
+		//Iterator<EclColumnMetaData> it = schema.iterator();
+		Iterator<EclColumnMetaData> it = defaultfields.iterator();
+		while (it.hasNext())
+		{
+			EclColumnMetaData field = (EclColumnMetaData)it.next();
+			if (field.getTableName().equalsIgnoreCase(tablename) && field.getColumnName().equalsIgnoreCase(fieldname))
+				return true;
+		}
+
+		return false;
+	}
+
+	public EclColumnMetaData getFieldMetaData(String fieldname)
+	{
+		Iterator<EclColumnMetaData> it = schema.iterator();
+		while (it.hasNext())
+		{
+			EclColumnMetaData field = (EclColumnMetaData)it.next();
+			if (field.getColumnName().equalsIgnoreCase(fieldname))
+				return field;
+		}
+
+		return null;
+	}
+
+	public Iterator<EclColumnMetaData> getColumnsMetaDataIterator()
+	{
+		return schema.iterator();
+	}
+
+	public String getDefaultTableName()
+	{
+		return defaulttable;
+	}
+
+	public boolean containsField(String fieldname) {
+		Iterator<EclColumnMetaData> it = defaultfields.iterator();
+		while (it.hasNext())
+		{
+			EclColumnMetaData field = (EclColumnMetaData)it.next();
+			if (field.getColumnName().equalsIgnoreCase(fieldname))
+				return true;
+		}
+
+		return false;
+	}
+
+	public ArrayList<EclColumnMetaData> getAllNonInFields()
+	{
+		ArrayList<EclColumnMetaData> expectedretcolumns = new ArrayList();
+
+		Iterator<EclColumnMetaData> it = defaultfields.iterator();
+		while (it.hasNext())
+		{
+			EclColumnMetaData field = (EclColumnMetaData)it.next();
+			if (field.getParamType() != EclDatabaseMetaData.procedureColumnIn)
+				expectedretcolumns.add(field);
+		}
+
+		return expectedretcolumns;
+	}
+
+	public ArrayList<EclColumnMetaData> getAllInFields()
+	{
+		ArrayList<EclColumnMetaData> inparams = new ArrayList();
+
+		Iterator<EclColumnMetaData> it = defaultfields.iterator();
+		while (it.hasNext())
+		{
+			EclColumnMetaData field = (EclColumnMetaData)it.next();
+			if (field.getParamType() == EclDatabaseMetaData.procedureColumnIn)
+				inparams.add(field);
+		}
+
+		return inparams;
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclResultSet.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclResultSet.java
@@ -1,0 +1,2698 @@
+package com.hpccsystems.ecljdbc;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+/**
+ *
+ * @author rpastrana
+ */
+public class EclResultSet implements ResultSet
+{
+	private boolean					closed		= false;
+	private List<List>				rows;
+	private int						index		= -1;
+	private EclResultSetMetadata	resultMetadata;
+	private EclDatabaseMetaData		dbMetadata;
+	private Statement				statement;
+	private String					test_query	= "SELECT 1";
+	private String 					defaultEclQueryReturnDatasetName;
+	private Object					lastResult;
+	private ArrayList<SQLWarning> 	warnings;
+
+	private static final int NumberOfCommonParamInThisIndex = 0;
+	private static final int LeftMostKeyIndexPosition = 1;
+	private static final int NumberofColsKeyedInThisIndex = 2;
+	private static final int INDEXSCORECRITERIA = 3;
+
+	public EclResultSet(List recrows, ArrayList<EclColumnMetaData> metadatacols, String tablename) throws SQLException
+	{
+		resultMetadata = new EclResultSetMetadata(metadatacols, tablename);
+		rows = new ArrayList<List>(recrows);
+		lastResult = new Object();
+		warnings = new ArrayList<SQLWarning>();
+	}
+
+	public EclResultSet(Statement statement, String query, Map inParameters) throws SQLException
+	{
+		warnings = new ArrayList<SQLWarning>();
+		try
+		{
+
+			//for debug:
+//			System.out.println("Query: " + query);
+//			Iterator entries = inParameters.entrySet().iterator();
+//
+//			while (entries.hasNext())
+//			{
+//				Entry thisEntry = (Entry) entries.next();
+//				Object key = thisEntry.getKey();
+//				Object value = thisEntry.getValue();
+//				System.out.println("EclResultSet:inparameter: "	+ key.toString() + ":" + value.toString());
+//			}
+
+			lastResult = new Object();
+			List<EclColumnMetaData> expectedretcolumns = null;
+			this.statement = statement;
+			EclConnection connection = (EclConnection) statement.getConnection();
+			dbMetadata = connection.getDatabaseMetaData();
+			ArrayList dsList = null;
+			rows = new ArrayList();
+			String indextousename = null;
+
+			SqlParser parser = new SqlParser();
+			parser.parse(query);
+			int sqlreqtype = parser.getSqlType();
+
+			//not sure this is actually needed...
+			parser.populateParametrizedExpressions(inParameters);
+
+			if(sqlreqtype == SqlParser.SQL_TYPE_SELECT)
+			{
+				String hpccfilename = Utils.handleQuotedString(parser.getTableName());
+				if(!dbMetadata.tableExists("", hpccfilename))
+					throw new Exception("Invalid table found: " + hpccfilename);
+
+				DFUFile dfufile = dbMetadata.getDFUFile(hpccfilename);
+				parser.verifySelectColumns(dfufile);
+
+				expectedretcolumns = parser.getSelectColumns();
+
+				if(((EclPreparedStatement)statement).isIndexSet())
+				{
+					indextousename = ((EclPreparedStatement)statement).getIndexToUse();
+				}
+
+				else
+				{
+					String indexhint = parser.getIndexHint();
+					boolean avoidindex = false;
+					if ( indexhint != null)
+					{
+						if (indexhint.trim().equals("0"))
+						{
+							avoidindex= true;
+							System.out.println("Will not use any index.");
+						}
+
+						if (!avoidindex)
+						{
+							indextousename = findAppropriateIndex(indexhint,  expectedretcolumns, parser);
+							if (indextousename == null)
+								System.out.println("Cannot use USE INDEX hint: " + indexhint);
+						}
+					}
+
+					if (indextousename == null && dfufile.hasRelatedIndexes() && !avoidindex)
+					{
+						indextousename = findAppropriateIndex(dfufile.getRelatedIndexesList(),  expectedretcolumns, parser);
+					}
+
+					((EclPreparedStatement)statement).setIndexToUse(indextousename);
+				}
+
+				//columns are base 1 indexed
+				resultMetadata = new EclResultSetMetadata(expectedretcolumns, hpccfilename);
+			}
+			else if(sqlreqtype == SqlParser.SQL_TYPE_SELECTCONST)
+			{
+				expectedretcolumns = parser.getSelectColumns();
+				resultMetadata = new EclResultSetMetadata(expectedretcolumns, "Constants");
+			}
+			else if(sqlreqtype == SqlParser.SQL_TYPE_CALL)
+			{
+				ArrayList<EclColumnMetaData> storeProcInParams = new ArrayList();
+
+				String hpccQuery = Utils.handleQuotedString(parser.getStoredProcName());
+				if(!dbMetadata.eclQueryExists("", hpccQuery))
+					throw new Exception("Invalid store procedure found");
+
+				defaultEclQueryReturnDatasetName = dbMetadata.getdefaultECLQueryResultDatasetName("", hpccQuery);
+
+				expectedretcolumns = dbMetadata.getStoredProcOutColumns("", hpccQuery);
+				storeProcInParams = dbMetadata.getStoredProcInColumns("",hpccQuery);
+				//columns are base 1 indexed
+				resultMetadata = new EclResultSetMetadata(expectedretcolumns, hpccQuery);
+			}
+			else
+			{
+				throw new SQLException("SQL request type not determined");
+			}
+
+			EclEngine eclengine = new EclEngine(parser, dbMetadata, connection.getProperties(), indextousename);
+			dsList = eclengine.execute();
+
+			// Get the data
+			fetchData(dsList,expectedretcolumns);
+			return;
+		}
+		catch (Exception ex)
+		{
+			if (ex.getMessage() != null)
+				warnings.add(new SQLWarning(ex.getMessage()));
+			throw new SQLException(ex);
+		}
+
+//		try
+//		{
+//
+//			lastResult = new Object();
+//
+//			this.statement = statement;
+//			EclConnection connection = (EclConnection) statement.getConnection();
+//			dbMetadata = connection.getDatabaseMetaData();
+//			HashMap parameters = new HashMap();
+//			rows = new ArrayList();
+//
+//			SqlParser parser = new SqlParser();
+//			parser.parse(query);
+//
+//			int sqlreqtype = parser.getSqlType();
+//
+//			//ArrayList<EclColumnMetaData> expectedretcolumns = new ArrayList();
+//			List<EclColumnMetaData> expectedretcolumns = new ArrayList();
+//			ArrayList<EclColumnMetaData> storeProcInParams = new ArrayList();
+//			String hpccfilename = "";
+//			String indextouse = null;
+//			String indexposfield = null;
+//			DFUFile indexfiletouse = null;
+//			StringBuilder eclcode = new StringBuilder("");
+//			int totalparamcount = 0;
+//			if(sqlreqtype == SqlParser.SQL_TYPE_SELECT)
+//			{}
+//			else if(sqlreqtype == 9999)
+//			{
+//				hpccfilename = Utils.handleQuotedString(parser.getTableName());
+//				if(!dbMetadata.tableExists("", hpccfilename))
+//					throw new Exception("Invalid table found: " + hpccfilename);
+//
+//				DFUFile dfufile = dbMetadata.getDFUFile(hpccfilename);
+//
+//				//in future this might need to be a container of dfufile(s)
+//				parser.verifySelectColumns(dfufile);
+//
+//				expectedretcolumns = parser.getSelectColumns();
+//
+//				totalparamcount = parser.getWhereClauseExpressionsCount();
+//				if (totalparamcount > 0)
+//				{
+//					String [] paramnames = parser.getWhereClauseNames();
+//					//String [] uniqueparameters = parser.getUniqueWhereClauseNames();
+//					parser.populateParametrizedExpressions(inParameters);
+//
+//					parameters.put("WHERECLAUSE", parser.getWhereClauseString());
+//
+//					//Choose an index to use
+//					if(!dfufile.isKeyFile() && dfufile.hasRelatedIndexes())
+//					{
+//						if(((ECLPreparedStatement)statement).isIndexSet())
+//						{
+//							indextouse = ((ECLPreparedStatement)statement).getIndexToUse();
+//						}
+//						else
+//						{
+//							List<String> relindexes = dfufile.getRelatedIndexesList();
+//							int indexscore [][] = new int 	[dfufile.getRelatedIndexesCount()]
+//															[INDEXSCORECRITERIA/*[FieldsInIndexCount][LeftMostKeyIndex][ColsKeyedcount]*/];
+//							int highscore = Integer.MIN_VALUE;
+//							boolean payloadIdxWithAtLeast1KeyedFieldFound = false;
+//
+//							for (int indexcounter = 0; indexcounter < relindexes.size(); indexcounter++)
+//							{
+//								String indexname = relindexes.get(indexcounter);
+//								DFUFile indexfile = dbMetadata.getDFUFile(indexname);
+//
+//								if (indexfile!= null && indexfile.isKeyFile() && indexfile.hasValidIdxFilePosField())
+//								{
+//									for(int j = 0; j < expectedretcolumns.size(); j++)
+//									{
+//										if(indexfile.containsField(expectedretcolumns.get(j), true))
+//											++indexscore[indexcounter][NumberOfCommonParamInThisIndex];
+//									}
+//
+//									if (payloadIdxWithAtLeast1KeyedFieldFound && indexscore[indexcounter][NumberOfCommonParamInThisIndex] == 0)
+//										break; //Don't bother with this index
+//
+//									int localleftmostindex = Integer.MAX_VALUE;
+//									Properties KeyColumns = indexfile.getKeyedColumns();
+//
+//									if(KeyColumns!=null)
+//									{
+//										for (int i = 0; i < paramnames.length; i++)
+//										{
+//											String currentparam = paramnames[i];
+//											if(KeyColumns.contains(currentparam))
+//											{
+//												++indexscore[indexcounter][NumberofColsKeyedInThisIndex];
+//												int paramindex = indexfile.getKeyColumnIndex(currentparam);
+//												if (localleftmostindex>paramindex)
+//													localleftmostindex = paramindex;
+//											}
+//										}
+//										indexscore[indexcounter][LeftMostKeyIndexPosition] = localleftmostindex;
+//									}
+//
+//									if (indexscore[indexcounter][NumberOfCommonParamInThisIndex]==expectedretcolumns.size()
+//											&& indexscore[indexcounter][NumberofColsKeyedInThisIndex] > 0
+//											&& (!parser.whereClauseContainsOrOperator()))
+//										payloadIdxWithAtLeast1KeyedFieldFound = true; // during scoring, give this priority
+//								}
+//							}
+//
+//							for (int i = 0; i<dfufile.getRelatedIndexesCount(); i++)
+//							{
+//								if (indexscore[i][NumberOfCommonParamInThisIndex] == 0 || indexscore[i][NumberofColsKeyedInThisIndex] == 0) //does one imply the other?
+//									continue; //not good enough
+//
+//								if (payloadIdxWithAtLeast1KeyedFieldFound && indexscore[i][NumberOfCommonParamInThisIndex]<expectedretcolumns.size())
+//									continue; //not good enough
+//
+//								if (indexscore[i][NumberofColsKeyedInThisIndex] < parser.getWhereClauseExpressionsCount() && parser.whereClauseContainsOrOperator())
+//									continue; //not so sure about this rule.
+//
+//								//TODO if current is not payload index, check for fpos field if not found... discard???
+//								//int localscore = ((indexscore[i][NumberOfCommonParamInThisIndex]/selectColumns.size()) * 5) -
+//								int localscore = ((indexscore[i][NumberOfCommonParamInThisIndex]/expectedretcolumns.size()) * 5) -
+//											 	 (((indexscore[i][LeftMostKeyIndexPosition]/totalparamcount)-1) * 3) +
+//											 	 ((indexscore[i][NumberofColsKeyedInThisIndex]) * 2);
+//
+//								if (highscore < localscore )
+//								{
+//									highscore = localscore;
+//									indextouse = relindexes.get(i);
+//
+//									if (payloadIdxWithAtLeast1KeyedFieldFound && indexscore[i][NumberOfCommonParamInThisIndex]==expectedretcolumns.size())
+//										parameters.put("PAYLOADINDEX", "true");
+//									else
+//										parameters.remove("PAYLOADINDEX");
+//								}
+//							}
+//						}
+//
+//						if (indextouse != null)
+//						{
+//							indexfiletouse = dbMetadata.getDFUFile(indextouse);
+//							indexposfield = indexfiletouse.getIdxFilePosField();
+//
+//							Vector<String> keyed = new Vector<String>();
+//							Vector<String> wild = new Vector<String>();
+//
+//							//Create keyed and wild string
+//							Properties keyedcols = indexfiletouse.getKeyedColumns();
+//							for (int i = 1; i <= keyedcols.size(); i++)
+//							{
+//								String keyedcolname = (String)keyedcols.get(i);
+//								if(parser.whereClauseContainsKey(keyedcolname))
+//									keyed.add(" " + parser.getExpressionFromName(keyedcolname).toString() + " ");
+//								else if (keyed.isEmpty())
+//									wild.add(" " + keyedcolname + " ");
+//							}
+//
+//							StringBuilder keyedandwild = new StringBuilder();
+//							if (parameters.containsKey("PAYLOADINDEX"))
+//							{
+//								if (keyed.size()>0)
+//								{
+//									keyedandwild.append("KEYED( ");
+//									for (int i = 0 ; i < keyed.size(); i++)
+//									{
+//										keyedandwild.append(keyed.get(i));
+//										if (i < keyed.size()-1)
+//											keyedandwild.append(" AND ");
+//									}
+//									keyedandwild.append(" )");
+//								}
+//								if (wild.size()>0)
+//								{
+//									//TODO should I bother making sure there's a KEYED entry ?
+//									for (int i = 0 ; i < wild.size(); i++)
+//									{
+//										keyedandwild.append(" and WILD( ");
+//										keyedandwild.append(wild.get(i));
+//										keyedandwild.append(" )");
+//									}
+//								}
+//
+//								/*Properties nonkeyedcols = indexfiletouse.getNonKeyedColumns();
+//								for (int i = 1; i <= nonkeyedcols.size(); i++)
+//								{
+//									String nonkeyedcolname = (String)nonkeyedcols.get(i);
+//									//if(parameters.containsKey(nonkeyedcolname))
+//									if(parser.whereClauseContainsKey(nonkeyedcolname))
+//										//keyedandwild.append(" and ").append(nonkeyedcolname).append(" = \'").append(parameters.get(nonkeyedcolname)).append('\'');
+//										keyedandwild.append(" and ").append(parser.getExpressionFromName(nonkeyedcolname).toString());
+//								}*/
+//
+//								keyedandwild.append(" and (").append(parser.getWhereClauseString()).append(" )");
+//							}
+//							else //non-payload just AND the keyed expressions
+//							{
+//								keyedandwild.append("( ");
+//								keyedandwild.append(parser.getWhereClauseString());
+//								keyedandwild.append(" )");
+//
+//								/*if (keyed.size()>0)
+//								{
+//									keyedandwild.append("( ");
+//									for (int i = 0 ; i < keyed.size(); i++)
+//									{
+//										keyedandwild.append(keyed.get(i));
+//										if (i < keyed.size()-1)
+//											keyedandwild.append(" AND ");
+//									}
+//									keyedandwild.append(" )");
+//								}*/
+//							}
+//
+//							parameters.put("KEYEDWILD", keyedandwild.toString());
+//							((ECLPreparedStatement)statement).setIndexToUse(indexfiletouse.getFullyQualifiedName());
+//							System.out.println("Found index to use: " + indextouse + " field: " + indexposfield);
+//						}
+//						else
+//							System.out.println("No appropriate index found");
+//					}
+//				}
+//				parameters.put("PARAMCOUNT", totalparamcount);
+//
+//				if(dfufile.hasFileRecDef())
+//				{
+//					if (indextouse != null && indexposfield != null)
+//						eclcode.append(dfufile.getFileRecDefwithIndexpos(dbMetadata.getDFUFile(indextouse).getFieldMetaData(indexposfield), "filerecstruct"));
+//					else
+//						eclcode.append(dfufile.getFileRecDef("filerecstruct"));
+//				}
+//				else
+//					throw new Exception("Target HPCC file ("+hpccfilename+") does not contain ECL record definition");
+//
+//				if(!dfufile.isKeyFile())
+//					eclcode.append("fileds := DATASET(\'~").append(dfufile.getFullyQualifiedName()).append("\', filerecstruct,").append(dfufile.getFormat()).append("); ");
+//				else
+//				{
+//					//eclcode.append("fileds := INDEX( filerecstruct, \'~").append(dfufile.getFullyQualifiedName()).append("\');");
+//					eclcode.append("fileds := INDEX( ");
+//					eclcode.append('{');
+//					eclcode.append(dfufile.getKeyedFieldsAsDelmitedString(',', "filerecstruct"));
+//					eclcode.append("},{");
+//					eclcode.append(dfufile.getNonKeyedFieldsAsDelmitedString(',', "filerecstruct"));
+//					eclcode.append("},");
+//					eclcode.append("\'~").append(dfufile.getFullyQualifiedName()).append("\');");
+//				}
+//
+//				StringBuilder selectstruct = new StringBuilder(" selectstruct:=RECORD ");
+//				String datasource = indextouse == null || parameters.containsKey("PAYLOADINDEX") ? "fileds" : "fetchedds";
+//
+//				String scalarOutput = null;
+//
+//				for (int i = 0; i < expectedretcolumns.size(); i++)
+//				{
+//					EclColumnMetaData col = expectedretcolumns.get(i);
+//
+//					if (col.getColumnType() == EclColumnMetaData.COLUMN_TYPE_CONSTANT)
+//						selectstruct.append(col.getEclType()).append(" ").append(col.getColumnName()).append(" := ").append(col.getConstantValue()).append("; ");
+//
+//					else if (col.getColumnType() == EclColumnMetaData.COLUMN_TYPE_FNCTION)
+//					{
+//						if (col.getColumnName().equalsIgnoreCase("COUNT"))
+//						{
+//							parameters.put("COUNTFN", "TRUE");
+//							selectstruct.append("countout := ");
+//							if (parser.hasGroupByColumns())
+//							{
+//								selectstruct.append(col.getColumnName().toUpperCase()).append("( GROUP");
+//								List<EclColumnMetaData> funccols = col.getFunccols();
+//								//for count() only one param allowed
+//								if (funccols.size() > 0)
+//								{
+//									String paramname = funccols.get(0).getColumnName();
+//									if (!paramname.equals("*") && funccols.get(0).getColumnType() != EclColumnMetaData.COLUMN_TYPE_CONSTANT)
+//									{
+//										selectstruct.append(", ");
+//										selectstruct.append(datasource);
+//										selectstruct.append(".");
+//										selectstruct.append(paramname);
+//										selectstruct.append("<> \'\'");
+//									}
+//								}
+//								selectstruct.append(" );");
+//							}
+//							else
+//								selectstruct.append(" totalcount;");
+//
+//							col.setSQLType(java.sql.Types.NUMERIC);
+//						}
+//					}
+//					else
+//						selectstruct.append(col.getEclType()).append(" ").append(col.getColumnName()).append(" := ").append(datasource).append(".").append(col.getColumnName()).append("; ");
+//
+//					if (i == 0 && expectedretcolumns.size() == 1 )
+//						parameters.put("SCALAROUTNAME", col.getColumnName());
+//				}
+//				selectstruct.append("END; ");
+//
+//				parameters.put("SELECTSTRUCT", selectstruct.toString());
+//
+//				//columns are base 1 indexed
+//				resultMetadata = new EclResultsetMetadata(expectedretcolumns, hpccfilename);
+//
+//			}
+//			else if(sqlreqtype == SqlParser.SQL_TYPE_CALL)
+//			{
+//				hpccfilename = Utils.handleQuotedString(parser.getStoredProcName());
+//				if(!dbMetadata.eclQueryExists("", hpccfilename))
+//					throw new Exception("Invalid store procedure found");
+//
+//				defaultEclQueryReturnDatasetName = dbMetadata.getdefaultECLQueryResultDatasetName("", hpccfilename);
+//
+//				expectedretcolumns = dbMetadata.getStoredProcOutColumns("", hpccfilename);
+//				storeProcInParams = dbMetadata.getStoredProcInColumns("",hpccfilename);
+//				//columns are base 1 indexed
+//				resultMetadata = new EclResultsetMetadata(expectedretcolumns, hpccfilename);
+//
+//				String[] procInParamValues = parser.getStoredProcInParamVals();
+//
+//				int paramcount = 0;
+//				for (int i = 0; i < storeProcInParams.size(); i++)
+//				{
+//					if (procInParamValues[i].contains("${")	|| procInParamValues[i].equals("?"))
+//					{
+//						Object value = inParameters.get(new Integer(++paramcount));
+//						parameters.put(storeProcInParams.get(i).getColumnName(), value);
+//						System.out.println("Found Parameter - "	+ storeProcInParams.get(i).getColumnName() + " = " + value);
+//					}
+//					else
+//					{
+//						parameters.put(storeProcInParams.get(i).getColumnName(), procInParamValues[i]);
+//					}
+//				}
+//			}
+//			else if(sqlreqtype == SqlParser.SQL_TYPE_SELECTCONST)
+//			{
+//				System.out.println("Processing test_query...");
+//				//ArrayList<EclColumnMetaData> columns = new ArrayList();
+//				eclcode.append("selectstruct:=RECORD ");
+//				expectedretcolumns = parser.getSelectColumns();
+//				defaultEclQueryReturnDatasetName = "ConstECLQueryResult";
+//				StringBuilder ecloutput = new StringBuilder(" OUTPUT(DATASET([{ ");
+//				for (int i = 1;  i <= expectedretcolumns.size(); i++)
+//				{
+//					EclColumnMetaData col = expectedretcolumns.get(i-1);
+//					eclcode.append(col.getEclType()).append(" ").append(col.getColumnName()).append("; ");
+//					ecloutput.append(col.getConstantValue());
+//					if (i < expectedretcolumns.size())
+//						ecloutput.append(", ");
+//				}
+//				ecloutput.append("}],selectstruct), NAMED(\'");
+//				ecloutput.append(defaultEclQueryReturnDatasetName);
+//				ecloutput.append("\'));");
+//
+//				eclcode.append(" END; ");
+//				eclcode.append(ecloutput.toString());
+//
+//
+//				resultMetadata = new EclResultsetMetadata(expectedretcolumns, "Constants");
+//
+//			}
+//			else
+//			{
+//				throw new SQLException("SQL request type not determined");
+//			}
+//
+//			if(parser.hasOrderByColumns())
+//			{
+//				parameters.put("ORDERBY",parser.getOrderByString());
+//			}
+//			if (parser.hasGroupByColumns())
+//				parameters.put("GROUPBY",parser.getGroupByString());
+//			if (parser.hasLimitBy())
+//				parameters.put("LIMIT",parser.getLimit());
+//
+//			EclEngine eclengine = new EclEngine(hpccfilename, defaultEclQueryReturnDatasetName, connection.getProperties());
+//			ArrayList dsList = null;
+//
+//			if(sqlreqtype == SqlParser.SQL_TYPE_SELECT)
+//			{
+//				dsList = eclengine.executeSelect(eclcode.toString(), parameters, indexfiletouse);
+//			}
+//			else if(sqlreqtype == SqlParser.SQL_TYPE_CALL)
+//			{
+//				dsList = eclengine.executeCall(parameters);
+//			}
+//			else if(sqlreqtype == SqlParser.SQL_TYPE_SELECTCONST)
+//			{
+//				dsList = eclengine.executeSelectConstant(eclcode.toString());
+//			}
+//
+//			/*if (wsEcl.hasResultSchema())
+//			{
+//				Properties res = new Properties();f
+//				//EclDatabaseMetaData.registerSchemaElements(wsEcl.getResultschema().item(0), res, "");
+//
+//				NodeList resSchema = wsEcl.getResultschema();
+//				for (int i = 0; i < resSchema.getLength(); i++)
+//				{
+//					org.w3c.dom.Node node = resSchema.item(i);
+//					String nodename = node.getAttributes().getNamedItem("name").getNodeValue();
+//					if (nodename.equalsIgnoreCase(defaultEclQueryReturnDatasetName))
+//					{
+//						System.out.print("we found result schema");
+//						NodeList schemas = node.getChildNodes();
+//						for (int j = 0; j < schemas.getLength(); j++)
+//						{
+//							org.w3c.dom.Node schema = schemas.item(j);
+//							if(schema.getNodeType() != org.w3c.dom.Node.TEXT_NODE)
+//							{
+//								resultMetadata.parseResultSchema(schema);
+//								//dbMetadata.registerSchemaElements(schema, res, "");
+//								break;
+//							}
+//						}
+//						break;
+//					}
+//				}
+//			}*/
+//
+//			// Get the data
+//			fetchData(dsList,expectedretcolumns);
+//
+//		}
+//		catch (Exception ex)
+//		{
+//			if (ex.getMessage() != null)
+//				warnings.add(new SQLWarning(ex.getMessage()));
+//			throw new SQLException(ex);
+//		}
+	}
+
+	private void fetchData(ArrayList dsList, List<EclColumnMetaData> expectedretcolumns)
+	{
+		// Get the data
+		// Iterate the Datasets - need to find the appropriate result dataset
+		for (int i = 0; i < dsList.size(); i++)
+		{
+			// Iterate the rows
+			ArrayList inRowList = (ArrayList) dsList.get(i);
+			for (int j = 0; j < inRowList.size(); j++)
+			{
+				//ArrayList rowValues = new ArrayList();
+				//create row with default values b/c HPCC will not return a column for empty fields
+				ArrayList rowValues = resultMetadata.createDefaultResultRow();
+				rows.add(rowValues);
+
+				// Iterate the columns and add values
+				ArrayList inColumnList = (ArrayList) inRowList.get(j);
+				for (int m = 0; m < expectedretcolumns.size(); m++)
+				{
+					for (int k = 0; k < inColumnList.size(); k++)
+					{
+						EclColumn inColumn = (EclColumn) inColumnList.get(k);
+						EclColumnMetaData mthexpectedcol = expectedretcolumns.get(m);
+						if (mthexpectedcol.getColumnName().equalsIgnoreCase(inColumn.getName()) ||
+							mthexpectedcol.getAlias() != null && mthexpectedcol.getAlias().equalsIgnoreCase(inColumn.getName()))
+							rowValues.set(m, inColumn.getValue());
+					}
+				}
+			}
+		}
+	}
+
+	public String findAppropriateIndex(String index, List<EclColumnMetaData> expectedretcolumns, /*HashMap parameters, */ SqlParser parser)
+	{
+		List<String> indexhint = new ArrayList<String>();
+		indexhint.add(index);
+		return findAppropriateIndex(indexhint, expectedretcolumns, parser);
+	}
+
+	public String findAppropriateIndex(List<String> relindexes, List<EclColumnMetaData> expectedretcolumns, /*HashMap parameters, */ SqlParser parser)
+	{
+		String indextouse = null;
+		String [] sqlqueryparamnames = parser.getWhereClauseNames();
+
+		int totalparamcount = parser.getWhereClauseExpressionsCount();
+
+		int indexscore [][] = new int 	[relindexes.size()]
+										[INDEXSCORECRITERIA/*[FieldsInIndexCount][LeftMostKeyIndex][ColsKeyedcount]*/];
+		int highscore = Integer.MIN_VALUE;
+		boolean payloadIdxWithAtLeast1KeyedFieldFound = false;
+
+		for (int indexcounter = 0; indexcounter < relindexes.size(); indexcounter++)
+		{
+			String indexname = relindexes.get(indexcounter);
+			DFUFile indexfile = dbMetadata.getDFUFile(indexname);
+
+			if (indexfile!= null && indexfile.isKeyFile() && indexfile.hasValidIdxFilePosField())
+			{
+				for(int j = 0; j < expectedretcolumns.size(); j++)
+				{
+					if(indexfile.containsField(expectedretcolumns.get(j), true))
+						++indexscore[indexcounter][NumberOfCommonParamInThisIndex];
+				}
+
+				if (payloadIdxWithAtLeast1KeyedFieldFound && indexscore[indexcounter][NumberOfCommonParamInThisIndex] == 0)
+					break; //Don't bother with this index
+
+				int localleftmostindex = Integer.MAX_VALUE;
+				Properties KeyColumns = indexfile.getKeyedColumns();
+
+				if(KeyColumns!=null)
+				{
+					for (int i = 0; i < sqlqueryparamnames.length; i++)
+					{
+						String currentparam = sqlqueryparamnames[i];
+						if(KeyColumns.contains(currentparam))
+						{
+							++indexscore[indexcounter][NumberofColsKeyedInThisIndex];
+							int paramindex = indexfile.getKeyColumnIndex(currentparam);
+							if (localleftmostindex>paramindex)
+								localleftmostindex = paramindex;
+						}
+					}
+					indexscore[indexcounter][LeftMostKeyIndexPosition] = localleftmostindex;
+				}
+
+				if (indexscore[indexcounter][NumberOfCommonParamInThisIndex]==expectedretcolumns.size()
+						&& indexscore[indexcounter][NumberofColsKeyedInThisIndex] > 0
+						&& (!parser.whereClauseContainsOrOperator()))
+					payloadIdxWithAtLeast1KeyedFieldFound = true; // during scoring, give this priority
+			}
+		}
+
+		for (int i = 0; i<relindexes.size(); i++)
+		{
+			//if (indexscore[i][NumberOfCommonParamInThisIndex] == 0 || indexscore[i][NumberofColsKeyedInThisIndex] == 0) //does one imply the other?
+			if (indexscore[i][NumberofColsKeyedInThisIndex] == 0) //does one imply the other?
+				continue; //not good enough
+
+			if (payloadIdxWithAtLeast1KeyedFieldFound && indexscore[i][NumberOfCommonParamInThisIndex]<expectedretcolumns.size())
+				continue; //not good enough
+
+			if (indexscore[i][NumberofColsKeyedInThisIndex] < parser.getWhereClauseExpressionsCount() && parser.whereClauseContainsOrOperator())
+				continue; //not so sure about this rule.
+
+			//TODO if current is not payload index, check for fpos field if not found... discard???
+			//int localscore = ((indexscore[i][NumberOfCommonParamInThisIndex]/selectColumns.size()) * 5) -
+			int localscore = ((indexscore[i][NumberOfCommonParamInThisIndex]/expectedretcolumns.size()) * 5) -
+						 	 (((indexscore[i][LeftMostKeyIndexPosition]/totalparamcount)-1) * 3) +
+						 	 ((indexscore[i][NumberofColsKeyedInThisIndex]) * 2);
+
+			if (highscore < localscore )
+			{
+				highscore = localscore;
+				indextouse = relindexes.get(i);
+			}
+		}
+
+		return indextouse;
+	}
+
+//	public DFUFile findAppropriateIndexOLD(List<String> relindexes, List<EclColumnMetaData> expectedretcolumns, HashMap parameters, SqlParser parser)
+//	{
+//		String indextouse = null;
+//		DFUFile indexfiletouse = null;
+//		String [] sqlqueryparamnames = parser.getWhereClauseNames();
+//
+//		int totalparamcount = parser.getWhereClauseExpressionsCount();
+//
+//		int indexscore [][] = new int 	[relindexes.size()]
+//										[INDEXSCORECRITERIA/*[FieldsInIndexCount][LeftMostKeyIndex][ColsKeyedcount]*/];
+//		int highscore = Integer.MIN_VALUE;
+//		boolean payloadIdxWithAtLeast1KeyedFieldFound = false;
+//
+//		for (int indexcounter = 0; indexcounter < relindexes.size(); indexcounter++)
+//		{
+//			String indexname = relindexes.get(indexcounter);
+//			DFUFile indexfile = dbMetadata.getDFUFile(indexname);
+//
+//			if (indexfile!= null && indexfile.isKeyFile() && indexfile.hasValidIdxFilePosField())
+//			{
+//				for(int j = 0; j < expectedretcolumns.size(); j++)
+//				{
+//					if(indexfile.containsField(expectedretcolumns.get(j), true))
+//						++indexscore[indexcounter][NumberOfCommonParamInThisIndex];
+//				}
+//
+//				if (payloadIdxWithAtLeast1KeyedFieldFound && indexscore[indexcounter][NumberOfCommonParamInThisIndex] == 0)
+//					break; //Don't bother with this index
+//
+//				int localleftmostindex = Integer.MAX_VALUE;
+//				Properties KeyColumns = indexfile.getKeyedColumns();
+//
+//				if(KeyColumns!=null)
+//				{
+//					for (int i = 0; i < sqlqueryparamnames.length; i++)
+//					{
+//						String currentparam = sqlqueryparamnames[i];
+//						if(KeyColumns.contains(currentparam))
+//						{
+//							++indexscore[indexcounter][NumberofColsKeyedInThisIndex];
+//							int paramindex = indexfile.getKeyColumnIndex(currentparam);
+//							if (localleftmostindex>paramindex)
+//								localleftmostindex = paramindex;
+//						}
+//					}
+//					indexscore[indexcounter][LeftMostKeyIndexPosition] = localleftmostindex;
+//				}
+//
+//				if (indexscore[indexcounter][NumberOfCommonParamInThisIndex]==expectedretcolumns.size()
+//						&& indexscore[indexcounter][NumberofColsKeyedInThisIndex] > 0
+//						&& (!parser.whereClauseContainsOrOperator()))
+//					payloadIdxWithAtLeast1KeyedFieldFound = true; // during scoring, give this priority
+//			}
+//		}
+//
+//		for (int i = 0; i<relindexes.size(); i++)
+//		{
+//			if (indexscore[i][NumberOfCommonParamInThisIndex] == 0 || indexscore[i][NumberofColsKeyedInThisIndex] == 0) //does one imply the other?
+//				continue; //not good enough
+//
+//			if (payloadIdxWithAtLeast1KeyedFieldFound && indexscore[i][NumberOfCommonParamInThisIndex]<expectedretcolumns.size())
+//				continue; //not good enough
+//
+//			if (indexscore[i][NumberofColsKeyedInThisIndex] < parser.getWhereClauseExpressionsCount() && parser.whereClauseContainsOrOperator())
+//				continue; //not so sure about this rule.
+//
+//			//TODO if current is not payload index, check for fpos field if not found... discard???
+//			//int localscore = ((indexscore[i][NumberOfCommonParamInThisIndex]/selectColumns.size()) * 5) -
+//			int localscore = ((indexscore[i][NumberOfCommonParamInThisIndex]/expectedretcolumns.size()) * 5) -
+//						 	 (((indexscore[i][LeftMostKeyIndexPosition]/totalparamcount)-1) * 3) +
+//						 	 ((indexscore[i][NumberofColsKeyedInThisIndex]) * 2);
+//
+//			if (highscore < localscore )
+//			{
+//				highscore = localscore;
+//				indextouse = relindexes.get(i);
+//
+//				if (payloadIdxWithAtLeast1KeyedFieldFound && indexscore[i][NumberOfCommonParamInThisIndex]==expectedretcolumns.size())
+//					parameters.put("PAYLOADINDEX", "true");
+//				else
+//					parameters.remove("PAYLOADINDEX");
+//			}
+//		}
+//
+//		if (indextouse != null)
+//		{
+//			indexfiletouse = dbMetadata.getDFUFile(indextouse);
+//
+//			//indexposfield = indexfiletouse.getIdxFilePosField();
+//
+//			Vector<String> keyed = new Vector<String>();
+//			Vector<String> wild = new Vector<String>();
+//
+//			//Create keyed and wild string
+//			Properties keyedcols = indexfiletouse.getKeyedColumns();
+//			for (int i = 1; i <= keyedcols.size(); i++)
+//			{
+//				String keyedcolname = (String)keyedcols.get(i);
+//				if(parser.whereClauseContainsKey(keyedcolname))
+//					keyed.add(" " + parser.getExpressionFromName(keyedcolname).toString() + " ");
+//				else if (keyed.isEmpty())
+//					wild.add(" " + keyedcolname + " ");
+//			}
+//
+//			StringBuilder keyedandwild = new StringBuilder();
+//			if (parameters.containsKey("PAYLOADINDEX"))
+//			{
+//				if (keyed.size()>0)
+//				{
+//					keyedandwild.append("KEYED( ");
+//					for (int i = 0 ; i < keyed.size(); i++)
+//					{
+//						keyedandwild.append(keyed.get(i));
+//						if (i < keyed.size()-1)
+//							keyedandwild.append(" AND ");
+//					}
+//					keyedandwild.append(" )");
+//				}
+//				if (wild.size()>0)
+//				{
+//					//TODO should I bother making sure there's a KEYED entry ?
+//					for (int i = 0 ; i < wild.size(); i++)
+//					{
+//						keyedandwild.append(" and WILD( ");
+//						keyedandwild.append(wild.get(i));
+//						keyedandwild.append(" )");
+//					}
+//				}
+//
+//				keyedandwild.append(" and (").append(parser.getWhereClauseString()).append(" )");
+//			}
+//			else //non-payload just AND the keyed expressions
+//			{
+//				keyedandwild.append("( ");
+//				keyedandwild.append(parser.getWhereClauseString());
+//				keyedandwild.append(" )");
+//			}
+//
+//			parameters.put("KEYEDWILD", keyedandwild.toString());
+//			((ECLPreparedStatement)statement).setIndexToUse(indexfiletouse.getFullyQualifiedName());
+//			//System.out.println("Found index to use: " + indextouse + " field: " + indexposfield);
+//		}
+//		else
+//			System.out.println("No appropriate index found");
+//
+//		return indexfiletouse;
+//	}
+
+	public int getRowCount()
+	{
+		return rows.size();
+	}
+
+
+	public boolean next() throws SQLException
+	{
+		index++;
+		if (index >= rows.size())
+		{
+			index--;
+			return false;
+		} else
+		{
+			return true;
+		}
+	}
+
+
+	public void close() throws SQLException
+	{
+		closed = true;
+		lastResult = new Object(); // not null
+	}
+
+
+	public boolean wasNull() throws SQLException
+	{
+		return lastResult == null;
+	}
+
+
+	public String getString(int columnIndex) throws SQLException
+	{
+		//System.out.println("getString( " + columnIndex +")");
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return (String) lastResult;
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public boolean getBoolean(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				//content of row field is Object string, need to get value of string and parse as boolean
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return false;
+				return Boolean.parseBoolean(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public byte getByte(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return 0;
+				return String.valueOf(lastResult).getBytes()[0];
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public short getShort(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Short
+				return Short.parseShort(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public int getInt(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Int
+				return Integer.parseInt(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public long getLong(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Long
+				return Long.parseLong(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public float getFloat(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Float
+				return Float.parseFloat(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public double getDouble(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Double
+				return Double.parseDouble(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public BigDecimal getBigDecimal(int columnIndex, int scale)	throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as BigDecimal
+				BigDecimal bd = new BigDecimal(String.valueOf(lastResult));
+				return bd.setScale(scale);
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public byte[] getBytes(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return String.valueOf(lastResult).getBytes();
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public Date getDate(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as Date
+				return Date.valueOf(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public Time getTime(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as Time
+				return Time.valueOf(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public Timestamp getTimestamp(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as Timestamp
+				return Timestamp.valueOf(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public InputStream getAsciiStream(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return new ByteArrayInputStream(String.valueOf(lastResult).getBytes());
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public InputStream getUnicodeStream(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return new ByteArrayInputStream(String.valueOf(lastResult).getBytes());
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public InputStream getBinaryStream(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return new ByteArrayInputStream(String.valueOf(lastResult).getBytes());
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public String getString(String columnLabel) throws SQLException
+	{
+		//System.out.println("getString( " + columnLabel +")");
+		if (index >= 0  && index <= rows.size())
+		{
+			int column = resultMetadata.getColumnIndex(columnLabel);
+
+			if (column < 0)
+				throw new SQLException("Invalid Column Label found: " + columnLabel);
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(column - 1);
+				if (lastResult == null)
+					return null;
+				return (String)lastResult;
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public boolean getBoolean(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int column = resultMetadata.getColumnIndex(columnLabel);
+
+			if (column < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(column - 1);
+				if (lastResult == null)
+					return false;
+				return Boolean.parseBoolean(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public byte getByte(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int column = resultMetadata.getColumnIndex(columnLabel);
+
+			if (column < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(column - 1);
+				if (lastResult == null)
+					return 0;
+				return String.valueOf(lastResult).getBytes()[0];
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public short getShort(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int column = resultMetadata.getColumnIndex(columnLabel);
+
+			if (column < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(column - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Short
+				return Short.parseShort(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public int getInt(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int column = resultMetadata.getColumnIndex(columnLabel);
+
+			if (column < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(column - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Int
+				return Integer.parseInt(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public long getLong(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int column = resultMetadata.getColumnIndex(columnLabel);
+
+			if (column < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(column - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Long
+				return Long.parseLong(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public float getFloat(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int column = resultMetadata.getColumnIndex(columnLabel);
+
+			if (column < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(column - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Float
+				return Float.parseFloat(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public double getDouble(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int column = resultMetadata.getColumnIndex(columnLabel);
+
+			if (column < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(column - 1);
+				if (lastResult == null)
+					return 0;
+				//content of row field is Object string, need to get value of string and parse as Double
+				return Double.parseDouble(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as BigDecimal
+				BigDecimal bd = new BigDecimal(String.valueOf(lastResult));
+				return bd.setScale(scale);
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public byte[] getBytes(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return String.valueOf(lastResult).getBytes();
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public Date getDate(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as Date
+				return Date.valueOf(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public Time getTime(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as Time
+				return Time.valueOf(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public Timestamp getTimestamp(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as Timestamp
+				return Timestamp.valueOf(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public InputStream getAsciiStream(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return new ByteArrayInputStream(String.valueOf(lastResult).getBytes());
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public InputStream getUnicodeStream(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return new ByteArrayInputStream(String.valueOf(lastResult).getBytes());
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public InputStream getBinaryStream(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return new ByteArrayInputStream(String.valueOf(lastResult).getBytes());
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public SQLWarning getWarnings() throws SQLException
+	{
+		return warnings.isEmpty() ? null : warnings.get(0);
+	}
+
+
+	public void clearWarnings() throws SQLException
+	{
+		warnings.clear();
+	}
+
+
+	public String getCursorName() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public ResultSetMetaData getMetaData() throws SQLException
+	{
+		return resultMetadata;
+	}
+
+
+	public Object getObject(int columnIndex) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			//System.out.println("EclResultSet being queried for tablename: " + resultMetadata.getTableName(0) + " column: " + columnIndex + " total number of columns: " + rows.get(index).size() + " Current row: " + index) ;
+			//System.out.println("Columlabel: " + resultMetadata.getColumnLabel(columnIndex));
+			//System.out.println("Columlabel: " + resultMetadata.getColumnClassName(columnIndex));
+			lastResult = rows.get(index).get(columnIndex - 1);
+			if (lastResult == null)
+				return null;
+
+			//obj = Class.forName(resultMetadata.getColumnClassName(columnIndex));
+			//System.out.println("results object id: " + (Object)this.hashCode());
+			//System.out.println("returning object" + (lastResult==null ? ": null" : " of type " + resultMetadata.getColumnClassName(columnIndex) +  " : " + lastResult.toString()));
+
+			return lastResult;
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public Object getObject(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult =  row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				return lastResult;
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public int findColumn(String columnLabel) throws SQLException
+	{
+		return resultMetadata.getColumnIndex(columnLabel);
+	}
+
+
+	public Reader getCharacterStream(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Reader getCharacterStream(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public BigDecimal getBigDecimal(int columnIndex) throws SQLException
+	{
+		if (index >= 0 && index <= rows.size())
+			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+			{
+				lastResult = rows.get(index).get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as BigDecimal
+				return new BigDecimal(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Invalid Column Index");
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public BigDecimal getBigDecimal(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				lastResult = row.get(columnIndex - 1);
+				if (lastResult == null)
+					return null;
+				//content of row field is Object string, need to get value of string and parse as BigDecimal
+				return new BigDecimal(String.valueOf(lastResult));
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public boolean isBeforeFirst() throws SQLException
+	{
+		return (index < 0) ? true : false;
+	}
+
+
+	public boolean isAfterLast() throws SQLException
+	{
+		return (index > rows.size() - 1) ? true : false;
+	}
+
+
+	public boolean isFirst() throws SQLException
+	{
+		return  index == 0 ? true : false;
+	}
+
+
+	public boolean isLast() throws SQLException
+	{
+		return  (index == rows.size() - 1) ? true : false;
+	}
+
+
+	public void beforeFirst() throws SQLException
+	{
+		throw new UnsupportedOperationException("Not supported");
+	}
+
+
+	public void afterLast() throws SQLException
+	{
+		throw new UnsupportedOperationException("Not supported");
+	}
+
+
+	public boolean first() throws SQLException
+	{
+		if (rows.size() > 0)
+		{
+			index = 0;
+			return true;
+		}
+		else
+			return false;
+	}
+
+
+	public boolean last() throws SQLException
+	{
+		if (rows.size() > 0)
+		{
+			index = rows.size() - 1;
+			return true;
+		}
+		else
+			return false;
+	}
+
+
+	public int getRow() throws SQLException
+	{
+		return index + 1;
+	}
+
+
+	public boolean absolute(int row) throws SQLException
+	{
+		if (row > 0 && row <= rows.size())
+		{
+			index = row - 1;
+			return true;
+		} else
+		{
+			return false;
+		}
+	}
+
+
+	public boolean relative(int rows) throws SQLException
+	{
+		int tmpindex = index + rows;
+		if (tmpindex > 0 && tmpindex <= this.rows.size())
+		{
+			index = tmpindex;
+			return true;
+		} else
+		{
+			return false;
+		}
+	}
+
+
+	public boolean previous() throws SQLException
+	{
+		if (index > 1)
+		{
+			index--;
+			return true;
+		} else
+		{
+			return false;
+		}
+	}
+
+
+	public void setFetchDirection(int direction) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public int getFetchDirection() throws SQLException
+	{
+		return ResultSet.FETCH_FORWARD;
+	}
+
+
+	public void setFetchSize(int rows) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public int getFetchSize() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public int getType() throws SQLException
+	{
+		return ResultSet.TYPE_SCROLL_INSENSITIVE;
+	}
+
+
+	public int getConcurrency() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public boolean rowUpdated() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public boolean rowInserted() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public boolean rowDeleted() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateNull(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateBoolean(int columnIndex, boolean x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateByte(int columnIndex, byte x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateShort(int columnIndex, short x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateInt(int columnIndex, int x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateLong(int columnIndex, long x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateFloat(int columnIndex, float x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateDouble(int columnIndex, double x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateBigDecimal(int columnIndex, BigDecimal x)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateString(int columnIndex, String x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateBytes(int columnIndex, byte[] x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateDate(int columnIndex, Date x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateTime(int columnIndex, Time x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateTimestamp(int columnIndex, Timestamp x)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateAsciiStream(int columnIndex, InputStream x, int length)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateBinaryStream(int columnIndex, InputStream x, int length)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateCharacterStream(int columnIndex, Reader x, int length)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateObject(int columnIndex, Object x, int scaleOrLength)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateObject(int columnIndex, Object x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateNull(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateBoolean(String columnLabel, boolean x)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateByte(String columnLabel, byte x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateShort(String columnLabel, short x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateInt(String columnLabel, int x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateLong(String columnLabel, long x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateFloat(String columnLabel, float x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateDouble(String columnLabel, double x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateBigDecimal(String columnLabel, BigDecimal x)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateString(String columnLabel, String x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateBytes(String columnLabel, byte[] x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateDate(String columnLabel, Date x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateTime(String columnLabel, Time x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateTimestamp(String columnLabel, Timestamp x)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateAsciiStream(String columnLabel, InputStream x, int length)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateBinaryStream(String columnLabel, InputStream x, int length)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateCharacterStream(String columnLabel, Reader reader,
+			int length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateObject(String columnLabel, Object x, int scaleOrLength)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateObject(String columnLabel, Object x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void insertRow() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateRow() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void deleteRow() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void refreshRow() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void cancelRowUpdates() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void moveToInsertRow() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void moveToCurrentRow() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Statement getStatement() throws SQLException
+	{
+		return statement;
+	}
+
+
+	public Object getObject(int columnIndex, Map<String, Class<?>> map)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Ref getRef(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Blob getBlob(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Clob getClob(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Array getArray(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Object getObject(String columnLabel, Map<String, Class<?>> map)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Ref getRef(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Blob getBlob(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Clob getClob(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Array getArray(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Date getDate(int columnIndex, Calendar cal) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Date getDate(String columnLabel, Calendar cal) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Time getTime(int columnIndex, Calendar cal) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Time getTime(String columnLabel, Calendar cal) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Timestamp getTimestamp(int columnIndex, Calendar cal)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public Timestamp getTimestamp(String columnLabel, Calendar cal)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public URL getURL(int columnIndex) throws SQLException
+	{
+		try
+		{
+			if (index >= 0 && index <= rows.size())
+				if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
+				{
+					lastResult = rows.get(index).get(columnIndex - 1);
+					if (lastResult == null)
+						return null;
+					//content of row field is Object string, need to get value of string and parse as BigDecimal
+					return new URL(String.valueOf(lastResult));
+				}
+				else
+					throw new SQLException("Invalid Column Index");
+			else
+				throw new SQLException("Invalid Row Index");
+
+		} catch (MalformedURLException e)
+		{
+			throw new SQLException(e.getMessage());
+		}
+	}
+
+
+	public URL getURL(String columnLabel) throws SQLException
+	{
+		if (index >= 0  && index <= rows.size())
+		{
+			int columnIndex = resultMetadata.getColumnIndex(columnLabel);
+
+			if (columnIndex < 0)
+				throw new SQLException("Invalid Column Label found");
+
+			List<?> row = rows.get(index);
+			if (row != null)
+			{
+				try
+				{
+					lastResult = row.get(columnIndex - 1);
+					if (lastResult == null)
+						return null;
+					return new URL(String.valueOf(lastResult));
+				}
+				catch (MalformedURLException e)
+				{
+					throw new SQLException(e.getMessage());
+				}
+			}
+			else
+				throw new SQLException("Null Row found");
+		}
+		else
+			throw new SQLException("Invalid Row Index");
+	}
+
+
+	public void updateRef(int columnIndex, Ref x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateRef(int columnIndex, Ref x) Not supported yet.");
+	}
+
+
+	public void updateRef(String columnLabel, Ref x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateRef(String columnLabel, Ref x) Not supported yet.");
+	}
+
+
+	public void updateBlob(int columnIndex, Blob x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBlob(int columnIndex, Blob x)  Not supported yet.");
+	}
+
+
+	public void updateBlob(String columnLabel, Blob x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBlob(String columnLabel, Blob x) Not supported yet.");
+	}
+
+
+	public void updateClob(int columnIndex, Clob x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateClob(int columnIndex, Clob x) Not supported yet.");
+	}
+
+
+	public void updateClob(String columnLabel, Clob x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateClob(String columnLabel, Clob x) Not supported yet.");
+	}
+
+
+	public void updateArray(int columnIndex, Array x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateArray(int columnIndex, Array x) Not supported yet.");
+	}
+
+
+	public void updateArray(String columnLabel, Array x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateArray(String columnLabel, Array x)  Not supported yet.");
+	}
+
+
+	public RowId getRowId(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getRowId(int columnIndex) Not supported yet.");
+	}
+
+
+	public RowId getRowId(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getRowId(String columnLabel) Not supported yet.");
+	}
+
+
+	public void updateRowId(int columnIndex, RowId x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateRowId(int columnIndex, RowId x) Not supported yet.");
+	}
+
+
+	public void updateRowId(String columnLabel, RowId x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateRowId(String columnLabel, RowId x) Not supported yet.");
+	}
+
+
+	public int getHoldability() throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getHoldability() Not supported yet.");
+	}
+
+
+	public boolean isClosed() throws SQLException
+	{
+		return closed;
+	}
+
+
+	public void updateNString(int columnIndex, String nString)	throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNString(int columnIndex, String nString) Not supported yet.");
+	}
+
+
+	public void updateNString(String columnLabel, String nString)
+			throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNString(String columnLabel, String nString) Not supported yet.");
+	}
+
+
+	public void updateNClob(int columnIndex, NClob nClob) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: Not supported yet.");
+	}
+
+
+	public void updateNClob(String columnLabel, NClob nClob) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNClob(String columnLabel, NClob nClob) Not supported yet.");
+	}
+
+
+	public NClob getNClob(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getNClob(int columnIndex) Not supported yet.");
+	}
+
+
+	public NClob getNClob(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getNClob(String columnLabel) Not supported yet.");
+	}
+
+
+	public SQLXML getSQLXML(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getSQLXML(int columnIndex) Not supported yet.");
+	}
+
+
+	public SQLXML getSQLXML(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getSQLXML(String columnLabel) Not supported yet.");
+	}
+
+
+	public void updateSQLXML(int columnIndex, SQLXML xmlObject)	throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateSQLXML(int columnIndex, SQLXML xmlObject) Not supported yet.");
+	}
+
+
+	public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateSQLXML(String columnLabel, SQLXML xmlObject) Not supported yet.");
+	}
+
+
+	public String getNString(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getNString(int columnIndex) Not supported yet.");
+	}
+
+
+	public String getNString(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getNString(String columnLabel) Not supported yet.");
+	}
+
+
+	public Reader getNCharacterStream(int columnIndex) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getNCharacterStream(int columnIndex) Not supported yet.");
+	}
+
+
+	public Reader getNCharacterStream(String columnLabel) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: getNCharacterStream(String columnLabel) Not supported yet.");
+	}
+
+
+	public void updateNCharacterStream(int columnIndex, Reader x, long length)	throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNCharacterStream(int columnIndex, Reader x, long length) Not supported yet.");
+	}
+
+
+	public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNCharacterStream(String columnLabel, Reader reader, long length) Not supported yet.");
+	}
+
+
+	public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateAsciiStream(int columnIndex, InputStream x, long length) Not supported yet.");
+	}
+
+
+	public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBinaryStream(int columnIndex, InputStream x, long length) Not supported yet.");
+	}
+
+
+	public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateCharacterStream(int columnIndex, Reader x, long length) Not supported yet.");
+	}
+
+
+	public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateAsciiStream(String columnLabel, InputStream x, long length) Not supported yet.");
+	}
+
+
+	public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBinaryStream(String columnLabel, InputStream x, long length) Not supported yet.");
+	}
+
+
+	public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateCharacterStream(String columnLabel, Reader reader, long length) Not supported yet.");
+	}
+
+
+	public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBlob(int columnIndex, InputStream inputStream, long length) Not supported yet.");
+	}
+
+
+	public void updateBlob(String columnLabel, InputStream inputStream,	long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBlob(String columnLabel, InputStream inputStream,	long length) Not supported yet.");
+	}
+
+
+	public void updateClob(int columnIndex, Reader reader, long length)	throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateClob(int columnIndex, Reader reader, long length) Not supported yet.");
+	}
+
+
+	public void updateClob(String columnLabel, Reader reader, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateClob(String columnLabel, Reader reader, long length) Not supported yet.");
+	}
+
+
+	public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNClob(int columnIndex, Reader reader, long length) Not supported yet.");
+	}
+
+
+	public void updateNClob(String columnLabel, Reader reader, long length)	throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNClob(String columnLabel, Reader reader, long length) Not supported yet.");
+	}
+
+
+	public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNCharacterStream(int columnIndex, Reader x) Not supported yet.");
+	}
+
+
+	public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNCharacterStream(String columnLabel, Reader reader) Not supported yet.");
+	}
+
+
+	public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateAsciiStream(int columnIndex, InputStream x)Not supported yet.");
+	}
+
+
+	public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBinaryStream Not supported yet.");
+	}
+
+
+	public void updateCharacterStream(int columnIndex, Reader x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateCharacterStream Not supported yet.");
+	}
+
+
+	public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateAsciiStream Not supported yet.");
+	}
+
+
+	public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBinaryStream Not supported yet.");
+	}
+
+
+	public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateCharacterStream Not supported yet.");
+	}
+
+
+	public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBlob(int columnIndex, InputStream inputStream) Not supported yet.");
+	}
+
+
+	public void updateBlob(String columnLabel, InputStream inputStream)	throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateBlob(String columnLabel, InputStream inputStream) Not supported yet.");
+	}
+
+
+	public void updateClob(int columnIndex, Reader reader) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateClob(int columnIndex, Reader reader) Not supported yet.");
+	}
+
+
+	public void updateClob(String columnLabel, Reader reader) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateClob(String columnLabel, Reader reader)  Not supported yet.");
+	}
+
+
+	public void updateNClob(int columnIndex, Reader reader) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNClob Not supported yet.");
+	}
+
+
+	public void updateNClob(String columnLabel, Reader reader) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: updateNClob Not supported yet.");
+	}
+
+
+	public <T> T unwrap(Class<T> iface) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: unwrap Not supported yet.");
+	}
+
+
+	public boolean isWrapperFor(Class<?> iface) throws SQLException
+	{
+		throw new UnsupportedOperationException("EclResultSet: isWrapperFor Not supported yet.");
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclResultSetMetadata.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclResultSetMetadata.java
@@ -1,0 +1,214 @@
+package com.hpccsystems.ecljdbc;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EclResultSetMetadata implements ResultSetMetaData{
+
+    private List <EclColumnMetaData> columnList;
+    private String tableName;
+    private String schemaName 	= "HPCC";
+    private String catalogName 	= "roxie";
+    //private EclDatabaseMetaData dbmetadata;
+
+    public EclResultSetMetadata(List <EclColumnMetaData> columnList, String tableName)
+    {
+        this.columnList = columnList;
+        this.tableName = tableName;
+    }
+
+    @SuppressWarnings("rawtypes")
+	public ArrayList createDefaultResultRow()
+    {
+    	ArrayList rowValues = new ArrayList();
+
+    	for(int i = 0; i < columnList.size(); i++)
+    	{
+    		//some columns might not be nullable!
+    		//rowValues.add(i, new Object());
+    		if (columnList.get(i).isConstant())
+    			rowValues.add(i,columnList.get(i).getConstantValue());
+    		else
+    			rowValues.add(i, null);
+    	}
+    	return rowValues;
+    }
+
+
+    public int getColumnCount() throws SQLException {
+        return columnList.size();
+    }
+
+
+    public boolean isAutoIncrement(int column) throws SQLException {
+        return false;
+    }
+
+
+    public boolean isCaseSensitive(int column) throws SQLException {
+        return false;
+    }
+
+
+    public boolean isSearchable(int column) throws SQLException {
+        return false;
+    }
+
+
+    public boolean isCurrency(int column) throws SQLException {
+        return false;
+    }
+
+
+    public int isNullable(int column) throws SQLException {
+        return 1;
+    }
+
+
+    public boolean isSigned(int column) throws SQLException {
+        return false;
+    }
+
+
+    public int getColumnDisplaySize(int column) throws SQLException {
+        return 255;
+    }
+
+
+    public String getColumnLabel(int column) throws SQLException {
+        if (column >= 1 && column <= columnList.size())
+           return columnList.get(column-1).getColumnName();
+        else
+           throw new SQLException("Invalid Column Index = " + column);
+    }
+
+
+    public String getColumnName(int column) throws SQLException {
+        if (column >= 1 && column <= columnList.size())
+           return columnList.get(column-1).getColumnName();
+        else
+           throw new SQLException("Invalid Column Index = column");
+    }
+
+
+    public String getSchemaName(int column) throws SQLException {
+        return schemaName;
+    }
+
+
+    public int getPrecision(int column) throws SQLException {
+        return 0;
+    }
+
+
+    public int getScale(int column) throws SQLException {
+        return 0;
+    }
+
+
+    public String getTableName(int column) throws SQLException {
+        return tableName;
+    }
+
+
+    public String getCatalogName(int column) throws SQLException {
+        return catalogName;
+    }
+
+
+    public int getColumnType(int column) throws SQLException
+    {
+		if (column >= 1 && column <= columnList.size())
+			return columnList.get(column - 1).getSQLType();
+		else
+			throw new SQLException("Invalid Column Index = " + column);
+    }
+
+
+    public String getColumnTypeName(int column) throws SQLException
+    {
+		if (column >= 1 && column <= columnList.size())
+			return EclDatabaseMetaData.getFieldName(columnList.get(column - 1).getSQLType());
+		else
+			throw new SQLException("Invalid Column Index = " + column);
+    }
+
+
+    public boolean isReadOnly(int column) throws SQLException
+    {
+    	return true;
+    }
+
+
+    public boolean isWritable(int column) throws SQLException
+    {
+    	return false;
+    }
+
+
+    public boolean isDefinitelyWritable(int column) throws SQLException
+    {
+        return false;
+    }
+
+
+    public String getColumnClassName(int column) throws SQLException
+    {
+    	if (column >= 1 && column <= columnList.size())
+    	{
+    		return EclDatabaseMetaData.convertSQLtype2JavaClassName(columnList.get(column - 1).getSQLType());
+		}
+		else
+		{
+			throw new SQLException("Invalid Column Index = " + column);
+		}
+    }
+
+
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public int getColumnIndex(String columnLabel)
+	{
+			int colindex = -1;
+			try
+			{
+				int columCount = this.getColumnCount();
+				for (int col = 1; col <= columCount; col++)
+				{
+					if (this.getColumnLabel(col).equalsIgnoreCase(columnLabel))
+					{
+						colindex = col;
+						break;
+					}
+				}
+			}
+			catch (SQLException e){}
+
+			return colindex;
+	}
+
+	public String[] getInParamNames()
+	{
+		String [] inparams = new String [this.columnList.size()];
+		for(int i =0; i<columnList.size(); i++)
+		{
+			inparams[i] = columnList.get(i).getColumnName();
+		}
+
+		return inparams;
+	}
+
+	/*public void parseResultSchema(Node schema)
+	{
+		EclDatabaseMetaData.registerSchemaElements(schema, resultElements, "");
+	}*/
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclStatement.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclStatement.java
@@ -1,0 +1,225 @@
+package com.hpccsystems.ecljdbc;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.Statement;
+
+/**
+ *
+ * @author ChalaAX
+ */
+public class EclStatement implements Statement {
+
+    public ResultSet executeQuery(String sql) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: executeQuery(String sql) Not supported yet.");
+    }
+
+
+    public int executeUpdate(String sql) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: executeUpdate(String sql) Not supported yet.");
+    }
+
+
+    public void close() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: close() Not supported yet.");
+    }
+
+
+    public int getMaxFieldSize() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getMaxFieldSize() Not supported yet.");
+    }
+
+
+    public void setMaxFieldSize(int max) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: setMaxFieldSize(int max) Not supported yet.");
+    }
+
+
+    public int getMaxRows() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getMaxRows() Not supported yet.");
+    }
+
+
+    public void setMaxRows(int max) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: setMaxRows(int max) Not supported yet.");
+    }
+
+
+    public void setEscapeProcessing(boolean enable) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: setEscapeProcessing(boolean enable) Not supported yet.");
+    }
+
+
+    public int getQueryTimeout() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement:  getQueryTimeout() Not supported yet.");
+    }
+
+
+    public void setQueryTimeout(int seconds) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: setQueryTimeout(int seconds) Not supported yet.");
+    }
+
+
+    public void cancel() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: cancel()  Not supported yet.");
+    }
+
+
+    public SQLWarning getWarnings() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getWarnings Not supported yet.");
+    }
+
+
+    public void clearWarnings() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: clearWarnings() Not supported yet.");
+    }
+
+
+    public void setCursorName(String name) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement:  setCursorName(String name) Not supported yet.");
+    }
+
+
+    public boolean execute(String sql) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: execute(String sql) Not supported yet.");
+    }
+
+
+    public ResultSet getResultSet() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getResultSet Not supported yet.");
+    }
+
+
+    public int getUpdateCount() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement:getUpdateCount  Not supported yet.");
+    }
+
+
+    public boolean getMoreResults() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getMoreResults Not supported yet.");
+    }
+
+
+    public void setFetchDirection(int direction) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: only ResultSet.FETCH_FORWARD supported");
+    }
+
+
+    public int getFetchDirection() throws SQLException {
+        //throw new UnsupportedOperationException("EclStatement: getFetchDirection() Not supported yet.");
+    	return ResultSet.FETCH_FORWARD;
+    }
+
+
+    public void setFetchSize(int rows) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: setFetchSize(int rows) Not supported yet.");
+    }
+
+
+    public int getFetchSize() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getFetchSize() Not supported yet.");
+    }
+
+
+    public int getResultSetConcurrency() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getResultSetConcurrency() Not supported yet.");
+    }
+
+
+    public int getResultSetType() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement:  getResultSetType() Not supported yet.");
+    }
+
+
+    public void addBatch(String sql) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: addBatch(String sql) Not supported yet.");
+    }
+
+
+    public void clearBatch() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: clearBatch() Not supported yet.");
+    }
+
+
+    public int[] executeBatch() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: executeBatch() Not supported yet.");
+    }
+
+
+    public Connection getConnection() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getConnection() Not supported yet.");
+    }
+
+
+    public boolean getMoreResults(int current) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getMoreResults(int current) Not supported yet.");
+    }
+
+
+    public ResultSet getGeneratedKeys() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getGeneratedKeys() Not supported yet.");
+    }
+
+
+    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: executeUpdate(String sql, int autoGeneratedKeys) Not supported yet.");
+    }
+
+
+    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement:  executeUpdate(String sql, int[] columnIndexes) Not supported yet.");
+    }
+
+
+    public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: executeUpdate(String sql, String[] columnNames) Not supported yet.");
+    }
+
+
+    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: execute(String sql, int autoGeneratedKeys) Not supported yet.");
+    }
+
+
+    public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement:  execute(String sql, int[] columnIndexes) Not supported yet.");
+    }
+
+
+    public boolean execute(String sql, String[] columnNames) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: execute(String sql, String[] columnNames) Not supported yet.");
+    }
+
+
+    public int getResultSetHoldability() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: getResultSetHoldability Not supported yet.");
+    }
+
+
+    public boolean isClosed() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: isClosed() Not supported yet.");
+    }
+
+
+    public void setPoolable(boolean poolable) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: Not supported yet.");
+    }
+
+
+    public boolean isPoolable() throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: Not supported yet.");
+    }
+
+
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: Not supported yet.");
+    }
+
+
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new UnsupportedOperationException("EclStatement: Not supported yet.");
+    }
+
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclVersionTracker.java.in
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclVersionTracker.java.in
@@ -1,0 +1,8 @@
+package org.hpccsystems.ecljdbc;
+
+public class EclVersionTracker 
+{
+	static final int ECLJDBCMajorVersion = ${majorver};
+	static final int ECLJDBCMinorVersion = ${minorver};
+	static final int ECLJDBCPatchVersion = ${point};
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlColumn.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlColumn.java
@@ -1,0 +1,155 @@
+package com.hpccsystems.ecljdbc;
+
+import java.util.List;
+
+public class SqlColumn
+{
+	private String name;
+	private String alias;
+	private String parenttable;
+	private int type;
+	private List<SqlColumn> functionParams;
+	private String constVal;
+	private int position;
+
+
+	final static int UNKNOWN_COLUMN_TYPE = -1;
+	final static int CONST_COLUMN_TYPE = 1;
+	final static int FIELDNAME_COLUMN_TYPE = 2;
+	final static int FUNCTION_COLUMN_TYPE = 3;
+
+	public SqlColumn()
+	{
+		name = null;
+		alias = null;
+		parenttable = null;
+		type = UNKNOWN_COLUMN_TYPE;
+		functionParams = null;
+		constVal = null;
+		position = -1;
+	}
+
+	public SqlColumn(String fullname, int coltype, int position)
+	{
+		String [] nameparts = name.split("\\.");
+		if (nameparts.length > 1)
+		{
+			parenttable = nameparts[0];
+		}
+		else
+			parenttable = null;
+
+		this.name = nameparts[nameparts.length-1];
+		alias = null;
+		functionParams = null;
+		type = coltype;
+		constVal = null;
+		this.position = position;
+	}
+
+	public SqlColumn(String fullname, int position)
+	{
+
+		String [] nameparts = fullname.split("\\.");
+		if (nameparts.length > 1)
+		{
+			parenttable = nameparts[0];
+		}
+		else
+			parenttable = null;
+
+		this.name = nameparts[nameparts.length-1];
+		alias = null;
+		type = UNKNOWN_COLUMN_TYPE;
+		functionParams = null;
+		constVal = null;
+		this.position = position;
+	}
+
+	public SqlColumn(String parentname, String columnname, int position)
+	{
+		parenttable = parentname;
+		this.name = columnname;
+		alias = null;
+		type = FIELDNAME_COLUMN_TYPE;
+		functionParams = null;
+		constVal = null;
+		this.position = position;
+	}
+
+	public SqlColumn(String columnname, List<SqlColumn> funcols, int position)
+	{
+		this.name = columnname;
+		alias = null;
+		type = FUNCTION_COLUMN_TYPE;
+		functionParams = funcols;
+		constVal = null;
+		this.position = position;
+	}
+
+	public SqlColumn(String columnname, String constVal, String alias, int position)
+	{
+		this.name = columnname;
+		this.alias = alias;
+		type = CONST_COLUMN_TYPE;
+		functionParams = null;
+		this.constVal = constVal;
+		this.position = position;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getAlias() {
+		return alias;
+	}
+
+	public void setAlias(String alias) {
+		this.alias = alias;
+	}
+
+	public String getParenttable() {
+		return parenttable;
+	}
+
+	public void setParenttable(String parenttable) {
+		this.parenttable = parenttable;
+	}
+
+	public int getType() {
+		return type;
+	}
+
+	public void setType(int type) {
+		this.type = type;
+	}
+
+	public List<SqlColumn> getFunctionParams() {
+		return functionParams;
+	}
+
+	public void setFunctionParams(List<SqlColumn> functionParams) {
+		this.functionParams = functionParams;
+	}
+
+	public String getConstVal() {
+		return constVal;
+	}
+
+	public void setConstVal(String constVal) {
+		this.constVal = constVal;
+	}
+	public int getPosition() {
+		return position;
+	}
+
+	public void setPosition(int position) {
+		this.position = position;
+	}
+
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlExpression.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlExpression.java
@@ -1,0 +1,90 @@
+package com.hpccsystems.ecljdbc;
+
+public class SqlExpression
+{
+	public static final int LOGICAL_OPERATOR_TYPE = 1;
+	public static final int LOGICAL_EXPRESSION_TYPE = 2;
+
+	private String name;
+	private SqlOperator operator;
+	private String value;
+	private int type;
+	private boolean isParametrized;
+
+	public SqlExpression(String name, String operator, String value)
+	{
+		this.name = name;
+		this.operator = new SqlOperator(operator);
+		this.value = value;
+		type = LOGICAL_EXPRESSION_TYPE;
+	}
+
+	public SqlExpression(String operator)
+	{
+		name = null;
+		this.operator = new SqlOperator(operator);
+		value = null;
+		type = LOGICAL_OPERATOR_TYPE;
+		isParametrized = false;
+	}
+
+	public SqlExpression(int type)
+	{
+		name = null;
+		operator = null;
+		value = null;
+		this.type = type;
+		isParametrized = false;
+	}
+
+	public int getType()
+	{
+		return type;
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public SqlOperator getOperator() {
+		return operator;
+	}
+	public void setOperator(SqlOperator operator) {
+		this.operator = operator;
+	}
+
+	public void setOperator(String operator) {
+		this.operator = new SqlOperator(operator);
+	}
+
+	public String getValue() {
+		return value;
+	}
+	public void setValue(String value)
+	{
+		this.value = value;
+
+		if (value != null && value.length() > 0 && (value.contains("${") || value.equals("?")))
+			isParametrized = true;
+		else
+			isParametrized = false;
+	}
+
+	public boolean isParametrized(String param)
+	{
+		return isParametrized;
+	}
+
+	public boolean isParametrized()
+	{
+		return isParametrized;
+	}
+
+	@Override
+	public String toString()
+	{
+		return (type == LOGICAL_EXPRESSION_TYPE ? name + " "  + operator.toString() + " " + value : " " + operator.toString() + " ");
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlOperator.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlOperator.java
@@ -1,0 +1,68 @@
+package com.hpccsystems.ecljdbc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SqlOperator
+{
+	private static List<String> validOps;
+	public static final String eq = new String("=");
+	public static final String neq = new String("<>");
+	public static final String isNull = new String("IS NULL");
+	public static final String isNotNull = new String("IS NOT NULL");
+	public static final String gt = new String(">");
+	public static final String lt = new String("<");
+	public static final String gte = new String(">=");
+	public static final String lte = new String("<=");
+	public static final String and = new String("AND");
+	public static final String or = new String("OR");
+	public static final String not = new String("NOT");
+	public static final String exists = new String("EXISTS");
+	public static final String like = new String("LIKE");
+	public static final String in = new String("IN");
+
+	private final String value;
+
+	public String getValue()
+	{
+		return value;
+	}
+
+	public boolean isValid()
+	{
+		return value == null ? false : true;
+	}
+
+	public SqlOperator(String operator)
+	{
+		if (validOps == null)
+		{
+			validOps = new ArrayList<String>();
+			validOps.add(eq);
+			validOps.add(neq);
+			validOps.add(isNull);
+			validOps.add(isNotNull);
+			validOps.add(gt);
+			validOps.add(lt);
+			validOps.add(gte);
+			validOps.add(lte);
+			validOps.add(and);
+			validOps.add(or);
+			validOps.add(not);
+			validOps.add(exists);
+			validOps.add(like);
+			validOps.add(in);
+		}
+
+		if( validOps.contains(operator.toUpperCase()))
+				value = operator.toUpperCase();
+		else
+				value = null;
+	}
+
+	@Override
+	public String toString()
+	{
+		return value == null ? "" : value;
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlParser.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlParser.java
@@ -1,0 +1,1100 @@
+package com.hpccsystems.ecljdbc;
+
+import java.sql.SQLException;
+import java.util.*;
+
+
+/**
+ * Class is used for parsing sql statements.
+ *
+ * @author Zoran Milakovic <-- just noticed this need to ask Arjuna about this
+ */
+public class SqlParser {
+
+	//public static final String INSERT = "insert";
+	//public static final String UPDATE = "update";
+	//public static final String SELECT = "select";
+	//public static final String CONSTSELECT = "constselect";
+	//public static final String CALL = "call";
+	//private static final String QUOTE_ESCAPE = "''";
+	private static final String COMMA_ESCAPE = "~#####1~";
+
+	public final static short 	SQL_TYPE_UNKNOWN = -1;
+	public final static short 	SQL_TYPE_SELECT = 1;
+	public final static short 	SQL_TYPE_SELECTCONST = 2;
+	public final static short 	SQL_TYPE_CALL = 3;
+
+	private String tableName;
+	private String tableAlias;
+	//private String whereStatement;
+	private int sqlType;
+	//private String[] selectColumns;
+	private List<EclColumnMetaData> selectColumns;
+	private String[] columnValues;
+	//private String[] columnWhereNames;
+	//private String[] columnWhereValues;
+	private SqlWhereClause whereclause;
+	private String[] columnGroupByNames;
+	private String[] columnOrderByNames;
+	private String[] procInParamValues;
+	private String storedProcName;
+	private int limit;
+	private boolean columnsVerified;
+	private String indexHint;
+
+	/**
+	 * Parse sql statement.
+	 *
+	 * @param sql
+	 *            defines SQL statement
+	 * @exception Exception
+	 *                Description of Exception
+	 * @since
+	 */
+	public void parse(String sql) throws Exception
+	{
+		System.out.println("#####INCOMING SQL: " + sql);
+		columnsVerified = false;
+		limit = -1;
+		tableName = null;
+		tableAlias = null;
+		//selectColumns = new String[0];
+		selectColumns = new ArrayList<EclColumnMetaData>();
+		columnValues = new String[0];
+		//columnWhereNames = new String[0];
+		//columnWhereValues = new String[0];
+		whereclause = new SqlWhereClause();
+		procInParamValues = new String[0];
+		//whereStatement = null;
+		storedProcName = null;
+		sqlType = SQL_TYPE_UNKNOWN;
+		sql = sql.trim();
+		sql = Utils.removeAllNewLines(sql);
+		indexHint = null;
+
+		// replace comma(,) in values between quotes(')
+		StringTokenizer tokQuote = new StringTokenizer(sql.toString(), "'",	true);
+		StringBuffer sb = new StringBuffer();
+		boolean openParent1 = false;
+		while (tokQuote.hasMoreTokens()) {
+			String next = tokQuote.nextToken();
+			if (openParent1) {
+				next = Utils.replaceAll(next, ",", COMMA_ESCAPE);
+			}
+			sb.append(next);
+			if (next.equalsIgnoreCase("'")) {
+				if (openParent1 == true) {
+					openParent1 = false;
+				} else {
+					openParent1 = true;
+				}
+			}
+		}
+		// END replacement
+		sql = sb.toString();
+		String upperSql = sql.toUpperCase();
+
+		// handle unsupported statements
+		if (upperSql.startsWith("ALTER ")) {
+			throw new Exception("ALTER TABLE statements are not supported.");
+		}
+		if (upperSql.startsWith("DROP ")) {
+			throw new Exception("DROP statements are not supported.");
+		}
+		if (upperSql.startsWith("INSERT ")) {
+			throw new Exception("INSERT statements are not supported.");
+		}
+		if (upperSql.startsWith("UPDATE ")) {
+			throw new Exception("UPDATE statements are not supported.");
+		}
+		if (upperSql.contains(" UNION ")) {
+			throw new Exception("UNIONS are not supported.");
+		}
+		if (upperSql.contains(" JOIN ")) {
+			throw new Exception("JOINS are not supported.");
+		}
+
+		// CALL SP
+		if (upperSql.startsWith("CALL"))
+		{
+			sqlType = SQL_TYPE_CALL;
+			int callPos = upperSql.lastIndexOf("CALL ");
+			int storedProcPos = sql.lastIndexOf("(");
+			int paramlistend =  sql.lastIndexOf(")");
+			String paramToken = "";
+
+			if (storedProcPos == -1)
+				storedProcName = sql.substring(callPos+5);
+			else
+			{
+				if (paramlistend == -1)
+					throw new SQLException("Missing closing param in: " + sql);
+				storedProcName = sql.substring(callPos+5, storedProcPos);
+				paramToken = sql.substring(storedProcPos+1, paramlistend);
+			}
+
+			if(paramToken.length() >0 )
+			{
+				StringTokenizer tokenizer = new StringTokenizer(paramToken, ",");
+				procInParamValues = new String[tokenizer.countTokens()];
+				int i = 0;
+				while (tokenizer.hasMoreTokens())
+				{
+					procInParamValues[i] = tokenizer.nextToken().trim();
+				}
+
+			}
+		}
+		// SELECT
+		if (upperSql.startsWith("SELECT "))
+		{
+			sqlType = SQL_TYPE_SELECT;
+			int fromPos  = upperSql.lastIndexOf(" FROM ");
+
+			if (fromPos == -1)
+			{
+				if (parseConstantSelect(sql))
+				{
+					System.out.println("Found Select <constant>");
+					sqlType = SQL_TYPE_SELECTCONST;
+					return;
+				}
+				else
+					throw new Exception("Malformed SQL. Missing FROM statement.");
+			}
+
+			int useindexPos = upperSql.lastIndexOf(" USE INDEX(");
+			/* Allow multiple spaces between USE and INDEX?
+			 * if (useindexPos > 0)
+			{
+				String afterUSE = upperSql.substring(useindexPos+4);
+				int inderelativepos = afterUSE.indexOf("INDEX(");
+
+				if(inderelativepos < 0)
+					throw new SQLException(" Malformed SQL statement near \'USE\' ");
+				else if(inderelativepos > 1)
+				{
+					String use [] = afterUSE.split("INDEX");
+					if(use[0].trim().length() != 0)
+						throw new SQLException(" Malformed SQL statement near \'USE\' ");
+				}
+
+			}*/
+
+			int wherePos = upperSql.lastIndexOf(" WHERE ");
+			int groupPos = upperSql.lastIndexOf(" GROUP BY ");
+			int orderPos = upperSql.lastIndexOf(" ORDER BY ");
+			int limitPos = upperSql.lastIndexOf(" LIMIT ");
+
+			if ( useindexPos != -1 && useindexPos < fromPos)
+				throw new Exception("Malformed SQL. USING clause placement.");
+
+			if (wherePos != -1 && wherePos < fromPos)
+				throw new Exception("Malformed SQL. WHERE clause placement.");
+
+			try
+			{
+				if (limitPos != -1)
+				{
+					limit = Integer.valueOf(upperSql.substring(limitPos+6).trim());
+					upperSql = upperSql.substring(0, limitPos);
+				}
+			}
+			catch (NumberFormatException ne)
+			{
+				throw new Exception("Error near :\'" + upperSql.substring(limitPos)+"\'");
+			}
+
+			String orderByToken = "";
+			String groupByToken = "";
+
+			if (groupPos != -1 && (orderPos == -1 || groupPos < orderPos))
+			{
+				if (orderPos == -1)
+				{
+					groupByToken = upperSql.substring(groupPos + 10);
+				}
+				else
+				{
+					groupByToken = upperSql.substring(groupPos + 10, orderPos);
+					orderByToken = upperSql.substring(orderPos + 10);
+
+					/*int dirPos = orderByColumn.lastIndexOf("ASC");
+					if (dirPos == -1)
+						dirPos = orderByColumn.lastIndexOf("DESC");
+
+					//not else if from above if!!
+					if (dirPos != -1)
+					{
+						orderByAscending = Boolean.toString(orderByColumn.contains("ASC"));
+						orderByColumn = orderByColumn.substring(0,dirPos).trim();
+					}
+					else
+						orderByAscending = "true";
+						*/
+
+				}
+
+				upperSql = upperSql.substring(0, groupPos);
+
+			}
+			else if (orderPos != -1 && (groupPos == -1 || orderPos < groupPos))
+			{
+				if (groupPos == -1)
+				{
+					orderByToken = upperSql.substring(orderPos + 10);
+				}
+				else
+				{
+					orderByToken = upperSql.substring(orderPos + 10, groupPos);
+					groupByToken = upperSql.substring(groupPos + 10);
+
+				}
+
+				/*int dirPos = orderByColumn.lastIndexOf("ASC");
+				if (dirPos == -1)
+					dirPos = orderByColumn.lastIndexOf("DESC");
+
+				//not else if from above if!!
+				if (dirPos != -1)
+				{
+					orderByAscending = Boolean.toString(orderByColumn.contains("ASC"));
+					orderByColumn = orderByColumn.substring(0, dirPos).trim();
+				}
+				else
+					orderByAscending = "true";
+				*/
+				upperSql = upperSql.substring(0, orderPos);
+			}
+
+			if (orderByToken.length()>0)
+			{
+				StringTokenizer tokenizer = new StringTokenizer(orderByToken, ",");
+
+				columnOrderByNames = new String[tokenizer.countTokens()];
+				int i = 0;
+				while (tokenizer.hasMoreTokens())
+				{
+					String orderbycolumn = tokenizer.nextToken().trim();
+					boolean orderbyascending = true;
+
+					int dirPos = orderbycolumn.lastIndexOf("ASC");
+					if (dirPos == -1)
+						dirPos = orderbycolumn.lastIndexOf("DESC");
+
+					//not else if from above if!!
+					if (dirPos != -1)
+					{
+						orderbyascending = orderbycolumn.contains("ASC");
+						orderbycolumn = orderbycolumn.substring(0,dirPos).trim();
+					}
+					columnOrderByNames[i++] = (orderbyascending == true ? "" : "-") + orderbycolumn;
+				}
+			}
+
+			if (groupByToken.length()>0)
+			{
+				StringTokenizer tokenizer = new StringTokenizer(groupByToken, ",");
+				columnGroupByNames = new String[tokenizer.countTokens()];
+				int i = 0;
+				while (tokenizer.hasMoreTokens())
+				{
+					columnGroupByNames[i++] = tokenizer.nextToken().trim();
+				}
+			}
+
+			sql = sql.substring(0,upperSql.length());
+			String fullTableName = null;
+			if (wherePos == -1 && useindexPos == -1)
+			{
+				fullTableName = sql.substring(fromPos + 6).trim();
+			}
+			else
+			{
+				fullTableName = sql.substring(fromPos + 6, (useindexPos == -1) ? wherePos : useindexPos).trim();
+			}
+
+			int asPos = fullTableName.lastIndexOf(" AS ");
+			if (asPos == -1)
+				asPos = fullTableName.lastIndexOf(" ");
+
+			if (asPos != -1)
+			{
+				tableName = fullTableName.substring(0, asPos).trim();
+				tableAlias = fullTableName.substring(asPos+1).trim();
+			}
+			else
+				tableName = fullTableName;
+
+			StringTokenizer comatokens = new StringTokenizer(sql.substring(7, fromPos), ",");
+
+			for(int sqlcolpos = 1; comatokens.hasMoreTokens();)
+			{
+				EclColumnMetaData colmetadata = null;
+				String col = comatokens.nextToken().trim();
+				if (col.contains("("))
+				{
+					int funcparampos = 1;
+					List<EclColumnMetaData> funccols = new ArrayList<EclColumnMetaData>();
+
+					String funcname = col.substring(0,col.indexOf('('));
+					//if (funcname.equalsIgnoreCase("count"))
+					//	hasCount = true;
+
+					col = col.substring(col.indexOf('(')+1).trim();
+
+					if (col.contains(")"))
+					{
+						col = col.substring(0, col.indexOf(")")).trim();
+						if (col.length()>0)
+							funccols.add(new EclColumnMetaData(col,funcparampos++,java.sql.Types.OTHER));
+					}
+					else
+					{
+						funccols.add(new EclColumnMetaData(col,funcparampos++,java.sql.Types.OTHER));
+						while (comatokens.hasMoreTokens())
+						{
+							col = comatokens.nextToken().trim();
+							if (col.contains(")"))
+							{
+								col = col.substring(0, col.indexOf(")"));
+								funccols.add(new EclColumnMetaData(col,funcparampos++,java.sql.Types.OTHER));
+								break;
+							}
+							funccols.add(new EclColumnMetaData(col,funcparampos++,java.sql.Types.OTHER));
+						}
+					}
+					colmetadata = new EclColumnMetaData(funcname, sqlcolpos++, funccols);
+
+				}
+
+				if(col.contains("."))
+				{
+					String colsplit [] = col.split("\\.");
+					if (colsplit.length > 1)
+					{
+						if (!colsplit[0].equals(tableName) && !colsplit[0].equals(tableAlias))
+							throw new SQLException("Invalid field found: " + col);
+						else
+							col = colsplit[colsplit.length-1];
+					}
+				}
+
+				if (colmetadata == null)
+					colmetadata = new EclColumnMetaData(col,sqlcolpos++,java.sql.Types.OTHER);
+
+				selectColumns.add(colmetadata);
+			}
+
+			if (useindexPos != -1)
+			{
+				String useindexstr = sql.substring(useindexPos + 11);
+				int useindexend = useindexstr.indexOf(")");
+				if (useindexend < 0 )
+					throw new SQLException("Malformed USE INDEX() clause.");
+				indexHint = useindexstr.substring(0,useindexend).trim();
+				System.out.println(indexHint);
+			}
+
+			if (wherePos != -1)
+			{
+				String strWhere = sql.substring(wherePos + 7);
+				String splitedwhereands [] = strWhere.split(" and | AND |,");
+
+				for (int i = 0; i < splitedwhereands.length; i++)
+				{
+					String splitedwhereandors [] = splitedwhereands[i].split(" or | OR ");
+
+					SqlExpression andoperator = new SqlExpression("AND");
+
+					for (int y = 0; y < splitedwhereandors.length; y++)
+					{
+						SqlExpression exp = new SqlExpression(SqlExpression.LOGICAL_EXPRESSION_TYPE);
+						SqlExpression orperator = new SqlExpression("OR");
+
+						String trimmedExpression = splitedwhereandors[y].trim();
+						String operator = null;
+
+						//order matters here!
+						if (trimmedExpression.indexOf(SqlOperator.gte)!=-1)
+							operator = SqlOperator.gte;
+						else if (trimmedExpression.indexOf(SqlOperator.lte)!=-1)
+							operator = SqlOperator.lte;
+						else if (trimmedExpression.indexOf(SqlOperator.neq)!=-1)
+							operator = SqlOperator.neq;
+						else if (trimmedExpression.indexOf(SqlOperator.eq)!=-1)
+							operator = SqlOperator.eq;
+						else if (trimmedExpression.indexOf(SqlOperator.gt)!=-1)
+							operator = SqlOperator.gt;
+						else if (trimmedExpression.indexOf(SqlOperator.lt)!=-1)
+							operator = SqlOperator.lt;
+						else
+							throw new SQLException("Invalid logical operator found: " + trimmedExpression);
+
+
+						String splitedsqlexp [] = splitedwhereandors[y].trim().split(operator);
+
+						if (splitedsqlexp.length <= 0 ) //something went wrong, only the operator was found?
+							throw new SQLException("Invalid SQL Where cluse found around: " + splitedwhereandors[y]);
+
+						exp.setName(splitedsqlexp[0].trim());
+						exp.setOperator(operator);
+						if (splitedsqlexp.length>1)
+							exp.setValue(splitedsqlexp[1].trim());
+
+						whereclause.addExpression(exp);
+
+						if (y < splitedwhereandors.length-1)
+							whereclause.addExpression(orperator);
+					}
+
+					if (i < splitedwhereands.length-1)
+						whereclause.addExpression(andoperator);
+				}
+
+				System.out.println(whereclause);
+
+//				while (tokenizerWhere.hasMoreTokens())
+//				{
+//					String strToken = tokenizerWhere.nextToken();
+//					if (strToken.toLowerCase().indexOf(" and ") != -1) {
+//						String temp = strToken;
+//						int andPos = 0;
+//						out: do {
+//							andPos = temp.toLowerCase().indexOf(" and ");
+//							String strTokenAdd;
+//							if (andPos != -1) {
+//								strTokenAdd = temp.substring(0, andPos).trim();
+//							} else {
+//								strTokenAdd = temp.trim();
+//							}
+//							int delimiter2 = strTokenAdd.indexOf("=");
+//							if (delimiter2 != -1) {
+//								String valueAdd = strTokenAdd.substring(
+//										delimiter2 + 1).trim();
+//								valueAdd = Utils.handleQuotedString(valueAdd);
+//								whereCols.add(strTokenAdd.substring(0,
+//										delimiter2).trim());
+//								valueAdd = Utils.replaceAll(valueAdd,
+//										COMMA_ESCAPE, ",");
+//								valueAdd = Utils.replaceAll(valueAdd,
+//										QUOTE_ESCAPE, "'");
+//								whereValues.add(valueAdd);
+//							} else {
+//								int delimiter3 = strTokenAdd.toLowerCase()
+//										.indexOf(" is ");
+//								whereCols.add(strTokenAdd.substring(0,
+//										delimiter3).trim());
+//								whereValues.add(null);
+//							}
+//							temp = temp.substring(andPos + 5);
+//							if (temp.toLowerCase().indexOf(" and ") == -1) {
+//								strTokenAdd = temp.trim();
+//								int delimiter4 = strTokenAdd.indexOf("=");
+//								if (delimiter4 != -1) {
+//									String valueAdd = strTokenAdd.substring(
+//											delimiter4 + 1).trim();
+//									valueAdd = Utils
+//											.handleQuotedString(valueAdd);
+//									whereCols.add(strTokenAdd.substring(0,
+//											delimiter4).trim());
+//									valueAdd = Utils.replaceAll(valueAdd,
+//											COMMA_ESCAPE, ",");
+//									valueAdd = Utils.replaceAll(valueAdd,
+//											QUOTE_ESCAPE, "'");
+//									whereValues.add(valueAdd);
+//								} else {
+//									int delimiter3 = strTokenAdd.toLowerCase()
+//											.indexOf(" is ");
+//									whereCols.add(strTokenAdd.substring(0,
+//											delimiter3).trim());
+//									whereValues.add(null);
+//								}
+//								break out;
+//							}
+//
+//						} while (true);
+//
+//					}
+//					else
+//					{
+//						int delimiter = strToken.indexOf("=");
+//						if (delimiter != -1) {
+//							String value = strToken.substring(delimiter + 1)
+//									.trim();
+//							value = Utils.handleQuotedString(value);
+//							whereCols.add(strToken.substring(0, delimiter)
+//									.trim());
+//							value = Utils.replaceAll(value, COMMA_ESCAPE, ",");
+//							value = Utils.replaceAll(value, QUOTE_ESCAPE, "'");
+//							whereValues.add(value);
+//						} else {
+//							int delimiter1 = strToken.toLowerCase().indexOf(
+//									" is ");
+//							whereCols.add(strToken.substring(0, delimiter1)
+//									.trim());
+//							whereValues.add(null);
+//						}
+//					}
+//				}
+//
+//				columnWhereNames = new String[whereCols.size()];
+//				columnWhereValues = new String[whereValues.size()];
+//				whereCols.copyInto(columnWhereNames);
+//				whereValues.copyInto(columnWhereValues);
+//
+			}
+		}
+		// INSERT
+		/*if (upperSql.startsWith("INSERT ")) {
+			if (upperSql.lastIndexOf(" VALUES") == -1) {
+				throw new Exception("Malformed SQL. Missing VALUES statement.");
+			}
+			sqlType = INSERT;
+			int intoPos = 0;
+			if (upperSql.indexOf(" INTO ") != -1) {
+				intoPos = upperSql.indexOf(" INTO ") + 6;
+			} else {
+				intoPos = upperSql.indexOf("INSERT ") + 7;
+			}
+			int bracketPos = upperSql.indexOf("(");
+			int lastBracketPos = upperSql.indexOf(")");
+			tableName = sql.substring(intoPos, bracketPos).trim();
+
+			Vector<String> cols = new Vector<String>();
+			StringTokenizer tokenizer = new StringTokenizer(upperSql.substring(
+					bracketPos + 1, lastBracketPos), ",");
+			while (tokenizer.hasMoreTokens()) {
+				cols.add(tokenizer.nextToken().trim());
+			}
+			selectColumns = new String[cols.size()];
+			cols.copyInto(selectColumns);
+
+			int valuesPos = upperSql.indexOf("VALUES");
+			String endStatement = sql.substring(valuesPos + 6).trim();
+			bracketPos = endStatement.indexOf("(");
+			lastBracketPos = endStatement.lastIndexOf(")");
+			Vector<String> values = new Vector<String>();
+			StringTokenizer tokenizer2 = new StringTokenizer(
+					endStatement.substring(bracketPos + 1, lastBracketPos), ",");
+			while (tokenizer2.hasMoreTokens()) {
+				String value = tokenizer2.nextToken().trim();
+				value = Utils.handleQuotedString(value);
+				value = Utils.replaceAll(value, COMMA_ESCAPE, ",");
+				value = Utils.replaceAll(value, QUOTE_ESCAPE, "'");
+				values.add(value);
+			}
+			columnValues = new String[values.size()];
+			values.copyInto(columnValues);
+		}
+
+		// UPDATE
+		if (upperSql.startsWith("UPDATE ")) {
+			if (upperSql.lastIndexOf(" SET ") == -1) {
+				throw new Exception("Malformed SQL. Missing SET statement.");
+			}
+			sqlType = UPDATE;
+			int updatePos = upperSql.indexOf("UPDATE");
+			int setPos = upperSql.indexOf(" SET ");
+			//int equalPos = upperSql.indexOf("=");
+			int wherePos = upperSql.indexOf(" WHERE ");
+			tableName = sql.substring(updatePos + 6, setPos).trim();
+
+			String setString = "";
+			if (wherePos != -1) {
+				setString = sql.substring(setPos + 5, wherePos);
+			} else {
+				setString = sql.substring(setPos + 5, sql.length());
+			}
+			StringTokenizer tokenizerSet = new StringTokenizer(setString, ",");
+			Vector<String> setNames = new Vector<String>();
+			Vector<String> setValues = new Vector<String>();
+
+			while (tokenizerSet.hasMoreTokens()) {
+				String strToken = tokenizerSet.nextToken();
+				int delimiter = strToken.indexOf("=");
+				setNames.add(strToken.substring(0, delimiter).trim());
+				String value = strToken.substring(delimiter + 1).trim();
+				value = Utils.handleQuotedString(value);
+				value = Utils.replaceAll(value, COMMA_ESCAPE, ",");
+				value = Utils.replaceAll(value, QUOTE_ESCAPE, "'");
+				setValues.add(value);
+			}
+
+			selectColumns = new String[setNames.size()];
+			columnValues = new String[setValues.size()];
+			setNames.copyInto(selectColumns);
+			setValues.copyInto(columnValues);
+			if (wherePos != -1) {
+				String strWhere = sql.substring(wherePos + 6).trim();
+				Vector<String> whereCols = new Vector<String>();
+				Vector<String> whereValues = new Vector<String>();
+				StringTokenizer tokenizerWhere = new StringTokenizer(strWhere,
+						",");
+
+				while (tokenizerWhere.hasMoreTokens()) {
+					String strToken = tokenizerWhere.nextToken();
+					if (strToken.toLowerCase().indexOf(" and ") != -1) {
+						String temp = strToken;
+						int andPos = 0;
+						out: do {
+							andPos = temp.toLowerCase().indexOf(" and ");
+							String strTokenAdd;
+							if (andPos != -1) {
+								strTokenAdd = temp.substring(0, andPos).trim();
+							} else {
+								strTokenAdd = temp.trim();
+							}
+							int delimiter2 = strTokenAdd.indexOf("=");
+							if (delimiter2 != -1) {
+								String valueAdd = strTokenAdd.substring(
+										delimiter2 + 1).trim();
+								valueAdd = Utils.handleQuotedString(valueAdd);
+								whereCols.add(strTokenAdd.substring(0,
+										delimiter2).trim());
+								valueAdd = Utils.replaceAll(valueAdd,
+										COMMA_ESCAPE, ",");
+								valueAdd = Utils.replaceAll(valueAdd,
+										QUOTE_ESCAPE, "'");
+								whereValues.add(valueAdd);
+							} else {
+								int delimiter3 = strTokenAdd.toLowerCase()
+										.indexOf(" is ");
+								whereCols.add(strTokenAdd.substring(0,
+										delimiter3).trim());
+								whereValues.add(null);
+							}
+							temp = temp.substring(andPos + 5);
+							if (temp.toLowerCase().indexOf(" and ") == -1) {
+								strTokenAdd = temp.trim();
+								int delimiter4 = strTokenAdd.indexOf("=");
+								if (delimiter4 != -1) {
+									String valueAdd = strTokenAdd.substring(
+											delimiter4 + 1).trim();
+									valueAdd = Utils
+											.handleQuotedString(valueAdd);
+									whereCols.add(strTokenAdd.substring(0,
+											delimiter4).trim());
+									valueAdd = Utils.replaceAll(valueAdd,
+											COMMA_ESCAPE, ",");
+									valueAdd = Utils.replaceAll(valueAdd,
+											QUOTE_ESCAPE, "'");
+									whereValues.add(valueAdd);
+								} else {
+									int delimiter3 = strTokenAdd.toLowerCase()
+											.indexOf(" is ");
+									whereCols.add(strTokenAdd.substring(0,
+											delimiter3).trim());
+									whereValues.add(null);
+								}
+								break out;
+							}
+
+						} while (true);
+
+					} else {
+						int delimiter = strToken.indexOf("=");
+						if (delimiter != -1) {
+							String value = strToken.substring(delimiter + 1)
+									.trim();
+							value = Utils.handleQuotedString(value);
+							whereCols.add(strToken.substring(0, delimiter)
+									.trim());
+							value = Utils.replaceAll(value, COMMA_ESCAPE, ",");
+							value = Utils.replaceAll(value, QUOTE_ESCAPE, "'");
+							whereValues.add(value);
+						} else {
+							int delimiter1 = strToken.toLowerCase().indexOf(
+									" is ");
+							whereCols.add(strToken.substring(0, delimiter1)
+									.trim());
+							whereValues.add(null);
+						}
+					}
+				}
+				columnWhereNames = new String[whereCols.size()];
+				columnWhereValues = new String[whereValues.size()];
+				whereCols.copyInto(columnWhereNames);
+				whereValues.copyInto(columnWhereValues);
+			}
+		}*/
+	}
+
+	private boolean parseConstantSelect(String sql) throws Exception
+	{
+		String sqlUpper = sql.toUpperCase();
+		int wherePos = sqlUpper.lastIndexOf(" WHERE ");
+		int groupPos = sqlUpper.lastIndexOf(" GROUP BY ");
+		int orderPos = sqlUpper.lastIndexOf(" ORDER BY ");
+		int limitPos = sqlUpper.lastIndexOf(" LIMIT ");
+
+		if (wherePos > 0 || groupPos > 0 || orderPos > 0)
+			return false;
+		try
+		{
+			if (limitPos > 0)
+			{
+				limit = Integer.valueOf(sqlUpper.substring(limitPos+6).trim());
+				sql = sqlUpper.substring(0, limitPos);
+			}
+		}
+		catch (NumberFormatException ne)
+		{
+			throw new Exception("Error near :\'" + sql.substring(limitPos)+"\'");
+		}
+
+		//At this point we have select <something>
+		StringTokenizer tokenizer = new StringTokenizer(sql.substring(6), ",");
+
+		for (int pos = 1; tokenizer.hasMoreTokens();)
+		{
+			String col = tokenizer.nextToken().trim();
+			EclColumnMetaData column = null;
+
+			if(Utils.isLiteralString(col))
+			{
+				column = new EclColumnMetaData("ConstStr"+pos, pos++, java.sql.Types.VARCHAR);
+				column.setEclType("STRING");
+			}
+			else if (Utils.isNumeric(col))
+			{
+				column = new EclColumnMetaData("ConstNum"+pos, pos++, java.sql.Types.NUMERIC);
+				column.setEclType("INTEGER");
+			}
+
+			column.setColumnType(EclColumnMetaData.COLUMN_TYPE_CONSTANT);
+			column.setConstantValue(col);
+
+			selectColumns.add(column);
+		}
+
+		return true;
+	}
+
+	public boolean columnsHasWildcard()
+	{
+		Iterator<EclColumnMetaData> it = selectColumns.iterator();
+		while (it.hasNext())
+		{
+			if(it.next().getColumnName().contains("*"))
+				return true;
+		}
+		return false;
+	}
+
+	public int orderByCount()
+	{
+		return columnOrderByNames==null ? 0 : columnOrderByNames.length;
+	}
+
+	public boolean hasOrderByColumns()
+	{
+		return columnOrderByNames != null && columnOrderByNames.length>0 ? true : false;
+	}
+
+	public int groupByCount()
+	{
+		return columnGroupByNames==null ? 0 : columnGroupByNames.length;
+	}
+
+	public String getOrderByColumn(int index)
+	{
+
+		return (columnOrderByNames == null || index < 0 || index >= columnOrderByNames.length) ? "" : columnOrderByNames[index];
+	}
+
+	public String getOrderByString()
+	{
+		StringBuilder tmp = new StringBuilder("");
+		for (int i = 0; i<columnOrderByNames.length; i++)
+		{
+			tmp.append(columnOrderByNames[i]);
+			if (i!=columnOrderByNames.length-1)
+				tmp.append(',');
+		}
+		return tmp.toString();
+	}
+
+	public String getOrderByString(char delimiter)
+	{
+		StringBuilder tmp = new StringBuilder("");
+		for (int i = 0; i<columnOrderByNames.length; i++)
+		{
+			tmp.append(columnOrderByNames[i]);
+			if (i!=columnOrderByNames.length-1)
+				tmp.append(delimiter);
+		}
+		return tmp.toString();
+	}
+
+	public String getGroupByString()
+	{
+		StringBuilder tmp = new StringBuilder("");
+		for (int i = 0; i<columnGroupByNames.length; i++)
+		{
+			tmp.append(columnGroupByNames[i]);
+			if (i!=columnGroupByNames.length-1)
+				tmp.append(',');
+		}
+		return tmp.toString();
+	}
+
+	public String getGroupByString(char delimiter)
+	{
+		StringBuilder tmp = new StringBuilder("");
+		for (int i = 0; i<columnGroupByNames.length; i++)
+		{
+			tmp.append(columnGroupByNames[i]);
+			if (i!=columnGroupByNames.length-1)
+				tmp.append(delimiter);
+		}
+		return tmp.toString();
+	}
+
+	public String getGroupByColumn(int index)
+	{
+
+		return (columnGroupByNames == null || index < 0 || index >= columnGroupByNames.length) ? "" : columnGroupByNames[index];
+	}
+
+	public boolean hasGroupByColumns()
+	{
+		return columnGroupByNames != null && columnGroupByNames.length>0 ? true : false;
+	}
+
+	public boolean hasLimitBy()
+	{
+		return limit == -1 ? false : true;
+	}
+
+	public String [] getStoredProcInParamVals() {
+		return procInParamValues;
+	}
+
+	public String getStoredProcName() {
+		return storedProcName;
+	}
+
+	public String getTableAlias() {
+		return tableAlias;
+	}
+
+	public int getSqlType() {
+		return sqlType;
+	}
+
+	public int getLimit() {
+		return limit;
+	}
+
+	public String getTableName() {
+		return tableName;
+	}
+
+	public String[] getColumnNames()
+	{
+		Iterator<EclColumnMetaData> it = selectColumns.iterator();
+		String [] selcols = new String[selectColumns.size()];
+		for (int i = 0 ; it.hasNext(); i++)
+			selcols[i] = it.next().getColumnName();
+
+		return selcols;
+	}
+
+	public void populateParametrizedExpressions(Map inParameters) throws SQLException
+	{
+
+		if (inParameters.size()>0)
+		{
+			if (whereclause != null && whereclause.getExpressionsCount() > 0)
+			{
+				Iterator<SqlExpression> expressionit = whereclause.getExpressions();
+				int paramIndex = 0;
+				while (expressionit.hasNext())
+				{
+					SqlExpression exp = expressionit.next();
+					if (exp.isParametrized())
+					{
+						String value = (String)inParameters.get(new Integer(++paramIndex));
+						if (value == null)
+							throw new SQLException("Could not bound parametrized expression(" + exp +") to parameter");
+						exp.setValue(value);
+					}
+				}
+				//System.out.println(whereclause);
+			}
+			else if (procInParamValues.length > 0)
+			{
+				int paramindex = 0;
+				for (int columindex = 0; columindex < procInParamValues.length;columindex++)
+				{
+					if(isParametrized(procInParamValues[columindex]))
+					{
+						String value = (String)inParameters.get(new Integer(++paramindex));
+						if (value == null)
+							throw new SQLException("Could not bound parameter");
+						procInParamValues[columindex] = value;
+					}
+				}
+			}
+		}
+	}
+
+	boolean isParametrized( String param)
+	{
+		return  (param.contains("${")|| param.equals("?"));
+	}
+
+//	public String[] getWhereColumnNames() {
+//		return columnWhereNames;
+//	}
+//
+//	public String[] getWhereColumnValues() {
+//		return columnWhereValues;
+//	}
+
+	public String[] getColumnValues() {
+		return columnValues;
+	}
+
+	public int getWhereClauseExpressionsCount()
+	{
+		return whereclause.getExpressionsCount();
+	}
+
+	public String[] getWhereClauseNames()
+	{
+		return whereclause.getExpressionNames();
+	}
+
+	public String[] getUniqueWhereClauseNames()
+	{
+		return whereclause.getUniqueExpressionNames();
+	}
+
+	public SqlExpression getExpressionFromName(String name)
+	{
+		return whereclause.getExpressionFromName(name);
+	}
+
+	public boolean whereClauseContainsKey(String name) {
+		return whereclause.containsKey(name);
+	}
+
+	public String getWhereClauseString()
+	{
+		return whereclause.toString();
+	}
+
+	public int getUniqueWhereColumnCount()
+	{
+		return whereclause.getUniqueColumnCount();
+	}
+
+	public boolean whereClauseContainsOrOperator()
+	{
+		return whereclause.isOrOperatorUsed();
+	}
+
+	public static void main(String[] args) throws Exception
+	{
+		SqlParser parser = new SqlParser();
+		parser.parse("select firstname from fetchpeoplebyzipservice USE INDEX(tutorial::rp::peoplebyzipindex2) where zipvalue=?");
+		System.out.println(parser.getTableName());
+	}
+
+	public List<EclColumnMetaData> getSelectColumns()
+	{
+		return selectColumns;
+	}
+
+	public void expandWildCardColumn(Enumeration<Object> allFields)
+	{
+		Iterator<EclColumnMetaData> it = selectColumns.iterator();
+		for(int i = 0; it.hasNext(); i++)
+		{
+			if (it.next().getColumnName().equals("*"))
+			{
+				System.out.println("Expanding wildcard, select columns order might be altered");//fine for now, we do need to address at some point
+				selectColumns.remove(i);
+				while (allFields.hasMoreElements())
+				{
+					EclColumnMetaData element = (EclColumnMetaData)allFields.nextElement();
+					selectColumns.add(element);
+				}
+				break;
+			}
+		}
+	}
+
+	public boolean areColumnsVerified()
+	{
+		return columnsVerified;
+	}
+
+	public void verifySelectColumns(DFUFile dfufile) throws Exception
+	{
+		if (areColumnsVerified())
+			return;
+
+		for (int i = 0; i < selectColumns.size(); i++)
+		{
+			verifyColumn(selectColumns.get(i), dfufile);
+		}
+
+		if (columnsHasWildcard())
+			expandWildCardColumn(dfufile.getAllFields());
+
+		columnsVerified = true;
+	}
+
+	public void verifyColumn(EclColumnMetaData column, DFUFile dfufile) throws Exception
+	{
+		String fieldName = column.getColumnName();
+
+		if (!dfufile.containsField(column))
+		{
+			if (!fieldName.trim().equals("*"))
+			{
+				if  (column.getColumnType() == EclColumnMetaData.COLUMN_TYPE_FNCTION)
+				{
+					if (column.getAlias() == null)
+						column.setAlias(fieldName + "Out");
+					List<EclColumnMetaData>funccols = column.getFunccols();
+					for (int i = 0; i<funccols.size(); i++)
+					{
+						verifyColumn(funccols.get(i), dfufile);
+					}
+
+				}
+				else if(Utils.isLiteralString(fieldName))
+				{
+					column.setColumnName("ConstStr"+ column.getIndex());
+					column.setEclType("STRING");
+					column.setSQLType(java.sql.Types.VARCHAR);
+					column.setColumnType(EclColumnMetaData.COLUMN_TYPE_CONSTANT);
+					column.setConstantValue(fieldName);
+				}
+				else if (Utils.isNumeric(fieldName))
+				{
+					column.setColumnName("ConstNum" + column.getIndex());
+					column.setEclType("INTEGER");
+					column.setSQLType(java.sql.Types.NUMERIC);
+					column.setColumnType(EclColumnMetaData.COLUMN_TYPE_CONSTANT);
+					column.setConstantValue(fieldName);
+				}
+				else
+					throw new Exception("Invalid column found");
+			}
+		}
+		else
+		{
+			column.setEclType(dfufile.getFieldMetaData(fieldName).getEclType());
+		}
+	}
+
+	public String getIndexHint() {
+		return indexHint;
+	}
+
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlWhereClause.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/SqlWhereClause.java
@@ -1,0 +1,129 @@
+package com.hpccsystems.ecljdbc;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class SqlWhereClause
+{
+	private List<SqlExpression> expressions;
+	private List<String> expressionUniqueColumnNames;
+	private int expressionsCount;
+	private int operatorsCount;
+	private boolean orOperatorUsed;
+
+	public SqlWhereClause()
+	{
+		expressions = new ArrayList<SqlExpression>();
+		expressionUniqueColumnNames = new ArrayList<String>();
+		expressionsCount = 0;
+		operatorsCount = 0;
+		orOperatorUsed = false;
+	}
+
+	public void addExpression(SqlExpression expression)
+	{
+		expressions.add(expression);
+		if (expression.getType() == SqlExpression.LOGICAL_EXPRESSION_TYPE)
+		{
+			expressionsCount++;
+			if (!expressionUniqueColumnNames.contains(expression.getName()))
+					expressionUniqueColumnNames.add(expression.getName());
+		}
+		else
+		{
+			operatorsCount++;
+			if (expression.getOperator().getValue().equals(SqlOperator.or))
+				orOperatorUsed = true;
+		}
+	}
+
+	public Iterator<SqlExpression> getExpressions()
+	{
+		return expressions.iterator();
+	}
+
+	public int getExpressionsCount() {
+		return expressionsCount;
+	}
+
+	public int getOperatorsCount() {
+		return operatorsCount;
+	}
+
+	@Override
+	public String toString()
+	{
+		String clause = new String("");
+		Iterator<SqlExpression> it = expressions.iterator();
+		while (it.hasNext())
+		{
+			clause += ((SqlExpression)it.next()).toString();
+		}
+		return clause;
+	}
+
+	public String [] getExpressionNames()
+	{
+		String [] names = new String[getExpressionsCount()];
+		Iterator<SqlExpression> it = expressions.iterator();
+		int i = 0;
+		while (it.hasNext())
+		{
+			SqlExpression exp = it.next();
+			if (exp.getType() == SqlExpression.LOGICAL_EXPRESSION_TYPE)
+			{
+				names[i++] = exp.getName();
+			}
+		}
+		return names;
+	}
+
+	public SqlExpression getExpressionFromName(String name)
+	{
+		Iterator<SqlExpression> it = expressions.iterator();
+		while (it.hasNext())
+		{
+			SqlExpression exp = it.next();
+			if (exp.getType() == SqlExpression.LOGICAL_EXPRESSION_TYPE && exp.getName().equals(name))
+			{
+				return exp;
+			}
+		}
+		return null;
+	}
+
+	public boolean containsKey(String name)
+	{
+		Iterator<SqlExpression> it = expressions.iterator();
+		while (it.hasNext())
+		{
+			SqlExpression exp = it.next();
+			if (exp.getType() == SqlExpression.LOGICAL_EXPRESSION_TYPE && exp.getName().equals(name))
+				return true;
+		}
+		return false;
+	}
+
+	public int getUniqueColumnCount()
+	{
+		return expressionUniqueColumnNames.size();
+	}
+
+	public String[] getUniqueExpressionNames()
+	{
+		String [] names = new String[getUniqueColumnCount()];
+		Iterator<String> it = expressionUniqueColumnNames.iterator();
+		int i = 0;
+		while (it.hasNext())
+		{
+			names[i++] = it.next();
+		}
+		return names;
+	}
+
+	public boolean isOrOperatorUsed()
+	{
+		return orOperatorUsed;
+	}
+}

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/Utils.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/Utils.java
@@ -1,0 +1,198 @@
+package com.hpccsystems.ecljdbc;
+
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
+
+public class Utils
+{
+	static final char pad = '=';
+	static final char BASE64_enc[] =  {'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
+            						  'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',
+			                          '0','1','2','3','4','5','6','7','8','9','+','"'};
+
+	static final char BASE64_dec[] =
+	{
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x3e, (char)0x00, (char)0x00, (char)0x00, (char)0x3f,
+		(char)0x34, (char)0x35, (char)0x36, (char)0x37, (char)0x38, (char)0x39, (char)0x3a, (char)0x3b, (char)0x3c, (char)0x3d, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x01, (char)0x02, (char)0x03, (char)0x04, (char)0x05, (char)0x06, (char)0x07, (char)0x08, (char)0x09, (char)0x0a, (char)0x0b, (char)0x0c, (char)0x0d, (char)0x0e,
+		(char)0x0f, (char)0x10, (char)0x11, (char)0x12, (char)0x13, (char)0x14, (char)0x15, (char)0x16, (char)0x17, (char)0x18, (char)0x19, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x1a, (char)0x1b, (char)0x1c, (char)0x1d, (char)0x1e, (char)0x1f, (char)0x20, (char)0x21, (char)0x22, (char)0x23, (char)0x24, (char)0x25, (char)0x26, (char)0x27, (char)0x28,
+		(char)0x29, (char)0x2a, (char)0x2b, (char)0x2c, (char)0x2d, (char)0x2e, (char)0x2f, (char)0x30, (char)0x31, (char)0x32, (char)0x33, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00,
+		(char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00, (char)0x00
+	};
+
+//	public static String Base64Decode(byte [] input)
+//	{
+//		StringBuilder out = new StringBuilder("");
+//
+//		char c1, c2, c3, c4;
+//	    char d1, d2, d3, d4;
+//
+//	    for(int i = 0;;)
+//	    {
+//	        c1 = (char)input[i++];
+//			if (c1 == 0)
+//				break;
+//			//else if (!isspace(c1))
+//			else if (!String.valueOf(c1).equals(" "))
+//			{
+//				c2 = (char)input[i++];
+//				c3 = (char)input[i++];
+//				c4 = (char)input[i++];
+//				d1 = BASE64_dec[c1];
+//				d2 = BASE64_dec[c2];
+//				d3 = BASE64_dec[c3];
+//				d4 = BASE64_dec[c4];
+//
+//				out.append((char)((d1 << 2) | (d2 >> 4)));
+//
+//				if(c3 == pad)
+//					break;
+//
+//				out.append((char)((d2 << 4) | (d3 >> 2)));
+//
+//				if(c4 == pad)
+//					break;
+//
+//				out.append((char)((d3 << 6) | d4));
+//			}
+//	    }
+//
+//	    return out.toString();
+//	}
+
+	public static String Base64Encode(byte [] input, boolean addLineBreaks)
+	{
+		int length = input.length;
+		StringBuilder out = new StringBuilder("");
+		char one;
+		char two;
+		char three;
+
+		int i;
+		for (i = 0; i < length &&  length -i >= 3;)
+		{
+			one = (char)input[i++];
+			two = (char)input[i++];
+			three = (char)input[i++];
+
+			out.append((char)BASE64_enc[one >> 2]);
+			out.append((char)BASE64_enc[((one << 4) & 0x30 | (two >> 4))]);
+			out.append((char)BASE64_enc[((two << 2) & 0x3c | (three >> 6))]);
+			out.append((char)BASE64_enc[three & 0x3f]);
+
+			if(addLineBreaks && (i % 54 ==0))
+				out.append("\n");
+
+			switch( length - i)
+			{
+				case 2:
+					one = (char)input[i++];
+					two = (char)input[i++];
+
+					out.append((char)BASE64_enc[one >> 2]);
+					out.append((char)BASE64_enc[((one << 4) & 0x30 | (two >> 4))]);
+					out.append((char)BASE64_enc[((two << 2) & 0x3c)]);
+					out.append(pad);
+					break;
+
+				case 1:
+					one = (char)input[i++];
+
+					out.append((char)BASE64_enc[one >> 2]);
+					out.append((char)BASE64_enc[((one << 4) & 0x30)]);
+					out.append(pad);
+					out.append(pad);
+					break;
+			}
+
+		}
+		return out.toString();
+	}
+
+	public static String removeAllNewLines(String str)
+	{
+		return str.replaceAll("\\r\\n|\\r|\\n", " ");
+	}
+
+	public static boolean isLiteralString(String str)
+	{
+		String trimmed  = str.trim();
+		if( trimmed.charAt(0) != '\'' && trimmed.charAt(0) != '\"')
+			return false;
+		if( trimmed.charAt(trimmed.length()-1) != '\'' && trimmed.charAt(trimmed.length()-1) != '\"')
+			return false;
+
+		return true;
+	}
+
+	public static boolean isNumeric(String str)
+	{
+		NumberFormat format = NumberFormat.getInstance(Locale.US);
+		try
+		{
+			format.parse(str);
+		}
+		catch (ParseException e)
+		{
+			return false;
+		}
+
+		return true;
+	}
+	public static String replaceAll(String input, String forReplace, String replaceWith)
+	{
+		if (input == null)
+			return "null";
+
+		StringBuffer result = new StringBuffer();
+		boolean hasMore = true;
+		while (hasMore)
+		{
+			int start = input.indexOf(forReplace);
+			int end = start + forReplace.length();
+			if (start != -1)
+			{
+				result.append(input.substring(0, start) + replaceWith);
+				input = input.substring(end);
+			}
+			else
+			{
+				hasMore = false;
+				result.append(input);
+			}
+		}
+		if (result.toString().equals(""))
+			return input; // nothing is changed
+		else
+			return result.toString();
+	}
+
+	public static String handleQuotedString(String quotedString)
+	{
+		if (quotedString == null)
+			return "null";
+		String retVal = quotedString;
+		if ((retVal.startsWith("'") && retVal.endsWith("'")))
+		{
+			if (!retVal.equals("''"))
+			{
+				retVal = retVal.substring(retVal.indexOf("'") + 1,
+						retVal.lastIndexOf("'"));
+			}
+			else
+				retVal = "";
+		}
+		return retVal;
+	}
+}


### PR DESCRIPTION
Java representation of the HPCC System, which provides an SQL based
interface into the HPCC System based on JDBC standards.
HPCC files are treated as DB Tables and published queries are treated
as StoredProcedures.
Heavily dependent on WsEcl and WsEclWatch ESP services for metadata, and
100% dependent on WsEclDirect for execution of dynamic ECL created from
SQL query.
This Version contains a copy of the CMake HPCC version variables, because the stand alone
CMake variables file will not be available until 3.8.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
