### PR TITLE
Fix gh-#2065 Replace 'SMC' in ECLWatch/ConfigMgr UI

### DIFF
--- a/deployment/envgen/main.cpp
+++ b/deployment/envgen/main.cpp
@@ -102,7 +102,7 @@ void usage()
   puts("          directory and to set eclwatch's enableSystemUseRewrite to true, the following options");
   puts("          can be provided.");
   puts("          \"-override DropZone,@directory,/mnt/disk1/mydropzone ");
-  puts("          -override espsmc,@enableSystemUseRewrite,true\"");
+  puts("          -override eclwatch,@enableSystemUseRewrite,true\"");
   puts("   -help: print out this usage.");
 }
 

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -73,7 +73,7 @@ public:
             return false;
         if (optQuerySetName.isEmpty())
         {
-            fprintf(stdout, "\n ... Missing package name\n\n");
+            fprintf(stdout, "\n ... Missing query set name\n\n");
             usage();
             return false;
         }
@@ -128,6 +128,8 @@ public:
                 optQuerySetName.set(arg);
                 break;
             }
+            if (iter.matchOption(optPackageMap, ECLOPT_PACKAGEMAP))
+                continue;
             switch (EclCmdCommon::matchCommandLineOption(iter))
             {
                 case EclCmdOptionNoMatch:
@@ -147,7 +149,7 @@ public:
             return false;
         if (optQuerySetName.isEmpty())
         {
-            fprintf(stdout, "\n ... Missing package name\n\n");
+            fprintf(stdout, "\n ... Missing query set name\n\n");
             usage();
             return false;
         }

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1471,7 +1471,7 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
     if (optDebugMemLeak)
     {
         StringBuffer title;
-        title.append(inputFiles.item(0).queryFilename()).newline();
+        title.append(inputFileNames.item(0)).newline();
         initLeakCheck(title);
     }
 

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1691,25 +1691,56 @@ extern HQL_API unsigned queryCurrentTransformDepth();                   // debug
 extern HQL_API bool isExternalFunction(IHqlExpression * funcdef);
 
 typedef enum { 
-    childdataset_none,
-    childdataset_dataset_noscope, // single dataset but this operation doesn't use any fields from it.
-    childdataset_dataset,  // single dataset, fields are referenced by <dataset>.field
-    childdataset_datasetleft,  // single dataset, fields are referenced by <dataset>|LEFT.field
-    childdataset_left,  // single dataset, fields are referenced by LEFT.field
-    childdataset_leftright,   // two datasets, fields are referenced by LEFT|RIGHT.field
-    childdataset_same_left_right,  // single dataset, fields are referenced by LEFT|RIGHT.field
-    childdataset_top_left_right,  // single dataset, fields are referenced by <dataset>|LEFT|RIGHT.field
-    childdataset_many_noscope, // multiple input files, no reference to any fields.
-    childdataset_many,  // multiple input files, fields reference by <active>.field
-    childdataset_nway_left_right, // set of files for first parameter, fields accessed via LEFT and RIGHT
+    //Flags to indicate which datasets are available in scope
+    childdataset_hasnone    = 0x0000,   // dataset->queryNormalizedSelector()
+    childdataset_hasdataset = 0x0001,   // dataset->queryNormalizedSelector()
+    childdataset_hasleft    = 0x0002,   // no_left
+    childdataset_hasright   = 0x0004,   // no_right
+    childdataset_hasactive  = 0x0008,   // no_activetable
+    childdataset_hasevaluate= 0x0010,   // weird!
+
+    //Flags that indicate the number/type of the dataset parameters to the operator
+    childdataset_dsmask     = 0xFF00,
+    childdataset_dsnone     = 0x0000,   // No datasets
+    childdataset_ds         = 0x0100,   // A single dataset
+    childdataset_dsds       = 0x0200,   // two datasets
+    childdataset_dschild    = 0x0300,   // a dataset with second dependent on the first (normalize)
+    childdataset_dsmany     = 0x0400,   // many datasetes
+    childdataset_dsset      = 0x0500,   // [set-of-datasets]
+    childdataset_dsif       = 0x0600,   // IF(<cond>, ds, ds)
+    childdataset_dscase     = 0x0700,   // CASE
+    childdataset_dsmap      = 0x0800,   // MAP
+
+    //Combinations of the two sets of flags above for the cases which are currently used.
+    childdataset_none               = childdataset_dsnone|childdataset_hasnone,
+    childdataset_dataset_noscope    = childdataset_ds|childdataset_none,
+    childdataset_dataset            = childdataset_ds|childdataset_hasdataset,
+    childdataset_datasetleft        = childdataset_ds|childdataset_hasdataset|childdataset_hasleft,
+    childdataset_left               = childdataset_ds|childdataset_hasleft,
+    childdataset_leftright          = childdataset_dsds|childdataset_hasleft|childdataset_hasright,
+    childdataset_same_left_right    = childdataset_ds|childdataset_hasleft|childdataset_hasright,
+    childdataset_top_left_right     = childdataset_ds|childdataset_hasdataset|childdataset_hasleft|childdataset_hasright,
+    childdataset_many_noscope       = childdataset_dsmany|childdataset_none,
+    childdataset_many               = childdataset_dsmany|childdataset_hasactive,
+    childdataset_nway_left_right    = childdataset_dsset|childdataset_hasleft|childdataset_hasright,
+
     //weird exceptions
-    childdataset_evaluate, // EVALUATE
-    childdataset_if, // IF - second and third are datasets
-    childdataset_case, // CASE
-    childdataset_map, // MAP
+    childdataset_evaluate           = childdataset_ds|childdataset_hasevaluate,
+    childdataset_if                 = childdataset_dsif|childdataset_none,
+    childdataset_case               = childdataset_dscase|childdataset_none,
+    childdataset_map                = childdataset_dsmap|childdataset_none,
     childdataset_max
 } childDatasetType;
 extern HQL_API childDatasetType getChildDatasetType(IHqlExpression * expr);
+inline bool hasLeft(childDatasetType value) { return (value & childdataset_hasleft) != 0; }
+inline bool hasRight(childDatasetType value) { return (value & childdataset_hasright) != 0; }
+inline bool hasLeftRight(childDatasetType value) { return (value & (childdataset_hasleft|childdataset_hasright)) == (childdataset_hasleft|childdataset_hasright); }
+inline bool hasSameLeftRight(childDatasetType value)
+{
+    return hasLeftRight(value) &&
+        (((value & childdataset_dsmask) == childdataset_ds) ||
+         ((value & childdataset_dsmask) == childdataset_dsset));
+}
 
 // To improve error message.
 extern HQL_API StringBuffer& getFriendlyTypeStr(IHqlExpression* e, StringBuffer& s);

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -551,7 +551,10 @@ bool EspHttpBinding::basicAuth(IEspContext* ctx)
     bool authenticated = m_secmgr->authorize(*user, rlist);
     if(!authenticated)
     {
-        ctx->AuditMessage(AUDIT_TYPE_ACCESS_FAILURE, "Authentication", "Access Denied: User or password invalid", NULL);
+        if (user->getAuthenticateStatus() == AS_PASSWORD_EXPIRED)
+            ctx->AuditMessage(AUDIT_TYPE_ACCESS_FAILURE, "Authentication", "ESP password is expired", NULL);
+        else
+            ctx->AuditMessage(AUDIT_TYPE_ACCESS_FAILURE, "Authentication", "Access Denied: User or password invalid", NULL);
         return false;
     }
     bool authorized = true;

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -450,7 +450,6 @@ int CEspHttpServer::processRequest()
                     if(realmbuf.length() == 0)
                         realmbuf.append("ESP");
                     m_response->sendBasicChallenge(realmbuf.str(), !isSoapPost);
-                    break;
                 }
                 return 0;
             }

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -649,7 +649,7 @@ bool Cws_accessEx::onAddUser(IEspContext &context, IEspAddUserRequest &req, IEsp
             resp.setRetmsg("username can't be empty");
             return false;
         }
-        if(strchr(username, (int)' '))
+        if(strchr(username, ' '))
         {
             resp.setRetcode(-1);
             resp.setRetmsg("Username can't contain spaces");

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -141,7 +141,9 @@ void Cws_accessEx::init(IPropertyTree *cfg, const char *process, const char *ser
             else
                 head.append(colon - bptr, bptr);
 
-            if(stricmp(head.str(), "WsAttributesAccess") == 0)
+            if(strieq(head.str(), "SMC"))
+                head.clear().append("Management Console");
+            else if(stricmp(head.str(), "WsAttributesAccess") == 0)
                 continue;
 
             Owned<IEspDnStruct> onedn = createDnStruct();

--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -189,7 +189,7 @@ bool Cws_accountEx::onVerifyUser(IEspContext &context, IEspVerifyUserRequest &re
     try
     {
         ISecUser* usr = context.queryUser();
-        if(!usr || !usr->isAuthenticated())
+        if(!usr || usr->getAuthenticateStatus() != AS_AUTHENTICATED)
         {
             resp.setRetcode(-1);
             return false;

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -30,7 +30,7 @@
 #include "dfuwu.hpp"
 #include "exception_util.hpp"
 
-static const char* FEATURE_URL = "SmcAccess";
+static const char* FEATURE_URL = "BaseAccess";
 const char* THORQUEUE_FEATURE = "ThorQueueAccess";
 
 const char* PERMISSIONS_FILENAME = "espsmc_permissions.xml";

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -26,7 +26,7 @@ xmlns:seisint="http://seisint.com"  xmlns:set="http://exslt.org/sets" exclude-re
     <xsl:param name="instance" select="'rmoondhra'"/>
     <xsl:param name="outputFilePath" select="'c:\development\deployment\xmlenv\dummy.xml'"/>
     <xsl:param name="isLinuxInstance" select="0"/>    
-    <xsl:param name="espServiceName" select="'espsmc'"/>
+    <xsl:param name="espServiceName" select="'eclwatch'"/>
 
     <xsl:template match="text()"/>
 

--- a/initfiles/componentfiles/configxml/buildsetCC.xml.in
+++ b/initfiles/componentfiles/configxml/buildsetCC.xml.in
@@ -93,7 +93,7 @@
              schema="esp.xsd"/>
    <BuildSet deployable="no"
              installSet="deploy_map.xml"
-             name="espsmc"
+             name="eclwatch"
              path="componentfiles/espsmc"
              processName="EspService"
              schema="espsmcservice.xsd">
@@ -102,13 +102,13 @@
                 defaultSecurePort="18010"
                 type="WsSMC">
      <Authenticate access="Read"
-                   description="Root access to SMC service"
+                   description="Base access to ESP services"
                    path="/"
                    required="Read"
-                   resource="SmcAccess"/>
-     <AuthenticateFeature description="Access to SMC service"
-                          path="SmcAccess"
-                          resource="SmcAccess"
+                   resource="BaseAccess"/>
+     <AuthenticateFeature description="Base access to ESP services"
+                          path="BaseAccess"
+                          resource="BaseAccess"
                           service="ws_smc"/>
      <AuthenticateFeature description="Access to thor queues"
                           path="ThorQueueAccess"

--- a/initfiles/componentfiles/configxml/cgencomplist_linux.xml
+++ b/initfiles/componentfiles/configxml/cgencomplist_linux.xml
@@ -84,7 +84,7 @@
   <Component name="espjavelinapiau" processName='EspService' schema='espjavelinapi.xsd' deployable='no'>
     <File name="@temp/esp_service_javelinapiau.xsl" method="esp_service_module"/>
   </Component>
-  <Component name="espsmc" processName='EspService' schema='espsmcservice.xsd' deployable='no'>
+  <Component name="eclwatch" processName='EspService' schema='espsmcservice.xsd' deployable='no'>
     <File name="plugins.xsl" method="esp_plugin" destName="plugins.xml" destPath="@temp"/>
     <File name="@temp/esp_service_WsSMC.xsl" method="esp_service_module"/>
   </Component>

--- a/initfiles/componentfiles/configxml/cgencomplist_win.xml
+++ b/initfiles/componentfiles/configxml/cgencomplist_win.xml
@@ -87,7 +87,7 @@
   <Component name="espjavelinapiau" processName='EspService' schema='espjavelinapi.xsd' deployable='no'>
     <File name="@temp\esp_service_javelinapiau.xsl" method="esp_service_module"/>
   </Component>
-  <Component name="espsmc" processName='EspService' schema='espsmcservice.xsd' deployable='no'>
+  <Component name="eclwatch" processName='EspService' schema='espsmcservice.xsd' deployable='no'>
     <File name="plugins.xsl" method="esp_plugin" destName="plugins.xml" destPath="@temp"/>
     <File name="@temp\esp_service_WsSMC.xsl" method="esp_service_module"/>
   </Component>

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd
@@ -39,7 +39,7 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="name" type="xs:string" use="optional" default="espsmc">
+            <xs:attribute name="name" type="xs:string" use="optional" default="eclwatch">
                 <xs:annotation>
                     <xs:appinfo>
                         <required>true</required>

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -39,7 +39,7 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="name" type="xs:string" use="optional" default="espsmc">
+            <xs:attribute name="name" type="xs:string" use="optional" default="eclwatch">
                 <xs:annotation>
                     <xs:appinfo>
                         <required>true</required>
@@ -49,7 +49,7 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="description" type="xs:string" use="optional" default="ESP services for SMC">
+            <xs:attribute name="description" type="xs:string" use="optional" default="ESP services for Management Console">
                 <xs:annotation>
                     <xs:appinfo>
                         <tooltip>Description for this process</tooltip>

--- a/initfiles/componentfiles/thor/stop_thor
+++ b/initfiles/componentfiles/thor/stop_thor
@@ -44,7 +44,7 @@ if [ "$#" -lt "2" ] || [ "$2" != "keep_sentinel" ]; then
     sleep 1
 fi
 
-masterproc="thormaster_$THORNAME"
+masterproc="$instancedir/thormaster_$THORNAME"
 while [ "`${PIDOF} $masterproc`" != "" ]
 do
   echo --------------------------
@@ -58,7 +58,7 @@ done
 echo --------------------------
 echo stopping thor slaves 
 
-slaveproc="thorslave_$THORNAME"
+slaveproc="$instancedir/thorslave_$THORNAME"
 if [ "$localthor" = "true" ]; then
     killall -9 $slaveproc
 else

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -86,7 +86,7 @@
              schema="esp.xsd"/>
    <BuildSet deployable="no"
              installSet="deploy_map.xml"
-             name="espsmc"
+             name="eclwatch"
              path="componentfiles/espsmc"
              processName="EspService"
              schema="espsmcservice.xsd">
@@ -95,13 +95,13 @@
                 defaultSecurePort="18010"
                 type="WsSMC">
      <Authenticate access="Read"
-                   description="Root access to SMC service"
+                   description="Base access to ESP services"
                    path="/"
                    required="Read"
-                   resource="SmcAccess"/>
-     <AuthenticateFeature description="Access to SMC service"
-                          path="SmcAccess"
-                          resource="SmcAccess"
+                   resource="BaseAccess"/>
+     <AuthenticateFeature description="Base access to ESP services"
+                          path="BaseAccess"
+                          resource="BaseAccess"
                           service="ws_smc"/>
      <AuthenticateFeature description="Access to thor queues"
                           path="ThorQueueAccess"
@@ -491,7 +491,7 @@
                    method="none"/>
    <EspBinding defaultForPort="true"
                defaultServiceVersion=""
-               name="smc"
+               name="eclwatch"
                port="8010"
                protocol="http"
                resourcesBasedn="ou=SMC,ou=EspServices,ou=ecl"
@@ -499,14 +499,14 @@
                workunitsBasedn="ou=workunits,ou=ecl"
                wsdlServiceAddress="">
     <Authenticate access="Read"
-                  description="Root access to SMC service"
+                  description="Base access to ESP services"
                   path="/"
                   required="Read"
-                  resource="SmcAccess"/>
+                  resource="BaseAccess"/>
     <AuthenticateFeature authenticate="Yes"
-                         description="Access to SMC service"
-                         path="SmcAccess"
-                         resource="SmcAccess"
+                         description="Base access to ESP services"
+                         path="BaseAccess"
+                         resource="BaseAccess"
                          service="ws_smc"/>
     <AuthenticateFeature authenticate="Yes"
                          description="Access to thor queues"
@@ -668,8 +668,8 @@
   <EspService allowNewRoxieOnDemandQuery="false"
               AWUsCacheTimeout="15"
               build="${projname}_${version}-${stagever}"
-              buildSet="espsmc"
-              description="ESP services for SMC"
+              buildSet="eclwatch"
+              description="ESP services for Management Console"
               disableUppercaseTranslation="false"
               enableSystemUseRewrite="false"
               excludePartitions="/,/dev*,/sys,/usr,/proc/*"
@@ -687,13 +687,13 @@
                defaultSecurePort="18010"
                type="WsSMC">
     <Authenticate access="Read"
-                  description="Root access to SMC service"
+                  description="Base access to ESP services"
                   path="/"
                   required="Read"
-                  resource="SmcAccess"/>
-    <AuthenticateFeature description="Access to SMC service"
-                         path="SmcAccess"
-                         resource="SmcAccess"
+                  resource="BaseAccess"/>
+    <AuthenticateFeature description="Base access to ESP services"
+                         path="BaseAccess"
+                         resource="BaseAccess"
                          service="ws_smc"/>
     <AuthenticateFeature description="Access to thor queues"
                          path="ThorQueueAccess"

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -29,9 +29,9 @@
  *     CLdapSecUser                                       *
  **********************************************************/
 CLdapSecUser::CLdapSecUser(const char *name, const char *pw) : 
-    m_pw(pw), m_isAuthenticated(false)
+    m_pw(pw), m_authenticateStatus(AS_UNKNOWN)
 {
-    setName(name);  
+    setName(name);
 }
 
 CLdapSecUser::~CLdapSecUser()
@@ -39,10 +39,6 @@ CLdapSecUser::~CLdapSecUser()
 }
 
 //non-interfaced functions
-void CLdapSecUser::setAuthenticated(bool authenticated)
-{
-    m_isAuthenticated = authenticated;
-}
 void CLdapSecUser::setUserID(unsigned userid)
 {
     m_userid = userid;
@@ -156,12 +152,6 @@ bool CLdapSecUser::setPeer(const char *Peer)
 }
 
 
-bool CLdapSecUser::isAuthenticated()
-{
-    return m_isAuthenticated;
-}
-
-
 ISecCredentials & CLdapSecUser::credentials()
 {
     return *this;
@@ -201,7 +191,7 @@ void CLdapSecUser::copyTo(ISecUser& destination)
     if(!dest)
         return;
 
-    dest->setAuthenticated(isAuthenticated());
+    dest->setAuthenticateStatus(getAuthenticateStatus());
     dest->setName(getName());
     dest->setFullName(getFullName());
     dest->setFirstName(getFirstName());
@@ -585,12 +575,12 @@ bool CLdapSecManager::authenticate(ISecUser* user)
     if(!user)
         return false;
 
-    if(user->isAuthenticated())
+    if(user->getAuthenticateStatus() == AS_AUTHENTICATED)
         return true;
 
     if(m_permissionsCache.isCacheEnabled() && !m_usercache_off && m_permissionsCache.lookup(*user))
     {
-        user->setAuthenticated(true);
+        user->setAuthenticateStatus(AS_AUTHENTICATED);
         return true;
     }
 
@@ -600,7 +590,7 @@ bool CLdapSecManager::authenticate(ISecUser* user)
         if(m_permissionsCache.isCacheEnabled() && !m_usercache_off)
             m_permissionsCache.add(*user);
 
-        user->setAuthenticated(true);
+        user->setAuthenticateStatus(AS_AUTHENTICATED);
     }
 
     return ok;

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -45,7 +45,7 @@ private:
     StringAttr   m_pw;
     StringAttr   m_Fqdn;
     StringAttr   m_Peer;
-    bool         m_isAuthenticated;
+    authStatus   m_authenticateStatus;
     CDateTime    m_passwordExpiration;//local time
     unsigned     m_userid;
     MemoryBuffer m_usersid;
@@ -70,7 +70,6 @@ public:
     virtual ~CLdapSecUser();
 
 //non-interfaced functions
-    virtual void setAuthenticated(bool authenticated);
     void setUserID(unsigned userid);
     void setUserSid(int sidlen, const char* sid);
     MemoryBuffer& getUserSid();
@@ -85,7 +84,6 @@ public:
     virtual bool setLastName(const char * lname);
     const char * getRealm();
     bool setRealm(const char * name);
-    bool isAuthenticated();
     ISecCredentials & credentials();
     virtual unsigned getUserID();
     virtual void copyTo(ISecUser& source);
@@ -130,6 +128,9 @@ public:
        }
        return numDays;
    }
+
+   authStatus getAuthenticateStatus()           { return m_authenticateStatus; }
+   void setAuthenticateStatus(authStatus status){ m_authenticateStatus = status; }
 
    ISecUser * clone();
     virtual void setProperty(const char* name, const char* value){}

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -32,7 +32,7 @@ private:
     StringBuffer    m_name;
     StringBuffer    m_pw;
     StringBuffer    m_encodedPw;
-    bool            m_isAuthenticated;
+    authStatus      m_authenticateStatus;
     StringBuffer    m_fullname;
     StringBuffer    m_firstname;
     StringBuffer    m_lastname;
@@ -47,17 +47,12 @@ public:
     IMPLEMENT_IINTERFACE
 
     CSecureUser(const char *name, const char *pw) : 
-        m_name(name), m_pw(pw), m_isAuthenticated(false),m_userID(0), m_status(SecUserStatus_Unknown)
+        m_name(name), m_pw(pw), m_authenticateStatus(AS_UNKNOWN), m_userID(0), m_status(SecUserStatus_Unknown)
     {
     }
 
     virtual ~CSecureUser()
     {
-    }
-
-    virtual void setAuthenticated(bool authenticated)
-    {
-        m_isAuthenticated = authenticated;
     }
 
 //interface ISecUser
@@ -148,11 +143,6 @@ public:
         return true;
     }
 
-    bool isAuthenticated()
-    {
-        return m_isAuthenticated;
-    }
-
     ISecCredentials & credentials()
     {
         return *this;
@@ -212,10 +202,12 @@ public:
     virtual CDateTime & getPasswordExpiration(CDateTime& expirationDate){ assertex(false); return expirationDate; }
     virtual bool setPasswordExpiration(CDateTime& expirationDate) { assertex(false);return true; }
     virtual int getPasswordDaysRemaining() {assertex(false);return -1;}
+    virtual authStatus getAuthenticateStatus() {return m_authenticateStatus;}
+    virtual void setAuthenticateStatus(authStatus status){m_authenticateStatus = status;}
 
     virtual void copyTo(ISecUser& destination)
     {
-        destination.setAuthenticated(isAuthenticated());
+        destination.setAuthenticateStatus(getAuthenticateStatus());
         destination.setName(getName());
         destination.setFullName(getFullName());
         destination.setFirstName(getFirstName());
@@ -227,7 +219,6 @@ public:
         CDateTime tmpTime;
         destination.setPasswordExpiration(getPasswordExpiration(tmpTime));
         destination.setStatus(getStatus());
-
         if(m_parameters.get()==NULL)
             return;
         CriticalBlock b(crit);

--- a/system/security/shared/basesecurity.cpp
+++ b/system/security/shared/basesecurity.cpp
@@ -138,7 +138,7 @@ bool CBaseSecurityManager::unsubscribe(ISecAuthenticEvents & events)
 
 bool CBaseSecurityManager::authorize(ISecUser & sec_user, ISecResourceList * Resources)
 {   
-    if(!sec_user.isAuthenticated())
+    if(sec_user.getAuthenticateStatus() != AS_AUTHENTICATED)
     {
         bool bOk = ValidateUser(sec_user);
         if(bOk == false)
@@ -389,7 +389,7 @@ bool CBaseSecurityManager::ValidateUser(ISecUser & sec_user)
             {
                 //we seem to be coming from a different peer... this is not good
                 WARNLOG("Found user %d in cache, but have to re-validate IP, because it was coming from %s but is now coming from %s",sec_user.getUserID(), cachedclientip, clientip.str());
-                sec_user.setAuthenticated(false);
+                sec_user.setAuthenticateStatus(AS_INVALID_CREDENTIALS);
                 sec_user.setPeer(clientip.str());
                 m_permissionsCache.removeFromUserCache(sec_user);
                 bReturn =  false;
@@ -411,7 +411,7 @@ bool CBaseSecurityManager::ValidateUser(ISecUser & sec_user)
 
         if(bReturn)
         {
-            sec_user.setAuthenticated(true);
+            sec_user.setAuthenticateStatus(AS_AUTHENTICATED);
             return true;
         }
     }
@@ -428,13 +428,13 @@ bool CBaseSecurityManager::ValidateUser(ISecUser & sec_user)
             if(ValidateSourceIP(sec_user,m_safeIPList)==false)
             {
                 ERRLOG("IP check failed for user:%s coming from %s",sec_user.getName(),sec_user.getPeer());
-                sec_user.setAuthenticated(false);
+                sec_user.setAuthenticateStatus(AS_INVALID_CREDENTIALS);
                 return false;
             }
         }
         if(m_permissionsCache.isCacheEnabled())
             m_permissionsCache.add(sec_user);
-        sec_user.setAuthenticated(true);
+        sec_user.setAuthenticateStatus(AS_AUTHENTICATED);
     }
     return true;
 }

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -131,6 +131,15 @@ interface ISecCredentials : extends IInterface
     virtual int getPasswordDaysRemaining() = 0;
 };
 
+//LDAP authentication status
+enum authStatus
+{
+    AS_AUTHENTICATED = 0,
+    AS_UNKNOWN = 1,//have not attempted to authenticate
+    AS_UNEXPECTED_ERROR = 2,
+    AS_INVALID_CREDENTIALS = 3,
+    AS_PASSWORD_EXPIRED = 4
+};
 
 class CDateTime;
 interface ISecUser : extends IInterface
@@ -151,8 +160,8 @@ interface ISecUser : extends IInterface
     virtual bool setPeer(const char * Peer) = 0;
     virtual SecUserStatus getStatus() = 0;
     virtual bool setStatus(SecUserStatus Status) = 0;
-    virtual bool isAuthenticated() = 0;
-    virtual void setAuthenticated(bool authenticated) = 0;
+    virtual authStatus getAuthenticateStatus() = 0;
+    virtual void setAuthenticateStatus(authStatus status) = 0;
     virtual ISecCredentials & credentials() = 0;
     virtual unsigned getUserID() = 0;
     virtual void copyTo(ISecUser & destination) = 0;


### PR DESCRIPTION
Existing ECLWatch Permission area shows 'SMC' as feature name.
The 'SMC' is a deprecated term. This fix changes it to 'HPCC'.
Most of the changes are in environment.xml and other deployment
scripts which create the term into esp.xml. This fix also
changes the term espsmc to eclwatch.

Similar changes will be done for EE.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
