### PR TITLE
Roxie selftest regression causing core

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2784,6 +2784,7 @@ class LazyIOTest: public CppUnit::TestFixture
         DBGLOG("Testing localPresent=%d localCorrect=%d", localPresent, localCorrect);
         remove("cppfile_localfile1");
         FILE *x = fopen("cppfile_localfile2", "wb");
+        assertex(x);
         fputs("Test", x);
         fclose(x);
         if (localPresent)
@@ -2793,6 +2794,7 @@ class LazyIOTest: public CppUnit::TestFixture
             else
             {
                 FILE *x = fopen("cppfile_localfile1", "wb");
+                assertex(x);
                 fputs("Pink1", x);
                 fclose(x);
             }

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -3707,7 +3707,8 @@ protected:
     {
         Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
         CountingRowAllocatorCache rowCache;
-        FixedSizeHeaplet * heaplet = new FixedSizeHeaplet(&rowCache, 32);
+        void * memory = suballoc_aligned(1, true);
+        FixedSizeHeaplet * heaplet = new (memory) FixedSizeHeaplet(&rowCache, 32);
         Semaphore sem;
         CasAllocatorThread * threads[numCasThreads];
         for (unsigned i1 = 0; i1 < numCasThreads; i1++)


### PR DESCRIPTION
Recent change to the operator(new) behaviour in roxiemem missed the
case in the selftest code that allocates a heaplet. As a result it
was allocating an invalid healet object and coring in the selftest
code.

Also add some checking to the ccdfile test cases to prevent a core if
current directory is not writable when running the selftest.

Fixes 2307.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
