### PR TITLE
Fix gh-2888 add superfile operations to esp log

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -149,9 +149,6 @@
                 <form id="listitems" action="/WsDfu/SuperfileAction">
                 <xsl:apply-templates select="subfiles" mode="list"/>
                 <input type="hidden" name="superfile" value="{Name}"/>
-                </form>
-                <form action="/WsDfu/SuperfileAddRaw">
-                <input type="hidden" name="superfile" value="{Name}"/>
                 <p/>
                 <table xmlns="" name="table1">
                 <xsl:if test="string-length(Wuid)">

--- a/esp/eclwatch/ws_XSLT/dfu_superedit.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_superedit.xslt
@@ -78,9 +78,6 @@
             <form id="listitems" action="/WsDfu/SuperfileAction">
             <xsl:apply-templates select="subfiles" mode="list"/>
             <input type="hidden" name="superfile" value="{superfile}"/>
-            </form>
-            <form action="/WsDfu/SuperfileAddRaw">
-            <input type="hidden" name="superfile" value="{superfile}"/>
             <p/>
             <table xmlns="" name="table1">
             <tr>

--- a/esp/eclwatch/ws_XSLT/dfu_superresult.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_superresult.xslt
@@ -41,26 +41,22 @@
 <th align="left">
 <h2>Operation Result</h2>
 </th>
-<tr>
-<td>
-        <xsl:choose>
-            <xsl:when test="retcode=0">
-                <xsl:value-of select="superfile"/> operation succeeded.
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="rtitle"/> operation failed.
-            </xsl:otherwise>
-        </xsl:choose>
-</td>
-</tr>
-<tr>
-<td>
-<br/>
-<br/>
-<!--a href="javascript:go('/WsDfu/SuperfileList?superfile={superfile}')"><xsl:value-of select="superfile"/></a-->
-<a href="javascript:go('/WsDfu/DFUInfo?Name={superfile}')"><xsl:value-of select="superfile"/></a>
-</td>
-</tr>
+    <tr>
+        <td>
+            <xsl:value-of select="superfile"/> operation succeeded.
+        </td>
+    </tr>
+    <xsl:if test="retcode=0">
+        <tr>
+            <td>
+                <br/>
+                <br/>
+                <a href="javascript:go('/WsDfu/DFUInfo?Name={superfile}')">
+                    <xsl:value-of select="superfile"/>
+                </a>
+            </td>
+        </tr>
+    </xsl:if>
 </tbody>
 </table>
 

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -647,7 +647,6 @@ ESPservice [
 
     ESPmethod [resp_xsl_default("/esp/xslt/addto_superfile.xslt")] AddtoSuperfile(AddtoSuperfileRequest, AddtoSuperfileResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/dfu_superedit.xslt")] SuperfileList(SuperfileListRequest, SuperfileListResponse);
-    ESPmethod [resp_xsl_default("/esp/xslt/dfu_superresult.xslt")] SuperfileAddRaw(SuperfileAddRawRequest, SuperfileAddRawResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/dfu_superresult.xslt")] SuperfileAction(SuperfileActionRequest, SuperfileActionResponse);
     
     ESPmethod Savexml(SavexmlRequest, SavexmlResponse);

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -978,8 +978,8 @@ void CWsDfuEx::parseStringArray(const char *input, StringArray& strarray)
     if (!input || !*input)
         return;
 
-    char *ptr = (char *) input;
-    char *pptr = ptr;
+    const char *ptr = input;
+    const char *pptr = ptr;
     while (pptr[0])
     {
         if (pptr[0] == ',')
@@ -997,8 +997,6 @@ void CWsDfuEx::parseStringArray(const char *input, StringArray& strarray)
         tmp.set(ptr, pptr-ptr);
         strarray.append(tmp.get());
     }
-
-    return;
 }
 
 int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
@@ -1032,12 +1030,12 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
         if (existingSuperfile)
         {
             if (!df)
-                  throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",superfile);
+                throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",superfile);
             if(!df->querySuperFile())
-                  throw MakeStringException(ECLWATCH_NOT_SUPERFILE,"%s is not a superfile.",superfile);
+                throw MakeStringException(ECLWATCH_NOT_SUPERFILE,"%s is not a superfile.",superfile);
         }
         else if (df)
-            throw MakeStringException(ECLWATCH_FILE_ALREADY_EXISTS,"The file %s has already existed.",superfile);
+            throw MakeStringException(ECLWATCH_FILE_ALREADY_EXISTS,"The file %s already exists.",superfile);
     }
 
     StringBuffer msg;

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1046,12 +1046,11 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
 
     unsigned filesInMsgBuf = 0;
     StringBuffer msgBuf = msgHead;
-    const char** ptrs = (const char**)alloca(sizeof(char*)*num);
+    PointerArrayOf<char> subfileArray;
     for(unsigned i = 0; i < num; i++)
     {
-        ptrs[i] = subfiles.item(i);
-
-        msgBuf.appendf("%s, ", ptrs[i]);
+        subfileArray.append((char*) subfiles.item(i));
+        msgBuf.appendf("%s, ", subfiles.item(i));
         filesInMsgBuf++;
         if (filesInMsgBuf > 9)
         {
@@ -1068,9 +1067,9 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
 
     synchronized block(m_superfilemutex);
     if(strieq(action, "add"))
-        dfuhelper->addSuper(superfile, num, ptrs, beforeSubFile, userdesc.get());
+        dfuhelper->addSuper(superfile, num, (const char**) subfileArray.getArray(), beforeSubFile, userdesc.get());
     else
-        dfuhelper->removeSuper(superfile, num, ptrs, deleteFile, userdesc.get());
+        dfuhelper->removeSuper(superfile, num, (const char**) subfileArray.getArray(), deleteFile, userdesc.get());
 
     return num;
 }

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1038,20 +1038,31 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
             throw MakeStringException(ECLWATCH_FILE_ALREADY_EXISTS,"The file %s already exists.",superfile);
     }
 
-    StringBuffer msg;
+    StringBuffer msgHead;
     if(username.length() > 0)
-        msg.appendf("CWsDfuEx::SuperfileAction User=%s Action=%s, Superfile=%s Subfile(s)= ", username.str(), action, superfile);
+        msgHead.appendf("CWsDfuEx::SuperfileAction User=%s Action=%s, Superfile=%s Subfile(s)= ", username.str(), action, superfile);
     else
-        msg.appendf("CWsDfuEx::SuperfileAction User=<unknown> Action=%s, Superfile=%s Subfile(s)= ", action, superfile);
+        msgHead.appendf("CWsDfuEx::SuperfileAction User=<unknown> Action=%s, Superfile=%s Subfile(s)= ", action, superfile);
 
+    unsigned filesInMsgBuf = 0;
+    StringBuffer msgBuf = msgHead;
     const char** ptrs = (const char**)alloca(sizeof(char*)*num);
     for(unsigned i = 0; i < num; i++)
     {
         ptrs[i] = subfiles.item(i);
-        msg.appendf("%s, ", ptrs[i]);
+
+        msgBuf.appendf("%s, ", ptrs[i]);
+        filesInMsgBuf++;
+        if (filesInMsgBuf > 9)
+        {
+            PROGLOG(msgBuf.str());
+            msgBuf = msgHead;
+            filesInMsgBuf = 0;
+        }
     }
 
-    PROGLOG(msg.str());
+    if (filesInMsgBuf > 0)
+        PROGLOG(msgBuf.str());
 
     Owned<IDFUhelper> dfuhelper = createIDFUhelper();
 

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -973,6 +973,99 @@ bool CWsDfuEx::setSpaceItemByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuf
     return true;
 }
 
+void CWsDfuEx::parseStringArray(const char *input, StringArray& strarray)
+{
+    if (!input || !*input)
+        return;
+
+    char *ptr = (char *) input;
+    char *pptr = ptr;
+    while (pptr[0])
+    {
+        if (pptr[0] == ',')
+        {
+            StringAttr tmp;
+            tmp.set(ptr, pptr-ptr);
+            strarray.append(tmp.get());
+            ptr = pptr + 1;
+        }
+        pptr++;
+    }
+    if (pptr > ptr)
+    {
+        StringAttr tmp;
+        tmp.set(ptr, pptr-ptr);
+        strarray.append(tmp.get());
+    }
+
+    return;
+}
+
+int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
+                               const char* beforeSubFile, bool existingSuperfile, bool deleteFile)
+{
+    if (!action || !*action)
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Superfile action not specified");
+
+    if(!strieq(action, "add") && !strieq(action, "remove"))
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Only Add or Remove is allowed.");
+
+    if (!superfile || !*superfile)
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Superfile name not specified");
+
+    unsigned num = subfiles.length();
+    if (num < 1)
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Subfile not specified");
+
+    StringBuffer username;
+    context.getUserID(username);
+    Owned<IUserDescriptor> userdesc;
+    if(username.length() > 0)
+    {
+        const char* passwd = context.queryPassword();
+        userdesc.setown(createUserDescriptor());
+        userdesc->set(username.str(), passwd);
+    }
+
+    {//a file lock created by the lookup() will be released after '}'
+        Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(superfile, userdesc.get(), true);   
+        if (existingSuperfile)
+        {
+            if (!df)
+                  throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",superfile);
+            if(!df->querySuperFile())
+                  throw MakeStringException(ECLWATCH_NOT_SUPERFILE,"%s is not a superfile.",superfile);
+        }
+        else if (df)
+            throw MakeStringException(ECLWATCH_FILE_ALREADY_EXISTS,"The file %s has already existed.",superfile);
+    }
+
+    StringBuffer msg;
+    if(username.length() > 0)
+        msg.appendf("CWsDfuEx::SuperfileAction User=%s Action=%s, Superfile=%s Subfile(s)= ", username.str(), action, superfile);
+    else
+        msg.appendf("CWsDfuEx::SuperfileAction User=<unknown> Action=%s, Superfile=%s Subfile(s)= ", action, superfile);
+
+    const char** ptrs = (const char**)alloca(sizeof(char*)*num);
+    for(unsigned i = 0; i < num; i++)
+    {
+        ptrs[i] = subfiles.item(i);
+        msg.appendf("%s, ", ptrs[i]);
+    }
+
+    PROGLOG(msg.str());
+
+    Owned<IDFUhelper> dfuhelper = createIDFUhelper();
+
+    synchronized block(m_superfilemutex);
+    if(strieq(action, "add"))
+        dfuhelper->addSuper(superfile, num, ptrs, beforeSubFile, userdesc.get());
+    else
+        dfuhelper->removeSuper(superfile, num, ptrs, deleteFile, userdesc.get());
+
+    return num;
+}
+
 bool CWsDfuEx::onAddtoSuperfile(IEspContext &context, IEspAddtoSuperfileRequest &req, IEspAddtoSuperfileResponse &resp)
 {
     try
@@ -980,162 +1073,51 @@ bool CWsDfuEx::onAddtoSuperfile(IEspContext &context, IEspAddtoSuperfileRequest 
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Write, false))
             throw MakeStringException(ECLWATCH_DFU_ACCESS_DENIED, "Failed to AddtoSuperfile. Permission denied.");
 
-        StringBuffer username;
-        context.getUserID(username);
-
-        Owned<IUserDescriptor> userdesc;
-        if(username.length() > 0)
-        {
-            const char* passwd = context.queryPassword();
-            userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), passwd);
-        }
-
-        resp.setSubfiles(req.getSubfiles());
-
         double version = context.getClientVersion();
-        if (version > 1.15)
-        {
-            StringArray fileNames;
-            const char* files = req.getSubfiles();
-
-            if (files && *files)
-            {
-                char* pTr = (char*) files;
-                while (pTr)
-                {
-                    char* ppTr = strchr(pTr, ',');
-                    if (!ppTr)
-                    {
-                        fileNames.append(pTr);
-                        break;
-                    }
-
-                    if (ppTr - pTr > 1)
-                    {
-                        char fileName[255];
-                        strncpy(fileName, pTr, ppTr - pTr);
-                        fileName[ppTr - pTr] = 0;
-                        fileNames.append(fileName);
-                    }
-                    pTr = ppTr+1;
-                }
-                
-                if (fileNames.length() > 0)
-                    resp.setSubfileNames(fileNames);
-            }
-        }
         if (version > 1.17)
         {
             const char* backTo = req.getBackToPage();
             if (backTo && *backTo)
                 resp.setBackToPage(backTo);
         }
+        resp.setSubfiles(req.getSubfiles());
 
         const char* superfile = req.getSuperfile();
-        if (superfile && *superfile)
+        if (!superfile || !*superfile)
         {
-            bool option = req.getExistingFile();
-            if (option)
-            {
-                Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(superfile, userdesc.get(), true);   
-                if (!df)
-                {
-                      throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",superfile);
-                    return false;
-                }
-                
-                if(!df->querySuperFile())
-                {
-                      throw MakeStringException(ECLWATCH_NOT_SUPERFILE,"%s is not a superfile.",superfile);
-                    return false;
-                }
-            }
-            else
-            {
-                Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(superfile, userdesc.get(), true);   
-                if (df)
-                {
-                      throw MakeStringException(ECLWATCH_FILE_ALREADY_EXISTS,"The file %s has already existed.",superfile);
-                    return false;
-                }
-            }
-
-            Owned<IDFUhelper> dfuhelper = createIDFUhelper();
             if (version > 1.15)
-            {
-                StringArray& subfileNames = req.getNames();
-                int num = subfileNames.length();
-                const char** ptrs = NULL;
-                if(num > 0)
+            {//Display the subfiles inside a table
+                const char* files = req.getSubfiles();
+                if (files && *files)
                 {
-                    ptrs = (const char**)alloca(sizeof(char*)*num);
-                    for(int i = 0; i < num; i++)
-                        ptrs[i] = subfileNames.item(i);
-                }
-                else if (option)
-                {
-                      throw MakeStringException(ECLWATCH_INVALID_INPUT,"No file has been selected to be added to file %s.",superfile);
-                    return false;
-                }
-
-                {
-                    synchronized block(m_superfilemutex);
-                    dfuhelper->addSuper(superfile, num, ptrs, NULL, userdesc.get());
-                }
-            }
-            else
-            {
-                StringArray subfiles;
-                const char *subfilesStr = req.getSubfiles();
-                char *ptr = (char *) subfilesStr;
-                char *pptr = (char *) subfilesStr;
-                while (pptr[0])
-                {
-                    if (pptr[0] == ',')
-                    {
-                        char buf[1024];
-                        strncpy(buf, ptr, pptr-ptr);
-                        buf[pptr-ptr] = 0;
-                        subfiles.append(buf);
-                        ptr = pptr + 1;
-                    }
-                    
-                    pptr++;
-                }
-                if (pptr > ptr)
-                {
-                    char buf[1024];
-                    strncpy(buf, ptr, pptr-ptr);
-                    buf[pptr-ptr] = 0;
-                    subfiles.append(buf);
-                }
-
-                int num = subfiles.length();
-                const char** ptrs = NULL;
-                if(num > 0)
-                {
-                    ptrs = (const char**)alloca(sizeof(char*)*num);
-                    for(int i = 0; i < num; i++)
-                        ptrs[i] = subfiles.item(i);
-                }
-                else if (option)
-                {
-                      throw MakeStringException(ECLWATCH_INVALID_INPUT,"No file has been selected to be added to file %s.",superfile);
-                    return false;
-                }
-
-                {
-                    synchronized block(m_superfilemutex);
-                    dfuhelper->addSuper(superfile, num, ptrs, NULL, userdesc.get());
+                    StringArray subfileNames;
+                    parseStringArray(files, subfileNames);
+                    if (subfileNames.length() > 0)
+                        resp.setSubfileNames(subfileNames);
                 }
             }
 
-            resp.setRedirectUrl(StringBuffer("/WsDFU/DFUInfo?Name=").append(superfile));
+            return true;//Display a form for user to specify superfile
         }
+
+        if (version > 1.15)
+        {
+            superfileAction(context, "add", superfile, req.getNames(), NULL, req.getExistingFile(), false);
+        }
+        else
+        {
+            StringArray subfileNames;
+            const char *subfilesStr = req.getSubfiles();
+            if (subfilesStr && *subfilesStr)
+                parseStringArray(subfilesStr, subfileNames);
+
+            superfileAction(context, "add", superfile, subfileNames, NULL, req.getExistingFile(), false);
+        }
+
+        resp.setRedirectUrl(StringBuffer("/WsDFU/DFUInfo?Name=").append(superfile));
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -3088,113 +3070,21 @@ bool CWsDfuEx::onSuperfileAction(IEspContext &context, IEspSuperfileActionReques
 {
     try
     {
-        StringBuffer username;
-        context.getUserID(username);
-        Owned<IUserDescriptor> userdesc;
-        if(username.length() > 0)
-        {
-            const char* passwd = context.queryPassword();
-            userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), passwd);
-        }
+        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Write, false))
+            throw MakeStringException(ECLWATCH_DFU_ACCESS_DENIED, "Failed to Superfile action. Permission denied.");
 
-        Owned<IDFUhelper> dfuhelper = createIDFUhelper();
         const char* action = req.getAction();
-        if(stricmp(action, "add") == 0)
-        {
-            StringArray& subfiles = req.getSubfiles();
-            int num = subfiles.length();
-            const char** ptrs = NULL;
-            if(num > 0)
-            {
-                ptrs = (const char**)alloca(sizeof(char*)*num);
-                for(int i = 0; i < num; i++)
-                    ptrs[i] = subfiles.item(i);
-            }
-            {
-                synchronized block(m_superfilemutex);
-                dfuhelper->addSuper(req.getSuperfile(), num, ptrs, req.getBefore(), userdesc.get());
-            }
-        }
-        else if(stricmp(action, "remove") == 0)
-        {
-            StringArray& subfiles = req.getSubfiles();
-            int num = subfiles.length();
-            const char** ptrs = NULL;
-            if(num > 0)
-            {
-                ptrs = (const char**)alloca(sizeof(char*)*num);
-                for(int i = 0; i < num; i++)
-                    ptrs[i] = subfiles.item(i);
-            }
-            {
-                synchronized block(m_superfilemutex);
-                dfuhelper->removeSuper(req.getSuperfile(), num, ptrs, req.getDelete(), userdesc.get()); 
-            }
-        }
-        
-        resp.setSuperfile(req.getSuperfile());
+        const char* superfile = req.getSuperfile();
+        superfileAction(context, action, superfile, req.getSubfiles(), req.getBefore(), true, req.getDelete());
+
         resp.setRetcode(0);
-    }
-    catch(IException* e)
-    {   
-        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
-    }
-    return true;
-}
-
-bool CWsDfuEx::onSuperfileAddRaw(IEspContext &context, IEspSuperfileAddRawRequest &req, IEspSuperfileAddRawResponse &resp)
-{
-    try
-    {
-        StringBuffer username;
-        context.getUserID(username);
-        Owned<IUserDescriptor> userdesc;
-        if(username.length() > 0)
+        if (superfile && *superfile && action && strieq(action, "remove"))
         {
-            const char* passwd = context.queryPassword();
-            userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), passwd);
+            Owned<IDistributedSuperFile> fp = queryDistributedFileDirectory().lookupSuperFile(superfile,NULL);
+            if (!fp)
+                resp.setRetcode(-1); //Superfile has been removed.
         }
-
-        StringArray subfiles;
-        const char* sfstr = req.getSubfiles();
-        if(sfstr != NULL && *sfstr != '\0')
-        {
-            const char* ptr = sfstr;
-            while(*ptr != '\0')
-            {
-                StringBuffer onesub;
-                while(*ptr != '\0' && *ptr != ',' && *ptr != ' ')
-                {
-                    onesub.append((char)(*ptr));
-                    ptr++;
-                }
-                if(onesub.length() > 0)
-                    subfiles.append(onesub.str());
-                while(*ptr == ',' || *ptr == ' ')
-                    ptr++;
-            }
-        }
-
-        int num = subfiles.length();
-        const char** ptrs = NULL;
-        if(num > 0)
-        {
-            ptrs = (const char**)alloca(sizeof(char*)*num);
-            for(int i = 0; i < num; i++)
-                ptrs[i] = subfiles.item(i);
-        }
-
-        Owned<IDFUhelper> dfuhelper = createIDFUhelper();
-
-        {
-            synchronized block(m_superfilemutex);
-            dfuhelper->addSuper(req.getSuperfile(), num, ptrs, req.getBefore(), userdesc.get());
-        }
-        
         resp.setSuperfile(req.getSuperfile());
-        resp.setRetcode(0);
     }
     catch(IException* e)
     {   

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -89,7 +89,6 @@ public:
     virtual bool onAddRemote(IEspContext &context, IEspAddRemoteRequest &req, IEspAddRemoteResponse &resp);
     virtual bool onSuperfileList(IEspContext &context, IEspSuperfileListRequest &req, IEspSuperfileListResponse &resp);
     virtual bool onSuperfileAction(IEspContext &context, IEspSuperfileActionRequest &req, IEspSuperfileActionResponse &resp);
-    virtual bool onSuperfileAddRaw(IEspContext &context, IEspSuperfileAddRawRequest &req, IEspSuperfileAddRawResponse &resp);
 
 private:
     void getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *dirname, IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& numFiles, int& numDirs);
@@ -137,7 +136,9 @@ private:
                                         __int64& count, __int64& read, __int64& total, StringBuffer& message, StringArray& columnLabels, 
                                         StringArray& columnLabelsType, IArrayOf<IEspDFUData>& DataList, bool webDisableUppercaseTranslation);
     bool getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, int& permission);
-
+    void parseStringArray(const char *input, StringArray& strarray);
+    int superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
+        const char* beforeSubFile, bool existingSuperfile, bool deleteFile);
 private:
     bool         m_disableUppercaseTranslation;
     StringBuffer m_clusterName;


### PR DESCRIPTION
Superfile operations (add/remove) should be logged
into esp log. This fix also cleans ESP code for
superfile operations, including the method
SuperfileAddRaw() which has not been used for years.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
