### PR TITLE
Ensure hpcc-init setup has been called

### DIFF
--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -34,6 +34,7 @@ if [ $# -lt 9 ]; then
   exit 1
 fi
 
+sudo /etc/init.d/hpcc-init -c dafilesrv setup
 mkdir -p $instancedir
 mkdir -p `dirname $logredirect`
 exec >>$logredirect 2>&1


### PR DESCRIPTION
Hpcc runtime directories must exist, the component directories can be
created by the component, but Thor cannot create the parent directories,
e.g. /var/log/HPCCSystems

Slaves used to call hpcc-init -c <thorcomponent> setup in slave scripts, but
cannot anymore, see gh-1609 and gh-1412 for reasons.

Since Dafilesrv must exist on all nodes, perform a dafilesrv setup to
ensures these common directories exist.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
