### PR TITLE
gh-2326 - Fix DFUWorkunit link on ECLWatch activity page.

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -892,7 +892,13 @@
                     <xsl:otherwise>/FileSpray/GetDFUWorkunit</xsl:otherwise>
                 </xsl:choose>
             </xsl:variable>
-            <a href="javascript:go('{$href-method}?Wuid={Wuid}')">
+            <xsl:variable name="href-wuidparam">
+                <xsl:choose>
+                    <xsl:when test="substring(Wuid,1,1) != 'D'">Wuid</xsl:when>
+                    <xsl:otherwise>wuid</xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <a href="javascript:go('{$href-method}?{$href-wuidparam}={Wuid}')">
                 <xsl:choose>
                     <xsl:when test="State='running'">
                         <b>


### PR DESCRIPTION
Change the link for running DFU Workunit jobs so that they correctly specify the
wuid parameter for GetDFUWorkunit.

Fixes gh-2326

Signed-off-by: Jo Prichard jo.prichard@lexisnexis.com
