### PR TITLE
gh-2169 Add wildcard support to ecl unpublish for queryids

### DIFF
--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -645,6 +645,22 @@ private:
     bool optNoRoot;
 };
 
+void outputQueryActionResults(const IArrayOf<IConstQuerySetQueryActionResult> &results, const char *act, const char *qs)
+{
+    ForEachItemIn(i, results)
+    {
+        IConstQuerySetQueryActionResult &item = results.item(i);
+        const char *id = item.getQueryId();
+        if (item.getSuccess())
+            fprintf(stdout, "\n%s %s/%s\n", act, qs, id ? id : "");
+        else if (item.getCode()|| item.getMessage())
+        {
+            const char *msg = item.getMessage();
+            fprintf(stderr, "Query %s Error (%d) %s\n", id ? id : "", item.getCode(), msg ? msg : "");
+        }
+    }
+}
+
 class EclCmdActivate : public EclCmdWithQueryTarget
 {
 public:
@@ -677,13 +693,7 @@ public:
         else if (results.empty())
             fprintf(stderr, "\nError Empty Result!\n");
         else
-        {
-            IConstQuerySetQueryActionResult &item = results.item(0);
-            if (item.getSuccess())
-                fprintf(stdout, "\nActivated %s/%s\n", optQuerySet.sget(), optQuery.sget());
-            else if (item.getCode()|| item.getMessage())
-                fprintf(stderr, "Error (%d) %s\n", item.getCode(), item.getMessage());
-        }
+            outputQueryActionResults(results, "Activated", optQuerySet.sget());
         return 0;
     }
     virtual void usage()
@@ -735,13 +745,7 @@ public:
         else if (results.empty())
             fprintf(stderr, "\nError Empty Result!\n");
         else
-        {
-            IConstQuerySetQueryActionResult &item = results.item(0);
-            if (item.getSuccess())
-                fprintf(stdout, "\nUnpublished %s/%s\n", optQuerySet.sget(), optQuery.sget());
-            else if (item.getCode()|| item.getMessage())
-                fprintf(stderr, "Error (%d) %s\n", item.getCode(), item.getMessage());
-        }
+            outputQueryActionResults(results, "Unpublished", optQuerySet.sget());
         return 0;
     }
     virtual void usage()

--- a/system/jlib/jregexp.hpp
+++ b/system/jlib/jregexp.hpp
@@ -88,6 +88,18 @@ protected:
 
 };
 
+inline bool isWildString(const char *s)
+{
+    if (s && *s) {
+        do {
+            if ('?'==*s || '*'==*s)
+                return true;
+        }
+        while (*++s);
+    }
+    return false;
+}
+
 bool jlib_decl WildMatch(const char *src, int srclen, const char *pat, int patlen,bool nocase);
 bool jlib_decl WildMatch(const char *src, const char *pat, bool nocase=false);
 bool jlib_decl WildMatchReplace(const char *src, const char *pat, const char *repl, bool nocase, StringBuffer &out);


### PR DESCRIPTION
Query ids with wildcards must be surrounded by quotes to prevent shell
expansion.

Example:

ecl unpublish hthor "myquery*"

Fixes gh-2169.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
