### PR TITLE
gh-2390 rollup matching transform result, not left

### DIFF
--- a/testing/ecl/key/rollup1.xml
+++ b/testing/ecl/key/rollup1.xml
@@ -10,3 +10,6 @@
  <Row><r>3</r></Row>
  <Row><r>9</r></Row>
 </Dataset>
+<Dataset name='Result 3'>
+ <Row><r>1</r><res>112389</res></Row>
+</Dataset>

--- a/testing/ecl/rollup1.ecl
+++ b/testing/ecl/rollup1.ecl
@@ -1,8 +1,20 @@
+import std.system.thorlib;
+
 d := dataset([{1},{1},{2},{3},{4},{8},{9}], { unsigned r; });
 
 d t(d L, d r) := transform
-SELF.r := IF (L.r=3,SKIP,L.r + 1);
+ SELF.r := IF (L.r=3,SKIP,L.r + 1);
 END;
 
-rollup(d, t(LEFT, RIGHT), LEFT.r = RIGHT.r);
+rollup(d, t(LEFT, RIGHT), LEFT.r = RIGHT.r, LOCAL);
 rollup(d, t(LEFT, RIGHT), LEFT.r >= RIGHT.r-1, LOCAL);
+
+// spread across nodes and perform global rollup to string
+distd := DISTRIBUTE(d, r / (thorlib.nodes()+1));
+p := PROJECT(distd, TRANSFORM({ d, string res:=''; }, SELF := LEFT));
+p t2(p l, p r) := transform
+ SELF.res := IF(L.res='',(string)l.r+(string)r.r,(string)l.res + (string)r.r);
+ SELF.r := IF(R.r=4, SKIP, L.r);
+ SELF := l;
+END;
+rollup(p, true, t2(LEFT, RIGHT));


### PR DESCRIPTION
Consquently, a match could occur, despite neighbouring rows mismatching.
If the matching key is changed in the transform and the result matches the
next row, but not the original previous row, the rollup continued.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
