### PR TITLE
Fix gh-2654 Skip library tests in hthor regression suite

### DIFF
--- a/testing/ecl/aaalibrary2.ecl
+++ b/testing/ecl/aaalibrary2.ecl
@@ -16,6 +16,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
+//nothor
+//nothorlcr
+
 #option ('targetService', 'aaaLibrary2')
 #option ('createServiceAlias', true)
 

--- a/testing/ecl/aaalibrary3a.ecl
+++ b/testing/ecl/aaalibrary3a.ecl
@@ -16,6 +16,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
+//nothor
+//nothorlcr
+
 #option ('targetService', 'aaaLibrary3a')
 #option ('createServiceAlias', true)
 

--- a/testing/ecl/aaalibrary3b.ecl
+++ b/testing/ecl/aaalibrary3b.ecl
@@ -16,6 +16,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
+//nothor
+//nothorlcr
+
 #option ('targetService', 'aaaLibrary3b')
 #option ('createServiceAlias', true)
 

--- a/testing/ecl/aaalibrary4.ecl
+++ b/testing/ecl/aaalibrary4.ecl
@@ -16,6 +16,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
+//nothor
+//nothorlcr
+
 #option ('targetService', 'aaaLibrary4')
 #option ('createServiceAlias', true)
 

--- a/testing/ecl/aaalibrary5.ecl
+++ b/testing/ecl/aaalibrary5.ecl
@@ -16,6 +16,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
+//nothor
+//nothorlcr
+
 #option ('targetService', 'aaaLibrary5')
 #option ('createServiceAlias', true)
 

--- a/testing/ecl/library2.ecl
+++ b/testing/ecl/library2.ecl
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
 //nothor
 //nothorlcr
 //The library is defined and built in aaalibrary2.ecl

--- a/testing/ecl/library3.ecl
+++ b/testing/ecl/library3.ecl
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
 //nothor
 //nothorlcr
 

--- a/testing/ecl/library4.ecl
+++ b/testing/ecl/library4.ecl
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
 //nothor
 //nothorlcr
 

--- a/testing/ecl/library5.ecl
+++ b/testing/ecl/library5.ecl
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+//nohthor
 //nothor
 //nothorlcr
 //The library is defined and built in aaalibrary5.ecl


### PR DESCRIPTION
Until #2653 is fixed, the library_.ecl tests in hthor should be skipped.
Also skip the aaalibrary_.ecl tests in thor as they have no purpose until
library support is implemented there.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
