### PR TITLE
Fix gh-3088 - fix possible memory manager deadlock

### DIFF
--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -355,6 +355,14 @@ public:
         inline CThorSpillableRowArrayLock(const CThorSpillableRowArray &_rows) : rows(_rows) { rows.lock(); }
         inline ~CThorSpillableRowArrayLock() { rows.unlock(); }
     };
+    class CThorSpillableRowArrayUnlock
+    {
+        CThorSpillableRowArrayUnlock(CThorSpillableRowArrayLock &); // avoid accidental use
+        const CThorSpillableRowArray & rows;
+    public:
+        inline CThorSpillableRowArrayUnlock(const CThorSpillableRowArray &_rows) : rows(_rows) { rows.unlock(); }
+        inline ~CThorSpillableRowArrayUnlock() { rows.lock(); }
+    };
 
     CThorSpillableRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, rowidx_t initialSize=InitialSortElements, size32_t commitDelta=CommitStep);
     ~CThorSpillableRowArray();


### PR DESCRIPTION
Deadlock could occur, if resizing a spillable row array at the same time
that an oom condition occurs.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
