### PR TITLE
Ensure Dali subscription removed on exception

### DIFF
--- a/dali/base/dasubs.cpp
+++ b/dali/base/dasubs.cpp
@@ -465,8 +465,7 @@ public:
         }
         catch (IDaliClient_Exception *e) {
             PrintExceptionLog(e,"Dali CDaliSubscriptionManagerStub::add");
-            e->Release();
-            abort();
+            throw;
         }
     }
 
@@ -486,10 +485,7 @@ public:
         }
         catch (IDaliClient_Exception *e) {
             PrintExceptionLog(e,"Dali CDaliSubscriptionManagerStub::remove");
-            if (e->errorCode()!=DCERR_server_closed)
-                abort();
             e->Release();
-            return;
         }
         subscriptions.remove(idx);
         ids.remove(idx);


### PR DESCRIPTION
An exception during subscription removal was causing it to be left behind.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
