### PR TITLE
Results fail to display correctly.

### DIFF
--- a/esp/files/ECLPlayground.js
+++ b/esp/files/ECLPlayground.js
@@ -76,7 +76,8 @@ define([
 						dom.byId("loadingMessage").innerHTML = wu.state;
 						if (wu.isComplete() || ++monitorCount % 5 == 0) {
 							wu.getInfo({
-								onGetResults: displayResults
+								onGetResults: displayResults,
+								onGetAll: displayAll
 							});
 						}
 					});


### PR DESCRIPTION
When clicking "show" for a specific result, either none would display
or wrong one would be selected.

Fixed gh-2415

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
