### PR TITLE
Add ecldirect to eclwatch

### DIFF
--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -86,6 +86,10 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
             <xsl:with-param name="bindingNode" select="$bindingNode"/>
             <xsl:with-param name="authNode" select="$authNode"/>
         </xsl:apply-templates>
+        <xsl:apply-templates select="." mode="EclDirect">
+          <xsl:with-param name="bindingNode" select="$bindingNode"/>
+          <xsl:with-param name="authNode" select="$authNode"/>
+        </xsl:apply-templates>
         <xsl:apply-templates select="." mode="FileSpray_Serv">
             <xsl:with-param name="bindingNode" select="$bindingNode"/>
             <xsl:with-param name="authNode" select="$authNode"/>
@@ -328,7 +332,33 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
         </EspBinding>
     </xsl:template>
 
-    <!-- WS-FILESPRAY -->
+    <!-- EclDirect -->
+    <xsl:template match="EspService" mode="EclDirect">
+      <xsl:param name="authNode"/>
+      <xsl:param name="bindingNode"/>
+
+      <xsl:variable name="serviceType" select="'EclDirect'"/>
+      <xsl:variable name="bindType" select="'EclDirectSoapBinding'"/>
+      <xsl:variable name="servicePlugin">
+        <xsl:choose>
+          <xsl:when test="$isLinuxInstance">libEclDirect.so</xsl:when>
+          <xsl:otherwise>EclDirect.dll</xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <xsl:variable name="serviceName" select="concat('ecldirect', '_', @name, '_', $process)"/>
+      <xsl:variable name="bindName" select="concat('ecldirect', '_', $bindingNode/@name, '_', $process)"/>
+
+      <EspService name="{$serviceName}" type="{$serviceType}" plugin="{$servicePlugin}"/>
+      <EspBinding name="{$bindName}" service="{$serviceName}" protocol="{$bindingNode/@protocol}" type="{$bindType}" plugin="{$servicePlugin}" netAddress="0.0.0.0" port="{$bindingNode/@port}">
+        <xsl:call-template name="bindAuthentication">
+          <xsl:with-param name="bindingNode" select="$bindingNode"/>
+          <xsl:with-param name="authMethod" select="$authNode/@method"/>
+        </xsl:call-template>
+      </EspBinding>
+    </xsl:template>
+
+  <!-- WS-FILESPRAY -->
     <xsl:template match="EspService" mode="FileSpray_Serv">
         <xsl:param name="bindingNode"/>
         <xsl:param name="authNode"/>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -352,9 +352,9 @@
              processName="EspService"
              schema="esp_service_ecldirect.xsd">
     <Properties bindingType="EclDirectSoapBinding"
-                defaultPort="8010"
+                defaultPort="8008"
                 defaultResourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
-                defaultSecurePort="18010"
+                defaultSecurePort="18008"
                 plugin="ecldirect"
                 type="ecldirect">
      <Authenticate access="Read"
@@ -624,26 +624,6 @@
                          resource="WsEclAccess"
                          service="ws_ecl"/>
    </EspBinding>
-   <EspBinding defaultForPort="true"
-               defaultServiceVersion=""
-               name="ecldirect"
-               port="8010"
-               protocol="http"
-               resourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
-               service="ecldirect"
-               workunitsBasedn="ou=workunits,ou=ecl"
-               wsdlServiceAddress="">
-    <Authenticate access="Read"
-                  description="Root access to ECL Direct service"
-                  path="/"
-                  required="Read"
-                  resource="EclDirectAccess"/>
-    <AuthenticateFeature authenticate="Yes"
-                         description="Access to ECL Direct service"
-                         path="EclDirectAccess"
-                         resource="EclDirectAccess"
-                         service="ecldirect"/>
-   </EspBinding>
    <HTTPS acceptSelfSigned="true"
           CA_Certificates_Path="ca.pem"
           certificateFileName="certificate.cer"
@@ -883,28 +863,6 @@
                          path="WsEclAccess"
                          resource="WsEclAccess"
                          service="ws_ecl"/>
-   </Properties>
-  </EspService>
-  <EspService build="${projname}_${version}-${stagever}"
-              buildSet="ecldirect"
-              clusterName="hthor"
-              description="ESP service for running raw ECL queries"
-              name="ecldirect">
-   <Properties bindingType="EclDirectSoapBinding"
-               defaultPort="8010"
-               defaultResourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
-               defaultSecurePort="18010"
-               plugin="ecldirect"
-               type="ecldirect">
-    <Authenticate access="Read"
-                  description="Root access to ECL Direct service"
-                  path="/"
-                  required="Read"
-                  resource="EclDirectAccess"/>
-    <AuthenticateFeature description="Access to ECL Direct service"
-                         path="EclDirectAccess"
-                         resource="EclDirectAccess"
-                         service="ecldirect"/>
    </Properties>
   </EspService>
   <FTSlaveProcess build="${projname}_${version}-${stagever}"

--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -1,7 +1,7 @@
 
 [Algorithm]
 max_comps_per_node=4
-do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver
+do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver,ecldirect
 avoid_combo=dali-eclagent,dali-sasha
 comps_on_all_nodes=dafilesrv,ftslave
 topology_for_comps=thor,hthor,roxie


### PR DESCRIPTION
Add a default ecldirect to eclwatch to enable eclplayground and run ecl links on the same port as eclwatch.
Removed the standalone ecldirect esp service and esp service binding in the default environment and via wizard as it is no longer needed.

WIP #2219

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
