### PR TITLE
Fix compilation error in x86_64 / gcc 4.6.3 (int64_t)

### DIFF
--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -241,7 +241,7 @@ protected:
 #if ARCHIVE_VERSION_NUMBER < 3000000
     off_t curPos;
 #else
-    unsigned __int64 curPos;
+    int64_t curPos;
 #endif
     offset_t lastPos;
     size_t curBuffSize;


### PR DESCRIPTION
In 64-bit systems, int64_t is not long long but long, as defined by stdint.h, and the compilation failed with gcc 4.6.3 (Ubuntu 12.04 x86_64 kernel 3.2.0-24).

```
In member function ‘virtual size32_t ArchiveFileIO::read(offset_t, size32_t, void*)’:
error: invalid conversion from ‘uint64_t* {aka long unsigned int*}’ to ‘int64_t* {aka long int*}’ [-fpermissive]
initializing argument 4 of ‘int archive_read_data_block(archive*, const void**, size_t*, int64_t*)’ [-fpermissive]
```

Since curPos is only used to iterate through the archive, there is no problem making it int64_t and be consistent across platforms.
