### PR TITLE
Noreturn in start-stop-daemon

### DIFF
--- a/tools/start-stop-daemon/CMakeLists.txt
+++ b/tools/start-stop-daemon/CMakeLists.txt
@@ -17,7 +17,8 @@
 
 project(start-stop-daemon)
 
-add_definitions( -DHAVE_C_ATTRIBUTE )
+add_definitions( -Wno-noreturn )
+
 set( SRC start-stop-daemon.c )
 set( HEADER macros.h )
 


### PR DESCRIPTION
Enabling the HAVE_C_ATTRIBUTE in start-stop-daemon
to correct the behaviour (and suppress warnings)
has the side effect to add another warning, this
time, pointing to a bug in the code.

Since we can't/shouldn't change the source code,
and GCC doesn't recognize -Wno-invalid-noreturn,
the only option is to ignore the first warning.
