### PR TITLE
Fix a couple of issues with the previous change

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -32368,7 +32368,7 @@ protected:
             ASSERT(in.state == TestInput::STATEreset);
             ASSERT(!input2 || in2.state == TestInput::STATEreset);
             ctx->queryRowManager().reportLeaks();
-            ASSERT(ctx->queryRowManager().numPagesAfterCleanup() == 0);
+            ASSERT(ctx->queryRowManager().numPagesAfterCleanup(true) == 0);
         }
     }
 

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -414,7 +414,7 @@ interface IRowManager : extends IInterface
     virtual void *finalizeRow(void *final, size32_t originalSize, size32_t finalSize, unsigned activityId) = 0;
     virtual void setMemoryLimit(memsize_t size, memsize_t spillSize = 0) = 0;
     virtual unsigned allocated() = 0;
-    virtual unsigned numPagesAfterCleanup() = 0; // calls releaseEmptyPages() then returns
+    virtual unsigned numPagesAfterCleanup(bool forceFreeAll) = 0; // calls releaseEmptyPages() then returns
     virtual bool releaseEmptyPages(bool forceFreeAll) = 0; // ensures any empty pages are freed back to the heap
     virtual unsigned getMemoryUsage() = 0;
     virtual bool attachDataBuff(DataBuffer *dataBuff) = 0 ;


### PR DESCRIPTION
The last element in a huge heap was not being freed.  It should be,
since it is never reused anyway.

The regression tests were failing because of the new delay in releasing
the last page.

(Moved the flags field from the derived classes to base class)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
