### PR TITLE
Fix gh-2393 Error on keyed child index

### DIFF
--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -6749,7 +6749,7 @@ void HqlGram::checkIndexFieldType(IHqlExpression * expr, bool isPayload, bool in
                 {
                     if (type->isSigned() ||
                         ((type->getTypeCode() == type_littleendianint) && (type->getSize() != 1)))
-                        reportWarning(ERR_INDEX_BADTYPE, errpos.pos, "Signed or little-endian field %s is not supported inside a keyed record field ", name->str());
+                        reportError(ERR_INDEX_BADTYPE, errpos.pos, "Signed or little-endian field %s is not supported inside a keyed record field ", name->str());
                 }
                 break;
             default:


### PR DESCRIPTION
Keyed index on child record integer fields should have the same treatment as normal integer fields for indexing, ie. big-endian/biased. The change is not trivial and it doesn't work for now, so this is an error as far as the current ECL is concerned.

There is another issue (#969) that deals with the root of the problem.
