### PR TITLE
Fix gh-2747 empty page from Users link for non-admin

### DIFF
--- a/esp/services/ws_access/ws_accessService.hpp
+++ b/esp/services/ws_access/ws_accessService.hpp
@@ -28,7 +28,6 @@
 class Cws_accessSoapBindingEx : public Cws_accessSoapBinding
 {
     StringBuffer m_authType;
-    Owned<IXslProcessor> xslp;
 
 public:
     Cws_accessSoapBindingEx(IPropertyTree *cfg, const char *name, const char *process, http_soap_log_level llevel=hsl_none) : Cws_accessSoapBinding(cfg, name, process, llevel)
@@ -59,12 +58,6 @@ public:
     }
 
     virtual int onGetForm(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method);
-
-    int getQualifiedNames(IEspContext& ctx, MethodInfoArray & methods)
-    {
-        return methods.ordinality();
-    }
-    void setXslProcessor(IInterface *xslp_){xslp.set(dynamic_cast<IXslProcessor *>(xslp_));}
 };
 
 class Cws_accessEx : public Cws_access


### PR DESCRIPTION
When logged in as a non-administrator user in eclwatch, and
you click on any of the 'Users/Permissions' links (Users,
Groups, Permissions) it returns a blank page. Previously,
the page showed an exception: Access denied, administrators
only.

The exception did not show because XslProcessor cannot be
found for the exception xslt. The XslProcessor of
Cws_accessSoapBinding was replaced by the XslProcessor of
Cws_accessSoapBindingEx, which is incorrect. This fix
removes the the XslProcessor of Cws_accessSoapBindingEx.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
