### PR TITLE
Remove setActive, add cache lookups to transaction

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1313,9 +1313,8 @@ public:
     
     IDistributedFile *lookupFile(const char *name,unsigned timeout)
     {
-        // dont expect *that* many so do a linear search for now
         IDistributedFile * ret = findFile(name);
-        if (ret) 
+        if (ret)
             return LINK(ret);
         ret = queryDistributedFileDirectory().lookup(name,udesc,false,this,timeout);
         if (!ret)
@@ -1346,16 +1345,26 @@ public:
         return ret;
     }
 
+    IDistributedSuperFile *lookupSuperFileCached(const char *name, unsigned timeout)
+    {
+        IDistributedSuperFile *ret;
+        bool prev = isactive;
+        isactive = true;
+        try {
+            ret = lookupSuperFile(name, timeout);
+        }
+        catch (IException *)
+        {
+            isactive = prev;
+            throw;
+        }
+        isactive = prev;
+        return ret;
+    }
+
     bool active()
     {
         return isactive;
-    }
-
-    bool setActive(bool on)
-    {
-        bool old = isactive;
-        isactive = on;
-        return old;
     }
 
     void clearFiles()

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -182,9 +182,9 @@ interface IDistributedFileTransaction: extends IInterface
     virtual void autoCommit()=0; // if transaction not active, commit straight away
     virtual void rollback()=0;
     virtual bool active()=0;
-    virtual bool setActive(bool on)=0; // returns old value (used internally)
     virtual IDistributedFile *lookupFile(const char *lfn,unsigned timeout=INFINITE)=0;
     virtual IDistributedSuperFile *lookupSuperFile(const char *slfn,unsigned timeout=INFINITE)=0;
+    virtual IDistributedSuperFile *lookupSuperFileCached(const char *slfn,unsigned timeout=INFINITE)=0;
     virtual IUserDescriptor *queryUser()=0;
     virtual bool addDelayedDelete(const char *lfn,bool remphys,IUserDescriptor *user)=0; // used internally to delay deletes untill commit 
     virtual void addAction(CDFAction *action)=0; // internal

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -711,9 +711,7 @@ public:
         Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
         // We need this here, since caching only happens with active transactions
         // MORE - abstract this with DFSAccess, or at least enable caching with a flag
-        transaction->setActive(true);
-        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFile(superfname);
-        transaction->setActive(false);
+        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFileCached(superfname);
 
         bool newfile = false;
         if (!superfile) {
@@ -743,9 +741,7 @@ public:
         Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
         // We need this here, since caching only happens with active transactions
         // MORE - abstract this with DFSAccess, or at least enable caching with a flag
-        transaction->setActive(true);
-        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFile(superfname);
-        transaction->setActive(false);
+        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFileCached(superfname);
 
         if (!superfile)
             throwError1(DFUERR_DSuperFileNotFound, superfname);

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -987,22 +987,7 @@ static bool lookupSuperFile(ICodeContext *ctx, const char *lsuperfn, Owned<IDist
             throw MakeStringException(0, "Foreign superfile not allowed: %s", lsfn.str());
     }
     if (cacheFiles)
-    {
-        struct CTempActiveTransaction
-        {
-            CTempActiveTransaction(IDistributedFileTransaction *_transaction, bool onOff) : transaction(_transaction)
-            {
-                prev = transaction->setActive(onOff);
-            }
-            ~CTempActiveTransaction()
-            {
-                transaction->setActive(prev);
-            }
-            IDistributedFileTransaction *transaction;
-            bool prev;
-        } temp(transaction, true);
-        file.setown(transaction->lookupSuperFile(lsfn.str()));
-    }
+        file.setown(transaction->lookupSuperFileCached(lsfn.str()));
     else
         file.setown(transaction->lookupSuperFile(lsfn.str()));
     if (file.get())


### PR DESCRIPTION
Removing the invasive setActive() method from transaction,
and its uses from FileServices and DFUUtil, and adding
a re-entrant cache parameter to control caching of files
when transaction is not active.
