### PR TITLE
FIX: gh-2862 Ignore case of web service.method

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -1199,7 +1199,7 @@ void CWSCHelperThread::createXmlSoapQuery(CommonXmlWriter &xmlWriter, ConstPoint
 void CWSCHelperThread::processQuery(ConstPointerArray &inputRows)
 {
     unsigned xmlWriteFlags = 0;
-    unsigned xmlReadFlags = xr_ignoreNameSpaces; 
+    unsigned xmlReadFlags = xr_ignoreNameSpaces | xr_ignoreCaseServiceMethodName;
     if (master->flags & SOAPFtrim)
         xmlWriteFlags |= XWFtrim;
     if ((master->flags & SOAPFpreserveSpace) == 0)

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -137,7 +137,7 @@ interface jlib_thrown_decl IXMLReadException : extends IException
 };
 extern jlib_decl IXMLReadException *createXmlReadException(int code, const char *msg, const char *context, unsigned line, offset_t offset);
 
-enum XmlReaderOptions { xr_none=0x00, xr_ignoreWhiteSpace=0x01, xr_noRoot=0x02, xr_ignoreNameSpaces=0x04 };
+enum XmlReaderOptions { xr_none=0x00, xr_ignoreWhiteSpace=0x01, xr_noRoot=0x02, xr_ignoreNameSpaces=0x04, xr_ignoreCaseServiceMethodName=0x08 };
 
 interface IXMLReader : extends IInterface
 {


### PR DESCRIPTION
If the casing of ECL SOAPCALL servicename/method specified in the ECL does
not exactly match the case returned in the response, then no data will be
returned (and its almost impossible for the ECL developer to know why).
Since ECL is not a strongly case sensitive language, it was
agreed to allow mismatched case in that situation.
This fix modifies the XPath parser "match" method to support a "noCase"
flag, also modifies the XMLParser to ignore the case if parsing the
service.method node (controlled by a flag passed in the ctor for the parser.
Also modified the SOAPCALL parser instantiation to pass this flag, which
ensures other users of the XML parser are not affected

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
