### PR TITLE
Fix internal assert on (obscure) side-effects in workflow

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -6178,7 +6178,6 @@ IHqlExpression * WorkflowTransformer::transformRootAction(IHqlExpression * expr)
     switch (op)
     {
     case no_compound:
-        throwUnexpected();
         if (expr->isAction())
             return createCompoundWorkflow(expr);
         break;


### PR DESCRIPTION
Remove redundant internal error.  I'm not sure why this line was there
since the following code was correct.  It could be triggered by an
expression with an implicit side-effect (e.g., a preceeding output)
used in a SEQUENTIAL which also happened to be dependent on some
other worflow actions.
(See example awrobel.eclxml in private regression suite.)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
