### PR TITLE
Significant speed up for complex SEQUENTIALS

### DIFF
--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -602,6 +602,14 @@ private:
 //Useful for processing 
 class HQL_API HoistingHqlTransformer : public NewHqlTransformer
 {
+    class IndependentTransformMap : public CInterface
+    {
+    public:
+        IHqlExpression * getTransformed(IHqlExpression * expr);
+        void setTransformed(IHqlExpression * expr, IHqlExpression * transformed);
+    protected:
+        HqlExprArray cache;
+    };
 public:
     enum { HTFnoteconditionalactions = 0x01, 
            HTFnoteconditionaldatasets= 0x02,
@@ -613,6 +621,7 @@ public:
 
     void appendToTarget(IHqlExpression & curOwned);
     void setFlags(unsigned _flags) { flags = _flags; }
+    void setParent(const HoistingHqlTransformer * parent);
     void transformRoot(const HqlExprArray & in, HqlExprArray & out);
     IHqlExpression * transformRoot(IHqlExpression * expr);
 
@@ -627,7 +636,8 @@ protected:
 
     virtual void analyseExpr(IHqlExpression * expr);
     virtual IHqlExpression * createTransformed(IHqlExpression * expr);
-    virtual IHqlExpression * transformIndependent(IHqlExpression * expr) = 0;
+    IHqlExpression * transformIndependent(IHqlExpression * expr);
+    virtual IHqlExpression * doTransformIndependent(IHqlExpression * expr) = 0;
 
     void transformArray(const HqlExprArray & in, HqlExprArray & out);
     IHqlExpression * transformEnsureResult(IHqlExpression * expr);
@@ -640,10 +650,10 @@ protected:
             ((flags & HTFnoteconditionaldatarows) && expr->isDatarow()));
     }
 
-
 private:
     HqlExprArray *      target;
     unsigned flags;
+    Owned<IndependentTransformMap> independentCache;
 
 protected:
     unsigned conditionDepth;

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -619,7 +619,7 @@ public:
         return transformed.getClear();
     }
 
-    virtual IHqlExpression * transformIndependent(IHqlExpression * expr) { return LINK(expr); }
+    virtual IHqlExpression * doTransformIndependent(IHqlExpression * expr) { return LINK(expr); }
 
     bool hasCandidate() const { return candidate; }
     ChildGraphBuilder * getBuilder() { return builder.getClear(); };

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -119,9 +119,10 @@ protected:
     virtual void setTransformed(IHqlExpression * expr, IHqlExpression * transformed);
     virtual void setTransformedSelector(IHqlExpression * expr, IHqlExpression * transformed);
 
-    virtual IHqlExpression * transformIndependent(IHqlExpression * expr)
+    virtual IHqlExpression * doTransformIndependent(IHqlExpression * expr)
     {
         ThorScalarTransformer nested(options);
+        nested.setParent(this);
         nested.analyse(expr, 0);
         if (nested.needToTransform())
             return nested.transformRoot(expr);
@@ -550,11 +551,12 @@ protected:
 
     virtual void doAnalyseExpr(IHqlExpression * expr);
 
-    virtual IHqlExpression * transformIndependent(IHqlExpression * expr)
+    virtual IHqlExpression * doTransformIndependent(IHqlExpression * expr)
     {
         if (containsUnknownIndependentContents || seenLocalGlobalScope)
         {
             ExplicitGlobalTransformer nested(wu, translator);
+            nested.setParent(this);
             nested.analyse(expr, 0);
             if (nested.needToTransform())
                 return nested.transformRoot(expr);
@@ -597,9 +599,10 @@ protected:
     virtual void doAnalyseExpr(IHqlExpression * expr);
     bool isComplex(IHqlExpression * expr, bool checkGlobal);
 
-    virtual IHqlExpression * transformIndependent(IHqlExpression * expr)
+    virtual IHqlExpression * doTransformIndependent(IHqlExpression * expr)
     {
         ScalarGlobalTransformer nested(translator);
+        nested.setParent(this);
         nested.analyse(expr, 0);
         return nested.transformRoot(expr);
     }
@@ -634,9 +637,10 @@ protected:
     virtual IHqlExpression * createTransformed(IHqlExpression * expr);
     virtual ANewTransformInfo * createTransformInfo(IHqlExpression * expr) { return CREATE_NEWTRANSFORMINFO(ScopeMigrateInfo, expr); }
 
-    virtual IHqlExpression * transformIndependent(IHqlExpression * expr)
+    virtual IHqlExpression * doTransformIndependent(IHqlExpression * expr)
     {
         NewScopeMigrateTransformer nested(wu, translator);
+        nested.setParent(this);
         nested.analyse(expr, 0);
         return nested.transformRoot(expr);
     }
@@ -1039,11 +1043,12 @@ public:
 protected:
     virtual IHqlExpression * createTransformed(IHqlExpression * expr);
 
-    virtual IHqlExpression * transformIndependent(IHqlExpression * expr)
+    virtual IHqlExpression * doTransformIndependent(IHqlExpression * expr)
     {
         if (!containsCompound(expr))
             return LINK(expr);
         NestedCompoundTransformer nested(translator);
+        nested.setParent(this);
         nested.analyse(expr, 0);                    // analyse called so set up whether expressions are unconditional etc.
         return nested.transformRoot(expr);
     }


### PR DESCRIPTION
If SEQUENTIAL statements were heavily nested they would be repeatedly
transformed - because nothing is commoned up between sequential
branches.  This change adds a cache so that they ae only transformed
once.  Had little effect on most queries, but a drastic (1/4 of time)
effect on a couple.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
