### PR TITLE
Fix gh-2478 wrong order of machines in preflight page

### DIFF
--- a/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
+++ b/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
@@ -65,6 +65,7 @@
 
    <xsl:variable name="autoRefresh" select="$reqInfo/AutoRefresh"/>
    <xsl:variable name="numColumns" select="count(/GetTargetClusterInfoResponse/Columns/Item)"/>
+   <xsl:variable name="countTargetClusters" select="count(/GetTargetClusterInfoResponse/TargetClusterInfoList/TargetClusterInfo)"/>
 
     <xsl:template match="/GetTargetClusterInfoResponse">
       <html>
@@ -89,6 +90,7 @@
               </script>
 
               <script language="JavaScript1.2">
+                var countTCs=<xsl:value-of select="$countTargetClusters"/>;
                 <xsl:text disable-output-escaping="yes"><![CDATA[
                   var allowReloadPage = true;
                   var sortableTable = null;
@@ -97,6 +99,7 @@
 
                   function onLoad()
                   {
+                    document.getElementsByName('TargetClusters.itemcount')[0].value = countTCs;
                     initSelection('resultsTable');
                     initPreflightControls();
 
@@ -254,6 +257,7 @@
           <form id="listitems" action="/ws_machine/GetTargetClusterInfo" method="post">
             <input type="hidden" name="Path" value="{$reqInfo/Path}"/>
             <input type="hidden" name="Cluster" value="{$clusterName}"/>
+            <input type="hidden" name="TargetClusters.itemcount" value=""/>
                <xsl:choose>
                   <xsl:when test="Exceptions">
                      <h1><xsl:value-of select="Exceptions"/></h1>
@@ -328,7 +332,7 @@
     <table id="resultsTable" class="sort-table" width="100%">
       <tr class="grey">
         <td valign="top" width="20">
-          <input type="checkbox" name="TargetClusters_i{count(preceding::TargetClusterInfo)}" checked="1"
+          <input type="checkbox" name="TargetClusters.{count(preceding::TargetClusterInfo)}" checked="1"
                                 value="{$type}:{$name}" title="Select this target cluster" onclick="return clickTCCheckbox('{$type}', '{$name}', this);"></input>
         </td>
         <td align="left" width="20">

--- a/esp/eclwatch/ws_XSLT/machines.xslt
+++ b/esp/eclwatch/ws_XSLT/machines.xslt
@@ -113,6 +113,8 @@
                 function onLoad()
                 {                           
                     initSelection('resultsTable');
+                    document.getElementsByName('Addresses.itemcount')[0].value = totalItems;
+
                     <xsl:if test="$ShowPreflightInfo and not($SwapNode)">initPreflightControls();</xsl:if>
                     onRowCheck(false);
                     var table = document.getElementById('resultsTable');
@@ -194,6 +196,7 @@
                 </xsl:if>
                 <input type="hidden" name="Path" value="{/TpMachineQueryResponse/Path}"/>
                 <input type="hidden" name="Cluster" value="{$clusterName}"/>
+                <input type="hidden" name="Addresses.itemcount" value=""/>
                 <h3>
                     <xsl:choose>
                         <xsl:when test="$SwapNode">Select a spare node to swap</xsl:when>
@@ -310,12 +313,12 @@
                 <xsl:if test="$ShowPreflightInfo">
                     <xsl:choose>
                         <xsl:when test="not($SwapNode)">
-                            <input type="checkbox" name="Addresses_i{position()}" value="{Netaddress}|{ConfigNetaddress}:{Type}:{$clusterName}:{OS}:{translate(Directory, ':', '$')}:{ProcessNumber}" onclick="return clicked(this, event)">
+                            <input type="checkbox" name="Addresses.{position()-1}" value="{Netaddress}|{ConfigNetaddress}:{Type}:{$clusterName}:{OS}:{translate(Directory, ':', '$')}:{ProcessNumber}" onclick="return clicked(this, event)">
                                 <xsl:attribute name="checked">true</xsl:attribute>
                             </input>
                         </xsl:when>
                         <xsl:otherwise>
-                            <input type="checkbox" name="Addresses_i{position()}" value="{Netaddress}:{Type}:{$clusterName}:{OS}:{translate(Directory, ':', '$')}:{ProcessNumber}" onclick="return clicked(this, event)"/>
+                            <input type="checkbox" name="Addresses.{position()-1}" value="{Netaddress}:{Type}:{$clusterName}:{OS}:{translate(Directory, ':', '$')}:{ProcessNumber}" onclick="return clicked(this, event)"/>
                         </xsl:otherwise>
                     </xsl:choose>
                 </xsl:if>

--- a/esp/eclwatch/ws_XSLT/services.xslt
+++ b/esp/eclwatch/ws_XSLT/services.xslt
@@ -112,9 +112,9 @@
             function onLoad()
             {
                 initSelection('resultsTable');
+                document.getElementsByName('Addresses.itemcount')[0].value = totalItems;
                 initPreflightControls();
                 onRowCheck(true);
-                //alert(totalItems);
             }
             function toggleDetails(id)
             {
@@ -193,7 +193,8 @@
                 <th>Network Address</th>
                 <th>Directory</th>
             </tr>
-            
+
+            <input type="hidden" name="Addresses.itemcount" value=""/>
             <xsl:call-template name="showMachines">
                 <xsl:with-param name="caption" select="'DALI Servers'"/>
                 <xsl:with-param name="nodes" select="TpDalis/TpDali"/>
@@ -353,7 +354,7 @@
                     </xsl:if>
                     <td width="1%" valign="top">
                         <xsl:if test="$showCheckbox">
-                            <input type="checkbox" name="Addresses_i{count(preceding::TpMachine)}" 
+                            <input type="checkbox" name="Addresses.{count(preceding::TpMachine)}"
                                 value="{Netaddress}|{ConfigNetaddress}:{Type}:{$compName}:{OS}:{translate(Directory, ':', '$')}" onclick="return clicked(this, event)">
                                 <xsl:if test="$checked">
                                     <xsl:attribute name="checked">true</xsl:attribute>

--- a/esp/eclwatch/ws_XSLT/targetclusters.xslt
+++ b/esp/eclwatch/ws_XSLT/targetclusters.xslt
@@ -105,13 +105,14 @@
 
           function onLoad()
           {
+            document.getElementsByName('TargetClusters.itemcount')[0].value = countTCs;
             initSelection('resultsTable');
 
             if (countTCs > 0)
             {
               for (i=0; i<countTCs; i++)
               { 
-                var ch = document.getElementById('TargetClusters_i'+i);
+                var ch = document.getElementById('TargetClusters.'+i);
                 if (ch && ch.checked)
                 {
                   clusterChecked++;
@@ -229,11 +230,12 @@
             <body class="yui-skin-sam" onload="nof5();onLoad();">
                 <h3>Target Clusters:</h3>
                 <form id="listitems" action="/ws_machine/GetTargetClusterInfo" method="post">
-          <xsl:for-each select="TpTargetClusters/TpTargetCluster">
-                         <xsl:call-template name="show-cluster">
-                              <xsl:with-param name="type" select="Type"/>
-                <xsl:with-param name="name" select="Name"/>
-             </xsl:call-template>
+                    <input type="hidden" name="TargetClusters.itemcount" value=""/>
+                    <xsl:for-each select="TpTargetClusters/TpTargetCluster">
+                        <xsl:call-template name="show-cluster">
+                            <xsl:with-param name="type" select="Type"/>
+                            <xsl:with-param name="name" select="Name"/>
+                        </xsl:call-template>
                     </xsl:for-each>
           <xsl:call-template name="ShowPreflightControls">
             <xsl:with-param name="method" select="'GetMachineInfo'"/>
@@ -264,7 +266,7 @@
         <table id="resultsTable" class="sort-table" width="100%">
             <tr class="grey">
                 <td valign="top" width="20">
-          <input type="checkbox" id="TargetClusters_i{count(preceding::TpTargetCluster)}" name="TargetClusters_i{count(preceding::TpTargetCluster)}"
+          <input type="checkbox" id="TargetClusters.{count(preceding::TpTargetCluster)}" name="TargetClusters.{count(preceding::TpTargetCluster)}"
                                 value="{$type}:{$name}" title="Select this target cluster" onclick="return clickTCCheckbox('{$type}', '{$name}', this);"></input>
         </td>
         <td align="left" width="20">

--- a/esp/scm/ws_topology.ecm
+++ b/esp/scm/ws_topology.ecm
@@ -248,19 +248,19 @@ ESPStruct TpQueue
 ESPStruct TpServices
 {
     ESParray<ESPstruct TpDali>        TpDalis;
+    ESParray<ESPstruct TpDfuServer>   TpDfuServers;
+    ESParray<ESPstruct TpDkcSlave>    TpDkcSlaves;
+    ESParray<ESPstruct TpDropZone>    TpDropZones;
+    ESParray<ESPstruct TpEclAgent>    TpEclAgents;
     ESParray<ESPstruct TpEclServer>   TpEclServers;
     ESParray<ESPstruct TpEclServer>   TpEclCCServers;
-    ESParray<ESPstruct TpEclAgent>    TpEclAgents;
     [min_ver("1.16")] ESParray<ESPstruct TpEclScheduler>  TpEclSchedulers;
     ESParray<ESPstruct TpEspServer>   TpEspServers;
-    ESParray<ESPstruct TpDfuServer>   TpDfuServers;
-    ESParray<ESPstruct TpSashaServer> TpSashaServers;
-    ESParray<ESPstruct TpMySqlServer> TpMySqlServers;
-    ESParray<ESPstruct TpLdapServer>  TpLdapServers;
-    ESParray<ESPstruct TpDropZone>    TpDropZones;
     ESParray<ESPstruct TpFTSlave>     TpFTSlaves;
-    ESParray<ESPstruct TpDkcSlave>    TpDkcSlaves;
     ESParray<ESPstruct TpGenesisServer> TpGenesisServers;
+    ESParray<ESPstruct TpLdapServer>  TpLdapServers;
+    ESParray<ESPstruct TpMySqlServer> TpMySqlServers;
+    ESParray<ESPstruct TpSashaServer> TpSashaServers;
 };
 
 //  ===========================================================================

--- a/esp/services/ws_machine/machines.xslt
+++ b/esp/services/ws_machine/machines.xslt
@@ -213,6 +213,7 @@
              </xsl:if>
              <input type="hidden" name="Path" value="{$reqInfo/Path}"/>
              <input type="hidden" name="Cluster" value="{$clusterName}"/>
+             <input type="hidden" name="Addresses.itemcount" value="{count(Machines/MachineInfoEx)}"/>
                <xsl:choose>
                   <xsl:when test="Exceptions">
                      <h1><xsl:value-of select="Exceptions"/></h1>
@@ -383,10 +384,10 @@
             </xsl:if-->
            <xsl:choose>
             <xsl:when test="string(ComponentName)='AgentExec'">
-               <input type="checkbox" name="Addresses_i{position()}" value="{Address}|{ConfigAddress}:EclAgentProcess:eclagent:{OS}:{translate(ComponentPath, ':', '$')}" onclick="return clicked(this, event)" checked="true"/>
+               <input type="checkbox" name="Addresses.{position()-1}" value="{Address}|{ConfigAddress}:EclAgentProcess:eclagent:{OS}:{translate(ComponentPath, ':', '$')}" onclick="return clicked(this, event)" checked="true"/>
             </xsl:when>
             <xsl:otherwise>
-              <input type="checkbox" name="Addresses_i{position()}" value="{Address}|{ConfigAddress}:{ProcessType}:{ComponentName}:{OS}:{translate(ComponentPath, ':', '$')}:{ProcessNumber}" onclick="return clicked(this, event)" checked="true"/>
+              <input type="checkbox" name="Addresses.{position()-1}" value="{Address}|{ConfigAddress}:{ProcessType}:{ComponentName}:{OS}:{translate(ComponentPath, ':', '$')}:{ProcessNumber}" onclick="return clicked(this, event)" checked="true"/>
             </xsl:otherwise>
            </xsl:choose>
          </td>


### PR DESCRIPTION
The machines in the preflight page should display in a
correct order. On a default one-node system, looking at
the thor cluster preflight page, the position in the
list of the thor slave and master seems to swap every
time when the page is updated. Two problems have been
found: 1. the machine list inside the preflight request
does not asks for the list to be processed in an order;
2. the preflight code uses a map to store the machine
list and the map re-orders the machines. Those problems
have been fixed now.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
