### PR TITLE
gh-2390 ROLLUP should compare previous input row

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -2223,11 +2223,13 @@ void CHThorRollupActivity::ready()
 {
     CHThorSimpleActivityBase::ready();
     left.setown(input->nextInGroup());
+    prev.set(left);
 }
 
 void CHThorRollupActivity::done()
 {
     left.clear();
+    prev.clear();
     right.clear();
     CHThorSimpleActivityBase::done();
 }
@@ -2237,7 +2239,7 @@ const void *CHThorRollupActivity::nextInGroup()
     loop
     {
         right.setown(input->nextInGroup());
-        if(!left || !right || !helper.matches(left,right))
+        if(!prev || !right || !helper.matches(prev,right))
         {
             const void * ret = left.getClear();
             if(ret)
@@ -2245,6 +2247,7 @@ const void *CHThorRollupActivity::nextInGroup()
                 processed++;
             }
             left.setown(right.getClear());
+            prev.set(left);
             return ret;
         }
         try
@@ -2255,6 +2258,7 @@ const void *CHThorRollupActivity::nextInGroup()
             {
                 left.setown(rowBuilder.finalizeRowClear(outSize));
             }
+            prev.set(right);
         }
         catch(IException * e)
         {

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -436,6 +436,7 @@ class CHThorRollupActivity : public CHThorSimpleActivityBase
 {
     IHThorRollupArg &helper;
     OwnedConstHThorRow left;
+    OwnedConstHThorRow prev;
     OwnedConstHThorRow right;
 public:
     CHThorRollupActivity(IAgentContext &agent, unsigned _activityId, unsigned _subgraphId, IHThorRollupArg &_arg, ThorActivityKind _kind);

--- a/testing/ecl/key/rollup1.xml
+++ b/testing/ecl/key/rollup1.xml
@@ -1,0 +1,6 @@
+<Dataset name='Result 1'>
+ <Row><r>2</r></Row>
+ <Row><r>2</r></Row>
+ <Row><r>3</r></Row>
+ <Row><r>4</r></Row>
+</Dataset>

--- a/testing/ecl/key/rollup1.xml
+++ b/testing/ecl/key/rollup1.xml
@@ -3,4 +3,10 @@
  <Row><r>2</r></Row>
  <Row><r>3</r></Row>
  <Row><r>4</r></Row>
+ <Row><r>8</r></Row>
+ <Row><r>9</r></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><r>3</r></Row>
+ <Row><r>9</r></Row>
 </Dataset>

--- a/testing/ecl/rollup1.ecl
+++ b/testing/ecl/rollup1.ecl
@@ -1,7 +1,8 @@
-d := dataset([{1},{1},{2},{3},{4}], { unsigned r; });
+d := dataset([{1},{1},{2},{3},{4},{8},{9}], { unsigned r; });
 
 d t(d L, d r) := transform
-SELF.r := L.r + 1;
+SELF.r := IF (L.r=3,SKIP,L.r + 1);
 END;
 
-rollup(d, t(LEFT, RIGHT), LEFT.r = RIGHT.r, LOCAL);
+rollup(d, t(LEFT, RIGHT), LEFT.r = RIGHT.r);
+rollup(d, t(LEFT, RIGHT), LEFT.r >= RIGHT.r-1, LOCAL);

--- a/testing/ecl/rollup1.ecl
+++ b/testing/ecl/rollup1.ecl
@@ -1,0 +1,7 @@
+d := dataset([{1},{1},{2},{3},{4}], { unsigned r; });
+
+d t(d L, d r) := transform
+SELF.r := L.r + 1;
+END;
+
+rollup(d, t(LEFT, RIGHT), LEFT.r = RIGHT.r, LOCAL);


### PR DESCRIPTION
ROLLUP was in some cases using the current value of the output row
to compare against the next input row, rather than the previus input
row. This could lead to unexpected behaviour if the fields being
compared were not copied from the inptu to the output.

In Thor, only LOCAL rollup behaves this way, as otherwise it is
transformed to use GROUP.

This commit fixes the Roxie and hthor cases.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
