### PR TITLE
Fix gh-2040

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -654,7 +654,7 @@ void FileSprayer::addEmptyFilesToPartition()
 
 void FileSprayer::afterTransfer()
 {
-    if (calcInputCRC())
+    if (!compressedInput && calcInputCRC())
     {
         LOG(MCdebugProgressDetail, job, "Checking input CRCs");
         CRC32Merger partCRC;


### PR DESCRIPTION
I cannot be sure that will actually fix the bug, since I can't
reproduce it, but this change makes sense, given that compressed
files have (by definition) CRC=0, so it doesn't make sense to
compare the CRC of the origin with the destination, especially
part-by-part.
