### PR TITLE
Add WorkUnit XML option for breaking out Exceptions by severity

### DIFF
--- a/common/fileview2/fileview.hpp
+++ b/common/fileview2/fileview.hpp
@@ -231,7 +231,12 @@ extern "C" FILEVIEW_API unsigned getResultXml(IStringVal & ret, INewResultSet * 
 
 extern "C" FILEVIEW_API unsigned getResultCursorBin(MemoryBuffer & ret, IResultSetCursor * cursor, unsigned start=0, unsigned count=0);
 extern "C" FILEVIEW_API unsigned getResultBin(MemoryBuffer & ret, INewResultSet * cursor, unsigned start=0, unsigned count=0);
-extern "C" FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *user, const char *pw, const IConstWorkUnit *wu, IStringVal &str, bool inclschema, WUExceptionSeverity minSeverity=ExceptionSeverityInformation, bool noroot=false);
+
+#define WorkUnitXML_InclSchema      0x0001
+#define WorkUnitXML_NoRoot          0x0002
+#define WorkUnitXML_SeverityTags    0x0004
+
+extern "C" FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *user, const char *pw, const IConstWorkUnit *wu, IStringVal &str, unsigned flags=0, WUExceptionSeverity minSeverity=ExceptionSeverityInformation);
 
 extern FILEVIEW_API void startRemoteDataSourceServer(const char * queue, const char * cluster);
 extern FILEVIEW_API void stopRemoteDataSourceServer();

--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -72,7 +72,7 @@ public:
     void appendResults(IConstWorkUnit *wu, const char *username, const char *pw)
     {
         StringBufferAdaptor resultXML(buffer);
-        getFullWorkUnitResultsXML(username, pw, wu, resultXML, false, ExceptionSeverityError, true);
+        getFullWorkUnitResultsXML(username, pw, wu, resultXML, WorkUnitXML_NoRoot, ExceptionSeverityError);
     }
 
     void appendSingleResult(IConstWorkUnit *wu, const char *resultname, const char *username, const char *pw)
@@ -545,7 +545,7 @@ void WuWebView::expandResults(const char *xml, StringBuffer &out, unsigned flags
 void WuWebView::expandResults(StringBuffer &out, unsigned flags)
 {
     SCMStringBuffer xml;
-    getFullWorkUnitResultsXML(username.get(), pw.get(), cw, xml, false, ExceptionSeverityInformation);
+    getFullWorkUnitResultsXML(username.get(), pw.get(), cw, xml);
     expandResults(xml.str(), out, flags);
 }
 
@@ -569,7 +569,7 @@ void WuWebView::applyResultsXSLT(const char *filename, const char *xml, StringBu
 void WuWebView::applyResultsXSLT(const char *filename, StringBuffer &out)
 {
     SCMStringBuffer xml;
-    getFullWorkUnitResultsXML(username.get(), pw.get(), cw, xml, false, ExceptionSeverityInformation);
+    getFullWorkUnitResultsXML(username.get(), pw.get(), cw, xml);
     applyResultsXSLT(filename, xml.str(), out);
 }
 

--- a/esp/services/ecldirect/EclDirectService.cpp
+++ b/esp/services/ecldirect/EclDirectService.cpp
@@ -168,7 +168,7 @@ bool CEclDirectEx::onRunEcl(IEspContext &context, IEspRunEclRequest & req, IEspR
         Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
 
         SCMStringBuffer resultXML;
-        getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), resultXML, false);
+        getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), resultXML);
         resp.setResults(resultXML.str());
 
         cw.clear();

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1111,7 +1111,10 @@ bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWU
             case WUStateUnknown:
             {
                 SCMStringBuffer result;
-                getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), result, false, ExceptionSeverityInformation, req.getNoRootTag());
+                unsigned flags = WorkUnitXML_SeverityTags;
+                if (req.getNoRootTag())
+                    flags |= WorkUnitXML_NoRoot;
+                getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), result, flags);
                 resp.setResults(result.str());
                 break;
             }


### PR DESCRIPTION
Used initially to break out exceptions by severity when using "ecl run"
from command line.

Fixes gh-2221.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
