### PR TITLE
Fix gh-2788 - rogue error following disk full

### DIFF
--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -371,7 +371,7 @@ void CDiskWriteSlaveActivityBase::close()
                 else
                     out->flush(&fileCRC);
             }
-            else
+            else if (!abortSoon)
                 out->flush();
             out.clear();
         }
@@ -490,20 +490,30 @@ void CDiskWriteSlaveActivityBase::process()
 
         try
         {
-            open(); 
+            open();
             assertex(out||outraw);
             write();
         }
         catch (IException *)
         {
             abortSoon = true;
-            close();
+            try { close(); }
+            catch (IException *e)
+            {
+                EXCLOG(e, "close()");
+                e->Release();
+            }
             throw;
         }
         catch (CATCHALL)
         {
             abortSoon = true;
-            close();
+            try { close(); }
+            catch (IException *e)
+            {
+                EXCLOG(e, "close()");
+                e->Release();
+            }
             throw;
         }
         close();


### PR DESCRIPTION
A disk full condition, caused the compress writer to throw a spurious follow
on error, as disk write tried to close the input in the exception handling

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
