### PR TITLE
Mark regress query with IFACTION TBD

### DIFF
--- a/testing/ecl/when8.ecl
+++ b/testing/ecl/when8.ecl
@@ -16,6 +16,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//skip type==thorlcr TBD
+
 r := {unsigned f1, unsigned f2, unsigned f3, unsigned f4 };
 
 r t(unsigned a, unsigned b, unsigned c, unsigned d) := TRANSFORM


### PR DESCRIPTION
There's an unresolved issue with asynchronous launch of graphs from an ifaction.
ifaction.ecl was marked tbd in gh-2400, when8.ecl also has an ifaction and should be marked TBD.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
