### PR TITLE
Fix gh-2607 - avoid issues with UTF8 locale

### DIFF
--- a/testing/ecl/pipe4.ecl
+++ b/testing/ecl/pipe4.ecl
@@ -22,7 +22,12 @@ import std.str;
 //Number of leading spaces will force the lines to come out in the correct order
 d := dataset(['</Zingo>', ' <Zango>Line3</Zango>', '  <Zango>Middle</Zango>', '   <Zango>Line1</Zango>', '    <Zingo>' ], { string line}) : stored('nofold');
 
-p1 := PIPE(d(line!='p1'), 'sort', { string lout{XPATH('')} }, xml('Zingo/Zango'), output(csv));
+#IF (__OS__ = 'windows')
+pipeCmd := 'sort';
+#ELSE
+pipeCmd := 'sh -c \'export LC_ALL=C; sort\'';
+#END
+p1 := PIPE(d(line!='p1'), pipeCmd, { string lout{XPATH('')} }, xml('Zingo/Zango'), output(csv));
 
 output(p1, { string l := Str.FindReplace(lout, '\r', ' ') } );
 

--- a/testing/ecl/pipe7.ecl
+++ b/testing/ecl/pipe7.ecl
@@ -23,10 +23,16 @@ d1 := dataset(['</Dataset>', ' <Row>Line3</Row>', '  <Row>Middle</Row>', '   <Ro
 d2 := dataset([' <Row>Line3</Row>', '  <Row>Middle</Row>', '   <Row>Line1</Row>'], { string line }) : stored('nofold2');
 d3 := dataset([' <Dataset><Row>Line3</Row></Dataset>', '  <Dataset><Row>Middle</Row></Dataset>', '   <Dataset><Row>Line1</Row></Dataset>'], { string line }) : stored('nofold3');
 
-p1 := PIPE(d1, 'sort', { string lout{XPATH('')} }, xml('Dataset/Row'), output(csv));
-p2 := PIPE(d2, 'sort', { string lout{XPATH('')} }, xml(noroot), output(csv));
-p3 := PIPE(d3, 'sort', { string lout{XPATH('')} }, xml('Dataset/Row'), output(csv), repeat);
-p4 := PIPE(d2, 'sort', { string lout{XPATH('')} }, xml('Row', noroot), output(csv), repeat);
+#IF (__OS__ = 'windows')
+pipeCmd := 'sort';
+#ELSE
+pipeCmd := 'sh -c \'export LC_ALL=C; sort\'';
+#END
+
+p1 := PIPE(d1, pipeCmd, { string lout{XPATH('')} }, xml('Dataset/Row'), output(csv));
+p2 := PIPE(d2, pipeCmd, { string lout{XPATH('')} }, xml(noroot), output(csv));
+p3 := PIPE(d3, pipeCmd, { string lout{XPATH('')} }, xml('Dataset/Row'), output(csv), repeat);
+p4 := PIPE(d2, pipeCmd, { string lout{XPATH('')} }, xml('Row', noroot), output(csv), repeat);
 
 output(p1, { string l := Str.FindReplace(lout, '\r', ' ') } );
 output(p2, { string l := Str.FindReplace(lout, '\r', ' ') } );


### PR DESCRIPTION
Standard distro. locale tends to be .UTF8
which causes these pipe tests that use sort to not behave as expected

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
