### PR TITLE
gh-3182 32bit Windows build failure

### DIFF
--- a/cmake_modules/optionDefaults.cmake
+++ b/cmake_modules/optionDefaults.cmake
@@ -1,7 +1,11 @@
 
 if ( NOT PREFIX )
 if ( WIN32 )
-    set( PREFIX "$ENV{ProgramFiles(x86)}" )
+    if ("$ENV{ProgramFiles(x86)}" STREQUAL "")
+        set( PREFIX "$ENV{ProgramFiles}" )
+    else()
+        set( PREFIX "$ENV{ProgramFiles(x86)}" )
+    endif()
     string(REGEX REPLACE "\\\\" "/" PREFIX ${PREFIX})    
 else (WIN32)
     set( PREFIX "/opt" )


### PR DESCRIPTION
Building 32bit platform on a Windows 32bit OS causes cmake errors.

Fixes gh-3182

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
