### PR TITLE
Ensure stdout is flushed for stand alone roxie

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -967,6 +967,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                 StringBuffer query;
                 query.appendf("<roxie format='%s'/>", format);
                 roxieServer->runOnce(query.str()); // MORE - should use the wu listener instead I suspect
+                fflush(stdout);  // in windows if output is redirected results don't appear without flushing
             }
             catch (IException *E)
             {


### PR DESCRIPTION
On windows, when output was redirected to a file, the output could fail
to be included.  fflush()ing stdout ensures the output is written.

Fixes #2718.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
