### PR TITLE
Draft bash completion ECL tools

### DIFF
--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -191,6 +191,13 @@ if [ -d ${INSTALL_DIR}/etc/init.d/install ]; then
     done
 fi
 
+# bash completion
+if [ -d ${INSTALL_DIR}/etc/bash_completion.d ] && [ -d /etc/bash_completion.d ]; then
+    for subInstall in $(ls ${INSTALL_DIR}/etc/bash_completion.d | grep -v dpkg-tmp); do
+        installFile ${INSTALL_DIR}/etc/bash_completion.d/$subInstall /etc/bash_completion.d/$subInstall 1 || exit 1
+    done
+fi
+
 if [ ! -d ${homePath}/.ssh ]; then
     mkdir -p ${homePath}/.ssh
 fi

--- a/initfiles/bash/etc/init.d/uninstall-init.in
+++ b/initfiles/bash/etc/init.d/uninstall-init.in
@@ -49,3 +49,9 @@ removeSymlink "/usr/bin/eclplus"
 removeSymlink "/usr/bin/soapplus"
 removeSymlink "/usr/bin/testsocket"
 removeSymlink "/usr/bin/wuget"
+
+if [ -d ${INSTALL_DIR}/etc/bash_completion.d ] && [ -d /etc/bash_completion.d ]; then
+    for subInstall in $(ls ${INSTALL_DIR}/etc/bash_completion.d | grep -v dpkg-tmp); do
+        removeSymlink /etc/bash_completion.d/$subInstall
+    done
+fi

--- a/initfiles/etc/bash_completion/CMakeLists.txt
+++ b/initfiles/etc/bash_completion/CMakeLists.txt
@@ -15,6 +15,10 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
-ADD_SUBDIRECTORY(DIR_NAME)
-ADD_SUBDIRECTORY(sshkey)
-ADD_SUBDIRECTORY(bash_completion)
+FOREACH( oFILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/eclcc
+    ${CMAKE_CURRENT_SOURCE_DIR}/eclplus
+    ${CMAKE_CURRENT_SOURCE_DIR}/eclagent
+)
+    install ( FILES ${oFILES} DESTINATION ${INSTALL_DIR}/etc/bash_completion.d COMPONENT Runtime )
+ENDFOREACH ( oFILES )

--- a/initfiles/etc/bash_completion/CMakeLists.txt
+++ b/initfiles/etc/bash_completion/CMakeLists.txt
@@ -16,6 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 FOREACH( oFILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/ecl
     ${CMAKE_CURRENT_SOURCE_DIR}/eclcc
     ${CMAKE_CURRENT_SOURCE_DIR}/eclplus
     ${CMAKE_CURRENT_SOURCE_DIR}/eclagent

--- a/initfiles/etc/bash_completion/ecl
+++ b/initfiles/etc/bash_completion/ecl
@@ -1,0 +1,48 @@
+###############################################################################
+#
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+
+# Bash completion file for ecl
+#
+# To test, run ". ./ecl" and then test completion on ecl
+# File must be copied/linked from /etc/bash_completion.d/ to work seamlessly
+# You must have ". /etc/bash_completion" on your bashrc file (you probably have it)
+
+_ecl()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # Command options
+    case ${prev} in
+         queries)
+             opts="list copy"
+             ;;
+         ecl)
+             opts="--version deploy publish unpublish run activate deactivate queries"
+             ;;
+         *)
+             opts="-cl --cluster=<host:ip> -n --name=<name> -v --verbose -s --server=<host:port> -u --username=<user> -pw --password==<pw> --main=<definition> --ecl-only --limit=N -A --activate --wait=<ms>"
+             ;;
+    esac
+
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+}
+complete -F _ecl ecl

--- a/initfiles/etc/bash_completion/eclagent
+++ b/initfiles/etc/bash_completion/eclagent
@@ -1,0 +1,44 @@
+###############################################################################
+#
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+
+# Bash completion file for eclagent
+#
+# To test, run ". ./eclagent" and then test completion on eclagent
+# File must be copied/linked from /etc/bash_completion.d/ to work seamlessly
+# You must have ". /etc/bash_completion" on your bashrc file (you probably have it)
+
+_eclagent()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "${prev}" in
+        eclagent)
+            opts="wuid=<id> process=<name>"
+            ;;
+        *)
+            opts="daliServers=<host:port> versions=<version> wfreset=1 noretry=1"
+            ;;
+    esac
+
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+}
+complete -F _eclagent eclagent

--- a/initfiles/etc/bash_completion/eclcc
+++ b/initfiles/etc/bash_completion/eclcc
@@ -40,12 +40,12 @@ _eclcc()
     # Options with parameters
     case "${prev}" in
         -I|-L)
-            local files=$(find . -maxdepth 1)
+            local files=$(find . -maxdepth 1 -name ${cur}\* | sed 's/\.\///')
             COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
             return 0
             ;;
         -o|-logfile|-specs)
-            local files=$(find . -maxdepth 1)
+            local files=$(find . -maxdepth 1 -name ${cur}\* | sed 's/\.\///')
             COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
             return 0
             ;;
@@ -59,7 +59,7 @@ _eclcc()
     esac
 
     # ECL source filename
-    local files=$(find . -maxdepth 1)
+    local files=$(find . -maxdepth 1 -name ${cur}\* | sed 's/\.\///')
     COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
     return 0
 }

--- a/initfiles/etc/bash_completion/eclcc
+++ b/initfiles/etc/bash_completion/eclcc
@@ -1,0 +1,66 @@
+###############################################################################
+#
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+
+# Bash completion file for eclcc
+#
+# To test, run ". ./eclcc" and then test completion on eclcc
+# File must be copied/linked from /etc/bash_completion.d/ to work seamlessly
+# You must have ". /etc/bash_completion" on your bashrc file (you probably have it)
+
+_eclcc()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="--help --verbose --version -v -S -E -q -g -wu -Wc, -I -L -o -target -main -syntax -manifest -shared -specs -logfile -factivitiesPerCpp=N -fapplyInstantEclTransformations -fapplyInstantEclTransformationsLimit -fcheckAsserts -fmaxCompileThreads=N -fnoteRecordSizeInGraph -fpickBestEngine -fshowActivitySizeInGraph -fshowMetaInGraph -fshowRecordCountInGraph -fspanMultipleCpp"
+
+
+    # Dash options
+    if [[ ${cur} == -* ]] ; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+
+    # Options with parameters
+    case "${prev}" in
+        -I|-L)
+            local files=$(find . -maxdepth 1)
+            COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
+            return 0
+            ;;
+        -o|-logfile|-specs)
+            local files=$(find . -maxdepth 1)
+            COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
+            return 0
+            ;;
+        -target)
+            local targets="roxie thor hthor"
+            COMPREPLY=( $(compgen -W "${targets}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+        ;;
+    esac
+
+    # ECL source filename
+    local files=$(find . -maxdepth 1)
+    COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
+    return 0
+}
+complete -F _eclcc eclcc

--- a/initfiles/etc/bash_completion/eclplus
+++ b/initfiles/etc/bash_completion/eclplus
@@ -1,0 +1,64 @@
+###############################################################################
+#
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+
+# Bash completion file for eclplus
+#
+# To test, run ". ./eclplus" and then test completion on eclplus
+# File must be copied/linked from /etc/bash_completion.d/ to work seamlessly
+# You must have ". /etc/bash_completion" on your bashrc file (you probably have it)
+
+_eclplus()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="action format cluster=<hthor|thor|roxie> owner=<user> password=<pw> server=<host:port> timeout= ecl=<file.ecl> file=<logicalName> output=<outfile> jobname=<name> pagesize=<size> query stored= -I -L -g -E"
+
+    # Options with parameters
+    case "${prev}" in
+        -I|-L)
+            local files=$(find . -maxdepth 1)
+            COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
+            return 0
+            ;;
+        action)
+            local actions="list view dump delete abot query graph"
+            COMPREPLY=( $(compgen -W "${actions}" -- ${cur}) )
+            return 0
+            ;;
+        format)
+            local formats="default xml csv csvh runecl binary"
+            COMPREPLY=( $(compgen -W "${formats}" -- ${cur}) )
+            return 0
+            ;;
+        query)
+            local files=$(find . -maxdepth 1)
+            COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+        ;;
+    esac
+
+    # Root options
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+
+}
+complete -F _eclplus eclplus

--- a/initfiles/etc/bash_completion/eclplus
+++ b/initfiles/etc/bash_completion/eclplus
@@ -33,7 +33,7 @@ _eclplus()
     # Options with parameters
     case "${prev}" in
         -I|-L)
-            local files=$(find . -maxdepth 1)
+            local files=$(find . -maxdepth 1 -name ${cur}\* | sed 's/\.\///')
             COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
             return 0
             ;;
@@ -48,7 +48,7 @@ _eclplus()
             return 0
             ;;
         query)
-            local files=$(find . -maxdepth 1)
+            local files=$(find . -maxdepth 1 -name ${cur}\* | sed 's/\.\///')
             COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
             return 0
             ;;


### PR DESCRIPTION
Simplified bash-completion for eclcc, eclagent and eclrun, installed under
/opt/HPCC/etc/bash_completion.d and linked/unlinked at install/uninstall
time to /etc/bash_completion.d.

This should be enough for systems with bash completion to work out automatically,
but as with other completion, you have to restart the console to get it working after
install.

For now, this patch has only three tools and the mechanism to install/uninstall
them. Further patches will bring more tools.

Note that some options (-foo=bar) can't be completed correctly, issues that GCC also
has (thus, why I haven't spend too much time looking for alternatives). We can fix
those issues after we have all tools with some basic bash completion.
