### PR TITLE
gh-3223 Fix Submit button problem on preflight result page

### DIFF
--- a/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
+++ b/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
@@ -115,9 +115,10 @@
                     var inputs = document.getElementById("listitems").getElementsByTagName("input");
                     for(var i=0, len=inputs.length; i<len; i++)
                     {
-                      if(inputs[i].name.match(/^TargetClusters_i\d+$/))
+                      if(inputs[i].name.match(/^TargetClusters.\d+$/))
                       {
-                          clusterChecked++;
+                          if (inputs[i].checked)
+                              clusterChecked++;
                       }
                     }
                     document.forms[0].submitBtn.disabled = clusterChecked == 0;


### PR DESCRIPTION
Run a preflight from EclWatch Target Cluster page. The preflight
result page shows. But, the submit button on that page is
disabled. A user may not be able to submit a preflight request
again if not change the checkboxs. The problem was because the
xslt script did not check the checkboxs correctly when the
preflight page was loaded. This fix uses correct element names to
find out the checkboxs. If any of those checboxes is checked, the
script enables the submit button.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
