### PR TITLE
Invalid links to download resources.

### DIFF
--- a/esp/eclwatch/ws_XSLT/graph_gvc_common.xslt
+++ b/esp/eclwatch/ws_XSLT/graph_gvc_common.xslt
@@ -82,7 +82,7 @@
                   <div id="no_control_msg" style="display:none; visibility:hidden">Graph Control needs to be installed to view activity graphs.</div>
                   Your Version:<span id="current_version">Not installed.</span><br />
                   Server Version:<span id="server_version">20110523</span><br />
-                  <a href="/WsRoxieQuery/BrowseResources">HPCC Tools Download Page</a>
+                  <a href="/WsSMC/BrowseResources">HPCC Tools Download Page</a>
                 </div>
               </td>
             </tr>

--- a/esp/files/scripts/graphgvc.js
+++ b/esp/files/scripts/graphgvc.js
@@ -242,7 +242,7 @@ function checkVersion() {
           var curVersion = pluginLHS().version;
           if (curVersion == null) {
               alert("Graph Control Needs to be installed to visualize activity graphs.");
-              document.location = '/WsRoxieQuery/BrowseResources';
+              document.location = '/WsSMC/BrowseResources';
               return false;
           }
           document.getElementById('current_version').innerHTML = curVersion;


### PR DESCRIPTION
This pull request just implements the change as outlined in the issue report and would need testing - but I suspect that it can't be any worse than the current situation.

FYI The new target URL on my test server just says:

"No resource found from your installation.  You may visit http://hpccsystems.com/download for resources. "

Fixes gh-2760

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
