### PR TITLE
gh-3101 Give warning when DICTIONARY used as an identifier

### DIFF
--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -73,6 +73,7 @@
 #define WRN_FILENAMEIGNORED         1047
 #define WRN_EXPORT_IGNORED          1048
 #define WRN_RECORDMANYFIELDS        1049
+#define WRN_RESERVED_FUTURE         1050 /* Identifier likely to be reserved in future versions */
 //#define ECL_WARN_END          1100
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -659,6 +659,11 @@ DENORMALIZE         { RETURNSYM(DENORMALIZE); }
 DEPRECATED          { RETURNSYM(DEPRECATED); }
 DESC                { RETURNSYM(DESC); }
 DESCEND             { RETURNSYM(DESC); }
+DICTIONARY          {
+                        lexer->reportWarning(returnToken, WRN_RESERVED_FUTURE, "%s", "DICTIONARY will be a reserved word from release 3.10");
+                        setupdatepos;
+                        return lookupIdentifierToken(returnToken, lexer, lookup, activeState, CUR_TOKEN_TEXT);
+                    }
 DISTRIBUTE          { RETURNSYM(DISTRIBUTE); }
 DISTRIBUTED         { RETURNSYM(DISTRIBUTED); }
 DISTRIBUTION        { RETURNSYM(DISTRIBUTION); }


### PR DESCRIPTION
Give a warning on any use of DICTIONARY as an identifier, to reduce the
chances of broken ECL when it becomes a keyword in 3.10

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
