### PR TITLE
Add include path to regressions

### DIFF
--- a/ecl/regress/regress.sh
+++ b/ecl/regress/regress.sh
@@ -50,6 +50,7 @@ compare_only=0
 eclcc=
 diff=
 np=`grep -c processor /proc/cpuinfo`
+export ECLCC_ECLINCLUDE_PATH=
 
 ## Get cmd line options (overrite default args)
 if [[ $1 = '' ]]; then


### PR DESCRIPTION
Clears include path options to avoid inclusion of all ECL files in the current directory. 

Fixes #2300, some broken compilations with the `-static` flag enabled.
