### PR TITLE
gh-2998 Remove some getRecordSize(NULL) calls

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -3397,7 +3397,6 @@ public:
         unsigned keyprocessedBefore = keyprocessed;
         bool continuationFailed = false;
         const byte *rawSeek = NULL;
-        size32_t eclKeySize = indexHelper->queryDiskRecordSize()->getRecordSize(NULL);
         if (steppingRow)
             rawSeek = steppingRow;
         bool continuationNeeded = false;


### PR DESCRIPTION
Remove some calls to getRecordSize(NULL) in Roxie (all results were unused).

Note that I no longer pass the (code) record size to createKeyMerger - this
means that mismatches won't be deteced at this point, but Roxie should have
picked them up earlier anyway (with a full meta compare).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
