### PR TITLE
Fix schemas not matching results when using xpaths

### DIFF
--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -3355,7 +3355,7 @@ extern "C" FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSet
         text.append("<XmlSchema name=\"").append(schemaName).append("\">");
         const IResultSetMetaData & meta = cursor->queryResultSet()->getMetaData();
         StringBufferAdaptor adaptor(text);
-        meta.getXmlSchema(adaptor, false);
+        meta.getXmlXPathSchema(adaptor, false);
         text.append("</XmlSchema>").newline();
     }
 


### PR DESCRIPTION
Causes missing column values in display of results when using old display pages.

Does not seem to fix the new result display.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
