### PR TITLE
Fix gh-2533 - n-way merge fail

### DIFF
--- a/testing/ecl/key/mergenway.xml
+++ b/testing/ecl/key/mergenway.xml
@@ -1,0 +1,10 @@
+<Dataset name='Result 1'>
+ <Row><kind>1</kind><word>boy                 </word><doc>281474976710658</doc><segment>0</segment><wpos>29</wpos><wip>1</wip><flags>1</flags><original>boy                 </original><dpos>144</dpos></Row>
+ <Row><kind>1</kind><word>boy                 </word><doc>281474976710661</doc><segment>0</segment><wpos>32</wpos><wip>1</wip><flags>1</flags><original>boy                 </original><dpos>145</dpos></Row>
+ <Row><kind>1</kind><word>sheep               </word><doc>281474976710659</doc><segment>0</segment><wpos>8</wpos><wip>1</wip><flags>1</flags><original>sheep               </original><dpos>42</dpos></Row>
+ <Row><kind>1</kind><word>sheep               </word><doc>281474976710661</doc><segment>0</segment><wpos>5</wpos><wip>1</wip><flags>1</flags><original>sheep               </original><dpos>17</dpos></Row>
+ <Row><kind>1</kind><word>sheep               </word><doc>562949953421313</doc><segment>0</segment><wpos>6</wpos><wip>1</wip><flags>1</flags><original>sheep               </original><dpos>17</dpos></Row>
+ <Row><kind>1</kind><word>sheep               </word><doc>844424930131969</doc><segment>0</segment><wpos>2</wpos><wip>1</wip><flags>3</flags><original>Sheep               </original><dpos>1</dpos></Row>
+ <Row><kind>1</kind><word>sheep               </word><doc>844424930131971</doc><segment>0</segment><wpos>3</wpos><wip>1</wip><flags>1</flags><original>sheep               </original><dpos>7</dpos></Row>
+ <Row><kind>1</kind><word>sheep               </word><doc>844424930131971</doc><segment>0</segment><wpos>6</wpos><wip>1</wip><flags>1</flags><original>sheep               </original><dpos>23</dpos></Row>
+</Dataset>

--- a/testing/ecl/mergenway.ecl
+++ b/testing/ecl/mergenway.ecl
@@ -1,0 +1,30 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+//UseStandardFiles
+//UseIndexes
+//varskip payload
+//varskip varload
+//varskip trans
+//nothor
+
+boy := STEPPED(TS_WordIndex(keyed(kind = TS_kindType.TextEntry and word = 'boy')), doc);
+sheep := STEPPED(TS_WordIndex(keyed(kind = TS_kindType.TextEntry and word = 'sheep')), doc);
+both := MERGE([boy, sheep], SORTED(kind, word, doc));
+
+output(both);

--- a/thorlcr/activities/merge/thmergeslave.cpp
+++ b/thorlcr/activities/merge/thmergeslave.cpp
@@ -545,11 +545,13 @@ public:
     {
         CThorNarySlaveActivity::start();
         merger.initInputs(expandedInputs.length(), expandedInputs.getArray());
+        dataLinkStart();
     }
     void stop()
     {
         merger.done();
         CThorNarySlaveActivity::stop();
+        dataLinkStop();
     }
     void reset()
     {


### PR DESCRIPTION
Missing dataLinkStart/dataLinkStop causing n-way merge activity to fail

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
@gissues:{"order":75,"status":"backlog"}
