### PR TITLE
Fix a minor issue with the selectors for ROLLUP(GROUP)

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -1947,6 +1947,7 @@ childDatasetType getChildDatasetType(IHqlExpression * expr)
     case no_graphloop:
     case no_filtergroup:
     case no_normalizegroup:
+    case no_rollupgroup:
         return childdataset_left;
     case no_denormalize:
     case no_denormalizegroup:
@@ -1966,7 +1967,6 @@ childDatasetType getChildDatasetType(IHqlExpression * expr)
         return childdataset_same_left_right;
     case no_dedup:
     case no_rollup:
-    case no_rollupgroup:
         return childdataset_top_left_right;
     case no_iterate:
         return childdataset_same_left_right;


### PR DESCRIPTION
ROLLUP(GROUP) only has the LEFT selector available, not RIGHT/top.
Found while investigating another issue.  Only likely ill effect
would have been minor. (E.g., an internal error instead of scoping
error, or failure to optimize code)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
