### PR TITLE
gh-3054 Fix incorrect 'Cluster Stopped' display for hThor and Roxie

### DIFF
--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -137,6 +137,10 @@ int CEclAgentExecutionServer::run()
         ERRLOG("Terminating unexpectedly");
     }
 
+    CSDSServerStatus serverStatus("HThorServer");
+    serverStatus.queryProperties()->setProp("@queue",queueNames.str());
+    serverStatus.queryProperties()->setProp("@cluster", agentName);
+    serverStatus.commitProperties();
     writeSentinelFile(sentinelFile);
 
     try 

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -389,9 +389,9 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 const char* name = node.queryProp("@name");
                 if (name && *name)
                 {
+                    node.getProp("@queue", qname);
                     if (0 == stricmp("ThorMaster", name))
                     {
-                        node.getProp("@queue", qname);
                         node.getProp("@thorname",instance);
                     }
                     else if (0 == stricmp(name, "ECLAgent"))

--- a/roxie/ccd/ccddali.hpp
+++ b/roxie/ccd/ccddali.hpp
@@ -53,6 +53,8 @@ interface IRoxieDaliHelper : extends IInterface
     virtual bool connect(unsigned timeout) = 0;
     virtual void disconnect() = 0;
     virtual void waitConnected() = 0;
+    virtual void noteQueuesRunning(const char *queueNames) = 0;
+    virtual void noteWorkunitRunning(const char *wu, bool running) = 0;
 };
 
 

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -31044,6 +31044,7 @@ public:
                     {
                         Owned<IJobQueue> queue = createJobQueue(queueNames.str());
                         queue->connect();
+                        daliHelper->noteQueuesRunning(queueNames.str());
                         while (running)
                         {
                             Owned<IJobQueueItem> item = queue->dequeue(5000);
@@ -31276,12 +31277,14 @@ public:
     {
         Owned <IRoxieDaliHelper> daliHelper = connectToDali();
         Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid.get(), NULL);
+        daliHelper->noteWorkunitRunning(wuid.get(), true);
         if (!wu)
             throw MakeStringException(ROXIE_DALI_ERROR, "Failed to open workunit %s", wuid.get());
         Owned<IQueryFactory> queryFactory = createServerQueryFactoryFromWu(wuid.get());
         Owned<StringContextLogger> logctx = new StringContextLogger(wuid.get());
         doMain(wu, queryFactory, *logctx);
         sendUnloadMessage(queryFactory->queryHash(), wuid.get(), *logctx);
+        daliHelper->noteWorkunitRunning(wuid.get(), false);
     }
 
     void doMain(IConstWorkUnit *wu, IQueryFactory *queryFactory, StringContextLogger &logctx)


### PR DESCRIPTION
In 3.8.0, Roxie and hThor clusters walways displayed 'Cluster stopped'
on the main activities page, even though the clusters were in fact running
properly.

This patch fixes that, and also ensures that workunits being run on
roxie via queue are displayed on the activities page.

Fixes gh-3054.
Fixes gh-2017.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
