### PR TITLE
Fix internal error on complex nested field selection

### DIFF
--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1491,6 +1491,7 @@ extern HQL_API IHqlExpression * createUniqueSelectorSequence();
 extern HQL_API IHqlExpression * createDummySelectorSequence();
 extern HQL_API IHqlExpression * expandBetween(IHqlExpression * expr);
 extern HQL_API bool isAlwaysActiveRow(IHqlExpression * expr);
+extern HQL_API bool isAlwaysNewRow(IHqlExpression * expr);
 extern HQL_API IHqlExpression * ensureActiveRow(IHqlExpression * expr);
 extern HQL_API bool isIndependentOfScope(IHqlExpression * expr);
 extern HQL_API bool isActivityIndependentOfScope(IHqlExpression * expr);
@@ -1624,6 +1625,7 @@ inline IHqlExpression * querySelSeq(IHqlExpression * expr)
 extern HQL_API IHqlExpression * createGroupedAttribute(ITypeInfo * type);
 extern HQL_API bool isSameUnqualifiedType(ITypeInfo * l, ITypeInfo * r);
 extern HQL_API bool isSameFullyUnqualifiedType(ITypeInfo * l, ITypeInfo * r);
+extern HQL_API IHqlExpression * queryNewSelectAttrExpr();
 
 //The following are wrappers for the code generator specific getInfoFlags()
 //inline bool isTableInvariant(IHqlExpression * expr)       { return (expr->getInfoFlags() & HEFtableInvariant) != 0; }

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -5243,7 +5243,7 @@ static void gatherConstantFilterMappings(HqlConstantPercolator & mappings, IHqlE
         {
             IHqlExpression * lhs = expr->queryChild(0);
             //MORE: Should also handle subselects now that the constant percolator does
-            if ((lhs->getOperator() != no_select) || lhs->hasProperty(newAtom) || lhs->queryChild(0) != selector)
+            if ((lhs->getOperator() != no_select) || isNewSelector(lhs) || lhs->queryChild(0) != selector)
                 break;
 
             IHqlExpression * rhs = expr->queryChild(1);
@@ -5782,7 +5782,7 @@ IHqlExpression * foldHqlExpression(IHqlExpression * expr, ITemplateContext *temp
     case no_attr:
         return LINK(expr);
     case no_select:
-        if (!expr->hasProperty(newAtom))
+        if (!isNewSelector(expr))
             return LINK(expr);
         break;
     }

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -500,7 +500,7 @@ public:
     ITypeInfo *promoteSetToSameType(HqlExprArray & exprs, attribute &errpos);
     ITypeInfo * queryElementType(const attribute & errpos, IHqlExpression * list);
     IHqlExpression *createINExpression(node_operator op, IHqlExpression *expr, IHqlExpression *set, attribute &errpos);
-    IHqlExpression * createLoopCondition(IHqlExpression * left, IHqlExpression * arg1, IHqlExpression * arg2, IHqlExpression * seq);
+    IHqlExpression * createLoopCondition(IHqlExpression * left, IHqlExpression * arg1, IHqlExpression * arg2, IHqlExpression * seq, IHqlExpression * rowsid);
     void setTemplateAttribute();
     void warnIfFoldsToConstant(IHqlExpression * expr, const attribute & errpos);
     void warnIfRecordPacked(IHqlExpression * expr, const attribute & errpos);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -7405,7 +7405,7 @@ simpleDataSet
                             IHqlExpression * counter = $9.getExpr();
                             if (counter)
                                 body = createComma(body, createAttribute(_countProject_Atom, counter));
-                            IHqlExpression * loopCondition = parser->createLoopCondition(left, $6.getExpr(), NULL, $14.queryExpr());
+                            IHqlExpression * loopCondition = parser->createLoopCondition(left, $6.getExpr(), NULL, $14.queryExpr(), $12.queryExpr());
                             IHqlExpression * loopExpr = createDataset(no_loop, left, createComma(loopCondition, body, $10.getExpr(), createComma($12.getExpr(), $14.getExpr())));
                             parser->checkLoopFlags($1, loopExpr);
                             $$.setExpr(loopExpr);
@@ -7422,7 +7422,7 @@ simpleDataSet
                             IHqlExpression * counter = $11.getExpr();
                             if (counter)
                                 body = createComma(body, createAttribute(_countProject_Atom, counter));
-                            IHqlExpression * loopCondition = parser->createLoopCondition(left, $6.getExpr(), $8.getExpr(), $16.queryExpr());
+                            IHqlExpression * loopCondition = parser->createLoopCondition(left, $6.getExpr(), $8.getExpr(), $16.queryExpr(), $14.queryExpr());
                             IHqlExpression * loopExpr = createDataset(no_loop, left, createComma(loopCondition, body, $12.getExpr(), createComma($14.getExpr(), $16.getExpr())));
                             parser->checkLoopFlags($1, loopExpr);
                             $$.setExpr(loopExpr);

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -5536,7 +5536,7 @@ IHqlExpression * HqlGram::createDistributeCond(IHqlExpression * leftDs, IHqlExpr
     return cond;
 }
 
-IHqlExpression * HqlGram::createLoopCondition(IHqlExpression * leftDs, IHqlExpression * arg1, IHqlExpression * arg2, IHqlExpression * seq)
+IHqlExpression * HqlGram::createLoopCondition(IHqlExpression * leftDs, IHqlExpression * arg1, IHqlExpression * arg2, IHqlExpression * seq, IHqlExpression * rowsid)
 {
     IHqlExpression * count = NULL;
     IHqlExpression * filter = NULL;
@@ -5553,14 +5553,11 @@ IHqlExpression * HqlGram::createLoopCondition(IHqlExpression * leftDs, IHqlExpre
         {
             //if refers to fields in LEFT then must be a row filter
             OwnedHqlExpr left = createSelector(no_left, leftDs, seq);
-            if (containsSelector(arg1, left))
-            {
-                filter = arg1;
-            }
-            else
-            {
+            OwnedHqlExpr rows = createDataset(no_rows, LINK(left), LINK(rowsid));
+            if (containsExpression(arg1, rows) || !containsSelector(arg1, left))
                 loopCond = arg1;
-            }
+            else
+                filter = arg1;
         }
     }
     else

--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -1159,21 +1159,6 @@ inline bool activityHidesSelector(IHqlExpression * expr, IHqlExpression * select
 }
 
 
-class HQL_API HqlSelectorLocator : public NewHqlTransformer
-{
-public:
-    HqlSelectorLocator(IHqlExpression * _selector);
-
-    virtual void analyseExpr(IHqlExpression * expr);
-    virtual void analyseSelector(IHqlExpression * expr);
-
-    bool containsSelector(IHqlExpression * expr);
-
-protected:
-    bool foundSelector;
-    OwnedHqlExpr selector;
-};
-
 class HQL_API HqlSelectorAnywhereLocator : public NewHqlTransformer
 {
 public:

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -2295,7 +2295,7 @@ void DependencyGatherer::doGatherDependencies(IHqlExpression * expr)
     case no_attr_link:
         return;
     case no_select:
-        if (!expr->hasProperty(newAtom))
+        if (!isNewSelector(expr))
             return;
         max = 1;        // by now there should be no default values as children of fields.
         break;
@@ -2726,8 +2726,11 @@ IHqlExpression * queryNextMultiLevelDataset(IHqlExpression * expr, bool followAc
     }
 
     IHqlExpression * root = queryRoot(expr);
-    if (!root || (root->getOperator() != no_select) || (!followActiveSelectors && !root->hasProperty(newAtom)))
+    if (!root || (root->getOperator() != no_select))
         return NULL;
+    if (!followActiveSelectors && !isNewSelector(root))
+        return NULL;
+
     IHqlExpression * ds = root->queryChild(0);
     loop
     {
@@ -4269,10 +4272,6 @@ IHqlExpression * SplitDatasetAttributeTransformer::createTransformed(IHqlExpress
     case no_globalscope:
     case no_nothor:
         return LINK(expr);
-//  case NO_AGGREGATE:
-//  case no_createset:
-        //See comment in analyse above
-//      return LINK(expr);
     }
 
     return NewHqlTransformer::createTransformed(expr);

--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -479,7 +479,7 @@ IReferenceSelector * HqlCppTranslator::buildNewRow(BuildCtx & ctx, IHqlExpressio
             IHqlExpression * field = expr->queryChild(1);
 #endif
             Owned<IReferenceSelector> selector;
-            if (expr->hasProperty(newAtom))
+            if (isNewSelector(expr))
                 selector.setown(buildNewRow(ctx, expr->queryChild(0)));
             else
                 selector.setown(buildActiveRow(ctx, expr->queryChild(0)));
@@ -570,7 +570,7 @@ IReferenceSelector * HqlCppTranslator::buildActiveRow(BuildCtx & ctx, IHqlExpres
 #ifdef _DEBUG
             IHqlExpression * field = expr->queryChild(1);
 #endif
-            Owned<IReferenceSelector> selector = buildNewOrActiveRow(ctx, expr->queryChild(0), expr->hasProperty(newAtom));
+            Owned<IReferenceSelector> selector = buildNewOrActiveRow(ctx, expr->queryChild(0), isNewSelector(expr));
             return selector->select(ctx, expr);
         }
     case no_id2blob:

--- a/ecl/hqlcpp/hqlcse.cpp
+++ b/ecl/hqlcpp/hqlcse.cpp
@@ -504,7 +504,8 @@ bool CseSpotter::checkPotentialCSE(IHqlExpression * expr, CseSpotterInfo * extra
     case no_field:
         throwUnexpected();
     case no_select:
-        return false; //expr->hasProperty(newAtom);
+        //MORE: ds[n].x would probably be worth cseing.
+        return false;
     case no_list:
     case no_datasetlist:
     case no_getresult:      // these are commoned up in the code generator, so don't do it twice.
@@ -1105,7 +1106,7 @@ IHqlExpression * spotScalarCSE(IHqlExpression * expr, IHqlExpression * limit)
     switch (expr->getOperator())
     {
     case no_select:
-        if (!expr->hasProperty(newAtom))
+        if (!isNewSelector(expr))
             return LINK(expr);
         break;
     }
@@ -1267,9 +1268,12 @@ bool TableInvariantTransformer::isInvariant(IHqlExpression * expr)
         break;
     case no_select:
         {
-            IHqlExpression * ds = expr->queryChild(0);
-            if ((expr->hasProperty(newAtom) || ds->isDatarow()) && !expr->isDataset())
-                invariant = isInvariant(ds);
+            if (!expr->isDataset())
+            {
+                IHqlExpression * ds = expr->queryChild(0);
+                if (expr->hasProperty(newAtom) || ds->isDatarow())
+                    invariant = isInvariant(ds);
+            }
             break;
         }
     case no_newaggregate:

--- a/ecl/hqlcpp/hqlgraph.cpp
+++ b/ecl/hqlcpp/hqlgraph.cpp
@@ -312,7 +312,7 @@ void LogicalGraphCreator::createGraphActivity(IHqlExpression * expr)
         dependencyKind = NULL;
         break;
     case no_select:
-        if (!expr->hasProperty(newAtom))
+        if (!isNewSelector(expr))
         {
             last = first;
         }
@@ -490,8 +490,7 @@ bool LogicalGraphCreator::gatherGraphActivities(IHqlExpression * expr, HqlExprAr
     {
     case no_select:
         {
-            IHqlExpression * attr = expr->queryProperty(newAtom);
-            if (attr)
+            if (isNewSelector(expr))
             {
                 if (exprIsGlobal(expr))
                     createRootGraphActivity(expr);

--- a/ecl/hqlcpp/hqlinline.cpp
+++ b/ecl/hqlcpp/hqlinline.cpp
@@ -112,7 +112,7 @@ static unsigned calcInlineFlags(BuildCtx * ctx, IHqlExpression * expr)
     {
     case no_select:
         //MORE: What about child datasets in nested records?
-        if (expr->hasProperty(newAtom))
+        if (isNewSelector(expr))
         {
             unsigned childFlags = getInlineFlags(ctx, expr->queryChild(0));
             if ((childFlags & HEFevaluateinline) && isMultiLevelDatasetSelector(expr, false))

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -486,7 +486,9 @@ IHqlExpression * ComplexImplicitProjectInfo::createOutputProject(IHqlExpression 
         assigns.append(*createAssign(createSelectExpr(LINK(self), LINK(cur)), createSelectExpr(LINK(left), LINK(cur))));
     }
     IHqlExpression * transform = createValue(no_transform, makeTransformType(newOutputRecord->getType()), assigns);
-    return createDataset(no_hqlproject, LINK(ds), createComma(transform, LINK(seq)));
+    if (ds->isDataset())
+        return createDataset(no_hqlproject, LINK(ds), createComma(transform, LINK(seq)));
+    return createRow(no_projectrow, LINK(ds), createComma(transform, LINK(seq)));
 }
 
 

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -2812,7 +2812,7 @@ IHqlExpression * ThorHqlTransformer::normalizeSelect(IHqlExpression * expr)
     a.b.xyz would need to be converted to in.parent.xyz.  It will generate very inefficient code, so not going
     to go this way at the moment.
     */
-    if (!expr->hasProperty(newAtom) || !expr->isDataset())
+    if (!isNewSelector(expr) || !expr->isDataset())
         return NULL;
 
     IHqlExpression * ds = expr->queryChild(0);
@@ -8097,7 +8097,6 @@ static IHqlExpression * splitSelector(IHqlExpression * expr, SharedHqlExpr & old
     IHqlExpression * ds = expr->queryChild(0);
     if (expr->hasProperty(newAtom))
     {
-
         oldDataset.set(ds);
         OwnedHqlExpr left = createSelector(no_left, ds, querySelSeq(expr));
         return createSelectExpr(left.getClear(), LINK(expr->queryChild(1)));
@@ -8574,7 +8573,6 @@ no_select
     attached to select node.  That may contain the following attributes:
         global  - is an outer level activity
         noTable - no other tables are active at this point      e.g., global[1].field;
-        relatedAccess - it contains access to other active tables.
         relatedTable - I think this could be deprecated in favour of the flag above.
 
 Datasets
@@ -8602,7 +8600,6 @@ void HqlScopeTagger::beginTableScope()
 void HqlScopeTagger::endTableScope(HqlExprArray & attrs, IHqlExpression * ds, IHqlExpression * newExpr)
 {
 #if 1
-    //This is still needed because the relatedAccess test doesn't seem to work correctly for HOLe datasets
     //A quick test which is often succeeds.
     if (isDatasetRelatedToScope(ds))
         attrs.append(*createAttribute(relatedTableAtom));


### PR DESCRIPTION
In some circumstances it was possible to get the following error:
Attempting to lookup field <name> in a dataset which has no active element.
This is preventing another option being enabled that would solve some
problems with conditional evaluation of expressions.

The root cause is the handling of no_select.  A no_select should have a
newAtom attribute associated with it if it is selecting a field from a
new row.  So a[1].b.c is represented as
  select(select(a[1],b,new),c)

Some places were incorrectly checking if the current select had an
associated new attribute instead of checking if the root select had
one.

no_select(no_selectnth) now always has a newAttribute associated with it.
This simplifies and optimizes the processing of unnormalized trees.

This also contains a fix for hqliproj projecting a datarow, and better
expansion of (a.b.c.d within transforms)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
