### PR TITLE
gh-3151 Fix Thor's setIORetryCount setting

### DIFF
--- a/system/jlib/jio.cpp
+++ b/system/jlib/jio.cpp
@@ -49,6 +49,7 @@ static unsigned ioRetryCount=0;
 void setIORetryCount(unsigned _ioRetryCount) // non atomic, expected to be called just once at process start up.
 {
     ioRetryCount = _ioRetryCount;
+    PROGLOG("setIORetryCount set to : %d", ioRetryCount);
 }
 
 extern jlib_decl offset_t checked_lseeki64( int handle, offset_t offset, int origin )

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -277,7 +277,6 @@ int main( int argc, char *argv[]  )
         if (!master)
             usage();
 
-        setIORetryCount(globals->getPropInt("Debug/@ioRetries")); // default == 0 == off
         const char *slave = globals->queryProp("@SLAVE");
         if (slave)
         {
@@ -349,6 +348,8 @@ int main( int argc, char *argv[]  )
             }
 
 // Initialization from globals
+            setIORetryCount(globals->getPropInt("Debug/@ioRetries")); // default == 0 == off
+
             StringBuffer str;
             if (globals->getProp("@externalProgDir", str.clear()))
                 _mkdir(str.str());


### PR DESCRIPTION
Thor slaves were calling setIORetryCount too early, before the slaves had
deserialized the thor config settings from the master. Consequently it
remained set to default (off) even if configured.

Also add a line of logging so know called.

Fixes gh-3151

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
