### PR TITLE
Fix gh-2549 Add pwd expiry column to ECLWatch users screen

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_users.xslt
+++ b/esp/eclwatch/ws_XSLT/access_users.xslt
@@ -131,8 +131,9 @@
                 <colgroup>
                     <col width="5"/>
                     <col width="150"/>
-                    <col width="200"/>
-                    <col width="250"/>
+                    <col width="175"/>
+                    <col width="100"/>
+                    <col width="300"/>
                 </colgroup>
                 <thead>
                 <tr class="grey">
@@ -144,6 +145,7 @@
                 </th>
                 <th align="left">User ID</th>
                 <th>Full Name</th>
+                <th>Password Expires</th>
                 <th>Operation</th>
                 </tr>
                 </thead>
@@ -211,6 +213,9 @@
         </td>
         <td>
         <xsl:value-of select="fullname"/>
+        </td>
+        <td>
+        <xsl:value-of select="passwordexpiration"/>
         </td>
         <td>
             <a href="javascript:go('/ws_access/UserInfoEditInput?username={username}')">Edit</a>

--- a/esp/scm/ws_access.ecm
+++ b/esp/scm/ws_access.ecm
@@ -20,6 +20,7 @@ ESPstruct UserInfo
 {
     string username;
     string fullname;
+    [min_ver("1.07")] string passwordexpiration;
 };
 
 ESPstruct GroupInfo
@@ -647,7 +648,7 @@ ESPresponse [nil_remove] UserAccountExportResponse
 };
 
 
-ESPservice [version("1.06"), default_client_version("1.06"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
+ESPservice [version("1.07"), default_client_version("1.07"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
 {
     ESPmethod [client_xslt("/esp/xslt/access_users.xslt")] Users(UserRequest, UserResponse);
     ESPmethod [client_xslt("/esp/xslt/access_useredit.xslt")] UserEdit(UserEditRequest, UserEditResponse);

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -414,6 +414,29 @@ bool Cws_accessEx::onUsers(IEspContext &context, IEspUserRequest &req, IEspUserR
                 Owned<IEspUserInfo> oneusr = createUserInfo();
                 oneusr->setUsername(usr->getName());
                 oneusr->setFullname(usr->getFullName());
+
+                double version = context.getClientVersion();
+                if (version >= 1.07)
+                {
+                    StringBuffer sb;
+                    switch (usr->getPasswordDaysRemaining())//-1 if expired, -2 if never expires
+                    {
+                    case -1:
+                        sb.set("Expired");
+                        break;
+                    case -2:
+                        sb.set("Never");
+                        break;
+                    default:
+                        {
+                            CDateTime dt;
+                            usr->getPasswordExpiration(dt);
+                            dt.getDateString(sb);
+                            break;
+                        }
+                    }
+                    oneusr->setPasswordexpiration(sb.str());
+                }
                 espusers.append(*oneusr.getLink());
             }
         }

--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -165,7 +165,7 @@ bool Cws_accountEx::onMyAccount(IEspContext &context, IEspMyAccountRequest &req,
             else
             {
                 dt.getString(sb);
-                sb.replace('T', (char)' ');
+                sb.replace('T', (char)0);//chop off timestring
             }
             resp.setPasswordExpiration(sb.str());
             resp.setPasswordDaysRemaining(user->getPasswordDaysRemaining());


### PR DESCRIPTION
In ECLWatch 'users' screen, only visible to an admin, add a
"Password Expiration" column that shows the user's password expiration
date, or "Expired" or "Never"

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
