### PR TITLE
Ecljdbc jar build

### DIFF
--- a/plugins/dbconnectors/ecljdbc/CMakeLists.txt
+++ b/plugins/dbconnectors/ecljdbc/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 project(ecljdbc Java)
 option(USE_ECLJDBC "Configure use of DB Connectors")
 if ( USE_ECLJDBC )
+
+	set ( HPCC_ECLJDBC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java/com/hpccsystems/ecljdbc)
+	set ( HPCC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+	include(${HPCC_SOURCE_DIR}/version.cmake)
+
 	add_subdirectory (src/main/java/com/hpccsystems/ecljdbc)
 
         find_package(JNI REQUIRED)

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/CMakeLists.txt
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/CMakeLists.txt
@@ -1,27 +1,24 @@
 cmake_minimum_required(VERSION 2.8)
 
-#configure_file("EclVersionTracker.java.in" "EclVersionTracker.java")
-
 set ( HPCC_ECLJDBC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set ( HPCC_SOURCE_DIR ${HPCC_ECLJDBC_SOURCE_DIR}/../../../../../../../../../..)
+set ( HPCC_SOURCE_DIR ${HPCC_ECLJDBC_SOURCE_DIR}/../../../../../../../../..)
 include(${HPCC_SOURCE_DIR}/version.cmake)
+
+configure_file("EclVersionTracker.java.in" "${HPCC_ECLJDBC_SOURCE_DIR}/EclVersionTracker.java")
 
 set ( CMAKE_MODULE_PATH "${HPCC_SOURCE_DIR}/cmake_modules")
 set ( EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin" )
 set ( PRODUCT_PREFIX "hpccsystems" )
 
-#include(${HPCC_SOURCE_DIR}/cmake_modules/optionDefaults.cmake)
-#include(${HPCC_SOURCE_DIR}/cmake_modules/commonSetup.cmake)
-
 SET (CLASS_DIR "class")
 #SET (JAR_DIR "jar")
 FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CLASS_DIR})
 #FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${JAR_DIR})
-#SET (JAR_FILE ecljdbc.jar)
 SET (JAR_FILE "${PRODUCT_PREFIX}-ecljdbc_${HPCC_PROJECT}-${HPCC_MAJOR}.${HPCC_MINOR}.${HPCC_POINT}.jar")
 SET (JAVA_FILES
-EclDatabaseMetaData.java EclQuery.java SqlExpression.java DFUFile.java EclDriver.java EclResultSet.java SqlOperator.java EclColumn.java EclEngine.java EclResultSetMetadata.java SqlParser.java EclColumnMetaData.java EclPreparedStatement.java EclStatement.java SqlWhereClause.java EclConnection.java EclQueries.java SqlColumn.java Utils.java 
-#EclDatabaseMetaData.java EclQuery.java SqlExpression.java DFUFile.java EclDriver.java EclResultSet.java SqlOperator.java EclColumn.java EclEngine.java EclResultSetMetadata.java SqlParser.java EclColumnMetaData.java EclPreparedStatement.java EclStatement.java SqlWhereClause.java EclConnection.java EclQueries.java SqlColumn.java Utils.java ${CMAKE_CURRENT_BINARY_DIR}/EclVersionTracker.java
+
+EclDatabaseMetaData.java EclQuery.java SqlExpression.java DFUFile.java EclDriver.java EclResultSet.java SqlOperator.java EclColumn.java EclEngine.java EclResultSetMetadata.java SqlParser.java EclColumnMetaData.java EclPreparedStatement.java EclStatement.java SqlWhereClause.java EclConnection.java EclQueries.java SqlColumn.java Utils.java EclVersionTracker.java
+
 )
 
 # compile all .java files with javac to .class
@@ -40,11 +37,11 @@ DEPENDS
 ${CMAKE_CURRENT_BINARY_DIR}/${JAVA_FILES}.class
 COMMAND ${CMAKE_COMMAND}
 ARGS -E chdir ${CMAKE_CURRENT_BINARY_DIR}/${CLASS_DIR}
-#${CMAKE_Java_ARCHIVE} -cfv ${JAR_DIR}/${JAR_FILE} ${CLASS_DIR}/com/hpccsystems/ecljdbc
 ${CMAKE_Java_ARCHIVE} -cfv ${CMAKE_CURRENT_BINARY_DIR}/${JAR_FILE} com/hpccsystems/ecljdbc
 )
 
 # the target
 ADD_CUSTOM_TARGET(
 ${JAR_FILE}
-ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${JAR_FILE})
+ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${JAR_FILE}
+)

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/CMakeLists.txt
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 
-set ( HPCC_ECLJDBC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set ( HPCC_SOURCE_DIR ${HPCC_ECLJDBC_SOURCE_DIR}/../../../../../../../../..)
-include(${HPCC_SOURCE_DIR}/version.cmake)
+#set ( HPCC_ECLJDBC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+#set ( HPCC_SOURCE_DIR ${HPCC_ECLJDBC_SOURCE_DIR}/../../../../../../../../..)
+#include(${HPCC_SOURCE_DIR}/version.cmake)
 
 configure_file("EclVersionTracker.java.in" "${HPCC_ECLJDBC_SOURCE_DIR}/EclVersionTracker.java")
 

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDatabaseMetaData.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDatabaseMetaData.java
@@ -1001,20 +1001,19 @@ public class EclDatabaseMetaData implements DatabaseMetaData {
 	@Override
 	public String getDriverVersion() throws SQLException
 	{
-		return EclDriver.ECLJDBCMajorVersion + "." + EclDriver.ECLJDBCMinorVersion + "." + EclDriver.ECLJDBCPatchVersion ;
-
+		return EclVersionTracker.HPCCMajor + "." + EclVersionTracker.HPCCMinor + "." + EclVersionTracker.HPCCPoint;
 	}
 
 	@Override
 	public int getDriverMajorVersion()
 	{
-		return EclDriver.ECLJDBCMajorVersion;
+		return EclVersionTracker.HPCCMajor;
 	}
 
 	@Override
 	public int getDriverMinorVersion()
 	{
-		return EclDriver.ECLJDBCMinorVersion;
+		return EclVersionTracker.HPCCMinor;
 	}
 
 	@Override

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDriver.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDriver.java
@@ -26,10 +26,6 @@ public class EclDriver implements Driver
 		}
 	}
 
-	static final int ECLJDBCMajorVersion = 0;
-	static final int ECLJDBCMinorVersion = 1;
-	static final int ECLJDBCPatchVersion = 0;
-
 	public EclDriver()
 	{
 	}
@@ -85,14 +81,12 @@ public class EclDriver implements Driver
 
 	public int getMajorVersion()
 	{
-		System.out.println("ECLDRIVER GETMAJORVERSION");
-		return ECLJDBCMajorVersion;
+		return EclVersionTracker.HPCCMajor;
 	}
 
 
 	public int getMinorVersion() {
-		System.out.println("ECLDRIVER GETMINORVERSION");
-		return ECLJDBCMinorVersion;
+		return EclVersionTracker.HPCCMinor;
 	}
 
 

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclVersionTracker.java.in
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclVersionTracker.java.in
@@ -1,8 +1,11 @@
-package org.hpccsystems.ecljdbc;
+package com.hpccsystems.ecljdbc;
 
 public class EclVersionTracker 
 {
-	static final int ECLJDBCMajorVersion = ${majorver};
-	static final int ECLJDBCMinorVersion = ${minorver};
-	static final int ECLJDBCPatchVersion = ${point};
+	static final String HPCCProject 	= "${HPCC_PROJECT}";
+	static final int HPCCMajor 			= ${HPCC_MAJOR};
+	static final int HPCCMinor 			= ${HPCC_MINOR};
+	static final int HPCCPoint 			= ${HPCC_POINT};
+	static final String HPCCPMaturity 	= "${HPCC_POINT}";
+	static final int HPCCSequence 		= ${HPCC_SEQUENCE};
 }


### PR DESCRIPTION
Bug #2229 ECLJDBC driver inherits platform's version values.

Although the ECL JDBC driver is a stand-alone JAVA based application, without
any direct dependency on the platform, it will be versioned in parallel with the
platform. In order to achieve this, a simple java class is generated by the CMAKE
configuration process. This "version tracker" class contains final static values
based on the platform's cmake version variables. The entire project is free to use
those fields for version reporting purposes.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
