### PR TITLE
Allow dynamic file resolution in Roxie

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -2342,6 +2342,16 @@ public:
         finalRow.clear();
     }
 
+    virtual const char *queryDynamicFileName() const
+    {
+        return helper->getFileName();
+    }
+
+    virtual void setVariableFileInfo()
+    {
+        // noop (but not unexpected)
+    }
+
     virtual bool needsRowAllocator()
     {
         return true;
@@ -2736,6 +2746,16 @@ public:
     virtual bool needsRowAllocator()
     {
         return true;
+    }
+
+    virtual const char *queryDynamicFileName() const
+    {
+        return helper->getFileName();
+    }
+
+    virtual void setVariableFileInfo()
+    {
+        // noop (but not unexpected)
     }
 
     virtual void doProcess(IMessagePacker *output)

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -100,6 +100,7 @@ CActivityFactory::CActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFac
     helperFactory(_helperFactory),
     kind(_kind)
 {
+    variableFileName = _queryFactory.dynamicFileResolution();
     if (helperFactory)
     {
         Owned<IHThorArg> helper = helperFactory();
@@ -220,6 +221,11 @@ public:
             return queryContext.getClear();
         }
         return NULL;
+    }
+
+    virtual bool dynamicFileResolution() const
+    {
+        return variableFileName;
     }
 
 protected:
@@ -371,7 +377,7 @@ protected:
         lastPartNo.partNo = 0xffff;
         lastPartNo.fileNo = 0xffff;
         isOpt = false;
-        variableFileName = false;
+        variableFileName = _factory->dynamicFileResolution();
         meta.set(basehelper->queryOutputMeta());
     }
 
@@ -772,7 +778,7 @@ public:
         forceUnkeyed(_forceUnkeyed)
     {
         helper = (IHThorDiskReadBaseArg *) basehelper;
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName = variableFileName || (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         isOpt = (helper->getFlags() & TDRoptional) != 0;
         diskSize.set(helper->queryDiskRecordSize());
         processed = 0;
@@ -916,7 +922,7 @@ public:
         : CSlaveActivityFactory(_graphNode, _subgraphId, _queryFactory, _helperFactory)
     {
         Owned<IHThorDiskReadBaseArg> helper = (IHThorDiskReadBaseArg *) helperFactory();
-        bool variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName = variableFileName || (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (helper->getFlags() & TDRoptional) != 0;
@@ -3010,7 +3016,7 @@ public:
         m.setBuffer(indexLayoutSize, indexLayoutMeta.getdata());
         activityMeta.setown(deserializeRecordMeta(m, true));
         layoutTranslators.setown(new TranslatorArray);
-        bool variableFileName = (helper->getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName = variableFileName || (helper->getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (helper->getFlags() & TIRoptional) != 0;
@@ -3164,7 +3170,7 @@ public:
         stepExtra(SSEFreadAhead, NULL)
     {
         indexHelper = (IHThorIndexReadBaseArg *) basehelper;
-        variableFileName = (indexHelper->getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName = variableFileName || (indexHelper->getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
         isOpt = (indexHelper->getFlags() & TDRoptional) != 0;
         inputData = NULL;
         inputCount = 0;
@@ -4208,7 +4214,7 @@ public:
     {
         Owned<IHThorFetchBaseArg> helper = (IHThorFetchBaseArg *) helperFactory();
         IHThorFetchContext * fetchContext = static_cast<IHThorFetchContext *>(helper->selectInterface(TAIfetchcontext_1));
-        bool variableFileName = (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName = variableFileName || (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (fetchContext->getFetchFlags() & FFdatafileoptional) != 0;
@@ -4256,7 +4262,7 @@ public:
         helper = (IHThorFetchBaseArg *) basehelper;
         fetchContext = static_cast<IHThorFetchContext *>(helper->selectInterface(TAIfetchcontext_1));
         base = 0;
-        variableFileName = (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName = variableFileName || (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         isOpt = (fetchContext->getFetchFlags() & FFdatafileoptional) != 0;
         onCreate();
         inputData = (char *) serializedCreate.readDirect(0);
@@ -4595,7 +4601,7 @@ public:
         : factory(_aFactory), CRoxieKeyedActivity(_logctx, _packet, _hFactory, _aFactory)
     {
         helper = (IHThorKeyedJoinArg *) basehelper;
-        variableFileName = (helper->getJoinFlags() & (JFvarindexfilename|JFdynamicindexfilename)) != 0;
+        variableFileName = variableFileName || (helper->getJoinFlags() & (JFvarindexfilename|JFdynamicindexfilename)) != 0;
         inputDone = 0;
         processed = 0;
         candidateCount = 0;
@@ -4900,7 +4906,7 @@ public:
     {
         Owned<IHThorKeyedJoinArg> helper = (IHThorKeyedJoinArg *) helperFactory();
         assertex(helper->diskAccessRequired());
-        bool variableFileName = (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName = variableFileName || (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (helper->getFetchFlags() & FFdatafileoptional) != 0;
@@ -4954,7 +4960,7 @@ public:
         // MORE - no continuation row support?
         base = 0;
         helper = (IHThorKeyedJoinArg *) basehelper;
-        variableFileName = (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName = variableFileName || (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         onCreate();
         inputData = (const char *) serializedCreate.readDirect(0);
         inputLimit = inputData + (serializedCreate.length() - serializedCreate.getPos());

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -326,7 +326,19 @@ public:
     {
         assertex(isConnected);
         Owned<IWorkUnitFactory> wuFactory = getWorkUnitFactory();
-        Owned<IWorkUnit> w = wuFactory->updateWorkUnit(wuid);
+        Owned<IWorkUnit> w;
+        StringAttr newWuid;
+        if (wuid && *wuid)
+        {
+            w.setown(wuFactory->updateWorkUnit(wuid));
+            newWuid.set(wuid);
+        }
+        else
+        {
+            w.setown(wuFactory->createWorkUnit(NULL, NULL, NULL));
+            w->getWuid(StringAttrAdaptor(newWuid));
+        }
+
         if (!w)
             return NULL;
         w->setAgentSession(myProcessSession());
@@ -344,7 +356,7 @@ public:
         }
         w->commit();
         w.clear();
-        return wuFactory->openWorkUnit(wuid, false);
+        return wuFactory->openWorkUnit(newWuid.get(), false);
     }
 
     static IRoxieDaliHelper *connectToDali()

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -950,9 +950,9 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         if (runOnce)
         {
             Owned <IRoxieListener> roxieServer;
-            if (standAloneDll) // Local
+            if (standAloneDll)
                 roxieServer.setown(createRoxieWorkUnitListener(1, false, standAloneDll.getClear()->queryDll()));
-            else // Dali
+            else
                 roxieServer.setown(createRoxieSocketListener(0, 1, 0, false));
             try
             {

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -124,10 +124,14 @@ public:
         Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid, NULL);
         if (wu)
         {
-            SCMStringBuffer dllName;
+            SCMStringBuffer name;
             Owned<IConstWUQuery> q = wu->getQuery();
-            q->getQueryDllName(dllName);
-            return getQueryDll(dllName.str(), false);
+            q->getQueryDllName(name);
+            if (name.length() != 0)
+                return getQueryDll(name.str(), false);
+            q->getQueryCppName(name);
+            assertex(name.length() != 0);
+            return getQueryDll(name.str(), true);
         }
         else
             return NULL;
@@ -190,6 +194,7 @@ protected:
     unsigned priority;
     unsigned libraryInterfaceHash;
     hash64_t hashValue;
+    bool dynamicFiles;
 
     static SpinLock queriesCrit;
     static CopyMapXToMyClass<hash64_t, hash64_t, CQueryFactory> queryMap;
@@ -806,6 +811,7 @@ public:
                 memoryLimit = (memsize_t) stateInfo->getPropInt64("@memoryLimit", memoryLimit);
                 timeLimit = (unsigned) stateInfo->getPropInt("@timeLimit", timeLimit);
                 warnTimeLimit = (unsigned) stateInfo->getPropInt("@warnTimeLimit", warnTimeLimit);
+                dynamicFiles = stateInfo->getPropBool("@dynamicFiles", false);
             }
 
             Owned<IConstWUGraphIterator> graphs = &wu->getGraphs(GraphTypeActivities);
@@ -1090,6 +1096,16 @@ public:
             graphs->query().getName(graphName);
             ret.append(graphName.str());
         }
+    }
+
+    virtual void setDynamicFileResolution(bool flag)
+    {
+        dynamicFiles = flag;
+    }
+
+    virtual bool dynamicFileResolution() const
+    {
+        return dynamicFiles;
     }
 
 protected:

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -111,6 +111,9 @@ interface IQueryFactory : extends IInterface
     virtual void noteQuery(time_t startTime, bool failed, unsigned elapsed, unsigned memused, unsigned slavesReplyLen, unsigned bytesOut) = 0;
     virtual IPropertyTree *getQueryStats(time_t from, time_t to) = 0;
     virtual void getGraphNames(StringArray &ret) const = 0;
+
+    virtual void setDynamicFileResolution(bool flag) = 0; // resolve files on-demand
+    virtual bool dynamicFileResolution() const = 0; // resolve files on-demand
 };
 
 class ActivityArray : public CInterface
@@ -161,6 +164,7 @@ protected:
     UnsignedArray childQueryIndexes;
     CachedOutputMetaData meta;
     mutable StatsCollector mystats;
+    bool variableFileName;
 
 public:
     CActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -607,6 +607,10 @@ public:
         mystats.noteStatistic(statCode, value, count);
     }
 
+    virtual bool dynamicFileResolution() const
+    {
+        return variableFileName;
+    }
 };
 
 class CRoxieServerMultiInputInfo
@@ -874,6 +878,7 @@ protected:
     activityState state;
     bool createPending;
     bool debugging;
+    bool variableFileName;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -895,6 +900,7 @@ public:
         debugging = _probeManager != NULL; // Don't want to collect timing stats from debug sessions
         colocalParent = NULL;
         createPending = true;
+        variableFileName = _factory->dynamicFileResolution();
     }
     
     CRoxieServerActivity(const IRoxieServerActivityFactory *_factory, IProbeManager *_probeManager, IHThorArg &_helper)
@@ -19539,7 +19545,6 @@ protected:
     Owned<ISourceRowPrefetcher> prefetcher;
     bool eof;
     bool isKeyed;
-    bool variableFileName;
     bool isOpt;
     bool maySkip;
     bool isLocal;
@@ -19568,7 +19573,7 @@ public:
         isKeyed = false;
         stopAfter = I64C(0x7FFFFFFFFFFFFFFF);
         diskSize.set(helper.queryDiskRecordSize());
-        variableFileName = (helper.getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName = variableFileName || (helper.getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         isOpt = (helper.getFlags() & TDRoptional) != 0;
     }
 
@@ -20563,7 +20568,6 @@ public:
     bool isLocal;
     bool sorted;
     bool maySkip;
-    bool variableFileName;
     Owned<IFilePartMap> map;
     Owned<IFileIOArray> files;
     Owned<IInMemoryIndexManager> manager;
@@ -20578,7 +20582,7 @@ public:
         isLocal = _graphNode.getPropBool("att[@name='local']/@value");
         Owned<IHThorDiskReadBaseArg> helper = (IHThorDiskReadBaseArg *) helperFactory();
         sorted = (helper->getFlags() & TDRunsorted) == 0;
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
+        variableFileName = variableFileName || (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         maySkip = (helper->getFlags() & (TDRkeyedlimitskips|TDRkeyedlimitcreates|TDRlimitskips|TDRlimitcreates)) != 0;
         quotes = separators = terminators = NULL;
         if (!variableFileName)
@@ -20659,7 +20663,6 @@ protected:
     CSkippableRemoteResultAdaptor remote;
     CIndexTransformCallback callback;
     bool sorted;
-    bool variableFileName;
     bool variableInfoPending;
     bool isOpt;
     bool isLocal;
@@ -20696,7 +20699,7 @@ public:
     {
         indexHelper.setCallback(&callback);
         steppedExtra = static_cast<IHThorSteppedSourceExtra *>(indexHelper.selectInterface(TAIsteppedsourceextra_1));
-        variableFileName = (indexHelper.getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName = variableFileName || (indexHelper.getFlags() & (TIRvarfilename|TIRdynamicfilename)) != 0;
         variableInfoPending = false;
         isOpt = (indexHelper.getFlags() & TIRoptional) != 0;
         seekGEOffset = 0;
@@ -21271,7 +21274,6 @@ class CRoxieServerSimpleIndexReadActivity : public CRoxieServerActivity, impleme
     Owned<const IResolvedFile> varFileInfo;
     const RemoteActivityId &remoteId;
     bool firstRead;
-    bool variableFileName;
     bool variableInfoPending;
     bool isOpt;
     bool isLocal;
@@ -21338,7 +21340,7 @@ public:
         steppedExtra = static_cast<IHThorSteppedSourceExtra *>(indexHelper.selectInterface(TAIsteppedsourceextra_1));
         limitTransformExtra = static_cast<IHThorSourceLimitTransformExtra *>(indexHelper.selectInterface(TAIsourcelimittransformextra_1));
         unsigned flags = indexHelper.getFlags();
-        variableFileName = (flags & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName = variableFileName || (flags & (TIRvarfilename|TIRdynamicfilename)) != 0;
         variableInfoPending = false;
         isOpt = (flags & TIRoptional) != 0;
         optimizeSteppedPostFilter = (flags & TIRunfilteredtransform) != 0;
@@ -21659,7 +21661,6 @@ public:
     bool isLocal;
     bool maySkip;
     bool sorted;
-    bool variableFileName;
     bool enableFieldTranslation;
     unsigned rawSize;
     unsigned maxSeekLookahead;
@@ -21683,7 +21684,7 @@ public:
         activityMeta.setown(deserializeRecordMeta(m, true));
         enableFieldTranslation = queryFactory.getEnableFieldTranslation();
         translatorArray.setown(new TranslatorArray);
-        variableFileName = (flags & (TIRvarfilename|TIRdynamicfilename)) != 0;
+        variableFileName = variableFileName || (flags & (TIRvarfilename|TIRdynamicfilename)) != 0;
         if (!variableFileName)
         {
             bool isOpt = (flags & TIRoptional) != 0;
@@ -22587,15 +22588,13 @@ class CRoxieServerCountDiskActivityFactory : public CRoxieServerActivityFactory
 {
 public:
     unsigned __int64 answer;
-    bool variableFileName;
     Owned<const IResolvedFile> datafile;
 
     CRoxieServerCountDiskActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, IPropertyTree &_graphNode)
         : CRoxieServerActivityFactory(_id, _subgraphId, _queryFactory, _helperFactory, _kind)
     {
         Owned<IHThorCountFileArg> helper = (IHThorCountFileArg *) helperFactory();
-        variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
-        assertex(helper->queryRecordSize()->isFixedSize());
+        variableFileName = variableFileName || (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         if (!variableFileName)
         {
             unsigned recsize = helper->queryRecordSize()->getFixedSize();
@@ -22652,7 +22651,6 @@ class CRoxieServerFetchActivity : public CRoxieServerActivity, implements IRecor
     CRemoteResultAdaptor remote;
     RecordPullerThread puller;
     bool needsRHS;
-    bool variableFileName;
     bool isOpt;
     Owned<const IResolvedFile> varFileInfo;
 
@@ -22662,7 +22660,7 @@ public:
     {
         fetchContext = static_cast<IHThorFetchContext *>(helper.selectInterface(TAIfetchcontext_1));
         needsRHS = helper.transformNeedsRhs();
-        variableFileName = (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName = variableFileName || (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         isOpt = (fetchContext->getFetchFlags() & FFdatafileoptional) != 0;
     }
 
@@ -22799,7 +22797,6 @@ class CRoxieServerFetchActivityFactory : public CRoxieServerActivityFactory
 {
     RemoteActivityId remoteId;
     Owned<IFilePartMap> map;
-    bool variableFileName;
     Owned<const IResolvedFile> datafile;
 public:
     CRoxieServerFetchActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, const RemoteActivityId &_remoteId, IPropertyTree &_graphNode)
@@ -22807,7 +22804,7 @@ public:
     {
         Owned<IHThorFetchBaseArg> helper = (IHThorFetchBaseArg *) helperFactory();
         IHThorFetchContext *fetchContext = static_cast<IHThorFetchContext *>(helper->selectInterface(TAIfetchcontext_1));
-        variableFileName = (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFileName = variableFileName || (fetchContext->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         if (!variableFileName)
         {
             datafile.setown(_queryFactory.queryPackage().lookupFileName(fetchContext->getFileName(), (fetchContext->getFetchFlags() & FFdatafileoptional) != 0, true));
@@ -23987,7 +23984,7 @@ public:
           map(_map)
     {
         CRoxieServerKeyedJoinBase::setInput(0, head.queryOutput(0));
-        variableFetchFileName = (helper.getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableFetchFileName =  variableFileName || (helper.getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
     }
     
     virtual const IResolvedFile *queryVarFileInfo() const
@@ -24354,8 +24351,8 @@ public:
         enableFieldTranslation = queryFactory.getEnableFieldTranslation();
         translatorArray.setown(new TranslatorArray);
         joinFlags = helper->getJoinFlags();
-        variableIndexFileName = (joinFlags & (JFvarindexfilename|JFdynamicindexfilename)) != 0;
-        variableFetchFileName = (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
+        variableIndexFileName = variableFileName || (joinFlags & (JFvarindexfilename|JFdynamicindexfilename)) != 0;
+        variableFetchFileName = variableFileName || (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) != 0;
         if (!variableIndexFileName)
         {
             bool isOpt = (joinFlags & JFindexoptional) != 0;
@@ -28678,7 +28675,7 @@ public:
         {
             IRoxieDaliHelper *daliHelper = checkDaliConnection();
             assertex(daliHelper );
-            workUnit.setown(daliHelper->attachWorkunit(wuid, _factory->queryDll())); 
+            workUnit.setown(daliHelper->attachWorkunit(wuid, _factory->queryDll()));
             if (!workUnit)
                 throw MakeStringException(ROXIE_DALI_ERROR, "Failed to open workunit %s", wuid);
             startWorkUnit();
@@ -30999,9 +30996,10 @@ private:
 
 class RoxieWorkUnitListener : public RoxieListener
 {
+    ILoadedDllEntry *dll;
 public:
-    RoxieWorkUnitListener(unsigned _poolSize, bool _suspended)
-      : RoxieListener(_poolSize, _suspended)
+    RoxieWorkUnitListener(unsigned _poolSize, bool _suspended, ILoadedDllEntry *_dll)
+      : RoxieListener(_poolSize, _suspended), dll(_dll)
     {
     }
 
@@ -31015,10 +31013,7 @@ public:
         return 0;
     }
 
-    virtual void runOnce(const char*)
-    {
-        UNIMPLEMENTED;
-    }
+    virtual void runOnce(const char* query);
 
     virtual void stopListening()
     {
@@ -31243,9 +31238,10 @@ protected:
 
 class RoxieWorkUnitWorker : public RoxieQueryWorker
 {
+    ILoadedDllEntry *dll;
 public:
-    RoxieWorkUnitWorker(RoxieListener *_pool)
-        : RoxieQueryWorker(_pool)
+    RoxieWorkUnitWorker(RoxieListener *_pool, ILoadedDllEntry *_dll)
+        : RoxieQueryWorker(_pool), dll(_dll)
     {
     }
 
@@ -31255,13 +31251,27 @@ public:
         RoxieQueryWorker::init(_r);
     }
 
+    virtual void runOnce(const char *query)
+    {
+        main();
+    }
+
     virtual void main()
     {
         Owned <IRoxieDaliHelper> daliHelper = connectToDali();
-        Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid.get(), NULL);
+        Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid.get(), dll);
+        bool newWu = false;
+        if (!wuid.get() || !*wuid.get())
+        {
+            assertex(dll); // standalone code has no WUID yet, but it must have a dll
+            wu->getWuid(StringAttrAdaptor(wuid));
+            newWu = true;
+        }
         if (!wu)
             throw MakeStringException(ROXIE_DALI_ERROR, "Failed to open workunit %s", wuid.get());
         Owned<IQueryFactory> queryFactory = createServerQueryFactoryFromWu(wuid.get());
+        if (newWu)
+            queryFactory->setDynamicFileResolution(true);
         Owned<StringContextLogger> logctx = new StringContextLogger(wuid.get());
         doMain(wu, queryFactory, *logctx);
         sendUnloadMessage(queryFactory->queryHash(), wuid.get(), *logctx);
@@ -31992,7 +32002,7 @@ IArrayOf<IRoxieListener> socketListeners;
 
 IPooledThread *RoxieWorkUnitListener::createNew()
 {
-    return new RoxieWorkUnitWorker(this);
+    return new RoxieWorkUnitWorker(this, NULL);
 }
 
 IPooledThread *RoxieSocketListener::createNew()
@@ -32006,6 +32016,12 @@ void RoxieSocketListener::runOnce(const char *query)
     p->runOnce(query);
 }
 
+void RoxieWorkUnitListener::runOnce(const char* query)
+{
+    Owned<RoxieWorkUnitWorker> p = new RoxieWorkUnitWorker(this, dll);
+    p->runOnce(query);
+}
+
 IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended)
 {
     if (traceLevel)
@@ -32013,11 +32029,11 @@ IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsi
     return new RoxieSocketListener(port, poolSize, listenQueue, suspended);
 }
 
-IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended)
+IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended, ILoadedDllEntry *dll)
 {
     if (traceLevel)
         DBGLOG("Creating Roxie workunit listener, pool size %d%s", poolSize, suspended?" SUSPENDED":"");
-    return new RoxieWorkUnitListener(poolSize, suspended);
+    return new RoxieWorkUnitListener(poolSize, suspended, dll);
 }
 
 bool suspendRoxieListener(unsigned port, bool suspended)

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -75,7 +75,7 @@ interface IRoxieServerQueryPacket : public IInterface, public ILRUChain
 };
 
 IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended);
-IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended);
+IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended, ILoadedDllEntry *dll);
 bool suspendRoxieListener(unsigned port, bool suspended);
 extern IArrayOf<IRoxieListener> socketListeners;
 
@@ -299,6 +299,7 @@ interface IRoxieServerActivityFactory : extends IActivityFactory
     virtual IRoxieServerSideCache *queryServerSideCache() const = 0;
     virtual IDefRecordMeta *queryActivityMeta() const = 0;
     virtual void noteStatistic(unsigned statCode, unsigned __int64 value, unsigned count) const = 0;
+    virtual bool dynamicFileResolution() const = 0;
 };
 interface IGraphResult : public IInterface
 {

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1295,7 +1295,8 @@ public:
     {
         Owned<IPropertyTree> newQuerySet = createPTree("QuerySet");
         newQuerySet->setProp("@name", "_standalone");
-        newQuerySet->addPropTree("Query", standaloneDll.getLink());
+        Owned<IPropertyTree> query = newQuerySet->addPropTree("Query", standaloneDll.getLink());
+        query->setPropBool("@dynamicFiles", true);
         Owned<CRoxieSlaveQuerySetManagerSet> newSlaveManagers = new CRoxieSlaveQuerySetManagerSet(numChannels);
         Owned<IRoxieQuerySetManager> newServerManager = createServerManager();
         newServerManager->load(newQuerySet, *packages);


### PR DESCRIPTION
Add dynamic flag to query factory, which activity
factories will use to define if dynamic file
resolution is to be turned on by default or just
specific to certain activities (TDXdynamicfilename).

Commoning up the variableFileName flag on all activities
to make sure we set the correct one and it gets
used on all activities that need it.

Implementing runOnce() on WorkUnit worker, so to
concentrate dynamic resolution to workunit execution
only, working for both dispatched and standalone
query types.

Seting the standalone/workunit payloads to have dynamic
file resolution, but still keeps deployed
queries as Roxie's standard resolve-on-startup.

Adding dynamicFiles flag to the query's property tree
when creating a standalone query package manager,
so the globalPackageSetManager propagates it to
QueryFactories when created.

Creating workunit when attaching without a WUID (which
happens with standalone queries), so we can use the
same worker for dynamic queries on both standalone
and one-off workunit queries.

Querying DLLs from a Workunit will also work if
it's a stand alone executable (the property tree holds
them in separate, but similar, places).

No regressions found.
