### PR TITLE
Generate .ldaprc file using configgen

### DIFF
--- a/deployment/deploy/XMLTags.h
+++ b/deployment/deploy/XMLTags.h
@@ -55,6 +55,7 @@
 #define XML_TAG_INSTALLSET             "InstallSet"
 #define XML_TAG_INSTANCE               "Instance"
 #define XML_TAG_INSTANCES              "Instances"
+#define XML_TAG_LDAPSERVERPROCESS      "LDAPServerProcess"
 #define XML_TAG_LOCATION               "Location"
 #define XML_TAG_MAP                    "Map"
 #define XML_TAG_MAPTABLES              "MapTables"

--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -933,7 +933,7 @@ public:
     //---------------------------------------------------------------------------
   CConfigGenMgr(IConstEnvironment& environment, IDeploymentCallback& callback, 
     IPropertyTree* pSelectedComponents, const char* inputDir, const char* outputDir, const char* compName, const char* compType, const char* ipAddr)
-    : CEnvironmentDeploymentEngine(environment, callback, pSelectedComponents),
+    : CEnvironmentDeploymentEngine(environment, callback, NULL),
     m_inDir(inputDir), 
     m_outDir(outputDir),
     m_compName(compName),

--- a/initfiles/componentfiles/configxml/CMakeLists.txt
+++ b/initfiles/componentfiles/configxml/CMakeLists.txt
@@ -61,6 +61,7 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/generic.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/installset.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/ldapserver.xsd
+    ${CMAKE_CURRENT_SOURCE_DIR}/ldapserver.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/mysqlserver.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/regress.xsd

--- a/initfiles/componentfiles/configxml/cgencomplist_linux.xml
+++ b/initfiles/componentfiles/configxml/cgencomplist_linux.xml
@@ -49,6 +49,9 @@
   <Component name="esp" processName='EspProcess' schema='esp.xsd'>
     <File name="esp.xsl" method="xslt" destName="esp.xml"/>
   </Component>
+  <Component name="ldapServer" processName="LDAPServerProcess">
+    <File name="ldapserver.xsl" method="xslt" destName=".ldaprc"/>
+  </Component>
   <Component name="regressionSuite" processName='RegressionSuite' schema='regress.xsd'>
     <File name="regressionSuite.xsl" method="xslt" destName="test_suites.bat"/>
     <File name="runregress.xsl" method="xslt" destName="regress.ini"/>

--- a/initfiles/componentfiles/configxml/cgencomplist_win.xml
+++ b/initfiles/componentfiles/configxml/cgencomplist_win.xml
@@ -52,6 +52,9 @@
   <Component name="GAB_Configuration">
     <File name="GABConfig.xsl" method="xslt" destName="@name+.cfg"/>
   </Component>
+  <Component name="ldapServer" processName="LDAPServerProcess">
+    <File name="ldapserver.xsl" method="xslt" destName=".ldaprc"/>
+  </Component>
   <Component name="regressionSuite" processName='RegressionSuite' schema='regress.xsd'>
     <File name="regressionSuite.xsl" method="xslt" destName="test_suites.bat"/>
     <File name="runregress.xsl" method="xslt" destName="regress.ini"/>

--- a/initfiles/componentfiles/configxml/ldapserver.xsl
+++ b/initfiles/componentfiles/configxml/ldapserver.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xml:space="default">
+<xsl:param name="process" select="'unknown'"/>
+
+<xsl:strip-space elements="*"/>
+<xsl:output method="text" indent="no" omit-xml-declaration="yes"/>
+
+<xsl:template match="text()"/>
+    <xsl:template match="/">
+        <xsl:apply-templates select="Environment/Software/LDAPServerProcess[@name=$process]"/>
+    </xsl:template>
+
+   <xsl:template match="LDAPServerProcess">
+ host <xsl:value-of select="Instance[1]/@netAddress"/>
+ #base dc=internal,dc=sds
+ filesBasedn="<xsl:value-of select="@filesBasedn"/>"
+ resourcesBasedn="<xsl:value-of select="@resourcesBasedn"/>"
+ sudoersBasedn="<xsl:value-of select="@sudoersBasedn"/>"
+ systemBasedn="<xsl:value-of select="@systemBasedn"/>"
+ usersBasedn="<xsl:value-of select="@usersBasedn"/>"
+ workunitsBasedn="<xsl:value-of select="@workunitsBasedn"/>"
+   </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Added two new configgen options for ldap
1. -listldaps to list all ldapserver instances in the environment
2. -ldapconfig to generate the .ldaprc file for a given ldapserver instance
   into a specified directory.

Fixes gh-2263

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
