### PR TITLE
Add unordered to hash dedup

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -10700,6 +10700,11 @@ dedupFlag
                         }
     | MANY              {   $$.setExpr(createAttribute(manyAtom)); }
     | HASH              {   $$.setExpr(createAttribute(hashAtom)); }
+    | UNORDERED
+                        {
+                            $$.setExpr(createAttribute(unorderedAtom));
+                            $$.setPosition($1);
+                        }
     ;
 
 rollupExtra

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -13334,6 +13334,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityDedup(BuildCtx & ctx, IHqlExpr
         {
             StringBuffer flags;
             if (recordTypesMatch(dataset, keyDataset)) flags.append("|HFDwholerecord");
+            if (expr->hasProperty(unorderedAtom)) flags.append("|HFDunordered");
             if (flags.length())
                 doBuildUnsignedFunction(instance->classctx, "getFlags", flags.str()+1);
         }

--- a/ecl/regress/hashdedup.ecl
+++ b/ecl/regress/hashdedup.ecl
@@ -33,3 +33,7 @@ count(d);
 //Whole record
 d2 := dedup(namesTable, hash);
 count(d2);
+
+//Whole record, unordered
+d3 := dedup(namesTable, all, hash, unordered);
+count(d3);

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -1797,6 +1797,7 @@ struct IHThorHashDistributeArg : public IHThorArg
 enum
 {
     HFDwholerecord  = 0x0001,
+    HFDunordered    = 0x0002
 };
 
 struct IHThorHashDedupArg : public IHThorArg


### PR DESCRIPTION
The engines should always output deterministic results on dedups, unless
this option is enabled (disabled by default), when they can ignore the
extra complication and output on a first-come-first-serve basis.
