### PR TITLE
gh-2725 Roxie standalone program delay

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -445,13 +445,16 @@ public:
         LINK(daliHelper);
         if (!daliHelper || !daliHelper->isAlive())
             daliHelper = new CRoxieDaliHelper();
-        while (waitToConnect && !daliHelper->connected())
+        if (waitToConnect && fileNameServiceDali.length() && (!topology || !topology->getPropBool("@lockDali", false)))
         {
-            unsigned delay = 1000;
-            if (delay > waitToConnect)
-                delay = waitToConnect;
-            Sleep(delay);
-            waitToConnect -= delay;
+            while (waitToConnect && !daliHelper->connected())
+            {
+                unsigned delay = 1000;
+                if (delay > waitToConnect)
+                    delay = waitToConnect;
+                Sleep(delay);
+                waitToConnect -= delay;
+            }
         }
         return daliHelper;
     }


### PR DESCRIPTION
If roxie is running without a dali (for example, a standalone program compiled
with -target=roxie), it will pause for 5 seconds at startup to give the dali
connect thread a chance to connect, even though that thread is never started.

This is a new problem introduced in 3.8.0 rc7.

Fixes gh-2725.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
