### PR TITLE
#2489 fix getprocs and getproccolumns

### DIFF
--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/ECLEngine.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/ECLEngine.java
@@ -228,7 +228,7 @@ public class ECLEngine
 									eclEnteties.put("SCALAROUTNAME", col.getColumnName());
 							}
 
-							col.setSQLType(java.sql.Types.NUMERIC);
+							col.setSqlType(java.sql.Types.NUMERIC);
 						}
 						else if (col.getColumnName().equalsIgnoreCase("MAX"))
 						{

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCColumnMetaData.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCColumnMetaData.java
@@ -87,16 +87,6 @@ public class HPCCColumnMetaData {
 		return constantValue;
 	}
 
-	public int getSQLType()
-	{
-		return sqlType;
-	}
-
-	public void setSQLType(int type)
-	{
-		this.sqlType = type;
-	}
-
 	public String getColumnName()
 	{
 		return columnName;
@@ -151,6 +141,11 @@ public class HPCCColumnMetaData {
 	// {
 	// return (String)this.restrictions.get(restriction);
 	// }
+
+	public void setSqlType(int type)
+	{
+		sqlType = type;
+	}
 
 	public int getSqlType()
 	{

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCDatabaseMetaData.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCDatabaseMetaData.java
@@ -895,7 +895,7 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 
 	@Override
 	public boolean supportsOuterJoins() throws SQLException {
-		return true;
+		return false;
 	}
 
 	@Override
@@ -1214,6 +1214,7 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 		if (!isQuerySetMetaDataCached())
 			setQuerySetMetaDataCached(fetchHPCCQueriesInfo());
 
+		boolean wildprocsearch = procedureNamePattern == null || procedureNamePattern.length()==0 || procedureNamePattern.contains("*") || procedureNamePattern.contains("%");
 		System.out.println("ECLDATABASEMETADATA GETPROCS catalog: " + catalog +", schemaPattern: " + schemaPattern + ", procedureNamePattern: " + procedureNamePattern);
 
 		metacols.add(new HPCCColumnMetaData("PROCEDURE_CAT", 1, java.sql.Types.VARCHAR));
@@ -1231,19 +1232,22 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 			HPCCQuery query = (HPCCQuery) queries.nextElement();
 			String queryname = query.getName();
 
-				//if(!wildproceduresearch && !procedureNamePattern.equalsIgnoreCase(queryname))
-				//	continue;
+			if(!wildprocsearch && !query.isQueryNameMatch(procedureNamePattern))
+				continue;
 
-				ArrayList rowValues = new ArrayList();
-				procedures.add(rowValues);
-				rowValues.add("");
-				rowValues.add(query.getQuerySet());
-				rowValues.add(query.getQuerySet()+"::"+queryname);
-				rowValues.add("");
-				rowValues.add("");
-				rowValues.add("");
-				rowValues.add("QuerySet: " + query.getQuerySet());
-				rowValues.add(procedureResultUnknown);
+			ArrayList rowValues = new ArrayList();
+			procedures.add(rowValues);
+			rowValues.add("");
+			rowValues.add(query.getQuerySet());
+			rowValues.add(query.getQuerySet()+"::"+queryname);
+			rowValues.add("");
+			rowValues.add("");
+			rowValues.add("");
+			rowValues.add("QuerySet: " + query.getQuerySet());
+			rowValues.add(procedureResultUnknown);
+
+			if(!wildprocsearch)
+				break;
 		}
 
 		return new HPCCResultSet(procedures, metacols, "Procedures");
@@ -1259,8 +1263,6 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 
 		if (!isQuerySetMetaDataCached())
 			setQuerySetMetaDataCached(fetchHPCCQueriesInfo());
-
-		System.out.println("ECLDATABASEMETADATA GETPROCS catalog: " + catalog +", schemaPattern: " + schemaPattern + ", procedureNamePattern: " + procedureNamePattern);
 
 		boolean wildprocsearch = procedureNamePattern == null || procedureNamePattern.length()==0 || procedureNamePattern.contains("*") || procedureNamePattern.contains("%");
 		boolean wildcolumnsearch = columnNamePattern == null || columnNamePattern.length()==0 || columnNamePattern.contains("*") || columnNamePattern.contains("%");
@@ -1285,31 +1287,29 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 		while(queries.hasMoreElements())
 		{
 			HPCCQuery query = (HPCCQuery)queries.nextElement();
-			String eclqueryname = query.getName();
-			if(!wildprocsearch && !procedureNamePattern.equalsIgnoreCase(eclqueryname))
+
+			if(!wildprocsearch && !query.isQueryNameMatch(procedureNamePattern))
 				continue;
 
-			String tablename = query.getDefaultTableName();
+			Iterator<HPCCColumnMetaData> queryfields = query.getAllFields().iterator();
 
-			Iterator<HPCCColumnMetaData> e = query.getAllFields().iterator();
-
-			while (e.hasNext())
+			while (queryfields.hasNext())
 			{
-				HPCCColumnMetaData col = (HPCCColumnMetaData)e.next();
+				HPCCColumnMetaData col = (HPCCColumnMetaData)queryfields.next();
 				String fieldname = col.getColumnName();
 				if(!wildcolumnsearch && !columnNamePattern.equalsIgnoreCase(fieldname))
 					continue;
 
-				coltype = getProcFieldType(eclqueryname,tablename, fieldname);
+				coltype = col.getSqlType();
 
-				System.out.println("Proc col Found: "  + eclqueryname+"#"+tablename+"."+fieldname + " of type: " + coltype + "("+convertSQLtype2JavaClassName(coltype)+")");
+				System.out.println("Proc col Found: "  + query.getName() + "." + fieldname + " of type: " + coltype + "("+convertSQLtype2JavaClassName(coltype)+")");
 
 				ArrayList rowValues = new ArrayList();
 				procedurecols.add(rowValues);
 
 				/* 1*/rowValues.add(catalog);
 				/* 2*/rowValues.add(schemaPattern);
-				/* 3*/rowValues.add(query.getName());
+				/* 3*/rowValues.add(query.getQuerySet()+"::"+query.getName());
 				/* 4*/rowValues.add(fieldname);
 				/* 5*/rowValues.add(col.getParamType());
 				/* 6*/rowValues.add(coltype);
@@ -1517,7 +1517,6 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 		while(files.hasMoreElements())
 		{
 			DFUFile file = (DFUFile)files.nextElement();
-			//String filename = file.getFileName();
 			String filename = file.getFullyQualifiedName();
 			if(!wildtablesearch && !tableNamePattern.equalsIgnoreCase(filename))
 				continue;

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCDriver.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCDriver.java
@@ -135,7 +135,7 @@ public class HPCCDriver implements Driver
 			//"select 1 as ONE"
 			//"call myroxie::fetchpeoplebyzipservice(33445)"
 			//"call fetchpeoplebyzipservice(33445)"
-			"call fetchpeoplebyzipservice()"
+			"call fetchpeoplebyzipservice(33445)"
 			//"select MIN(zip), city from tutorial::rp::tutorialperson where zip  > '33445'"
 
 			//"select tbl.* from progguide::exampledata::peopleaccts tbl"
@@ -285,8 +285,14 @@ public class HPCCDriver implements Driver
 			ResultSet procs = conn.getMetaData().getProcedures(null, null, null);
 
 			System.out.println("procs found: ");
-			while (procs.next()) {
+			while (procs.next())
+			{
 				System.out.println("   " + procs.getString("PROCEDURE_NAME"));
+				ResultSet proccols = conn.getMetaData().getProcedureColumns(null,null,procs.getString("PROCEDURE_NAME"),"%");
+				while (proccols.next())
+				{
+					System.out.println(proccols.getString("PROCEDURE_NAME")+"."+ proccols.getString("COLUMN_NAME"));
+				}
 			}
 
 			/*

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCQuery.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCQuery.java
@@ -261,4 +261,32 @@ public class HPCCQuery
 	{
 		QuerySet = qsname;
 	}
+
+	public boolean isQueryNameMatch(String fullname)
+	{
+		String querysplit [] = fullname.split("::");
+		String inname ="";
+		String inqs ="";
+		if(querysplit.length > 2)
+		{
+			for (int i = 1; i < querysplit.length; i++)
+				inname += "::" + querysplit[i];
+			inqs = querysplit[0];
+		}
+		else if (querysplit.length == 2)
+		{
+			inqs = querysplit[0];
+			inname = querysplit[1];
+		}
+		else if (querysplit.length == 1)
+			inname = querysplit[0];
+		else
+			return false;
+
+		if (!inname.equalsIgnoreCase(this.Name) ||
+			(inqs.length() > 0 && !inqs.equalsIgnoreCase(this.QuerySet)))
+			return false;
+
+		return true;
+	}
 }

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCResultSetMetadata.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCResultSetMetadata.java
@@ -105,7 +105,7 @@ public class HPCCResultSetMetadata implements ResultSetMetaData{
     public int getColumnType(int column) throws SQLException
     {
 		if (column >= 1 && column <= columnList.size())
-			return columnList.get(column - 1).getSQLType();
+			return columnList.get(column - 1).getSqlType();
 		else
 			throw new SQLException("Invalid Column Index = " + column);
     }
@@ -113,7 +113,7 @@ public class HPCCResultSetMetadata implements ResultSetMetaData{
     public String getColumnTypeName(int column) throws SQLException
     {
 		if (column >= 1 && column <= columnList.size())
-			return HPCCDatabaseMetaData.getFieldName(columnList.get(column - 1).getSQLType());
+			return HPCCDatabaseMetaData.getFieldName(columnList.get(column - 1).getSqlType());
 		else
 			throw new SQLException("Invalid Column Index = " + column);
     }
@@ -137,7 +137,7 @@ public class HPCCResultSetMetadata implements ResultSetMetaData{
     {
     	if (column >= 1 && column <= columnList.size())
     	{
-    		return HPCCDatabaseMetaData.convertSQLtype2JavaClassName(columnList.get(column - 1).getSQLType());
+			return HPCCDatabaseMetaData.convertSQLtype2JavaClassName(columnList.get(column - 1).getSqlType());
 		}
 		else
 		{

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLParser.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLParser.java
@@ -301,6 +301,8 @@ public class SQLParser
 						colmetadata = new HPCCColumnMetaData(funcname, sqlcolpos++, funccols);
 					else
 						throw new SQLException("Function " + funcname + " does not map to ECL as written");
+
+					colmetadata.setSqlType(func.getReturnType().getSqlType());
 				}
 				else if(col.contains("."))
 				{
@@ -760,7 +762,7 @@ public class SQLParser
 				{
 					column.setColumnName("ConstStr"+ column.getIndex());
 					column.setEclType("STRING");
-					column.setSQLType(java.sql.Types.VARCHAR);
+					column.setSqlType(java.sql.Types.VARCHAR);
 					column.setColumnType(HPCCColumnMetaData.COLUMN_TYPE_CONSTANT);
 					column.setConstantValue(fieldName);
 				}
@@ -768,7 +770,7 @@ public class SQLParser
 				{
 					column.setColumnName("ConstNum" + column.getIndex());
 					column.setEclType("INTEGER");
-					column.setSQLType(java.sql.Types.NUMERIC);
+					column.setSqlType(java.sql.Types.NUMERIC);
 					column.setColumnType(HPCCColumnMetaData.COLUMN_TYPE_CONSTANT);
 					column.setConstantValue(fieldName);
 				}


### PR DESCRIPTION
Remove superfluous set/getSQLType methods from columnmetadata.
Enable wildsearch in getprocs and getproccolumns
Enable queryset::publishedquery search
Assign Stored Proc return type based on definition.

Commit code reviewed by Whitehead. 

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
