### PR TITLE
Fix gh-#2071 DFS exception when View Data File

### DIFF
--- a/common/fileview2/fvrelate.cpp
+++ b/common/fileview2/fvrelate.cpp
@@ -361,6 +361,20 @@ void ViewFileWeb::gatherWeb(const char * rootFilename, const ViewGatherOptions &
 }
 
 
+void ViewFileWeb::gatherWeb(const char * rootFilename, IDistributedFile * alreadyResolved, const ViewGatherOptions & options)
+{
+    ViewWalkOptions localOptions(options);
+    if (!localOptions.kind)
+        localOptions.kind = S_LINK_RELATIONSHIP_KIND;
+    localOptions.isExplicitFile = true;
+
+    if (!walkFile(rootFilename, alreadyResolved, localOptions))
+        throwError1(FVERR_CouldNotResolveX, rootFilename);
+
+    //MORE: Should possibly percolate relations between superfiles down to files they contain.
+}
+
+
 void ViewFileWeb::gatherWebFromPattern(const char * filenamePattern, const ViewGatherOptions & options)
 {
     ViewWalkOptions localOptions(options);

--- a/common/fileview2/fvrelate.cpp
+++ b/common/fileview2/fvrelate.cpp
@@ -349,15 +349,7 @@ void ViewFileWeb::gatherBrowseFiles(BrowseCreateInfo & info, ViewFile * file, CR
 
 void ViewFileWeb::gatherWeb(const char * rootFilename, const ViewGatherOptions & options)
 {
-    ViewWalkOptions localOptions(options);
-    if (!localOptions.kind)
-        localOptions.kind = S_LINK_RELATIONSHIP_KIND;
-    localOptions.isExplicitFile = true;
-
-    if (!walkFile(rootFilename, NULL, localOptions))
-        throwError1(FVERR_CouldNotResolveX, rootFilename);
-
-    //MORE: Should possibly percolate relations between superfiles down to files they contain.
+    gatherWeb(rootFilename, NULL, options);
 }
 
 

--- a/common/fileview2/fvrelate.hpp
+++ b/common/fileview2/fvrelate.hpp
@@ -102,6 +102,7 @@ interface IViewFileWeb : public IInterface
 {
 public:
     virtual void gatherWeb(const char * rootFilename, const ViewGatherOptions & options) = 0;
+    virtual void gatherWeb(const char * rootFilename, IDistributedFile * alreadyResolved, const ViewGatherOptions & options) = 0;
     virtual void gatherWebFromPattern(const char * pattern, const ViewGatherOptions & options) = 0;
     virtual IViewRelatedFile * queryFile(unsigned i) = 0;
     virtual IViewRelatedFileIterator * getFileIterator() = 0;

--- a/common/fileview2/fvrelate.ipp
+++ b/common/fileview2/fvrelate.ipp
@@ -197,6 +197,7 @@ public:
     IMPLEMENT_IINTERFACE
 
     virtual void gatherWeb(const char * rootFilename, const ViewGatherOptions & options);
+    virtual void gatherWeb(const char * rootFilename, IDistributedFile * alreadyResolved, const ViewGatherOptions & options);
     virtual void gatherWebFromPattern(const char * filenamePattern, const ViewGatherOptions & options);
     virtual IViewRelatedFileIterator * getFileIterator();
     virtual IViewRelatedFile * queryFile(unsigned i);


### PR DESCRIPTION
When ldap is turned on and a user trys to view a data file,
the DFS exception '3 Lookup access denied for scope' shows.
The exception is thrown by the ViewFileWeb object when it
does a file look-up. Since the data file has been resolved
by WsDFU service, WsDFU service should pass the solved file
point to ViewFileWeb object and the ViewFileWeb may use the
point without doing the file loop-up. This fix adds a
method to the ViewFileWeb class. The method allows the
solved file point being given to the ViewFileWeb.

I also revise the code in WsDFU service for better
functionalities.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
