### PR TITLE
ECLPlayground: Fixed issue when hosted within an iFrame.

### DIFF
--- a/esp/files/ECLPlayground.css
+++ b/esp/files/ECLPlayground.css
@@ -138,4 +138,3 @@ h1 {
 	max-height: 60px;
 	background-color: rgb(238, 238, 238);
 }
-

--- a/esp/files/ECLPlayground.htm
+++ b/esp/files/ECLPlayground.htm
@@ -74,7 +74,7 @@
                 ECL Playground</div>
             <div style="float: right; display: inline-block; vertical-align: middle">
                 <label id="sampleSelectLabel" for="sampleSelect">Sample:</label>
-                <div id="sampleSelect" style="overflow: visible !important;">
+                <div id="sampleSelect" style="overflow: visible !important">
                 </div>
             </div>
         </div>

--- a/esp/files/ECLPlayground.js
+++ b/esp/files/ECLPlayground.js
@@ -29,14 +29,14 @@ define([
 	"hpcc/SampleSelectControl",
 	"hpcc/ESPWorkunit"
 ], function (fx, baseWindow, dom, domStyle, domGeometry, on, ready, registry, EclEditor, GraphControl, ResultsControl, Select, Workunit) {
-	var		wu = null,
+	var wu = null,
 			editorControl = null,
 			graphControl = null,
 			resultsControl = null,
 			sampleSelectControl = null,
 
 			initUi = function () {
-				var wuid = dojo.queryToObject(dojo.doc.location.search.substr((dojo.doc.location.search[0] === "?" ? 1 : 0)))["Wuid"];
+				var wuid = dojo.queryToObject(dojo.doc.location.search.substr((dojo.doc.location.search.substr(0, 1) == "?" ? 1 : 0)))["Wuid"];
 				on(dom.byId("submitBtn"), "click", doSubmit);
 
 				if (wuid) {
@@ -64,8 +64,8 @@ define([
 			},
 
 			initUiResults = function () {
-				var wuid = dojo.queryToObject(dojo.doc.location.search.substr((dojo.doc.location.search[0] === "?" ? 1 : 0)))["Wuid"];
-				var sequence = dojo.queryToObject(dojo.doc.location.search.substr((dojo.doc.location.search[0] === "?" ? 1 : 0)))["Sequence"];
+				var wuid = dojo.queryToObject(dojo.doc.location.search.substr((dojo.doc.location.search.substr(0, 1) == "?" ? 1 : 0)))["Wuid"];
+				var sequence = dojo.queryToObject(dojo.doc.location.search.substr((dojo.doc.location.search.substr(0, 1) == "?" ? 1 : 0)))["Sequence"];
 				initResultsControl(sequence);
 				if (wuid) {
 					wu = new Workunit({

--- a/esp/files/scripts/ESPBase.js
+++ b/esp/files/scripts/ESPBase.js
@@ -25,17 +25,21 @@ define([
 		},
 
 		getParam: function (key) {
-			var value = dojo.queryToObject(dojo.doc.location.search.substr((dojo.doc.location.search[0] === "?" ? 1 : 0)))[key];
+			var value = dojo.queryToObject(dojo.doc.location.search.substr((dojo.doc.location.search.substr(0, 1) == "?" ? 1 : 0)))[key];
+
 			if (value)
 				return value;
 			return config[key];
 		},
 
-		getBaseURL: function () {
+		getBaseURL: function (service) {
+			if (!service) {
+				service = "WsWorkunits";
+			}
 			var serverIP = this.getParam("serverIP");
 			if (serverIP)
-				return "http://" + serverIP + ":8010/WsWorkunits";
-			return "/WsWorkunits";
+				return "http://" + serverIP + ":8010/" + service;
+			return "/" + service;
 		},
 
 		getValue: function (domXml, tagName, knownObjectArrays) {

--- a/esp/files/scripts/ResultsControl.js
+++ b/esp/files/scripts/ResultsControl.js
@@ -48,6 +48,7 @@ define([
 				if (nval.id in context.delayLoad) {
 					context.delayLoad[nval.id].placeAt(nval.containerNode, "last");
 					context.delayLoad[nval.id].startup();
+					nval.resize();
 					delete context.delayLoad[nval.id];
 				}
 			});

--- a/esp/files/scripts/SampleSelectControl.js
+++ b/esp/files/scripts/SampleSelectControl.js
@@ -40,7 +40,6 @@ define([
 				value: "default.ecl",
 				maxHeight: -1,
 				style: {
-					overflow: "overflow: visible !important",
 					padding: 0
 				},
 				onChange: function () {


### PR DESCRIPTION
ECL Playground fails to load when it is hosted within a frame.  In IDE
this shows a popup window.  In regular IE it was a silent error.

Fixed an issue with result viewer inside a frame (not resizing on
initial load).

Fixed an issue parsing Key=Value params from URL (again related to fames
and inner).

Fixes gh-2357
Fixes gh-2366

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
