### PR TITLE
Fix gh-2624 remote.ecl mismatch test in Roxie regression suite

### DIFF
--- a/testing/ecl/roxie/key/remote.xml
+++ b/testing/ecl/roxie/key/remote.xml
@@ -1,51 +1,63 @@
 <Dataset name='Result 1'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+ <Row><Result_1>3.0</Result_1></Row>
 </Dataset>
 <Dataset name='Result 2'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+ <Row><Result_2>3.0</Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+ <Row><Result_3>3.0</Result_3></Row>
 </Dataset>
 <Dataset name='Result 4'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+ <Row><Result_4>3.0</Result_4></Row>
 </Dataset>
 <Dataset name='Result 5'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+ <Row><Result_5>3.0</Result_5></Row>
 </Dataset>
 <Dataset name='Result 6'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+ <Row><Result_6>3.0</Result_6></Row>
 </Dataset>
 <Dataset name='Result 7'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+ <Row><Result_7>3.0</Result_7></Row>
 </Dataset>
 <Dataset name='Result 8'>
+ <Row><Result_8>3.0</Result_8></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+</Dataset>
+<Dataset name='Result 11'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+</Dataset>
+<Dataset name='Result 12'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+</Dataset>
+<Dataset name='Result 13'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+</Dataset>
+<Dataset name='Result 14'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+</Dataset>
+<Dataset name='Result 15'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname></Row>
+</Dataset>
+<Dataset name='Result 16'>
  <Row><lname>Anderson                 </lname><fname>Jane           </fname></Row>
  <Row><lname>Anderson                 </lname><fname>Joe            </fname></Row>
  <Row><lname>Anderson                 </lname><fname>John           </fname></Row>

--- a/testing/ecl/roxie/remote.ecl
+++ b/testing/ecl/roxie/remote.ecl
@@ -16,44 +16,62 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+IMPORT Std.system.thorlib as thorlib;
+
 //UseStandardFiles
 // NOTE - uses sequential as otherwise we use too many threads (allegedly)
 
 // Try some remote activities reading from normal indexes and local indexes
 
-index_best := topn(DG_FetchIndex1(LName[1]='A'), 3, LName, FName);
+index_best := topn(LIMIT(DG_FetchIndex1(LName[1]='A'),1000000), 3, LName, FName);
 index_best_all := allnodes(index_best);
-o1 := output(DEDUP(sort(index_best_all, LName, FName),LName, FName, KEEP(2)), {LName, FName});
+s1 := sort(index_best_all, LName, FName);
+count(s1) / thorlib.nodes();
+o1 := output(DEDUP(s1,LName, FName, KEEP(1)), {LName, FName});
 
 index_best_all_local := allnodes(LOCAL(index_best));
-o2 := output(sort(index_best_all_local, LName, FName), {LName, FName});
+s2 := sort(index_best_all_local, LName, FName);
+count(s2) / thorlib.nodes();
+o2 := output(DEDUP(s2,LName, FName, KEEP(1)), {LName, FName});
 
 // Now try with disk files
 
 disk_best := topn(DG_FetchFile(LName[1]='A'), 3, LName, FName);
 disk_best_all := allnodes(disk_best);
-o3 := output(DEDUP(sort(disk_best_all, LName, FName), LName, FName, KEEP(2)), {LName, FName});
+s3 := sort(disk_best_all, LName, FName);
+count(s3) / thorlib.nodes();
+o3 := output(DEDUP(s3,LName, FName, KEEP(1)), {LName, FName});
 
 disk_best_all_local := allnodes(LOCAL(disk_best));
-o4 := output(sort(disk_best_all_local, LName, FName), {LName, FName});
+s4 := sort(disk_best_all_local, LName, FName);
+count(s4) / thorlib.nodes();
+o4 := output(DEDUP(s4,LName, FName, KEEP(1)), {LName, FName});
 
 // Now try with in-memory files
 
 preload_best := topn(DG_FetchFilePreload(LName[1]='A'), 3, LName, FName);
 preload_best_all := allnodes(preload_best);
-o5 := output(DEDUP(sort(preload_best_all, LName, FName), LName, FName, KEEP(2)), {LName, FName});
+s5 := sort(preload_best_all, LName, FName);
+count(s5) / thorlib.nodes();
+o5 := output(DEDUP(s5,LName, FName, KEEP(1)), {LName, FName});
 
 preload_best_all_local := allnodes(LOCAL(preload_best));
-o6 := output(sort(preload_best_all_local, LName, FName), {LName, FName});
+s6 := sort(preload_best_all_local, LName, FName);
+count(s6) / thorlib.nodes();
+o6 := output(DEDUP(s6,LName, FName, KEEP(1)), {LName, FName});
 
 // Now try with keyed in-memory files
 
 preload_indexed_best := topn(DG_FetchFilePreloadIndexed(KEYED(LName[1]='A')), 3, LName, FName);
 preload_indexed_best_all := allnodes(preload_indexed_best);
-o7 := output(DEDUP(sort(preload_indexed_best_all, LName, FName), LName, FName, KEEP(2)), {LName, FName});
+s7 := sort(preload_indexed_best_all, LName, FName);
+count(s7) / thorlib.nodes();
+o7 := output(DEDUP(s7,LName, FName, KEEP(1)), {LName, FName});
 
 preload_indexed_best_all_local := allnodes(LOCAL(preload_indexed_best));
-o8 := output(sort(preload_indexed_best_all_local, LName, FName), {LName, FName});
+s8 := sort(preload_indexed_best_all_local, LName, FName);
+count(s8) / thorlib.nodes();
+o8 := output(DEDUP(s8,LName, FName, KEEP(1)), {LName, FName});
 
 
 SEQUENTIAL(o1,o2,o3,o4,o5,o6,o7,o8);


### PR DESCRIPTION
Rework the test so that the output is independent of the number of nodes
in the system, while still testing that the number of results returned
from the ALLNODES() is proportional to the cluster size.

This requires that issue #2656 is fixed if it is to work correctly on
clusters with > 1 channel.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
