### PR TITLE
Add ExpressionDumper basic logic

### DIFF
--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1813,5 +1813,6 @@ extern HQL_API bool getBoolProperty(IHqlExpression * expr, _ATOM name, bool dft=
 extern HQL_API void setLegacyEclSemantics(bool _value);
 extern HQL_API bool queryLegacyEclSemantics();
 void exportSymbols(IPropertyTree* data, IHqlScope * scope, HqlLookupContext & ctx);
+extern HQL_API void dump_expression(IHqlExpression * expr, int depth);
 
 #endif

--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -271,6 +271,33 @@ protected:
     _ATOM search;
 };
 
+/**
+ * The aim of this class is to provide a complete and accurate view
+ * of the expression node for debug purposes. This includes printing
+ * information about the structure (which node contains which other
+ * nodes), and the information on each node (values, attributes, etc).
+ *
+ * For now, a simple depth-limited redundant checking tree dumper is
+ * implemented, but the final goal is to produce a meaningful dump of
+ * all expressions involved in creating the node in question. In that
+ * case, a tree might not be the best representation.
+ */
+class HQL_API ExpressionDumper : protected QuickHqlTransformer
+{
+public:
+    ExpressionDumper(int _depth);
+
+    virtual void analyse(IHqlExpression * expr);
+    StringBuffer& getString();
+
+protected:
+    void doAnalyseBody(IHqlExpression * expr, bool recurse);
+    void appendMinimalInfo(IHqlExpression *expr);
+    StringBuffer string;
+    int depth;
+    int maxDepth;
+};
+
 //---------------------------------------------------------------------------
 
 class HQL_API HqlSectionAnnotator : public QuickHqlTransformer


### PR DESCRIPTION
This is the first draft of the tree dumper to help debug and trace compiler expressions. It's implemented as a transformer and it walks down the tree with max depth defined on any IHqlExpression.

Some examples of the dump:

```
00879AE0 : op(:=)
 00896C60 : op(.)
  008968D0 : op(SELF)
   00895DE0 : op(RECORD)
  00896200 : op(<field>), name
 00879A30 : op( | )
  00879980 : op( | )
   00896E00 : op(<constant>), Value = Charlie 
   00879840 : op(<implicit-cast>)
  00897120 : op(<constant>), Value =  Bravo

008968D0 : op(SELF)
 00895DE0 : op(RECORD)
  00896170 : op(<field>), id
  00896200 : op(<field>), name

00898EF0 : op(<constant>), Value = 10
```

It's by no means complete, but it's a start to add more complex dump capabilities.

For instance, I've added this to `foldConstantOperator()` and to `CTreeOptimizer::analyseExpr()` to dump the expressions coming to the optimiser. I also tested in GDB, while stepping through code, you can easily inspect the expression by:

```
(gdb) p dump_expression(expr, 4)
```

and you'll see a tree like the ones above.

In my TODO list:
- Make sure all transform methods are properly voided
- Add flags and tags to known nodes (ALL, DISTRIBUTED, LOCAL, etc)
- Add a list of ignored nodes (or dumped nodes, whichever is shorter)

This class, or the dump function are not added anywhere, so there's no impact on current execution. This first use is probably in GDB, but it could be added to specific places around optimisations, if thought relevant.

Enjoy!
