### PR TITLE
gh-2384 Incorrect libarchive dependency in lucid/maverick

### DIFF
--- a/cmake_modules/dependencies/lucid.cmake
+++ b/cmake_modules/dependencies/lucid.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.40.0, libicu42, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.40.0, libicu42, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1")

--- a/cmake_modules/dependencies/natty.cmake
+++ b/cmake_modules/dependencies/natty.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.42.0, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.42.0, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1")


### PR DESCRIPTION
The (new) dependency on libarchive was not correct for Ubuntu 10.04
and 11.04 (where the package is called libarchive1).

Fixes gh-2384.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
