### PR TITLE
Reducing eclcc memory consumption 

### DIFF
--- a/common/deftype/deftype.ipp
+++ b/common/deftype/deftype.ipp
@@ -30,13 +30,11 @@ class CStringTypeInfo;
 class CBoolTypeInfo;
 class CVoidTypeInfo;
 
-class CTypeInfo : public ITypeInfo, public CInterface
+class CTypeInfo : public CInterfaceOf<ITypeInfo>
 {
 protected:
     size32_t length;
 public:
-    IMPLEMENT_IINTERFACE
-
     CTypeInfo(size32_t _length) : length(_length) {};
     ~CTypeInfo();
 

--- a/common/deftype/defvalue.ipp
+++ b/common/deftype/defvalue.ipp
@@ -22,14 +22,12 @@
 #include "eclrtl.hpp"
 #include "defvalue.hpp"
 
-class DEFTYPE_API CValue : public CInterface, public IValue
+class DEFTYPE_API CValue : public CInterfaceOf<IValue>
 {
 protected:
     ITypeInfo *type;
 
 public:
-    IMPLEMENT_IINTERFACE;
-
     CValue(ITypeInfo *);
     ~CValue();
 

--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -40,6 +40,7 @@ _ATOM assertConstAtom;
 _ATOM atAtom;
 _ATOM atmostAtom;
 _ATOM _attrAligned_Atom;
+_ATOM _attrLocationIndependent_Atom;
 _ATOM _attrRecordCount_Atom;
 _ATOM _attrSerializedForm_Atom;
 _ATOM _attrSize_Atom;
@@ -419,6 +420,7 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKEATOM(at);
     MAKEATOM(atmost);
     MAKESYSATOM(attrAligned)->setAttrId(EAaligned);
+    MAKESYSATOM(attrLocationIndependent)->setAttrId(EAlocationIndependent);
     MAKESYSATOM(attrRecordCount)->setAttrId(EArecordCount);
     MAKESYSATOM(attrSerializedForm)->setAttrId(EAserializedForm);
     MAKESYSATOM(attrSize)->setAttrId(EAsize);

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -43,6 +43,7 @@ extern HQL_API _ATOM assertConstAtom;
 extern HQL_API _ATOM atAtom;
 extern HQL_API _ATOM atmostAtom;
 extern HQL_API _ATOM _attrAligned_Atom;
+extern HQL_API _ATOM _attrLocationIndependent_Atom;
 extern HQL_API _ATOM _attrRecordCount_Atom;
 extern HQL_API _ATOM _attrSerializedForm_Atom;
 extern HQL_API _ATOM _attrSize_Atom;
@@ -389,6 +390,7 @@ enum
     EAsize,
     EAaligned,
     EAunadorned,
+    EAlocationIndependent,
     EAmax
 };
 

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1055,6 +1055,7 @@ extern HQL_API int getPrecedence(node_operator op);
 
 struct BindParameterContext;
 interface IHqlAnnotation;
+class HQL_API CUsedTablesBuilder;
 interface IHqlExpression : public IInterface
 {
     virtual _ATOM queryName() const = 0;
@@ -1135,7 +1136,6 @@ interface IHqlExpression : public IInterface
     virtual unsigned getSymbolFlags() const = 0;              // only valid for a named symbol
     virtual bool isExported() const = 0;
 
-    virtual unsigned            getCachedEclCRC() = 0;          // do not call directly - use getExpressionCRC()
     virtual IHqlExpression * queryAnnotationParameter(unsigned i) const = 0;
 
 // The following are added to allow efficient storage/retreival in a hashtable.
@@ -1144,6 +1144,11 @@ interface IHqlExpression : public IInterface
     virtual unsigned            getHash() const = 0;
     virtual bool                equals(const IHqlExpression & other) const = 0;
 
+//purely used for internal processing.  Should not be called directly
+    virtual void gatherTablesUsed(CUsedTablesBuilder & used) = 0;
+    virtual unsigned            getCachedEclCRC() = 0;          // do not call directly - use getExpressionCRC()
+
+public:
 // The following inline functions are purely derived from the functions in this interface
     inline int getPrecedence() const { return ::getPrecedence(getOperator()); }
     inline bool isAnnotation() const { return getAnnotationKind() != annotate_none; }

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1148,7 +1148,6 @@ interface IHqlExpression : public IInterface
     virtual void gatherTablesUsed(CUsedTablesBuilder & used) = 0;
     virtual unsigned            getCachedEclCRC() = 0;          // do not call directly - use getExpressionCRC()
 
-public:
 // The following inline functions are purely derived from the functions in this interface
     inline int getPrecedence() const { return ::getPrecedence(getOperator()); }
     inline bool isAnnotation() const { return getAnnotationKind() != annotate_none; }
@@ -1215,7 +1214,6 @@ extern HQL_API IHqlExpression *createValue(node_operator op, ITypeInfo * type, u
 extern HQL_API IHqlExpression *createValue(node_operator op, ITypeInfo * type, HqlExprArray & args);        //NB: This deletes the array that is passed
 extern HQL_API IHqlExpression *createValueSafe(node_operator op, ITypeInfo * type, const HqlExprArray & args);
 extern HQL_API IHqlExpression *createValueSafe(node_operator op, ITypeInfo * type, const HqlExprArray & args, unsigned from, unsigned max);
-extern HQL_API IHqlExpression *createValueFromList(node_operator op, ITypeInfo * type, ...);
 extern HQL_API IHqlExpression *createValueFromCommaList(node_operator op, ITypeInfo * type, IHqlExpression * argsExpr);
 
 //These all consume their arguments

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -309,7 +309,7 @@ protected:
     HqlExprAttr normalized;
 };
 
-class CFileContents : public CInterface, implements IFileContents
+class CFileContents : public CInterfaceOf<IFileContents>
 {
 private:
     Linked<IFile> file;
@@ -321,7 +321,6 @@ public:
     CFileContents(IFile * _file, ISourcePath * _sourcePath);
     CFileContents(const char *query, ISourcePath * _sourcePath);
     CFileContents(unsigned len, const char *query, ISourcePath * _sourcePath);
-    IMPLEMENT_IINTERFACE;
 
     virtual IFile * queryFile() { return file; }
     virtual ISourcePath * querySourcePath() { return sourcePath; }

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -267,6 +267,16 @@ public:
     inline void resetTransformExtra(IInterface * _extra, unsigned depth);
 };
 
+//The following couple of classes are here primarily to save memory.  
+//It is preferrable not to artificially introduce extra classes, but one representative large example has
+//12M+ instances, and not including the tables/type save 16 and 8 bytes each.  That quickly becomes a significant
+//amount of memory.
+//
+//The nodes with significant number of instances are (no_assign, no_select and annotations).  
+//One further possibilitiy is to add a CHqlAssignExpression which could also remove the tables and type. 
+//If any more class splitting is contemplated it would be worth revisiting in terms of policies.
+
+//This class calculates which tables the expression references to ensure it is evaluated in the correct conext.
 class HQL_API CHqlExpressionWithTables : public CHqlExpression
 {
 public:

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -310,23 +310,45 @@ public:
 };
 
 
-class CHqlSelectExpression : public CHqlExpression
+class CHqlSelectBaseExpression : public CHqlExpression
 {
 public:
     static IHqlExpression * makeSelectExpression(IHqlExpression * left, IHqlExpression * right, IHqlExpression * attr);
     static IHqlExpression * makeSelectExpression(HqlExprArray & ownedOperands);
 
     virtual IHqlExpression *clone(HqlExprArray &newkids);
-    virtual IHqlExpression *queryNormalizedSelector(bool skipIndex);
     virtual ITypeInfo *queryType() const;
     virtual ITypeInfo *getType();
 
+    virtual void calcNormalized() = 0;
+
 protected:
-    CHqlSelectExpression();
+    CHqlSelectBaseExpression();
 
     void setOperands(IHqlExpression * left, IHqlExpression * right, IHqlExpression * attr);
     void setOperands(HqlExprArray & _ownedOperands);
+};
 
+class CHqlNormalizedSelectExpression : public CHqlSelectBaseExpression
+{
+    friend class CHqlSelectBaseExpression;
+public:
+    virtual IHqlExpression *queryNormalizedSelector(bool skipIndex);
+    virtual void calcNormalized();
+
+protected:
+    CHqlNormalizedSelectExpression() {}
+};
+
+class CHqlSelectExpression : public CHqlSelectBaseExpression
+{
+    friend class CHqlSelectBaseExpression;
+public:
+    virtual IHqlExpression *queryNormalizedSelector(bool skipIndex);
+    virtual void calcNormalized();
+
+protected:
+    CHqlSelectExpression() {}
 
 protected:
     HqlExprAttr normalized;

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -11096,7 +11096,7 @@ void testHqlInternals()
 {
     printf("Sizes: const(%u) expr(%u) select(%u) dataset(%u) annotation(%u)\n",
             (unsigned)sizeof(CHqlConstant),
-            (unsigned)sizeof(CHqlExpression),
+            (unsigned)sizeof(CHqlExpressionWithType),
             (unsigned)sizeof(CHqlSelectExpression),
             (unsigned)sizeof(CHqlDataset),
             (unsigned)sizeof(CHqlAnnotation));

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -2541,7 +2541,7 @@ class PseudoPatternScope : public CHqlScope
 {
 public:
     PseudoPatternScope(IHqlExpression * _patternList);
-    IMPLEMENT_IINTERFACE
+    IMPLEMENT_IINTERFACE_USING(CHqlScope)
 
     virtual void defineSymbol(_ATOM name, _ATOM moduleName, IHqlExpression *value, bool isExported, bool isShared, unsigned flags, IFileContents *fc, int bodystart, int lineno, int column) { ::Release(value); PSEUDO_UNIMPLEMENTED; }
     virtual void defineSymbol(_ATOM name, _ATOM moduleName, IHqlExpression *value, bool isExported, bool isShared, unsigned flags) { ::Release(value); PSEUDO_UNIMPLEMENTED; }
@@ -11094,6 +11094,13 @@ void parseAttribute(IHqlScope * scope, IFileContents * contents, HqlLookupContex
 
 void testHqlInternals()
 {
+    printf("Sizes: const(%u) expr(%u) select(%u) dataset(%u) annotation(%u)\n",
+            (unsigned)sizeof(CHqlConstant),
+            (unsigned)sizeof(CHqlExpression),
+            (unsigned)sizeof(CHqlSelectExpression),
+            (unsigned)sizeof(CHqlDataset),
+            (unsigned)sizeof(CHqlAnnotation));
+
     //
     // test getOpString()
     int error = 0,i;

--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -301,11 +301,10 @@ enum
     NTFselectorOriginal     = 0x0002,
 };
 
-class HQL_API ANewTransformInfo : implements IInterface, public CInterface
+class HQL_API ANewTransformInfo : implements CInterfaceOf<IInterface> 
 {
 public:
     ANewTransformInfo(IHqlExpression * _original);
-    IMPLEMENT_IINTERFACE
 
     virtual IHqlExpression * queryTransformed() = 0;
     virtual IHqlExpression * queryTransformedSelector() = 0;

--- a/ecl/hqlcpp/hqlhoist.hpp
+++ b/ecl/hqlcpp/hqlhoist.hpp
@@ -183,11 +183,11 @@ protected:
     void transformAllCandidates();
 
 protected:
-    CIArrayOf<ConditionalContextInfo> candidates;
+    IArrayOf<ConditionalContextInfo> candidates;
     ConditionalContextInfo * activeParent;
     OwnedHqlExpr rootExpr;
     CopyCIArrayOf<CHqlExprMultiGuard> childGuards;
-    CopyCIArrayOf<ConditionalContextInfo> insertLocations;
+    ICopyArrayOf<ConditionalContextInfo> insertLocations;
     unsigned seq;
     bool alwaysEvaluateGuardedTogether;
     bool noteManyUnconditionalParents;

--- a/ecl/hqlcpp/hqliproj.ipp
+++ b/ecl/hqlcpp/hqliproj.ipp
@@ -293,7 +293,6 @@ class ComplexImplicitProjectInfo : public ImplicitProjectInfo
 {
 public:
     ComplexImplicitProjectInfo(IHqlExpression * _original, ProjectExprKind _kind);
-    IMPLEMENT_IINTERFACE
 
     virtual ComplexImplicitProjectInfo * queryComplexInfo() { return this; }
 

--- a/system/jlib/jhash.ipp
+++ b/system/jlib/jhash.ipp
@@ -72,11 +72,9 @@ class jlib_decl Mapping : extends MappingBase
 };
 
 
-class jlib_decl AtomBase : implements IAtom, public CInterface
+class jlib_decl AtomBase : public CInterfaceOf<IAtom>
 {
 public:
-    IMPLEMENT_IINTERFACE
-
     AtomBase(const void * k)  
     { 
         key = strdup((const char *)k); 


### PR DESCRIPTION
- Use template classes for implementing the linkcounts.
  This avoids having an extra VMT for CInterface - it can reuse the
  vmt of the interface.
- Change attributes so they are stored as linked list of entries
  instead of an array.  Reduces size if an expression has no attributes
  and allows firther changes later.
- Don't create an extra attribute for unadorned attribute
- Simplify format of serialized form
- Use an attribute to store location independent expression
- Optimize the representation of referenced tables
  Reduce from 24 bytes to 12 bytes in 32bit, 32 to 16 in 64bit
  Optimize the storage of a single table
- Clean up symbol code
- Improve statistics for opcode counts

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
