### PR TITLE
Fix compilation error in x86_64 / gcc 4.6.3

### DIFF
--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -241,7 +241,7 @@ protected:
 #if ARCHIVE_VERSION_NUMBER < 3000000
     off_t curPos;
 #else
-    unsigned __int64 curPos;
+    int64_t curPos;
 #endif
     offset_t lastPos;
     size_t curBuffSize;

--- a/dali/base/daaudit.cpp
+++ b/dali/base/daaudit.cpp
@@ -55,13 +55,6 @@ enum MAuditRequestKind {
 #define DATEEND     10
 #define TIMEEND     19
 
-unsigned get2dig(const char *s)
-{
-    if (!isdigit(*s)||!isdigit(s[1]))
-        return 0;
-    return (*s-'0')*10+s[1]-'0';
-}
-
 class CDaliAuditServer: public IDaliServer, public Thread
 {  // Server side
 
@@ -155,11 +148,11 @@ public:
         StringBuffer fname;
         ForEach(*files) {
             files->getName(fname.clear());
-            unsigned fday = get2dig(fname.str()+11);
-            unsigned fmonth = get2dig(fname.str()+8);
-            unsigned fyear = get2dig(fname.str()+14);
+            unsigned fyear = atoi(fname.str()+8);
+            unsigned fmonth = atoi(fname.str()+13);
+            unsigned fday = atoi(fname.str()+16);
             if (fday&&fmonth&&fyear) {
-                dt.setDate(fyear+2000,fmonth,fday);
+                dt.setDate(fyear,fmonth,fday);
                 if ((dt.compareDate(to)<=0)&&(dt.compareDate(from)>=0)) {
                     IInterface *e = &files->get();
                     bool added;

--- a/dali/sasha/sasha.cpp
+++ b/dali/sasha/sasha.cpp
@@ -173,7 +173,7 @@ void DumpWorkunitTimings(IPropertyTree *wu)
                         unsigned day;
                         dt.getDate(year,month,day);
                         StringBuffer logname(basename);
-                        logname.appendf("%02d_%02d_%02d.log",month,day,year%100);
+                        logname.appendf("%04d_%02d_%02d.log",year,month,day);
 //                      printf("**%s\n",logname.str());
                         if (strcmp(logname.str(),curfilename.str())!=0) {
                             fileio.clear();

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -589,6 +589,8 @@ public:
         request->setProcess(optProcess);
         request->setPackageName(optFileName);
         request->setOverWrite(optOverWrite);
+        if (!optDaliIp.isEmpty())
+            request->setDaliIp(optDaliIp.get());
 
         Owned<IClientCopyFilesResponse> resp = packageProcessClient->CopyFiles(request);
         return 0;

--- a/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
@@ -350,9 +350,10 @@
             </xsl:attribute>
             <td>
                 <xsl:if test="isDirectory=0">
-                    <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this, event)"/>
                     <xsl:variable name="popup">return DFUFilePopup('<xsl:value-of select="$info_query"/>', '<xsl:value-of select="Name"/>', '<xsl:value-of select="ClusterName"/>', '<xsl:value-of select="Replicate"/>', '<xsl:value-of select="FromRoxieCluster"/>', '<xsl:value-of select="BrowseData"/>', '<xsl:value-of select="position()"/>')</xsl:variable>
-                    <xsl:attribute name="oncontextmenu"><xsl:value-of select="$popup"/></xsl:attribute>
+                    <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this, event)">
+                        <xsl:attribute name="oncontextmenu"><xsl:value-of select="$popup"/></xsl:attribute>
+                    </input>
           <img id="mn{position()}" class="menu1" src="/esp/files/img/menu1.png" onclick="{$popup}">&#160;</img>
         </xsl:if>
             </td>

--- a/esp/eclwatch/ws_XSLT/dropzonefile.xslt
+++ b/esp/eclwatch/ws_XSLT/dropzonefile.xslt
@@ -361,9 +361,9 @@
   </xsl:template>
 
   <xsl:template match="PhysicalFileStruct">
+    <xsl:param name="dirs" select="1"/>
     <xsl:variable name="size" select="number(filesize)"/>
     <xsl:variable name="dir" select="number(isDir)"/>
-    <xsl:param name="dirs" select="1"/>
     <xsl:choose>
       <xsl:when test="$dir">
         <tr onmouseenter="this.bgColor = '#F0F0FF'">
@@ -409,16 +409,7 @@
             <input type="checkbox" name="Names_i{position()}" value="{name}" onclick="return checkSelected(this)"/>
           </td>
           <td align="left">
-            <!--xsl:choose>
-              <xsl:when test="$size > 8000000">
-                <xsl:value-of select="name"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <a href="javascript:go('/FileSpray/DownloadFile?Name={name}&amp;NetAddress={../../NetAddress}&amp;Path={../../Path}&amp;OS={../../OS}')">
-                  <xsl:value-of select="name"/>
-                </a>
-              </xsl:otherwise>
-            </xsl:choose-->
+
             <a title="Download file..." href="javascript:go('/FileSpray/DownloadFile?Name={name}&amp;NetAddress={../../NetAddress}&amp;Path={../../Path}&amp;OS={../../OS}')">
               <xsl:value-of select="name"/>
             </a>

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -2385,7 +2385,7 @@ public:
             {
                 if(rc == LDAP_ALREADY_EXISTS)
                 {
-                    throw MakeStringException(-1, "can't add %s to sudoers, already exists", username);
+                    throw MakeStringException(-1, "can't add %s to sudoers, an LDAP object with this name already exists", username);
                 }
                 else
                 {
@@ -3293,7 +3293,7 @@ public:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                throw MakeStringException(-1, "can't add group %s, already exists", groupname);
+                throw MakeStringException(-1, "can't add group %s, an LDAP object with this name already exists", groupname);
             }
             else
             {
@@ -3678,7 +3678,7 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                throw MakeStringException(-1, "can't add dc %s, already exists", dc);
+                throw MakeStringException(-1, "can't add dc %s, an LDAP object with this name already exists", dc);
             }
             else
             {
@@ -4470,7 +4470,7 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                //WARNLOG("Can't insert ou=%s,%s to Ldap Server, already exists", name, basedn);
+                //WARNLOG("Can't insert ou=%s,%s to Ldap Server, an LDAP object with this name already exists", name, basedn);
                 return false;
             }
             else
@@ -4751,11 +4751,11 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                //WARNLOG("Can't insert %s to Ldap Server, already exists", resourcename);
+                //WARNLOG("Can't insert %s to Ldap Server, an LDAP object with this name already exists", resourcename);
                 if(lessException)
                     return false;
                 else
-                    throw MakeStringException(-1, "Can't insert %s, already exists", resourcename);
+                    throw MakeStringException(-1, "Can't insert %s, an LDAP object with this name already exists", resourcename);
             }
             else
             {
@@ -5009,8 +5009,8 @@ private:
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
-                DBGLOG("Can't add user %s, already exists", username);
-                throw MakeStringException(-1, "Can't add user %s, already exists", username);
+                DBGLOG("Can't add user %s, an LDAP object with this name already exists", username);
+                throw MakeStringException(-1, "Can't add user %s, an LDAP object with this name already exists", username);
             }
             else
             {

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -4820,10 +4820,11 @@ private:
 
         // UF_ACCOUNTDISABLE 0x0002
         act_ctrl_val &= 0xFFFFFFFD;
-        
+#ifdef _DONT_EXPIRE_PASSWORD
         // UF_DONT_EXPIRE_PASSWD 0x10000
         if (m_passwordNeverExpires)
             act_ctrl_val |= 0x10000;
+#endif
 
         StringBuffer new_act_ctrl;
         new_act_ctrl.append(act_ctrl_val);

--- a/system/xmllib/libxslt_processor.cpp
+++ b/system/xmllib/libxslt_processor.cpp
@@ -537,6 +537,12 @@ int CLibXslTransform::transform(xmlChar **xmlbuff, int &len)
         mp.append(sizeof(const char *) * params.length(), params.getArray()).append((unsigned __int64)0);
 
     xmlDocPtr res = xsltApplyStylesheetUser(xsldoc, xmldoc, (mp.length()) ? (const char**)mp.toByteArray() : NULL, NULL, NULL, ctxt);
+    if (!res)
+    {
+        if (exceptions && exceptions->ordinality())
+            throw exceptions.getClear();
+        throw MakeStringException(XSLERR_TransformFailed, "Failed running xlst using libxslt.");
+    }
 
     try
     {

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -575,6 +575,7 @@ public:
                             denormRows.kill();
                             break;
                         case TAKjoin:
+                        case TAKhashjoin:
                         case TAKselfjoin:
                             gotsz = helper->transform(ret, defaultLeft, nextright);
                             nextR();
@@ -624,6 +625,7 @@ public:
                         denormCount = 0;
                         break;
                     case TAKjoin:
+                    case TAKhashjoin:
                     case TAKselfjoin:
                         if (!rightgroupmatched[rightidx]) 
                             gotsz = helper->transform(ret, defaultLeft, rightgroup.query(rightidx));
@@ -647,6 +649,7 @@ public:
                         gotsz = helper->transform(ret, nextleft, NULL, 0, (const void **)NULL);
                         break;
                     case TAKjoin:
+                    case TAKhashjoin:
                     case TAKselfjoin:
                         gotsz = helper->transform(ret, nextleft, defaultRight);
                         break;
@@ -702,6 +705,7 @@ public:
                             break;
                         }
                         case TAKjoin:
+                        case TAKhashjoin:
                         case TAKselfjoin:
                             gotsz = helper->transform(ret,nextleft,rightgroup.query(rightidx));
                             break;


### PR DESCRIPTION
In 64-bit systems, `int64_t` is not `long long` but `long`, as defined by `stdint.h`, and the compilation failed with gcc 4.6.3 (Ubuntu 12.04 x86_64 kernel 3.2.0-24).

```
In member function ‘virtual size32_t ArchiveFileIO::read(offset_t, size32_t, void*)’:
error: invalid conversion from ‘uint64_t* {aka long unsigned int*}’ to ‘int64_t* {aka long int*}’ [-fpermissive]
initializing argument 4 of ‘int archive_read_data_block(archive*, const void**, size_t*, int64_t*)’ [-fpermissive]
```

Since `curPos` is only used to iterate through the archive, there is no problem making it `int64_t` and be consistent across platforms.
