### PR TITLE
Remove potential double // in dllserver records

### DIFF
--- a/common/dllserver/dllserver.cpp
+++ b/common/dllserver/dllserver.cpp
@@ -481,7 +481,7 @@ void DllServer::copyFileLocally(RemoteFilename & targetName, RemoteFilename & so
 
     targetLocalPath.append(rootDir);
     recursiveCreateDirectory(targetLocalPath.str());
-    targetLocalPath.append(PATHSEPCHAR);
+    addPathSepChar(targetLocalPath);
     splitFilename(sourceLocalPath.str(),NULL,NULL,&targetLocalPath,&targetLocalPath);
 
     SocketEndpoint hostEndpoint;


### PR DESCRIPTION
Noticed while looking at what might be needed for gh-2684 that some
dll entries in dali had double // in the locations. I don't think
this is likely to have any ill effect.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
