### PR TITLE
FIX gh-2418 LDAP Dali dont use NULL user descriptor

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -959,7 +959,7 @@ public:
     bool getProtectedInfo(const CDfsLogicalFileName &logicalname, StringArray &names, UnsignedArray &counts);
     IDFProtectedIterator *lookupProtectedFiles(const char *owner=NULL,bool notsuper=false,bool superonly=false);
 
-    static bool cannotRemove(CDfsLogicalFileName &name,StringBuffer &reason,bool ignoresub, unsigned timeoutms);
+    static bool cannotRemove(CDfsLogicalFileName &name,IUserDescriptor *user,StringBuffer &reason,bool ignoresub, unsigned timeoutms);
     void setFileProtect(CDfsLogicalFileName &dlfn, const char *owner, bool set, const INode *foreigndali=NULL,IUserDescriptor *user=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
 
     unsigned setDefaultTimeout(unsigned timems)
@@ -6642,10 +6642,10 @@ IDistributedSuperFile *CDistributedFileDirectory::createSuperFile(const char *_l
 }
 
 // MORE - this should go when remove file gets into transactions
-bool CDistributedFileDirectory::cannotRemove(CDfsLogicalFileName &dlfn,StringBuffer &reason,bool ignoresub, unsigned timeoutms)
+bool CDistributedFileDirectory::cannotRemove(CDfsLogicalFileName &dlfn,IUserDescriptor *user,StringBuffer &reason,bool ignoresub, unsigned timeoutms)
 {
     // This is a hack while we don't move remove out of dir
-    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(dlfn, NULL, false, NULL, 6*1000);
+    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(dlfn, user, false, NULL, 6*1000);
     if (file.get())
         return !file->canRemove(reason, ignoresub);
     return false;
@@ -6660,7 +6660,7 @@ bool CDistributedFileDirectory::doRemoveEntry(CDfsLogicalFileName &dlfn,IUserDes
     if (!checkLogicalName(dlfn,user,true,true,true,"remove"))
         return false;
     StringBuffer reason;
-    if (cannotRemove(dlfn,reason,ignoresub,defaultTimeout)) {
+    if (cannotRemove(dlfn,user,reason,ignoresub,defaultTimeout)) {
 #ifdef EXTRA_LOGGING
         PROGLOG("CDistributedFileDirectory::doRemoveEntry(cannotRemove) %s",reason.str());
 #endif


### PR DESCRIPTION
Passing NULL as user descriptor to CDistributedFileDirectory::cannotRemove
causes the LDAP file scope checking to use the default user, which is
incorrect because this user will likely have different scope visibility

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
