### PR TITLE
Fix limitations with meta information for FAIL

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -10298,9 +10298,9 @@ IHqlExpression *createDataset(node_operator op, HqlExprArray & parms)
             break;
         }
     case no_null:
+    case no_fail:
     case no_anon:
     case no_pseudods:
-    case no_fail:
     case no_skip:
     case no_all:
     case no_workunit_dataset:
@@ -10314,6 +10314,7 @@ IHqlExpression *createDataset(node_operator op, HqlExprArray & parms)
     case no_purevirtual:
     case no_libraryinput:
         {
+            bool matchesAnyMeta =  ((op == no_null) || (op == no_fail));
             IHqlExpression * record = &parms.item(0);
             IHqlExpression * metadata = queryProperty(_metadata_Atom, parms);
             bool linkCounted = (queryProperty(_linkCounted_Atom, parms) || recordRequiresSerialization(record));
@@ -10325,7 +10326,10 @@ IHqlExpression *createDataset(node_operator op, HqlExprArray & parms)
                 ITypeInfo * recordType = createRecordType(record);
                 assertex(recordType->getTypeCode() == type_record);
                 ITypeInfo * rowType = makeRowType(recordType);
-                type.setown(makeTableType(rowType, LINK(distribution), NULL, NULL));
+                if (matchesAnyMeta)
+                    type.setown(makeTableType(rowType, LINK(queryAnyDistributionAttribute()), LINK(queryAnyOrderSortlist()), LINK(queryAnyOrderSortlist())));
+                else
+                    type.setown(makeTableType(rowType, LINK(distribution), NULL, NULL));
                 IHqlExpression * grouped = queryProperty(groupedAtom, parms);
                 if (grouped)
                 {

--- a/ecl/hql/hqlmeta.hpp
+++ b/ecl/hql/hqlmeta.hpp
@@ -26,6 +26,8 @@ extern HQL_API IHqlExpression * queryMatchGroupOrderSortlist();
 extern HQL_API IHqlExpression * getUnknownAttribute();
 extern HQL_API IHqlExpression * getUnknownSortlist();
 extern HQL_API IHqlExpression * getMatchGroupOrderSortlist();
+extern HQL_API IHqlExpression * queryAnyOrderSortlist();
+extern HQL_API IHqlExpression * queryAnyDistributionAttribute();
 
 extern HQL_API IHqlExpression * getExistingSortOrder(IHqlExpression * dataset, bool isLocal, bool ignoreGrouping);
 

--- a/ecl/regress/bug100253.ecl
+++ b/ecl/regress/bug100253.ecl
@@ -1,0 +1,53 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+layout := {
+    unsigned1 id,
+    string s1,
+};
+
+layout2 := {
+    unsigned1 id,
+    string s2,
+};
+
+ds1 := dataset([{1,'1'},{2,'2'}], layout);
+ds2 := dataset([{1,'one'},{2,'two'}], layout2);
+
+ds1_dist := distribute(ds1, id);
+ds2_dist := distribute(ds2, id);
+
+// FAIL causes compiler to lose knowledge of distribution
+ds1A := if(exists(ds1_dist(s1 = '1')),
+           ds1_dist,
+           fail(ds1_dist, 'message'));
+
+// The graph shows that this join is NOT local
+ds3 := join(ds1A, ds2_dist,
+            left.id = right.id);
+output(ds3);
+
+// compiler retains knowledge of distribution
+ds1B := if(exists(ds1_dist(s1 = '1')),
+           ds1_dist,
+           ds1_dist(s1 = '2'));
+
+// The graph shows that this join IS local.
+ds4 := join(ds1B, ds2_dist,
+            left.id = right.id);
+output(ds4);

--- a/ecl/regress/bug100253b.ecl
+++ b/ecl/regress/bug100253b.ecl
@@ -1,0 +1,53 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+layout := {
+    unsigned1 id,
+    string s1,
+};
+
+layout2 := {
+    unsigned1 id,
+    string s2,
+};
+
+ds1 := dataset([{1,'1'},{2,'2'}], layout);
+ds2 := dataset([{1,'one'},{2,'two'}], layout2);
+
+ds1_dist := sort(nofold(ds1), id);
+ds2_dist := sort(nofold(ds2), id);
+
+// FAIL causes compiler to lose knowledge of distribution
+ds1A := if(exists(ds1_dist(s1 = '1')),
+           ds1_dist,
+           fail(ds1_dist, 'message'));
+
+// The graph shows that this join is NOT local
+ds3 := join(ds1A, ds2_dist,
+            left.id = right.id);
+output(ds3);
+
+// compiler retains knowledge of distribution
+ds1B := if(exists(ds1_dist(s1 = '1')),
+           ds1_dist,
+           ds1_dist(s1 = '2'));
+
+// The graph shows that this join IS local.
+ds4 := join(ds1B, ds2_dist,
+            left.id = right.id);
+output(ds4);


### PR DESCRIPTION
IF(cond, dataset, FAIL) should inherit the meta information from the
left dataset.  This fix adds an "ANY" sort order/distribution which
allows the meta information to be calculated correctly.

It is possible this could also be used for some other node types (e.g.,
anything that has a single row).

Fixes Bugzilla bug #100253

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
