### PR TITLE
ECL Examples Typo

### DIFF
--- a/initfiles/examples/IMDB/FileActors.ecl
+++ b/initfiles/examples/IMDB/FileActors.ecl
@@ -109,7 +109,7 @@ IMDB.LayoutActors tActors(ThreeColumns L) := TRANSFORM
   self.rolename     := FindWithin(L.filmname,'[',']');
   self.credit_pos   := (integer2)FindWithin(L.filmname,'<','>');
   self.episode_name := FindWithin(L.filmname,'{','}');
-  self.episode_num  := FindWithin(L.filmname,'(#',')');
+  self.episode_num  := FindWithin(L.filmname,'(#',')}');
   SELF              := L; // Copy across everything but movie name
 END;
 


### PR DESCRIPTION
Minor typo in FileActors.ecl.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
