### PR TITLE
Fix gh-2503 Truncated Archive when download

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1402,7 +1402,7 @@ bool WsWuInfo::getResultViews(StringArray &viewnames, unsigned flags)
     return false;
 }
 
-void appendIOStreamContent(MemoryBuffer &mb, IFileIOStream *ios)
+void appendIOStreamContent(MemoryBuffer &mb, IFileIOStream *ios, bool forDownload)
 {
     StringBuffer line;
     bool eof = false;
@@ -1424,7 +1424,7 @@ void appendIOStreamContent(MemoryBuffer &mb, IFileIOStream *ios)
         }
 
         mb.append(line.length(), line.str());
-        if (mb.length() > 640000)
+        if (!forDownload && (mb.length() > 640000))
             break;
     }
 }
@@ -1538,7 +1538,7 @@ void WsWuInfo::getWorkunitThorLog(MemoryBuffer& buf)
     }
 }
 
-void WsWuInfo::getWorkunitThorSlaveLog(const char *slaveip, MemoryBuffer& buf)
+void WsWuInfo::getWorkunitThorSlaveLog(const char *slaveip, MemoryBuffer& buf, bool forDownload)
 {
    if (isEmpty(slaveip))
       throw MakeStringException(ECLWATCH_INVALID_INPUT,"ThorSlave IP not specified.");
@@ -1569,7 +1569,7 @@ void WsWuInfo::getWorkunitThorSlaveLog(const char *slaveip, MemoryBuffer& buf)
         throw MakeStringException(ECLWATCH_CANNOT_READ_FILE,"Cannot read file %s.",logdir.str());
 
     OwnedIFileIOStream ios = createBufferedIOStream(rIO);
-    appendIOStreamContent(buf, ios.get());
+    appendIOStreamContent(buf, ios.get(), forDownload);
 }
 
 void WsWuInfo::getWorkunitResTxt(MemoryBuffer& buf)
@@ -1621,7 +1621,7 @@ void WsWuInfo::getWorkunitXml(const char* plainText, MemoryBuffer& buf)
     buf.append(xml.length(), xml.str());
 }
 
-void WsWuInfo::getWorkunitCpp(const char *cppname, const char* description, const char* ipAddress, MemoryBuffer& buf)
+void WsWuInfo::getWorkunitCpp(const char *cppname, const char* description, const char* ipAddress, MemoryBuffer& buf, bool forDownload)
 {
     if (isEmpty(description))
         throw MakeStringException(ECLWATCH_INVALID_INPUT, "File not specified.");
@@ -1644,7 +1644,7 @@ void WsWuInfo::getWorkunitCpp(const char *cppname, const char* description, cons
     OwnedIFileIOStream ios = createBufferedIOStream(rIO);
     if (!ios)
         throw MakeStringException(ECLWATCH_CANNOT_READ_FILE,"Cannot read %s.", description);
-    appendIOStreamContent(buf, ios.get());
+    appendIOStreamContent(buf, ios.get(), forDownload);
 }
 
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -166,12 +166,12 @@ public:
 
     void getWorkunitEclAgentLog(MemoryBuffer& buf);
     void getWorkunitThorLog(MemoryBuffer& buf);
-    void getWorkunitThorSlaveLog(const char *slaveip, MemoryBuffer& buf);
+    void getWorkunitThorSlaveLog(const char *slaveip, MemoryBuffer& buf, bool forDownload);
     void getWorkunitResTxt(MemoryBuffer& buf);
     void getWorkunitArchiveQuery(MemoryBuffer& buf);
     void getWorkunitDll(StringBuffer &name, MemoryBuffer& buf);
     void getWorkunitXml(const char* plainText, MemoryBuffer& buf);
-    void getWorkunitCpp(const char* cppname, const char* description, const char* ipAddress, MemoryBuffer& buf);
+    void getWorkunitCpp(const char* cppname, const char* description, const char* ipAddress, MemoryBuffer& buf, bool forDownload);
     void getEventScheduleFlag(IEspECLWorkunit &info);
 
 public:

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2405,7 +2405,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
             }
             else if (strieq(File_Cpp,req.getType()) && notEmpty(req.getName()))
             {
-                winfo.getWorkunitCpp(req.getName(), req.getDescription(), req.getIPAddress(),mb);
+                winfo.getWorkunitCpp(req.getName(), req.getDescription(), req.getIPAddress(),mb, opt > 0);
                 openSaveFile(context, opt, req.getName(), HTTP_TYPE_TEXT_PLAIN, mb, resp);
             }
             else if (strieq(File_DLL,req.getType()))
@@ -2427,7 +2427,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
             }
             else if (strieq(File_ThorSlaveLog,req.getType()))
             {
-                winfo.getWorkunitThorSlaveLog(req.getSlaveIP(), mb);
+                winfo.getWorkunitThorSlaveLog(req.getSlaveIP(), mb, opt > 0);
                 openSaveFile(context, opt, "ThorSlave.log", HTTP_TYPE_TEXT_PLAIN, mb, resp);
             }
             else if (strieq(File_EclAgentLog,req.getType()))


### PR DESCRIPTION
When a large workunit archive is downloaded through
WsWorkunits, it is truncated to 640k. This fix removes
the 640k limit for the file download.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
