### PR TITLE
Optimize (and fix) appending a row to a dataset

### DIFF
--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -2939,6 +2939,13 @@ void HqlCppTranslator::buildDatasetAssign(BuildCtx & ctx, IHqlCppDatasetBuilder 
 
         if (!done)
         {
+            BoundRow * match = static_cast<BoundRow *>(ctx.queryAssociation(expr, AssocRow, NULL));
+            if (match && target->buildLinkRow(subctx, match))
+                done = true;
+        }
+
+        if (!done)
+        {
             BoundRow * targetRow = target->buildCreateRow(subctx);
             Owned<IReferenceSelector> targetRef = buildActiveRow(subctx, targetRow->querySelector());
             buildRowAssign(subctx, targetRef, expr);

--- a/ecl/hqlcpp/hqlcset.ipp
+++ b/ecl/hqlcpp/hqlcset.ipp
@@ -31,7 +31,7 @@ public:
 
 protected:
     virtual void buildIterateClass(BuildCtx & ctx, StringBuffer & cursorName, BuildCtx * initctx) = 0;
-    IHqlExpression * createRow(BuildCtx & ctx, const char * prefix, StringBuffer & rowName);
+    IHqlExpression * createRow(BuildCtx & ctx, const char * prefix, StringBuffer & rowName, bool conditional);
 
 protected:
     HqlCppTranslator & translator;


### PR DESCRIPTION
Fixes a potential problem when selecting a row from a dataset.  The
row that was selected could be the default row - and if so the selected
row would not be link counted.  So clear the link counted flag if the
row could possibly return a non-link counted default.

Also optimize the code for the case where the row has already been
generated, otherwise the same code could be generated again.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
