### PR TITLE
Fix bug in number of rows if transform has skip

### DIFF
--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -2614,7 +2614,14 @@ IHqlExpression * calcRowInformation(IHqlExpression * expr)
             IHqlExpression * count = expr->queryChild(0);
             IValue * value = count->queryValue();
             if (value)
-                info.setN(value->getIntValue());
+            {
+                IHqlExpression * transform = expr->queryChild(1);
+                __int64 maxCount = value->getIntValue();
+                if (containsSkip(transform))
+                    info.setRange(0, maxCount);
+                else
+                    info.setN(maxCount);
+            }
             // leave it be, if it's a constant expression or a variable
             break;
         }

--- a/ecl/regress/dataset_transform.ecl
+++ b/ecl/regress/dataset_transform.ecl
@@ -54,3 +54,10 @@ output(ds5);
 output(true);
 dsd := DATASET(10, t1(COUNTER), DISTRIBUTED);
 output(dsd);
+
+r t3(unsigned value) := transform,skip(value % 2 = 1)
+    SELF.i := value * 10;
+end;
+
+ds6 := DATASET(10, t3(COUNTER));
+output(ds6);


### PR DESCRIPTION
DATASET(count, <transform-with-skip>) should have a row count range of
0..<count>, not just <count>

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
