### PR TITLE
#2494 Create placeholder class for development

### DIFF
--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCVersionTracker.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCVersionTracker.java
@@ -1,0 +1,11 @@
+package com.hpccsystems.jdbcdriver;
+
+public class HPCCVersionTracker
+{
+	static final String HPCCProject 	= "PLACEHOLDER";
+	static final int HPCCMajor 			= 0;
+	static final int HPCCMinor 			= 0;
+	static final int HPCCPoint 			= 0;
+	static final String HPCCPMaturity 	= "PLACEHOLDER";
+	static final int HPCCSequence 		= 0;
+}


### PR DESCRIPTION
The placeholder "HPCCVersionTracker.java" class is overwritten by CMAKE
process with appropriate HPCC Version values.
The placeholder class allows development of the project outside of CMAKE.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
