### PR TITLE
Fix build break on strict compilers

### DIFF
--- a/thorlcr/shared/thor.hpp
+++ b/thorlcr/shared/thor.hpp
@@ -36,6 +36,8 @@ typedef size32_t rowidx_t;
 #define RCIDXMAX ((rowidx_t)(size32_t)-1)
 #define RIPF ""
 
+#include "jexcept.hpp"
+
 // validate that type T doesn't truncate
 template <class T>
 inline rowcount_t validRC(T X)


### PR DESCRIPTION
Stricter c++ compilers check template validity at point of
declaration rather than point of expansion, and complain about
a missing include file.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
