### PR TITLE
fix 2540 DFU File and HPCC query fetch limit

### DIFF
--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCConnection.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCConnection.java
@@ -32,7 +32,7 @@ public class HPCCConnection implements Connection
 	public static final String WSECLWATCHPORTDEFAULT = "8010";
 	public static final String WSECLPORTDEFAULT = "8002";
 	public static final String WSECLDIRECTPORTDEFAULT = "8008";
-	public static final String FETCHPAGESIZEDEFAULT = "100";
+	public static final int FETCHPAGESIZEDEFAULT = 100;
 	public static final String LAZYLOADDEFAULT = "true";
 
     private boolean closed;
@@ -85,7 +85,7 @@ public class HPCCConnection implements Connection
 			this.props.setProperty("password", "");
 
 		if (!this.props.containsKey("PageSize") || !HPCCJDBCUtils.isNumeric(this.props.getProperty("PageSize")))
-			this.props.setProperty("PageSize", FETCHPAGESIZEDEFAULT);
+			this.props.setProperty("PageSize", String.valueOf(FETCHPAGESIZEDEFAULT));
 
 		boolean setdefaultreslim = false;
 		if (this.props.containsKey("EclResultLimit"))
@@ -118,22 +118,24 @@ public class HPCCConnection implements Connection
 			System.out.println("Invalid Numeric EclResultLimit value detected, using default value: " + ECLRESULTLIMDEFAULT);
 		}
 
-		// basicAuth
-		String userPassword = this.props.getProperty("username") + ":"
-				+ props.getProperty("password");
+		String basicAuth = createBasicAuth(this.props.getProperty("username"), props.getProperty("password"));
 
-       String basicAuth = "Basic " + HPCCJDBCUtils.Base64Encode(userPassword.getBytes(), false);
-       this.props.put("BasicAuth", basicAuth);
+		this.props.put("BasicAuth", basicAuth);
 
-       if (!this.props.containsKey("LazyLoad"))
-			this.props.setProperty("LazyLoad", LAZYLOADDEFAULT);
+		if (!this.props.containsKey("LazyLoad"))
+		this.props.setProperty("LazyLoad", LAZYLOADDEFAULT);
 
-       metadata = new HPCCDatabaseMetaData(props);
+		metadata = new HPCCDatabaseMetaData(props);
 
-       //TODO not doing anything w/ this yet, just exposing it to comply w/ API definition...
-       clientInfo = new Properties();
+		//TODO not doing anything w/ this yet, just exposing it to comply w/ API definition...
+		clientInfo = new Properties();
 
-       System.out.println("EclConnection initialized - server: " + this.serverAddress);
+		System.out.println("EclConnection initialized - server: " + this.serverAddress);
+    }
+
+    public static String createBasicAuth(String username, String passwd)
+    {
+    	return "Basic " + HPCCJDBCUtils.Base64Encode((username + ":" + passwd).getBytes(), false);
     }
 
     public Properties getProperties()

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCConnection.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCConnection.java
@@ -26,6 +26,15 @@ import java.util.Properties;
 public class HPCCConnection implements Connection
 {
 	public static final String ECLRESULTLIMDEFAULT = "100";
+	public static final String CLUSTERDEFAULT = "hthor";
+	public static final String QUERYSETDEFAULT = "hthor";
+	public static final String SERVERADDRESSDEFAULT = "localhost";
+	public static final String WSECLWATCHPORTDEFAULT = "8010";
+	public static final String WSECLPORTDEFAULT = "8002";
+	public static final String WSECLDIRECTPORTDEFAULT = "8008";
+	public static final String FETCHPAGESIZEDEFAULT = "100";
+	public static final String LAZYLOADDEFAULT = "true";
+
     private boolean closed;
     private HPCCDatabaseMetaData metadata;
     private Properties props;
@@ -36,7 +45,7 @@ public class HPCCConnection implements Connection
     {
 		closed = false;
 
-		this.serverAddress = "localhost";
+		this.serverAddress = SERVERADDRESSDEFAULT;
 
 		if (props.containsKey("ServerAddress"))
 			this.serverAddress = props.getProperty("ServerAddress");
@@ -46,34 +55,37 @@ public class HPCCConnection implements Connection
 		this.props = props;
 
 		if (!this.props.containsKey("Cluster"))
-			this.props.setProperty("Cluster", "hthor");
+			this.props.setProperty("Cluster", CLUSTERDEFAULT);
 
 		if (!this.props.containsKey("QuerySet"))
-			this.props.setProperty("QuerySet", "hthor");
+			this.props.setProperty("QuerySet", QUERYSETDEFAULT);
 
 		if (!this.props.containsKey("WsECLWatchAddress"))
 			this.props.setProperty("WsECLWatchAddress", serverAddress);
 
 		if (!this.props.containsKey("WsECLWatchPort"))
-			this.props.setProperty("WsECLWatchPort", "8010");
+			this.props.setProperty("WsECLWatchPort", WSECLWATCHPORTDEFAULT);
 
 		if (!this.props.containsKey("WsECLAddress"))
 			this.props.setProperty("WsECLAddress", serverAddress);
 
 		if (!this.props.containsKey("WsECLPort"))
-			this.props.setProperty("WsECLPort", "8002");
+			this.props.setProperty("WsECLPort", WSECLPORTDEFAULT);
 
 		if (!this.props.containsKey("WsECLDirectAddress"))
 			this.props.setProperty("WsECLDirectAddress", serverAddress);
 
 		if (!this.props.containsKey("WsECLDirectPort"))
-			this.props.setProperty("WsECLDirectPort", "8008");
+			this.props.setProperty("WsECLDirectPort", WSECLDIRECTPORTDEFAULT);
 
 		if (!this.props.containsKey("username"))
 			this.props.setProperty("username", "");
 
 		if (!this.props.containsKey("password"))
 			this.props.setProperty("password", "");
+
+		if (!this.props.containsKey("PageSize") || !HPCCJDBCUtils.isNumeric(this.props.getProperty("PageSize")))
+			this.props.setProperty("PageSize", FETCHPAGESIZEDEFAULT);
 
 		boolean setdefaultreslim = false;
 		if (this.props.containsKey("EclResultLimit"))
@@ -114,7 +126,7 @@ public class HPCCConnection implements Connection
        this.props.put("BasicAuth", basicAuth);
 
        if (!this.props.containsKey("LazyLoad"))
-			this.props.setProperty("LazyLoad", "True");
+			this.props.setProperty("LazyLoad", LAZYLOADDEFAULT);
 
        metadata = new HPCCDatabaseMetaData(props);
 

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
@@ -151,7 +151,7 @@ public class HPCCJDBCUtils
 		return true;
 	}
 
-	public static long stringToLong(String str)
+	public static long stringToLong(String str, long uponError)
 	{
 		try
 		{
@@ -160,11 +160,11 @@ public class HPCCJDBCUtils
 		}
 		catch (ParseException e)
 		{
-			return 0;
+			return uponError;
 		}
 	}
 
-	public static int stringToInt(String str)
+	public static int stringToInt(String str, int uponError)
 	{
 		try
 		{
@@ -173,7 +173,7 @@ public class HPCCJDBCUtils
 		}
 		catch (ParseException e)
 		{
-			return 0;
+			return uponError;
 		}
 	}
 

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 
 public class HPCCJDBCUtils
 {
+	public static NumberFormat format = NumberFormat.getInstance(Locale.US);
 	static final char pad = '=';
 	static final char BASE64_enc[] =  {'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
             						  'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',
@@ -138,7 +139,6 @@ public class HPCCJDBCUtils
 
 	public static boolean isNumeric(String str)
 	{
-		NumberFormat format = NumberFormat.getInstance(Locale.US);
 		try
 		{
 			format.parse(str);
@@ -150,6 +150,33 @@ public class HPCCJDBCUtils
 
 		return true;
 	}
+
+	public static long stringToLong(String str)
+	{
+		try
+		{
+			Number num = format.parse(str);
+			return num.longValue();
+		}
+		catch (ParseException e)
+		{
+			return 0;
+		}
+	}
+
+	public static int stringToInt(String str)
+	{
+		try
+		{
+			Number num = format.parse(str);
+			return num.intValue();
+		}
+		catch (ParseException e)
+		{
+			return 0;
+		}
+	}
+
 	public static String replaceAll(String input, String forReplace, String replaceWith)
 	{
 		if (input == null)

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCLogicalFiles.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCLogicalFiles.java
@@ -9,11 +9,14 @@ public class HPCCLogicalFiles
 {
 	private Properties files;
 	private List<String> superfiles;
+	private long reportedFileCount;
 
 	public HPCCLogicalFiles()
 	{
 		files = new Properties();
 		superfiles = new ArrayList<String>();
+
+		reportedFileCount = 0;
 	}
 
 	public void putFile(String fullyQualifiedName, DFUFile file)
@@ -70,6 +73,20 @@ public class HPCCLogicalFiles
 		return eclrecdef;
 	}
 
+	public void updateSuperFile(String superfilename)
+	{
+		DFUFile superfile = (DFUFile) files.get(superfilename);
+		if (!superfile.hasFileRecDef())
+		{
+			if(superfile.containsSubfiles())
+			{
+				System.out.println("Processing superfile: " + superfile.getFullyQualifiedName());
+				superfile.setFileRecDef(getSubfileRecDef(superfile));
+				files.put(superfile.getFullyQualifiedName(), superfile);
+			}
+		}
+	}
+
 	public void updateSuperFiles()
 	{
 		int superfilescount = superfiles.size();
@@ -85,10 +102,38 @@ public class HPCCLogicalFiles
 					System.out.println("Processing superfile: " + superfile.getFullyQualifiedName());
 					superfile.setFileRecDef(getSubfileRecDef(superfile));
 					if(superfile.hasFileRecDef())
+					{
+						files.put(superfile.getFullyQualifiedName(), superfile);
 						superfilesupdated++;
+					}
 				}
 			}
 		}
 		System.out.println("Update superfiles' record definition ( " + superfilesupdated + " out of " + superfilescount + " )");
+	}
+
+	public long getReportedFileCount()
+	{
+		return reportedFileCount;
+	}
+
+	public void setReportedFileCount(long reportedFileCount)
+	{
+		this.reportedFileCount = reportedFileCount;
+	}
+
+	public void setReportedFileCount(String reportedFileCountStr)
+	{
+		this.reportedFileCount = HPCCJDBCUtils.stringToLong(reportedFileCountStr);
+	}
+
+	public int getCachedFileCount()
+	{
+		return files.size();
+	}
+
+	public int getCachedSuperFileCount()
+	{
+		return superfiles.size();
 	}
 }

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCLogicalFiles.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCLogicalFiles.java
@@ -124,7 +124,7 @@ public class HPCCLogicalFiles
 
 	public void setReportedFileCount(String reportedFileCountStr)
 	{
-		this.reportedFileCount = HPCCJDBCUtils.stringToLong(reportedFileCountStr);
+		this.reportedFileCount = HPCCJDBCUtils.stringToLong(reportedFileCountStr, 0);
 	}
 
 	public int getCachedFileCount()

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCQueries.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCQueries.java
@@ -55,4 +55,14 @@ public class HPCCQueries {
 	{
 		return queries.size();
 	}
+
+	public boolean containsQueryName(String eclqueryname)
+	{
+		return queries.containsKey(eclqueryname);
+	}
+
+	public boolean containsQueryName(String clustername, String eclqueryname)
+	{
+		return queries.containsKey((clustername.length()>0 ? clustername +"::" : "") + eclqueryname);
+	}
 }

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCResultSet.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCResultSet.java
@@ -39,7 +39,6 @@ public class HPCCResultSet implements ResultSet
 	private HPCCResultSetMetadata	resultMetadata;
 	private HPCCDatabaseMetaData	dbMetadata;
 	private Statement				statement;
-	private String					test_query	= "SELECT 1";
 	private String 					defaultEclQueryReturnDatasetName;
 	private Object					lastResult;
 	private ArrayList<SQLWarning> 	warnings;
@@ -78,9 +77,9 @@ public class HPCCResultSet implements ResultSet
 			if(sqlreqtype == SQLParser.SQL_TYPE_SELECT)
 			{
 				String hpccfilename = HPCCJDBCUtils.handleQuotedString(parser.getTableName());
-				if(!dbMetadata.tableExists("", hpccfilename))
-					throw new Exception("Invalid table found: " + hpccfilename);
 				DFUFile dfufile = dbMetadata.getDFUFile(hpccfilename);
+				if (dfufile == null)
+					throw new Exception("Invalid table name found: " + hpccfilename);
 				if (!dfufile.hasFileRecDef())
 					throw new Exception("Cannot query: " + hpccfilename + " because it does not contain a record definition.");
 				parser.verifySelectColumns(dfufile);
@@ -128,7 +127,7 @@ public class HPCCResultSet implements ResultSet
 				ArrayList<HPCCColumnMetaData> storeProcInParams = new ArrayList();
 				HPCCQuery hpccQuery = dbMetadata.getHpccQuery(HPCCJDBCUtils.handleQuotedString(parser.getStoredProcName()));
 				if (hpccQuery == null)
-					throw new Exception("Invalid store procedure found");
+					throw new Exception("Invalid store procedure found. Check QuerySet configuration.");
 				defaultEclQueryReturnDatasetName = hpccQuery.getDefaultTableName();
 				expectedretcolumns = hpccQuery.getAllNonInFields();
 				storeProcInParams = hpccQuery.getAllInFields();
@@ -283,7 +282,6 @@ public class HPCCResultSet implements ResultSet
 	}
 	public String getString(int columnIndex) throws SQLException
 	{
-		//System.out.println("getString( " + columnIndex +")");
 		if (index >= 0 && index <= rows.size())
 			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
 			{
@@ -535,7 +533,6 @@ public class HPCCResultSet implements ResultSet
 	}
 	public String getString(String columnLabel) throws SQLException
 	{
-		//System.out.println("getString( " + columnLabel +")");
 		if (index >= 0  && index <= rows.size())
 		{
 			int column = resultMetadata.getColumnIndex(columnLabel);
@@ -919,15 +916,7 @@ public class HPCCResultSet implements ResultSet
 	{
 		if (index >= 0  && index <= rows.size())
 		{
-			//System.out.println("EclResultSet being queried for tablename: " + resultMetadata.getTableName(0) + " column: " + columnIndex + " total number of columns: " + rows.get(index).size() + " Current row: " + index) ;
-			//System.out.println("Columlabel: " + resultMetadata.getColumnLabel(columnIndex));
-			//System.out.println("Columlabel: " + resultMetadata.getColumnClassName(columnIndex));
 			lastResult = rows.get(index).get(columnIndex - 1);
-			if (lastResult == null)
-				return null;
-			//obj = Class.forName(resultMetadata.getColumnClassName(columnIndex));
-			//System.out.println("results object id: " + (Object)this.hashCode());
-			//System.out.println("returning object" + (lastResult==null ? ": null" : " of type " + resultMetadata.getColumnClassName(columnIndex) +  " : " + lastResult.toString()));
 			return lastResult;
 		}
 		else

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLOperator.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLOperator.java
@@ -6,22 +6,53 @@ import java.util.List;
 public class SQLOperator
 {
 	private static List<String> validOps;
-	public static final String eq = new String("=");
-	public static final String neq = new String("<>");
+
+	//When adding a new opereator, make sure to add it to validOps array
+	public static final String eq = 	new String("=");
+	public static final String neq = 	new String("<>");
+	public static final String neq2 = 	new String("!=");
 	public static final String isNull = new String("IS NULL");
 	public static final String isNotNull = new String("IS NOT NULL");
-	public static final String gt = new String(">");
-	public static final String lt = new String("<");
-	public static final String gte = new String(">=");
-	public static final String lte = new String("<=");
-	public static final String and = new String("AND");
-	public static final String or = new String("OR");
-	public static final String not = new String("NOT");
+	public static final String gt = 	new String(">");
+	public static final String lt = 	new String("<");
+	public static final String gte = 	new String(">=");
+	public static final String lte = 	new String("<=");
+	public static final String and = 	new String("AND");
+	public static final String or = 	new String("OR");
+	public static final String not = 	new String("NOT");
 	public static final String exists = new String("EXISTS");
-	public static final String like = new String("LIKE");
-	public static final String in = new String("IN");
+	public static final String like = 	new String("LIKE");
+	public static final String in = 	new String("IN");
+
+	static
+	{
+		validOps = new ArrayList<String>();
+		validOps.add(eq);
+		validOps.add(neq);
+		validOps.add(neq2);
+		validOps.add(isNull);
+		validOps.add(isNotNull);
+		validOps.add(gt);
+		validOps.add(lt);
+		validOps.add(gte);
+		validOps.add(lte);
+		validOps.add(and);
+		validOps.add(or);
+		validOps.add(not);
+		validOps.add(exists);
+		validOps.add(like);
+		validOps.add(in);
+	}
 
 	private final String value;
+
+	public SQLOperator(String operator)
+	{
+		if( validOps.contains(operator.toUpperCase()))
+				value = operator.toUpperCase();
+		else
+				value = null;
+	}
 
 	public String getValue()
 	{
@@ -30,34 +61,7 @@ public class SQLOperator
 
 	public boolean isValid()
 	{
-		return value == null ? false : true;
-	}
-
-	public SQLOperator(String operator)
-	{
-		if (validOps == null)
-		{
-			validOps = new ArrayList<String>();
-			validOps.add(eq);
-			validOps.add(neq);
-			validOps.add(isNull);
-			validOps.add(isNotNull);
-			validOps.add(gt);
-			validOps.add(lt);
-			validOps.add(gte);
-			validOps.add(lte);
-			validOps.add(and);
-			validOps.add(or);
-			validOps.add(not);
-			validOps.add(exists);
-			validOps.add(like);
-			validOps.add(in);
-		}
-
-		if( validOps.contains(operator.toUpperCase()))
-				value = operator.toUpperCase();
-		else
-				value = null;
+		return validOps.contains(value);
 	}
 
 	@Override

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLParser.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLParser.java
@@ -360,6 +360,8 @@ public class SQLParser
 							operator = SQLOperator.lte;
 						else if (trimmedExpression.indexOf(SQLOperator.neq)!=-1)
 							operator = SQLOperator.neq;
+						else if (trimmedExpression.indexOf(SQLOperator.neq2)!=-1)
+							operator = SQLOperator.neq2;
 						else if (trimmedExpression.indexOf(SQLOperator.eq)!=-1)
 							operator = SQLOperator.eq;
 						else if (trimmedExpression.indexOf(SQLOperator.gt)!=-1)

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/test/jdbcdriver/HPCCDriverTest.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/test/jdbcdriver/HPCCDriverTest.java
@@ -3,6 +3,7 @@ package com.hpccsystems.test.jdbcdriver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +52,23 @@ public class HPCCDriverTest
 				System.out.println("   " + tables.getString("TABLE_NAME") + " Remarks: \'" + tables.getString("REMARKS")+"\'");
 			}
 
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			System.out.println(e.getMessage());
+			success = false;
+		}
+		return success;
+	}
+
+	private static boolean  createStandAloneDataMetadata(Properties conninfo)
+	{
+		boolean success = true;
+		try
+		{
+			HPCCDatabaseMetaData dbmetadata = new HPCCDatabaseMetaData(conninfo);
+			success = getDatabaseInfo(dbmetadata);
 		}
 		catch (Exception e)
 		{
@@ -273,24 +291,36 @@ public class HPCCDriverTest
 
 	private static boolean getDatabaseInfo(HPCCConnection conn)
 	{
+		try
+		{
+			return getDatabaseInfo((HPCCDatabaseMetaData)conn.getMetaData());
+		}
+		catch (SQLException e)
+		{
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	private static boolean getDatabaseInfo(HPCCDatabaseMetaData dbmetadata)
+	{
 		boolean success = true;
 		try
 		{
-			HPCCDatabaseMetaData meta =  (HPCCDatabaseMetaData)conn.getMetaData();
-			String hpccname = meta.getDatabaseProductName();
-			String hpccprodver = meta.getDatabaseProductVersion();
-			int major = meta.getDatabaseMajorVersion();
-			int minor = meta.getDatabaseMinorVersion();
-			String sqlkeywords = meta.getSQLKeywords();
+			String hpccname = dbmetadata.getDatabaseProductName();
+			String hpccprodver = dbmetadata.getDatabaseProductVersion();
+			int major = dbmetadata.getDatabaseMajorVersion();
+			int minor = dbmetadata.getDatabaseMinorVersion();
+			String sqlkeywords = dbmetadata.getSQLKeywords();
 
 			System.out.println("HPCC System Info:");
 			System.out.println("\tProduct Name: " + hpccname);
 			System.out.println("\tProduct Version: " + hpccprodver);
 			System.out.println("\tProduct Major: " + major);
 			System.out.println("\tProduct Minor: " + minor);
-			System.out.println("\tDriver Name: " + meta.getDriverName());
-			System.out.println("\tDriver Major: " + meta.getDriverMajorVersion());
-			System.out.println("\tDriver Minor: " + meta.getDriverMinorVersion());
+			System.out.println("\tDriver Name: " + dbmetadata.getDriverName());
+			System.out.println("\tDriver Major: " + dbmetadata.getDriverMajorVersion());
+			System.out.println("\tDriver Minor: " + dbmetadata.getDriverMinorVersion());
 			System.out.println("\tSQL Key Words: " + sqlkeywords);
 		}
 		catch (Exception e)
@@ -307,6 +337,8 @@ public class HPCCDriverTest
 		try
 		{
 			//success &= testLazyLoading(propsinfo);
+
+			success &= createStandAloneDataMetadata(propsinfo);
 
 			HPCCConnection connectionprops = connectViaProps(propsinfo);
 			if (connectionprops == null)


### PR DESCRIPTION
These changes fix the issue where too many DFU Logical files and/or HPCC queries present on the target HPCC system could freeze and/or crash the client using the HPCC JDBC Driver.

There is now a method for limiting the number of Files/queries fetched at any one time, and on-demand file/query fetch is enabled.

Code Reviewed (on gh issue) by @garonsky .

This fix should be in included in 3.8.x HPCC JDBC Driver.
