### PR TITLE
Make Dali filesBasedn required

### DIFF
--- a/initfiles/componentfiles/configxml/dali.xsd
+++ b/initfiles/componentfiles/configxml/dali.xsd
@@ -328,7 +328,7 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>
-    <xs:attribute name="filesBasedn" type="xs:string" use="optional" default="ou=Files,ou=ecl">
+    <xs:attribute name="filesBasedn" type="xs:string" use="required" default="ou=Files,ou=ecl">
       <xs:annotation>
         <xs:appinfo>
           <tooltip>base location for ldap file scopes</tooltip>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -384,6 +384,7 @@
   <DaliServerProcess build="${projname}_${version}-${stagever}"
                      buildSet="dali"
                      environment="${CONFIG_DIR}/${ENV_XML_FILE}"
+                     filesBasedn="ou=Files,ou=ecl"
                      name="mydali"
                      recoverFromIncErrors="true">
    <Instance computer="localhost"


### PR DESCRIPTION
Make the Dali filesBasedn attribute required so that it gets written into
the environment when generated via wizard. Made similar change in the
default environment.xml

Signed-off-by: Sridhar Meda sridhar.meda@lexisnexis.com
