### PR TITLE
Roxie dynamic files - DO NOT PULL

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -100,6 +100,7 @@ CActivityFactory::CActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFac
     helperFactory(_helperFactory),
     kind(_kind)
 {
+    variableFileName = _queryFactory.dynamicFileResolution();
     if (helperFactory)
     {
         Owned<IHThorArg> helper = helperFactory();
@@ -220,6 +221,11 @@ public:
             return queryContext.getClear();
         }
         return NULL;
+    }
+
+    virtual bool dynamicFileResolution() const
+    {
+        return variableFileName;
     }
 
 protected:
@@ -371,7 +377,7 @@ protected:
         lastPartNo.partNo = 0xffff;
         lastPartNo.fileNo = 0xffff;
         isOpt = false;
-        variableFileName = false;
+        variableFileName = _factory->dynamicFileResolution();
         meta.set(basehelper->queryOutputMeta());
     }
 
@@ -772,7 +778,7 @@ public:
         forceUnkeyed(_forceUnkeyed)
     {
         helper = (IHThorDiskReadBaseArg *) basehelper;
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName |= (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         isOpt = (helper->getFlags() & TDRoptional) != 0;
         diskSize.set(helper->queryDiskRecordSize());
         processed = 0;
@@ -916,7 +922,7 @@ public:
         : CSlaveActivityFactory(_graphNode, _subgraphId, _queryFactory, _helperFactory)
     {
         Owned<IHThorDiskReadBaseArg> helper = (IHThorDiskReadBaseArg *) helperFactory();
-        bool variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName |= (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (helper->getFlags() & TDRoptional) != 0;
@@ -3010,7 +3016,7 @@ public:
         m.setBuffer(indexLayoutSize, indexLayoutMeta.getdata());
         activityMeta.setown(deserializeRecordMeta(m, true));
         layoutTranslators.setown(new TranslatorArray);
-        bool variableFileName = (helper->getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName |= (helper->getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (helper->getFlags() & TIRoptional) != 0;
@@ -3164,7 +3170,7 @@ public:
         stepExtra(SSEFreadAhead, NULL)
     {
         indexHelper = (IHThorIndexReadBaseArg *) basehelper;
-        variableFileName = (indexHelper->getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName |= (indexHelper->getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
         isOpt = (indexHelper->getFlags() & TDRoptional) != 0;
         inputData = NULL;
         inputCount = 0;
@@ -4208,7 +4214,7 @@ public:
     {
         Owned<IHThorFetchBaseArg> helper = (IHThorFetchBaseArg *) helperFactory();
         IHThorFetchContext * fetchContext = static_cast<IHThorFetchContext *>(helper->selectInterface(TAIfetchcontext_1));
-        bool variableFileName = (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName |= (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (fetchContext->getFetchFlags() & FFdatafileoptional) != 0;
@@ -4256,7 +4262,7 @@ public:
         helper = (IHThorFetchBaseArg *) basehelper;
         fetchContext = static_cast<IHThorFetchContext *>(helper->selectInterface(TAIfetchcontext_1));
         base = 0;
-        variableFileName = (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName |= (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         isOpt = (fetchContext->getFetchFlags() & FFdatafileoptional) != 0;
         onCreate();
         inputData = (char *) serializedCreate.readDirect(0);
@@ -4595,7 +4601,7 @@ public:
         : factory(_aFactory), CRoxieKeyedActivity(_logctx, _packet, _hFactory, _aFactory)
     {
         helper = (IHThorKeyedJoinArg *) basehelper;
-        variableFileName = (helper->getJoinFlags() & (JFvarindexfilename|JFdynamicindexfilename)) != 0;
+        variableFileName |= (helper->getJoinFlags() & (JFvarindexfilename|JFdynamicindexfilename)) != 0;
         inputDone = 0;
         processed = 0;
         candidateCount = 0;
@@ -4900,7 +4906,7 @@ public:
     {
         Owned<IHThorKeyedJoinArg> helper = (IHThorKeyedJoinArg *) helperFactory();
         assertex(helper->diskAccessRequired());
-        bool variableFileName = (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName |= (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (helper->getFetchFlags() & FFdatafileoptional) != 0;
@@ -4954,7 +4960,7 @@ public:
         // MORE - no continuation row support?
         base = 0;
         helper = (IHThorKeyedJoinArg *) basehelper;
-        variableFileName = (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName |= (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         onCreate();
         inputData = (const char *) serializedCreate.readDirect(0);
         inputLimit = inputData + (serializedCreate.length() - serializedCreate.getPos());

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -326,9 +326,20 @@ public:
     {
         assertex(isConnected);
         Owned<IWorkUnitFactory> wuFactory = getWorkUnitFactory();
-        Owned<IWorkUnit> w = wuFactory->updateWorkUnit(wuid);
-        if (!w)
-            return NULL;
+        Owned<IWorkUnit> w;
+        StringAttr newWuid;
+        if (wuid && *wuid)
+        {
+            w.setown(wuFactory->updateWorkUnit(wuid));
+            if (!w)
+                return NULL;
+        }
+        else
+        {
+            w.setown(wuFactory->createWorkUnit(NULL, NULL, NULL));
+            w->getWuid(StringAttrAdaptor(newWuid));
+            wuid = newWuid.get();
+        }
         w->setAgentSession(myProcessSession());
         if (source)
         {

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -934,7 +934,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         delete [] primaries;
         setDaliServixSocketCaching(true);  // enable daliservix caching
         loadPlugins();
-        globalPackageSetManager = createRoxiePackageSetManager(standAloneDll.getClear());
+        globalPackageSetManager = createRoxiePackageSetManager(standAloneDll);
         globalPackageSetManager->load();
         unsigned snifferChannel = numChannels+2; // MORE - why +2 not +1 ??
         ROQ = createOutputQueueManager(snifferChannel, isCCD ? numSlaveThreads : 1);
@@ -949,7 +949,13 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         setSEHtoExceptionHandler(&abortHandler);
         if (runOnce)
         {
-            Owned <IRoxieListener> roxieServer = createRoxieSocketListener(0, 1, 0, false);
+            Owned <IRoxieListener> roxieServer;
+            if (fileNameServiceDali.length() == 0) // Local
+                roxieServer.setown(createRoxieSocketListener(0, 1, 0, false));
+            else // Dali
+            {
+                roxieServer.setown(createRoxieWorkUnitListener(1, false, standAloneDll->queryDll()));
+            }
             try
             {
                 const char *format = globals->queryProp("format");
@@ -966,7 +972,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                 }
                 StringBuffer query;
                 query.appendf("<roxie format='%s'/>", format);
-                roxieServer->runOnce(query.str()); // MORE - should use the wu listener instead I suspect
+                roxieServer->runOnce(query.str());
             }
             catch (IException *E)
             {
@@ -989,7 +995,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                 if (port)
                     roxieServer.setown(createRoxieSocketListener(port, numThreads, listenQueue, suspended));
                 else
-                    roxieServer.setown(createRoxieWorkUnitListener(numThreads, suspended));
+                    roxieServer.setown(createRoxieWorkUnitListener(numThreads, suspended, NULL));
                 Owned<IPropertyTreeIterator> accesses = serverInfo.getElements("Access");
                 ForEach(*accesses)
                 {

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -190,6 +190,7 @@ protected:
     unsigned priority;
     unsigned libraryInterfaceHash;
     hash64_t hashValue;
+    bool dynamicFiles;
 
     static SpinLock queriesCrit;
     static CopyMapXToMyClass<hash64_t, hash64_t, CQueryFactory> queryMap;
@@ -722,7 +723,7 @@ public:
     unsigned channelNo;
 
     CQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, unsigned _channelNo) 
-        : id(_id), package(_package), dll(_dll), channelNo(_channelNo), hashValue(_hashValue)
+        : id(_id), package(_package), dll(_dll), channelNo(_channelNo), hashValue(_hashValue), dynamicFiles(false)
     {
         package.Link();
         isSuspended = false;
@@ -1104,6 +1105,15 @@ protected:
         }
     }
 
+    virtual void setDynamicFileResolution(bool flag)
+    {
+        dynamicFiles = flag;
+    }
+
+    virtual bool dynamicFileResolution() const
+    {
+        return dynamicFiles;
+    }
 };
 
 CriticalSection CQueryFactory::queryCreateLock;

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -124,10 +124,15 @@ public:
         Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid, NULL);
         if (wu)
         {
-            SCMStringBuffer dllName;
+            SCMStringBuffer name;
             Owned<IConstWUQuery> q = wu->getQuery();
-            q->getQueryDllName(dllName);
-            return getQueryDll(dllName.str(), false);
+            q->getQueryDllName(name);
+            if (name.length() != 0)
+                return getQueryDll(name.str(), false);
+            q->getQueryCppName(name);
+            if (name.length() != 0)
+                return getQueryDll(name.str(), true);
+            assertex(0);
         }
         else
             return NULL;
@@ -723,7 +728,8 @@ public:
     unsigned channelNo;
 
     CQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, unsigned _channelNo) 
-        : id(_id), package(_package), dll(_dll), channelNo(_channelNo), hashValue(_hashValue), dynamicFiles(false)
+        : id(_id), package(_package), dll(_dll), channelNo(_channelNo), hashValue(_hashValue),
+          dynamicFiles(_dll!=NULL) // this is too broad
     {
         package.Link();
         isSuspended = false;
@@ -1093,6 +1099,16 @@ public:
         }
     }
 
+    virtual void setDynamicFileResolution(bool flag)
+    {
+        dynamicFiles = flag;
+    }
+
+    virtual bool dynamicFileResolution() const
+    {
+        return dynamicFiles;
+    }
+
 protected:
     void checkSuspended() const
     {
@@ -1103,16 +1119,6 @@ protected:
                 err.appendf(" because %s", errorMessage.str());
             throw MakeStringException(ROXIE_QUERY_SUSPENDED, "Query %s is suspended%s", id.get(), err.str());
         }
-    }
-
-    virtual void setDynamicFileResolution(bool flag)
-    {
-        dynamicFiles = flag;
-    }
-
-    virtual bool dynamicFileResolution() const
-    {
-        return dynamicFiles;
     }
 };
 

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -164,6 +164,7 @@ protected:
     UnsignedArray childQueryIndexes;
     CachedOutputMetaData meta;
     mutable StatsCollector mystats;
+    bool variableFileName;
 
 public:
     CActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -111,6 +111,9 @@ interface IQueryFactory : extends IInterface
     virtual void noteQuery(time_t startTime, bool failed, unsigned elapsed, unsigned memused, unsigned slavesReplyLen, unsigned bytesOut) = 0;
     virtual IPropertyTree *getQueryStats(time_t from, time_t to) = 0;
     virtual void getGraphNames(StringArray &ret) const = 0;
+
+    virtual void setDynamicFileResolution(bool flag) = 0; // resolve files on-demand
+    virtual bool dynamicFileResolution() const = 0; // resolve files on-demand
 };
 
 class ActivityArray : public CInterface

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -607,6 +607,10 @@ public:
         mystats.noteStatistic(statCode, value, count);
     }
 
+    virtual bool dynamicFileResolution() const
+    {
+        return variableFileName;
+    }
 };
 
 class CRoxieServerMultiInputInfo
@@ -874,6 +878,7 @@ protected:
     activityState state;
     bool createPending;
     bool debugging;
+    bool variableFileName;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -895,6 +900,7 @@ public:
         debugging = _probeManager != NULL; // Don't want to collect timing stats from debug sessions
         colocalParent = NULL;
         createPending = true;
+        variableFileName = _factory->dynamicFileResolution();
     }
     
     CRoxieServerActivity(const IRoxieServerActivityFactory *_factory, IProbeManager *_probeManager, IHThorArg &_helper)
@@ -19539,7 +19545,6 @@ protected:
     Owned<ISourceRowPrefetcher> prefetcher;
     bool eof;
     bool isKeyed;
-    bool variableFileName;
     bool isOpt;
     bool maySkip;
     bool isLocal;
@@ -19568,7 +19573,7 @@ public:
         isKeyed = false;
         stopAfter = I64C(0x7FFFFFFFFFFFFFFF);
         diskSize.set(helper.queryDiskRecordSize());
-        variableFileName = (helper.getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName |= (helper.getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         isOpt = (helper.getFlags() & TDRoptional) != 0;
     }
 
@@ -20563,7 +20568,6 @@ public:
     bool isLocal;
     bool sorted;
     bool maySkip;
-    bool variableFileName;
     Owned<IFilePartMap> map;
     Owned<IFileIOArray> files;
     Owned<IInMemoryIndexManager> manager;
@@ -20578,7 +20582,7 @@ public:
         isLocal = _graphNode.getPropBool("att[@name='local']/@value");
         Owned<IHThorDiskReadBaseArg> helper = (IHThorDiskReadBaseArg *) helperFactory();
         sorted = (helper->getFlags() & TDRunsorted) == 0;
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName |= (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         maySkip = (helper->getFlags() & (TDRkeyedlimitskips|TDRkeyedlimitcreates|TDRlimitskips|TDRlimitcreates)) != 0;
         quotes = separators = terminators = NULL;
         if (!variableFileName)
@@ -20659,7 +20663,6 @@ protected:
     CSkippableRemoteResultAdaptor remote;
     CIndexTransformCallback callback;
     bool sorted;
-    bool variableFileName;
     bool variableInfoPending;
     bool isOpt;
     bool isLocal;
@@ -20696,7 +20699,7 @@ public:
     {
         indexHelper.setCallback(&callback);
         steppedExtra = static_cast<IHThorSteppedSourceExtra *>(indexHelper.selectInterface(TAIsteppedsourceextra_1));
-        variableFileName = (indexHelper.getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName |= (indexHelper.getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
         variableInfoPending = false;
         isOpt = (indexHelper.getFlags() & TIRoptional) != 0;
         seekGEOffset = 0;
@@ -21271,7 +21274,6 @@ class CRoxieServerSimpleIndexReadActivity : public CRoxieServerActivity, impleme
     Owned<const IResolvedFile> varFileInfo;
     const RemoteActivityId &remoteId;
     bool firstRead;
-    bool variableFileName;
     bool variableInfoPending;
     bool isOpt;
     bool isLocal;
@@ -21338,7 +21340,7 @@ public:
         steppedExtra = static_cast<IHThorSteppedSourceExtra *>(indexHelper.selectInterface(TAIsteppedsourceextra_1));
         limitTransformExtra = static_cast<IHThorSourceLimitTransformExtra *>(indexHelper.selectInterface(TAIsourcelimittransformextra_1));
         unsigned flags = indexHelper.getFlags();
-        variableFileName = (flags & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName |= (flags & (TIRvarfilename|TIRdynamicfilename)) != 0;
         variableInfoPending = false;
         isOpt = (flags & TIRoptional) != 0;
         optimizeSteppedPostFilter = (flags & TIRunfilteredtransform) != 0;
@@ -21659,7 +21661,6 @@ public:
     bool isLocal;
     bool maySkip;
     bool sorted;
-    bool variableFileName;
     bool enableFieldTranslation;
     unsigned rawSize;
     unsigned maxSeekLookahead;
@@ -21683,7 +21684,7 @@ public:
         activityMeta.setown(deserializeRecordMeta(m, true));
         enableFieldTranslation = queryFactory.getEnableFieldTranslation();
         translatorArray.setown(new TranslatorArray);
-        variableFileName = (flags & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName |= (flags & (TIRvarfilename|TIRdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (flags & TIRoptional) != 0;
@@ -22587,15 +22588,13 @@ class CRoxieServerCountDiskActivityFactory : public CRoxieServerActivityFactory
 {
 public:
     unsigned __int64 answer;
-    bool variableFileName;
     Owned<const IResolvedFile> datafile;
 
     CRoxieServerCountDiskActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, IPropertyTree &_graphNode)
         : CRoxieServerActivityFactory(_id, _subgraphId, _queryFactory, _helperFactory, _kind)
     {
         Owned<IHThorCountFileArg> helper = (IHThorCountFileArg *) helperFactory();
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
-        assertex(helper->queryRecordSize()->isFixedSize());
+        variableFileName |= (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         if (!variableFileName)
         {
             unsigned recsize = helper->queryRecordSize()->getFixedSize();
@@ -22652,7 +22651,6 @@ class CRoxieServerFetchActivity : public CRoxieServerActivity, implements IRecor
     CRemoteResultAdaptor remote;
     RecordPullerThread puller;
     bool needsRHS;
-    bool variableFileName;
     bool isOpt;
     Owned<const IResolvedFile> varFileInfo;
 
@@ -22662,7 +22660,7 @@ public:
     {
         fetchContext = static_cast<IHThorFetchContext *>(helper.selectInterface(TAIfetchcontext_1));
         needsRHS = helper.transformNeedsRhs();
-        variableFileName = (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName |= (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         isOpt = (fetchContext->getFetchFlags() & FFdatafileoptional) != 0;
     }
 
@@ -22799,7 +22797,6 @@ class CRoxieServerFetchActivityFactory : public CRoxieServerActivityFactory
 {
     RemoteActivityId remoteId;
     Owned<IFilePartMap> map;
-    bool variableFileName;
     Owned<const IResolvedFile> datafile;
 public:
     CRoxieServerFetchActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, const RemoteActivityId &_remoteId, IPropertyTree &_graphNode)
@@ -22807,7 +22804,7 @@ public:
     {
         Owned<IHThorFetchBaseArg> helper = (IHThorFetchBaseArg *) helperFactory();
         IHThorFetchContext *fetchContext = static_cast<IHThorFetchContext *>(helper->selectInterface(TAIfetchcontext_1));
-        variableFileName = (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName |= (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         if (!variableFileName)
         {
             datafile.setown(_queryFactory.queryPackage().lookupFileName(fetchContext->getFileName(), (fetchContext->getFetchFlags() & FFdatafileoptional) != 0, true));
@@ -23987,7 +23984,7 @@ public:
           map(_map)
     {
         CRoxieServerKeyedJoinBase::setInput(0, head.queryOutput(0));
-        variableFetchFileName = (helper.getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFetchFileName = (helper.getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0 || variableFileName;
     }
     
     virtual const IResolvedFile *queryVarFileInfo() const
@@ -24354,8 +24351,8 @@ public:
         enableFieldTranslation = queryFactory.getEnableFieldTranslation();
         translatorArray.setown(new TranslatorArray);
         joinFlags = helper->getJoinFlags();
-        variableIndexFileName = (joinFlags & (JFvarindexfilename|JFdynamicindexfilename)) != 0;
-        variableFetchFileName = (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableIndexFileName = (joinFlags & (JFvarindexfilename|JFdynamicindexfilename)) != 0 || variableFileName;
+        variableFetchFileName = (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0 || variableFileName;
         if (!variableIndexFileName)
         {
             bool isOpt = (joinFlags & JFindexoptional) != 0;

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -30996,9 +30996,10 @@ private:
 
 class RoxieWorkUnitListener : public RoxieListener
 {
+    ILoadedDllEntry *dll;
 public:
-    RoxieWorkUnitListener(unsigned _poolSize, bool _suspended)
-      : RoxieListener(_poolSize, _suspended)
+    RoxieWorkUnitListener(unsigned _poolSize, bool _suspended, ILoadedDllEntry *_dll)
+      : RoxieListener(_poolSize, _suspended), dll(_dll)
     {
     }
 
@@ -31012,10 +31013,7 @@ public:
         return 0;
     }
 
-    virtual void runOnce(const char*)
-    {
-        UNIMPLEMENTED;
-    }
+    virtual void runOnce(const char* query);
 
     virtual void stopListening()
     {
@@ -31240,9 +31238,10 @@ protected:
 
 class RoxieWorkUnitWorker : public RoxieQueryWorker
 {
+    ILoadedDllEntry *dll;
 public:
-    RoxieWorkUnitWorker(RoxieListener *_pool)
-        : RoxieQueryWorker(_pool)
+    RoxieWorkUnitWorker(RoxieListener *_pool, ILoadedDllEntry *_dll)
+        : RoxieQueryWorker(_pool), dll(_dll)
     {
     }
 
@@ -31252,12 +31251,19 @@ public:
         RoxieQueryWorker::init(_r);
     }
 
+    virtual void runOnce(const char *query)
+    {
+        main();
+    }
+
     virtual void main()
     {
         Owned <IRoxieDaliHelper> daliHelper = connectToDali();
-        Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid.get(), NULL);
+        Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid.get(), dll);
         if (!wu)
             throw MakeStringException(ROXIE_DALI_ERROR, "Failed to open workunit %s", wuid.get());
+        if (!wuid.get())
+            wu->getWuid(StringAttrAdaptor(wuid));
         Owned<IQueryFactory> queryFactory = createServerQueryFactoryFromWu(wuid.get());
         // All WorkUnits should use dynamic file resolution
         queryFactory->setDynamicFileResolution(true);
@@ -31991,7 +31997,7 @@ IArrayOf<IRoxieListener> socketListeners;
 
 IPooledThread *RoxieWorkUnitListener::createNew()
 {
-    return new RoxieWorkUnitWorker(this);
+    return new RoxieWorkUnitWorker(this, NULL);
 }
 
 IPooledThread *RoxieSocketListener::createNew()
@@ -32005,6 +32011,12 @@ void RoxieSocketListener::runOnce(const char *query)
     p->runOnce(query);
 }
 
+void RoxieWorkUnitListener::runOnce(const char* query)
+{
+    Owned<RoxieWorkUnitWorker> p = new RoxieWorkUnitWorker(this, dll);
+    p->runOnce(query);
+}
+
 IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended)
 {
     if (traceLevel)
@@ -32012,11 +32024,11 @@ IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsi
     return new RoxieSocketListener(port, poolSize, listenQueue, suspended);
 }
 
-IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended)
+IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended, ILoadedDllEntry *dll)
 {
     if (traceLevel)
         DBGLOG("Creating Roxie workunit listener, pool size %d%s", poolSize, suspended?" SUSPENDED":"");
-    return new RoxieWorkUnitListener(poolSize, suspended);
+    return new RoxieWorkUnitListener(poolSize, suspended, dll);
 }
 
 bool suspendRoxieListener(unsigned port, bool suspended)

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -31262,6 +31262,8 @@ public:
         if (!wu)
             throw MakeStringException(ROXIE_DALI_ERROR, "Failed to open workunit %s", wuid.get());
         Owned<IQueryFactory> queryFactory = createServerQueryFactoryFromWu(wuid.get());
+        // All WorkUnits should use dynamic file resolution
+        queryFactory->setDynamicFileResolution(true);
         Owned<StringContextLogger> logctx = new StringContextLogger(wuid.get());
         doMain(wu, queryFactory, *logctx);
         sendUnloadMessage(queryFactory->queryHash(), wuid.get(), *logctx);

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -299,6 +299,7 @@ interface IRoxieServerActivityFactory : extends IActivityFactory
     virtual IRoxieServerSideCache *queryServerSideCache() const = 0;
     virtual IDefRecordMeta *queryActivityMeta() const = 0;
     virtual void noteStatistic(unsigned statCode, unsigned __int64 value, unsigned count) const = 0;
+    virtual bool dynamicFileResolution() const = 0;
 };
 interface IGraphResult : public IInterface
 {

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -75,7 +75,7 @@ interface IRoxieServerQueryPacket : public IInterface, public ILRUChain
 };
 
 IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended);
-IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended);
+IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended, ILoadedDllEntry *dll);
 bool suspendRoxieListener(unsigned port, bool suspended);
 extern IArrayOf<IRoxieListener> socketListeners;
 


### PR DESCRIPTION
This pull request will completely break Roxie, but I need some serious code review.

The main points are:
1. Adding a dynamic flag resolution to QueryFactory. Done this way (instead of in RoxiePackage, as originally intented), because all access to the flag was done via queryF->RoxieP, ie. to avoid more indirections. I don't mind either way, if anyone think it's better to be in RoxiePackage, I can easily change that.
2. Common `variableFileName` in all activities to be set first by the dynamicResolution flag in the factories (on Base-most concrete class), and then by specific activity helpers' flags (such as `TDXdynamicfilename`). Factories' flag is set by QueryFactory's flag on Base-most concrete class's constructor as well.
3. Setting the flag allows Roxie to resolve files dynamically as it would when `#option ('allowVariableRoxieFilenames', 1);` is set.

The main problems:
1. `attachWorkUnit` has been changed to also create if there was none. This should be split into two different methods, maybe.
2. `getWorkUnitDll` should know the difference between shared objects and executables, either by receiving this information or by inspecting the workunit (a new flag apart from @dll?)
3. Due to `CQueryFactory` constructor being called from numerous places, I've hacked in a dll check to make it dynamic, but this is wrong. I need to find out which places should have the flag set via the public method `setDynamicFileResolution()`.

The main good things:
1. Now, `runOnce` can use both SocketListener and WorkunitListener, so we can limit the dynamic flag to workunits only (though this has not been done yet).
2. The dynamic resolution logic in activities and factories is consistent and very central, and the changes are minor in that area, so should not affect current behaviour much.

What I want to know?
1. This is a big change (for a first-timer in Roxie), so I need to make sure I'm on the right path before I consolidate more changes in that direction.
2. Not just general guidelines, but comments on architectural style would be welcomed.

This is the example I'm trying to run (the OVERWRITE makes it fail in Roxie):

```
filename := 'regress::roxie::fileaccess';
rec := record
    string line;
end;
raw := dataset([{'foo'},{'bar'},{'baz'}], rec);
output(raw,,filename,CSV,OVERWRITE);
ds := dataset(filename, rec, CSV);
output(ds);

$ eclcc static.ecl
$ ./static DALISERVERS=localhost
```

This works with current patches.
