### PR TITLE
Fix double output of SOAP struct array root tag

### DIFF
--- a/esp/bindings/SOAP/Platform/soapparam.hpp
+++ b/esp/bindings/SOAP/Platform/soapparam.hpp
@@ -797,7 +797,7 @@ public:
         if (!arr.ordinality())
             return;
         StringBuffer s;
-        toStr(rpc_call.queryContext(), s, tagname, itemname, elementtype, basepath, prefix);
+        toStr(rpc_call.queryContext(), s, NULL, itemname, elementtype, basepath, prefix);
         rpc_call.add_value(basepath, prefix, tagname, elementtype, s.str(), false);
     }
 


### PR DESCRIPTION
Root tag of output twice for array of structures when using rpc_call object.

Needed in 3.10.x and master only.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
