### PR TITLE
gh-3027 Roxie logs capured in .stderr file

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -567,6 +567,8 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(topology, "roxie");
             if (globals->getPropBool("--stdlog", traceLevel != 0) || topology->getPropBool("@forceStdLog", false))
                 lf->setMsgFields(MSGFIELD_time | MSGFIELD_thread | MSGFIELD_prefix);
+            else
+                removeLog();
             lf->setMaxDetail(TopDetail);
             lf->beginLogging();
             logDirectory.set(lf->queryLogDir());


### PR DESCRIPTION
The option to suppress logging to stderr seems to have got lost in
a recent refactoring, leading to the roxie log being repeated in the
xxx.stderr file as well as the roxie.xxx.log

Fixes gh-3027.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
