### PR TITLE
Adjust LDAP password expiration from UTC to local time

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1125,17 +1125,17 @@ public:
 #ifdef _DEBUG
                             CDateTime lastPWChange;
                             lastPWChange.setFromFILETIME(time);
+                            lastPWChange.adjustTime(lastPWChange.queryUtcToLocalDelta());
                             StringBuffer sb;
                             lastPWChange.getString(sb);
 #endif
                             time += maxPWAge;
                             expiry.setFromFILETIME(time);
+                            expiry.adjustTime(expiry.queryUtcToLocalDelta());
                             user.setPasswordExpiration(expiry);
 #ifdef _DEBUG
-                            CDateTime whenExpires;
-                            whenExpires.setFromFILETIME(time);
                             StringBuffer sb2;
-                            whenExpires.getString(sb2);
+                            expiry.getString(sb2);
 #endif
                         }
                         else

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -46,7 +46,7 @@ private:
     StringAttr   m_Fqdn;
     StringAttr   m_Peer;
     bool         m_isAuthenticated;
-    CDateTime    m_passwordExpiration;
+    CDateTime    m_passwordExpiration;//local time
     unsigned     m_userid;
     MemoryBuffer m_usersid;
     BufferArray  m_groupsids;
@@ -114,17 +114,14 @@ public:
    {
        if (m_passwordExpiration.isNull())
            return -2;//-2 if never expires
-
        CDateTime expiry(m_passwordExpiration);
-       expiry.setTime(0,0,0,0);
-
        CDateTime now;
        now.setNow();
        now.adjustTime(now.queryUtcToLocalDelta());
        if (expiry <= now)
            return -1;//-1 if already expired
+       expiry.setTime(0,0,0,0);
        now.setTime(23,59,59);
-
        int numDays = 0;
        while (expiry > now)
        {


### PR DESCRIPTION
Currently password expiration is store in UTC while the code that computes
time until expiration expects it to be local.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
