### PR TITLE
gh-2764 Core dumps possible if mix debug/release .so's

### DIFF
--- a/system/jlib/jhash.hpp
+++ b/system/jlib/jhash.hpp
@@ -54,9 +54,6 @@ interface jlib_decl IAtom : extends IMapping
     virtual const char * getNamePtr() const;
     inline const char * str() const { return getAtomNamePtr(); }
     inline operator const char *() const { return getAtomNamePtr(); }
-#ifdef _DEBUG
-    const char* DBG_readable;
-#endif
 };
 typedef IAtom *_ATOM;
 

--- a/system/jlib/jhash.ipp
+++ b/system/jlib/jhash.ipp
@@ -80,9 +80,6 @@ public:
     AtomBase(const void * k)  
     { 
         key = strdup((const char *)k); 
-#ifdef _DEBUG
-        DBG_readable = key;
-#endif
     }
     ~AtomBase()               { free(key); }
 


### PR DESCRIPTION
The unicodelib plugin compiled in debug mode can core if used with a jlib
compiled in release mode (and probably the reverse). This is caused by
the different definition of the Atom class in the two modes, which causes
chaos if inline calls to the constructor are made in both modes.

Modern debuggers are capable of displaying the value in an Atom without
the 'DbgReadable' field, so remove it.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
