### PR TITLE
loading an empty xml stream, created wrong root node type

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -5104,7 +5104,7 @@ IPropertyTree *createPTree(ISimpleReadStream &stream, byte flags, XmlReaderOptio
     if (iMaker->queryRoot())
         return LINK(iMaker->queryRoot());
     else
-        return createPTree(flags);
+        return iMaker->create(NULL);
 }
 
 IPropertyTree *createPTree(IFileIO &ifileio, byte flags, XmlReaderOptions readFlags, IPTreeMaker *iMaker)

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -156,6 +156,7 @@ interface IPTreeMaker : extends IPTreeNotifyEvent
     virtual IPropertyTree *queryRoot() = 0;
     virtual IPropertyTree *queryCurrentNode() = 0;
     virtual void reset() = 0;
+    virtual IPropertyTree *create(const char *tag) = 0;
 };
 
 interface IPTreeNodeCreator : extends IInterface

--- a/system/jlib/jptree.ipp
+++ b/system/jlib/jptree.ipp
@@ -630,6 +630,10 @@ public:
         }
         currentNode = NULL;
     }
+    virtual IPropertyTree *create(const char *tag)
+    {
+        return nodeCreator->create(tag);
+    }
 };
 
 #ifdef __64BIT__


### PR DESCRIPTION
Noticed in Dali, when loading a 0 length store file (see gh-2292)
The IPTreeMaker used to load, created a standard impl. of a IPropertyTree,
when it should have/needed to ask the maker to create the appropriate type.

The result (in Dali) was that it assumed all nodes were of the correct impl.
(CServerRemoteTree) and crashed accessing it via a cast.

NB: only an issue when loading an empty file/stream

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
