### PR TITLE
added ECL plug in for Eclipse document to the master CMakeLists.txt

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -62,6 +62,7 @@ add_subdirectory(RunningHPCCinaVirtualMachine)
 add_subdirectory(UsingConfigManager)
 add_subdirectory(HDFSConnector)
 add_subdirectory(ECLPlayground)
+add_subdirectory(ECLPluginForEclipse)
 
 
 


### PR DESCRIPTION
change to add ECL plug in for Eclipse document to the master CMakeLists.txt
