### PR TITLE
Fix some issues detected by Valgrind

### DIFF
--- a/common/fileview2/fvidxsource.cpp
+++ b/common/fileview2/fvidxsource.cpp
@@ -42,7 +42,7 @@ static IKeyIndex *openKeyFile(IDistributedFilePart *keyFile)
             {
                 StringBuffer remotePath;
                 rfn.getRemotePath(remotePath);
-                unsigned crc;
+                unsigned crc = 0;
                 keyFile->getCrc(crc);
                 return createKeyIndex(remotePath.str(), crc, false, false);
             }

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -51,7 +51,7 @@ static IKeyIndex *openKeyFile(IDistributedFilePart & keyFile)
             {
                 StringBuffer remotePath;
                 rfn.getRemotePath(remotePath);
-                unsigned crc;
+                unsigned crc = 0;
                 keyFile.getCrc(crc);
                 return createKeyIndex(remotePath.str(), crc, false, false);
             }

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2141,7 +2141,7 @@ public:
                     assertex(numParts > 0);
                     IPartDescriptor *pdesc = fdesc->queryPart(numParts - 1);
                     Owned<ILazyFileIO> keyFile = createDynamicFile(subNames.item(idx), pdesc, ROXIE_KEY, numParts);
-                    unsigned crc;
+                    unsigned crc = 0;
                     pdesc->getCrc(crc);
                     StringBuffer pname;
                     pdesc->getPath(pname);

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -29467,9 +29467,11 @@ public:
             loop
             {
                 char c0 = *val++;
-                char c1 = *val++;
-                if (!c0 || !c1)
+                if (!c0)
                     break;
+                char c1 = *val++;
+                if (!c1)
+                    break; // Shouldn't really happen - we expect even length
                 unsigned c2 = (hex2digit(c0) << 4) | hex2digit(c1);
                 result.append((unsigned char) c2);
             }


### PR DESCRIPTION
Running Roxie under Valgrind revealed some minor issues. I don't think any would cause
a problem in real world.

getCRC does not set the crc if none is available, so make sure to initialize it.
Potential read of one char beyond allocated string buffer when readhing hex data.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
