### PR TITLE
gh-2147 - eclcc regression reading plugins path

### DIFF
--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -456,7 +456,7 @@ void FileSystemEclCollection::processFilePath(IErrorReceiver * errs, const char 
         makeAbsolutePath(dirPath.str(), absolutePath);
         if (!containsFileWildcard(dirTail))
         {
-            absolutePath.append(dirTail);
+            addPathSepChar(absolutePath).append(dirTail);
             Owned<IFile> file = createIFile(absolutePath);
             if (file->isDirectory() == foundYes)
             {

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -4900,10 +4900,9 @@ StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out, bool mustE
     else
     {
         // no error, will attempt to resolve(realpath) as much of relpath as possible and append rest
-        const char *end = relpath+strlen(relpath);
-        if ('/' == *end) --end;
-        if (end != relpath)
+        if (strlen(relpath))
         {
+            const char *end = relpath+strlen(relpath);
             const char *path = relpath;
             const char *tail = end;
             StringBuffer head;
@@ -4914,7 +4913,7 @@ StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out, bool mustE
                     out.append(rPath);
                     if (tail != end)
                         out.append(tail);
-                    return out;
+                    return removeTrailingPathSepChar(out);
                 }
                 // mark next tail
                 loop
@@ -4936,11 +4935,12 @@ StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out, bool mustE
         else
         {
             appendCurrentDirectory(out, true);
-            addPathSepChar(out).append(relpath);
+            if (strlen(relpath))
+                addPathSepChar(out).append(relpath);
         }
     }
 #endif
-    return out;
+    return removeTrailingPathSepChar(out);
 }
 
 StringBuffer &makeAbsolutePath(StringBuffer &relpath,bool mustExist)

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -492,6 +492,20 @@ inline StringBuffer &addPathSepChar(StringBuffer &path,char sepchar=0)
     return path;
 }
 
+inline StringBuffer &removeTrailingPathSepChar(StringBuffer &path)
+{
+    if (path.length()>1 && isPathSepChar(path.charAt(path.length()-1)))
+    {
+#ifdef _WIN32
+    // In addition to not removing \ if it's the only char in the path, you should not remove it the path
+    // is of the form c:\
+        if (path.length()>3 || path.charAt(1) != ':')
+#endif
+            path.remove(path.length()-1, 1);
+    }
+    return path;
+}
+
 inline StringBuffer &addNonEmptyPathSepChar(StringBuffer &path,char sepchar=0)
 {
     size32_t len = path.length();


### PR DESCRIPTION
There are some inconsistencies in how makeAbsolutePath treats trailing pathsep
chars, which led to the refactoring of eclcc's file handling not always behaving
correctly.

For consistency with the realpath() function, makeAbsolutePath will now ALWAYS
return strings WITHOUT a trailing directory path.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
