### PR TITLE
OSX packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,9 @@ if ( NOT MAKE_DOCS_ONLY )
     HPCC_ADD_SUBDIRECTORY (thorlcr "PLATFORM")
 endif()
 HPCC_ADD_SUBDIRECTORY (docs "PLATFORM")
-HPCC_ADD_SUBDIRECTORY (lib2)
+if (APPLE)
+  HPCC_ADD_SUBDIRECTORY (lib2)
+endif (APPLE)
 
 ###
 ## CPack install and packaging setup.
@@ -281,6 +283,7 @@ else()
 endif()
 
 if (APPLE)
+    set ( CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}-${CPACK_SYSTEM_NAME}")
     set ( CPACK_MONOLITHIC_INSTALL TRUE )
     set ( CPACK_PACKAGE_VENDOR "HPCC Systems" )
     file(WRITE "${PROJECT_BINARY_DIR}/welcome.txt" 

--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -173,7 +173,6 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
 
   macro(HPCC_ADD_EXECUTABLE target)
     add_executable(${target} ${ARGN})
-    set (executables ${executables} ${target} CACHE INTERNAL "")
   endmacro(HPCC_ADD_EXECUTABLE target)
 
   macro(HPCC_ADD_LIBRARY target)

--- a/ecl/ecl-package/CMakeLists.txt
+++ b/ecl/ecl-package/CMakeLists.txt
@@ -43,12 +43,12 @@ ADD_DEFINITIONS( -D_CONSOLE )
 
 HPCC_ADD_EXECUTABLE ( ecl-package ${SRCS} )
 add_dependencies ( ecl-package espscm ws_packageprocess )
-install ( TARGETS ecl-package DESTINATION ${DIR_NAME}/bin )
+install ( TARGETS ecl-package DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( ecl-package
         jlib
         esphttp
         workunit
     )
 
-install ( PROGRAMS ecl-package.install DESTINATION ${DIR_NAME}/etc/init.d/install COMPONENT Runtime )
+install ( PROGRAMS ecl-package.install DESTINATION ${OSSDIR}/etc/init.d/install COMPONENT Runtime )
 

--- a/ecl/eclcmd/queries/CMakeLists.txt
+++ b/ecl/eclcmd/queries/CMakeLists.txt
@@ -43,7 +43,7 @@ ADD_DEFINITIONS( -D_CONSOLE )
 
 HPCC_ADD_EXECUTABLE ( ecl-queries ${SRCS} )
 add_dependencies ( ecl-queries espscm ws_workunits )
-install ( TARGETS ecl-queries DESTINATION ${DIR_NAME}/bin )
+install ( TARGETS ecl-queries DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( ecl-queries
         jlib
         esphttp

--- a/lib2/CMakeLists.txt
+++ b/lib2/CMakeLists.txt
@@ -18,37 +18,35 @@
 cmake_minimum_required(VERSION 2.8)
 PROJECT(lib2)
 
-  MACRO (FIXUP_MACPORTS apps dylibs)
-	foreach(dylib ${dylibs})
-		get_filename_component(dylib_path ${dylib} REALPATH)
-	endforeach(dylib)
-	foreach(dylib ${dylibs})
-		get_filename_component(dylib_path ${dylib} REALPATH)
-		get_filename_component(dylib_name_ext ${dylib_path} NAME)
-		install(PROGRAMS "${dylib_path}" DESTINATION "${OSSDIR}/lib2")
-		set(fixupCommand "") 
-		foreach(app ${apps})                                                                                                                                     
-			set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/${app}\")")
-			#HACK HACK - Should be able resolve alias's to alias's correctly?
-			string(REPLACE ".28.0.dylib" ".28.dylib" dylib_28_path "${dylib_path}")
-			if (NOT "${dylib_28_path}" STREQUAL "${dylib_path}")
-				set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_28_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/${app}\")")
-			endif ()
-			string(REPLACE ".48.1.dylib" ".48.dylib" dylib_48_path "${dylib_path}")
-			if (NOT "${dylib_48_path}" STREQUAL "${dylib_path}")
-				set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_48_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/${app}\")")
-			endif ()
-		endforeach(app)
-		install(CODE "${fixupCommand}")
-	endforeach(dylib)
-  ENDMACRO(FIXUP_MACPORTS)
-
 if (APPLE)
     set(DYLIBS ${ICU_LIBRARIES})
     set(DYLIBS ${DYLIBS} ${BOOST_REGEX_LIBRARIES})
     set(DYLIBS ${DYLIBS} ${XALAN_LIBRARIES})
     set(DYLIBS ${DYLIBS} ${XERCES_LIBRARIES})
-    list(REMOVE_DUPLICATES executables)
-    list(REMOVE_ITEM executables "esdl" "hidl" "configgen")
-    FIXUP_MACPORTS("${executables}" "${DYLIBS}")
+    
+    foreach(dylib ${DYLIBS})
+        get_filename_component(dylib_path ${dylib} REALPATH)
+        get_filename_component(dylib_name_ext ${dylib_path} NAME)
+
+        set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \${file})")
+
+        #HACK HACK - Should be able resolve alias's to alias's correctly?
+        string(REPLACE ".28.0.dylib" ".28.dylib" dylib_28_path "${dylib_path}")
+        if (NOT "${dylib_28_path}" STREQUAL "${dylib_path}")
+            set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_28_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \${file})")
+        endif ()
+
+        string(REPLACE ".48.1.dylib" ".48.dylib" dylib_48_path "${dylib_path}")
+        if (NOT "${dylib_48_path}" STREQUAL "${dylib_path}")
+            set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_48_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \${file})")
+        endif ()
+
+        install(PROGRAMS "${dylib_path}" DESTINATION "${OSSDIR}/lib2")
+        install(CODE "
+            file(GLOB files \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/*\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib/*.dylib\")
+            foreach(file \${files})
+              ${fixupCommand}
+            endforeach ()
+        ")
+    endforeach(dylib)
 endif()


### PR DESCRIPTION
Added "fixing" code for our dylibs which reference third party dylibs.
Package name was missing a "-".
ecl-queries and ecl-package were being installed to wrong location.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
