### PR TITLE
Add a logout feature to ldap security manager

### DIFF
--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -746,6 +746,17 @@ int CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser & user, const c
         return -1;
 }
 
+bool CLdapSecManager::logout(ISecUser& sec_user)
+{
+    sec_user.setAuthenticateStatus(AS_UNKNOWN);
+    if  (m_permissionsCache.isCacheEnabled())
+    {
+        m_permissionsCache.removePermissions(sec_user);
+        m_permissionsCache.removeFromUserCache(sec_user);
+    }
+    return  true;
+}
+
 int CLdapSecManager::getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename)
 {
     if(!resourcename || !*resourcename)

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -359,6 +359,7 @@ public:
     bool authorize(ISecUser& sec_user, ISecResourceList * Resources);
     bool authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISecResourceList * Resources);
     int authorizeEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename);
+    virtual bool logout(ISecUser& sec_user);
     virtual int authorizeFileScope(ISecUser & user, const char * filescope);
     virtual bool authorizeFileScope(ISecUser & user, ISecResourceList * resources);
     virtual int authorizeWorkunitScope(ISecUser & user, const char * wuscope);

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -160,7 +160,11 @@ public:
             return rlist->queryResource(0)->getAccessFlags();
         else
             return -1;
-    }   
+    }
+    virtual bool logout(ISecUser& sec_user)
+    {
+        UNIMPLEMENTED;
+    }
     virtual int getAccessFlagsEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename)
     {
         UNIMPLEMENTED;

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -269,6 +269,7 @@ interface ISecManager : extends IInterface
     virtual bool authorize(ISecUser & user, ISecResourceList * resources) = 0;
     virtual bool authorizeEx(SecResourceType rtype, ISecUser & user, ISecResourceList * resources) = 0;
     virtual int authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename) = 0;
+    virtual bool logout(ISecUser & user) = 0;
     virtual int getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename) = 0;
     virtual int authorizeFileScope(ISecUser & user, const char * filescope) = 0;
     virtual bool authorizeFileScope(ISecUser & user, ISecResourceList * resources) = 0;


### PR DESCRIPTION
Need to provide an interface to log out a CLdapSecManager user,
which will be needed for gh-2174 ('ECLWatch should provide LOGOUT
feature')
