### PR TITLE
Remove unnecessary extern C

### DIFF
--- a/common/dllserver/dllserver.hpp
+++ b/common/dllserver/dllserver.hpp
@@ -86,9 +86,9 @@ interface IDllServer : extends IInterface
     virtual void registerDll(const char * name, const char * kind, const char * dllPath) = 0;
 };
 
-extern "C" DLLSERVER_API IDllServer & queryDllServer();
-extern "C" DLLSERVER_API void closeDllServer();
-extern "C" DLLSERVER_API void initDllServer(const char * localRoot);
+extern DLLSERVER_API IDllServer & queryDllServer();
+extern DLLSERVER_API void closeDllServer();
+extern DLLSERVER_API void initDllServer(const char * localRoot);
 extern DLLSERVER_API void testDllServer();
 
 #endif

--- a/common/fileview2/fileview.hpp
+++ b/common/fileview2/fileview.hpp
@@ -209,34 +209,34 @@ interface IResultSetFactory : extends IInterface
 
 
 //provided to wrap the exceptions for clarion....
-extern "C" FILEVIEW_API IResultSet* createResultSet(IResultSetFactory & factory, IStringVal & error, IConstWUResult * wuResult, const char * wuid);
-extern "C" FILEVIEW_API IResultSet* createFileResultSet(IResultSetFactory & factory, IStringVal & error, const char * logicalFile, const char * queue = NULL, const char * cluster = NULL);
-extern "C" FILEVIEW_API INewResultSet* createNewResultSet(IResultSetFactory & factory, IStringVal & error, IConstWUResult * wuResult, const char * wuid);
-extern "C" FILEVIEW_API INewResultSet* createNewFileResultSet(IResultSetFactory & factory, IStringVal & error, const char * logicalFile, const char * queue, const char * cluster);
-extern "C" FILEVIEW_API INewResultSet* createNewResultSetSeqName(IResultSetFactory & factory, IStringVal & error, const char * wuid, unsigned sequence, const char * name);
+extern FILEVIEW_API IResultSet* createResultSet(IResultSetFactory & factory, IStringVal & error, IConstWUResult * wuResult, const char * wuid);
+extern FILEVIEW_API IResultSet* createFileResultSet(IResultSetFactory & factory, IStringVal & error, const char * logicalFile, const char * queue = NULL, const char * cluster = NULL);
+extern FILEVIEW_API INewResultSet* createNewResultSet(IResultSetFactory & factory, IStringVal & error, IConstWUResult * wuResult, const char * wuid);
+extern FILEVIEW_API INewResultSet* createNewFileResultSet(IResultSetFactory & factory, IStringVal & error, const char * logicalFile, const char * queue, const char * cluster);
+extern FILEVIEW_API INewResultSet* createNewResultSetSeqName(IResultSetFactory & factory, IStringVal & error, const char * wuid, unsigned sequence, const char * name);
 
 
-extern "C" FILEVIEW_API IResultSetFactory * getResultSetFactory(const char * username, const char * password);
-extern "C" FILEVIEW_API IResultSetFactory * getSecResultSetFactory(ISecManager &secmgr, ISecUser &secuser);
+extern FILEVIEW_API IResultSetFactory * getResultSetFactory(const char * username, const char * password);
+extern FILEVIEW_API IResultSetFactory * getSecResultSetFactory(ISecManager &secmgr, ISecUser &secuser);
 
-extern "C" FILEVIEW_API IResultSetFactory * getRemoteResultSetFactory(const char * remoteServer, const char * username, const char * password);
-extern "C" FILEVIEW_API IResultSetFactory * getSecRemoteResultSetFactory(const char * remoteServer, ISecManager &secmgr, ISecUser &secuser);
+extern FILEVIEW_API IResultSetFactory * getRemoteResultSetFactory(const char * remoteServer, const char * username, const char * password);
+extern FILEVIEW_API IResultSetFactory * getSecRemoteResultSetFactory(const char * remoteServer, ISecManager &secmgr, ISecUser &secuser);
 
 //Formatting applied remotely, so it can be accessed between different operating systems...
-extern "C" FILEVIEW_API IResultSetFactory * getRemoteResultSetFactory(const char * remoteServer, const char * username, const char * password);
-extern "C" FILEVIEW_API int findResultSetColumn(const INewResultSet * results, const char * columnName);
+extern FILEVIEW_API IResultSetFactory * getRemoteResultSetFactory(const char * remoteServer, const char * username, const char * password);
+extern FILEVIEW_API int findResultSetColumn(const INewResultSet * results, const char * columnName);
 
-extern "C" FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSetCursor * cursor, const char * name, unsigned start=0, unsigned count=0, const char * schemaName=NULL);
-extern "C" FILEVIEW_API unsigned getResultXml(IStringVal & ret, INewResultSet * cursor,  const char* name, unsigned start=0, unsigned count=0, const char * schemaName=NULL);
+extern FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSetCursor * cursor, const char * name, unsigned start=0, unsigned count=0, const char * schemaName=NULL);
+extern FILEVIEW_API unsigned getResultXml(IStringVal & ret, INewResultSet * cursor,  const char* name, unsigned start=0, unsigned count=0, const char * schemaName=NULL);
 
-extern "C" FILEVIEW_API unsigned getResultCursorBin(MemoryBuffer & ret, IResultSetCursor * cursor, unsigned start=0, unsigned count=0);
-extern "C" FILEVIEW_API unsigned getResultBin(MemoryBuffer & ret, INewResultSet * cursor, unsigned start=0, unsigned count=0);
+extern FILEVIEW_API unsigned getResultCursorBin(MemoryBuffer & ret, IResultSetCursor * cursor, unsigned start=0, unsigned count=0);
+extern FILEVIEW_API unsigned getResultBin(MemoryBuffer & ret, INewResultSet * cursor, unsigned start=0, unsigned count=0);
 
 #define WorkUnitXML_InclSchema      0x0001
 #define WorkUnitXML_NoRoot          0x0002
 #define WorkUnitXML_SeverityTags    0x0004
 
-extern "C" FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *user, const char *pw, const IConstWorkUnit *wu, IStringVal &str, unsigned flags=0, WUExceptionSeverity minSeverity=ExceptionSeverityInformation);
+extern FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *user, const char *pw, const IConstWorkUnit *wu, IStringVal &str, unsigned flags=0, WUExceptionSeverity minSeverity=ExceptionSeverityInformation);
 
 extern FILEVIEW_API void startRemoteDataSourceServer(const char * queue, const char * cluster);
 extern FILEVIEW_API void stopRemoteDataSourceServer();

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -3217,8 +3217,8 @@ IResultSetMetaData * CRemoteResultSetFactory::createResultSetMeta(const char * w
 
 //---------------------------------------------------------------------------
 
-extern "C" FILEVIEW_API IResultSet* createResultSet(IResultSetFactory & factory, IStringVal & error, IConstWUResult * wuResult, const char * wuid);
-extern "C" FILEVIEW_API IResultSet* createFileResultSet(IResultSetFactory & factory, IStringVal & error, const char * logicalFile, const char * queue, const char * cluster);
+extern FILEVIEW_API IResultSet* createResultSet(IResultSetFactory & factory, IStringVal & error, IConstWUResult * wuResult, const char * wuid);
+extern FILEVIEW_API IResultSet* createFileResultSet(IResultSetFactory & factory, IStringVal & error, const char * logicalFile, const char * queue, const char * cluster);
 
 IResultSet* createResultSet(IResultSetFactory & factory, IStringVal & error, IConstWUResult * wuResult, const char * wuid)
 {
@@ -3319,7 +3319,7 @@ IResultSetFactory * getRemoteResultSetFactory(const char * remoteServer, const c
     return new CRemoteResultSetFactory(remoteServer, username, password);
 }
 
-extern "C" FILEVIEW_API void getNumRows(IResultSet * rs, IStringVal &ret)
+extern FILEVIEW_API void getNumRows(IResultSet * rs, IStringVal &ret)
 {
     if (rs)
     {
@@ -3347,7 +3347,7 @@ int findResultSetColumn(const INewResultSet * results, const char * columnName)
 }
 
 
-extern "C" FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSetCursor * cursor, const char * name, unsigned start, unsigned count, const char * schemaName)
+extern FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSetCursor * cursor, const char * name, unsigned start, unsigned count, const char * schemaName)
 {
     StringBuffer text;
     if (schemaName)
@@ -3383,13 +3383,13 @@ extern "C" FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSet
     return c;
 }
 
-extern "C" FILEVIEW_API unsigned getResultXml(IStringVal & ret, INewResultSet * result, const char* name,unsigned start, unsigned count, const char * schemaName)
+extern FILEVIEW_API unsigned getResultXml(IStringVal & ret, INewResultSet * result, const char* name,unsigned start, unsigned count, const char * schemaName)
 {
     Owned<IResultSetCursor> cursor = result->createCursor();
     return getResultCursorXml(ret, cursor, name, start, count, schemaName);
 }
 
-extern "C" FILEVIEW_API unsigned getResultCursorBin(MemoryBuffer & ret, IResultSetCursor * cursor, unsigned start, unsigned count)
+extern FILEVIEW_API unsigned getResultCursorBin(MemoryBuffer & ret, IResultSetCursor * cursor, unsigned start, unsigned count)
 {
     const IResultSetMetaData & meta = cursor->queryResultSet()->getMetaData();
     unsigned numCols = meta.getColumnCount();
@@ -3407,7 +3407,7 @@ extern "C" FILEVIEW_API unsigned getResultCursorBin(MemoryBuffer & ret, IResultS
     return c;
 }
 
-extern "C" FILEVIEW_API unsigned getResultBin(MemoryBuffer & ret, INewResultSet * result, unsigned start, unsigned count)
+extern FILEVIEW_API unsigned getResultBin(MemoryBuffer & ret, INewResultSet * result, unsigned start, unsigned count)
 {
     Owned<IResultSetCursor> cursor = result->createCursor();
     return getResultCursorBin(ret, cursor, start, count);
@@ -3431,7 +3431,7 @@ inline const char *getSeverityTagname(WUExceptionSeverity severity, unsigned fla
     return "Exception";
 }
 
-extern "C" FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *username, const char *password, const IConstWorkUnit *cw, IStringVal &str, unsigned flags, WUExceptionSeverity minSeverity)
+extern FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *username, const char *password, const IConstWorkUnit *cw, IStringVal &str, unsigned flags, WUExceptionSeverity minSeverity)
 {
     SCMStringBuffer wuid;
     cw->getWuid(wuid);

--- a/ecl/hql/hqlthql.hpp
+++ b/ecl/hql/hqlthql.hpp
@@ -22,14 +22,14 @@
 #include "hql.hpp"
 #include "hqlexpr.hpp"
 
-extern "C" HQL_API StringBuffer &toECL(IHqlExpression * expr, StringBuffer &s, bool recurse=false, bool xgmmlGraphText = false);
-extern "C" HQL_API StringBuffer &toECLSimple(IHqlExpression * expr, StringBuffer &s);
-extern "C" HQL_API void splitECL(IHqlExpression * expr, StringBuffer &s, StringBuffer &d);
-extern "C" HQL_API StringBuffer &toUserECL(StringBuffer &s, IHqlExpression * expr, bool recurse);
-extern "C" HQL_API StringBuffer &getExprECL(IHqlExpression * expr, StringBuffer & out, bool minimalSelectors=false, bool xgmmlGraphText=false);
-extern "C" HQL_API StringBuffer &getRecordECL(IHqlExpression * expr, StringBuffer & out);
-extern "C" HQL_API StringBuffer & processedTreeToECL(IHqlExpression * expr, StringBuffer &s);
-extern "C" HQL_API StringBuffer &getExprIdentifier(StringBuffer & out, IHqlExpression * expr);
-extern "C" HQL_API void dbglogExpr(IHqlExpression * expr);
+extern HQL_API StringBuffer &toECL(IHqlExpression * expr, StringBuffer &s, bool recurse=false, bool xgmmlGraphText = false);
+extern HQL_API StringBuffer &toECLSimple(IHqlExpression * expr, StringBuffer &s);
+extern HQL_API void splitECL(IHqlExpression * expr, StringBuffer &s, StringBuffer &d);
+extern HQL_API StringBuffer &toUserECL(StringBuffer &s, IHqlExpression * expr, bool recurse);
+extern HQL_API StringBuffer &getExprECL(IHqlExpression * expr, StringBuffer & out, bool minimalSelectors=false, bool xgmmlGraphText=false);
+extern HQL_API StringBuffer &getRecordECL(IHqlExpression * expr, StringBuffer & out);
+extern HQL_API StringBuffer & processedTreeToECL(IHqlExpression * expr, StringBuffer &s);
+extern HQL_API StringBuffer &getExprIdentifier(StringBuffer & out, IHqlExpression * expr);
+extern HQL_API void dbglogExpr(IHqlExpression * expr);
 
 #endif


### PR DESCRIPTION
Unnecessary (and broken) extern C attributes breaking Clang compilation.

The rationale is that an extern C function doesn't get mangled and there is
no way to represent references in plain C. GCC probably creates it as a
pointer, but if we were to create another similar function that returns a
pointer, they would be indistinguishable from each other.

It's not breaking anything, but helps consistency, since the extern C attribute
is unnecessary anyway.
