### PR TITLE
Ensure jobtemp spill files are replicated

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -4773,17 +4773,14 @@ void GlobalAttributeInfo::doSplitGlobalDefinition(ITypeInfo * type, IHqlExpressi
             }
         case no_stored:
             args.append(*createAttribute(ownedAtom));
-            args.append(*createAttribute(_noReplicate_Atom));
             args.append(*createAttribute(sequenceAtom, getStoredSequenceNumber()));
             break;
         case no_checkpoint:
             args.append(*createAttribute(ownedAtom));
-            args.append(*createAttribute(_noReplicate_Atom));
             args.append(*createAttribute(sequenceAtom, getLocalSequenceNumber()));
             break;
         case no_once:
             args.append(*createAttribute(ownedAtom));
-            args.append(*createAttribute(_noReplicate_Atom));
             args.append(*createAttribute(sequenceAtom, getOnceSequenceNumber()));
             break;
         case no_global:
@@ -4791,13 +4788,11 @@ void GlobalAttributeInfo::doSplitGlobalDefinition(ITypeInfo * type, IHqlExpressi
             args.append(*createAttribute(sequenceAtom, getLocalSequenceNumber()));
             args.append(*createAttribute(ownedAtom));
             args.append(*createAttribute(jobTempAtom));
-            args.append(*createAttribute(_noReplicate_Atom));
             break;
         default:
             //global, independent, success, failure, etc. etc.
             args.append(*createAttribute(ownedAtom));
             args.append(*createAttribute(jobTempAtom));
-            args.append(*createAttribute(_noReplicate_Atom));
             args.append(*createAttribute(sequenceAtom, getLocalSequenceNumber()));
             break;
         }


### PR DESCRIPTION
There can be a large period of time between thor executing different
graphs in a workunit, e.g., if other high priority jobs take precedence.
This means it is more likely that a machine may have been swapped in
the meantime.  Therefore any file which has lifetime beyond a single
graph should be replicated - otherwise the entire job may need to be
rerun.

Fixes #1944.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
