### PR TITLE
Superattr blank

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -4441,7 +4441,7 @@ public:
                 const char *name = ait->queryName();
                 if ((stricmp(name,"@size")!=0)&&(stricmp(name,"@recordCount")!=0)) {
                     const char *v = ait->queryValue();
-                    if (!v||!*v)
+                    if (!v)
                         continue;
                     bool ok = true;
                     for (unsigned i=1;i<subfiles.ordinality();i++) {


### PR DESCRIPTION
The code that checks and builds up the attributes for the
super (in CDistributedSuperFile::getFileDescriptor), ignored attributes
which were set to blank.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
