### PR TITLE
Unlock File/Directory monitoring singleton

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -275,6 +275,8 @@ private:
             s_configFileMonitorSingleton.setown(new CWsDeployFileInfo::CConfigFileMonitorThread(CONFIG_MONITOR_CHECK_INTERVAL, CONFIG_MONITOR_TIMEOUT_PERIOD));
             s_configFileMonitorSingleton->init();
           }
+
+          slock.unlock();
         }
 
         return s_configFileMonitorSingleton.get();
@@ -442,6 +444,7 @@ public:
         setConfigChanged(true);
       }
       setSkipNotification(false);
+      return true;
     };
     virtual const char* getConfigFilePath()
     {


### PR DESCRIPTION
Added corresponding unlock for file/directory monitoring singleton lock added in gh-2170 which is a fix for gh-2057.

Fixes gh-2371

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
