### PR TITLE
gh-1988 - exit non-grouped existaggregate early

### DIFF
--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -182,11 +182,15 @@ public:
         {
             hadElement = true;
             sz = helper->processFirst(resultcr, next);
-            loop {
-                next.setown(input->ungroupedNextRow());
-                if (!next)
-                    break;
-                sz = helper->processNext(resultcr, next);
+            if (container.getKind() != TAKexistsaggregate)
+            {
+                while (!abortSoon)
+                {
+                    next.setown(input->ungroupedNextRow());
+                    if (!next)
+                        break;
+                    sz = helper->processNext(resultcr, next);
+                }
             }
         }
         doStopInput();

--- a/thorlcr/activities/aggregate/thgroupaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thgroupaggregateslave.cpp
@@ -22,7 +22,7 @@ class GroupAggregateSlaveActivity : public CSlaveActivity, public CThorDataLink
 {
 
 private:
-    bool eof;
+    bool eof, ungroupedExistsAggregate;
     IHThorAggregateArg * helper;
     IThorDataLink *input;
 
@@ -47,6 +47,7 @@ public:
         eof = false;
         input=inputs.item(0);
         startInput(input);
+        ungroupedExistsAggregate = (container.getKind() == TAKexistsaggregate) && !input->isGrouped();
         dataLinkStart("GROUPAGGREGATE", container.queryId());
     }
 
@@ -67,8 +68,8 @@ public:
         if (row)
         {
             sz = helper->processFirst(out, row);
-            bool abortEarly = (container.getKind() == TAKexistsaggregate) && !input->isGrouped();
-            if (!abortEarly)
+            // NB: if ungrouped existsAggregate, no need to look at rest of input
+            if (!ungroupedExistsAggregate)
             {
                 while (!abortSoon)
                 {

--- a/thorlcr/activities/aggregate/thgroupaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thgroupaggregateslave.cpp
@@ -48,8 +48,6 @@ public:
         input=inputs.item(0);
         startInput(input);
         dataLinkStart("GROUPAGGREGATE", container.queryId());
-        if (!input->isGrouped())
-            ActPrintLog("WARNING: non-grouped data as input to GroupAggregate");
     }
 
     void stop()
@@ -69,12 +67,16 @@ public:
         if (row)
         {
             sz = helper->processFirst(out, row);
-            loop
+            bool abortEarly = (container.getKind() == TAKexistsaggregate) && !input->isGrouped();
+            if (!abortEarly)
             {
-                row.setown(input->nextRow());
-                if (!row)
-                    break;
-                sz = helper->processNext(out, row);
+                while (!abortSoon)
+                {
+                    row.setown(input->nextRow());
+                    if (!row)
+                        break;
+                    sz = helper->processNext(out, row);
+                }
             }
             if (!input->isGrouped())
                 eof = true;


### PR DESCRIPTION
For a non-grouped TAKexistsaggregate, once the 1st record is read, there's
not need to read rest of input

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
