### PR TITLE
Ensure the allocations from the roxie heap are aligned

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -3916,7 +3916,7 @@ protected:
         }
 
         //Check small allocations are also aligned
-        size32_t limitSize = FixedSizeHeaplet::dataAreaSize() / firstFractionalHeap;
+        size32_t limitSize = firstFractionalHeap;
         for (size_t nextSize = 1; nextSize < limitSize; nextSize++)
         {
             OwnedRoxieRow row = rowManager->allocate(nextSize, 0);

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -54,6 +54,11 @@
 #define ACTIVITY_FLAG_ISREGISTERED      0x00400000
 #define MAX_ACTIVITY_ID                 0x003fffff
 
+#define ALLOC_ALIGNMENT                 sizeof(void *)          // Minimum alignment of data allocated from the heap manager
+#define PACKED_ALIGNMENT                4                       // Minimum alignment of packed blocks
+
+#define MAX_FRAC_ALLOCATOR              20
+
 //================================================================================
 // Roxie heap
 


### PR DESCRIPTION
A range of the allocations returned from the roxie heap (between
1Mb/20 and 1Mb) were not always 8 byte aligned.  This caused a
misaligned memory access because gcc assumed a block of memory
was correctly aligned.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
