### PR TITLE
makeAbsolutePath regression

### DIFF
--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -4927,7 +4927,7 @@ StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out, bool mustE
                 }
                 if (tail == relpath)
                     break; // bail out and guess
-                head.append(tail-relpath, relpath);
+                head.clear().append(tail-relpath, relpath);
                 path = head.str();
             }
         }


### PR DESCRIPTION
Previous change to makeAbsolutePath (not in any labelled release) was not
behaving correctly on paths that did not exist, due to a missing clear().
This would cause any path that had more than one trailing component that
did not exist to be expanded incorrectly.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
