### PR TITLE
Add --no-reload option to ecl-publish and ecl-queries-copy

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -54,6 +54,8 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_PASSWORD_INI "eclPassword"
 #define ECLOPT_PASSWORD_ENV "ECL_PASSWORD"
 
+#define ECLOPT_NORELOAD "--no-reload"
+
 #define ECLOPT_ACTIVATE "--activate"
 #define ECLOPT_ACTIVATE_S "-A"
 #define ECLOPT_ACTIVATE_INI "activateDefault"

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -451,8 +451,8 @@ public:
             "                          (defaults to cluster defined inside workunit)\n"
             "   -n, --name=<val>       query name to use for published workunit\n"
             "   -A, --activate         activates query when published\n"
-            "   --no-reload            do not request the (roxie) cluster to reload\n"
-            "   --wait=<ms>            maximum time to wait for cluster to finish updating\n",
+            "   --no-reload            Do not request a reload of the (roxie) cluster\n"
+            "   --wait=<ms>            Max time to wait in milliseconds\n"
             stdout);
         EclCmdWithEclTarget::usage();
     }

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -324,7 +324,7 @@ private:
 class EclCmdPublish : public EclCmdWithEclTarget
 {
 public:
-    EclCmdPublish() : optActivate(false), activateSet(false), optMsToWait(10000)
+    EclCmdPublish() : optActivate(false), activateSet(false), optNoReload(false), optMsToWait(10000)
     {
         optObj.accept = eclObjWuid | eclObjArchive | eclObjSharedObject;
     }
@@ -344,13 +344,15 @@ public:
                 continue;
             if (iter.matchOption(optCluster, ECLOPT_CLUSTER)||iter.matchOption(optCluster, ECLOPT_CLUSTER_S))
                 continue;
-            if (iter.matchOption(optCluster, ECLOPT_WAIT))
+            if (iter.matchOption(optMsToWait, ECLOPT_WAIT))
                 continue;
             if (iter.matchFlag(optActivate, ECLOPT_ACTIVATE)||iter.matchFlag(optActivate, ECLOPT_ACTIVATE_S))
             {
                 activateSet=true;
                 continue;
             }
+            if (iter.matchFlag(optNoReload, ECLOPT_NORELOAD))
+                continue;
             if (EclCmdWithEclTarget::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }
@@ -408,6 +410,7 @@ public:
         if (optCluster.length())
             req->setCluster(optCluster.get());
         req->setWait(optMsToWait);
+        req->setNoReload(optNoReload);
 
         Owned<IClientWUPublishWorkunitResponse> resp = client->WUPublishWorkunit(req);
         const char *id = resp->getQueryId();
@@ -448,6 +451,7 @@ public:
             "                          (defaults to cluster defined inside workunit)\n"
             "   -n, --name=<val>       query name to use for published workunit\n"
             "   -A, --activate         activates query when published\n"
+            "   --no-reload            do not request the (roxie) cluster to reload\n"
             "   --wait=<ms>            maximum time to wait for cluster to finish updating\n",
             stdout);
         EclCmdWithEclTarget::usage();
@@ -455,9 +459,10 @@ public:
 private:
     StringAttr optCluster;
     StringAttr optName;
-    int optMsToWait;
+    unsigned optMsToWait;
     bool optActivate;
     bool activateSet;
+    bool optNoReload;
 };
 
 class EclCmdRun : public EclCmdWithEclTarget

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -356,7 +356,7 @@ public:
             "   <target_queryset>      name of queryset to copy the query into\n"
             "   -cl, --cluster=<name>  Local cluster to associate with remote workunit\n"
             "   -A, --activate         Activate the new query\n"
-            "   --no-reload            Do not ask the (roxie) cluster to reload\n"
+            "   --no-reload            Do not request a reload of the (roxie) cluster\n"
             "   --wait=<ms>            Max time to wait in milliseconds\n"
             " Common Options:\n",
             stdout);

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -260,7 +260,7 @@ private:
 class EclCmdQueriesCopy : public EclCmdCommon
 {
 public:
-    EclCmdQueriesCopy() : optActivate(false), optMsToWait(10000)
+    EclCmdQueriesCopy() : optActivate(false), optNoReload(false), optMsToWait(10000)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -282,6 +282,8 @@ public:
                 continue;
             }
             if (iter.matchFlag(optActivate, ECLOPT_ACTIVATE)||iter.matchFlag(optActivate, ECLOPT_ACTIVATE_S))
+                continue;
+            if (iter.matchFlag(optNoReload, ECLOPT_NORELOAD))
                 continue;
             if (iter.matchOption(optCluster, ECLOPT_CLUSTER)||iter.matchOption(optCluster, ECLOPT_CLUSTER_S))
                 continue;
@@ -323,6 +325,7 @@ public:
         req->setCluster(optCluster.get());
         req->setActivate(optActivate);
         req->setWait(optMsToWait);
+        req->setNoReload(optNoReload);
 
         Owned<IClientWUQuerySetCopyQueryResponse> resp = client->WUQuerysetCopyQuery(req);
         if (resp->getExceptions().ordinality())
@@ -353,6 +356,7 @@ public:
             "   <target_queryset>      name of queryset to copy the query into\n"
             "   -cl, --cluster=<name>  Local cluster to associate with remote workunit\n"
             "   -A, --activate         Activate the new query\n"
+            "   --no-reload            Do not ask the (roxie) cluster to reload\n"
             "   --wait=<ms>            Max time to wait in milliseconds\n"
             " Common Options:\n",
             stdout);
@@ -364,6 +368,7 @@ private:
     StringAttr optCluster;
     unsigned optMsToWait;
     bool optActivate;
+    bool optNoReload;
 };
 
 IEclCommand *createEclQueriesCommand(const char *cmdname)

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1063,6 +1063,7 @@ ESPrequest WUPublishWorkunitRequest
     bool showFiles(0);
     bool CopyLocal(0);
     int Wait(10000);
+    bool NoReload(0);
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse
@@ -1248,6 +1249,7 @@ ESPrequest WUQuerySetCopyQueryRequest
     string Cluster;
     int Activate;
     int Wait(10000);
+    bool NoReload(0);
 };
 
 ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -319,32 +319,32 @@ IPropertyTree *sendRoxieControlAllNodes(const SocketEndpoint &ep, const char *ms
 
 bool reloadCluster(IConstWUClusterInfo *clusterInfo, unsigned wait)
 {
-    if (clusterInfo->getPlatform()==RoxieCluster)
+    if (0==wait || !clusterInfo || clusterInfo->getPlatform()!=RoxieCluster)
+        return true;
+
+    const SocketEndpointArray &addrs = clusterInfo->getRoxieServers();
+    if (addrs.length())
     {
-        const SocketEndpointArray &addrs = clusterInfo->getRoxieServers();
-        if (addrs.length())
+        try
         {
-            try
-            {
-                Owned<IPropertyTree> result = sendRoxieControlAllNodes(addrs.item(0), "<control:reload/>", false, wait);
-                const char *status = result->queryProp("Endpoint[1]/Status");
-                if (!status || !strieq(status, "ok"))
-                    return false;
-            }
-            catch(IMultiException *me)
-            {
-                StringBuffer err;
-                DBGLOG("ERROR control:reloading roxie query info %s", me->errorMessage(err.append(me->errorCode()).append(' ')).str());
-                me->Release();
+            Owned<IPropertyTree> result = sendRoxieControlAllNodes(addrs.item(0), "<control:reload/>", false, wait);
+            const char *status = result->queryProp("Endpoint[1]/Status");
+            if (!status || !strieq(status, "ok"))
                 return false;
-            }
-            catch(IException *e)
-            {
-                StringBuffer err;
-                DBGLOG("ERROR control:reloading roxie query info %s", e->errorMessage(err.append(e->errorCode()).append(' ')).str());
-                e->Release();
-                return false;
-            }
+        }
+        catch(IMultiException *me)
+        {
+            StringBuffer err;
+            DBGLOG("ERROR control:reloading roxie query info %s", me->errorMessage(err.append(me->errorCode()).append(' ')).str());
+            me->Release();
+            return false;
+        }
+        catch(IException *e)
+        {
+            StringBuffer err;
+            DBGLOG("ERROR control:reloading roxie query info %s", e->errorMessage(err.append(e->errorCode()).append(' ')).str());
+            e->Release();
+            return false;
         }
     }
     return true;
@@ -410,8 +410,10 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
         resp.setClusterFiles(clusterfiles);
     }
 
-    bool reloaded = reloadCluster(clusterInfo, (unsigned)req.getWait());
-    resp.setReloadFailed(!reloaded);
+    bool reloadFailed = false;
+    if (0!=req.getWait() && !req.getNoReload())
+        reloadFailed = !reloadCluster(clusterInfo, (unsigned)req.getWait());
+    resp.setReloadFailed(reloadFailed);
 
     return true;
 }
@@ -901,8 +903,11 @@ bool CWsWorkunitsEx::onWUQuerysetCopyQuery(IEspContext &context, IEspWUQuerySetC
 
     StringArray querysetClusters;
     getQuerySetTargetClusters(target, querysetClusters);
-    ForEachItemIn(i, querysetClusters)
-        reloadCluster(querysetClusters.item(i), remainingMsWait(req.getWait(), start));
 
+    if (0!=req.getWait() && !req.getNoReload())
+    {
+        ForEachItemIn(i, querysetClusters)
+            reloadCluster(querysetClusters.item(i), remainingMsWait(req.getWait(), start));
+    }
     return true;
 }


### PR DESCRIPTION
--no-reload will prevent signalling roxie to do an imediate reload
of queries.

--wait=0 will also not bother to reload since it would immediately
time out.

Users should prefer --no-reload as the effects of --wait=0 may
change over time.

Fixes gh-2694

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
