### PR TITLE
Remove configmgr multiSlave references

### DIFF
--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -1249,7 +1249,6 @@ void CConfigEnvHelper::UpdateThorAttributes(IPropertyTree* pParentNode)
         }
     }
 
-    setAttribute(pParentNode, XML_ATTR_MULTISLAVES, multiSlaves ? "true" : "false");
     setAttribute(pParentNode, "@localThor", localThor ? "true" : "false");
 }
 


### PR DESCRIPTION
Remove references to multiSlave attribute in ConfigMgr code. Xsl references have not been removed as comments mention backward compatibility.

Fixes gh-1742

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
