### PR TITLE
Allow roxiemem heap flags to be passed

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -9794,7 +9794,7 @@ IHThorException * makeHThorException(ThorActivityKind kind, unsigned activityId,
 
 extern HTHOR_API IEngineRowAllocator * createHThorRowAllocator(IRowManager & _rowManager, IOutputMetaData * _meta, unsigned _activityId, unsigned _allocatorId)
 {
-    return createRoxieRowAllocator(_rowManager, _meta, _activityId, _allocatorId, false);
+    return createRoxieRowAllocator(_rowManager, _meta, _activityId, _allocatorId, roxiemem::RHFnone);
 }
 
 static class RowCallbackHook : implements IRtlRowCallback

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -28119,7 +28119,7 @@ public:
     {
         // MORE - may need to do some caching/commoning up here otherwise GRAPH in a child query may use too many
         SpinBlock b(allAllocatorsLock);
-        IEngineRowAllocator * ret = createRoxieRowAllocator(*rowManager, meta, activityId, allAllocators.ordinality(), false);
+        IEngineRowAllocator * ret = createRoxieRowAllocator(*rowManager, meta, activityId, allAllocators.ordinality(), roxiemem::RHFnone);
         LINK(ret);
         allAllocators.append(*ret);
         return ret;

--- a/roxie/roxiemem/roxierow.hpp
+++ b/roxie/roxiemem/roxierow.hpp
@@ -35,8 +35,8 @@
 #define ALLOCATORID_CHECK_MASK  0x00300000
 #define ALLOCATORID_MASK                0x000fffff
 
-extern roxiemem_decl IEngineRowAllocator * createRoxieRowAllocator(roxiemem::IRowManager & _rowManager, IOutputMetaData * _meta, unsigned _activityId, unsigned _allocatorId, bool packed);
-extern roxiemem_decl IEngineRowAllocator * createCrcRoxieRowAllocator(roxiemem::IRowManager & rowManager, IOutputMetaData * meta, unsigned activityId, unsigned allocatorId, bool packed);
+extern roxiemem_decl IEngineRowAllocator * createRoxieRowAllocator(roxiemem::IRowManager & _rowManager, IOutputMetaData * _meta, unsigned _activityId, unsigned _allocatorId, roxiemem::RoxieHeapFlags flags);
+extern roxiemem_decl IEngineRowAllocator * createCrcRoxieRowAllocator(roxiemem::IRowManager & rowManager, IOutputMetaData * meta, unsigned activityId, unsigned allocatorId, roxiemem::RoxieHeapFlags flags);
 
 extern roxiemem_decl bool isRowCheckValid(unsigned allocatorId, const void * row);
 

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1663,11 +1663,11 @@ protected:
     mutable IArrayOf<IEngineRowAllocator> allAllocators;
     mutable SpinLock allAllocatorsLock;
     Owned<roxiemem::IRowManager> rowManager;
-    bool usePacked;
+    roxiemem::RoxieHeapFlags flags;
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CThorAllocator(memsize_t memSize, bool _usePacked) : usePacked(_usePacked)
+    CThorAllocator(memsize_t memSize, roxiemem::RoxieHeapFlags _flags) : flags(_flags)
     {
         rowManager.setown(roxiemem::createRowManager(memSize, NULL, queryDummyContextLogger(), this, false));
         rtlSetReleaseRowHook(this);
@@ -1684,7 +1684,7 @@ public:
     {
         // MORE - may need to do some caching/commoning up here otherwise GRAPH in a child query may use too many
         SpinBlock b(allAllocatorsLock);
-        IEngineRowAllocator *ret = createRoxieRowAllocator(*rowManager, meta, activityId, allAllocators.ordinality(), usePacked);
+        IEngineRowAllocator *ret = createRoxieRowAllocator(*rowManager, meta, activityId, allAllocators.ordinality(), flags);
         LINK(ret);
         allAllocators.append(*ret);
         return ret;
@@ -1782,7 +1782,7 @@ public:
 class CThorCrcCheckingAllocator : public CThorAllocator
 {
 public:
-    CThorCrcCheckingAllocator(memsize_t memSize, bool usePacked) : CThorAllocator(memSize, usePacked)
+    CThorCrcCheckingAllocator(memsize_t memSize, roxiemem::RoxieHeapFlags flags) : CThorAllocator(memSize, flags)
     {
     }
 // IThorAllocator
@@ -1790,7 +1790,7 @@ public:
     {
         // MORE - may need to do some caching/commoning up here otherwise GRAPH in a child query may use too many
         SpinBlock b(allAllocatorsLock);
-        IEngineRowAllocator *ret = createCrcRoxieRowAllocator(*rowManager, meta, activityId, allAllocators.ordinality(), usePacked);
+        IEngineRowAllocator *ret = createCrcRoxieRowAllocator(*rowManager, meta, activityId, allAllocators.ordinality(), flags);
         LINK(ret);
         allAllocators.append(*ret);
         return ret;
@@ -1802,10 +1802,15 @@ IThorAllocator *createThorAllocator(memsize_t memSize, bool crcChecking, bool us
 {
     PROGLOG("CRC allocator %s", crcChecking?"ON":"OFF");
     PROGLOG("Packed allocator %s", usePacked?"ON":"OFF");
-    if (crcChecking)
-        return new CThorCrcCheckingAllocator(memSize, usePacked);
+    roxiemem::RoxieHeapFlags flags;
+    if (usePacked)
+        flags = roxiemem::RHFpacked;
     else
-        return new CThorAllocator(memSize, usePacked);
+        flags = roxiemem::RHFnone;
+    if (crcChecking)
+        return new CThorCrcCheckingAllocator(memSize, flags);
+    else
+        return new CThorAllocator(memSize, flags);
 }
 
 


### PR DESCRIPTION
Allow RoxieHeapFlags to be passed to the create allocator methods.
This is to enable per allocator options like RHFpacked and RHFunique.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
