### PR TITLE
LDAPConfig to filter out DC entries for DNS

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -142,7 +142,7 @@ public:
     }
 };
 
-bool LdapServerDown(int rc)
+inline bool LdapServerDown(int rc)
 {
     return rc==LDAP_SERVER_DOWN||rc==LDAP_UNAVAILABLE||rc==LDAP_TIMEOUT;
 }
@@ -5080,14 +5080,19 @@ int LdapUtils::getServerInfo(const char* ldapserver, int ldapport, StringBuffer&
             StringBuffer onedn;
             while((curdn = domains[i]) != NULL)
             {
-                if(*curdn != '\0' && (strncmp(curdn, "dc=", 3) == 0 || strncmp(curdn, "DC=", 3) == 0))
+                if(*curdn != '\0' && (strncmp(curdn, "dc=", 3) == 0 || strncmp(curdn, "DC=", 3) == 0) && strstr(curdn,"DC=ForestDnsZones")==0 && strstr(curdn,"DC=DomainDnsZones")==0 )
                 {
                     if(domainDN.length() == 0)
                     {
                         StringBuffer curdomain;
                         LdapUtils::getName(curdn, curdomain);
                         if(onedn.length() == 0)
+                        {
+                            DBGLOG("Queried '%s', selected basedn '%s'",curdn, curdomain.str());
                             onedn.append(curdomain.str());
+                        }
+                        else
+                            DBGLOG("Ignoring %s", curdn);
                         if(!domainname || !*domainname || stricmp(curdomain.str(), domainname) == 0)
                             domainDN.append(curdn);
                     }


### PR DESCRIPTION
When LDAPConfig queries the domain controller for the DC= baseDC adornments,
if DNS is enabled then those entries are returned in addition to the usual
one (dc=internal,dc=sds). In the past we have gotten lucky and the one
we wanted was returned first, but now that we have raised several controllers
we have found this isn't always the case. This fix filters out the DNS entries
and then selects the first one. It is possible as we go forward that there
may be additional ones returned, in which case we may need to externalize
the baseDC setting to configmanager.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
