### PR TITLE
Fix gh-3070 superfile deleted when removing its subfiles

### DIFF
--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -738,7 +738,7 @@ public:
     }
 
 
-    void removeSuper(const char *superfname, unsigned numtodelete, const char **subfiles, bool delsub, IUserDescriptor *user)
+    void removeSuper(const char *superfname, unsigned numtodelete, const char **subfiles, bool delsub, bool removesuperfile, IUserDescriptor *user)
     {
         Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
         // We need this here, since caching only happens with active transactions
@@ -788,7 +788,7 @@ public:
             transaction->commit();
         }
         // Delete superfile if empty
-        if (superfile->numSubFiles() == 0) {
+        if (removesuperfile && (superfile->numSubFiles() == 0)) {
             superfile.clear();
             // MORE - add file deletion to transaction
             queryDistributedFileDirectory().removeEntry(superfname);

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -34,7 +34,7 @@ interface IDfuFileCopier: extends IInterface
 interface IDFUhelper: extends IInterface
 {
     virtual void addSuper(const char *superfname, unsigned numtoadd=0, const char **subfiles=NULL, const char *before=NULL, IUserDescriptor *user=NULL) = 0;
-    virtual void removeSuper(const char *superfname, unsigned numtodelete=0, const char **subfiles=NULL, bool delsub=false, IUserDescriptor *user=NULL) = 0;
+    virtual void removeSuper(const char *superfname, unsigned numtodelete=0, const char **subfiles=NULL, bool delsub=false, bool removesuperfile=true, IUserDescriptor *user=NULL) = 0;
     virtual void listSubFiles(const char *superfname,StringAttrArray &out, IUserDescriptor *user=NULL) = 0;
     virtual StringBuffer &getFileXML(const char *lfn,StringBuffer &out, IUserDescriptor *user=NULL) = 0;
     virtual void addFileXML(const char *lfn,const StringBuffer &xml, IUserDescriptor *user=NULL) = 0;

--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -45,6 +45,7 @@
                          {
                            document.getElementById('TopSelectAll').checked = select;
                            document.getElementById('BottomSelectAll').checked = select;
+                           document.getElementById('removeSuperfile').checked = select;
                            selectAll(select);
                          }
                          function onRowCheck(checked)
@@ -363,7 +364,7 @@
         <tr class="grey">
         <th>
         <xsl:if test="Item[2]">
-            <xsl:attribute name="name">selectAll1</xsl:attribute>
+            <xsl:attribute name="id">selectAll1</xsl:attribute>
             <input type="checkbox" id="TopSelectAll" title="Select or deselect all subfiles" onclick="selectAll0(this.checked)"/>
         </xsl:if>
         </th>
@@ -387,12 +388,27 @@
             </tr>
             </table>
         </xsl:if>
-        <table id="btnTable" style="margin:20 0 0 0">
-        <colgroup>
-            <col span="8" width="100"/>
-        </colgroup>
+        <table id="btnTable" style="margin:0 0 20 20">
+            <tr>
+                <td>
+                    <xsl:if test="Item[1]">
+                        <input type="checkbox" id="removeSuperfile" name="removeSuperfile" title="Remove Superfile when the file has no subfile" disabled="true">Remove Superfile</input>
+                    </xsl:if>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <xsl:choose>
+                        <xsl:when test="Item[1]">
+                            <input type="submit" class="sbutton" id="deleteBtn" name="action" value="remove" disabled="true" onclick="return confirm('Are you sure you want to delete the following subfiles ?\n\n'+getSelected(document.forms['listitems']).substring(1,1000))"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <input type="button" class="sbutton" id="deleteBtn" value="Delete" onclick="submitaction('Delete','{../Name}@{../Cluster}')"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </td>
+            </tr>
         </table>
-        <input type="submit" class="sbutton" id="deleteBtn" name="action" value="remove" disabled="true" onclick="return confirm('Are you sure you want to delete the following subfiles ?\n\n'+getSelected(document.forms['listitems']).substring(1,1000))"/>
     </xsl:template>
 
     <xsl:template match="Item" mode="list">

--- a/esp/files/scripts/multiselect.js
+++ b/esp/files/scripts/multiselect.js
@@ -91,20 +91,28 @@ function selectAll(select)
 
 function checkSelectAllCheckBoxes(check)
 {
-   if(document.forms[0] != null)
-   {
-       //var all = document.forms[0].all;
-       //if (all) {
-           selectAllCell = document.getElementById("selectAll1");
-           if (selectAllCell && selectAllCell.children[0])
-               selectAllCell.children[0].checked = check;
+    if(document.forms[0] === null)
+        return;
 
-           selectAllCell = document.getElementById("selectAll2");
-           if (selectAllCell)
-               selectAllCell.children[0].checked = check;
-           selectAllCheckboxChecked = check;
-       //}
-   }
+    selectAllCell = document.getElementById("selectAll1");
+    if (selectAllCell && selectAllCell.children[0])
+        selectAllCell.children[0].checked = check;
+
+    selectAllCell = document.getElementById("selectAll2");
+    if (selectAllCell && selectAllCell.children[0])
+        selectAllCell.children[0].checked = check;
+
+    selectAllCheckboxChecked = check;
+
+    selectRemoveSuperfile = document.getElementById("removeSuperfile");
+    if (selectRemoveSuperfile)
+    {
+        selectRemoveSuperfile.checked = false; /*default: not delete superfile*/
+        if (check)
+            selectRemoveSuperfile.disabled = false; /*enable it only when all files are selected to delete*/
+        else
+            selectRemoveSuperfile.disabled = true;
+    }
 }
 
 

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -268,6 +268,7 @@ ESPrequest SuperfileActionRequest
     ESParray<string> subfiles;
     string before;
     bool delete;
+    bool removeSuperfile;
 };
 
 ESPresponse [exceptions_inline, nil_remove] SuperfileActionResponse

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1000,7 +1000,7 @@ void CWsDfuEx::parseStringArray(const char *input, StringArray& strarray)
 }
 
 int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
-                               const char* beforeSubFile, bool existingSuperfile, bool deleteFile)
+                               const char* beforeSubFile, bool existingSuperfile, bool deleteFile, bool removeSuperfile)
 {
     if (!action || !*action)
         throw MakeStringException(ECLWATCH_INVALID_INPUT, "Superfile action not specified");
@@ -1069,7 +1069,7 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
     if(strieq(action, "add"))
         dfuhelper->addSuper(superfile, num, (const char**) subfileArray.getArray(), beforeSubFile, userdesc.get());
     else
-        dfuhelper->removeSuper(superfile, num, (const char**) subfileArray.getArray(), deleteFile, userdesc.get());
+        dfuhelper->removeSuper(superfile, num, (const char**) subfileArray.getArray(), deleteFile, removeSuperfile, userdesc.get());
 
     return num;
 }
@@ -3083,7 +3083,7 @@ bool CWsDfuEx::onSuperfileAction(IEspContext &context, IEspSuperfileActionReques
 
         const char* action = req.getAction();
         const char* superfile = req.getSuperfile();
-        superfileAction(context, action, superfile, req.getSubfiles(), req.getBefore(), true, req.getDelete());
+        superfileAction(context, action, superfile, req.getSubfiles(), req.getBefore(), true, req.getDelete(), req.getRemoveSuperfile());
 
         resp.setRetcode(0);
         if (superfile && *superfile && action && strieq(action, "remove"))

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -138,7 +138,7 @@ private:
     bool getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, int& permission);
     void parseStringArray(const char *input, StringArray& strarray);
     int superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
-        const char* beforeSubFile, bool existingSuperfile, bool deleteFile);
+        const char* beforeSubFile, bool existingSuperfile, bool deleteFile, bool removeSuperfile =  true);
 private:
     bool         m_disableUppercaseTranslation;
     StringBuffer m_clusterName;


### PR DESCRIPTION
In existing EclWatch, removing all subfiles from a superfile
will delete the superfile itself.  This fix adds a checkbox
on Removing Subfiles page before a user deletes subfiles.
The checkbox will be enabled when a user is selected to
delete all of the subfiles. The user may choose not to delete
the superfile by de-selecting the checkbox.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
