### PR TITLE
Fix gh-2834 - variable length indexwrite fix

### DIFF
--- a/system/jhtree/ctfile.cpp
+++ b/system/jhtree/ctfile.cpp
@@ -356,7 +356,8 @@ bool CWriteNode::add(offset_t pos, const void *indata, size32_t insize, unsigned
         hdr.keyBytes += bytes;
     }
 
-    assertex(insize<=keyLen);
+    if (insize>keyLen)
+        throw MakeStringException(0, "key+payload exceeds max length");
     memcpy(lastKeyValue, indata, insize);
     lastSequence = sequence;
     hdr.numKeys++;

--- a/system/jhtree/ctfile.hpp
+++ b/system/jhtree/ctfile.hpp
@@ -39,7 +39,7 @@
 #define HTREE_COMPRESSED_KEY 0x40
 #define HTREE_QUICK_COMPRESSED_KEY 0x48
 #define KEYBUILD_VERSION 1 // unsigned short. NB: This should upped if a change would make existing keys incompatible with current build.
-
+#define KEYBUILD_MAXLENGTH 0x7FFF
 
 // structure to be read into - NO VIRTUALS.
 // This header layout corresponds to FairCom cTree layout for compatibility with old systems ...

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -23,6 +23,7 @@
 #include "dadfs.hpp"
 #include "dautils.hpp"
 
+#include "ctfile.hpp"
 #include "eclrtl.hpp"
 #include "thorfile.hpp"
 
@@ -61,8 +62,8 @@ public:
         dlfn.set(helper->getFileName());
         isLocal = 0 != (TIWlocal & helper->getFlags());
         unsigned maxSize = helper->queryDiskRecordSize()->getMinRecordSize();
-        if (maxSize >= 0x8000)
-            throw MakeActivityException(this, 0, "Index minimum record length (%d) exceeds 32767 internal limit", maxSize);
+        if (maxSize > KEYBUILD_MAXLENGTH)
+            throw MakeActivityException(this, 0, "Index minimum record length (%d) exceeds %d internal limit", maxSize, KEYBUILD_MAXLENGTH);
 
         singlePartKey = 0 != (helper->getFlags() & TIWsmall) || dlfn.isExternal();
         clusters.kill();

--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -167,7 +167,9 @@ public:
             }
         }
         assertex(!(helper->queryDiskRecordSize()->getMetaFlags() & MDFneedserialize));
-        maxDiskRecordSize = helper->queryDiskRecordSize()->isVariableSize() ? 4096 : helper->queryDiskRecordSize()->getFixedSize();
+        // NB: the max [ecl] length is not used, other than setting a max field in the header.
+        // However, legacy systems (<=702) check that query rec length == key rec len.
+        maxDiskRecordSize = helper->queryDiskRecordSize()->getRecordSize(NULL);
         reportOverflow = false;
     }
 


### PR DESCRIPTION
Hard-coded 4k limit increased to 32k (the upper limit as defined by the key
header definition)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
