### PR TITLE
gh-3203 Script error on ECLWatch from within ECL IDE

### DIFF
--- a/esp/eclwatch/ws_XSLT/fs_desprayCopyForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_desprayCopyForm.xslt
@@ -209,6 +209,9 @@
                 function onChangeGroup()
                 {
                     var groups = document.getElementById("destGroup");
+                    if (groups == null) //destGroup does not exist for Despray.
+                        return;
+
                     var selected = groups.options[groups.selectedIndex];
                     if (selected.title.substring(0,1) == 'T')
                         setThorGroup();


### PR DESCRIPTION
When despraying files from within ECL IDE, the following script
error shows: Unable to get value of the proprety 'options'. The
problem was because of an incorrect access to the 'options'
attribute of the 'DestGroup' select box which does not exist on
the Despray form. (The same xslt script is shared by Despray
and Copy). This fix checks existence of select box before
accessing its attribute.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
