### PR TITLE
Treat a query containing a single row as output(row)

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -4702,6 +4702,18 @@ query
 
                             $$.setExpr(output, $1);
                         }
+    | dataRow optfailure
+                        {
+                            IHqlExpression * expr = $1.getExpr();
+                            OwnedHqlExpr failure = $2.getExpr();
+
+                            HqlExprArray meta;
+                            expr = attachWorkflowOwn(meta, expr, failure, NULL);
+                            expr = parser->attachPendingWarnings(expr);
+                            expr = parser->attachMetaAttributes(expr, meta);
+
+                            $$.setExpr(createValue(no_outputscalar, makeVoidType(), expr), $1);
+                        }
     | action optfailure {
                             IHqlExpression * expr = $1.getExpr();
                             OwnedHqlExpr failure = $2.getExpr();

--- a/ecl/regress/issue2201.ecl
+++ b/ecl/regress/issue2201.ecl
@@ -1,0 +1,32 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+namesRecord :=
+            RECORD
+string20        surname;
+string10        forename;
+integer2        age := 25;
+            END;
+
+namesTable := dataset([
+        {'Hawthorn','Gavin',31},
+        {'Hawthorn','Mia',30},
+        {'Smithe','Pru',10},
+        {'X','Z'}], namesRecord);
+
+namesTable[1];


### PR DESCRIPTION
Treat a row expression as output(row) for consistency with the way
datasets and expressions are handled.

Fixes #2201.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
