### PR TITLE
Allow graph results to have spill priority

### DIFF
--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -59,7 +59,7 @@ protected:
         if (1 == numPartialResults)
             return firstRow;
 
-        CThorExpandingRowArray partialResults(*this, true, false, true, numPartialResults);
+        CThorExpandingRowArray partialResults(*this, this, true, false, true, numPartialResults);
         partialResults.setRow(0, firstRow);
         --numPartialResults;
 

--- a/thorlcr/activities/filter/thfilterslave.cpp
+++ b/thorlcr/activities/filter/thfilterslave.cpp
@@ -278,14 +278,14 @@ public:
                 groupStream.clear();
                 return NULL;
             }
-            CThorExpandingRowArray rows(*this);
+            CThorExpandingRowArray rows(*this, this);
             groupLoader->loadGroup(input, abortSoon, &rows);
             if (rows.ordinality())
             {
                 // JCSMORE - if isValid would take a stream, group wouldn't need to be in mem.
                 if (helper->isValid(rows.ordinality(), rows.getRowArray()))
                 {
-                    CThorSpillableRowArray spillableRows(*this);
+                    CThorSpillableRowArray spillableRows(*this, this);
                     spillableRows.transferFrom(rows);
                     groupStream.setown(spillableRows.createRowStream());
                 }
@@ -345,7 +345,7 @@ public:
                 ret.setown(input->nextRowGE(seek, numFields, wasCompleteMatch, stepExtra));
 #endif
 
-        CThorExpandingRowArray rows(*this);
+        CThorExpandingRowArray rows(*this, this);
         groupStream.setown(groupLoader->loadGroup(input, abortSoon, &rows));
         if (rows.ordinality())
         {

--- a/thorlcr/activities/funnel/thfunnelslave.cpp
+++ b/thorlcr/activities/funnel/thfunnelslave.cpp
@@ -535,7 +535,7 @@ public:
 
 
     CombineSlaveActivity(CGraphElementBase *_container) 
-        : CSlaveActivity(_container), CThorDataLink(this), rows(*this)
+        : CSlaveActivity(_container), CThorDataLink(this), rows(*this, this)
     {
         grouped = container.queryGrouped();
     }

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -1989,7 +1989,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     HashDedupSlaveActivityBase(CGraphElementBase *_container)
-        : CSlaveActivity(_container), CThorDataLink(this), htabrows(*this, true)
+        : CSlaveActivity(_container), CThorDataLink(this), htabrows(*this, this, true)
     {
         htsize = 0;
         inputstopped = false;

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -114,7 +114,7 @@ public:
     CJoinGroup *prev;  // Doubly-linked list to allow us to keep track of ones that are still in use
     CJoinGroup *next;
 
-    CJoinGroup(CActivityBase &_activity) : activity(_activity), rows(_activity)
+    CJoinGroup(CActivityBase &_activity) : activity(_activity), rows(_activity, NULL)
     {
         // Used for head object only
         prev = NULL;
@@ -161,7 +161,7 @@ public:
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CJoinGroup(CActivityBase &_activity, const void *_left, IJoinProcessor *_join, CJoinGroup *_groupStart) : activity(_activity), join(_join), rows(_activity)
+    CJoinGroup(CActivityBase &_activity, const void *_left, IJoinProcessor *_join, CJoinGroup *_groupStart) : activity(_activity), join(_join), rows(_activity, NULL)
     {
 #ifdef TRACE_USAGE
         atomic_inc(&join->getdebug(0));
@@ -889,7 +889,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
             stopped = aborted = writeWaiting = replyWaiting = false;
             pendingSends = pendingReplies = 0;
             for (unsigned n=0; n<nodes; n++)
-                dstLists.append(new CThorExpandingRowArray(owner));
+                dstLists.append(new CThorExpandingRowArray(owner, owner.fetchInputMetaRowIf));
             fetchMin = owner.helper->queryJoinFieldsRecordSize()->getMinRecordSize();
             perRowMin = NEWFETCHSENDHEADERSZ+fetchMin;
             maxRequests = NEWFETCHPRMEMLIMIT<perRowMin ? 1 : (NEWFETCHPRMEMLIMIT / perRowMin);
@@ -1041,7 +1041,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                     if (total)
                     {
                         assertex(!replyWaiting);
-                        CThorExpandingRowArray dstList(owner);
+                        CThorExpandingRowArray dstList(owner, owner.fetchInputMetaRowIf);
                         unsigned dstP=0;
                         loop
                         {

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -262,7 +262,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     CLookupJoinActivity(CGraphElementBase *_container, joinkind_t _joinKind) 
-        : CSlaveActivity(_container), CThorDataLink(this), joinKind(_joinKind), broadcaster(this, abortSoon), rhs(*this, true)
+        : CSlaveActivity(_container), CThorDataLink(this), joinKind(_joinKind), broadcaster(this, abortSoon), rhs(*this, NULL, true)
     {
         gotRHS = false;
         joinType = JT_Undefined;

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -354,7 +354,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     CJoinHelper(CActivityBase &_activity, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : activity(_activity), allocator(_allocator), denormTmp(NULL), rightgroup(_activity), denormRows(_activity)
+        : activity(_activity), allocator(_allocator), denormTmp(NULL), rightgroup(_activity, NULL), denormRows(_activity, NULL)
     {
         kind = activity.queryContainer().getKind();
         helper = _helper; 
@@ -859,7 +859,7 @@ public:
                     break;
                 case JSmatch: // matching left to right group       
                     if (mcoreintercept) {
-                        CThorExpandingRowArray leftgroup(activity);
+                        CThorExpandingRowArray leftgroup(activity, NULL);
                         while (getL()) {
                             if (leftgroup.ordinality()) {
                                 int cmp = compareL->docompare(nextleft,leftgroup.query(leftgroup.ordinality()-1));
@@ -951,7 +951,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     SelfJoinHelper(CActivityBase &_activity, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : activity(_activity), allocator(_allocator), curgroup(_activity)
+        : activity(_activity), allocator(_allocator), curgroup(_activity, &_activity)
     {
         helper = _helper;       
         outputmetaL = NULL;
@@ -1427,11 +1427,11 @@ public:
         CThorExpandingRowArray rgroup;
         const void *row;
         inline cWorkItem(CActivityBase &_activity, CThorExpandingRowArray *_lgroup, CThorExpandingRowArray *_rgroup)
-            : activity(_activity), lgroup(_activity), rgroup(_activity)
+            : activity(_activity), lgroup(_activity, &_activity), rgroup(_activity, &_activity)
         {
             set(_lgroup,_rgroup);
         }
-        inline cWorkItem(CActivityBase &_activity) : activity(_activity), lgroup(_activity), rgroup(_activity)
+        inline cWorkItem(CActivityBase &_activity) : activity(_activity), lgroup(_activity, &_activity), rgroup(_activity, &_activity)
         {
             clear();
         }

--- a/thorlcr/activities/rollup/throllupslave.cpp
+++ b/thorlcr/activities/rollup/throllupslave.cpp
@@ -83,7 +83,7 @@ class CDedupAllHelper : public CSimpleInterface, implements IRowStream
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CDedupAllHelper(CActivityBase *_activity) : activity(_activity), rows(*_activity)
+    CDedupAllHelper(CActivityBase *_activity) : activity(_activity), rows(*_activity, _activity)
     {
         in = NULL;
         helper = NULL;
@@ -539,7 +539,7 @@ public:
         ActivityTimer t(totalCycles, timeActivities, NULL);
         if (!eoi)
         {
-            CThorExpandingRowArray rows(*this);
+            CThorExpandingRowArray rows(*this, queryRowInterfaces(input));
             groupLoader->loadGroup(input, abortSoon, &rows);
             unsigned count = rows.ordinality();
             if (count)

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -359,7 +359,7 @@ rowcount_t getCount(CActivityBase &activity, unsigned partialResults, rowcount_t
 const void *getAggregate(CActivityBase &activity, unsigned partialResults, IRowInterfaces &rowIf, IHThorCompoundAggregateExtra &aggHelper, mptag_t mpTag)
 {
     // JCSMORE - pity this isn't common routine with similar one in aggregate, but helper is not common
-    CThorExpandingRowArray slaveResults(activity, true, false, true, partialResults);
+    CThorExpandingRowArray slaveResults(activity, &activity, true, false, true, partialResults);
     unsigned _partialResults = partialResults;
     while (_partialResults--)
     {

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -49,6 +49,7 @@
 #include "thormisc.hpp"
 #include "workunit.hpp"
 #include "thorcommon.hpp"
+#include "thmem.hpp"
 
 #include "thor.hpp"
 #include "eclhelper.hpp"
@@ -129,8 +130,8 @@ interface IThorGraphResults : extends IEclGraphResults
 {
     virtual void clear() = 0;
     virtual IThorResult *getResult(unsigned id, bool distributed=false) = 0;
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed) = 0;
-    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed) = 0;
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT) = 0;
+    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT) = 0;
     virtual unsigned addResult(IThorResult *result) = 0;
     virtual void setResult(unsigned id, IThorResult *result) = 0;
     virtual unsigned count() = 0;
@@ -741,8 +742,8 @@ public:
 
     virtual IThorResult *getResult(unsigned id, bool distributed=false);
     virtual IThorResult *getGraphLoopResult(unsigned id, bool distributed=false);
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
-    virtual IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
+    virtual IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
 
 // ILocalGraph
     virtual void getResult(size32_t & len, void * & data, unsigned id);
@@ -1086,10 +1087,10 @@ public:
         // NB: stream static after this, i.e. nothing can be added to this result
         return LINK(&results.item(id));
     }
-    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
-    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+    virtual IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
+    virtual IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT)
     {
-        return createResult(activity, results.ordinality(), rowIf, distributed);
+        return createResult(activity, results.ordinality(), rowIf, distributed, spillPriority);
     }
     virtual unsigned addResult(IThorResult *result)
     {
@@ -1120,7 +1121,7 @@ public:
     }
 };
 
-extern graph_decl IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+extern graph_decl IThorResult *createResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
 
 
 class CGraphElementBase;

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1760,6 +1760,7 @@ class CCollatedResult : public CSimpleInterface, implements IThorResult
     CriticalSection crit;
     PointerArrayOf<CThorExpandingRowArray> results;
     Owned<IThorResult> result;
+    unsigned spillPriority;
 
     void ensure()
     {
@@ -1823,7 +1824,7 @@ class CCollatedResult : public CSimpleInterface, implements IThorResult
                 }
             }
         }
-        Owned<IThorResult> _result = ::createResult(activity, rowIf, false);
+        Owned<IThorResult> _result = ::createResult(activity, rowIf, false, spillPriority);
         Owned<IRowWriter> resultWriter = _result->getWriter();
         for (unsigned s=0; s<numSlaves; s++)
         {
@@ -1841,154 +1842,7 @@ class CCollatedResult : public CSimpleInterface, implements IThorResult
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CCollatedResult(CMasterGraph &_graph, CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _id) : graph(_graph), activity(_activity), rowIf(_rowIf), id(_id)
-    {
-        for (unsigned n=0; n<graph.queryJob().querySlaves(); n++)
-            results.append(new CThorExpandingRowArray(activity));
-    }
-    ~CCollatedResult()
-    {
-        ForEachItemIn(l, results)
-        {
-            CThorExpandingRowArray *result = results.item(l);
-            delete result;
-        }
-    }
-    void setId(unsigned _id)
-    {
-        id = _id;
-    }
-
-// IThorResult
-    virtual IRowWriter *getWriter() { throwUnexpected(); }
-    virtual void setResultStream(IRowWriterMultiReader *stream, rowcount_t count)
-    {
-        throwUnexpected();
-    }
-    virtual IRowStream *getRowStream()
-    {
-        ensure();
-        return result->getRowStream();
-    }
-    virtual IRowInterfaces *queryRowInterfaces()
-    {
-        return rowIf;
-    }
-    virtual CActivityBase *queryActivity()
-    {
-        return &activity;
-    }
-    virtual bool isDistributed() const { return false; }
-    virtual void serialize(MemoryBuffer &mb)
-    {
-        ensure();
-        result->serialize(mb);
-    }
-    virtual void getResult(size32_t & retSize, void * & ret)
-    {
-        ensure();
-        return result->getResult(retSize, ret);
-    }
-    virtual void getLinkedResult(unsigned & count, byte * * & ret)
-    {
-        ensure();
-        return result->getLinkedResult(count, ret);
-    }
-};
-
-///////////////////
-
-class CCollatedResult : public CSimpleInterface, implements IThorResult
-{
-    CMasterGraph &graph;
-    CActivityBase &activity;
-    IRowInterfaces *rowIf;
-    unsigned id;
-    CriticalSection crit;
-    PointerArrayOf<CThorExpandingRowArray> results;
-    Owned<IThorResult> result;
-
-    void ensure()
-    {
-        CriticalBlock b(crit);
-        if (result)
-            return;
-        mptag_t replyTag = createReplyTag();
-        CMessageBuffer msg;
-        msg.append(GraphGetResult);
-        msg.append(activity.queryJob().queryKey());
-        msg.append(graph.queryGraphId());
-        msg.append(id);
-        msg.append(replyTag);
-        ((CJobMaster &)graph.queryJob()).broadcastToSlaves(msg, masterSlaveMpTag, LONGTIMEOUT, NULL, NULL, true);
-
-        unsigned numSlaves = graph.queryJob().querySlaves();
-        for (unsigned n=0; n<numSlaves; n++)
-            results.item(n)->kill();
-        rank_t sender;
-        MemoryBuffer mb;
-        Owned<ISerialStream> stream = createMemoryBufferSerialStream(mb);
-        CThorStreamDeserializerSource rowSource(stream);
-        unsigned todo = numSlaves;
-
-        loop
-        {
-            loop
-            {
-                if (activity.queryAbortSoon())
-                    return;
-                msg.clear();
-                if (activity.receiveMsg(msg, RANK_ALL, replyTag, &sender, 60*1000))
-                    break;
-                ActPrintLog(&activity, "WARNING: tag %d timedout, retrying", (unsigned)replyTag);
-            }
-            sender = sender - 1; // 0 = master
-            if (!msg.length())
-            {
-                --todo;
-                if (0 == todo)
-                    break; // done
-            }
-            else
-            {
-                bool error;
-                msg.read(error);
-                if (error)
-                {
-                    Owned<IThorException> e = deserializeThorException(msg);
-                    e->setSlave(sender);
-                    throw e.getClear();
-                }
-                ThorExpand(msg, mb.clear());
-
-                CThorExpandingRowArray *slaveResults = results.item(sender);
-                while (!rowSource.eos())
-                {
-                    RtlDynamicRowBuilder rowBuilder(rowIf->queryRowAllocator());
-                    size32_t sz = rowIf->queryRowDeserializer()->deserialize(rowBuilder, rowSource);
-                    slaveResults->append(rowBuilder.finalizeRowClear(sz));
-                }
-            }
-        }
-        Owned<IThorResult> _result = ::createResult(activity, rowIf, false);
-        Owned<IRowWriter> resultWriter = _result->getWriter();
-        for (unsigned s=0; s<numSlaves; s++)
-        {
-            CThorExpandingRowArray *slaveResult = results.item(s);
-            ForEachItemIn(r, *slaveResult)
-            {
-                const void *row = slaveResult->query(r);
-                LinkThorRow(row);
-                resultWriter->putRow(row);
-            }
-        }
-        result.setown(_result.getClear());
-    }
-
-public:
-    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
-
-    CCollatedResult(CMasterGraph &_graph, CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _id) : graph(_graph), activity(_activity), rowIf(_rowIf), id(_id)
+    CCollatedResult(CMasterGraph &_graph, CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _id, unsigned _spillPriority) : graph(_graph), activity(_activity), rowIf(_rowIf), id(_id), spillPriority(_spillPriority)
     {
         for (unsigned n=0; n<graph.queryJob().querySlaves(); n++)
             results.append(new CThorExpandingRowArray(activity, rowIf));
@@ -2722,16 +2576,16 @@ bool CMasterGraph::deserializeStats(unsigned node, MemoryBuffer &mb)
     return true;
 }
 
-IThorResult *CMasterGraph::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed)
+IThorResult *CMasterGraph::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
-    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, id);
+    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, id, spillPriority);
     localResults->setResult(id, result);
     return result;
 }
 
-IThorResult *CMasterGraph::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed)
+IThorResult *CMasterGraph::createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
-    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, 0);
+    Owned<CCollatedResult> result = new CCollatedResult(*this, activity, rowIf, 0, spillPriority);
     unsigned id = graphLoopResults->addResult(result);
     result->setId(id);
     return result;

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -78,8 +78,8 @@ public:
     virtual void start();
     virtual void done();
     virtual void abort(IException *e);
-    IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed);
-    IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed);
+    IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
+    IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
 
 // IExceptionHandler
     virtual bool fireException(IException *e);

--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -330,7 +330,7 @@ void CThorKeyArray::createSortedPartition(unsigned pn)
         newpos->append(filepos?filepos->item(ra[p]):filerecsize*(offset_t)ra[p]);
     }
     filepos.setown(newpos.getClear());
-    CThorExpandingRowArray newrows(activity);
+    CThorExpandingRowArray newrows(activity, rowif);
     newrows.ensure(pn);
     for (i = 1; i<pn; i++)
     {

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -474,7 +474,7 @@ public:
         }
         else
         {
-            collector->setup(&iCompare, isStable, rc_mixed, UINT_MAX); // must not spill
+            collector->setup(&iCompare, isStable, rc_mixed, SPILL_PRIORITY_DISABLE); // must not spill
             collector->transferRowsIn(localRows);
 
             // JCSMORE - very odd, threaded, but semaphores ensuring sequential writes, why?

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -166,7 +166,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     CWriteIntercept(CActivityBase &_activity, IRowInterfaces *_rowIf, unsigned _interval)
-        : activity(_activity), rowIf(_rowIf), interval(_interval), sampleRows(activity, true)
+        : activity(_activity), rowIf(_rowIf), interval(_interval), sampleRows(activity, rowIf, true)
     {
         interval = _interval;
         idx = 0;
@@ -429,7 +429,7 @@ public:
     CMiniSort(CActivityBase &_activity, IRowInterfaces &_rowIf, ICommunicator &_clusterComm, unsigned _partNo, unsigned _numNodes, mptag_t _mpTag)
         : activity(_activity), rowIf(_rowIf), clusterComm(_clusterComm), partNo(_partNo), numNodes(_numNodes), mpTag(_mpTag)
     {
-        collector.setown(createThorRowCollector(activity));
+        collector.setown(createThorRowCollector(activity, &rowIf));
         serializer = rowIf.queryRowSerializer();
         deserializer = rowIf.queryRowDeserializer();
         allocator = rowIf.queryRowAllocator();
@@ -466,7 +466,6 @@ public:
                     break;
                 idx += done;
             }
-            collector->setup(&rowIf);
             Owned<IRowWriter> writer = collector->getWriter();
             appendFromPrimaryNode(*writer); // will be sorted, may spill
             writer.clear();
@@ -475,7 +474,7 @@ public:
         }
         else
         {
-            collector->setup(&rowIf, &iCompare, isStable, rc_mixed, UINT_MAX); // must not spill
+            collector->setup(&iCompare, isStable, rc_mixed, UINT_MAX); // must not spill
             collector->transferRowsIn(localRows);
 
             // JCSMORE - very odd, threaded, but semaphores ensuring sequential writes, why?
@@ -729,7 +728,7 @@ public:
 
     CThorSorter(CActivityBase *_activity, SocketEndpoint &ep, IDiskUsage *_iDiskUsage, ICommunicator *_clusterComm, mptag_t _mpTagRPC)
         : activity(_activity), myendpoint(ep), iDiskUsage(_iDiskUsage), clusterComm(_clusterComm), mpTagRPC(_mpTagRPC),
-          rowArray(*_activity), threaded("CThorSorter", this)
+          rowArray(*_activity, _activity), threaded("CThorSorter", this)
     {
         numnodes = 0;
         partno = 0;

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -649,10 +649,10 @@ class COverflowableBuffer : public CSimpleInterface, implements IRowWriterMultiR
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    COverflowableBuffer(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _grouped, bool _shared)
+    COverflowableBuffer(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _grouped, bool _shared, unsigned spillPriority)
         : activity(_activity), rowIf(_rowIf), grouped(_grouped), shared(_shared)
     {
-        collector.setown(createThorRowCollector(activity, rowIf, NULL, false, rc_mixed, SPILL_PRIORITY_OVERFLOWABLE_BUFFER, grouped));
+        collector.setown(createThorRowCollector(activity, rowIf, NULL, false, rc_mixed, spillPriority, grouped));
         writer.setown(collector->getWriter());
         eoi = false;
     }
@@ -680,9 +680,9 @@ public:
     }
 };
 
-IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowIf, bool grouped, bool shared)
+IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowIf, bool grouped, bool shared, unsigned spillPriority)
 {
-    return new COverflowableBuffer(activity, rowIf, grouped, shared);
+    return new COverflowableBuffer(activity, rowIf, grouped, shared, spillPriority);
 }
 
 

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -653,8 +653,8 @@ public:
         : activity(_activity), rowIf(_rowIf), grouped(_grouped), shared(_shared)
     {
         collector.setown(createThorRowCollector(activity, rowIf, NULL, false, rc_mixed, SPILL_PRIORITY_OVERFLOWABLE_BUFFER, grouped));
-		writer.setown(collector->getWriter());
-		eoi = false;
+        writer.setown(collector->getWriter());
+        eoi = false;
     }
     ~COverflowableBuffer()
     {
@@ -695,7 +695,7 @@ class CRowSet : public CSimpleInterface
     unsigned chunk;
     CThorExpandingRowArray rows;
 public:
-    CRowSet(CActivityBase &activity, unsigned _chunk) : rows(activity, true), chunk(_chunk)
+    CRowSet(CActivityBase &activity, unsigned _chunk) : rows(activity, &activity, true), chunk(_chunk)
     {
     }
     void reset(unsigned _chunk)

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -26,6 +26,7 @@
 #include "jbuff.hpp"
 #include "jcrc.hpp"
 #include "thorcommon.hpp"
+#include "thmem.hpp"
 
 
 #ifdef _WIN32
@@ -87,7 +88,7 @@ interface IRowWriterMultiReader : extends IRowWriter
     virtual IRowStream *getReader() = 0;
 };
 
-extern graph_decl IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowif, bool grouped, bool shared=false);
+extern graph_decl IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowif, bool grouped, bool shared=false, unsigned spillPriority=SPILL_PRIORITY_OVERFLOWABLE_BUFFER);
 // NB first write all then read (not interleaved!)
 
 #endif

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -477,12 +477,6 @@ void CThorExpandingRowArray::doSort(unsigned n, void **const rows, ICompare &com
         parqsortvec((void **const)rows, n, compare, maxCores);
 }
 
-CThorExpandingRowArray::CThorExpandingRowArray(CActivityBase &_activity, bool _allowNulls, bool _stableSort, bool _throwOnOom, rowcount_t initialSize) : activity(_activity)
-{
-    init(initialSize, _stableSort);
-    setup(&_activity, _allowNulls, _stableSort, _throwOnOom);
-}
-
 CThorExpandingRowArray::CThorExpandingRowArray(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _allowNulls, bool _stableSort, bool _throwOnOom, rowcount_t initialSize) : activity(_activity)
 {
     init(initialSize, _stableSort);
@@ -894,23 +888,11 @@ void CThorSpillableRowArray::registerWriteCallback(IWritePosCallback &cb)
     CThorSpillableRowArrayLock block(*this);
     writeCallbacks.append(cb); // NB not linked to avoid circular dependency
 }
+
 void CThorSpillableRowArray::unregisterWriteCallback(IWritePosCallback &cb)
 {
     CThorSpillableRowArrayLock block(*this);
     writeCallbacks.zap(cb);
-}
-
-CThorSpillableRowArray::CThorSpillableRowArray(CThorSpillableRowArray &other)
-    : CThorExpandingRowArray(other.activity), commitDelta(CommitStep)
-{
-    transferFrom(other);
-}
-
-CThorSpillableRowArray::CThorSpillableRowArray(CActivityBase &activity, bool allowNulls, bool stable, rowcount_t initialSize, size32_t _commitDelta)
-    : CThorExpandingRowArray(activity, &activity, false, stable, false, initialSize), commitDelta(_commitDelta)
-{
-    commitRows = 0;
-    firstRow = 0;
 }
 
 CThorSpillableRowArray::CThorSpillableRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls, bool stable, rowcount_t initialSize, size32_t _commitDelta)
@@ -967,7 +949,7 @@ bool CThorSpillableRowArray::ensure(rowcount_t requiredRows)
     }
     ReleaseThorRow(oldRows);
     ReleaseThorRow(oldStableSortTmp);
-	return true;
+    return true;
 }
 
 void CThorSpillableRowArray::sort(ICompare &compare, unsigned maxCores)
@@ -1261,21 +1243,26 @@ protected:
         totalRows = overflowCount = outStreams = 0;
     }
 public:
-    CThorRowCollectorBase(CActivityBase &_activity)
+    CThorRowCollectorBase(CActivityBase &_activity, IRowInterfaces *_rowIf, ICompare *_iCompare, bool _isStable, RowCollectorFlags _diskMemMix, unsigned _spillPriority)
         : activity(_activity),
-          spillableRows(_activity)
+          rowIf(_rowIf), iCompare(_iCompare), isStable(_isStable), diskMemMix(_diskMemMix), spillPriority(_spillPriority),
+          spillableRows(_activity, _rowIf)
     {
-        rowIf = NULL;
-        iCompare = NULL;
-        preserveGrouping = isStable = false;
+        preserveGrouping = false;
         totalRows = 0;
         overflowCount = 0;
-        diskMemMix = rc_mixed;
-        spillPriority = 50;
         outStreams = 0;
-        activity.queryJob().queryRowManager()->addRowBuffer(this);
-        mmRegistered = true;
+        mmRegistered = false;
+        if (rc_allMem == diskMemMix)
+            spillPriority = UINT_MAX; // all mem, implies no spilling
+        else if (UINT_MAX != spillPriority)
+        {
+            activity.queryJob().queryRowManager()->addRowBuffer(this);
+            mmRegistered = true;
+        }
         maxCores = activity.queryMaxCores();
+
+        spillableRows.setup(rowIf, false, isStable);
     }
     ~CThorRowCollectorBase()
     {
@@ -1283,9 +1270,38 @@ public:
         if (mmRegistered)
             activity.queryJob().queryRowManager()->removeRowBuffer(this);
     }
-    void setup(IRowInterfaces *_rowIf, ICompare *_iCompare, bool _isStable, RowCollectorFlags _diskMemMix, unsigned _spillPriority)
+    void transferRowsOut(CThorExpandingRowArray &out, bool sort)
     {
-        rowIf = _rowIf;
+        CThorSpillableRowArray::CThorSpillableRowArrayLock block(spillableRows);
+        spillableRows.flush();
+        totalRows += spillableRows.numCommitted();
+        if (sort && iCompare)
+            spillableRows.sort(*iCompare, maxCores);
+        out.transferFrom(spillableRows);
+    }
+// IThorRowCollectorCommon
+    virtual rowcount_t numRows() const
+    {
+        return totalRows+spillableRows.numCommitted();
+    }
+    virtual unsigned numOverflows() const
+    {
+        return overflowCount;
+    }
+    virtual unsigned overflowScale() const
+    {
+        // 1 if no spill
+        if (!overflowCount)
+            return 1;
+        return overflowCount*2+3; // bit arbitrary
+    }
+    virtual void transferRowsIn(CThorExpandingRowArray &src)
+    {
+        reset();
+        spillableRows.transferFrom(src);
+    }
+    virtual void setup(ICompare *_iCompare, bool _isStable, RowCollectorFlags _diskMemMix, unsigned _spillPriority)
+    {
         iCompare = _iCompare;
         isStable = _isStable;
         diskMemMix = _diskMemMix;
@@ -1298,39 +1314,6 @@ public:
             activity.queryJob().queryRowManager()->removeRowBuffer(this);
         }
         spillableRows.setup(rowIf, false, isStable);
-    }
-    void transferRowsOut(CThorExpandingRowArray &out, bool sort)
-    {
-        CThorSpillableRowArray::CThorSpillableRowArrayLock block(spillableRows);
-        spillableRows.flush();
-        totalRows += spillableRows.numCommitted();
-        if (sort && iCompare)
-            spillableRows.sort(*iCompare, maxCores);
-        out.transferFrom(spillableRows);
-    }
-    bool hasOverflowed() const
-    {
-        return 0 != overflowCount;
-    }
-    rowcount_t numRows() const
-    {
-        return totalRows+spillableRows.numCommitted();
-    }
-    unsigned numOverflows() const
-    {
-        return overflowCount;
-    }
-    unsigned overflowScale() const
-    {
-        // 1 if no spill
-        if (!overflowCount)
-            return 1;
-        return overflowCount*2+3; // bit arbitrary
-    }
-    void transferRowsIn(CThorExpandingRowArray &src)
-    {
-        reset();
-        spillableRows.transferFrom(src);
     }
 // IBufferedRowCallback
     virtual unsigned getPriority() const
@@ -1377,19 +1360,20 @@ class CThorRowLoader : public CThorRowCollectorBase, implements IThorRowLoader
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CThorRowLoader(CActivityBase &activity) : CThorRowCollectorBase(activity)
+    CThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
+        : CThorRowCollectorBase(activity, rowIf, iCompare, isStable, diskMemMix, spillPriority)
     {
     }
 // IThorRowCollectorCommon
-    virtual void setup(IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
-    {
-        CThorRowCollectorBase::setup(rowIf, iCompare, isStable, diskMemMix, spillPriority);
-    }
     virtual rowcount_t numRows() const { return CThorRowCollectorBase::numRows(); }
     virtual unsigned numOverflows() const { return CThorRowCollectorBase::numOverflows(); }
     virtual unsigned overflowScale() const { return CThorRowCollectorBase::overflowScale(); }
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort) { CThorRowCollectorBase::transferRowsOut(dst, sort); }
     virtual void transferRowsIn(CThorExpandingRowArray &src) { CThorRowCollectorBase::transferRowsIn(src); }
+    virtual void setup(ICompare *iCompare, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50)
+    {
+        CThorRowCollectorBase::setup(iCompare, isStable, diskMemMix, spillPriority);
+    }
 // IThorRowLoader
     virtual IRowStream *load(IRowStream *in, const bool &abort, bool preserveGrouping, CThorExpandingRowArray *allMemRows)
     {
@@ -1404,9 +1388,7 @@ public:
 
 IThorRowLoader *createThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
 {
-    Owned<IThorRowLoader> loader = new CThorRowLoader(activity);
-    loader->setup(rowIf, iCompare, isStable, diskMemMix, spillPriority);
-    return loader.getClear();
+    return new CThorRowLoader(activity, rowIf, iCompare, isStable, diskMemMix, spillPriority);
 }
 
 IThorRowLoader *createThorRowLoader(CActivityBase &activity, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
@@ -1421,21 +1403,25 @@ class CThorRowCollector : public CThorRowCollectorBase, implements IThorRowColle
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CThorRowCollector(CActivityBase &activity) : CThorRowCollectorBase(activity)
+    CThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority)
+        : CThorRowCollectorBase(activity, rowIf, iCompare, isStable, diskMemMix, spillPriority)
     {
     }
 // IThorRowCollectorCommon
-    virtual void setup(IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority, bool preserveGrouping)
+    virtual void setPreserveGrouping(bool tf)
     {
-        assertex(!iCompare || !preserveGrouping); // can't sort if group preserving
-        CThorRowCollectorBase::setup(rowIf, iCompare, isStable, diskMemMix, spillPriority);
-        setPreserveGrouping(preserveGrouping);
+        assertex(!iCompare || !tf); // can't sort if group preserving
+        CThorRowCollectorBase::setPreserveGrouping(tf);
     }
     virtual rowcount_t numRows() const { return CThorRowCollectorBase::numRows(); }
     virtual unsigned numOverflows() const { return CThorRowCollectorBase::numOverflows(); }
     virtual unsigned overflowScale() const { return CThorRowCollectorBase::overflowScale(); }
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort) { CThorRowCollectorBase::transferRowsOut(dst, sort); }
     virtual void transferRowsIn(CThorExpandingRowArray &src) { CThorRowCollectorBase::transferRowsIn(src); }
+    virtual void setup(ICompare *iCompare, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50)
+    {
+        CThorRowCollectorBase::setup(iCompare, isStable, diskMemMix, spillPriority);
+    }
 // IThorRowCollector
     virtual IRowWriter *getWriter()
     {
@@ -1476,8 +1462,8 @@ public:
 
 IThorRowCollector *createThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare, bool isStable, RowCollectorFlags diskMemMix, unsigned spillPriority, bool preserveGrouping)
 {
-    Owned<IThorRowCollector> collector = new CThorRowCollector(activity);
-    collector->setup(rowIf, iCompare, isStable, diskMemMix, spillPriority, preserveGrouping);
+    Owned<IThorRowCollector> collector = new CThorRowCollector(activity, rowIf, iCompare, isStable, diskMemMix, spillPriority);
+    collector->setPreserveGrouping(preserveGrouping);
     return collector.getClear();
 }
 

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -259,7 +259,7 @@ public:
     }
 };
 
-// NB: Shared/spillable, hols all rows in mem until needs to spill.
+// NB: Shared/spillable, holds all rows in mem until needs to spill.
 // spills all to disk, and stream continue reading from row in file
 class CSharedSpillableRowSet : public CSpillableStreamBase, implements IInterface
 {
@@ -1254,8 +1254,8 @@ public:
         outStreams = 0;
         mmRegistered = false;
         if (rc_allMem == diskMemMix)
-            spillPriority = UINT_MAX; // all mem, implies no spilling
-        else if (UINT_MAX != spillPriority)
+            spillPriority = SPILL_PRIORITY_DISABLE; // all mem, implies no spilling
+        else if (SPILL_PRIORITY_DISABLE != spillPriority)
         {
             activity.queryJob().queryRowManager()->addRowBuffer(this);
             mmRegistered = true;
@@ -1307,8 +1307,8 @@ public:
         diskMemMix = _diskMemMix;
         spillPriority = _spillPriority;
         if (rc_allMem == diskMemMix)
-            spillPriority = UINT_MAX; // all mem, implies no spilling
-        if (mmRegistered && (UINT_MAX == spillPriority))
+            spillPriority = SPILL_PRIORITY_DISABLE; // all mem, implies no spilling
+        if (mmRegistered && (SPILL_PRIORITY_DISABLE == spillPriority))
         {
             mmRegistered = false;
             activity.queryJob().queryRowManager()->removeRowBuffer(this);
@@ -1322,7 +1322,7 @@ public:
     }
     virtual bool freeBufferedRows(bool critical)
     {
-        if (UINT_MAX == spillPriority)
+        if (SPILL_PRIORITY_DISABLE == spillPriority)
             return false;
         CThorSpillableRowArray::CThorSpillableRowArrayLock block(spillableRows);
         return spillRows();

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -215,13 +215,17 @@ enum {
 
 graph_decl StringBuffer &getRecordString(const void *key, IOutputRowSerializer *serializer, const char *prefix, StringBuffer &out);
 
+#define SPILL_PRIORITY_DEFAULT 50
+#define SPILL_PRIORITY_DISABLE UINT_MAX
+
 #define SPILL_PRIORITY_JOIN 10
 #define SPILL_PRIORITY_SELFJOIN 10
 #define SPILL_PRIORITY_HASHJOIN 10
 #define SPILL_PRIORITY_LARGESORT 10
 #define SPILL_PRIORITY_GROUPSORT 20
-#define SPILL_PRIORITY_OVERFLOWABLE_BUFFER 50
-#define SPILL_PRIORITY_SPILLABLE_STREAM 50
+#define SPILL_PRIORITY_OVERFLOWABLE_BUFFER SPILL_PRIORITY_DEFAULT
+#define SPILL_PRIORITY_SPILLABLE_STREAM SPILL_PRIORITY_DEFAULT
+#define SPILL_PRIORITY_RESULT SPILL_PRIORITY_DEFAULT
 
 class CThorSpillableRowArray;
 class graph_decl CThorExpandingRowArray : public CSimpleInterface
@@ -483,10 +487,10 @@ interface IThorRowCollector : extends IThorRowCollectorCommon
     virtual IRowStream *getStream(bool shared=false) = 0;
 };
 
-extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50);
-extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50);
-extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50, bool preserveGrouping=false);
-extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50, bool preserveGrouping=false);
+extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT);
+extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT);
+extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT, bool preserveGrouping=false);
+extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT, bool preserveGrouping=false);
 
 
 

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -246,7 +246,6 @@ protected:
     void doSort(unsigned n, void **const rows, ICompare &compare, unsigned maxCores);
 
 public:
-    CThorExpandingRowArray(CActivityBase &activity, bool allowNulls=false, bool stableSort=false, bool throwOnOom=true, rowcount_t initialSize=InitialSortElements);
     CThorExpandingRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, bool stableSort=false, bool throwOnOom=true, rowcount_t initialSize=InitialSortElements);
     ~CThorExpandingRowArray();
     CActivityBase &queryActivity() { return activity; }
@@ -365,8 +364,6 @@ public:
         inline ~CThorSpillableRowArrayLock() { rows.unlock(); }
     };
 
-    CThorSpillableRowArray(CThorSpillableRowArray &other); // NB: swaps
-    CThorSpillableRowArray(CActivityBase &activity, bool allowNulls=false, bool stableSort=false, rowcount_t initialSize=InitialSortElements, size32_t commitDelta=CommitStep);
     CThorSpillableRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, bool stableSort=false, rowcount_t initialSize=InitialSortElements, size32_t commitDelta=CommitStep);
     ~CThorSpillableRowArray();
     // NB: throwOnOom false
@@ -469,18 +466,18 @@ interface IThorRowCollectorCommon : extends IInterface
     virtual unsigned overflowScale() const = 0;
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort=true) = 0;
     virtual void transferRowsIn(CThorExpandingRowArray &src) = 0;
+    virtual void setup(ICompare *iCompare, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50) = 0;
 };
 
 interface IThorRowLoader : extends IThorRowCollectorCommon
 {
-    virtual void setup(IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50) = 0;
     virtual IRowStream *load(IRowStream *in, const bool &abort, bool preserveGrouping=false, CThorExpandingRowArray *allMemRows=NULL) = 0;
     virtual IRowStream *loadGroup(IRowStream *in, const bool &abort, CThorExpandingRowArray *allMemRows=NULL) = 0;
 };
 
 interface IThorRowCollector : extends IThorRowCollectorCommon
 {
-    virtual void setup(IRowInterfaces *rowIf, ICompare *iCompare=NULL, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50, bool preserveGrouping=false) = 0;
+    virtual void setPreserveGrouping(bool tf) = 0;
     virtual IRowWriter *getWriter() = 0;
     virtual void reset() = 0;
     virtual IRowStream *getStream(bool shared=false) = 0;


### PR DESCRIPTION
Allow graph results to have spill priority

This was mainly to address a problem with an attempt to spill the counter
result, which had no serializer and hence crashed. But don't want it to try
to spill the counter result anyway (as always 1 row).

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
