### PR TITLE
gh-3161 Pass user descriptor when checking logical files

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -130,7 +130,7 @@ public:
         delete [] dlfns;
     }
 
-    static CMultiDLFN *create(const char *_mlfn)
+    static CMultiDLFN *create(const char *_mlfn, IUserDescriptor *_udesc)
     {
         StringBuffer mlfn(_mlfn);
         mlfn.trim();
@@ -167,7 +167,7 @@ public:
                     else
                         tmp.append(mlfn).append(suffix);
                     tmp.clip().toLowerCase();
-                    Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),false,true);
+                    Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),false,true,NULL,_udesc);
                     mlfn.setLength(start-s);
                     ForEach(*iter) {
                         IPropertyTree &attr = iter->query();
@@ -220,6 +220,7 @@ CDfsLogicalFileName::CDfsLogicalFileName()
 {
     allowospath = false;
     multi = NULL;
+    udesc = NULL;
     clear();
 }
 
@@ -280,7 +281,7 @@ void CDfsLogicalFileName::set(const char *name)
         return;
     skipSp(name);
     try {
-        multi = CMultiDLFN::create(name);
+        multi = CMultiDLFN::create(name,udesc);
     }
     catch (IException *e) {
         StringBuffer err;
@@ -2698,6 +2699,7 @@ public:
 
     bool init(const char *fname,IUserDescriptor *user,bool onlylocal,bool onlydfs, bool write)
     {
+        lfn.setUserDescriptor(user);
         fileExists = false;
         if (!onlydfs)
             lfn.allowOsPath(true);

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -26,6 +26,7 @@
 #include "jfile.hpp"
 #include "jlog.hpp"
 #include "mpbase.hpp"
+#include "dasess.hpp"
 
 #ifndef da_decl
 #define da_decl __declspec(dllimport)
@@ -58,6 +59,7 @@ class da_decl CDfsLogicalFileName
     CMultiDLFN *multi;   // for temp superfile
     bool external;
     bool allowospath;
+    IUserDescriptor *udesc;
 public:
     CDfsLogicalFileName();
     ~CDfsLogicalFileName();
@@ -69,6 +71,7 @@ public:
     bool setFromMask(const char *partmask,const char *rootdir=NULL);
     void clear();
     bool isSet() const;
+    void setUserDescriptor(IUserDescriptor *_udesc) { udesc = _udesc; }
     /*
      * Foreign files are distributed files whose meta data is stored on a foreign
      * Dali Server, so their names are resolved externally.


### PR DESCRIPTION
Current dautils classes are not always passing user descriptor to dali
which causes dali to use the default user instead. Fix that problem by
passing the user to the helper classes, which then passes in the msg
to dali

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
