### PR TITLE
Fix gh-1836 Configmgr - Navigator Window Scroll Position Jumps in IE onclick

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -370,7 +370,7 @@ function createNavigationTree(navTreeData) {
   var navDS = new YAHOO.util.DataSource(navTreeData);
   navDS.responseType = YAHOO.util.DataSource.TYPE_JSARRAY;
   navDS.responseSchema = { fields: ["Name", "DisplayName", "Build", "BuildSet", "parent", "id", "depth", "menu", "Params", "CompType"] };
-  var navDT = new YAHOO.widget.DataTable(
+  var navDT = new YAHOO.widget.ScrollingDataTable(
             'pageBody',
             [
                 { key: "DisplayName", label: "Name", width: 275, maxAutoWidth: 275, formatter: function(el, oRecord, oColumn, oData) {


### PR DESCRIPTION
- (IE specific) When clicking on an item in the tree in the navigator window the scroll position will no longer reset to the top 
- (IE specific) When clicking on an item in the context menu in the navigator window the scroll position will no longer reset   to the top

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
