### PR TITLE
gh-3209 Add Block input form to WsECl

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.hpp
+++ b/esp/services/ws_ecl/ws_ecl_service.hpp
@@ -146,7 +146,7 @@ public:
     void xsltTransform(const char* xml, unsigned int len, const char* xslFileName, IProperties *params, StringBuffer& ret);
 
     int getWsEcl2TabView(CHttpRequest* request, CHttpResponse* response, const char *thepath);
-    int getGenForm(IEspContext &context, CHttpRequest* request, CHttpResponse* response, WsEclWuInfo &wsinfo);
+    int getGenForm(IEspContext &context, CHttpRequest* request, CHttpResponse* response, WsEclWuInfo &wsinfo, bool boxform);
     int getWsEcl2Form(CHttpRequest* request, CHttpResponse* response, const char *thepath);
 
     bool isValidServiceName(IEspContext &context, const char *name){return true;}

--- a/esp/xslt/CMakeLists.txt
+++ b/esp/xslt/CMakeLists.txt
@@ -38,6 +38,7 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/yuitree.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/xmlformatter.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_form.xsl
+    ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_boxform.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_links.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_tabview.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_xmltest.xsl

--- a/esp/xslt/wsecl3_boxform.xsl
+++ b/esp/xslt/wsecl3_boxform.xsl
@@ -9,19 +9,15 @@
 ]>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.0" xml:space="default" exclude-result-prefixes="xsd">
     <xsl:strip-space elements="*"/>
-    <!-- TODO: change indent="no" for performance -->
     <xsl:output method="html" indent="yes" omit-xml-declaration="yes" version="4.01" doctype-public="-//W3C//DTD HTML 4.01 Transitional//EN" doctype-system="http://www.w3.org/TR/html4/loose.dtd"/>
 
     <xsl:param name="queryParams" select="''"/>
     <xsl:variable name="QueryInput" select="/FormInfo/Request"/>
     <xsl:variable name="queryPath" select="/FormInfo/QuerySet"/>
     <xsl:variable name="methodName" select="/FormInfo/QueryName"/>
-    <xsl:variable name="wuid" select="/FormInfo/WUID"/>
     <xsl:variable name="methodHelp" select="/FormInfo/Help"/>
     <xsl:variable name="methodDesc" select="/FormInfo/Info"/>
     <xsl:variable name="serviceVersion" select="/FormInfo/Version"/>
-    <xsl:variable name="requestLabel" select="/FormInfo/RequestElement"/>
-    <xsl:variable name="requestElement" select="/FormInfo/RequestElement"/>
 
     <!-- ===============================================================================
   global settings
@@ -35,9 +31,6 @@
               <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/fonts/fonts-min.css"/>
               <link rel="stylesheet" type="text/css" href="/esp/files/css/espdefault.css"/>
               <link rel="stylesheet" type="text/css" href="/esp/files/gen_form.css"/>
-              <script type="text/javascript" src="/esp/files/req_array.js"/>
-              <script type="text/javascript" src="/esp/files/hashtable.js"/>
-              <script type="text/javascript" src="/esp/files/gen_form.js"/>
               <script type="text/javascript">
 
       <xsl:text disable-output-escaping="yes">
@@ -53,12 +46,6 @@ function setESPFormAction()
     {
         if (actval.value=="esp_soap")
             actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/soap/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
-        else if (actval.value=="esp_json")
-            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/json/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
-        else if (actval.value=="roxie_soap")
-            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/roxiesoap/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
-        else if (actval.value=="roxie_xml")
-            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/roxiexml/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
         else if (actval.value=="run_xslt")
             actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/xslt/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
         else if (actval.value=="xml")
@@ -66,12 +53,8 @@ function setESPFormAction()
         else
             actionpath= "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/xslt/query/', $queryPath, '/', $methodName, '?view=')"/><xsl:text disable-output-escaping="yes"><![CDATA["+actval.value;
     }
-    //alert("actionpath = " + actionpath);
-    var dest = document.getElementById('esp_dest');
-    if (dest && dest.checked)
-         form.action = document.getElementById('dest_url').value;
-    else
-        form.action = actionpath;
+
+    form.action = actionpath;
     return true;
 }
 
@@ -185,10 +168,7 @@ function switchInputForm()
                   <td align="left">
                     <select id="submit_type" name="submit_type_">
                         <xsl:for-each select="/FormInfo/CustomViews/Result">
-                            <option>
-                              <xsl:attribute name="value"><xsl:value-of select="."/></xsl:attribute>
-                              <xsl:value-of select="."/>
-                            </option>
+                            <option value="{.}"><xsl:value-of select="."/></option>
                         </xsl:for-each>
                         <option value="run_xslt">Output Tables</option>
                         <option value="xml">Output XML</option>

--- a/esp/xslt/wsecl3_boxform.xsl
+++ b/esp/xslt/wsecl3_boxform.xsl
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+## Copyright (c) 2012 HPCC Systems.  All rights reserved.
+-->
+<!DOCTYPE xsl:stylesheet [
+<!ENTITY nbsp "&#160;">
+<!ENTITY apos "&#39;">
+]>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.0" xml:space="default" exclude-result-prefixes="xsd">
+    <xsl:strip-space elements="*"/>
+    <!-- TODO: change indent="no" for performance -->
+    <xsl:output method="html" indent="yes" omit-xml-declaration="yes" version="4.01" doctype-public="-//W3C//DTD HTML 4.01 Transitional//EN" doctype-system="http://www.w3.org/TR/html4/loose.dtd"/>
+
+    <xsl:param name="queryParams" select="''"/>
+    <xsl:variable name="QueryInput" select="/FormInfo/Request"/>
+    <xsl:variable name="queryPath" select="/FormInfo/QuerySet"/>
+    <xsl:variable name="methodName" select="/FormInfo/QueryName"/>
+    <xsl:variable name="wuid" select="/FormInfo/WUID"/>
+    <xsl:variable name="methodHelp" select="/FormInfo/Help"/>
+    <xsl:variable name="methodDesc" select="/FormInfo/Info"/>
+    <xsl:variable name="serviceVersion" select="/FormInfo/Version"/>
+    <xsl:variable name="requestLabel" select="/FormInfo/RequestElement"/>
+    <xsl:variable name="requestElement" select="/FormInfo/RequestElement"/>
+
+    <!-- ===============================================================================
+  global settings
+  ================================================================================ -->
+   <!-- config -->
+   <xsl:template match="FormInfo">
+      <html>
+          <head>
+              <title>WsECL Service form</title>
+              <link rel="shortcut icon" href="/esp/files/img/affinity_favicon_1.ico"/>
+              <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/fonts/fonts-min.css"/>
+              <link rel="stylesheet" type="text/css" href="/esp/files/css/espdefault.css"/>
+              <link rel="stylesheet" type="text/css" href="/esp/files/gen_form.css"/>
+              <script type="text/javascript" src="/esp/files/req_array.js"/>
+              <script type="text/javascript" src="/esp/files/hashtable.js"/>
+              <script type="text/javascript" src="/esp/files/gen_form.js"/>
+              <script type="text/javascript">
+
+      <xsl:text disable-output-escaping="yes">
+<![CDATA[
+function setESPFormAction()
+{
+    var form = document.forms['esp_form'];
+    if (!form)  return false;
+
+    var actval = document.getElementById('submit_type');
+    var actionpath = "/jserror";
+    if (actval && actval.value)
+    {
+        if (actval.value=="esp_soap")
+            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/soap/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+        else if (actval.value=="esp_json")
+            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/json/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+        else if (actval.value=="roxie_soap")
+            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/roxiesoap/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+        else if (actval.value=="roxie_xml")
+            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/roxiexml/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+        else if (actval.value=="run_xslt")
+            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/xslt/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+        else if (actval.value=="xml")
+            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/submit/query/', $queryPath, '/', $methodName, '?view=xml&amp;display')"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+        else
+            actionpath= "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/xslt/query/', $queryPath, '/', $methodName, '?view=')"/><xsl:text disable-output-escaping="yes"><![CDATA["+actval.value;
+    }
+    //alert("actionpath = " + actionpath);
+    var dest = document.getElementById('esp_dest');
+    if (dest && dest.checked)
+         form.action = document.getElementById('dest_url').value;
+    else
+        form.action = actionpath;
+    return true;
+}
+
+function switchInputForm()
+{
+    var inputform = document.getElementById('SelectForm');
+    if (inputform.value!="DynamicForm")
+       return false;
+    document.location.href = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/ecl/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+    return true;
+}
+]]></xsl:text>
+<xsl:call-template name="GetHtmlHeadAddon"/>
+</script>
+</head>
+      <body class="yui-skin-sam" onload="onPageLoad()">
+               <p align="center"/>
+                <table cellSpacing="0" cellPadding="1" width="100%" bgColor="#4775FF" border="0">
+                    <tr align="left" class="service">
+                        <td height="23">
+                            <font color="#efefef">
+                                <b>
+                                    <xsl:value-of select="/FormInfo/QuerySet"/>
+                                    <xsl:if test="number($serviceVersion)&gt;0">
+                                        <xsl:value-of select="concat(' [Version ', $serviceVersion, ']')"/>
+                                    </xsl:if>
+                                </b>
+                            </font>
+                        </td>
+                    </tr>
+                    <tr class="method">
+                        <td height="23" align="left">
+                            <xsl:variable name="params">
+                                <xsl:if test="$queryParams">
+                                    <xsl:value-of select="concat('&amp;', substring($queryParams,2))"/>
+                                </xsl:if>
+                            </xsl:variable>
+                            <b><xsl:value-of select="$methodName"/>
+                            </b>&nbsp;<a>
+                                <xsl:attribute name="href"><xsl:call-template name="build_link"><xsl:with-param name="type" select="'wsdl'"/></xsl:call-template></xsl:attribute>
+                                <xsl:attribute name="target">_blank</xsl:attribute>
+                                <img src="/esp/files/img/wsdl.gif" title="WSDL" border="0" align="bottom"/>
+                            </a>&nbsp;<a>
+                                <xsl:attribute name="href"><xsl:call-template name="build_link"><xsl:with-param name="type" select="'xsd'"/></xsl:call-template></xsl:attribute>
+                                <xsl:attribute name="target">_blank</xsl:attribute>
+                                <img src="/esp/files/img/xsd.gif" title="Schema" border="0" align="bottom"/>
+                            </a>&nbsp;<a>
+                                <xsl:attribute name="href"><xsl:call-template name="build_link"><xsl:with-param name="type" select="'reqxml'"/></xsl:call-template></xsl:attribute>
+                                <img src="/esp/files/img/reqxml.gif" title="Sample Request XML" border="0" align="bottom"/>
+                            </a>&nbsp;<a>
+                                <xsl:attribute name="href"><xsl:call-template name="build_link"><xsl:with-param name="type" select="'respxml'"/></xsl:call-template></xsl:attribute>
+                                <img src="/esp/files/img/respxml.gif" title="Sample Response XML" border="0" align="bottom"/>
+                            </a>&nbsp;&nbsp;
+                            <select id="SelectForm" name="select_form" onChange="switchInputForm()">
+                               <option value="InputBox" selected="selected">Input Box</option>
+                               <option value="DynamicForm">Dynamic Form</option>
+                            </select>&nbsp;<br/>
+                        </td>
+                    </tr>
+                    <xsl:if test="$methodDesc and $methodDesc!=''">
+                    <tr>
+                        <td class="desc">
+                            <table cellSpacing="0" border="0">
+                                <tr>
+                                    <td valign="middle" align="left">
+                                        <br/>
+                                        <xsl:value-of disable-output-escaping="yes" select="$methodDesc"/>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    </xsl:if>
+                    <xsl:if test="$methodHelp and $methodHelp!=''">
+                    <tr>
+                        <td class="help">
+                            <table cellSpacing="0" border="0">
+                                <tr>
+                                    <td valign="middle" align="left">
+                                        <xsl:value-of disable-output-escaping="yes" select="$methodHelp"/>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    </xsl:if>
+                    <tr bgColor="#efefef">
+                        <td>
+                            <p align="left"/>
+                            <xsl:variable name="action">
+                                <xsl:call-template name="build_link"><xsl:with-param name="type" select="'action'"/></xsl:call-template>
+                            </xsl:variable>
+            <form id="esp_form" method="POST" enctype="application/x-www-form-urlencoded" action="/jserror">
+               <xsl:attribute name="onSubmit">return setESPFormAction()</xsl:attribute>
+               <table cellSpacing="0" width="100%" border="0">
+                 <tr>
+                  <td>Query Input:</td>
+                </tr>
+                <tr><td bgcolor="#030303" height="1"/></tr>
+                <tr><td height="4"/></tr>
+                <tr>
+                  <td>
+                   <textarea name="_boxFormInput" rows="40" cols="120"><xsl:value-of select="$QueryInput"/>
+                   </textarea>
+                  </td>
+                </tr>
+                <tr><td height="4"/></tr>
+                <tr><td bgcolor="#030303" height="1"/></tr>
+                <tr><td height="6"/></tr>
+                <tr class="commands">
+                  <td align="left">
+                    <select id="submit_type" name="submit_type_">
+                        <xsl:for-each select="/FormInfo/CustomViews/Result">
+                            <option>
+                              <xsl:attribute name="value"><xsl:value-of select="."/></xsl:attribute>
+                              <xsl:value-of select="."/>
+                            </option>
+                        </xsl:for-each>
+                        <option value="run_xslt">Output Tables</option>
+                        <option value="xml">Output XML</option>
+                        <option value="esp_soap">SOAP Test</option>
+                    </select>&nbsp;
+                    <input type="submit" value="Submit" name="S1"/>
+                  </td>
+                 </tr>
+                </table>
+            </form>
+                      </td>
+                    </tr>
+                 </table>
+              </body>
+          </html>
+    </xsl:template>
+    <xsl:template name="GetHtmlHeadAddon">
+        <xsl:variable name="items" select="//xsd:annotation/xsd:appinfo/form/@html_head"/>
+        <xsl:variable name="s" select="string($items)"/>
+        <xsl:value-of select="$s" disable-output-escaping="yes"/>
+    </xsl:template>
+    <xsl:template name="build_link">
+        <xsl:param name="type" select="'unkown'"/>
+         <xsl:variable name="params">
+              <xsl:if test="$queryParams">
+                  <xsl:value-of select="concat('&amp;', substring($queryParams,2))"/>
+              </xsl:if>
+          </xsl:variable>
+          <xsl:choose>
+              <xsl:when test="$type='reqxml'"><xsl:value-of select="concat('/WsEcl/example/request/query/', $queryPath, '/', $methodName,'?display')"/></xsl:when>
+              <xsl:when test="$type='respxml'"><xsl:value-of select="concat('/WsEcl/example/response/query/', $queryPath, '/', $methodName,'?display')"/></xsl:when>
+              <xsl:when test="$type='xsd'"><xsl:value-of select="concat('/WsEcl/definitions/query/', $queryPath, '/', $methodName,'/main/',$methodName,'.xsd')"/></xsl:when>
+              <xsl:when test="$type='wsdl'"><xsl:value-of select="concat('/WsEcl/definitions/query/', $queryPath, '/', $methodName,'/main/',$methodName,'.wsdl')"/></xsl:when>
+              <xsl:when test="$type='action'"><xsl:value-of select="concat('/WsEcl/submit/query/', $queryPath, '/', $methodName,$queryParams)"/></xsl:when>
+          </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>
+<!-- ********************************************************************************************************** -->

--- a/esp/xslt/wsecl3_form.xsl
+++ b/esp/xslt/wsecl3_form.xsl
@@ -93,7 +93,8 @@
                 <script type="text/javascript" src="/esp/files/req_array.js"/>
                 <script type="text/javascript" src="/esp/files/hashtable.js"/>
                 <script type="text/javascript" src="/esp/files/gen_form.js"/>
-                <script type="text/javascript"><xsl:text disable-output-escaping="yes"><![CDATA[
+                <script type="text/javascript"><xsl:text disable-output-escaping="yes">
+                <![CDATA[
   var isIE = (navigator.appName == "Microsoft Internet Explorer");
 
   function getRequestFormHtml()
@@ -175,7 +176,17 @@ function setESPFormAction()  // reqType: 0: regular form, 1: soap, 2: form param
 
     return true;
 }
-]]></xsl:text>
+function switchInputForm()
+{
+    var inputform = document.getElementById('SelectForm');
+    if (inputform.value!="InputBox")
+       return false;
+    document.location.href = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/box/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+    return true;
+}
+
+]]>
+</xsl:text>
 <xsl:call-template name="GetHtmlHeadAddon"/>
 </script>
 
@@ -226,7 +237,11 @@ function setESPFormAction()  // reqType: 0: regular form, 1: soap, 2: form param
                             </a>&nbsp;<a>
                                 <xsl:attribute name="href"><xsl:call-template name="build_link"><xsl:with-param name="type" select="'respxml'"/></xsl:call-template></xsl:attribute>
                                 <img src="/esp/files/img/respxml.gif" title="Sample Response XML" border="0" align="bottom"/>
-                            </a>
+                            </a>&nbsp;&nbsp;
+                            <select id="SelectForm" name="select_form" onChange="switchInputForm()">
+                               <option value="DynamicForm" selected="selected">Dynamic Form</option>
+                              <option value="InputBox">Input Box</option>
+                            </select>&nbsp;<br/>
                         </td>
                     </tr>
                     <xsl:if test="$methodDesc and $methodDesc!=''">

--- a/esp/xslt/wsecl3_tabview.xsl
+++ b/esp/xslt/wsecl3_tabview.xsl
@@ -114,7 +114,7 @@
                     </ul>
                     <div class="yui-content"  style="height:94%">
                             <div id="tab1" style="height:100%">
-                                <iframe src="/WsEcl/forms/ecl/query/{$qset}/{$qname}" width="100%" height="100%" frameborder="0" border="0">
+                                <iframe src="/WsEcl/forms/default/query/{$qset}/{$qname}" width="100%" height="100%" frameborder="0" border="0">
                                     <p>Your browser does not support iframes.</p>
                                 </iframe>
                         </div>


### PR DESCRIPTION
Allow users to easily paste entire xml requests into WsEcl without
losing the execution options included with the dynamically
structured forms.

Remember the last choice of form type in a cookie to allow users to
continuously work in the way they find most useful.

Fixes gh-3209.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
