### PR TITLE
Fix problem incorrectly removing COUNTER from PROJECT

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -7614,12 +7614,7 @@ simpleDataSet
                             IHqlExpression *ds = $3.getExpr();
                             OwnedHqlExpr counter = $7.getExpr();
                             if (counter)
-                            {
-                                if (!transformContainsCounter(te, counter))
-                                    parser->reportWarning(WRN_COUNTER_NOT_USED,$6.pos,"COUNTER not used inside the transform");
-                                else
-                                    te = createComma(te, createAttribute(_countProject_Atom, LINK(counter)));
-                            }
+                                te = createComma(te, createAttribute(_countProject_Atom, LINK(counter)));
                             $$.setExpr(createDataset(no_hqlproject, ds, te));
                             $$.setPosition($1);
                         }

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -2209,6 +2209,12 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
         }
         break;
     case no_hqlproject:
+        {
+            IHqlExpression * counterAttr = transformed->queryProperty(_countProject_Atom);
+            if (counterAttr && !transformContainsCounter(transformed->queryChild(1), counterAttr->queryChild(0)))
+                return removeProperty(transformed, _countProject_Atom);
+            //fallthrough
+        }
     case no_newusertable:
         if (transformed->hasProperty(keyedAtom))
         {


### PR DESCRIPTION
There was code in the grammar to check if a COUNTER was used in the
transform of a COUNT PROJECT, and if not report a warning and
convert it to a standard PROJECT.
However the check doesn't work in all cases because it is being
applied to an expression tree that hasn't been normalized.

Move the optimization to hqlopt where the expression tree has
been normalized.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
