### PR TITLE
gh-3188 Fix ws_ecl resource leak after calling resolveQueryAlias

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
+++ b/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
@@ -12,7 +12,7 @@ WsEclWuInfo::WsEclWuInfo(const char *wuid_, const char *qset, const char *qname,
         if (!qstree)
             throw MakeStringException(-1, "QuerySet %s not found", qset);
 
-        IPropertyTree *query = resolveQueryAlias(qstree, qname);
+        Owned<IPropertyTree> query = resolveQueryAlias(qstree, qname);
         if (!query)
             throw MakeStringException(-1, "Query %s/%s not found", qset, qname);
         if (query->getPropBool("@suspended"))


### PR DESCRIPTION
This was a regression in 3.8.2 and is also needed in 3.10.x.

Add Owned to manage the result of resolveQueryAlias.

This leak caused a read lock to be kept on the query/queryset
blocking any additional updates.

Fixes gh-3188.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
