### PR TITLE
Optimise NORMALIZE to DATASET

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -64,6 +64,8 @@
 //#define GATHER_LINK_STATS
 //#define VERIFY_EXPR_INTEGRITY
 
+// To debug a symbol in the C++ generated code, use SEARCH_NAME*
+// and set a breakpoint on debugMatchedName() below
 #ifdef _DEBUG
 //#define DEBUG_SCOPE
 //#define CHECK_RECORD_CONSITENCY

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4220,11 +4220,11 @@ IHqlExpression * CExprFolderTransformer::doFoldTransformed(IHqlExpression * unfo
             IHqlExpression * ds = expr->queryChild(0);
             IHqlExpression * count = expr->queryChild(1);
             IHqlExpression * transform = expr->queryChild(2);
-            if (!hasSingleRow(ds) || !count->isConstant()) // Complicate things more
+            OwnedHqlExpr left = createSelector(no_left, ds, querySelSeq(expr));
+            if (!hasSingleRow(ds) || exprReferencesDataset(count, left)) // Complicate things more
                 break;
 
             // Replace LEFT from normalize transform (if used) by ROW's contents
-            OwnedHqlExpr left = createSelector(no_left, ds, querySelSeq(expr));
             OwnedHqlExpr newTransform;
             if (exprReferencesDataset(transform, left)) {
                 OwnedHqlExpr newRow;

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4214,6 +4214,51 @@ IHqlExpression * CExprFolderTransformer::doFoldTransformed(IHqlExpression * unfo
     case no_and:
         return foldAndExpr(expr, (foldOptions & HFOx_op_not_x) != 0);
     //Operations that involve constant folding on datasets.
+    case no_normalize:
+        {
+            // Identify expressions
+            IHqlExpression * ds = expr->queryChild(0);
+            IHqlExpression * count = expr->queryChild(1);
+            IHqlExpression * transform = expr->queryChild(2);
+            if (!hasSingleRow(ds) || !count->isConstant()) // Complicate things more
+                break;
+
+            // Replace LEFT from normalize transform (if used) by ROW's contents
+            OwnedHqlExpr left = createSelector(no_left, ds, querySelSeq(expr));
+            OwnedHqlExpr newTransform;
+            if (exprReferencesDataset(transform, left)) {
+                OwnedHqlExpr newRow;
+                // Make sure it's one of the recognised formats
+                switch (ds->getOperator())
+                {
+                case no_datasetfromrow: // DATASET(ROW(transform))
+                    {
+                        IHqlExpression * row = ds->queryChild(0);
+                        if (row->getOperator() == no_createrow)
+                            newRow.set(row);
+                        break;
+                    }
+                case no_inlinetable:    // DATASET([transform()]) or DATASET([value],{ myfield })
+                    {
+                        IHqlExpression * transformList = ds->queryChild(0);
+                        assertex(transformList->getOperator() == no_transformlist);
+                        newRow.setown(createRow(no_createrow, LINK(transformList->queryChild(0))));
+                        break;
+                    }
+                }
+                if (!newRow || !newRow->isPure())
+                    break;
+
+                OwnedHqlExpr replacementRow = createRow(no_newrow, LINK(newRow));
+                newTransform.setown(replaceSelector(transform, left, replacementRow));
+            }
+            HqlExprArray args;
+            unwindChildren(args, expr, 1); // (count, trans)
+            if (newTransform)
+                args.replace(*newTransform.getClear(), 1);
+
+            return createDataset(no_dataset_from_transform, args);
+        }
     case no_filter:
         {
             IHqlExpression * child = expr->queryChild(0);

--- a/ecl/regress/normalize-dataset-opt.ecl
+++ b/ecl/regress/normalize-dataset-opt.ecl
@@ -1,0 +1,104 @@
+
+// Omit optimisation that could render some of the cases below trivial
+#option ('percolateConstants', false);
+
+// ====================== Record type
+myRec := RECORD
+    unsigned id;
+    string name;
+END;
+
+// ====================== Independent transformation
+myRec myTransf(unsigned c) := TRANSFORM
+    SELF.id := c;
+    SELF.name := 'Charlie ' + c + ' Bravo';
+END;
+
+// ====================== Dependent transformation
+myRec myTransf2(myRec L, unsigned c) := TRANSFORM
+    SELF.id := L.id + c;
+    SELF.name := 'Charlie ' + c + ' Bravo';
+    SELF := L;
+END;
+
+hundred := 100 : stored('hundred');
+
+// ====================== This is what the optimization should look like
+output('Dataset count transform');
+dsO := dataset(10, myTransf(COUNTER));
+output(dsO);
+
+// ====================== Single row from transform
+output('Single row from transform');
+dsA := dataset(ROW(myTransf(100)));
+dsAT := normalize(dsA, 11, myTransf(COUNTER));
+output(dsAT);
+dsAN := normalize(dsA, 11, myTransf2(LEFT, COUNTER));
+output(dsAN);
+
+// ====================== Single row from dynamic transform
+output('Single row from dynamic transform');
+dsAx := dataset(ROW(myTransf(hundred)));
+dsAxT := normalize(dsAx, 12, myTransf(COUNTER));
+output(dsAxT);
+// Do not optimise, as LEFT is unknown at compilation time
+dsAxN := normalize(dsAx, 12, myTransf2(LEFT, COUNTER));
+output(dsAxN);
+
+// ====================== Transform
+output('Transform');
+dsB := dataset([myTransf(100)]);
+dsBT := normalize(dsB, 13, myTransf(COUNTER));
+output(dsBT);
+dsBN := normalize(dsB, 13, myTransf2(LEFT, COUNTER));
+output(dsBN);
+
+// ====================== Transform dynamic
+output('Transform dynamic');
+dsBx := dataset([myTransf(hundred)]);
+dsBxT := normalize(dsBx, 14, myTransf(COUNTER));
+output(dsBxT);
+// Do not optimise, as LEFT is unknown at compilation time
+dsBxN := normalize(dsBx, 14, myTransf2(LEFT, COUNTER));
+output(dsBxN);
+
+// ====================== Single value dataset
+output('Single value dataset');
+dsC := dataset(ROW({100,''},myRec));
+dsCT := normalize(dsC, 15, myTransf(COUNTER));
+output(dsCT);
+dsCN := normalize(dsC, 15, myTransf2(LEFT, COUNTER));
+output(dsCN);
+
+// ====================== DO NOT OPTIMISE
+
+// ====================== Multiple rows
+output('Multiple rows');
+dsM := dataset([{100,'first'},{101,'second'}], myRec);
+dsMT := normalize(dsM, 17, myTransf(COUNTER));
+output(dsMT);
+dsMN := normalize(dsM, 17, myTransf2(LEFT, COUNTER));
+output(dsMN);
+
+// ====================== Single independent row
+output('Single independent row');
+dsI := ROW({1000,''},myRec) : independent;
+// This should be optimised, since myTransf doesn't reference row
+dsIT := normalize(dataset(dsI), 18, myTransf(COUNTER));
+output(dsIT);
+dsIN := normalize(dataset(dsI), 18, myTransf2(LEFT, COUNTER));
+output(dsIN);
+
+// ====================== Random row
+output('Random row');
+dsR := dataset([myTransf(random())]);
+// This should be optimised, since myTransf doesn't reference row
+dsRT := normalize(dsR, 19, myTransf(COUNTER));
+output(dsRT);
+dsRN := normalize(dsR, 19, myTransf2(LEFT, COUNTER));
+output(dsRN);
+
+// ====================== Normalize with LEFT.childDS
+output('LEFT referenced children');
+dsL := dataset(ROW({10,'foo'},myRec));
+dsLN := normalize(dsL, LEFT.id, myTransf(COUNTER));

--- a/ecl/regress/normalize-dataset-opt.ecl
+++ b/ecl/regress/normalize-dataset-opt.ecl
@@ -102,3 +102,4 @@ output(dsRN);
 output('LEFT referenced children');
 dsL := dataset(ROW({10,'foo'},myRec));
 dsLN := normalize(dsL, LEFT.id, myTransf(COUNTER));
+output(dsLN);

--- a/testing/ecl/key/normalize-dataset-opt.xml
+++ b/testing/ecl/key/normalize-dataset-opt.xml
@@ -299,3 +299,15 @@
 <Dataset name='Result 24'>
  <Row><Result_24>LEFT referenced children</Result_24></Row>
 </Dataset>
+<Dataset name='Result 25'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+</Dataset>

--- a/testing/ecl/key/normalize-dataset-opt.xml
+++ b/testing/ecl/key/normalize-dataset-opt.xml
@@ -1,0 +1,301 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>Dataset count transform</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>Single row from transform</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>11</id><name>Charlie 11 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><id>101</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>102</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>103</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>104</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>105</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>106</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>107</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>108</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>109</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>110</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>111</id><name>Charlie 11 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>Single row from dynamic transform</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>11</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>12</id><name>Charlie 12 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><id>101</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>102</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>103</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>104</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>105</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>106</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>107</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>108</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>109</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>110</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>111</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>112</id><name>Charlie 12 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><Result_9>Transform</Result_9></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>11</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>12</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>13</id><name>Charlie 13 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 11'>
+ <Row><id>101</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>102</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>103</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>104</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>105</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>106</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>107</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>108</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>109</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>110</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>111</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>112</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>113</id><name>Charlie 13 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 12'>
+ <Row><Result_12>Transform dynamic</Result_12></Row>
+</Dataset>
+<Dataset name='Result 13'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>11</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>12</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>13</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>14</id><name>Charlie 14 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 14'>
+ <Row><id>101</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>102</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>103</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>104</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>105</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>106</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>107</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>108</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>109</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>110</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>111</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>112</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>113</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>114</id><name>Charlie 14 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 15'>
+ <Row><Result_15>Single value dataset</Result_15></Row>
+</Dataset>
+<Dataset name='Result 16'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>11</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>12</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>13</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>14</id><name>Charlie 14 Bravo</name></Row>
+ <Row><id>15</id><name>Charlie 15 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 17'>
+ <Row><id>101</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>102</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>103</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>104</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>105</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>106</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>107</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>108</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>109</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>110</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>111</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>112</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>113</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>114</id><name>Charlie 14 Bravo</name></Row>
+ <Row><id>115</id><name>Charlie 15 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 18'>
+ <Row><Result_18>Multiple rows</Result_18></Row>
+</Dataset>
+<Dataset name='Result 19'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>11</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>12</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>13</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>14</id><name>Charlie 14 Bravo</name></Row>
+ <Row><id>15</id><name>Charlie 15 Bravo</name></Row>
+ <Row><id>16</id><name>Charlie 16 Bravo</name></Row>
+ <Row><id>17</id><name>Charlie 17 Bravo</name></Row>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>11</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>12</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>13</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>14</id><name>Charlie 14 Bravo</name></Row>
+ <Row><id>15</id><name>Charlie 15 Bravo</name></Row>
+ <Row><id>16</id><name>Charlie 16 Bravo</name></Row>
+ <Row><id>17</id><name>Charlie 17 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 20'>
+ <Row><id>101</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>102</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>103</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>104</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>105</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>106</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>107</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>108</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>109</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>110</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>111</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>112</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>113</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>114</id><name>Charlie 14 Bravo</name></Row>
+ <Row><id>115</id><name>Charlie 15 Bravo</name></Row>
+ <Row><id>116</id><name>Charlie 16 Bravo</name></Row>
+ <Row><id>117</id><name>Charlie 17 Bravo</name></Row>
+ <Row><id>102</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>103</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>104</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>105</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>106</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>107</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>108</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>109</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>110</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>111</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>112</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>113</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>114</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>115</id><name>Charlie 14 Bravo</name></Row>
+ <Row><id>116</id><name>Charlie 15 Bravo</name></Row>
+ <Row><id>117</id><name>Charlie 16 Bravo</name></Row>
+ <Row><id>118</id><name>Charlie 17 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 21'>
+ <Row><Result_21>Single independent row</Result_21></Row>
+</Dataset>
+<Dataset name='Result 22'>
+ <Row><id>1</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>2</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>3</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>4</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>5</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>6</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>7</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>8</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>9</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>10</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>11</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>12</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>13</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>14</id><name>Charlie 14 Bravo</name></Row>
+ <Row><id>15</id><name>Charlie 15 Bravo</name></Row>
+ <Row><id>16</id><name>Charlie 16 Bravo</name></Row>
+ <Row><id>17</id><name>Charlie 17 Bravo</name></Row>
+ <Row><id>18</id><name>Charlie 18 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 23'>
+ <Row><id>1001</id><name>Charlie 1 Bravo</name></Row>
+ <Row><id>1002</id><name>Charlie 2 Bravo</name></Row>
+ <Row><id>1003</id><name>Charlie 3 Bravo</name></Row>
+ <Row><id>1004</id><name>Charlie 4 Bravo</name></Row>
+ <Row><id>1005</id><name>Charlie 5 Bravo</name></Row>
+ <Row><id>1006</id><name>Charlie 6 Bravo</name></Row>
+ <Row><id>1007</id><name>Charlie 7 Bravo</name></Row>
+ <Row><id>1008</id><name>Charlie 8 Bravo</name></Row>
+ <Row><id>1009</id><name>Charlie 9 Bravo</name></Row>
+ <Row><id>1010</id><name>Charlie 10 Bravo</name></Row>
+ <Row><id>1011</id><name>Charlie 11 Bravo</name></Row>
+ <Row><id>1012</id><name>Charlie 12 Bravo</name></Row>
+ <Row><id>1013</id><name>Charlie 13 Bravo</name></Row>
+ <Row><id>1014</id><name>Charlie 14 Bravo</name></Row>
+ <Row><id>1015</id><name>Charlie 15 Bravo</name></Row>
+ <Row><id>1016</id><name>Charlie 16 Bravo</name></Row>
+ <Row><id>1017</id><name>Charlie 17 Bravo</name></Row>
+ <Row><id>1018</id><name>Charlie 18 Bravo</name></Row>
+</Dataset>
+<Dataset name='Result 24'>
+ <Row><Result_24>LEFT referenced children</Result_24></Row>
+</Dataset>

--- a/testing/ecl/normalize-dataset-opt.ecl
+++ b/testing/ecl/normalize-dataset-opt.ecl
@@ -96,3 +96,4 @@ output(dsIN);
 output('LEFT referenced children');
 dsL := dataset(ROW({10,'foo'},myRec));
 dsLN := normalize(dsL, LEFT.id, myTransf(COUNTER));
+output(dsLN);

--- a/testing/ecl/normalize-dataset-opt.ecl
+++ b/testing/ecl/normalize-dataset-opt.ecl
@@ -1,0 +1,98 @@
+
+// Omit optimisation that could render some of the cases below trivial
+#option ('percolateConstants', false);
+
+// ====================== Record type
+myRec := RECORD
+    unsigned id;
+    string name;
+END;
+
+// ====================== Independent transformation
+myRec myTransf(unsigned c) := TRANSFORM
+    SELF.id := c;
+    SELF.name := 'Charlie ' + c + ' Bravo';
+END;
+
+// ====================== Dependent transformation
+myRec myTransf2(myRec L, unsigned c) := TRANSFORM
+    SELF.id := L.id + c;
+    SELF.name := 'Charlie ' + c + ' Bravo';
+    SELF := L;
+END;
+
+hundred := 100 : stored('hundred');
+
+// ====================== This is what the optimization should look like
+output('Dataset count transform');
+dsO := dataset(10, myTransf(COUNTER));
+output(dsO);
+
+// ====================== Single row from transform
+output('Single row from transform');
+dsA := dataset(ROW(myTransf(100)));
+dsAT := normalize(dsA, 11, myTransf(COUNTER));
+output(dsAT);
+dsAN := normalize(dsA, 11, myTransf2(LEFT, COUNTER));
+output(dsAN);
+
+// ====================== Single row from dynamic transform
+output('Single row from dynamic transform');
+dsAx := dataset(ROW(myTransf(hundred)));
+dsAxT := normalize(dsAx, 12, myTransf(COUNTER));
+output(dsAxT);
+// Do not optimise, as LEFT is unknown at compilation time
+dsAxN := normalize(dsAx, 12, myTransf2(LEFT, COUNTER));
+output(dsAxN);
+
+// ====================== Transform
+output('Transform');
+dsB := dataset([myTransf(100)]);
+dsBT := normalize(dsB, 13, myTransf(COUNTER));
+output(dsBT);
+dsBN := normalize(dsB, 13, myTransf2(LEFT, COUNTER));
+output(dsBN);
+
+// ====================== Transform dynamic
+output('Transform dynamic');
+dsBx := dataset([myTransf(hundred)]);
+dsBxT := normalize(dsBx, 14, myTransf(COUNTER));
+output(dsBxT);
+// Do not optimise, as LEFT is unknown at compilation time
+dsBxN := normalize(dsBx, 14, myTransf2(LEFT, COUNTER));
+output(dsBxN);
+
+// ====================== Single value dataset
+output('Single value dataset');
+dsC := dataset(ROW({100,''},myRec));
+dsCT := normalize(dsC, 15, myTransf(COUNTER));
+output(dsCT);
+dsCN := normalize(dsC, 15, myTransf2(LEFT, COUNTER));
+output(dsCN);
+
+// ====================== DO NOT OPTIMISE
+
+// ====================== Multiple rows
+output('Multiple rows');
+dsM := dataset([{100,'first'},{101,'second'}], myRec);
+dsMT := normalize(dsM, 17, myTransf(COUNTER));
+output(dsMT);
+dsMN := normalize(dsM, 17, myTransf2(LEFT, COUNTER));
+output(dsMN);
+
+// ====================== Single independent row
+output('Single independent row');
+dsI := ROW({1000,''},myRec) : independent;
+// This should be optimised, since myTransf doesn't reference row
+dsIT := normalize(dataset(dsI), 18, myTransf(COUNTER));
+output(dsIT);
+dsIN := normalize(dataset(dsI), 18, myTransf2(LEFT, COUNTER));
+output(dsIN);
+
+// ====================== Random row
+// Random numbers don't do well in comparison tests... ;)
+
+// ====================== Normalize with LEFT.childDS
+output('LEFT referenced children');
+dsL := dataset(ROW({10,'foo'},myRec));
+dsLN := normalize(dsL, LEFT.id, myTransf(COUNTER));


### PR DESCRIPTION
This optimisation regards transforming a number of
normalize(row, count, trans(COUNTER)) constructs into
dataset(count, trans(COUNTER)). Added DATASET
to the code that filters unused fields of a transform.

Tests added, on both compiler and regression suites.
All compiler changes were expected, no transform
bodies changed, only simplification from ROW+NORMALIZE
to DATASET.
