### PR TITLE
gh-3107 Dont check file scope twice before delete

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -439,14 +439,16 @@ interface IDistributedFileDirectory: extends IInterface
                                         IUserDescriptor *user=NULL,
                                         bool writeaccess=false,
                                         IDistributedFileTransaction *transaction=NULL, // transaction only used for looking up superfile sub files
-                                        unsigned timeout=INFINITE
+                                        unsigned timeout=INFINITE,
+                                        bool checkScope=true
                                     ) = 0;  // links, returns NULL if not found
 
     virtual IDistributedFile *lookup(   const CDfsLogicalFileName &logicalname,
                                         IUserDescriptor *user=NULL,
                                         bool writeaccess=false,
                                         IDistributedFileTransaction *transaction=NULL, // transaction only used for looking up superfile sub files
-                                        unsigned timeout=INFINITE
+                                        unsigned timeout=INFINITE,
+                                        bool checkScope=true
                                     ) = 0;  // links, returns NULL if not found
 
     virtual IDistributedFile *createNew(IFileDescriptor *desc,bool includeports=false) = 0;


### PR DESCRIPTION
Change IDistributedFileDirectory::lookup to accept a boolean controlling
whether or not we should check file scope. Default this argument to TRUE,
but explicitly pass FALSE from cannotRemove to make sure we only check
the scope once

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
