### PR TITLE
Compress query init and trace timing

### DIFF
--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -23,6 +23,7 @@
 #include "jthread.hpp"
 #include "jprop.hpp"
 #include "jiter.ipp"
+#include "jlzw.hpp"
 
 #include "jhtree.hpp"
 #include "mpcomm.hpp"
@@ -153,6 +154,9 @@ public:
                 {
                     case QueryInit:
                     {
+                        MemoryBuffer mb;
+                        decompressToBuffer(mb, msg);
+                        msg.swapWith(mb);
                         mptag_t mptag, slaveMsgTag;
                         deserializeMPtag(msg, mptag);
                         queryClusterComm().flush(mptag);


### PR DESCRIPTION
The query shared object serialized to the slaves, was uncompressed. If large
it can take a little time, so worth compressing

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
