### PR TITLE
Fix gh-2333 Outdated Optional packages still display

### DIFF
--- a/build-config.h.cmake
+++ b/build-config.h.cmake
@@ -89,3 +89,7 @@
 #ifndef BUILD_LEVEL
     #cmakedefine BUILD_LEVEL "${BUILD_LEVEL}"
 #endif
+
+#ifndef USE_RESOURCE
+    #cmakedefine USE_RESOURCE "${USE_RESOURCE}"
+#endif

--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -68,6 +68,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   option(DOCS_DRUPAL "Create Drupal HTML Docs" OFF)
   option(DOCS_EPUB "Create EPUB Docs" OFF)
   option(DOCS_MOBI "Create Mobi Docs" OFF)
+  option(USE_RESOURCE "Use resource download in ECLWatch" OFF)
   
   if ( USE_XALAN AND USE_LIBXSLT )
       set(USE_XALAN OFF)

--- a/esp/eclwatch/ws_XSLT/hpccresourcelist.xslt
+++ b/esp/eclwatch/ws_XSLT/hpccresourcelist.xslt
@@ -54,27 +54,46 @@
       </head>
       <body class="yui-skin-sam" onload="nof5();onLoad()">
         <form id="HPCCResourceForm" name="HPCCResourceForm" >
-          <xsl:choose>
-            <xsl:when test="not(HPCCResourceRepositories/HPCCResourceRepository[1])">
-              <br/><br/>No resource found from your installation.<br/><br/>
-              <xsl:if test="string-length(PortalURL)">
-                <br/>You may visit <a href="{PortalURL}" target="_blank">
-                  <xsl:value-of select="PortalURL"/>
-                </a> for resources.
-              </xsl:if>
-            </xsl:when>
-            <xsl:otherwise>
-              <br/>
-              <b>Click a link below to download a version from your installation.
-              <xsl:if test="string-length(PortalURL)">
-                <br/>You may visit <a href="{PortalURL}" target="_blank">
-                <xsl:value-of select="PortalURL"/>
-                </a> for other versions.
-              </xsl:if>
-              </b><br/><br/>
-              <xsl:apply-templates/>
-            </xsl:otherwise>
-          </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="UseResource = 0">
+                    <xsl:choose>
+                        <xsl:when test="string-length(PortalURL)">
+                            Visit <a href="{PortalURL}" target="_blank">
+                              <xsl:value-of select="PortalURL"/>
+                            </a> for resources.
+                        </xsl:when>
+                        <xsl:otherwise>
+                            The resources are temporarily unavailable. Please try again later.
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:choose>
+                        <xsl:when test="not(HPCCResourceRepositories/HPCCResourceRepository[1])">
+                            <br/><br/>No resource found from your installation.<br/><br/>
+                            <xsl:if test="string-length(PortalURL)">
+                                <br/>You may visit <a href="{PortalURL}" target="_blank">
+                                    <xsl:value-of select="PortalURL"/>
+                                </a> for resources.
+                            </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <br/>
+                            <b>
+                                Click a link below to download a version from your installation.
+                                <xsl:if test="string-length(PortalURL)">
+                                    <br/>You may visit <a href="{PortalURL}" target="_blank">
+                                        <xsl:value-of select="PortalURL"/>
+                                    </a> for other versions.
+                                </xsl:if>
+                            </b>
+                            <br/>
+                            <br/>
+                            <xsl:apply-templates/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:otherwise>
+            </xsl:choose>
         </form>
       </body>
     </html>

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -256,10 +256,11 @@ BrowseResourcesResponse
     string PortalURL;
     string NetAddress;
     int OS;
+    [min_ver("1.13")] bool UseResource;
     ESParray<ESPstruct HPCCResourceRepository> HPCCResourceRepositories;
 };
 
-ESPservice [noforms, version("1.12"), default_client_version("1.12"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [noforms, version("1.13"), default_client_version("1.13"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPuses ESPStruct Capability;
     ESPuses ESPStruct Permission;

--- a/esp/services/ws_smc/CMakeLists.txt
+++ b/esp/services/ws_smc/CMakeLists.txt
@@ -55,6 +55,8 @@ include_directories (
          ./../../smc/SMCLib 
          ./../../bindings/SOAP/xpp 
          ./../../../system/security/LdapSecurity
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 # NOTE - this should not be needed, it's the result of poor encapsulation and using CLdapSecManager directly 

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -18,6 +18,8 @@
 
 #pragma warning (disable : 4786)
 
+#include "build-config.h"
+
 #ifdef _USE_OPENLDAP
 #include "ldapsecurity.ipp"
 #endif
@@ -1260,6 +1262,8 @@ bool CWsSMCEx::onBrowseResources(IEspContext &context, IEspBrowseResourcesReques
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_SMC_ACCESS_DENIED, "Failed to Browse Resources. Permission denied.");
 
+        double version = context.getClientVersion();
+
         Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
         Owned<IConstEnvironment> constEnv = factory->openEnvironmentByFile();
 
@@ -1280,6 +1284,13 @@ bool CWsSMCEx::onBrowseResources(IEspContext &context, IEspBrowseResourcesReques
 
         if (m_PortalURL.length() > 0)
             resp.setPortalURL(m_PortalURL.str());
+
+#ifndef USE_RESOURCE
+        if (version > 1.12)
+            resp.setUseResource(false);
+#else
+        if (version > 1.12)
+            resp.setUseResource(true);
 
         //Now, get a list of resources stored inside the ESP box
         IArrayOf<IEspHPCCResourceRepository> resourceRepositories;
@@ -1398,6 +1409,7 @@ bool CWsSMCEx::onBrowseResources(IEspContext &context, IEspBrowseResourcesReques
 
         if (resourceRepositories.ordinality())
             resp.setHPCCResourceRepositories(resourceRepositories);
+#endif
     }
     catch(IException* e)
     {


### PR DESCRIPTION
This fix adds a cmake option 'USE_RESOURCE' and the
default value is OFF. As the default, ECLWatch will only
display a web link to the hpcc website for resources
and will not show the download link for optional packages.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
