### PR TITLE
gh-658 Add user option to eclplus

### DIFF
--- a/ecl/eclplus/eclplus.cpp
+++ b/ecl/eclplus/eclplus.cpp
@@ -43,7 +43,9 @@ IClientWsWorkunits * createWorkunitsClient(IProperties * _globals)
         url.append("/");
     url.append("WsWorkUnits");
     wuclient->addServiceUrl(url.str());
-    const char* username = _globals->queryProp("owner");
+    const char* username = _globals->queryProp("user");
+    if (!username)
+        username = _globals->queryProp("owner");
     const char* password = _globals->queryProp("password");
     if(username != NULL)
         wuclient->setUsernameToken(username, password, NULL);

--- a/ecl/eclplus/main.cpp
+++ b/ecl/eclplus/main.cpp
@@ -54,6 +54,7 @@ void usage()
 {
     printf("eclplus action=[list|view|dump|delete|abort|query|graph]\n");
     printf("\t{owner=<userid>| wuid=<wuid>}\n");
+    printf("\tuser=<username>\n");
     printf("\tpassword=<password>\n");
     printf("\tcluster=<cluster>\n");
     printf("\tserver=<server | server:port | http://server:port | https://server:port>\n");


### PR DESCRIPTION
Previously the meaning of the owner option was overloaded to mean both
user and the owner to filter on when listing workunits, etc.

Add support for a user option to explicitly specify the user running
the command.

If user is not specified owner will still be used as the username for
backward compatability.

Fixes gh-658.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
