### PR TITLE
Fix join nosort primary regression

### DIFF
--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -1111,7 +1111,7 @@ public:
         // I think this dependant on row being same format as meta
 
         unsigned numsplits=numnodes-1;
-        CThorExpandingRowArray splits(*activity, rowif, true);
+        CThorExpandingRowArray splits(*activity, auxrowif, true);
         char *s=cosortfilenames;
         unsigned i;
         for(i=0;i<numnodes;i++) {
@@ -1143,7 +1143,7 @@ public:
     {
         ActPrintLog(activity, "Previous partition");
         unsigned numsplits=numnodes-1;
-        CThorExpandingRowArray splits(*activity, rowif, true);
+        CThorExpandingRowArray splits(*activity, auxrowif, true);
         unsigned i;
         for(i=1;i<numnodes;i++) {
             CSortNode &slave = slaves.item(i);


### PR DESCRIPTION
A global join, where primary side already sorted, the partitioning code was
using the wrong row interfaces causing a crash.
This slipped by because legacy code also provided the wrong rowIf, but got
away with it because it wasn't transferred in a array swap operation

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
