### PR TITLE
remove outer Response and Results tags from RunEclEx result xml

### DIFF
--- a/esp/services/ecldirect/EclDirectService.cpp
+++ b/esp/services/ecldirect/EclDirectService.cpp
@@ -309,7 +309,7 @@ bool CEclDirectEx::onRunEclEx(IEspContext &context, IEspRunEclExRequest & req, I
         }
         else
         {
-            unsigned xmlflags = WWV_ADD_RESULTS_TAG | WWV_ADD_RESPONSE_TAG;
+            unsigned xmlflags = 0;
             if (outputFormat != CRunEclExFormat_ExtendedXml)
                 xmlflags |= WWV_OMIT_SCHEMAS;
             if (context.queryRequestParameters()->hasProp("display_xslt"))


### PR DESCRIPTION
This will align with the output of the original method, and simplify
client parsing of the result.

Fixes gh-3025

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
