### PR TITLE
gh-3221 Various memory optimizations for eclcc

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -172,6 +172,8 @@ public:
     Linked<IPropertyTree> archive;
     Linked<IErrorReceiver> errs;
     Linked<IWorkUnit> wu;
+    Owned<IEclRepository> dataServer;  // A member which can be cleared after parsing the query
+    OwnedHqlExpr query;  // parsed query - cleared when generating to free memory
     StringAttr eclVersion;
     const char * outputFilename;
     FILE * errout;
@@ -225,11 +227,11 @@ protected:
     IFileIO * createArchiveOutputFile(EclCompileInstance & instance);
     ICppCompiler * createCompiler(const char * coreName);
     void generateOutput(EclCompileInstance & instance);
-    void instantECL(EclCompileInstance & instance, IWorkUnit *wu, IHqlExpression * query, const char * queryFullName, IErrorReceiver *errs, const char * outputFile);
+    void instantECL(EclCompileInstance & instance, IWorkUnit *wu, const char * queryFullName, IErrorReceiver *errs, const char * outputFile);
     bool isWithinPath(const char * sourcePathname, const char * searchPath);
     void getComplexity(IWorkUnit *wu, IHqlExpression * query, IErrorReceiver *errs);
     void outputXmlToOutputFile(EclCompileInstance & instance, IPropertyTree * xml);
-    void processSingleQuery(EclCompileInstance & instance, IEclRepository * dataServer,
+    void processSingleQuery(EclCompileInstance & instance,
                                IFileContents * queryContents,
                                const char * queryAttributePath);
     void processXmlFile(EclCompileInstance & instance, const char *archiveXML);
@@ -556,11 +558,10 @@ void EclCC::reportCompileErrors(IErrorReceiver *errs, const char * processName)
 
 //=========================================================================================
 
-void EclCC::instantECL(EclCompileInstance & instance, IWorkUnit *wu, IHqlExpression * query, const char * queryFullName, IErrorReceiver *errs, const char * outputFile)
+void EclCC::instantECL(EclCompileInstance & instance, IWorkUnit *wu, const char * queryFullName, IErrorReceiver *errs, const char * outputFile)
 {
-    OwnedHqlExpr qquery = LINK(query);
     StringBuffer processName(outputFile);
-    if (qquery && containsAnyActions(qquery))
+    if (instance.query && containsAnyActions(instance.query))
     {
         try
         {
@@ -571,17 +572,20 @@ void EclCC::instantECL(EclCompileInstance & instance, IWorkUnit *wu, IHqlExpress
             {
                 Owned<IHqlExprDllGenerator> generator = createDllGenerator(errs, processName.toCharArray(), NULL, wu, templateDir, optTargetClusterType, NULL, false);
 
-                setWorkunitHash(wu, qquery);
+                setWorkunitHash(wu, instance.query);
                 if (!optShared)
                     wu->setDebugValueInt("standAloneExe", 1, true);
                 EclGenerateTarget target = optWorkUnit ? EclGenerateNone : (optNoCompile ? EclGenerateCpp : optShared ? EclGenerateDll : EclGenerateExe);
                 if (optManifestFilename)
                     generator->addManifest(optManifestFilename);
                 if (instance.srcArchive)
+                {
                     generator->addManifestFromArchive(instance.srcArchive);
+                    instance.srcArchive.clear();
+                }
                 generator->setSaveGeneratedFiles(optSaveCpp);
 
-                bool generateOk = generator->processQuery(qquery, target);
+                bool generateOk = generator->processQuery(instance.query, target);  // NB: May clear instance.query
                 if (generateOk && !optNoCompile)
                 {
                     Owned<ICppCompiler> compiler = createCompiler(processName.toCharArray());
@@ -760,13 +764,12 @@ bool EclCC::checkWithinRepository(StringBuffer & attributePath, const char * sou
 }
 
 
-void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * dataServer,
+void EclCC::processSingleQuery(EclCompileInstance & instance,
                                IFileContents * queryContents,
                                const char * queryAttributePath)
 {
     Owned<IErrorReceiver> wuErrs = new WorkUnitErrorReceiver(instance.wu, "eclcc");
     Owned<IErrorReceiver> errs = createCompoundErrorReceiver(instance.errs, wuErrs);
-    Linked<IEclRepository> repository = dataServer;
 
     //All dlls/exes are essentially cloneable because you may be running multiple instances at once
     //The only exception would be a dll created for a one-time query.  (Currently handled by eclserver.)
@@ -778,17 +781,15 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
         instance.wu->setDebugValue("targetCompiler", compilerTypeText[optTargetCompiler], true);
 
     bool withinRepository = (queryAttributePath && *queryAttributePath);
-    Owned<IHqlScope> scope;
     bool syntaxChecking = instance.wu->getDebugValueBool("syntaxCheck", false);
     size32_t prevErrs = errs->errCount();
     unsigned startTime = msTick();
-    OwnedHqlExpr qquery;
     const char * sourcePathname = queryContents ? queryContents->querySourcePath()->str() : NULL;
     const char * defaultErrorPathname = sourcePathname ? sourcePathname : queryAttributePath;
 
     {
         //Minimize the scope of the parse context to reduce lifetime of cached items.
-        HqlParseContext parseCtx(repository, instance.archive);
+        HqlParseContext parseCtx(instance.dataServer, instance.archive);
         if (optGenerateMeta || optIncludeMeta)
         {
             HqlParseContext::MetaOptions options;
@@ -808,7 +809,6 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
             instance.archive->setPropBool("@legacyMode", instance.legacyMode);
 
         parseCtx.ignoreUnknownImport = instance.ignoreUnknownImport;
-        scope.setown(createPrivateScope());
 
         try
         {
@@ -822,8 +822,8 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
                     instance.archive->setProp("Query/@attributePath", queryAttributePath);
                 }
 
-                qquery.setown(getResolveAttributeFullPath(queryAttributePath, LSFpublic, ctx));
-                if (!qquery && !syntaxChecking && (errs->errCount() == prevErrs))
+                instance.query.setown(getResolveAttributeFullPath(queryAttributePath, LSFpublic, ctx));
+                if (!instance.query && !syntaxChecking && (errs->errCount() == prevErrs))
                 {
                     StringBuffer msg;
                     msg.append("Could not resolve attribute ").append(queryAttributePath);
@@ -832,10 +832,11 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
             }
             else
             {
+                Owned<IHqlScope> scope = createPrivateScope();
                 if (instance.legacyMode)
                     importRootModulesToScope(scope, ctx);
 
-                qquery.setown(parseQuery(scope, queryContents, ctx, NULL, true));
+                instance.query.setown(parseQuery(scope, queryContents, ctx, NULL, true));
 
                 if (instance.archive)
                 {
@@ -849,10 +850,10 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
                 }
             }
 
-            gatherWarnings(ctx.errs, qquery);
+            gatherWarnings(ctx.errs, instance.query);
 
-            if (qquery && !syntaxChecking && !optGenerateMeta)
-                qquery.setown(convertAttributeToQuery(qquery, ctx));
+            if (instance.query && !syntaxChecking && !optGenerateMeta)
+                instance.query.setown(convertAttributeToQuery(instance.query, ctx));
 
             if (instance.wu->getDebugValueBool("addTimingToWorkunit", true))
                 instance.wu->setTimerInfo("EclServer: parse query", NULL, msTick()-startTime, 1, 0);
@@ -869,7 +870,10 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
         }
     }
 
-    if (!syntaxChecking && (errs->errCount() == prevErrs) && (!qquery || !containsAnyActions(qquery)))
+    //Free up the repository (and any cached expressions) as soon as the expression has been parsed
+    instance.dataServer.clear();
+
+    if (!syntaxChecking && (errs->errCount() == prevErrs) && (!instance.query || !containsAnyActions(instance.query)))
     {
         errs->reportError(3, "Query is empty", defaultErrorPathname, 1, 0, 0);
         return;
@@ -902,7 +906,10 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
     }
 
     if (errs->errCount() == prevErrs)
-        instantECL(instance, instance.wu, qquery, scope->queryFullName(), errs, targetFilename);
+    {
+        const char * queryFullName = NULL;
+        instantECL(instance, instance.wu, queryFullName, errs, targetFilename);
+    }
     else 
     {
         if (stdIoHandle(targetFilename) == -1)
@@ -924,9 +931,9 @@ void EclCC::processSingleQuery(EclCompileInstance & instance, IEclRepository * d
 
 void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML)
 {
-    Owned<IPropertyTree> archiveTree = createPTreeFromXMLString(archiveXML, ipt_caseInsensitive);
+    instance.srcArchive.setown(createPTreeFromXMLString(archiveXML, ipt_caseInsensitive));
 
-    instance.srcArchive.set(archiveTree);
+    IPropertyTree * archiveTree = instance.srcArchive;
     Owned<IPropertyTreeIterator> iter = archiveTree->getElements("Option");
     ForEach(*iter) 
     {
@@ -961,15 +968,17 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
     else
         archiveCollection.setown(createArchiveEclCollection(archiveTree));
 
-    Owned<IEclRepository> archiveServer = createRepository(archiveCollection);
+    EclRepositoryArray repositories;
+    repositories.append(*LINK(pluginsRepository));
+
+    Owned<IFileContents> contents;
+    StringBuffer fullPath; // Here so it doesn't get freed when leaving the else block
+
     if (queryText || queryAttributePath)
     {
         const char * sourceFilename = archiveTree->queryProp("Query/@originalFilename");
-        Owned<IEclRepository> dataServer = createCompoundRepositoryF(pluginsRepository.get(), archiveServer.get(), NULL);
-
         Owned<ISourcePath> sourcePath = createSourcePath(sourceFilename);
-        Owned<IFileContents> contents = createFileContentsFromText(queryText, sourcePath);
-        processSingleQuery(instance, dataServer, contents, queryAttributePath);
+        contents.setown(createFileContentsFromText(queryText, sourcePath));
     }
     else
     {
@@ -981,15 +990,22 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
             throw MakeStringException(1, "No query found in xml");
 
         instance.wu->setDebugValueInt("syntaxCheck", true, true);
-        StringBuffer fullPath;
         fullPath.append(syntaxCheckModule).append('.').append(syntaxCheckAttribute);
+        queryAttributePath = fullPath.str();
 
         //Create a repository with just that attribute, and place it before the archive in the resolution order.
         Owned<IFileContents> contents = createFileContentsFromText(queryText, NULL);
-        Owned<IEclRepository> syntaxCheckRepository = createSingleDefinitionEclRepository(syntaxCheckModule, syntaxCheckAttribute, contents);
-        Owned<IEclRepository> dataServer = createCompoundRepositoryF(pluginsRepository.get(), syntaxCheckRepository.get(), archiveServer.get(), NULL);
-        processSingleQuery(instance, dataServer, NULL, fullPath.str());
+        repositories.append(*createSingleDefinitionEclRepository(syntaxCheckModule, syntaxCheckAttribute, contents));
     }
+
+    repositories.append(*createRepository(archiveCollection));
+    instance.dataServer.setown(createCompoundRepository(repositories));
+
+    //Ensure classes are not linked by anything else
+    archiveCollection.clear();
+    repositories.kill();
+
+    processSingleQuery(instance, contents, queryAttributePath);
 }
 
 
@@ -1069,8 +1085,9 @@ void EclCC::processFile(EclCompileInstance & instance)
 
         repositories.append(*LINK(includeRepository));
 
-        Owned<IEclRepository> searchRepository = createCompoundRepository(repositories);
-        processSingleQuery(instance, searchRepository, queryText, attributePath.str());
+        instance.dataServer.setown(createCompoundRepository(repositories));
+        repositories.kill();
+        processSingleQuery(instance, queryText, attributePath.str());
     }
 
     if (instance.reportErrorSummary() && !instance.archive)
@@ -1203,8 +1220,8 @@ void EclCC::processReference(EclCompileInstance & instance, const char * queryAt
     if (optArchive || optGenerateDepend)
         instance.archive.setown(createAttributeArchive());
 
-    Owned<IEclRepository> searchRepository = createCompoundRepositoryF(pluginsRepository.get(), libraryRepository.get(), includeRepository.get(), NULL);
-    processSingleQuery(instance, searchRepository, NULL, queryAttributePath);
+    instance.dataServer.setown(createCompoundRepositoryF(pluginsRepository.get(), libraryRepository.get(), includeRepository.get(), NULL));
+    processSingleQuery(instance, NULL, queryAttributePath);
 
     if (instance.reportErrorSummary())
         return;

--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -51,12 +51,10 @@ public:
 //-------------------------------------------------------------------------------------------------------------------
 
 //MORE: Split this into a common base and a Source?
-class CEclSource : public CInterface, implements IEclSource
+class CEclSource : public CInterfaceOf<IEclSource>
 {
 public:
     CEclSource(_ATOM _eclName, EclSourceType _type) : eclName(_eclName), type(_type) { }
-
-    IMPLEMENT_IINTERFACE
 
 //interface IEclSource
     virtual IProperties * getProperties() { return NULL; }
@@ -68,8 +66,8 @@ public:
     virtual IEclSourceIterator * getContained() = 0;
 
 protected:
-    _ATOM eclName;
     EclSourceType type;
+    _ATOM eclName;
 };
 
 

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -2949,7 +2949,8 @@ extern HQL_API IHqlExpression * normalizeListCasts(IHqlExpression * expr)
     case no_cast:
     case no_implicitcast:
         {
-            OwnedHqlExpr normalized = normalizeListCasts(expr->queryChild(0));
+            IHqlExpression * arg = expr->queryChild(0);
+            OwnedHqlExpr normalized = normalizeListCasts(arg);
             OwnedHqlExpr ret = ensureExprType(normalized, expr->queryType());
             if (ret == expr->queryBody())
                 return LINK(expr);
@@ -3187,6 +3188,7 @@ void CHqlExpression::initFlagsBeforeOperands()
         infoFlags |= HEFonFailDependent;
         break;
     case no_variable:
+    case no_quoted:
         infoFlags2 &= ~(HEF2constant);
         break;
     case no_xmltext:
@@ -4465,20 +4467,36 @@ CHqlExpression *CHqlExpressionWithType::makeExpression(node_operator _op, ITypeI
 
 CHqlExpression *CHqlExpressionWithType::makeExpression(node_operator _op, ITypeInfo *_type, ...)
 {
-    va_list args;
-    va_start(args, _type);
-    HqlExprArray operands;
+    unsigned numArgs = 0;
+    va_list argscount;
+    va_start(argscount, _type);
     for (;;)
     {
-        IHqlExpression *parm = va_arg(args, IHqlExpression *);
+        IHqlExpression *parm = va_arg(argscount, IHqlExpression *);
         if (!parm)
             break;
-#ifdef _DEBUG
-        assertex(QUERYINTERFACE(parm, IHqlExpression));
-#endif
-        operands.append(*parm);
+        numArgs++;
     }
-    va_end(args);
+    va_end(argscount);
+
+    HqlExprArray operands;
+    if (numArgs)
+    {
+        va_list args;
+        va_start(args, _type);
+        operands.ensure(numArgs);
+        for (;;)
+        {
+            IHqlExpression *parm = va_arg(args, IHqlExpression *);
+            if (!parm)
+                break;
+#ifdef _DEBUG
+            assertex(QUERYINTERFACE(parm, IHqlExpression));
+#endif
+            operands.append(*parm);
+        }
+        va_end(args);
+    }
     return makeExpression(_op, _type, operands);
 }
 
@@ -7143,14 +7161,13 @@ IFileContents * createFileContents(IFile * file, ISourcePath * sourcePath)
     return new CFileContents(file, sourcePath);
 }
 
-class CFileContentsSubset : public CInterface, implements IFileContents
+class CFileContentsSubset : public CInterfaceOf<IFileContents>
 {
 public:
     CFileContentsSubset(IFileContents * _contents, size32_t _offset, size32_t _len)
         : contents(_contents), offset(_offset), len(_len)
     {
     }
-    IMPLEMENT_IINTERFACE
 
     virtual IFile * queryFile() { return contents->queryFile(); }
     virtual ISourcePath * querySourcePath() { return contents->querySourcePath(); }
@@ -13650,14 +13667,6 @@ extern HQL_API void unlockTransformMutex()
 }
 
 //==============================================================================================================
-
-struct SavedValue : public CInterface, public IInterface
-{
-    SavedValue(unsigned _value) { value = _value; }
-    IMPLEMENT_IINTERFACE;
-
-    unsigned value;
-};
 
 unsigned getExpressionCRC(IHqlExpression * expr)
 {

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -123,7 +123,7 @@ enum
     HEFunbound                  = 0x00000010,
     HEFinternalVirtual          = 0x00000020,
     HEFcontainsDatasetAliasLocally= 0x00000040,
-  HEF____unsued2____          = 0x00000080,
+  HEF____unused2____          = 0x00000080,
   HEF____unused3____          = 0x00000100,
     HEFfunctionOfGroupAggregate = 0x00000200,
     HEFvolatile                 = 0x00000400,           // value changes each time called - e.g., random()

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -123,7 +123,7 @@ enum
     HEFunbound                  = 0x00000010,
     HEFinternalVirtual          = 0x00000020,
     HEFcontainsDatasetAliasLocally= 0x00000040,
-  HEF____unused2____          = 0x00000080,
+  HEF____unsued2____          = 0x00000080,
   HEF____unused3____          = 0x00000100,
     HEFfunctionOfGroupAggregate = 0x00000200,
     HEFvolatile                 = 0x00000400,           // value changes each time called - e.g., random()

--- a/ecl/hqlcpp/hqlcpp.hpp
+++ b/ecl/hqlcpp/hqlcpp.hpp
@@ -126,10 +126,18 @@ public:
     virtual void flushResources(const char *filename, ICodegenContextCallback * ctxCallback) = 0;
 };
 
+// A class used to hold the context about the expression being processed at this point in time.
+// Note: expr is updated as the query is processed to ensure that the parsed tree etc. get freed up early.
+class HQLCPP_API HqlQueryContext
+{
+public:
+    OwnedHqlExpr expr;  // Modified as the query is processed.
+};
+
 interface HQLCPP_API IHqlCppTranslator : public IInterface
 {
 public:
-    virtual bool buildCpp(IHqlCppInstance & _code, IHqlExpression * expr) = 0;
+    virtual bool buildCpp(IHqlCppInstance & _code, HqlQueryContext & query) = 0;
 };
 
 extern HQLCPP_API IHqlCppInstance * createCppInstance(IWorkUnit * wu, const char * wupathname);

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -444,7 +444,6 @@ class WorkflowItem : public CInterface
 public:
     WorkflowItem(unsigned _wfid) : wfid(_wfid) { }
     WorkflowItem(IHqlExpression * _function);
-    IMPLEMENT_IINTERFACE;
 
     bool isFunction() const { return function != NULL; }
     IHqlExpression * getFunction() const;
@@ -785,7 +784,7 @@ public:
     IMPLEMENT_IINTERFACE
 
 //interface IHqlCppTranslator
-    virtual bool buildCpp(IHqlCppInstance & _code, IHqlExpression * expr);
+    virtual bool buildCpp(IHqlCppInstance & _code, HqlQueryContext & query);
     virtual double getComplexity(IHqlCppInstance & _code, IHqlExpression * expr);
     virtual bool spanMultipleCppFiles()         { return options.spanMultipleCpp; }
     virtual unsigned getNumExtraCppFiles()      { return activitiesThisCpp ? curCppFile : 0; }
@@ -1024,7 +1023,7 @@ public:
     ITimeReporter * queryTimeReporter() const { return timeReporter; }
 
     void updateClusterType();
-    bool buildCode(IHqlExpression * exprlist, const char * embeddedLibraryName, bool isEmbeddedLibrary);
+    bool buildCode(HqlQueryContext & query, const char * embeddedLibraryName, bool isEmbeddedLibrary);
 
     inline StringBuffer & generateExprCpp(StringBuffer & out, IHqlExpression * expr)
     {
@@ -1783,7 +1782,7 @@ protected:
 
 
     void markThorBoundaries(WorkflowArray & array);
-    bool transformGraphForGeneration(IHqlExpression * exprlist, WorkflowArray & exprs);
+    bool transformGraphForGeneration(HqlQueryContext & query, WorkflowArray & exprs);
     void processEmbeddedLibraries(HqlExprArray & exprs, HqlExprArray & internalLibraries, bool isLibrary);
     void pickBestEngine(WorkflowArray & array);
     void pickBestEngine(HqlExprArray & exprs);
@@ -1805,7 +1804,7 @@ protected:
     double getComplexity(WorkflowArray & exprs);
     double getComplexity(HqlExprArray & exprs);
     double getComplexity(IHqlExpression * expr, ClusterType cluster);
-    bool prepareToGenerate(IHqlExpression * exprlist, WorkflowArray & exprs, bool isEmbeddedLibrary);
+    bool prepareToGenerate(HqlQueryContext & query, WorkflowArray & exprs, bool isEmbeddedLibrary);
     IHqlExpression * getResourcedGraph(IHqlExpression * expr, IHqlExpression * graphIdExpr);
     IHqlExpression * getResourcedChildGraph(BuildCtx & ctx, IHqlExpression * expr, IHqlExpression * graphIdExpr, unsigned numResults, node_operator graphKind);
     IHqlExpression * optimizeCompoundSource(IHqlExpression * expr, unsigned flags);

--- a/ecl/hqlcpp/hqlecl.hpp
+++ b/ecl/hqlcpp/hqlecl.hpp
@@ -43,7 +43,7 @@ public:
     virtual bool generateDll(ICppCompiler * _compiler) = 0;
     virtual bool generateExe(ICppCompiler * _compiler) = 0;
     virtual bool generatePackage(const char * packageName) = 0;
-    virtual bool processQuery(IHqlExpression * expr, EclGenerateTarget generateTarget) = 0;
+    virtual bool processQuery(OwnedHqlExpr & parsedQuery, EclGenerateTarget generateTarget) = 0;
     virtual void setMaxCompileThreads(unsigned max) = 0;
     virtual void addManifest(const char *filename) = 0;
     virtual void addManifestFromArchive(IPropertyTree *archive) = 0;

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -5347,32 +5347,31 @@ bool isLibraryScope(IHqlExpression * expr)
     return expr->isScope();
 }
 
-bool HqlCppTranslator::prepareToGenerate(IHqlExpression * exprlist, WorkflowArray & actions, bool isEmbeddedLibrary)
+bool HqlCppTranslator::prepareToGenerate(HqlQueryContext & query, WorkflowArray & actions, bool isEmbeddedLibrary)
 {
-    bool createLibrary = isLibraryScope(exprlist);
+    bool createLibrary = isLibraryScope(query.expr);
 
-    OwnedHqlExpr query = LINK(exprlist);
     if (createLibrary)
     {
-        if (query->getOperator() != no_funcdef)
+        if (query.expr->getOperator() != no_funcdef)
             throwError(HQLERR_LibraryMustBeFunctional);
 
         ::Release(outputLibrary);
         outputLibrary = NULL;
         outputLibraryId.setown(createAttribute(graphAtom, getSizetConstant(nextActivityId())));
-        outputLibrary = new HqlCppLibraryImplementation(*this, queryImplementationInterface(query), outputLibraryId, targetClusterType);
+        outputLibrary = new HqlCppLibraryImplementation(*this, queryImplementationInterface(query.expr), outputLibraryId, targetClusterType);
 
         if (!isEmbeddedLibrary)
         {
             SCMStringBuffer libraryName;
             wu()->getJobName(libraryName);
-            wu()->setLibraryInformation(libraryName.str(), outputLibrary->getInterfaceHash(), getLibraryCRC(query));
+            wu()->setLibraryInformation(libraryName.str(), outputLibrary->getInterfaceHash(), getLibraryCRC(query.expr));
         }
     }
     else
     {
         if (options.applyInstantEclTransformations)
-            query.setown(doInstantEclTransformations(query, options.applyInstantEclTransformationsLimit));
+            query.expr.setown(doInstantEclTransformations(query.expr, options.applyInstantEclTransformationsLimit));
     }
 
     if (!transformGraphForGeneration(query, actions))
@@ -5456,11 +5455,11 @@ void dumpActivityCounts()
 
 
 
-bool HqlCppTranslator::buildCode(IHqlExpression * exprlist, const char * embeddedLibraryName, bool isEmbeddedLibrary)
+bool HqlCppTranslator::buildCode(HqlQueryContext & query, const char * embeddedLibraryName, bool isEmbeddedLibrary)
 {
     unsigned time = msTick();
     WorkflowArray workflow;
-    bool ok = prepareToGenerate(exprlist, workflow, isEmbeddedLibrary);
+    bool ok = prepareToGenerate(query, workflow, isEmbeddedLibrary);
     if (ok)
     {
         //This is done late so that pickBestEngine has decided which engine we are definitely targeting.
@@ -5526,7 +5525,7 @@ bool HqlCppTranslator::buildCode(IHqlExpression * exprlist, const char * embedde
     return ok;
 }
 
-bool HqlCppTranslator::buildCpp(IHqlCppInstance & _code, IHqlExpression * exprlist)
+bool HqlCppTranslator::buildCpp(IHqlCppInstance & _code, HqlQueryContext & query)
 {
     if (!internalScope)
         return false;
@@ -5542,7 +5541,7 @@ bool HqlCppTranslator::buildCpp(IHqlCppInstance & _code, IHqlExpression * exprli
         useInclude("eclrtl.hpp");
 
         HqlExprArray internalLibraries;
-        OwnedHqlExpr query = separateLibraries(exprlist, internalLibraries);
+        query.expr.setown(separateLibraries(query.expr, internalLibraries));
 
         //General internal libraries first, in dependency order
         ForEachItemIn(i, internalLibraries)
@@ -5556,11 +5555,13 @@ bool HqlCppTranslator::buildCpp(IHqlCppInstance & _code, IHqlExpression * exprli
             StringBuffer internalLibraryName;
             name->queryValue()->getStringValue(internalLibraryName);
             overrideOptionsForLibrary();
-            if (!buildCode(definition, internalLibraryName.str(), true))
+            HqlQueryContext libraryQuery;
+            libraryQuery.expr.set(definition);
+            if (!buildCode(libraryQuery, internalLibraryName.str(), true))
                 return false;
         }
 
-        if (isLibraryScope(exprlist))
+        if (isLibraryScope(query.expr))
             overrideOptionsForLibrary();
         else
             overrideOptionsForQuery();
@@ -5710,7 +5711,9 @@ double HqlCppTranslator::getComplexity(IHqlCppInstance & _code, IHqlExpression *
 {
     WorkflowArray workflow;
 
-    if (!prepareToGenerate(exprlist, workflow, false))
+    HqlQueryContext query;
+    query.expr.set(exprlist);
+    if (!prepareToGenerate(query, workflow, false))
         return 0;
 
     return getComplexity(workflow);

--- a/ecl/hqlcpp/hqlstmt.cpp
+++ b/ecl/hqlcpp/hqlstmt.cpp
@@ -1006,6 +1006,8 @@ HqlStmt::HqlStmt(StmtKind _kind, HqlStmts * _container)
 
 void HqlStmt::addExpr(IHqlExpression * expr)
 {
+    //Only allocate a single extra expression at a time, since statements generally have very few (1) expressions
+    exprs.ensure(exprs.ordinality()+1);
     exprs.append(*expr);
 }
 

--- a/ecl/hqlcpp/hqlstmt.ipp
+++ b/ecl/hqlcpp/hqlstmt.ipp
@@ -38,12 +38,11 @@ typedef UnsignedShortArray DefinitionHashArray;
 class HqlStmts;
 class PeepHoleOptimizer;
 
-class HqlStmt : public IHqlStmt, public CInterface
+class HqlStmt : public CInterfaceOf<IHqlStmt>
 {
 public:
     HqlStmt(StmtKind _kind, HqlStmts * _container);
-    IMPLEMENT_IINTERFACE
-
+    
     virtual StmtKind                getStmt();
     virtual StringBuffer &          getTextExtra(StringBuffer & out);
     virtual bool                    isIncluded() const;
@@ -82,9 +81,9 @@ protected:
 #pragma warning( disable : 4275 ) // hope this warning not significant! (may get link errors I guess)
 #endif
 
-typedef CIArrayOf<HqlStmt> HqlStmtArray;
+typedef IArrayOf<HqlStmt> HqlStmtArray;
 
-class HQLCPP_API HqlStmts : public CIArrayOf<HqlStmt>
+class HQLCPP_API HqlStmts : public IArrayOf<HqlStmt>
 {
     friend class BuildCtx;
     friend class PeepHoleOptimizer;

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -12228,13 +12228,16 @@ IHqlExpression * HqlCppTranslator::separateLibraries(IHqlExpression * query, Hql
 }
 
 
-bool HqlCppTranslator::transformGraphForGeneration(IHqlExpression * query, WorkflowArray & workflow)
+bool HqlCppTranslator::transformGraphForGeneration(HqlQueryContext & query, WorkflowArray & workflow)
 {
     HqlExprArray exprs;
-    if (isLibraryScope(query))
-        outputLibrary->mapLogicalToImplementation(exprs, query);
+    if (isLibraryScope(query.expr))
+        outputLibrary->mapLogicalToImplementation(exprs, query.expr);
     else
-        query->unwindList(exprs, no_comma);
+        query.expr->unwindList(exprs, no_comma);
+
+    //Ensure the incoming query will be freed up when no longer used
+    query.expr.clear();
 
     traceExpressions("before transform graph for generation", exprs);
     //Don't change the engine if libraries are involved, otherwise things will get very confused.


### PR DESCRIPTION
- Free up the original parsed expression instead of keeping it throughout
  whole generation.
- Use CIntrefaceOf<> in a couple more places
- Only allocate exact number of elements in a couple of arrays

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
