### PR TITLE
New ESP accounts should have expiring passwords

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -4820,10 +4820,11 @@ private:
 
         // UF_ACCOUNTDISABLE 0x0002
         act_ctrl_val &= 0xFFFFFFFD;
-        
+#ifdef _DONT_EXPIRE_PASSWORD
         // UF_DONT_EXPIRE_PASSWD 0x10000
         if (m_passwordNeverExpires)
             act_ctrl_val |= 0x10000;
+#endif
 
         StringBuffer new_act_ctrl;
         new_act_ctrl.append(act_ctrl_val);


### PR DESCRIPTION
Currently, when ECLWatch is used to create an ESP account, it sets the
"DONT EXPIRE PASSWORD" bit in "userAccountControl" attribute.  This is
not correct, since account password expiration should be controlled by
the domain policy (except for system users). This code change removes
the setting of that feature.
It should be noted that when we do enable an LDAP password expiration,
a script or some other mechanism needs to be utilized to clear that bit
in all existing accounts or expiration will not occur.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
