### PR TITLE
Rationalize cluster name command line usage

### DIFF
--- a/docs/HPCCClientTools/CT_Mods/CT_ECL_CLI.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_ECL_CLI.xml
@@ -108,20 +108,20 @@
       <sect2 role="brk">
         <title>ecl deploy</title>
 
-        <para><emphasis role="bold">ecl deploy --cluster=&lt;value&gt;
+        <para><emphasis role="bold">ecl deploy --target=&lt;value&gt;
         --name=&lt;value&gt; &lt;ecl_file | - &gt; </emphasis></para>
 
-        <para><emphasis role="bold">ecl deploy --cluster=&lt;value&gt;
+        <para><emphasis role="bold">ecl deploy --target=&lt;value&gt;
         --name=&lt;value&gt; &lt;archive | - &gt; </emphasis></para>
 
-        <para><emphasis role="bold">ecl deploy [--cluster=&lt;value&gt;]
+        <para><emphasis role="bold">ecl deploy [--target=&lt;value&gt;]
         [--name=&lt;value&gt;] &lt;so | dll | - &gt;</emphasis></para>
 
         <para>Examples:</para>
 
-        <programlisting>ecl deploy --cluster=roxie --name=FindPersonService findperson.ecl
-ecl deploy --cluster=roxie --name=FindPersonService ArchiveQuery.xml
-ecl deploy --cluster=roxie --name=FindPersonService libW20120224-125557.so
+        <programlisting>ecl deploy --target=roxie --name=FindPersonService findperson.ecl
+ecl deploy --target=roxie --name=FindPersonService ArchiveQuery.xml
+ecl deploy --target=roxie --name=FindPersonService libW20120224-125557.so
 </programlisting>
 
         <para>A hyphen (-) specifies that the object should be read from
@@ -168,9 +168,9 @@ ecl deploy --cluster=roxie --name=FindPersonService libW20120224-125557.so
                 </row>
 
                 <row>
-                  <entry>-cl, --cluster</entry>
+                  <entry>-t, --target</entry>
 
-                  <entry>The cluster to associate workunit with</entry>
+                  <entry>The target cluster to associate workunit with</entry>
                 </row>
 
                 <row>
@@ -258,27 +258,27 @@ ecl deploy --cluster=roxie --name=FindPersonService libW20120224-125557.so
       <sect2 role="brk">
         <title>ecl publish</title>
 
-        <para><emphasis role="bold">ecl publish [--cluster=&lt;val&gt;]
+        <para><emphasis role="bold">ecl publish [--target=&lt;val&gt;]
         [--name=&lt;val&gt;] [--activate] &lt;wuid&gt; </emphasis></para>
 
-        <para><emphasis role="bold">ecl publish [--cluster=&lt;val&gt;]
+        <para><emphasis role="bold">ecl publish [--target=&lt;val&gt;]
         [--name=&lt;val&gt;] [--activate] &lt;so | dll | -
         &gt;</emphasis></para>
 
-        <para><emphasis role="bold">ecl publish --cluster=&lt;val&gt;
+        <para><emphasis role="bold">ecl publish --target=&lt;val&gt;
         --name=&lt;val&gt; [--activate] &lt;archive | - &gt;
         </emphasis></para>
 
-        <para><emphasis role="bold">ecl publish --cluster=&lt;val&gt;
+        <para><emphasis role="bold">ecl publish --target=&lt;val&gt;
         --name=&lt;val&gt; [--activate] &lt;ecl_file | -
         &gt;</emphasis></para>
 
         <para>Examples:</para>
 
-        <programlisting>ecl publish --cluster=roxie --name=FindPersonService -A W20120224-125557
-ecl publish --cluster=roxie --name=FindPersonService -A libW20120224-125557.so
-ecl publish --cluster=roxie --name=FindPersonService -A ArchiveQuery.xml
-ecl publish --cluster=roxie --name=FindPersonService --activate findperson.ecl
+        <programlisting>ecl publish --target=roxie --name=FindPersonService -A W20120224-125557
+ecl publish --target=roxie --name=FindPersonService -A libW20120224-125557.so
+ecl publish --target=roxie --name=FindPersonService -A ArchiveQuery.xml
+ecl publish --target=roxie --name=FindPersonService --activate findperson.ecl
 </programlisting>
 
         <para>A hyphen (-) specifies that the object should be read from
@@ -331,9 +331,9 @@ ecl publish --cluster=roxie --name=FindPersonService --activate findperson.ecl
                 </row>
 
                 <row>
-                  <entry>-cl, --cluster</entry>
+                  <entry>-t, --target</entry>
 
-                  <entry>The cluster to associate workunit with</entry>
+                  <entry>The target cluster to associate workunit with</entry>
                 </row>
 
                 <row>
@@ -516,32 +516,32 @@ ecl publish --cluster=roxie --name=FindPersonService --activate findperson.ecl
         <title>ecl run</title>
 
         <para><emphasis role="bold">ecl run
-        [--cluster=&lt;val&gt;][--input=&lt;file|xml&gt;][--wait=&lt;ms&gt;]
+        [--target=&lt;val&gt;][--input=&lt;file|xml&gt;][--wait=&lt;ms&gt;]
         &lt;wuid&gt; </emphasis></para>
 
         <para><emphasis role="bold">ecl run
-        [--cluster=&lt;c&gt;][--input=&lt;file|xml&gt;][--wait=&lt;ms&gt;]
+        [--target=&lt;c&gt;][--input=&lt;file|xml&gt;][--wait=&lt;ms&gt;]
         &lt;queryset&gt; &lt;query&gt; </emphasis></para>
 
         <para><emphasis role="bold">ecl run
-        [--cluster=&lt;c&gt;][--name=&lt;nm&gt;][--input=&lt;file|xml&gt;][--wait=&lt;i&gt;]
+        [--target=&lt;c&gt;][--name=&lt;nm&gt;][--input=&lt;file|xml&gt;][--wait=&lt;i&gt;]
         &lt;dll|-&gt; </emphasis></para>
 
-        <para><emphasis role="bold">ecl run --cluster=&lt;c&gt;
+        <para><emphasis role="bold">ecl run --target=&lt;c&gt;
         --name=&lt;nm&gt; [--input=&lt;file|xml&gt;][--wait=&lt;i&gt;]
         &lt;archive|-&gt; </emphasis></para>
 
-        <para><emphasis role="bold">ecl run --cluster=&lt;c&gt;
+        <para><emphasis role="bold">ecl run --target=&lt;c&gt;
         --name=&lt;nm&gt; [--input=&lt;file|xml&gt;][--wait=&lt;i&gt;]
         &lt;eclfile|-&gt;</emphasis></para>
 
         <para><emphasis role="bold">Examples</emphasis>:</para>
 
-        <programlisting>ecl run --cluster=thor --input=data.xml --wait=1000 W20120224-125557
-ecl run --cluster=thor --input=data.xml --wait=1000 thor findpersonservice
-ecl run --cluster=thor --input=data.xml --wait=1000 ArchiveQuery.xml
-ecl run --cluster=thor --input=data.xml --wait=1000 findperson.ecl
-ecl run --cluster=thor --input="&lt;request&gt;&lt;LName&gt;JONES&lt;/LName&gt;&lt;/request&gt;" findperson.ecl
+        <programlisting>ecl run --target=thor --input=data.xml --wait=1000 W20120224-125557
+ecl run --target=thor --input=data.xml --wait=1000 thor findpersonservice
+ecl run --target=thor --input=data.xml --wait=1000 ArchiveQuery.xml
+ecl run --target=thor --input=data.xml --wait=1000 findperson.ecl
+ecl run --target=thor --input="&lt;request&gt;&lt;LName&gt;JONES&lt;/LName&gt;&lt;/request&gt;" findperson.ecl
 </programlisting>
 
         <para>A hyphen (-) specifies that the object should be read from
@@ -594,9 +594,9 @@ ecl run --cluster=thor --input="&lt;request&gt;&lt;LName&gt;JONES&lt;/LName&gt;&
                 </row>
 
                 <row>
-                  <entry>-cl, --cluster</entry>
+                  <entry>-t, --target</entry>
 
-                  <entry>The cluster to associate workunit with</entry>
+                  <entry>The target cluster to associate workunit with</entry>
                 </row>
 
                 <row>
@@ -860,7 +860,7 @@ ecl run --cluster=thor --input="&lt;request&gt;&lt;LName&gt;JONES&lt;/LName&gt;&
         <title id="eclquerieslist">ecl queries list</title>
 
         <para><emphasis role="bold">ecl queries list
-        [&lt;queryset&gt;][--cluster=&lt;cluster&gt;][--show=&lt;flags&gt;]</emphasis></para>
+        [&lt;queryset&gt;][--target=&lt;cluster&gt;][--show=&lt;flags&gt;]</emphasis></para>
 
         <para><emphasis role="bold"></emphasis></para>
 
@@ -906,10 +906,10 @@ ecl queries list roxie myroxie --show=A </programlisting>
                 </row>
 
                 <row>
-                  <entry>-cl, --cluster</entry>
+                  <entry>-t, --target</entry>
 
-                  <entry>The cluster associated with the queries to
-                  list</entry>
+                  <entry>The target cluster associated with the queries
+                  to list</entry>
                 </row>
 
                 <row>
@@ -1041,9 +1041,9 @@ ecl queries copy //192.168.1.10:8010/thor/findperson thor
                 </row>
 
                 <row>
-                  <entry>-cl, --cluster</entry>
+                  <entry>-t, --target</entry>
 
-                  <entry>The cluster to associate with the remote
+                  <entry>The target cluster to associate with the remote
                   workunit</entry>
                 </row>
 
@@ -1524,7 +1524,7 @@ ecl package delete --queryset=roxie mypkg.pkg --overwritename=false
         <para>Examples:</para>
 
         <programlisting>ecl package list
-ecl package list --cluster=roxie
+ecl package list --process=roxie
 </programlisting>
 
         <para></para>
@@ -1557,11 +1557,11 @@ ecl package list --cluster=roxie
                 </row>
 
                 <row>
-                  <entry>--cluster</entry>
+                  <entry>--process</entry>
 
-                  <entry>The name of the cluster from which to list
-                  information. Default is all clusters associated with the
-                  Dali server.</entry>
+                  <entry>The name of the process cluster for which to list
+                  information. Default is all process clusters associated
+                  with the Dali server.</entry>
                 </row>
 
                 <row>
@@ -1603,16 +1603,16 @@ ecl package list --cluster=roxie
         <title>ecl package info</title>
 
         <para><emphasis role="bold">ecl package info [options]
-        [--cluster=&lt;clusterName&gt; |
+        [--process=&lt;processCluster&gt; |
         --packageName=MyPackage]</emphasis></para>
 
         <para>Examples:</para>
 
         <programlisting>ecl package info --packageName=mypackage
-ecl package list --cluster=roxie
+ecl package list --process=myroxie
 </programlisting>
 
-        <para>Specify either --cluster or packageName.</para>
+        <para>Specify either --process or packageName.</para>
 
         <para><informaltable colsep="0" frame="none" rowsep="0">
             <tgroup cols="2">
@@ -1645,15 +1645,15 @@ ecl package list --cluster=roxie
                   <entry>--packageName</entry>
 
                   <entry>The name of the package from which to list
-                  information. (Specify either --cluster or
+                  information. (Specify either --process or
                   packageName)</entry>
                 </row>
 
                 <row>
-                  <entry>--cluster</entry>
+                  <entry>--process</entry>
 
-                  <entry>The name of the cluster from which to list
-                  information. (Specify either --cluster or
+                  <entry>The name of the process cluster for which to
+                  list information. (Specify either --process or 
                   packageName)</entry>
                 </row>
 

--- a/docs/HPCCClientTools/CT_Mods/ECLCC.xml
+++ b/docs/HPCCClientTools/CT_Mods/ECLCC.xml
@@ -194,19 +194,19 @@
               </row>
 
               <row>
-                <entry>-target=hthor</entry>
+                <entry>-platform=hthor</entry>
 
                 <entry>Generate code for hthor executable (default)</entry>
               </row>
 
               <row>
-                <entry>-target=roxie</entry>
+                <entry>-platform=roxie</entry>
 
                 <entry>Generate code for roxie cluster</entry>
               </row>
 
               <row>
-                <entry>-target=thor</entry>
+                <entry>-platform=thor</entry>
 
                 <entry>Generate code for thor cluster</entry>
               </row>

--- a/docs/Visualizing/Visualizing.xml
+++ b/docs/Visualizing/Visualizing.xml
@@ -188,9 +188,9 @@
 
           <para>For example:</para>
 
-          <programlisting>ecl deploy myarchive.xml --server=192.168.219.8 --cluster=thor</programlisting>
+          <programlisting>ecl deploy myarchive.xml --server=192.168.219.8 --target=thor</programlisting>
 
-          <programlisting>ecl publish &lt;WUID&gt; --server=192.168.219.8 --cluster=thor --activate--name=pie</programlisting>
+          <programlisting>ecl publish &lt;WUID&gt; --server=192.168.219.8 --target=thor --activate--name=pie</programlisting>
 
           <para />
         </listitem>
@@ -402,13 +402,13 @@
       </listitem>
     </itemizedlist>
 
-    <programlisting>ecl deploy myarchive.xml --server=10.239.219.8 --cluster=thor</programlisting>
+    <programlisting>ecl deploy myarchive.xml --server=10.239.219.8 --target=thor</programlisting>
 
     <para>
       <emphasis>where --server= is the IP address of your ESP server
       and</emphasis>
 
-      <emphasis>--cluster= is the target cluster name.</emphasis>
+      <emphasis>--target= is the target cluster name.</emphasis>
     </para>
 
     <itemizedlist mark="bullet">
@@ -421,11 +421,11 @@
       </listitem>
     </itemizedlist>
 
-    <programlisting>ecl publish &lt;WUID&gt; --server=10.239.219.8 --cluster=thor --activate --name=pie</programlisting>
+    <programlisting>ecl publish &lt;WUID&gt; --server=10.239.219.8 --target=thor --activate --name=pie</programlisting>
 
     <para>
       <emphasis>where &lt;WUID&gt; is the workuint id number, --server= is the
-      IP address of your ESP server, and --cluster= is the target cluster
+      IP address of your ESP server, and --target= is the target cluster
       name.</emphasis>
     </para>
 

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -18,11 +18,8 @@ Copyright (C) 2011 HPCC Systems.
 #define ECLOPT_PACKAGEMAP "--packagemap"
 #define ECLOPT_OVERWRITE "--overwrite"
 #define ECLOPT_PACKAGE "--packagename"
-#define ECLOPT_DALIIP "--daliip"
-#define ECLOPT_PROCESS "--process"
 #define ECLOPT_PACKAGESET "--packageset"
 #define ECLOPT_PACKAGESET_S "-ps"
-
 
 //=========================================================================================
 
@@ -221,8 +218,8 @@ public:
             const char *arg = iter.query();
             if (*arg!='-')
             {
-                if (optCluster.isEmpty())
-                    optCluster.set(arg);
+                if (optProcess.isEmpty())
+                    optProcess.set(arg);
                 else
                 {
                     fprintf(stderr, "\nargument is already defined %s\n", arg);
@@ -230,7 +227,9 @@ public:
                 }
                 continue;
             }
-            if (iter.matchOption(optCluster, ECLOPT_CLUSTER))
+            if (iter.matchOption(optProcess, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optProcess, ECLOPT_CLUSTER_DEPRECATED_S))
+                continue;
+            if (iter.matchOption(optProcess, ECLOPT_PROCESS)||iter.matchOption(optProcess, ECLOPT_PROCESS_S))
                 continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
@@ -241,9 +240,9 @@ public:
     {
         if (!EclCmdCommon::finalizeOptions(globals))
             return false;
-        if (optCluster.isEmpty())
+        if (optProcess.isEmpty())
         {
-            fprintf(stderr, "\nCluster must be specified\n");
+            fprintf(stderr, "\nProcess cluster must be specified\n");
             usage();
             return false;
         }
@@ -254,7 +253,7 @@ public:
         Owned<IClientWsPackageProcess> packageProcessClient = getWsPackageSoapService(optServer, optPort, optUsername, optPassword);
 
         Owned<IClientListPackageRequest> request = packageProcessClient->createListPackageRequest();
-        request->setCluster(optCluster);
+        request->setCluster(optProcess);
 
         Owned<IClientListPackageResponse> resp = packageProcessClient->ListPackage(request);
         if (resp->getExceptions().ordinality())
@@ -291,13 +290,13 @@ public:
         fprintf(stdout,"\nUsage:\n\n"
             "ecl package list [options] \n\n"
             "   Options:\n"
-            "      [--cluster<cluster>   name of cluster to retrieve package information.  Defaults to all package information stored in dali\n"
+            "      -p, --process=<process> name of process cluster for which to retrieve package information.  Defaults to all package information stored in dali\n"
         );
         EclCmdCommon::usage();
     }
 private:
 
-    StringAttr optCluster;
+    StringAttr optProcess;
 };
 
 class EclCmdPackageInfo: public EclCmdCommon
@@ -328,7 +327,9 @@ public:
                 }
                 continue;
             }
-            else if (iter.matchOption(optCluster, ECLOPT_CLUSTER))
+            if (iter.matchOption(optProcess, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optProcess, ECLOPT_CLUSTER_DEPRECATED_S))
+                continue;
+            if (iter.matchOption(optProcess, ECLOPT_PROCESS)||iter.matchOption(optProcess, ECLOPT_PROCESS_S))
                 continue;
             else if (iter.matchOption(optPkgName, ECLOPT_PACKAGE))
                 continue;
@@ -345,10 +346,10 @@ public:
             return false;
         }
         StringBuffer err;
-        if (!optPkgName.isEmpty() && !optCluster.isEmpty())
-            err.append("\n ... Specify either a cluster name of a package name, but NOT both\n\n");
-        else if (optPkgName.isEmpty() && optCluster.isEmpty())
-            err.append("\n ... Specify either a cluster name of a package name\n\n");
+        if (!optPkgName.isEmpty() && !optProcess.isEmpty())
+            err.append("\n ... Specify either a process cluster name or a package name, but NOT both\n\n");
+        else if (optPkgName.isEmpty() && optProcess.isEmpty())
+            err.append("\n ... Specify either a process cluster name or a package name\n\n");
 
         if (err.length())
         {
@@ -364,7 +365,7 @@ public:
 
         Owned<IClientGetPackageRequest> request = packageProcessClient->createGetPackageRequest();
         request->setPackageName(optPkgName);
-        request->setCluster(optCluster);
+        request->setCluster(optProcess);
 
         Owned<IClientGetPackageResponse> resp = packageProcessClient->GetPackage(request);
         if (resp->getExceptions().ordinality())
@@ -378,14 +379,14 @@ public:
         fprintf(stdout,"\nUsage:\n\n"
             "ecl package info [options] [<packageName>]\n\n"
             "   Options:\n"
-            "      [--cluster=<cluster> | --packageName=<packageName>]  specify either a cluster name or a pacakge name to retrieve information\n"
+            "      [-p,--process=<process> | --packageName=<packageName>]  specify either a process cluster name or a package name to retrieve information\n"
         );
         EclCmdCommon::usage();
     }
 private:
 
     StringAttr optPkgName;
-    StringAttr optCluster;
+    StringAttr optProcess;
 };
 
 class EclCmdPackageDelete : public EclCmdCommon
@@ -615,7 +616,7 @@ public:
                 }
                 continue;
             }
-            if (iter.matchOption(optProcess, ECLOPT_PROCESS))
+            if (iter.matchOption(optProcess, ECLOPT_PROCESS)||iter.matchOption(optProcess, ECLOPT_PROCESS_S))
                 continue;
             if (iter.matchOption(optDaliIp, ECLOPT_DALIIP))
                 continue;
@@ -675,8 +676,8 @@ public:
         fprintf(stdout,"\nUsage:\n\n"
             "ecl package copyFiles [options] [<filename>]\n\n"
             "   Options:\n"
-            "      --process=<processcluster>    name of the process cluster to copy files\n"
-            "      --overwrite=<true/false>      overwrite data file if it already exists on the target cluster. defaults to false\n"
+            "      -p, --process=<process>      name of the process cluster to copy files\n"
+            "      --overwrite=<true/false>     overwrite data file if it already exists on the process cluster. defaults to false\n"
             "      --daliip=<daliip>            ip of the source dali to use for file lookups\n"
         );
         EclCmdCommon::usage();

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1425,10 +1425,11 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
             if (batchPart >= batchSplit)
                 batchPart = 0;
         }
-        else if (iter.matchOption(tempArg, "-target")) //deprecated name
-            return setTargetPlatformOption(tempArg.get(), optTargetClusterType);
-        else if (iter.matchOption(tempArg, "-platform"))
-            return setTargetPlatformOption(tempArg.get(), optTargetClusterType);
+        else if (iter.matchOption(tempArg, "-platform") || /*deprecated*/ iter.matchOption(tempArg, "-target"))
+        {
+            if (!setTargetPlatformOption(tempArg.get(), optTargetClusterType))
+                return false;
+        }
         else if (iter.matchFlag(logVerbose, "-v") || iter.matchFlag(logVerbose, "--verbose"))
         {
             Owned<ILogMsgFilter> filter = getDefaultLogMsgFilter();

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -133,7 +133,7 @@ class EclccCompileThread : public CInterface, implements IPooledThread
             }
         }
         eclccCmd.appendf(" -o%s", wuid);
-        eclccCmd.appendf(" -target=%s", target);
+        eclccCmd.appendf(" -platform=%s", target);
 
         Owned<IStringIterator> debugValues = &workunit->getDebugValues();
         ForEach (*debugValues)

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -80,14 +80,20 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 
 #define ECLOPT_WUID "--wuid"
 #define ECLOPT_WUID_S "-wu"
-#define ECLOPT_CLUSTER "--cluster"
-#define ECLOPT_CLUSTER_S "-cl"
+#define ECLOPT_CLUSTER_DEPRECATED "--cluster"
+#define ECLOPT_CLUSTER_DEPRECATED_S "-cl"
+#define ECLOPT_TARGET "--target"
+#define ECLOPT_TARGET_S "-t"
 #define ECLOPT_NAME "--name"
 #define ECLOPT_NAME_S "-n"
 #define ECLOPT_QUERYSET "--queryset"
 #define ECLOPT_QUERYSET_S "-qs"
 #define ECLOPT_VERSION "--version"
 #define ECLOPT_SHOW "--show"
+
+#define ECLOPT_DALIIP "--daliip"
+#define ECLOPT_PROCESS "--process"
+#define ECLOPT_PROCESS_S "-p"
 
 #define ECLOPT_LIB_PATH_S "-L"
 #define ECLOPT_IMP_PATH_S "-I"

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -250,7 +250,9 @@ public:
         for (; !iter.done(); iter.next())
         {
             const char *arg = iter.query();
-            if (iter.matchOption(optCluster, ECLOPT_CLUSTER)||iter.matchOption(optCluster, ECLOPT_CLUSTER_S))
+            if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
+                continue;
+            if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
                 continue;
             if (iter.matchOption(optName, ECLOPT_NAME)||iter.matchOption(optName, ECLOPT_NAME_S))
                 continue;
@@ -279,7 +281,7 @@ public:
             fprintf(stderr, "\nWUID (%s) cannot be the target for deployment\n", optObj.getDescription(s).str());
             return false;
         }
-        if ((optObj.type==eclObjSource || optObj.type==eclObjArchive) && optCluster.isEmpty())
+        if ((optObj.type==eclObjSource || optObj.type==eclObjArchive) && optTargetCluster.isEmpty())
         {
             fprintf(stderr, "\nCluster must be specified when deploying from ECL Source or Archive\n");
             return false;
@@ -293,7 +295,7 @@ public:
         client->addServiceUrl(url.str());
         if (optUsername.length())
             client->setUsernameToken(optUsername.get(), optPassword.sget(), NULL);
-        return doDeploy(*this, client, optCluster.get(), optName.get(), NULL, optNoArchive) ? 0 : 1;
+        return doDeploy(*this, client, optTargetCluster.get(), optName.get(), NULL, optNoArchive) ? 0 : 1;
     }
     virtual void usage()
     {
@@ -303,21 +305,21 @@ public:
             "text, file, archive, shared object, or dll.  The workunit will be created in\n"
             "the 'compiled' state.\n"
             "\n"
-            "ecl deploy --cluster=<val> --name=<val> <ecl_file|->\n"
-            "ecl deploy --cluster=<val> --name=<val> <archive|->\n"
-            "ecl deploy [--cluster=<val>] [--name=<val>] <so|dll|->\n\n"
+            "ecl deploy --target=<val> --name=<val> <ecl_file|->\n"
+            "ecl deploy --target=<val> --name=<val> <archive|->\n"
+            "ecl deploy [--target=<val>] [--name=<val>] <so|dll|->\n\n"
             "   -                      specifies object should be read from stdin\n"
             "   <ecl_file|->           ecl text file to deploy\n"
             "   <archive|->            ecl archive to deploy\n"
             "   <so|dll|->             workunit dll or shared object to deploy\n"
             " Options:\n"
-            "   -cl, --cluster=<val>   cluster to associate workunit with\n"
+            "   -t, --target=<val>     target cluster to associate workunit with\n"
             "   -n, --name=<val>       workunit job name\n",
             stdout);
         EclCmdWithEclTarget::usage();
     }
 private:
-    StringAttr optCluster;
+    StringAttr optTargetCluster;
     StringAttr optName;
 };
 
@@ -342,7 +344,9 @@ public:
                 continue;
             if (iter.matchOption(optName, ECLOPT_NAME)||iter.matchOption(optName, ECLOPT_NAME_S))
                 continue;
-            if (iter.matchOption(optCluster, ECLOPT_CLUSTER)||iter.matchOption(optCluster, ECLOPT_CLUSTER_S))
+            if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
+                continue;
+            if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
                 continue;
             if (iter.matchOption(optMsToWait, ECLOPT_WAIT))
                 continue;
@@ -376,7 +380,7 @@ public:
         }
         if (optObj.type==eclObjArchive || optObj.type==eclObjSource)
         {
-            if (optCluster.isEmpty())
+            if (optTargetCluster.isEmpty())
             {
                 fprintf(stderr, "\nCluster must be specified when publishing ECL Text or Archive\n");
                 return false;
@@ -395,7 +399,7 @@ public:
         StringBuffer wuid;
         if (optObj.type==eclObjWuid)
             wuid.set(optObj.value.get());
-        else if (!doDeploy(*this, client, optCluster.get(), optName.get(), &wuid, optNoArchive))
+        else if (!doDeploy(*this, client, optTargetCluster.get(), optName.get(), &wuid, optNoArchive))
             return 1;
 
         StringBuffer descr;
@@ -407,8 +411,8 @@ public:
         req->setActivate(optActivate);
         if (optName.length())
             req->setJobName(optName.get());
-        if (optCluster.length())
-            req->setCluster(optCluster.get());
+        if (optTargetCluster.length())
+            req->setCluster(optTargetCluster.get());
         req->setWait(optMsToWait);
         req->setNoReload(optNoReload);
 
@@ -437,17 +441,17 @@ public:
             "If the query is being created from an ECL file, archive, shared object, dll,\n"
             "or text, a workunit is first created and then published to the queryset.\n"
             "\n"
-            "ecl publish [--cluster=<val>] [--name=<val>] [--activate] <wuid>\n"
-            "ecl publish [--cluster=<val>] [--name=<val>] [--activate] <so|dll|->\n"
-            "ecl publish --cluster=<val> --name=<val> [--activate] <archive|->\n"
-            "ecl publish --cluster=<val> --name=<val> [--activate] <ecl_file|->\n\n"
+            "ecl publish [--target=<val>] [--name=<val>] [--activate] <wuid>\n"
+            "ecl publish [--target=<val>] [--name=<val>] [--activate] <so|dll|->\n"
+            "ecl publish --target=<val> --name=<val> [--activate] <archive|->\n"
+            "ecl publish --target=<val> --name=<val> [--activate] <ecl_file|->\n\n"
             "   -                      specifies object should be read from stdin\n"
             "   <wuid>                 workunit to publish\n"
             "   <archive|->            archive to publish\n"
             "   <ecl_file|->           ECL text file to publish\n"
             "   <so|dll|->             workunit dll or shared object to publish\n"
             " Options:\n"
-            "   -cl, --cluster=<val>   cluster to publish workunit to\n"
+            "   -t, --target=<val>     target cluster to publish workunit to\n"
             "                          (defaults to cluster defined inside workunit)\n"
             "   -n, --name=<val>       query name to use for published workunit\n"
             "   -A, --activate         activates query when published\n"
@@ -457,7 +461,7 @@ public:
         EclCmdWithEclTarget::usage();
     }
 private:
-    StringAttr optCluster;
+    StringAttr optTargetCluster;
     StringAttr optName;
     unsigned optMsToWait;
     bool optActivate;
@@ -488,7 +492,9 @@ public:
                 continue;
             if (iter.matchOption(optName, ECLOPT_NAME)||iter.matchOption(optName, ECLOPT_NAME_S))
                 continue;
-            if (iter.matchOption(optCluster, ECLOPT_CLUSTER)||iter.matchOption(optCluster, ECLOPT_CLUSTER_S))
+            if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
+                continue;
+            if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
                 continue;
             if (iter.matchOption(optInput, ECLOPT_INPUT)||iter.matchOption(optInput, ECLOPT_INPUT_S))
                 continue;
@@ -517,7 +523,7 @@ public:
         }
         if (optObj.type==eclObjArchive || optObj.type==eclObjSource)
         {
-            if (optCluster.isEmpty())
+            if (optTargetCluster.isEmpty())
             {
                 fprintf(stderr, "\nCluster must be specified when running ECL Text or Archive\n");
                 return false;
@@ -568,15 +574,15 @@ public:
         else
         {
             req->setCloneWorkunit(false);
-            if (!doDeploy(*this, client, optCluster.get(), optName.get(), &wuid, optNoArchive, optVerbose))
+            if (!doDeploy(*this, client, optTargetCluster.get(), optName.get(), &wuid, optNoArchive, optVerbose))
                 return 1;
             req->setWuid(wuid.str());
             if (optVerbose)
                 fprintf(stdout, "Running deployed workunit %s\n", wuid.str());
         }
 
-        if (optCluster.length())
-            req->setCluster(optCluster.get());
+        if (optTargetCluster.length())
+            req->setCluster(optTargetCluster.get());
         req->setWait((int)optWaitTime);
         if (optInput.length())
             req->setInput(optInput.get());
@@ -610,18 +616,18 @@ public:
             "Query input can be provided in xml form via the --input parameter.  Input\n"
             "xml can be provided directly or by refrencing a file\n"
             "\n"
-            "ecl run [--cluster=<val>][--input=<file|xml>][--wait=<ms>] <wuid>\n"
-            "ecl run [--cluster=<c>][--input=<file|xml>][--wait=<ms>] <queryset> <query>\n"
-            "ecl run [--cluster=<c>][--name=<nm>][--input=<file|xml>][--wait=<i>] <dll|->\n"
-            "ecl run --cluster=<c> --name=<nm> [--input=<file|xml>][--wait=<i>] <archive|->\n"
-            "ecl run --cluster=<c> --name=<nm> [--input=<file|xml>][--wait=<i>] <eclfile|->\n\n"
+            "ecl run [--target=<val>][--input=<file|xml>][--wait=<ms>] <wuid>\n"
+            "ecl run [--target=<c>][--input=<file|xml>][--wait=<ms>] <queryset> <query>\n"
+            "ecl run [--target=<c>][--name=<nm>][--input=<file|xml>][--wait=<i>] <dll|->\n"
+            "ecl run --target=<c> --name=<nm> [--input=<file|xml>][--wait=<i>] <archive|->\n"
+            "ecl run --target=<c> --name=<nm> [--input=<file|xml>][--wait=<i>] <eclfile|->\n\n"
             "   -                      specifies object should be read from stdin\n"
             "   <wuid>                 workunit to publish\n"
             "   <archive|->            archive to publish\n"
             "   <ecl_file|->           ECL text file to publish\n"
             "   <so|dll|->             workunit dll or shared object to publish\n"
             " Options:\n"
-            "   -cl, --cluster=<val>   cluster to run job on\n"
+            "   -t, --target=<val>     target cluster to run job on\n"
             "                          (defaults to cluster defined inside workunit)\n"
             "   -n, --name=<val>       job name\n"
             "   -in,--input=<file|xml> file or xml content to use as query input\n"
@@ -631,7 +637,7 @@ public:
         EclCmdWithEclTarget::usage();
     }
 private:
-    StringAttr optCluster;
+    StringAttr optTargetCluster;
     StringAttr optName;
     StringAttr optInput;
     IArrayOf<IEspNamedValue> variables;

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -102,7 +102,9 @@ public:
                 optQuerySet.set(arg);
                 continue;
             }
-            if (iter.matchOption(optCluster, ECLOPT_CLUSTER) || iter.matchOption(optCluster, ECLOPT_CLUSTER_S))
+            if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
+                continue;
+            if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
                 continue;
             StringAttr temp;
             if (iter.matchOption(temp, ECLOPT_SHOW))
@@ -214,7 +216,7 @@ public:
 
         Owned<IClientWUMultiQuerySetDetailsRequest> req = client->createWUMultiQuerysetDetailsRequest();
         req->setQuerySetName(optQuerySet.get());
-        req->setClusterName(optCluster.get());
+        req->setClusterName(optTargetCluster.get());
         req->setFilterType("All");
 
         Owned<IClientWUMultiQuerySetDetailsResponse> resp = client->WUMultiQuerysetDetails(req);
@@ -237,10 +239,10 @@ public:
             "cluster will be shown. If no queryset or cluster is specified all querysets\n"
             "are shown.\n"
             "\n"
-            "ecl queries list [<queryset>][--cluster=<cluster>][--show=<flags>]\n\n"
+            "ecl queries list [<queryset>][--target=<val>][--show=<flags>]\n\n"
             " Options:\n"
             "   <queryset>             name of queryset to get list of queries for\n"
-            "   -cl, --cluster=<name>  name of cluster to get list of published queries for\n"
+            "   -t, --target=<val>     target cluster to get list of published queries for\n"
             "   --show=<flags>         show only queries with matching flags\n"
             " Flags:\n"
             "   A                      query is active\n"
@@ -252,7 +254,7 @@ public:
         EclCmdCommon::usage();
     }
 private:
-    StringAttr optCluster;
+    StringAttr optTargetCluster;
     StringAttr optQuerySet;
     unsigned flags;
 };
@@ -285,7 +287,9 @@ public:
                 continue;
             if (iter.matchFlag(optNoReload, ECLOPT_NORELOAD))
                 continue;
-            if (iter.matchOption(optCluster, ECLOPT_CLUSTER)||iter.matchOption(optCluster, ECLOPT_CLUSTER_S))
+            if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
+                continue;
+            if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
                 continue;
             if (iter.matchOption(optMsToWait, ECLOPT_WAIT))
                 continue;
@@ -303,7 +307,7 @@ public:
             fputs("source and target must both be specified.\n\n", stderr);
             return false;
         }
-        if (optSourceQueryPath.get()[0]=='/' && optSourceQueryPath.get()[1]=='/' && optCluster.isEmpty())
+        if (optSourceQueryPath.get()[0]=='/' && optSourceQueryPath.get()[1]=='/' && optTargetCluster.isEmpty())
         {
             fputs("cluster must be specified for remote copies.\n\n", stderr);
             return false;
@@ -322,7 +326,7 @@ public:
         Owned<IClientWUQuerySetCopyQueryRequest> req = client->createWUQuerysetCopyQueryRequest();
         req->setSource(optSourceQueryPath.get());
         req->setTarget(optTargetQuerySet.get());
-        req->setCluster(optCluster.get());
+        req->setCluster(optTargetCluster.get());
         req->setActivate(optActivate);
         req->setWait(optMsToWait);
         req->setNoReload(optNoReload);
@@ -354,7 +358,7 @@ public:
             "                          in the form: //ip:port/queryset/query\n"
             "                          or: queryset/query\n"
             "   <target_queryset>      name of queryset to copy the query into\n"
-            "   -cl, --cluster=<name>  Local cluster to associate with remote workunit\n"
+            "   -t, --target=<val>     Local target cluster to associate with remote workunit\n"
             "   -A, --activate         Activate the new query\n"
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
             "   --wait=<ms>            Max time to wait in milliseconds\n"
@@ -365,7 +369,7 @@ public:
 private:
     StringAttr optSourceQueryPath;
     StringAttr optTargetQuerySet;
-    StringAttr optCluster;
+    StringAttr optTargetCluster;
     unsigned optMsToWait;
     bool optActivate;
     bool optNoReload;

--- a/ecl/regress/regress.sh
+++ b/ecl/regress/regress.sh
@@ -93,7 +93,7 @@ fi
 
 if [[ $eclcc != '' ]]; then
     ## Set flags
-    default_flags="-P$target_dir -legacy -target=thorlcr -fforceGenerate -fregressionTest -b -S -shared"
+    default_flags="-P$target_dir -legacy -platform=thorlcr -fforceGenerate -fregressionTest -b -S -shared"
     flags="$default_flags $include_dir -fshowMetaInGraph $userflags"
 
     ## Prepare target directory

--- a/initfiles/etc/bash_completion/ecl
+++ b/initfiles/etc/bash_completion/ecl
@@ -34,11 +34,14 @@ _ecl()
          queries)
              opts="list copy"
              ;;
+         package)
+             opts="add copyFiles delete activate deactivate list info"
+             ;;
          ecl)
-             opts="--version deploy publish unpublish run activate deactivate queries"
+             opts="--version deploy publish unpublish run activate deactivate queries package"
              ;;
          *)
-             opts="-cl --cluster=<host:ip> -n --name=<name> -v --verbose -s --server=<host:port> -u --username=<user> -pw --password==<pw> --main=<definition> --ecl-only --limit=N -A --activate --wait=<ms>"
+             opts="-t --target=<name> -n --name=<name> -v --verbose -s --server=<host:port> -u --username=<user> -pw --password==<pw> --main=<definition> --ecl-only --limit=N -A --activate --wait=<ms>"
              ;;
     esac
 

--- a/initfiles/etc/bash_completion/eclcc
+++ b/initfiles/etc/bash_completion/eclcc
@@ -49,9 +49,9 @@ _eclcc()
             COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
             return 0
             ;;
-        -target)
-            local targets="roxie thor hthor"
-            COMPREPLY=( $(compgen -W "${targets}" -- ${cur}) )
+        -platform)
+            local platforms="roxie thor hthor"
+            COMPREPLY=( $(compgen -W "${platforms}" -- ${cur}) )
             return 0
             ;;
         *)


### PR DESCRIPTION
Renames ecl command line option --cluster to --target
Renames the eclcc option -target to -platform.

This creates consistency and helps to prevent use of the
ambiguous term "cluster".

In both cases we continue accept the deprecated names for
backward compatibility.

Fixes gh-2734

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
