### PR TITLE
Fix #1515 invalid c++ if csvread contains a child query

### DIFF
--- a/ecl/hqlcpp/hqlinline.cpp
+++ b/ecl/hqlcpp/hqlinline.cpp
@@ -1141,6 +1141,11 @@ void ParentExtract::gatherActiveRows(BuildCtx & ctx)
                 //NB: Alias expansions get rebound when they are bound into the context.
                 newRow = LINK(&cur);
             }
+            else if (!cur.isBinary())
+            {
+                //CSV and xml datasets need their elements serialized into the parent extract
+                newRow = new NonLocalIndirectRow(cur, NULL, childSerialization);
+            }
             else if (serialization)
             {
                 //A cursor active in the current scope => add it to the extract, and create an alias in the

--- a/ecl/regress/nestedcsv.ecl
+++ b/ecl/regress/nestedcsv.ecl
@@ -1,0 +1,35 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#option ('targetClusterType', 'hthor');
+
+namesRecord :=
+            RECORD
+string20        surname;
+string10        forename;
+integer2        age := 25;
+            END;
+
+namesTable := dataset('x',namesRecord,FLAT);
+
+namesCsv := dataset('x.csv',namesRecord,CSV);
+
+
+t := TABLE(namesCsv, { surname, exists(namesTable(namesTable.surname = namesCsv.surname)); });
+
+output(t);


### PR DESCRIPTION
If a compound csv read (e.g., containing a project) contained
a colocal child query, the data from the parent row wasn't correctly
passed to the child activities.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
