### PR TITLE
Fix gh-2933 - Ensure pid files are removed on reboot

### DIFF
--- a/initfiles/componentfiles/thor/run_thor
+++ b/initfiles/componentfiles/thor/run_thor
@@ -21,16 +21,17 @@ thorpid=0
 ulimit -c unlimited
 ulimit -n 8192
 
+RUN_THOR_PID_NAME="$PID/run_thor.`basename $PWD`.pid"
 # prevent two thors starting together
-if [ -e run_thor.lck ]; then
-  oldpid=`cat run_thor.lck`
+if [ -e $RUN_THOR_PID_NAME ]; then
+  oldpid=`cat $RUN_THOR_PID_NAME`
   while ps h $oldpid ; do 
      echo waiting for process $oldpid to finish
      sleep 5
   done
 fi
-trap "rm -f run_thor.lck" exit
-echo $$ > run_thor.lck
+trap "rm -f $RUN_THOR_PID_NAME" exit
+echo $$ > $RUN_THOR_PID_NAME
 
 export SENTINEL="thor.sentinel"
 while [ 1 ]; do

--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -43,7 +43,7 @@ cd $instancedir
 
 echo "slave init `date`"
 
-lckfile="start_slave_${slaveport}.lck"
+lckfile="$PID/start_slave_${hpcc_compname}_${slavenum}.pid"
 
 # prevent two slaves starting together
 while [ -e $lckfile ]; do


### PR DESCRIPTION
Thor creates some additional pid files in it's instance directory.
If the node is cold booted, these pid files persist and are checked on the next Thor startup, by that time the pids could belond to other processes, in which case Thor can deadlock waiting for an old pid to exit, or in the case of slaves, could kill a random hpcc process believing it was a thorslave.

Ensure pid files are written to /var/run, which is cleared on reboot

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
