### PR TITLE
Add ESP support for Json formatted response

### DIFF
--- a/esp/bindings/SOAP/Platform/soapparam.cpp
+++ b/esp/bindings/SOAP/Platform/soapparam.cpp
@@ -1,0 +1,663 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#include "esphttp.hpp"
+
+#include "jstring.hpp"
+#include "jprop.hpp"
+
+#include "soapesp.hpp"
+#include "soapmessage.hpp"
+#include "soapparam.hpp"
+
+void BaseEspParam::toJSON(IEspContext *ctx, StringBuffer &s, const char *tagname)
+{
+    if (isNil && nilBH==nilRemove)
+        return;
+    appendJSONName(s, tagname);
+    toJSONValue(s);
+}
+
+void BaseEspParam::toXML(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode)
+{
+    if (isNil && nilBH==nilRemove)
+        return;
+    appendXMLOpenTag(s, tagname, prefix);
+    toXMLValue(s, encode);
+    appendXMLCloseTag(s, tagname, prefix);
+}
+
+void BaseEspParam::toStr(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *basepath, bool encode, const char *xsdtype, const char *prefix)
+{
+    if (isNil && nilBH!=nilIgnore)
+        return;
+
+    if (ctx->getResponseFormat()==ESPSerializationJSON)
+        return toJSON(ctx, s, tagname);
+    toXML(ctx, s, tagname, prefix, encode);
+}
+
+void BaseEspParam::marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char *xsdtype, const char *prefix)
+{
+    addRpcValue(rpc_call, tagname, basepath, xsdtype, prefix, NULL);
+}
+
+bool BaseEspParam::unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+    StringBuffer path(basepath);
+    if (basepath!=NULL && basepath[0]!=0)
+        path.append("/");
+    path.append(tagname);
+
+    if (updateValue(rpc_call, path.str()))
+    {
+        if (optGroup && rpc_call.queryContext())
+            rpc_call.queryContext()->addOptGroup(optGroup);
+        isNil = false;
+    }
+    return isNil;
+}
+
+bool BaseEspParam::unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup)
+{
+    if (updateValue(soapval, tagname))
+    {
+        if (ctx && optGroup)
+            ctx->addOptGroup(optGroup);
+        isNil = false;
+    }
+    return isNil;
+}
+
+bool BaseEspParam::unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+    StringBuffer path;
+    if (basepath && *basepath)
+        path.append(basepath).append('.');
+    path.append(tagname);
+
+    if (updateValue(params.queryProp(path.str())))
+    {
+        isNil = false;
+        if (ctx && optGroup)
+            ctx->addOptGroup(optGroup);
+    }
+    return isNil;
+}
+
+void SoapStringParam::toXMLValue(StringBuffer &s, bool encode)
+{
+    if (!encode)
+        s.append(value);
+    else
+        encodeUtf8XML(value.str(), s, getEncodeNewlines() ? ENCODE_NEWLINES : 0);
+}
+
+void SoapStringParam::toJSONValue(StringBuffer &s)
+{
+    appendJSONValue(s, NULL, (isNil) ? NULL : value.str());
+}
+
+void SoapStringParam::addRpcValue(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char *xsdtype, const char *prefix, bool *encodex)
+{
+    if (!isNil || nilBH==nilIgnore)
+        rpc_call.add_value(basepath, prefix, tagname, xsdtype, value.str(), (!encodex) ? rpc_call.getEncodeXml() : *encodex);
+}
+
+bool SoapStringParam::updateValue(IRpcMessage &rpc_call, const char *path)
+{
+    StringBuffer tmp;
+    if (rpc_call.get_value(path, tmp))
+    {
+        value.set(tmp.str());
+        return true;
+    }
+    return false;
+}
+
+bool SoapStringParam::updateValue(CSoapValue &soapval, const char *tagname)
+{
+    return soapval.get_value(tagname, value.clear());
+}
+
+bool SoapStringParam::updateValue(const char *s)
+{
+    if (!s)
+        return false;
+    return esp_convert(s, value.clear());
+}
+
+bool SoapStringParam::unmarshallAttach(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+    if(attachments)
+    {
+        StringBuffer key;
+        if (basepath && *basepath)
+            key.append(basepath).append(".");
+        key.append(tagname);
+
+        StringBuffer* data = attachments->getValue(key.str());
+        if (data)
+        {
+            StringBuffer path;
+            if (basepath && *basepath)
+                path.append(basepath).append(".");
+            path.append(tagname);
+            isNil=false;
+            value.clear().swapWith(*data);
+            if (ctx && optGroup)
+                ctx->addOptGroup(optGroup);
+            return true;
+        }
+    }
+    return false;
+}
+
+void BaseEspStruct::marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char *xsdtype, const char *prefix)
+{
+    StringBuffer xml;
+    Owned<IProperties> props;
+    serializeContent(rpc_call.queryContext(), xml, props);
+
+    if (xml.length() || nilBH==nilIgnore || props)
+        rpc_call.add_value(basepath, prefix, tagname, xsdtype, xml.str(), false);
+    if (props)
+        rpc_call.add_attr(basepath, tagname, NULL, *props);
+}
+
+void BaseEspStruct::toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname)
+{
+    size32_t start = s.length();
+    appendJSONName(s, tagname);
+    s.append('{');
+    size32_t check = s.length();
+    serializeContent(ctx, s);
+    if (s.length()==check)
+        s.setLength(start);
+    else
+        s.append('}');
+}
+
+void BaseEspStruct::toXML(IEspContext *ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode)
+{
+    size32_t start = s.length();
+    appendXMLOpenTag(s, tagname, prefix, false);
+    size32_t check = s.length();
+    serializeAttributes(ctx, s);
+    s.append('>');
+    serializeContent(ctx, s);
+    if (nilBH==nilIgnore || s.length()!=check+1)
+        appendXMLCloseTag(s, tagname, prefix);
+    else
+        s.setLength(start);
+}
+
+void BaseEspStruct::toStr(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *basepath, bool encode, const char *xsdtype, const char *prefix)
+{
+    if (ctx->getResponseFormat()==ESPSerializationJSON)
+        return toJSON(ctx, s, tagname);
+    toXML(ctx, s, tagname, prefix, encode);
+}
+
+bool BaseEspStruct::unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+    StringBuffer path;
+    if (basepath && *basepath)
+    {
+        path.append(basepath);
+        if (path.charAt(path.length()-1)!='/')
+            path.append("/");
+    }
+    path.append(tagname);
+    if (updateValue(rpc_call, path.str()))
+    {
+        if (optGroup && rpc_call.queryContext())
+            rpc_call.queryContext()->addOptGroup(optGroup);
+        return true;
+    }
+    return false;
+}
+
+bool BaseEspStruct::unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup)
+{
+    CSoapValue *sv = soapval.get_value(tagname);
+    if (sv)
+    {
+        updateValue(ctx, *sv);
+        if (ctx && optGroup)
+            ctx->addOptGroup(optGroup);
+        return true;
+    }
+    return false;
+}
+
+bool BaseEspStruct::unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+   StringBuffer path;
+   if (basepath && *basepath)
+       path.append(basepath).append(".");
+   path.append(tagname);
+
+   if (updateValue(ctx, params, attachments, path.str()))
+   {
+       if (ctx && optGroup)
+           ctx->addOptGroup(optGroup);
+       return true;
+   }
+   return false;
+}
+
+void SoapParamBinary::marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char *xsdtype, const char *prefix)
+{
+    StringBuffer sb64;
+    JBASE64_Encode(value.toByteArray(), value.length(), sb64);
+    rpc_call.add_value(basepath, prefix, tagname, xsdtype, sb64);
+}
+
+void SoapParamBinary::toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname)
+{
+    if (s.length() && !strchr("{[:", s.charAt(s.length()-1)))
+        s.append(", ");
+    if (tagname && *tagname)
+        s.append('"').append(tagname).append("\": ");
+    s.append('"');
+    JBASE64_Encode(value.toByteArray(), value.length(), s);
+    s.append('"');
+    return;
+}
+
+void SoapParamBinary::toXML(IEspContext *ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode)
+{
+    appendXMLOpenTag(s, tagname, prefix);
+    JBASE64_Encode(value.toByteArray(), value.length(), s);
+    appendXMLCloseTag(s, tagname, prefix);
+}
+
+void SoapParamBinary::toStr(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *basepath, bool encode, const char *xsdtype, const char *prefix)
+{
+    if (ctx->getResponseFormat()==ESPSerializationJSON)
+        return toJSON(ctx, s, tagname);
+    toXML(ctx, s, tagname, prefix, encode);
+}
+
+bool SoapParamBinary::unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+    StringBuffer path(basepath);
+    if (basepath!=NULL && basepath[0]!=0)
+        path.append("/");
+    path.append(tagname);
+
+    StringBuffer sb64;
+    bool ret = rpc_call.get_value(path.str(), sb64);
+    if (ret && optGroup && rpc_call.queryContext())
+        rpc_call.queryContext()->addOptGroup(optGroup);
+
+    if(sb64.length())
+        JBASE64_Decode(sb64.str(), value);
+
+    return ret;
+}
+
+bool SoapParamBinary::unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup)
+{
+    return false;
+}
+
+bool SoapParamBinary::unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+    StringBuffer path;
+    if (basepath && *basepath)
+        path.append(basepath).append(".");
+    path.append(tagname);
+
+    const char* val = params.queryProp(path.str());
+    if(val)
+    {
+        if (ctx && optGroup)
+            ctx->addOptGroup(optGroup);
+        JBASE64_Decode(params.queryProp(path.str()), value);
+        return true;
+    }
+    return false;
+}
+
+
+void SoapAttachString::marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char *xsdtype, const char *prefix)
+{
+    rpc_call.add_value(basepath, prefix, tagname, "Attachment", value);
+}
+
+void SoapAttachString::toJSON(IEspContext *ctx, StringBuffer &s, const char *tagname)
+{
+    appendJSONValue(s, tagname, value);
+}
+
+void SoapAttachString::toXML(IEspContext *ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode)
+{
+    appendXMLTag(s, tagname, value, prefix, ENCODE_NONE);
+}
+
+void SoapAttachString::toStr(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *basepath, bool encode, const char *xsdtype, const char *prefix)
+{
+    if (ctx->getResponseFormat()==ESPSerializationJSON)
+        return toJSON(ctx, s, tagname);
+    toXML(ctx, s, tagname, prefix, encode);
+}
+
+bool SoapAttachString::unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char* optGroup,const char *xsdtype, const char *prefix)
+{
+    StringBuffer path(basepath);
+    if (basepath!=NULL && basepath[0]!=0)
+        path.append("/");
+    path.append(tagname);
+
+    if (rpc_call.get_value(path.str(), value)) {
+        if (optGroup && rpc_call.queryContext())
+            rpc_call.queryContext()->addOptGroup(optGroup);
+        return true;
+    }
+    return false;
+}
+
+bool SoapAttachString::unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup)
+{
+    return false;
+}
+
+bool SoapAttachString::unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char *xsdtype, const char *prefix)
+{
+    return false;
+}
+
+StringBuffer &buildVarPath(StringBuffer &path, const char *tagname, const char *basepath, const char *item, const char *tail, int *idx)
+{
+    path.clear();
+    if (basepath)
+        path.append(basepath).append(".");
+    path.append(tagname);
+    if (item)
+        path.append(".").append(item);
+    if (tail)
+        path.append(".").append(tail);
+    if (idx)
+        path.append(".").append(*idx);
+    return path;
+}
+
+void EspBaseArrayParam::toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *itemname)
+{
+    unsigned count = getLength();
+    if (!count)
+    {
+        if (nilBH!=nilRemove)
+        {
+            if (s.length() && !strchr("{[:", s.charAt(s.length()-1)))
+                s.append(", ");
+            if (tagname && *tagname)
+                s.append('\"').append(tagname).append("\": ");
+            s.append("[]");
+        }
+        return;
+    }
+
+    if (ctx->getResponseFormat()==ESPSerializationJSON)
+    {
+        appendJSONName(s, tagname);
+        if (tagname && *tagname && itemname && *itemname)
+            s.append('{');
+        if (!itemname || !*itemname)
+            itemname = getItemTag(itemname);
+        appendJSONName(s, itemname);
+        s.append('[');
+        for (unsigned  i=0; i<count; i++)
+            toStrItem(ctx, s, i, itemname);
+        s.append(']');
+        if (tagname && *tagname && itemname && *itemname)
+            s.append('}');
+    }
+}
+
+void EspBaseArrayParam::toXML(IEspContext *ctx, StringBuffer &s, const char *tagname, const char *itemname, const char *prefix, bool encode)
+{
+    itemname = getItemTag(itemname);
+    unsigned count = getLength();
+    if (!count)
+    {
+        if (nilBH != nilRemove)
+            appendXMLOpenTag(s, tagname, prefix, true, true);
+        return;
+    }
+
+    appendXMLOpenTag(s, tagname, prefix);
+    for (unsigned  i=0; i<count; i++)
+        toStrItem(ctx, s, i, itemname);
+    appendXMLCloseTag(s, tagname, prefix);
+}
+
+void EspBaseArrayParam::toStr(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *itemname, const char *elementtype, const char *basepath, const char *prefix)
+{
+    if (ctx->getResponseFormat()==ESPSerializationJSON)
+        return toJSON(ctx, s, tagname, itemname);
+    toXML(ctx, s, tagname, itemname, prefix, true);
+}
+
+bool EspBaseArrayParam::unmarshallItems(IEspContext* ctx, CSoapValue *sv, const char *itemname, const char *optGroup)
+{
+    if (!sv)
+        return false;
+
+    SoapValueArray* children = sv->query_children();
+    if (children)
+    {
+        if (ctx && optGroup)
+            ctx->addOptGroup(optGroup);
+        ForEachItemIn(i, *children)
+            append(ctx, children->item(i));
+        return true;
+    }
+    return false;
+}
+
+bool EspBaseArrayParam::unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup, const char *itemname)
+{
+    return unmarshallItems(ctx, soapval.get_value(tagname), itemname, optGroup);
+}
+
+bool EspBaseArrayParam::unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char* optGroup, const char *prefix)
+{
+    StringBuffer path(basepath);
+    if (basepath!=NULL && basepath[0]!=0)
+        path.append("/");
+    path.append(tagname);
+
+    return unmarshallItems(rpc_call.queryContext(), dynamic_cast<CRpcMessage *>(&rpc_call)->get_value(path), NULL, optGroup);
+}
+
+bool EspBaseArrayParam::unmarshallAttach(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+    bool hasValue = false;
+    if(attachments)
+    {
+        StringBuffer path;
+        buildVarPath(path, tagname, basepath, NULL, "itemlist", NULL);
+        if (params.hasProp(path.str()))
+        {
+            hasValue = true;
+            //sparse array encoding
+            char *itemlist = strdup(params.queryProp(path.str()));
+            char *delim=NULL;
+            if (itemlist)
+            {
+                for(char *finger=itemlist; finger; finger=(delim) ? delim+1 : NULL)
+                {
+                    if ((delim=strchr(finger, '+')))
+                        *delim=0;
+                    if (*finger)
+                    {
+                        buildVarPath(path, tagname, basepath, finger, NULL, NULL);
+                        StringBuffer* data = attachments->getValue(path.str());
+                        if (data)
+                            append(data->str());
+                    }
+                }
+                free(itemlist);
+            }
+        }
+        else
+        {
+            buildVarPath(path, tagname, basepath, NULL, "itemcount", NULL);
+            int count=params.getPropInt(path.str(), -1);
+            if (count>0)
+            {
+                hasValue = true;
+                for (int idx=0; idx<count; idx++)
+                {
+                    buildVarPath(path, tagname, basepath, NULL, NULL, &idx);
+                    StringBuffer* data = attachments->getValue(path.str());
+                    if (data)
+                        append(data->str());
+                }
+            }
+        }
+    }
+
+    if (hasValue && ctx && optGroup)
+        ctx->addOptGroup(optGroup);
+
+    return hasValue;
+}
+
+bool EspBaseArrayParam::unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
+{
+    if (unmarshallRawArray(params, tagname, basepath))
+    {
+        if (ctx && optGroup)
+            ctx->addOptGroup(optGroup);
+        return true;
+    }
+
+    StringBuffer path;
+    if (basepath && *basepath)
+       path.append(basepath).append(".");
+    path.append(tagname);
+    const char *pathstr=path.str();
+
+    bool hasValue = false;
+    Owned<IPropertyIterator> iter = params.getIterator();
+
+    if (pathstr && *pathstr && iter && iter->first())
+    {
+        int taglen = strlen(pathstr);
+        while (iter->isValid())
+        {
+            const char *keyname=iter->getPropKey();
+            if (strncmp(keyname, pathstr, taglen)==0)
+            {
+                if (strlen(keyname)==taglen || !strncmp(keyname+taglen, "_rd_", 4))
+                {
+                    const char *finger = params.queryProp(iter->getPropKey());
+                    StringBuffer itemval;
+                    while (*finger)
+                    {
+                        if (*finger=='\r')
+                            finger++;
+
+                        if (*finger=='\n')
+                        {
+                            if (itemval.length())
+                                append(itemval.str());
+                            itemval.clear();
+                        }
+                        else
+                        {
+                            itemval.append(*finger);
+                        }
+                        finger++;
+                    }
+                    if (itemval.length())
+                    {
+                        append(itemval.str());
+                        hasValue = true;
+                    }
+                }
+                else if (strncmp(keyname+taglen, "_v", 2)==0)
+                {
+                    if (params.getPropInt(keyname)) {
+                        append(keyname+taglen+2);
+                        hasValue = true;
+                    }
+                }
+                else if (strncmp(keyname+taglen, "_i", 2)==0)
+                {
+                    append(params.queryProp(iter->getPropKey()));
+                    hasValue = true;
+                }
+            }
+
+            iter->next();
+        }
+    }
+
+    if (hasValue && ctx && optGroup)
+        ctx->addOptGroup(optGroup);
+
+    return hasValue;
+}
+
+bool EspBaseArrayParam::unmarshallRawArray(IProperties &params, const char *tagname, const char *basepath)
+{
+    StringBuffer path;
+    buildVarPath(path, tagname, basepath, NULL, "itemlist", NULL);
+    if (params.hasProp(path.str()))
+    {
+        //sparse array encoding
+        char *itemlist=strdup(params.queryProp(path.str()));
+        char *delim=NULL;
+        if (itemlist)
+        {
+            for(char *finger=itemlist; finger; finger=(delim) ? delim+1 : NULL)
+            {
+                if ((delim=strchr(finger, '+')))
+                    *delim=0;
+                if (*finger)
+                {
+                    buildVarPath(path, tagname, basepath, finger, NULL, NULL);
+                    append(params.queryProp(path));
+                }
+            }
+            free(itemlist);
+            return true;
+        }
+    }
+    else
+    {
+        buildVarPath(path, tagname, basepath, NULL, "itemcount", NULL);
+        int count=params.getPropInt(path.str(), -1);
+        if (count>0)
+        {
+            for (int idx=0; idx<count; idx++)
+            {
+                buildVarPath(path, tagname, basepath, NULL, NULL, &idx);
+                append(params.queryProp(path));
+            }
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/esp/bindings/SOAP/Platform/soapparam.cpp
+++ b/esp/bindings/SOAP/Platform/soapparam.cpp
@@ -271,8 +271,7 @@ void SoapParamBinary::marshall(IRpcMessage &rpc_call, const char *tagname, const
 
 void SoapParamBinary::toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname)
 {
-    if (s.length() && !strchr("{[:", s.charAt(s.length()-1)))
-        s.append(", ");
+    delimitJSON(s);
     if (tagname && *tagname)
         s.append('"').append(tagname).append("\": ");
     s.append('"');
@@ -406,8 +405,7 @@ void EspBaseArrayParam::toJSON(IEspContext* ctx, StringBuffer &s, const char *ta
     {
         if (nilBH!=nilRemove)
         {
-            if (s.length() && !strchr("{[:", s.charAt(s.length()-1)))
-                s.append(", ");
+            delimitJSON(s);
             if (tagname && *tagname)
                 s.append('\"').append(tagname).append("\": ");
             s.append("[]");

--- a/esp/bindings/SOAP/Platform/soapparam.hpp
+++ b/esp/bindings/SOAP/Platform/soapparam.hpp
@@ -19,8 +19,7 @@
 #ifndef _SOAP_PARAM_H_
 #define _SOAP_PARAM_H_
 
-
-//return whether nil, but only use the return in the case of http url parameters (bool for one nil means false)
+#include "esphttp.hpp"
 
 inline bool esp_convert(const char* sv, StringAttr& value){value.set(sv); return (!sv);}
 inline bool esp_convert(const char* sv, StringBuffer& value){value.clear().append(sv); return (!sv);}
@@ -36,57 +35,15 @@ inline bool esp_convert(const char* sv, double& value){value = (sv!=NULL) ? (dou
 inline bool esp_convert(const char* sv, float& value){value = (sv!=NULL) ? (float) atof(sv) : 0; return (!sv);}
 inline bool esp_convert(const char* sv, bool& value)
 {
-    //true if a property is sent in, but is not one of {0, false, off}
-    //value=(sv!=NULL && stricmp(sv, "0") && stricmp(sv, "false") && stricmp(sv, "off"));
-
-    //true if it is 1, true or on. The default should be false (e.g., for bad input)
     value = streq(sv,"1") || streq(sv,"true") || streq(sv,"on");
     return false;
 }
-
 
 typedef enum nilBehavior_
 {
     nilIgnore,
     nilRemove
 } nilBehavior;
-
-inline void append_start_tag(StringBuffer &str, const char *tagname, const char *xmlns, bool close, IProperties *props)
-{
-    str.append('<');
-    if (xmlns && *xmlns)
-        str.append(xmlns).append(':');
-    str.append(tagname);
-
-    if (props)
-    {
-        Owned<IPropertyIterator> piter = props->getIterator();
-        for (piter->first(); piter->isValid(); piter->next())
-        {
-            const char *keyname=piter->getPropKey();
-            const char* val = props->queryProp(keyname);
-            if (val && *val)
-            {
-                StringBuffer encoded;
-                encodeXML(val,encoded);
-                str.appendf(" %s=\"%s\"", keyname, encoded.str());
-            }
-        }
-    }
-    
-    if (close)
-        str.append('/');
-    str.append('>');
-}
-
-
-inline void append_end_tag(StringBuffer &str, const char *tagname, const char *xmlns)
-{
-    str.append("</");
-    if (xmlns && *xmlns)
-        str.append(xmlns).append(':');
-    str.append(tagname).append('>');
-}
 
 // workaround for StringBuffer.appendlong()
 template <typename type>
@@ -102,446 +59,160 @@ template <>
 inline void appendStringBuffer(StringBuffer& s, unsigned long value)
 {   s.appendulong(value); }
 
-//Applicable to primitive types, eg. unsigned short, unsigned long, etc.
-template <class cpptype, class inittype=cpptype> class SoapParam
+class ESPHTTP_API BaseEspParam
 {
-private:
-   cpptype value_;
+public:
    bool isNil;
    nilBehavior nilBH;
    bool allowHttpNil;
-
 public:
-    SoapParam(nilBehavior nb=nilIgnore, bool httpNil=true) : isNil(true), value_(0), nilBH(nb), allowHttpNil(httpNil){}
+    BaseEspParam(nilBehavior nb, bool httpNil) : isNil(true), nilBH(nb), allowHttpNil(httpNil){}
+    virtual ~BaseEspParam(){}
 
-    SoapParam(inittype val, nilBehavior nb=nilIgnore, bool httpNil=true) : value_(val), isNil(false), nilBH(nb), allowHttpNil(httpNil){}
-
-    virtual ~SoapParam(){}
-
-    cpptype getValue() const {return value_;}
-    operator cpptype () {return value_;}
-
-    const cpptype * operator ->() const {return &value_;}
-
-    void operator=(cpptype val) { value_ = val; isNil=false;};
     void Nil(){isNil=true;}
     bool is_nil(){return isNil;}
 
+    void copy(BaseEspParam &from)
+    {
+        isNil=from.isNil;
+        nilBH=from.nilBH;
+    }
+
+    virtual bool updateValue(IRpcMessage &rpc_call, const char *path)=0;
+    virtual bool updateValue(CSoapValue &soapval, const char *tagname)=0;
+    virtual bool updateValue(const char *s)=0;
+    virtual void addRpcValue(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char *xsdtype, const char *prefix, bool *encodex)=0;
+
+    virtual void toXMLValue(StringBuffer &s, bool encode)=0;
+    virtual void toJSONValue(StringBuffer &s)=0;
+    virtual void toXML(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode);
+    virtual void toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname);
+    void toStr(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true, const char *xsdtype="", const char *prefix="");
+
+    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *prefix="");
+
+    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="");
+    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL);
+    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="");
+
+    void setEncodeNewlines(bool encodenl)
+    {
+        UNIMPLEMENTED;
+    }
+};
+
+template <class cpptype, class inittype=cpptype> class SoapParam : public BaseEspParam
+{
+private:
+   cpptype value;
+
+public:
+    SoapParam(nilBehavior nb=nilIgnore, bool httpNil=true) : BaseEspParam(nb, httpNil){}
+    SoapParam(inittype val, nilBehavior nb=nilIgnore, bool httpNil=true) : BaseEspParam(nb, httpNil), value(val){}
+
+    cpptype getValue() const {return value;}
+    operator cpptype () {return value;}
+    const cpptype * operator ->() const {return &value;}
+    void operator=(cpptype val) { value = val; isNil=false;};
+
     void copy(SoapParam<cpptype, inittype> &from)
     {
-        value_=from.value_;
-        isNil=from.isNil;
-        nilBH=from.nilBH;
+        value=from.value;
+        BaseEspParam::copy(from);
     }
 
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *xmlns="")
+    virtual void toXMLValue(StringBuffer &s, bool encode)
+    {
+        appendStringBuffer(s, value);
+    }
+
+    virtual void toJSONValue(StringBuffer &s)
+    {
+        if (!isNil)
+            appendJSONValue(s, NULL, value);
+        else
+            appendJSONValue(s, NULL, (const char *)NULL);
+    }
+
+    void addRpcValue(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *prefix="", bool *encodex=NULL)
     {
         if (!isNil || nilBH==nilIgnore)
-            rpc_call.add_value(basepath, xmlns, tagname, xsdtype, value_);
+            rpc_call.add_value(basepath, prefix, tagname, xsdtype, value);
     }
 
-    void marshall(IEspContext* ctx,StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true, const char *xsdtype="", const char *xmlns="")
+    virtual bool updateValue(IRpcMessage &rpc_call, const char *path)
     {
-        if (!isNil || nilBH==nilIgnore)
-        {
-            StringBuffer temp;
-            appendStringBuffer(temp,value_);
-            append_start_tag(str, tagname, xmlns, false, NULL);
-            if (encodeXml)
-                encodeUtf8XML(temp.str(), str);
-            else
-                str.append(temp);
-            append_end_tag(str, tagname, xmlns);
-        }
+        return (rpc_call.get_value(path, value));
     }
 
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
+    virtual bool updateValue(CSoapValue &soapval, const char *tagname)
     {
-        StringBuffer path(basepath);
-
-        if (basepath!=NULL && basepath[0]!=0)
-            path.append("/");
-
-        path.append(tagname);
-
-        if (rpc_call.get_value(path.str(), value_)) {
-            if (optGroup && rpc_call.queryContext()) 
-                rpc_call.queryContext()->addOptGroup(optGroup);
-            isNil = false;
-        }
-        return isNil;
+        return soapval.get_value(tagname, value);
     }
 
-    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL)
+    virtual bool updateValue(const char *s)
     {
-        if (soapval.get_value(tagname, value_)) {
-            if (ctx && optGroup)
-                ctx->addOptGroup(optGroup);
-            isNil = false;
-        }
-        return isNil;
-    }
-
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-        StringBuffer path;
-        if (basepath && *basepath)
-            path.append(basepath).append(".");
-        path.append(tagname);
-
-        const char *pval=params.queryProp(path.str());
-        if (pval && (*pval || !allowHttpNil))
-        {
-            if (ctx && optGroup)
-                ctx->addOptGroup(optGroup);
-            isNil = false;
-            esp_convert(pval, value_);      
-        }
-        return isNil;
-    }   
-
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    void setEncodeNewlines(bool encodenl)
-    {
-        UNIMPLEMENTED;
+        if (!s || (!*s && allowHttpNil))
+            return false;
+        return esp_convert(s, value);
     }
 };
 
-class SoapStringParam
+template <class cpptype, cpptype initval> class SoapParamEx : public BaseEspParam
 {
 private:
-    StringBuffer value_;
-    bool isNil;
-    nilBehavior nilBH;
-    bool encodeNewlines;
+   cpptype value;
 
 public:
-    SoapStringParam(nilBehavior nb=nilIgnore) : isNil(true), nilBH(nb), encodeNewlines(false) {}
-
-    SoapStringParam(const char * val, nilBehavior nb=nilIgnore) : value_(val), isNil(val==NULL), nilBH(nb), encodeNewlines(false) {}
-
-    virtual ~SoapStringParam(){}
-
-    const StringBuffer & getValue() const {return value_;}
-    bool is_nil(){return isNil;}
-
-    operator const StringBuffer &() {return value_;}
-    const StringBuffer * operator ->() const {return &value_;}
-
-    StringBuffer &getBuffer(){return value_;}
-
-    void copy(SoapStringParam &from)
-    {
-        value_.clear().append(from.value_);
-        isNil=from.isNil;
-        nilBH=from.nilBH;
-    }
-    void operator=(StringBuffer &val) 
-    { 
-        value_.clear().append(val); 
-        isNil=false;
-    };
-
-    void set(const char *value, bool trim=false)
-    {
-        value_.clear().append(value); 
-        if (trim)
-            value_.trim();
-        isNil=(value==NULL);
-    }
-    const char *query()
-    {
-        return (isNil && nilBH==nilRemove) ? NULL : value_.str();
-    }
-
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *xmlns="", bool *encodex=NULL)
-    {
-        if (!isNil || nilBH==nilIgnore)
-            rpc_call.add_value(basepath, xmlns, tagname, xsdtype, value_.str(),(!encodex) ? rpc_call.getEncodeXml() : *encodex);
-    }
-
-    void marshall(IEspContext* ctx,StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true, const char *xsdtype="", const char *xmlns="")
-    {
-        if (nilBH==nilIgnore || !isNil)
-        {
-            append_start_tag(str, tagname, xmlns, false, NULL);
-            if (encodeXml)
-                encodeUtf8XML(value_.str(), str, encodeNewlines?ENCODE_NEWLINES:0);
-            else
-                str.append(value_);
-            append_end_tag(str, tagname, xmlns);
-        }
-    }
-
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-        StringBuffer path(basepath);
-
-        if (basepath!=NULL && basepath[0]!=0)
-            path.append("/");
-
-        path.append(tagname);
-
-        StringBuffer tmp;
-        if (rpc_call.get_value(path.str(), tmp))
-        {
-            isNil = false;
-            value_.set(tmp);
-            if (optGroup && rpc_call.queryContext())
-                rpc_call.queryContext()->addOptGroup(optGroup);
-            return true;
-        }
-        return false;
-    }
-
-    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL)
-    {
-        isNil = !soapval.get_value_str(tagname, value_.clear());
-        if (!isNil && ctx && optGroup) ctx->addOptGroup(optGroup);
-        return !isNil;
-    }
-
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-        StringBuffer path;
-        if (basepath && *basepath)
-            path.append(basepath).append(".");
-        path.append(tagname);
-        const char *pval = params.queryProp(path.str());
-        if (pval)
-        {
-            isNil=false;
-            esp_convert(pval, value_.clear());
-            if (ctx && optGroup)
-                ctx->addOptGroup(optGroup);
-            return true;
-        }
-        return false;
-    }
-
-    bool unmarshallAttach(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-        if(attachments)
-        {
-            StringBuffer key;
-            if (basepath && *basepath)
-                key.append(basepath).append(".");
-            key.append(tagname);
-
-            StringBuffer* data = attachments->getValue(key.str());
-            if (data)
-            {
-                StringBuffer path;
-                if (basepath && *basepath)
-                    path.append(basepath).append(".");
-                path.append(tagname);
-                isNil=false;
-                value_.clear().swapWith(*data);
-                if (ctx && optGroup) 
-                    ctx->addOptGroup(optGroup);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-
-    void setEncodeNewlines(bool encodenl)
-    {
-        encodeNewlines = encodenl;
-    }
-};
-
-
-template <class cpptype, class iftype, class inittype=cpptype> class SoapStruct
-{
-private:
-   cpptype value_;
-   nilBehavior nilBH;
-
-private:
-    operator cpptype () {return value_;}
-    void operator=(cpptype val) { value_ = val;};
-
-public:
-    SoapStruct(const char *serviceName, nilBehavior nb=nilIgnore) : value_(serviceName), nilBH(nb){}
-    virtual ~SoapStruct(){}
-
-    cpptype & getValue() {return value_;}
-
-    const cpptype * operator ->() const {return &value_;}
-    cpptype * operator ->() {return &value_;}
-
-    void copy(SoapStruct<cpptype, iftype, inittype> &from)
-    {
-        value_.copy(from.value_);
-        nilBH=from.nilBH;
-    }
-    void copy(iftype &ifrom)
-    {
-        value_.copy(ifrom);
-    }
-
-
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *xmlns="")
-    {
-        IProperties *props=NULL;
-        StringBuffer xml;
-        value_.serializeContent(rpc_call.queryContext(),xml, &props);
-        //value_.serialize(*rpc_call.queryContext(),xml,"");
-        //inittype::serializer(*rpc_call.queryContext(),value_,xml,false);
-        if (xml.length() || nilBH==nilIgnore || props)
-            rpc_call.add_value(basepath, xmlns, tagname, xsdtype, xml.str(), false);
-
-        if (props)
-            rpc_call.add_attr(basepath, tagname, NULL, *props);
-        if (props)
-            props->Release();
-    }
-
-    void marshall(IEspContext* ctx,StringBuffer &str, const char *tagname, const char *basepath="", const char *xsdtype="",  bool encodeXml=true, const char *xmlns="")
-    {
-        StringBuffer xml;
-        IProperties *props=NULL;
-        value_.serializeContent(ctx,xml,&props);
-        //value_.serialize(ctx,xml,"");     
-        //inittype::serializer(ctx,value_,xml,false);
-        if (props || xml.length() || nilBH==nilIgnore)
-            append_start_tag(str, tagname, xmlns, (xml.length()==0), props);
-        if (xml.length())
-        {
-            str.append(xml.str());
-            append_end_tag(str, tagname, xmlns);
-        }
-        if (props)
-            props->Release();
-    }
-
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-        StringBuffer path;
-        if (basepath && *basepath)
-        {
-            path.append(basepath);
-            if (path.charAt(path.length()-1)!='/')
-                path.append("/");
-        }
-        path.append(tagname);
-        if (value_.unserialize(rpc_call, NULL, path.str())) {
-            if (optGroup && rpc_call.queryContext())
-                rpc_call.queryContext()->addOptGroup(optGroup);
-            return true;
-        }
-        return false;
-    }
-
-    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL)
-    {
-        CSoapValue *sv = soapval.get_value(tagname);
-        if (sv) {
-            value_.unserialize(ctx,*sv);
-            if (ctx && optGroup)
-                ctx->addOptGroup(optGroup);
-            return true;
-        }
-        return false;
-    }
-
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-       StringBuffer path;
-       if (basepath && *basepath)
-           path.append(basepath).append(".");
-       path.append(tagname);
-   
-       if (value_.unserialize(ctx, params, attachments, path.str())) {
-           if (ctx && optGroup)
-               ctx->addOptGroup(optGroup);
-           return true;
-       }
-       return false;
-    }
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-
-    void setEncodeNewlines(bool encodenl)
-    {
-        UNIMPLEMENTED;
-    }
-};
-
-template <class cpptype, cpptype initval> class SoapParamEx
-{
-private:
-   cpptype value_;
-
-public:
-    SoapParamEx(nilBehavior nb=nilIgnore) : value_(initval){}
+    SoapParamEx(nilBehavior nb=nilIgnore) : BaseEspParam(nilIgnore, false), value(initval){isNil=false;}
 
     virtual ~SoapParamEx(){}
 
-    const cpptype & getValue() const {return value_;}
+    const cpptype & getValue() const {return value;}
 
-    operator cpptype () {return value_;}
-    const cpptype * operator ->() const {return &value_;}
-    cpptype * operator ->() {return &value_;}
-    //Applicable to primitive types, eg. unsigned short, unsigned long, etc.
-    void operator=(cpptype val) { value_ = val;};
+    operator cpptype () {return value;}
+    const cpptype * operator ->() const {return &value;}
+    cpptype * operator ->() {return &value;}
+    void operator=(cpptype val) { value = val;};
 
     void copy(SoapParamEx<cpptype, initval> &from)
     {
-        value_=from.value_;
+        value=from.value;
+        isNil = false;
     }
 
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *xmlns="")
+    void addRpcValue(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *prefix="", bool *encodex=NULL)
     {
-       rpc_call.add_value(basepath, xmlns, tagname, xsdtype, value_);
+        rpc_call.add_value(basepath, prefix, tagname, xsdtype, value);
     }
 
-    void marshall(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true, const char *xsdtype="", const char *xmlns="")
+    virtual void toXMLValue(StringBuffer &s, bool encode)
     {
-        append_start_tag(str, tagname, xmlns, false, NULL);
-        str.append(value_);
-        append_end_tag(str, tagname, xmlns);
+        s.append(value);
     }
 
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns="")
+    virtual void toJSONValue(StringBuffer &s)
     {
-      StringBuffer path(basepath);
-
-      if (basepath!=NULL && basepath[0]!=0)
-         path.append("/");
-  
-      path.append(tagname);
-  
-      return rpc_call.get_value(path.str(), value_);
+        if (!isNil)
+            appendJSONValue(s, NULL, value);
+        else
+            appendJSONValue(s, NULL, (const char *)NULL);
     }
 
-    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL)
+    virtual bool updateValue(IRpcMessage &rpc_call, const char *path)
     {
-        if (soapval.get_value(tagname, value_)) {
-            if (ctx && optGroup)
-                ctx->addOptGroup(optGroup);
-            return true;
-        }
-        return false;
+        return rpc_call.get_value(path, value);
     }
 
-
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
+    virtual bool updateValue(CSoapValue &soapval, const char *tagname)
     {
-        StringBuffer path;
-        if (basepath && *basepath)
-            path.append(basepath).append(".");
-        path.append(tagname);
-        return esp_convert(params.queryProp(path.str()), value_);
+        return soapval.get_value(tagname, value);
     }
 
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
+    virtual bool updateValue(const char *s)
+    {
+        return esp_convert(s, value);
+    }
 
     void setEncodeNewlines(bool encodenl)
     {
@@ -549,88 +220,224 @@ public:
     }
 };
 
-
-class SoapParamBinary
+class ESPHTTP_API SoapStringParam : public BaseEspParam
 {
 private:
-   MemoryBuffer value_;
+    StringBuffer value;
+    bool encodeNewlines;
+
+public:
+    SoapStringParam(nilBehavior nb=nilIgnore) : BaseEspParam(nb, true), encodeNewlines(false) {}
+    SoapStringParam(const char * val, nilBehavior nb=nilIgnore) : BaseEspParam(nb, !val), encodeNewlines(false) {}
+
+    virtual ~SoapStringParam(){}
+
+    const StringBuffer & getValue() const {return value;}
+    bool is_nil(){return isNil;}
+    bool getEncodeNewlines(){return encodeNewlines;}
+
+    operator const StringBuffer &() {return value;}
+    const StringBuffer * operator ->() const {return &value;}
+
+    StringBuffer &getBuffer(){return value;}
+
+    void copy(SoapStringParam &from)
+    {
+        value = from.value;
+        BaseEspParam::copy(from);
+    }
+
+    void operator=(StringBuffer &val) { value = val; isNil=false;};
+
+    void set(const char *val, bool trim=false)
+    {
+        value.set(val);
+        if (trim)
+            value.trim();
+        isNil = !val;
+    }
+    const char *query()
+    {
+        return (isNil && nilBH==nilRemove) ? NULL : value.str();
+    }
+
+    void setEncodeNewlines(bool b)
+    {
+        encodeNewlines = b;
+    }
+
+    virtual void toXMLValue(StringBuffer &s, bool encode);
+    virtual void toJSONValue(StringBuffer &s);
+
+    void addRpcValue(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char *xsdtype, const char *prefix, bool *encodex);
+    virtual bool updateValue(IRpcMessage &rpc_call, const char *path);
+    virtual bool updateValue(CSoapValue &soapval, const char *tagname);
+    virtual bool updateValue(const char *s);
+
+    bool unmarshallAttach(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="");
+};
+
+class ESPHTTP_API BaseEspStruct
+{
+private:
+   nilBehavior nilBH;
+
+public:
+    BaseEspStruct(nilBehavior nb=nilIgnore) : nilBH(nb){}
+    virtual ~BaseEspStruct(){}
+
+    void copy(BaseEspStruct &from)
+    {
+        nilBH=from.nilBH;
+    }
+
+    virtual bool updateValue(IRpcMessage &rpc_call, const char *path) = 0;
+    virtual bool updateValue(IEspContext *ctx, CSoapValue &soapval) = 0;
+    virtual bool updateValue(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *path) = 0;
+
+    virtual void serializeContent(IEspContext *ctx, StringBuffer &s, IProperties *props=NULL) = 0;
+    virtual void serializeAttributes(IEspContext *ctx, StringBuffer &s) = 0;
+
+    virtual void toXML(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode);
+    virtual void toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname);
+    void toStr(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", bool encode=true, const char *xsdtype="", const char *prefix="");
+
+    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *prefix="");
+    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="");
+    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL);
+    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="");
+};
+
+template <class cpptype, class iftype, class inittype=cpptype> class SoapStruct : public BaseEspStruct
+{
+private:
+   cpptype value;
+   nilBehavior nilBH;
+
+private:
+    operator cpptype () {return value;}
+    void operator=(cpptype val) { value = val;};
+
+public:
+    SoapStruct(const char *serviceName, nilBehavior nb=nilIgnore) : value(serviceName), nilBH(nb){}
+    virtual ~SoapStruct(){}
+
+    cpptype & getValue() {return value;}
+
+    const cpptype * operator ->() const {return &value;}
+    cpptype * operator ->() {return &value;}
+
+    void copy(SoapStruct<cpptype, iftype, inittype> &from)
+    {
+        value.copy(from.value);
+        nilBH=from.nilBH;
+    }
+
+    void copy(iftype &ifrom)
+    {
+        value.copy(ifrom);
+    }
+
+    virtual void serializeAttributes(IEspContext *ctx, StringBuffer &xml)
+    {
+        value.serializeAttributes(ctx, xml);
+    }
+
+    virtual void serializeContent(IEspContext *ctx, StringBuffer &xml, IProperties *props=NULL)
+    {
+        value.serializeContent(ctx, xml, (props) ? &props : NULL);
+    }
+
+    virtual bool updateValue(IRpcMessage &rpc_call, const char *path)
+    {
+        return value.unserialize(rpc_call, NULL, path);
+    }
+
+    virtual bool updateValue(IEspContext *ctx, CSoapValue &soapval)
+    {
+        return value.unserialize(ctx, soapval);
+    }
+
+    virtual bool updateValue(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *path)
+    {
+        return value.unserialize(ctx, params, attachments, path);
+    }
+
+    void setEncodeNewlines(bool encodenl)
+    {
+        UNIMPLEMENTED;
+    }
+};
+
+class ESPHTTP_API SoapParamBinary
+{
+private:
+   MemoryBuffer value;
 
 public:
     SoapParamBinary(nilBehavior nb=nilIgnore){}
 
     virtual ~SoapParamBinary(){}
 
-    const MemoryBuffer & getValue() const {return value_;}
+    const MemoryBuffer & getValue() const {return value;}
 
-    operator MemoryBuffer& () {return value_;}
-    const MemoryBuffer * operator ->() const {return &value_;}
-    MemoryBuffer * operator ->() {return &value_;}
+    operator MemoryBuffer& () {return value;}
+    const MemoryBuffer * operator ->() const {return &value;}
+    MemoryBuffer * operator ->() {return &value;}
 
-    void operator=(MemoryBuffer &val) { value_.clear().append(val);};
+    void operator=(MemoryBuffer &val) { value.clear().append(val);};
 
     void copy(SoapParamBinary &from)
     {
-        value_.clear().append(from.value_);
+        value.clear().append(from.value);
     }
 
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *xmlns="")
+    virtual void toXML(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode);
+    virtual void toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname);
+    void toStr(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true, const char *xsdtype="", const char *prefix="");
+
+    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *prefix="");
+    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="");
+    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL);
+    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="");
+
+    void setEncodeNewlines(bool encodenl)
     {
-        StringBuffer b64value;
-        JBASE64_Encode(value_.toByteArray(), value_.length(), b64value);
-        rpc_call.add_value(basepath, xmlns, tagname, xsdtype, b64value);
+        UNIMPLEMENTED;
     }
+};
 
-    void marshall(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true, const char *xsdtype="", const char *xmlns="")
+class ESPHTTP_API SoapAttachString
+{
+private:
+   StringBuffer value;
+
+public:
+    SoapAttachString(nilBehavior nb=nilIgnore){}
+
+    virtual ~SoapAttachString(){}
+
+    const StringBuffer & getValue() const {return value;}
+    const StringBuffer * operator ->() const {return &value;}
+
+    void copy(SoapAttachString &from)
     {
-        append_start_tag(str, tagname, xmlns, false, NULL);
-        JBASE64_Encode(value_.toByteArray(), value_.length(), str);
-        append_end_tag(str, tagname, xmlns);
+        value.clear().append(from.value);
     }
 
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-        StringBuffer path(basepath);
+    void operator=(StringBuffer val){ value.clear().append(val);}
 
-        if (basepath!=NULL && basepath[0]!=0)
-            path.append("/");
-        path.append(tagname);
+    void set(const char *val){ value.clear().append(val);}
+    const char *query(){return value.str();}
 
-        StringBuffer b64value;
-        bool ret = rpc_call.get_value(path.str(), b64value);
-        if (ret && optGroup && rpc_call.queryContext())
-            rpc_call.queryContext()->addOptGroup(optGroup);
+    virtual void toXML(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode);
+    virtual void toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname);
+    void toStr(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true, const char *xsdtype="", const char *prefix="");
 
-        if(b64value.length() > 0) 
-            JBASE64_Decode(b64value.str(), value_);
-
-        return ret;
-    }
-
-    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL)
-    {
-        //TODO: is this OK
-        //assertex(false);
-        return false;
-    }
-
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-        StringBuffer path;
-        if (basepath && *basepath)
-            path.append(basepath).append(".");
-        path.append(tagname);
-
-        const char* val = params.queryProp(path.str());
-        if(val) {
-            if (ctx && optGroup)
-                ctx->addOptGroup(optGroup);
-            JBASE64_Decode(params.queryProp(path.str()), value_);
-            return true;
-        }
-        return false;
-    }
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
+    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *prefix="");
+    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL,const char *xsdtype="", const char *prefix="");
+    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL);
+    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *prefix="");
 
     void setEncodeNewlines(bool encodenl)
     {
@@ -641,48 +448,57 @@ public:
 template <class cpptype> class SoapAttachParam
 {
 private:
-   cpptype value_;
+   cpptype value;
 
 public:
     SoapAttachParam(nilBehavior nb=nilIgnore){}
 
     virtual ~SoapAttachParam(){}
 
-    const cpptype & getValue() const {return value_;}
+    const cpptype & getValue() const {return value;}
 
-    operator cpptype () {return value_;}
-    const cpptype * operator ->() const {return &value_;}
-    cpptype * operator ->() {return &value_;}
+    operator cpptype () {return value;}
+    const cpptype * operator ->() const {return &value;}
+    cpptype * operator ->() {return &value;}
     //Applicable to primitive types, eg. unsigned short, unsigned long, etc.
-    void operator=(cpptype val) { value_ = val;};
+    void operator=(cpptype val) { value = val;};
 
     void copy(SoapAttachParam &from)
     {
-        value_=from.value_;
+        value=from.value;
     }
 
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *xmlns="")
+    virtual void toXML(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode)
     {
-        rpc_call.add_value(basepath, xmlns, tagname, "Attachment", value_);
+        appendXMLTag(s, tagname, value, prefix, ENCODE_NONE);
     }
 
-    void marshall(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="",const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
+    virtual void toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname)
     {
-        append_start_tag(str, tagname, xmlns, false, NULL);
-        str.append(value_);
-        append_end_tag(str, tagname, xmlns);
+        appendJSONValue(s, tagname, value);
     }
 
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
+    void toStr(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *xsdtype="", const char *prefix="")
+    {
+        if (ctx->getResponseFormat()==ESPSerializationJSON)
+            return toJSON(ctx, s, tagname);
+        return toXML(ctx, s, tagname, prefix);
+    }
+
+    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *prefix="")
+    {
+        rpc_call.add_value(basepath, prefix, tagname, "Attachment", value);
+    }
+
+    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="")
     {
         StringBuffer path(basepath);
-
         if (basepath!=NULL && basepath[0]!=0)
-         path.append("/");
-
+            path.append("/");
         path.append(tagname);
 
-        if (rpc_call.get_value(path.str(), value_)) {
+        if (rpc_call.get_value(path.str(), value))
+        {
             if (optGroup && rpc_call.queryContext())
                 rpc_call.queryContext()->addOptGroup(optGroup);
             return true;
@@ -692,13 +508,11 @@ public:
 
     bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL)
     {
-        //TODO: is this ok
         return false;
     }
 
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns="")
+    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *prefix="")
     {
-        //TODO: is this ok
         return false;
     }
 
@@ -708,93 +522,36 @@ public:
     }
 };
 
+ESPHTTP_API StringBuffer &buildVarPath(StringBuffer &path, const char *tagname, const char *basepath, const char *item, const char *tail, int *idx);
 
-class SoapAttachString
+class ESPHTTP_API EspBaseArrayParam
 {
-private:
-   StringBuffer value_;
+protected:
+    nilBehavior nilBH;
 
 public:
-    SoapAttachString(nilBehavior nb=nilIgnore){}
+    EspBaseArrayParam(nilBehavior nb) : nilBH(nb) { }
+    virtual ~EspBaseArrayParam() { }
 
-    virtual ~SoapAttachString(){}
+    virtual unsigned getLength()=0;
+    virtual const char *getItemTag(const char *in)=0;
 
-    const StringBuffer & getValue() const {return value_;}
-    const StringBuffer * operator ->() const {return &value_;}
+    virtual void append(IEspContext *ctx, CSoapValue& sv)=0;
+    //virtual bool append(IRpcMessage &rpc_call, const char *path)=0;
+    virtual void append(const char *s)=0;
 
-    void copy(SoapAttachString &from)
-    {
-        value_.clear().append(from.value_);
-    }
+    virtual void toXML(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *itemname, const char *prefix, bool encode);
+    virtual void toJSON(IEspContext* ctx, StringBuffer &s, const char *tagname, const char *itemname);
+    virtual void toStr(IEspContext* ctx,StringBuffer &str, const char *tagname, const char *itemname, const char *elementtype="", const char *basepath="", const char *prefix="");
+    virtual void toStrItem(IEspContext *ctx, StringBuffer &s, unsigned index, const char *name)=0;
 
-    void operator=(StringBuffer val){ value_.clear().append(val);}
-
-    void set(const char *val){ value_.clear().append(val);}
-    const char *query(){return value_.str();}
-
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xsdtype="", const char *xmlns="")
-    {
-        rpc_call.add_value(basepath, xmlns, tagname, "Attachment", value_);
-    }
-
-    void marshall(IEspContext* ctx,StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true, const char *xsdtype="", const char *xmlns="")
-    {
-        append_start_tag(str, tagname, xmlns, false, NULL);
-        str.append(value_);
-        append_end_tag(str, tagname, xmlns);
-    }
-
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL,const char *xsdtype="", const char *xmlns="")
-    {
-        StringBuffer path(basepath);
-
-        if (basepath!=NULL && basepath[0]!=0)
-         path.append("/");
-
-        path.append(tagname);
-
-        if (rpc_call.get_value(path.str(), value_)) {
-            if (optGroup && rpc_call.queryContext())
-                rpc_call.queryContext()->addOptGroup(optGroup);
-            return true;
-        }
-        return false;
-    }
-
-    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL) { 
-        //TODO: what to do with this
-        return false;
-    }
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){
-        //TODO: what to do with this
-        return false;
-    }
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-
-    void setEncodeNewlines(bool encodenl)
-    {
-        UNIMPLEMENTED;
-    }
+    virtual bool unmarshallItems(IEspContext* ctx, CSoapValue *sv, const char *itemname, const char* optGroup=NULL);
+    virtual bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup, const char *itemname="Item");
+    virtual bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char* optGroup, const char *prefix);
+    virtual bool unmarshallAttach(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix);
+    virtual bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix);
+    virtual bool unmarshallRawArray(IProperties &params, const char *tagname, const char *basepath);
 };
-
-inline StringBuffer &buildVarPath(StringBuffer &path, const char *tagname, const char *basepath, const char *item, const char *tail, int *idx)
-{
-    path.clear();
-    if (basepath)
-        path.append(basepath).append(".");
-    path.append(tagname);
-    if (item)
-        path.append(".").append(item);
-    if (tail)
-        path.append(".").append(tail);
-    if (idx)
-        path.append(".").append(*idx);
-    return path;
-}
-
-//--------------------------------------------
-// soap array template
 
 // generic version: works for string or other types, such as string enum
 template <class arraytype>
@@ -813,375 +570,131 @@ template <> inline void append_to_array<FloatArray>(FloatArray& array, const cha
 
 template <> inline void append_to_array<DoubleArray>(DoubleArray& array, const char* item) { array.append(atof(item)); }
 
-template <class arraytype, class itemtype> 
-class SoapArrayParam
+template <class arraytype, class itemtype>
+class SoapArrayParam : public EspBaseArrayParam
 {
 protected:
-    arraytype array_;
+    arraytype arr;
     nilBehavior nilBH;
 
 public:
-    SoapArrayParam(nilBehavior nb=nilIgnore) : nilBH(nb) { }
+    SoapArrayParam(nilBehavior nb=nilIgnore) : EspBaseArrayParam(nb) { }
     virtual ~SoapArrayParam() { }
 
-    arraytype &getValue() {return array_;}
+    arraytype &getValue() {return arr;}
 
-    operator arraytype () {return  array_;}
-//  operator const arraytype &() const {return  array_;}
-    operator arraytype &() {return  array_;}
-    arraytype * operator ->() {return &array_;}
+    operator arraytype () {return  arr;}
+    operator arraytype &() {return  arr;}
+    arraytype * operator ->() {return &arr;}
 
     void copy(SoapArrayParam<arraytype,itemtype> &from)
     {
-        array_.kill();
+        arr.kill();
         arraytype fromArray = from.getValue();
         ForEachItemIn(idx, fromArray)
-          array_.append(fromArray.item(idx));
+          arr.append(fromArray.item(idx));
     }
 
-    // marshall
-    virtual void marshall(IRpcMessage &rpc_call, const char *tagname, const char *elementname="Item", const char *elementtype="", const char *basepath="", const char *xmlns="");
-    virtual void marshall(IEspContext* ctx,StringBuffer &str, const char *tagname, const char *elementname="Item", const char *elementtype="", const char *basepath="", const char *xmlns="");
+    virtual unsigned getLength()
+    {
+        return arr.ordinality();
+    }
 
-    // unmarshall
-    virtual bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL, const char *elementname="Item");
-    virtual bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *xmlns="");
-    virtual bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="");
-    virtual bool unmarshallAttach(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="");
+    virtual const char *getItemTag(const char *in)
+    {
+        return in;
+    }
 
-    bool unmarshallRawArray(IProperties &params, const char *tagname, const char *basepath);
+    virtual void append(IEspContext *ctx, CSoapValue& sv)
+    {
+        itemtype itemval;
+        sv.get_value("", itemval);
+        arr.append(itemval);
+    }
+
+    virtual void append(const char *s)
+    {
+        if (s && *s)
+            append_to_array(arr, s);
+    }
+
+    virtual void toStrItem(IEspContext *ctx, StringBuffer &s, unsigned index, const char *name)
+    {
+        s.append(arr.item(index));
+    }
+
+    inline void toStr(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *itemname, const char *elementtype="", const char *basepath="", const char *prefix="")
+    {
+        EspBaseArrayParam::toStr(ctx, str, tagname, itemname, elementtype, basepath, prefix);
+    }
+
+    inline void marshall(IRpcMessage &rpc_call, const char *tagname, const char *itemname, const char *elementtype, const char *basepath, const char *prefix)
+    {
+        rpc_call.add_value(basepath, prefix, tagname, prefix, itemname, elementtype, arr);
+    }
+
+    inline bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *prefix="")
+    {  return EspBaseArrayParam::unmarshall(rpc_call,tagname,basepath,optGroup,prefix); }
+
+    inline bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL,const char *xsdtype="", const char *prefix="")
+    {  return EspBaseArrayParam::unmarshall(ctx, params, attachments, tagname, basepath, optGroup, xsdtype, prefix); }
+
+    inline bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL, const char *itemname="Item")
+    {  return EspBaseArrayParam::unmarshall(ctx, soapval, tagname, optGroup, itemname); }
 
     void setEncodeNewlines(bool encodenl) { UNIMPLEMENTED; }
 };
 
-template <class arraytype, class itemtype> 
-inline void SoapArrayParam<arraytype,itemtype>::marshall(IRpcMessage &rpc_call, const char *tagname, const char *elementname, const char *elementtype, const char *basepath, const char *xmlns)
-{
-    rpc_call.add_value(basepath, xmlns, tagname, xmlns, elementname, elementtype, array_);
-}
-
-template <class arraytype, class itemtype> 
-inline void SoapArrayParam<arraytype,itemtype>::marshall(IEspContext* ctx,StringBuffer &str, const char *tagname, const char *elementname, const char *elementtype, const char *basepath, const char *xmlns)
-{
-    const unsigned nItems = array_.ordinality();
-    if (nItems == 0) 
-    {
-        if (nilBH != nilRemove)
-            append_start_tag(str, tagname, xmlns, true, NULL);
-    }
-    else
-    {
-        append_start_tag(str, tagname, xmlns, false, NULL);
-        for (unsigned  i=0; i<nItems; i++)
-        {
-            itemtype val = array_.item(i);
-            append_start_tag(str, elementname, xmlns, false, NULL);
-            str.append(val);
-            append_end_tag(str, elementname, xmlns);
-        }
-        append_end_tag(str, tagname, xmlns);
-    }
-}
-
-template <class arraytype, class itemtype> 
-inline bool SoapArrayParam<arraytype,itemtype>::unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup, const char *elementname)
-{
-    CSoapValue *sv= soapval.get_value(tagname);
-    if (sv)
-    {
-        SoapValueArray* children = sv->query_children();        
-        if (children)
-        {
-            if (ctx && optGroup)
-                ctx->addOptGroup(optGroup);     
-            itemtype itemval;
-            ForEachItemIn(x, *children)
-            {
-                CSoapValue& onechild = children->item(x);
-                onechild.get_value("",itemval);
-                array_.append(itemval);
-            }               
-            return true;
-        }
-    }
-    return false;
-}
-
-
-
-template <class arraytype, class itemtype> 
-inline bool SoapArrayParam<arraytype,itemtype>::unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath, const char* optGroup, const char *xmlns)
-{
-    StringBuffer path(basepath);
-
-    if (basepath!=NULL && basepath[0]!=0)
-        path.append("/");
-
-    path.append(tagname);
-
-    if (rpc_call.get_value(path.str(), array_))
-    {
-        if (optGroup && rpc_call.queryContext())
-            rpc_call.queryContext()->addOptGroup(optGroup);
-        return true;
-    }
-
-    return false;
-}
-
-template <class arraytype, class itemtype> 
-inline bool SoapArrayParam<arraytype,itemtype>::unmarshallAttach(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *xmlns)
-{
-    bool hasValue = false;
-
-    if(attachments)
-    {
-        StringBuffer path;
-        buildVarPath(path, tagname, basepath, NULL, "itemlist", NULL);
-        if (params.hasProp(path.str()))
-        {
-            hasValue = true;
-            //sparse array encoding
-            char *itemlist=strdup(params.queryProp(path.str()));
-            char *delim=NULL;
-            if (itemlist)
-            {
-                for(char *finger=itemlist; finger; finger=(delim) ? delim+1 : NULL)
-                {
-                    if ((delim=strchr(finger, '+'))) 
-                        *delim=0;
-                    if (*finger)
-                    {
-                        buildVarPath(path, tagname, basepath, finger, NULL, NULL);
-                        StringBuffer* data = attachments->getValue(path.str());
-                        if (data) 
-                            append_to_array(array_,data->str());
-                    }
-                }
-                free(itemlist);
-            }
-        }
-        else
-        {
-            buildVarPath(path, tagname, basepath, NULL, "itemcount", NULL);
-            int count=params.getPropInt(path.str(), -1);
-            if (count>0)
-            {
-                hasValue = true;
-                for (int idx=0; idx<count; idx++)
-                {
-                    buildVarPath(path, tagname, basepath, NULL, NULL, &idx);
-                    StringBuffer* data = attachments->getValue(path.str());
-                    if (data) 
-                        append_to_array(array_,data->str());
-                }
-            }
-        }
-    }
-
-    if (hasValue && ctx && optGroup)
-        ctx->addOptGroup(optGroup);
-
-    return hasValue;
-}
-
-template <class arraytype, class itemtype> 
-inline bool SoapArrayParam<arraytype,itemtype>::unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *xmlns)
-{
-    if (unmarshallRawArray(params, tagname, basepath)) {
-        if (ctx && optGroup)
-            ctx->addOptGroup(optGroup);
-        return true;
-    }
-
-    //supported encodings
-    //property = value
-    //--------   ---------
-    //tagname_vb_value = boolean
-    //tagname_iv_index = value
-
-    StringBuffer path;
-    if (basepath && *basepath)
-       path.append(basepath).append(".");
-    path.append(tagname);
-    const char *pathstr=path.str();
-
-    bool hasValue = false;
-    Owned<IPropertyIterator> iter = params.getIterator();
-
-    if (pathstr && *pathstr && iter && iter->first())
-    {
-        int taglen = strlen(pathstr);
-        while (iter->isValid())
-        {
-            const char *keyname=iter->getPropKey();
-            if (strncmp(keyname, pathstr, taglen)==0)
-            {
-                if (strlen(keyname)==taglen || !strncmp(keyname+taglen, "_rd_", 4))
-                {
-                    const char *finger = params.queryProp(iter->getPropKey());
-                    StringBuffer itemval;
-                    while (*finger)
-                    {
-                        if (*finger=='\r')
-                            finger++;
-
-                        if (*finger=='\n')
-                        {
-                            if (itemval.length())
-                                append_to_array(array_,itemval.str());
-                            itemval.clear();
-                        }
-                        else
-                        {
-                            itemval.append(*finger);
-                        }
-                        finger++;
-                    }
-                    if (itemval.length()) {
-                        append_to_array(array_,itemval.str());
-                        hasValue = true;
-                    }
-                }
-                else if (strncmp(keyname+taglen, "_v", 2)==0)
-                {
-                    if (params.getPropInt(keyname)) {
-                        append_to_array(array_,keyname+taglen+2);
-                        hasValue = true;
-                    }
-                }
-                else if (strncmp(keyname+taglen, "_i", 2)==0)
-                {
-                    //array_.add(name , val ); 
-                    append_to_array(array_,params.queryProp(iter->getPropKey()));
-                    hasValue = true;
-                }
-            }
-
-            iter->next();
-        }
-    }
-    
-    if (hasValue && ctx && optGroup)
-        ctx->addOptGroup(optGroup);
-
-    return hasValue;
-}
-
-//void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-//void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-template <class arraytype, class itemtype> 
-inline bool SoapArrayParam<arraytype,itemtype>::unmarshallRawArray(IProperties &params, const char *tagname, const char *basepath)
-{
-    bool rt = false;
-
-    StringBuffer path;
-    buildVarPath(path, tagname, basepath, NULL, "itemlist", NULL);
-    if (params.hasProp(path.str()))
-    {
-        //sparse array encoding
-        char *itemlist=strdup(params.queryProp(path.str()));
-        char *delim=NULL;
-        if (itemlist)
-        {
-            for(char *finger=itemlist; finger; finger=(delim) ? delim+1 : NULL)
-            {
-                if ((delim=strchr(finger, '+'))) 
-                    *delim=0;
-                if (*finger)
-                {
-                    buildVarPath(path, tagname, basepath, finger, NULL, NULL);
-                    const char* val = params.queryProp(path);
-                    if (val)
-                        append_to_array(array_,val);
-                }
-            }
-            free(itemlist);
-
-            rt = true;
-        }
-    }
-    else
-    {
-        buildVarPath(path, tagname, basepath, NULL, "itemcount", NULL);
-        int count=params.getPropInt(path.str(), -1);
-        if (count>0)
-        {
-            for (int idx=0; idx<count; idx++)
-            {
-                buildVarPath(path, tagname, basepath, NULL, NULL, &idx);
-                const char* val = params.queryProp(path);
-                if (val)
-                    append_to_array(array_,val);
-            }
-            rt = true;
-        }
-    }
-
-    return rt;
-}
 
 //--------------------------------------------
 // string array
 
-class SoapStringArray : public SoapArrayParam<StringArray,const char*>
+class SoapStringArray : public SoapArrayParam<StringArray, const char*>
 {
     typedef SoapArrayParam<StringArray,const char*> BASE;
+
 public:
     SoapStringArray(nilBehavior nb) : SoapArrayParam<StringArray,const char*>(nb) { }
 
-    virtual void marshall(IRpcMessage &rpc_call, const char *tagname, const char *elementname="Item", const char *elementtype="", const char *basepath="", const char *xmlns="")
-    { BASE::marshall(rpc_call,tagname,elementname,basepath,xmlns); }
-    
-    virtual void marshall(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *elementname="Item", const char *elementtype="", const char *basepath="", const char *xmlns="")
+    virtual void toStr(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *itemname, const char *elementtype="", const char *basepath="", const char *prefix="")
     {
-        const unsigned nItems = array_.ordinality();
-        if (nItems == 0) 
-        {
-            if (nilBH != nilRemove)
-                append_start_tag(str, tagname, xmlns, true, NULL);
-        }
+        BASE::toStr(ctx, str, tagname, itemname, elementtype, basepath, prefix);
+    }
+
+    void toStrItemJSON(StringBuffer &s, unsigned index)
+    {
+        const char *val = arr.item(index);
+        if (!val)
+            return;
+        appendJSONValue(s, NULL, val);
+    }
+
+    virtual void toStrItem(IEspContext *ctx, StringBuffer &s, unsigned index, const char *name)
+    {
+        if (ctx->getResponseFormat()==ESPSerializationJSON)
+            toStrItemJSON(s, index);
         else
-        {
-            append_start_tag(str, tagname, xmlns, false, NULL);
-            for (unsigned  i=0; i<nItems; i++)
-            {
-                const char* val = array_.item(i);               
-                append_start_tag(str, elementname, xmlns, false, NULL);
-                encodeUtf8XML(val,str); // string specific
-                append_end_tag(str, elementname, xmlns);
-            }
-            append_end_tag(str, tagname, xmlns);
-        }
+            encodeUtf8XML(arr.item(index), s);
     }
 
-    virtual bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char *elementname="Item")
+    virtual void append(IEspContext *ctx, CSoapValue& v)
     {
-        CSoapValue *sv= soapval.get_value(tagname);
-        if (sv)
-        {
-            SoapValueArray* children = sv->query_children();
-            
-            if (children)
-            {
-                StringBuffer itemval;
-                ForEachItemIn(x, *children)
-                {
-                    CSoapValue& onechild = children->item(x);
-                    onechild.get_value_str("",itemval.clear());
-                    append_to_array(array_,itemval.str());
-                }
-                return true;
-            }
-        }
-        return false;
+        StringBuffer s;
+        v.get_value("", s);
+        append_to_array(arr, s.str());
     }
 
-    virtual bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *xmlns="")
-    {  return BASE::unmarshall(rpc_call,tagname,basepath,optGroup,xmlns); }
+    virtual void marshall(IRpcMessage &rpc_call, const char *tagname, const char *itemname="Item", const char *elementtype="", const char *basepath="", const char *prefix="")
+    {  BASE::marshall(rpc_call, tagname, itemname, elementtype, basepath, prefix); }
 
-    virtual bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL,const char *xsdtype="", const char *xmlns="")
-    {  return BASE::unmarshall(ctx,params, attachments,tagname,basepath,optGroup,xmlns); }
+    inline bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *prefix="")
+    {  return BASE::unmarshall(rpc_call,tagname,basepath,optGroup,prefix); }
+
+    inline bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL,const char *xsdtype="", const char *prefix="")
+    {  return BASE::unmarshall(ctx, params, attachments, tagname, basepath, optGroup, xsdtype, prefix); }
+
+    inline bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL, const char *itemname="Item")
+    {  return BASE::unmarshall(ctx, soapval, tagname, optGroup, itemname); }
 };
 
 //--------------------------------------------
@@ -1241,119 +754,79 @@ public:
 //----------------------------------------------------------
 // struct array
 
-template <class basetype, class cltype> 
-class SoapStructArrayParam
+template <class basetype, class cltype>
+class SoapStructArrayParam : public EspBaseArrayParam
 {
 public:
-    SoapStructArrayParam(nilBehavior nb=nilIgnore){}
+    SoapStructArrayParam(nilBehavior nb=nilRemove) : EspBaseArrayParam(nilRemove /*Backward compatabiltiy*/){}
     virtual ~SoapStructArrayParam()
     {
     }
 
-    IArrayOf<basetype>  &getValue(){return array_;}
+    IArrayOf<basetype>  &getValue(){return arr;}
 
-    operator IArrayOf<basetype>  & () {return  array_;}
-    IArrayOf<basetype>  * operator ->() {return &array_;}
+    operator IArrayOf<basetype>  & () {return  arr;}
+    IArrayOf<basetype>  * operator ->() {return &arr;}
 
     void copy(SoapStructArrayParam<basetype, cltype> &from)
     {
-        array_.kill();
-        int count= from.array_.ordinality();
+        arr.kill();
+        int count= from.arr.ordinality();
         for (int index = 0; index<count; index++)
         {
-            from.array_.item(index).Link();
-            array_.append(from.array_.item(index));
+            from.arr.item(index).Link();
+            arr.append(from.arr.item(index));
         }
     }
 
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *elementname="", const char *elementtype="", const char *basepath="", const char *xmlns="")
+    virtual void toStr(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *itemname, const char *elementtype="Item", const char *basepath="", const char *prefix="")
     {
-        int count= array_.ordinality();
-        if (count > 0)
-        {
-            StringBuffer xml;
-            IEspContext* ctx = rpc_call.queryContext();
-            for (int index = 0; index<count; index++)
-            {
-                basetype &ifc = array_.item(index);
-                cltype *cl = dynamic_cast<cltype *>(&ifc);
-
-                if (cl)
-                    cl->serialize(ctx,xml, elementname);
-                else
-                    //cltype::serializer(ifc, xml, elementname);
-                    cltype::serializer(ctx,ifc, xml);
-            }
-
-            rpc_call.add_value(basepath, xmlns, tagname, elementtype, xml.str(), false);
-        }
+        return EspBaseArrayParam::toStr(ctx, str, tagname, itemname, elementtype, basepath, prefix);
     }
 
-    void marshall(IEspContext* ctx,StringBuffer &xml, const char *tagname, const char *elementname=NULL, const char *basepath="", const char *xsdtype="", const char *xmlns="")
+    virtual void toStrItem(IEspContext *ctx, StringBuffer &str, unsigned index, const char *name)
     {
-        int count= array_.ordinality();
-        if (count > 0)
-        {
-            xml.appendf("<%s>", tagname);
-            for (int index = 0; index<count; index++)
-            {
-                basetype &ifc = array_.item(index);
-                cltype *cl = dynamic_cast<cltype *>(&ifc);
-
-                if (cl)
-                    cl->serialize(ctx,xml, elementname);
-                else
-                    //cltype::serializer(ifc, xml, elementname);
-                    cltype::serializer(ctx,ifc, xml);
-            }
-            xml.appendf("</%s>", tagname);
-        }
+        basetype &b = arr.item(index);
+        cltype *cl = dynamic_cast<cltype *>(&b);
+        if (cl)
+            cl->serializeItem(ctx, str, name);
     }
 
-    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL)
+    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *itemname="", const char *elementtype="", const char *basepath="", const char *prefix="")
     {
-        CSoapValue *sv= soapval.get_value(tagname);
-        if (sv)
-        {
-            SoapValueArray* children = sv->query_children();
-            if (children)
-            {
-                if (ctx && optGroup)
-                    ctx->addOptGroup(optGroup);
-                ForEachItemIn(x, *children)
-                {
-                    CSoapValue& onechild = children->item(x);
-                    cltype *bt = new cltype("unknown");
-                    bt->unserialize(ctx,onechild);
-                    array_.append(*static_cast<basetype*>(bt));
-                }
-                return true;
-            }
-        }
-        return false;
+        if (!arr.ordinality())
+            return;
+        StringBuffer s;
+        toStr(rpc_call.queryContext(), s, tagname, itemname, elementtype, basepath, prefix);
+        rpc_call.add_value(basepath, prefix, tagname, elementtype, s.str(), false);
     }
 
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *xmlns="")
+    virtual unsigned getLength(){return arr.ordinality();}
+    virtual const char *getItemTag(const char *in)
     {
-        //MTimeSection timing(NULL, "SoapStructureArray Unmarshalling");
-        CRpcMessage *rpcmsg=dynamic_cast<CRpcMessage *>(&rpc_call);
-        if (rpcmsg)
-        {
-            StringBuffer path(basepath);
-            if (basepath!=NULL && basepath[0]!=0)
-                path.append("/");
-            path.append(tagname);
-            CSoapValue *soapval=rpcmsg->get_value(path.str());
-            if (soapval) {
-                if (optGroup && rpc_call.queryContext())
-                    rpc_call.queryContext()->addOptGroup(optGroup);
-                return unmarshall(rpc_call.queryContext(),*soapval, NULL);
-            }
-        }
-        return false;
+        return in;
     }
 
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns="")
+    virtual void append(const char *){ UNIMPLEMENTED; }
+
+    virtual void append(IEspContext *ctx, CSoapValue& v)
+    {
+        cltype *cl = new cltype("unknown");
+        cl->unserialize(ctx, v);
+        arr.append(*static_cast<basetype*>(cl));
+    }
+
+    inline bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL, const char *itemname="Item")
+    {
+        return EspBaseArrayParam::unmarshall(ctx, soapval, tagname, optGroup, itemname);
+    }
+
+    inline bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *prefix="")
+    {
+        return EspBaseArrayParam::unmarshall(rpc_call, tagname, basepath, optGroup, prefix);
+    }
+
+    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *prefix="")
     {
         StringBuffer path;
         buildVarPath(path, tagname, basepath, cltype::queryXsdElementName(), "itemlist", NULL);
@@ -1361,26 +834,25 @@ public:
         if (params.hasProp(path.str()))
         {
             //sparse array encoding
-            char *itemlist=strdup(params.queryProp(path.str()));
+            char *itemlist = strdup(params.queryProp(path.str()));
             char *delim=NULL;
             if (itemlist)
-            {               
+            {
                 for(char *finger=itemlist; finger; finger=(delim) ? delim+1 : NULL)
                 {
-                    if ((delim=strchr(finger, '+'))) 
+                    if ((delim=strchr(finger, '+')))
                         *delim=0;
                     if (*finger)
                     {
                         buildVarPath(path, tagname, basepath, cltype::queryXsdElementName(), finger, NULL);
                         cltype *bt = new cltype("unknown");
                         bt->unserialize(ctx,params, attachments, path.str());
-                        array_.append(*static_cast<basetype*>(bt));
+                        arr.append(*static_cast<basetype*>(bt));
                         hasValue = true;
                     }
                 }
                 free(itemlist);
             }
-
         }
         else
         {
@@ -1393,7 +865,7 @@ public:
                     buildVarPath(path, tagname, basepath, cltype::queryXsdElementName(), NULL, &idx);
                     cltype *bt = new cltype("unknown");
                     bt->unserialize(ctx,params, attachments, path.str());
-                    array_.append(*static_cast<basetype*>(bt));
+                    arr.append(*static_cast<basetype*>(bt));
                     hasValue = true;
                 }
             }
@@ -1401,185 +873,42 @@ public:
         return hasValue;
     }
 
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-
     void setEncodeNewlines(bool encodenl)
     {
         UNIMPLEMENTED;
     }
 
 private:
-    IArrayOf<basetype> array_;
+    IArrayOf<basetype> arr;
 };
 
-template <class enumtype, enumtype defvalue> 
-class SoapEnumParam
-{
-private:
-   enumtype value_;
-   int count_;
-
-   StringArray enumstrings;
-
-public:
-    SoapEnumParam(const char **strings, nilBehavior nb=nilIgnore)
-    {
-        setEnumStrings(strings);
-    }
-
-    SoapEnumParam(nilBehavior nb=nilIgnore)
-    {
-        value_ = defvalue;
-        count_=0;
-    }
-
-    virtual ~SoapEnumParam(){}
-    enumtype getValue() const {return value_;}
-    operator enumtype () const {return  value_;}
-    const enumtype * operator ->() const {return &value_;}
-    enumtype * operator ->() {return &value_;}
-
-    void copy(SoapEnumParam<enumtype, defvalue>  &from)
-    {
-        value_=from.value_;
-        count_=from.count_;
-        enumstrings.kill();
-        ForEachItemIn(idx, from.enumstrings)
-            enumstrings.append(from.enumstrings.item(idx));
-    }
-
-    const enumtype & operator =(enumtype &value) {value_=value; return value_;}
-
-    void setValue(enumtype valuex)
-    {
-        if (valuex >= count_)
-            value_ = defvalue;
-        else
-            value_ = valuex;
-    }
-
-    void setEnumStrings(const char **strings)
-    {
-        value_ = defvalue;
-        count_=0;
-
-        if (strings!=NULL)
-        {
-            while(strings[count_]!=NULL)
-            {
-                enumstrings.append(strings[count_]);
-                count_++;
-            }
-        }
-    }
-
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char *xmlns="")
-    {
-        rpc_call.add_value(basepath, xmlns, tagname, "string", enumstrings.item(value_));
-    }
-
-    void marshall(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", const char *xsdtype="", const char *xmlns="")
-    {
-    }
-
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *xmlns="")
-    {
-        StringBuffer path(basepath);
-        StringAttr strvalue;
-
-        if (basepath!=NULL && basepath[0]!=0)
-            path.append("/");
-
-        path.append(tagname);
-
-        rpc_call.get_value(path.str(), strvalue);
-
-        int tempval = defvalue;
-
-        if (strvalue.length())
-            tempval = enumstrings.find(strvalue.get());
-
-        if (tempval != NotFound) {
-            if (optGroup && rpc_call.queryContext())
-                rpc_call.queryContext()->addOptGroup(optGroup);
-            value_ = (enumtype) tempval;
-            return true;
-        }
-        else {
-            value_ = defvalue;
-            return false;
-        }
-    }
-
-    bool unmarshall(CSoapValue &soapval, const char *tagname, const char* optGroup) {
-        return false;
-    }
-
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
-    {
-        StringBuffer path;
-        if (basepath && *basepath)
-            path.append(basepath).append(".");
-        path.append(tagname);
-
-        StringAttr strvalue;
-        esp_convert(params.queryProp(path.str()), strvalue);
-
-        int tempval = defvalue;
-        if (strvalue.length())
-            tempval = enumstrings.find(strvalue.get());
-
-        if (tempval != NotFound) {
-            if (ctx && optGroup)
-                ctx->addOptGroup(optGroup);
-            value_ = (enumtype) tempval;
-            return true;
-        }
-        else {
-            value_ = defvalue;
-            return false;
-        }
-    }
-    
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-
-    void setEncodeNewlines(bool encodenl)
-    {
-        UNIMPLEMENTED;
-    }
-};
-
-// This template is used for auto generation of ESPenum
-// TODO: merge to use the orginal template
-template <class enumtype> 
+template <class enumtype>
 class SoapEnumParamNew
 {
 private:
    enumtype defvalue;
-   enumtype value_;
+   enumtype value;
    int count_;
    StringAttr typeName_,baseType_;
 
    StringArray enumstrings;
-   const char* asString() { return toString(value_); }
+   const char* asString() { return toString(value); }
 
 public:
     SoapEnumParamNew(nilBehavior nb=nilIgnore)
     {
-        defvalue = value_ = (enumtype)-1; 
+        defvalue = value = (enumtype)-1;
         count_ = 0;
     }
 
     SoapEnumParamNew(enumtype defvalue_)
     {
         defvalue = defvalue_;
-        value_ = (enumtype)-1; 
+        value = (enumtype)-1;
         count_ = 0;
     }
 
-    void setDefaultValue(const char* s) 
+    void setDefaultValue(const char* s)
     {
         if (s)
         {
@@ -1588,21 +917,21 @@ public:
             if (tempval == NotFound)
                 throw MakeStringException(-1, "Invalid value for type %s: %s", typeName_.get(), s);
             else
-                defvalue = (enumtype)tempval;   
+                defvalue = (enumtype)tempval;
         }
     }
 
     virtual ~SoapEnumParamNew(){}
 
-    enumtype getValue() const { return (value_>=0) ? value_ : defvalue; }
+    enumtype getValue() const { return (value>=0) ? value : defvalue; }
     operator const char* ()   { return asString(); }
 
     operator enumtype () const {return  getValue();}
-    const enumtype * operator ->() const { return (value_>=0) ? &value_ : &defvalue;}
-    enumtype * operator ->() {return (value_>=0) ? &value_ : &defvalue;}
+    const enumtype * operator ->() const { return (value>=0) ? &value : &defvalue;}
+    enumtype * operator ->() {return (value>=0) ? &value : &defvalue;}
 
-    const char* toString(enumtype val) 
-    { 
+    const char* toString(enumtype val)
+    {
        if (val<0)
        {
            if (defvalue>=0)
@@ -1610,8 +939,8 @@ public:
            else
                return "";
        }
-       else 
-           return enumstrings.item((int)val); 
+       else
+           return enumstrings.item((int)val);
     }
 
     enumtype toEnum(const char* s)
@@ -1619,17 +948,16 @@ public:
         if (s)
         {
             int tempval = enumstrings.find(s);
-
             if (tempval != NotFound)
                 return (enumtype)tempval;
         }
-                
+
         throw MakeStringException(-1, "Invalid value for type %s: %s", typeName_.get(), s ? s : "");
     }
 
     void copy(SoapEnumParamNew<enumtype>  &from)
     {
-        value_=from.value_;
+        value=from.value;
         count_=from.count_;
         enumstrings.kill();
         ForEachItemIn(idx, from.enumstrings)
@@ -1639,9 +967,9 @@ public:
     void setValue(enumtype valuex)
     {
         if (0<=valuex && valuex < count_)
-            value_ = valuex;
+            value = valuex;
         else if (valuex == -1)
-            value_ = defvalue;
+            value = defvalue;
         else
             throw MakeStringException(-1, "Invalid value for type %s: %d", typeName_.get(), valuex);
     }
@@ -1651,11 +979,10 @@ public:
         if (s)
         {
             int tempval = enumstrings.find(s);
-
             if (tempval == NotFound)
                 throw MakeStringException(-1, "Invalid value for type %s: %s", typeName_.get(), s);
             else
-                value_ = (enumtype)tempval; 
+                value = (enumtype)tempval;
         }
     }
 
@@ -1663,7 +990,7 @@ public:
     {
         typeName_.set(typeName);
         baseType_.set(baseType);
-        value_ = defvalue;
+        value = defvalue;
         count_=0;
 
         if (strings!=NULL)
@@ -1674,22 +1001,22 @@ public:
                 count_++;
             }
         }
-
     }
 
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char* elementname, const char* elementtype="",const char *basepath="", const char *xmlns="")
+    void toStr(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true,const char *xsdtype="", const char *prefix="")
     {
-        rpc_call.add_value(basepath, xmlns, tagname, "string", enumstrings.item(value_));
+        if (ctx->getResponseFormat()==ESPSerializationJSON)
+            appendJSONValue(str, tagname, asString());
+        else
+            appendXMLTag(str, tagname, asString(), prefix);
     }
 
-    void marshall(IEspContext* ctx, StringBuffer &str, const char *tagname, const char *basepath="", bool encodeXml=true,const char *xsdtype="", const char *xmlns="")
+    void marshall(IRpcMessage &rpc_call, const char *tagname, const char* itemname, const char* elementtype="",const char *basepath="", const char *prefix="")
     {
-        append_start_tag(str, tagname, xmlns, false, NULL);
-        str.append(asString());
-        append_end_tag(str, tagname, xmlns);
+        rpc_call.add_value(basepath, prefix, tagname, "string", enumstrings.item(value));
     }
 
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *xmlns="")
+    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *prefix="")
     {
         StringBuffer path(basepath);
         StringAttr strvalue;
@@ -1720,7 +1047,7 @@ public:
         return false;
     }
 
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
+    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="")
     {
         StringBuffer path;
         if (basepath && *basepath)
@@ -1736,21 +1063,17 @@ public:
         }
         return false;
     }
-    
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
 
     void setEncodeNewlines(bool encodenl)
     {
         UNIMPLEMENTED;
     }
 
-    void getXsdDefinition_(IEspContext &context, IHttpMessage *request, StringBuffer &schema, 
-        BoolHash &added, const char* descriptions[])
+    void getXsdDefinition_(IEspContext &context, IHttpMessage *request, StringBuffer &schema, BoolHash &added, const char* descriptions[])
     {
         if (added.getValue(typeName_))
             return;
-        
+
         added.setValue(typeName_, 1);
 
         schema.appendf("<xsd:simpleType name=\"%s\">", typeName_.get());
@@ -1774,17 +1097,8 @@ public:
     }
 };
 
-/*
-inline CGradeLevel Array__Member2Param(CGradeLevel &src)              { return src; }
-inline void Array__Assign(CGradeLevel & dest, CGradeLevel const & src){ dest = src; }
-inline bool Array__Equal(CGradeLevel const & m, CGradeLevel const p)  { return m==p; }
-inline CGradeLevel Array__Empty(CGradeLevel *)                        { return GradeLevel_Undefined; }
-inline void Array__Destroy(CGradeLevel & ) { }
-MAKEArrayOf(CGradeLevel, CGradeLevel, GradeLevelArray)
-*/
-
-template <class enumtype, class cxtype, class arraytype> 
-class SoapEnumArrayParam
+template <class enumtype, class cxtype, class arraytype>
+class SoapEnumArrayParam : public EspBaseArrayParam
 {
 public:
     SoapEnumArrayParam(nilBehavior nb=nilIgnore){}
@@ -1792,102 +1106,65 @@ public:
     {
     }
 
-    arraytype  &getValue(){return array_;}
+    arraytype  &getValue(){return arr;}
+    operator arraytype  & () {return  arr;}
+    arraytype  * operator ->() {return &arr;}
 
-    operator arraytype  & () {return  array_;}
-    arraytype  * operator ->() {return &array_;}
+    virtual const char *getItemTag(const char *in)
+    {
+        return (in && *in) ? in : cxtype::queryXsdElementName();
+    }
+
+    virtual unsigned getLength(){return arr.ordinality();}
+
+    virtual void append(IEspContext *ctx, CSoapValue& sv)
+    {
+        StringBuffer s;
+        sv.serializeContent(s, NULL);
+        arr.append(cxtype::enumOf(s));
+    }
+    //virtual bool append(IRpcMessage &rpc_call, const char *path)=0;
+    virtual void append(const char *s)
+    {
+        arr.append(cxtype::enumOf(s));
+    }
 
     void copy(SoapEnumArrayParam<enumtype, cxtype, arraytype> &from)
     {
-        array_.kill();
-        int count= from.array_.ordinality();
+        arr.kill();
+        int count= from.arr.ordinality();
         for (int index = 0; index<count; index++)
-            array_.append(from.array_.item(index));
+            arr.append(from.arr.item(index));
     }
 
-    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *elementname="", const char *elementtype="", const char *basepath="", const char *xmlns="")
+    virtual void toStrItem(IEspContext *ctx, StringBuffer &s, unsigned index, const char *name)
     {
-        int count= array_.ordinality();
+        if (ctx->getResponseFormat()==ESPSerializationJSON)
+            appendJSONValue(s, name, cxtype::stringOf(arr.item(index)));
+        else
+            appendXMLTag(s, name, cxtype::stringOf(arr.item(index)));
+    }
+
+    void marshall(IRpcMessage &rpc_call, const char *tagname, const char *itemname="", const char *elementtype="", const char *basepath="", const char *prefix="")
+    {
+        int count= arr.ordinality();
         if (count > 0)
-        {           
-            const char* itemTag = (!elementname || !*elementname) ? cxtype::queryXsdElementName() : elementname;
+        {
+            const char* itemTag = (!itemname || !*itemname) ? cxtype::queryXsdElementName() : itemname;
 
             StringBuffer xml;
             for (int index = 0; index<count; index++)
             {
-                enumtype e = array_.item(index);
+                enumtype e = arr.item(index);
                 xml.appendf("<%s>", itemTag);
                 encodeUtf8XML(cxtype::stringOf(e),xml);
                 xml.appendf("</%s>", itemTag);
             }
-
-            rpc_call.add_value(basepath, xmlns, tagname, elementtype, xml.str(), false);
+            rpc_call.add_value(basepath, prefix, tagname, elementtype, xml.str(), false);
         }
     }
 
-    void marshall(IEspContext* ctx,StringBuffer &xml, const char *tagname, const char *elementname=NULL, const char *basepath="", const char *xsdtype="", const char *xmlns="")
-    {
-        int count= array_.ordinality();
-        if (count > 0)
-        {
-            const char* itemTag = (!elementname || !*elementname) ? cxtype::queryXsdElementName() : elementname;
-            xml.appendf("<%s>", tagname);
-
-            for (int index = 0; index<count; index++)
-            {
-                enumtype e = array_.item(index);
-                xml.appendf("<%s>", itemTag);
-                encodeUtf8XML(cxtype::stringOf(e),xml);
-                xml.appendf("</%s>", itemTag);
-            }
-            xml.appendf("</%s>", tagname);
-        }
-    }
-
-    bool unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup=NULL)
-    {
-        CSoapValue *sv= soapval.get_value(tagname);
-        if (sv)
-        {
-            SoapValueArray* children = sv->query_children();
-            if (children)
-            {
-                if (ctx && optGroup)
-                    ctx->addOptGroup(optGroup);
-                ForEachItemIn(x, *children)
-                {
-                    CSoapValue& onechild = children->item(x);
-                    StringBuffer s;
-                    onechild.serializeContent(s,NULL);
-                    array_.append(cxtype::enumOf(s));
-                }
-                return true;
-            }
-        }
-        return false;
-    }
-
-    bool unmarshall(IRpcMessage &rpc_call, const char *tagname, const char *basepath="", const char* optGroup=NULL, const char *xmlns="")
-    {
-        CRpcMessage *rpcmsg=dynamic_cast<CRpcMessage *>(&rpc_call);
-        if (rpcmsg)
-        {
-            StringBuffer path(basepath);
-            if (basepath!=NULL && basepath[0]!=0)
-                path.append("/");
-            path.append(tagname);
-            CSoapValue *soapval=rpcmsg->get_value(path.str());
-            if (soapval) {
-                if (optGroup && rpc_call.queryContext())
-                    rpc_call.queryContext()->addOptGroup(optGroup);
-                unmarshall(rpc_call.queryContext(), *soapval, NULL);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *xmlns="")
+    bool unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath=NULL, const char* optGroup=NULL, const char *xsdtype="", const char *prefix="")
     {
         StringBuffer path;
         buildVarPath(path, tagname, basepath, cxtype::queryXsdElementName(), "itemlist", NULL);
@@ -1901,18 +1178,16 @@ public:
             {
                 for(char *finger=itemlist; finger; finger=(delim) ? delim+1 : NULL)
                 {
-                    if ((delim=strchr(finger, '+'))) 
+                    if ((delim=strchr(finger, '+')))
                         *delim=0;
                     if (*finger)
                     {
-                        //buildVarPath(path, tagname, basepath, cxtype::queryXsdElementName(), finger, NULL);
-                        array_.append(cxtype::enumOf(finger));
+                        arr.append(cxtype::enumOf(finger));
                         hasValue = true;
                     }
                 }
                 free(itemlist);
             }
-
         }
         else
         {
@@ -1925,7 +1200,7 @@ public:
                     buildVarPath(path, tagname, basepath, cxtype::queryXsdElementName(), NULL, &idx);
                     const char* val = params.queryProp(path);
                     if (val) {
-                        array_.append(cxtype::enumOf(val));
+                        arr.append(cxtype::enumOf(val));
                         hasValue = true;
                     }
                 }
@@ -1938,16 +1213,13 @@ public:
         return hasValue;
     }
 
-    //void unmarshall(const char * msg, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-    //void unmarshall(IPropertyTree * localnode, const char *tagname, const char *basepath=NULL, const char *xsdtype="", const char *xmlns=""){}
-
     void setEncodeNewlines(bool encodenl)
     {
         UNIMPLEMENTED;
     }
 
 private:
-    arraytype array_;
+    arraytype arr;
 };
 
 

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -101,7 +101,6 @@ protected:
     StringArray  m_headers;
 
     Owned<IEspContext> m_context;
-
     IArrayOf<CEspCookie> m_cookies;
 
     Owned<CMimeMultiPart> m_multipart;
@@ -112,8 +111,6 @@ protected:
     int readContent();  
     int readContentTillSocketClosed();
     virtual void addParameter(const char* paramname, const char *value);
-//  void addRawXMLParameter(const char* paramname, const char *value);
-//  void addRawXMLParameter(const char* path, IPropertyTree* tree);
     virtual void addAttachment(const char* name, StringBuffer& value);
 
     virtual StringBuffer& constructHeaderBuffer(StringBuffer& headerbuf, bool inclLength);
@@ -318,6 +315,7 @@ private:
     sub_service     m_sstype;
     bool            m_authrequired;
     int             m_MaxRequestEntityLength;
+    ESPSerializationFormat respSerializationFormat;
 
     virtual int parseFirstLine(char* oneline);
     virtual StringBuffer& constructHeaderBuffer(StringBuffer& headerbuf, bool inclLen);
@@ -409,6 +407,11 @@ public:
 inline bool canRedirect(CHttpRequest &req)
 {
     return !req.queryParameters()->hasProp("rawxml_");
+}
+
+inline bool skipXslt(IEspContext &context)
+{
+    return (context.getResponseFormat()!=ESPSerializationANY);  //for now
 }
 
 #endif

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -75,6 +75,8 @@ private:
     bool        m_hasException;
     int         m_exceptionCode;
 
+    ESPSerializationFormat respSerializationFormat;
+
 public:
     IMPLEMENT_IINTERFACE;
 
@@ -83,6 +85,7 @@ public:
         m_hasException =  false;
         m_creationTime = msTick();
         m_active=ActiveRequests::getCount();
+        respSerializationFormat=ESPSerializationANY;
     }
 
     ~CEspContext()
@@ -454,6 +457,9 @@ public:
 
         DBGLOG("TxSummary[%s]", logstr.str());
     }
+
+    virtual ESPSerializationFormat getResponseFormat(){return respSerializationFormat;}
+    virtual void setResponseFormat(ESPSerializationFormat fmt){respSerializationFormat = fmt;}
 };
 
 //---------------------------------------------------------

--- a/esp/protocols/http/CMakeLists.txt
+++ b/esp/protocols/http/CMakeLists.txt
@@ -41,6 +41,7 @@ set (    SRCS
          ../../bindings/SOAP/Platform/soapbind.cpp 
          ../../bindings/SOAP/Platform/soapmessage.cpp 
          ../../bindings/SOAP/Platform/soapservice.cpp 
+         ../../bindings/SOAP/Platform/soapparam.cpp
          ../../platform/espcontext.cpp 
          ../../platform/espprotocol.cpp 
          ../../platform/espthread.cpp 

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -48,60 +48,12 @@ SCMinterface IHttpMessage (IInterface)
     StringBuffer& getContent(StringBuffer& buf);
 };
 
-/*
-XSCMinterface IEspContext(IInterface)
+typedef enum ESPSerializationFormat_
 {
-    void setUserID(const char* userid);
-    StringBuffer& getUserID(StringBuffer& userid);
-    const char *queryUserId();
-
-    void setPassword(const char* password);
-    StringBuffer& getPassword(StringBuffer& password);
-    const char *queryPassword();
-
-    void setRealm(const char* realm);
-    StringBuffer& getRealm(StringBuffer& realm);
-    const char *queryRealm();
-
-    void setUser(ISecUser* user);
-    ISecUser* queryUser();
-
-    void setResources(ISecResourceList* rlist);
-    ISecResourceList* queryResources();
-
-    void setSecManger(ISecManager* mgr);
-    ISecManager* querySecManager();
-
-    void setContextPath(const char *path);
-    const char * getContextPath();
-
-    void setBindingValue(void *value);
-    void * getBindingValue();
-
-    void setServiceValue(void *value);
-    void * getServiceValue();
-
-    void setToBeAuthenticated(bool val);
-    bool toBeAuthenticated();
-
-    void setPeer(const char* peer);
-    StringBuffer& getPeer(StringBuffer& peer);
-    void setFeatureAuthMap(IAuthMap* map);
-
-
-    IAuthMap* queryAuthMap();
-
-    bool authorizeFeature(const char* pszFeatureUrl, SecAccessFlags& access);
-    bool authorizeFeatures(StringArray& features, IEspStringIntMap& pmap);
-    
-
-    bool validateFeatureAccess(const char* pszFeatureUrl, unsigned required, bool throwExcpt);
-    void setServAddress(const char *host, short port);
-    void getServAddress(StringBuffer& host, short &port);
-    void AuditMessage(AuditType type, const char *filterType, const char *title, const char *parms);
-
-};
-*/
+    ESPSerializationANY,
+    ESPSerializationXML,
+    ESPSerializationJSON
+} ESPSerializationFormat;
 
 #define ESPCTX_NO_NAMESPACES    0x00000001
 #define ESPCTX_WSDL             0x00000010
@@ -196,6 +148,9 @@ interface IEspContext : extends IInterface
     virtual void addTraceSummaryValue(const char *name, int value)=0;
     virtual void addTraceSummaryTimeStamp(const char *name)=0;
     virtual void flushTraceSummary()=0;
+
+    virtual ESPSerializationFormat getResponseFormat()=0;
+    virtual void setResponseFormat(ESPSerializationFormat fmt)=0;
 };
 
 

--- a/esp/services/WsDeploy/WsDeployEngine.cpp
+++ b/esp/services/WsDeploy/WsDeployEngine.cpp
@@ -136,7 +136,7 @@ m_version(1)
 
   StringBuffer xml;
   CDeployInfo& depInfo = dynamic_cast<CDeployInfo&>( deployInfo );
-  depInfo.serialize(ctx,xml);
+  depInfo.serializeStruct(ctx, xml);
 
   m_pResponseXml.setown( createPTreeFromXMLString(xml.str()) );
   m_pSelComps = m_pResponseXml->queryPropTree("Components");

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -5298,7 +5298,7 @@ bool CWsDeployFileInfo::deploy(IEspContext &context, IEspDeployRequest& req, IEs
   {
     resp.setStatus( "Please select at least one component to deploy!" );
     CDeployOptions& depOptions = dynamic_cast<CDeployOptions&>( depInfo.getOptions() );
-    depOptions.serialize(&context,deployResult, "Options");
+    depOptions.serializeStruct(&context,deployResult, "Options");
   }
   else
   {

--- a/plugins/fileservices/CMakeLists.txt
+++ b/plugins/fileservices/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries ( fileservices
          remote 
          dalibase 
          environment 
+         esphttp
          dllserver 
          nbcd 
          eclrtl  

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -1822,8 +1822,7 @@ jlib_decl StringBuffer &appendJSONName(StringBuffer &s, const char *name)
 {
     if (!name || !*name)
         return s;
-    if (s.length() && !strchr("{[:", s.charAt(s.length()-1)))
-        s.append(", ");
+    delimitJSON(s);
     return encodeJSON(s.append('"'), name).append("\": ");
 }
 

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -1793,6 +1793,74 @@ const char *decodeXML(const char *x, StringBuffer &ret, unsigned len, const char
     return x;
 }
 
+StringBuffer & appendXMLOpenTag(StringBuffer &xml, const char *tag, const char *prefix, bool complete, bool close, const char *uri)
+{
+    if (!tag || !*tag)
+        return xml;
+
+    xml.append('<');
+    appendXMLTagName(xml, tag, prefix);
+
+    if (uri && *uri)
+    {
+        xml.append(" xmlns");
+        if (prefix && *prefix)
+            xml.append(':').append(prefix);
+        xml.append("=\"").append(uri).append('\"');
+    }
+
+    if (complete)
+    {
+        if (close)
+            xml.append('/');
+        xml.append('>');
+    }
+    return xml;
+}
+
+jlib_decl StringBuffer &appendJSONName(StringBuffer &s, const char *name)
+{
+    if (!name || !*name)
+        return s;
+    if (s.length() && !strchr("{[:", s.charAt(s.length()-1)))
+        s.append(", ");
+    return encodeJSON(s.append('"'), name).append("\": ");
+}
+
+StringBuffer &encodeJSON(StringBuffer &s, const char *value)
+{
+    if (!value)
+        return s;
+    for (; *value; value++)
+    {
+        switch (*value)
+        {
+            case '\b':
+                s.append("\\b");
+                break;
+            case '\f':
+                s.append("\\f");
+                break;
+            case '\n':
+                s.append("\\n");
+                break;
+            case '\r':
+                s.append("\\r");
+                break;
+            case '\t':
+                s.append("\\t");
+                break;
+            case '\"':
+            case '\\':
+            case '/':
+                s.append('\\'); //fall through
+            default:
+                s.append(*value);
+        }
+    }
+    return s;
+}
+
 void decodeCppEscapeSequence(StringBuffer & out, const char * in, bool errorIfInvalid)
 {
     out.ensureCapacity((size32_t)strlen(in));

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -404,6 +404,13 @@ inline StringBuffer &appendXMLTag(StringBuffer &xml, const char *tag, const char
     return appendXMLCloseTag(xml, tag, prefix);
 }
 
+inline StringBuffer &delimitJSON(StringBuffer &s)
+{
+    if (s.length() && !strchr("{[:", s.charAt(s.length()-1)))
+        s.append(", ");
+    return s;
+}
+
 jlib_decl StringBuffer &encodeJSON(StringBuffer &s, const char *value);
 jlib_decl StringBuffer &appendJSONName(StringBuffer &s, const char *name);
 

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -346,6 +346,7 @@ public:
 #define ENCODE_SPACES 1
 #define ENCODE_NEWLINES 2
 #define ENCODE_WHITESPACE 3
+#define ENCODE_NONE 4
 
 interface IEntityHelper
 {
@@ -360,7 +361,7 @@ extern jlib_decl StringBuffer & appendStringAsSQL(StringBuffer & out, unsigned l
 extern jlib_decl StringBuffer & appendStringAsECL(StringBuffer & out, unsigned len, const char * src);
 extern jlib_decl StringBuffer & appendStringAsQuotedECL(StringBuffer &out, unsigned len, const char * src);
 
-extern jlib_decl void extractItem(StringBuffer & res, const char * src, const char * sep, int whichItem, bool caps);
+jlib_decl void extractItem(StringBuffer & res, const char * src, const char * sep, int whichItem, bool caps);
 extern jlib_decl const char *encodeXML(const char *x, StringBuffer &ret, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=false);
 extern jlib_decl const char *decodeXML(const char *x, StringBuffer &ret, unsigned len=(unsigned)-1, const char **errMark=NULL, IEntityHelper *entityHelper=NULL);
 extern jlib_decl const char *encodeXML(const char *x, IIOStream &out, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=false);
@@ -371,26 +372,77 @@ inline const char *encodeUtf8XML(const char *x, StringBuffer &ret, unsigned flag
     return encodeXML(x, ret, flags, len, true);
 }
 
-inline StringBuffer & appendXMLOpenTag(StringBuffer &xml, const char *tag)
+inline StringBuffer &appendXMLTagName(StringBuffer &xml, const char *tag, const char *prefix=NULL)
 {
-    if (tag && *tag)
-        xml.append('<').append(tag).append('>');
+    if (prefix && *prefix)
+        xml.append(prefix).append(':');
+    xml.append(tag);
     return xml;
 }
 
-inline StringBuffer & appendXMLCloseTag(StringBuffer &xml, const char *tag)
+extern jlib_decl StringBuffer & appendXMLOpenTag(StringBuffer &xml, const char *tag, const char *prefix=NULL, bool complete=true, bool close=false, const char *uri=NULL);
+
+inline StringBuffer & appendXMLCloseTag(StringBuffer &xml, const char *tag, const char *prefix=NULL)
 {
-    if (tag && *tag)
-        xml.append("</").append(tag).append('>');
-    return xml;
+    if (!tag || !*tag)
+        return xml;
+
+    xml.append("</");
+    return appendXMLTagName(xml, tag, prefix).append('>');
 }
 
-inline StringBuffer &appendXMLTag(StringBuffer &xml, const char *tag, const char *value, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=true)
+inline StringBuffer &appendXMLTag(StringBuffer &xml, const char *tag, const char *value, const char *prefix=NULL, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=true)
 {
-    appendXMLOpenTag(xml, tag);
+    appendXMLOpenTag(xml, tag, prefix);
     if (value && *value)
-        encodeXML(value, xml, flags, len, utf8);
-    return appendXMLCloseTag(xml, tag);
+    {
+        if (flags != ENCODE_NONE)
+            encodeXML(value, xml, flags, len, utf8);
+        else
+            xml.append(value);
+    }
+    return appendXMLCloseTag(xml, tag, prefix);
+}
+
+jlib_decl StringBuffer &encodeJSON(StringBuffer &s, const char *value);
+jlib_decl StringBuffer &appendJSONName(StringBuffer &s, const char *name);
+
+template <typename type>
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, type value)
+{
+    appendJSONName(s, name);
+    return s.append(value);
+}
+
+//specialization
+template <>
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, bool value)
+{
+    appendJSONName(s, name);
+    return s.append((value) ? "true" : "false");
+}
+
+template <>
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, const char *value)
+{
+    appendJSONName(s, name);
+    if (!value)
+        return s.append("null");
+    return encodeJSON(s.append('"'), value).append('"');
+}
+
+template <>
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, long value)
+{
+    appendJSONName(s, name);
+    return s.appendlong(value);
+}
+
+template <>
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, unsigned long value)
+{
+    appendJSONName(s, name);
+    s.appendulong(value);
 }
 
 extern jlib_decl void decodeCppEscapeSequence(StringBuffer & out, const char * in, bool errorIfInvalid);

--- a/tools/hidl/hidlcomp.h
+++ b/tools/hidl/hidlcomp.h
@@ -443,7 +443,7 @@ public:
     void write_esp_declaration();
     void write_esp_ng_declaration(int pos);
     void write_esp_init(bool &isFirst, bool removeNil);
-    void write_esp_marshall(bool isRpc, const char *var, bool encodeXml, bool checkVer=false, int indent=1);
+    void write_esp_marshall(bool isRpc, bool encodeXml, bool checkVer=false, int indent=1);
     void write_esp_unmarshall(const char *rpcvar, bool useBasePath=false, int indents=1);
     void write_esp_unmarshall_properties(const char *propvar, const char *attachvar, int indents=1);
     void write_esp_unmarshall_soapval(const char *var, int indents=1);
@@ -485,8 +485,8 @@ public:
         return kind;
     }
 
+    const char* getArrayItemTag();
     const char* getArrayItemXsdType();
-
     const char* getArrayImplType();
 
     bool hasNameTag(){return (typname && !stricmp(typname, "EspTextFile"));}


### PR DESCRIPTION
Refactors ESP message serialization code, encapsulates format
specific code, and adds support for JSON responses.

For now, desired format is specified in the request url by adding
an extension to the method name at the end of the path.

i.e. for XML:
http://host:8010/MyService/MyMethod.xml?Wuid=W20120621-123710

for JSON:
http://host:8010/MyService/MyMethod.json?Wuid=W20120621-123710

Fixes gh-2741.
