### PR TITLE
Fix crash comparing varunicode constants

### DIFF
--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -1673,6 +1673,9 @@ extern DEFTYPE_API ITypeInfo *makeUnicodeType(unsigned len, _ATOM locale)
 
 extern DEFTYPE_API ITypeInfo *makeVarUnicodeType(unsigned len, _ATOM locale)
 {
+    if(!locale)
+        locale = emptyAtom;
+
     CUnicodeTypeKey key;
     key.length = len;
     key.locale.set(locale);

--- a/ecl/regress/bug104762.ecl
+++ b/ecl/regress/bug104762.ecl
@@ -1,0 +1,40 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+// ---- Start ECL code ----
+
+tempRec := record
+        unicode overflow   {maxlength(5000000)};
+end;
+tempVRec := record
+        varunicode overflow   {maxlength(5000000)};
+end;
+
+ds1 := dataset([{'This is some string'},
+                {''}], tempRec);
+ds2 := dataset([{'This is some string'},
+                {''}], tempVRec);
+
+
+output(ds1(overflow!=u''));     // fine
+output(ds1(overflow!=''));     // fine
+output(ds2(overflow!=u''));    // fine
+
+output(ds2(overflow!=''));  // EclServer Terminated Unexpectedly
+
+// ---- End ECL code ----

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -225,6 +225,7 @@ bool rtlGetNormalizedUnicodeLocaleName(unsigned len, char const * in, char * out
 
 RTLLocale * queryRTLLocale(char const * locale)
 {
+    if (!locale) locale = "";
     CriticalBlock b(localeCrit);
     RTLLocale * loc = localeMap->getValue(locale);
     if(!loc)


### PR DESCRIPTION
Add protection in the runtime function, and match the default collation
to the code in makeUnicodeType()

Fixes bugzilla issue 104762

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
