### PR TITLE
Fix HTML returned for exceptions when xml response requested

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -2411,13 +2411,22 @@ bool CHttpResponse::handleExceptions(IXslProcessor *xslp, IMultiException *me, c
         text.append('\n');
         WARNLOG("Exception(s) in %s::%s - %s", serv, meth, text.str());
 
-        if (errorXslt)
+        bool returnXml = context->queryRequestParameters()->hasProp("rawxml_");
+        if (errorXslt || returnXml)
         {
             me->serialize(text.clear());
-            StringBuffer theOutput;
-            xslTransformHelper(xslp, text.str(), errorXslt, theOutput, context->queryXslParameters());
-            setContent(theOutput.str());
-            setContentType("text/html");
+            if (returnXml)
+            {
+                setContent(text.str());
+                setContentType("text/xml");
+            }
+            else
+            {
+                StringBuffer theOutput;
+                xslTransformHelper(xslp, text.str(), errorXslt, theOutput, context->queryXslParameters());
+                setContent(theOutput.str());
+                setContentType("text/html");
+            }
             send();
             return true;
         }


### PR DESCRIPTION
The parameter "rawxml_" is currently used to specify that the caller
wants an xml formatted response.

XML was returned for successful transactions but HTML was returned for exceptions. 
Will now return XML for exceptions as well.

Fixes gh-2469.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
