### PR TITLE
Typo & Dataset(count) row fix

### DIFF
--- a/dali/regress/daregress.cpp
+++ b/dali/regress/daregress.cpp
@@ -566,7 +566,7 @@ static void testDFSTrans()
     dsub1->attach("regress::trans::sub1");
     dsub1.clear();
 
-    if (dir.exists("regress::trans::sub1",true,false) && !dir.removeEntry("regress::trans::sub2")) {
+    if (dir.exists("regress::trans::sub2",true,false) && !dir.removeEntry("regress::trans::sub2")) {
         ERROR("Can't remove sub2");
         return;
     }
@@ -575,7 +575,7 @@ static void testDFSTrans()
     dsub2->attach("regress::trans::sub2");
     dsub2.clear();
 
-    if (dir.exists("regress::trans::sub1",true,false) && !dir.removeEntry("regress::trans::sub3")) {
+    if (dir.exists("regress::trans::sub3",true,false) && !dir.removeEntry("regress::trans::sub3")) {
         ERROR("Can't remove sub3");
         return;
     }
@@ -584,7 +584,7 @@ static void testDFSTrans()
     dsub3->attach("regress::trans::sub3");
     dsub3.clear();
 
-    if (dir.exists("regress::trans::sub1",true,false) && !dir.removeEntry("regress::trans::sub4")) {
+    if (dir.exists("regress::trans::sub4",true,false) && !dir.removeEntry("regress::trans::sub4")) {
         ERROR("Can't remove sub4");
         return;
     }

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -15985,16 +15985,16 @@ ABoundActivity * HqlCppTranslator::doBuildActivityCountTransform(BuildCtx & ctx,
     ensureRowAllocated(funcctx, "crSelf");
     BoundRow * selfCursor = bindSelf(funcctx, instance->dataset, "crSelf");
     IHqlExpression * self = selfCursor->querySelector();
-    associateCounter(funcctx, counter, "row");
+    associateCounter(funcctx, counter, "(row+1)");
     buildTransformBody(funcctx, transform, NULL, NULL, instance->dataset, self);
 
     // unsigned numRows() - count is guaranteed by lexer
     doBuildUnsigned64Function(instance->startctx, "numRows", count);
 
+    // unsigned getFlags()
     doBuildTempTableFlags(instance->startctx, expr, isConstantTransform(transform));
 
     buildInstanceSuffix(instance);
-
     return instance->getBoundActivity();
 }
 

--- a/testing/ecl/key/dataset_transform.xml
+++ b/testing/ecl/key/dataset_transform.xml
@@ -7,7 +7,6 @@
  <Row><Result_3>Constant, 10</Result_3></Row>
 </Dataset>
 <Dataset name='Result 4'>
- <Row><i>0</i></Row>
  <Row><i>10</i></Row>
  <Row><i>20</i></Row>
  <Row><i>30</i></Row>
@@ -17,12 +16,12 @@
  <Row><i>70</i></Row>
  <Row><i>80</i></Row>
  <Row><i>90</i></Row>
+ <Row><i>100</i></Row>
 </Dataset>
 <Dataset name='Result 5'>
  <Row><Result_5>Constant expression, 50</Result_5></Row>
 </Dataset>
 <Dataset name='Result 6'>
- <Row><i>0</i></Row>
  <Row><i>10</i></Row>
  <Row><i>20</i></Row>
  <Row><i>30</i></Row>
@@ -72,6 +71,7 @@
  <Row><i>470</i></Row>
  <Row><i>480</i></Row>
  <Row><i>490</i></Row>
+ <Row><i>500</i></Row>
 </Dataset>
 <Dataset name='Result 7'>
  <Row><Result_7>Variable 5, row constant</Result_7></Row>
@@ -87,7 +87,6 @@
  <Row><Result_9>Distributed 10</Result_9></Row>
 </Dataset>
 <Dataset name='Result 10'>
- <Row><i>0</i></Row>
  <Row><i>10</i></Row>
  <Row><i>20</i></Row>
  <Row><i>30</i></Row>
@@ -97,4 +96,5 @@
  <Row><i>70</i></Row>
  <Row><i>80</i></Row>
  <Row><i>90</i></Row>
+ <Row><i>100</i></Row>
 </Dataset>


### PR DESCRIPTION
Two simple fixes for 3.8: a typo on daregress and the correct range
for inline datasets from counter.
