### PR TITLE
Fix problem with memory allocator with few allocations

### DIFF
--- a/ecl/regress/heap1.ecl
+++ b/ecl/regress/heap1.ecl
@@ -1,0 +1,38 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+import std.System.Debug;
+
+startTime := Debug.msTick() : independent;
+
+namesRecord :=
+            RECORD
+string         x;
+            END;
+
+namesRecord t(unsigned c) := TRANSFORM
+    len := [4,16,32,64][(c % 4) + 1];
+    SELF.x := 'x'[1..len];
+END;
+
+numIter := 1000000;
+ds := NOFOLD(DATASET(numIter, t(COUNTER)));
+
+output(COUNT(ds));
+
+output('Time taken = ' + (string)(Debug.msTick()-startTime));

--- a/ecl/regress/heap2.ecl
+++ b/ecl/regress/heap2.ecl
@@ -1,0 +1,38 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+import std.System.Debug;
+
+startTime := Debug.msTick() : independent;
+
+namesRecord :=
+            RECORD
+string         x;
+            END;
+
+namesRecord t(unsigned c) := TRANSFORM
+    len := [8,20,44,108][(c % 4) + 1];
+    SELF.x := 'x'[1..len];
+END;
+
+numIter := 10000000;
+ds := NOFOLD(DATASET(numIter, t(COUNTER)));
+filtered := ds(length(x) = 8);
+output(count(nofold(sort(filtered, x))));
+
+output('Time taken = ' + (string)(Debug.msTick()-startTime));

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -415,7 +415,7 @@ interface IRowManager : extends IInterface
     virtual void setMemoryLimit(memsize_t size, memsize_t spillSize = 0) = 0;
     virtual unsigned allocated() = 0;
     virtual unsigned numPagesAfterCleanup() = 0; // calls releaseEmptyPages() then returns
-    virtual void releaseEmptyPages() = 0; // ensures any empty pages are freed back to the heap
+    virtual bool releaseEmptyPages(bool forceFreeAll) = 0; // ensures any empty pages are freed back to the heap
     virtual unsigned getMemoryUsage() = 0;
     virtual bool attachDataBuff(DataBuffer *dataBuff) = 0 ;
     virtual void noteDataBuffReleased(DataBuffer *dataBuff) = 0 ;


### PR DESCRIPTION
If a fixed size heaplet oscillated between having 0 and 1 entries
allocated within it, a situation could arise where the page was
continually being allocated and freed.  This change ensures the
last page is only freed when memory is critical.

Each attempt to allocate a page also checks if there are any pages
that can be freed up in any heaplet.  If one of the other heaplets
had large numbers of entries it could take a long time to check if that
heaplet had any pages that could be freed.   This should be addressed
separately.  However, the two combined caused a spike in cpu usage for
certain graphs.

Fixes #2402

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
