### PR TITLE
Delay reading files in the include directories

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -6277,7 +6277,7 @@ IHqlExpression * CHqlNamedSymbol::cloneSymbol(_ATOM optname, IHqlExpression * op
 
 IFileContents * CHqlNamedSymbol::getBodyContents()
 {
-    return createFileContentsSubset(text, bodypos, endpos-bodypos);
+    return createFileContentsSubset(text, bodypos, getEndPos()-bodypos);
 }
 
 IFileContents * CHqlNamedSymbol::queryDefinitionText() const

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -451,7 +451,12 @@ public:
     virtual int  getStartColumn() const { return startColumn; }
     virtual int getStartPos() const { return startpos; }
     virtual int getBodyPos() const { return bodypos; }
-    virtual int getEndPos() const { return endpos; }
+    virtual int getEndPos() const
+    {
+        if ((endpos == 0) && text)
+            return text->length();
+        return endpos;
+    }
 
 //interface IHqlNamedAnnotation
     virtual IFileContents * getBodyContents();

--- a/ecl/hql/hqlrepository.cpp
+++ b/ecl/hql/hqlrepository.cpp
@@ -363,7 +363,7 @@ IHqlExpression * CNewEclRepository::createSymbol(IHqlRemoteScope * rScope, IEclS
     default:
         throwUnexpected();
     }
-    return ::createSymbol(eclName, scope->queryName(), body.getClear(), NULL, true, true, symbolFlags, contents, 0, 0, 0, 0, contents ? contents->length() : 0);
+    return ::createSymbol(eclName, scope->queryName(), body.getClear(), NULL, true, true, symbolFlags, contents, 0, 0, 0, 0, 0);
 }
 
 


### PR DESCRIPTION
Improves the startup time for eclcc in non-legacy mode.
The call to contents->length() had the side-effect of loading the file
into memory (since it may need to convert formats etc.).  This fix
delays the call to length() until it is needed.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
