### PR TITLE
Add options to 'ecl run' for setting debug and stored variables

### DIFF
--- a/ecl/ecl-package/CMakeLists.txt
+++ b/ecl/ecl-package/CMakeLists.txt
@@ -16,6 +16,7 @@ project( ecl-package )
 include(${HPCC_SOURCE_DIR}/esp/scm/espscm.cmake)
 
 set (    SRCS
+         ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_packageprocess_esp.cpp
          ecl-package.cpp
          ${HPCC_SOURCE_DIR}/ecl/eclcmd/eclcmd_shell.cpp

--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -30,6 +30,7 @@ project( ecl )
 include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS
+         ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp
          eclcmd.hpp
          ecl.cpp

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -19,6 +19,8 @@
 #ifndef ECLCMD_COMMON_HPP
 #define ECLCMD_COMMON_HPP
 
+#include "ws_workunits.hpp"
+
 //=========================================================================================
 
 interface IEclCommand : extends IInterface
@@ -97,6 +99,8 @@ bool extractEclCmdOption(StringBuffer & option, IProperties * globals, const cha
 bool extractEclCmdOption(StringAttr & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);
 bool extractEclCmdOption(bool & option, IProperties * globals, const char * envName, const char * propertyName, bool defval);
 bool extractEclCmdOption(unsigned & option, IProperties * globals, const char * envName, const char * propertyName, unsigned defval);
+
+bool matchVariableOption(ArgvIterator &iter, const char prefix, IArrayOf<IEspNamedValue> &values);
 
 enum eclObjParameterType
 {
@@ -186,6 +190,7 @@ public:
             "   --main=<definition>    definition to use from legacy ECL repository\n"
             "   --ecl-only             send ecl text to hpcc without generating archive\n"
             "   --limit=<limit>        sets the result limit for the query, defaults to 100\n"
+            "   -f<option>[=value]     set an ECL option (equivalent to #option)\n"
             " eclcc options:\n"
             "   -Ipath                 Add path to locations to search for ecl imports\n"
             "   -Lpath                 Add path to locations to search for system libraries\n"
@@ -198,6 +203,7 @@ public:
     StringBuffer optImpPath;
     StringAttr optManifest;
     StringAttr optAttributePath;
+    IArrayOf<IEspNamedValue> debugValues;
     unsigned optResultLimit;
     bool optNoArchive;
 };

--- a/ecl/eclcmd/queries/CMakeLists.txt
+++ b/ecl/eclcmd/queries/CMakeLists.txt
@@ -16,6 +16,7 @@ project( ecl-queries )
 include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS
+         ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp
          ecl-queries.cpp
          ../eclcmd_shell.cpp

--- a/ecl/eclplus/CMakeLists.txt
+++ b/ecl/eclplus/CMakeLists.txt
@@ -29,6 +29,7 @@ include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS 
          ../../esp/bindings/bindutil.cpp 
+         ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp 
          DeleteHelper.cpp 
          DumpHelper.cpp 

--- a/esp/clients/WUManager/CMakeLists.txt
+++ b/esp/clients/WUManager/CMakeLists.txt
@@ -28,6 +28,7 @@ project( wumanager )
 include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS 
+         ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp
          WUManager.cpp 
     )

--- a/esp/scm/common.ecm
+++ b/esp/scm/common.ecm
@@ -1,0 +1,23 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+ESPStruct [nil_remove] NamedValue
+{
+    string Name;
+    string Value;
+};

--- a/esp/scm/espscm.cmake
+++ b/esp/scm/espscm.cmake
@@ -27,6 +27,7 @@ GET_TARGET_PROPERTY(HIDL_EXE hidl LOCATION)
 GET_TARGET_PROPERTY(ESDL_EXE esdl LOCATION)
 
 set ( ESPSCM_SRCS
+      common.ecm
       ecl.ecm
       ecldirect.ecm
       ecllib.ecm

--- a/esp/scm/smcscm.cmake
+++ b/esp/scm/smcscm.cmake
@@ -28,6 +28,7 @@ GET_TARGET_PROPERTY(HIDL_EXE hidl LOCATION)
 GET_TARGET_PROPERTY(ESDL_EXE esdl LOCATION)
 
 set ( ESPSCM_SRCS
+      common.ecm
       ws_dfu.ecm
       ws_dfuXref.ecm
       ws_fs.ecm

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -296,6 +296,7 @@ ESPrequest [nil_remove] WUDeployWorkunitRequest
     string FileName;
     binary Object;
     int ResultLimit;
+    ESParray<ESPstruct NamedValue> DebugValues;
 };
 
 ESPresponse [exceptions_inline] WUDeployWorkunitResponse

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -132,6 +132,12 @@ ESPStruct [nil_remove] DebugValue
     string Value;
 };
 
+ESPStruct [nil_remove] NamedValue
+{
+    string Name;
+    string Value;
+};
+
 ESPStruct [nil_remove] WUActionResult
 {
     string Wuid;
@@ -492,6 +498,8 @@ ESPrequest WURunRequest
     int Wait(-1);
     [rows(15)] string Input;
     bool NoRootTag(0);
+    ESParray<ESPstruct NamedValue> DebugValues;
+    ESParray<ESPstruct NamedValue> Variables;
 };
 
 ESPresponse [exceptions_inline] WURunResponse

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -19,6 +19,8 @@
 #include "xslprocessor.hpp" 
 //  ===========================================================================
 
+EspInclude(common);
+
 ESPStruct [nil_remove] ECLException
 {
     string Source;
@@ -127,12 +129,6 @@ ESPStruct [nil_remove] ECLQuery
 //  ===========================================================================
 
 ESPStruct [nil_remove] DebugValue
-{
-    string Name;
-    string Value;
-};
-
-ESPStruct [nil_remove] NamedValue
 {
     string Name;
     string Value;

--- a/esp/services/ws_workunits/CMakeLists.txt
+++ b/esp/services/ws_workunits/CMakeLists.txt
@@ -29,6 +29,7 @@ include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS
          ../../../dali/sasha/sacmd.cpp
+         ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_fs_esp.cpp
          ${HPCC_SOURCE_DIR}/esp/scm/ws_workunits.ecm

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3505,7 +3505,7 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
     wu->commit();
     wu.clear();
 
-    submitWsWorkunit(context, wuid.str(), req.getCluster(), NULL, 0, true, false);
+    submitWsWorkunit(context, wuid.str(), req.getCluster(), NULL, 0, true, false, NULL, NULL, &req.getDebugValues());
     waitForWorkUnitToCompile(wuid.str(), req.getWait());
 
     WsWuInfo winfo(context, wuid.str());

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -118,7 +118,24 @@ void setWsWuXmlParameters(IWorkUnit *wu, const char *xml, IArrayOf<IConstNamedVa
         ForEachItemIn(i, *variables)
         {
             IConstNamedValue &item = variables->item(i);
-            paramTree->setProp(item.getName(), item.getValue());
+            const char *name = item.getName();
+            const char *value = item.getValue();
+            if (!name || !*name)
+                continue;
+            if (!value)
+            {
+                size_t len = strlen(name);
+                char last = name[len-1];
+                if (last == '-' || last == '+')
+                {
+                    StringAttr s(name, len-1);
+                    paramTree->setPropInt(s.get(), last == '+' ? 1 : 0);
+                }
+                else
+                    paramTree->setPropInt(name, 1);
+                continue;
+            }
+            paramTree->setProp(name, value);
         }
         toXML(paramTree, extParamXml);
         xml=extParamXml.str();
@@ -165,7 +182,24 @@ void submitWsWorkunit(IEspContext& context, IConstWorkUnit* cw, const char* clus
         ForEachItemIn(i, *debugs)
         {
             IConstNamedValue &item = debugs->item(i);
-            wu->setDebugValue(item.getName(), item.getValue(), true);
+            const char *name = item.getName();
+            const char *value = item.getValue();
+            if (!name || !*name)
+                continue;
+            if (!value)
+            {
+                size_t len = strlen(name);
+                char last = name[len-1];
+                if (last == '-' || last == '+')
+                {
+                    StringAttr s(name, len-1);
+                    wu->setDebugValueInt(s.get(), last == '+' ? 1 : 0, true);
+                }
+                else
+                    wu->setDebugValueInt(name, 1, true);
+                continue;
+            }
+            wu->setDebugValue(name, value, true);
         }
     }
 


### PR DESCRIPTION
New options -deb.<name>=<value> and -var.<name>=<value>.

-deb.<name>=<value> can be used to set workunit debug values.
-var.<name>=<value> can be used to set input (stored) variables.

example:
ecl run add.ecl -cl=hthor -var.n1=11 -var.n2=22 -dbg.maxruntime=1000

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
