### PR TITLE
move ECL Playground link setup from EclDirect to ws_workunits

### DIFF
--- a/esp/services/ecldirect/EclDirectService.hpp
+++ b/esp/services/ecldirect/EclDirectService.hpp
@@ -61,7 +61,6 @@ public:
     {
         IPropertyTree *folder = ensureNavFolder(data, "ECL", "Run Ecl code and review Ecl workunits", NULL, false, 2);
         ensureNavLink(*folder, "Run Ecl", "/EclDirect/RunEclEx/Form", "Submit ECL text for execution", NULL, NULL, 3);
-        ensureNavLink(*folder, "ECL Playground", "/esp/files/ECLPlayground.htm", "ECL Editor, Executor, Graph and Result Viewer", NULL, NULL, 4);
     }
 
     virtual int onGet(CHttpRequest* request, CHttpResponse* response);

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -125,6 +125,7 @@ public:
             IPropertyTree *folder = ensureNavFolder(data, "ECL", "Run Ecl code and review Ecl workunits", NULL, false, 2);
             ensureNavLink(*folder, "Search Workunits", "/WsWorkunits/WUQuery?form_", "Search Workunits", NULL, NULL, 1);
             ensureNavLink(*folder, "Browse Workunits", "/WsWorkunits/WUQuery", "Browse Workunits", NULL, NULL, 2);
+            ensureNavLink(*folder, "ECL Playground", "/esp/files/ECLPlayground.htm", "ECL Editor, Executor, Graph and Result Viewer", NULL, NULL, 4);
 
             IPropertyTree *folderQueryset = ensureNavFolder(data, "Query Sets", NULL, NULL, false, 3);
             ensureNavLink(*folderQueryset, "Browse", "/WsWorkunits/WUQuerySets", "Browse Published Queries");


### PR DESCRIPTION
Makes more sense because ws_workunits is a dependeny for ECL Playground,
and the link should not be present with standalone EclDirect.

Fixes gh-2422.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
