### PR TITLE
Fix regression in eclcc accessing a uninitialised member

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -168,7 +168,7 @@ class EclCC
 {
 public:
     EclCC(int _argc, const char **_argv)
-        : programName(argv[0])
+        : programName(_argv[0])
     {
         argc = _argc;
         argv = _argv;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
