### PR TITLE
gh-2712, avoid lock on add/del subfiles in DFU

### DIFF
--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -788,9 +788,7 @@ public:
             transaction->commit();
         }
         // Delete superfile if empty
-        if (superfile->numSubFiles() != 0) {
-            if (numtodelete == 0)
-                throwError1(DFUERR_DSuperFileNotEmpty, superfname);
+        if (superfile->numSubFiles() == 0) {
             superfile.clear();
             // MORE - add file deletion to transaction
             queryDistributedFileDirectory().removeEntry(superfname);


### PR DESCRIPTION
This is a temporary solution until a proper fix can be done.

The short-term proper fix in to allow caching on inactive
transactions via a flag (that should also deprecate the
TempTransaction object in FileServices).

The long-term proper fix is to finally make all access to
the DFS from a single entry point, ie. DFSAccess.
