### PR TITLE
Unused paths in CMake config

### DIFF
--- a/esp/services/ws_packageprocess/CMakeLists.txt
+++ b/esp/services/ws_packageprocess/CMakeLists.txt
@@ -38,7 +38,6 @@ include_directories (
          ${HPCC_SOURCE_DIR}/dali/base
          ${HPCC_SOURCE_DIR}/common/environment
          ${HPCC_SOURCE_DIR}/dali/dfu
-         ${HPCC_SOURCE_DIR}/dali/dfutil
          ${HPCC_SOURCE_DIR}/common/remote
     )
 

--- a/thorlcr/msort/CMakeLists.txt
+++ b/thorlcr/msort/CMakeLists.txt
@@ -46,7 +46,6 @@ include_directories (
          ./../../dali/base 
          ./../shared 
          ./../../system/jlib 
-         ./../../system/icu/include 
          ./../../common/workunit 
          ./../../common/commonext 
          ./../thorutil 


### PR DESCRIPTION
Two unused (long gone?) paths still in CMake config were
adding warnings to Eclipse (invalid path in project). I've checked
in other repositories that use HPCC and they also don't have, so
possibly just a left-over that can easily be removed.

There is one more (build/oss) but that can be easily fixed manually
(by creating the dir) and shows up in many CMake files, so not
changing it here.
