### PR TITLE
gh-2429 Remove hardcoded ip reference for roxie.

### DIFF
--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.cpp
@@ -789,7 +789,6 @@ bool CWsRoxieQueryEx::onRoxieQueryProcessGraph(IEspContext &context, IEspRoxieQu
         SocketEndpoint ep;
         getClusterConfig(ROXIE_CLUSTER, cluster, ROXIE_FARMERPROCESS1, netAddress, port);
         ep.set(netAddress.str(), port);
-        ep.set("10.239.219.15", port); // jo remove
         Owned<IRoxieCommunicationClient> roxieClient = createRoxieCommunicationClient(ep, ROXIEMANAGER_TIMEOUT);
 
         Owned<IPropertyTree> xgmml = getXgmmlGraph(queryName, ep, graphName);


### PR DESCRIPTION
Was causing "Graph not Found" error when loading roxie graphs.

Signed-off-by: Jo Prichard jo.prichard@lexisnexis.com
