### PR TITLE
gh-3005 Fix ECLAgent::getPlatform() problem

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1605,11 +1605,10 @@ char *EclAgent::getPlatform()
 {
     if (!isStandAloneExe)
     {
-        SCMStringBuffer cluster;
-        queryWorkUnit()->getClusterName(cluster);
-        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster.str());
+        const char * cluster = clusterNames.tos();
+        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
         if (!clusterInfo)
-            throw MakeStringException(-1, "Unknown Cluster '%s'", cluster.str());
+            throw MakeStringException(-1, "Unknown Cluster '%s'", cluster);
         return (char*)clusterTypeString(clusterInfo->getPlatform());
     }
     else

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1601,6 +1601,21 @@ void EclAgent::getEventExtra(size32_t & outLen, char * & outStr, const char * ta
     rtlExtractTag(outLen, outStr, text, tag, "Event");
 }
 
+char *EclAgent::getPlatform()
+{
+    if (!isStandAloneExe)
+    {
+        SCMStringBuffer cluster;
+        queryWorkUnit()->getClusterName(cluster);
+        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster.str());
+        if (!clusterInfo)
+            throw MakeStringException(-1, "Unknown Cluster '%s'", cluster.str());
+        return (char*)clusterTypeString(clusterInfo->getPlatform());
+    }
+    else
+        return (char *)"standalone";
+}
+
 char *EclAgent::getEnv(const char *name, const char *defaultValue) const 
 {
     const char *val = globals->queryProp(name);

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -584,7 +584,7 @@ public:
     virtual const char *queryWuid();
     virtual IDistributedFileTransaction *querySuperFileTransaction();
     virtual unsigned getPriority() const { return 0; }
-    virtual char *getPlatform() { return strdup(isStandAloneExe ? "standalone" : "hthor"); }
+    virtual char *getPlatform();
     virtual char *getEnv(const char *name, const char *defaultValue) const;
     virtual char *getOS()
     {


### PR DESCRIPTION
Currently ICodeContext::getPlatform in eclagent returns "hthor". However
it needs to behave more like getNodes() which looks up the cluster and
returns thor/thorlcr depending on the cluster type. This fix makes calls
to get the cluster name, queries for that cluster's info , and maps the
"platform" attribute to a cluster type string

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
