### PR TITLE
Fix gh-3081 Thor slave not shown when group name not set

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -7347,7 +7347,7 @@ StringBuffer &getClusterGroupName(IPropertyTree &cluster, StringBuffer &groupNam
 {
     const char *name = cluster.queryProp("@name");
     const char *nodeGroupName = cluster.queryProp("@nodeGroup");
-    if (nodeGroupName)
+    if (nodeGroupName && *nodeGroupName)
         name = nodeGroupName;
     groupName.append(name);
     return groupName.trim().toLowerCase();


### PR DESCRIPTION
The preflight does not see slave node after resizing/renaming
cluster. The problem also happens on Cluster Process page
(before the preflight page). It was due to empty group name
read from getClusterGroupName(). This fix checks the attribute
'nodeGroup', If it is emoty, use the attribute 'name' as group
name.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
