### PR TITLE
ECLJDBC Rename EclLimit to EclResultLimit and add range check

### DIFF
--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclConnection.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclConnection.java
@@ -23,7 +23,9 @@ import java.util.Properties;
  * @author rpastrana
  */
 
-public class EclConnection implements Connection {
+public class EclConnection implements Connection
+{
+	public static final String ECLRESULTLIMDEFAULT = "100";
     private boolean closed;
     private EclDatabaseMetaData metadata;
     private Properties props;
@@ -71,8 +73,36 @@ public class EclConnection implements Connection {
 		if (!this.props.containsKey("password"))
 			this.props.setProperty("password", "");
 
-		if (!this.props.containsKey("EclLimit"))
-			this.props.setProperty("EclLimit", "100");
+		boolean setdefaultreslim = false;
+		if (this.props.containsKey("EclResultLimit"))
+		{
+			String eclreslim = this.props.getProperty("EclResultLimit").trim();
+			try
+			{
+				if(Utils.isNumeric(eclreslim))
+				{
+					if (Integer.valueOf(eclreslim).intValue() <= 0)
+						setdefaultreslim = true;
+				}
+				else
+				{
+					if(!eclreslim.equalsIgnoreCase("ALL"))
+						setdefaultreslim = true;
+				}
+			}
+			catch (Exception e)
+			{
+				setdefaultreslim = true;
+			}
+		}
+		else
+			setdefaultreslim = true;
+
+		if (setdefaultreslim)
+		{
+			this.props.setProperty("EclResultLimit", ECLRESULTLIMDEFAULT);
+			System.out.println("Invalid Numeric EclResultLimit value detected, using default value: " + ECLRESULTLIMDEFAULT);
+		}
 
 		// basicAuth
 		String userPassword = this.props.getProperty("username") + ":"

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDriver.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclDriver.java
@@ -100,22 +100,17 @@ public class EclDriver implements Driver
 		try
 		{
 			Properties info = new Properties();
-			info.put("ServerAddress", "192.168.124.128"); //Mine
-			//info.put("ServerAddress", "10.239.20.80"); //clo
-			//info.put("ServerAddress", "10.239.219.10"); //fishbeck
-			//info.put("ServerAddress", "172.25.237.145"); //arjuna
+			info.put("ServerAddress", "192.168.124.128");
 
 			info.put("Cluster", "thor");
 			info.put("WsECLWatchPort", "8010");
-			info.put("EclLimit", "10");
+			info.put("EclResultLimit", "ALL");
 			info.put("WsECLPort", "8002");
 			info.put("WsECLDirectPort", "8008");
-			info.put("username", "_rpastrana");
-			info.put("password", "a");
+			info.put("username", "myhpccusername");
+			info.put("password", "myhpccpass");
 
-			//conn = (EclConnection) d.connect("url:jdbc:ecl;ServerAddress=192.168.124.128;Cluster=myroxie",info);
-			//conn = (EclConnection) d.connect("url:jdbc:ecl;ServerAddress=10.239.20.80;Cluster=thor;EclLimit=8",info);
-			//conn = (EclConnection) d.connect("url:jdbc:ecl;ServerAddress=10.239.219.10;Cluster=thor;EclLimit=8",info);
+			//conn = (EclConnection) d.connect("url:jdbc:ecl;ServerAddress=10.239.219.10;Cluster=thor;EclResultLimit=8",info);
 			conn = (EclConnection) d.connect("url:jdbc:ecl;",info);
 
 			PreparedStatement p = conn.prepareStatement(
@@ -136,7 +131,7 @@ public class EclDriver implements Driver
 			//"select count(city)  from tutorial::rp::tutorialperson where zip = '33445'"//where zip = '33445'"
 			//"select * from enron::final where tos = 'randy.young@enron.com' limit 1000"
 			//"select count(*), zip from tutorial::rp::tutorialperson where zip = '33445' "
-			"select * from tutorial::rp::tutorialperson where zip > '32605'"
+			"select zip from tutorial::rp::tutorialperson where zip < '32605' group by zip"
 			//"select MAX(firstname), lastname from tutorial::rp::tutorialperson  limit 1000"
 			//"select 1"
 			//"select zip, city from tutorial::rp::tutorialperson where city = 'ABBEVILLE' "

--- a/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclEngine.java
+++ b/plugins/dbconnectors/ecljdbc/src/main/java/com/hpccsystems/ecljdbc/EclEngine.java
@@ -530,18 +530,22 @@ public class EclEngine
 					if (!parameters.containsKey("GROUPBY"))
 					{
 						if (parameters.containsKey("COUNTFN"))
+						{
 							sb.append("scalarout := COUNT(idxds");
+							sb.append(", KEYED);\n");
+						}
 						if (parameters.containsKey("MAXFN"))
 						{
 							sb.append("scalarout := MAX(idxds, fileds.");
 							sb.append(parameters.get("FNCOLS"));
+							sb.append(", KEYED);\n");
 						}
 						if (parameters.containsKey("MINFN"))
 						{
 							sb.append("scalarout := MIN(idxds, fileds.");
 							sb.append(parameters.get("FNCOLS"));
+							sb.append(", KEYED);\n");
 						}
-						sb.append(", KEYED);\n");
 					}
 
 					if (parameters.containsKey("SCALAROUTNAME"))
@@ -648,8 +652,8 @@ public class EclEngine
 				sb.append(",");
 				if (parameters.containsKey("LIMIT"))
 					sb.append(parameters.get("LIMIT"));
-				else
-					sb.append( props.getProperty("EclLimit"));
+				else 
+					sb.append( props.getProperty("EclResultLimit"));;
 				sb.append("),NAMED(\'ECLJDBCSelectOutput\'));");
 			}
 


### PR DESCRIPTION
The name EclLimit can be misconstrued therefore the property
more accurately describes its function

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
