### PR TITLE
Fix gh-2849 Move Total Thor Time to end of Timings

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -368,6 +368,9 @@ bool WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
         return true;
     try
     {
+        StringBuffer totalThorTimeValue;
+        unsigned totalThorTimerCount; //Do we need this?
+
         IArrayOf<IEspECLTimer> timers;
         Owned<IStringIterator> it = &cw->getTimers();
         ForEach(*it)
@@ -382,6 +385,13 @@ bool WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
             for (unsigned i = 0; i < name.length(); i++)
              if (name.s.charAt(i)=='_')
                  name.s.setCharAt(i, ' ');
+
+            if (strieq(name.str(), TOTALTHORTIME))
+            {
+                totalThorTimeValue = fd;
+                totalThorTimerCount = count;
+                continue;
+            }
 
             Owned<IEspECLTimer> t= createECLTimer("","");
             t->setName(name.str());
@@ -408,6 +418,16 @@ bool WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
 
             timers.append(*t.getLink());
         }
+
+        if (totalThorTimeValue.length() > 0)
+        {
+            Owned<IEspECLTimer> t= createECLTimer("","");
+            t->setName(TOTALTHORTIME);
+            t->setValue(totalThorTimeValue.str());
+            t->setCount(totalThorTimerCount);
+            timers.append(*t.getLink());
+        }
+
         info.setTimers(timers);
         return true;
     }
@@ -828,7 +848,7 @@ void WsWuInfo::getCommon(IEspECLWorkunit &info, unsigned flags)
     if (version > 1.27)
     {
         StringBuffer totalThorTimeStr;
-        unsigned totalThorTimeMS = cw->getTimerDuration("Total thor time", NULL);
+        unsigned totalThorTimeMS = cw->getTimerDuration(TOTALTHORTIME, NULL);
         formatDuration(totalThorTimeStr, totalThorTimeMS);
         info.setTotalThorTime(totalThorTimeStr.str());
     }

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -43,6 +43,8 @@ namespace ws_workunits {
 #define    File_DLL "dll"
 #define    File_ArchiveQuery "ArchiveQuery"
 
+#define    TOTALTHORTIME    "Total thor time"
+
 #define    TEMPZIPDIR "tempzipfiles"
 
 static const long MAXXLSTRANSFER = 5000000;


### PR DESCRIPTION
In EclWatch workunit details under Timings, "Total thor time"
is sometimes difficult to find because it is in the middle of
all the timings instead of being on the end. Having it on the
end would make it easier to find.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
