### PR TITLE
Fix eclcmd build issue

### DIFF
--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -452,7 +452,7 @@ public:
             "   -n, --name=<val>       query name to use for published workunit\n"
             "   -A, --activate         activates query when published\n"
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
-            "   --wait=<ms>            Max time to wait in milliseconds\n"
+            "   --wait=<ms>            Max time to wait in milliseconds\n",
             stdout);
         EclCmdWithEclTarget::usage();
     }


### PR DESCRIPTION
missing comma in usage

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
