### PR TITLE
Fix global merge on 1node regression

### DIFF
--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -71,6 +71,8 @@ CThorKeyArray::CThorKeyArray(
 void CThorKeyArray::clear()
 {
     keys.kill();
+    sizes.clear();
+    filepos.clear();
     totalserialsize = 0;
     serialrowsize = 0;
     totalfilesize = 0;


### PR DESCRIPTION
On a 1node system, global merge was failing, because the key array was not
being cleared properly

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
