### PR TITLE
Add ifdef wrapper for CppUnit

### DIFF
--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -23,6 +23,8 @@
 #    Cmake Input File for unittests
 #####################################################
 
+if (USE_CPPUNIT)
+
 project( unitests )
 
 set (    SRCS
@@ -47,3 +49,5 @@ target_link_libraries ( unittests
          remote
          cppunit
     )
+
+endif ()

--- a/testing/unittests/unittests.cpp
+++ b/testing/unittests/unittests.cpp
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ############################################################################## */
 
+#ifdef _USE_CPPUNIT
 #include "platform.h"
 #include "jlib.hpp"
 #include "jlog.hpp"
@@ -101,3 +102,4 @@ int main(int argc, char* argv[])
     return wasSucessful;
 }
 
+#endif // _USE_CPPUNIT


### PR DESCRIPTION
On machines without the cppunit installed, the newly added unittest driver was obviously not compiling.
