### PR TITLE
Remove code that is no longer required

### DIFF
--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -275,7 +275,6 @@ _ATOM recordAtom;
 _ATOM recursiveAtom;
 _ATOM referenceAtom;
 _ATOM refreshAtom;
-_ATOM relatedTableAtom;
 _ATOM _remote_Atom;
 _ATOM renameAtom;
 _ATOM repeatAtom;
@@ -656,7 +655,6 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKEATOM(recursive);
     MAKEATOM(reference);
     MAKEATOM(refresh);
-    MAKEATOM(relatedTable);
     MAKESYSATOM(remote);
     MAKEATOM(rename);
     MAKEATOM(repeat);

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -279,7 +279,6 @@ extern HQL_API _ATOM recordAtom;
 extern HQL_API _ATOM recursiveAtom;
 extern HQL_API _ATOM referenceAtom;
 extern HQL_API _ATOM refreshAtom;
-extern HQL_API _ATOM relatedTableAtom;
 extern HQL_API _ATOM _remote_Atom;
 extern HQL_API _ATOM renameAtom;
 extern HQL_API _ATOM repeatAtom;

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -7259,10 +7259,7 @@ IHqlExpression * NewScopeMigrateTransformer::createTransformed(IHqlExpression * 
                         if (!isInlineTrivialDataset(row) && !isContextDependent(row) && !transformed->isDataset())
                         {
                             if (isIndependentOfScope(row))
-                            {
-                                OwnedHqlExpr newSelect = createNewSelectExpr(LINK(row), LINK(transformed->queryChild(1)));
-                                return hoist(expr, newSelect);
-                            }
+                                return hoist(expr, transformed);
                         }
                     }
                 }

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -7242,18 +7242,6 @@ IHqlExpression * NewScopeMigrateTransformer::createTransformed(IHqlExpression * 
             IHqlExpression * newAttr = transformed->queryProperty(newAtom);
             if (newAttr)
             {
-                if (newAttr->hasProperty(globalAtom))
-                {
-                    OwnedHqlExpr noGlobalNew = removeProperty(newAttr, globalAtom);
-                    return replaceOwnedProperty(transformed, noGlobalNew.getClear());
-                }
-                if (newAttr->hasProperty(relatedTableAtom))
-                {
-                    //Remove relatedTableAtom, since only used by this transformer, should really be using activityDepth instead
-                    OwnedHqlExpr noRelatedNew = removeProperty(newAttr, relatedTableAtom);
-                    return replaceOwnedProperty(transformed, noRelatedNew.getClear());
-                }
-
                 if (isUsedUnconditionally(expr))
                 {
                     if (extra->maxActivityDepth != 0)
@@ -7283,17 +7271,6 @@ IHqlExpression * NewScopeMigrateTransformer::createTransformed(IHqlExpression * 
         break;
     case NO_AGGREGATE:
         {
-            if (expr->hasProperty(globalAtom))
-            {
-                //Remove globalAtom, since only used by this transformer, should really be using activityDepth instead
-                return removeProperty(transformed, globalAtom);
-            }
-            //ditto, relatedTableAtom only used for this transform
-            if (expr->hasProperty(relatedTableAtom))
-            {
-                return removeProperty(transformed, relatedTableAtom);
-            }
-
             if (isUsedUnconditionally(expr))
             {
                 if (extra->maxActivityDepth != 0)
@@ -8598,42 +8575,6 @@ HqlScopeTagger::HqlScopeTagger(IErrorReceiver * _errors)
 }
 
 
-void HqlScopeTagger::beginTableScope()
-{
-}
-
-void HqlScopeTagger::endTableScope(HqlExprArray & attrs, IHqlExpression * ds, IHqlExpression * newExpr)
-{
-#if 1
-    //A quick test which is often succeeds.
-    if (isDatasetRelatedToScope(ds))
-        attrs.append(*createAttribute(relatedTableAtom));
-    else
-    {
-        //if is actually the base table of the query that would be related, not the
-        IHqlDataset * d = ds->queryDataset();
-        if (d)
-        {
-            d = d->queryRootTable();
-            if (d)
-            {
-                IHqlExpression * root = queryExpression(d);
-                if (isDatasetRelatedToScope(root))
-                    attrs.append(*createAttribute(relatedTableAtom));
-            }
-        }
-    }
-#endif
-
-    //MORE: Remove this asap ...
-    //This is only used by NewScopeMigrateTransformer, and the logic should really be contained within that transformer.
-    //However, initial attempts to remove it (see activityDepth code) caused code generation problems.
-#ifndef REMOVE_GLOBAL_ANNOTATION
-    if (!insideActivity())
-        attrs.append(*createAttribute(globalAtom));
-#endif
-}
-
 bool HqlScopeTagger::isValidNormalizeSelector(IHqlExpression * expr)
 {
     loop
@@ -8766,7 +8707,6 @@ IHqlExpression * HqlScopeTagger::transformSelect(IHqlExpression * expr)
         }
     }
 
-    beginTableScope();
     pushScope();
     OwnedHqlExpr newDs = transformNewDataset(ds, false);
     popScope();
@@ -9036,17 +8976,6 @@ IHqlExpression * HqlScopeTagger::createTransformed(IHqlExpression * expr)
         break;
     case no_select:
         return transformSelect(expr);
-    case NO_AGGREGATE:
-    case no_createset:
-        {
-            beginTableScope();
-            OwnedHqlExpr transformed = Parent::createTransformed(expr);
-
-            HqlExprArray args;
-            unwindChildren(args, transformed);
-            endTableScope(args, expr->queryChild(0), transformed);
-            return transformed->clone(args);
-        }
     case no_call:
     case no_externalcall:
     case no_rowvalue:

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -644,7 +644,6 @@ protected:
     IHqlExpression * hoist(IHqlExpression * expr, IHqlExpression * hoisted);
     IHqlExpression * transformCond(IHqlExpression * expr);
 
-    inline unsigned extraIndex() { return activityDepth != 0 ? 0 : 1; }
     inline ScopeMigrateInfo * queryBodyExtra(IHqlExpression * expr)     { return static_cast<ScopeMigrateInfo *>(queryTransformExtra(expr->queryBody())); }
 
 private:

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -956,8 +956,6 @@ public:
     void reportWarnings();
 
 protected:
-    void beginTableScope();
-    void endTableScope(HqlExprArray & attrs, IHqlExpression * ds, IHqlExpression * newExpr);
     void checkActiveRow(IHqlExpression * expr);
     IHqlExpression * transformSelect(IHqlExpression * expr);
 


### PR DESCRIPTION
A long time ago these attributes were required on the expressions to
cope with implicit relationships between SQL-like tables.  That code
has now gone, so these attributes can also be removed.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
