### PR TITLE
gh-3200 Return StringBuffer reference from appendJSONValue

### DIFF
--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -449,7 +449,7 @@ template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, unsigned long value)
 {
     appendJSONName(s, name);
-    s.appendulong(value);
+    return s.appendulong(value);
 }
 
 extern jlib_decl void decodeCppEscapeSequence(StringBuffer & out, const char * in, bool errorIfInvalid);


### PR DESCRIPTION
appendJSONValue was not returning anything, but is defined to return
a StringBuffer&amp;.

Fixes gh-3200

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
