### PR TITLE
gh-3196 Fix internal error submitting functional definition

### DIFF
--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -7243,7 +7243,10 @@ extern HQL_API bool expandMissingDefaultsAsStoreds(HqlExprArray & args, IHqlExpr
                 OwnedHqlExpr nullValue = createNullExpr(formal->queryType());
                 OwnedHqlExpr storedName = createConstant(formal->queryName()->str());
                 OwnedHqlExpr stored = createValue(no_stored, makeVoidType(), storedName.getClear());
-                args.append(*createValue(no_colon, formal->getType(), LINK(nullValue), LINK(stored)));
+                HqlExprArray colonArgs;
+                colonArgs.append(*LINK(nullValue));
+                colonArgs.append(*LINK(stored));
+                args.append(*createWrapper(no_colon, formal->queryType(), colonArgs));
             }
         }
     }


### PR DESCRIPTION
If a functional definition had dataset parameters with no default value,
then compiling that attribute as a query would trigger an internal error
because a CHqlExpression was created instead of a CHqlDataset.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
