### PR TITLE
gh-3172 Avoid spurious error on empty inline wildcard superfiles

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -191,6 +191,9 @@ public:
             ForEachItemIn(i3,lfnout) {
                 lfns.append(lfnout.item(i3));
             }
+            // if wildcards, create object even if 0 matches,
+            // if 0 matches, the logical file will look like an empty temp. super "{}"
+            return new CMultiDLFN(mlfn.str(),lfns);
         }
         if (lfns.ordinality()==0)
             return NULL;


### PR DESCRIPTION
Creating a temp super that has no matches, causes a spurious error:
"Wildcards not allowed in filename.."

This is because, it doesn't return a multi logical file construct, and
leaves the logical filename with wildcards intact, which is later complains
about.
Fix by creating a multi lfn construct in wildcard case with 0 matches.

Fixes gh-3172

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
