### PR TITLE
Deleting external temp file dependencies inside CQ

### DIFF
--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -392,10 +392,12 @@ protected:
     CFileUsageTable tmpFiles;
     CJobBase &job;
     mutable CriticalSection crit;
+    bool errorOnMissing;
+
 public:
     IMPLEMENT_IINTERFACE;
 
-    CGraphTempHandler(CJobBase &_job) : job(_job) { }
+    CGraphTempHandler(CJobBase &_job, bool _errorOnMissing) : job(_job), errorOnMissing(_errorOnMissing) { }
     ~CGraphTempHandler()
     {
     }
@@ -849,7 +851,7 @@ public:
     const char *queryGraphName() const { return graphName; }
     bool queryForceLogging(graph_id graphId, bool def) const;
     ITimeReporter &queryTimeReporter() { return *timeReporter; }
-    virtual IGraphTempHandler *createTempHandler() = 0;
+    virtual IGraphTempHandler *createTempHandler(bool errorOnMissing) = 0;
     virtual CGraphBase *createGraph() = 0;
     void joinGraph(CGraphBase &graph);
     void startGraph(CGraphBase &graph, IGraphCallback &callback, bool checkDependencies, size32_t parentExtractSize, const byte *parentExtract);

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -652,7 +652,7 @@ public:
 class CMasterGraphTempHandler : public CGraphTempHandler
 {
 public:
-    CMasterGraphTempHandler(CJobBase &job) : CGraphTempHandler(job) { }
+    CMasterGraphTempHandler(CJobBase &job, bool errorOnMissing) : CGraphTempHandler(job, errorOnMissing) { }
 
     virtual bool removeTemp(const char *name)
     {
@@ -1239,7 +1239,7 @@ CJobMaster::CJobMaster(IConstWorkUnit &_workunit, const char *graphName, const c
     mpJobTag = allocateMPTag();
     slavemptag = allocateMPTag();
     slaveMsgHandler = new CSlaveMessageHandler(*this, slavemptag);
-    tmpHandler.setown(new CMasterGraphTempHandler(*this));
+    tmpHandler.setown(createTempHandler(true));
 }
 
 CJobMaster::~CJobMaster()
@@ -1707,9 +1707,9 @@ IBarrier *CJobMaster::createBarrier(mptag_t tag)
     return new CBarrierMaster(*jobComm, tag);
 }
 
-IGraphTempHandler *CJobMaster::createTempHandler()
+IGraphTempHandler *CJobMaster::createTempHandler(bool errorOnMissing)
 {
-    return new CMasterGraphTempHandler(*this);
+    return new CMasterGraphTempHandler(*this, errorOnMissing);
 }
 
 bool CJobMaster::fireException(IException *e)
@@ -2291,7 +2291,7 @@ void CMasterGraph::sendGraph()
     CMessageBuffer msg;
     msg.append(GraphInit);
     msg.append(job.queryKey());
-    node->serialize(msg); // everthing
+    node->serialize(msg); // everything
     if (TAG_NULL == executeReplyTag)
         executeReplyTag = queryJob().allocateMPTag();
     serializeMPtag(msg, executeReplyTag);

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -147,7 +147,7 @@ public:
     }
     
 // CJobBase impls.
-    virtual IGraphTempHandler *createTempHandler();
+    virtual IGraphTempHandler *createTempHandler(bool errorOnMissing);
     virtual CGraphBase *createGraph();
 
     CMasterGraphElement *locateActivity(activity_id id)

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -958,7 +958,7 @@ public:
 class CSlaveGraphTempHandler : public CGraphTempHandler
 {
 public:
-    CSlaveGraphTempHandler(CJobBase &job) : CGraphTempHandler(job)
+    CSlaveGraphTempHandler(CJobBase &job, bool errorOnMissing) : CGraphTempHandler(job, errorOnMissing)
     {
     }
     virtual bool removeTemp(const char *name)
@@ -1026,7 +1026,7 @@ CJobSlave::CJobSlave(ISlaveWatchdog *_watchdog, IPropertyTree *_workUnitInfo, co
 #endif
     querySo.setown(createDllEntry(_querySo, false, NULL));
     codeCtx = new CThorCodeContextSlave(*this, *querySo, *userDesc, slavemptag);
-    tmpHandler.setown(new CSlaveGraphTempHandler(*this));
+    tmpHandler.setown(createTempHandler(true));
     startJob();
 }
 
@@ -1101,9 +1101,9 @@ IBarrier *CJobSlave::createBarrier(mptag_t tag)
     return new CBarrierSlave(*jobComm, tag);
 }
 
-IGraphTempHandler *CJobSlave::createTempHandler()
+IGraphTempHandler *CJobSlave::createTempHandler(bool errorOnMissing)
 {
-    return new CSlaveGraphTempHandler(*this);
+    return new CSlaveGraphTempHandler(*this, errorOnMissing);
 }
 
 // IGraphCallback

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -158,7 +158,7 @@ public:
 
     virtual __int64 getWorkUnitValueInt(const char *prop, __int64 defVal) const;
     virtual StringBuffer &getWorkUnitValue(const char *prop, StringBuffer &str) const;
-    virtual IGraphTempHandler *createTempHandler();
+    virtual IGraphTempHandler *createTempHandler(bool errorOnMissing);
     virtual CGraphBase *createGraph()
     {
         return new CSlaveGraph(*this);


### PR DESCRIPTION
gh-2336

temp/spill files, generated by dependent subgraphs that are read within CQ
need to expect that the temp file may not have been generated within the CQ
set, i.e. they dependency may be external to the CQ set.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
