### PR TITLE
Additional small regression in recent esp serialization refactoring

### DIFF
--- a/esp/bindings/SOAP/Platform/soapparam.hpp
+++ b/esp/bindings/SOAP/Platform/soapparam.hpp
@@ -107,7 +107,7 @@ private:
    cpptype value;
 
 public:
-    SoapParam(nilBehavior nb=nilIgnore, bool httpNil=true) : BaseEspParam(nb, httpNil){}
+    SoapParam(nilBehavior nb=nilIgnore, bool httpNil=true) : BaseEspParam(nb, httpNil), value(0){}
     SoapParam(inittype val, nilBehavior nb=nilIgnore, bool httpNil=true) : BaseEspParam(nb, httpNil), value(val){}
 
     cpptype getValue() const {return value;}


### PR DESCRIPTION
Incoming numeric ESP service parameters without explicit default
may not be initialized.  Regression in 3.10 and master only.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
