### PR TITLE
Add missing call (which currently has no effect)

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -4712,6 +4712,7 @@ void CHqlExpression::cacheTablesProcessChildScope()
             OwnedHqlExpr right = createSelector(no_right, rightDs, selSeq);
             cacheChildrenTablesUsed(2, max);
             inScopeTables.zap(*right);
+            queryRemoveRows(inScopeTables, this, left, right);
             if (op == no_normalize)
             {
                 //two datasets form of normalize is weird because right dataset is based on left


### PR DESCRIPTION
Fix a potential bug if no_rows was ever tracked as in scope instead of
the left selector.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
