### PR TITLE
Fix some of the clang warnings

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -2841,9 +2841,9 @@ static bool lookupHostAddress(const char *name,unsigned *netaddr)
     }
     if (best) {
         if (best->ai_family==AF_INET6)
-            memcpy(netaddr,&(((sockaddr_in6 *)best->ai_addr)->sin6_addr),sizeof(netaddr));
+            memcpy(netaddr,&(((sockaddr_in6 *)best->ai_addr)->sin6_addr),sizeof(in6_addr));
         else {
-            memcpy(netaddr+3,&(((sockaddr_in *)best->ai_addr)->sin_addr),sizeof(netaddr[3]));
+            memcpy(netaddr+3,&(((sockaddr_in *)best->ai_addr)->sin_addr),sizeof(in_addr));
             netaddr[2] = 0xffff0000;
             netaddr[1] = 0;
             netaddr[0] = 0;

--- a/system/mp/mpcomm.cpp
+++ b/system/mp/mpcomm.cpp
@@ -327,7 +327,7 @@ public:
 
     unsigned flush(CBufferQueueNotify &nfy)
     {
-        bool count = 0;
+        unsigned count = 0;
         CriticalBlock block(sect);
         ForEachQueueItemInRev(i,received) {
             if (nfy.notify(received.item(i))) {

--- a/tools/start-stop-daemon/CMakeLists.txt
+++ b/tools/start-stop-daemon/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 project(start-stop-daemon)
 
+add_definitions( -DHAVE_C_ATTRIBUTE )
 set( SRC start-stop-daemon.c )
 set( HEADER macros.h )
 


### PR DESCRIPTION
As reported by #2695, one warning per commit.
