### PR TITLE
gh-3009 LOCAL on a keyed join causes Roxie to misbehave

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -20581,7 +20581,7 @@ public:
     CRoxieServerDiskReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, const RemoteActivityId &_remoteId, IPropertyTree &_graphNode)
         : CRoxieServerActivityFactory(_id, _subgraphId, _queryFactory, _helperFactory, _kind), remoteId(_remoteId)
     {
-        isLocal = _graphNode.getPropBool("att[@name='local']/@value");
+        isLocal = _graphNode.getPropBool("att[@name='local']/@value") && queryFactory.queryChannel()!=0;
         Owned<IHThorDiskReadBaseArg> helper = (IHThorDiskReadBaseArg *) helperFactory();
         sorted = (helper->getFlags() & TDRunsorted) == 0;
         variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
@@ -21671,7 +21671,7 @@ public:
         Owned<IHThorIndexReadBaseArg> indexHelper = (IHThorIndexReadBaseArg *) helperFactory();
         unsigned flags = indexHelper->getFlags();
         sorted = (flags & TIRsorted) != 0;
-        isLocal = _graphNode.getPropBool("att[@name='local']/@value");
+        isLocal = _graphNode.getPropBool("att[@name='local']/@value") && queryFactory.queryChannel()!=0;
         rtlDataAttr indexLayoutMeta;
         size32_t indexLayoutSize;
         if(!indexHelper->getIndexLayout(indexLayoutSize, indexLayoutMeta.refdata()))
@@ -22841,7 +22841,7 @@ public:
         {
             if (_graphNode.getPropBool("att[@name='_isSpill']/@value", false) || _graphNode.getPropBool("att[@name='_isSpillGlobal']/@value", false))
                 return;  // ignore 'spills'
-            bool isLocal = _graphNode.getPropBool("att[@name='local']/@value");
+            bool isLocal = _graphNode.getPropBool("att[@name='local']/@value") && queryFactory.queryChannel()!=0;
             bool isOpt = _graphNode.getPropBool("att[@name='_isOpt']/@value") || pretendAllOpt;
             if (queryNodeIndexName(_graphNode))
             {
@@ -24336,7 +24336,7 @@ public:
         : CRoxieServerMultiInputFactory(_id, _subgraphId, _queryFactory, _helperFactory, _kind), headId(_headId), tailId(_tailId)
     {
         Owned<IHThorKeyedJoinArg> helper = (IHThorKeyedJoinArg *) helperFactory();
-        isLocal = _graphNode.getPropBool("att[@name='local']/@value");
+        isLocal = _graphNode.getPropBool("att[@name='local']/@value") && queryFactory.queryChannel()!=0;
         isSimple = isLocal;
         rtlDataAttr indexLayoutMeta;
         size32_t indexLayoutSize;


### PR DESCRIPTION
LOCAL on a keyed join is really only meaningful inside an ALLNODES
(typically used with NOROOT indexes). However, as coded, LOCAL would
cause incorrect behaviour if specified in other situations.

This change causes the local to be ignored except in an ALLNODES or
potentially in a child query called from remote code such as an index
filter condition. It's debatable what the correct behaviour in the latter
case is.

It's also debatable whether the compiler should have given a warning or
error when LOCAL is specified in cases that do not make sense.

Fixes gh-3009.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
