### PR TITLE
Skip library2a in hthor

### DIFF
--- a/testing/ecl/library2a.ecl
+++ b/testing/ecl/library2a.ecl
@@ -18,6 +18,7 @@
 
 //nothor
 //nothorlcr
+//nohthor
 //The library is defined and built in aaalibrary2.ecl
 
 namesRecord := 


### PR DESCRIPTION
I've changed this test to completely execute (thus using the external library) and forgot to disable it in hthor like the others.
