### PR TITLE
Fix gh-2642 Standalone hthor programs fail to start

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1854,7 +1854,8 @@ void EclAgent::doProcess()
             if (w->hasDebugValue("traceLevel"))
                 traceLevel = w->getDebugValueInt("traceLevel", 10);
             w->setTracingValue("EclAgentBuild", BUILD_TAG);
-            w->addProcess("EclAgent", agentTopology->queryProp("@name"), logname.str());
+            if (agentTopology->hasProp("@name"))
+                w->addProcess("EclAgent", agentTopology->queryProp("@name"), logname.str());
             if (checkVersion && ((w->getCodeVersion() > ACTIVITY_INTERFACE_VERSION) || (w->getCodeVersion() < MIN_ACTIVITY_INTERFACE_VERSION)))
                 failv(0, "Workunit was compiled for eclagent interface version %d, this eclagent requires version %d..%d", w->getCodeVersion(), MIN_ACTIVITY_INTERFACE_VERSION, ACTIVITY_INTERFACE_VERSION);
             if(noRetry && (w->getState() == WUStateFailed))


### PR DESCRIPTION
The code to set the eclagent process name in the workunit fails in
standalone mode because there is no topology file to read the name
from.

This is a regression in pre-rc6 release candidates of 3.8.0.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
