### PR TITLE
DFU report error if fail to create target directory

### DIFF
--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -812,7 +812,8 @@ processedProgress:
 
             StringBuffer localFilename;
             localTempFilename.getPath(localFilename);
-            recursiveCreateDirectoryForFile(localFilename);
+            if (!recursiveCreateDirectoryForFile(localFilename))
+                throw MakeOsException(GetLastError(), "Failed to create directory for file: %s", localFilename.str());
 
             OwnedIFile outFile = createIFile(localFilename.str());
             OwnedIFileIO outio = outFile->openShared(IFOcreate,IFSHnone);


### PR DESCRIPTION
If the target directory for a dfu copy couldn't be created this fix
now reports an error.  Previously you got an error from the subsequent
file create which was harder to diagnose.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
