### PR TITLE
SelfJoin object leak, cause error if spilled

### DIFF
--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -979,7 +979,6 @@ public:
         strm.set(_strm);
         assertex(strmR==NULL);
         allocatorin.set(_allocatorL);
-        strm->Link();
         state = JSload;
         unsigned flags = helper->getJoinFlags();
         assertex((flags&JFslidingmatch)==0);


### PR DESCRIPTION
SelfJoin was leaking the lhs input stream, as a result, if a local selfjoin
had spilt whilst sorting, the spill files remained opened and an error
ensued.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
