### PR TITLE
Fix problem with inline dataset and packed records

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -3976,8 +3976,6 @@ endrecord
                             record->Link();     // link should be in startrecord, but can only link after closeExpr()
                             parser->popSelfScope();
                             OwnedHqlExpr newRecord = record->closeExpr();
-                            if (newRecord->hasProperty(packedAtom))
-                                newRecord.setown(getPackedRecord(newRecord));
                             $$.setExpr(newRecord.getClear());
                             parser->popLocale();
                             $$.setPosition($1);

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -11090,6 +11090,8 @@ IHqlExpression * HqlTreeNormalizer::createTransformedBody(IHqlExpression * expr)
     case no_record:
         {
             OwnedHqlExpr transformed = completeTransform(expr);
+            if (transformed->hasProperty(packedAtom))
+                transformed.setown(getPackedRecord(transformed));
 
             if (options.ensureRecordsHaveSymbols)
             {

--- a/ecl/regress/packed3.ecl
+++ b/ecl/regress/packed3.ecl
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+rec := RECORD,packed
+  STRING name;
+  unsigned1 flag;
+  real value;
+END;
+
+
+ds := DATASET([{'Gavin',1,100.0},{'James',2,98.6}], rec);
+
+output(ds);


### PR DESCRIPTION
The processing on ,PACKED on a record was being applied too soon
which meant that the records were reordered, but the values in
inline datsets were not reordered to match.

packed3.ecl illustrates  the problem.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
