### PR TITLE
Fix issues with distributed results in child queries

### DIFF
--- a/thorlcr/activities/loop/thloop.cpp
+++ b/thorlcr/activities/loop/thloop.cpp
@@ -124,7 +124,7 @@ public:
         if (!CLoopActivityMasterBase::doinit())
             return;
         IHThorLoopArg *helper = (IHThorLoopArg *) queryHelper();
-        Owned<IThorGraphResults> results = createThorGraphResults(3);
+        Owned<IThorGraphResults> results = queryGraph().createThorGraphResults(3);
         queryContainer().queryLoopGraph()->prepareLoopResults(*this, results);
         if (helper->getFlags() & IHThorLoopArg::LFcounter)
             queryContainer().queryLoopGraph()->prepareCounterResult(*this, results, 1, 2);
@@ -172,7 +172,7 @@ public:
         if (!CLoopActivityMasterBase::doinit())
             return;
         IHThorGraphLoopArg *helper = (IHThorGraphLoopArg *) queryHelper();
-        Owned<IThorGraphResults> results = createThorGraphResults(1);
+        Owned<IThorGraphResults> results = queryGraph().createThorGraphResults(1);
         if (helper->getFlags() & IHThorGraphLoopArg::GLFcounter)
             queryContainer().queryLoopGraph()->prepareCounterResult(*this, results, 1, 0);
         loopGraph->setResults(results);
@@ -189,9 +189,8 @@ public:
             return;
         unsigned maxIterations = helper->numIterations();
         if ((int)maxIterations < 0) maxIterations = 0;
-        Owned<IThorGraphResults> loopResults = createThorGraphResults(maxIterations);
+        Owned<IThorGraphResults> loopResults = queryGraph().createThorGraphResults(maxIterations);
         IThorResult *result = loopResults->createResult(*this, 0, this, true);
-        Owned<IRowWriter> resultWriter = result->getWriter();
 
         helper->createParentExtract(extractBuilder);
 
@@ -215,139 +214,25 @@ CActivityBase *createGraphLoopActivityMaster(CMasterGraphElement *container)
 
 class CLocalResultActivityMasterBase : public CMasterActivity
 {
-    PointerArrayOf<CThorExpandingRowArray> results;
-
 protected:
     Owned<IRowInterfaces> inputRowIf;
 
 public:
     CLocalResultActivityMasterBase(CMasterGraphElement *info) : CMasterActivity(info)
     {
-        mpTag = container.queryJob().allocateMPTag();
-        for (unsigned n=0; n<container.queryJob().querySlaves(); n++)
-            results.append(new CThorExpandingRowArray(*this));
-    }
-    ~CLocalResultActivityMasterBase()
-    {
-        ForEachItemIn(r, results)
-        {
-            CThorExpandingRowArray *result = results.item(r);
-            delete result;
-        }
-        results.kill();
     }
     virtual void init()
     {
         reset();
     }
-    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
-    {
-        if (!container.queryLocalOrGrouped())
-            serializeMPtag(dst, mpTag);
-    }
-    virtual IThorResult *createResult() = 0;
+    virtual void createResult() = 0;
     virtual void process()
     {
         assertex(container.queryResultsGraph());
-        Owned<CGraphBase> graph = container.queryOwner().queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
+        Owned<CGraphBase> graph = queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
         IHThorLocalResultWriteArg *helper = (IHThorLocalResultWriteArg *)queryHelper();
         inputRowIf.setown(createRowInterfaces(container.queryInput(0)->queryHelper()->queryOutputMeta(),queryActivityId(),queryCodeContext()));
-
-        IThorResult *result = createResult();
-        if (!result->isLocal())
-        {
-            Owned<IRowWriter> resultWriter = result->getWriter();
-            unsigned todo = container.queryJob().querySlaves();
-            for (unsigned n=0; n<todo; n++)
-                results.item(n)->kill();
-            rank_t sender;
-            MemoryBuffer mb;
-            CMessageBuffer msg;
-            Owned<ISerialStream> stream = createMemoryBufferSerialStream(mb);
-            CThorStreamDeserializerSource rowSource(stream);
-            loop
-            {
-                loop
-                {
-                    if (abortSoon)
-                        return;
-                    msg.clear();
-                    if (receiveMsg(msg, RANK_ALL, mpTag, &sender, 60*1000))
-                        break;
-                    ActPrintLog("WARNING: tag %d timedout, retrying", (unsigned)mpTag);
-                }
-                sender = sender - 1; // 0 = master
-                if (!msg.length())
-                {
-                    --todo;
-                    if (0 == todo)
-                        break; // done
-                }
-                else
-                {
-                    ThorExpand(msg, mb.clear());
-
-                    CThorExpandingRowArray *slaveResults = results.item(sender);
-                    while (!rowSource.eos())
-                    {
-                        RtlDynamicRowBuilder rowBuilder(inputRowIf->queryRowAllocator());
-                        size32_t sz = inputRowIf->queryRowDeserializer()->deserialize(rowBuilder, rowSource);
-                        slaveResults->append(rowBuilder.finalizeRowClear(sz));
-                    }
-                }
-            }
-            mb.clear();
-            CMemoryRowSerializer mbs(mb);
-            CThorExpandingRowArray *slaveResult = results.item(0);
-            unsigned rowNum=0;
-            unsigned resultNum=1;
-            loop
-            {
-                while (resultNum)
-                {
-                    if (rowNum == slaveResult->ordinality())
-                    {
-                        loop
-                        {
-                            if (resultNum == results.ordinality())
-                            {
-                                resultNum = 0; // eos
-                                break;
-                            }
-                            slaveResult = results.item(resultNum++);
-                            if (slaveResult->ordinality())
-                            {
-                                rowNum = 0;
-                                break;
-                            }
-                        }
-                        if (!resultNum) // eos
-                            break;
-                    }
-                    const void *row = slaveResult->query(rowNum++);
-                    inputRowIf->queryRowSerializer()->serialize(mbs, (const byte *)row);
-                    LinkThorRow(row);
-                    resultWriter->putRow(row);
-                    if (mb.length() > 0x80000)
-                        break;
-                }
-                msg.clear();
-                if (mb.length())
-                {
-                    ThorCompress(mb.toByteArray(), mb.length(), msg);
-                    mb.clear();
-                }
-                BooleanOnOff onOff(receiving);
-                ((CJobMaster &)container.queryJob()).broadcastToSlaves(msg, mpTag, LONGTIMEOUT, NULL, NULL, true);
-                if (0 == msg.length())
-                    break;
-            }
-        }
-    }
-    virtual void abort()
-    {
-        CMasterActivity::abort();
-        cancelReceiveMsg(RANK_ALL, mpTag);
+        createResult();
     }
 };
 
@@ -357,15 +242,11 @@ public:
     CLocalResultActivityMaster(CMasterGraphElement *info) : CLocalResultActivityMasterBase(info)
     {
     }
-    virtual IThorResult *createResult()
+    virtual void createResult()
     {
         IHThorLocalResultWriteArg *helper = (IHThorLocalResultWriteArg *)queryHelper();
-        Owned<CGraphBase> graph = container.queryOwner().queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
-        bool local = container.queryOwner().isLocalOnly();
-        IThorResult *result = graph->queryResult(helper->querySequence());
-        if (result)
-            local = result->isLocal();
-        return graph->createResult(*this, helper->querySequence(), this, local); // NB graph owns result
+        Owned<CGraphBase> graph = queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
+        graph->createResult(*this, helper->querySequence(), this, true); // NB graph owns result
     }
 };
 
@@ -380,11 +261,11 @@ public:
     CGraphLoopResultWriteActivityMaster(CMasterGraphElement *info) : CLocalResultActivityMasterBase(info)
     {
     }
-    virtual IThorResult *createResult()
+    virtual void createResult()
     {
         IHThorGraphLoopResultWriteArg *helper = (IHThorGraphLoopResultWriteArg *)queryHelper();
-        Owned<CGraphBase> graph = container.queryOwner().queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
-        return graph->createGraphLoopResult(*this, inputRowIf); // NB graph owns result
+        Owned<CGraphBase> graph = queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
+        graph->createGraphLoopResult(*this, inputRowIf, true); // NB graph owns result
     }
 };
 

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -130,7 +130,7 @@ public:
         __uint64 numRows = helper->numRows();
         // local when generated from a child query (the range is per node, don't split)
         bool isLocal = container.queryOwnerId() && container.queryOwner().isLocalOnly();
-        if (!isLocal && (helper->getFlags() & TTFdistributed != 0))
+        if (!isLocal && ((helper->getFlags() & TTFdistributed) != 0))
         {
             __uint64 nodes = container.queryCodeContext()->getNodes();
             __uint64 nodeid = container.queryCodeContext()->getNodeNum();

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -49,21 +49,19 @@ class CThorGraphResult : public CInterface, implements IThorResult, implements I
     Owned<IRowWriterMultiReader> rowBuffer;
     IRowInterfaces *rowIf;
     IEngineRowAllocator *allocator;
-    bool stopped, readers;
-    bool local;
+    bool stopped, readers, distributed;
 
     void init()
     {
-        stopped = false;
+        stopped = readers = false;
         allocator = rowIf->queryRowAllocator();
         meta = allocator->queryOutputMeta();
         rowStreamCount = 0;
-        readers = false;
     }
 public:
     IMPLEMENT_IINTERFACE;
 
-    CThorGraphResult(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _local) : activity(_activity), rowIf(_rowIf), local(_local)
+    CThorGraphResult(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _distributed) : activity(_activity), rowIf(_rowIf), distributed(_distributed)
     {
         init();
         rowBuffer.setown(createOverflowableBuffer(activity, rowIf, true, true));
@@ -95,13 +93,13 @@ public:
         readers = true;
         return rowBuffer->getReader();
     }
-    virtual bool isLocal() const { return local; }
-    virtual IOutputMetaData *queryMeta() { return meta; }
-    virtual void getResult(size32_t &len, void * & data)
+    virtual IRowInterfaces *queryRowInterfaces() { return rowIf; }
+    virtual CActivityBase *queryActivity() { return &activity; }
+    virtual bool isDistributed() const { return distributed; }
+    virtual void serialize(MemoryBuffer &mb)
     {
         Owned<IRowStream> stream = getRowStream();
         bool grouped = meta->isGrouped();
-        MemoryBuffer mb;
         if (grouped)
         {
             OwnedConstThorRow prev = stream->nextRow();
@@ -138,6 +136,11 @@ public:
                 mb.append(sz, row.get());
             }
         }
+    }
+    virtual void getResult(size32_t &len, void * & data)
+    {
+        MemoryBuffer mb;
+        serialize(mb);
         len = mb.length();
         data = mb.detach();
     }
@@ -166,94 +169,21 @@ public:
 
 /////
 
-class CThorGraphResults : public CInterface, implements IThorGraphResults
+IThorResult *CThorGraphResults::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed)
 {
-    class CThorUninitializedGraphResults : public CInterface, implements IThorResult
-    {
-        unsigned id;
-
-    public:
-        IMPLEMENT_IINTERFACE
-
-        CThorUninitializedGraphResults(unsigned _id) { id = _id; }
-        virtual IRowWriter *getWriter() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
-        virtual void setResultStream(IRowWriterMultiReader *stream, rowcount_t count) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
-        virtual IRowStream *getRowStream() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
-        virtual IOutputMetaData *queryMeta() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
-        virtual bool isLocal() const { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
-        virtual void getResult(size32_t & retSize, void * & ret) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
-        virtual void getLinkedResult(unsigned & count, byte * * & ret) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
-    };
-    IArrayOf<IThorResult> results;
-    CriticalSection cs;
-    void ensureAtleast(unsigned id)
-    {
-        while (results.ordinality() < id)
-            results.append(*new CThorUninitializedGraphResults(results.ordinality()));
-    }
-public:
-    IMPLEMENT_IINTERFACE;
-
-    CThorGraphResults(unsigned _numResults) { }
-    virtual void clear()
-    {
-        CriticalBlock procedure(cs);
-        results.kill();
-    }
-    virtual IThorResult *queryResult(unsigned id)
-    {
-        CriticalBlock procedure(cs);
-        if (results.ordinality() <= id)
-            return NULL;
-        IThorResult *res = &results.item(id);
-        if (QUERYINTERFACE(res, CThorUninitializedGraphResults))
-            return NULL;
-        return res;
-    }
-    virtual IThorResult *getResult(unsigned id)
-    {
-        CriticalBlock procedure(cs);
-        ensureAtleast(id+1);
-        // NB: stream static after this, i.e. nothing can be added to this result
-        return LINK(&results.item(id));
-    }
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool local=false)
-    {
-        Owned<CThorGraphResult> result = new CThorGraphResult(activity, rowIf, local);
-        setResult(id, result);
-        return result;
-    }
-    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool local=false)
-    {
-        return createResult(activity, results.ordinality(), rowIf, local);
-    }
-    virtual void setResult(unsigned id, IThorResult *result)
-    {
-        CriticalBlock procedure(cs);
-        ensureAtleast(id);
-        if (results.isItem(id))
-            results.replace(*LINK(result), id);
-        else
-            results.append(*LINK(result));
-    }
-    virtual unsigned count() { return results.ordinality(); }
-    virtual void getResult(size32_t & retSize, void * & ret, unsigned id)
-    {
-        results.item(id).getResult(retSize, ret);
-    }
-    virtual void getLinkedResult(unsigned & count, byte * * & ret, unsigned id)
-    {
-        results.item(id).getLinkedResult(count, ret);
-    }
-};
-
-IThorGraphResults *createThorGraphResults(unsigned num)
-{
-    return new CThorGraphResults(num);
+    Owned<IThorResult> result = ::createResult(activity, rowIf, distributed);
+    setResult(id, result);
+    return result;
 }
 
-//////////
+/////
 
+IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+{
+    return new CThorGraphResult(activity, rowIf, distributed);
+}
+
+/////
 class CThorBoundLoopGraph : public CInterface, implements IThorBoundLoopGraph
 {
     CGraphBase *graph;
@@ -277,7 +207,7 @@ public:
         thor_loop_counter_t * res = (thor_loop_counter_t *)counterRow.ensureCapacity(sizeof(thor_loop_counter_t),NULL);
         *res = loopCounter;
         OwnedConstThorRow counterRowFinal = counterRow.finalizeRowClear(sizeof(thor_loop_counter_t));
-        IThorResult *counterResult = results->createResult(activity, pos, countRowIf, true);
+        IThorResult *counterResult = results->createResult(activity, pos, countRowIf, false);
         Owned<IRowWriter> counterResultWriter = counterResult->getWriter();
         counterResultWriter->putRow(counterRowFinal.getClear());
     }
@@ -285,12 +215,12 @@ public:
     {
         if (!resultRowIf)
             resultRowIf.setown(createRowInterfaces(resultMeta, activityId, activity.queryCodeContext()));
-        IThorResult *loopResult = results->createResult(activity, 0, resultRowIf, true); // loop output, create and mark local
-        IThorResult *inputResult = results->createResult(activity, 1, resultRowIf, true);
+        IThorResult *loopResult = results->createResult(activity, 0, resultRowIf, !activity.queryGraph().isLocalChild()); // loop output
+        IThorResult *inputResult = results->createResult(activity, 1, resultRowIf, !activity.queryGraph().isLocalChild());
     }
     virtual IRowStream *execute(CActivityBase &activity, unsigned counter, IRowWriterMultiReader *inputStream, unsigned rowStreamCount, size32_t parentExtractSz, const byte *parentExtract)
     {
-        Owned<IThorGraphResults> results = createThorGraphResults(3);
+        Owned<IThorGraphResults> results = graph->createThorGraphResults(3);
         prepareLoopResults(activity, results);
         if (counter)
         {
@@ -301,12 +231,14 @@ public:
         if (inputStream)
             inputResult->setResultStream(inputStream, rowStreamCount);
         graph->executeChild(parentExtractSz, parentExtract, results, NULL);
+        if (0 == graph->queryJob().queryMyRank())
+            return NULL; // unset and unused on master
         Owned<IThorResult> result0 = results->getResult(0);
         return result0->getRowStream();
     }
     virtual void execute(CActivityBase &activity, unsigned counter, IThorGraphResults *graphLoopResults, size32_t parentExtractSz, const byte *parentExtract)
     {
-        Owned<IThorGraphResults> results = createThorGraphResults(1);
+        Owned<IThorGraphResults> results = graph->createThorGraphResults(1);
         if (counter)
         {
             prepareCounterResult(activity, results, counter, 0);
@@ -1304,13 +1236,18 @@ void CGraphBase::doExecute(size32_t parentExtractSz, const byte *parentExtract, 
     }
     try
     {
-        if (exception && !queryOwner())
+        if (exception)
         {
-            StringBuffer str;
-            Owned<IThorException> e = MakeGraphException(this, exception->errorCode(), "%s", exception->errorMessage(str).str());
-            e->setGraphId(graphId);
-            e->setAction(tea_abort);
-            fireException(e);
+            if (NULL == owner || isGlobal())
+                waitBarrier->cancel();
+            if (!queryOwner())
+            {
+                StringBuffer str;
+                Owned<IThorException> e = MakeGraphException(this, exception->errorCode(), "%s", exception->errorMessage(str).str());
+                e->setGraphId(graphId);
+                e->setAction(tea_abort);
+                fireException(e);
+            }
         }
     }
     catch (IException *e)
@@ -1666,6 +1603,14 @@ void CGraphBase::GraphPrintLog(IException *e, const char *format, ...)
     va_end(args);
 }
 
+void CGraphBase::setGlobal(bool tf)
+{
+    global = tf;
+    Owned<IThorGraphIterator> iter = getChildGraphs();
+    ForEach(*iter)
+        iter->query().setGlobal(tf);
+}
+
 void CGraphBase::createFromXGMML(IPropertyTree *_node, CGraphBase *_owner, CGraphBase *_parent, CGraphBase *resultsGraph)
 {
     owner = _owner;
@@ -1692,7 +1637,7 @@ void CGraphBase::createFromXGMML(IPropertyTree *_node, CGraphBase *_owner, CGrap
         tmpHandler.setown(queryJob().createTempHandler());
     }
 
-    bool localChild = false;
+    localChild = false;
     if (owner && parentActivityId)
     {
         CGraphElementBase *parentElement = owner->queryElement(parentActivityId);
@@ -1704,9 +1649,11 @@ void CGraphBase::createFromXGMML(IPropertyTree *_node, CGraphBase *_owner, CGrap
             case TAKloopdataset:
             case TAKgraphloop:
             case TAKparallelgraphloop:
-                if (!parentElement->queryLocal())
-                    global = true;
+            {
+                if (parentElement->queryOwner().isLocalChild())
+                    localChild = true;
                 break;
+            }
             default:
                 localChild = true;
                 break;
@@ -1741,6 +1688,35 @@ void CGraphBase::createFromXGMML(IPropertyTree *_node, CGraphBase *_owner, CGrap
                 global = isGlobalActivity(*act);
         }
     }
+
+    if (!localChild)
+    {
+        ForEach(*nodes)
+        {
+            IPropertyTree &e = nodes->query();
+            ThorActivityKind kind = (ThorActivityKind) e.getPropInt("att[@name=\"_kind\"]/@value");
+            switch (kind)
+            {
+                case TAKlooprow:
+                case TAKloopcount:
+                case TAKloopdataset:
+                case TAKgraphloop:
+                case TAKparallelgraphloop:
+                {
+                    unsigned loopId = e.getPropInt("att[@name=\"_loopid\"]/@value");
+                    // if any need sub graph or dependency if subgraphs need global execution,
+                    // then all loop subgraphs must be executed globally (sync'd with master)
+                    Owned<CGraphBase> loopGraph = getChildGraph(loopId);
+                    if (!loopGraph->isLocalOnly())
+                        loopGraph->setGlobal();
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+    }
+
     Owned<IPropertyTreeIterator> edges = xgmml->getElements("edge");
     ForEach(*edges)
     {
@@ -1854,46 +1830,36 @@ void CGraphBase::executeChild(size32_t parentExtractSz, const byte *parentExtrac
     doExecuteChild(parentExtractSz, parentExtract);
 }
 
-IThorResult *CGraphBase::queryResult(unsigned id)
+IThorResult *CGraphBase::getResult(unsigned id, bool distributed)
 {
-    return localResults->queryResult(id);
+    return localResults->getResult(id, distributed);
 }
 
-IThorResult *CGraphBase::getResult(unsigned id)
+IThorResult *CGraphBase::getGraphLoopResult(unsigned id, bool distributed)
 {
-    return localResults->getResult(id);
+    return graphLoopResults->getResult(id, distributed);
 }
 
-IThorResult *CGraphBase::queryGraphLoopResult(unsigned id)
+IThorResult *CGraphBase::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed)
 {
-    return graphLoopResults->queryResult(id);
+    return localResults->createResult(activity, id, rowIf, distributed);
 }
 
-IThorResult *CGraphBase::getGraphLoopResult(unsigned id)
+IThorResult *CGraphBase::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
 {
-    return graphLoopResults->getResult(id);
-}
-
-IThorResult *CGraphBase::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool local)
-{
-    return localResults->createResult(activity, id, rowIf, local);
-}
-
-IThorResult *CGraphBase::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf)
-{
-    return graphLoopResults->createResult(activity, rowIf, true);
+    return graphLoopResults->createResult(activity, rowIf, distributed);
 }
 
 // ILocalGraph
 void CGraphBase::getResult(size32_t & len, void * & data, unsigned id)
 {
-    Owned<IThorResult> result = localResults->getResult(id);
+    Owned<IThorResult> result = getResult(id, true); // will get collated distributed result
     result->getResult(len, data);
 }
 
 void CGraphBase::getLinkedResult(unsigned & count, byte * * & ret, unsigned id)
 {
-    Owned<IThorResult> result = localResults->getResult(id);
+    Owned<IThorResult> result = getResult(id, true); // will get collated distributed result
     result->getLinkedResult(count, ret);
 }
 
@@ -1965,6 +1931,12 @@ bool CGraphBase::isLocalOnly() const // checks all dependencies, if something ne
         localOnly = (int)::isLocalOnly(*this);
     return 1==localOnly;
 }
+
+IThorGraphResults *CGraphBase::createThorGraphResults(unsigned num)
+{
+    return new CThorGraphResults(num);
+}
+
 
 ////
 

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -624,7 +624,7 @@ public:
     bool isLocalOnly() const; // this graph and all upstream dependencies
     bool isLocalChild() const { return localChild; }
     void setCompleteEx(bool tf=true) { complete = tf; }
-    void setGlobal(bool tf=true);
+    void setGlobal(bool tf) { global = tf; }
     const byte *setParentCtx(size32_t _parentExtractSz, const byte *parentExtract)
     {
         parentExtractSz = _parentExtractSz;

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -44,6 +44,8 @@
 #include "eclhelper.hpp"
 #include "thexception.hpp"
 #include "thactivitymaster.ipp"
+#include "thmem.hpp"
+#include "thcompressutil.hpp"
 
 static CriticalSection *jobManagerCrit;
 MODULE_INIT(INIT_PRIORITY_STANDARD)
@@ -286,7 +288,7 @@ void CSlaveMessageHandler::main()
                 }
                 case smt_actMsg:
                 {
-                    LOG(MCdebugProgress, unknownJob, "smt_podata called from slave %d", sender-1);
+                    LOG(MCdebugProgress, unknownJob, "smt_actMsg called from slave %d", sender-1);
                     graph_id gid;
                     msg.read(gid);
                     activity_id id;
@@ -298,6 +300,21 @@ void CSlaveMessageHandler::main()
                     CMasterActivity *activity = (CMasterActivity *)container->queryActivity();
                     assertex(activity);
                     activity->handleSlaveMessage(msg); // don't block
+                    break;
+                }
+                case smt_getresult:
+                {
+                    LOG(MCdebugProgress, unknownJob, "smt_getresult called from slave %d", sender-1);
+                    graph_id gid;
+                    msg.read(gid);
+                    Owned<CMasterGraph> graph = (CMasterGraph *)job.getGraph(gid);
+                    unsigned resultId;
+                    msg.read(resultId);
+                    mptag_t replyTag = graph->queryJob().deserializeMPTag(msg);
+                    assertex(graph);
+                    Owned<IThorResult> result = graph->getResult(resultId);
+                    Owned<IRowStream> resultStream = result->getRowStream();
+                    sendInChunks(graph->queryJob().queryJobComm(), sender, replyTag, resultStream, result->queryRowInterfaces());
                     break;
                 }
             }
@@ -1734,6 +1751,153 @@ bool CJobMaster::fireException(IException *e)
 
 ///////////////////
 
+class CCollatedResult : public CSimpleInterface, implements IThorResult
+{
+    CMasterGraph &graph;
+    CActivityBase &activity;
+    IRowInterfaces *rowIf;
+    unsigned id;
+    CriticalSection crit;
+    PointerArrayOf<CThorExpandingRowArray> results;
+    Owned<IThorResult> result;
+
+    void ensure()
+    {
+        CriticalBlock b(crit);
+        if (result)
+            return;
+        mptag_t replyTag = createReplyTag();
+        CMessageBuffer msg;
+        msg.append(GraphGetResult);
+        msg.append(activity.queryJob().queryKey());
+        msg.append(graph.queryGraphId());
+        msg.append(id);
+        msg.append(replyTag);
+        ((CJobMaster &)graph.queryJob()).broadcastToSlaves(msg, masterSlaveMpTag, LONGTIMEOUT, NULL, NULL, true);
+
+        unsigned numSlaves = graph.queryJob().querySlaves();
+        for (unsigned n=0; n<numSlaves; n++)
+            results.item(n)->kill();
+        rank_t sender;
+        MemoryBuffer mb;
+        Owned<ISerialStream> stream = createMemoryBufferSerialStream(mb);
+        CThorStreamDeserializerSource rowSource(stream);
+        unsigned todo = numSlaves;
+
+        loop
+        {
+            loop
+            {
+                if (activity.queryAbortSoon())
+                    return;
+                msg.clear();
+                if (activity.receiveMsg(msg, RANK_ALL, replyTag, &sender, 60*1000))
+                    break;
+                ActPrintLog(&activity, "WARNING: tag %d timedout, retrying", (unsigned)replyTag);
+            }
+            sender = sender - 1; // 0 = master
+            if (!msg.length())
+            {
+                --todo;
+                if (0 == todo)
+                    break; // done
+            }
+            else
+            {
+                bool error;
+                msg.read(error);
+                if (error)
+                {
+                    Owned<IThorException> e = deserializeThorException(msg);
+                    e->setSlave(sender);
+                    throw e.getClear();
+                }
+                ThorExpand(msg, mb.clear());
+
+                CThorExpandingRowArray *slaveResults = results.item(sender);
+                while (!rowSource.eos())
+                {
+                    RtlDynamicRowBuilder rowBuilder(rowIf->queryRowAllocator());
+                    size32_t sz = rowIf->queryRowDeserializer()->deserialize(rowBuilder, rowSource);
+                    slaveResults->append(rowBuilder.finalizeRowClear(sz));
+                }
+            }
+        }
+        Owned<IThorResult> _result = ::createResult(activity, rowIf, false);
+        Owned<IRowWriter> resultWriter = _result->getWriter();
+        for (unsigned s=0; s<numSlaves; s++)
+        {
+            CThorExpandingRowArray *slaveResult = results.item(s);
+            ForEachItemIn(r, *slaveResult)
+            {
+                const void *row = slaveResult->query(r);
+                LinkThorRow(row);
+                resultWriter->putRow(row);
+            }
+        }
+        result.setown(_result.getClear());
+    }
+
+public:
+    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+
+    CCollatedResult(CMasterGraph &_graph, CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _id) : graph(_graph), activity(_activity), rowIf(_rowIf), id(_id)
+    {
+        for (unsigned n=0; n<graph.queryJob().querySlaves(); n++)
+            results.append(new CThorExpandingRowArray(activity));
+    }
+    ~CCollatedResult()
+    {
+        ForEachItemIn(l, results)
+        {
+            CThorExpandingRowArray *result = results.item(l);
+            delete result;
+        }
+    }
+    void setId(unsigned _id)
+    {
+        id = _id;
+    }
+
+// IThorResult
+    virtual IRowWriter *getWriter() { throwUnexpected(); }
+    virtual void setResultStream(IRowWriterMultiReader *stream, rowcount_t count)
+    {
+        throwUnexpected();
+    }
+    virtual IRowStream *getRowStream()
+    {
+        ensure();
+        return result->getRowStream();
+    }
+    virtual IRowInterfaces *queryRowInterfaces()
+    {
+        return rowIf;
+    }
+    virtual CActivityBase *queryActivity()
+    {
+        return &activity;
+    }
+    virtual bool isDistributed() const { return false; }
+    virtual void serialize(MemoryBuffer &mb)
+    {
+        ensure();
+        result->serialize(mb);
+    }
+    virtual void getResult(size32_t & retSize, void * & ret)
+    {
+        ensure();
+        return result->getResult(retSize, ret);
+    }
+    virtual void getLinkedResult(unsigned & count, byte * * & ret)
+    {
+        ensure();
+        return result->getLinkedResult(count, ret);
+    }
+};
+
+///////////////////
+
 //
 // CMasterGraph impl.
 //
@@ -2410,6 +2574,22 @@ bool CMasterGraph::deserializeStats(unsigned node, MemoryBuffer &mb)
     }
     return true;
 }
+
+IThorResult *CMasterGraph::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed)
+{
+    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, id);
+    localResults->setResult(id, result);
+    return result;
+}
+
+IThorResult *CMasterGraph::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+{
+    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, 0);
+    unsigned id = graphLoopResults->addResult(result);
+    result->setId(id);
+    return result;
+}
+
 
 ///////////////////////////////////////////////////
 

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -78,6 +78,9 @@ public:
     virtual void start();
     virtual void done();
     virtual void abort(IException *e);
+    IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
+    IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+
 // IExceptionHandler
     virtual bool fireException(IException *e);
 // IThorChildGraph impl.

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -107,6 +107,7 @@ public:
     void initWithActData(MemoryBuffer &in, MemoryBuffer &out);
     void getDone(MemoryBuffer &doneInfoMb);
     void serializeDone(MemoryBuffer &mb);
+    IThorResult *getGlobalResult(CActivityBase &activity, IRowInterfaces *rowIf, unsigned id);
 
     virtual void executeSubGraph(size32_t parentExtractSz, const byte *parentExtract);
     virtual void serializeStats(MemoryBuffer &mb);
@@ -117,6 +118,7 @@ public:
     virtual void abort(IException *e);
     virtual void done();
     virtual void end();
+    virtual IThorGraphResults *createThorGraphResults(unsigned num);
 
 // IExceptionHandler
     virtual bool fireException(IException *e)

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -300,7 +300,7 @@ extern graph_decl void reportExceptionToWorkunit(IConstWorkUnit &workunit,IExcep
 
 extern graph_decl IPropertyTree *globals;
 extern graph_decl mptag_t masterSlaveMpTag;
-enum SlaveMsgTypes { smt_errorMsg=1, smt_initGraphReq, smt_initActDataReq, smt_dataReq, smt_getPhysicalName, smt_getFileOffset, smt_actMsg };
+enum SlaveMsgTypes { smt_errorMsg=1, smt_initGraphReq, smt_initActDataReq, smt_dataReq, smt_getPhysicalName, smt_getFileOffset, smt_actMsg, smt_getresult };
 // Logging
 extern graph_decl const LogMsgJobInfo thorJob;
 
@@ -339,6 +339,9 @@ extern graph_decl IRowStream *createRowStreamFromNode(CActivityBase &activity, u
 extern graph_decl IRowServer *createRowServer(CActivityBase *activity, IRowStream *seq, ICommunicator &comm, mptag_t mpTag);
 
 extern graph_decl IRowStream *createUngroupStream(IRowStream *input);
+
+interface IRowInterfaces;
+extern graph_decl void sendInChunks(ICommunicator &comm, rank_t dst, mptag_t mpTag, IRowStream *input, IRowInterfaces *rowIf);
 
 #endif
 


### PR DESCRIPTION
Rewrite the way intermediate child query/loop query results are handled.
They need to be accessible by other global queries and remain distributed,
but also collated (on demand) by local child queries or context requests

Also fix an abort issue, where query could hang.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
