### PR TITLE
Prevent FROMXML being forced to execute inside a graph

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -945,6 +945,11 @@ YesNoOption HqlThorBoundaryTransformer::calcNormalizeThor(IHqlExpression * expr)
         switch (type->getTypeCode())
         {
         case type_row:
+            switch (op)
+            {
+            case no_fromxml:
+                return option;
+            }
             return OptionYes;
         case type_groupedtable:
         case type_table:


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
