### PR TITLE
Splitter in child query race

### DIFF
--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -295,7 +295,16 @@ public:
         grouped = false;
         eofHit = false;
         recsReady = 0;
-        inputsConfigured = false;
+        if (inputsConfigured)
+        {
+            // ensure old inputs cleared, to avoid being reused before re-setup on subsequent executions
+            ForEachItemIn(o, outputs)
+            {
+                CDelayedInput *delayedInput = (CDelayedInput *)outputs.item(o);
+                delayedInput->setInput(NULL);
+            }
+            inputsConfigured = false;
+        }
     }
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
     {


### PR DESCRIPTION
Small window, where a downstream activity might ask for meta info from
splitter output, before inputs have been reinitialized in reruns of a child
query.
Clear out old splitter input instances at end of query execute.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
