### PR TITLE
Ensure reuse of a file inherits all nescessary flags

### DIFF
--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -981,6 +981,13 @@ void ResourceGraphInfo::removeResources(const CResources & value)
 
 //---------------------------------------------------------------------------
 
+static void appendCloneProperty(HqlExprArray & args, IHqlExpression * expr, _ATOM name)
+{
+    IHqlExpression * prop = expr->queryProperty(name);
+    if (prop)
+        args.append(*LINK(prop));
+}
+
 ResourcerInfo::ResourcerInfo(IHqlExpression * _original, CResourceOptions * _options) 
 { 
     original.set(_original); 
@@ -1026,8 +1033,9 @@ void ResourcerInfo::addSpillFlags(HqlExprArray & args, bool isRead)
     if (outputToUseForSpill)
     {
         assertex(isRead);
-        if (outputToUseForSpill->hasProperty(__compressed__Atom))
-            args.append(*createAttribute(__compressed__Atom));
+        appendCloneProperty(args, outputToUseForSpill, __compressed__Atom);
+        appendCloneProperty(args, outputToUseForSpill, jobTempAtom);
+        appendCloneProperty(args, outputToUseForSpill, _spill_Atom);
     }
     else
     {


### PR DESCRIPTION
If the resourcing code reuses an existing output it need to inherit
the job temp flag in addition to whether the file is compressed.

Fixes #2516.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
