### PR TITLE
Fix gh-2979, Return type warning is universal

### DIFF
--- a/tools/start-stop-daemon/CMakeLists.txt
+++ b/tools/start-stop-daemon/CMakeLists.txt
@@ -17,11 +17,7 @@
 
 project(start-stop-daemon)
 
-if (CMAKE_COMPILER_IS_GNUCC)
-  if (CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.1)
-    add_definitions( -Wno-noreturn )
-  endif ()
-endif ()
+add_definitions( -Wno-return-type )
 
 set( SRC start-stop-daemon.c )
 set( HEADER macros.h )


### PR DESCRIPTION
Tested on gcc versions: 4.1.2, 4.4.7, 4.5.3 and 4.6.3, clang 3.2 and all of them worked.
