### PR TITLE
Fix gh-2656 thorlib.nodes() always returns 1 on Roxie

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -30156,7 +30156,7 @@ public:
     virtual bool fileExists(const char * filename) { throwUnexpected(); }
     virtual void deleteFile(const char * logicalName) { throwUnexpected(); }
 
-    virtual unsigned getNodes() { return 1; }
+    virtual unsigned getNodes() { return numChannels; }
     virtual unsigned getNodeNum() { return 1; }
     virtual char *getFilePart(const char *logicalPart, bool create=false) { UNIMPLEMENTED; }
     virtual unsigned __int64 getFileOffset(const char *logicalPart) { throwUnexpected(); }


### PR DESCRIPTION
It's hard to guess what people want to use nodes() for - for some uses when
writing code that needs to work on thor or roxie, 1 may be the best answer.
But for other uses it's no good at all.

Given that it's always possible to code IF(platform='roxie',1,nodes()) if
that's the semantics you want, I think it would be more useful for nodes()
on Roxie to return the number of channels.

This could conceivably break code that is relying on the old semantics.
Though I suspect any such code would be unusual.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
