### PR TITLE
Mac initscript fix

### DIFF
--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -78,7 +78,7 @@ if [[ $platform == 'linux' ]]; then
                     break
             fi
     done
-elif [[ $platform == 'mac']]; then
+elif [[ $platform == 'mac' ]]; then
     NEW_LIB="${PATH_PREFIX}/lib"
     for D in ${DYLD_LIBRARY_PATH//:/ } ; do
         if [ "${D}" = "${NEW_LIB}" ]; then
@@ -119,7 +119,7 @@ if [ `basename -- "$0"` = "hpcc_setenv" ]; then
         else
                 echo "# \$LD_LIBRARY_PATH already contains ${PATH_PREFIX}/plugins"
         fi
-    elif [[ $platform == 'mac']]; then
+    elif [[ $platform == 'mac' ]]; then
         if [ -n "${NEW_LIB}" ]; then
             echo "export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH:+${DYLD_LIBRARY_PATH}:}${NEW_LIB}"
         else
@@ -148,7 +148,7 @@ else
         if [ -n "${NEW_LIB2}" ]; then
                 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}:}${NEW_LIB2}
         fi
-    elif [[ $platform == 'mac']]; then
+    elif [[ $platform == 'mac' ]]; then
         if [ -n "${NEW_LIB}" ]; then
             export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH:+${DYLD_LIBRARY_PATH}:}${NEW_LIB}
         fi


### PR DESCRIPTION
missing space in bash expressions

Signed-off-by: Jake Smith jsmith@node219017.boca.local
