### PR TITLE
Fix stack fault if memory callback allocates memory

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -1638,7 +1638,7 @@ public:
         //If already processing this callback then don't call it again
         if (activeCallbacks.contains(callback))
         {
-            DBGLOG("RoxieMemMgr: IBufferedRowCallback[%p]::freeBufferdRows() allocated memory", callback);
+            DBGLOG("RoxieMemMgr: allocation in IBufferedRowCallback[%p]::freeBufferedRows() requested new page", callback);
             return false;
         }
 


### PR DESCRIPTION
If a registered IBufferedRowCallback allocated memory while attempting
to free memory in freeBufferedRows() it could recursively call the same
callback resulting in a stackfault.

This change ensure any active callbacks are not called to free memory
allowing another callback to free the necessary memory, or a heap
exception to be generated instead.

Fixes #2446

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
