### PR TITLE
Fix gh-2731 not disable 'retain superfile structure'

### DIFF
--- a/esp/eclwatch/ws_XSLT/fs_desprayCopyForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_desprayCopyForm.xslt
@@ -24,7 +24,6 @@
     <xsl:param name="method" select="'Despray'"/>
     <xsl:param name="sourceLogicalName" select="''"/>
     <xsl:param name="compressflag" select="''"/>
-    <xsl:param name="supercopyflag" select="''"/>
     <xsl:template match="/Environment">
     <xsl:choose>
       <xsl:when test="ErrorMessage">
@@ -729,14 +728,7 @@
             <tr>
                 <td>Retain Superfile Structure:</td>
                 <td>
-                    <xsl:choose>
-                        <xsl:when test="$supercopyflag &gt; 1">
-                            <input type="checkbox" name="superCopy" value="1" checked="true"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <input type="checkbox" name="superCopy" value="0" disabled="false"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
+                    <input type="checkbox" name="superCopy" value="1" checked="true"/>
                 </td>
             </tr>
             <span id="roxie_span" style="display:none">

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -155,7 +155,6 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
                                 params->setProp("@compressflag", 1);
                             }
                         }
-                        params->setProp("@supercopyflag", 0); //super copy only for remote copy
                     }
                     catch (IException *E)
                     {
@@ -173,7 +172,6 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
             else
             {
                 params->setProp("@compressflag", 1);
-                params->setProp("@supercopyflag", 2);
             }
 
             StringBuffer wuid;


### PR DESCRIPTION
The option 'retain superfile structure' is disabled when
trying to copy a super-file from the Copy drop-down menu
in eclwatch. It was disabled because the 'copy super-file
function' did not work at that time. This fix enables the
option.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
