### PR TITLE
Fix gh-2660 CATCH,SKIP in Roxie not aborting upstream activities

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -18356,7 +18356,7 @@ public:
 protected:
     void onException(IException *E)
     {
-        stop(true);
+        input->stop(true);
         ReleaseRoxieRowSet(buff);
         if (createRow)
         {

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -18356,6 +18356,7 @@ public:
 protected:
     void onException(IException *E)
     {
+        stop(true);
         ReleaseRoxieRowSet(buff);
         if (createRow)
         {

--- a/testing/ecl/roxie/badcatch.ecl
+++ b/testing/ecl/roxie/badcatch.ecl
@@ -1,0 +1,42 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+MyRec := RECORD
+    STRING50 Value1;
+    unsigned Value2;
+END;
+
+MyRec t1(unsigned c) := transform
+  SELF.value1 := 'X';
+  SELF.value2 := c;
+END;
+
+ds := DATASET(100000, t1(COUNTER));
+
+MyRec FailTransform := transform
+  self.value1 := FAILMESSAGE[1..17];
+  self.value2 := FAILCODE
+END;
+
+splitds := nofold(ds(Value1 != 'f'));
+limited := LIMIT(splitds, 2);
+
+recovered := CATCH(limited, SKIP);
+
+count(splitds);
+count(recovered);

--- a/testing/ecl/roxie/key/badcatch.xml
+++ b/testing/ecl/roxie/key/badcatch.xml
@@ -1,0 +1,6 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>100000</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>0</Result_2></Row>
+</Dataset>

--- a/testing/ecl/when6c.ecl
+++ b/testing/ecl/when6c.ecl
@@ -31,12 +31,13 @@ ds := dataset([
         t(9,3,4,5),
         t(3,4,2,9)]);
 
-simple := limit(dedup(nofold(ds), f1),1);
+simple := dedup(nofold(ds), f1);
 
 osum := output(TABLE(simple, { s := sum(group, f1) }, f3));
 
-x1 := when(simple, osum, failure);
+x1 := when(LIMIT(simple,1), osum, failure);
 
-o1 := output(TABLE(x1, { f1 }));
+o1 := TABLE(x1, { f1 });
 o2 := output(TABLE(simple, { c := count(group) }, f3));
-when(o1, o2, failure);
+
+output(catch(when(o1, o2, failure), SKIP));


### PR DESCRIPTION
CATCH,SKIP in Roxie is not properly aborting the upstream activities when a failure
is caught. This results in some diagnostic tracing about unexpected activity states,
but also means that WHEN() activities above the CATCH are not appropriately triggered.
This causes failures in when6c.ecl regression test.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
