### PR TITLE
Fix gh-2287 CSV options not visible in DFU workunit

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_wuid.xslt
@@ -271,6 +271,9 @@
         <xsl:apply-templates select="RowTag"/>
         <xsl:apply-templates select="SourceNumParts"/>
         <xsl:apply-templates select="SourceDirectory"/>
+        <xsl:apply-templates select="SourceCsvSeparate"/>
+        <xsl:apply-templates select="SourceCsvTerminate"/>
+        <xsl:apply-templates select="SourceCsvQuote"/>
         <xsl:apply-templates select="DestLogicalName"/>
         <xsl:apply-templates select="DestGroupName"/>
         <xsl:apply-templates select="DestDirectory"/>

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -60,6 +60,10 @@ ESPStruct [nil_remove] DFUWorkunit
     bool Overwrite;
     bool Compress;
 
+    [min_ver("1.04")] string SourceCsvSeparate;
+    [min_ver("1.04")] string SourceCsvQuote;
+    [min_ver("1.04")] string SourceCsvTerminate;
+
     string TimeStarted;
     string TimeStopped;
     string StateMessage;
@@ -581,7 +585,7 @@ ESPresponse [exceptions_inline, nil_remove] DeleteDropZoneFilesResponse
 };
 
 ESPservice [
-    version("1.03"), default_client_version("1.03"),
+    version("1.04"), default_client_version("1.04"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
 {
     ESPuses ESPstruct DFUWorkunit;

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -160,7 +160,7 @@ void ParsePath(const char * fullPath, StringBuffer &ip, StringBuffer &filePath, 
 const char * const NODATETIME="1970-01-01T00:00:00Z";
 
 // Assign from a dfuwu workunit structure to an esp request workunit structure. 
-static void DeepAssign(IConstDFUWorkUnit *src, IEspDFUWorkunit &dest)
+static void DeepAssign(IEspContext &context, IConstDFUWorkUnit *src, IEspDFUWorkunit &dest)
 {
     if(src == NULL)
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "'Source DFU workunit' doesn't exist.");
@@ -173,6 +173,7 @@ static void DeepAssign(IConstDFUWorkUnit *src, IEspDFUWorkunit &dest)
     if (!root)
         throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
+    double version = context.getClientVersion();
     StringBuffer tmp, encoded;
     dest.setID(src->queryId());
     if (src->getClusterName(tmp.clear()).length()!=0)
@@ -345,6 +346,18 @@ static void DeepAssign(IConstDFUWorkUnit *src, IEspDFUWorkunit &dest)
         file->getRowTag(rowtag);
         if(rowtag.length() > 0)
             dest.setRowTag(rowtag.str());
+
+        if (version > 1.03 && (file->getFormat() == DFUff_csv))
+        {
+            StringBuffer separate, terminate, quote;
+            file->getCsvOptions(separate,terminate,quote);
+            if(separate.length() > 0)
+                dest.setSourceCsvSeparate(separate.str());
+            if(terminate.length() > 0)
+                dest.setSourceCsvTerminate(terminate.str());
+            if(quote.length() > 0)
+                dest.setSourceCsvQuote(quote.str());
+        }
     }
 
     file = src->queryDestination();
@@ -1224,7 +1237,7 @@ bool CFileSprayEx::onGetDFUWorkunit(IEspContext &context, IEspGetDFUWorkunit &re
         {
             IEspDFUWorkunit &result = resp.updateResult();
             
-            DeepAssign(wu, result);
+            DeepAssign(context, wu, result);
             int n = resp.getResult().getState();
             if (n == DFUstate_scheduled || n == DFUstate_queued || n == DFUstate_started)
             {
@@ -1314,7 +1327,7 @@ bool CFileSprayEx::onCreateDFUWorkunit(IEspContext &context, IEspCreateDFUWorkun
         wu->commit();
         const char * d = wu->queryId();
         IEspDFUWorkunit &result = resp.updateResult();
-        DeepAssign(wu, result);
+        DeepAssign(context, wu, result);
         result.setOverwrite(false);
         result.setReplicate(true);
     }


### PR DESCRIPTION
This fix adds CSV options to DFU Workunit Details page
for DFU sprays of CSV sources.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
