### PR TITLE
Roxie assert error on partially suspended queries

### DIFF
--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -563,11 +563,13 @@ protected:
 
     virtual IRoxieServerActivityFactory *getRoxieServerActivityFactory(unsigned id) const
     {
+        checkSuspended();
         return LINK(QUERYINTERFACE(findActivity(id), IRoxieServerActivityFactory));
     }
 
     virtual ISlaveActivityFactory *getSlaveActivityFactory(unsigned id) const
     {
+        checkSuspended();
         IActivityFactory *f = findActivity(id);
         return LINK(QUERYINTERFACE(f, ISlaveActivityFactory)); // MORE - don't dynamic cast yuk
     }
@@ -1086,6 +1088,19 @@ public:
             ret.append(graphName.str());
         }
     }
+
+protected:
+    void checkSuspended() const
+    {
+        if (isSuspended)
+        {
+            StringBuffer err;
+            if (errorMessage.length())
+                err.appendf(" because %s", errorMessage.str());
+            throw MakeStringException(ROXIE_QUERY_SUSPENDED, "Query %s is suspended%s", id.get(), err.str());
+        }
+    }
+
 };
 
 CriticalSection CQueryFactory::queryCreateLock;
@@ -1240,18 +1255,6 @@ public:
     virtual IPropertyTree *getQueryStats(time_t from, time_t to)
     {
         return queryStats->getStats(from, to);
-    }
-
-protected:
-    void checkSuspended() const
-    {
-        if (isSuspended)
-        {
-            StringBuffer err;
-            if (errorMessage.length())
-                err.appendf(" because %s", errorMessage.str());
-            throw MakeStringException(ROXIE_QUERY_SUSPENDED, "Query %s is suspended%s", id.get(), err.str());
-        }
     }
 
 };


### PR DESCRIPTION
If a Roxie slave thinks that a query is suspended, but the server does not
(this can happen when a file part is missing, for example), then the error
reported if the query is executed wille be an internal assert failure
rather than something more helpful.

See issue gh-2096.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
