### PR TITLE
Fix a few example files to avoid newly introduced error

### DIFF
--- a/ecl/regress/fetch12.ecl
+++ b/ecl/regress/fetch12.ecl
@@ -518,7 +518,6 @@ DG_IntegerRecord := RECORD
 END;
 
 DG_IntegerDataset := DATASET(DG_IntegerDatasetName, DG_IntegerRecord, thor);
-DG_IntegerIndex := INDEX(DG_IntegerDataset, { i6, nested }, { DG_IntegerDataset }, DG_IntegerIndexName);
 
 
 #line(0)

--- a/ecl/regress/hthor_setup.ecl
+++ b/ecl/regress/hthor_setup.ecl
@@ -533,8 +533,8 @@ DG_MemFile := DATASET(DG_MemFileName,DG_MemFileRec,FLAT);
 
 //record structures
 DG_NestedIntegerRecord := RECORD
-  INTEGER4 i4;
-  UNSIGNED3 u3;
+  big_endian unsigned INTEGER4 i4;
+  big_endian UNSIGNED3 u3;
 END;
 
 DG_IntegerRecord := RECORD

--- a/ecl/regress/sqsimple.ecl
+++ b/ecl/regress/sqsimple.ecl
@@ -17,7 +17,6 @@
 ############################################################################## */
 
 #option ('childQueries', true);
-#option ('maxInlineDepth', 0);
 #option ('pickBestEngine', false);
 
 unsigned8 skipId := 4 : stored('skipId');


### PR DESCRIPTION
Using an integer field inside a nested record in an index is now an
error.  This fixes a few regression examples to avoid the error.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
