### PR TITLE
Fix gh-2476 Cluster name cannot be hard coded

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -901,7 +901,15 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
     IArrayOf<IConstThorLogInfo> thorLogList;
     if (cw->getWuidVersion() > 0)
     {
-        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo("thor");
+        SCMStringBuffer clusterName;
+        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cw->getClusterName(clusterName).str());
+        if (!clusterInfo)
+        {
+            SCMStringBuffer wuid;
+            WARNLOG("Cannot find TargetClusterInfo for workunit %s", cw->getWuid(wuid).str());
+            return countThorLog;
+        }
+
         unsigned numberOfSlaves = clusterInfo->getSize();
 
         Owned<IStringIterator> thorInstances = cw->getProcesses("Thor");

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -421,8 +421,6 @@ bool WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
     return false;
 }
 
-const unsigned MAXTHORS = 1024;
-
 bool WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
 {
     try
@@ -971,23 +969,26 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
     }
     else //legacy wuid
     {
-        SCMStringBuffer name;
-        for (int i0 = 1; i0 < MAXTHORS; i0++)
+        Owned<IStringIterator> thorLogs = cw->getLogs("Thor");
+        ForEach (*thorLogs)
         {
+            SCMStringBuffer name;
+            thorLogs->str(name);
+            if (name.length() < 1)
+                continue;
+
+            countThorLog++;
+
             StringBuffer fileType;
-            if (i0 < 2)
+            if (countThorLog < 2)
                 fileType.append(File_ThorLog);
             else
-                fileType.appendf("%s%d", File_ThorLog, i0);
-            cw->getDebugValue(fileType.str(), name);
-            if(name.length() < 1)
-                break;
+                fileType.appendf("%s%d", File_ThorLog, countThorLog);
 
             Owned<IEspECLHelpFile> h= createECLHelpFile("","");
             h->setName(name.str());
             h->setType(fileType.str());
             helpers.append(*h.getLink());
-            name.clear();
         }
 
         StringBuffer logDir;


### PR DESCRIPTION
In the fix for gh-2476, the thor cluster name is hard
coded as 'thor', which is wrong.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
