### PR TITLE
gh-2806 Add ecl-roxie cli support for attaching/detaching roxie from dali

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1152,6 +1152,8 @@ extern WORKUNIT_API bool validateTargetClusterName(const char *clustname);
 extern WORKUNIT_API IConstWUClusterInfo* getTargetClusterInfo(const char *clustname);
 typedef IArrayOf<IConstWUClusterInfo> CConstWUClusterInfoArray;
 extern WORKUNIT_API unsigned getEnvironmentClusterInfo(CConstWUClusterInfoArray &clusters);
+extern WORKUNIT_API void getRoxieProcessServers(const char *process, SocketEndpointArray &servers);
+
 
 extern WORKUNIT_API bool getWorkUnitCreateTime(const char *wuid,CDateTime &time); // based on WUID
 extern WORKUNIT_API bool restoreWorkUnit(const char *base,const char *wuid);

--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
@@ -1057,6 +1057,14 @@
               </row>
 
               <row>
+                <entry>RoxieControlAccess</entry>
+
+                <entry>Access to Roxie Process Cluster Control</entry>
+
+                <entry>Full</entry>
+              </row>
+
+              <row>
                 <entry>OwnWorkunitsAccess</entry>
 
                 <entry>Access to View Own Workunit</entry>

--- a/docs/wip/ECL_Watch.xml
+++ b/docs/wip/ECL_Watch.xml
@@ -1947,6 +1947,19 @@
 
                   <entry><para>Full</para></entry>
                 </row>
+                <row>
+                  <entry>
+                    <para>RoxieControlAccess</para>
+                  </entry>
+
+                  <entry>
+                    <para>Access to Roxie Process Cluster Control</para>
+                  </entry>
+
+                  <entry>
+                    <para>Full</para>
+                  </entry>
+                </row>
               </tbody>
             </tgroup>
           </informaltable></para>

--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -24,6 +24,7 @@
 #####################################################
 
 add_subdirectory (queries)
+add_subdirectory (roxie)
 
 project( ecl )
 

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -199,6 +199,7 @@ void EclCMDShell::usage()
            "   activate    activate a published query\n"
            "   deactivate  deactivate the given query alias name\n"
            "   queries     show or manipulate queries and querysets\n"
+           "   roxie       commands specific to roxie clusters\n"
            "\nRun 'ecl help <command>' for more information on a specific command\n\n"
     );
 }

--- a/ecl/eclcmd/roxie/CMakeLists.txt
+++ b/ecl/eclcmd/roxie/CMakeLists.txt
@@ -1,0 +1,56 @@
+##############################################################################
+# Copyright (C) 2012 HPCC Systems.
+##############################################################################
+
+
+# Component: ecl-roxie
+#####################################################
+# Description:
+# ------------
+#    Cmake Input File for ecl-roxie
+#####################################################
+
+
+project( ecl-roxie )
+
+include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
+
+set (    SRCS
+         ${ESPSCM_GENERATED_DIR}/common_esp.cpp
+         ${ESPSCM_GENERATED_DIR}/ws_smc_esp.cpp
+         ecl-roxie.cpp
+         ../eclcmd_shell.cpp
+         ../eclcmd_common.hpp
+         ../eclcmd_common.cpp
+    )
+
+include_directories (
+         ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
+         ${HPCC_SOURCE_DIR}/system/include
+         ${HPCC_SOURCE_DIR}/system/jlib
+         ${HPCC_SOURCE_DIR}/common/workunit
+         ${HPCC_SOURCE_DIR}/esp/clients
+         ${HPCC_SOURCE_DIR}/esp/bindings
+         ${HPCC_SOURCE_DIR}/esp/bindings/SOAP/xpp
+         ${HPCC_SOURCE_DIR}/esp/platform
+         ${HPCC_SOURCE_DIR}/system/security/shared
+         ${HPCC_SOURCE_DIR}/system/include
+         ${HPCC_SOURCE_DIR}/system/xmllib
+         ${HPCC_SOURCE_DIR}/ecl/eclcmd
+    )
+
+ADD_DEFINITIONS( -D_CONSOLE )
+
+HPCC_ADD_EXECUTABLE ( ecl-roxie ${SRCS} )
+add_dependencies ( ecl-roxie espscm ws_workunits )
+install ( TARGETS ecl-roxie RUNTIME DESTINATION ${EXEC_DIR} )
+target_link_libraries ( ecl-roxie
+        jlib
+        esphttp
+        workunit
+    )
+
+if (UNIX)
+install ( PROGRAMS ecl-roxie.install DESTINATION etc/init.d/install COMPONENT Runtime )
+endif (UNIX)

--- a/ecl/eclcmd/roxie/ecl-roxie.cpp
+++ b/ecl/eclcmd/roxie/ecl-roxie.cpp
@@ -1,0 +1,195 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+#include <stdio.h>
+#include "jlog.hpp"
+#include "jfile.hpp"
+#include "jargv.hpp"
+
+#include "build-config.h"
+
+#include "ws_smc.hpp"
+
+#include "eclcmd.hpp"
+#include "eclcmd_common.hpp"
+#include "eclcmd_core.hpp"
+
+#define INIFILE "ecl.ini"
+#define SYSTEMCONFDIR CONFIG_DIR
+#define DEFAULTINIFILE "ecl.ini"
+#define SYSTEMCONFFILE ENV_CONF_FILE
+
+//=========================================================================================
+
+class EclCmdRoxieAttach : public EclCmdCommon
+{
+public:
+    EclCmdRoxieAttach(bool _attach) : optMsToWait(10000), attach(_attach)
+    {
+    }
+    virtual bool parseCommandLineOptions(ArgvIterator &iter)
+    {
+        for (; !iter.done(); iter.next())
+        {
+            const char *arg = iter.query();
+            if (*arg!='-')
+            {
+                if (optProcess.isEmpty())
+                    optProcess.set(arg);
+                else
+                {
+                    fprintf(stderr, "\nunrecognized argument %s\n", arg);
+                    return false;
+                }
+                continue;
+            }
+            if (iter.matchOption(optMsToWait, ECLOPT_WAIT))
+                continue;
+            if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
+                return false;
+        }
+        return true;
+    }
+    virtual bool finalizeOptions(IProperties *globals)
+    {
+        if (!EclCmdCommon::finalizeOptions(globals))
+            return false;
+        if (optProcess.isEmpty())
+        {
+            fputs("process cluster must be specified.\n\n", stderr);
+            return false;
+        }
+        return true;
+    }
+
+    virtual int processCMD()
+    {
+        Owned<IClientWsSMC> client = createWsSMCClient();
+        VStringBuffer url("http://%s:%s/WsSMC", optServer.sget(), optPort.sget());
+        client->addServiceUrl(url.str());
+        if (optUsername.length())
+            client->setUsernameToken(optUsername.get(), optPassword.sget(), NULL);
+
+        Owned<IClientRoxieControlCmdRequest> req = client->createRoxieControlCmdRequest();
+        req->setWait(optMsToWait);
+        req->setProcessCluster(optProcess);
+        req->setCommand(attach ? CRoxieControlCmd_ATTACH : CRoxieControlCmd_DETACH);
+
+        Owned<IClientRoxieControlCmdResponse> resp = client->RoxieControlCmd(req);
+        if (resp->getExceptions().ordinality())
+            outputMultiExceptions(resp->getExceptions());
+        IArrayOf<IConstRoxieControlEndpointInfo> &endpoints = resp->getEndpoints();
+        bool failed = false;
+        ForEachItemIn(i, endpoints)
+        {
+            IConstRoxieControlEndpointInfo &ep = endpoints.item(i);
+            if (!ep.getStatus() || !strieq(ep.getStatus(), "ok"))
+            {
+                if (!failed)
+                    failed = true;
+                fprintf(stderr, "    %s - %s\n", ep.getAddress(), ep.getStatus() ? ep.getStatus() : "Unknown");
+            }
+            else if (optVerbose)
+                fprintf(stdout, "    %s - %s\n", ep.getAddress(), ep.getStatus());
+        }
+        if (failed)
+            fprintf(stderr, "\nOne or more endpoints did not report status 'ok'\n");
+        return 0;
+    }
+    virtual void usage()
+    {
+        if (attach)
+            fputs("\nUsage:\n"
+                "\n"
+                "The 'roxie attach' command (re)attaches a roxie process cluster to its"
+                "DALI allowing changes to the environment or contents of its assigned\n"
+                "querysets to take effect.\n"
+                "\n"
+                "ecl roxie attatch <process_cluster>\n"
+                " Options:\n"
+                "   <process_cluster>      the roxie process cluster to attach\n",
+                stdout);
+        else
+            fputs("\nUsage:\n"
+                "\n"
+                "The 'roxie detach' command detaches a roxie process cluster from DALI\n"
+                "preventing changes to the environment or contents of its assigned\n"
+                "querysets from taking effect.\n"
+                "\n"
+                "ecl roxie detatch <process_cluster>\n"
+                " Options:\n"
+                "   <process_cluster>      the roxie process cluster to detach\n",
+                stdout);
+
+        fputs("\n"
+            "   --wait=<ms>            Max time to wait in milliseconds\n"
+            " Common Options:\n",
+            stdout);
+        EclCmdCommon::usage();
+    }
+private:
+    StringAttr optProcess;
+    unsigned optMsToWait;
+    bool attach;
+};
+
+IEclCommand *createEclRoxieCommand(const char *cmdname)
+{
+    if (!cmdname || !*cmdname)
+        return NULL;
+    if (strieq(cmdname, "attach"))
+        return new EclCmdRoxieAttach(true);
+    if (strieq(cmdname, "detach"))
+        return new EclCmdRoxieAttach(false);
+    return NULL;
+}
+
+//=========================================================================================
+
+class EclRoxieCMDShell : public EclCMDShell
+{
+public:
+    EclRoxieCMDShell(int argc, const char *argv[], EclCommandFactory _factory, const char *_version)
+        : EclCMDShell(argc, argv, _factory, _version)
+    {
+    }
+
+    virtual void usage()
+    {
+        fprintf(stdout,"\nUsage:\n\n"
+            "ecl roixe <command> [command options]\n\n"
+            "   Queries Commands:\n"
+            "      attach         (re)attach a roxie cluster from dali\n"
+            "      detach         detach a roxie cluster from dali\n"
+        );
+    }
+};
+
+static int doMain(int argc, const char *argv[])
+{
+    EclRoxieCMDShell processor(argc, argv, createEclRoxieCommand, BUILD_TAG);
+    return processor.run();
+}
+
+int main(int argc, const char *argv[])
+{
+    InitModuleObjects();
+    queryStderrLogMsgHandler()->setMessageFields(0);
+    unsigned exitCode = doMain(argc, argv);
+    releaseAtoms();
+    exit(exitCode);
+}

--- a/ecl/eclcmd/roxie/ecl-roxie.install
+++ b/ecl/eclcmd/roxie/ecl-roxie.install
@@ -1,0 +1,1 @@
+installFile "$binPath/ecl-roxie" "/usr/bin/ecl-roxie" 1 || exit 1

--- a/ecl/eclcmd/roxie/sourcedoc.xml
+++ b/ecl/eclcmd/roxie/sourcedoc.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+################################################################################
+#    Copyright (C) 2011 HPCC Systems.
+#
+#    All rights reserved. This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+-->
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN" "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+<section>
+    <title>ecl/ecl</title>
+
+    <para>
+        The ecl/ecl directory contains the sources for the ecl-roxie command line tool.
+    </para>
+</section>

--- a/esp/clients/roxiecontrol.cpp
+++ b/esp/clients/roxiecontrol.cpp
@@ -1,0 +1,108 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#include "roxiecontrol.hpp"
+#include "jmisc.hpp"
+
+const unsigned roxieQueryRoxieTimeOut = 60000;
+
+void checkRoxieControlExceptions(IPropertyTree *msg)
+{
+    Owned<IMultiException> me = MakeMultiException();
+    Owned<IPropertyTreeIterator> endpoints = msg->getElements("Endpoint");
+    ForEach(*endpoints)
+    {
+        IPropertyTree &endp = endpoints->query();
+        Owned<IPropertyTreeIterator> exceptions = endp.getElements("Exception");
+        ForEach (*exceptions)
+        {
+            IPropertyTree &ex = exceptions->query();
+            me->append(*MakeStringException(ex.getPropInt("Code"), "Endpoint %s: %s", endp.queryProp("@ep"), ex.queryProp("Message")));
+        }
+    }
+    if (me->ordinality())
+        throw me.getClear();
+}
+
+static inline unsigned waitMsToSeconds(unsigned wait)
+{
+    if (wait==0 || wait==(unsigned)-1)
+        return wait;
+    return wait/1000;
+}
+
+IPropertyTree *sendRoxieControlQuery(ISocket *sock, const char *msg, unsigned wait)
+{
+    size32_t msglen = strlen(msg);
+    size32_t len = msglen;
+    _WINREV(len);
+    sock->write(&len, sizeof(len));
+    sock->write(msg, msglen);
+
+    StringBuffer resp;
+    loop
+    {
+        sock->read(&len, sizeof(len));
+        if (!len)
+            break;
+        _WINREV(len);
+        size32_t size_read;
+        sock->read(resp.reserveTruncate(len), len, len, size_read, waitMsToSeconds(wait));
+        if (size_read<len)
+            throw MakeStringException(-1, "Error reading roxie control message response");
+    }
+
+    Owned<IPropertyTree> ret = createPTreeFromXMLString(resp.str());
+    checkRoxieControlExceptions(ret);
+    return ret.getClear();
+}
+
+bool sendRoxieControlLock(ISocket *sock, bool allOrNothing, unsigned wait)
+{
+    Owned<IPropertyTree> resp = sendRoxieControlQuery(sock, "<control:lock/>", wait);
+    if (allOrNothing)
+    {
+        int lockCount = resp->getPropInt("Lock", 0);
+        int serverCount = resp->getPropInt("NumServers", 0);
+        return (lockCount && (lockCount == serverCount));
+    }
+
+    return resp->getPropInt("Lock", 0) != 0;
+}
+
+static inline unsigned remainingMsWait(unsigned wait, unsigned start)
+{
+    if (wait==0 || wait==(unsigned)-1)
+        return wait;
+    unsigned waited = msTick()-start;
+    return (wait>waited) ? wait-waited : 0;
+}
+
+IPropertyTree *sendRoxieControlAllNodes(ISocket *sock, const char *msg, bool allOrNothing, unsigned wait)
+{
+    unsigned start = msTick();
+    if (!sendRoxieControlLock(sock, allOrNothing, wait))
+        throw MakeStringException(-1, "Roxie control:lock failed");
+    return sendRoxieControlQuery(sock, msg, remainingMsWait(wait, start));
+}
+
+IPropertyTree *sendRoxieControlAllNodes(const SocketEndpoint &ep, const char *msg, bool allOrNothing, unsigned wait)
+{
+    Owned<ISocket> sock = ISocket::connect_timeout(ep, wait);
+    return sendRoxieControlAllNodes(sock, msg, allOrNothing, wait);
+}

--- a/esp/clients/roxiecontrol.hpp
+++ b/esp/clients/roxiecontrol.hpp
@@ -1,0 +1,33 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#ifndef _ESP_roxiecontrol_HPP__
+#define _ESP_roxiecontrol_HPP__
+
+#include "jlib.hpp"
+#include "jsocket.hpp"
+#include "jptree.hpp"
+#include "roxiecontrol.hpp"
+
+//bool sendRoxieControlLock(ISocket *sock, bool allOrNothing, unsigned wait)
+
+IPropertyTree *sendRoxieControlQuery(ISocket *sock, const char *msg, unsigned wait);
+IPropertyTree *sendRoxieControlAllNodes(ISocket *sock, const char *msg, bool allOrNothing, unsigned wait);
+IPropertyTree *sendRoxieControlAllNodes(const SocketEndpoint &ep, const char *msg, bool allOrNothing, unsigned wait);
+
+#endif

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -259,15 +259,39 @@ BrowseResourcesResponse
     ESParray<ESPstruct HPCCResourceRepository> HPCCResourceRepositories;
 };
 
+ESPenum RoxieControlCmd : string
+{
+    ATTACH("Attach"),
+    DETACH("Detach"),
+    RELOAD("Reload")
+};
+
+ESPrequest RoxieControlCmdRequest
+{
+    string ProcessCluster;
+    ESPenum RoxieControlCmd Command("Attach");
+    int Wait;
+};
+
+ESPStruct RoxieControlEndpointInfo
+{
+    string Address;
+    bool Attached;
+    string StateHash;
+    string Status;
+};
+
+ESPresponse
+[
+    exceptions_inline, nil_remove
+]
+RoxieControlCmdResponse
+{
+    ESParray<ESPstruct RoxieControlEndpointInfo, Endpoint> Endpoints;
+};
+
 ESPservice [noforms, version("1.12"), default_client_version("1.12"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
-    ESPuses ESPStruct Capability;
-    ESPuses ESPStruct Permission;
-    ESPuses ESPStruct ThorCluster;
-    ESPuses ESPStruct HThorCluster;
-    ESPuses ESPStruct ActiveWorkunit;
-    ESPuses ESPStruct DFUJob;
-
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);
 
@@ -289,6 +313,8 @@ ESPservice [noforms, version("1.12"), default_client_version("1.12"), exceptions
     ESPmethod NotInCommunityEdition(NotInCommunityEditionRequest, NotInCommunityEditionResponse);
 
     ESPmethod [resp_xsl_default("/esp/xslt/hpccresourcelist.xslt")] BrowseResources(BrowseResourcesRequest, BrowseResourcesResponse);
+
+    ESPmethod RoxieControlCmd(RoxieControlCmdRequest, RoxieControlCmdResponse);
 };
 
 SCMexportdef(WSSMC);

--- a/esp/services/ws_smc/CMakeLists.txt
+++ b/esp/services/ws_smc/CMakeLists.txt
@@ -28,7 +28,9 @@ project( ws_smc )
 include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS 
+         ${HPCC_SOURCE_DIR}/esp/scm/ws_smc.ecm
          ${ESPSCM_GENERATED_DIR}/ws_smc_esp.cpp 
+         ${HPCC_SOURCE_DIR}/esp/clients/roxiecontrol.cpp
          ws_smcPlugin.cpp 
          ws_smcService.cpp 
     )

--- a/esp/services/ws_smc/espsmc_permissions.txt
+++ b/esp/services/ws_smc/espsmc_permissions.txt
@@ -23,6 +23,9 @@ ws_smc:
         Full - thor activity, MoveJobDown, MoveJobUp, MoveJobBack, 
                  MoveJobFront, RemoveJob, StopQueue, ResumeQueue, PauseQueue, 
                  ClearQueue
+    RoxieControlAccess:
+        Full - roxie control commands: attach, detach, reload
+
 ws_config:
     ConfigAccess: 
         Read - Read only access to super computer environment

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -61,6 +61,7 @@ public:
     bool onNotInCommunityEdition(IEspContext &context, IEspNotInCommunityEditionRequest &req, IEspNotInCommunityEditionResponse &resp);
 
     virtual bool onBrowseResources(IEspContext &context, IEspBrowseResourcesRequest & req, IEspBrowseResourcesResponse & resp);
+    virtual bool onRoxieControlCmd(IEspContext &context, IEspRoxieControlCmdRequest &req, IEspRoxieControlCmdResponse &resp);
 
 private:
     void addCapabilities( IPropertyTree* pFeatureNode, const char* access, 

--- a/esp/services/ws_workunits/CMakeLists.txt
+++ b/esp/services/ws_workunits/CMakeLists.txt
@@ -33,6 +33,7 @@ set (    SRCS
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_fs_esp.cpp
          ${HPCC_SOURCE_DIR}/esp/scm/ws_workunits.ecm
+         ${HPCC_SOURCE_DIR}/esp/clients/roxiecontrol.cpp
          ws_workunitsPlugin.cpp
          ws_workunitsService.cpp
          ws_workunitsService.hpp

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -24,6 +24,7 @@
 #include "dadfs.hpp"
 #include "dfuwu.hpp"
 #include "eclhelper.hpp"
+#include "roxiecontrol.hpp"
 
 const unsigned roxieQueryRoxieTimeOut = 60000;
 
@@ -233,90 +234,12 @@ bool CWsWorkunitsEx::onWUCopyLogicalFiles(IEspContext &context, IEspWUCopyLogica
     return true;
 }
 
-void checkRoxieControlExceptions(IPropertyTree *msg)
-{
-    Owned<IMultiException> me = MakeMultiException();
-    Owned<IPropertyTreeIterator> endpoints = msg->getElements("Endpoint");
-    ForEach(*endpoints)
-    {
-        IPropertyTree &endp = endpoints->query();
-        Owned<IPropertyTreeIterator> exceptions = endp.getElements("Exception");
-        ForEach (*exceptions)
-        {
-            IPropertyTree &ex = exceptions->query();
-            me->append(*MakeStringException(ex.getPropInt("Code"), "Endpoint %s: %s", endp.queryProp("@ep"), ex.queryProp("Message")));
-        }
-    }
-    if (me->ordinality())
-        throw me.getClear();
-}
-
-static inline unsigned waitMsToSeconds(unsigned wait)
-{
-    if (wait==0 || wait==(unsigned)-1)
-        return wait;
-    return wait/1000;
-}
-
-IPropertyTree *sendRoxieControlQuery(ISocket *sock, const char *msg, unsigned wait)
-{
-    size32_t msglen = strlen(msg);
-    size32_t len = msglen;
-    _WINREV(len);
-    sock->write(&len, sizeof(len));
-    sock->write(msg, msglen);
-
-    StringBuffer resp;
-    loop
-    {
-        sock->read(&len, sizeof(len));
-        if (!len)
-            break;
-        _WINREV(len);
-        size32_t size_read;
-        sock->read(resp.reserveTruncate(len), len, len, size_read, waitMsToSeconds(wait));
-        if (size_read<len)
-            throw MakeStringException(ECLWATCH_CONTROL_QUERY_FAILED, "Error reading roxie control message response");
-    }
-
-    Owned<IPropertyTree> ret = createPTreeFromXMLString(resp.str());
-    checkRoxieControlExceptions(ret);
-    return ret.getClear();
-}
-
-bool sendRoxieControlLock(ISocket *sock, bool allOrNothing, unsigned wait)
-{
-    Owned<IPropertyTree> resp = sendRoxieControlQuery(sock, "<control:lock/>", wait);
-    if (allOrNothing)
-    {
-        int lockCount = resp->getPropInt("Lock", 0);
-        int serverCount = resp->getPropInt("NumServers", 0);
-        return (lockCount && (lockCount == serverCount));
-    }
-
-    return resp->getPropInt("Lock", 0) != 0;
-}
-
 static inline unsigned remainingMsWait(unsigned wait, unsigned start)
 {
     if (wait==0 || wait==(unsigned)-1)
         return wait;
     unsigned waited = msTick()-start;
     return (wait>waited) ? wait-waited : 0;
-}
-
-IPropertyTree *sendRoxieControlAllNodes(ISocket *sock, const char *msg, bool allOrNothing, unsigned wait)
-{
-    unsigned start = msTick();
-    if (!sendRoxieControlLock(sock, allOrNothing, wait))
-        throw MakeStringException(ECLWATCH_CONTROL_QUERY_FAILED, "Roxie control:lock failed");
-    return sendRoxieControlQuery(sock, msg, remainingMsWait(wait, start));
-}
-
-IPropertyTree *sendRoxieControlAllNodes(const SocketEndpoint &ep, const char *msg, bool allOrNothing, unsigned wait)
-{
-    Owned<ISocket> sock = ISocket::connect_timeout(ep, wait);
-    return sendRoxieControlAllNodes(sock, msg, allOrNothing, wait);
 }
 
 bool reloadCluster(IConstWUClusterInfo *clusterInfo, unsigned wait)

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -39,6 +39,7 @@
 #include "dadfs.hpp"
 #include "dfuwu.hpp"
 #include "thorplugin.hpp"
+#include "roxiecontrol.hpp"
 
 #ifdef _USE_ZLIB
 #include "zcrypt.hpp"


### PR DESCRIPTION
Add "ecl roxie detach <process_cluster>" to disconnect roxie from dali.
Add "ecl roxie attach <process_cluster>" to connect roxie to dali.

Allows operation teams to prevent changes to a roxie cluster while its
actively in production.  Detaching roxie from DALI prevents changes,
attaching roxie to DALI allows changes.

Fixes gh-2806.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
