### PR TITLE
gh-2614 Regression suite failing on library tests

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -737,8 +737,9 @@
           <para><orderedlist>
               <listitem>
                 <para>In your browser, go to the <emphasis role="bold">ECL
-                Watch</emphasis> URL. For example, http://nnn.nnn.nnn.nnn:8010,
-                where nnn.nnn.nnn.nnn is your node's IP address.</para>
+                Watch</emphasis> URL. For example,
+                http://nnn.nnn.nnn.nnn:8010, where nnn.nnn.nnn.nnn is your
+                node's IP address.</para>
 
                 <para><informaltable colsep="1" frame="all" rowsep="1">
                     <?dbfo keep-together="always"?>
@@ -785,12 +786,12 @@
 
               <listitem>
                 <para>Click on the <emphasis role="bold">ECL IDE and Client
-                Tools </emphasis>link. </para>
+                Tools </emphasis>link.</para>
               </listitem>
 
               <listitem>
                 <para>Follow the instructions on the web page to install the
-                ECL IDE. </para>
+                ECL IDE.</para>
               </listitem>
 
               <listitem>
@@ -1088,7 +1089,12 @@
       advantage of the true power of an HPCC—the ability to perform operations
       using Massively Parallel Processing (MPP). This section provides the
       steps to expand your single-node system into a multi-node system using
-      the Configuration Manager Wizard.</para>
+      the Configuration Manager Wizard. </para>
+
+      <para>To run a multi-node system, ensure that you have exactly the same
+      packages installed on every node. Follow the steps below to configure
+      your multi-node system to leverage the full power of Massively Parallel
+      Processing. </para>
 
       <sect2 id="configuring-a-multi-node-system">
         <title>Using the Configuration Manager Wizard</title>
@@ -1097,7 +1103,8 @@
         nodes. Before you start this section, you must have already downloaded
         the correct packages for your distro from the HPCC Systems website:
         <ulink
-        url="http://hpccsystems.com/download/free-community-edition">http://hpccsystems.com/download/free-community-edition</ulink></para>
+        url="http://hpccsystems.com/download/free-community-edition">http://hpccsystems.com/download/free-community-edition</ulink>.
+        </para>
 
         <orderedlist>
           <listitem>
@@ -1208,7 +1215,7 @@
             button.</para>
 
             <para>Alternatively, you could find the IP addresses using Auto
-            Discovery by selecting the Auto Discovery button. </para>
+            Discovery by selecting the Auto Discovery button.</para>
 
             <para>Now you will define how many nodes to use for the Roxie and
             Thor clusters.</para>

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -273,33 +273,36 @@ public:
         if (ok)
         {
             workunit->setState(WUStateCompiled);
-            if (isLibrary(workunit))
+            if (workunit->getAction()==WUActionRun || workunit->getAction()==WUActionUnknown)  // Assume they meant run....
             {
-                workunit->setState(WUStateCompleted);
-            }
-            else if (workunit->getAction()==WUActionRun || workunit->getAction()==WUActionUnknown)  // Assume they meant run....
-            {
-                workunit->schedule();
-                SCMStringBuffer dllBuff;
-                Owned<IConstWUQuery> wuQuery = workunit->getQuery();
-                wuQuery->getQueryDllName(dllBuff);
-                wuQuery.clear();
-                if (dllBuff.length() > 0)
+                if (isLibrary(workunit))
                 {
-                    workunit.clear();
-                    if (!runWorkUnit(wuid, clusterName.str()))
-                    {
-                        Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
-                        workunit.setown(factory->updateWorkUnit(wuid));
-                        reportError("Failed to execute workunit", 2);
-                        if (workunit->getState() != WUStateAborted)
-                            workunit->setState(WUStateFailed);
-                    }
+                    workunit->setState(WUStateCompleted);
                 }
                 else
                 {
-                    reportError("Failed to execute workunit (unknown DLL name)", 2);
-                    workunit->setState(WUStateFailed);
+                    workunit->schedule();
+                    SCMStringBuffer dllBuff;
+                    Owned<IConstWUQuery> wuQuery = workunit->getQuery();
+                    wuQuery->getQueryDllName(dllBuff);
+                    wuQuery.clear();
+                    if (dllBuff.length() > 0)
+                    {
+                        workunit.clear();
+                        if (!runWorkUnit(wuid, clusterName.str()))
+                        {
+                            Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
+                            workunit.setown(factory->updateWorkUnit(wuid));
+                            reportError("Failed to execute workunit", 2);
+                            if (workunit->getState() != WUStateAborted)
+                                workunit->setState(WUStateFailed);
+                        }
+                    }
+                    else
+                    {
+                        reportError("Failed to execute workunit (unknown DLL name)", 2);
+                        workunit->setState(WUStateFailed);
+                    }
                 }
             }
         }

--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -73,25 +73,43 @@
             var thorLogDate;
             var numberOfSlaves;
          
+            function CheckSlaveLogInput(e, allows)
+            {
+                var key, keychar;
+                if (window.event)
+                {
+                    key = window.event.keyCode;
+                    keychar = String.fromCharCode(key);
+                }
+                else if (e)
+                {
+                    key = e.keyCode;
+                    keychar = String.fromCharCode(e.which);
+                }
+                else
+                   return true;
+
+                if (key == 13) //for 'enter' key
+                {
+                    GetThorSlaveLog();
+                    return true;
+                }
+
+                if (key ==  8 || key == 37 || key == 39) //8/37/39: backspace/left/right
+                   return true;
+
+                if (((allows).indexOf(keychar) > -1))
+                   return true;
+                else
+                   return false;
+            }
+
             function CheckSlaveNum(e)
             {
                 if (document.getElementById('NumberSlaves').disabled == 'true')
                     return false;
 
-                var key;
-                if (window.event)
-                   key = window.event.keyCode;
-                else if (e)
-                   key = e.which;
-                else
-                   return true;
-
-                var keychar = String.fromCharCode(key);
-
-                if ((("0123456789").indexOf(keychar) > -1))
-                   return true;
-                else
-                   return false;
+                return CheckSlaveLogInput(e, '0123456789');
             }
 
             function CheckSlaveAddress(e)
@@ -99,20 +117,7 @@
                 if (document.getElementById('SlaveAddress').disabled == 'true')
                     return false;
 
-                var key;
-                if (window.event)
-                   key = window.event.keyCode;
-                else if (e)
-                   key = e.which;
-                else
-                   return true;
-
-                var keychar = String.fromCharCode(key);
-
-                if ((("0123456789_.").indexOf(keychar) > -1))
-                   return true;
-                else
-                   return false;
+                return CheckSlaveLogInput(e, '0123456789_.');
             }
 
             function thorProcessChanged(value)

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -901,7 +901,15 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
     IArrayOf<IConstThorLogInfo> thorLogList;
     if (cw->getWuidVersion() > 0)
     {
-        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo("thor");
+        SCMStringBuffer clusterName;
+        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cw->getClusterName(clusterName).str());
+        if (!clusterInfo)
+        {
+            SCMStringBuffer wuid;
+            WARNLOG("Cannot find TargetClusterInfo for workunit %s", cw->getWuid(wuid).str());
+            return countThorLog;
+        }
+
         unsigned numberOfSlaves = clusterInfo->getSize();
 
         Owned<IStringIterator> thorInstances = cw->getProcesses("Thor");

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -421,8 +421,6 @@ bool WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
     return false;
 }
 
-const unsigned MAXTHORS = 1024;
-
 bool WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
 {
     try
@@ -971,23 +969,26 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
     }
     else //legacy wuid
     {
-        SCMStringBuffer name;
-        for (int i0 = 1; i0 < MAXTHORS; i0++)
+        Owned<IStringIterator> thorLogs = cw->getLogs("Thor");
+        ForEach (*thorLogs)
         {
+            SCMStringBuffer name;
+            thorLogs->str(name);
+            if (name.length() < 1)
+                continue;
+
+            countThorLog++;
+
             StringBuffer fileType;
-            if (i0 < 2)
+            if (countThorLog < 2)
                 fileType.append(File_ThorLog);
             else
-                fileType.appendf("%s%d", File_ThorLog, i0);
-            cw->getDebugValue(fileType.str(), name);
-            if(name.length() < 1)
-                break;
+                fileType.appendf("%s%d", File_ThorLog, countThorLog);
 
             Owned<IEspECLHelpFile> h= createECLHelpFile("","");
             h->setName(name.str());
             h->setType(fileType.str());
             helpers.append(*h.getLink());
-            name.clear();
         }
 
         StringBuffer logDir;

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -168,6 +168,9 @@ void submitWsWorkunit(IEspContext& context, const char *wuid, const char* cluste
 {
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
     Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid, false);
+    if(!cw)
+        throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid);
+
     return submitWsWorkunit(context, cw, cluster, snapshot, maxruntime, compile, resetWorkflow, paramXml);
 }
 
@@ -356,6 +359,8 @@ bool doAction(IEspContext& context, StringArray& wuids, int action, IProperties*
             {
                 Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
                 Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid, false);
+                if(!cw)
+                    throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid);
 
                 StringBuffer strAction;
                 Owned<IEspWUActionResult> res = createWUActionResult("", "");
@@ -942,6 +947,9 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
                 }
 
                 Owned<IConstWorkUnit> cw(factory->openWorkUnit(wuid.str(), false));
+                if(!cw)
+                    throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid.str());
+
                 submitWsWorkunit(context, cw, NULL, NULL, 0, req.getRecompile(), req.getResetWorkflow());
             }
             catch (IException *E)
@@ -1077,6 +1085,9 @@ bool CWsWorkunitsEx::onWUSubmit(IEspContext &context, IEspWUSubmitRequest &req, 
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
         Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        if(!cw)
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+
         if (cw->getAction()==WUActionExecuteExisting)
         {
             ExecuteExistingQueryInfo info(cw);
@@ -1175,6 +1186,8 @@ bool CWsWorkunitsEx::onWUWaitCompiled(IEspContext &context, IEspWUWaitRequest &r
         secWaitForWorkUnitToCompile(req.getWuid(), *context.querySecManager(), *context.queryUser(), req.getWait());
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
         Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        if(!cw)
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
         resp.setStateID(cw->getState());
     }
     catch(IException* e)
@@ -2246,6 +2259,8 @@ void getWsWuResult(IEspContext &context, const char* wuid, const char *name, con
 {
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
     Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid, false);
+    if(!cw)
+        throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid);
     Owned<IConstWUResult> result;
 
     if (notEmpty(name))
@@ -2583,6 +2598,8 @@ bool CWsWorkunitsEx::onWUResultSummary(IEspContext &context, IEspWUResultSummary
     {
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
         Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        if(!cw)
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
         ensureWsWorkunitAccess(context, *cw, SecAccess_Read);
 
         resp.setWuid(req.getWuid());
@@ -3122,6 +3139,8 @@ bool CWsWorkunitsEx::onWUProcessGraph(IEspContext &context,IEspWUProcessGraphReq
     {
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
         Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        if(!cw)
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
         ensureWsWorkunitAccess(context, *cw, SecAccess_Read);
 
         Owned <IConstWUGraph> graph = cw->getGraph(req.getName());
@@ -3158,6 +3177,8 @@ bool CWsWorkunitsEx::onWUGetGraph(IEspContext& context, IEspWUGetGraphRequest& r
     {
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
         Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        if(!cw)
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
         ensureWsWorkunitAccess(context, *cw, SecAccess_Read);
 
         WUGraphIDType id;

--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -64,13 +64,10 @@ echo $$ > $lckfile
 ulimit -c unlimited
 ulimit -n 8192
 
-slaveproc="thorslave_${hpcc_compname}"
-ln -s -f `which $prog` $slaveproc
-
 echo "slave starting `date`"
 
-echo $instancedir/$slaveproc master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth
-$instancedir/$slaveproc master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth 2>/dev/null 1>/dev/null &
+echo $prog master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth
+$prog master=$master slave=.:$slaveport slavenum=$slavenum logDir=$logpth 2>/dev/null 1>/dev/null &
 slavepid=$!
 echo $slavepid > $PID_NAME
 if [ "$slavepid" -eq "0" ]; then

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/DFUFile.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/DFUFile.java
@@ -395,29 +395,29 @@ public class DFUFile
 		{
 			try
 			{
-				StringTokenizer comatokens = null;
+				StringTokenizer commatokens = null;
 				//ECL RECORD can be defined as { type name,...,type name}; or RECORD type name;...;type name;END;
 				//TODO we should handle nested file types
 				if (eclString.toUpperCase().contains("RECORD"))
 				{
 					String tmp = eclString.substring(eclString.indexOf("RECORD")+6, eclString.indexOf("END"));
-					comatokens = new StringTokenizer(tmp, ";");
+					commatokens = new StringTokenizer(tmp, ";");
 				}
 				else if (eclString.contains("{"))
 				{
 					String tmp = eclString.substring(eclString.indexOf('{')+1, eclString.indexOf('}'));
-					comatokens = new StringTokenizer(tmp, ",");
+					commatokens = new StringTokenizer(tmp, ",");
 				}
 
-				if (comatokens != null)
+				if (commatokens != null)
 				{
 					int index = 0;
-					while (comatokens.hasMoreTokens())
+					while (commatokens.hasMoreTokens())
 					{
-						String comatoken = comatokens.nextToken().trim();
-						String spacesplit [] = comatoken.split("\\s+");
+						String commatoken = commatokens.nextToken().trim();
+						String spacesplit [] = commatoken.split("\\s+");
 
-						String name = spacesplit[spacesplit.length-1].trim();
+						String name = spacesplit[spacesplit.length-1];
 						if (name.length() > 0)
 						{
 							StringBuffer type = new StringBuffer();

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/DFUFile.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/DFUFile.java
@@ -402,13 +402,11 @@ public class DFUFile
 				{
 					String tmp = eclString.substring(eclString.indexOf("RECORD")+6, eclString.indexOf("END"));
 					comatokens = new StringTokenizer(tmp, ";");
-
 				}
 				else if (eclString.contains("{"))
 				{
 					String tmp = eclString.substring(eclString.indexOf('{')+1, eclString.indexOf('}'));
 					comatokens = new StringTokenizer(tmp, ",");
-
 				}
 
 				if (comatokens != null)
@@ -416,20 +414,29 @@ public class DFUFile
 					int index = 0;
 					while (comatokens.hasMoreTokens())
 					{
-						StringTokenizer spacetokens = new StringTokenizer(comatokens.nextToken()," \n");
-						if(spacetokens.hasMoreTokens())
+						String comatoken = comatokens.nextToken().trim();
+						String spacesplit [] = comatoken.split("\\s+");
+
+						String name = spacesplit[spacesplit.length-1].trim();
+						if (name.length() > 0)
 						{
-							String type = spacetokens.nextToken();
-							String name = spacetokens.nextToken();
-							HPCCColumnMetaData columnmeta = new HPCCColumnMetaData(name, index, HPCCDatabaseMetaData.convertECLtype2SQLtype(type.toUpperCase()));
-							columnmeta.setEclType(type);
-							//columnmeta.setTableName(this.FileName);
+							StringBuffer type = new StringBuffer();
+							for (int i = 0; i< spacesplit.length-1; i++)
+							{
+								type.append(spacesplit[i]);
+								if (i+1 < spacesplit.length-1)
+									type.append(" ");
+							}
+
+							HPCCColumnMetaData columnmeta = new HPCCColumnMetaData(name, index, HPCCDatabaseMetaData.convertECLtype2SQLtype(type.toString().toUpperCase()));
+							columnmeta.setEclType(type.toString());
 							columnmeta.setTableName(this.FullyQualifiedName);
 
 							Ecl += type + " " + name + "; ";
 							Fields.put(name.toUpperCase(), columnmeta);
+
+							index++;
 						}
-						index++;
 					}
 				}
 			}
@@ -438,10 +445,6 @@ public class DFUFile
 				System.out.println("Invalid ECL Record definition found in " + this.getFullyQualifiedName() + " details.");
 				return;
 			}
-			/*finally
-			{
-				Ecl += "END; ";
-			}*/
 		}
 	}
 

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCConnection.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCConnection.java
@@ -32,7 +32,7 @@ public class HPCCConnection implements Connection
 	public static final String WSECLWATCHPORTDEFAULT = "8010";
 	public static final String WSECLPORTDEFAULT = "8002";
 	public static final String WSECLDIRECTPORTDEFAULT = "8008";
-	public static final String FETCHPAGESIZEDEFAULT = "100";
+	public static final int FETCHPAGESIZEDEFAULT = 100;
 	public static final String LAZYLOADDEFAULT = "true";
 
     private boolean closed;
@@ -85,7 +85,7 @@ public class HPCCConnection implements Connection
 			this.props.setProperty("password", "");
 
 		if (!this.props.containsKey("PageSize") || !HPCCJDBCUtils.isNumeric(this.props.getProperty("PageSize")))
-			this.props.setProperty("PageSize", FETCHPAGESIZEDEFAULT);
+			this.props.setProperty("PageSize", String.valueOf(FETCHPAGESIZEDEFAULT));
 
 		boolean setdefaultreslim = false;
 		if (this.props.containsKey("EclResultLimit"))
@@ -118,22 +118,24 @@ public class HPCCConnection implements Connection
 			System.out.println("Invalid Numeric EclResultLimit value detected, using default value: " + ECLRESULTLIMDEFAULT);
 		}
 
-		// basicAuth
-		String userPassword = this.props.getProperty("username") + ":"
-				+ props.getProperty("password");
+		String basicAuth = createBasicAuth(this.props.getProperty("username"), props.getProperty("password"));
 
-       String basicAuth = "Basic " + HPCCJDBCUtils.Base64Encode(userPassword.getBytes(), false);
-       this.props.put("BasicAuth", basicAuth);
+		this.props.put("BasicAuth", basicAuth);
 
-       if (!this.props.containsKey("LazyLoad"))
-			this.props.setProperty("LazyLoad", LAZYLOADDEFAULT);
+		if (!this.props.containsKey("LazyLoad"))
+		this.props.setProperty("LazyLoad", LAZYLOADDEFAULT);
 
-       metadata = new HPCCDatabaseMetaData(props);
+		metadata = new HPCCDatabaseMetaData(props);
 
-       //TODO not doing anything w/ this yet, just exposing it to comply w/ API definition...
-       clientInfo = new Properties();
+		//TODO not doing anything w/ this yet, just exposing it to comply w/ API definition...
+		clientInfo = new Properties();
 
-       System.out.println("EclConnection initialized - server: " + this.serverAddress);
+		System.out.println("EclConnection initialized - server: " + this.serverAddress);
+    }
+
+    public static String createBasicAuth(String username, String passwd)
+    {
+    	return "Basic " + HPCCJDBCUtils.Base64Encode((username + ":" + passwd).getBytes(), false);
     }
 
     public Properties getProperties()

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCConnection.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCConnection.java
@@ -26,6 +26,15 @@ import java.util.Properties;
 public class HPCCConnection implements Connection
 {
 	public static final String ECLRESULTLIMDEFAULT = "100";
+	public static final String CLUSTERDEFAULT = "hthor";
+	public static final String QUERYSETDEFAULT = "hthor";
+	public static final String SERVERADDRESSDEFAULT = "localhost";
+	public static final String WSECLWATCHPORTDEFAULT = "8010";
+	public static final String WSECLPORTDEFAULT = "8002";
+	public static final String WSECLDIRECTPORTDEFAULT = "8008";
+	public static final String FETCHPAGESIZEDEFAULT = "100";
+	public static final String LAZYLOADDEFAULT = "true";
+
     private boolean closed;
     private HPCCDatabaseMetaData metadata;
     private Properties props;
@@ -36,7 +45,7 @@ public class HPCCConnection implements Connection
     {
 		closed = false;
 
-		this.serverAddress = "localhost";
+		this.serverAddress = SERVERADDRESSDEFAULT;
 
 		if (props.containsKey("ServerAddress"))
 			this.serverAddress = props.getProperty("ServerAddress");
@@ -46,34 +55,37 @@ public class HPCCConnection implements Connection
 		this.props = props;
 
 		if (!this.props.containsKey("Cluster"))
-			this.props.setProperty("Cluster", "hthor");
+			this.props.setProperty("Cluster", CLUSTERDEFAULT);
 
 		if (!this.props.containsKey("QuerySet"))
-			this.props.setProperty("QuerySet", "hthor");
+			this.props.setProperty("QuerySet", QUERYSETDEFAULT);
 
 		if (!this.props.containsKey("WsECLWatchAddress"))
 			this.props.setProperty("WsECLWatchAddress", serverAddress);
 
 		if (!this.props.containsKey("WsECLWatchPort"))
-			this.props.setProperty("WsECLWatchPort", "8010");
+			this.props.setProperty("WsECLWatchPort", WSECLWATCHPORTDEFAULT);
 
 		if (!this.props.containsKey("WsECLAddress"))
 			this.props.setProperty("WsECLAddress", serverAddress);
 
 		if (!this.props.containsKey("WsECLPort"))
-			this.props.setProperty("WsECLPort", "8002");
+			this.props.setProperty("WsECLPort", WSECLPORTDEFAULT);
 
 		if (!this.props.containsKey("WsECLDirectAddress"))
 			this.props.setProperty("WsECLDirectAddress", serverAddress);
 
 		if (!this.props.containsKey("WsECLDirectPort"))
-			this.props.setProperty("WsECLDirectPort", "8008");
+			this.props.setProperty("WsECLDirectPort", WSECLDIRECTPORTDEFAULT);
 
 		if (!this.props.containsKey("username"))
 			this.props.setProperty("username", "");
 
 		if (!this.props.containsKey("password"))
 			this.props.setProperty("password", "");
+
+		if (!this.props.containsKey("PageSize") || !HPCCJDBCUtils.isNumeric(this.props.getProperty("PageSize")))
+			this.props.setProperty("PageSize", FETCHPAGESIZEDEFAULT);
 
 		boolean setdefaultreslim = false;
 		if (this.props.containsKey("EclResultLimit"))
@@ -114,7 +126,7 @@ public class HPCCConnection implements Connection
        this.props.put("BasicAuth", basicAuth);
 
        if (!this.props.containsKey("LazyLoad"))
-			this.props.setProperty("LazyLoad", "True");
+			this.props.setProperty("LazyLoad", LAZYLOADDEFAULT);
 
        metadata = new HPCCDatabaseMetaData(props);
 

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCDatabaseMetaData.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCDatabaseMetaData.java
@@ -69,6 +69,8 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 	private boolean lazyLoad;
 	private int pageSize;
 
+	private DocumentBuilderFactory dbf;
+
 	final static String PROCEDURE_NAME = "PROCEDURE_NAME";
 	final static String TABLE_NAME = "TABLE_NAME";
 
@@ -93,7 +95,7 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 		eclqueries = new HPCCQueries();
 		SQLFieldMapping = new HashMap<Integer, String>();
 
-		System.out.println("EclDatabaseMetaData initialized");
+		 dbf = DocumentBuilderFactory.newInstance();
 
 		if (!isHPCCMetaDataCached())
 		{
@@ -115,6 +117,8 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 		}
 
 		setSQLTypeNames();
+
+		System.out.println("EclDatabaseMetaData initialized");
 	}
 
 	private static void setSQLTypeNames()
@@ -1997,7 +2001,6 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 
 		try
 		{
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			Document dom = db.parse(xml);
 
@@ -2265,7 +2268,6 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 
 		try
 		{
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			Document dom = db.parse(xml);
 
@@ -2485,7 +2487,6 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 
 			InputStream xml = clusterInfoConnection.getInputStream();
 
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			Document dom = db.parse(xml);
 
@@ -2503,9 +2504,9 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 			System.out.println("Could not fetch cluster information.");
 			return false;
 		}
-
 		return true;
 	}
+
 	private boolean fetchClusterInfo()
 	{
 		if (wseclwatchaddress == null || wseclwatchport == null)
@@ -2532,7 +2533,6 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 
 			InputStream xml = clusterInfoConnection.getInputStream();
 
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			Document dom = db.parse(xml);
 
@@ -2579,10 +2579,8 @@ public class HPCCDatabaseMetaData implements DatabaseMetaData {
 
 			InputStream xml = querysetconnection.getInputStream();
 
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			Document dom = db.parse(xml);
-
 
 			NodeList activityList = dom.getElementsByTagName("ActivityResponse");
 			if (activityList.getLength() > 0)

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
@@ -151,7 +151,7 @@ public class HPCCJDBCUtils
 		return true;
 	}
 
-	public static long stringToLong(String str)
+	public static long stringToLong(String str, long uponError)
 	{
 		try
 		{
@@ -160,11 +160,11 @@ public class HPCCJDBCUtils
 		}
 		catch (ParseException e)
 		{
-			return 0;
+			return uponError;
 		}
 	}
 
-	public static int stringToInt(String str)
+	public static int stringToInt(String str, int uponError)
 	{
 		try
 		{
@@ -173,7 +173,7 @@ public class HPCCJDBCUtils
 		}
 		catch (ParseException e)
 		{
-			return 0;
+			return uponError;
 		}
 	}
 

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCJDBCUtils.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 
 public class HPCCJDBCUtils
 {
+	public static NumberFormat format = NumberFormat.getInstance(Locale.US);
 	static final char pad = '=';
 	static final char BASE64_enc[] =  {'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
             						  'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',
@@ -138,7 +139,6 @@ public class HPCCJDBCUtils
 
 	public static boolean isNumeric(String str)
 	{
-		NumberFormat format = NumberFormat.getInstance(Locale.US);
 		try
 		{
 			format.parse(str);
@@ -150,6 +150,33 @@ public class HPCCJDBCUtils
 
 		return true;
 	}
+
+	public static long stringToLong(String str)
+	{
+		try
+		{
+			Number num = format.parse(str);
+			return num.longValue();
+		}
+		catch (ParseException e)
+		{
+			return 0;
+		}
+	}
+
+	public static int stringToInt(String str)
+	{
+		try
+		{
+			Number num = format.parse(str);
+			return num.intValue();
+		}
+		catch (ParseException e)
+		{
+			return 0;
+		}
+	}
+
 	public static String replaceAll(String input, String forReplace, String replaceWith)
 	{
 		if (input == null)

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCLogicalFiles.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCLogicalFiles.java
@@ -9,11 +9,14 @@ public class HPCCLogicalFiles
 {
 	private Properties files;
 	private List<String> superfiles;
+	private long reportedFileCount;
 
 	public HPCCLogicalFiles()
 	{
 		files = new Properties();
 		superfiles = new ArrayList<String>();
+
+		reportedFileCount = 0;
 	}
 
 	public void putFile(String fullyQualifiedName, DFUFile file)
@@ -70,6 +73,20 @@ public class HPCCLogicalFiles
 		return eclrecdef;
 	}
 
+	public void updateSuperFile(String superfilename)
+	{
+		DFUFile superfile = (DFUFile) files.get(superfilename);
+		if (!superfile.hasFileRecDef())
+		{
+			if(superfile.containsSubfiles())
+			{
+				System.out.println("Processing superfile: " + superfile.getFullyQualifiedName());
+				superfile.setFileRecDef(getSubfileRecDef(superfile));
+				files.put(superfile.getFullyQualifiedName(), superfile);
+			}
+		}
+	}
+
 	public void updateSuperFiles()
 	{
 		int superfilescount = superfiles.size();
@@ -85,10 +102,38 @@ public class HPCCLogicalFiles
 					System.out.println("Processing superfile: " + superfile.getFullyQualifiedName());
 					superfile.setFileRecDef(getSubfileRecDef(superfile));
 					if(superfile.hasFileRecDef())
+					{
+						files.put(superfile.getFullyQualifiedName(), superfile);
 						superfilesupdated++;
+					}
 				}
 			}
 		}
 		System.out.println("Update superfiles' record definition ( " + superfilesupdated + " out of " + superfilescount + " )");
+	}
+
+	public long getReportedFileCount()
+	{
+		return reportedFileCount;
+	}
+
+	public void setReportedFileCount(long reportedFileCount)
+	{
+		this.reportedFileCount = reportedFileCount;
+	}
+
+	public void setReportedFileCount(String reportedFileCountStr)
+	{
+		this.reportedFileCount = HPCCJDBCUtils.stringToLong(reportedFileCountStr);
+	}
+
+	public int getCachedFileCount()
+	{
+		return files.size();
+	}
+
+	public int getCachedSuperFileCount()
+	{
+		return superfiles.size();
 	}
 }

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCLogicalFiles.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCLogicalFiles.java
@@ -124,7 +124,7 @@ public class HPCCLogicalFiles
 
 	public void setReportedFileCount(String reportedFileCountStr)
 	{
-		this.reportedFileCount = HPCCJDBCUtils.stringToLong(reportedFileCountStr);
+		this.reportedFileCount = HPCCJDBCUtils.stringToLong(reportedFileCountStr, 0);
 	}
 
 	public int getCachedFileCount()

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCQueries.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCQueries.java
@@ -55,4 +55,14 @@ public class HPCCQueries {
 	{
 		return queries.size();
 	}
+
+	public boolean containsQueryName(String eclqueryname)
+	{
+		return queries.containsKey(eclqueryname);
+	}
+
+	public boolean containsQueryName(String clustername, String eclqueryname)
+	{
+		return queries.containsKey((clustername.length()>0 ? clustername +"::" : "") + eclqueryname);
+	}
 }

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCResultSet.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/HPCCResultSet.java
@@ -39,7 +39,6 @@ public class HPCCResultSet implements ResultSet
 	private HPCCResultSetMetadata	resultMetadata;
 	private HPCCDatabaseMetaData	dbMetadata;
 	private Statement				statement;
-	private String					test_query	= "SELECT 1";
 	private String 					defaultEclQueryReturnDatasetName;
 	private Object					lastResult;
 	private ArrayList<SQLWarning> 	warnings;
@@ -78,9 +77,9 @@ public class HPCCResultSet implements ResultSet
 			if(sqlreqtype == SQLParser.SQL_TYPE_SELECT)
 			{
 				String hpccfilename = HPCCJDBCUtils.handleQuotedString(parser.getTableName());
-				if(!dbMetadata.tableExists("", hpccfilename))
-					throw new Exception("Invalid table found: " + hpccfilename);
 				DFUFile dfufile = dbMetadata.getDFUFile(hpccfilename);
+				if (dfufile == null)
+					throw new Exception("Invalid table name found: " + hpccfilename);
 				if (!dfufile.hasFileRecDef())
 					throw new Exception("Cannot query: " + hpccfilename + " because it does not contain a record definition.");
 				parser.verifySelectColumns(dfufile);
@@ -128,7 +127,7 @@ public class HPCCResultSet implements ResultSet
 				ArrayList<HPCCColumnMetaData> storeProcInParams = new ArrayList();
 				HPCCQuery hpccQuery = dbMetadata.getHpccQuery(HPCCJDBCUtils.handleQuotedString(parser.getStoredProcName()));
 				if (hpccQuery == null)
-					throw new Exception("Invalid store procedure found");
+					throw new Exception("Invalid store procedure found. Check QuerySet configuration.");
 				defaultEclQueryReturnDatasetName = hpccQuery.getDefaultTableName();
 				expectedretcolumns = hpccQuery.getAllNonInFields();
 				storeProcInParams = hpccQuery.getAllInFields();
@@ -283,7 +282,6 @@ public class HPCCResultSet implements ResultSet
 	}
 	public String getString(int columnIndex) throws SQLException
 	{
-		//System.out.println("getString( " + columnIndex +")");
 		if (index >= 0 && index <= rows.size())
 			if (columnIndex >= 1 && columnIndex <= rows.get(index).size())
 			{
@@ -535,7 +533,6 @@ public class HPCCResultSet implements ResultSet
 	}
 	public String getString(String columnLabel) throws SQLException
 	{
-		//System.out.println("getString( " + columnLabel +")");
 		if (index >= 0  && index <= rows.size())
 		{
 			int column = resultMetadata.getColumnIndex(columnLabel);
@@ -919,15 +916,7 @@ public class HPCCResultSet implements ResultSet
 	{
 		if (index >= 0  && index <= rows.size())
 		{
-			//System.out.println("EclResultSet being queried for tablename: " + resultMetadata.getTableName(0) + " column: " + columnIndex + " total number of columns: " + rows.get(index).size() + " Current row: " + index) ;
-			//System.out.println("Columlabel: " + resultMetadata.getColumnLabel(columnIndex));
-			//System.out.println("Columlabel: " + resultMetadata.getColumnClassName(columnIndex));
 			lastResult = rows.get(index).get(columnIndex - 1);
-			if (lastResult == null)
-				return null;
-			//obj = Class.forName(resultMetadata.getColumnClassName(columnIndex));
-			//System.out.println("results object id: " + (Object)this.hashCode());
-			//System.out.println("returning object" + (lastResult==null ? ": null" : " of type " + resultMetadata.getColumnClassName(columnIndex) +  " : " + lastResult.toString()));
 			return lastResult;
 		}
 		else

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLOperator.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLOperator.java
@@ -6,22 +6,53 @@ import java.util.List;
 public class SQLOperator
 {
 	private static List<String> validOps;
-	public static final String eq = new String("=");
-	public static final String neq = new String("<>");
+
+	//When adding a new opereator, make sure to add it to validOps array
+	public static final String eq = 	new String("=");
+	public static final String neq = 	new String("<>");
+	public static final String neq2 = 	new String("!=");
 	public static final String isNull = new String("IS NULL");
 	public static final String isNotNull = new String("IS NOT NULL");
-	public static final String gt = new String(">");
-	public static final String lt = new String("<");
-	public static final String gte = new String(">=");
-	public static final String lte = new String("<=");
-	public static final String and = new String("AND");
-	public static final String or = new String("OR");
-	public static final String not = new String("NOT");
+	public static final String gt = 	new String(">");
+	public static final String lt = 	new String("<");
+	public static final String gte = 	new String(">=");
+	public static final String lte = 	new String("<=");
+	public static final String and = 	new String("AND");
+	public static final String or = 	new String("OR");
+	public static final String not = 	new String("NOT");
 	public static final String exists = new String("EXISTS");
-	public static final String like = new String("LIKE");
-	public static final String in = new String("IN");
+	public static final String like = 	new String("LIKE");
+	public static final String in = 	new String("IN");
+
+	static
+	{
+		validOps = new ArrayList<String>();
+		validOps.add(eq);
+		validOps.add(neq);
+		validOps.add(neq2);
+		validOps.add(isNull);
+		validOps.add(isNotNull);
+		validOps.add(gt);
+		validOps.add(lt);
+		validOps.add(gte);
+		validOps.add(lte);
+		validOps.add(and);
+		validOps.add(or);
+		validOps.add(not);
+		validOps.add(exists);
+		validOps.add(like);
+		validOps.add(in);
+	}
 
 	private final String value;
+
+	public SQLOperator(String operator)
+	{
+		if( validOps.contains(operator.toUpperCase()))
+				value = operator.toUpperCase();
+		else
+				value = null;
+	}
 
 	public String getValue()
 	{
@@ -30,34 +61,7 @@ public class SQLOperator
 
 	public boolean isValid()
 	{
-		return value == null ? false : true;
-	}
-
-	public SQLOperator(String operator)
-	{
-		if (validOps == null)
-		{
-			validOps = new ArrayList<String>();
-			validOps.add(eq);
-			validOps.add(neq);
-			validOps.add(isNull);
-			validOps.add(isNotNull);
-			validOps.add(gt);
-			validOps.add(lt);
-			validOps.add(gte);
-			validOps.add(lte);
-			validOps.add(and);
-			validOps.add(or);
-			validOps.add(not);
-			validOps.add(exists);
-			validOps.add(like);
-			validOps.add(in);
-		}
-
-		if( validOps.contains(operator.toUpperCase()))
-				value = operator.toUpperCase();
-		else
-				value = null;
+		return validOps.contains(value);
 	}
 
 	@Override

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLParser.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/jdbcdriver/SQLParser.java
@@ -360,6 +360,8 @@ public class SQLParser
 							operator = SQLOperator.lte;
 						else if (trimmedExpression.indexOf(SQLOperator.neq)!=-1)
 							operator = SQLOperator.neq;
+						else if (trimmedExpression.indexOf(SQLOperator.neq2)!=-1)
+							operator = SQLOperator.neq2;
 						else if (trimmedExpression.indexOf(SQLOperator.eq)!=-1)
 							operator = SQLOperator.eq;
 						else if (trimmedExpression.indexOf(SQLOperator.gt)!=-1)

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/test/jdbcdriver/HPCCDriverTest.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/test/jdbcdriver/HPCCDriverTest.java
@@ -3,6 +3,7 @@ package com.hpccsystems.test.jdbcdriver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +52,23 @@ public class HPCCDriverTest
 				System.out.println("   " + tables.getString("TABLE_NAME") + " Remarks: \'" + tables.getString("REMARKS")+"\'");
 			}
 
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			System.out.println(e.getMessage());
+			success = false;
+		}
+		return success;
+	}
+
+	private static boolean  createStandAloneDataMetadata(Properties conninfo)
+	{
+		boolean success = true;
+		try
+		{
+			HPCCDatabaseMetaData dbmetadata = new HPCCDatabaseMetaData(conninfo);
+			success = getDatabaseInfo(dbmetadata);
 		}
 		catch (Exception e)
 		{
@@ -273,24 +291,36 @@ public class HPCCDriverTest
 
 	private static boolean getDatabaseInfo(HPCCConnection conn)
 	{
+		try
+		{
+			return getDatabaseInfo((HPCCDatabaseMetaData)conn.getMetaData());
+		}
+		catch (SQLException e)
+		{
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	private static boolean getDatabaseInfo(HPCCDatabaseMetaData dbmetadata)
+	{
 		boolean success = true;
 		try
 		{
-			HPCCDatabaseMetaData meta =  (HPCCDatabaseMetaData)conn.getMetaData();
-			String hpccname = meta.getDatabaseProductName();
-			String hpccprodver = meta.getDatabaseProductVersion();
-			int major = meta.getDatabaseMajorVersion();
-			int minor = meta.getDatabaseMinorVersion();
-			String sqlkeywords = meta.getSQLKeywords();
+			String hpccname = dbmetadata.getDatabaseProductName();
+			String hpccprodver = dbmetadata.getDatabaseProductVersion();
+			int major = dbmetadata.getDatabaseMajorVersion();
+			int minor = dbmetadata.getDatabaseMinorVersion();
+			String sqlkeywords = dbmetadata.getSQLKeywords();
 
 			System.out.println("HPCC System Info:");
 			System.out.println("\tProduct Name: " + hpccname);
 			System.out.println("\tProduct Version: " + hpccprodver);
 			System.out.println("\tProduct Major: " + major);
 			System.out.println("\tProduct Minor: " + minor);
-			System.out.println("\tDriver Name: " + meta.getDriverName());
-			System.out.println("\tDriver Major: " + meta.getDriverMajorVersion());
-			System.out.println("\tDriver Minor: " + meta.getDriverMinorVersion());
+			System.out.println("\tDriver Name: " + dbmetadata.getDriverName());
+			System.out.println("\tDriver Major: " + dbmetadata.getDriverMajorVersion());
+			System.out.println("\tDriver Minor: " + dbmetadata.getDriverMinorVersion());
 			System.out.println("\tSQL Key Words: " + sqlkeywords);
 		}
 		catch (Exception e)
@@ -307,6 +337,8 @@ public class HPCCDriverTest
 		try
 		{
 			//success &= testLazyLoading(propsinfo);
+
+			success &= createStandAloneDataMetadata(propsinfo);
 
 			HPCCConnection connectionprops = connectViaProps(propsinfo);
 			if (connectionprops == null)

--- a/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/test/jdbcdriver/HPCCDriverTestThread.java
+++ b/plugins/dbconnectors/hpccjdbc/src/com/hpccsystems/test/jdbcdriver/HPCCDriverTestThread.java
@@ -1,0 +1,61 @@
+package com.hpccsystems.test.jdbcdriver;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import com.hpccsystems.jdbcdriver.HPCCConnection;
+import com.hpccsystems.jdbcdriver.HPCCPreparedStatement;
+import com.hpccsystems.jdbcdriver.HPCCResultSet;
+
+public class HPCCDriverTestThread extends Thread
+{
+	private HPCCConnection theconnection;
+	private String thesql;
+	private Properties theparams;
+	private boolean success;
+	private boolean running;
+
+	public HPCCDriverTestThread(HPCCConnection connection, String SqlStr, Properties parameters)
+	{
+		theconnection = connection;
+		thesql = SqlStr;
+		theparams = parameters;
+		success = true;
+		running = false;
+	}
+
+	@Override
+	public void run()
+	{
+		PreparedStatement prepstatement;
+		try
+		{
+			running = true;
+			prepstatement = theconnection.prepareStatement(thesql);
+
+			prepstatement.clearParameters();
+			for(int i = 1; i <= theparams.size(); i++)
+				prepstatement.setObject(i, theparams.getProperty(String.valueOf(i)));
+
+			HPCCResultSet qrs = (HPCCResultSet)((HPCCPreparedStatement)prepstatement).executeQuery();
+			HPCCDriverTest.printOutResultSet(qrs, Thread.currentThread().getId());
+			running = false;
+		}
+		catch (SQLException e)
+		{
+			success = false;
+			e.printStackTrace();
+		}
+	}
+
+	public boolean isSuccess()
+	{
+		return success;
+	}
+
+	public boolean isRunning()
+	{
+		return running;
+	}
+}

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -436,13 +436,14 @@ bool CppCompiler::compileFile(IThreadPool * pool, const char * filename, Semapho
     if (!filename || *filename == 0)
         return false;
 
-    StringBuffer fullFileName;
-    fullFileName.clear().append("\"").append(filename).append(".cpp").append("\"").append(" ");
-
     StringBuffer cmdline;
-    cmdline.append(CC_NAME[targetCompiler]);
-    cmdline.append(" ").append(sourceDir);
-    cmdline.append(fullFileName);
+    cmdline.append(CC_NAME[targetCompiler]).append(" \"");
+    if (sourceDir.length())
+    {
+        cmdline.append(sourceDir);
+        addPathSepChar(cmdline);
+    }
+    cmdline.append(filename).append(".cpp\" ");
     expandCompileOptions(cmdline);
 
     if (useDebugLibrary)


### PR DESCRIPTION
ecl publish was giving an error if the state of a workunit after the
compile step was completed (rather than compiled).

eclccserver should only set the state to completed on library workunits
if the requested action is 'run'

Related to gh-2614 but not a complete fix for that issue, as non-roxie
cases will still fail until regression suite changed to use publish for
the library queries.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
