### PR TITLE
ESP not logging failed permissions

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -568,7 +568,7 @@ bool EspHttpBinding::basicAuth(IEspContext* ctx)
             if(access < required)
             {
                 const char *desc=curres->getDescription();
-                ESPLOG(LogMax, "Access denied to: %s. Access=%d, Required=%d\n", desc?desc:"<no-desc>", access, required);
+                ESPLOG(LogMin, "Access for user '%s' denied to: %s. Access=%d, Required=%d", user->getName(), desc?desc:"<no-desc>", access, required);
                 ctx->AuditMessage(AUDIT_TYPE_ACCESS_FAILURE, "Authorization", "Access Denied: Not Authorized", "Resource: %s [%s]", curres->getName(), (desc) ? desc : "");
                 authorized = false;
                 break;

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1180,7 +1180,7 @@ public:
                     rc = LdapUtils::LdapBind(user_ld, m_ldapconfig->getDomain(), username, password, userdnbuf.str(), m_ldapconfig->getServerType(), m_ldapconfig->getAuthMethod());
                     ldap_unbind(user_ld);
                 }
-                DBGLOG("finished LdapBind for user %s", username);
+                DBGLOG("finished LdapBind for user %s, rc=%d", username, rc);
                 if(!LdapServerDown(rc) || retries > LDAPSEC_MAX_RETRIES)
                     break;
                 sleep(LDAPSEC_RETRY_WAIT);


### PR DESCRIPTION
With the default ESP loglevel settings, a user who provides valid
credentials but is not allowed access to a resource gets nothing logged
about this state. Admins are falsely led to believe the given password
was invalid.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
