### PR TITLE
Remove hard-coded locale settings in init scripts

### DIFF
--- a/initfiles/bin/init_configesp
+++ b/initfiles/bin/init_configesp
@@ -29,7 +29,6 @@ rm -f ${SENTINEL}
 
 ulimit -c unlimited
 ulimit -n 8192
-export LANG=en_US
 SNMPID=$$
 
 killed() {

--- a/initfiles/bin/init_dfuserver
+++ b/initfiles/bin/init_dfuserver
@@ -41,7 +41,6 @@ killed() {
 }
 
 trap "killed" SIGINT SIGTERM SIGKILL
-export LANG=en_US
 
 dfuserver 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME

--- a/initfiles/bin/init_eclagent.in
+++ b/initfiles/bin/init_eclagent.in
@@ -43,7 +43,6 @@ killed (){
 
 
 trap "killed" SIGINT SIGTERM SIGKILL
-export LANG=en_US
 
 ulimit -c unlimited
 agentexec 1>/dev/null 2>/dev/null &

--- a/initfiles/bin/init_esp
+++ b/initfiles/bin/init_esp
@@ -28,7 +28,6 @@ rm -f ${SENTINEL}
 
 ulimit -c unlimited
 ulimit -n 8192
-export LANG=en_US
 SNMPID=$$
 
 killed() {

--- a/initfiles/bin/init_sasha
+++ b/initfiles/bin/init_sasha
@@ -56,7 +56,6 @@ killed() {
 }
 
 trap "killed" SIGINT SIGTERM SIGKILL
-export LANG=en_US
 saserver 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait


### PR DESCRIPTION
These scripts had : export LANG=en_US
for no apparent reason

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
