### PR TITLE
ISSUE:1881 ConfigMgr-notify user if component is not part of install

### DIFF
--- a/deployment/deploy/XMLTags.h
+++ b/deployment/deploy/XMLTags.h
@@ -28,6 +28,7 @@
 #define XML_TAG_PROGRAMS               "Programs"
 #define XML_TAG_DATA                   "Data"
 #define XML_TAG_ENVSETTINGS            "EnvSettings"
+#define XML_TAG_DIRECTORIES            "Directories"
 
 #define XML_TAG_ATTRIBUTESERVER        "AttributeServer"
 #define XML_TAG_ATTRSERVERINSTANCE     "AttrServerInstance"
@@ -80,6 +81,9 @@
 #define XML_TAG_TOPOLOGY               "Topology"
 #define XML_TAG_VERSION                "Version"
 #define XML_TAG_ROXIECLUSTER           "RoxieCluster"
+#define XML_TAG_LOCALENVFILE           "LocalEnvFile"
+#define XML_TAG_LOCALCONFFILE          "LocalConfFile"
+#define XML_TAG_LOCALENVCONFFILE       "LocalEnvConfFile"
 
 #define XML_ATTR_AGENTPORT             "@agentPort"
 #define XML_ATTR_ATTRSERVER            "@attrServer"

--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -679,6 +679,48 @@ private:
     StringBuffer m_ip;
 };
 
+
+class CConfigHelper
+{
+public:
+
+  CConfigHelper();
+  virtual ~CConfigHelper();
+
+  void init(const IPropertyTree *cfg, const char* esp_name);
+
+  bool isInBuildSet(const char* comp_process_name, const char* comp_name) const;
+
+  const char* getConfigXMLDir() const
+  {
+    return m_strConfigXMLDir.toCharArray();
+  };
+  const char* getBuildSetFileName() const
+  {
+    return m_strBuildSetFileName.toCharArray();
+  };
+  const char* getEnvConfFile() const
+  {
+    return m_strEnvConfFile.toCharArray();
+  };
+  const char* getConfFile() const
+  {
+    return m_strConfFile.toCharArray();
+  };
+  const char* getBuildSetFilePath() const
+  {
+    return m_strBuildSetFilePath.toCharArray();
+  };
+
+protected:
+  Owned<IPropertyTree> m_pDefBldSet;
+  StringBuffer  m_strConfigXMLDir;
+  StringBuffer  m_strBuildSetFileName;
+  StringBuffer  m_strEnvConfFile;
+  StringBuffer  m_strConfFile;
+  StringBuffer  m_strBuildSetFilePath;
+};
+
 class CWsDeployExCE : public CWsDeploy
 {
 public:
@@ -732,6 +774,7 @@ public:
     const char* getBackupDir() { return m_backupDir.str(); }
     const char* getProcessName() { return m_process.str(); }
     const char* getSourceDir() { return m_sourceDir.str(); }
+    CConfigHelper m_configHelper;
 
 private:
   virtual void getWizOptions(StringBuffer& sb);


### PR DESCRIPTION
Add an informative exception notification message
when a component in the environment configuration
is not part of the buildset.

Add ConfigHelper class to avoid duplicated code.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
