### PR TITLE
FIX gh-2205 Use logfile creator for roxiePipe logfile

### DIFF
--- a/roxie/roxiepipe/roxiepipe.cpp
+++ b/roxie/roxiepipe/roxiepipe.cpp
@@ -457,14 +457,6 @@ int main(int argc, char *argv[])
     StringBuffer query;
     StringBuffer resultName;
     StringBuffer logFile;
-#ifdef _WIN32
-    logFile.append(".\\roxiepipe");
-#else   
-    logFile.append("/c$/roxiepipe");
-#endif
-    addFileTimestamp(logFile, true);
-    logFile.append(".log");
-
     unsigned numThreads = 2;
     bool retryMode = true;
 
@@ -589,8 +581,14 @@ int main(int argc, char *argv[])
         }
     }
 
-    queryLogMsgManager()->changeMonitorFilterOwn(queryStderrLogMsgHandler(), getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_disaster | MSGCLS_error | MSGCLS_warning, DefaultDetail, true));
-    attachStandardFileLogMsgMonitor(logFile.str(), NULL, MSGFIELD_STANDARD, MSGAUD_all, MSGCLS_all, TopDetail, false, true);
+    //Build logfile from component properties settings
+    Owned<IComponentLogFileCreator> lf;
+    lf.setown(createComponentLogFileCreator(".", "roxiepipe"));
+    if (logFile.length())
+        lf->setCompleteFilespec(logFile.str());
+    lf->setCreateAliasFile(false);
+    lf->beginLogging();
+    PROGLOG("Logging to %s",lf->queryLogFileSpec());
     queryLogMsgManager()->removeMonitor(queryStderrLogMsgHandler()); // only want fprintf(stderr)
 
     if (!fatalError.length())

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -2625,7 +2625,7 @@ private:
 
     //available after logging started
     StringBuffer logDir;        //access via queryLogDir()
-    StringBuffer aliasFileSpec; //access via queryLogDir()
+    StringBuffer aliasFileSpec; //access via queryAliasFileSpec()
     StringBuffer expandedLogSpec;//access via queryLogFileSpec()
 
 private:
@@ -2671,7 +2671,7 @@ public:
     void setExtension(const char * _ext)     { extension.set(_ext); }
     void setPrefix(const char * _prefix)     { prefix.set(_prefix); }
     void setName(const char * _name)         { name.set(_name); }
-    void setCompleteFilespec(const char * _fs){ fullFileSpec.set(_fs); }
+    void setCompleteFilespec(const char * _fs){fullFileSpec.set(_fs); setExtension(NULL); setRolling(false);}
     void setPostfix(const char * _postfix)   { postfix.set(_postfix); }
     void setCreateAliasFile(bool _create)    { createAlias = _create; }
     void setAliasName(const char * _aliasName)   { aliasName.set(_aliasName); }
@@ -2734,7 +2734,9 @@ public:
 
         ILogMsgHandler * lmh;
         if (rolling)
+        {
             lmh = getRollingFileLogMsgHandler(logFileSpec.str(), extension, msgFields, append, flushes, NULL, aliasFileSpec.str(), true);
+        }
         else
         {
             StringBuffer lfs;


### PR DESCRIPTION
RoxiePipe should use the component logfile creator to ensure logs
are placed in the correct location. Current code puts them in the wrong
place. Also fixed a problem where the logfile creator was appending '.log'
even when user specified a logfile.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
