### PR TITLE
Fix gh-3076 Add Slave Number column on Cluster pages

### DIFF
--- a/esp/services/ws_machine/machines.xslt
+++ b/esp/services/ws_machine/machines.xslt
@@ -65,6 +65,7 @@
    <xsl:variable name="autoRefresh" select="$reqInfo/AutoRefresh"/>
    <xsl:variable name="numColumns" select="count(/GetMachineInfoResponse/Columns/Item)"/>
    <xsl:variable name="SwapNode" select="$reqInfo/OldIP/text() and $clusterType='THORSPARENODES'"/>
+   <xsl:variable name="numSlaveNodes" select="count(/GetMachineInfoResponse/Machines/MachineInfoEx/ProcessType[text()='ThorSlaveProcess'])"/>
    
   <xsl:template match="/GetMachineInfoResponse">
     <html>
@@ -158,12 +159,16 @@
                        case 'Processes': 
                        case 'Processes Down':
                        case 'Condition':
+                       case 'Component':
                        case 'State':
                           sort = 'String'; 
                           break;
                        case 'Up Time':
                        case 'Computer Up Time': 
                           sort = 'TimePeriod'; 
+                          break;
+                       case 'Slave Number':
+                          sort = 'Number';
                           break;
                        default:
                           sort = "Percentage";
@@ -301,6 +306,9 @@
                </th>
                <th>Location</th>
                <th>Component</th>
+               <xsl:if test="$numSlaveNodes > 0">
+                  <th>Slave Number</th>
+               </xsl:if>
                <xsl:choose>
                   <xsl:when test="../Columns/Item">
                      <xsl:for-each select="../Columns/Item[text()='Condition']">
@@ -406,16 +414,18 @@
             <xsl:value-of select="DisplayType"/>
             <xsl:if test="string(ComponentName)!=''">
                <br/>
-               <xsl:choose>
-                  <xsl:when test="ProcessType='ThorSlaveProcess'">
-                     <xsl:value-of select="concat('[', ProcessNumber, ']')"/>
-                  </xsl:when>
-                  <xsl:when test="ProcessType!='ThorMasterProcess' and ProcessType!='RoxieServerProcess'">
-                     <xsl:value-of select="concat('[', ComponentName, ']')"/>
-                  </xsl:when>
-               </xsl:choose>
+                <xsl:if test="ProcessType!='ThorMasterProcess' and ProcessType!='RoxieServerProcess'">
+                    <xsl:value-of select="concat('[', ComponentName, ']')"/>
+                </xsl:if>
             </xsl:if>
          </td>
+         <xsl:if test="$numSlaveNodes > 0">
+             <td>
+                <xsl:if test="ProcessType='ThorSlaveProcess'">
+                    <xsl:value-of select="ProcessNumber"/>
+                </xsl:if>
+             </td>
+         </xsl:if>
          <xsl:choose>
             <xsl:when test="UpTime/text()">
                   <xsl:variable name="cond" select="ComponentInfo/Condition"/>

--- a/esp/services/ws_machine/preflightControls.xslt
+++ b/esp/services/ws_machine/preflightControls.xslt
@@ -87,31 +87,30 @@
          {
           if (!fromTargetClusterPage)
           {
-            if ((name=='Start') || (name=='Stop'))
-              method = name;   
-            else
-                    document.forms['listitems'].action = '/ws_machine/' + name;
+             if ((name=='Start') || (name=='Stop'))
+                method = name;
+             else
+                document.forms['listitems'].action = '/ws_machine/' + name;
 
-            var c = document.forms['listitems'].all;
-            if (name != 'GetMachineInfo')
-               c['GetMachineInfo'].style.display="none";
-               
-            if (name != 'GetMetrics' && c['GetMetrics'] != undefined)
-               c['GetMetrics'].style.display="none";
-            
-            if (name != 'RemoteExec')
-               c['RemoteExec'].style.display="none";
-                  
-            if (name != 'Start' && name != 'Stop')
-               c['StartStop'].style.display="none";
-                  
-            c['AutoRefreshSection'].style.display= name == "GetMachineInfo" ? "block" : "none";
-            if (name!='Start' && name!='Stop')
-               c[name].style.display='block';
-                    else
-               c['StartStop'].style.display='block';
+             if (name != 'GetMachineInfo')
+                document.getElementById('GetMachineInfo').style.display="none";
 
-            method = name;
+             if (name != 'GetMetrics' && document.getElementById('GetMetrics') != undefined)
+                document.getElementById('GetMetrics').style.display="none";
+
+             if (name != 'RemoteExec')
+                document.getElementById('RemoteExec').style.display="none";
+                  
+             if (name != 'Start' && name != 'Stop')
+                document.getElementById('StartStop').style.display="none";
+
+             document.getElementById('AutoRefreshSection').style.display= name == "GetMachineInfo" ? "block" : "none";
+             if (name!='Start' && name!='Stop')
+                document.getElementById(name).style.display='block';
+             else
+                document.getElementById('StartStop').style.display='block';
+
+             method = name;
           }
           else
           {


### PR DESCRIPTION
On EclWatch Thor Cluster page and Preflight page, a Slave
Number column is added, which allows a user to sort cluster
components by slave number.

Two addtional bugs are fixed: Sort function does not on
Firefox; Sort on Component column does not work due to
wrong column type.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
