### PR TITLE
Fix issue with childif and graph progress

### DIFF
--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -158,7 +158,7 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
                 if (res != 0)
                 {
                     localOffset += lineLength;
-                    ++progress;
+                    ++activity.diskProgress;
                     return row.finalizeRowClear(res);
                 }
             }

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2354,7 +2354,10 @@ public:
         rhsProgressCount = joinhelper->getRhsProgress();
         strmL.clear();
         strmR.clear();
-        joinhelper.clear();
+        {
+            CriticalBlock b(joinHelperCrit);
+            joinhelper.clear();
+        }
         dataLinkStop();
     }
     void kill()

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -72,7 +72,6 @@ CDiskPartHandlerBase::CDiskPartHandlerBase(CDiskReadSlaveActivityBase &_activity
     which = 0;
     eoi = false;
     kindStr = activityKindStr(activity.queryContainer().getKind());
-    progress = 0;
 }
 
 void CDiskPartHandlerBase::setPart(IPartDescriptor *_partDesc, unsigned partNoSerialized)
@@ -247,6 +246,7 @@ const char *CDiskReadSlaveActivityBase::queryLogicalFilename(unsigned index)
 void CDiskReadSlaveActivityBase::start()
 {
     markStart = true;
+    diskProgress = 0;
 }
 
 void CDiskReadSlaveActivityBase::kill()
@@ -277,7 +277,7 @@ IRowInterfaces * CDiskReadSlaveActivityBase::queryDiskRowInterfaces()
 void CDiskReadSlaveActivityBase::serializeStats(MemoryBuffer &mb)
 {
     CSlaveActivity::serializeStats(mb);
-    mb.append(getHandlerProgress());
+    mb.append(diskProgress);
 }
 
 

--- a/thorlcr/activities/thdiskbaseslave.ipp
+++ b/thorlcr/activities/thdiskbaseslave.ipp
@@ -40,7 +40,6 @@ protected:
     StringAttr filename, logicalFilename;
     unsigned __int64 fileBaseOffset;
     const char *kindStr;
-    rowcount_t progress;
 
     CDiskReadSlaveActivityBase &activity;
 
@@ -49,7 +48,6 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     CDiskPartHandlerBase(CDiskReadSlaveActivityBase &activity);
-    rowcount_t getProgress() { return progress; }
     virtual void close(CRC32 &fileCRC) = 0;
     virtual void open();
 
@@ -85,11 +83,11 @@ protected:
     ThorDataLinkMetaInfo cachedMetaInfo;
     Owned<CDiskPartHandlerBase> partHandler;
     Owned<IExpander> eexp;
+    rowcount_t diskProgress;
 
 public:
     CDiskReadSlaveActivityBase(CGraphElementBase *_container);
     const char *queryLogicalFilename(unsigned index);
-    rowcount_t getHandlerProgress() { return partHandler.get()?partHandler->getProgress():0; }
     IRowInterfaces * queryDiskRowInterfaces();
     void start();
 

--- a/thorlcr/activities/xmlread/thxmlreadslave.cpp
+++ b/thorlcr/activities/xmlread/thxmlreadslave.cpp
@@ -107,7 +107,7 @@ class CXmlReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
                         lastMatch.clear();
                         if (sz) {
                             localOffset = 0;
-                            ++progress;
+                            ++activity.diskProgress;
                             return row.finalizeRowClear(sz);
                         }
                     }

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -240,15 +240,13 @@ unsigned __int64 CSlaveActivity::queryLocalCycles() const
     if (1 == inputs.ordinality())
     {
         IThorDataLink *input = inputs.item(0);
-        CSlaveActivity &inputAct = * (CSlaveActivity *)input->queryFromActivity();
-        inputCycles += inputAct.queryTotalCycles();
+        inputCycles += input->queryTotalCycles();
     }
     else
     {
-        if (((unsigned)-1) != container.whichBranch && inputs.isItem(container.whichBranch))
+        if (TAKchildif == container.getKind())
         {
-            IThorDataLink *input = inputs.item(container.whichBranch);
-            if (input != NULL)
+            if (inputs.ordinality() && (((unsigned)-1) != container.whichBranch))
                 inputCycles += inputs.item(container.whichBranch)->queryTotalCycles();
         }
         else

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -59,7 +59,6 @@ public:
     virtual void init(MemoryBuffer &in, MemoryBuffer &out) { }
     virtual void processDone(MemoryBuffer &mb) { };
     virtual void abort();
-    virtual void kill() { CActivityBase::kill(); }
     virtual MemoryBuffer &queryInitializationData(unsigned slave) const;
     virtual MemoryBuffer &getInitializationData(unsigned slave, MemoryBuffer &mb) const;
 


### PR DESCRIPTION
The time stat. collection for a child if activity was causing an exception,
if connected to anything other than the 1st input

Also fix potential race in progress collection in join and diskread

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
