### PR TITLE
Allow RIGHT ONLY joins against indexes

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -13936,8 +13936,11 @@ bool isKeyedJoin(IHqlExpression * expr)
     {
         if (expr->hasProperty(allAtom) || expr->hasProperty(lookupAtom))
             return false;
-        if (expr->hasProperty(keyedAtom))
+        if (expr->hasProperty(keyedAtom) || containsAssertKeyed(expr->queryChild(2)))
             return true;
+        //Keyed joins only support INNER/LEFT.  Default to a normal join for other join types.
+        if (!isInnerJoin(expr) && !isLeftJoin(expr))
+            return false;
         if (isKey(expr->queryChild(1)))
             return true;
     }

--- a/ecl/regress/bug100824a.ecl
+++ b/ecl/regress/bug100824a.ecl
@@ -1,0 +1,44 @@
+/*##############################################################################
+
+    Copyright (C) 2012 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+Layout := {
+  unsigned id,
+};
+
+Model := module, virtual
+  dataset(layout) GetInvalid := dataset([], layout);
+end;
+
+//DocInfo := module(Model) // no syntax error; no runtime error; bad results
+ DocInfo := module // syntax error as expected
+
+  export dsLni := dataset([{1},{3}], layout);
+  export dskey:= dataset([{2},{3}], layout);
+  export keyDocId := index(dskey, {id}, {dskey}, '~dustin::delete::docId');
+
+  export GetInvalid
+    := join(dsLni, keyDocId,
+            left.id = right.id,
+            transform(right),
+            right only);
+end;
+
+sequential(
+  buildindex(DocInfo.keyDocid),
+  output(DocInfo.GetInvalid)
+);

--- a/ecl/regress/bug100824b.ecl
+++ b/ecl/regress/bug100824b.ecl
@@ -1,0 +1,38 @@
+/*##############################################################################
+
+    Copyright (C) 2012 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+vmod := module, virtual
+end;
+
+mymod := module(vmod) // syntax error
+// mymod := module // no syntax error, runs as expected
+
+  shared layout := {
+    unsigned u1,
+    unsigned u2,
+  };
+
+  shared ds1 := dataset([{1,2},{3,4}], layout);
+  shared key2 := index(ds1, {u1}, {u2}, '~dustin::delete::key2');
+
+  export build2 := buildindex(key2, overwrite);
+end;
+
+sequential(
+  mymod.build2
+);

--- a/ecl/regress/bug100824c.ecl
+++ b/ecl/regress/bug100824c.ecl
@@ -1,0 +1,43 @@
+/*##############################################################################
+
+    Copyright (C) 2012 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+Layout := {
+  unsigned id,
+};
+
+Model := module, virtual
+  dataset(layout) GetInvalid := dataset([], layout);
+end;
+
+DocInfo := module(Model) // no syntax error; no runtime error; bad results
+
+  export dsLni := dataset([{1},{3}], layout);
+  export dskey:= dataset([{2},{3}], layout);
+  export keyDocId := index(dskey, {id}, {dskey}, '~dustin::delete::docId');
+
+  export GetInvalid
+    := join(dsLni, keyDocId,
+            left.id = right.id,
+            transform(right),
+            right only);
+end;
+
+sequential(
+  buildindex(DocInfo.keyDocid),
+  output(DocInfo.GetInvalid)
+);

--- a/ecl/regress/bug100824err.ecl
+++ b/ecl/regress/bug100824err.ecl
@@ -1,0 +1,43 @@
+/*##############################################################################
+
+    Copyright (C) 2012 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+Layout := {
+  unsigned id,
+};
+
+Model := module, virtual
+  dataset(layout) GetInvalid := dataset([], layout);
+end;
+
+DocInfo := module(Model) // no syntax error; no runtime error; bad results
+
+  export dsLni := dataset([{1},{3}], layout);
+  export dskey:= dataset([{2},{3}], layout);
+  export keyDocId := index(dskey, {id}, {dskey}, '~dustin::delete::docId');
+
+  export GetInvalid
+    := join(dsLni, keyDocId,
+            left.id = right.id,
+            transform(right),
+            right only, keyed);
+end;
+
+sequential(
+  buildindex(DocInfo.keyDocid),
+  output(DocInfo.GetInvalid)
+);

--- a/ecl/regress/bug100824err2.ecl
+++ b/ecl/regress/bug100824err2.ecl
@@ -1,0 +1,43 @@
+/*##############################################################################
+
+    Copyright (C) 2012 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+Layout := {
+  unsigned id,
+};
+
+Model := module, virtual
+  dataset(layout) GetInvalid := dataset([], layout);
+end;
+
+DocInfo := module(Model) // no syntax error; no runtime error; bad results
+
+  export dsLni := dataset([{1},{3}], layout);
+  export dskey:= dataset([{2},{3}], layout);
+  export keyDocId := index(dskey, {id}, {dskey}, '~dustin::delete::docId');
+
+  export GetInvalid
+    := join(dsLni, keyDocId,
+            keyed(left.id = right.id),
+            transform(right),
+            right only);
+end;
+
+sequential(
+  buildindex(DocInfo.keyDocid),
+  output(DocInfo.GetInvalid)
+);


### PR DESCRIPTION
Previously JOIN(ds,index,condition,RIGHT ONLY); generated an error
because keyed joins didn't support right only joins.  It also meant
that in some situations (see examples) the error was missed, and an
invalid keyed join was generated.

This change allows that join to occur - but still generates an error
if KEYED() is used in the join condition, or as an attribute of the
join.

Addresses bugzilla #100824

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
