### PR TITLE
Start slave fix

### DIFF
--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -64,13 +64,10 @@ echo $$ > $lckfile
 ulimit -c unlimited
 ulimit -n 8192
 
-slaveproc="thorslave_${hpcc_compname}"
-ln -s -f `which $prog` $slaveproc
-
 echo "slave starting `date`"
 
-echo $instancedir/$slaveproc master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth
-$instancedir/$slaveproc master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth 2>/dev/null 1>/dev/null &
+echo $prog master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth
+$prog master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth 2>/dev/null 1>/dev/null &
 slavepid=$!
 echo $slavepid > $PID_NAME
 if [ "$slavepid" -eq "0" ]; then


### PR DESCRIPTION
On multislave (per node) setups, the link was causing problems, where
randomly some slaves failed to start, if unlucky enough to start as link
removed/rewritten.
There is no need for link anymore

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
