### PR TITLE
Use the same module initialisation under windows.

### DIFF
--- a/system/jlib/jlib.hpp
+++ b/system/jlib/jlib.hpp
@@ -23,9 +23,7 @@
 
 #include "jexpdef.hpp"
 
-#if !defined(_WIN32)
 #define EXPLICIT_INIT
-#endif
 
 
 #ifdef _MSC_VER


### PR DESCRIPTION
As it stands windows uses the built in static variable construction,
while linux uses an internal mechanism.  The windows mechanism works
for dll dependencies, but it doesn't work for different priorities
within a module.

I hit an example where I wanted two priorities within the same module
which didn't work.  (Since worked around.)  I suspect it is partly
luck with the alphametic order of modules in eclcc that  stops it
causing problems already.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
