### PR TITLE
Fix gh-2860 https connection to EclWatch failed

### DIFF
--- a/system/security/securesocket/securesocket.cpp
+++ b/system/security/securesocket/securesocket.cpp
@@ -746,6 +746,13 @@ static void locking_function(int mode, int n, const char * file, int line)
         mutexArray[n]->unlock();
 }
 
+#ifndef _WIN32
+unsigned long pthreads_thread_id(void)
+{
+    return((unsigned long)pthread_self());
+}
+#endif
+
 static void initSSLLibrary()
 {
     CriticalBlock b(mutexCrit);
@@ -760,6 +767,9 @@ static void initSSLLibrary()
             mutexArray[i] = new Mutex;
         }
         CRYPTO_set_locking_callback(locking_function);
+#ifndef _WIN32
+        CRYPTO_set_id_callback((unsigned long (*)())pthreads_thread_id);
+#endif
     }
 }
 


### PR DESCRIPTION
This only happens on Linux. The error comes from
openssl lib. Browser is trying to create multiple
SSL connections to ESP. ESP creates multiple threads
and each thread uses openssl lib to accept the
connections. To make openssl thread-safe, ESP has to
provide a callback fucntion: CRYPTO_set_id_callback().

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
