### PR TITLE
getLogs not returning logs in legacy

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4674,14 +4674,13 @@ IStringIterator *CLocalWorkUnit::getLogs(const char *type, const char *instance)
     CriticalBlock block(crit);
     if (p->getPropInt("@wuidVersion") < 1) // legacy wuid
     {
-        if (!instance)
-            return new CStringPTreeTagIterator(p->getElements("Debug/*log*"));
-        else if(streq("EclAgent", instance))
-            return new CStringPTreeTagIterator(p->getElements("Debug/eclagentlog"));
-        else if (streq("Thor", instance))
-            return new CStringPTreeTagIterator(p->getElements("Debug/thorlog*"));
-        VStringBuffer xpath("Debug/%s", instance);
-        return new CStringPTreeAttrIterator(p->getElements(xpath.str()), xpath.str());
+        // NB: instance unused
+        if (streq("EclAgent", type))
+            return new CStringPTreeIterator(p->getElements("Debug/eclagentlog"));
+        else if (streq("Thor", type))
+            return new CStringPTreeIterator(p->getElements("Debug/thorlog*"));
+        VStringBuffer xpath("Debug/%s", type);
+        return new CStringPTreeIterator(p->getElements(xpath.str()));
     }
     else
         return new CStringPTreeAttrIterator(p->getElements(xpath.str()), "@log");


### PR DESCRIPTION
using wrong iterator type

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
