### PR TITLE
Fix gh-2480 Can't access archived workunits

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -134,7 +134,7 @@ public:
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(ctx.querySecManager(), ctx.queryUser());
         cw.setown(factory->openWorkUnit(wuid_, false));
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.", wuid_);
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.", wuid_);
     }
 
     bool getResultViews(StringArray &resultViews, unsigned flags);


### PR DESCRIPTION
In (EclWatch) Search Workunits page, when a user trys to
open an ECL workunit using the workunit ID, WsWorkunits
will try to open the workunit as a non-archived workunit
using WsWuInfo classs. If the ID cannot be found, WsWuInfo
will throw an exception. WsWorkunits should catch the
exception and try to open the workunit as an archived
workunit. The problem fixed here is that WsWorkunits does not
catch the exception correctly.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
