### PR TITLE
Fix ESP allowing JSON and XML responses to be redirected

### DIFF
--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -406,7 +406,12 @@ public:
 
 inline bool canRedirect(CHttpRequest &req)
 {
-    return !req.queryParameters()->hasProp("rawxml_");
+    if (req.queryParameters()->hasProp("rawxml_"))
+        return false;
+    IEspContext *ctx = req.queryContext();
+    if (ctx && ctx->getResponseFormat()!=ESPSerializationANY)
+        return false;
+    return true;
 }
 
 inline bool skipXslt(IEspContext &context)


### PR DESCRIPTION
Redirects direct the browser to another page and should not be allowed
when ESP methods are accessed as webservice APIs.

Fixes gh-3058.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
