### PR TITLE
Stop GRAPH(expr) always hoisting (debug operator)

### DIFF
--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -2212,6 +2212,7 @@ protected:
         case no_sizeof:
         case no_allnodes:
         case no_nohoist:
+        case no_forcegraph:
             return;
         case no_globalscope:
         case no_evalonce:

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -98,6 +98,7 @@ static bool isWorthHoisting(IHqlExpression * expr, bool asSubQuery)
         case no_section:
         case no_sectioninput:
         case no_dataset_alias:
+        case no_forcegraph:
             expr = expr->queryChild(0);
             break;
         case no_fail:


### PR DESCRIPTION
A minor fix to an internal undocumented operator.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
