### PR TITLE
gh-2815 - DelayedSizeMarker mb size patch batcher

### DIFF
--- a/system/jlib/jbuff.hpp
+++ b/system/jlib/jbuff.hpp
@@ -224,8 +224,12 @@ public:
     }
     inline void write()
     {
-        size32_t sz = mb.length() - (pos + sizeof(size32_t));
+        size32_t sz = size();
         mb.writeDirect(pos, sizeof(sz), &sz);
+    }
+    inline size32_t size() const
+    {
+        return mb.length() - (pos + sizeof(size32_t));
     }
     // resets position marker and writes another size to be filled subsequently by write()
     inline void restart()

--- a/system/jlib/jbuff.hpp
+++ b/system/jlib/jbuff.hpp
@@ -212,6 +212,29 @@ private:
     
 };
 
+// Utility class, to back patch a size into current position
+class jlib_decl DelayedSizeMarker
+{
+    MemoryBuffer &mb;
+    unsigned pos;
+public:
+    DelayedSizeMarker(MemoryBuffer &_mb) : mb(_mb)
+    {
+        restart();
+    }
+    inline void write()
+    {
+        size32_t sz = mb.length() - (pos + sizeof(size32_t));
+        mb.writeDirect(pos, sizeof(sz), &sz);
+    }
+    // resets position marker and writes another size to be filled subsequently by write()
+    inline void restart()
+    {
+        pos = mb.length();
+        mb.append((size32_t)0);
+    }
+};
+
 interface jlib_decl serializable : extends IInterface
 {
 public:


### PR DESCRIPTION
Utility class to back patch size into memory buffer

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
