### PR TITLE
gh-3183 Improve git commit message hook

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Every commit should have an issue reference at the start of the first line:
+echo Checking git message in $1
 
 (head -1 "$1" | grep -E -q "^gh-[0-9]+ ") || {
   echo >&2 "Missing GitHub issue"
@@ -8,11 +9,51 @@
   echo >&2 "Please see the guidelines for git commit messages in the CONTRIBUTORS file"
   echo >&2 "Your git commit message should start with a line of the form"
   echo >&2 ""
-  echo >&2 "gh-XXXX short description"
+  echo >&2 "gh-XXXX Short description"
   echo >&2 ""
   echo >&2 "where XXXX is the github issue number that this commit is referencing, and"
   echo >&2 "short description is a brief description of the issue that will appear in"
   echo >&2 "the --oneline version of the generated changelog."
+  echo >&2 ""
+  echo >&2 "Use git commit -s -t .git/COMMIT_EDITMSG to reopen previous message for editing"
+  exit 1
+}
+
+(head -1 "$1" | grep -E -q "[^.]$") || {
+  echo >&2 "Please don't use . at the end of the short description"
+  echo >&2 ""
+  echo >&2 "Please see the guidelines for git commit messages in the CONTRIBUTORS file"
+  echo >&2 "Your git commit message should start with a line of the form"
+  echo >&2 ""
+  echo >&2 "gh-XXXX Short description"
+  echo >&2 ""
+  echo >&2 "where XXXX is the github issue number that this commit is referencing, and"
+  echo >&2 "short description is a brief description of the issue that will appear in"
+  echo >&2 "the --oneline version of the generated changelog."
+  echo >&2 ""
+  echo >&2 "Use git commit -s -t .git/COMMIT_EDITMSG to reopen previous message for editing"
+  exit 1
+}
+
+(head -1 "$1" | grep -E -q "^gh-[0-9]+ [^a-z]") || {
+  echo >&2 "Short description should start with a capital"
+  echo >&2 ""
+  echo >&2 "Please see the guidelines for git commit messages in the CONTRIBUTORS file"
+  echo >&2 "Your git commit message should start with a line of the form"
+  echo >&2 ""
+  echo >&2 "gh-XXXX Short description"
+  echo >&2 ""
+  echo >&2 "where XXXX is the github issue number that this commit is referencing, and"
+  echo >&2 "short description is a brief description of the issue that will appear in"
+  echo >&2 "the --oneline version of the generated changelog."
+  echo >&2 ""
+  echo >&2 "Use git commit -s -t .git/COMMIT_EDITMSG to reopen previous message for editing"
+  exit 1
+}
+
+(head -2 "$1" | tail -1 | grep -E -q "^$") || {
+  echo >&2 "Short description must be followed by a blank line"
+  echo >&2 "Please see the guidelines for git commit messages in the CONTRIBUTORS file"
   exit 1
 }
 
@@ -21,6 +62,8 @@
   echo >&2 ""
   echo >&2 "Please see the guidelines for git commit messages in the CONTRIBUTORS file."
   echo >&2 "Lines in the commit message should be no longer than 80 characters."
+  echo >&2 ""
+  echo >&2 "Use git commit -s -t .git/COMMIT_EDITMSG to reopen previous message for editing"
   exit 1
 }
 
@@ -29,5 +72,7 @@
   echo >&2 ""
   echo >&2 "Please see the guidelines for git commit messages in the CONTRIBUTORS file."
   echo >&2 "All commits should be signed (use git commit -s)."
+  echo >&2 ""
+  echo >&2 "Use git commit -s -t .git/COMMIT_EDITMSG to reopen previous message for editing"
   exit 1
 }


### PR DESCRIPTION
Check for additional common faults in the git commit message formatting:
- Improper capitalization of short message
- . at end of short message
- missing blank line

Provide information about how to retrieve previous commit message when
rejecting.

Fixes gh-3183.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
