### PR TITLE
Mac Package Name + RPATH issue.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ else()
 endif()
 
 if (APPLE)
-    set ( CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}-${CPACK_SYSTEM_NAME}")
+    set ( CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}-${CPACK_SYSTEM_NAME}")
     set ( CPACK_MONOLITHIC_INSTALL TRUE )
     set ( CPACK_PACKAGE_VENDOR "HPCC Systems" )
     file(WRITE "${PROJECT_BINARY_DIR}/welcome.txt" 

--- a/lib2/CMakeLists.txt
+++ b/lib2/CMakeLists.txt
@@ -23,6 +23,7 @@ if (APPLE)
     set(DYLIBS ${DYLIBS} ${BOOST_REGEX_LIBRARIES})
     set(DYLIBS ${DYLIBS} ${XALAN_LIBRARIES})
     set(DYLIBS ${DYLIBS} ${XERCES_LIBRARIES})
+    set(DYLIBS ${DYLIBS} ${BINUTILS_LIBRARIES})
     
     foreach(dylib ${DYLIBS})
         get_filename_component(dylib_path ${dylib} REALPATH)
@@ -43,7 +44,7 @@ if (APPLE)
 
         install(PROGRAMS "${dylib_path}" DESTINATION "${OSSDIR}/lib2")
         install(CODE "
-            file(GLOB files \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/*\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib/*.dylib\")
+            file(GLOB files \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/bin/*\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib/*.dylib\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${OSSDIR}/lib2/*.dylib\")
             foreach(file \${files})
               ${fixupCommand}
             endforeach ()


### PR DESCRIPTION
Had a "_" which should be a "-"
rpath's need to be fixed for third party dylibs linking to other
thirdparty dylibs

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
