### PR TITLE
Minor refactor of child query spotting code

### DIFF
--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -4227,7 +4227,15 @@ IHqlExpression * HqlCppTranslator::buildGetLocalResult(BuildCtx & ctx, IHqlExpre
     if (expr->hasProperty(externalAtom))
     {
         IHqlExpression * resultInstance = queryPropertyChild(expr, externalAtom, 0);
-        assertex(ctx.queryMatchExpr(resultInstance));
+        if (!ctx.queryMatchExpr(resultInstance))
+        {
+            //Very unusual - a result is required from a child query, but that child query is actually in the
+            //the parent/grandparent.
+            CHqlBoundExpr match;
+            if (!buildExprInCorrectContext(ctx, expr, match, false))
+                throwUnexpected();
+            return match.getTranslatedExpr();
+        }
 
         HqlExprArray args;
         args.append(*LINK(resultInstance));

--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -4229,8 +4229,8 @@ IHqlExpression * HqlCppTranslator::buildGetLocalResult(BuildCtx & ctx, IHqlExpre
         IHqlExpression * resultInstance = queryPropertyChild(expr, externalAtom, 0);
         if (!ctx.queryMatchExpr(resultInstance))
         {
-            //Very unusual - a result is required from a child query, but that child query is actually in the
-            //the parent/grandparent.
+            //Very unusual - a result is required from a child query, but that child query is actually in
+            //the parent/grandparent.  We need to evaluate in the parent instead.
             CHqlBoundExpr match;
             if (!buildExprInCorrectContext(ctx, expr, match, false))
                 throwUnexpected();


### PR DESCRIPTION
- Remove a special case on no_createset
- Fix obscure problem where a child query of a parent is used from a
  different child query

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
