### PR TITLE
Consistently use queryname to generate root tags in WsEcl

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -2995,12 +2995,16 @@ IGroup *EclAgent::getHThorGroup(StringBuffer &out)
     unsigned ins = 0;
     SocketEndpoint ep(0,queryMyNode()->endpoint());
     Owned<IGroup> mygrp = createIGroup(1,&ep);
-    loop {
+    loop
+    {
         Owned<IGroup> grp = queryNamedGroupStore().lookup(mygroupname.str());
         if (!grp)
             break;
         if (grp->equals(mygrp))
+        {
+            out.append(mygroupname);
             return grp.getClear();
+        }
         ins++;
         mygroupname.setLength(l);
         mygroupname.append('_').append(ins);
@@ -3008,6 +3012,7 @@ IGroup *EclAgent::getHThorGroup(StringBuffer &out)
     // this shouldn't happen but..
     WARNLOG("Adding group %s",mygroupname.str());
     queryNamedGroupStore().add(mygroupname.str(),mygrp,true);
+    out.append(mygroupname);
     return queryNamedGroupStore().lookup(mygroupname.str());
 }
 

--- a/esp/files/ECLPlayground.htm
+++ b/esp/files/ECLPlayground.htm
@@ -74,7 +74,7 @@
                 ECL Playground</div>
             <div style="float: right; display: inline-block; vertical-align: middle">
                 <label id="sampleSelectLabel" for="sampleSelect">Sample:</label>
-                <div id="sampleSelect" style="overflow: visible !important">
+                <div id="sampleSelect">
                 </div>
             </div>
         </div>

--- a/esp/files/scripts/SampleSelectControl.js
+++ b/esp/files/scripts/SampleSelectControl.js
@@ -38,7 +38,7 @@ define([
 				name: this.id,
 				store: sampleStore,
 				value: "default.ecl",
-				maxHeight: -1,
+				maxHeight: 480,
 				style: {
 					padding: 0
 				},

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -2106,7 +2106,7 @@ int CWsEclBinding::onSubmitQueryOutputXML(IEspContext &context, CHttpRequest* re
         StringBuffer roxieresp;
         sendRoxieRequest(wsinfo.qsetname.get(), soapmsg, roxieresp, status);
 
-        Owned<IWuWebView> web = createWuWebView(*wsinfo.wu, NULL, getCFD(), true);
+        Owned<IWuWebView> web = createWuWebView(*wsinfo.wu, wsinfo.queryname.get(), getCFD(), true);
         if (web.get())
             web->expandResults(roxieresp.str(), output, xmlflags);
     }
@@ -2145,7 +2145,7 @@ int CWsEclBinding::onSubmitQueryOutputView(IEspContext &context, CHttpRequest* r
     if (strieq(clustertype.str(), "roxie"))
     {
         sendRoxieRequest(wsinfo.qsetname.get(), soapmsg, output, status);
-        Owned<IWuWebView> web = createWuWebView(*wsinfo.wu, NULL, getCFD(), true);
+        Owned<IWuWebView> web = createWuWebView(*wsinfo.wu, wsinfo.queryname.get(), getCFD(), true);
         if (!view)
             web->applyResultsXSLT(xsltfile.str(), output.str(), html);
         else
@@ -2583,7 +2583,7 @@ void CWsEclBinding::handleHttpPost(CHttpRequest *request, CHttpResponse *respons
     {
         StringBuffer output;
         sendRoxieRequest(wsinfo.qsetname.get(), soapfromjson, output, status);
-        Owned<IWuWebView> web = createWuWebView(*wsinfo.wu, NULL, getCFD(), true);
+        Owned<IWuWebView> web = createWuWebView(*wsinfo.wu, wsinfo.queryname.get(), getCFD(), true);
         if (web.get())
             web->expandResults(output.str(), soapresp, xmlflags);
     }
@@ -2673,7 +2673,7 @@ int CWsEclBinding::HandleSoapRequest(CHttpRequest* request, CHttpResponse* respo
         StringBuffer content(request->queryContent());
         StringBuffer output;
         sendRoxieRequest(wsinfo.qsetname.get(), content, output, status);
-        Owned<IWuWebView> web = createWuWebView(*wsinfo.wu, NULL, getCFD(), true);
+        Owned<IWuWebView> web = createWuWebView(*wsinfo.wu, wsinfo.queryname.get(), getCFD(), true);
         if (web.get())
             web->expandResults(output.str(), soapresp, xmlflags);
     }

--- a/version.cmake
+++ b/version.cmake
@@ -5,6 +5,6 @@ set ( HPCC_PROJECT "community" )
 set ( HPCC_MAJOR 3 )
 set ( HPCC_MINOR 8 )
 set ( HPCC_POINT 2 )
-set ( HPCC_MATURITY "closedown" )
+set ( HPCC_MATURITY "rc" )
 set ( HPCC_SEQUENCE 1 )
 ###


### PR DESCRIPTION
Previously WuWebView would sometimes default to using the jobname
instead of the queryname.

Fixes gh-2896
Fixes gh-2862

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
