### PR TITLE
Fix gh-2836 - buildindex var row,col_prefix fix

### DIFF
--- a/testing/ecl/key.ecl
+++ b/testing/ecl/key.ecl
@@ -24,7 +24,7 @@ import std.system.thorlib;
 
 trec := RECORD
  unsigned1 key;
- string1  v;
+ string v;
  unsigned2 node := 0;
 END;
 
@@ -58,11 +58,14 @@ iRec := RECORD
  d.filepos;
 END;
 
+
 // NB: avoid reusing same key file (see bug #13112)
 idx := INDEX(d, iRec, '~regress::key::test.idx');
 idx2 := INDEX(d, iRec, '~regress::key::test2.idx');
 idx3 := INDEX(d, iRec, '~regress::key::test3.idx');
 idx4 := INDEX(d, iRec, '~regress::key::test4.idx');
+idx5 := INDEX(d, iRec, {d}, '~regress::key::test5.idx');
+idx6 := INDEX(d, iRec, '~regress::key::test6.idx');
 
 thornodes := MAX(CHOOSEN(tmp, 1), thorlib.nodes()) : global;  // Force it to calculate nodes() on thor not hthor
 
@@ -75,5 +78,9 @@ OUTPUT((unsigned)(COUNT(idx2(key<3))/thornodes)),
 BUILDINDEX(idx3, OVERWRITE),
 OUTPUT((unsigned)(COUNT(idx3(key=5))/thornodes)),
 BUILDINDEX(idx4, OVERWRITE, FEW),
-OUTPUT((unsigned)(COUNT(idx4(key<>2))/thornodes))
+OUTPUT((unsigned)(COUNT(idx4(key<>2))/thornodes)),
+BUILDINDEX(idx5, COMPRESSED(FIRST), OVERWRITE),
+OUTPUT((unsigned)(COUNT(idx5(key<>2))/thornodes)),
+BUILDINDEX(idx6, COMPRESSED(ROW), OVERWRITE),
+OUTPUT((unsigned)(COUNT(idx6(key<>2))/thornodes))
 );

--- a/testing/ecl/key/key.xml
+++ b/testing/ecl/key/key.xml
@@ -20,3 +20,13 @@
 <Dataset name='Result 9'>
  <Row><Result_9>20000</Result_9></Row>
 </Dataset>
+<Dataset name='Result 10'>
+</Dataset>
+<Dataset name='Result 11'>
+ <Row><Result_11>20000</Result_11></Row>
+</Dataset>
+<Dataset name='Result 12'>
+</Dataset>
+<Dataset name='Result 13'>
+ <Row><Result_13>20000</Result_13></Row>
+</Dataset>


### PR DESCRIPTION
Building an index with COMPRESS(FIRST) and variable rows, caused excessive
amounts of memory to be used when reading the index. Because, the when the
nodes were unpacked, the max length \* numRows was allocated and retained per
expanded node.

This commit encodes the row lengths in the compressed format

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
