### PR TITLE
Disable intindex until we fix it

### DIFF
--- a/testing/ecl/intindex.ecl
+++ b/testing/ecl/intindex.ecl
@@ -16,10 +16,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//skip type==thorlcr TBD
+//skip type==hthor TBD
+//skip type==roxie TBD
 //UseStandardFiles
 
-fail('This test is temporarily disabled because it causes lockups in roxie/hthor and probably thor');
-/*
 output(choosen(DG_IntegerIndex, 3));
 
 output(DG_IntegerIndex(keyed(i6 = 4)));
@@ -30,4 +31,3 @@ output(DG_IntegerIndex(wild(i6),keyed(nested.i4 = 5)));
 output(DG_IntegerIndex(wild(i6),wild(nested.i4),keyed(nested.u3 = 6)));
 output(DG_IntegerIndex(i5 = 7));
 output(DG_IntegerIndex(i3 = 8));
-*/


### PR DESCRIPTION
This test is running only to fail on all platforms and
take precious seconds to do so. I'm disabling them for
now (since we have an open bug to fix it) and save
us a few seconds.
