### PR TITLE
Fix failed libxslt transforms causing core in libxml

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
@@ -350,9 +350,10 @@
             </xsl:attribute>
             <td>
                 <xsl:if test="isDirectory=0">
-                    <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this, event)"/>
                     <xsl:variable name="popup">return DFUFilePopup('<xsl:value-of select="$info_query"/>', '<xsl:value-of select="Name"/>', '<xsl:value-of select="ClusterName"/>', '<xsl:value-of select="Replicate"/>', '<xsl:value-of select="FromRoxieCluster"/>', '<xsl:value-of select="BrowseData"/>', '<xsl:value-of select="position()"/>')</xsl:variable>
-                    <xsl:attribute name="oncontextmenu"><xsl:value-of select="$popup"/></xsl:attribute>
+                    <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this, event)">
+                        <xsl:attribute name="oncontextmenu"><xsl:value-of select="$popup"/></xsl:attribute>
+                    </input>
           <img id="mn{position()}" class="menu1" src="/esp/files/img/menu1.png" onclick="{$popup}">&#160;</img>
         </xsl:if>
             </td>

--- a/esp/eclwatch/ws_XSLT/dropzonefile.xslt
+++ b/esp/eclwatch/ws_XSLT/dropzonefile.xslt
@@ -361,9 +361,9 @@
   </xsl:template>
 
   <xsl:template match="PhysicalFileStruct">
+    <xsl:param name="dirs" select="1"/>
     <xsl:variable name="size" select="number(filesize)"/>
     <xsl:variable name="dir" select="number(isDir)"/>
-    <xsl:param name="dirs" select="1"/>
     <xsl:choose>
       <xsl:when test="$dir">
         <tr onmouseenter="this.bgColor = '#F0F0FF'">
@@ -409,16 +409,7 @@
             <input type="checkbox" name="Names_i{position()}" value="{name}" onclick="return checkSelected(this)"/>
           </td>
           <td align="left">
-            <!--xsl:choose>
-              <xsl:when test="$size > 8000000">
-                <xsl:value-of select="name"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <a href="javascript:go('/FileSpray/DownloadFile?Name={name}&amp;NetAddress={../../NetAddress}&amp;Path={../../Path}&amp;OS={../../OS}')">
-                  <xsl:value-of select="name"/>
-                </a>
-              </xsl:otherwise>
-            </xsl:choose-->
+
             <a title="Download file..." href="javascript:go('/FileSpray/DownloadFile?Name={name}&amp;NetAddress={../../NetAddress}&amp;Path={../../Path}&amp;OS={../../OS}')">
               <xsl:value-of select="name"/>
             </a>

--- a/system/xmllib/libxslt_processor.cpp
+++ b/system/xmllib/libxslt_processor.cpp
@@ -537,6 +537,12 @@ int CLibXslTransform::transform(xmlChar **xmlbuff, int &len)
         mp.append(sizeof(const char *) * params.length(), params.getArray()).append((unsigned __int64)0);
 
     xmlDocPtr res = xsltApplyStylesheetUser(xsldoc, xmldoc, (mp.length()) ? (const char**)mp.toByteArray() : NULL, NULL, NULL, ctxt);
+    if (!res)
+    {
+        if (exceptions && exceptions->ordinality())
+            throw exceptions.getClear();
+        throw MakeStringException(XSLERR_TransformFailed, "Failed running xlst using libxslt.");
+    }
 
     try
     {


### PR DESCRIPTION
libxml was not checking the return of xsltApplyStylesheetUser which
was causing a subsequent call to libxslt to core.

The xsltApplyStylesheetUser failure was caused by minor bugs in
dfu_fileview.xslt and dropzonefile.xslt. These were not issues when
using xalan.

Fixes gh-2261 and Fixes gh-2262

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
