### PR TITLE
Roxie generated filenames for index parts were incorrect

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2058,7 +2058,7 @@ public:
                             IPartDescriptor *pdesc = fdesc->queryPart(partNo-1);
                             if (pdesc)
                             {
-                                part.setown(createDynamicFile(subNames.item(idx), pdesc, ROXIE_KEY, maxParts));
+                                part.setown(createDynamicFile(subNames.item(idx), pdesc, ROXIE_KEY, fdesc->numParts()));
                                 pdesc->getCrc(crc);
                             }
                         }


### PR DESCRIPTION
Roxie generating file names for index parts other than the top-level
key incorrectly. This would lead to some confusion, and possibly additional
copying of files, but no other ill effect as far as I can see.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
