### PR TITLE
Fix Clang errors

### DIFF
--- a/ecl/hql/hqlir.cpp
+++ b/ecl/hql/hqlir.cpp
@@ -855,12 +855,6 @@ static const char * getTypeText(type_t type)
     DUMP_CASE(type,ifblock);
     DUMP_CASE(type,function);
     DUMP_CASE(type,sortlist);
-    DUMP_CASE(type,modifier);
-    DUMP_CASE(type,unsigned);
-    DUMP_CASE(type,ebcdic);
-    DUMP_CASE(type,stringorunicode);
-    DUMP_CASE(type,numeric);
-    DUMP_CASE(type,scalar);
 
     case type_unused1:
     case type_unused2:

--- a/ecl/hql/hqlopt.ipp
+++ b/ecl/hql/hqlopt.ipp
@@ -112,7 +112,6 @@ protected:
     IHqlExpression * optimizeAggregateUnsharedDataset(IHqlExpression * expr, bool isSimpleCount);
     IHqlExpression * optimizeJoinCondition(IHqlExpression * expr);
     IHqlExpression * optimizeDistributeDedup(IHqlExpression * expr);
-    IHqlExpression * optimizeInlineJoin(IHqlExpression * expr);
     IHqlExpression * optimizeIf(IHqlExpression * expr);
     IHqlExpression * optimizeProjectInlineTable(IHqlExpression * transformed, bool childrenAreShared);
         


### PR DESCRIPTION
Two errors detected by Clang: returning false where a pointer was
expected, and using modifiers on a list of types.

This last one was probably an error in Clang, but it's a real
issue. We should enhance the dumper to extract the modifiers
before dumping the types and print them.
