### PR TITLE
Fix gh-2476 get thor slave log on node getting wrong log

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1546,6 +1546,21 @@ void WsWuInfo::getWorkunitThorSlaveLog(const char *slaveip, MemoryBuffer& buf)
     SCMStringBuffer logname;
     cw->getDebugValue(File_ThorLog, logname);
 
+    StringBuffer slaveIPPortStr;
+    slaveIPPortStr.appendf("thorslave.%s", slaveip);
+    const char* port = strchr(slaveip, ':');
+    if (port)
+    {
+        slaveIPPortStr.replace(':', '_');
+    }
+    else
+    {
+        slaveIPPortStr.appendf("_*");
+    }
+
+    StringBuffer thorLogFile = pathTail(logname.str());
+    thorLogFile.replaceString("thormaster", slaveIPPortStr.str());
+
     StringBuffer logdir;
     splitDirTail(logname.str(),logdir);
 
@@ -1555,7 +1570,7 @@ void WsWuInfo::getWorkunitThorSlaveLog(const char *slaveip, MemoryBuffer& buf)
     rfn.setIp(ep);
 
     Owned<IFile> dir = createIFile(rfn);
-    Owned<IDirectoryIterator> diriter = dir->directoryFiles("*.log");
+    Owned<IDirectoryIterator> diriter = dir->directoryFiles(thorLogFile.str());
     if (!diriter->first())
       throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find Thor slave log file %s.", logdir.str());
 


### PR DESCRIPTION
The problem is because the file structure of thor log has
been changed. Under the log folder, there are multiple log
files (instead of one THORMASTER.log). This fix reads the
file name of thor master log from WU XML file and re-creates
the file name for slave log based on the file name of thor
master, as well as the IP and, if any, the port number of
the slave node.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
