### PR TITLE
Potential aggregate merge issues if 0 recs on node

### DIFF
--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -60,7 +60,8 @@ protected:
             return firstRow;
 
         CThorExpandingRowArray partialResults(*this, this, true, false, true, numPartialResults);
-        partialResults.setRow(0, firstRow);
+        if (hadElement)
+            partialResults.setRow(0, firstRow);
         --numPartialResults;
 
         size32_t sz;

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -677,7 +677,7 @@ class CDiskAggregateSlave : public CDiskReadSlaveActivityRecord, public CThorDat
 {
     IHThorDiskAggregateArg *helper;
     Owned<IEngineRowAllocator> allocator;
-    bool eoi;
+    bool eoi, hadElement;
     CPartialResultAggregator aggregator;
 
 public:
@@ -721,7 +721,7 @@ public:
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
         CDiskReadSlaveActivityRecord::start();
-        eoi = false;
+        eoi = hadElement = false;
         dataLinkStart("DISKAGGREGATE", container.queryId());
     }
 
@@ -742,25 +742,30 @@ public:
         {
             partHandler->setPart(&partDescs.item(part), part);
             ++part;
-            loop {
+            loop
+            {
                 OwnedConstThorRow nextrow =  partHandler->nextRow();
                 if (!nextrow)
                     break;
-                if (segMonitorsMatch(nextrow)) {
+                if (segMonitorsMatch(nextrow))
+                {
+                    hadElement = true;
                     helper->processRow(row, nextrow); // can change row size TBD
                     sz = allocator->queryOutputMeta()->getRecordSize(row.getSelf()); // kludge
                 }
             }
         }
         eoi = true;
-        OwnedConstThorRow ret = row.finalizeRowClear(sz);
         if (container.queryLocalOrGrouped())
         {
             dataLinkIncrement();
-            return ret.getClear();
+            return row.finalizeRowClear(sz);
         }
         else
         {
+            OwnedConstThorRow ret;
+            if (hadElement)
+                ret.setown(row.finalizeRowClear(sz));
             aggregator.sendResult(ret.get());
             if (firstNode())
             {

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -736,7 +736,7 @@ public:
         if (eoi)
             return NULL;
         RtlDynamicRowBuilder row(allocator);
-        size32_t sz = helper->clearAggregate(row);
+        helper->clearAggregate(row);
         unsigned part = 0;
         while (!abortSoon && part<partDescs.ordinality())
         {
@@ -751,7 +751,6 @@ public:
                 {
                     hadElement = true;
                     helper->processRow(row, nextrow); // can change row size TBD
-                    sz = allocator->queryOutputMeta()->getRecordSize(row.getSelf()); // kludge
                 }
             }
         }
@@ -759,13 +758,17 @@ public:
         if (container.queryLocalOrGrouped())
         {
             dataLinkIncrement();
+            size32_t sz = allocator->queryOutputMeta()->getRecordSize(row.getSelf());
             return row.finalizeRowClear(sz);
         }
         else
         {
             OwnedConstThorRow ret;
             if (hadElement)
+            {
+                size32_t sz = allocator->queryOutputMeta()->getRecordSize(row.getSelf());
                 ret.setown(row.finalizeRowClear(sz));
+            }
             aggregator.sendResult(ret.get());
             if (firstNode())
             {

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -1285,7 +1285,7 @@ public:
         eoi = true;
 
         RtlDynamicRowBuilder row(allocator);
-        size32_t sz = helper->clearAggregate(row);
+        helper->clearAggregate(row);
         if (partDescs.ordinality())
         {
             partHelper.setPart(&partDescs.item(0), 0);
@@ -1295,21 +1295,24 @@ public:
                 if (!r) 
                     break;
                 hadElement = true;
-                helper->processRow(row, r);     // should return new size TBD
-                sz = allocator->queryOutputMeta()->getRecordSize(row.getSelf()); // kludge
+                helper->processRow(row, r);
                 callback.finishedRow();
             }
         }
         if (container.queryLocalOrGrouped())
         {
             dataLinkIncrement();
+            size32_t sz = allocator->queryOutputMeta()->getRecordSize(row.getSelf());
             return row.finalizeRowClear(sz);
         }
         else
         {
             OwnedConstThorRow ret;
             if (hadElement)
+            {
+                size32_t sz = allocator->queryOutputMeta()->getRecordSize(row.getSelf());
                 ret.setown(row.finalizeRowClear(sz));
+            }
             aggregator.sendResult(ret.get());
             if (firstNode())
             {


### PR DESCRIPTION
A node with no records was being treated as a default aggregate row, i.e.
result of clearAggregate()
This had consequences if the merging function was impacted by default
values.
The example where this was seen (in the ML library), was multiplying by a
field value in the aggregate row, the default value was 0.0, so the end
result was 0.0 if any node had 0 rows to aggregate.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
