### PR TITLE
Move h2h logs to standard loc

### DIFF
--- a/plugins/dataconnectors/hdfsconnector/CMakeLists.txt
+++ b/plugins/dataconnectors/hdfsconnector/CMakeLists.txt
@@ -12,9 +12,11 @@ add_subdirectory (ecl)
 	#generate config for script.
 	#add script processor for vars.
 
-	configure_file("hdfsconnector.conf.in" "hdfsconnector.conf")
+	set(HPCC_ETC_DIR "${CMAKE_INSTALL_PREFIX}/${OSSDIR}/etc")
+	set(HPCC_CONF_DIR "${CMAKE_INSTALL_PREFIX}/${OSSDIR}${CONFIG_DIR}")
+	set(HDFSCONN_CONF_FILE "hdfsconnector.conf")
 
-	set(HDFSCONFIG "${CMAKE_INSTALL_PREFIX}/${OSSDIR}${CONFIG_DIR}")
+	configure_file("hdfsconnector.conf.in" "hdfsconnector.conf")
 	configure_file("hdfspipe.in" "hdfspipe" @ONLY )
 
 	find_package(JNI REQUIRED)
@@ -35,7 +37,7 @@ add_subdirectory (ecl)
 	set ( INSTALLDIR "${OSSDIR}/bin")
 	Install ( TARGETS hdfsconnector DESTINATION ${INSTALLDIR} COMPONENT Runtime)
 	Install ( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/hdfspipe DESTINATION ${INSTALLDIR} COMPONENT Runtime )
-	Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/hdfsconnector.conf DESTINATION ${HDFSCONFIG} COMPONENT Runtime )
+	Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/hdfsconnector.conf DESTINATION ${HPCC_CONF_DIR} COMPONENT Runtime )
 	target_link_libraries ( hdfsconnector
 					${JAVA_JVM_LIBRARY}
 					${LIBHDFS_LIBRARIES})

--- a/plugins/dataconnectors/hdfsconnector/hdfsconnector.cpp
+++ b/plugins/dataconnectors/hdfsconnector/hdfsconnector.cpp
@@ -10,7 +10,6 @@ using namespace std;
 using std::string;
 using std::vector;
 
-//#define EOL "\n\r"
 #define EOL "\n"
 
 tOffset getBlockSize(hdfsFS * filefs, const char * filename)
@@ -821,7 +820,7 @@ int writeFlatOffset(hdfsFS * fs, const char * filename, unsigned nodeid, unsigne
 	size_t totalbytesread = 0;
 	size_t totalbyteswritten = 0;
 
-	fprintf(stderr, "Writing %s to HDFS [.", filepartname);
+	fprintf(stderr, "Writing %s to HDFS.", filepartname);
  	while(!in.eof())
  	{
  		memset(&char_ptr[0], 0, sizeof(char_ptr));
@@ -831,7 +830,6 @@ int writeFlatOffset(hdfsFS * fs, const char * filename, unsigned nodeid, unsigne
  		tSize num_written_bytes = hdfsWrite(*fs, writeFile, (void*)char_ptr, bytesread);
  		totalbyteswritten += num_written_bytes;
 
- 		fprintf(stderr, ".");
  		//Need to figure out how often this should be done
  		//if(totalbyteswritten % )
 
@@ -850,7 +848,6 @@ int writeFlatOffset(hdfsFS * fs, const char * filename, unsigned nodeid, unsigne
  		fprintf(stderr, "Failed to 'flush' %s\n", filepartname);
 		exit(-1);
 	}
- 	fprintf(stderr, "]");
 
 	fprintf(stderr,"\n total read: %lu, total written: %lu\n", totalbytesread, totalbyteswritten);
 

--- a/plugins/dataconnectors/hdfsconnector/hdfspipe.in
+++ b/plugins/dataconnectors/hdfsconnector/hdfspipe.in
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-source @HDFSCONFIG@/hdfsconnector.conf 
+source @HPCC_ETC_DIR@/init.d/hpcc_common
+set_environmentvars
+
+source @HPCC_CONF_DIR@/@HDFSCONN_CONF_FILE@ 
 
 CLASSPATH=$CLASSPATH:$HADOOP_LOCATION/conf
 
@@ -21,7 +24,6 @@ nodeid=0;
 
 for p in $*;
  do
-#   echo "[$p]" >> $LOG;
    if [ "$idfound" = "1" ];
    then
         nodeid=$p;
@@ -32,7 +34,17 @@ for p in $*;
    fi
 done;
 
-LOG=/tmp/HPCC-HDFSCONNECTOR.log.$nodeid.$PID
+#the log variable is read from the HPCC Platform config
+LOGS_LOCATION=$log
+HDFSCONNLOGLOC=$LOGS_LOCATION/mydataconnectors
+LOG=$HDFSCONNLOGLOC/HDFSCONNECTOR.$nodeid.$PID.log
+
+if [ -e $HDFSCONNLOGLOC ]
+  then
+    echo "log file found"	>> $LOG
+  else
+    mkdir $HDFSCONNLOGLOC
+fi
 
 echo "Script starting"		>> $LOG
 echo "Running as user: $USER"   >> $LOG


### PR DESCRIPTION
HPCC environment.conf variables are used to determine appropriate location.
New component "mydataconnector" dir is created and logs written there in
the following format: mydataconnectors/HDFSCONNECTOR.$nodeid.$PID.log.

Removed ability to overwrite h2h log location, per Phil's comment.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
