### PR TITLE
Fix gh-2202 Incorrect output from xml output(row)

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -1573,6 +1573,7 @@ public:
     virtual void        setResultIsAll(bool value);
     virtual void        setResultFormat(WUResultFormat format);
     virtual void        setResultXML(const char *val);
+    virtual void        setResultRow(unsigned len, const void * data);
 };
 
 class CLocalWUPlugin : public CInterface, implements IWUPlugin
@@ -7442,6 +7443,13 @@ void CLocalWUResult::setResultDecimal(const void *val, unsigned len)
     setResultTotalRowCount(1);
 }
 
+void CLocalWUResult::setResultRow(unsigned len, const void * data)
+{
+    p->setPropBin("Value", len, data);
+    setResultRowCount(1);
+    setResultTotalRowCount(1);
+    setResultFormat(ResultFormatRaw);
+}
 void CLocalWUResult::setResultIsAll(bool value)
 {
     p->setPropBool("@isAll", value);

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -314,6 +314,7 @@ interface IWUResult : extends IConstWUResult
     virtual void setResultIsAll(bool value) = 0;
     virtual void setResultFormat(WUResultFormat format) = 0;
     virtual void setResultXML(const char * xml) = 0;
+    virtual void setResultRow(unsigned len, const void * data) = 0;
 };
 
 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1138,17 +1138,18 @@ void EclAgent::doSetResultString(type_t type, const char *name, unsigned sequenc
     }
 }
 
+//used to output a row
 void EclAgent::setResultRaw(const char * name, unsigned sequence, int len, const void *val)
 {
     LOG(MCsetresult, unknownJob, "setResultRaw(%s,%d,(%d bytes))", nullText(name), sequence, len);
     Owned<IWUResult> r = updateResult(name, sequence);
     if (r)
     {
-        r->setResultRaw(len, val, ResultFormatRaw); 
+        r->setResultRow(len, val);
         r->setResultStatus(ResultStatusCalculated);
     }
     else
-        fail(0, "Unexpected parameters to setResultString");
+        fail(0, "Unexpected parameters to setResultRaw");
     if (writeResultsToStdout && (int) sequence >= 0)
     {
         if (outputFmt == ofSTD || outputFmt==ofRAW)


### PR DESCRIPTION
Added a new workunit method setResultRow() which saves a row and
sets the row count to 1. Call this new method from setResultRaw, which
is called by the workunit shared object to save a row. This fixes the
missing XML output because it now sets a row count, which is needed
by the xml writer

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
