### PR TITLE
Fix #2089 Disallow spaces in ESP user ID

### DIFF
--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -649,6 +649,12 @@ bool Cws_accessEx::onAddUser(IEspContext &context, IEspAddUserRequest &req, IEsp
             resp.setRetmsg("username can't be empty");
             return false;
         }
+        if(strchr(username, (int)' '))
+        {
+            resp.setRetcode(-1);
+            resp.setRetmsg("Username can't contain spaces");
+            return false;
+        }
 
         CLdapSecManager* secmgr0 = (CLdapSecManager*)secmgr;
         if((secmgr0->getLdapServerType() == ACTIVE_DIRECTORY) && (strlen(username) > 20))

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1130,21 +1130,11 @@ public:
                             for (int x=0; x < (int)val->bv_len; x++)
                                 time = time * 10 + ( (int)val->bv_val[x] - '0');
                             ldap_value_free_len(bvalues);
-#ifdef _DEBUG
-                            CDateTime lastPWChange;
-                            lastPWChange.setFromFILETIME(time);
-                            lastPWChange.adjustTime(lastPWChange.queryUtcToLocalDelta());
-                            StringBuffer sb;
-                            lastPWChange.getString(sb);
-#endif
+
                             time += maxPWAge;
                             expiry.setFromFILETIME(time);
                             expiry.adjustTime(expiry.queryUtcToLocalDelta());
                             user.setPasswordExpiration(expiry);
-#ifdef _DEBUG
-                            StringBuffer sb2;
-                            expiry.getString(sb2);
-#endif
                         }
                         else
                         {


### PR DESCRIPTION
Spaces should not be allowed in ESP user IDs. Check for spaces
and return error if they are specified

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
