### PR TITLE
Fix problem using unsigned numbers in #line

### DIFF
--- a/ecl/hqlcpp/hqlstmt.cpp
+++ b/ecl/hqlcpp/hqlstmt.cpp
@@ -376,7 +376,7 @@ IHqlStmt *  BuildCtx::addLine(const char * filename, unsigned lineNum)
     if (filename)
     {
         next->addExpr(createConstant(filename));
-        next->addExpr(getSizetConstant(lineNum));
+        next->addExpr(createConstant(createIntValue(lineNum, sizeof(int), true)));
     }
     return appendSimple(next);
 }


### PR DESCRIPTION
Some compilers appear to have a problem using unsigned constiants
(e.g., 5U) in a #line directive.  This fix ensures the unsigned
extension isn't added to the numbers.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
