### PR TITLE
gh-3094 Fix Configmgr - Writing modified optional attributes reverts their value

### DIFF
--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -3520,11 +3520,11 @@ function onMenuItemClickResetToDefault(p_sType, p_aArgs, p_oValue)
   var column = dt.getColumn(oTarget);
   var compName = top.document.navDT.getRecord(top.document.navDT.getSelectedRows()[0]).getData('Name');
   var bldSet = top.document.navDT.getRecord(top.document.navDT.getSelectedRows()[0]).getData('BuildSet');
-  var newValue = dt.getDefault(oTarget, record);
   var meta = record.getData(column.key + '_extra');
   var menuItemName = this.cfg.getProperty("text");
   var flag = (menuItemName === 'Write to environment');
-  
+  var newValue = (flag ? oldValue : dt.getDefault(oTarget, record));
+
   if (flag || newValue !== oldValue) {
      var form = top.window.document.forms['treeForm'];
      top.document.startWait(document);


### PR DESCRIPTION
- Add check to ensure that when writing optional attributes to the
  environment that the modified value is used and not the default value.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
