### PR TITLE
Resolve problems with ambiguous LEFT

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -14862,6 +14862,12 @@ IHqlExpression * createUniqueSelectorSequence()
 }
 
 
+IHqlExpression * createSelectorSequence(unsigned __int64 seq)
+{
+    return createSequence(no_attr, NULL, _selectorSequence_Atom, seq);
+}
+
+
 static UniqueSequenceCounter rowsidSequence;
 IHqlExpression * createUniqueRowsId()
 {

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -4561,7 +4561,7 @@ inline void addUniqueTable(HqlExprCopyArray & array, IHqlExpression * ds)
 
 inline void addHiddenTable(HqlExprCopyArray & array, IHqlExpression * ds, IHqlExpression * selSeq)
 {
-#if defined(GATHER_HIDDEN_SELECTORS) && !defined(ENSURE_SELSEQ_UID)
+#if defined(GATHER_HIDDEN_SELECTORS)
     if (array.find(*ds) == NotFound)
         array.append(*ds);
 #endif

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1492,6 +1492,7 @@ extern HQL_API IHqlExpression * createCounter();
 extern HQL_API IHqlExpression * createSelectorSequence();
 extern HQL_API IHqlExpression * createSequenceExpr();
 extern HQL_API IHqlExpression * createUniqueSelectorSequence();
+extern HQL_API IHqlExpression * createSelectorSequence(unsigned __int64 seq);
 extern HQL_API IHqlExpression * createDummySelectorSequence();
 extern HQL_API IHqlExpression * expandBetween(IHqlExpression * expr);
 extern HQL_API bool isAlwaysActiveRow(IHqlExpression * expr);

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -28,7 +28,10 @@
 #endif
 
 //#define USE_SELSEQ_UID
-//#define ENSURE_SELSEQ_UID
+//It is impossible to ensure that LEFT/RIGHT are unique, and cannot be nested.  For instance
+//x := PROJECT(ds, t(LEFT));
+//y := x(field not in SET(x, field2));
+//Once filters are moved in child queries then it can occur even when the common project cannot be hoisted.
 
 //Currently nearly all functional attributes are expanded when the call is parsed.
 //This is potentially inefficient, and makes it hard to dynamically control whether functions are expanded in line or generated out of line.

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -27,7 +27,7 @@
 //  #define USE_TBB
 #endif
 
-#define USE_SELSEQ_UID
+//#define USE_SELSEQ_UID
 //It is impossible to ensure that LEFT/RIGHT are unique, and cannot be nested.  For instance
 //x := PROJECT(ds, t(LEFT));
 //y := x(field not in SET(x, field2));

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -27,7 +27,7 @@
 //  #define USE_TBB
 #endif
 
-//#define USE_SELSEQ_UID
+#define USE_SELSEQ_UID
 //It is impossible to ensure that LEFT/RIGHT are unique, and cannot be nested.  For instance
 //x := PROJECT(ds, t(LEFT));
 //y := x(field not in SET(x, field2));

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4287,6 +4287,7 @@ IHqlExpression * CExprFolderTransformer::doFoldTransformed(IHqlExpression * unfo
             unwindChildren(args, expr, 1); // (count, trans)
             if (newTransform)
                 args.replace(*newTransform.getClear(), 1);
+            removeProperty(args, _selectorSequence_Atom);
 
             return createDataset(no_dataset_from_transform, args);
         }

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -366,6 +366,14 @@ struct TokenMap;
 
 class HqlGram;
 
+class LeftRightScope : public CInterface
+{
+public:
+    OwnedHqlExpr left;
+    OwnedHqlExpr right;
+    OwnedHqlExpr selSeq;
+};
+
 extern int eclyyparse(HqlGram * parser);
 class HqlGram : public CInterface, implements IErrorReceiver
 {
@@ -662,7 +670,6 @@ public:
 
 
     IHqlExpression * createUniqueId();  
-    IHqlExpression * doCreateUniqueSelectorSequence();
 
     void onOpenBra();
     void onCloseBra();
@@ -829,8 +836,7 @@ protected:
     IHqlScope* globalScope;
     ITypeInfo *current_type;
     HqlExprArray topScopes;
-    HqlExprArray leftScopes;
-    HqlExprArray rightScopes;
+    CIArrayOf<LeftRightScope> leftRightScopes;
     HqlExprArray rowsScopes;
     HqlExprArray rowsIds;
     HqlExprArray selfScopes;
@@ -860,7 +866,6 @@ protected:
     HqlExprAttr curFeatureParams;
     HqlExprCopyArray implicitFeatureNames;
     HqlExprCopyArray implicitFeatureValues;
-    HqlExprArray activeSelectorSequences;
     Owned<IHqlScope> parseScope;
     HqlExprAttr lastEnumValue;
     Owned<ITypeInfo> curEnumType;
@@ -884,22 +889,23 @@ protected:
     IHqlExpression * addDatasetSelector(IHqlExpression * lhs, IHqlExpression * rhs);
 
     void pushTopScope(IHqlExpression *);
-    void pushLeftScope(IHqlExpression *);
-    void pushRightScope(IHqlExpression *);
+    void pushLeftRightScope(IHqlExpression * left, IHqlExpression * right);
+    void pushPendingLeftRightScope(IHqlExpression * left, IHqlExpression * right);
+    void setRightScope(IHqlExpression *);
     void pushRowsScope(IHqlExpression *);
+
     void pushSelfScope(IHqlExpression *);
     void pushSelfScope(ITypeInfo * selfType);
-    void pushSelectorSequence(IHqlExpression * left, IHqlExpression * right);
-    void pushUniqueSelectorSequence();
-    IHqlExpression * popSelectorSequence();
+
+    IHqlExpression * getSelector(const attribute & errpos, node_operator side);
+
     IHqlExpression * createActiveSelectorSequence(IHqlExpression * left, IHqlExpression * right);
 
     IHqlExpression * getSelectorSequence();
     IHqlExpression * forceEnsureExprType(IHqlExpression * expr, ITypeInfo * type);
 
     void popTopScope();
-    void popLeftScope();
-    void popRightScope();
+    IHqlExpression * popLeftRightScope();
     IHqlExpression * popRowsScope();
     void popSelfScope();
     void swapTopScopeForLeftScope();
@@ -921,8 +927,6 @@ protected:
     IHqlExpression *queryLeftScope();
     IHqlExpression *queryRightScope();
     IHqlExpression *queryRowsScope();
-    IHqlExpression *getLeftScope();
-    IHqlExpression *getRightScope();
     IHqlExpression *getSelfScope();
     IHqlExpression *getSelfDotExpr(const attribute & errpos);
     IHqlExpression *resolveRows(const attribute & errpos, IHqlExpression * ds);

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -372,6 +372,8 @@ public:
     OwnedHqlExpr left;
     OwnedHqlExpr right;
     OwnedHqlExpr selSeq;
+    OwnedHqlExpr rowsScope;
+    OwnedHqlExpr rowsId;
 };
 
 extern int eclyyparse(HqlGram * parser);
@@ -837,8 +839,6 @@ protected:
     ITypeInfo *current_type;
     HqlExprArray topScopes;
     CIArrayOf<LeftRightScope> leftRightScopes;
-    HqlExprArray rowsScopes;
-    HqlExprArray rowsIds;
     HqlExprArray selfScopes;
     HqlExprArray localeStack;
     HqlExprArray localFunctionCache;
@@ -892,7 +892,7 @@ protected:
     void pushLeftRightScope(IHqlExpression * left, IHqlExpression * right);
     void pushPendingLeftRightScope(IHqlExpression * left, IHqlExpression * right);
     void setRightScope(IHqlExpression *);
-    void pushRowsScope(IHqlExpression *);
+    void beginRowsScope(node_operator side);
 
     void pushSelfScope(IHqlExpression *);
     void pushSelfScope(ITypeInfo * selfType);
@@ -905,10 +905,9 @@ protected:
     IHqlExpression * forceEnsureExprType(IHqlExpression * expr, ITypeInfo * type);
 
     void popTopScope();
+    IHqlExpression * endRowsScope();
     IHqlExpression * popLeftRightScope();
-    IHqlExpression * popRowsScope();
     void popSelfScope();
-    void swapTopScopeForLeftScope();
 
     void beginList();
     void addListElement(IHqlExpression * expr);
@@ -926,7 +925,6 @@ protected:
     IHqlExpression *getTopScope();
     IHqlExpression *queryLeftScope();
     IHqlExpression *queryRightScope();
-    IHqlExpression *queryRowsScope();
     IHqlExpression *getSelfScope();
     IHqlExpression *getSelfDotExpr(const attribute & errpos);
     IHqlExpression *resolveRows(const attribute & errpos, IHqlExpression * ds);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -2121,9 +2121,9 @@ actionStmt
                             // use an expr other than NULL to distinguish from error
                             $$.setExpr(createValue(no_loadxml, makeVoidType()), $1);
                         }
-    | UPDATE '(' startLeftSeqFilter ',' transform ')' endLeftFilter endSelectorSequence
+    | UPDATE '(' startLeftSeqFilter ',' transform ')' endSelectorSequence
                         {
-                            $$.setExpr(createValue(no_update, makeVoidType(), $3.getExpr(), $5.getExpr(), $8.getExpr()), $1);
+                            $$.setExpr(createValue(no_update, makeVoidType(), $3.getExpr(), $5.getExpr(), $7.getExpr()), $1);
                         }
     | BUILD '(' startTopFilter ',' ',' thorFilenameOrList optBuildFlags ')' endTopFilter
                         {
@@ -6786,17 +6786,17 @@ simpleDataRow
                             $$.setExpr(convertTempRowToCreateRow(parser->errorHandler, $3.pos, row));
                             $$.setPosition($1);
                         }
-    | ROW '(' startLeftSeqRow ',' recordDef ')' endLeftFilter endSelectorSequence
+    | ROW '(' startLeftSeqRow ',' recordDef ')' endSelectorSequence
                         {
                             OwnedHqlExpr row = $3.getExpr();
                             OwnedHqlExpr record = $5.getExpr();
-                            $8.release();
+                            $7.release();
                             OwnedHqlExpr transform = parser->createDefaultAssignTransform(record, row, $5);
                             $$.setExpr(createRow(no_createrow, transform.getClear()), $1);
                         }
-    | ROW '(' startLeftSeqRow ',' transform ')' endLeftFilter endSelectorSequence
+    | ROW '(' startLeftSeqRow ',' transform ')' endSelectorSequence
                         {
-                            $$.setExpr(parser->createProjectRow($3, $5, $8), $1);
+                            $$.setExpr(parser->createProjectRow($3, $5, $7), $1);
                         }
     | ROW '(' transform ')'
                         {
@@ -6824,9 +6824,9 @@ simpleDataRow
                             $$.setExpr(createRow(no_createrow, LINK(transform)));
                             $$.setPosition($1);
                         }
-    | PROJECT '(' startLeftSeqRow ',' transform ')' endLeftFilter endSelectorSequence
+    | PROJECT '(' startLeftSeqRow ',' transform ')' endSelectorSequence
                         {
-                            $$.setExpr(parser->createProjectRow($3, $5, $8), $1);
+                            $$.setExpr(parser->createProjectRow($3, $5, $7), $1);
                         }
     | GLOBAL '(' dataRow globalOpts ')'
                         {
@@ -7141,7 +7141,7 @@ simpleDataSet
                             $$.setExpr(createDatasetF(no_distribute, $3.getExpr(), value.getClear(), $11.getExpr(), NULL));
                             $$.setPosition($1);
                         }
-    | DISTRIBUTE '(' startTopFilter startDistributeAttrs ',' startRightDistributeSeqFilter endTopFilter ',' expression optKeyedDistributeAttrs ')' endRightFilter endLeftFilter endSelectorSequence
+    | DISTRIBUTE '(' startTopFilter startDistributeAttrs ',' startRightDistributeSeqFilter endTopFilter ',' expression optKeyedDistributeAttrs ')' endSelectorSequence
                         {
                             parser->normalizeExpression($9, type_boolean, false);
                             IHqlExpression * left = $3.getExpr();
@@ -7152,7 +7152,7 @@ simpleDataSet
                             if (!isKey(right))
                                 parser->reportError(ERR_EXPECTED_INDEX,$5,"Expected an index as the second parameter");
 
-                            IHqlExpression * ds = createDataset(no_keyeddistribute, left, createComma(right, cond, LINK(attr), $14.getExpr()));
+                            IHqlExpression * ds = createDataset(no_keyeddistribute, left, createComma(right, cond, LINK(attr), $12.getExpr()));
 
                             HqlExprArray leftSorts, rightSorts;
                             bool isLimitedSubstringJoin;
@@ -7168,16 +7168,16 @@ simpleDataSet
                             $$.setPosition($1);
                         }
 
-    | DISTRIBUTE '(' startTopFilter startDistributeAttrs ',' startRightDistributeSeqFilter endTopFilter optKeyedDistributeAttrs ')' endRightFilter endLeftFilter endSelectorSequence
+    | DISTRIBUTE '(' startTopFilter startDistributeAttrs ',' startRightDistributeSeqFilter endTopFilter optKeyedDistributeAttrs ')' endSelectorSequence
                         {
                             IHqlExpression * left = $3.getExpr();
                             IHqlExpression * right = $6.getExpr();
                             if (!isKey(right))
                                 parser->reportError(ERR_EXPECTED_INDEX,$6,"Expected an index as the second parameter");
 
-                            IHqlExpression * cond = parser->createDistributeCond(left, right, $6, $12);
+                            IHqlExpression * cond = parser->createDistributeCond(left, right, $6, $10);
 
-                            IHqlExpression * ds = createDataset(no_keyeddistribute, left, createComma(right, cond, $8.getExpr(), $12.getExpr()));
+                            IHqlExpression * ds = createDataset(no_keyeddistribute, left, createComma(right, cond, $8.getExpr(), $10.getExpr()));
                             //Should check that all index fields are accounted for...
 
                             $$.setExpr(ds);
@@ -7205,7 +7205,7 @@ simpleDataSet
                             $$.setExpr(createDataset(no_distribute, $3.getExpr(), value.getClear()));
                             $$.setPosition($1);
                         }
-    | JOIN '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression opt_join_transform_flags ')' endRightFilter endLeftFilter endSelectorSequence
+    | JOIN '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression opt_join_transform_flags ')' endSelectorSequence
                         {
                             parser->normalizeExpression($7, type_boolean, false);
 
@@ -7231,11 +7231,11 @@ simpleDataSet
 
                             if (!transform)
                             {
-                                IHqlExpression * seq = $12.queryExpr();
+                                IHqlExpression * seq = $10.queryExpr();
                                 transform.setown(parser->createDefJoinTransform(left,right,$1,seq,flags));
                             }
 
-                            IHqlExpression *join = createDataset(no_join, left, createComma(right, cond, createComma(transform.getClear(), flags.getClear(), $12.getExpr())));
+                            IHqlExpression *join = createDataset(no_join, left, createComma(right, cond, createComma(transform.getClear(), flags.getClear(), $10.getExpr())));
 
                             bool isLocal = join->hasProperty(localAtom);
                             parser->checkDistribution($3, left, isLocal, true);
@@ -7295,7 +7295,7 @@ simpleDataSet
                             $$.setExpr(join, $1);
                             parser->attachPendingWarnings($$);
                         }
-    | PROCESS '(' startLeftDelaySeqFilter ',' startRightRow ',' beginCounterScope transform ',' transform optCommonAttrs ')' endCounterScope endRightFilter endLeftFilter endSelectorSequence
+    | PROCESS '(' startLeftDelaySeqFilter ',' startRightRow ',' beginCounterScope transform ',' transform optCommonAttrs ')' endCounterScope endSelectorSequence
                         {
                             IHqlExpression * left = $3.getExpr();
                             IHqlExpression * right = $5.getExpr();
@@ -7305,7 +7305,7 @@ simpleDataSet
                                 attr = createComma(attr, createAttribute(_countProject_Atom, counter));
                             parser->ensureTransformTypeMatch($8, left);
                             parser->ensureTransformTypeMatch($10, right);
-                            $$.setExpr(createDataset(no_process, left, createComma(right, $8.getExpr(), $10.getExpr(), createComma(attr, $16.getExpr()))));
+                            $$.setExpr(createDataset(no_process, left, createComma(right, $8.getExpr(), $10.getExpr(), createComma(attr, $14.getExpr()))));
                             $$.setPosition($1);
                         }
     | ROLLUP '(' startTopLeftRightSeqFilter ',' expression ',' transform optCommonAttrs ')' endTopLeftRightFilter endSelectorSequence
@@ -7362,32 +7362,32 @@ simpleDataSet
                             $$.setExpr(createDataset(no_rollupgroup, $3.getExpr(), createComma($7.getExpr(), attr, $9.getExpr(), $11.getExpr())));
                             $$.setPosition($1);
                         }
-    | COMBINE '(' startLeftDelaySeqFilter ',' startRightFilter ')' endRightFilter endLeftFilter endSelectorSequence
+    | COMBINE '(' startLeftDelaySeqFilter ',' startRightFilter ')' endSelectorSequence
                         {
                             IHqlExpression * left = $3.getExpr();
                             IHqlExpression * right = $5.getExpr();
-                            IHqlExpression * transform = parser->createDefJoinTransform(parser->queryLeftScope(),parser->queryRightScope(),$1, $9.queryExpr(),NULL);
-                            IHqlExpression * combine = createDataset(no_combine, left, createComma(right, transform, $9.getExpr()));
+                            IHqlExpression * transform = parser->createDefJoinTransform(parser->queryLeftScope(),parser->queryRightScope(),$1, $7.queryExpr(),NULL);
+                            IHqlExpression * combine = createDataset(no_combine, left, createComma(right, transform, $7.getExpr()));
                             $$.setExpr(combine);
                             $$.setPosition($1);
                         }
-    | COMBINE '(' startLeftDelaySeqFilter ',' startRightFilter ',' transform optCommonAttrs ')' endRightFilter endLeftFilter endSelectorSequence
+    | COMBINE '(' startLeftDelaySeqFilter ',' startRightFilter ',' transform optCommonAttrs ')' endSelectorSequence
                         {
                             IHqlExpression * left = $3.getExpr();
                             IHqlExpression * right = $5.getExpr();
-                            IHqlExpression * combine = createDataset(no_combine, left, createComma(right, $7.getExpr(), $8.getExpr(), $12.getExpr()));
+                            IHqlExpression * combine = createDataset(no_combine, left, createComma(right, $7.getExpr(), $8.getExpr(), $10.getExpr()));
                             $$.setExpr(combine);
                             $$.setPosition($1);
                         }
-    | COMBINE '(' startLeftDelaySeqFilter ',' startRightFilter ',' startRightRowsGroup ',' transform optCommonAttrs ')' endRowsGroup endRightFilter endLeftFilter endSelectorSequence
+    | COMBINE '(' startLeftDelaySeqFilter ',' startRightFilter ',' startRightRowsGroup ',' transform optCommonAttrs ')' endRowsGroup endSelectorSequence
                         {
                             IHqlExpression * left = $3.getExpr();
                             IHqlExpression * right = $5.getExpr();
-                            IHqlExpression * combine = createDataset(no_combinegroup, left, createComma(right, $9.getExpr(), $10.getExpr(), createComma($12.getExpr(), $15.getExpr())));
+                            IHqlExpression * combine = createDataset(no_combinegroup, left, createComma(right, $9.getExpr(), $10.getExpr(), createComma($12.getExpr(), $13.getExpr())));
                             $$.setExpr(combine);
                             $$.setPosition($1);
                         }
-    | LOOP '(' startLeftRowsSeqFilter beginCounterScope ',' expression ',' dataSet endCounterScope loopOptions ')' endRowsGroup endLeftFilter endSelectorSequence
+    | LOOP '(' startLeftRowsSeqFilter beginCounterScope ',' expression ',' dataSet endCounterScope loopOptions ')' endRowsGroup endSelectorSequence
                         {
                             parser->normalizeExpression($6);
                             parser->ensureDatasetTypeMatch($8, $3.queryExpr());
@@ -7397,13 +7397,13 @@ simpleDataSet
                             IHqlExpression * counter = $9.getExpr();
                             if (counter)
                                 body = createComma(body, createAttribute(_countProject_Atom, counter));
-                            IHqlExpression * loopCondition = parser->createLoopCondition(left, $6.getExpr(), NULL, $14.queryExpr(), $12.queryExpr());
-                            IHqlExpression * loopExpr = createDataset(no_loop, left, createComma(loopCondition, body, $10.getExpr(), createComma($12.getExpr(), $14.getExpr())));
+                            IHqlExpression * loopCondition = parser->createLoopCondition(left, $6.getExpr(), NULL, $13.queryExpr(), $12.queryExpr());
+                            IHqlExpression * loopExpr = createDataset(no_loop, left, createComma(loopCondition, body, $10.getExpr(), createComma($12.getExpr(), $13.getExpr())));
                             parser->checkLoopFlags($1, loopExpr);
                             $$.setExpr(loopExpr);
                             $$.setPosition($1);
                         }
-    | LOOP '(' startLeftRowsSeqFilter beginCounterScope ',' expression ',' expression ',' dataSet endCounterScope loopOptions ')' endRowsGroup endLeftFilter endSelectorSequence
+    | LOOP '(' startLeftRowsSeqFilter beginCounterScope ',' expression ',' expression ',' dataSet endCounterScope loopOptions ')' endRowsGroup endSelectorSequence
                         {
                             parser->ensureDatasetTypeMatch($10, $3.queryExpr());
                             parser->normalizeExpression($6);
@@ -7414,13 +7414,13 @@ simpleDataSet
                             IHqlExpression * counter = $11.getExpr();
                             if (counter)
                                 body = createComma(body, createAttribute(_countProject_Atom, counter));
-                            IHqlExpression * loopCondition = parser->createLoopCondition(left, $6.getExpr(), $8.getExpr(), $16.queryExpr(), $14.queryExpr());
-                            IHqlExpression * loopExpr = createDataset(no_loop, left, createComma(loopCondition, body, $12.getExpr(), createComma($14.getExpr(), $16.getExpr())));
+                            IHqlExpression * loopCondition = parser->createLoopCondition(left, $6.getExpr(), $8.getExpr(), $15.queryExpr(), $14.queryExpr());
+                            IHqlExpression * loopExpr = createDataset(no_loop, left, createComma(loopCondition, body, $12.getExpr(), createComma($14.getExpr(), $15.getExpr())));
                             parser->checkLoopFlags($1, loopExpr);
                             $$.setExpr(loopExpr);
                             $$.setPosition($1);
                         }
-    | LOOP '(' startLeftRowsSeqFilter beginCounterScope ',' expression ',' expression ',' expression ',' dataSet endCounterScope loopOptions ')' endRowsGroup endLeftFilter endSelectorSequence
+    | LOOP '(' startLeftRowsSeqFilter beginCounterScope ',' expression ',' expression ',' expression ',' dataSet endCounterScope loopOptions ')' endRowsGroup endSelectorSequence
                         {
                             //LOOP(ds, <count>,<filter-cond>,<loop-cond>, f(rows(left)))
                             parser->ensureDatasetTypeMatch($12, $3.queryExpr());
@@ -7433,12 +7433,12 @@ simpleDataSet
                             if (counter)
                                 body = createComma(body, createAttribute(_countProject_Atom, counter));
                             IHqlExpression * loopCondition = createComma($6.getExpr(), $8.getExpr(), $10.getExpr());
-                            IHqlExpression * loopExpr = createDataset(no_loop, left, createComma(loopCondition, body, $14.getExpr(), createComma($16.getExpr(), $18.getExpr())));
+                            IHqlExpression * loopExpr = createDataset(no_loop, left, createComma(loopCondition, body, $14.getExpr(), createComma($16.getExpr(), $17.getExpr())));
                             parser->checkLoopFlags($1, loopExpr);
                             $$.setExpr(loopExpr);
                             $$.setPosition($1);
                         }
-    | GRAPH '(' startLeftRowsSeqFilter beginCounterScope ',' expression ',' dataSet endCounterScope graphOptions ')' endRowsGroup endLeftFilter endSelectorSequence
+    | GRAPH '(' startLeftRowsSeqFilter beginCounterScope ',' expression ',' dataSet endCounterScope graphOptions ')' endRowsGroup endSelectorSequence
                         {
                             parser->ensureDatasetTypeMatch($8, $3.queryExpr());
                             parser->normalizeExpression($6);
@@ -7448,18 +7448,18 @@ simpleDataSet
                             IHqlExpression * counter = $9.getExpr();
                             if (counter)
                                 body = createComma(body, createAttribute(_countProject_Atom, counter));
-                            IHqlExpression * loopExpr = createDataset(no_graphloop, left, createComma($6.getExpr(), body, $10.getExpr(), createComma($12.getExpr(), $14.getExpr())));
+                            IHqlExpression * loopExpr = createDataset(no_graphloop, left, createComma($6.getExpr(), body, $10.getExpr(), createComma($12.getExpr(), $13.getExpr())));
                             parser->checkLoopFlags($1, loopExpr);
                             $$.setExpr(loopExpr);
                             $$.setPosition($1);
                         }
-    | GRAPH '(' startLeftRowsSeqFilter ')' endRowsGroup endLeftFilter endSelectorSequence
+    | GRAPH '(' startLeftRowsSeqFilter ')' endRowsGroup endSelectorSequence
                         {
                             $5.release();
-                            $7.release();
+                            $6.release();
                             $$.setExpr(createDataset(no_forcegraph, $3.getExpr()), $1);
                         }
-    | ITERATE '(' startLeftRightSeqFilter ',' beginCounterScope transform optCommonAttrs ')' endCounterScope endLeftRightFilter endSelectorSequence
+    | ITERATE '(' startLeftRightSeqFilter ',' beginCounterScope transform optCommonAttrs ')' endCounterScope endSelectorSequence
                         {
                             parser->ensureTransformTypeMatch($6, $3.queryExpr());
 
@@ -7469,7 +7469,7 @@ simpleDataSet
                             IHqlExpression * counter = $9.getExpr();
                             if (counter)
                                 attr = createComma(attr, createAttribute(_countProject_Atom, counter));
-                            $$.setExpr(createDataset(no_iterate, ds, createComma(tr, attr, $11.getExpr())));
+                            $$.setExpr(createDataset(no_iterate, ds, createComma(tr, attr, $10.getExpr())));
                             $$.setPosition($1);
                             parser->checkDistribution($3, $$.queryExpr(), false);
                         }
@@ -7600,9 +7600,9 @@ simpleDataSet
                             $$.setExpr(createDataset(no_nonempty, args));
                             $$.setPosition($1);
                         }
-    | PROJECT '(' startLeftSeqFilter ',' beginCounterScope transform endCounterScope projectOptions ')' endLeftFilter endSelectorSequence
+    | PROJECT '(' startLeftSeqFilter ',' beginCounterScope transform endCounterScope projectOptions ')' endSelectorSequence
                         {
-                            IHqlExpression *te = createComma($6.getExpr(), $8.getExpr(), $11.getExpr());
+                            IHqlExpression *te = createComma($6.getExpr(), $8.getExpr(), $10.getExpr());
                             IHqlExpression *ds = $3.getExpr();
                             OwnedHqlExpr counter = $7.getExpr();
                             if (counter)
@@ -7610,12 +7610,12 @@ simpleDataSet
                             $$.setExpr(createDataset(no_hqlproject, ds, te));
                             $$.setPosition($1);
                         }
-    | PROJECT '(' startLeftSeqFilter ',' beginCounterScope recordDef endCounterScope projectOptions ')' endLeftFilter endSelectorSequence
+    | PROJECT '(' startLeftSeqFilter ',' beginCounterScope recordDef endCounterScope projectOptions ')' endSelectorSequence
                         {
-                            OwnedHqlExpr transform = parser->createRowAssignTransform($3, $6, $11);
+                            OwnedHqlExpr transform = parser->createRowAssignTransform($3, $6, $10);
                             $6.release();
                             $7.release();
-                            $$.setExpr(createDataset(no_hqlproject, $3.getExpr(), createComma(transform.getClear(), $8.getExpr(), $11.getExpr())));
+                            $$.setExpr(createDataset(no_hqlproject, $3.getExpr(), createComma(transform.getClear(), $8.getExpr(), $10.getExpr())));
                             $$.setPosition($1);
                         }
     | PULL '(' startTopFilter ')' endTopFilter
@@ -7623,7 +7623,7 @@ simpleDataSet
                             $$.setExpr(createDataset(no_metaactivity, $3.getExpr(), createAttribute(pullAtom)));
                             $$.setPosition($1);
                         }
-    | DENORMALIZE '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression ',' beginCounterScope transform endCounterScope optJoinFlags ')' endRightFilter endLeftFilter endSelectorSequence
+    | DENORMALIZE '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression ',' beginCounterScope transform endCounterScope optJoinFlags ')' endSelectorSequence
                         {
                             parser->normalizeExpression($7, type_boolean, false);
                             IHqlExpression * ds = $3.getExpr();
@@ -7635,17 +7635,17 @@ simpleDataSet
                                 counter = createAttribute(_countProject_Atom, counter);
 
                             //MORE: This should require local otherwise it needs to do a full join type thing.
-                            IHqlExpression * extra = createComma($5.getExpr(), $7.getExpr(), transform, createComma($12.getExpr(), counter, $16.getExpr()));
+                            IHqlExpression * extra = createComma($5.getExpr(), $7.getExpr(), transform, createComma($12.getExpr(), counter, $14.getExpr()));
                             $$.setExpr(createDataset(no_denormalize, ds, extra));
                             $$.setPosition($1);
                             parser->checkJoinFlags($1, $$.queryExpr());
                         }
-    | DENORMALIZE '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression ',' beginCounterScope startRightRowsGroup endCounterScope ',' transform optJoinFlags ')' endRowsGroup endRightFilter endLeftFilter endSelectorSequence
+    | DENORMALIZE '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression ',' beginCounterScope startRightRowsGroup endCounterScope ',' transform optJoinFlags ')' endRowsGroup endSelectorSequence
                         {
                             parser->normalizeExpression($7, type_boolean, false);
                             IHqlExpression * ds = $3.getExpr();
                             IHqlExpression * transform = $13.getExpr();
-                            IHqlExpression * extra = createComma($5.getExpr(), $7.getExpr(), transform, createComma($14.getExpr(), $16.getExpr(), $19.getExpr()));
+                            IHqlExpression * extra = createComma($5.getExpr(), $7.getExpr(), transform, createComma($14.getExpr(), $16.getExpr(), $17.getExpr()));
                             $$.setExpr(createDataset(no_denormalizegroup, ds, extra));
                             $$.setPosition($1);
                             $11.release();
@@ -7666,36 +7666,36 @@ simpleDataSet
                             $$.setExpr(createDataset(no_nothor, $3.getExpr(), NULL));
                             $$.setPosition($1);
                         }
-    | NORMALIZE '(' startLeftSeqFilter ',' expression ',' beginCounterScope transform endCounterScope optCommonAttrs ')' endLeftFilter endSelectorSequence
+    | NORMALIZE '(' startLeftSeqFilter ',' expression ',' beginCounterScope transform endCounterScope optCommonAttrs ')' endSelectorSequence
                         {
                             parser->normalizeExpression($5, type_numeric, false);
                             IHqlExpression * counter = $9.getExpr();
                             if (counter)
                                 counter = createAttribute(_countProject_Atom, counter);
-                            IHqlExpression * extra = createComma($5.getExpr(), $8.getExpr(), counter, createComma($10.getExpr(), $13.getExpr()));
+                            IHqlExpression * extra = createComma($5.getExpr(), $8.getExpr(), counter, createComma($10.getExpr(), $12.getExpr()));
                             $$.setExpr(createDataset(no_normalize, $3.getExpr(), extra));
                             $$.setPosition($1);
                         }
-    | NORMALIZE '(' startLeftSeqFilter ',' startRightFilter ',' beginCounterScope transform endCounterScope optCommonAttrs ')' endRightFilter endLeftFilter  endSelectorSequence
+    | NORMALIZE '(' startLeftSeqFilter ',' startRightFilter ',' beginCounterScope transform endCounterScope optCommonAttrs ')' endSelectorSequence
                         {
                             //NB: SelSeq is based only on the left dataset, not the right as well.
                             IHqlExpression * counter = $9.getExpr();
                             if (counter)
                                 counter = createAttribute(_countProject_Atom, counter);
-                            IHqlExpression * extra = createComma($5.getExpr(), $8.getExpr(), counter, createComma($10.getExpr(), $14.getExpr()));
+                            IHqlExpression * extra = createComma($5.getExpr(), $8.getExpr(), counter, createComma($10.getExpr(), $12.getExpr()));
                             $$.setExpr(createDataset(no_normalize, $3.getExpr(), extra));
                             $$.setPosition($1);
                         }
 /*
  * Needs more thought on the representation - so we can track distributions etc.
  * and need to implement an activity to generate it.
-    | NORMALIZE '(' startLeftSeqFilter ',' startLeftRowsGroup ',' beginCounterScope dataSet endCounterScope optCommonAttrs ')' endRowsGroup endLeftFilter endSelectorSequence
+    | NORMALIZE '(' startLeftSeqFilter ',' startLeftRowsGroup ',' beginCounterScope dataSet endCounterScope optCommonAttrs ')' endRowsGroup endSelectorSequence
                         {
                             parser->checkGrouped($3);
                             IHqlExpression * counter = $9.getExpr();
                             if (counter)
                                 counter = createAttribute(_countProject_Atom, counter);
-                            IHqlExpression *attr = createComma($10.getExpr(), $12.getExpr(), $14.getExpr());
+                            IHqlExpression *attr = createComma($10.getExpr(), $12.getExpr(), $13.getExpr());
                             $$.setExpr(createDataset(no_normalizegroup, $3.getExpr(), createComma($8.getExpr(), counter, attr)));
                             $$.setPosition($1);
                         }
@@ -7754,11 +7754,11 @@ simpleDataSet
                             $$.setExpr(createDataset(no_regroup, args));
                             $$.setPosition($1);
                         }
-    | HAVING '(' startLeftRowsSeqFilter ',' condList ')' endRowsGroup endLeftFilter endSelectorSequence
+    | HAVING '(' startLeftRowsSeqFilter ',' condList ')' endRowsGroup endSelectorSequence
                         {
                             parser->checkGrouped($3);
                             IHqlExpression *attr = NULL;        // possibly local may make sense if thor supported it as a global operation, but it would be too painful.
-                            $$.setExpr(createDataset(no_filtergroup, $3.getExpr(), createComma($5.getExpr(), attr, $7.getExpr(), $9.getExpr())));
+                            $$.setExpr(createDataset(no_filtergroup, $3.getExpr(), createComma($5.getExpr(), attr, $7.getExpr(), $8.getExpr())));
                             $$.setPosition($1);
                         }
     | KEYED '(' dataSet indexListOpt ')' endTopFilter
@@ -7816,7 +7816,7 @@ simpleDataSet
                         {
                             $$.setExpr(createDataset(no_dataset_alias, $3.getExpr(), ::createUniqueId()), $1);
                         }
-    | FETCH '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression ',' transform optCommonAttrs ')' endRightFilter endLeftFilter endSelectorSequence
+    | FETCH '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression ',' transform optCommonAttrs ')' endSelectorSequence
                         {
                             parser->normalizeExpression($7, type_int, false);
                             IHqlExpression * left = $3.getExpr();
@@ -7828,17 +7828,17 @@ simpleDataSet
                             if ((modeOp != no_thor) && (modeOp != no_flat) && (modeOp != no_csv) && (modeOp != no_xml))
                                 parser->reportError(ERR_FETCH_NON_DATASET, $3, "First parameter of FETCH should be a disk file");
 
-                            IHqlExpression *join = createDataset(no_fetch, left, createComma(right, $7.getExpr(), $9.getExpr(), createComma($10.getExpr(), $14.getExpr())));
+                            IHqlExpression *join = createDataset(no_fetch, left, createComma(right, $7.getExpr(), $9.getExpr(), createComma($10.getExpr(), $12.getExpr())));
 
                             $$.setExpr(join);
                             $$.setPosition($1);
                         }
-    | FETCH '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression optCommonAttrs ')' endRightFilter endLeftFilter endSelectorSequence
+    | FETCH '(' startLeftDelaySeqFilter ',' startRightFilter ',' expression optCommonAttrs ')' endSelectorSequence
                         {
                             parser->normalizeExpression($7, type_int, false);
                             IHqlExpression * left = $3.getExpr();
                             IHqlExpression * right = $5.getExpr();
-                            IHqlExpression * transform = parser->createDefJoinTransform(left, right, $7, $12.queryExpr(),NULL);
+                            IHqlExpression * transform = parser->createDefJoinTransform(left, right, $7, $10.queryExpr(),NULL);
 
                             node_operator modeOp = no_none;
                             if (left->getOperator() == no_table)
@@ -7846,7 +7846,7 @@ simpleDataSet
                             if ((modeOp != no_thor) && (modeOp != no_flat) && (modeOp != no_csv) && (modeOp != no_xml))
                                 parser->reportError(ERR_FETCH_NON_DATASET, $3, "First parameter of FETCH should be a disk file");
 
-                            IHqlExpression *join = createDataset(no_fetch, left, createComma(right, $7.getExpr(), transform, createComma($8.getExpr(), $12.getExpr())));
+                            IHqlExpression *join = createDataset(no_fetch, left, createComma(right, $7.getExpr(), transform, createComma($8.getExpr(), $10.getExpr())));
 
                             $$.setExpr(join);
                             $$.setPosition($1);
@@ -8606,21 +8606,21 @@ simpleDataSet
                             $$.setExpr(createDatasetF(no_executewhen, $3.getExpr(), $5.getExpr(), createAttribute(successAtom), NULL), $1);
                         }
     //Slightly unusual arrangement of the productions there to resolve s/r errors
-    | AGGREGATE '(' startLeftDelaySeqFilter ',' startRightRowsRecord ',' transform beginList ')' endRowsGroup endLeftRightFilter endSelectorSequence
+    | AGGREGATE '(' startLeftDelaySeqFilter ',' startRightRowsRecord ',' transform beginList ')' endRowsGroup endSelectorSequence
                         {
-                            $$.setExpr(parser->processUserAggregate($1, $3, $5, $7, NULL, NULL, $10, $12), $1);
+                            $$.setExpr(parser->processUserAggregate($1, $3, $5, $7, NULL, NULL, $10, $11), $1);
                         }
-    | AGGREGATE '(' startLeftDelaySeqFilter ',' startRightRowsRecord ',' transform beginList ',' sortList ')' endRowsGroup endLeftRightFilter endSelectorSequence
+    | AGGREGATE '(' startLeftDelaySeqFilter ',' startRightRowsRecord ',' transform beginList ',' sortList ')' endRowsGroup endSelectorSequence
                         {
-                            $$.setExpr(parser->processUserAggregate($1, $3, $5, $7, NULL, &$10, $12, $14), $1);
+                            $$.setExpr(parser->processUserAggregate($1, $3, $5, $7, NULL, &$10, $12, $13), $1);
                         }
-    | AGGREGATE '(' startLeftDelaySeqFilter ',' startRightRowsRecord ',' transform beginList ',' transform ')' endRowsGroup endLeftRightFilter endSelectorSequence
+    | AGGREGATE '(' startLeftDelaySeqFilter ',' startRightRowsRecord ',' transform beginList ',' transform ')' endRowsGroup endSelectorSequence
                         {
-                            $$.setExpr(parser->processUserAggregate($1, $3, $5, $7, &$10, NULL, $12, $14), $1);
+                            $$.setExpr(parser->processUserAggregate($1, $3, $5, $7, &$10, NULL, $12, $13), $1);
                         }
-    | AGGREGATE '(' startLeftDelaySeqFilter ',' startRightRowsRecord ',' transform beginList ',' transform ',' sortList ')' endRowsGroup endLeftRightFilter endSelectorSequence
+    | AGGREGATE '(' startLeftDelaySeqFilter ',' startRightRowsRecord ',' transform beginList ',' transform ',' sortList ')' endRowsGroup endSelectorSequence
                         {
-                            $$.setExpr(parser->processUserAggregate($1, $3, $5, $7, &$10, &$12, $14, $16), $1);
+                            $$.setExpr(parser->processUserAggregate($1, $3, $5, $7, &$10, &$12, $14, $15), $1);
                         }
 /*
   //This may cause s/r problems with the attribute version if a dataset name clashes with a hint id
@@ -9902,10 +9902,7 @@ startRightRowsRecord
     : recordDef
                         {
                             parser->setRightScope($1.queryExpr());                     
-
-                            OwnedHqlExpr selSeq = parser->getSelectorSequence();
-                            OwnedHqlExpr right = createSelector(no_right, parser->queryRightScope(), selSeq);
-                            parser->pushRowsScope(right);
+                            parser->beginRowsScope(no_right);
                             $$.inherit($1);
                         }
     ;
@@ -9994,9 +9991,7 @@ startLeftRowsSeqFilter
     : dataSet
                         {
                             parser->pushLeftRightScope($1.queryExpr(), NULL);
-                            OwnedHqlExpr selSeq = parser->getSelectorSequence();
-                            OwnedHqlExpr left = createSelector(no_left, parser->queryLeftScope(), selSeq);
-                            parser->pushRowsScope(left);
+                            parser->beginRowsScope(no_left);
                             $$.inherit($1);
                         }
     ;
@@ -10037,33 +10032,27 @@ endSelectorSequence
 
 startLeftRowsGroup
     : GROUP             {
-                            OwnedHqlExpr selSeq = parser->getSelectorSequence();
-                            OwnedHqlExpr left = createSelector(no_left, parser->queryLeftScope(), selSeq);
-                            parser->pushRowsScope(left);
+                            parser->beginRowsScope(no_left);
                             $$.clear();
                         }
     ;
 
 startLeftRows
     :                   {
-                            OwnedHqlExpr selSeq = parser->getSelectorSequence();
-                            OwnedHqlExpr left = createSelector(no_left, parser->queryLeftScope(), selSeq);
-                            parser->pushRowsScope(left);
+                            parser->beginRowsScope(no_left);
                             $$.clear();
                         }
     ;
 
 startRightRowsGroup
     : GROUP             {
-                            OwnedHqlExpr selSeq = parser->getSelectorSequence();
-                            OwnedHqlExpr right = createSelector(no_right, parser->queryRightScope(), selSeq);
-                            parser->pushRowsScope(right);
+                            parser->beginRowsScope(no_right);
                             $$.clear();
                         }
     ;
 
 endRowsGroup
-    :                   {   $$.setExpr(parser->popRowsScope()); }
+    :                   {   $$.setExpr(parser->endRowsScope()); }
     ;
 
 endSimpleFilter
@@ -10072,18 +10061,6 @@ endSimpleFilter
 
 endTopFilter
     :                   {   parser->popTopScope(); $$.clear(); }
-    ;
-
-endLeftFilter
-    :                   {   $$.clear(); }
-    ;
-
-endRightFilter
-    :                   {   $$.clear(); }
-    ;
-
-endLeftRightFilter
-    :                   {   $$.clear(); }
     ;
 
 endTopLeftFilter

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -9901,7 +9901,7 @@ startRightFilter
 startRightRowsRecord
     : recordDef
                         {
-                            parser->setRightScope($1.queryExpr());                     
+                            parser->setRightScope($1.queryExpr());  
                             parser->beginRowsScope(no_right);
                             $$.inherit($1);
                         }

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -441,16 +441,29 @@ void HqlGram::pushTopScope(IHqlExpression *newScope)
     insideEvaluate = false;
 }
 
-void HqlGram::pushLeftScope(IHqlExpression *newScope)
+void HqlGram::pushLeftRightScope(IHqlExpression * left, IHqlExpression * right)
 {
-    newScope->Link();
-    leftScopes.append(*newScope);
+    LeftRightScope * newScope = new LeftRightScope;
+    newScope->left.set(left);
+    newScope->right.set(right);
+    newScope->selSeq.setown(createActiveSelectorSequence(left, right));
+    leftRightScopes.append(*newScope);
 }
 
-void HqlGram::pushRightScope(IHqlExpression *newScope)
+void HqlGram::pushPendingLeftRightScope(IHqlExpression * left, IHqlExpression * right)
 {
-    newScope->Link();
-    rightScopes.append(*newScope);
+    LeftRightScope * newScope = new LeftRightScope;
+    newScope->left.set(left);
+    newScope->right.set(right);
+    leftRightScopes.append(*newScope);
+}
+
+void HqlGram::setRightScope(IHqlExpression *newScope)
+{
+    LeftRightScope & topScope = leftRightScopes.tos();
+    topScope.right.set(newScope);
+    if (!topScope.selSeq)
+        topScope.selSeq.setown(createActiveSelectorSequence(topScope.left, topScope.right));
 }
 
 void HqlGram::pushRowsScope(IHqlExpression *newScope)
@@ -481,18 +494,6 @@ void HqlGram::popTopScope()
     }
 }                                       
 
-void HqlGram::popLeftScope()
-{
-    if(leftScopes.length() > 0)
-        leftScopes.pop();
-}  
-
-void HqlGram::popRightScope()
-{
-    if(rightScopes.length() > 0)
-        rightScopes.pop();
-} 
-
 IHqlExpression * HqlGram::popRowsScope()
 {
     if(rowsScopes.length() > 0)
@@ -512,15 +513,33 @@ void HqlGram::popSelfScope()
 void HqlGram::swapTopScopeForLeftScope()
 {
     assertex(topScopes.ordinality() > 0);
-    leftScopes.append(topScopes.popGet());
-}                                       
+    pushLeftRightScope(&topScopes.popGet(), NULL);
+}
 
 IHqlExpression * HqlGram::getSelectorSequence()
 {
-    if (activeSelectorSequences.ordinality())
-        return LINK(&activeSelectorSequences.tos());
+    if (leftRightScopes.ordinality())
+        return LINK(leftRightScopes.tos().selSeq);
     //Can occur when LEFT is used in an invalid context
     return createDummySelectorSequence();
+}
+
+IHqlExpression * HqlGram::getSelector(const attribute & errpos, node_operator side)
+{
+    ForEachItemInRev(i, leftRightScopes)
+    {
+        LeftRightScope & curScope = leftRightScopes.item(i);
+        if (curScope.selSeq)
+        {
+            IHqlExpression * ds = (side == no_left) ? curScope.left : curScope.right;
+            if (ds)
+                return createSelector(side, ds, curScope.selSeq);
+        }
+    }
+    const char * sideText = (side == no_left) ? "LEFT" : "RIGHT";
+    reportError(ERR_LEFT_ILL_HERE, errpos, "%s not legal here", sideText);
+    OwnedHqlExpr selSeq = createDummySelectorSequence();
+    return createSelector(side, queryNullRecord(), selSeq);
 }
 
 void HqlGram::pushLocale(IHqlExpression *newLocale)
@@ -607,62 +626,35 @@ IHqlExpression * HqlGram::createUniqueId()
     return ::createUniqueId();
 }
 
-IHqlExpression * HqlGram::doCreateUniqueSelectorSequence()
-{
-    HqlExprArray args;
-    ForEachItemIn(i, defineScopes)
-    {
-        ActiveScopeInfo & curScope = defineScopes.item(i);
-        appendArray(args, curScope.activeParameters);
-    }
-
-    if (args.ordinality())
-    {
-        args.add(*createUniqueId(), 0);
-        return createAttribute(_selectorSequence_Atom, args);
-    }
-    return ::createUniqueSelectorSequence();
-}
-
-
-
 IHqlExpression * HqlGram::createActiveSelectorSequence(IHqlExpression * left, IHqlExpression * right)
 {
 #ifdef USE_SELSEQ_UID
     if (left || right)
     {
         HqlExprArray args;
-        if (left) args.append(*LINK(left->queryNormalizedSelector()));
-        if (right) args.append(*LINK(right->queryNormalizedSelector()));
+        if (left)
+            args.append(*LINK(left->queryNormalizedSelector()));
+        if (right)
+            args.append(*LINK(right->queryNormalizedSelector()));
         return createExprAttribute(_selectorSequence_Atom, args);
     }
 
     return ::createUniqueSelectorSequence();
-
-    return doCreateUniqueSelectorSequence();
 #else
     return createSelectorSequence();
 #endif
 }
 
-void HqlGram::pushSelectorSequence(IHqlExpression * ds1, IHqlExpression * ds2)
+IHqlExpression * HqlGram::popLeftRightScope()
 {
-    IHqlExpression * selSeq = createActiveSelectorSequence(ds1, ds2);   
-    activeSelectorSequences.append(*selSeq);
-}
+    if (leftRightScopes.ordinality())
+    {
+        LinkedHqlExpr selSeq(leftRightScopes.tos().selSeq);
+        leftRightScopes.pop();
+        return selSeq.getClear();
+    }
 
-void HqlGram::pushUniqueSelectorSequence()
-{
-    IHqlExpression * selSeq = ::createUniqueSelectorSequence();
-    activeSelectorSequences.append(*selSeq);
-}
-
-IHqlExpression * HqlGram::popSelectorSequence()
-{
-    if (activeSelectorSequences.ordinality())
-        return &activeSelectorSequences.popGet();
-    else
-        return createDummySelectorSequence();
+    return createDummySelectorSequence();
 }
 
 void HqlGram::beginList()
@@ -2589,8 +2581,7 @@ void HqlGram::releaseScopes()
     while(topScopes.length()>0)
         popTopScope();
 
-    leftScopes.kill();
-    rightScopes.kill();
+    leftRightScopes.kill();
     rowsScopes.kill();
     
     while (selfScopes.length()>0)
@@ -2769,20 +2760,6 @@ IHqlExpression *HqlGram::getTopScope()
     return ret;
 }
 
-IHqlExpression *HqlGram::getLeftScope()
-{
-    if (!leftScopes.length())
-        return NULL;
-    return &OLINK(leftScopes.tos());
-}
-
-IHqlExpression *HqlGram::getRightScope()
-{
-    if (!rightScopes.length())
-        return NULL;
-    return &OLINK(rightScopes.tos());
-}
-
 IHqlExpression *HqlGram::getSelfScope()
 {
     if (!selfScopes.length())
@@ -2794,16 +2771,24 @@ IHqlExpression *HqlGram::getSelfScope()
 
 IHqlExpression *HqlGram::queryLeftScope()
 {
-    if (!leftScopes.length())
-        return NULL;
-    return &leftScopes.tos();
+    ForEachItemInRev(i, leftRightScopes)
+    {
+        LeftRightScope & curScope = leftRightScopes.item(i);
+        if (curScope.left)
+            return curScope.left;
+    }
+    return NULL;
 }
 
 IHqlExpression *HqlGram::queryRightScope()
 {
-    if (!rightScopes.length())
-        return NULL;
-    return &rightScopes.tos();
+    ForEachItemInRev(i, leftRightScopes)
+    {
+        LeftRightScope & curScope = leftRightScopes.item(i);
+        if (curScope.right)
+            return curScope.right;
+    }
+    return NULL;
 }
 
 IHqlExpression *HqlGram::queryRowsScope()

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -8120,7 +8120,7 @@ IHqlExpression * HqlGram::checkEnsureRecordsMatch(IHqlExpression * left, IHqlExp
         return LINK(right);
     
     HqlExprArray assigns;
-    OwnedHqlExpr seq = createSelectorSequence();
+    OwnedHqlExpr seq = createActiveSelectorSequence(right, NULL);
     OwnedHqlExpr rightSelect = createSelector(no_left, right, seq);
     OwnedHqlExpr leftSelect = getSelf(left);
     if (!checkRecordCreateTransform(assigns, left->queryRecord(), leftSelect, right->queryRecord(), rightSelect, errpos))

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -634,7 +634,7 @@ IHqlExpression * HqlGram::createActiveSelectorSequence(IHqlExpression * left, IH
         HqlExprArray args;
         if (left) args.append(*LINK(left->queryNormalizedSelector()));
         if (right) args.append(*LINK(right->queryNormalizedSelector()));
-        return createAttribute(_selectorSequence_Atom, args);
+        return createExprAttribute(_selectorSequence_Atom, args);
     }
 
     return ::createUniqueSelectorSequence();

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -115,6 +115,8 @@ static IHqlExpression * optimizedReplaceSelector(IHqlExpression * expr, IHqlExpr
 }
 
 
+//oldDataset is either an active selector (e.g., no_left) or a dataset.
+//newDataset is either an active selector (e.g., no_left) or a dataset (implying activerow(dataset) or newrow(dataset).
 IHqlExpression * replaceSelector(IHqlExpression * expr, IHqlExpression * oldDataset, IHqlExpression * newDataset)
 {
     if (!expr) return NULL;
@@ -124,7 +126,6 @@ IHqlExpression * replaceSelector(IHqlExpression * expr, IHqlExpression * oldData
     IHqlExpression *ret = optimizedReplaceSelector(expr, oldDataset->queryNormalizedSelector(), newDataset);
     if (ret)
         return ret;
-
 
 #ifndef ENSURE_SELSEQ_UID
     node_operator op = oldDataset->getOperator();
@@ -158,6 +159,30 @@ void replaceSelectors(HqlExprArray & out, IHqlExpression * expr, unsigned first,
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+
+#if 0000
+void replaceSelectors(HqlExprArray & exprs, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset)
+{
+    unsigned max = exprs.ordinality();
+    unsigned iChild;
+    for (iChild = first; iChild < max; iChild++)
+    {
+        IHqlExpression *ret = optimizedReplaceSelector(&exprs.item(iChild), oldDataset->queryNormalizedSelector(), newDataset);
+        if (!ret)
+            break;
+        exprs.replace(*ret, iChild);
+    }
+
+    if (iChild == max)
+        return;
+
+    HqlMapSelectorTransformer transformer(oldDataset, newDataset);
+    for (; iChild < max; iChild++)
+        exprs.replace(*transformer.transformRoot(&exprs.item(iChild)), iChild);
+}
+
+
+#endif
 
 //NB: This can not be derived from NewHqlTransformer since it is called before the tree is normalised, and it creates
 //inconsistent expression trees.

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -127,11 +127,9 @@ IHqlExpression * replaceSelector(IHqlExpression * expr, IHqlExpression * oldData
     if (ret)
         return ret;
 
-#ifndef ENSURE_SELSEQ_UID
     node_operator op = oldDataset->getOperator();
     if (op == no_left || op == no_right)
         return newReplaceSelector(expr, oldDataset, newDataset);
-#endif
 
     HqlMapSelectorTransformer transformer(oldDataset, newDataset);
     return transformer.transformRoot(expr);

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -160,7 +160,6 @@ void replaceSelectors(HqlExprArray & out, IHqlExpression * expr, unsigned first,
 
 //---------------------------------------------------------------------------------------------------------------------
 
-#if 0000
 void replaceSelectors(HqlExprArray & exprs, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset)
 {
     unsigned max = exprs.ordinality();
@@ -181,8 +180,6 @@ void replaceSelectors(HqlExprArray & exprs, unsigned first, IHqlExpression * old
         exprs.replace(*transformer.transformRoot(&exprs.item(iChild)), iChild);
 }
 
-
-#endif
 
 //NB: This can not be derived from NewHqlTransformer since it is called before the tree is normalised, and it creates
 //inconsistent expression trees.

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -151,9 +151,21 @@ void replaceSelectors(HqlExprArray & out, IHqlExpression * expr, unsigned first,
     if (iChild == max)
         return;
 
-    HqlMapSelectorTransformer transformer(oldDataset, newDataset);
-    for (; iChild < max; iChild++)
-        out.append(*transformer.transformRoot(expr->queryChild(iChild)));
+    node_operator op = oldDataset->getOperator();
+    if (op == no_left || op == no_right)
+    {
+        NewSelectorReplacingTransformer transformer;
+        transformer.initSelectorMapping(oldDataset, newDataset);
+
+        for (; iChild < max; iChild++)
+            out.append(*transformer.transformRoot(expr->queryChild(iChild)));
+    }
+    else
+    {
+        HqlMapSelectorTransformer transformer(oldDataset, newDataset);
+        for (; iChild < max; iChild++)
+            out.append(*transformer.transformRoot(expr->queryChild(iChild)));
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -173,9 +185,21 @@ void replaceSelectors(HqlExprArray & exprs, unsigned first, IHqlExpression * old
     if (iChild == max)
         return;
 
-    HqlMapSelectorTransformer transformer(oldDataset, newDataset);
-    for (; iChild < max; iChild++)
-        exprs.replace(*transformer.transformRoot(&exprs.item(iChild)), iChild);
+    node_operator op = oldDataset->getOperator();
+    if (op == no_left || op == no_right)
+    {
+        NewSelectorReplacingTransformer transformer;
+        transformer.initSelectorMapping(oldDataset, newDataset);
+
+        for (; iChild < max; iChild++)
+            exprs.replace(*transformer.transformRoot(&exprs.item(iChild)), iChild);
+    }
+    else
+    {
+        HqlMapSelectorTransformer transformer(oldDataset, newDataset);
+        for (; iChild < max; iChild++)
+            exprs.replace(*transformer.transformRoot(&exprs.item(iChild)), iChild);
+    }
 }
 
 

--- a/ecl/hql/hqlpmap.hpp
+++ b/ecl/hql/hqlpmap.hpp
@@ -172,6 +172,7 @@ extern HQL_API IHqlExpression * replaceSelector(IHqlExpression * expr, IHqlExpre
 extern HQL_API void replaceSelectors(HqlExprArray & out, IHqlExpression * expr, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * updateChildSelectors(IHqlExpression * expr, IHqlExpression * oldSelector, IHqlExpression * newSelector, unsigned firstChild);
 extern HQL_API IHqlExpression * updateMappedFields(IHqlExpression * expr, IHqlExpression * oldRecord, IHqlExpression * newSelector, unsigned firstChild);
+//////extern HQL_API void replaceSelectors(HqlExprArray & out, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * scopedReplaceSelector(IHqlExpression * expr, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * replaceSelfRefSelector(IHqlExpression * expr, IHqlExpression * newDataset);
 

--- a/ecl/hql/hqlpmap.hpp
+++ b/ecl/hql/hqlpmap.hpp
@@ -171,7 +171,7 @@ extern HQL_API TableProjectMapper * createProjectMapper(IHqlExpression * mapping
 extern HQL_API IHqlExpression * replaceSelector(IHqlExpression * expr, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API void replaceSelectors(HqlExprArray & out, IHqlExpression * expr, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * updateChildSelectors(IHqlExpression * expr, IHqlExpression * oldSelector, IHqlExpression * newSelector, unsigned firstChild);
-extern HQL_API IHqlExpression * updateMappedFields(IHqlExpression * expr, IHqlExpression * oldRecord, IHqlExpression * newSelector, unsigned firstChild);
+extern HQL_API IHqlExpression * updateMappedFields(IHqlExpression * expr, IHqlExpression * oldSelector, IHqlExpression * newSelector, unsigned firstChild);
 extern HQL_API void replaceSelectors(HqlExprArray & out, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * scopedReplaceSelector(IHqlExpression * expr, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * replaceSelfRefSelector(IHqlExpression * expr, IHqlExpression * newDataset);

--- a/ecl/hql/hqlpmap.hpp
+++ b/ecl/hql/hqlpmap.hpp
@@ -172,7 +172,7 @@ extern HQL_API IHqlExpression * replaceSelector(IHqlExpression * expr, IHqlExpre
 extern HQL_API void replaceSelectors(HqlExprArray & out, IHqlExpression * expr, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * updateChildSelectors(IHqlExpression * expr, IHqlExpression * oldSelector, IHqlExpression * newSelector, unsigned firstChild);
 extern HQL_API IHqlExpression * updateMappedFields(IHqlExpression * expr, IHqlExpression * oldRecord, IHqlExpression * newSelector, unsigned firstChild);
-//////extern HQL_API void replaceSelectors(HqlExprArray & out, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset);
+extern HQL_API void replaceSelectors(HqlExprArray & out, unsigned first, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * scopedReplaceSelector(IHqlExpression * expr, IHqlExpression * oldDataset, IHqlExpression * newDataset);
 extern HQL_API IHqlExpression * replaceSelfRefSelector(IHqlExpression * expr, IHqlExpression * newDataset);
 

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -289,6 +289,8 @@ unsigned activityHidesSelectorGetNumNonHidden(IHqlExpression * expr, IHqlExpress
         return 0;
     case childdataset_datasetleft:
     case childdataset_left:
+        if (querySelSeq(expr) != selector->queryChild(1))
+            return 0;
         if ((op == no_left) && recordTypesMatch(selector, expr->queryChild(0)))
         {
             switch (expr->getOperator())
@@ -300,6 +302,8 @@ unsigned activityHidesSelectorGetNumNonHidden(IHqlExpression * expr, IHqlExpress
         }
         return 0;
     case childdataset_leftright:
+        if (querySelSeq(expr) != selector->queryChild(1))
+            return 0;
         if (op == no_left)
         {
             if (recordTypesMatch(selector, expr->queryChild(0)))
@@ -318,6 +322,8 @@ unsigned activityHidesSelectorGetNumNonHidden(IHqlExpression * expr, IHqlExpress
     case childdataset_same_left_right:
     case childdataset_top_left_right:
     case childdataset_nway_left_right:
+        if (querySelSeq(expr) != selector->queryChild(1))
+            return 0;
         if (recordTypesMatch(selector, expr->queryChild(0)))
             return 1;
         return 0;

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -3258,9 +3258,9 @@ IHqlExpression * updateChildSelectors(IHqlExpression * expr, IHqlExpression * ol
 }
 
 
-IHqlExpression * updateMappedFields(IHqlExpression * expr, IHqlExpression * oldRecord, IHqlExpression * newSelector, unsigned firstChild)
+IHqlExpression * updateMappedFields(IHqlExpression * expr, IHqlExpression * oldSelector, IHqlExpression * newSelector, unsigned firstChild)
 {
-    if (oldRecord == newSelector->queryRecord())
+    if (oldSelector->queryRecord() == newSelector->queryRecord())
         return LINK(expr);
 
     unsigned max = expr->numChildren();
@@ -3271,7 +3271,9 @@ IHqlExpression * updateMappedFields(IHqlExpression * expr, IHqlExpression * oldR
         args.append(*LINK(expr->queryChild(i)));
 
     NewSelectorReplacingTransformer transformer;
-    transformer.setRootMapping(newSelector, newSelector, oldRecord);
+    if (oldSelector != newSelector)
+        transformer.initSelectorMapping(oldSelector, newSelector);
+    transformer.setRootMapping(newSelector, newSelector, oldSelector->queryRecord());
     bool same = true;
     for (; i < max; i++)
     {

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -258,9 +258,6 @@ extern HQL_API bool isTransformTracing() { return tracing; }
 //if it does return the number of arguments that aren't hidden
 unsigned activityHidesSelectorGetNumNonHidden(IHqlExpression * expr, IHqlExpression * selector)
 {
-#ifdef ENSURE_SELSEQ_UID
-    return 0;
-#endif
     if (!selector)
         return 0;
     node_operator op = selector->getOperator();
@@ -1995,9 +1992,7 @@ HqlMapSelectorTransformer::HqlMapSelectorTransformer(IHqlExpression * oldDataset
         newDataset.setown(ensureActiveRow(newDataset));
 
     node_operator op = oldDataset->getOperator();
-#ifndef ENSURE_SELSEQ_UID
     assertex(op != no_left && op != no_right);
-#endif
     if (oldDataset->isDatarow() || (op == no_activetable) || (op == no_selfref))
     {
         setMappingOnly(oldDataset, newDataset);
@@ -2483,10 +2478,6 @@ bool onlyTransformOnce(IHqlExpression * expr)
     case no_sequence:
     case no_self:
     case no_selfref:
-#ifdef ENSURE_SELSEQ_UID
-    case no_left:
-    case no_right:
-#endif
     case no_flat:
     case no_any:
     case no_existsgroup:

--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -424,7 +424,7 @@ protected:
 //---------------------------------------------------------------------------
 
 //This class is used for applying transformations to trees that have already been normalized, or
-//that need to assocaite extra information with the the expressions being transformed
+//that need to associate extra information with the the expressions being transformed
 //If the transformer inserts,swaps or hoists expressions then it should ensure that createTransformed()
 //processes the annotations and the body at the same time - otherwise they can become separated.
 class HQL_API NewHqlTransformer : public ANewHqlTransformer
@@ -943,34 +943,6 @@ class HQL_API HqlScopedMapSelectorTransformer : public MergingHqlTransformer
 public:
     HqlScopedMapSelectorTransformer (IHqlExpression * oldValue, IHqlExpression * newValue);
 };
-
-
-#if 0
-class HQL_API SelectorReplacingTransformer : public MergingHqlTransformer
-{
-public:
-    SelectorReplacingTransformer();
-
-    void initSelectorMapping(IHqlExpression * oldValue, IHqlExpression * newValue);
-
-    virtual IHqlExpression * createTransformed(IHqlExpression * expr);
-
-    inline bool foundAmbiguity() const { return introducesAmbiguity; }
-
-protected:
-    void updateMapping();
-    virtual void pushChildContext(IHqlExpression * expr, IHqlExpression * transformed);
-
-protected:
-    OwnedHqlExpr oldSelector;
-    OwnedHqlExpr newSelector;
-    OwnedHqlExpr oldDataset;
-    OwnedHqlExpr newDataset;
-    bool isHidden;
-    bool introducesAmbiguity;
-    IHqlExpression * savedNewDataset;
-};
-#endif
 
 
 class HQL_API NewSelectorReplacingInfo : public NewTransformInfo

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -3449,6 +3449,14 @@ bool debugFindFirstDifference(IHqlExpression * left, IHqlExpression * right)
     return foundDifference();//something else
 }
 
+void debugTrackDifference(IHqlExpression * expr)
+{
+    static IHqlExpression * prev;
+    if (prev && prev != expr)
+        debugFindFirstDifference(prev, expr);
+    prev = expr;
+}
+
 //------------------------------------------------------------------------------------------------
 
 static IHqlExpression * expandConditions(IHqlExpression * expr, DependenciesUsed & dependencies, HqlExprArray & conds, HqlExprArray & values)

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -3415,7 +3415,19 @@ bool debugFindFirstDifference(IHqlExpression * left, IHqlExpression * right)
             return foundDifference();       // break point here.
         }
 
-        return foundDifference();       // break point here.
+        IHqlExpression * leftBody = left->queryBody(true);
+        IHqlExpression * rightBody = right->queryBody(true);
+        annotate_kind leftAK = left->getAnnotationKind();
+        annotate_kind rightAK = right->getAnnotationKind();
+        if (leftBody != rightBody)
+        {
+            if ((left == leftBody) || (right == rightBody))
+                return foundDifference();  // one side has an annotation, the other doesn't
+            return debugFindFirstDifference(leftBody, rightBody);
+        }
+        if (leftAK != rightAK)
+            return foundDifference();  // different annotation
+        return foundDifference();  // some difference in the annotation details
     }
     if (left->getOperator() != right->getOperator())
         return foundDifference();

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -606,6 +606,7 @@ extern HQL_API void encryptEclAttribute(IStringVal & out, size32_t len, const vo
 extern void decryptEclAttribute(MemoryBuffer & out, const char * in);
 
 extern HQL_API bool debugFindFirstDifference(IHqlExpression * left, IHqlExpression * right);
+extern HQL_API void debugTrackDifference(IHqlExpression * expr);
 
 extern HQL_API StringBuffer & convertToValidLabel(StringBuffer &out, const char * in, unsigned inlen);
 extern HQL_API bool arraysSame(CIArray & left, CIArray & right);

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1684,6 +1684,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.shuffleLocalJoinConditions,"shuffleLocalJoinConditions",false),
         DebugOption(options.projectNestedTables,"projectNestedTables",true),
         DebugOption(options.showSeqInGraph,"showSeqInGraph",false),  // For tracking down why projects are not commoned up
+        DebugOption(options.normalizeSelectorSequence,"normalizeSelectorSequence",false),  // For tracking down why projects are not commoned up
     };
 
     //get options values from workunit

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1683,6 +1683,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.reportFieldUsage,"reportFieldUsage",false),
         DebugOption(options.shuffleLocalJoinConditions,"shuffleLocalJoinConditions",false),
         DebugOption(options.projectNestedTables,"projectNestedTables",true),
+        DebugOption(options.showSeqInGraph,"showSeqInGraph",false),  // For tracking down why projects are not commoned up
     };
 
     //get options values from workunit

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -712,6 +712,7 @@ struct HqlCppOptions
     bool                reportFieldUsage;
     bool                shuffleLocalJoinConditions;
     bool                projectNestedTables;
+    bool                showSeqInGraph;
 };
 
 //Any information gathered while processing the query should be moved into here, rather than cluttering up the translator class

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -713,6 +713,7 @@ struct HqlCppOptions
     bool                shuffleLocalJoinConditions;
     bool                projectNestedTables;
     bool                showSeqInGraph;
+    bool                normalizeSelectorSequence;
 };
 
 //Any information gathered while processing the query should be moved into here, rather than cluttering up the translator class

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -2158,6 +2158,14 @@ void ActivityInstance::createGraphNode(IPropertyTree * defaultSubGraph, bool alw
     if (translator.queryOptions().includeHelperInGraph)
         addAttribute("helper", factoryName);
 
+    if (translator.queryOptions().showSeqInGraph)
+    {
+        IHqlExpression * selSeq = querySelSeq(dataset);
+        if (selSeq)
+            addAttributeInt("selSeq", selSeq->querySequenceExtra());
+    }
+
+
     if (translator.queryOptions().showMetaInGraph)
     {
         StringBuffer s;

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -935,11 +935,7 @@ static int compareHqlExprPtr(IInterface * * left, IInterface * * right)
 
 //------------------------------------------------------------------------
 
-#ifdef USE_MERGE
-ImplicitProjectInfo::ImplicitProjectInfo(IHqlExpression * _original, ProjectExprKind _kind) : MergingTransformInfo(_original), kind(_kind)
-#else
 ImplicitProjectInfo::ImplicitProjectInfo(IHqlExpression * _original, ProjectExprKind _kind) : NewTransformInfo(_original), kind(_kind)
-#endif
 {
     visited = false;
     gatheredSelectsUsed = false;
@@ -1232,11 +1228,7 @@ void ComplexImplicitProjectInfo::setMatchingOutput(ComplexImplicitProjectInfo * 
 
 static HqlTransformerInfo implicitProjectTransformerInfo("ImplicitProjectTransformer");
 ImplicitProjectTransformer::ImplicitProjectTransformer(HqlCppTranslator & _translator, bool _optimizeSpills)
-#ifdef USE_MERGE
-: MergingHqlTransformer(implicitProjectTransformerInfo), translator(_translator)
-#else
 : NewHqlTransformer(implicitProjectTransformerInfo), translator(_translator)
-#endif
 {
     const HqlCppOptions & transOptions = translator.queryOptions();
     targetClusterType = translator.getTargetClusterType();
@@ -2662,28 +2654,7 @@ void ImplicitProjectTransformer::logChange(const char * message, IHqlExpression 
 
 void ImplicitProjectTransformer::getTransformedChildren(IHqlExpression * expr, HqlExprArray & children)
 {
-    switch (getChildDatasetType(expr))
-    {
-#ifdef USE_MERGE
-    case childdataset_dataset: 
-    case childdataset_datasetleft: 
-    case childdataset_top_left_right:
-        {
-            IHqlExpression * arg0 = expr->queryChild(0);
-            OwnedHqlExpr child = transform(arg0);
-            children.append(*LINK(child));
-            pushChildContext(arg0, child);
-            transformChildren(expr, children);
-            popChildContext();
-            break;
-        }
-#endif
-    case childdataset_evaluate:
-        throwUnexpected();
-    default:
-        transformChildren(expr, children);
-        break;
-    }
+    transformChildren(expr, children);
 }
 
 IHqlExpression * ImplicitProjectTransformer::createParentTransformed(IHqlExpression * expr)

--- a/ecl/hqlcpp/hqliproj.ipp
+++ b/ecl/hqlcpp/hqliproj.ipp
@@ -26,6 +26,7 @@
 #include "hqlutil.hpp"
 
 //#define USE_IPROJECT_HASH
+//#define USE_MERGE
 
 enum ProjectExprKind
 {
@@ -228,7 +229,11 @@ struct ImplicitProjectOptions
 class ImplicitProjectInfo;
 
 class ComplexImplicitProjectInfo;
+#ifdef USE_MERGE
 class ImplicitProjectInfo : public MergingTransformInfo
+#else
+class ImplicitProjectInfo : public NewTransformInfo
+#endif
 {
 public:
     ImplicitProjectInfo(IHqlExpression * _original, ProjectExprKind _kind);
@@ -338,11 +343,15 @@ public:
 public:
 };
 
-//MORE: Could remove dependency on insideCompound if it was ok to have compound operators scattered through the
-//      contents of a compound item.  Probably would cause few problems, and would make life simpler
+#ifdef USE_MERGE
 class ImplicitProjectTransformer : public MergingHqlTransformer
 {
     typedef MergingHqlTransformer Parent;
+#else
+class ImplicitProjectTransformer : public NewHqlTransformer
+{
+    typedef NewHqlTransformer Parent;
+#endif
 
 public:
     ImplicitProjectTransformer(HqlCppTranslator & _translator, bool _optimizeSpills);
@@ -364,6 +373,7 @@ protected:
 
     void calculateFieldsUsed(IHqlExpression * expr);
     void connect(IHqlExpression * source, IHqlExpression * sink);
+    IHqlExpression * createParentTransformed(IHqlExpression * expr);
     void finalizeFields();
     void finalizeFields(IHqlExpression * expr);
     void gatherFieldsUsed(IHqlExpression * expr, ImplicitProjectInfo * extra);

--- a/ecl/hqlcpp/hqliproj.ipp
+++ b/ecl/hqlcpp/hqliproj.ipp
@@ -26,7 +26,6 @@
 #include "hqlutil.hpp"
 
 //#define USE_IPROJECT_HASH
-//#define USE_MERGE
 
 enum ProjectExprKind
 {
@@ -229,11 +228,7 @@ struct ImplicitProjectOptions
 class ImplicitProjectInfo;
 
 class ComplexImplicitProjectInfo;
-#ifdef USE_MERGE
-class ImplicitProjectInfo : public MergingTransformInfo
-#else
 class ImplicitProjectInfo : public NewTransformInfo
-#endif
 {
 public:
     ImplicitProjectInfo(IHqlExpression * _original, ProjectExprKind _kind);
@@ -343,15 +338,9 @@ public:
 public:
 };
 
-#ifdef USE_MERGE
-class ImplicitProjectTransformer : public MergingHqlTransformer
-{
-    typedef MergingHqlTransformer Parent;
-#else
 class ImplicitProjectTransformer : public NewHqlTransformer
 {
     typedef NewHqlTransformer Parent;
-#endif
 
 public:
     ImplicitProjectTransformer(HqlCppTranslator & _translator, bool _optimizeSpills);

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -2335,7 +2335,6 @@ protected:
 
     void gatherAmbiguousSelectors(IHqlExpression * expr)
     {
-#ifndef ENSURE_SELSEQ_UID
         //Horrible code to try and cope with ambiguous left selectors.
         //o Tree is ambiguous so same child expression can occur in different contexts - so can't depend on the context it is found in to work out if can hoist
         //o If any selector that is hidden within child expressions matches one in scope then can't hoist it.
@@ -2401,8 +2400,6 @@ protected:
                 break;
             }
         }
-
-#endif
     }
 
     bool isEvaluateable(IHqlExpression * ds, bool ignoreInline = false)

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -9377,10 +9377,6 @@ void LeftRightTransformInfo::inherit(const LeftRightTransformInfo * other)
 }
 
 
-/*
-This transformer is responsible for reducing the number of selseq used as sequence numbers - so that they only remain
-when nesting makes the selectors ambiguous.  That allows expressions to be commoned up that wouldn't otherwise.
-*/
 static HqlTransformerInfo LeftRightTransformerInfo("LeftRightTransformer");
 LeftRightTransformer::LeftRightTransformer() : NewHqlTransformer(LeftRightTransformerInfo)
 {

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -11788,10 +11788,9 @@ IHqlExpression * HqlTreeNormalizer::createTransformedBody(IHqlExpression * expr)
 #ifdef USE_SELSEQ_UID
             if (name == _selectorSequence_Atom)
             {
-#ifndef ENSURE_SELSEQ_UID
+                //Purely for testing what effect adding the unique sequences has on the parse time
                 if (options.simplifySelectorSequence)
                     return createDummySelectorSequence();
-#endif
 
                 //Ensure parameterised sequences generate a unique sequence number...
                 //Not sure the following is really necessary, but will reduce in memory tree size....
@@ -12031,7 +12030,6 @@ void normalizeHqlTree(HqlCppTranslator & translator, HqlExprArray & exprs)
     }
 
 #ifdef USE_SELSEQ_UID
-#ifndef ENSURE_SELSEQ_UID
     if (translator.queryOptions().detectAmbiguousSelector || translator.queryOptions().allowAmbiguousSelector)
     {
         LeftRightSelectorNormalizer transformer(translator.queryOptions().allowAmbiguousSelector);
@@ -12045,7 +12043,6 @@ void normalizeHqlTree(HqlCppTranslator & translator, HqlExprArray & exprs)
             replaceArray(exprs, transformed);
         }
     }
-#endif
 #endif
 
     if (false)
@@ -12313,6 +12310,7 @@ bool HqlCppTranslator::transformGraphForGeneration(IHqlExpression * query, Workf
     checkNormalized(workflow);
     DEBUG_TIMER("EclServer: tree transform: stored results", msTick()-time4);
 
+#ifdef NORMALIZE_SELSEQ
 #ifdef USE_SELSEQ_UID
     {
         unsigned time = msTick();
@@ -12324,6 +12322,7 @@ bool HqlCppTranslator::transformGraphForGeneration(IHqlExpression * query, Workf
         DEBUG_TIMERX(queryTimeReporter(), "EclServer: tree transform: left right", msTick()-time);
         //traceExpressions("after implicit alias", workflow);
     }
+#endif
 #endif
 
     if (queryOptions().createImplicitAliases)

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -854,6 +854,8 @@ public:
 public:
     CIArrayOf<SharedTableInfo> sharedTables;
     Owned<SharedTableInfo> shared;
+    OwnedHqlExpr        rawLeft;
+    OwnedHqlExpr        rawRight;
     bool                containsAmbiguity;
 };
 
@@ -878,6 +880,51 @@ protected:
 protected:
     CIArrayOf<SharedTableInfo> ambiguousTables;
     bool seenAmbiguity;
+    bool seenShared;
+};
+
+//---------------------------------------------------------------------------
+
+class LeftRightTransformInfo : public NewTransformInfo
+{
+public:
+    LeftRightTransformInfo(IHqlExpression * _expr) : NewTransformInfo(_expr) { containsAmbiguity = false; }
+
+    void add(SharedTableInfo * table);
+    void addAmbiguity(SharedTableInfo * table);
+    void inherit(const LeftRightTransformInfo * other);
+    void merge(SharedTableInfo * table);
+    bool noteUsed(IHqlExpression * seq);
+    SharedTableInfo * uses(IHqlExpression * tableBody) const;
+
+public:
+    CIArrayOf<SharedTableInfo> sharedTables;
+    Owned<SharedTableInfo> shared;
+    HqlExprCopyArray    seqs;
+    OwnedHqlExpr        rawLeft;
+    OwnedHqlExpr        rawRight;
+    bool                containsAmbiguity;
+};
+
+
+class LeftRightTransformer : public NewHqlTransformer
+{
+public:
+    LeftRightTransformer();
+
+    void process(HqlExprArray & exprs);
+
+protected:
+    virtual void analyseExpr(IHqlExpression * expr);
+    virtual ANewTransformInfo * createTransformInfo(IHqlExpression * expr);
+    virtual IHqlExpression * createTransformed(IHqlExpression * expr);
+
+    inline LeftRightTransformInfo * queryExtra(IHqlExpression * expr)  { return (LeftRightTransformInfo *)queryTransformExtra(expr); }
+    SharedTableInfo * createAmbiguityInfo(IHqlExpression * dataset, unsigned depth);
+    void incUsage(IHqlExpression * expr, IHqlExpression * seq);
+
+protected:
+    CIArrayOf<SharedTableInfo> ambiguousTables;
     bool seenShared;
 };
 

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -907,6 +907,10 @@ public:
 };
 
 
+/*
+This transformer is responsible for reducing the number of selseq used as sequence numbers - so that they only remain
+when nesting makes the selectors ambiguous.  That allows expressions to be commoned up that wouldn't otherwise.
+*/
 class LeftRightTransformer : public NewHqlTransformer
 {
 public:

--- a/ecl/regress/nestedjoin.ecl
+++ b/ecl/regress/nestedjoin.ecl
@@ -1,0 +1,52 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+
+idRecord := RECORD
+    UNSIGNED f2;
+END;
+
+parentRecord := RECORD
+   UNSIGNED f1;
+   DATASET(idRecord) children;
+END;
+
+ds1 := DATASET([
+    {1, [1,2,3] },
+    {2, [2,3,4] },
+    {3, [3] }], parentRecord);
+    
+ds2 := DATASET([
+    {1, [5, 3, 8]},
+    {2, [1,6] },
+    {3, []}], parentRecord);
+    
+j1 := JOIN(ds1, ds2, LEFT.f1 = RIGHT.f1 AND EXISTS(JOIN(LEFT.children, RIGHT.children, LEFT.f2 = RIGHT.f2)));
+
+jchild(parentRecord l, parentRecord r) := JOIN(l.children, r.children, LEFT.f2 = RIGHT.f2);
+j2 := JOIN(ds1, ds2, LEFT.f1 = RIGHT.f1 AND EXISTS(jchild(LEFT, RIGHT)));
+
+
+//LEFT is not valid as the second argument to the join until the right argument has been processed!
+j3 := JOIN(ds1, ds2, LEFT.f1 = RIGHT.f1 AND EXISTS(JOIN(LEFT.children, LEFT.children(f2 > 10), LEFT.f2 = RIGHT.f2)));
+
+sequential(
+    output(j1);
+    output(j2);
+    output(j3);
+);


### PR DESCRIPTION
Addresses issue #2864.  This fixes examples ambigleft.ecl and grouproll6.ecl are fixed by these changes.

This branch is very close to being ready to pull.  There are a few known issues:
- Memory consumption is much higher.  There are other branches trying to address that.

Some examples from internal .
jholt20 - unique selectors are generated before global constant folding, which means that some expressions  that would become identical are treated as different.

qrec - a two projects are pushed down the graph (over if branches), and would become common if they had the same sequence.

saltstep - converting exists(topn) to exists(choosen) could be  more efficient, but leads to an extra activity.

jwindle1 project doesn't get moved down the tree.
