### PR TITLE
Fix invalid assert assertex(required < choosenLimit)

### DIFF
--- a/ecl/regress/choosends.ecl
+++ b/ecl/regress/choosends.ecl
@@ -1,0 +1,39 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+idRecord := RECORD
+unsigned        id;
+            END;
+
+namesRecord :=
+            RECORD
+string20        surname;
+UNSIGNED1       cnt;
+dataset(idRecord)   ids{choosen(3)} := dataset([],idRecord);
+            END;
+
+namesTable := dataset([
+        {'Hawthorn',1},
+        {'Hawthorn',2},
+        {'Smithe',3},
+        {'X',4}], namesRecord);
+
+makeIds(unsigned num) := DATASET(num, transform(idRecord, SELF.id := COUNTER));
+
+p := PROJECT(namesTable, TRANSFORM(namesRecord, SELF.ids := makeIds(LEFT.cnt); SELF := LEFT));
+output(p);

--- a/rtl/eclrtl/rtlds.cpp
+++ b/rtl/eclrtl/rtlds.cpp
@@ -486,7 +486,7 @@ byte * * RtlLinkedDatasetBuilder::linkrows()
 
 void RtlLinkedDatasetBuilder::expand(size32_t required)
 {
-    assertex(required < choosenLimit);
+    assertex(required <= choosenLimit);
     //MORE: Next factoring change this so it passes this logic over to the row allocator
     size32_t newMax = max ? max : 4;
     while (newMax < required)

--- a/testing/ecl/choosends.ecl
+++ b/testing/ecl/choosends.ecl
@@ -1,0 +1,39 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+idRecord := RECORD
+unsigned        id;
+            END;
+
+namesRecord :=
+            RECORD
+string20        surname;
+UNSIGNED1       cnt;
+dataset(idRecord)   ids{choosen(3)} := dataset([],idRecord);
+            END;
+
+namesTable := dataset([
+        {'Hawthorn',1},
+        {'Hawthorn',2},
+        {'Smithe',3},
+        {'X',4}], namesRecord);
+
+makeIds(unsigned num) := DATASET(num, transform(idRecord, SELF.id := COUNTER));
+
+p := PROJECT(namesTable, TRANSFORM(namesRecord, SELF.ids := makeIds(LEFT.cnt); SELF := LEFT));
+output(p);

--- a/testing/ecl/key/choosends.xml
+++ b/testing/ecl/key/choosends.xml
@@ -1,0 +1,6 @@
+<Dataset name='Result 1'>
+ <Row><surname>Hawthorn            </surname><cnt>1</cnt><ids><Row><id>1</id></Row></ids></Row>
+ <Row><surname>Hawthorn            </surname><cnt>2</cnt><ids><Row><id>1</id></Row><Row><id>2</id></Row></ids></Row>
+ <Row><surname>Smithe              </surname><cnt>3</cnt><ids><Row><id>1</id></Row><Row><id>2</id></Row><Row><id>3</id></Row></ids></Row>
+ <Row><surname>X                   </surname><cnt>4</cnt><ids><Row><id>1</id></Row><Row><id>2</id></Row><Row><id>3</id></Row></ids></Row>
+</Dataset>


### PR DESCRIPTION
If a choosen limit was specified on a dataset field (a fairly rare
construct) an internal assert was being reported if the number of
rows added matched the maximum instead of exceeding it.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
