### PR TITLE
Fix gh-2579 Issue defining topology with same name and prefix

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -1735,11 +1735,16 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
       const char* pszNewValue = pSetting->queryProp("@newValue");
             
       StringBuffer xpath_key;
-      xpath_key.appendf("%s/%s/%s[%s='%s']", XML_TAG_SOFTWARE, XML_TAG_TOPOLOGY, XML_TAG_CLUSTER, XML_ATTR_NAME, pszNewValue);
-      //Check to see if the cluster name is already in use
-      IPropertyTree* pEnvCluster = pEnvRoot->queryPropTree(xpath_key);
-      if (pEnvCluster != NULL)
-        throw MakeStringException(-1, "Cluster - %s is already in use. Please enter a unique name for the Cluster.", pszNewValue);      
+
+      if (strcmp(pszAttrName,TAG_NAME) == 0)
+      {
+         xpath_key.appendf("%s/%s/%s[%s='%s']", XML_TAG_SOFTWARE, XML_TAG_TOPOLOGY, XML_TAG_CLUSTER, XML_ATTR_NAME, pszNewValue);
+
+        //Check to see if the cluster name is already in use
+        IPropertyTree* pEnvCluster = pEnvRoot->queryPropTree(xpath_key);
+        if (pEnvCluster != NULL)
+          throw MakeStringException(-1, "Cluster - %s is already in use. Please enter a unique name for the Cluster.", pszNewValue);      
+      }
 
       StringBuffer buf("Topology");
 


### PR DESCRIPTION
in any order.  Creating a name and prefix for a cluster
can be done in any order with no error message.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
