### PR TITLE
Fix gh-2990 - rowarray removeRows crash

### DIFF
--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -582,12 +582,13 @@ void CThorExpandingRowArray::removeRows(rowidx_t start, rowidx_t n)
     assertex(!n || rows);
     if (rows)
     {
-        for (rowidx_t i = start; i < start+n; i++)
+        rowidx_t end = start+n;
+        for (rowidx_t i = start; i < end; i++)
             ReleaseThorRow(rows[i]);
         //firstRow = 0;
-        numRows -= n;
         const void **from = rows+start;
-        memmove(from, from+n, n * sizeof(void *));
+        memmove(from, from+n, (numRows-end) * sizeof(void *));
+        numRows -= n;
     }
 }
 


### PR DESCRIPTION
CThorExpandingRowArray::removeRows, was memmoving memory beyond the row ptr
table, causing a segfault if unlucky.
This caused mini sort to fail.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
