### PR TITLE
Gh 2476

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -918,6 +918,8 @@ interface IConstWorkUnit : extends IInterface
     virtual IStringVal & getXmlParams(IStringVal & params) const = 0;
     virtual const IPropertyTree * getXmlParams() const = 0;
     virtual unsigned __int64 getHash() const = 0;
+    virtual IStringIterator *getLogs(const char *type, const char *instance=NULL) const = 0;
+    virtual IStringIterator *getProcesses(const char *type) const = 0;
 };
 
 
@@ -930,6 +932,7 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual IWUException * createException() = 0;
     virtual void setTimeStamp(const char * name, const char * instance, const char * event) = 0;
     virtual void addTimeStamp(const char * name, const char * instance, const char * event) = 0;
+    virtual void addProcess(const char *type, const char *instance, const char *log=NULL) = 0;
     virtual void setAction(WUAction action) = 0;
     virtual void setApplicationValue(const char * application, const char * propname, const char * value, bool overwrite) = 0;
     virtual void setApplicationValueInt(const char * application, const char * propname, int value, bool overwrite) = 0;

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1853,8 +1853,8 @@ void EclAgent::doProcess()
             LOG(MCrunlock, unknownJob, "Obtained workunit lock");
             if (w->hasDebugValue("traceLevel"))
                 traceLevel = w->getDebugValueInt("traceLevel", 10);
-            w->setTracingValue("EclAgentBuild", BUILD_TAG);  
-            w->setDebugValue("EclAgentLog", logname.str(), true);
+            w->setTracingValue("EclAgentBuild", BUILD_TAG);
+            w->addProcess("EclAgent", agentTopology->queryProp("@name"), logname.str());
             if (checkVersion && ((w->getCodeVersion() > ACTIVITY_INTERFACE_VERSION) || (w->getCodeVersion() < MIN_ACTIVITY_INTERFACE_VERSION)))
                 failv(0, "Workunit was compiled for eclagent interface version %d, this eclagent requires version %d..%d", w->getCodeVersion(), MIN_ACTIVITY_INTERFACE_VERSION, ACTIVITY_INTERFACE_VERSION);
             if(noRetry && (w->getState() == WUStateFailed))

--- a/testing/ecl/mergededup.ecl
+++ b/testing/ecl/mergededup.ecl
@@ -215,7 +215,6 @@ subcnt3 := COUNT(srtbfnl) - COUNT(mrgsrtb);
 ok3 := IF(subcnt3=0, 'counts okay', 'counts wrong');
 diff3 := IF(subcnt3=0, COUNT(JOIN(PROJECT(srtbfnl,AddSeq(LEFT,COUNTER)), PROJECT(DISTRIBUTED(mrgsrtb,j),AddSeq(LEFT,COUNTER)),(LEFT.k=RIGHT.k)AND(LEFT.i=RIGHT.i)AND(LEFT.j=RIGHT.j), LEFT ONLY, LOCAL)), subcnt3);
 //diff3 := IF(subcnt3=0, COUNT(COMBINE(srtbfnl, mrgsrtb, diff(LEFT, RIGHT))((i != 0) OR (j != 0))), subcnt3);
-
 ddpbfnl := DEDUP(srtbfnl, i, LOCAL);
 mrgddpb := MERGE(ddpb1, ddpb2, ddpb3, ddpb4, ddpb5, ddpb6, ddpb7, ddpb8, ddpb9, ddpb10, ddpb11, ddpb12, ddpb13, ddpb14, ddpb15, ddpb16, ddpb17, ddpb18, ddpb19, ddpb20, ddpb21, ddpb22, ddpb23, ddpb24, ddpb25, DEDUP, sorted(i),LOCAL);
 subcnt4 := COUNT(ddpbfnl) - COUNT(mrgddpb);
@@ -223,11 +222,18 @@ ok4 := IF(subcnt4=0, 'counts okay', 'counts wrong');
 diff4 := IF(subcnt4=0, COUNT(JOIN(PROJECT(ddpbfnl,AddSeq(LEFT,COUNTER)), PROJECT(DISTRIBUTED(mrgddpb,j),AddSeq(LEFT,COUNTER)),(LEFT.k=RIGHT.k)AND(LEFT.i=RIGHT.i)AND(LEFT.j=RIGHT.j), LEFT ONLY, LOCAL)), subcnt4);
 //diff4 := IF(subcnt4=0, COUNT(COMBINE(ddpbfnl, mrgddpb, diff(LEFT, RIGHT))((i != 0) OR (j != 0))), subcnt4);
 
+mrgsrtc := MERGE([srtb1, srtb2, srtb3, srtb4, srtb5, srtb6, srtb7, srtb8, srtb9, srtb10, srtb11, srtb12, srtb13, srtb14, srtb15, srtb16, srtb17, srtb18, srtb19, srtb20, srtb21, srtb22, srtb23, srtb24, srtb25], sorted(i));
+subcnt5 := COUNT(srtbfnl) - COUNT(mrgsrtc);
+ok5 := IF(subcnt5=0, 'counts okay', 'counts wrong');
+diff5 := IF(subcnt5=0, COUNT(JOIN(PROJECT(srtbfnl,AddSeq(LEFT,COUNTER)), PROJECT(DISTRIBUTED(mrgsrtc,j),AddSeq(LEFT,COUNTER)),(LEFT.k=RIGHT.k)AND(LEFT.i=RIGHT.i)AND(LEFT.j=RIGHT.j), LEFT ONLY, LOCAL)), subcnt5);
+
+
 output(JOIN(PROJECT(srtfnl,AddSeq(LEFT,COUNTER)), PROJECT(mrgsrt,AddSeq(LEFT,COUNTER)),(LEFT.k=RIGHT.k)AND(LEFT.i=RIGHT.i)AND(LEFT.j=RIGHT.j), LEFT ONLY));
-SEQUENTIAL(OUTPUT(ok1), OUTPUT(diff1), OUTPUT(ok2), OUTPUT(diff2), OUTPUT(ok3), OUTPUT(diff3), OUTPUT(ok4), OUTPUT(diff4));
+SEQUENTIAL(OUTPUT(ok1), OUTPUT(diff1), OUTPUT(ok2), OUTPUT(diff2), OUTPUT(ok3), OUTPUT(diff3), OUTPUT(ok4), OUTPUT(diff4), OUTPUT(ok5), OUTPUT(diff5));
 
 
 // Global tests for Thor
+
 unsigned numrecs := 1000 : stored('numrecs');
 
 trec := record


### PR DESCRIPTION
Related to gh-2476

addLog(type, instance, log) - will add if log doesn't already exist
getLogs(type [,instance]) - to retrieve logs of given type[,instance]
getProcesses - to retreive processes that have run as part of workunit, e.g.
Thor, EclAgent

Added a workunit version number also, for bkwd. compat. checks.
And a thor version for information only.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
