### PR TITLE
Added missing files to the clienttools package.

### DIFF
--- a/rtl/CMakeLists.txt
+++ b/rtl/CMakeLists.txt
@@ -17,6 +17,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 HPCC_ADD_SUBDIRECTORY (eclrtl)
-HPCC_ADD_SUBDIRECTORY (ecltpl "PLATFORM")
+HPCC_ADD_SUBDIRECTORY (ecltpl)
 HPCC_ADD_SUBDIRECTORY (include "PLATFORM")
 HPCC_ADD_SUBDIRECTORY (nbcd)

--- a/system/CMakeLists.txt
+++ b/system/CMakeLists.txt
@@ -17,7 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 HPCC_ADD_SUBDIRECTORY (hrpc)
-HPCC_ADD_SUBDIRECTORY (include "PLATFORM")
+HPCC_ADD_SUBDIRECTORY (include)
 HPCC_ADD_SUBDIRECTORY (jhtree)
 HPCC_ADD_SUBDIRECTORY (jlib)
 HPCC_ADD_SUBDIRECTORY (lzma)


### PR DESCRIPTION
fixes gh-2543 added missing ecltpl files.

fixes gh-2543 added platform.h to the clienttools package

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
