### PR TITLE
gh-3066 Roxie not releasing files fully after running workunit.

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -31295,7 +31295,9 @@ public:
         Owned<StringContextLogger> logctx = new StringContextLogger(wuid.get());
         doMain(wu, queryFactory, *logctx);
         sendUnloadMessage(queryFactory->queryHash(), wuid.get(), *logctx);
+        queryFactory.clear();
         daliHelper->noteWorkunitRunning(wuid.get(), false);
+        clearKeyStoreCache(false);   // Bit of a kludge - cache should really be smarter
     }
 
     void doMain(IConstWorkUnit *wu, IQueryFactory *queryFactory, StringContextLogger &logctx)


### PR DESCRIPTION
Roxie was not fully releasing index files that were loaded by a
workunit query. This could result in spurious errors reporting that
a different version of the index file was already loaded, if the
index was modified before the query was next run.

Ideally, the jhtree index cache would be restructured so that it does
not link the IKeyIndex objects in it, but rather releases the cached
entries when their link counts go to zero. However, that would be a
larger refactoring.

We already use the clearKeyStoreCache(false) call whenever QuerySet contents
changes to avoid this issue - add a call whenever a WorkUnit query finishes
too.

Fixes gh-3066.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
