### PR TITLE
Fix regressions in recent inline table code

### DIFF
--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -15817,7 +15817,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityTempTable(BuildCtx & ctx, IHql
         rowsExpr.setown(getBoundCount(bound));
         rowsExpr.setown(createTranslated(rowsExpr));
 
-        OwnedHqlExpr compare = createValue(no_ge, makeBoolType(), LINK(rowVar), LINK(rowsExpr));
+        OwnedHqlExpr compare = createValue(no_ge, makeBoolType(), LINK(rowVar), ensureExprType(rowsExpr, rowVar->queryType()));
         BuildCtx condctx(funcctx);
         buildFilter(condctx, compare);
         if (clearAction)
@@ -15875,14 +15875,17 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCreateRow(BuildCtx & ctx, IHql
         valuesAreConstant = true;
     }
 
-    Owned<ActivityInstance> instance = new ActivityInstance(*this, ctx, TAKtemprow, expr, "TempRow");
+    Owned<ActivityInstance> instance = new ActivityInstance(*this, ctx, TAKinlinetable, expr, "InlineRow");
     if (valueText.length())
     {
         StringBuffer graphLabel;
         elideString(valueText, MAX_ROW_VALUE_TEXT_LEN);
-        graphLabel.append(getActivityText(instance->kind)).append("\n{").append(valueText).append("}");
+        graphLabel.append("Inline Row\n{").append(valueText).append("}");
         instance->graphLabel.set(graphLabel.str());
     }
+    else
+        instance->graphLabel.set("Inline Row");
+
 
     //-----------------
     buildActivityFramework(instance);

--- a/rtl/include/eclhelper_base.hpp
+++ b/rtl/include/eclhelper_base.hpp
@@ -1343,7 +1343,7 @@ public:
     virtual unsigned getFlags()                         { return 0; }
 };
 
-class CThorTempRowArg : public CThorInlineTableArg
+class CThorInlineRowArg : public CThorInlineTableArg
 {
     virtual __uint64 numRows()                          { return 1; }
 };


### PR DESCRIPTION
- Wrong type was used in a comparison expression creating an assert
- Temp row was creating the wrong TAK kind - which meant it crashed
  at runtime.
- TempRow should have been changed to inlinerow (probably part of the
  cause of the TAKkind issue).

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
