### PR TITLE
gh-2763 Fix valgrind error running compiler test suite

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1655,7 +1655,10 @@ void EclCC::processBatchedFile(IFile & file, bool multiThreaded)
         fprintf(logFile, "Unexpected exception: %s", s.str());
     }
     if (handler)
+    {
         queryLogMsgManager()->removeMonitor(handler);
+        handler.clear();
+    }
 
     fflush(logFile);
     fclose(logFile);


### PR DESCRIPTION
Make sure that log handler is cleared before closing the log file.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
