### PR TITLE
gh-2122 Add pause/resume to dfuserver

### DIFF
--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1784,7 +1784,6 @@ public:
         }
         return true;
     }
-
     void resume()
     {
         Cconnlockblock block(this,true);
@@ -1792,6 +1791,19 @@ public:
             if (qd->root)
                 qd->root->setProp("@state","active");
         }
+    }
+    bool active()
+    {
+        // true if any active
+        Cconnlockblock block(this,false);
+        ForEachQueue(qd) {
+            if (qd->root) {
+                const char *state = qd->root->queryProp("@state");
+                if (state&&(strcmp(state,"active")!=0))
+                    return true;
+            }
+        }
+        return false;
     }
 
     IConversation *initiateConversation(IJobQueueItem *item)

--- a/common/workunit/wujobq.hpp
+++ b/common/workunit/wujobq.hpp
@@ -116,6 +116,7 @@ interface IJobQueue: extends IInterface
     virtual void stop()=0;      // sets stopped flags - all current and subsequent dequeues return NULL
     virtual bool stopped()=0;   // true if stopped
     virtual void resume()=0;    // removes paused or stopped flag
+    virtual bool active()=0;    // true if active
 
 // conversations:
     virtual IConversation *initiateConversation(IJobQueueItem *item)=0; // does enqueue - take ownership of item

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1630,13 +1630,100 @@ IDFUengine *createDFUengine()
     return new CDFUengine;
 }
 
-void stopDFUserver(const char *qname)
+static void reportDFUActionError(DFUQueueAction action, const char *queueName)
 {
-    Owned<IJobQueue> queue = createJobQueue(qname);
-    if (!queue.get()) {
-        throw MakeStringException(-1, "Cound not create queue");
+    StringBuffer buf;
+    switch(action)
+    {
+    case DFUQueueAction_pause:
+        buf.append("Error while trying to pause ");
+        break;
+    case DFUQueueAction_resume:
+        buf.append("Error while trying to resume ");
+        break;
+    case DFUQueueAction_stop:
+        buf.append("Error while trying to stop ");
+        break;
+    default:
+        buf.append("Error in ");
+        break;
     }
-    IJobQueueItem *item = createJobQueueItem("!STOP");
-    item->setEndpoint(queryMyNode()->endpoint());
-    queue->enqueue(item);
+    buf.append("the DFU server, queue ").append(queueName);
+    // NB - I don't like this
+    throw buf.str();
+}
+
+// NB - Old code would wait 2 seconds to stop, so maybe the timeout is not necessary for all actions
+static bool ensureDFUActionExecuted(IJobQueue *queue, DFUQueueAction action, unsigned timeout)
+{
+    unsigned tick = 500; // 1/2 s
+    loop
+    {
+        switch(action)
+        {
+        case DFUQueueAction_pause:
+            if (queue->paused())
+                return true;
+            break;
+        case DFUQueueAction_resume:
+            if (queue->active())
+                return true;
+            break;
+        case DFUQueueAction_stop:
+            if (queue->stopped())
+                return true;
+            break;
+        default:
+            return false;
+        }
+        WARNLOG("Waiting for state to change");
+        Sleep(tick);
+        if (timeout <= tick)
+            break;
+        timeout -= tick;
+    }
+    WARNLOG("Timed out while waiting for state to change");
+    return false;
+}
+
+// Execute action and make sure the result is what's expected or throw
+void applyDFUAction(const char *qname, DFUQueueAction action, unsigned timeout)
+{
+    if ((action == DFUQueueAction_none) || (!qname||!*qname))
+        return;
+
+    Owned<IJobQueue> queue = createJobQueue(qname);
+    if (!queue.get())
+        throw MakeStringException(-1, "Could not create queue %s", qname);
+//    queue->connect();
+
+    switch(action)
+    {
+    case DFUQueueAction_pause:
+        if (queue->paused()) {
+            WARNLOG("%s already paused", qname);
+            return;
+        }
+        WARNLOG("Pausing %s", qname);
+        queue->pause();
+        break;
+    case DFUQueueAction_resume:
+        if (queue->active()) {
+            WARNLOG("%s already running", qname);
+            return;
+        }
+        WARNLOG("Resuming %s", qname);
+        queue->resume();
+        break;
+    case DFUQueueAction_stop:
+        if (queue->stopped()) {
+            WARNLOG("%s already stopped", qname);
+            return;
+        }
+        WARNLOG("Stopping %s", qname);
+        queue->stop();
+        break;
+    }
+    if (!ensureDFUActionExecuted(queue, action, timeout))
+        reportDFUActionError(action, qname);
 }

--- a/dali/dfu/dfurun.hpp
+++ b/dali/dfu/dfurun.hpp
@@ -34,8 +34,15 @@ interface IDFUengine: extends IInterface
     virtual void setDefaultTransferBufferSize(size32_t size) = 0;
 };
 
+enum DFUQueueAction {
+    DFUQueueAction_none = 0,
+    DFUQueueAction_stop,
+    DFUQueueAction_pause,
+    DFUQueueAction_resume,
+};
+
 IDFUengine *createDFUengine();
-void stopDFUserver(const char *qname);
+void applyDFUAction(const char *qname, DFUQueueAction action, unsigned timeout=MP_WAIT_FOREVER);
 
 #endif
 

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -51,6 +51,7 @@ ILogMsgHandler * fileMsgHandler;
 Owned<IDFUengine> engine;
 
 #define DEFAULT_PERF_REPORT_DELAY 60
+#define ACTION_WAIT_TIMEOUT (1000*30) // 30 seconds
 
 //============================================================================
 
@@ -97,7 +98,6 @@ IPropertyTree *readOldIni()
     return ret;
 }
 
-
 int main(int argc, const char *argv[])
 {
     InitModuleObjects();
@@ -136,9 +136,19 @@ int main(int argc, const char *argv[])
         releaseAtoms();
         return 1;
     }
+    // Default is no action, aka Listening Server Mode
+    DFUQueueAction queueAction = DFUQueueAction_none;
+    // IF there is any action, execute and quite, aka Admin Tool Mode
+    // MORE - We should separate this code into an admin tool
+    if (globals->getPropInt("@STOP",0) != 0)
+        queueAction = DFUQueueAction_stop;
+    else if (globals->getPropInt("@PAUSE",0) != 0)
+        queueAction = DFUQueueAction_pause;
+    else if (globals->getPropInt("@RESUME",0) != 0)
+        queueAction = DFUQueueAction_resume;
+
     Owned<IFile> sentinelFile;
-    bool stop = globals->getPropInt("@STOP",0)!=0;
-    if (!stop) {
+    if (!queueAction) {
         sentinelFile.setown(createSentinelTarget());
         removeSentinelFile(sentinelFile);
         Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(globals, "dfuserver");
@@ -160,16 +170,17 @@ int main(int argc, const char *argv[])
     Owned<IReplicateServer> replserver;
     try {
         Owned<IGroup> serverGroup = createIGroup(daliServer.str(),DALI_SERVER_PORT);
-        initClientProcess(serverGroup, DCR_DfuServer, 0, NULL, NULL, stop?(1000*30):MP_WAIT_FOREVER);
+        initClientProcess(serverGroup, DCR_DfuServer, 0, NULL, NULL, queueAction?ACTION_WAIT_TIMEOUT:MP_WAIT_FOREVER);
         setPasswordsFromSDS();
 
-        if(!stop)
+        // Startup server mode
+        if(!queueAction)
         {
             if (globals->getPropBool("@enableSysLog",true))
                 UseSysLogForOperatorMessages();
 
             serverstatus = new CSDSServerStatus("DFUserver");
-            setDaliServixSocketCaching(true); // speeds up lixux operations
+            setDaliServixSocketCaching(true); // speeds up Linux operations
 
             startLogMsgParentReceiver();    // for auditing
             connectLogMsgManagerToDali();
@@ -177,6 +188,8 @@ int main(int argc, const char *argv[])
             engine.setown(createDFUengine());
             addAbortHandler(exitDFUserver);
         }
+
+        // Perform action on (or initialise) queues
         const char *q = queue.str();
         loop {
             StringBuffer subq;
@@ -185,10 +198,13 @@ int main(int argc, const char *argv[])
                 subq.append(comma-q,q);
             else
                 subq.append(q);
-            if (stop) {
-                stopDFUserver(subq.str());
+
+            if (queueAction)
+            {
+                applyDFUAction(subq.str(), queueAction, ACTION_WAIT_TIMEOUT);
             }
-            else {
+            else
+            {
                 StringBuffer mask;
                 mask.appendf("Queue[@name=\"%s\"][1]",subq.str());
                 IPropertyTree *t=serverstatus->queryProperties()->queryPropTree(mask.str());
@@ -204,34 +220,36 @@ int main(int argc, const char *argv[])
                 engine->setDefaultTransferBufferSize((size32_t)globals->getPropInt("@transferBufferSize"));
                 engine->startListener(subq.str(),serverstatus);
             }
+
             if (!comma)
                 break;
             q = comma+1;
             if (!*q)
                 break;
         }
+
+        // If there's also a monitor queue, start it (or apply action to it, too)
         q = globals->queryProp("@MONITORQUEUE");
         if (q&&*q) {
-            if (stop) {
-                stopDFUserver(q);
+            if (queueAction)
+            {
+                applyDFUAction(q, queueAction, ACTION_WAIT_TIMEOUT);
             }
-            else {
+            else
+            {
                 IPropertyTree *t=serverstatus->queryProperties()->addPropTree("MonitorQueue",createPTree());
                 t->setProp("@name",q);
                 engine->startMonitor(q,serverstatus,globals->getPropInt("@MONITORINTERVAL",60)*1000);
             }
         }
-        q = globals->queryProp("@REPLICATEQUEUE");
-        if (q&&*q) {
-            if (stop) {
-                // TBD?
-            }
-            else {
+
+        // If no queue action (aka server mode), start listener
+        if (!queueAction) {
+            q = globals->queryProp("@REPLICATEQUEUE");
+            if (q&&*q) {
                 replserver.setown(createReplicateServer(q));
                 replserver->runServer();
             }
-        }
-        if (!stop) {
             serverstatus->commitProperties();
 
             writeSentinelFile(sentinelFile);
@@ -248,12 +266,10 @@ int main(int argc, const char *argv[])
         e->Release();
     }
     catch (const char *s) {
-        WARNLOG("DFU: %s",s);
+        WARNLOG("DFU exception: %s",s);
     }
 
     delete serverstatus;
-    if (stop)
-        Sleep(2000);    // give time to stop
     engine.clear();
     globals.clear();
     closeEnvironment();


### PR DESCRIPTION
Not ready for pulling yet, but I need some code review and help to test this code. I'll re-target to 3.10.x once my doubts are solved.

I'm not sure the code is correct, though it looks so and follows what all other similar implementations are doing.

My tests have been ineffective, either because the code is wrong or because my tests are.

Tests:
- start dfuserver (via service hpdd-init start)
- submit jobs via dfuplus (loop [ dfuplus add sub; sleep 1; ]
- stop/pause/resume queue via "dfuserver STOP=1" like in init_dfuserver example

The queue does stop/pause/resume as seen by log on different runs (queue is already paused, etc). But jobs continue coming and being executed and files do change in the file-system.

One side effect of my new "isActive()" is that the queue can be both active and paused at the same time, which is weird, even though I (in theory), haven't changed the logic of queue liveness.
