### PR TITLE
Allow graph results to have spill priority

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -2385,7 +2385,7 @@ public:
             {
                 if(rc == LDAP_ALREADY_EXISTS)
                 {
-                    throw MakeStringException(-1, "can't add %s to sudoers, already exists", username);
+                    throw MakeStringException(-1, "can't add %s to sudoers, an LDAP object with this name already exists", username);
                 }
                 else
                 {
@@ -3293,7 +3293,7 @@ public:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                throw MakeStringException(-1, "can't add group %s, already exists", groupname);
+                throw MakeStringException(-1, "can't add group %s, an LDAP object with this name already exists", groupname);
             }
             else
             {
@@ -3678,7 +3678,7 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                throw MakeStringException(-1, "can't add dc %s, already exists", dc);
+                throw MakeStringException(-1, "can't add dc %s, an LDAP object with this name already exists", dc);
             }
             else
             {
@@ -4470,7 +4470,7 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                //WARNLOG("Can't insert ou=%s,%s to Ldap Server, already exists", name, basedn);
+                //WARNLOG("Can't insert ou=%s,%s to Ldap Server, an LDAP object with this name already exists", name, basedn);
                 return false;
             }
             else
@@ -4751,11 +4751,11 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                //WARNLOG("Can't insert %s to Ldap Server, already exists", resourcename);
+                //WARNLOG("Can't insert %s to Ldap Server, an LDAP object with this name already exists", resourcename);
                 if(lessException)
                     return false;
                 else
-                    throw MakeStringException(-1, "Can't insert %s, already exists", resourcename);
+                    throw MakeStringException(-1, "Can't insert %s, an LDAP object with this name already exists", resourcename);
             }
             else
             {
@@ -5009,8 +5009,8 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                DBGLOG("Can't add user %s, already exists", username);
-                throw MakeStringException(-1, "Can't add user %s, already exists", username);
+                DBGLOG("Can't add user %s, an LDAP object with this name already exists", username);
+                throw MakeStringException(-1, "Can't add user %s, an LDAP object with this name already exists", username);
             }
             else
             {

--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -59,7 +59,7 @@ protected:
         if (1 == numPartialResults)
             return firstRow;
 
-        CThorExpandingRowArray partialResults(*this, true, false, true, numPartialResults);
+        CThorExpandingRowArray partialResults(*this, this, true, false, true, numPartialResults);
         partialResults.setRow(0, firstRow);
         --numPartialResults;
 

--- a/thorlcr/activities/filter/thfilterslave.cpp
+++ b/thorlcr/activities/filter/thfilterslave.cpp
@@ -278,14 +278,14 @@ public:
                 groupStream.clear();
                 return NULL;
             }
-            CThorExpandingRowArray rows(*this);
+            CThorExpandingRowArray rows(*this, this);
             groupLoader->loadGroup(input, abortSoon, &rows);
             if (rows.ordinality())
             {
                 // JCSMORE - if isValid would take a stream, group wouldn't need to be in mem.
                 if (helper->isValid(rows.ordinality(), rows.getRowArray()))
                 {
-                    CThorSpillableRowArray spillableRows(*this);
+                    CThorSpillableRowArray spillableRows(*this, this);
                     spillableRows.transferFrom(rows);
                     groupStream.setown(spillableRows.createRowStream());
                 }
@@ -345,7 +345,7 @@ public:
                 ret.setown(input->nextRowGE(seek, numFields, wasCompleteMatch, stepExtra));
 #endif
 
-        CThorExpandingRowArray rows(*this);
+        CThorExpandingRowArray rows(*this, this);
         groupStream.setown(groupLoader->loadGroup(input, abortSoon, &rows));
         if (rows.ordinality())
         {

--- a/thorlcr/activities/funnel/thfunnelslave.cpp
+++ b/thorlcr/activities/funnel/thfunnelslave.cpp
@@ -535,7 +535,7 @@ public:
 
 
     CombineSlaveActivity(CGraphElementBase *_container) 
-        : CSlaveActivity(_container), CThorDataLink(this), rows(*this)
+        : CSlaveActivity(_container), CThorDataLink(this), rows(*this, this)
     {
         grouped = container.queryGrouped();
     }

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -1989,7 +1989,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     HashDedupSlaveActivityBase(CGraphElementBase *_container)
-        : CSlaveActivity(_container), CThorDataLink(this), htabrows(*this, true)
+        : CSlaveActivity(_container), CThorDataLink(this), htabrows(*this, this, true)
     {
         htsize = 0;
         inputstopped = false;

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -114,7 +114,7 @@ public:
     CJoinGroup *prev;  // Doubly-linked list to allow us to keep track of ones that are still in use
     CJoinGroup *next;
 
-    CJoinGroup(CActivityBase &_activity) : activity(_activity), rows(_activity)
+    CJoinGroup(CActivityBase &_activity) : activity(_activity), rows(_activity, NULL)
     {
         // Used for head object only
         prev = NULL;
@@ -161,7 +161,7 @@ public:
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CJoinGroup(CActivityBase &_activity, const void *_left, IJoinProcessor *_join, CJoinGroup *_groupStart) : activity(_activity), join(_join), rows(_activity)
+    CJoinGroup(CActivityBase &_activity, const void *_left, IJoinProcessor *_join, CJoinGroup *_groupStart) : activity(_activity), join(_join), rows(_activity, NULL)
     {
 #ifdef TRACE_USAGE
         atomic_inc(&join->getdebug(0));
@@ -889,7 +889,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
             stopped = aborted = writeWaiting = replyWaiting = false;
             pendingSends = pendingReplies = 0;
             for (unsigned n=0; n<nodes; n++)
-                dstLists.append(new CThorExpandingRowArray(owner));
+                dstLists.append(new CThorExpandingRowArray(owner, owner.fetchInputMetaRowIf));
             fetchMin = owner.helper->queryJoinFieldsRecordSize()->getMinRecordSize();
             perRowMin = NEWFETCHSENDHEADERSZ+fetchMin;
             maxRequests = NEWFETCHPRMEMLIMIT<perRowMin ? 1 : (NEWFETCHPRMEMLIMIT / perRowMin);
@@ -1041,7 +1041,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                     if (total)
                     {
                         assertex(!replyWaiting);
-                        CThorExpandingRowArray dstList(owner);
+                        CThorExpandingRowArray dstList(owner, owner.fetchInputMetaRowIf);
                         unsigned dstP=0;
                         loop
                         {

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -262,7 +262,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     CLookupJoinActivity(CGraphElementBase *_container, joinkind_t _joinKind) 
-        : CSlaveActivity(_container), CThorDataLink(this), joinKind(_joinKind), broadcaster(this, abortSoon), rhs(*this, true)
+        : CSlaveActivity(_container), CThorDataLink(this), joinKind(_joinKind), broadcaster(this, abortSoon), rhs(*this, NULL, true)
     {
         gotRHS = false;
         joinType = JT_Undefined;

--- a/thorlcr/activities/loop/thloop.cpp
+++ b/thorlcr/activities/loop/thloop.cpp
@@ -124,7 +124,7 @@ public:
         if (!CLoopActivityMasterBase::doinit())
             return;
         IHThorLoopArg *helper = (IHThorLoopArg *) queryHelper();
-        Owned<IThorGraphResults> results = createThorGraphResults(3);
+        Owned<IThorGraphResults> results = queryGraph().createThorGraphResults(3);
         queryContainer().queryLoopGraph()->prepareLoopResults(*this, results);
         if (helper->getFlags() & IHThorLoopArg::LFcounter)
             queryContainer().queryLoopGraph()->prepareCounterResult(*this, results, 1, 2);
@@ -172,7 +172,7 @@ public:
         if (!CLoopActivityMasterBase::doinit())
             return;
         IHThorGraphLoopArg *helper = (IHThorGraphLoopArg *) queryHelper();
-        Owned<IThorGraphResults> results = createThorGraphResults(1);
+        Owned<IThorGraphResults> results = queryGraph().createThorGraphResults(1);
         if (helper->getFlags() & IHThorGraphLoopArg::GLFcounter)
             queryContainer().queryLoopGraph()->prepareCounterResult(*this, results, 1, 0);
         loopGraph->setResults(results);
@@ -189,9 +189,8 @@ public:
             return;
         unsigned maxIterations = helper->numIterations();
         if ((int)maxIterations < 0) maxIterations = 0;
-        Owned<IThorGraphResults> loopResults = createThorGraphResults(maxIterations);
+        Owned<IThorGraphResults> loopResults = queryGraph().createThorGraphResults(maxIterations);
         IThorResult *result = loopResults->createResult(*this, 0, this, true);
-        Owned<IRowWriter> resultWriter = result->getWriter();
 
         helper->createParentExtract(extractBuilder);
 
@@ -215,139 +214,25 @@ CActivityBase *createGraphLoopActivityMaster(CMasterGraphElement *container)
 
 class CLocalResultActivityMasterBase : public CMasterActivity
 {
-    PointerArrayOf<CThorExpandingRowArray> results;
-
 protected:
     Owned<IRowInterfaces> inputRowIf;
 
 public:
     CLocalResultActivityMasterBase(CMasterGraphElement *info) : CMasterActivity(info)
     {
-        mpTag = container.queryJob().allocateMPTag();
-        for (unsigned n=0; n<container.queryJob().querySlaves(); n++)
-            results.append(new CThorExpandingRowArray(*this));
-    }
-    ~CLocalResultActivityMasterBase()
-    {
-        ForEachItemIn(r, results)
-        {
-            CThorExpandingRowArray *result = results.item(r);
-            delete result;
-        }
-        results.kill();
     }
     virtual void init()
     {
         reset();
     }
-    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
-    {
-        if (!container.queryLocalOrGrouped())
-            serializeMPtag(dst, mpTag);
-    }
-    virtual IThorResult *createResult() = 0;
+    virtual void createResult() = 0;
     virtual void process()
     {
         assertex(container.queryResultsGraph());
-        Owned<CGraphBase> graph = container.queryOwner().queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
+        Owned<CGraphBase> graph = queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
         IHThorLocalResultWriteArg *helper = (IHThorLocalResultWriteArg *)queryHelper();
         inputRowIf.setown(createRowInterfaces(container.queryInput(0)->queryHelper()->queryOutputMeta(),queryActivityId(),queryCodeContext()));
-
-        IThorResult *result = createResult();
-        if (!result->isLocal())
-        {
-            Owned<IRowWriter> resultWriter = result->getWriter();
-            unsigned todo = container.queryJob().querySlaves();
-            for (unsigned n=0; n<todo; n++)
-                results.item(n)->kill();
-            rank_t sender;
-            MemoryBuffer mb;
-            CMessageBuffer msg;
-            Owned<ISerialStream> stream = createMemoryBufferSerialStream(mb);
-            CThorStreamDeserializerSource rowSource(stream);
-            loop
-            {
-                loop
-                {
-                    if (abortSoon)
-                        return;
-                    msg.clear();
-                    if (receiveMsg(msg, RANK_ALL, mpTag, &sender, 60*1000))
-                        break;
-                    ActPrintLog("WARNING: tag %d timedout, retrying", (unsigned)mpTag);
-                }
-                sender = sender - 1; // 0 = master
-                if (!msg.length())
-                {
-                    --todo;
-                    if (0 == todo)
-                        break; // done
-                }
-                else
-                {
-                    ThorExpand(msg, mb.clear());
-
-                    CThorExpandingRowArray *slaveResults = results.item(sender);
-                    while (!rowSource.eos())
-                    {
-                        RtlDynamicRowBuilder rowBuilder(inputRowIf->queryRowAllocator());
-                        size32_t sz = inputRowIf->queryRowDeserializer()->deserialize(rowBuilder, rowSource);
-                        slaveResults->append(rowBuilder.finalizeRowClear(sz));
-                    }
-                }
-            }
-            mb.clear();
-            CMemoryRowSerializer mbs(mb);
-            CThorExpandingRowArray *slaveResult = results.item(0);
-            unsigned rowNum=0;
-            unsigned resultNum=1;
-            loop
-            {
-                while (resultNum)
-                {
-                    if (rowNum == slaveResult->ordinality())
-                    {
-                        loop
-                        {
-                            if (resultNum == results.ordinality())
-                            {
-                                resultNum = 0; // eos
-                                break;
-                            }
-                            slaveResult = results.item(resultNum++);
-                            if (slaveResult->ordinality())
-                            {
-                                rowNum = 0;
-                                break;
-                            }
-                        }
-                        if (!resultNum) // eos
-                            break;
-                    }
-                    const void *row = slaveResult->query(rowNum++);
-                    inputRowIf->queryRowSerializer()->serialize(mbs, (const byte *)row);
-                    LinkThorRow(row);
-                    resultWriter->putRow(row);
-                    if (mb.length() > 0x80000)
-                        break;
-                }
-                msg.clear();
-                if (mb.length())
-                {
-                    ThorCompress(mb.toByteArray(), mb.length(), msg);
-                    mb.clear();
-                }
-                BooleanOnOff onOff(receiving);
-                ((CJobMaster &)container.queryJob()).broadcastToSlaves(msg, mpTag, LONGTIMEOUT, NULL, NULL, true);
-                if (0 == msg.length())
-                    break;
-            }
-        }
-    }
-    virtual void abort()
-    {
-        CMasterActivity::abort();
-        cancelReceiveMsg(RANK_ALL, mpTag);
+        createResult();
     }
 };
 
@@ -357,15 +242,11 @@ public:
     CLocalResultActivityMaster(CMasterGraphElement *info) : CLocalResultActivityMasterBase(info)
     {
     }
-    virtual IThorResult *createResult()
+    virtual void createResult()
     {
         IHThorLocalResultWriteArg *helper = (IHThorLocalResultWriteArg *)queryHelper();
-        Owned<CGraphBase> graph = container.queryOwner().queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
-        bool local = container.queryOwner().isLocalOnly();
-        IThorResult *result = graph->queryResult(helper->querySequence());
-        if (result)
-            local = result->isLocal();
-        return graph->createResult(*this, helper->querySequence(), this, local); // NB graph owns result
+        Owned<CGraphBase> graph = queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
+        graph->createResult(*this, helper->querySequence(), this, true); // NB graph owns result
     }
 };
 
@@ -380,11 +261,11 @@ public:
     CGraphLoopResultWriteActivityMaster(CMasterGraphElement *info) : CLocalResultActivityMasterBase(info)
     {
     }
-    virtual IThorResult *createResult()
+    virtual void createResult()
     {
         IHThorGraphLoopResultWriteArg *helper = (IHThorGraphLoopResultWriteArg *)queryHelper();
-        Owned<CGraphBase> graph = container.queryOwner().queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
-        return graph->createGraphLoopResult(*this, inputRowIf); // NB graph owns result
+        Owned<CGraphBase> graph = queryJob().getGraph(container.queryResultsGraph()->queryGraphId());
+        graph->createGraphLoopResult(*this, inputRowIf, true); // NB graph owns result
     }
 };
 

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -354,7 +354,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     CJoinHelper(CActivityBase &_activity, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : activity(_activity), allocator(_allocator), denormTmp(NULL), rightgroup(_activity), denormRows(_activity)
+        : activity(_activity), allocator(_allocator), denormTmp(NULL), rightgroup(_activity, NULL), denormRows(_activity, NULL)
     {
         kind = activity.queryContainer().getKind();
         helper = _helper; 
@@ -855,7 +855,7 @@ public:
                     break;
                 case JSmatch: // matching left to right group       
                     if (mcoreintercept) {
-                        CThorExpandingRowArray leftgroup(activity);
+                        CThorExpandingRowArray leftgroup(activity, NULL);
                         while (getL()) {
                             if (leftgroup.ordinality()) {
                                 int cmp = compareL->docompare(nextleft,leftgroup.query(leftgroup.ordinality()-1));
@@ -947,7 +947,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     SelfJoinHelper(CActivityBase &_activity, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : activity(_activity), allocator(_allocator), curgroup(_activity)
+        : activity(_activity), allocator(_allocator), curgroup(_activity, &_activity)
     {
         helper = _helper;       
         outputmetaL = NULL;
@@ -1423,11 +1423,11 @@ public:
         CThorExpandingRowArray rgroup;
         const void *row;
         inline cWorkItem(CActivityBase &_activity, CThorExpandingRowArray *_lgroup, CThorExpandingRowArray *_rgroup)
-            : activity(_activity), lgroup(_activity), rgroup(_activity)
+            : activity(_activity), lgroup(_activity, &_activity), rgroup(_activity, &_activity)
         {
             set(_lgroup,_rgroup);
         }
-        inline cWorkItem(CActivityBase &_activity) : activity(_activity), lgroup(_activity), rgroup(_activity)
+        inline cWorkItem(CActivityBase &_activity) : activity(_activity), lgroup(_activity, &_activity), rgroup(_activity, &_activity)
         {
             clear();
         }

--- a/thorlcr/activities/rollup/throllupslave.cpp
+++ b/thorlcr/activities/rollup/throllupslave.cpp
@@ -83,7 +83,7 @@ class CDedupAllHelper : public CSimpleInterface, implements IRowStream
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CDedupAllHelper(CActivityBase *_activity) : activity(_activity), rows(*_activity)
+    CDedupAllHelper(CActivityBase *_activity) : activity(_activity), rows(*_activity, _activity)
     {
         in = NULL;
         helper = NULL;
@@ -539,7 +539,7 @@ public:
         ActivityTimer t(totalCycles, timeActivities, NULL);
         if (!eoi)
         {
-            CThorExpandingRowArray rows(*this);
+            CThorExpandingRowArray rows(*this, queryRowInterfaces(input));
             groupLoader->loadGroup(input, abortSoon, &rows);
             unsigned count = rows.ordinality();
             if (count)

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -130,7 +130,7 @@ public:
         __uint64 numRows = helper->numRows();
         // local when generated from a child query (the range is per node, don't split)
         bool isLocal = container.queryOwnerId() && container.queryOwner().isLocalOnly();
-        if (!isLocal && (helper->getFlags() & TTFdistributed != 0))
+        if (!isLocal && ((helper->getFlags() & TTFdistributed) != 0))
         {
             __uint64 nodes = container.queryCodeContext()->getNodes();
             __uint64 nodeid = container.queryCodeContext()->getNodeNum();

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -359,7 +359,7 @@ rowcount_t getCount(CActivityBase &activity, unsigned partialResults, rowcount_t
 const void *getAggregate(CActivityBase &activity, unsigned partialResults, IRowInterfaces &rowIf, IHThorCompoundAggregateExtra &aggHelper, mptag_t mpTag)
 {
     // JCSMORE - pity this isn't common routine with similar one in aggregate, but helper is not common
-    CThorExpandingRowArray slaveResults(activity, true, false, true, partialResults);
+    CThorExpandingRowArray slaveResults(activity, &activity, true, false, true, partialResults);
     unsigned _partialResults = partialResults;
     while (_partialResults--)
     {

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -58,13 +58,38 @@ class CThorGraphResult : public CInterface, implements IThorResult, implements I
         meta = allocator->queryOutputMeta();
         rowStreamCount = 0;
     }
+    class CStreamWriter : public CSimpleInterface, implements IRowWriterMultiReader
+    {
+        CThorGraphResult &owner;
+        CThorExpandingRowArray rows;
+    public:
+        IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+
+        CStreamWriter(CThorGraphResult &_owner) : owner(_owner), rows(owner.activity, owner.rowIf, true)
+        {
+        }
+
+    //IRowWriterMultiReader
+        virtual void putRow(const void *row)
+        {
+            rows.append(row);
+        }
+        virtual void flush() { }
+        virtual IRowStream *getReader()
+        {
+            return rows.createRowStream(0, (rowcount_t)-1, false);
+        }
+    };
 public:
     IMPLEMENT_IINTERFACE;
 
-    CThorGraphResult(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _distributed) : activity(_activity), rowIf(_rowIf), distributed(_distributed)
+    CThorGraphResult(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _distributed, unsigned spillPriority) : activity(_activity), rowIf(_rowIf), distributed(_distributed)
     {
         init();
-        rowBuffer.setown(createOverflowableBuffer(activity, rowIf, true, true));
+        if (SPILL_PRIORITY_DISABLE == spillPriority)
+            rowBuffer.setown(new CStreamWriter(*this));
+        else
+            rowBuffer.setown(createOverflowableBuffer(activity, rowIf, true, true));
     }
 
 // IRowWriter
@@ -169,18 +194,18 @@ public:
 
 /////
 
-IThorResult *CThorGraphResults::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed)
+IThorResult *CThorGraphResults::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
-    Owned<IThorResult> result = ::createResult(activity, rowIf, distributed);
+    Owned<IThorResult> result = ::createResult(activity, rowIf, distributed, spillPriority);
     setResult(id, result);
     return result;
 }
 
 /////
 
-IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
-    return new CThorGraphResult(activity, rowIf, distributed);
+    return new CThorGraphResult(activity, rowIf, distributed, spillPriority);
 }
 
 /////
@@ -207,7 +232,7 @@ public:
         thor_loop_counter_t * res = (thor_loop_counter_t *)counterRow.ensureCapacity(sizeof(thor_loop_counter_t),NULL);
         *res = loopCounter;
         OwnedConstThorRow counterRowFinal = counterRow.finalizeRowClear(sizeof(thor_loop_counter_t));
-        IThorResult *counterResult = results->createResult(activity, pos, countRowIf, false);
+        IThorResult *counterResult = results->createResult(activity, pos, countRowIf, false, SPILL_PRIORITY_DISABLE);
         Owned<IRowWriter> counterResultWriter = counterResult->getWriter();
         counterResultWriter->putRow(counterRowFinal.getClear());
     }
@@ -1840,14 +1865,14 @@ IThorResult *CGraphBase::getGraphLoopResult(unsigned id, bool distributed)
     return graphLoopResults->getResult(id, distributed);
 }
 
-IThorResult *CGraphBase::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed)
+IThorResult *CGraphBase::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
-    return localResults->createResult(activity, id, rowIf, distributed);
+    return localResults->createResult(activity, id, rowIf, distributed, spillPriority);
 }
 
-IThorResult *CGraphBase::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+IThorResult *CGraphBase::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
-    return graphLoopResults->createResult(activity, rowIf, distributed);
+    return graphLoopResults->createResult(activity, rowIf, distributed, spillPriority);
 }
 
 // ILocalGraph

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -435,7 +435,7 @@ class graph_decl CGraphBase : public CInterface, implements ILocalGraph, impleme
     CriticalSection evaluateCrit;
     CGraphElementTable containers;
     CGraphElementArray sinks;
-    bool sink, complete, global;
+    bool sink, complete, global, localChild;
     mutable int localOnly;
     activity_id parentActivityId;
     IPropertyTree *xgmml;
@@ -622,8 +622,9 @@ public:
     bool isCreated() const { return created; }
     bool isStarted() const { return started; }
     bool isLocalOnly() const; // this graph and all upstream dependencies
-    bool isLocalChild() const { return owner && !owner->isGlobal(); }
+    bool isLocalChild() const { return localChild; }
     void setCompleteEx(bool tf=true) { complete = tf; }
+    void setGlobal(bool tf=true);
     const byte *setParentCtx(size32_t _parentExtractSz, const byte *parentExtract)
     {
         parentExtractSz = _parentExtractSz;

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -49,6 +49,7 @@
 #include "thormisc.hpp"
 #include "workunit.hpp"
 #include "thorcommon.hpp"
+#include "thmem.hpp"
 
 #include "thor.hpp"
 #include "eclhelper.hpp"
@@ -129,8 +130,8 @@ interface IThorGraphResults : extends IEclGraphResults
 {
     virtual void clear() = 0;
     virtual IThorResult *getResult(unsigned id, bool distributed=false) = 0;
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed) = 0;
-    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed) = 0;
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT) = 0;
+    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT) = 0;
     virtual unsigned addResult(IThorResult *result) = 0;
     virtual void setResult(unsigned id, IThorResult *result) = 0;
     virtual unsigned count() = 0;
@@ -741,8 +742,8 @@ public:
 
     virtual IThorResult *getResult(unsigned id, bool distributed=false);
     virtual IThorResult *getGraphLoopResult(unsigned id, bool distributed=false);
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
-    virtual IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
+    virtual IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
 
 // ILocalGraph
     virtual void getResult(size32_t & len, void * & data, unsigned id);
@@ -1086,10 +1087,10 @@ public:
         // NB: stream static after this, i.e. nothing can be added to this result
         return LINK(&results.item(id));
     }
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
-    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
+    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT)
     {
-        return createResult(activity, results.ordinality(), rowIf, distributed);
+        return createResult(activity, results.ordinality(), rowIf, distributed, spillPriority);
     }
     virtual unsigned addResult(IThorResult *result)
     {
@@ -1120,7 +1121,7 @@ public:
     }
 };
 
-extern graph_decl IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+extern graph_decl IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
 
 
 class CGraphElementBase;

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -73,7 +73,8 @@ enum msgids
     Shutdown,
     GraphInit,
     GraphEnd,
-    GraphAbort
+    GraphAbort,
+    GraphGetResult
 };
 
 interface ICodeContextExt : extends ICodeContext
@@ -114,8 +115,10 @@ interface IThorResult : extends IInterface
     virtual IRowWriter *getWriter() = 0;
     virtual void setResultStream(IRowWriterMultiReader *stream, rowcount_t count) = 0;
     virtual IRowStream *getRowStream() = 0;
-    virtual IOutputMetaData *queryMeta() = 0;
-    virtual bool isLocal() const = 0;
+    virtual IRowInterfaces *queryRowInterfaces() = 0;
+    virtual CActivityBase *queryActivity() = 0;
+    virtual bool isDistributed() const = 0;
+    virtual void serialize(MemoryBuffer &mb) = 0;
     virtual void getResult(size32_t & retSize, void * & ret) = 0;
     virtual void getLinkedResult(unsigned & count, byte * * & ret) = 0;
 };
@@ -125,10 +128,10 @@ class CActivityBase;
 interface IThorGraphResults : extends IEclGraphResults
 {
     virtual void clear() = 0;
-    virtual IThorResult *queryResult(unsigned id) = 0;
-    virtual IThorResult *getResult(unsigned id) = 0;
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool local=false) = 0;
-    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool local=false) = 0;
+    virtual IThorResult *getResult(unsigned id, bool distributed=false) = 0;
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed) = 0;
+    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed) = 0;
+    virtual unsigned addResult(IThorResult *result) = 0;
     virtual void setResult(unsigned id, IThorResult *result) = 0;
     virtual unsigned count() = 0;
 };
@@ -437,7 +440,6 @@ class graph_decl CGraphBase : public CInterface, implements ILocalGraph, impleme
     activity_id parentActivityId;
     IPropertyTree *xgmml;
     CGraphTable childGraphs;
-    Owned<IThorGraphResults> localResults, graphLoopResults;
     Owned<IGraphTempHandler> tmpHandler;
 
     void clean();
@@ -527,6 +529,7 @@ class graph_decl CGraphBase : public CInterface, implements ILocalGraph, impleme
     } graphCodeContext;
 
 protected:
+    Owned<IThorGraphResults> localResults, graphLoopResults;
     CGraphBase *owner, *parent;
     Owned<IException> abortException;
     CGraphElementArrayCopy ifs;
@@ -619,6 +622,7 @@ public:
     bool isCreated() const { return created; }
     bool isStarted() const { return started; }
     bool isLocalOnly() const; // this graph and all upstream dependencies
+    bool isLocalChild() const { return owner && !owner->isGlobal(); }
     void setCompleteEx(bool tf=true) { complete = tf; }
     const byte *setParentCtx(size32_t _parentExtractSz, const byte *parentExtract)
     {
@@ -729,16 +733,15 @@ public:
     virtual void done();
     virtual void end();
     virtual void abort(IException *e);
+    virtual IThorGraphResults *createThorGraphResults(unsigned num);
 
 // IExceptionHandler
     virtual bool fireException(IException *e);
 
-    virtual IThorResult *queryResult(unsigned id);
-    virtual IThorResult *getResult(unsigned id);
-    virtual IThorResult *queryGraphLoopResult(unsigned id);
-    virtual IThorResult *getGraphLoopResult(unsigned id);
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool local=false);
-    virtual IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf);
+    virtual IThorResult *getResult(unsigned id, bool distributed=false);
+    virtual IThorResult *getGraphLoopResult(unsigned id, bool distributed=false);
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
+    virtual IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
 
 // ILocalGraph
     virtual void getResult(size32_t & len, void * & data, unsigned id);
@@ -949,6 +952,7 @@ public:
     ~CActivityBase();
     CGraphElementBase &queryContainer() const { return container; }
     CJobBase &queryJob() const { return container.queryJob(); }
+    CGraphBase &queryGraph() const { return container.queryOwner(); }
     inline const mptag_t queryMpTag() const { return mpTag; }
     inline const bool &queryAbortSoon() const { return abortSoon; }
     inline IHThorArg *queryHelper() const { return baseHelper; }
@@ -1037,11 +1041,91 @@ public:
     virtual IFileInProgressHandler &queryFileInProgressHandler() { UNIMPLEMENTED; return *((IFileInProgressHandler *)NULL); }
 };
 
+class graph_decl CThorGraphResults : public CInterface, implements IThorGraphResults
+{
+protected:
+    class CThorUninitializedGraphResults : public CInterface, implements IThorResult
+    {
+        unsigned id;
+
+    public:
+        IMPLEMENT_IINTERFACE
+
+        CThorUninitializedGraphResults(unsigned _id) { id = _id; }
+        virtual IRowWriter *getWriter() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual void setResultStream(IRowWriterMultiReader *stream, rowcount_t count) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual IRowStream *getRowStream() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual IRowInterfaces *queryRowInterfaces() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual CActivityBase *queryActivity() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual bool isDistributed() const { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual void serialize(MemoryBuffer &mb) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual void getResult(size32_t & retSize, void * & ret) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual void getLinkedResult(unsigned & count, byte * * & ret) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+    };
+    IArrayOf<IThorResult> results;
+    CriticalSection cs;
+    void ensureAtLeast(unsigned id)
+    {
+        while (results.ordinality() < id)
+            results.append(*new CThorUninitializedGraphResults(results.ordinality()));
+    }
+public:
+    IMPLEMENT_IINTERFACE;
+
+    CThorGraphResults(unsigned _numResults) { ensureAtLeast(_numResults); }
+    virtual void clear()
+    {
+        CriticalBlock procedure(cs);
+        results.kill();
+    }
+    virtual IThorResult *getResult(unsigned id, bool distributed)
+    {
+        CriticalBlock procedure(cs);
+        ensureAtLeast(id+1);
+        // NB: stream static after this, i.e. nothing can be added to this result
+        return LINK(&results.item(id));
+    }
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
+    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+    {
+        return createResult(activity, results.ordinality(), rowIf, distributed);
+    }
+    virtual unsigned addResult(IThorResult *result)
+    {
+        CriticalBlock procedure(cs);
+        unsigned id = results.ordinality();
+        setResult(id, result);
+        return id;
+    }
+    virtual void setResult(unsigned id, IThorResult *result)
+    {
+        CriticalBlock procedure(cs);
+        ensureAtLeast(id+1);
+        if (results.isItem(id))
+            results.replace(*LINK(result), id);
+        else
+            results.append(*LINK(result));
+    }
+    virtual unsigned count() { return results.ordinality(); }
+    virtual void getResult(size32_t & retSize, void * & ret, unsigned id)
+    {
+        Owned<IThorResult> result = getResult(id, true);
+        result->getResult(retSize, ret);
+    }
+    virtual void getLinkedResult(unsigned & count, byte * * & ret, unsigned id)
+    {
+        Owned<IThorResult> result = getResult(id, true);
+        result->getLinkedResult(count, ret);
+    }
+};
+
+extern graph_decl IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+
+
 class CGraphElementBase;
 typedef CGraphElementBase *(*CreateFunc)(IPropertyTree &node, CGraphBase &owner, CGraphBase *resultsGraph);
 extern graph_decl void registerCreateFunc(CreateFunc func);
 extern graph_decl CGraphElementBase *createGraphElement(IPropertyTree &node, CGraphBase &owner, CGraphBase *resultsGraph);
-extern graph_decl IThorGraphResults *createThorGraphResults(unsigned num);
 extern graph_decl IThorBoundLoopGraph *createBoundLoopGraph(CGraphBase *graph, IOutputMetaData *resultMeta, unsigned activityId);
 extern graph_decl bool isDiskInput(ThorActivityKind kind);
 

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1760,6 +1760,7 @@ class CCollatedResult : public CSimpleInterface, implements IThorResult
     CriticalSection crit;
     PointerArrayOf<CThorExpandingRowArray> results;
     Owned<IThorResult> result;
+    unsigned spillPriority;
 
     void ensure()
     {
@@ -1823,7 +1824,7 @@ class CCollatedResult : public CSimpleInterface, implements IThorResult
                 }
             }
         }
-        Owned<IThorResult> _result = ::createResult(activity, rowIf, false);
+        Owned<IThorResult> _result = ::createResult(activity, rowIf, false, spillPriority);
         Owned<IRowWriter> resultWriter = _result->getWriter();
         for (unsigned s=0; s<numSlaves; s++)
         {
@@ -1841,154 +1842,7 @@ class CCollatedResult : public CSimpleInterface, implements IThorResult
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CCollatedResult(CMasterGraph &_graph, CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _id) : graph(_graph), activity(_activity), rowIf(_rowIf), id(_id)
-    {
-        for (unsigned n=0; n<graph.queryJob().querySlaves(); n++)
-            results.append(new CThorExpandingRowArray(activity));
-    }
-    ~CCollatedResult()
-    {
-        ForEachItemIn(l, results)
-        {
-            CThorExpandingRowArray *result = results.item(l);
-            delete result;
-        }
-    }
-    void setId(unsigned _id)
-    {
-        id = _id;
-    }
-
-// IThorResult
-    virtual IRowWriter *getWriter() { throwUnexpected(); }
-    virtual void setResultStream(IRowWriterMultiReader *stream, rowcount_t count)
-    {
-        throwUnexpected();
-    }
-    virtual IRowStream *getRowStream()
-    {
-        ensure();
-        return result->getRowStream();
-    }
-    virtual IRowInterfaces *queryRowInterfaces()
-    {
-        return rowIf;
-    }
-    virtual CActivityBase *queryActivity()
-    {
-        return &activity;
-    }
-    virtual bool isDistributed() const { return false; }
-    virtual void serialize(MemoryBuffer &mb)
-    {
-        ensure();
-        result->serialize(mb);
-    }
-    virtual void getResult(size32_t & retSize, void * & ret)
-    {
-        ensure();
-        return result->getResult(retSize, ret);
-    }
-    virtual void getLinkedResult(unsigned & count, byte * * & ret)
-    {
-        ensure();
-        return result->getLinkedResult(count, ret);
-    }
-};
-
-///////////////////
-
-class CCollatedResult : public CSimpleInterface, implements IThorResult
-{
-    CMasterGraph &graph;
-    CActivityBase &activity;
-    IRowInterfaces *rowIf;
-    unsigned id;
-    CriticalSection crit;
-    PointerArrayOf<CThorExpandingRowArray> results;
-    Owned<IThorResult> result;
-
-    void ensure()
-    {
-        CriticalBlock b(crit);
-        if (result)
-            return;
-        mptag_t replyTag = createReplyTag();
-        CMessageBuffer msg;
-        msg.append(GraphGetResult);
-        msg.append(activity.queryJob().queryKey());
-        msg.append(graph.queryGraphId());
-        msg.append(id);
-        msg.append(replyTag);
-        ((CJobMaster &)graph.queryJob()).broadcastToSlaves(msg, masterSlaveMpTag, LONGTIMEOUT, NULL, NULL, true);
-
-        unsigned numSlaves = graph.queryJob().querySlaves();
-        for (unsigned n=0; n<numSlaves; n++)
-            results.item(n)->kill();
-        rank_t sender;
-        MemoryBuffer mb;
-        Owned<ISerialStream> stream = createMemoryBufferSerialStream(mb);
-        CThorStreamDeserializerSource rowSource(stream);
-        unsigned todo = numSlaves;
-
-        loop
-        {
-            loop
-            {
-                if (activity.queryAbortSoon())
-                    return;
-                msg.clear();
-                if (activity.receiveMsg(msg, RANK_ALL, replyTag, &sender, 60*1000))
-                    break;
-                ActPrintLog(&activity, "WARNING: tag %d timedout, retrying", (unsigned)replyTag);
-            }
-            sender = sender - 1; // 0 = master
-            if (!msg.length())
-            {
-                --todo;
-                if (0 == todo)
-                    break; // done
-            }
-            else
-            {
-                bool error;
-                msg.read(error);
-                if (error)
-                {
-                    Owned<IThorException> e = deserializeThorException(msg);
-                    e->setSlave(sender);
-                    throw e.getClear();
-                }
-                ThorExpand(msg, mb.clear());
-
-                CThorExpandingRowArray *slaveResults = results.item(sender);
-                while (!rowSource.eos())
-                {
-                    RtlDynamicRowBuilder rowBuilder(rowIf->queryRowAllocator());
-                    size32_t sz = rowIf->queryRowDeserializer()->deserialize(rowBuilder, rowSource);
-                    slaveResults->append(rowBuilder.finalizeRowClear(sz));
-                }
-            }
-        }
-        Owned<IThorResult> _result = ::createResult(activity, rowIf, false);
-        Owned<IRowWriter> resultWriter = _result->getWriter();
-        for (unsigned s=0; s<numSlaves; s++)
-        {
-            CThorExpandingRowArray *slaveResult = results.item(s);
-            ForEachItemIn(r, *slaveResult)
-            {
-                const void *row = slaveResult->query(r);
-                LinkThorRow(row);
-                resultWriter->putRow(row);
-            }
-        }
-        result.setown(_result.getClear());
-    }
-
-public:
-    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
-
-    CCollatedResult(CMasterGraph &_graph, CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _id) : graph(_graph), activity(_activity), rowIf(_rowIf), id(_id)
+    CCollatedResult(CMasterGraph &_graph, CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _id, unsigned _spillPriority) : graph(_graph), activity(_activity), rowIf(_rowIf), id(_id), spillPriority(_spillPriority)
     {
         for (unsigned n=0; n<graph.queryJob().querySlaves(); n++)
             results.append(new CThorExpandingRowArray(activity, rowIf));
@@ -2722,16 +2576,16 @@ bool CMasterGraph::deserializeStats(unsigned node, MemoryBuffer &mb)
     return true;
 }
 
-IThorResult *CMasterGraph::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed)
+IThorResult *CMasterGraph::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
-    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, id);
+    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, id, spillPriority);
     localResults->setResult(id, result);
     return result;
 }
 
-IThorResult *CMasterGraph::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+IThorResult *CMasterGraph::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
-    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, 0);
+    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, 0, spillPriority);
     unsigned id = graphLoopResults->addResult(result);
     result->setId(id);
     return result;

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -44,6 +44,8 @@
 #include "eclhelper.hpp"
 #include "thexception.hpp"
 #include "thactivitymaster.ipp"
+#include "thmem.hpp"
+#include "thcompressutil.hpp"
 
 static CriticalSection *jobManagerCrit;
 MODULE_INIT(INIT_PRIORITY_STANDARD)
@@ -286,7 +288,7 @@ void CSlaveMessageHandler::main()
                 }
                 case smt_actMsg:
                 {
-                    LOG(MCdebugProgress, unknownJob, "smt_podata called from slave %d", sender-1);
+                    LOG(MCdebugProgress, unknownJob, "smt_actMsg called from slave %d", sender-1);
                     graph_id gid;
                     msg.read(gid);
                     activity_id id;
@@ -298,6 +300,21 @@ void CSlaveMessageHandler::main()
                     CMasterActivity *activity = (CMasterActivity *)container->queryActivity();
                     assertex(activity);
                     activity->handleSlaveMessage(msg); // don't block
+                    break;
+                }
+                case smt_getresult:
+                {
+                    LOG(MCdebugProgress, unknownJob, "smt_getresult called from slave %d", sender-1);
+                    graph_id gid;
+                    msg.read(gid);
+                    Owned<CMasterGraph> graph = (CMasterGraph *)job.getGraph(gid);
+                    unsigned resultId;
+                    msg.read(resultId);
+                    mptag_t replyTag = graph->queryJob().deserializeMPTag(msg);
+                    assertex(graph);
+                    Owned<IThorResult> result = graph->getResult(resultId);
+                    Owned<IRowStream> resultStream = result->getRowStream();
+                    sendInChunks(graph->queryJob().queryJobComm(), sender, replyTag, resultStream, result->queryRowInterfaces());
                     break;
                 }
             }
@@ -1734,6 +1751,153 @@ bool CJobMaster::fireException(IException *e)
 
 ///////////////////
 
+class CCollatedResult : public CSimpleInterface, implements IThorResult
+{
+    CMasterGraph &graph;
+    CActivityBase &activity;
+    IRowInterfaces *rowIf;
+    unsigned id;
+    CriticalSection crit;
+    PointerArrayOf<CThorExpandingRowArray> results;
+    Owned<IThorResult> result;
+
+    void ensure()
+    {
+        CriticalBlock b(crit);
+        if (result)
+            return;
+        mptag_t replyTag = createReplyTag();
+        CMessageBuffer msg;
+        msg.append(GraphGetResult);
+        msg.append(activity.queryJob().queryKey());
+        msg.append(graph.queryGraphId());
+        msg.append(id);
+        msg.append(replyTag);
+        ((CJobMaster &)graph.queryJob()).broadcastToSlaves(msg, masterSlaveMpTag, LONGTIMEOUT, NULL, NULL, true);
+
+        unsigned numSlaves = graph.queryJob().querySlaves();
+        for (unsigned n=0; n<numSlaves; n++)
+            results.item(n)->kill();
+        rank_t sender;
+        MemoryBuffer mb;
+        Owned<ISerialStream> stream = createMemoryBufferSerialStream(mb);
+        CThorStreamDeserializerSource rowSource(stream);
+        unsigned todo = numSlaves;
+
+        loop
+        {
+            loop
+            {
+                if (activity.queryAbortSoon())
+                    return;
+                msg.clear();
+                if (activity.receiveMsg(msg, RANK_ALL, replyTag, &sender, 60*1000))
+                    break;
+                ActPrintLog(&activity, "WARNING: tag %d timedout, retrying", (unsigned)replyTag);
+            }
+            sender = sender - 1; // 0 = master
+            if (!msg.length())
+            {
+                --todo;
+                if (0 == todo)
+                    break; // done
+            }
+            else
+            {
+                bool error;
+                msg.read(error);
+                if (error)
+                {
+                    Owned<IThorException> e = deserializeThorException(msg);
+                    e->setSlave(sender);
+                    throw e.getClear();
+                }
+                ThorExpand(msg, mb.clear());
+
+                CThorExpandingRowArray *slaveResults = results.item(sender);
+                while (!rowSource.eos())
+                {
+                    RtlDynamicRowBuilder rowBuilder(rowIf->queryRowAllocator());
+                    size32_t sz = rowIf->queryRowDeserializer()->deserialize(rowBuilder, rowSource);
+                    slaveResults->append(rowBuilder.finalizeRowClear(sz));
+                }
+            }
+        }
+        Owned<IThorResult> _result = ::createResult(activity, rowIf, false);
+        Owned<IRowWriter> resultWriter = _result->getWriter();
+        for (unsigned s=0; s<numSlaves; s++)
+        {
+            CThorExpandingRowArray *slaveResult = results.item(s);
+            ForEachItemIn(r, *slaveResult)
+            {
+                const void *row = slaveResult->query(r);
+                LinkThorRow(row);
+                resultWriter->putRow(row);
+            }
+        }
+        result.setown(_result.getClear());
+    }
+
+public:
+    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+
+    CCollatedResult(CMasterGraph &_graph, CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _id) : graph(_graph), activity(_activity), rowIf(_rowIf), id(_id)
+    {
+        for (unsigned n=0; n<graph.queryJob().querySlaves(); n++)
+            results.append(new CThorExpandingRowArray(activity));
+    }
+    ~CCollatedResult()
+    {
+        ForEachItemIn(l, results)
+        {
+            CThorExpandingRowArray *result = results.item(l);
+            delete result;
+        }
+    }
+    void setId(unsigned _id)
+    {
+        id = _id;
+    }
+
+// IThorResult
+    virtual IRowWriter *getWriter() { throwUnexpected(); }
+    virtual void setResultStream(IRowWriterMultiReader *stream, rowcount_t count)
+    {
+        throwUnexpected();
+    }
+    virtual IRowStream *getRowStream()
+    {
+        ensure();
+        return result->getRowStream();
+    }
+    virtual IRowInterfaces *queryRowInterfaces()
+    {
+        return rowIf;
+    }
+    virtual CActivityBase *queryActivity()
+    {
+        return &activity;
+    }
+    virtual bool isDistributed() const { return false; }
+    virtual void serialize(MemoryBuffer &mb)
+    {
+        ensure();
+        result->serialize(mb);
+    }
+    virtual void getResult(size32_t & retSize, void * & ret)
+    {
+        ensure();
+        return result->getResult(retSize, ret);
+    }
+    virtual void getLinkedResult(unsigned & count, byte * * & ret)
+    {
+        ensure();
+        return result->getLinkedResult(count, ret);
+    }
+};
+
+///////////////////
+
 //
 // CMasterGraph impl.
 //
@@ -2410,6 +2574,22 @@ bool CMasterGraph::deserializeStats(unsigned node, MemoryBuffer &mb)
     }
     return true;
 }
+
+IThorResult *CMasterGraph::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed)
+{
+    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, id);
+    localResults->setResult(id, result);
+    return result;
+}
+
+IThorResult *CMasterGraph::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+{
+    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, 0);
+    unsigned id = graphLoopResults->addResult(result);
+    result->setId(id);
+    return result;
+}
+
 
 ///////////////////////////////////////////////////
 

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -78,8 +78,8 @@ public:
     virtual void start();
     virtual void done();
     virtual void abort(IException *e);
-    IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
-    IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+    IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
+    IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
 
 // IExceptionHandler
     virtual bool fireException(IException *e);

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -78,6 +78,9 @@ public:
     virtual void start();
     virtual void done();
     virtual void abort(IException *e);
+    IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
+    IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+
 // IExceptionHandler
     virtual bool fireException(IException *e);
 // IThorChildGraph impl.

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -107,6 +107,7 @@ public:
     void initWithActData(MemoryBuffer &in, MemoryBuffer &out);
     void getDone(MemoryBuffer &doneInfoMb);
     void serializeDone(MemoryBuffer &mb);
+    IThorResult *getGlobalResult(CActivityBase &activity, IRowInterfaces *rowIf, unsigned id);
 
     virtual void executeSubGraph(size32_t parentExtractSz, const byte *parentExtract);
     virtual void serializeStats(MemoryBuffer &mb);
@@ -117,6 +118,7 @@ public:
     virtual void abort(IException *e);
     virtual void done();
     virtual void end();
+    virtual IThorGraphResults *createThorGraphResults(unsigned num);
 
 // IExceptionHandler
     virtual bool fireException(IException *e)

--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -328,7 +328,7 @@ void CThorKeyArray::createSortedPartition(unsigned pn)
         newpos->append(filepos?filepos->item(ra[p]):filerecsize*(offset_t)ra[p]);
     }
     filepos.setown(newpos.getClear());
-    CThorExpandingRowArray newrows(activity);
+    CThorExpandingRowArray newrows(activity, rowif);
     newrows.ensure(pn);
     for (i = 1; i<pn; i++)
     {

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -473,7 +473,7 @@ public:
         }
         else
         {
-            collector->setup(&iCompare, isStable, rc_mixed, UINT_MAX); // must not spill
+            collector->setup(&iCompare, isStable, rc_mixed, SPILL_PRIORITY_DISABLE); // must not spill
             collector->transferRowsIn(localRows);
 
             // JCSMORE - very odd, threaded, but semaphores ensuring sequential writes, why?

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -166,7 +166,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     CWriteIntercept(CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _interval)
-        : activity(_activity), rowIf(_rowIf), interval(_interval), sampleRows(activity, true)
+        : activity(_activity), rowIf(_rowIf), interval(_interval), sampleRows(activity, rowIf, true)
     {
         interval = _interval;
         idx = 0;
@@ -428,7 +428,7 @@ public:
     CMiniSort(CActivityBase &_activity, IRowInterfaces &_rowIf, ICommunicator &_clusterComm, unsigned _partNo, unsigned _numNodes, mptag_t _mpTag)
         : activity(_activity), rowIf(_rowIf), clusterComm(_clusterComm), partNo(_partNo), numNodes(_numNodes), mpTag(_mpTag)
     {
-        collector.setown(createThorRowCollector(activity));
+        collector.setown(createThorRowCollector(activity, &rowIf));
         serializer = rowIf.queryRowSerializer();
         deserializer = rowIf.queryRowDeserializer();
         allocator = rowIf.queryRowAllocator();
@@ -465,7 +465,6 @@ public:
                     break;
                 idx += done;
             }
-            collector->setup(&rowIf);
             Owned<IRowWriter> writer = collector->getWriter();
             appendFromPrimaryNode(*writer); // will be sorted, may spill
             rowCount = collector->numRows();
@@ -474,7 +473,7 @@ public:
         }
         else
         {
-            collector->setup(&rowIf, &iCompare, isStable, rc_mixed, UINT_MAX); // must not spill
+            collector->setup(&iCompare, isStable, rc_mixed, UINT_MAX); // must not spill
             collector->transferRowsIn(localRows);
 
             // JCSMORE - very odd, threaded, but semaphores ensuring sequential writes, why?
@@ -728,7 +727,7 @@ public:
 
     CThorSorter(CActivityBase *_activity, SocketEndpoint &ep, IDiskUsage *_iDiskUsage, ICommunicator *_clusterComm, mptag_t _mpTagRPC)
         : activity(_activity), myendpoint(ep), iDiskUsage(_iDiskUsage), clusterComm(_clusterComm), mpTagRPC(_mpTagRPC),
-          rowArray(*_activity), threaded("CThorSorter", this)
+          rowArray(*_activity, _activity), threaded("CThorSorter", this)
     {
         numnodes = 0;
         partno = 0;

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -649,10 +649,10 @@ class COverflowableBuffer : public CSimpleInterface, implements IRowWriterMultiR
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    COverflowableBuffer(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _grouped, bool _shared)
+    COverflowableBuffer(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _grouped, bool _shared, unsigned spillPriority)
         : activity(_activity), rowIf(_rowIf), grouped(_grouped), shared(_shared)
     {
-        collector.setown(createThorRowCollector(activity, rowIf, NULL, false, rc_mixed, SPILL_PRIORITY_OVERFLOWABLE_BUFFER, grouped));
+        collector.setown(createThorRowCollector(activity, rowIf, NULL, false, rc_mixed, spillPriority, grouped));
         writer.setown(collector->getWriter());
         eoi = false;
     }
@@ -680,9 +680,9 @@ public:
     }
 };
 
-IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowIf, bool grouped, bool shared)
+IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowIf, bool grouped, bool shared, unsigned spillPriority)
 {
-    return new COverflowableBuffer(activity, rowIf, grouped, shared);
+    return new COverflowableBuffer(activity, rowIf, grouped, shared, spillPriority);
 }
 
 

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -653,8 +653,8 @@ public:
         : activity(_activity), rowIf(_rowIf), grouped(_grouped), shared(_shared)
     {
         collector.setown(createThorRowCollector(activity, rowIf, NULL, false, rc_mixed, SPILL_PRIORITY_OVERFLOWABLE_BUFFER, grouped));
-		writer.setown(collector->getWriter());
-		eoi = false;
+        writer.setown(collector->getWriter());
+        eoi = false;
     }
     ~COverflowableBuffer()
     {
@@ -695,7 +695,7 @@ class CRowSet : public CSimpleInterface
     unsigned chunk;
     CThorExpandingRowArray rows;
 public:
-    CRowSet(CActivityBase &activity, unsigned _chunk) : rows(activity, true), chunk(_chunk)
+    CRowSet(CActivityBase &activity, unsigned _chunk) : rows(activity, &activity, true), chunk(_chunk)
     {
     }
     void reset(unsigned _chunk)

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -26,6 +26,7 @@
 #include "jbuff.hpp"
 #include "jcrc.hpp"
 #include "thorcommon.hpp"
+#include "thmem.hpp"
 
 
 #ifdef _WIN32
@@ -87,7 +88,7 @@ interface IRowWriterMultiReader : extends IRowWriter
     virtual IRowStream *getReader() = 0;
 };
 
-extern graph_decl IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowif, bool grouped, bool shared=false);
+extern graph_decl IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowif, bool grouped, bool shared=false, unsigned spillPriority=SPILL_PRIORITY_OVERFLOWABLE_BUFFER);
 // NB first write all then read (not interleaved!)
 
 #endif

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -259,7 +259,7 @@ public:
     }
 };
 
-// NB: Shared/spillable, hols all rows in mem until needs to spill.
+// NB: Shared/spillable, holds all rows in mem until needs to spill.
 // spills all to disk, and stream continue reading from row in file
 class CSharedSpillableRowSet : public CSpillableStreamBase, implements IInterface
 {
@@ -1250,8 +1250,8 @@ public:
         outStreams = 0;
         mmRegistered = false;
         if (rc_allMem == diskMemMix)
-            spillPriority = UINT_MAX; // all mem, implies no spilling
-        else if (UINT_MAX != spillPriority)
+            spillPriority = SPILL_PRIORITY_DISABLE; // all mem, implies no spilling
+        else if (SPILL_PRIORITY_DISABLE != spillPriority)
         {
             activity.queryJob().queryRowManager()->addRowBuffer(this);
             mmRegistered = true;
@@ -1303,8 +1303,8 @@ public:
         diskMemMix = _diskMemMix;
         spillPriority = _spillPriority;
         if (rc_allMem == diskMemMix)
-            spillPriority = UINT_MAX; // all mem, implies no spilling
-        if (mmRegistered && (UINT_MAX == spillPriority))
+            spillPriority = SPILL_PRIORITY_DISABLE; // all mem, implies no spilling
+        if (mmRegistered && (SPILL_PRIORITY_DISABLE == spillPriority))
         {
             mmRegistered = false;
             activity.queryJob().queryRowManager()->removeRowBuffer(this);
@@ -1318,7 +1318,7 @@ public:
     }
     virtual bool freeBufferedRows(bool critical)
     {
-        if (UINT_MAX == spillPriority)
+        if (SPILL_PRIORITY_DISABLE == spillPriority)
             return false;
         CThorSpillableRowArray::CThorSpillableRowArrayLock block(spillableRows);
         return spillRows();

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -477,12 +477,6 @@ void CThorExpandingRowArray::doSort(unsigned n, void **const rows, ICompare &com
         parqsortvec((void **const)rows, n, compare, maxCores);
 }
 
-CThorExpandingRowArray::CThorExpandingRowArray(CActivityBase &_activity, bool _allowNulls, bool _stableSort, bool _throwOnOom, rowcount_t initialSize) : activity(_activity)
-{
-    init(initialSize, _stableSort);
-    setup(&_activity, _allowNulls, _stableSort, _throwOnOom);
-}
-
 CThorExpandingRowArray::CThorExpandingRowArray(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _allowNulls, bool _stableSort, bool _throwOnOom, rowcount_t initialSize) : activity(_activity)
 {
     init(initialSize, _stableSort);
@@ -894,23 +888,11 @@ void CThorSpillableRowArray::registerWriteCallback(IWritePosCallback &cb)
     CThorSpillableRowArrayLock block(*this);
     writeCallbacks.append(cb); // NB not linked to avoid circular dependency
 }
+
 void CThorSpillableRowArray::unregisterWriteCallback(IWritePosCallback &cb)
 {
     CThorSpillableRowArrayLock block(*this);
     writeCallbacks.zap(cb);
-}
-
-CThorSpillableRowArray::CThorSpillableRowArray(CThorSpillableRowArray &other)
-    : CThorExpandingRowArray(other.activity), commitDelta(CommitStep)
-{
-    transferFrom(other);
-}
-
-CThorSpillableRowArray::CThorSpillableRowArray(CActivityBase &activity, bool allowNulls, bool stable, rowcount_t initialSize, size32_t _commitDelta)
-    : CThorExpandingRowArray(activity, &activity, false, stable, false, initialSize), commitDelta(_commitDelta)
-{
-    commitRows = 0;
-    firstRow = 0;
 }
 
 CThorSpillableRowArray::CThorSpillableRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls, bool stable, rowcount_t initialSize, size32_t _commitDelta)
@@ -967,7 +949,7 @@ bool CThorSpillableRowArray::ensure(rowcount_t requiredRows)
     }
     ReleaseThorRow(oldRows);
     ReleaseThorRow(oldStableSortTmp);
-	return true;
+    return true;
 }
 
 void CThorSpillableRowArray::sort(ICompare &compare, unsigned maxCores)
@@ -1257,21 +1239,26 @@ protected:
         totalRows = overflowCount = outStreams = 0;
     }
 public:
-    CThorRowCollectorBase(CActivityBase &_activity)
+    CThorRowCollectorBase(CActivityBase &_activity, IRowInterfaces *_rowIf, ICompare *_iCompare, bool _isStable, RowCollectorFlags _diskMemMix, unsigned _spillPriority)
         : activity(_activity),
-          spillableRows(_activity)
+          rowIf(_rowIf), iCompare(_iCompare), isStable(_isStable), diskMemMix(_diskMemMix), spillPriority(_spillPriority),
+          spillableRows(_activity, _rowIf)
     {
-        rowIf = NULL;
-        iCompare = NULL;
-        preserveGrouping = isStable = false;
+        preserveGrouping = false;
         totalRows = 0;
         overflowCount = 0;
-        diskMemMix = rc_mixed;
-        spillPriority = 50;
         outStreams = 0;
-        activity.queryJob().queryRowManager()->addRowBuffer(this);
-        mmRegistered = true;
+        mmRegistered = false;
+        if (rc_allMem == diskMemMix)
+            spillPriority = UINT_MAX; // all mem, implies no spilling
+        else if (UINT_MAX != spillPriority)
+        {
+            activity.queryJob().queryRowManager()->addRowBuffer(this);
+            mmRegistered = true;
+        }
         maxCores = activity.queryMaxCores();
+
+        spillableRows.setup(rowIf, false, isStable);
     }
     ~CThorRowCollectorBase()
     {
@@ -1279,9 +1266,38 @@ public:
         if (mmRegistered)
             activity.queryJob().queryRowManager()->removeRowBuffer(this);
     }
-    void setup(IRowInterfaces *_rowIf, ICompare *_iCompare, bool _isStable, RowCollectorFlags _diskMemMix, unsigned _spillPriority)
+    void transferRowsOut(CThorExpandingRowArray &out, bool sort)
     {
-        rowIf = _rowIf;
+        CThorSpillableRowArray::CThorSpillableRowArrayLock block(spillableRows);
+        spillableRows.flush();
+        totalRows += spillableRows.numCommitted();
+        if (sort && iCompare)
+            spillableRows.sort(*iCompare, maxCores);
+        out.transferFrom(spillableRows);
+    }
+// IThorRowCollectorCommon
+    virtual rowcount_t numRows() const
+    {
+        return totalRows;
+    }
+    virtual unsigned numOverflows() const
+    {
+        return overflowCount;
+    }
+    virtual unsigned overflowScale() const
+    {
+        // 1 if no spill
+        if (!overflowCount)
+            return 1;
+        return overflowCount*2+3; // bit arbitrary
+    }
+    virtual void transferRowsIn(CThorExpandingRowArray &src)
+    {
+        reset();
+        spillableRows.transferFrom(src);
+    }
+    virtual void setup(ICompare *_iCompare, bool _isStable, RowCollectorFlags _diskMemMix, unsigned _spillPriority)
+    {
         iCompare = _iCompare;
         isStable = _isStable;
         diskMemMix = _diskMemMix;
@@ -1294,39 +1310,6 @@ public:
             activity.queryJob().queryRowManager()->removeRowBuffer(this);
         }
         spillableRows.setup(rowIf, false, isStable);
-    }
-    void transferRowsOut(CThorExpandingRowArray &out, bool sort)
-    {
-        CThorSpillableRowArray::CThorSpillableRowArrayLock block(spillableRows);
-        spillableRows.flush();
-        totalRows += spillableRows.numCommitted();
-        if (sort && iCompare)
-            spillableRows.sort(*iCompare, maxCores);
-        out.transferFrom(spillableRows);
-    }
-    bool hasOverflowed() const
-    {
-        return 0 != overflowCount;
-    }
-    rowcount_t numRows() const
-    {
-        return totalRows;
-    }
-    unsigned numOverflows() const
-    {
-        return overflowCount;
-    }
-    unsigned overflowScale() const
-    {
-        // 1 if no spill
-        if (!overflowCount)
-            return 1;
-        return overflowCount*2+3; // bit arbitrary
-    }
-    void transferRowsIn(CThorExpandingRowArray &src)
-    {
-        reset();
-        spillableRows.transferFrom(src);
     }
 // IBufferedRowCallback
     virtual unsigned getPriority() const
@@ -1373,19 +1356,20 @@ class CThorRowLoader : public CThorRowCollectorBase, implements IThorRowLoader
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CThorRowLoader(CActivityBase &activity) : CThorRowCollectorBase(activity)
+    CThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
+        : CThorRowCollectorBase(activity, rowIf, iCompare, isStable, diskMemMix, spillPriority)
     {
     }
 // IThorRowCollectorCommon
-    virtual void setup(IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
-    {
-        CThorRowCollectorBase::setup(rowIf, iCompare, isStable, diskMemMix, spillPriority);
-    }
     virtual rowcount_t numRows() const { return CThorRowCollectorBase::numRows(); }
     virtual unsigned numOverflows() const { return CThorRowCollectorBase::numOverflows(); }
     virtual unsigned overflowScale() const { return CThorRowCollectorBase::overflowScale(); }
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort) { CThorRowCollectorBase::transferRowsOut(dst, sort); }
     virtual void transferRowsIn(CThorExpandingRowArray &src) { CThorRowCollectorBase::transferRowsIn(src); }
+    virtual void setup(ICompare *iCompare, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50)
+    {
+        CThorRowCollectorBase::setup(iCompare, isStable, diskMemMix, spillPriority);
+    }
 // IThorRowLoader
     virtual IRowStream *load(IRowStream *in, const bool &abort, bool preserveGrouping, CThorExpandingRowArray *allMemRows)
     {
@@ -1400,9 +1384,7 @@ public:
 
 IThorRowLoader *createThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
 {
-    Owned<IThorRowLoader> loader = new CThorRowLoader(activity);
-    loader->setup(rowIf, iCompare, isStable, diskMemMix, spillPriority);
-    return loader.getClear();
+    return new CThorRowLoader(activity, rowIf, iCompare, isStable, diskMemMix, spillPriority);
 }
 
 IThorRowLoader *createThorRowLoader(CActivityBase &activity, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
@@ -1417,21 +1399,25 @@ class CThorRowCollector : public CThorRowCollectorBase, implements IThorRowColle
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CThorRowCollector(CActivityBase &activity) : CThorRowCollectorBase(activity)
+    CThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
+        : CThorRowCollectorBase(activity, rowIf, iCompare, isStable, diskMemMix, spillPriority)
     {
     }
 // IThorRowCollectorCommon
-    virtual void setup(IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority, bool preserveGrouping)
+    virtual void setPreserveGrouping(bool tf)
     {
-        assertex(!iCompare || !preserveGrouping); // can't sort if group preserving
-        CThorRowCollectorBase::setup(rowIf, iCompare, isStable, diskMemMix, spillPriority);
-        setPreserveGrouping(preserveGrouping);
+        assertex(!iCompare || !tf); // can't sort if group preserving
+        CThorRowCollectorBase::setPreserveGrouping(tf);
     }
     virtual rowcount_t numRows() const { return CThorRowCollectorBase::numRows(); }
     virtual unsigned numOverflows() const { return CThorRowCollectorBase::numOverflows(); }
     virtual unsigned overflowScale() const { return CThorRowCollectorBase::overflowScale(); }
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort) { CThorRowCollectorBase::transferRowsOut(dst, sort); }
     virtual void transferRowsIn(CThorExpandingRowArray &src) { CThorRowCollectorBase::transferRowsIn(src); }
+    virtual void setup(ICompare *iCompare, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50)
+    {
+        CThorRowCollectorBase::setup(iCompare, isStable, diskMemMix, spillPriority);
+    }
 // IThorRowCollector
     virtual IRowWriter *getWriter()
     {
@@ -1467,8 +1453,8 @@ public:
 
 IThorRowCollector *createThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority, bool preserveGrouping)
 {
-    Owned<IThorRowCollector> collector = new CThorRowCollector(activity);
-    collector->setup(rowIf, iCompare, isStable, diskMemMix, spillPriority, preserveGrouping);
+    Owned<IThorRowCollector> collector = new CThorRowCollector(activity, rowIf, iCompare, isStable, diskMemMix, spillPriority);
+    collector->setPreserveGrouping(preserveGrouping);
     return collector.getClear();
 }
 

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -215,13 +215,17 @@ enum {
 
 graph_decl StringBuffer &getRecordString(const void *key, IOutputRowSerializer *serializer, const char *prefix, StringBuffer &out);
 
+#define SPILL_PRIORITY_DEFAULT 50
+#define SPILL_PRIORITY_DISABLE UINT_MAX
+
 #define SPILL_PRIORITY_JOIN 10
 #define SPILL_PRIORITY_SELFJOIN 10
 #define SPILL_PRIORITY_HASHJOIN 10
 #define SPILL_PRIORITY_LARGESORT 10
 #define SPILL_PRIORITY_GROUPSORT 20
-#define SPILL_PRIORITY_OVERFLOWABLE_BUFFER 50
-#define SPILL_PRIORITY_SPILLABLE_STREAM 50
+#define SPILL_PRIORITY_OVERFLOWABLE_BUFFER SPILL_PRIORITY_DEFAULT
+#define SPILL_PRIORITY_SPILLABLE_STREAM SPILL_PRIORITY_DEFAULT
+#define SPILL_PRIORITY_RESULT SPILL_PRIORITY_DEFAULT
 
 class CThorSpillableRowArray;
 class graph_decl CThorExpandingRowArray : public CSimpleInterface
@@ -483,10 +487,10 @@ interface IThorRowCollector : extends IThorRowCollectorCommon
     virtual IRowStream *getStream(bool shared=false) = 0;
 };
 
-extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50);
-extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50);
-extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50, bool preserveGrouping=false);
-extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50, bool preserveGrouping=false);
+extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT);
+extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT);
+extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT, bool preserveGrouping=false);
+extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT, bool preserveGrouping=false);
 
 
 

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -246,7 +246,6 @@ protected:
     void doSort(unsigned n, void **const rows, ICompare &compare, unsigned maxCores);
 
 public:
-    CThorExpandingRowArray(CActivityBase &activity, bool allowNulls=false, bool stableSort=false, bool throwOnOom=true, rowcount_t initialSize=InitialSortElements);
     CThorExpandingRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, bool stableSort=false, bool throwOnOom=true, rowcount_t initialSize=InitialSortElements);
     ~CThorExpandingRowArray();
     CActivityBase &queryActivity() { return activity; }
@@ -365,8 +364,6 @@ public:
         inline ~CThorSpillableRowArrayLock() { rows.unlock(); }
     };
 
-    CThorSpillableRowArray(CThorSpillableRowArray &other); // NB: swaps
-    CThorSpillableRowArray(CActivityBase &activity, bool allowNulls=false, bool stableSort=false, rowcount_t initialSize=InitialSortElements, size32_t commitDelta=CommitStep);
     CThorSpillableRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, bool stableSort=false, rowcount_t initialSize=InitialSortElements, size32_t commitDelta=CommitStep);
     ~CThorSpillableRowArray();
     // NB: throwOnOom false
@@ -469,18 +466,18 @@ interface IThorRowCollectorCommon : extends IInterface
     virtual unsigned overflowScale() const = 0;
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort=true) = 0;
     virtual void transferRowsIn(CThorExpandingRowArray &src) = 0;
+    virtual void setup(ICompare *iCompare, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50) = 0;
 };
 
 interface IThorRowLoader : extends IThorRowCollectorCommon
 {
-    virtual void setup(IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50) = 0;
     virtual IRowStream *load(IRowStream *in, const bool &abort, bool preserveGrouping=false, CThorExpandingRowArray *allMemRows=NULL) = 0;
     virtual IRowStream *loadGroup(IRowStream *in, const bool &abort, CThorExpandingRowArray *allMemRows=NULL) = 0;
 };
 
 interface IThorRowCollector : extends IThorRowCollectorCommon
 {
-    virtual void setup(IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50, bool preserveGrouping=false) = 0;
+    virtual void setPreserveGrouping(bool tf) = 0;
     virtual IRowWriter *getWriter() = 0;
     virtual void reset() = 0;
     virtual IRowStream *getStream(bool shared=false) = 0;

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -300,7 +300,7 @@ extern graph_decl void reportExceptionToWorkunit(IConstWorkUnit &workunit,IExcep
 
 extern graph_decl IPropertyTree *globals;
 extern graph_decl mptag_t masterSlaveMpTag;
-enum SlaveMsgTypes { smt_errorMsg=1, smt_initGraphReq, smt_initActDataReq, smt_dataReq, smt_getPhysicalName, smt_getFileOffset, smt_actMsg };
+enum SlaveMsgTypes { smt_errorMsg=1, smt_initGraphReq, smt_initActDataReq, smt_dataReq, smt_getPhysicalName, smt_getFileOffset, smt_actMsg, smt_getresult };
 // Logging
 extern graph_decl const LogMsgJobInfo thorJob;
 
@@ -339,6 +339,9 @@ extern graph_decl IRowStream *createRowStreamFromNode(CActivityBase &activity, u
 extern graph_decl IRowServer *createRowServer(CActivityBase *activity, IRowStream *seq, ICommunicator &comm, mptag_t mpTag);
 
 extern graph_decl IRowStream *createUngroupStream(IRowStream *input);
+
+interface IRowInterfaces;
+extern graph_decl void sendInChunks(ICommunicator &comm, rank_t dst, mptag_t mpTag, IRowStream *input, IRowInterfaces *rowIf);
 
 #endif
 


### PR DESCRIPTION
Allow graph results to have spill priority

This was mainly to address a problem with an attempt to spill the counter
result, which had no serializer and hence crashed. But don't want it to try
to spill the counter result anyway (as always 1 row).

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
