### PR TITLE
Fix gh-2640 pipe8.ecl test failing in Roxie

### DIFF
--- a/testing/ecl/roxie/key/pipe8.xml
+++ b/testing/ecl/roxie/key/pipe8.xml
@@ -1,0 +1,25 @@
+<Dataset name='Result 1'>
+ <Row><id>1</id><names><Row><name>Gavin</name></Row><Row><name>John</name></Row></names></Row>
+ <Row><id>2</id><names><Row><name>Steve</name></Row><Row><name>Steve</name></Row><Row><name>Steve</name></Row></names></Row>
+ <Row><id>3</id><names></names></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><id>1</id><names><Row><name>Gavin</name></Row><Row><name>John</name></Row></names></Row>
+ <Row><id>2</id><names><Row><name>Steve</name></Row><Row><name>Steve</name></Row><Row><name>Steve</name></Row></names></Row>
+ <Row><id>3</id><names></names></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><l>&lt;Row&gt;&lt;id&gt;1&lt;/id&gt;&lt;names&gt;&lt;Row&gt;&lt;name&gt;Gavin&lt;/name&gt;&lt;/Row&gt;&lt;Row&gt;&lt;name&gt;John&lt;/name&gt;&lt;/Row&gt;&lt;/names&gt;&lt;/Row&gt;</l></Row>
+ <Row><l>&lt;Row&gt;&lt;id&gt;2&lt;/id&gt;&lt;names&gt;&lt;Row&gt;&lt;name&gt;Steve&lt;/name&gt;&lt;/Row&gt;&lt;Row&gt;&lt;name&gt;Steve&lt;/name&gt;&lt;/Row&gt;&lt;Row&gt;&lt;name&gt;Steve&lt;/name&gt;&lt;/Row&gt;&lt;/names&gt;&lt;/Row&gt;</l></Row>
+ <Row><l>&lt;Row&gt;&lt;id&gt;3&lt;/id&gt;&lt;names/&gt;&lt;/Row&gt;</l></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><lout>1234</lout></Row>
+ <Row><lout>Hello there</lout></Row>
+ <Row><lout>what a nice day</lout></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><id>1</id><names><Row><name>Gavin</name></Row><Row><name>John</name></Row></names></Row>
+ <Row><id>2</id><names><Row><name>Steve</name></Row><Row><name>Steve</name></Row><Row><name>Steve</name></Row></names></Row>
+ <Row><id>3</id><names></names></Row>
+</Dataset>


### PR DESCRIPTION
Roxie does not output an empty dataset to the xml result stream for
outputs to disk file or PIPE WRITE activities.

It's arguable whether it should. Easiest fix for the regression suite
issue is simply to give a sepate key for the roxie case.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
