### PR TITLE
FEATURE - hook-based git file reading

### DIFF
--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -507,7 +507,7 @@ inline StringBuffer &removeTrailingPathSepChar(StringBuffer &path)
     {
 #ifdef _WIN32
     // In addition to not removing / if it's the only char in the path, you should not remove it the path
-    // is of the form c:\
+    // is of the form "c:\"
         if (path.length()>3 || path.charAt(1) != ':')
 #endif
             path.remove(path.length()-1, 1);


### PR DESCRIPTION
Another attempt to fix compile errors/warnings that showed up on vc++ compiler,
due to rather strange c++ handling of a trailing \ in a comment.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
