### PR TITLE
Fix gh-1887  Configmgr on component rename focus is lost

### DIFF
--- a/esp/files/scripts/configmgr/common.js
+++ b/esp/files/scripts/configmgr/common.js
@@ -135,6 +135,26 @@ function setFocusToTable(dt) {
   top.document.navDT.fireEvent("tableBlurEvent");
 }
 
+function clickCurrentSelOrNameAndCompType(dt, name, compType, donotclick) {
+  var recordSet = dt.getRecordSet();
+  var recordSetLength = recordSet.getLength();
+
+  for (var index=0; index < recordSetLength; index++)
+  {
+    rec = recordSet.getRecord(index);
+    if (rec._oData.Name === name && (rec._oData.BuildSet === compType || rec._oData.CompType === compType))
+      break;
+  }
+  expandRecordWithId(dt, rec.getData('parent'));
+  var el = dt.getTrEl(rec);
+  dt.unselectAllCells();
+  dt.unselectAllRows();
+  var tdEl = dt.getFirstTdEl(rec);
+  if (!donotclick)
+    YAHOO.util.UserAction.click(tdEl);
+  top.document.lastSelectedRow = rec.getData('Name');
+}
+
 function clickCurrentSelOrName(dt, name, donotclick) {
   var rec = getCurrentSelRec(dt, name);
 

--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -833,7 +833,9 @@ function handleConfigCellClickEvent(oArgs, caller, isComplex) {
     if (record._oData.name === "name")
     {
       top.document.ResetFocus = true;
-      top.document.ResetFocusValue = newValue;
+      top.document.ResetFocusValueName = newValue;
+      if (typeof(record._oData.compType) !== "undefined")
+       top.document.ResetFocusCompType = record._oData.compType;
     }
     var attrName = getAttrName(datatable, column, record, isComplex); // = record.getData('name');
     var recordIndex = datatable.getRecordIndex(record);

--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -829,6 +829,12 @@ function handleConfigCellClickEvent(oArgs, caller, isComplex) {
 
       return;
     }
+
+    if (record._oData.name === "name")
+    {
+      top.document.ResetFocus = true;
+      top.document.ResetFocusValue = newValue;
+    }
     var attrName = getAttrName(datatable, column, record, isComplex); // = record.getData('name');
     var recordIndex = datatable.getRecordIndex(record);
 

--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -476,6 +476,12 @@ function createNavigationTree(navTreeData) {
     expandRecord(this, "Name", "Environment");
     expandRecord(this, "Name", "Software");
 
+    if (top.document.ResetFocus == true)
+    {
+      top.document.ResetFocus = false;
+      top.document.navDT.clickCurrentSelOrName(top.document.navDT,top.document.ResetFocusValue);
+    }
+
     top.document.activeTab = prevTab;
     if (typeof (prevSelRec) !== "undefined")
       clickCurrentSelOrName(this, prevSelRec);

--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -479,7 +479,7 @@ function createNavigationTree(navTreeData) {
     if (top.document.ResetFocus == true)
     {
       top.document.ResetFocus = false;
-      top.document.navDT.clickCurrentSelOrName(top.document.navDT,top.document.ResetFocusValue);
+      top.document.navDT.clickCurrentSelOrNameAndCompType(top.document.navDT,top.document.ResetFocusValueName, top.document.ResetFocusCompType);
     }
 
     top.document.activeTab = prevTab;
@@ -1243,6 +1243,7 @@ function createNavigationTree(navTreeData) {
   navDT.displayRoxieClusterReplaceServer = displayReplaceServerDlg;
   navDT.doPageRefresh = refresh;
   navDT.clickCurrentSelOrName = clickCurrentSelOrName;
+  navDT.clickCurrentSelOrNameAndCompType = clickCurrentSelOrNameAndCompType;
   navDT.displayAddInstance = displayAddInstanceDlg;
   navDT.promptVerifyPwd = promptVerifyPwd;
   navDT.promptNewRange = promptNewRange;


### PR DESCRIPTION
- When renaming components, the screen will refresh but focus will
  now be on the newly renamed component

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
