### PR TITLE
gh-2956 Roxie support for HTTPCALL activity

### DIFF
--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -424,6 +424,7 @@ protected:
         case TAKskiplimit:
         case TAKcreaterowlimit:
             return createRoxieServerSkipLimitActivityFactory(id, subgraphId, *this, helperFactory, kind);
+        case TAKhttp_rowdataset:
         case TAKsoap_rowdataset:
             return createRoxieServerSoapRowCallActivityFactory(id, subgraphId, *this, helperFactory, kind);
         case TAKsoap_rowaction:

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -24486,7 +24486,10 @@ public:
 
         if (soaphelper == NULL)
         {
-            soaphelper.setown(createSoapCallHelper(this, rowAllocator, authToken.str(), SCrow, pClientCert, *ctx, this));
+            if (factory->getKind()==TAKhttp_rowdataset)
+                soaphelper.setown(createHttpCallHelper(this, rowAllocator, authToken.str(), SCrow, pClientCert, *ctx, this));
+            else
+                soaphelper.setown(createSoapCallHelper(this, rowAllocator, authToken.str(), SCrow, pClientCert, *ctx, this));
             soaphelper->start();
         }
 


### PR DESCRIPTION
Roxie was throwing an exception "Unimplemented activity" if a query
tried to use HTTPCALL.

Fixes gh-2956.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
