### PR TITLE
gh-3176 -Wformat-security warning on ws_dfuService

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1054,14 +1054,14 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
         filesInMsgBuf++;
         if (filesInMsgBuf > 9)
         {
-            PROGLOG(msgBuf.str());
+            PROGLOG("%s",msgBuf.str());
             msgBuf = msgHead;
             filesInMsgBuf = 0;
         }
     }
 
     if (filesInMsgBuf > 0)
-        PROGLOG(msgBuf.str());
+        PROGLOG("%s", msgBuf.str());
 
     Owned<IDFUhelper> dfuhelper = createIDFUhelper();
 


### PR DESCRIPTION
Couldn't find a fix for this in 3.10 branch and 3.8 is quite different.
