### PR TITLE
gh-3120 Bad error when viewing WU result on WU Details page

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -211,10 +211,10 @@ void getSashaNode(SocketEndpoint &ep)
 }
 
 
-bool WsWuInfo::getSourceFiles(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getSourceFiles(IEspECLWorkunit &info, unsigned flags)
 {
     if (!(flags & WUINFO_IncludeSourceFiles))
-        return true;
+        return;
     try
     {
         Owned<IUserDescriptor> userdesc;
@@ -312,15 +312,14 @@ bool WsWuInfo::getSourceFiles(IEspECLWorkunit &info, unsigned flags)
         }
 
         info.setSourceFiles(files);
-        return true;
     }
     catch(IException* e)
     {
         StringBuffer eMsg;
-        ERRLOG("%s", e->errorMessage(eMsg).str()); //log original exception
+        ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setSourceFilesDesc(eMsg.str());
         e->Release();
     }
-    return false;
 }
 
 void WsWuInfo::getExceptions(IEspECLWorkunit &info, unsigned flags)
@@ -339,10 +338,10 @@ void WsWuInfo::getExceptions(IEspECLWorkunit &info, unsigned flags)
     }
 }
 
-bool WsWuInfo::getVariables(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getVariables(IEspECLWorkunit &info, unsigned flags)
 {
     if (!(flags & WUINFO_IncludeVariables))
-        return true;
+        return;
     try
     {
         IArrayOf<IEspECLResult> results;
@@ -351,21 +350,20 @@ bool WsWuInfo::getVariables(IEspECLWorkunit &info, unsigned flags)
             getResult(vars->query(), results, flags);
         info.setVariables(results);
         results.kill();
-        return true;
     }
     catch(IException* e)
     {
         StringBuffer eMsg;
         ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setVariablesDesc(eMsg.str());
         e->Release();
     }
-    return false;
 }
 
-bool WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
 {
     if (!(flags & WUINFO_IncludeTimers))
-        return true;
+        return;
     try
     {
         StringBuffer totalThorTimeValue;
@@ -429,125 +427,123 @@ bool WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
         }
 
         info.setTimers(timers);
-        return true;
     }
     catch(IException* e)
     {
         StringBuffer eMsg;
-        e->errorMessage(eMsg);
-        ERRLOG("%s", eMsg.str()); //log original exception
+        ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setTimersDesc(eMsg.str());
         e->Release();
     }
-    return false;
 }
 
-bool WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
 {
     try
     {
         Owned <IConstWUQuery> query = cw->getQuery();
-        if(query)
+        if(!query)
         {
-            SCMStringBuffer qname;
-            query->getQueryShortText(qname);
-            if(qname.length())
-            {
-                if((flags & WUINFO_TruncateEclTo64k) && (qname.length() > 64000))
-                    qname.setLen(qname.str(), 64000);
+            ERRLOG("Cannot get Query for this workunit.");
+            info.setHelpersDesc("Cannot get Query for this workunit.");
+        }
 
+        SCMStringBuffer qname;
+        query->getQueryShortText(qname);
+        if(qname.length())
+        {
+            if((flags & WUINFO_TruncateEclTo64k) && (qname.length() > 64000))
+                qname.setLen(qname.str(), 64000);
+
+            IEspECLQuery* q=&info.updateQuery();
+            q->setText(qname.str());
+        }
+
+        if (version > 1.34)
+        {
+            SCMStringBuffer mainDefinition;
+            query->getQueryMainDefinition(mainDefinition);
+            if(mainDefinition.length())
+            {
                 IEspECLQuery* q=&info.updateQuery();
-                q->setText(qname.str());
+                q->setQueryMainDefinition(mainDefinition.str());
             }
+        }
 
-            if (version > 1.34)
+        if (version > 1.30)
+        {
+            SCMStringBuffer qText;
+            query->getQueryText(qText);
+            if ((qText.length() > 0) && isArchiveQuery(qText.str()))
+                info.setHasArchiveQuery(true);
+        }
+
+        IArrayOf<IEspECLHelpFile> helpers;
+        getHelpFiles(query, FileTypeCpp, helpers);
+        getHelpFiles(query, FileTypeDll, helpers);
+        getHelpFiles(query, FileTypeResText, helpers);
+
+        getWorkunitThorLogInfo(helpers, info);
+
+        if (cw->getWuidVersion() > 0)
+        {
+            Owned<IStringIterator> eclAgentInstances = cw->getProcesses("EclAgent");
+            ForEach (*eclAgentInstances)
             {
-                SCMStringBuffer mainDefinition;
-                query->getQueryMainDefinition(mainDefinition);
-                if(mainDefinition.length())
-                {
-                    IEspECLQuery* q=&info.updateQuery();
-                    q->setQueryMainDefinition(mainDefinition.str());
-                }
-            }
+                SCMStringBuffer processName;
+                eclAgentInstances->str(processName);
+                if (processName.length() < 1)
+                    continue;
 
-            if (version > 1.30)
-            {
-                SCMStringBuffer qText;
-                query->getQueryText(qText);
-                if ((qText.length() > 0) && isArchiveQuery(qText.str()))
-                    info.setHasArchiveQuery(true);
-            }
-
-            IArrayOf<IEspECLHelpFile> helpers;
-            getHelpFiles(query, FileTypeCpp, helpers);
-            getHelpFiles(query, FileTypeDll, helpers);
-            getHelpFiles(query, FileTypeResText, helpers);
-
-            getWorkunitThorLogInfo(helpers, info);
-
-            if (cw->getWuidVersion() > 0)
-            {
-                Owned<IStringIterator> eclAgentInstances = cw->getProcesses("EclAgent");
-                ForEach (*eclAgentInstances)
-                {
-                    SCMStringBuffer processName;
-                    eclAgentInstances->str(processName);
-                    if (processName.length() < 1)
-                        continue;
-
-                    Owned<IStringIterator> eclAgentLogs = cw->getLogs("EclAgent", processName.str());
-                    ForEach (*eclAgentLogs)
-                    {
-                        SCMStringBuffer logName;
-                        eclAgentLogs->str(logName);
-                        if (logName.length() < 1)
-                            continue;
-
-                        Owned<IEspECLHelpFile> h= createECLHelpFile("","");
-                        h->setName(logName.str());
-                        h->setDescription(processName.str());
-                        h->setType(File_EclAgentLog);
-                        helpers.append(*h.getLink());
-                    }
-                }
-            }
-            else // legacy wuid
-            {
-                Owned<IStringIterator> eclAgentLogs = cw->getLogs("EclAgent");
+                Owned<IStringIterator> eclAgentLogs = cw->getLogs("EclAgent", processName.str());
                 ForEach (*eclAgentLogs)
                 {
-                    SCMStringBuffer name;
-                    eclAgentLogs->str(name);
-                    if (name.length() < 1)
+                    SCMStringBuffer logName;
+                    eclAgentLogs->str(logName);
+                    if (logName.length() < 1)
                         continue;
 
                     Owned<IEspECLHelpFile> h= createECLHelpFile("","");
-                    h->setName(name.str());
+                    h->setName(logName.str());
+                    h->setDescription(processName.str());
                     h->setType(File_EclAgentLog);
                     helpers.append(*h.getLink());
-                    break;
                 }
             }
-
-            info.setHelpers(helpers);
-
-            return true;
         }
+        else // legacy wuid
+        {
+            Owned<IStringIterator> eclAgentLogs = cw->getLogs("EclAgent");
+            ForEach (*eclAgentLogs)
+            {
+                SCMStringBuffer name;
+                eclAgentLogs->str(name);
+                if (name.length() < 1)
+                    continue;
+
+                Owned<IEspECLHelpFile> h= createECLHelpFile("","");
+                h->setName(name.str());
+                h->setType(File_EclAgentLog);
+                helpers.append(*h.getLink());
+                break;
+            }
+        }
+
+        info.setHelpers(helpers);
     }
-     catch(IException* e)
-     {
-         StringBuffer eMsg;
-         e->errorMessage(eMsg);
-         ERRLOG("%s", eMsg.str()); //log original exception
-         e->Release();
-     }
-     return false;
+    catch(IException* e)
+    {
+        StringBuffer eMsg;
+        ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setHelpersDesc(eMsg.str());
+        e->Release();
+    }
 }
 
-bool WsWuInfo::getApplicationValues(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getApplicationValues(IEspECLWorkunit &info, unsigned flags)
 {
     if (!(flags & WUINFO_IncludeApplicationValues))
-        return true;
+        return;
     try
     {
         IArrayOf<IEspApplicationValue> av;
@@ -567,22 +563,20 @@ bool WsWuInfo::getApplicationValues(IEspECLWorkunit &info, unsigned flags)
         }
 
         info.setApplicationValues(av);
-        return true;
     }
     catch(IException* e)
     {
         StringBuffer eMsg;
-        e->errorMessage(eMsg);
-        ERRLOG("%s", eMsg.str()); //log original exception
+        ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setApplicationValuesDesc(eMsg.str());
         e->Release();
     }
-    return false;
 }
 
-bool WsWuInfo::getDebugValues(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getDebugValues(IEspECLWorkunit &info, unsigned flags)
 {
     if (!(flags & WUINFO_IncludeDebugValues))
-        return true;
+        return;
     try
     {
         IArrayOf<IEspDebugValue> dv;
@@ -599,16 +593,14 @@ bool WsWuInfo::getDebugValues(IEspECLWorkunit &info, unsigned flags)
             dv.append(*t.getLink());
         }
         info.setDebugValues(dv);
-        return true;
     }
     catch(IException* e)
     {
         StringBuffer eMsg;
-        e->errorMessage(eMsg);
-        ERRLOG("%s", eMsg.str()); //log original exception
+        ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setDebugValuesDesc(eMsg.str());
         e->Release();
     }
-    return false;
 }
 
 const char *getGraphNum(const char *s,unsigned &num)
@@ -624,7 +616,7 @@ const char *getGraphNum(const char *s,unsigned &num)
     return s;
 }
 
-bool WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
 {
      if (version > 1.01)
      {
@@ -634,12 +626,18 @@ bool WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
         Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), 0, 5*60*1000);
         if (!conn)
         {
-            DBGLOG("Could not connect to SDS");
-            return false;
+            DBGLOG("Cannot connect to SDS");
+            info.setGraphsDesc("Cannot connect to SDS");
+            return;
         }
         IPropertyTree *wpt = conn->queryRoot();
         if (!wpt)
-            return false;
+        {
+            DBGLOG("Cannot get data from SDS");
+            info.setGraphsDesc("Cannot get data from SDS");
+            return;
+        }
+
         Owned<IPropertyTreeIterator> iter = wpt->getElements("Timings/Timing");
         StringBuffer name;
         IArrayOf<IConstECLTimingData> timingdatarray;
@@ -664,7 +662,8 @@ bool WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
      }
 
     if (!(flags & WUINFO_IncludeGraphs))
-        return true;
+        return;
+
     try
     {
         SCMStringBuffer runningGraph;
@@ -711,16 +710,14 @@ bool WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
             graphs.append(*g.getLink());
         }
         info.setGraphs(graphs);
-        return true;
     }
     catch(IException* e)
     {
         StringBuffer eMsg;
-        e->errorMessage(eMsg);
-        ERRLOG("%s", eMsg.str()); //log original exception
+        ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setGraphsDesc(eMsg.str());
         e->Release();
     }
-    return false;
 }
 
 void WsWuInfo::getGraphTimingData(IArrayOf<IConstECLTimingData> &timingData, unsigned flags)
@@ -890,26 +887,15 @@ void WsWuInfo::getInfo(IEspECLWorkunit &info, unsigned flags)
 
     getClusterInfo(info, flags);
     getExceptions(info, flags);
-
-    const char* msg = "This section cannot be dispayed due to an exception.";
-    if (!getHelpers(info, flags))
-        info.setHelpersDesc(msg);
-    if (!getGraphInfo(info, flags))
-        info.setGraphsDesc(msg);
-    if (!getSourceFiles(info, flags))
-        info.setSourceFilesDesc(msg);
-    if (!getResults(info, flags))
-        info.setResultsDesc(msg);
-    if (!getVariables(info, flags))
-        info.setVariablesDesc(msg);
-    if (!getTimers(info, flags))
-        info.setTimersDesc(msg);
-    if (!getDebugValues(info, flags))
-        info.setDebugValuesDesc(msg);
-    if (!getApplicationValues(info, flags))
-        info.setApplicationValuesDesc(msg);
-    if (!getWorkflow(info, flags))
-        info.setWorkflowsDesc(msg);
+    getHelpers(info, flags);
+    getGraphInfo(info, flags);
+    getSourceFiles(info, flags);
+    getResults(info, flags);
+    getVariables(info, flags);
+    getTimers(info, flags);
+    getDebugValues(info, flags);
+    getApplicationValues(info, flags);
+    getWorkflow(info, flags);
 }
 
 unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IEspECLWorkunit &info)
@@ -1125,10 +1111,8 @@ bool WsWuInfo::getClusterInfo(IEspECLWorkunit &info, unsigned flags)
     return true;
 }
 
-bool WsWuInfo::getWorkflow(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getWorkflow(IEspECLWorkunit &info, unsigned flags)
 {
-    bool success=true;
-
     bool eventCountRemaining = false;
     bool eventCountUnlimited = false;
     try
@@ -1181,9 +1165,9 @@ bool WsWuInfo::getWorkflow(IEspECLWorkunit &info, unsigned flags)
     }
     catch(IException* e)
     {
-        success = false;
         StringBuffer eMsg;
         ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setWorkflowsDesc(eMsg.str());
         e->Release();
     }
 
@@ -1191,7 +1175,6 @@ bool WsWuInfo::getWorkflow(IEspECLWorkunit &info, unsigned flags)
         info.setEventSchedule(2); //Can deschedule
     else if (eventCountUnlimited || eventCountRemaining)
         info.setEventSchedule(1); //Can reschedule
-    return success;
 }
 
 bool shouldFileContentBeShown(IEspContext &context, const char * logicalName)
@@ -1425,7 +1408,7 @@ void WsWuInfo::getResult(IConstWUResult &r, IArrayOf<IEspECLResult>& results, un
 }
 
 
-bool WsWuInfo::getResults(IEspECLWorkunit &info, unsigned flags)
+void WsWuInfo::getResults(IEspECLWorkunit &info, unsigned flags)
 {
     try
     {
@@ -1450,15 +1433,14 @@ bool WsWuInfo::getResults(IEspECLWorkunit &info, unsigned flags)
             info.setResults(results);
 
         results.kill();
-        return true;
     }
     catch(IException* e)
     {
         StringBuffer eMsg;
         ERRLOG("%s", e->errorMessage(eMsg).str());
+        info.setResultsDesc(eMsg.str());
         e->Release();
     }
-    return false;
 }
 
 void WsWuInfo::getHelpFiles(IConstWUQuery* query, WUFileType type, IArrayOf<IEspECLHelpFile>& helpers)

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -144,20 +144,20 @@ public:
     void getCommon(IEspECLWorkunit &info, unsigned flags);
     void getInfo(IEspECLWorkunit &info, unsigned flags);
 
-    bool getResults(IEspECLWorkunit &info, unsigned flags);
-    bool getVariables(IEspECLWorkunit &info, unsigned flags);
-    bool getDebugValues(IEspECLWorkunit &info, unsigned flags);
+    void getResults(IEspECLWorkunit &info, unsigned flags);
+    void getVariables(IEspECLWorkunit &info, unsigned flags);
+    void getDebugValues(IEspECLWorkunit &info, unsigned flags);
     bool getClusterInfo(IEspECLWorkunit &info, unsigned flags);
-    bool getApplicationValues(IEspECLWorkunit &info, unsigned flags);
+    void getApplicationValues(IEspECLWorkunit &info, unsigned flags);
     void getExceptions(IEspECLWorkunit &info, unsigned flags);
-    bool getSourceFiles(IEspECLWorkunit &info, unsigned flags);
-    bool getTimers(IEspECLWorkunit &info, unsigned flags);
-    bool getHelpers(IEspECLWorkunit &info, unsigned flags);
-    bool getGraphInfo(IEspECLWorkunit &info, unsigned flags);
+    void getSourceFiles(IEspECLWorkunit &info, unsigned flags);
+    void getTimers(IEspECLWorkunit &info, unsigned flags);
+    void getHelpers(IEspECLWorkunit &info, unsigned flags);
+    void getGraphInfo(IEspECLWorkunit &info, unsigned flags);
     void getGraphTimingData(IArrayOf<IConstECLTimingData> &timingData, unsigned flags);
 
     void getRoxieCluster(IEspECLWorkunit &info, unsigned flags);
-    bool getWorkflow(IEspECLWorkunit &info, unsigned flags);
+    void getWorkflow(IEspECLWorkunit &info, unsigned flags);
 
     void getHelpFiles(IConstWUQuery* query, WUFileType type, IArrayOf<IEspECLHelpFile>& helpers);
     void getSubFiles(IPropertyTreeIterator* f, IEspECLSourceFile* eclSuperFile, StringArray& fileNames);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1647,6 +1647,9 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
             getArchivedWUInfo(context, wuid.str(), resp);
         else
         {
+            //The access is checked here because getArchivedWUInfo() has its own access check.
+            ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Read);
+
             unsigned flags=0;
             if (req.getTruncateEclTo64k())
                 flags|=WUINFO_TruncateEclTo64k;


### PR DESCRIPTION
When a user views WU result on WU Details page and the
user does not have permission for the file, the existing
page shows that 'This section cannot be dispayed due to
an exception.' and original exception is written into log
file. This fix displays the original exception on the WU
Details page.

Fixes gh-3120.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
