### PR TITLE
gh-2614 Regression suite failing on library tests

### DIFF
--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -273,33 +273,36 @@ public:
         if (ok)
         {
             workunit->setState(WUStateCompiled);
-            if (isLibrary(workunit))
+            if (workunit->getAction()==WUActionRun || workunit->getAction()==WUActionUnknown)  // Assume they meant run....
             {
-                workunit->setState(WUStateCompleted);
-            }
-            else if (workunit->getAction()==WUActionRun || workunit->getAction()==WUActionUnknown)  // Assume they meant run....
-            {
-                workunit->schedule();
-                SCMStringBuffer dllBuff;
-                Owned<IConstWUQuery> wuQuery = workunit->getQuery();
-                wuQuery->getQueryDllName(dllBuff);
-                wuQuery.clear();
-                if (dllBuff.length() > 0)
+                if (isLibrary(workunit))
                 {
-                    workunit.clear();
-                    if (!runWorkUnit(wuid, clusterName.str()))
-                    {
-                        Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
-                        workunit.setown(factory->updateWorkUnit(wuid));
-                        reportError("Failed to execute workunit", 2);
-                        if (workunit->getState() != WUStateAborted)
-                            workunit->setState(WUStateFailed);
-                    }
+                    workunit->setState(WUStateCompleted);
                 }
                 else
                 {
-                    reportError("Failed to execute workunit (unknown DLL name)", 2);
-                    workunit->setState(WUStateFailed);
+                    workunit->schedule();
+                    SCMStringBuffer dllBuff;
+                    Owned<IConstWUQuery> wuQuery = workunit->getQuery();
+                    wuQuery->getQueryDllName(dllBuff);
+                    wuQuery.clear();
+                    if (dllBuff.length() > 0)
+                    {
+                        workunit.clear();
+                        if (!runWorkUnit(wuid, clusterName.str()))
+                        {
+                            Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
+                            workunit.setown(factory->updateWorkUnit(wuid));
+                            reportError("Failed to execute workunit", 2);
+                            if (workunit->getState() != WUStateAborted)
+                                workunit->setState(WUStateFailed);
+                        }
+                    }
+                    else
+                    {
+                        reportError("Failed to execute workunit (unknown DLL name)", 2);
+                        workunit->setState(WUStateFailed);
+                    }
                 }
             }
         }


### PR DESCRIPTION
ecl publish was giving an error if the state of a workunit after the
compile step was completed (rather than compiled).

eclccserver should only set the state to completed on library workunits
if the requested action is 'run'

Related to gh-2614 but not a complete fix for that issue, as non-roxie
cases will still fail until regression suite changed to use publish for
the library queries.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
