### PR TITLE
FIX HPCC-Systems/LN#472 JComp incorrectly quotes source file name

### DIFF
--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -436,13 +436,14 @@ bool CppCompiler::compileFile(IThreadPool * pool, const char * filename, Semapho
     if (!filename || *filename == 0)
         return false;
 
-    StringBuffer fullFileName;
-    fullFileName.clear().append("\"").append(filename).append(".cpp").append("\"").append(" ");
-
     StringBuffer cmdline;
-    cmdline.append(CC_NAME[targetCompiler]);
-    cmdline.append(" ").append(sourceDir);
-    cmdline.append(fullFileName);
+    cmdline.append(CC_NAME[targetCompiler]).append(" \"");
+    if (sourceDir.length())
+    {
+        cmdline.append(sourceDir);
+        addPathSepChar(cmdline);
+    }
+    cmdline.append(filename).append(".cpp\" ");
     expandCompileOptions(cmdline);
 
     if (useDebugLibrary)


### PR DESCRIPTION
If a source path is specified, jcomp incorrectly puts quotes around the
filename (/folder/"file.cpp"). This fix corrects that by quoting the
path and filename ("/folder/file.cpp")

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com

Rebased for 3.8 and minor change to avoid doubled path separators

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
