### PR TITLE
Ensure clearAggregate() fields are assigned in order

### DIFF
--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -7751,3 +7751,39 @@ bool userPreventsSort(IHqlExpression * noSortAttr, node_operator side)
         return name == rightAtom;
     throwUnexpected();
 }
+
+//-------------------------------------------------------------------------------------------------
+
+IHqlExpression * queryTransformAssign(IHqlExpression * transform, IHqlExpression * searchField)
+{
+    ForEachChild(i, transform)
+    {
+        IHqlExpression * cur = transform->queryChild(i);
+        switch (cur->getOperator())
+        {
+        case no_assignall:
+            {
+                IHqlExpression * ret = queryTransformAssign(cur, searchField);
+                if (ret)
+                    return ret;
+                break;
+            }
+        case no_assign:
+            {
+                IHqlExpression * lhs = cur->queryChild(0)->queryChild(1);
+                if (lhs == searchField)
+                    return cur;
+                break;
+            }
+        }
+    }
+    return NULL;
+}
+
+IHqlExpression * queryTransformAssignValue(IHqlExpression * transform, IHqlExpression * searchField)
+{
+    IHqlExpression * value = queryTransformAssign(transform, searchField);
+    if (value)
+        return value->queryChild(1);
+    return NULL;
+}

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -644,5 +644,7 @@ extern HQL_API IECLError * annotateExceptionWithLocation(IException * e, IHqlExp
 extern HQL_API IHqlExpression * convertAttributeToQuery(IHqlExpression * expr, HqlLookupContext & ctx);
 extern HQL_API StringBuffer & appendLocation(StringBuffer & s, IHqlExpression * location, const char * suffix = NULL);
 extern HQL_API bool userPreventsSort(IHqlExpression * noSortAttr, node_operator side);
+extern HQL_API IHqlExpression * queryTransformAssign(IHqlExpression * transform, IHqlExpression * searchField);
+extern HQL_API IHqlExpression * queryTransformAssignValue(IHqlExpression * transform, IHqlExpression * searchField);
 
 #endif

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -1487,6 +1487,7 @@ public:
     void addDependency(BuildCtx & ctx, ABoundActivity * element, ABoundActivity * dependent, _ATOM kind, const char * label=NULL, int controlId = 0);
     void addFileDependency(IHqlExpression * name, ABoundActivity * whoAmI);
 
+    void doBuildClearAggregateRecord(BuildCtx & ctx, IHqlExpression * record, IHqlExpression * self, IHqlExpression * transform);
     void doBuildAggregateClearFunc(BuildCtx & ctx, IHqlExpression * expr);
     void doBuildAggregateFirstFunc(BuildCtx & ctx, IHqlExpression * expr);
     void doBuildAggregateNextFunc(BuildCtx & ctx, IHqlExpression * expr);

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -58,34 +58,6 @@ enum
 
 //-------------------------------------------------------------------------------------------------
 
-IHqlExpression * queryTransformAssign(IHqlExpression * transform, IHqlExpression * searchField)
-{
-    ForEachChild(i, transform)
-    {
-        IHqlExpression * cur = transform->queryChild(i);
-        switch (cur->getOperator())
-        {
-        case no_assignall:
-            {
-                IHqlExpression * ret = queryTransformAssign(cur, searchField);
-                if (ret)
-                    return ret;
-                break;
-            }
-        case no_assign:
-            {
-                IHqlExpression * lhs = cur->queryChild(0)->queryChild(1);
-                if (lhs == searchField)
-                    return cur->queryChild(1);
-                break;
-            }
-        }
-    }
-    return NULL;
-}
-
-//-------------------------------------------------------------------------------------------------
-
 void UsedFieldSet::addUnique(IHqlExpression * field)
 {
     //MORE: Add if (!all test to short-circuit contains)
@@ -556,7 +528,7 @@ void UsedFieldSet::gatherTransformValuesUsed(HqlExprArray * selfSelects, SelectU
             }
             if (values)
             {
-                IHqlExpression * transformValue = queryTransformAssign(transform, &cur);
+                IHqlExpression * transformValue = queryTransformAssignValue(transform, &cur);
                 //If no transform value is found then we almost certainly have an invalid query (e.g, LEFT inside a
                 //global).  Don't add the value - you'll definitely get a later follow on error
                 assertex(transformValue);
@@ -573,7 +545,7 @@ void UsedFieldSet::gatherTransformValuesUsed(HqlExprArray * selfSelects, SelectU
         {
             IHqlExpression * field = curNested.field;
             OwnedHqlExpr selected = selector ? createSelectExpr(LINK(selector), LINK(field)) : NULL;
-            IHqlExpression * transformValue = queryTransformAssign(transform, field);
+            IHqlExpression * transformValue = queryTransformAssignValue(transform, field);
             assertex(transformValue);
             bool includeThis = true;
             if (!curNested.includeAll() && transformValue->isPure())
@@ -3228,9 +3200,9 @@ IHqlExpression * ImplicitProjectTransformer::updateSelectors(IHqlExpression * ne
 
 const SelectUsedArray & ImplicitProjectTransformer::querySelectsUsedForField(IHqlExpression * transform, IHqlExpression * field)
 {
-    IHqlExpression * transformValues = queryTransformAssign(transform, field);
+    IHqlExpression * transformValues = queryTransformAssignValue(transform, field);
     if (!transformValues)
-         transformValues = queryTransformAssign(transform, field);
+         transformValues = queryTransformAssignValue(transform, field);
     return querySelectsUsed(transformValues);
 }
 


### PR DESCRIPTION
For a TABLE() that performs an aggregation (no_newaggregate)
the order of the fields in the transform matches
the order of the fields in the target record.  However, for the new
AGGREGATE operator (no_aggregate) they may not match.  If the record
contains variable length fields, and assignments are done out of order
it can lead to invalid memory accesses.

This change ensures assignments are made in field rather than transform
order.

Fixes #2350.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
