### PR TITLE
gh-3138 fix missing error deleting subfile

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2549,9 +2549,14 @@ public:
         if (!ignoresub) {
             // And has super owners
             Owned<IPropertyTreeIterator> iter = root->getElements("SuperOwner");
-            if (iter->isValid()) {
-                const char *supername = iter->query().queryProp("@name");
-                reason.appendf("Cannot remove file %s as owned by SuperFile %s", logicalname, supername);
+            if (iter->first()) {
+                reason.append("Cannot remove file ").append(logicalname).append(" as owned by SuperFile(s): ");
+                loop {
+                    reason.append(iter->query().queryProp("@name"));
+                    if (!iter->next())
+                        break;
+                    reason.append(", ");
+                }
                 return false;
             }
         }


### PR DESCRIPTION
Regression introduced by gh-2042.

Deleting a logical file owned by a super file should cause an error.
The change in gh-2042 wasn't iterating through SuperOwners correctly.

Fixes gh-3138

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
