### PR TITLE
gh-2150 Clone file information after publishing/copying a query

### DIFF
--- a/common/workunit/CMakeLists.txt
+++ b/common/workunit/CMakeLists.txt
@@ -36,6 +36,7 @@ set (    SRCS
 
 include_directories ( 
          ./../../common/workunit
+         ./../../common/remote
          ./../../system/mp 
          ./../../dali/ft 
          ./../../common/deftype 

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -18,8 +18,6 @@ Copyright (C) 2011 HPCC Systems.
 #define ECLOPT_PACKAGEMAP "--packagemap"
 #define ECLOPT_OVERWRITE "--overwrite"
 #define ECLOPT_PACKAGE "--packagename"
-#define ECLOPT_DALIIP "--daliip"
-#define ECLOPT_PROCESS "--process"
 
 //=========================================================================================
 

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -52,6 +52,11 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_PASSWORD_INI "eclPassword"
 #define ECLOPT_PASSWORD_ENV "ECL_PASSWORD"
 
+#define ECLOPT_OVERWRITE "--overwrite"
+#define ECLOPT_OVERWRITE_S "-O"
+#define ECLOPT_OVERWRITE_INI "overwriteDefault"
+#define ECLOPT_OVERWRITE_ENV NULL
+
 #define ECLOPT_ACTIVATE "--activate"
 #define ECLOPT_ACTIVATE_S "-A"
 #define ECLOPT_ACTIVATE_INI "activateDefault"
@@ -73,6 +78,9 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_INPUT_S "-in"
 
 #define ECLOPT_NOROOT "--noroot"
+
+#define ECLOPT_DALIIP "--daliip"
+#define ECLOPT_PROCESS "--process"
 
 #define ECLOPT_WUID "--wuid"
 #define ECLOPT_WUID_S "-wu"

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -281,7 +281,11 @@ public:
                 }
                 continue;
             }
+            if (iter.matchOption(optDaliIP, ECLOPT_DALIIP))
+                continue;
             if (iter.matchFlag(optActivate, ECLOPT_ACTIVATE)||iter.matchFlag(optActivate, ECLOPT_ACTIVATE_S))
+                continue;
+            if (iter.matchFlag(optOverwrite, ECLOPT_OVERWRITE)||iter.matchFlag(optOverwrite, ECLOPT_OVERWRITE_S))
                 continue;
             if (iter.matchOption(optCluster, ECLOPT_CLUSTER)||iter.matchOption(optCluster, ECLOPT_CLUSTER_S))
                 continue;
@@ -321,7 +325,9 @@ public:
         req->setSource(optSourceQueryPath.get());
         req->setTarget(optTargetQuerySet.get());
         req->setCluster(optCluster.get());
+        req->setDaliServer(optDaliIP.get());
         req->setActivate(optActivate);
+        req->setOverwrite(optOverwrite);
         req->setWait(optMsToWait);
 
         Owned<IClientWUQuerySetCopyQueryResponse> resp = client->WUQuerysetCopyQuery(req);
@@ -351,8 +357,10 @@ public:
             "                          in the form: //ip:port/queryset/query\n"
             "                          or: queryset/query\n"
             "   <target_queryset>      name of queryset to copy the query into\n"
+            "   --daliip=<ip>          For file copying if remote version < 3.8\n"
             "   -cl, --cluster=<name>  Local cluster to associate with remote workunit\n"
             "   -A, --activate         Activate the new query\n"
+            "   -O, --overwrite        Overwrite existing files\n"
             "   --wait=<ms>            Max time to wait in milliseconds\n"
             " Common Options:\n",
             stdout);
@@ -362,8 +370,10 @@ private:
     StringAttr optSourceQueryPath;
     StringAttr optTargetQuerySet;
     StringAttr optCluster;
+    StringAttr optDaliIP;
     unsigned optMsToWait;
     bool optActivate;
+    bool optOverwrite;
 };
 
 IEclCommand *createEclQueriesCommand(const char *cmdname)

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -614,6 +614,7 @@ ESPresponse [exceptions_inline] WULogFileResponse
     [min_ver("1.36")] string QueryName;
     [min_ver("1.36")] string QueryId;
     [min_ver("1.36")] string FileName;
+    [min_ver("1.38")] string DaliServer;
     [http_content("application/octet-stream")] binary thefile;
 };
 
@@ -1043,8 +1044,6 @@ ESPrequest WUPublishWorkunitRequest
     string JobName;
     int Activate;
     bool NotifyCluster(false);
-    bool showFiles(0);
-    bool CopyLocal(0);
     int Wait(10000);
 };
 
@@ -1229,7 +1228,9 @@ ESPrequest WUQuerySetCopyQueryRequest
     string Source;
     string Target;
     string Cluster;
+    string DaliServer;
     int Activate;
+    bool Overwrite(false);
     int Wait(10000);
 };
 
@@ -1239,7 +1240,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.37"), default_client_version("1.37"),
+    version("1.38"), default_client_version("1.38"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/CMakeLists.txt
+++ b/esp/services/ws_workunits/CMakeLists.txt
@@ -29,6 +29,7 @@ include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS
          ../../../dali/sasha/sacmd.cpp
+         ../../../dali/dfu/dfuutil.cpp
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_fs_esp.cpp
          ${HPCC_SOURCE_DIR}/esp/scm/ws_workunits.ecm
@@ -39,6 +40,7 @@ set (    SRCS
          ws_workunitsHelpers.hpp
          ws_workunitsAuditLogs.cpp
          ws_workunitsQuerySets.cpp
+         wufilelist.cpp
     )
 
 include_directories (
@@ -48,8 +50,10 @@ include_directories (
          ./../../../dali/dfu
          ./../../../dali/sasha
          ./../../../common/roxiemanager
+         ./../../../common/remote
          ./../../../system/jlib
          ./../../../common/environment
+         ./../../../roxie/roxie
          ./../../services
          ./../common
          ./../../../system/xmllib

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -533,6 +533,8 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
 
     DBGLOG("Initializing %s service [process = %s]", service, process);
 
+    daliServers.set(cfg->queryProp("Software/EspProcess/@daliServers"));
+
     wuActionTable.setValue("delete", ActionDelete);
     wuActionTable.setValue("abort", ActionAbort);
     wuActionTable.setValue("pausenow", ActionPauseNow);
@@ -2374,6 +2376,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
                 StringBuffer name;
                 winfo.getWorkunitDll(name, mb);
                 resp.setFileName(name.str());
+                resp.setDaliServer(daliServers.get());
                 openSaveFile(context, opt, req.getName(), HTTP_TYPE_OCTET_STREAM, mb, resp);
             }
             else if (strieq(File_Res,req.getType()))

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -103,6 +103,7 @@ public:
 private:
     unsigned awusCacheMinutes;
     StringBuffer queryDirectory;
+    StringAttr daliServers;
     Owned<DataCache> dataCache;
     Owned<ArchivedWuCache> archivedWuCache;
     WUSchedule m_sched;

--- a/esp/services/ws_workunits/wufilelist.cpp
+++ b/esp/services/ws_workunits/wufilelist.cpp
@@ -1,0 +1,472 @@
+/*##############################################################################
+
+    Copyright (C) 2012 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#include "wufilelist.hpp"
+
+#include "jptree.hpp"
+#include "workunit.hpp"
+#include "eclhelper.hpp"
+#include "dautils.hpp"
+#include "dadfs.hpp"
+#include "dasess.hpp"
+
+#define WF_LOOKUP_TIMEOUT (1000*15)  // 15 seconds
+
+bool getIsOpt(const IPropertyTree &graphNode)
+{
+    if (graphNode.hasProp("att[@name='_isOpt']"))
+        return graphNode.getPropBool("att[@name='_isOpt']/@value", false);
+    else
+        return graphNode.getPropBool("att[@name='_isIndexOpt']/@value", false);
+}
+
+const char *skipForeign(const char *name, StringBuffer *ip=NULL)
+{
+    if (*name=='~')
+        name++;
+    const char *d1 = strstr(name, "::");
+     if (d1)
+     {
+        StringBuffer cmp;
+        if (strieq("foreign", cmp.append(d1-name, name).trim().str()))
+        {
+            // foreign scope - need to strip off the ip and port
+            d1 += 2;  // skip ::
+
+            const char *d2 = strstr(d1,"::");
+            if (d2)
+            {
+                if (ip)
+                    ip->append(d2-d1, d1).trim();
+                d2 += 2;
+                while (*d2 == ' ')
+                    d2++;
+
+                name = d2;
+            }
+        }
+    }
+    return name;
+}
+
+class WuReferencedFile : public CInterface, implements IWuReferencedFile
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    WuReferencedFile(const char *name, bool isSubFile=false) : flags(0)
+    {
+        StringBuffer ip;
+        logicalName.append(skipForeign(name, &ip));
+        if (ip.length())
+            foreignNode.setown(createINode(ip.str()));
+        if (isSubFile)
+            flags |= WuRefSubFile;
+    }
+
+    void reset()
+    {
+        flags &= WuRefSubFile;
+    }
+    void processLocalFileInfo(IDistributedFile *df, const char *cluster, StringArray *subfiles);
+    void processRemoteFileTree(IPropertyTree *tree, bool foreign, StringArray *subfiles);
+
+    void resolveLocal(const char *cluster, IUserDescriptor *user, StringArray *subfiles);
+    void resolveRemote(IUserDescriptor *user, INode *remote, const char *cluster, bool checkLocalFirst, StringArray *subfiles);
+    void resolve(const char *cluster, IUserDescriptor *user, INode *remote, bool checkLocalFirst, StringArray *subfiles);
+
+    virtual const char *getLogicalName(){return logicalName.str();}
+    virtual unsigned getFlags(){return flags;}
+    virtual const SocketEndpoint &getForeignIP(){return foreignNode->endpoint();}
+    virtual void cloneInfo(IDFUhelper *helper, IUserDescriptor *user, INode *remote, const char *cluster, bool overwrite=false);
+    void cloneSuperInfo(IUserDescriptor *user, INode *remote, bool overwrite);
+
+public:
+    StringBuffer logicalName;
+    Owned<INode> foreignNode;
+
+    unsigned flags;
+};
+
+void WuReferencedFile::processLocalFileInfo(IDistributedFile *df, const char *cluster, StringArray *subfiles)
+{
+    IDistributedSuperFile *super = df->querySuperFile();
+    if (super)
+    {
+        flags |= WuRefFileSuper;
+        if (subfiles)
+        {
+            Owned<IDistributedFileIterator> it = super->getSubFileIterator();
+            ForEach(*it)
+            {
+                IDistributedFile &sub = it->query();
+                StringBuffer name;
+                sub.getLogicalName(name);
+                subfiles->append(name.str());
+            }
+        }
+    }
+    else
+    {
+        if (!cluster || !*cluster)
+            return;
+        if (df->findCluster(cluster)==NotFound)
+            flags |= WuRefFileNotOnCluster;
+    }
+}
+
+void WuReferencedFile::processRemoteFileTree(IPropertyTree *tree, bool foreign, StringArray *subfiles)
+{
+    flags |= WuRefFileRemote;
+    if (foreign)
+        flags |= WuRefFileForeign;
+    if (streq(tree->queryName(), queryDfsXmlBranchName(DXB_SuperFile)))
+    {
+        flags |= WuRefFileSuper;
+        if (subfiles)
+        {
+            Owned<IPropertyTreeIterator> it = tree->getElements("SubFile");
+            ForEach(*it)
+                subfiles->append(it->query().queryProp("@name"));
+        }
+    }
+
+}
+
+void WuReferencedFile::resolveLocal(const char *cluster, IUserDescriptor *user, StringArray *subfiles)
+{
+    reset();
+    Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalName.str(), user);
+    if(df)
+        processLocalFileInfo(df, cluster, subfiles);
+    else
+        flags |= WuRefFileNotFound;
+}
+
+void WuReferencedFile::resolveRemote(IUserDescriptor *user, INode *remote, const char *cluster, bool checkLocalFirst, StringArray *subfiles)
+{
+    reset();
+    IDistributedFileDirectory &dir = queryDistributedFileDirectory();
+    if (checkLocalFirst)
+    {
+        Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalName.str(), user);
+        if(df)
+            return processLocalFileInfo(df, cluster, subfiles);
+    }
+    Owned<IPropertyTree> tree;
+    if (foreignNode)
+        tree.setown(dir.getFileTree(logicalName.str(), foreignNode, user, WF_LOOKUP_TIMEOUT, false));
+    if (!tree && remote)
+        tree.setown(dir.getFileTree(logicalName.str(), remote, user, WF_LOOKUP_TIMEOUT, false));
+    if (tree)
+        return processRemoteFileTree(tree, false, subfiles);
+    else
+    {
+        flags |= WuRefFileNotFound;
+        return;
+    }
+}
+
+void WuReferencedFile::resolve(const char *cluster, IUserDescriptor *user, INode *remote, bool checkLocalFirst, StringArray *subfiles)
+{
+    if (foreignNode || remote)
+        return resolveRemote(user, remote, cluster, checkLocalFirst, subfiles);
+    return resolveLocal(cluster, user, subfiles);
+}
+
+void WuReferencedFile::cloneInfo(IDFUhelper *helper, IUserDescriptor *user, INode *remote, const char *cluster, bool overwrite)
+{
+    if (flags & WuRefFileSuper)
+        return;
+
+    StringBuffer addr;
+    if (flags & WuRefFileForeign)
+        foreignNode->endpoint().getUrlStr(addr);
+    else if (remote)
+        remote->endpoint().getUrlStr(addr);
+
+    try
+    {
+        helper->createSingleFileClone(logicalName.str(), logicalName.str(), cluster,
+            DFUcpdm_c_replicated_by_d, true, NULL, user, addr.str(), NULL, overwrite, false);
+    }
+    catch (IException *e)
+    {
+        flags |= WuRefFileCopyInfoFailed;
+        DBGLOG(e);
+        e->Release();
+    }
+    catch (...)
+    {
+        flags |= WuRefFileCopyInfoFailed;
+        DBGLOG("Unknown error copying file info for %s, from %s", logicalName.str(), addr.str());
+    }
+}
+
+void WuReferencedFile::cloneSuperInfo(IUserDescriptor *user, INode *remote, bool overwrite)
+{
+    if (!(flags & WuRefFileRemote))
+        return;
+
+    try
+    {
+        Owned<IPropertyTree> tree;
+        IDistributedFileDirectory &dir = queryDistributedFileDirectory();
+        if (foreignNode)
+            tree.setown(dir.getFileTree(logicalName.str(), foreignNode, user, WF_LOOKUP_TIMEOUT, false));
+        if (!tree && remote)
+            tree.setown(dir.getFileTree(logicalName.str(), remote, user, WF_LOOKUP_TIMEOUT, false));
+        if (!tree)
+            return;
+
+        Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalName.str(), user);
+        if(df)
+        {
+            if (!overwrite)
+                return;
+           df->detach();
+           df.clear();
+        }
+
+        Owned<IDistributedSuperFile> superfile = dir.createSuperFile(logicalName.str(), true, false, user);
+        Owned<IPropertyTreeIterator> subfiles = tree->getElements("SubFile");
+        ForEach(*subfiles)
+        {
+            const char *name = subfiles->query().queryProp("@name");
+            if (name && *name)
+                superfile->addSubFile(name, false, NULL, false);
+        }
+    }
+    catch (IException *e)
+    {
+        flags |= WuRefFileCopyInfoFailed;
+        DBGLOG(e);
+        e->Release();
+    }
+    catch (...)
+    {
+        flags |= WuRefFileCopyInfoFailed;
+        DBGLOG("Unknown error copying superfile info for %s", logicalName.str());
+    }
+}
+
+class WuReferencedFileList : public CInterface, implements IWuReferencedFileList
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    WuReferencedFileList(IConstWorkUnit *_cw, const char *remoteIP, const char *username, const char *pw) : cw(_cw)
+    {
+        if (username && pw)
+        {
+            user.setown(createUserDescriptor());
+            user->set(username, pw);
+        }
+        if (remoteIP && *remoteIP)
+            remote.setown(createINode(remoteIP, 7070));
+        gatherFileNamesFromGraphs();
+    }
+
+    void gatherFileNamesFromGraphs();
+    virtual IWuReferencedFileIterator *getFiles();
+    virtual void cloneFileInfo(bool overwrite, bool cloneSuperInfo);
+    virtual void cloneRelationships();
+    virtual void cloneAllInfo(bool overwrite, bool cloneSuperInfo)
+    {
+        cloneFileInfo(overwrite, cloneSuperInfo);
+        cloneRelationships();
+    }
+    virtual void resolveFiles(const char *process, bool checkLocalFirst, bool addSubFiles);
+    void resolveSubFiles(StringArray &subfiles, bool checkLocalFirst);
+
+public:
+    Linked<IConstWorkUnit> cw;
+    Owned<IUserDescriptor> user;
+    Owned<INode> remote;
+    MapStringToMyClass<WuReferencedFile> map;
+    StringAttr cluster;
+};
+
+class WuReferencedFileIterator : public CInterface, implements IWuReferencedFileIterator
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    WuReferencedFileIterator(WuReferencedFileList *_list)
+    {
+        list.set(_list);
+        iter.setown(new HashIterator(list->map));
+    }
+
+    virtual bool first()
+    {
+        return iter->first();
+    }
+
+    virtual bool next()
+    {
+        return iter->next();
+    }
+    virtual bool isValid()
+    {
+        return iter->isValid();
+    }
+    virtual IWuReferencedFile  & query()
+    {
+        return *dynamic_cast<IWuReferencedFile*>(list->map.mapToValue(&iter->query()));
+    }
+
+public:
+    Owned<WuReferencedFileList> list;
+    Owned<HashIterator> iter;
+};
+
+bool isIndexActivity(ThorActivityKind kind)
+{
+    switch (kind)
+    {
+        case TAKindexexists:
+        case TAKindexwrite:
+        case TAKindexread:
+        case TAKindexcount:
+        case TAKindexnormalize:
+        case TAKindexaggregate:
+        case TAKindexgroupaggregate:
+        case TAKindexgroupexists:
+        case TAKindexgroupcount:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void WuReferencedFileList::gatherFileNamesFromGraphs()
+{
+    Owned<IConstWUGraphIterator> graphs = &cw->getGraphs(GraphTypeActivities);
+    ForEach(*graphs)
+    {
+        Owned <IPropertyTree> xgmml = graphs->query().getXGMMLTree(false);
+        Owned<IPropertyTreeIterator> iter = xgmml->getElements("//node[att/@name='_fileName']");
+        ForEach(*iter)
+        {
+            IPropertyTree &node = iter->query();
+            const char *logicalName = node.queryProp("att[@name='_fileName']/@value");
+            if (!logicalName)
+                continue;
+            ThorActivityKind kind = (ThorActivityKind) node.getPropInt("att[@name='_kind']/@value", TAKnone);
+            //not likely to be part of roxie queries, but for forward compatibility:
+            if(kind==TAKdiskwrite || kind==TAKindexwrite || kind==TAKcsvwrite || kind==TAKxmlwrite)
+                continue;
+            if (node.getPropBool("att[@name='_isSpill']/@value") ||
+                node.getPropBool("att[@name='_isTransformSpill']/@value"))
+                continue;
+            Owned<WuReferencedFile> file = new WuReferencedFile(logicalName);
+            if (file->logicalName.length() && !map.getValue(file->getLogicalName()))
+            {
+                const char *ln = file->getLogicalName();
+                map.setValue(ln, file.getClear());
+            }
+        }
+    }
+}
+
+void WuReferencedFileList::resolveSubFiles(StringArray &subfiles, bool checkLocalFirst)
+{
+    StringArray childSubFiles;
+    ForEachItemIn(i, subfiles)
+    {
+        Owned<WuReferencedFile> file = new WuReferencedFile(subfiles.item(i), true);
+        if (file->logicalName.length() && !map.getValue(file->getLogicalName()))
+        {
+            file->resolve(cluster.get(), user, remote, checkLocalFirst, &childSubFiles);
+            const char *ln = file->getLogicalName();
+            map.setValue(ln, file.getClear());
+        }
+    }
+    if (childSubFiles.length())
+        resolveSubFiles(childSubFiles, checkLocalFirst);
+}
+
+void WuReferencedFileList::resolveFiles(const char *process, bool checkLocalFirst, bool expandSuperFiles)
+{
+    cluster.set(process);
+    StringArray subfiles;
+    {
+        Owned<IWuReferencedFileIterator> files = getFiles();
+        ForEach(*files)
+            files->query().resolve(process, user, remote, checkLocalFirst, expandSuperFiles ? &subfiles : NULL);
+    }
+    if (expandSuperFiles)
+        resolveSubFiles(subfiles, checkLocalFirst);
+}
+
+void WuReferencedFileList::cloneFileInfo(bool overwrite, bool cloneSuperInfo)
+{
+    Owned<IDFUhelper> helper = createIDFUhelper();
+    Owned<IWuReferencedFileIterator> files = getFiles();
+    ForEach(*files)
+    {
+        IWuReferencedFile &file = files->query();
+        if (cloneSuperInfo && (file.getFlags() & WuRefFileSuper))
+            file.cloneSuperInfo(user, remote, overwrite);
+        else if (file.getFlags() & (WuRefFileRemote | WuRefFileForeign | WuRefFileNotOnCluster))
+            file.cloneInfo(helper, user, remote, cluster, overwrite);
+    }
+}
+
+void WuReferencedFileList::cloneRelationships()
+{
+    if (!remote || remote->endpoint().isNull())
+        return;
+
+    StringBuffer addr;
+    remote->endpoint().getUrlStr(addr);
+    IDistributedFileDirectory &dir = queryDistributedFileDirectory();
+    Owned<IWuReferencedFileIterator> files = getFiles();
+    ForEach(*files)
+    {
+        IWuReferencedFile &file = files->query();
+        if (!(file.getFlags() & WuRefFileRemote))
+            continue;
+        Owned<IFileRelationshipIterator> iter = dir.lookupFileRelationships(file.getLogicalName(), NULL,
+            NULL, NULL, NULL, NULL, NULL, addr.str(), WF_LOOKUP_TIMEOUT);
+
+        ForEach(*iter)
+        {
+            IFileRelationship &r=iter->query();
+            const char* assoc = r.querySecondaryFilename();
+            if (!assoc)
+                continue;
+            if (*assoc == '~')
+                assoc++;
+            IWuReferencedFile *refAssoc = map.getValue(assoc);
+            if (refAssoc && !(refAssoc->getFlags() & WuRefFileCopyInfoFailed))
+            {
+                dir.addFileRelationship(file.getLogicalName(), assoc, r.queryPrimaryFields(), r.querySecondaryFields(),
+                    r.queryKind(), r.queryCardinality(), r.isPayload(), r.queryDescription());
+            }
+        }
+    }
+}
+
+IWuReferencedFileIterator *WuReferencedFileList::getFiles()
+{
+    return new WuReferencedFileIterator(this);
+}
+
+IWuReferencedFileList *createReferencedFileList(IConstWorkUnit *cw, const char *remoteIP, const char *user, const char *pw)
+{
+    return new WuReferencedFileList(cw, remoteIP, user, pw);
+}

--- a/esp/services/ws_workunits/wufilelist.hpp
+++ b/esp/services/ws_workunits/wufilelist.hpp
@@ -1,0 +1,61 @@
+/*##############################################################################
+
+    Copyright (C) 2012 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#ifndef WUFILE_LIST_HPP
+#define WUFILE_LIST_HPP
+
+#include "jlib.hpp"
+#include "workunit.hpp"
+#include "dadfs.hpp"
+#include "dfuutil.hpp"
+
+#define WuRefFileNone           0x000
+#define WuRefFileIndex          0x001
+#define WuRefFileNotOnCluster   0x002
+#define WuRefFileNotFound       0x004
+#define WuRefFileRemote         0x008
+#define WuRefFileForeign        0x010
+#define WuRefFileSuper          0x020
+#define WuRefSubFile            0x040
+#define WuRefFileCopyInfoFailed 0x080
+
+interface IWuReferencedFile : extends IInterface
+{
+    virtual const char *getLogicalName()=0;
+    virtual unsigned getFlags()=0;
+    virtual const SocketEndpoint &getForeignIP()=0;
+    virtual void resolve(const char *cluster, IUserDescriptor *user, INode *remote, bool checkLocalFirst, StringArray *subfiles)=0;
+    virtual void cloneInfo(IDFUhelper *helper, IUserDescriptor *user, INode *remote, const char *cluster, bool overwrite=false)=0;
+    virtual void cloneSuperInfo(IUserDescriptor *user, INode *remote, bool overwrite=false)=0;
+};
+
+
+interface IWuReferencedFileIterator : extends IIteratorOf<IWuReferencedFile> { };
+
+interface IWuReferencedFileList : extends IInterface
+{
+    virtual IWuReferencedFileIterator *getFiles()=0;
+    virtual void resolveFiles(const char *process, bool checkLocalFirst, bool addSubFiles)=0;
+    virtual void cloneAllInfo(bool overwrite, bool cloneSuperInfo)=0;
+    virtual void cloneFileInfo(bool overwrite, bool cloneSuperInfo)=0;
+    virtual void cloneRelationships()=0;
+};
+
+IWuReferencedFileList *createReferencedFileList(IConstWorkUnit *cw, const char *remoteIP, const char *user, const char *pw);
+
+#endif //WUFILE_LIST_HPP


### PR DESCRIPTION
When publishing or copying a query to roxie, if files are not on the
given cluster, file information should be cloned either from the remote
environment or from another cluster.

Fixes gh-2150

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
