### PR TITLE
Issue 2152 (ECLPlayground)

### DIFF
--- a/esp/files/ECLPlayground.htm
+++ b/esp/files/ECLPlayground.htm
@@ -103,7 +103,7 @@ somePeople;
         </div>
         <div id="rightPane" class="edgePanel" data-dojo-props="minSize:120, region: 'right', splitter:true"
             data-dojo-type="dijit.layout.TabContainer" style="width: 240px;">
-            <div id="graphs" style="width: 100%; height: 100%; overflow: hidden">
+            <div id="graphs" style="background-color:#808080;width: 100%; height: 100%; overflow: hidden">
             </div>
         </div>
         <div id="resultsPane" class="edgePanel" data-dojo-props="minSize:120, region: 'bottom', splitter:true, tabPosition: 'bottom'"

--- a/esp/files/ECLPlayground.js
+++ b/esp/files/ECLPlayground.js
@@ -17,6 +17,7 @@
 define([
 	"dojo/_base/fx",
 	"dojo/_base/window",
+	"dojo/_base/sniff",
 	"dojo/dom",
 	"dojo/dom-style",
 	"dojo/dom-geometry",
@@ -28,7 +29,7 @@ define([
 	"hpcc/ResultsControl",
 	"hpcc/SampleSelectControl",
 	"hpcc/ESPWorkunit"
-], function (fx, baseWindow, dom, domStyle, domGeometry, on, ready, registry, EclEditor, GraphControl, ResultsControl, Select, Workunit) {
+], function (fx, baseWindow, sniff, dom, domStyle, domGeometry, on, ready, registry, EclEditor, GraphControl, ResultsControl, Select, Workunit) {
 	var wu = null,
 			editorControl = null,
 			graphControl = null,
@@ -61,6 +62,11 @@ define([
 						wu.monitor(monitorEclPlayground);
 					}
 				}, 1);
+
+				if (!sniff("chrome")) {
+					watchSplitters(dijit.byId("appLayout").getSplitter("right"));
+					watchSplitters(dijit.byId("appLayout").getSplitter("bottom"));
+				}
 			},
 
 			initUiResults = function () {
@@ -143,6 +149,15 @@ define([
 					onErrorClick: function (line, col) {
 						editorControl.setCursor(line, col);
 					}
+				});
+			},
+
+			watchSplitters = function (spl) {
+				dojo.connect(spl, "_startDrag", function () {
+					dojo.style(dojo.byId('gvc'), "display", "none");
+				});
+				dojo.connect(spl, "_stopDrag", function (evt) {
+					dojo.style(dojo.byId('gvc'), "display", "block");
 				});
 			},
 


### PR DESCRIPTION
When resizing the graph control by means of a splitter, it flashes in IE + FF.
This isn't a true fix, it just hides the control during the move.

Fixes gh-2152
Fixes gh-2405

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
