### PR TITLE
Fix gh2460 dropzones not selectable for file upload

### DIFF
--- a/esp/eclwatch/ws_XSLT/dropzonefile.xslt
+++ b/esp/eclwatch/ws_XSLT/dropzonefile.xslt
@@ -251,7 +251,7 @@
                                 <xsl:attribute name="title">
                                   <xsl:value-of select="Path"/>;<xsl:value-of select="Linux"/>
                                 </xsl:attribute>
-                                <xsl:if test="$netAddress0=NetAddress and $path0=Path">
+                                <xsl:if test="$netAddress0=NetAddress and ($path0=Path or $path0=concat(Path,'/') or $path0=concat(Path,'\\'))">
                                   <xsl:attribute name="selected">selected</xsl:attribute>
                                 </xsl:if>
                                 <xsl:value-of select="Computer"/>/<xsl:value-of select="Name"/>


### PR DESCRIPTION
On the Upload/Download files page, when multiple dropzones
are set and a user selects the second dropzone, EclWatch
would automatically reselect the default (first) dropzone.
Eclwatch selects the dropzone based on both network address
and dropzone path. When an extra path seperator is at the
end of the dropzone path, the selection fails. The code in
this fix takes care of the extra path seperator.
