### PR TITLE
Fix assert when ebcdic string used in filename

### DIFF
--- a/ecl/regress/ebcdiclower.ecl
+++ b/ecl/regress/ebcdiclower.ecl
@@ -1,0 +1,24 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+
+filename1 := NOFOLD((ebcdic string)'Gavin');
+filename2 := NOFOLD((ebcdic string)'gavin');
+
+ds := dataset(filename1, { string x }, thor);
+output(ds,,filename2);


### PR DESCRIPTION
A fairly obscure error, but ebcdic strings that were used in filenames
would trigger an assert in debug mode, and not normalize a filename
correctly in release.  (It would have had few ill effects.)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
