### PR TITLE
Fix gh-2955 Spaces not trimmed from workunit id

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -206,15 +206,15 @@ void copyWULogicalFilesToTarget(IEspContext &context, IConstWUClusterInfo &clust
 
 bool CWsWorkunitsEx::onWUCopyLogicalFiles(IEspContext &context, IEspWUCopyLogicalFilesRequest &req, IEspWUCopyLogicalFilesResponse &resp)
 {
-    if (isEmpty(req.getWuid()))
-        throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT, "WUCopyLogicalFiles WUID parameter not set.");
+    StringBuffer wuid = req.getWuid();
+    checkAndTrimWorkunit("WUCopyLogicalFiles", wuid);
 
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-    Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+    Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
     if (!cw)
-        throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s", req.getWuid());
+        throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s", wuid.str());
 
-    resp.setWuid(req.getWuid());
+    resp.setWuid(wuid.str());
 
     SCMStringBuffer cluster;
     if (notEmpty(req.getCluster()))
@@ -358,15 +358,15 @@ bool reloadCluster(const char *cluster, unsigned wait)
 
 bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWorkunitRequest & req, IEspWUPublishWorkunitResponse & resp)
 {
-    if (isEmpty(req.getWuid()))
-        throw MakeStringException(ECLWATCH_NO_WUID_SPECIFIED,"No Workunit ID has been specified.");
+    StringBuffer wuid = req.getWuid();
+    checkAndTrimWorkunit("WUPublishWorkunit", wuid);
 
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-    Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+    Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
     if (!cw)
-        throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot find the workunit %s", req.getWuid());
+        throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot find the workunit %s", wuid.str());
 
-    resp.setWuid(req.getWuid());
+    resp.setWuid(wuid.str());
 
     SCMStringBuffer queryName;
     if (notEmpty(req.getJobName()))
@@ -374,7 +374,7 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
     else
         cw->getJobName(queryName).str();
     if (!queryName.length())
-        throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Query/Job name not defined for publishing workunit %s", req.getWuid());
+        throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Query/Job name not defined for publishing workunit %s", wuid.str());
 
     SCMStringBuffer cluster;
     if (notEmpty(req.getCluster()))
@@ -382,7 +382,7 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
     else
         cw->getClusterName(cluster);
     if (!cluster.length())
-        throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Cluster name not defined for publishing workunit %s", req.getWuid());
+        throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Cluster name not defined for publishing workunit %s", wuid.str());
 
     Owned <IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster.str());
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -375,9 +375,19 @@ bool doAction(IEspContext& context, StringArray& wuids, int action, IProperties*
     bool bAllSuccess = true;
     for(aindex_t i=0; i<wuids.length();i++)
     {
-        const char* wuid=wuids.item(i);
+        StringBuffer wuidStr = wuids.item(i);
+        const char* wuid = wuidStr.trim().str();
         if (isEmpty(wuid))
+        {
+            WARNLOG("Empty Workunit ID");
             continue;
+        }
+        if (!looksLikeAWuid(wuid))
+        {
+            WARNLOG("Invalid Workunit ID: %s",wuid);
+            continue;
+        }
+
         try
         {
             if (action == ActionRestore)
@@ -664,6 +674,18 @@ bool CWsWorkunitsEx::isValidCluster(const char *cluster)
     return false;
 }
 
+void CWsWorkunitsEx::checkAndTrimWorkunit(const char* methodName, StringBuffer& input)
+{
+    const char* trimmedInput = input.trim().str();
+    if (isEmpty(trimmedInput))
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "%s: Workunit ID not set", methodName);
+
+    if (!looksLikeAWuid(trimmedInput))
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "%s: Invalid Workunit ID: %s", methodName, trimmedInput);
+
+    return;
+}
+
 bool CWsWorkunitsEx::onWUCreate(IEspContext &context, IEspWUCreateRequest &req, IEspWUCreateResponse &resp)
 {
     try
@@ -708,27 +730,30 @@ bool CWsWorkunitsEx::onWUUpdate(IEspContext &context, IEspWUUpdateRequest &req, 
 {
     try
     {
-        ensureWsWorkunitAccess(context, req.getWuid(), SecAccess_Write);
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUUpdate", wuid);
+
+        ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Write);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",wuid.str());
         if(req.getProtected() != req.getProtectedOrig())
         {
             cw->protect(req.getProtected());
             cw.clear();
-            cw.setown(factory->openWorkUnit(req.getWuid(), false));
+            cw.setown(factory->openWorkUnit(wuid.str(), false));
             if(!cw)
-                throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+                throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",wuid.str());
         }
 
         if ((req.getState() == WUStateRunning)||(req.getState() == WUStateDebugPaused)||(req.getState() == WUStateDebugRunning))
         {
             WsWuInfo winfo(context, cw);
             winfo.getInfo(resp.updateWorkunit(), WUINFO_All);
-            resp.setRedirectUrl(StringBuffer("/WsWorkunits/WUInfo?Wuid=").append(req.getWuid()).str());
-            AuditSystemAccess(context.queryUserId(), true, "Updated %s", req.getWuid());
+            resp.setRedirectUrl(StringBuffer("/WsWorkunits/WUInfo?Wuid=").append(wuid).str());
+            AuditSystemAccess(context.queryUserId(), true, "Updated %s", wuid.str());
             return true;
         }
 
@@ -736,7 +761,7 @@ bool CWsWorkunitsEx::onWUUpdate(IEspContext &context, IEspWUUpdateRequest &req, 
         if(!req.getState_isNull() && (req.getStateOrig_isNull() || req.getState() != req.getStateOrig()))
         {
             if (!req.getStateOrig_isNull() && cw->getState() != (WUState) req.getStateOrig())
-                throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT, "Cannot update workunit %s because its state has been changed internally. Please refresh the page and try again.", req.getWuid());
+                throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT, "Cannot update workunit %s because its state has been changed internally. Please refresh the page and try again.", wuid.str());
 
             WUState state = (WUState) req.getState();
             if(state < WUStateSize)
@@ -825,13 +850,13 @@ bool CWsWorkunitsEx::onWUUpdate(IEspContext &context, IEspWUUpdateRequest &req, 
         if (thorSlaveIP.length() > 0)
         {
             StringBuffer url;
-            url.appendf("/WsWorkunits/WUInfo?Wuid=%s&ThorSlaveIP=%s", req.getWuid(), thorSlaveIP.str());
+            url.appendf("/WsWorkunits/WUInfo?Wuid=%s&ThorSlaveIP=%s", wuid.str(), thorSlaveIP.str());
             resp.setRedirectUrl(url.str());
         }
         else
-            resp.setRedirectUrl(StringBuffer("/WsWorkunits/WUInfo?Wuid=").append(req.getWuid()).str());
+            resp.setRedirectUrl(StringBuffer("/WsWorkunits/WUInfo?Wuid=").append(wuid).str());
 
-        AuditSystemAccess(context.queryUserId(), true, "Updated %s", req.getWuid());
+        AuditSystemAccess(context.queryUserId(), true, "Updated %s", wuid.str());
     }
     catch(IException* e)
     {
@@ -989,11 +1014,16 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
     {
         Owned<IMultiException> me = MakeMultiException();
         SCMStringBuffer wuid;
+        StringArray wuids;
 
         for(aindex_t i=0; i<req.getWuids().length();i++)
         {
-            wuid.set(req.getWuids().item(i));
-            ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Write);
+            StringBuffer wuidStr = req.getWuids().item(i);
+            checkAndTrimWorkunit("WUResubmit", wuidStr);
+
+            ensureWsWorkunitAccess(context, wuidStr.str(), SecAccess_Write);
+
+            wuid.set(wuidStr.str());
 
             try
             {
@@ -1008,6 +1038,8 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
                     SCMStringBuffer token;
                     wu->setSecurityToken(createToken(wuid.str(), context.queryUserId(), context.queryPassword(), token).str());
                 }
+
+                wuids.append(wuid.str());
 
                 Owned<IConstWorkUnit> cw(factory->openWorkUnit(wuid.str(), false));
                 if(!cw)
@@ -1031,13 +1063,13 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
         int timeToWait = req.getBlockTillFinishTimer();
         if (timeToWait != 0)
         {
-            for(aindex_t i=0; i<req.getWuids().length(); i++)
-                waitForWorkUnitToComplete(req.getWuids().item(i), timeToWait);
+            for(aindex_t i=0; i<wuids.length(); i++)
+                waitForWorkUnitToComplete(wuids.item(i), timeToWait);
         }
 
-        if(req.getWuids().length()==1)
+        if(wuids.length()==1)
         {
-            resp.setRedirectUrl(StringBuffer("/WsWorkunits/WUInfo?Wuid=").append(wuid).str());
+            resp.setRedirectUrl(StringBuffer("/WsWorkunits/WUInfo?Wuid=").append(wuids.item(0)));
         }
     }
     catch(IException* e)
@@ -1078,7 +1110,9 @@ bool CWsWorkunitsEx::onWUSchedule(IEspContext &context, IEspWUScheduleRequest &r
 {
     try
     {
-        DBGLOG("Schedule workunit: %s", req.getWuid());
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUSchedule", wuid);
+
         const char* cluster = req.getCluster();
         if (isEmpty(cluster))
              throw MakeStringException(ECLWATCH_INVALID_INPUT,"No Cluster defined.");
@@ -1086,7 +1120,7 @@ bool CWsWorkunitsEx::onWUSchedule(IEspContext &context, IEspWUScheduleRequest &r
             throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid cluster name: %s", cluster);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        WorkunitUpdate wu(factory->updateWorkUnit(req.getWuid()));
+        WorkunitUpdate wu(factory->updateWorkUnit(wuid.str()));
 
         ensureWsWorkunitAccess(context, *wu.get(), SecAccess_Write);
         switch(wu->getState())
@@ -1120,9 +1154,9 @@ bool CWsWorkunitsEx::onWUSchedule(IEspContext &context, IEspWUScheduleRequest &r
             wu->setDebugValueInt("maxRunTime", req.getMaxRunTime(), true);
 
         SCMStringBuffer token;
-        wu->setSecurityToken(createToken(req.getWuid(), context.queryUserId(), context.queryPassword(), token).str());
+        wu->setSecurityToken(createToken(wuid.str(), context.queryUserId(), context.queryPassword(), token).str());
 
-        AuditSystemAccess(context.queryUserId(), true, "Scheduled %s", req.getWuid());
+        AuditSystemAccess(context.queryUserId(), true, "Scheduled %s", wuid.str());
     }
     catch(IException* e)
     {
@@ -1136,10 +1170,9 @@ bool CWsWorkunitsEx::onWUSubmit(IEspContext &context, IEspWUSubmitRequest &req, 
 {
     try
     {
-        if (isEmpty(req.getWuid()))
-            throw MakeStringException(ECLWATCH_INVALID_INPUT, "No workunit ID provided.");
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUSubmit", wuid);
 
-        DBGLOG("Submit workunit: %s", req.getWuid());
         const char *cluster = req.getCluster();
         if (isEmpty(cluster))
             throw MakeStringException(ECLWATCH_INVALID_INPUT,"No Cluster defined.");
@@ -1147,9 +1180,9 @@ bool CWsWorkunitsEx::onWUSubmit(IEspContext &context, IEspWUSubmitRequest &req, 
             throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid cluster name: %s", cluster);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid.str());
 
         if (cw->getAction()==WUActionExecuteExisting)
         {
@@ -1166,9 +1199,9 @@ bool CWsWorkunitsEx::onWUSubmit(IEspContext &context, IEspWUSubmitRequest &req, 
             submitWsWorkunit(context, cw, cluster, req.getSnapshot(), req.getMaxRunTime(), true, false);
 
         if (req.getBlockTillFinishTimer() != 0)
-            waitForWorkUnitToComplete(req.getWuid(), req.getBlockTillFinishTimer());
+            waitForWorkUnitToComplete(wuid.str(), req.getBlockTillFinishTimer());
 
-        resp.setRedirectUrl(StringBuffer("/WsWorkunits/WUInfo?Wuid=").append(req.getWuid()).str());
+        resp.setRedirectUrl(StringBuffer("/WsWorkunits/WUInfo?Wuid=").append(wuid).str());
     }
     catch(IException* e)
     {
@@ -1185,11 +1218,15 @@ bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWU
         if (notEmpty(cluster) && !isValidCluster(cluster))
             throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid cluster name: %s", cluster);
 
-        const char *runWuid = req.getWuid();
+        StringBuffer wuidStr = req.getWuid();
+        const char* runWuid = wuidStr.trim().str();
         StringBuffer wuid;
 
         if (runWuid && *runWuid)
         {
+            if (!looksLikeAWuid(runWuid))
+                throw MakeStringException(ECLWATCH_INVALID_INPUT, "Invalid Workunit ID: %s", runWuid);
+
             if (req.getCloneWorkunit())
                 runWsWorkunit(context, wuid, runWuid, cluster, req.getInput(), &req.getVariables(), &req.getDebugValues());
             else
@@ -1246,11 +1283,13 @@ bool CWsWorkunitsEx::onWUWaitCompiled(IEspContext &context, IEspWUWaitRequest &r
 {
     try
     {
-        secWaitForWorkUnitToCompile(req.getWuid(), *context.querySecManager(), *context.queryUser(), req.getWait());
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUWaitCompiled", wuid);
+        secWaitForWorkUnitToCompile(wuid.str(), *context.querySecManager(), *context.queryUser(), req.getWait());
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid.str());
         resp.setStateID(cw->getState());
     }
     catch(IException* e)
@@ -1264,7 +1303,9 @@ bool CWsWorkunitsEx::onWUWaitComplete(IEspContext &context, IEspWUWaitRequest &r
 {
     try
     {
-        resp.setStateID(secWaitForWorkUnitToComplete(req.getWuid(), *context.querySecManager(), *context.queryUser(), req.getWait(), req.getReturnOnWait()));
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUWaitComplete", wuid);
+        resp.setStateID(secWaitForWorkUnitToComplete(wuid.str(), *context.querySecManager(), *context.queryUser(), req.getWait(), req.getReturnOnWait()));
     }
     catch(IException* e)
     {
@@ -1277,8 +1318,10 @@ bool CWsWorkunitsEx::onWUCDebug(IEspContext &context, IEspWUDebugRequest &req, I
 {
     try
     {
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUCDebug", wuid);
         StringBuffer result;
-        secDebugWorkunit(req.getWuid(), *context.querySecManager(), *context.queryUser(), req.getCommand(), result);
+        secDebugWorkunit(wuid.str(), *context.querySecManager(), *context.queryUser(), req.getCommand(), result);
         resp.setResult(result);
     }
     catch(IException* e)
@@ -1560,12 +1603,8 @@ bool getWsWuInfoFromSasha(IEspContext &context, SocketEndpoint &ep, const char* 
 
 #define     WUDETAILS_REFRESH_MINS 1
 
-void getArchivedWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEspWUInfoResponse &resp)
+void getArchivedWUInfo(IEspContext &context, const char *wuid, IEspWUInfoResponse &resp)
 {
-    const char *wuid = req.getWuid();
-    if (isEmpty(req.getWuid()))
-        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Workunit ID not specified.");
-
     Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
 
@@ -1578,7 +1617,7 @@ void getArchivedWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEspWUInfoR
     {
         IPropertyTree &instance = instances->query();
         SocketEndpoint ep(instance.queryProp("@netAddress"), instance.getPropInt("@port", 8877));
-        if (getWsWuInfoFromSasha(context, ep, req.getWuid(), &resp.updateWorkunit()))
+        if (getWsWuInfoFromSasha(context, ep, wuid, &resp.updateWorkunit()))
         {
             resp.setAutoRefresh(WUDETAILS_REFRESH_MINS);
             resp.setCanCompile(false);
@@ -1597,8 +1636,11 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
 {
     try
     {
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUInfo", wuid);
+
         if (req.getType() && strieq(req.getType(), "archived workunits"))
-            getArchivedWUInfo(context, req, resp);
+            getArchivedWUInfo(context, wuid.str(), resp);
         else
         {
             unsigned flags=0;
@@ -1627,7 +1669,7 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
 
             try
             {
-                WsWuInfo winfo(context, req.getWuid());
+                WsWuInfo winfo(context, wuid.str());
                 winfo.getInfo(resp.updateWorkunit(), flags);
 
                 if (req.getIncludeResultsViewNames())
@@ -1641,7 +1683,7 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
             {
                 if (e->errorCode() != ECLWATCH_CANNOT_OPEN_WORKUNIT)
                     throw e;
-                getArchivedWUInfo(context, req, resp);
+                getArchivedWUInfo(context, wuid.str(), resp);
             }
 
             switch (resp.getWorkunit().getStateID())
@@ -1683,8 +1725,12 @@ bool CWsWorkunitsEx::onWUInfoDetails(IEspContext &context, IEspWUInfoRequest &re
 
 bool CWsWorkunitsEx::onWUResultView(IEspContext &context, IEspWUResultViewRequest &req, IEspWUResultViewResponse &resp)
 {
-    ensureWsWorkunitAccess(context, req.getWuid(), SecAccess_Read);
-    Owned<IWuWebView> wv = createWuWebView(req.getWuid(), NULL, getCFD(), true);
+    StringBuffer wuid = req.getWuid();
+    checkAndTrimWorkunit("WUResultView", wuid);
+
+    ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Read);
+
+    Owned<IWuWebView> wv = createWuWebView(wuid.str(), NULL, getCFD(), true);
     StringBuffer html;
     wv->renderSingleResult(req.getViewName(), req.getResultName(), html);
     resp.setResult(html.str());
@@ -2223,12 +2269,18 @@ bool CWsWorkunitsEx::onWUQuery(IEspContext &context, IEspWUQueryRequest & req, I
 {
     try
     {
-        DBGLOG("Started CWsWorkunitsEx::onWUQuery\n");
+        StringBuffer wuidStr = req.getWuid();
+        const char* wuid = wuidStr.trim().str();
 
         if (req.getType() && strieq(req.getType(), "archived workunits"))
             doWUQueryFromArchive(context, *archivedWuCache, awusCacheMinutes, req, resp);
-        else if(notEmpty(req.getWuid()))
-            doWUQueryBySingleWuid(context, req.getWuid(), resp);
+        else if(notEmpty(wuid))
+        {
+            if (!looksLikeAWuid(wuid))
+                throw MakeStringException(ECLWATCH_INVALID_INPUT, "Invalid Workunit ID: %s", wuid);
+
+            doWUQueryBySingleWuid(context, wuid, resp);
+        }
         else if (notEmpty(req.getECL()) || notEmpty(req.getApplicationName()) || notEmpty(req.getApplicationKey()) || notEmpty(req.getApplicationData()))
             doWUQueryByXPath(context, req, resp);
         else if (notEmpty(req.getLogicalFile()) && req.getLogicalFileSearchType() && strieq(req.getLogicalFileSearchType(), "Created"))
@@ -2453,10 +2505,17 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
 {
     try
     {
-        DBGLOG("CWsWorkunitsEx::onWUFile WUID=%s",req.getWuid());
+        StringBuffer wuidStr = req.getWuid();
+        const char* wuidIn = wuidStr.trim().str();
+        if (wuidIn && *wuidIn)
+        {
+            if (!looksLikeAWuid(wuidIn))
+                throw MakeStringException(ECLWATCH_INVALID_INPUT, "Invalid Workunit ID");
 
-        ensureWsWorkunitAccess(context, req.getWuid(), SecAccess_Read);
-        StringAttr wuid(req.getWuid());
+            ensureWsWorkunitAccess(context, wuidIn, SecAccess_Read);
+        }
+
+        StringAttr wuid(wuidIn);
         if (wuid.isEmpty() && notEmpty(req.getQuerySet()) && notEmpty(req.getQuery()))
         {
             Owned<IPropertyTree> registry = getQueryRegistry(req.getQuerySet(), false);
@@ -2541,7 +2600,15 @@ bool CWsWorkunitsEx::onWUResultBin(IEspContext &context,IEspWUResultBinRequest &
 {
     try
     {
-        ensureWsWorkunitAccess(context, req.getWuid(), SecAccess_Read);
+        StringBuffer wuidStr = req.getWuid();
+        const char* wuidIn = wuidStr.trim().str();
+        if (wuidIn && *wuidIn)
+        {
+            if (!looksLikeAWuid(wuidIn))
+                throw MakeStringException(ECLWATCH_INVALID_INPUT, "Invalid Workunit ID: %s", wuidIn);
+
+            ensureWsWorkunitAccess(context, wuidIn, SecAccess_Read);
+        }
 
         MemoryBuffer mb;
         __int64 total=0;
@@ -2550,10 +2617,10 @@ bool CWsWorkunitsEx::onWUResultBin(IEspContext &context,IEspWUResultBinRequest &
         SCMStringBuffer name;
 
         bool bin = (req.getFormat() && strieq(req.getFormat(),"raw"));
-        if (notEmpty(req.getWuid()) && notEmpty(req.getResultName()))
-            getWsWuResult(context, req.getWuid(), req.getResultName(), NULL, 0, start, count, total, name, bin, mb);
-        else if (notEmpty(req.getWuid()) && (req.getSequence() >= 0))
-            getWsWuResult(context, req.getWuid(), NULL, NULL, req.getSequence(), start, count, total, name, bin,mb);
+        if (notEmpty(wuidIn) && notEmpty(req.getResultName()))
+            getWsWuResult(context, wuidIn, req.getResultName(), NULL, 0, start, count, total, name, bin, mb);
+        else if (notEmpty(wuidIn) && (req.getSequence() >= 0))
+            getWsWuResult(context, wuidIn, NULL, NULL, req.getSequence(), start, count, total, name, bin,mb);
         else if (notEmpty(req.getLogicalName()))
         {
             const char* logicalName = req.getLogicalName();
@@ -2638,7 +2705,7 @@ bool CWsWorkunitsEx::onWUResultBin(IEspContext &context,IEspWUResultBinRequest &
         }
 
         resp.setName(name.str());
-        resp.setWuid(req.getWuid());
+        resp.setWuid(wuidIn);
         resp.setSequence(req.getSequence());
         resp.setStart(start);
         if (requested > total)
@@ -2659,13 +2726,16 @@ bool CWsWorkunitsEx::onWUResultSummary(IEspContext &context, IEspWUResultSummary
 {
     try
     {
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUResultSummary", wuid);
+
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid.str());
         ensureWsWorkunitAccess(context, *cw, SecAccess_Read);
 
-        resp.setWuid(req.getWuid());
+        resp.setWuid(wuid.str());
         resp.setSequence(req.getSequence());
 
         IArrayOf<IEspECLResult> results;
@@ -2720,7 +2790,15 @@ bool CWsWorkunitsEx::onWUResult(IEspContext &context, IEspWUResultRequest &req, 
 {
     try
     {
-        ensureWsWorkunitAccess(context, req.getWuid(), SecAccess_Read);
+        StringBuffer wuidStr = req.getWuid();
+        const char* wuid = wuidStr.trim().str();
+        if (wuid && *wuid)
+        {
+            if (!looksLikeAWuid(wuid))
+                throw MakeStringException(ECLWATCH_INVALID_INPUT, "Invalid Workunit ID: %s", wuid);
+
+            ensureWsWorkunitAccess(context, wuid, SecAccess_Read);
+        }
 
         MemoryBuffer mb;
         SCMStringBuffer name;
@@ -2733,11 +2811,11 @@ bool CWsWorkunitsEx::onWUResult(IEspContext &context, IEspWUResultRequest &req, 
         VStringBuffer filter("start=%"I64F"d;count=%d", start, count);
         addToQueryString(filter, "clusterName", req.getCluster(), ';');
         addToQueryString(filter, "logicalName", req.getLogicalName(), ';');
-        addToQueryString(filter, "wuid", req.getWuid(), ';');
+        if (wuid && *wuid)
+            addToQueryString(filter, "wuid", wuid, ';');
         addToQueryString(filter, "resultName", req.getResultName(), ';');
         filter.appendf(";seq=%d;", seq);
 
-        const char* wuid = req.getWuid();
         const char* logicalName = req.getLogicalName();
         const char* clusterName = req.getCluster();
         const char* resultName = req.getResultName();
@@ -2974,16 +3052,15 @@ bool CWsWorkunitsEx::onWUListLocalFileRequired(IEspContext& context, IEspWUListL
 {
     try
     {
-        const char* wuid = req.getWuid();
-        if (isEmpty(wuid))
-            throw MakeStringException(ECLWATCH_INVALID_INPUT, "Workunit ID not defined.");
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUListLocalFileRequired", wuid);
 
-        ensureWsWorkunitAccess(context, wuid, SecAccess_Read);
+        ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Read);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid, false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if (!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT, "Workunit %s not found.", wuid);
+            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT, "Workunit %s not found.", wuid.str());
 
         IArrayOf<IEspLogicalFileUpload> localFiles;
         Owned<IConstLocalFileUploadIterator> it = cw->getLocalFileUploads();
@@ -3074,14 +3151,10 @@ bool CWsWorkunitsEx::onWUAddLocalFileToWorkunit(IEspContext& context, IEspWUAddL
 {
     try
     {
-        const char* wuid = req.getWuid();
-        if (isEmpty(wuid))
-        {
-            resp.setResult("WUID is not defined!");
-            return true;
-        }
-        ensureWsWorkunitAccess(context, wuid, SecAccess_Write);
-        resp.setWuid(wuid);
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUAddLocalFileToWorkunit", wuid);
+        ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Write);
+        resp.setWuid(wuid.str());
 
         const char* varname = req.getName();
         if (isEmpty(varname))
@@ -3096,7 +3169,7 @@ bool CWsWorkunitsEx::onWUAddLocalFileToWorkunit(IEspContext& context, IEspWUAddL
         unsigned len = req.getLength();
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        WorkunitUpdate wu(factory->updateWorkUnit(wuid));
+        WorkunitUpdate wu(factory->updateWorkUnit(wuid.str()));
         if (!wu)
         {
             resp.setResult("Workunit not found!");
@@ -3200,10 +3273,13 @@ bool CWsWorkunitsEx::onWUProcessGraph(IEspContext &context,IEspWUProcessGraphReq
 {
     try
     {
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUProcessGraph", wuid);
+
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid.str());
         ensureWsWorkunitAccess(context, *cw, SecAccess_Read);
 
         Owned <IConstWUGraph> graph = cw->getGraph(req.getName());
@@ -3238,10 +3314,13 @@ bool CWsWorkunitsEx::onWUGetGraph(IEspContext& context, IEspWUGetGraphRequest& r
 {
     try
     {
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUGetGraph", wuid);
+
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid.str());
         ensureWsWorkunitAccess(context, *cw, SecAccess_Read);
 
         WUGraphIDType id;
@@ -3338,14 +3417,17 @@ bool CWsWorkunitsEx::onWUGraphInfo(IEspContext &context,IEspWUGraphInfoRequest &
 {
     try
     {
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUGraphInfo", wuid);
+
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",wuid.str());
 
         ensureWsWorkunitAccess(context, *cw, SecAccess_Write);
 
-        resp.setWuid(req.getWuid());
+        resp.setWuid(wuid.str());
         resp.setName(req.getName());
         resp.setRunning(isRunning(*cw));
         if (notEmpty(req.getGID()))
@@ -3364,14 +3446,17 @@ bool CWsWorkunitsEx::onWUGVCGraphInfo(IEspContext &context,IEspWUGVCGraphInfoReq
 {
     try
     {
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUGVCGraphInfo", wuid);
+
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",wuid.str());
 
         ensureWsWorkunitAccess(context, *cw, SecAccess_Read);
 
-        resp.setWuid(req.getWuid());
+        resp.setWuid(wuid.str());
         resp.setName(req.getName());
         resp.setRunning(isRunning(*cw));
         if (notEmpty(req.getGID()))
@@ -3401,15 +3486,16 @@ bool CWsWorkunitsEx::onWUGraphTiming(IEspContext &context, IEspWUGraphTimingRequ
 {
     try
     {
-        DBGLOG("WUGraphTiming WUID=%s", req.getWuid());
+        StringBuffer wuid = req.getWuid();
+        checkAndTrimWorkunit("WUGraphTiming", wuid);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(req.getWuid(), false);
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str(), false);
         if(!cw)
-            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",req.getWuid());
+            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",wuid.str());
         ensureWsWorkunitAccess(context, *cw, SecAccess_Read);
 
-        resp.updateWorkunit().setWuid(req.getWuid());
+        resp.updateWorkunit().setWuid(wuid.str());
 
         WsWuInfo winfo(context, cw);
         IArrayOf<IConstECLTimingData> timingData;

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -41,6 +41,7 @@ public:
     bool isValidCluster(const char *cluster);
     void deploySharedObject(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEspWUDeployWorkunitResponse & resp, const char *dir, const char *xml=NULL);
     void deploySharedObject(IEspContext &context, StringBuffer &wuid, const char *filename, const char *cluster, const char *name, const MemoryBuffer &obj, const char *dir, const char *xml=NULL);
+    void checkAndTrimWorkunit(const char* methodName, StringBuffer& input);
 
     bool onWUQuery(IEspContext &context, IEspWUQueryRequest &req, IEspWUQueryResponse &resp);
     bool onWUPublishWorkunit(IEspContext &context, IEspWUPublishWorkunitRequest & req, IEspWUPublishWorkunitResponse & resp);


### PR DESCRIPTION
Searching for a workunit with an id that ends in a space
leads to an internal error. This fix trims both left spaces
and right spaces of a workunit id input for all of the
methods in ws_workunit. This fix also checks the format
of the id and, if the id contains invalid characters,
displays an error: 'Invalid Workunit ID'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
