### PR TITLE
Fix gh-2490 Add config to exclude ldapServer

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -4270,7 +4270,7 @@ bool CWsDeployFileInfo::handleInstance(IEspContext &context, IEspHandleInstanceR
         }
       }
 
-      if (!checkForRequiredComponents(pEnvRoot, pComputerNode->queryProp(XML_ATTR_NETADDRESS), reqdCompNames))
+      if (!checkForRequiredComponents(pEnvRoot, pComputerNode->queryProp(XML_ATTR_NETADDRESS), reqdCompNames, buildSet))
         reqdComps.appendf("\n%s", pComputerNode->queryProp(XML_ATTR_NETADDRESS));
     }
 
@@ -4344,7 +4344,7 @@ bool CWsDeployFileInfo::addReqdComps(IEspContext &context, IEspAddReqdCompsReque
   {
     IPropertyTree& pComputer = iterComp->query();
 
-    if (!checkForRequiredComponents(pEnvRoot, pComputer.queryProp(XML_ATTR_NETADDRESS), reqCompNames, true))
+    if (!checkForRequiredComponents(pEnvRoot, pComputer.queryProp(XML_ATTR_NETADDRESS), reqCompNames, "",true))
       failed.appendf("\n%s", pComputer.queryProp(XML_ATTR_NETADDRESS));
   }
 
@@ -6872,12 +6872,13 @@ CWsDeployExCE* createWsDeployCE(IPropertyTree *cfg, const char* name)
 }
 
 bool CWsDeployFileInfo::checkForRequiredComponents(IPropertyTree* pEnvRoot, const char* ip,
-                                                   StringBuffer& reqdCompNames, bool autoadd/*=false*/)
+                                                   StringBuffer& reqdCompNames, const StringBuffer& buildSet, bool autoadd/*=false*/)
 {
-  StringBuffer prop, xpath, genEnvConf;
+  StringBuffer prop, prop2, xpath, genEnvConf;
   Owned<IProperties> algProps;
-  StringArray compOnAllNodes;
+  StringArray compOnAllNodes,compExcludeOnAllNodes;
   bool retVal = true;
+  bool bExclude = false;
 
   xpath.clear().appendf("Software/EspProcess/EspService[@name='%s']/LocalConfFile", m_pService->getName());
   const char* pConfFile = m_pService->getCfg()->queryProp(xpath.str());
@@ -6910,7 +6911,20 @@ bool CWsDeployFileInfo::checkForRequiredComponents(IPropertyTree* pEnvRoot, cons
         throw MakeStringException( -1 , "The algorithm file %s does not exists", genEnvConf.str());
 
       algProps->getProp("comps_on_all_nodes", prop);
+      algProps->getProp("exclude_from_comps_on_all_nodes", prop2);
+
       DelimToStringArray(prop.str(), compOnAllNodes, ",");
+      DelimToStringArray(prop2.str(), compExcludeOnAllNodes, ",");
+
+      for (unsigned i = 0; buildSet.length() != 0 && i < compExcludeOnAllNodes.ordinality(); i++)
+      {
+        if (strcmp(compExcludeOnAllNodes.item(i),buildSet.toCharArray()) == 0)
+        {
+          bExclude = true;
+          break;
+        }
+      }
+
       const char* flag = pParams->queryProp("autoaddallnodescomp");
 
       if (!autoadd)
@@ -6918,7 +6932,7 @@ bool CWsDeployFileInfo::checkForRequiredComponents(IPropertyTree* pEnvRoot, cons
     }
   }
 
-  for(unsigned i = 0; i < compOnAllNodes.ordinality(); i++)
+  for(unsigned i = 0; bExclude == false && i < compOnAllNodes.ordinality(); i++)
   {
     xpath.clear().appendf("./Programs/Build/BuildSet[@name=\"%s\"]", compOnAllNodes.item(i));
     Owned<IPropertyTreeIterator> buildSetIter = pEnvRoot->getElements(xpath.str());

--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -532,7 +532,7 @@ private:
     void saveEnvironment(IEspContext* pContext, IConstWsDeployReqInfo *reqInfo, StringBuffer& errMsg, bool saveAs = false);
     void unlockEnvironment(IEspContext* pContext, IConstWsDeployReqInfo *reqInfo, const char* xmlarg, StringBuffer& sbMsg, bool saveEnv = false);
     void setEnvironment(IEspContext &context, IConstWsDeployReqInfo *reqInfo, const char* newEnv, const char* fnName, StringBuffer& sbBackup, bool validate = true, bool updateDali = true);
-    bool checkForRequiredComponents(IPropertyTree* pEnvRoot, const char* ip, StringBuffer& reqdCompNames, bool autoAdd=false);
+    bool checkForRequiredComponents(IPropertyTree* pEnvRoot, const char* ip, StringBuffer& reqdCompNames, const StringBuffer& buildSet, bool autoAdd=false);
   
     Owned<CSdsSubscription>   m_pSubscription;
     Owned<IConstEnvironment>  m_constEnvRdOnly;

--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -4,6 +4,7 @@ max_comps_per_node=4
 do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver,ecldirect
 avoid_combo=dali-eclagent,dali-sasha
 comps_on_all_nodes=dafilesrv,ftslave
+exclude_from_comps_on_all_nodes=ldapServer
 topology_for_comps=thor,hthor,roxie
 do_not_gen_optional=dali,thor
 roxie_agent_redundancy=1,2,1


### PR DESCRIPTION
from comps_on_all_nodes configuration setting in genenvrules.conf.

Add exclude_from_comps_on_all_nodes configuration option.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
