### PR TITLE
Fix crash on linux generating a field usage report

### DIFF
--- a/ecl/hql/hqlusage.cpp
+++ b/ecl/hql/hqlusage.cpp
@@ -344,7 +344,8 @@ static IPropertyTree * addSelect(IPropertyTree * xml, IHqlExpression * expr, boo
     expandSelectText(text, expr);
     Owned<IPropertyTree> field = createPTree(isUsed ? "field" : "unused");
     field->setProp("@name", text.str());
-    return xml->addPropTree(field->queryName(), field.getClear());
+    const char * tag = field->queryName();
+    return xml->addPropTree(tag, field.getClear());
 }
 
 SourceFieldUsage::SourceFieldUsage(IHqlExpression * _source)


### PR DESCRIPTION
The code was passing parameters field.getClear() and field->queryName(),
but the execution order isn't defined, leading to an invalid access of
field->

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
