### PR TITLE
Ensure SDS client connection removed

### DIFF
--- a/dali/base/dacsds.ipp
+++ b/dali/base/dacsds.ipp
@@ -406,6 +406,8 @@ public:
     virtual bool updateEnvironment(IPropertyTree *newEnv, bool forceGroupUpdate, StringBuffer &response);
 
 private:
+    void noteDisconnected(CRemoteConnection &connection);
+
     CriticalSection crit;
     CCopyConnectionHashTable connections;
     Semaphore concurrentRequests;


### PR DESCRIPTION
An exception during a SDS close causes the connection to remain in the
client connections list. The connection object is likely to be
released/destroyed and cause problems later if accessed.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
