### PR TITLE
Protect against potential act. init race

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -585,12 +585,10 @@ void CGraphElementBase::deserializeStartContext(MemoryBuffer &mb)
 
 void CGraphElementBase::onCreate()
 {
-    {
-        CriticalBlock b(crit);
-        if (onCreateCalled)
-            return;
-        onCreateCalled = true;
-    }
+    CriticalBlock b(crit);
+    if (onCreateCalled)
+        return;
+    onCreateCalled = true;
     baseHelper.setown(helperFactory());
     if (!nullAct)
     {
@@ -749,12 +747,10 @@ void CGraphElementBase::preStart(size32_t parentExtractSz, const byte *parentExt
 
 void CGraphElementBase::initActivity()
 {
-    {
-        CriticalBlock b(crit);
-        if (activity)
-            return;
-        activity.setown(factory());
-    }
+    CriticalBlock b(crit);
+    if (activity)
+        return;
+    activity.setown(factory());
     switch (getKind())
     {
         case TAKlooprow:

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -585,14 +585,18 @@ void CGraphElementBase::deserializeStartContext(MemoryBuffer &mb)
 
 void CGraphElementBase::onCreate()
 {
-    if (onCreateCalled) return;
+    {
+        CriticalBlock b(crit);
+        if (onCreateCalled)
+            return;
+        onCreateCalled = true;
+    }
     baseHelper.setown(helperFactory());
     if (!nullAct)
     {
         CGraphElementBase *ownerActivity = owner->queryOwner() ? owner->queryOwner()->queryElement(ownerId) : NULL;
         baseHelper->onCreate(queryCodeContext(), ownerActivity ? ownerActivity->queryHelper() : NULL, haveCreateCtx?&createCtxMb:NULL);
     }
-    onCreateCalled = true;
 }
 
 void CGraphElementBase::onStart(size32_t parentExtractSz, const byte *parentExtract)
@@ -745,9 +749,12 @@ void CGraphElementBase::preStart(size32_t parentExtractSz, const byte *parentExt
 
 void CGraphElementBase::initActivity()
 {
-    if (activity)
-        return;
-    activity.setown(factory());
+    {
+        CriticalBlock b(crit);
+        if (activity)
+            return;
+        activity.setown(factory());
+    }
     switch (getKind())
     {
         case TAKlooprow:

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -234,6 +234,7 @@ class CJobBase;
 class graph_decl CGraphElementBase : public CInterface, implements IInterface
 {
 protected:
+    CriticalSection crit;
     Owned<IHThorArg> baseHelper;
     ThorActivityKind kind;
     activity_id id, ownerId;


### PR DESCRIPTION
Possibly only an issue for global loop initialization, where slaves
subgraphs can cause requests to master as master graph is initializing

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
