### PR TITLE
ECLPlayground:  Warnings not displaying.

### DIFF
--- a/esp/files/ECLPlayground.js
+++ b/esp/files/ECLPlayground.js
@@ -76,7 +76,8 @@ define([
 						dom.byId("loadingMessage").innerHTML = wu.state;
 						if (wu.isComplete() || ++monitorCount % 5 == 0) {
 							wu.getInfo({
-								onGetResults: displayResults
+								onGetResults: displayResults,
+								onGetAll: displayAll
 							});
 						}
 					});
@@ -158,20 +159,16 @@ define([
 					wu.getInfo({
 						onGetExceptions: displayExceptions,
 						onGetResults: displayResults,
-						onGetGraphs: displayGraphs
+						onGetGraphs: displayGraphs,
+						onGetAll: displayAll
 					});
 				}
 			},
 
 			displayExceptions = function (exceptions) {
-				if (exceptions.length) {
-					editorControl.setErrors(wu.exceptions);
-					resultsControl.addExceptionTab(wu.exceptions);
-				}
 			},
 
 			displayResults = function (results) {
-				resultsControl.refreshResults(wu);
 			},
 
 			displayGraphs = function (graphs) {
@@ -180,6 +177,13 @@ define([
 						graphControl.loadXGMML(xgmml, true);
 					});
 				}
+			},
+
+			displayAll = function (workunit) {
+				if (wu.exceptions.length) {
+					editorControl.setErrors(wu.exceptions);
+				}
+				resultsControl.refresh(wu);
 			},
 
 			doSubmit = function (evt) {

--- a/esp/files/scripts/CMakeLists.txt
+++ b/esp/files/scripts/CMakeLists.txt
@@ -47,7 +47,7 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/ESPBase.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ESPWorkunit.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ESPResult.js
-    ${CMAKE_CURRENT_SOURCE_DIR}/WUResultStore.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/WsWorkunits.js
     ${CMAKE_CURRENT_SOURCE_DIR}/GraphControl.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ResultsControl.js
     ${CMAKE_CURRENT_SOURCE_DIR}/SampleSelectControl.js

--- a/esp/files/scripts/ESPResult.js
+++ b/esp/files/scripts/ESPResult.js
@@ -17,16 +17,16 @@
 define([
 	"dojo/_base/declare",
 	"dojo/data/ObjectStore",
-	"hpcc/WUResultStore",
+	"hpcc/WsWorkunits",
 	"hpcc/ESPBase"
-], function (declare, ObjectStore, WUResultStore, ESPBase) {
+], function (declare, ObjectStore, WsWorkunits, ESPBase) {
 	return declare(ESPBase, {
 		store: null,
 		Total: "-1",
 
 		constructor: function (args) {
 			declare.safeMixin(this, args);
-			this.store = new WUResultStore({
+			this.store = new WsWorkunits.WUResult({
 				wuid: this.wuid,
 				sequence: this.Sequence,
 				isComplete: this.isComplete()

--- a/esp/files/scripts/ResultsControl.js
+++ b/esp/files/scripts/ResultsControl.js
@@ -113,13 +113,18 @@ define([
 			return this.addTab(result.getName(), paneID);
 		},
 
-		refreshResults: function (wu) {
+		refresh: function (wu) {
 			if (this.workunit != wu) {
 				this.clear();
 				this.workunit = wu;
 			}
-			for (var i = 0; i < this.workunit.results.length; ++i) {
-				var result = this.workunit.results[i];
+			this.addExceptionTab(this.workunit.exceptions);
+			this.addResultsTab(this.workunit.results);
+		},
+
+		addResultsTab: function (results) {
+			for (var i = 0; i < results.length; ++i) {
+				var result = results[i];
 				if (result.Sequence in this.sequenceResultStoreMap) {
 					this.sequenceResultStoreMap[result.Sequence].isComplete = result.isComplete();
 				} else {
@@ -132,32 +137,34 @@ define([
 		},
 
 		addExceptionTab: function (exceptions) {
-			var resultNode = this.addTab("Error/Warning(s)");
-			store = new Memory({ data: exceptions });
-			dataStore = new ObjectStore({ objectStore: store });
+			if (exceptions.length) {
+				var resultNode = this.addTab("Error/Warning(s)");
+				store = new Memory({ data: exceptions });
+				dataStore = new ObjectStore({ objectStore: store });
 
-			grid = new DataGrid({
-				store: dataStore,
-				query: { id: "*" },
-				structure: [
-					{ name: "Severity", field: "Severity" },
-					{ name: "Line", field: "LineNo" },
-					{ name: "Column", field: "Column" },
-					{ name: "Code", field: "Code" },
-					{ name: "Message", field: "Message", width: "auto" }
-					]
-			});
-			grid.placeAt(resultNode.containerNode, "last");
-			grid.startup();
+				grid = new DataGrid({
+					store: dataStore,
+					query: { id: "*" },
+					structure: [
+						{ name: "Severity", field: "Severity" },
+						{ name: "Line", field: "LineNo" },
+						{ name: "Column", field: "Column" },
+						{ name: "Code", field: "Code" },
+						{ name: "Message", field: "Message", width: "auto" }
+						]
+				});
+				grid.placeAt(resultNode.containerNode, "last");
+				grid.startup();
 
-			var context = this;
-			grid.on("RowClick", function (evt) {
-				var idx = evt.rowIndex;
-				var item = this.getItem(idx);
-				var line = parseInt(this.store.getValue(item, "LineNo"), 10);
-				var col = parseInt(this.store.getValue(item, "Column"), 10);
-				context.onErrorClick(line, col);
-			}, true);
+				var context = this;
+				grid.on("RowClick", function (evt) {
+					var idx = evt.rowIndex;
+					var item = this.getItem(idx);
+					var line = parseInt(this.store.getValue(item, "LineNo"), 10);
+					var col = parseInt(this.store.getValue(item, "Column"), 10);
+					context.onErrorClick(line, col);
+				}, true);
+			}
 		}
 	});
 });


### PR DESCRIPTION
If a WU has warnings and results (no errors) the warning tab would not be displayed.
Moved renamed WUResultStore.js to WsWorkunits.js and added WUQuery call.

Fixes gh-2283
Fixes gh-2415

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
