### PR TITLE
Fix gh-3024 Allow set permissions for repository root

### DIFF
--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -2374,7 +2374,7 @@ bool Cws_accessEx::onPermissionAction(IEspContext &context, IEspPermissionAction
 
                     StringBuffer namebuf(resourceNameStr);
                     SecResourceType rtype = str2type(rtypestr);
-                    if(rtype == RT_MODULE && (stricmp(namebuf.str(), "codegenerator.cpp")) && stricmp(name, "repository") != 0 && Utils::strncasecmp(name, "repository.", 11) != 0)
+                    if(rtype == RT_MODULE && stricmp(namebuf.str(), "codegenerator.cpp") && stricmp(namebuf.str(), "repository") != 0 && Utils::strncasecmp(namebuf.str(), "repository.", 11) != 0)
                         namebuf.insert(0, "repository.");
                     if(prefix && *prefix)
                         namebuf.insert(0, prefix);


### PR DESCRIPTION
When examining repository module type, code was referencing incorrect
resource name variable, resulting in "repository." being prepended to the
resource name (so "repository" became "repository.repository". Corrected
code to look at namebuf.str and tested on Windows and Ubuntu. The 0
return code will be address in gh-3023

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
