### PR TITLE
Move dbgassertex to jlib so it can be used elsewhere

### DIFF
--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -40,13 +40,6 @@
 #define ROXIEMM_LARGE_MEMORY_EXHAUSTED    ROXIEMM_ERROR_START+4
 
 
-//Use for asserts that are highly unlikely to occur, and would likely to be reproduced in debug mode.
-#ifdef _DEBUG
-#define dbgassertex(x) assertex(x)
-#else
-#define dbgassertex(x)
-#endif
-
 #ifdef __64BIT__
 #define HEAP_ALIGNMENT_SIZE I64C(0x100000u)                     // 1 mb heaplets - may be too big?
 #else

--- a/system/jlib/jiface.hpp
+++ b/system/jlib/jiface.hpp
@@ -54,6 +54,13 @@ void jlib_decl RaiseAssertCore(const char *assertion, const char *file, unsigned
 #define verify(p) ((void) (p))
 #endif
 
+//Use for asserts that are highly unlikely to occur, and would likely to be reproduced in debug mode.
+#ifdef _DEBUG
+#define dbgassertex(x) assertex(x)
+#else
+#define dbgassertex(x)
+#endif
+
 #define DEAD_PSEUDO_COUNT               0x3fffffff
 
 //The simplest implementation of IInterface.  Can be used in situations where speed is critical, and


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
