### PR TITLE
Fix configmr crash when invalid sourefile is in query string

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -206,7 +206,7 @@ private:
             {
               bool bDoNotify = true;
 
-              if ( (diffIter->getFlags() == IDDIunchanged) || (pConfigFileObserver != NULL && (strcmp( pConfigFileObserver->getConfigFilePath(), diffIter->query().queryFilename() ) != 0)) )
+              if ( diffIter->getFlags() == IDDIunchanged || diffIter->query().queryFilename() == NULL || pConfigFileObserver == NULL || pConfigFileObserver->getConfigFilePath() == NULL || (strcmp( pConfigFileObserver->getConfigFilePath(), diffIter->query().queryFilename() ) != 0) )
               {
                 bDoNotify = false;
               }
@@ -448,7 +448,12 @@ public:
     };
     virtual const char* getConfigFilePath()
     {
-       return m_pFile->queryFilename();
+      if (m_pFile == NULL)
+      {
+        return NULL;
+      } 
+       
+      return m_pFile->queryFilename();
     };
     virtual void updateConfigFromFile();
     virtual bool deploy(IEspContext &context, IEspDeployRequest &req, IEspDeployResponse &resp);


### PR DESCRIPTION
Passing in a cached or manually entererd query string containing
a invalid sourcefile may result in a crash of configmgr when generating
a new environment.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
