### PR TITLE
Ecldirect port should be same as eclwatch port

### DIFF
--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -901,8 +901,15 @@ void CWizardInputs::getEspBindingInformation(IPropertyTree* pNewEnvTree)
          IPropertyTree* pEspServiceInSWTree = pNewEnvTree->queryPropTree(xpath.str());
          if(pEspServiceInSWTree)
          {
-           xpath.clear().append("./Properties/@defaultPort");
+           xpath.clear().append("./Properties/@defaultWizardPort");
            const char* port = pEspService->queryProp(xpath.str());
+
+           if (!port || !*port)
+           {
+             xpath.clear().append("./Properties/@defaultPort");
+             port = pEspService->queryProp(xpath.str());
+           }
+
            xpath.clear().append("./Properties/@defaultResourcesBasedn");
            const char* resourceBasedn = pEspService->queryProp(xpath.str());
 

--- a/initfiles/componentfiles/configxml/buildsetCC.xml.in
+++ b/initfiles/componentfiles/configxml/buildsetCC.xml.in
@@ -360,8 +360,10 @@
              schema="esp_service_ecldirect.xsd">
     <Properties bindingType="EclDirectSoapBinding"
                 defaultPort="8008"
+                defaultWizardPort="8010"
                 defaultResourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
                 defaultSecurePort="18008"
+                defaultWizardSecurePort="18010"
                 plugin="ecldirect"
                 type="ecldirect">
      <Authenticate access="Read"

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -352,9 +352,11 @@
              processName="EspService"
              schema="esp_service_ecldirect.xsd">
     <Properties bindingType="EclDirectSoapBinding"
-                defaultPort="8010"
+                defaultPort="8008"
+                defaultWizardPort="8010"
                 defaultResourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
-                defaultSecurePort="18010"
+                defaultSecurePort="18008"
+                defaultWizardSecurePort="18010"
                 plugin="ecldirect"
                 type="ecldirect">
      <Authenticate access="Read"


### PR DESCRIPTION
When using wizard to generate an environment, the ecldirect esp binding port
should be the same as eclwatch port so that the "ecl playground" and "run ecl" links
show up on the eclwatch page. Creation of ecldirect via advanced mode should still default 
the port to 8008. Also updated the buildset defaults for ecldirect in the default environment.

Fixes #2219

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
