### PR TITLE
gh-2187 hpcc-init fails to stop thor on Ubuntu 12.04

### DIFF
--- a/initfiles/componentfiles/thor/stop_thor
+++ b/initfiles/componentfiles/thor/stop_thor
@@ -44,7 +44,7 @@ if [ "$#" -lt "2" ] || [ "$2" != "keep_sentinel" ]; then
     sleep 1
 fi
 
-masterproc="thormaster_$THORNAME"
+masterproc="$instancedir/thormaster_$THORNAME"
 while [ "`${PIDOF} $masterproc`" != "" ]
 do
   echo --------------------------
@@ -58,7 +58,7 @@ done
 echo --------------------------
 echo stopping thor slaves 
 
-slaveproc="thorslave_$THORNAME"
+slaveproc="$instancedir/thorslave_$THORNAME"
 if [ "$localthor" = "true" ]; then
     killall -9 $slaveproc
 else


### PR DESCRIPTION
There is a regression in the killall program in the current Ubuntu 12.04
distro's repositories, which prevents killall from working as advertised
on longer executable names.

See https://bugs.launchpad.net/ubuntu/+source/psmisc/+bug/970638

Testing suggests that providing a full pathname that the executable was launched
with, as opposed to just the tail name, will work around the issue.

Without this workaround, thor cannot be properly stopped on Ubuntu 12.04 systems.

Fixes gh-2187.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
