### PR TITLE
Potential failure in overflow buffer code

### DIFF
--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -648,6 +648,7 @@ class COverflowableBuffer : public CSimpleInterface, implements IRowWriterMultiR
     Owned<IRowWriter> diskout;
     Owned<IFile> tmpfile;
     unsigned readersInUse;
+    SpinLock readerLock;
 
     void diskSwitch()
     {
@@ -707,6 +708,7 @@ public:
     }
     void readerStop()
     {
+        SpinBlock b(readerLock);
         --readersInUse;
     }
     void flush()
@@ -719,6 +721,7 @@ public:
     }
     IRowStream *getReader()
     {
+        SpinBlock b(readerLock);
         flush();
         class COverflowReader : public CSimpleInterface, implements IRowStream
         {


### PR DESCRIPTION
Some thread unsafeness in the overflow buffering code, could lead multiple
readers to cause the readersInUse count to go astray, and result in a
spurious assert later and/or other potential issues

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
