### PR TITLE
Add usage message to Roxie

### DIFF
--- a/initfiles/bin/init_roxie
+++ b/initfiles/bin/init_roxie
@@ -57,7 +57,7 @@ killed() {
 }
 
 trap "killed" SIGINT SIGTERM SIGKILL
-nohup roxie topology=RoxieTopology.xml logfile=$logfilename restarts=$restarts stdlog=0 2>>$logfilename.stderr 1>>$logfilename.stdout & 
+nohup roxie --topology=RoxieTopology.xml --logfile=$logfilename --restarts=$restarts --stdlog=0 2>>$logfilename.stderr 1>>$logfilename.stdout &
 echo $! > $PID_NAME 
 wait
 
@@ -66,7 +66,7 @@ while [ -e ${SENTINEL} ]; do
     export restarts=$(($restarts+1))
     echo Restarting $restarts >> $logfilename.stderr
     echo Restarting $restarts >> $logfilename.stdout
-    nohup roxie topology=RoxieTopology.xml logfile=$logfilename restarts=$restarts stdlog=0 2>>$logfilename.stderr 1>>$logfilename.stdout &
+    nohup roxie --topology=RoxieTopology.xml --logfile=$logfilename --restarts=$restarts --stdlog=0 2>>$logfilename.stderr 1>>$logfilename.stdout &
     echo $! > $PID_NAME
     wait
 done

--- a/roxie/roxie/roxie.cpp
+++ b/roxie/roxie/roxie.cpp
@@ -19,7 +19,40 @@
 #include "platform.h"
 #include "ccd.hpp"
 
+static void roxie_server_usage()
+{
+    printf("\nRoxie Server: Starts the Roxie service or executes a one-off query.\n");
+    printf("\troxie [options below]\n");
+
+    // Not documenting use of internal options: selftest, restarts, enableSysLog and host
+    printf("\nService:\n");
+    printf("\t--topology=[XML-file]\t: Reads Roxie topology (deafult RoxieTopology.xml)\n");
+    printf("\t--port=[integer]\t\t: Network port (default 9876)\n");
+    printf("\nOne-off query:\n");
+    printf("\t--loadWorkunit=[so|dll]\t: Load and execute shared library\n");
+    printf("\t-[xml|csv|raw]\t\t: Output format (default ascii)\n");
+    printf("\n");
+
+    // If changing these, please change ccdmain.cpp's roxie_common_usage() as well
+    printf("Generic:\n");
+    printf("\t--daliServers=[host1,...]\t: List of Dali servers to use\n");
+    printf("\t--tracelevel=[integer]\t: Amount of information to dump on logs\n");
+    printf("\t--stdlog=[boolean]\t: Standard log format (based on tracelevel)\n");
+    printf("\t--logfile=[format]\t: Outputs to logfile, rather than stdout\n");
+    printf("\t--help|-h\t: This message\n");
+    printf("\n");
+}
+
 int main(int argc, const char *argv[])
 {
+    for (unsigned i=0; i<argc; i++)
+    {
+        if (stricmp(argv[i], "--help")==0 ||
+            stricmp(argv[i], "-h")==0)
+        {
+            roxie_server_usage();
+            return EXIT_SUCCESS;
+        }
+    }
     return start_query(argc, argv);
 }


### PR DESCRIPTION
Adding help function to Roxie server and standalone binaries.

Examples:

Calling the server binary directly:

```
Roxie Server: Starts the Roxie service or executes a one-off query.

Service:
topology=[XML-file] : Reads Roxie topology (deafult RoxieTopology.xml)
port=[integer]      : Network port (default 9876)

One-off query:
loadWorkunit=[so|dll]   : Load and execute shared library
-[xml|csv|raw]      : Output format (default ascii)

Generic:
daliServers=[host1,...] : List of Dali servers to use
tracelevel=[integer]    : Amount of information to dump on logs
stdlog=[boolean]    : Standard log format (based on tracelevel)
logfile=[format]    : Outputs to logfile, rather than stdout

Testing:
selftest [test1 ...]    : Unit tests to run (default is all)
```

Or calling a compiled Roxie binary:

```
$ ./dynamic help
Usage: dynamic [options]

Options:
daliServers=[host1,...] : List of Dali servers to use
tracelevel=[integer]    : Amount of information to dump on logs
stdlog=[boolean]    : Standard log format (based on tracelevel)
logfile=[format]    : Outputs to logfile, rather than stdout
```

Also changed `-selftest` to `selftest` for consistency. This has no external visibility.
