### PR TITLE
Protect against a crash with invalid ECL

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -9641,7 +9641,9 @@ protected:
                     }
 
                     HqlDummyLookupContext dummyctx(ctx.errors);
-                    return newModule->queryScope()->lookupSymbol(selectedName, makeLookupFlags(true, expr->hasProperty(ignoreBaseAtom), false), dummyctx);
+                    IHqlScope * newScope = newModule->queryScope();
+                    assertex(newScope);
+                    return newScope->lookupSymbol(selectedName, makeLookupFlags(true, expr->hasProperty(ignoreBaseAtom), false), dummyctx);
                 }
                 break;
             }


### PR DESCRIPTION
We had an example of a invalid query crashing ECLserver at this point.
I am yet to track down the cause, but this will allow an archive to be
created to enable it to be debugged properly.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
