### PR TITLE
gh-2476 - resolve some thor log issues

### DIFF
--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -69,8 +69,8 @@ ln -s -f `which $prog` $slaveproc
 
 echo "slave starting `date`"
 
-echo $instancedir/$slaveproc master=$master slave=.:$slaveport logDir=$logpth
-$instancedir/$slaveproc master=$master slave=.:$slaveport logDir=$logpth 2>/dev/null 1>/dev/null &
+echo $instancedir/$slaveproc master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth
+$instancedir/$slaveproc master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth 2>/dev/null 1>/dev/null &
 slavepid=$!
 echo $slavepid > $PID_NAME
 if [ "$slavepid" -eq "0" ]; then

--- a/thorlcr/activities/filter/thfilterslave.cpp
+++ b/thorlcr/activities/filter/thfilterslave.cpp
@@ -309,11 +309,11 @@ public:
 
         if (groupStream)
         {
-			loop
-			{
-				OwnedConstThorRow row = groupStream->nextRow();
-				if (!row)
-					break;
+            loop
+            {
+                OwnedConstThorRow row = groupStream->nextRow();
+                if (!row)
+                break;
                 if (stepCompare->docompare(row, seek, numFields) >= 0)
                 {
                     dataLinkIncrement();

--- a/thorlcr/activities/rollup/throllupslave.cpp
+++ b/thorlcr/activities/rollup/throllupslave.cpp
@@ -141,7 +141,7 @@ public:
         }
         return NULL;
     }
-	virtual void stop() { }
+    virtual void stop() { }
 };
 
 class CDedupRollupBaseActivity : public CSlaveActivity, implements IStopInput

--- a/thorlcr/master/thgraphmanager.hpp
+++ b/thorlcr/master/thgraphmanager.hpp
@@ -24,7 +24,7 @@ interface IException;
 CSDSServerStatus &queryServerStatus();
 CSDSServerStatus &openThorServerStatus();
 void closeThorServerStatus();
-void thorMain();
+void thorMain(ILogMsgHandler *logHandler);
 void abortThor(IException *e=NULL, bool abortCurrentJob=true);
 void setExitCode(int code);
 int queryExitCode();

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -486,13 +486,15 @@ int main( int argc, char *argv[]  )
     StringBuffer nodeGroup, logUrl;
     Owned<IPerfMonHook> perfmonhook;
 
-    try {
+    ILogMsgHandler *logHandler;
+    try
+    {
         {
             Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(globals, "thor");
             lf->setName("thormaster");//override default filename
             lf->setCreateAliasFile(false);
             lf->setMsgFields(MSGFIELD_timeDate | MSGFIELD_msgID | MSGFIELD_process | MSGFIELD_thread | MSGFIELD_code);
-            lf->beginLogging();
+            logHandler = lf->beginLogging();
             createUNCFilename(lf->queryLogFileSpec(), logUrl, false);
         }
         LOG(MCdebugProgress, thorJob, "Opened log file %s", logUrl.toCharArray());
@@ -738,7 +740,7 @@ int main( int argc, char *argv[]  )
             LOG(daliAuditLogCat, ",Progress,Thor,Startup,%s,%s,%s,%s",nodeGroup.str(),thorname,queueName.str(),logUrl.str());
             auditStartLogged = true;
 
-            thorMain();
+            thorMain(logHandler);
             LOG(daliAuditLogCat, ",Progress,Thor,Terminate,%s,%s,%s",thorname,nodeGroup.str(),queueName.str());
         }
         else

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -229,8 +229,14 @@ public:
                         }
                         else
                             soPath.append(remoteSoPath);
-                        PROGLOG("Using query: %s", soPath.str());
+
                         Owned<IPropertyTree> workUnitInfo = createPTree(msg);
+                        StringBuffer user;
+                        workUnitInfo->getProp("user", user);
+
+                        PROGLOG("Started wuid=%s, user=%s, graph=%s\n", wuid.get(), user.str(), graphName.get());
+
+                        PROGLOG("Using query: %s", soPath.str());
                         Owned<CJobSlave> job = new CJobSlave(watchdog, workUnitInfo, graphName, soPath.str(), mptag, slaveMsgTag);
                         jobs.replace(*LINK(job));
 
@@ -245,11 +251,15 @@ public:
                     {
                         StringAttr key;
                         msg.read(key);
-                        PROGLOG("QueryDone, removing %s from jobs", key.get());
                         CJobSlave *job = jobs.find(key.get());
+                        StringAttr wuid = job->queryWuid();
+                        StringAttr graphName = job->queryGraphName();
+
+                        PROGLOG("QueryDone, removing %s from jobs", key.get());
                         jobs.removeExact(job);
                         PROGLOG("QueryDone, removed %s from jobs", key.get());
 
+                        PROGLOG("Finished wuid=%s, graph=%s", wuid.get(), graphName.get());
                         msg.clear();
                         msg.append(false);
                         break;

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -573,7 +573,7 @@ void CThorExpandingRowArray::transferFrom(CThorExpandingRowArray &donor)
 
 void CThorExpandingRowArray::transferFrom(CThorSpillableRowArray &donor)
 {
-	transferFrom((CThorExpandingRowArray &)donor);
+    transferFrom((CThorExpandingRowArray &)donor);
 }
 
 void CThorExpandingRowArray::removeRows(rowidx_t start, rowidx_t n)


### PR DESCRIPTION
1) Ensure thor records current thor master log in workunit
2) Change format of thor slave logs to thorslave.<slavenum>.<date>.log
Which will make it easier for external services (e.g. eclwatch) to fetch correct log

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
