### PR TITLE
Fix gh-2208 sink timings were not handled properly

### DIFF
--- a/thorlcr/activities/null/thnullslave.cpp
+++ b/thorlcr/activities/null/thnullslave.cpp
@@ -33,7 +33,6 @@ public:
     }
     virtual void process()
     {
-        ActivityTimer t(totalCycles, timeActivities, NULL);
         startInput(inputs.item(0));
         stopInput(inputs.item(0));
     }

--- a/thorlcr/activities/result/thresultslave.cpp
+++ b/thorlcr/activities/result/thresultslave.cpp
@@ -39,7 +39,6 @@ public:
     }
     void process()
     {
-        ActivityTimer t(totalCycles, timeActivities, NULL);
         processed = 0;
 
         input = inputs.item(0);

--- a/thorlcr/slave/slave.ipp
+++ b/thorlcr/slave/slave.ipp
@@ -37,6 +37,7 @@ protected:
     CThreadedPersistent threaded;
     rowcount_t processed;
     unsigned __int64 lastCycles;
+    SpinLock cycleLock;
 
     virtual void endProcess() = 0;
     virtual void process() { }


### PR DESCRIPTION
Rest of acts time accumulated per rec. timing (nextRow)
Sinks account time since last request (serializeStats), but they were
continuing to account time, beyond the time they were active, which normally
meant until whole subgraph was finished, which meant sink timings
meaningless.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
