### PR TITLE
Fix potential use of NULL pointer in printf %s

### DIFF
--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -9620,7 +9620,10 @@ IHqlExpression * HqlGram::resolveImportModule(const attribute & errpos, IHqlExpr
     OwnedHqlExpr resolved = parent->queryScope()->lookupSymbol(childName, LSFpublic, lookupCtx);
     if (!resolved)
     {
-        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a field named '%s'", parent->queryName()->str(), childName->str());
+        const char * parentName = parent->queryName()->str();
+        if (!parentName)
+            parentName = "$";
+        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a field named '%s'", parentName, childName->str());
         return NULL;
     }
     IHqlScope * ret = resolved->queryScope();

--- a/ecl/regress/badimport.ecl
+++ b/ecl/regress/badimport.ecl
@@ -1,0 +1,19 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+import $.x;


### PR DESCRIPTION
Import $.x from an ecl file submitted to eclcc could use NULL as the module
name in the error text (see example).  It could only happen if $ was the
module (otherwise it would have matched a name), so use "$" instead.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
