### PR TITLE
Fixes gh-2930 Add Employee ID to ECLWatch Users

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_userinfoeditinput.xslt
+++ b/esp/eclwatch/ws_XSLT/access_userinfoeditinput.xslt
@@ -63,6 +63,12 @@
                 </td>
             </tr>
             <tr>
+                <td>Employee ID:</td>
+                <td>
+                    <input type="text" name="employeeID" value="{employeeID}" size="35"/>
+                </td>
+            </tr>
+            <tr>
                 <td/>
                 <td><input type="submit" value="Submit" name="S1"/></td>
             </tr>

--- a/esp/eclwatch/ws_XSLT/account_myaccount.xslt
+++ b/esp/eclwatch/ws_XSLT/account_myaccount.xslt
@@ -78,6 +78,14 @@
             </tr>
             <tr>
               <td>
+                <b>Employee ID: </b>
+              </td>
+              <td>
+                <xsl:value-of select="employeeID"/>
+              </td>
+            </tr>
+            <tr>
+              <td>
                 <b>Password Expiration: </b>
               </td>
               <td>

--- a/esp/files/useradd.html
+++ b/esp/files/useradd.html
@@ -30,7 +30,7 @@
                     }
                     else
                     {
-                            f.S1.disabled=true;
+                        f.S1.disabled=true;
                     }
                 }
             </script>
@@ -45,6 +45,7 @@
         <tr><td><b>User ID: </b></td><td><input type="text" name="username" size="20" onKeyPress="checkfields(this.form)"/></td></tr>
         <tr><td><b>First Name: </b></td><td><input type="text" name="firstname" size="20" value="" onKeyPress="checkfields(this.form)" onChange="checkfields(this.form)"/></td></tr>
         <tr><td><b>Last Name: </b></td><td><input type="text" name="lastname" size="20" value="" onKeyPress="checkfields(this.form)"/></td></tr>
+        <tr><td><b>Employee ID: </b></td><td><input type="text" name="employeeID" size="20" value="" onKeyPress="checkfields(this.form)"/></td></tr>
         <tr><td><b>Password: </b></td><td><input type="password" name="password1" size="20" value="" onKeyPress="checkfields(this.form)" onChange="checkfields(this.form)"/></td></tr>
         <tr><td><b>Retype password: </b></td><td><input type="password" name="password2" size="20" value="" onKeyPress="checkfields(this.form)" onChange="checkfields(this.form)"/></td></tr>
         <tr><td></td><td><input type="submit" value="Submit" disabled="form.username.value=''" name="S1" /> &nbsp; <input type="reset" value="Clear"  onClick="S1.disabled='true'"/> </td>

--- a/esp/scm/ws_access.ecm
+++ b/esp/scm/ws_access.ecm
@@ -179,6 +179,7 @@ ESPresponse UserInfoEditInputResponse
     string username;
     string firstname;
     string lastname;
+    [min_ver("1.07")] string employeeID;
 };
 
 ESPrequest UserInfoEditRequest
@@ -186,6 +187,7 @@ ESPrequest UserInfoEditRequest
     string username;
     string firstname;
     string lastname;
+    [min_ver("1.07")] string employeeID;
 };
 
 ESPresponse UserInfoEditResponse
@@ -200,6 +202,7 @@ ESPrequest AddUserRequest
     [label("User Name"), cols(20)] string username;
     [label("First Name"), cols(20)] string firstname;
     [label("Last Name"), cols(20)] string lastname;
+    [label("Employee ID"), cols(20)] string employeeID;
     [label("Password"), password, cols(20)] password1;
     [label("Retype password"), password, cols(20)] password2;
 };
@@ -647,7 +650,7 @@ ESPresponse [nil_remove] UserAccountExportResponse
 };
 
 
-ESPservice [version("1.06"), default_client_version("1.06"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
+ESPservice [version("1.07"), default_client_version("1.07"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
 {
     ESPmethod [client_xslt("/esp/xslt/access_users.xslt")] Users(UserRequest, UserResponse);
     ESPmethod [client_xslt("/esp/xslt/access_useredit.xslt")] UserEdit(UserEditRequest, UserEditResponse);

--- a/esp/scm/ws_account.ecm
+++ b/esp/scm/ws_account.ecm
@@ -39,12 +39,14 @@ ESPresponse [exceptions_inline] MyAccountResponse
     string lastName;
     string passwordExpiration;
     int    passwordDaysRemaining;
+    [min_ver("1.01")] string employeeID;
 };
 
 
 ESPrequest UpdateUserRequest
 {
     [label("User Name"), cols(20)] string username;
+    [label("Employee ID"), cols(20)] string employeeID;
     [label("Old Password"), password, cols(20)] oldpass;
     [label("New password"), password, cols(20)] newpass1;
     [label("Retype new password"), password, cols(20)] newpass2;
@@ -67,7 +69,7 @@ ESPresponse [exceptions_inline] VerifyUserResponse
 	int retcode;
 };
 
-ESPservice [exceptions_inline("./smc_xslt/exceptions.xslt")] ws_account
+ESPservice [version("1.01"), default_client_version("1.01"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_account
 {
     ESPmethod [client_xslt("/esp/xslt/account_myaccount.xslt")] MyAccount(MyAccountRequest, MyAccountResponse);
     ESPmethod [client_xslt("/esp/xslt/account_input.xslt")] UpdateUserInput(UpdateUserInputRequest, UpdateUserInputResponse);

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -646,7 +646,7 @@ bool Cws_accessEx::onAddUser(IEspContext &context, IEspAddUserRequest &req, IEsp
         if(username == NULL || *username == '\0')
         {
             resp.setRetcode(-1);
-            resp.setRetmsg("username can't be empty");
+            resp.setRetmsg("Username can't be empty");
             return false;
         }
         if(strchr(username, ' '))
@@ -669,7 +669,15 @@ bool Cws_accessEx::onAddUser(IEspContext &context, IEspAddUserRequest &req, IEsp
         if(pass1 == NULL || pass2 == NULL || *pass1 == '\0' || *pass2 == '\0' || strcmp(pass1, pass2) != 0)
         {
             resp.setRetcode(-1);
-            resp.setRetmsg("password and retype can't be empty and must match.");
+            resp.setRetmsg("Password and retype can't be empty and must match.");
+            return false;
+        }
+
+        const char* employeeID = req.getEmployeeID();
+        if(employeeID != NULL && (0 != strchr(employeeID, ' ')))
+        {
+            resp.setRetcode(-1);
+            resp.setRetmsg("Employee ID can't cannot contain spaces");
             return false;
         }
 
@@ -683,6 +691,8 @@ bool Cws_accessEx::onAddUser(IEspContext &context, IEspAddUserRequest &req, IEsp
             user->setLastName(lastname);
         if(pass1 != NULL)
             cred.setPassword(pass1);
+        if(employeeID != NULL)
+            user->setEmployeeID(employeeID);
         try
         {
             secmgr->addUser(*user.get());
@@ -2670,10 +2680,17 @@ bool Cws_accessEx::onUserInfoEdit(IEspContext &context, IEspUserInfoEditRequest 
 
         const char* firstname = req.getFirstname();
         const char* lastname = req.getLastname();
+        const char* employeeID = req.getEmployeeID();
         if((!firstname || !*firstname) && (!lastname || !*lastname))
         {
             resp.setRetcode(-1);
             resp.setRetmsg("Please specify both firstname and lastname");
+            return false;
+        }
+        if(employeeID && *employeeID && strchr(employeeID, ' '))
+        {
+            resp.setRetcode(-1);
+            resp.setRetmsg("Employee ID cannot contain spaces");
             return false;
         }
 
@@ -2681,6 +2698,7 @@ bool Cws_accessEx::onUserInfoEdit(IEspContext &context, IEspUserInfoEditRequest 
 
         user->setFirstName(firstname);
         user->setLastName(lastname);
+        user->setEmployeeID(employeeID);
 
         try
         {
@@ -2730,6 +2748,7 @@ bool Cws_accessEx::onUserInfoEditInput(IEspContext &context, IEspUserInfoEditInp
 
         resp.setFirstname(user->getFirstName());
         resp.setLastname(user->getLastName());
+        resp.setEmployeeID(user->getEmployeeID());
     }
     catch(IException* e)
     {

--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -172,6 +172,7 @@ bool Cws_accountEx::onMyAccount(IEspContext &context, IEspMyAccountRequest &req,
             resp.setFirstName(user->getFirstName());
             resp.setLastName(user->getLastName());
             resp.setUsername(user->getName());
+            resp.setEmployeeID(user->getEmployeeID());
         }
     }
     catch(IException* e)

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1035,7 +1035,7 @@ public:
                 filter.append("uid=");
             filter.append(username);
 
-            char* attrs[] = {"cn", "userAccountControl", "pwdLastSet", "givenName", "sn", NULL};
+            char* attrs[] = {"cn", "userAccountControl", "pwdLastSet", "givenName", "sn", "employeeID", NULL};
 
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* sys_ld = ((CLdapConnection*)lconn.get())->getLd();
@@ -1113,6 +1113,12 @@ public:
                     //UF_DONT_EXPIRE_PASSWD 0x10000
                     if (atoi((char*)values[0]) & 0x10000)//this can be true at the account level, even if domain policy requires password
                         m_passwordNeverExpires = true;
+                    ldap_value_free( values );
+                }
+                else if((stricmp(attribute, "employeeID") == 0) && ( values = ldap_get_values( sys_ld, entry, attribute))  != NULL )
+                {
+                    if(values[0] != NULL)
+                        user.setEmployeeID(values[0]);
                     ldap_value_free( values );
                 }
                 else if((stricmp(attribute, "pwdLastSet") == 0) && (bvalues = ldap_get_values_len(sys_ld, entry, attribute)) != NULL )
@@ -1495,7 +1501,7 @@ public:
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
 
-            char        *attrs[] = {"cn", "givenName", "sn", "gidnumber", "uidnumber", "homedirectory", "loginshell", "objectClass", NULL};
+            char        *attrs[] = {"cn", "givenName", "sn", "gidnumber", "uidnumber", "homedirectory", "loginshell", "objectClass", "employeeID", NULL};
             CLDAPMessage searchResult;
             int rc = ldap_search_ext_s(ld, (char*)basedn, LDAP_SCOPE_SUBTREE, (char*)filter.str(), attrs, 0, NULL, NULL, &timeOut, LDAP_NO_LIMIT,   &searchResult.msg );
 
@@ -1567,6 +1573,15 @@ public:
                         {
                             if(values[0] != NULL)
                                 ((CLdapSecUser*)&user)->setHomedirectory(values[0]);
+                            ldap_value_free( values );
+                        }
+                    }
+                    else if(stricmp(attribute, "employeeID") == 0)
+                    {
+                        if (( values = ldap_get_values( ld, message, attribute)) != NULL )
+                        {
+                            if(values[0] != NULL)
+                                ((CLdapSecUser*)&user)->setEmployeeID(values[0]);
                             ldap_value_free( values );
                         }
                     }
@@ -2098,6 +2113,7 @@ public:
             StringBuffer cnbuf;
             const char* fname = user.getFirstName();
             const char* lname = user.getLastName();
+            const char* employeeID = user.getEmployeeID();
             if(fname && *fname && lname && *lname)
             {
                 cnbuf.append(fname).append(" ").append(lname);
@@ -2119,6 +2135,13 @@ public:
                 sn_values
             };
 
+            char *eid_values[] = { (char*)employeeID, NULL };
+            LDAPMod eid_attr = {
+                employeeID && *employeeID ? LDAP_MOD_REPLACE : LDAP_MOD_DELETE,
+                "employeeID",
+                employeeID && *employeeID ? eid_values : NULL
+            };
+
             char *cn_values[] = {(char*)cnbuf.str(), NULL };
             LDAPMod cn_attr = 
             {
@@ -2135,7 +2158,7 @@ public:
                 dispname_values
             };
 
-            LDAPMod *attrs[4];
+            LDAPMod *attrs[5];
             int ind = 0;
         
             attrs[ind++] = &gn_attr;
@@ -2144,6 +2167,7 @@ public:
             if(m_ldapconfig->getServerType() == ACTIVE_DIRECTORY)
             {
                 attrs[ind++] = &dispname_attr;
+                attrs[ind++] = &eid_attr;
             }
             else
             {
@@ -4980,7 +5004,16 @@ private:
             username_values
         };
 
-        LDAPMod *attrs[8];
+        const char * employeeID = (char*)user.getEmployeeID();
+        char* employeeID_values[] = {(char*)employeeID, NULL};
+        LDAPMod employeeID_attr =
+        {
+            LDAP_MOD_ADD,
+            "employeeID",
+            employeeID_values
+        };
+
+        LDAPMod *attrs[9];
         int ind = 0;
         
         attrs[ind++] = &cn_attr;
@@ -4995,6 +5028,8 @@ private:
         {
             attrs[ind++] = &username_attr;
             attrs[ind++] = &dispname_attr;
+            if(employeeID != NULL && *employeeID != '\0')
+                attrs[ind++] = &employeeID_attr;
         }
         else
         {

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -201,6 +201,7 @@ void CLdapSecUser::copyTo(ISecUser& destination)
     dest->setUserSid(m_usersid.length(), m_usersid.toByteArray());
     dest->setUserID(m_userid);
     dest->setPasswordExpiration(m_passwordExpiration);
+    dest->setEmployeeID(getEmployeeID());
 }
 
 ISecUser * CLdapSecUser::clone()

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -45,6 +45,7 @@ private:
     StringAttr   m_pw;
     StringAttr   m_Fqdn;
     StringAttr   m_Peer;
+    StringAttr   m_employeeID;
     authStatus   m_authenticateStatus;
     CDateTime    m_passwordExpiration;//local time
     unsigned     m_userid;
@@ -131,6 +132,9 @@ public:
 
    authStatus getAuthenticateStatus()           { return m_authenticateStatus; }
    void setAuthenticateStatus(authStatus status){ m_authenticateStatus = status; }
+
+   virtual const char * getEmployeeID()                 { return m_employeeID.get(); }
+   virtual void setEmployeeID(const char * employeeID)  { m_employeeID.set(employeeID); }
 
    ISecUser * clone();
     virtual void setProperty(const char* name, const char* value){}
@@ -343,6 +347,7 @@ private:
     bool authenticate(ISecUser* user);
     StringBuffer m_description;
     unsigned m_passwordExpirationWarningDays;
+    StringBuffer m_employeeID;
 
 public:
     IMPLEMENT_IINTERFACE
@@ -438,6 +443,10 @@ public:
     virtual unsigned getPasswordExpirationWarningDays()
     {
         return m_passwordExpirationWarningDays;
+    }
+    virtual const char * getEmployeeID()
+    {
+        return m_employeeID.str();
     }
 };
 

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -36,6 +36,7 @@ private:
     StringBuffer    m_fullname;
     StringBuffer    m_firstname;
     StringBuffer    m_lastname;
+    StringBuffer    m_employeeID;
     unsigned        m_userID;
     StringBuffer    m_Fqdn;
     StringBuffer    m_Peer;
@@ -104,6 +105,19 @@ public:
         }
         return true;
     }
+
+    virtual const char * getEmployeeID()
+    {
+        return m_employeeID.str();
+    }
+    virtual void setEmployeeID(const char * employeeID)
+    {
+        m_employeeID.clear();
+        if(employeeID && *employeeID)
+            m_employeeID.append(employeeID);
+    }
+
+
     const char * getRealm()
     {
         return m_realm.str();
@@ -218,6 +232,7 @@ public:
         destination.credentials().setPassword(credentials().getPassword());
         CDateTime tmpTime;
         destination.setPasswordExpiration(getPasswordExpiration(tmpTime));
+        destination.setEmployeeID(getEmployeeID());
         destination.setStatus(getStatus());
         if(m_parameters.get()==NULL)
             return;

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -113,6 +113,7 @@ private:
     StringBuffer               m_dbserver;
     StringBuffer               m_dbuser;
     StringBuffer               m_dbpassword;
+    StringBuffer               m_employeeID;
     int                        m_poolsize;
     SecPasswordEncoding        m_dbpasswordEncoding;
     MapStrToInt                m_usermap;
@@ -283,6 +284,10 @@ public:
     virtual unsigned getPasswordExpirationWarningDays()
     {
         return m_passwordExpirationWarningDays;
+    }
+    virtual const char *getEmployeeID()
+    {
+        return m_employeeID.toCharArray();
     }
 
 protected:

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -173,6 +173,8 @@ interface ISecUser : extends IInterface
     virtual void setPropertyInt(const char * name, int value) = 0;
     virtual int getPropertyInt(const char * name) = 0;
     virtual ISecUser * clone() = 0;
+    virtual const char * getEmployeeID() = 0;
+    virtual void setEmployeeID(const char * employeeID) = 0;
 };
 
 
@@ -298,6 +300,7 @@ interface ISecManager : extends IInterface
     virtual bool authorizeWorkunitScope(ISecUser & user, ISecResourceList * resources) = 0;
     virtual const char * getDescription() = 0;
     virtual unsigned getPasswordExpirationWarningDays() = 0;
+    virtual const char * getEmployeeID() = 0;
 };
 
 interface IExtSecurityManager


### PR DESCRIPTION
Add EmployeeID field to Add User screen, and save this (optional) field in
LDAP when user is created. Display employeeID as part of MyAccount screen
Allow admin to modify/delete employee id via user info edit screen 

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
