### PR TITLE
Mac Installer Tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ if ( NOT MAKE_DOCS_ONLY )
     HPCC_ADD_SUBDIRECTORY (thorlcr "PLATFORM")
 endif()
 HPCC_ADD_SUBDIRECTORY (docs "PLATFORM")
+HPCC_ADD_SUBDIRECTORY (lib2)
 
 ###
 ## CPack install and packaging setup.
@@ -277,6 +278,18 @@ if (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.1")
     endif()
 else()
     message("WARNING: CMAKE 2.8.1 or later required to create RPMs from this project")
+endif()
+
+if (APPLE)
+    set ( CPACK_MONOLITHIC_INSTALL TRUE )
+    set ( CPACK_PACKAGE_VENDOR "HPCC Systems" )
+    file(WRITE "${PROJECT_BINARY_DIR}/welcome.txt" 
+        "HPCC Systems - Client Tools\r"
+        "===========================\r\r"
+        "This installer will install the HPCC Systems Client Tools.")
+    set ( CPACK_RESOURCE_FILE_README "${PROJECT_BINARY_DIR}/welcome.txt" )
+    set ( CPACK_RESOURCE_FILE_LICENSE "${HPCC_SOURCE_DIR}/${LICENSE_FILE}" )
+    set ( CPACK_PACKAGE_DESCRIPTION_SUMMARY "HPCC Systems Client Tools." )
 endif()
 
 ###

--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -171,6 +171,11 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
     endif ()
   endif ()
 
+  macro(HPCC_ADD_EXECUTABLE target)
+    add_executable(${target} ${ARGN})
+    set (executables ${executables} ${target} CACHE INTERNAL "")
+  endmacro(HPCC_ADD_EXECUTABLE target)
+
   macro(HPCC_ADD_LIBRARY target)
     add_library(${target} ${ARGN})
   endmacro(HPCC_ADD_LIBRARY target)
@@ -473,7 +478,11 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   ###
   ## The following sets the install directories and names.
   ###
-  set ( OSSDIR "${DIR_NAME}" )
+  if ( PLATFORM )
+    set ( OSSDIR "${DIR_NAME}" )
+  else()
+    set ( OSSDIR "${DIR_NAME}/${version}/clienttools" )
+  endif()
   set ( CPACK_INSTALL_PREFIX "${PREFIX}" )
   set ( CPACK_PACKAGING_INSTALL_PREFIX "${PREFIX}" )
   set ( CMAKE_INSTALL_PREFIX "${PREFIX}" )
@@ -481,60 +490,11 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib")
   SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-  MACRO (FIXUP_MACPORTS apps dylibs)
-	foreach(dylib ${dylibs})
-		get_filename_component(dylib_path ${dylib} REALPATH)
-		install(PROGRAMS "${dylib_path}" DESTINATION "${OSSDIR}/lib2")
-	endforeach(dylib)
-	foreach(dylib ${dylibs})
-		get_filename_component(dylib_path ${dylib} REALPATH)
-		get_filename_component(dylib_name_ext ${dylib_path} NAME)
-		install(CODE "
-				execute_process(COMMAND install_name_tool -id \"@loader_path/../lib2/${dylib_name_ext}\" ${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib2/${dylib_name_ext})
-		" ) 
-		foreach(app ${apps})
-			#HACK HACK - Could be done generically with some REGEX?
-			string(REPLACE ".28.0.dylib" ".28.dylib" dylib_28_path "${dylib_path}")
-			string(REPLACE ".48.1.dylib" ".48.dylib" dylib_48_path "${dylib_path}")
-			install(CODE "
-				execute_process(COMMAND install_name_tool -change \"${dylib_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" ${EXECUTABLE_OUTPUT_PATH}/${app})
-				execute_process(COMMAND install_name_tool -change \"${dylib_28_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" ${EXECUTABLE_OUTPUT_PATH}/${app})
-				execute_process(COMMAND install_name_tool -change \"${dylib_48_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" ${EXECUTABLE_OUTPUT_PATH}/${app})
-			" ) 
-		endforeach(app)
-	endforeach(dylib)
-  ENDMACRO()
-
   if (APPLE)
-    SET(CMAKE_INSTALL_RPATH "@loader_path/../lib")
+    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
     set(CMAKE_INSTALL_NAME_DIR "@loader_path/../lib") 
-    set(APPS
-      "dafilesrv"
-      "dfuplus"
-      "ecl"
-      "ecl-package"
-      "ecl-queries"
-      "eclcc"
-      "eclplus"
-      "wuget"
-    )
-    set(DYLIBS)
-    if (USE_ICU)
-      set(DYLIBS ${DYLIBS} ${ICU_LIBRARIES})
-    endif ()
-    if (USE_BOOST_REGEX)
-      set(DYLIBS ${DYLIBS} ${BOOST_REGEX_LIBRARIES})
-    endif ()
-    if (USE_XALAN)
-      set(DYLIBS ${DYLIBS} ${XALAN_LIBRARIES})
-    endif ()
-    if (USE_XERCES)
-      set(DYLIBS ${DYLIBS} ${XERCES_LIBRARIES})
-    endif ()
-    FIXUP_MACPORTS("${APPS}" "${DYLIBS}")
   endif()
-  
+
   MACRO (FETCH_GIT_TAG workdir edition result)
       execute_process(COMMAND "${GIT_COMMAND}" describe --tags --dirty --abbrev=6 --match ${edition}*
         WORKING_DIRECTORY "${workdir}"

--- a/common/fileview2/CMakeLists.txt
+++ b/common/fileview2/CMakeLists.txt
@@ -107,7 +107,7 @@ set (    SRCS
 ADD_DEFINITIONS ( -D_CONSOLE )
 
 if( PLATFORM )
-    add_executable ( fvserver ${SRCS} )
+    HPCC_ADD_EXECUTABLE ( fvserver ${SRCS} )
     set_target_properties(fvserver PROPERTIES 
         COMPILE_FLAGS -D_CONSOLE
     )

--- a/common/monitoring/prosysinfo/CMakeLists.txt
+++ b/common/monitoring/prosysinfo/CMakeLists.txt
@@ -29,5 +29,5 @@ set (    SRCS
          main.cpp 
     )
 
-add_executable ( prosysinfo ${SRCS} )
+HPCC_ADD_EXECUTABLE ( prosysinfo ${SRCS} )
 install ( TARGETS prosysinfo DESTINATION ${OSSDIR}/bin )

--- a/dali/dafilesrv/dafilesrv.cmake
+++ b/dali/dafilesrv/dafilesrv.cmake
@@ -39,7 +39,7 @@ if (WIN32)
     set (CMAKE_EXE_LINKER_FLAGS "/STACK:65536 ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
-add_executable ( dafilesrv ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dafilesrv ${SRCS} )
 set_target_properties (dafilesrv PROPERTIES COMPILE_FLAGS -D_CONSOLE)
 install ( TARGETS dafilesrv DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( dafilesrv

--- a/dali/dafilesrv/dafscontrol.cmake
+++ b/dali/dafilesrv/dafscontrol.cmake
@@ -40,7 +40,7 @@ include_directories (
          ./../../common/environment 
     )
 
-add_executable ( dafscontrol ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dafscontrol ${SRCS} )
 set_target_properties (dafscontrol PROPERTIES COMPILE_FLAGS -D_CONSOLE)
 install ( TARGETS dafscontrol DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( dafscontrol  

--- a/dali/daliadmin/CMakeLists.txt
+++ b/dali/daliadmin/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( daliadmin ${SRCS} )
+HPCC_ADD_EXECUTABLE ( daliadmin ${SRCS} )
 install ( TARGETS daliadmin DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( daliadmin  
          jlib

--- a/dali/dalidiag/CMakeLists.txt
+++ b/dali/dalidiag/CMakeLists.txt
@@ -40,7 +40,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( dalidiag ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dalidiag ${SRCS} )
 install ( TARGETS dalidiag DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( dalidiag 
          jlib

--- a/dali/dalistop/CMakeLists.txt
+++ b/dali/dalistop/CMakeLists.txt
@@ -40,7 +40,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( dalistop ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dalistop ${SRCS} )
 install ( TARGETS dalistop DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( dalistop 
          jlib

--- a/dali/datest/datest.cmake
+++ b/dali/datest/datest.cmake
@@ -37,7 +37,7 @@ include_directories (
          ./../../system/jlib 
     )
 
-add_executable ( datest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( datest ${SRCS} )
 set_target_properties (datest PROPERTIES COMPILE_FLAGS -D_CONSOLE)
 target_link_libraries ( datest 
          jlib

--- a/dali/datest/dfuwutest.cmake
+++ b/dali/datest/dfuwutest.cmake
@@ -41,7 +41,7 @@ include_directories (
          ../../common/environment 
     )
 
-add_executable ( dfuwutest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dfuwutest ${SRCS} )
 set_target_properties (dfuwutest PROPERTIES COMPILE_FLAGS -D_CONSOLE)
 target_link_libraries ( dfuwutest
          workunit

--- a/dali/daunittest/CMakeLists.txt
+++ b/dali/daunittest/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( daunittest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( daunittest ${SRCS} )
 target_link_libraries ( daunittest
          jlib
          mp 

--- a/dali/dfu/dfuserver.cmake
+++ b/dali/dfu/dfuserver.cmake
@@ -48,7 +48,7 @@ include_directories (
          ./../../common/workunit 
     )
 
-add_executable ( dfuserver ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dfuserver ${SRCS} )
 set_target_properties ( dfuserver PROPERTIES 
         COMPILE_FLAGS "-D_CONSOLE -D_DFUSERVER"
         )

--- a/dali/dfuplus/CMakeLists.txt
+++ b/dali/dfuplus/CMakeLists.txt
@@ -57,7 +57,7 @@ set_source_files_properties (dfuplus.cpp PROPERTIES COMPILE_FLAGS -DDAFILESRV_LO
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( dfuplus ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dfuplus ${SRCS} )
 add_dependencies ( dfuplus espscm )
 install ( TARGETS dfuplus DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( dfuplus

--- a/dali/dfuxref/CMakeLists.txt
+++ b/dali/dfuxref/CMakeLists.txt
@@ -44,7 +44,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -D_CONSOLE -DMAIN_DFUXREF )
 
-add_executable ( dfuxref ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dfuxref ${SRCS} )
 install ( TARGETS dfuxref DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( dfuxref 
          jlib

--- a/dali/ft/ftslave.cmake
+++ b/dali/ft/ftslave.cmake
@@ -37,7 +37,7 @@ include_directories (
          ./../../system/jlib 
     )
 
-add_executable ( ftslave ${SRCS} )
+HPCC_ADD_EXECUTABLE ( ftslave ${SRCS} )
 set_target_properties (ftslave PROPERTIES COMPILE_FLAGS -D_CONSOLE)
 install ( TARGETS ftslave DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( ftslave

--- a/dali/hellodali/CMakeLists.txt
+++ b/dali/hellodali/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( hellodali ${SRCS} )
+HPCC_ADD_EXECUTABLE ( hellodali ${SRCS} )
 install ( TARGETS hellodali DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( hellodali
          jlib

--- a/dali/regress/CMakeLists.txt
+++ b/dali/regress/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( daregress ${SRCS} )
+HPCC_ADD_EXECUTABLE ( daregress ${SRCS} )
 install ( TARGETS daregress DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( daregress  
          jlib

--- a/dali/sasha/CMakeLists.txt
+++ b/dali/sasha/CMakeLists.txt
@@ -68,7 +68,7 @@ if (WIN32)
     endif ()
 endif()
 
-add_executable ( saserver ${SRCS} )
+HPCC_ADD_EXECUTABLE ( saserver ${SRCS} )
 install ( TARGETS saserver DESTINATION ${OSSDIR}/bin)
 
 
@@ -103,7 +103,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -D_CONSOLE )
 
-add_executable ( sasha ${SRCS} )
+HPCC_ADD_EXECUTABLE ( sasha ${SRCS} )
 install ( TARGETS sasha DESTINATION ${OSSDIR}/bin)
 
 target_link_libraries ( sasha 

--- a/dali/server/CMakeLists.txt
+++ b/dali/server/CMakeLists.txt
@@ -53,7 +53,7 @@ if (WIN32)
     endif ()
 endif()
 
-add_executable ( daserver ${SRCS} )
+HPCC_ADD_EXECUTABLE ( daserver ${SRCS} )
 install ( TARGETS daserver DESTINATION ${OSSDIR}/bin)
 target_link_libraries ( daserver 
          jlib

--- a/dali/treeview/CMakeLists.txt
+++ b/dali/treeview/CMakeLists.txt
@@ -45,7 +45,7 @@ if (WIN32)
         )
 
     add_definitions("-D_AFXDLL")
-    add_executable ( treeview WIN32 ${SRCS} )
+    HPCC_ADD_EXECUTABLE ( treeview WIN32 ${SRCS} )
     install ( TARGETS treeview DESTINATION ${OSSDIR}/bin )
     target_link_libraries ( treeview
              jlib

--- a/dali/updtdalienv/CMakeLists.txt
+++ b/dali/updtdalienv/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( updtdalienv ${SRCS} )
+HPCC_ADD_EXECUTABLE ( updtdalienv ${SRCS} )
 install ( TARGETS updtdalienv DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( updtdalienv  
          jlib

--- a/deployment/configgen/CMakeLists.txt
+++ b/deployment/configgen/CMakeLists.txt
@@ -40,7 +40,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -D_CONSOLE )
 
-add_executable ( configgen ${SRCS} )
+HPCC_ADD_EXECUTABLE ( configgen ${SRCS} )
 install ( TARGETS configgen DESTINATION ${OSSDIR}/sbin )
 target_link_libraries ( configgen 
         deploy 

--- a/deployment/envgen/CMakeLists.txt
+++ b/deployment/envgen/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -D_CONSOLE )
 
-add_executable ( envgen ${SRCS} )
+HPCC_ADD_EXECUTABLE ( envgen ${SRCS} )
 install ( TARGETS envgen DESTINATION ${OSSDIR}/sbin )
 target_link_libraries ( envgen 
         deploy

--- a/ecl/agentexec/CMakeLists.txt
+++ b/ecl/agentexec/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( agentexec ${SRCS} )
+HPCC_ADD_EXECUTABLE ( agentexec ${SRCS} )
 install ( TARGETS agentexec DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( agentexec
          jlib 

--- a/ecl/agentexec/agentexec.cmake
+++ b/ecl/agentexec/agentexec.cmake
@@ -44,7 +44,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -D_CONSOLE )
 
-add_executable ( agentexec ${SRCS} )
+HPCC_ADD_EXECUTABLE ( agentexec ${SRCS} )
 install ( TARGETS agentexec DESTINATION ${OSSDIR}/bin )
 
 target_link_libraries ( agentexec

--- a/ecl/ecl-package/CMakeLists.txt
+++ b/ecl/ecl-package/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( ecl-package ${SRCS} )
+HPCC_ADD_EXECUTABLE ( ecl-package ${SRCS} )
 add_dependencies ( ecl-package espscm ws_packageprocess )
 install ( TARGETS ecl-package DESTINATION ${DIR_NAME}/bin )
 target_link_libraries ( ecl-package

--- a/ecl/eclagent/CMakeLists.txt
+++ b/ecl/eclagent/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -DNO_SYBASE -D_CONSOLE )
 
-add_executable ( eclagent ${SRCS} )
+HPCC_ADD_EXECUTABLE ( eclagent ${SRCS} )
 install ( TARGETS eclagent DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( eclagent
       hthor           

--- a/ecl/eclcc/CMakeLists.txt
+++ b/ecl/eclcc/CMakeLists.txt
@@ -51,7 +51,7 @@ if (WIN32)
     set (CMAKE_EXE_LINKER_FLAGS "/STACK:10000000 ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
-add_executable ( eclcc ${SRCS} )
+HPCC_ADD_EXECUTABLE ( eclcc ${SRCS} )
 install ( TARGETS eclcc DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( eclcc 
          jlib

--- a/ecl/eclccserver/CMakeLists.txt
+++ b/ecl/eclccserver/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories (
          ./../../system/jlib 
     )
 
-add_executable ( eclccserver ${SRCS} ${INCLUDES} )
+HPCC_ADD_EXECUTABLE ( eclccserver ${SRCS} ${INCLUDES} )
 install ( TARGETS eclccserver DESTINATION ${OSSDIR}/bin )
 
 target_link_libraries ( eclccserver 

--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -65,7 +65,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( ecl ${SRCS} )
+HPCC_ADD_EXECUTABLE ( ecl ${SRCS} )
 add_dependencies ( ecl espscm workunit ws_workunits )
 install ( TARGETS ecl DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( ecl

--- a/ecl/eclcmd/queries/CMakeLists.txt
+++ b/ecl/eclcmd/queries/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( ecl-queries ${SRCS} )
+HPCC_ADD_EXECUTABLE ( ecl-queries ${SRCS} )
 add_dependencies ( ecl-queries espscm ws_workunits )
 install ( TARGETS ecl-queries DESTINATION ${DIR_NAME}/bin )
 target_link_libraries ( ecl-queries

--- a/ecl/eclplus/CMakeLists.txt
+++ b/ecl/eclplus/CMakeLists.txt
@@ -60,7 +60,7 @@ include_directories (
 
 ADD_DEFINITIONS( -DECLPLUS_EXPORTS -D_CONSOLE )
 
-add_executable ( eclplus ${SRCS} )
+HPCC_ADD_EXECUTABLE ( eclplus ${SRCS} )
 add_dependencies ( eclplus espscm )
 install ( TARGETS eclplus DESTINATION ${OSSDIR}/bin )
 target_link_libraries (  eclplus 

--- a/ecl/eclscheduler/CMakeLists.txt
+++ b/ecl/eclscheduler/CMakeLists.txt
@@ -44,7 +44,7 @@ include_directories (
          ./../../ecl/schedulectrl
     )
 
-add_executable ( eclscheduler ${SRCS} ${INCLUDES} )
+HPCC_ADD_EXECUTABLE ( eclscheduler ${SRCS} ${INCLUDES} )
 install ( TARGETS eclscheduler DESTINATION ${OSSDIR}/bin )
 
 target_link_libraries ( eclscheduler 

--- a/ecl/scheduleadmin/CMakeLists.txt
+++ b/ecl/scheduleadmin/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -DNO_SYBASE -D_CONSOLE )
 
-add_executable ( scheduleadmin ${SRCS} )
+HPCC_ADD_EXECUTABLE ( scheduleadmin ${SRCS} )
 install ( TARGETS scheduleadmin DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( scheduleadmin 
          jlib

--- a/ecl/wutest/CMakeLists.txt
+++ b/ecl/wutest/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( wutest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( wutest ${SRCS} )
 target_link_libraries ( wutest 
          jlib
          remote 

--- a/esp/clients/WUManager/CMakeLists.txt
+++ b/esp/clients/WUManager/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( wumanager ${SRCS} )
+HPCC_ADD_EXECUTABLE ( wumanager ${SRCS} )
 add_dependencies ( wumanager espscm )
 #install ( TARGETS wumanager DESTINATION ${OSSDIR}/bin ) # do not install - this is an example program
 

--- a/esp/platform/CMakeLists.txt
+++ b/esp/platform/CMakeLists.txt
@@ -49,7 +49,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( esp ${SRCS} )
+HPCC_ADD_EXECUTABLE ( esp ${SRCS} )
 install ( TARGETS esp DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( esp 
          jlib

--- a/esp/services/esp_compile_scm/CMakeLists.txt
+++ b/esp/services/esp_compile_scm/CMakeLists.txt
@@ -151,7 +151,7 @@ set (    SRCS
     )
 
 # OBJS = 
-add_executable ( esp_compile_scm ${SRCS} )
+HPCC_ADD_EXECUTABLE ( esp_compile_scm ${SRCS} )
 install ( TARGETS esp_compile_scm DESTINATION ${OSSDIR}/bin )
 
 

--- a/esp/test/httptest/CMakeLists.txt
+++ b/esp/test/httptest/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( httptest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( httptest ${SRCS} )
 
 target_link_libraries ( httptest 
          jlib

--- a/esp/tools/soapplus/CMakeLists.txt
+++ b/esp/tools/soapplus/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( soapplus ${SRCS} )
+HPCC_ADD_EXECUTABLE ( soapplus ${SRCS} )
 install ( TARGETS soapplus DESTINATION ${OSSDIR}/bin COMPONENT Runtime)
 
 target_link_libraries ( soapplus 

--- a/initfiles/CMakeLists.txt
+++ b/initfiles/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 2.8)
 PROJECT(initfiles)
 
-ADD_EXECUTABLE(processor processor.cpp)
+HPCC_ADD_EXECUTABLE(processor processor.cpp)
 
 MACRO(GENERATE_BASH processor bash-vars in out)
     GET_TARGET_PROPERTY(processorLocation processor LOCATION)

--- a/lib2/CMakeLists.txt
+++ b/lib2/CMakeLists.txt
@@ -1,0 +1,54 @@
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+cmake_minimum_required(VERSION 2.8)
+PROJECT(lib2)
+
+  MACRO (FIXUP_MACPORTS apps dylibs)
+	foreach(dylib ${dylibs})
+		get_filename_component(dylib_path ${dylib} REALPATH)
+	endforeach(dylib)
+	foreach(dylib ${dylibs})
+		get_filename_component(dylib_path ${dylib} REALPATH)
+		get_filename_component(dylib_name_ext ${dylib_path} NAME)
+		install(PROGRAMS "${dylib_path}" DESTINATION "${OSSDIR}/lib2")
+		set(fixupCommand "") 
+		foreach(app ${apps})                                                                                                                                     
+			set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/${app}\")")
+			#HACK HACK - Should be able resolve alias's to alias's correctly?
+			string(REPLACE ".28.0.dylib" ".28.dylib" dylib_28_path "${dylib_path}")
+			if (NOT "${dylib_28_path}" STREQUAL "${dylib_path}")
+				set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_28_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/${app}\")")
+			endif ()
+			string(REPLACE ".48.1.dylib" ".48.dylib" dylib_48_path "${dylib_path}")
+			if (NOT "${dylib_48_path}" STREQUAL "${dylib_path}")
+				set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_48_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/${app}\")")
+			endif ()
+		endforeach(app)
+		install(CODE "${fixupCommand}")
+	endforeach(dylib)
+  ENDMACRO(FIXUP_MACPORTS)
+
+if (APPLE)
+    set(DYLIBS ${ICU_LIBRARIES})
+    set(DYLIBS ${DYLIBS} ${BOOST_REGEX_LIBRARIES})
+    set(DYLIBS ${DYLIBS} ${XALAN_LIBRARIES})
+    set(DYLIBS ${DYLIBS} ${XERCES_LIBRARIES})
+    list(REMOVE_DUPLICATES executables)
+    list(REMOVE_ITEM executables "esdl" "hidl" "configgen")
+    FIXUP_MACPORTS("${executables}" "${DYLIBS}")
+endif()

--- a/plugins/dataconnectors/hdfsconnector/CMakeLists.txt
+++ b/plugins/dataconnectors/hdfsconnector/CMakeLists.txt
@@ -32,7 +32,7 @@ add_subdirectory (ecl)
 					${JAVA_INCLUDE_PATH2}
 					${LIBHDFS_INCLUDE_DIR}	)
 
-	add_executable( hdfsconnector ${SRC} )
+	HPCC_ADD_EXECUTABLE( hdfsconnector ${SRC} )
 
 	set ( INSTALLDIR "${OSSDIR}/bin")
 	Install ( TARGETS hdfsconnector DESTINATION ${INSTALLDIR} COMPONENT Runtime)

--- a/roxie/roxie/CMakeLists.txt
+++ b/roxie/roxie/CMakeLists.txt
@@ -53,7 +53,7 @@ if (WIN32)
     set (CMAKE_EXE_LINKER_FLAGS "/STACK:65536 ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
-add_executable ( roxie ${SRCS} )
+HPCC_ADD_EXECUTABLE ( roxie ${SRCS} )
 install ( TARGETS roxie DESTINATION ${OSSDIR}/bin )
 
 target_link_libraries ( roxie

--- a/roxie/roxieclienttest/CMakeLists.txt
+++ b/roxie/roxieclienttest/CMakeLists.txt
@@ -36,7 +36,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( roxieclienttest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( roxieclienttest ${SRCS} )
 target_link_libraries ( roxieclienttest 
          jlib
          roxieclient 

--- a/roxie/roxiepipe/CMakeLists.txt
+++ b/roxie/roxiepipe/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( roxiepipe ${SRCS} )
+HPCC_ADD_EXECUTABLE ( roxiepipe ${SRCS} )
 install ( TARGETS roxiepipe DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( roxiepipe
          jlib

--- a/roxie/udplib/udptransport.cmake
+++ b/roxie/udplib/udptransport.cmake
@@ -39,7 +39,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -D_CONSOLE )
 
-add_executable ( udptransport ${SRCS} )
+HPCC_ADD_EXECUTABLE ( udptransport ${SRCS} )
 #install ( TARGETS udptransport DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( udptransport 
          jlib

--- a/services/runagent/frunagent.cmake
+++ b/services/runagent/frunagent.cmake
@@ -46,7 +46,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -D_CONSOLE )
 
-add_executable ( frunagent ${SRCS} )
+HPCC_ADD_EXECUTABLE ( frunagent ${SRCS} )
 install ( TARGETS frunagent DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( frunagent 
          jlib

--- a/services/runagent/frunssh.cmake
+++ b/services/runagent/frunssh.cmake
@@ -39,7 +39,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -D_CONSOLE -DRMTSSH_LOCAL)
 
-add_executable ( frunssh ${SRCS} )
+HPCC_ADD_EXECUTABLE ( frunssh ${SRCS} )
 install ( TARGETS frunssh DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( frunssh 
          jlib 

--- a/system/mp/test/CMakeLists.txt
+++ b/system/mp/test/CMakeLists.txt
@@ -39,7 +39,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( mptest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( mptest ${SRCS} )
 target_link_libraries ( mptest 
          jlib
          mp 

--- a/system/security/test/ldapsecuritytest/CMakeLists.txt
+++ b/system/security/test/ldapsecuritytest/CMakeLists.txt
@@ -39,7 +39,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( ldapsecuritytest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( ldapsecuritytest ${SRCS} )
 target_link_libraries ( ldapsecuritytest 
          jlib
          LdapSecurity 

--- a/system/security/test/myssl/CMakeLists.txt
+++ b/system/security/test/myssl/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( myssl ${SRCS} )
+HPCC_ADD_EXECUTABLE ( myssl ${SRCS} )
 install ( TARGETS myssl DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( myssl 
          jlib

--- a/system/xmllibtest/CMakeLists.txt
+++ b/system/xmllibtest/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( xmllibtest ${SRCS} )
+HPCC_ADD_EXECUTABLE ( xmllibtest ${SRCS} )
 add_dependencies ( xmllibtest xmllib )
 install ( TARGETS xmllibtest DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( xmllibtest

--- a/thorlcr/master/CMakeLists.txt
+++ b/thorlcr/master/CMakeLists.txt
@@ -65,7 +65,7 @@ if (WIN32)
     set (CMAKE_EXE_LINKER_FLAGS "/STACK:65536 ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
-add_executable ( thormaster_lcr ${SRCS} )
+HPCC_ADD_EXECUTABLE ( thormaster_lcr ${SRCS} )
 install ( TARGETS thormaster_lcr DESTINATION ${OSSDIR}/bin )
 target_link_libraries (  thormaster_lcr 
          jlib

--- a/thorlcr/slave/CMakeLists.txt
+++ b/thorlcr/slave/CMakeLists.txt
@@ -63,7 +63,7 @@ if (WIN32)
     set (CMAKE_EXE_LINKER_FLAGS "/STACK:65536 ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
-add_executable ( thorslave_lcr ${SRCS} )
+HPCC_ADD_EXECUTABLE ( thorslave_lcr ${SRCS} )
 install ( TARGETS thorslave_lcr DESTINATION ${OSSDIR}/bin )
 target_link_libraries (  thorslave_lcr 
          jlib

--- a/tools/backupnode/CMakeLists.txt
+++ b/tools/backupnode/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( backupnode ${SRCS} )
+HPCC_ADD_EXECUTABLE ( backupnode ${SRCS} )
 install ( TARGETS backupnode DESTINATION ${OSSDIR}/bin )
 
 target_link_libraries (  backupnode 

--- a/tools/combine/CMakeLists.txt
+++ b/tools/combine/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( combine ${SRCS} )
+HPCC_ADD_EXECUTABLE ( combine ${SRCS} )
 install ( TARGETS combine DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( combine
          jlib

--- a/tools/copyexp/CMakeLists.txt
+++ b/tools/copyexp/CMakeLists.txt
@@ -37,7 +37,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( copyexp ${SRCS} )
+HPCC_ADD_EXECUTABLE ( copyexp ${SRCS} )
 install ( TARGETS copyexp DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( copyexp
          jlib 

--- a/tools/dumpkey/CMakeLists.txt
+++ b/tools/dumpkey/CMakeLists.txt
@@ -39,7 +39,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( dumpkey ${SRCS} )
+HPCC_ADD_EXECUTABLE ( dumpkey ${SRCS} )
 install ( TARGETS dumpkey DESTINATION ${OSSDIR}/bin )
 
 target_link_libraries ( dumpkey 

--- a/tools/esdl/CMakeLists.txt
+++ b/tools/esdl/CMakeLists.txt
@@ -52,6 +52,6 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE -O0 )
 
-add_executable ( esdl ${SRCS} )
+HPCC_ADD_EXECUTABLE ( esdl ${SRCS} )
 #install ( TARGETS esdl DESTINATION ${OSSDIR}/bin )
 

--- a/tools/esdl/esdl.cmake
+++ b/tools/esdl/esdl.cmake
@@ -45,7 +45,7 @@ add_custom_command ( OUTPUT esdllex.cpp
 
 set ( SRCS esdlgram.cpp esdllex.cpp main.cpp esdlcomp.cpp esdl_utils.cpp )
 # esdlgram.y esdllex.l main.cpp esdlcomp.cpp esdl_utils.cpp 
-add_executable ( esdl ${SRCS} )
+HPCC_ADD_EXECUTABLE ( esdl ${SRCS} )
 install ( TARGETS esdl DESTINATION ${OSSDIR}/bin )
 #add_dependencies ( esdl esdlgram.cpp esdlgram.h esdllex.cpp )
 

--- a/tools/fcached/CMakeLists.txt
+++ b/tools/fcached/CMakeLists.txt
@@ -38,7 +38,7 @@ ADD_DEFINITIONS( -DMODULE_PRIORITY=1 -D_CONSOLE )
 
 set ( SRCS fcached.cpp )
 
-add_executable ( fcached ${SRCS} )
+HPCC_ADD_EXECUTABLE ( fcached ${SRCS} )
 install ( TARGETS fcached DESTINATION ${OSSDIR}/bin )
 
 

--- a/tools/genht/CMakeLists.txt
+++ b/tools/genht/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( genht ${SRCS} )
+HPCC_ADD_EXECUTABLE ( genht ${SRCS} )
 target_link_libraries ( genht
         jlib 
     )

--- a/tools/hidl/CMakeLists.txt
+++ b/tools/hidl/CMakeLists.txt
@@ -52,5 +52,5 @@ include_directories (
 set_source_files_properties (${CMAKE_CURRENT_BINARY_DIR}/hidlgram.cpp PROPERTIES COMPILE_FLAGS -fno-strict-aliasing)
 
 ADD_DEFINITIONS( -D_CONSOLE)
-add_executable ( hidl ${SRCS} )
+HPCC_ADD_EXECUTABLE ( hidl ${SRCS} )
 #install ( TARGETS hidl DESTINATION ${OSSDIR}/bin )

--- a/tools/keydiff/keydiff.cmake
+++ b/tools/keydiff/keydiff.cmake
@@ -39,7 +39,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -DNO_SYBASE -D_CONSOLE )
 
-add_executable ( keydiff ${SRCS} )
+HPCC_ADD_EXECUTABLE ( keydiff ${SRCS} )
 install ( TARGETS keydiff DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( keydiff 
          jlib

--- a/tools/keydiff/keypatch.cmake
+++ b/tools/keydiff/keypatch.cmake
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS ( -DNO_SYBASE -D_CONSOLE )
 
-add_executable ( keypatch ${SRCS} )
+HPCC_ADD_EXECUTABLE ( keypatch ${SRCS} )
 install ( TARGETS keypatch DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( keypatch 
          jlib

--- a/tools/pskill/CMakeLists.txt
+++ b/tools/pskill/CMakeLists.txt
@@ -26,6 +26,6 @@ project( pstart )
 
 if (WIN32)
     include_directories (../../system/win32)
-    add_executable ( pskill main.cpp )
+    HPCC_ADD_EXECUTABLE ( pskill main.cpp )
     target_link_libraries ( pskill psapi.lib)
 endif ()

--- a/tools/pstart/CMakeLists.txt
+++ b/tools/pstart/CMakeLists.txt
@@ -26,5 +26,5 @@ project( pstart )
 
 if (WIN32)
     include_directories (../../system/win32)
-    add_executable ( pstart main.cpp )
+    HPCC_ADD_EXECUTABLE ( pstart main.cpp )
 endif ()

--- a/tools/start-stop-daemon/CMakeLists.txt
+++ b/tools/start-stop-daemon/CMakeLists.txt
@@ -22,6 +22,6 @@ set( HEADER macros.h )
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 
-add_executable( start-stop-daemon ${SRC} ${HEADER})
+HPCC_ADD_EXECUTABLE( start-stop-daemon ${SRC} ${HEADER})
 install ( TARGETS start-stop-daemon DESTINATION ${OSSDIR}/bin )
 

--- a/tools/swapnode/swapnode.cmake
+++ b/tools/swapnode/swapnode.cmake
@@ -40,7 +40,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE -DENABLE_AUTOSWAP )
 
-add_executable ( swapnode ${SRCS} )
+HPCC_ADD_EXECUTABLE ( swapnode ${SRCS} )
 install ( TARGETS swapnode DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( swapnode
          jlib

--- a/tools/testsocket/CMakeLists.txt
+++ b/tools/testsocket/CMakeLists.txt
@@ -32,7 +32,7 @@ include_directories (
 ADD_DEFINITIONS( -D_CONSOLE )
 
 set ( SRCS testsocket.cpp )
-add_executable ( testsocket ${SRCS} )
+HPCC_ADD_EXECUTABLE ( testsocket ${SRCS} )
 target_link_libraries ( testsocket
          jlib
          )

--- a/tools/vkey/CMakeLists.txt
+++ b/tools/vkey/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories (
 ADD_DEFINITIONS( -DMODULE_PRIORITY=1 -D_CONSOLE )
 
 set ( SRCS vkey.cpp )
-add_executable ( vkey ${SRCS} )
+HPCC_ADD_EXECUTABLE ( vkey ${SRCS} )
 target_link_libraries ( vkey 
          jlib
          )

--- a/tools/wuget/CMakeLists.txt
+++ b/tools/wuget/CMakeLists.txt
@@ -33,7 +33,7 @@ include_directories (
 ADD_DEFINITIONS( -DMODULE_PRIORITY=1 -D_CONSOLE )
 
 set ( SRCS wuget.cpp )
-add_executable ( wuget ${SRCS} )
+HPCC_ADD_EXECUTABLE ( wuget ${SRCS} )
 target_link_libraries ( wuget
          jlib
          dllserver

--- a/tools/xmlsize/CMakeLists.txt
+++ b/tools/xmlsize/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
-add_executable ( xmlsize ${SRCS} )
+HPCC_ADD_EXECUTABLE ( xmlsize ${SRCS} )
 install ( TARGETS xmlsize DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( xmlsize
          jlib


### PR DESCRIPTION
Improved display messages.
Fixed "usage" size information.
Generalised known executable list.
Add version information to client tools install folder.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
