### PR TITLE
Fix gh-2515 Improve behaviour of getWuid() in Roxie

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -30117,7 +30117,19 @@ public:
     { 
         return strdup("roxie"); 
     }
-    virtual char *getWuid() { throwUnexpected(); }
+    virtual char *getWuid()
+    {
+        if (workUnit)
+        {
+            SCMStringBuffer wuid;
+            workUnit->getWuid(wuid);
+            return strdup(wuid.str());
+        }
+        else
+        {
+            throw MakeStringException(ROXIE_INVALID_ACTION, "No workunit associated with this context");
+        }
+    }
 
     // persist-related code - usage of persist should have been caught and rejected at codegen time
     virtual char * getExpandLogicalName(const char * logicalName) { throwUnexpected(); }


### PR DESCRIPTION
When ECL code calls thorlib.wuid() in a roxie query it gives an internal
error which does not help identify the issue.

Most Roxie queries do not have a unique WUID to return, and an error
seems reasonable (but more specific). A query that was executed via a
dali queue DOES have a workunit, and the wuid should be returned in
such cases.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
