### PR TITLE
gh-3157 Use target as queryset name for all cluster types

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -548,7 +548,6 @@ interface IConstWUClusterInfo : extends IInterface
     virtual ClusterType getPlatform() const = 0;
     virtual IStringVal & getAgentQueue(IStringVal & str) const = 0;
     virtual IStringVal & getServerQueue(IStringVal & str) const = 0;
-    virtual IStringVal & getQuerySetName(IStringVal & str) const = 0;
     virtual IStringVal & getRoxieProcess(IStringVal & str) const = 0;
     virtual const StringArray & getThorProcesses() const = 0;
     virtual const SocketEndpointArray & getRoxieServers() const = 0;
@@ -1218,7 +1217,6 @@ extern WORKUNIT_API IPropertyTree * resolveQueryAlias(IPropertyTree * queryRegis
 extern WORKUNIT_API IPropertyTree * getQueryRegistry(const char * wsEclId, bool readonly);
 extern WORKUNIT_API IPropertyTree * getQueryRegistryRoot();
 extern WORKUNIT_API void setQueryCommentForNamedQuery(IPropertyTree * queryRegistry, const char *id, const char *queryComment);
-extern WORKUNIT_API StringArray &getQuerySetTargetClusters(const char *queryset, StringArray &clusters);
 
 extern WORKUNIT_API void setQuerySuspendedState(IPropertyTree * queryRegistry, const char * name, bool suspend);
 

--- a/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
@@ -273,7 +273,7 @@
         </script>
       </head>
       <body onload="nof5();onLoad()" class="yui-skin-sam">
-        <h3><xsl:value-of select="QuerySetName"/> Queryset </h3>
+        <h3><xsl:value-of select="QuerySetName"/> Target </h3>
         <div id="QuerysetTab" class="yui-navset">
           <ul class="yui-nav">
             <li class="selected">
@@ -283,7 +283,7 @@
             </li>
             <li>
               <a href="#tab2">
-                <em>Aliases</em>
+                <em>Active</em>
               </a>
             </li>
           </ul>

--- a/esp/eclwatch/ws_XSLT/WUQuerysets.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQuerysets.xslt
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
@@ -35,7 +35,7 @@
 
             </head>
             <body onload="nof5();" class="yui-skin-sam">
-                <h3>Querysets</h3>
+                <h3>Targets</h3>
         <xsl:apply-templates select="Querysets"/>
         <xsl:if test="count(Querysets)=0">
           <p>The are no Querysets available.</p>
@@ -49,7 +49,7 @@
     <table class="sort-table" id="resultsTable">
       <thead>
         <tr class="grey">
-          <th>QuerySet Name </th>
+          <th>Target Name </th>
         </tr>
       </thead>
       <tbody>

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -272,7 +272,7 @@ void CWsEclBinding::getNavigationData(IEspContext &context, IPropertyTree & data
     data.addProp("@action", "NavMenuEvent");
     data.addProp("@appName", "WsECL 3.0");
 
-    ensureNavDynFolder(data, "QuerySets", "QuerySets", "root=true", NULL);
+    ensureNavDynFolder(data, "Targets", "Targets", "root=true", NULL);
 }
 
 IPropertyTree * getQueryRegistries()
@@ -293,15 +293,13 @@ void CWsEclBinding::getRootNavigationFolders(IEspContext &context, IPropertyTree
     data.addProp("@action", "NavMenuEvent");
     data.addProp("@appName", "WsECL 3.0");
 
-    Owned<IPropertyTree> qstree = getQueryRegistries();
-    Owned<IPropertyTreeIterator> querysets = qstree->getElements("QuerySet");
+    Owned<IStringIterator> targets = getTargetClusters(NULL, NULL);
 
-    ForEach(*querysets)
+    SCMStringBuffer target;
+    ForEach(*targets)
     {
-        IPropertyTree &qs = querysets->query();
-        const char *name=qs.queryProp("@id");
-        VStringBuffer parms("queryset=%s", name);
-        ensureNavDynFolder(data, name, name, parms.str(), NULL);
+        VStringBuffer parms("queryset=%s", targets->str(target).str());
+        ensureNavDynFolder(data, target.str(), target.str(), parms.str(), NULL);
     }
 }
 
@@ -2249,14 +2247,17 @@ bool xppGotoTag(XmlPullParser &xppx, const char *tagname, StartTag &stag)
     return false;
 }
 
-void CWsEclBinding::sendRoxieRequest(const char *process, StringBuffer &req, StringBuffer &resp, StringBuffer &status)
+void CWsEclBinding::sendRoxieRequest(const char *target, StringBuffer &req, StringBuffer &resp, StringBuffer &status)
 {
-    if (!process || !*process)
-        throw MakeStringException(-1, "process cluster matching query set not found");
+    Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(target);
+    if (!clusterInfo)
+        throw MakeStringException(-1, "target cluster not found");
 
-    ISmartSocketFactory *conn = wsecl->connMap.getValue(process);
+    SCMStringBuffer process;
+    clusterInfo->getRoxieProcess(process);
+    ISmartSocketFactory *conn = wsecl->connMap.getValue(process.str());
     if (!conn)
-        throw MakeStringException(-1, "process cluster matching query set not found: %s", process);
+        throw MakeStringException(-1, "process cluster not found: %s", process.str());
 
     SocketEndpoint &ep = conn->nextEndpoint();
 

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -134,7 +134,7 @@ public:
             ensureNavLink(*folder, "Browse Workunits", "/WsWorkunits/WUQuery", "Browse Workunits", NULL, NULL, 2);
             ensureNavLink(*folder, "ECL Playground", "/esp/files/ECLPlayground.htm", "ECL Editor, Executor, Graph and Result Viewer", NULL, NULL, 4);
 
-            IPropertyTree *folderQueryset = ensureNavFolder(data, "Query Sets", NULL, NULL, false, 3);
+            IPropertyTree *folderQueryset = ensureNavFolder(data, "Queries", NULL, NULL, false, 3);
             ensureNavLink(*folderQueryset, "Browse", "/WsWorkunits/WUQuerySets", "Browse Published Queries");
         }
     }

--- a/initfiles/componentfiles/configxml/RoxieTopology.xsl
+++ b/initfiles/componentfiles/configxml/RoxieTopology.xsl
@@ -87,6 +87,11 @@
                     <xsl:with-param name="daliservers" select="@daliServers"/>
                 </xsl:call-template>
             </xsl:attribute>
+            <xsl:attribute name="querySets">
+                <xsl:call-template name="GetQueueNames">
+                    <xsl:with-param name="roxie" select="@name"/>
+                </xsl:call-template>
+            </xsl:attribute>
             <xsl:attribute name="pluginDirectory">
                 <xsl:variable name="path" select="translate(@pluginsPath, '/$', '\:')"/>
                 <xsl:variable name="path2">
@@ -305,6 +310,14 @@
       <xsl:with-param name="path" select="substring-after($path, '\')"/>
     </xsl:call-template>
   </xsl:if>
+</xsl:template>
+
+<xsl:template name="GetQueueNames">
+  <xsl:param name="roxie"/>
+  <xsl:for-each select="/Environment/Software/Topology/Cluster/RoxieCluster[@process=$roxie]">
+   <xsl:value-of select="../@name"/>
+   <xsl:if test="position() != last()">,</xsl:if>
+  </xsl:for-each>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -323,6 +323,8 @@ extern unsigned headRegionSize;
 extern CriticalSection ccdChannelsCrit;
 extern IPropertyTree* ccdChannels;
 extern IPropertyTree* topology;
+extern StringArray allQuerySetNames;
+
 extern bool crcResources;
 extern bool logFullQueries;
 extern bool blindLogging;

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -310,19 +310,12 @@ public:
         return ret.getClear();
     }
 
-    static const char *getPackageSetPath(StringBuffer &buf, const char *id)
+    virtual IPropertyTree *getPackageSets()
     {
-        buf.appendf("PackageSets/PackageSet[@id='%s']", id);
-        return buf.str();
-    }
-
-    virtual IPropertyTree *getPackageSet(const char *id)
-    {
-        Owned<IPropertyTree> ret = loadDaliTree("PackageSets/PackageSet", id);
+        Owned<IPropertyTree> ret = loadDaliTree("PackageSets", NULL);
         if (!ret)
         {
-            ret.setown(createPTree("PackageSet"));
-            ret->setProp("@id", id);
+            ret.setown(createPTree("PackageSets"));
         }
         return ret.getClear();
     }
@@ -514,10 +507,10 @@ public:
         return getSubscription(id, getQuerySetPath(xpath, id), notifier);
     }
 
-    virtual IDaliPackageWatcher *getPackageSetSubscription(const char *id, ISDSSubscription *notifier)
+    virtual IDaliPackageWatcher *getPackageSetsSubscription(ISDSSubscription *notifier)
     {
         StringBuffer xpath;
-        return getSubscription(id, getPackageSetPath(xpath, id), notifier);
+        return getSubscription("PackageSets", "PackageSets", notifier);
     }
 
     virtual IDaliPackageWatcher *getPackageMapSubscription(const char *id, ISDSSubscription *notifier)

--- a/roxie/ccd/ccddali.hpp
+++ b/roxie/ccd/ccddali.hpp
@@ -44,8 +44,8 @@ interface IRoxieDaliHelper : extends IInterface
     virtual IConstWorkUnit *attachWorkunit(const char *wuid, ILoadedDllEntry *source) = 0;
     virtual IPropertyTree *getQuerySet(const char *id) = 0;
     virtual IDaliPackageWatcher *getQuerySetSubscription(const char *id, ISDSSubscription *notifier) = 0;
-    virtual IPropertyTree *getPackageSet(const char *id) = 0;
-    virtual IDaliPackageWatcher *getPackageSetSubscription(const char *id, ISDSSubscription *notifier) = 0;
+    virtual IPropertyTree *getPackageSets() = 0;
+    virtual IDaliPackageWatcher *getPackageSetsSubscription(ISDSSubscription *notifier) = 0;
     virtual IPropertyTree *getPackageMap(const char *id) = 0;
     virtual IDaliPackageWatcher *getPackageMapSubscription(const char *id, ISDSSubscription *notifier) = 0;
     virtual void releaseSubscription(IDaliPackageWatcher *subscription) = 0;

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -92,6 +92,7 @@ bool roxieMulticastEnabled = true;
 IPropertyTree* topology;
 CriticalSection ccdChannelsCrit;
 IPropertyTree* ccdChannels;
+StringArray allQuerySetNames;
 
 bool crcResources;
 bool useRemoteResources;
@@ -834,7 +835,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
 #else
         topology->addPropBool("@linuxOS", true);
 #endif
-
+        CslToStringArray(topology->queryProp("@querySets"), allQuerySetNames, true);
         if (!numChannels)
             throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - numChannels attribute must be specified");
 

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -117,19 +117,12 @@ public:
             return new CQueryDll(dllName, dll.getClear());
         }
     }
-    static const IQueryDll *getWorkUnitDll(const char *wuid)
+    static const IQueryDll *getWorkUnitDll(IConstWorkUnit *wu)
     {
-        Owned <IRoxieDaliHelper> daliHelper = connectToDali();
-        Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(wuid, NULL);
-        if (wu)
-        {
-            SCMStringBuffer dllName;
-            Owned<IConstWUQuery> q = wu->getQuery();
-            q->getQueryDllName(dllName);
-            return getQueryDll(dllName.str(), false);
-        }
-        else
-            return NULL;
+        SCMStringBuffer dllName;
+        Owned<IConstWUQuery> q = wu->getQuery();
+        q->getQueryDllName(dllName);
+        return getQueryDll(dllName.str(), false);
     }
     virtual HelperFactory *getFactory(const char *helperName) const
     {
@@ -157,9 +150,9 @@ extern const IQueryDll *createExeQueryDll(const char *exeName)
     return CQueryDll::getQueryDll(exeName, true);
 }
 
-extern const IQueryDll *createWuQueryDll(const char *wuid)
+extern const IQueryDll *createWuQueryDll(IConstWorkUnit *wu)
 {
-    return CQueryDll::getWorkUnitDll(wuid);
+    return CQueryDll::getWorkUnitDll(wu);
 }
 
 
@@ -174,6 +167,7 @@ extern const IQueryDll *createWuQueryDll(const char *wuid)
 class CQueryFactory : public CInterface, implements IQueryFactory, implements IResourceContext
 {
 protected:
+    IRoxieLibraryLookupContext *libraryContext;  // has linked to me
     const IRoxiePackage &package;
     Owned<const IQueryDll> dll;
     MapStringToActivityArray graphMap;
@@ -721,8 +715,8 @@ public:
     IMPLEMENT_IINTERFACE;
     unsigned channelNo;
 
-    CQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, unsigned _channelNo) 
-        : id(_id), package(_package), dll(_dll), channelNo(_channelNo), hashValue(_hashValue)
+    CQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, unsigned _channelNo, IRoxieLibraryLookupContext *_libraryContext)
+        : id(_id), package(_package), dll(_dll), channelNo(_channelNo), hashValue(_hashValue), libraryContext(_libraryContext)
     {
         package.Link();
         isSuspended = false;
@@ -746,6 +740,11 @@ public:
         package.Release();
     }
 
+    virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const
+    {
+        return libraryContext->lookupLibrary(libraryName, expectedInterfaceHash, logctx);
+    }
+
     virtual void beforeDispose()
     {
         SpinBlock b(queriesCrit);
@@ -766,10 +765,12 @@ public:
             return NULL;
     }
 
-    static hash64_t getQueryHash(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo)
+    static hash64_t getQueryHash(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo, IRoxieLibraryLookupContext *libraryContext)
     {
         hash64_t hashValue = rtlHash64VStr(dll->queryDll()->queryName(), package.queryHash());
         hashValue = rtlHash64VStr(id, hashValue);
+        if (libraryContext)  // Unit tests don't set it
+            hashValue = rtlHash64VStr(libraryContext->queryId(), hashValue);  // MORE - bit odd...
         if (stateInfo)
         {
             StringBuffer xml;
@@ -1144,7 +1145,8 @@ protected:
     }
 
 public:
-    CRoxieServerQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue) : CQueryFactory(_id, _dll, _package, _hashValue, 0)
+    CRoxieServerQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, IRoxieLibraryLookupContext *_libraryContext)
+        : CQueryFactory(_id, _dll, _package, _hashValue, 0, _libraryContext)
     {
         queryStats.setown(createQueryStatsAggregator(id.get(), statsExpiryTime));
     }
@@ -1262,27 +1264,28 @@ public:
 
 };
 
-IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo)
+extern IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo, IRoxieLibraryLookupContext *libraryContext)
 {
     CriticalBlock b(CQueryFactory::queryCreateLock);
-    hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo);
+    hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo, libraryContext);
     IQueryFactory *cached = getQueryFactory(hashValue, 0);
     if (cached)
     {
         ::Release(dll);
         return cached;
     }
-    Owned<CRoxieServerQueryFactory> newFactory = new CRoxieServerQueryFactory(id, dll, package, hashValue);
+    Owned<CRoxieServerQueryFactory> newFactory = new CRoxieServerQueryFactory(id, dll, package, hashValue, libraryContext);
     newFactory->load(stateInfo);
     return newFactory.getClear();
 }
 
-extern IQueryFactory *createServerQueryFactoryFromWu(const char *wuid)
+extern IQueryFactory *createServerQueryFactoryFromWu(IConstWorkUnit *wu, IRoxieLibraryLookupContext *libraryContext)
 {
-    Owned<const IQueryDll> dll = createWuQueryDll(wuid);
+    Owned<const IQueryDll> dll = createWuQueryDll(wu);
     if (!dll)
         return NULL;
-    return createServerQueryFactory(wuid, dll.getClear(), queryRootPackage(), NULL); // MORE - if use a constant for id might cache better?
+    SCMStringBuffer wuid;
+    return createServerQueryFactory(wu->getWuid(wuid).str(), dll.getClear(), queryRootPackage(), NULL, libraryContext); // MORE - if use a constant for id might cache better?
 }
 
 //==============================================================================================================================================
@@ -1460,8 +1463,8 @@ class CSlaveQueryFactory : public CQueryFactory
     }
 
 public:
-    CSlaveQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, unsigned _channelNo)
-        : CQueryFactory(_id, _dll, _package, _hashValue, _channelNo)
+    CSlaveQueryFactory(const char *_id, const IQueryDll *_dll, const IRoxiePackage &_package, hash64_t _hashValue, unsigned _channelNo, IRoxieLibraryLookupContext *_libraryContext)
+        : CQueryFactory(_id, _dll, _package, _hashValue, _channelNo, _libraryContext)
     {
     }
 
@@ -1510,27 +1513,28 @@ public:
     }
 };
 
-IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, unsigned channel, const IPropertyTree *stateInfo)
+IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, unsigned channel, const IPropertyTree *stateInfo, IRoxieLibraryLookupContext *libraryContext)
 {
     CriticalBlock b(CQueryFactory::queryCreateLock);
-    hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo);
+    hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo, libraryContext);
     IQueryFactory *cached = getQueryFactory(hashValue, channel);
     if (cached)
     {
         ::Release(dll);
         return cached;
     }
-    Owned<CSlaveQueryFactory> newFactory = new CSlaveQueryFactory(id, dll, package, hashValue, channel);
+    Owned<CSlaveQueryFactory> newFactory = new CSlaveQueryFactory(id, dll, package, hashValue, channel, libraryContext);
     newFactory->load(stateInfo);
     return newFactory.getClear();
 }
 
-extern IQueryFactory *createSlaveQueryFactoryFromWu(const char *wuid, unsigned channelNo)
+extern IQueryFactory *createSlaveQueryFactoryFromWu(IConstWorkUnit *wu, unsigned channelNo, IRoxieLibraryLookupContext *libraryContext)
 {
-    Owned<const IQueryDll> dll = createWuQueryDll(wuid);
+    Owned<const IQueryDll> dll = createWuQueryDll(wu);
     if (!dll)
         return NULL;
-    return createSlaveQueryFactory(wuid, dll.getClear(), queryRootPackage(), channelNo, NULL);  // MORE - if use a constant for id might cache better?
+    SCMStringBuffer wuid;
+    return createSlaveQueryFactory(wu->getWuid(wuid).str(), dll.getClear(), queryRootPackage(), channelNo, NULL, libraryContext);  // MORE - if use a constant for id might cache better?
 }
 
 IRecordLayoutTranslator * createRecordLayoutTranslator(const char *logicalName, IDefRecordMeta const * diskMeta, IDefRecordMeta const * activityMeta)

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -110,6 +110,8 @@ interface IQueryFactory : extends IInterface
     virtual void noteQuery(time_t startTime, bool failed, unsigned elapsed, unsigned memused, unsigned slavesReplyLen, unsigned bytesOut) = 0;
     virtual IPropertyTree *getQueryStats(time_t from, time_t to) = 0;
     virtual void getGraphNames(StringArray &ret) const = 0;
+
+    virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
 };
 
 class ActivityArray : public CInterface
@@ -215,13 +217,16 @@ interface IQueryDll : public IInterface
 
 extern const IQueryDll *createQueryDll(const char *dllName);
 extern const IQueryDll *createExeQueryDll(const char *exeName);
+extern const IQueryDll *createWuQueryDll(IConstWorkUnit *wu);
+
+interface IRoxieLibraryLookupContext;
 
 extern IRecordLayoutTranslator *createRecordLayoutTranslator(const char *logicalName, IDefRecordMeta const * diskMeta, IDefRecordMeta const * activityMeta);
-extern IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo);
-extern IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, unsigned _channelNo, const IPropertyTree *stateInfo);
+extern IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo, IRoxieLibraryLookupContext *libraryContext);
+extern IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, unsigned _channelNo, const IPropertyTree *stateInfo, IRoxieLibraryLookupContext *libraryContext);
 extern IQueryFactory *getQueryFactory(hash64_t hashvalue, unsigned channel);
-extern IQueryFactory *createServerQueryFactoryFromWu(const char *wuid);
-extern IQueryFactory *createSlaveQueryFactoryFromWu(const char *wuid, unsigned channelNo);
+extern IQueryFactory *createServerQueryFactoryFromWu(IConstWorkUnit *wu, IRoxieLibraryLookupContext *libraryContext);
+extern IQueryFactory *createSlaveQueryFactoryFromWu(IConstWorkUnit *wu, unsigned channelNo, IRoxieLibraryLookupContext *libraryContext);
 
 inline unsigned findParentId(IPropertyTree &node)
 {

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -595,6 +595,7 @@ void decIbytiDelay(unsigned channel, unsigned factor = 2)
 
 static SpinLock onDemandQueriesCrit;
 static MapXToMyClass<hash64_t, hash64_t, IQueryFactory> onDemandQueryCache;
+static MapXToMyClass<hash64_t, hash64_t, IRoxieLibraryLookupContext> onDemandLibraryLookupCache;
 
 void sendUnloadMessage(hash64_t hash, const char *id, const IRoxieContextLogger &logctx)
 {
@@ -622,12 +623,14 @@ void doUnload(IRoxieQueryPacket *packet, const IRoxieContextLogger &logctx)
     hash64_t hashValue = header.queryHash;
     SpinBlock b(onDemandQueriesCrit);
     onDemandQueryCache.remove(hashValue+channelNo);
+    onDemandLibraryLookupCache.remove(hashValue+channelNo);
 }
 
-void cacheOnDemandQuery(hash64_t hashValue, unsigned channelNo, IQueryFactory *query)
+void cacheOnDemandQuery(hash64_t hashValue, unsigned channelNo, IQueryFactory *query, IRoxieLibraryLookupContext *libraryContext)
 {
     SpinBlock b(onDemandQueriesCrit);
     onDemandQueryCache.setValue(hashValue+channelNo, query);
+    onDemandLibraryLookupCache.setValue(hashValue+channelNo, libraryContext);
 }
 
 //=================================================================================
@@ -994,11 +997,18 @@ public:
         hash64_t queryHash = packet->queryHeader().queryHash;
         unsigned activityId = packet->queryHeader().activityId & ~ROXIE_PRIORITY_MASK;
         Owned<IQueryFactory> queryFactory = getQueryFactory(queryHash, channel);
+        Owned<IRoxieLibraryLookupContext> libraryContext;
         if (!queryFactory && logctx.queryWuid())
         {
-            queryFactory.setown(createSlaveQueryFactoryFromWu(logctx.queryWuid(), channel));
+            // Ensure that any library lookup is done in the correct QuerySet...
+            Owned <IRoxieDaliHelper> daliHelper = connectToDali();
+            Owned<IConstWorkUnit> wu = daliHelper->attachWorkunit(logctx.queryWuid(), NULL);
+            SCMStringBuffer target;
+            wu->getClusterName(target);
+            libraryContext.setown(globalPackageSetManager->getLibraryLookupContext(target.str()));
+            queryFactory.setown(createSlaveQueryFactoryFromWu(wu, channel, libraryContext));
             if (queryFactory)
-                cacheOnDemandQuery(queryHash, channel, queryFactory);
+                cacheOnDemandQuery(queryHash, channel, queryFactory, libraryContext);
         }
         if (!queryFactory)
         {

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -49,7 +49,6 @@ interface IPackageMap : public IInterface
     virtual const IRoxiePackage *queryPackage(const char *name) const = 0;
     // Lookup package using fuzzy id
     virtual const IRoxiePackage *matchPackage(const char *name) const = 0;
-    virtual const char *queryQuerySetId() const = 0;
     virtual const char *queryPackageId() const = 0;
     virtual bool isActive() const = 0;
 };
@@ -100,12 +99,17 @@ interface IFileIOArray : extends IInterface
     virtual StringBuffer &getId(StringBuffer &) const = 0;
 };
 
-interface IRoxieQuerySetManager : extends IInterface
+interface IRoxieLibraryLookupContext : extends IInterface
+{
+    virtual IQueryFactory *lookupLibrary(const char * libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
+    virtual const char *queryId() const = 0;
+};
+
+interface IRoxieQuerySetManager : extends IRoxieLibraryLookupContext
 {
     virtual bool isActive() const = 0;
-    virtual IQueryFactory *lookupLibrary(const char * libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
     virtual IQueryFactory *getQuery(const char *id, const IRoxieContextLogger &ctx) const = 0;
-    virtual void load(const IPropertyTree *querySet, const IPackageMap &packages, hash64_t &hash) = 0;
+    virtual void load(const IPropertyTree *querySet, const IPackageMap &packages, hash64_t &hash, IRoxieLibraryLookupContext *libraryContext) = 0;
     virtual void getStats(const char *queryName, const char *graphName, StringBuffer &reply, const IRoxieContextLogger &logctx) const = 0;
     virtual void resetQueryTimings(const char *queryName, const IRoxieContextLogger &logctx) = 0;
     virtual void resetAllQueryTimings() = 0;
@@ -122,19 +126,20 @@ interface IRoxieDebugSessionManager : extends IInterface
 
 interface IRoxieQuerySetManagerSet : extends IInterface
 {
-    virtual void load(const IPropertyTree *querySets, const IPackageMap &packages, hash64_t &hash) = 0;
+    virtual void load(const IPropertyTree *querySets, const IPackageMap &packages, hash64_t &hash, IRoxieLibraryLookupContext *libraryContext) = 0;
 };
 
 interface IRoxieQueryPackageManagerSet : extends IInterface
 {
     virtual void load() = 0;
     virtual void doControlMessage(IPropertyTree *xml, StringBuffer &reply, const IRoxieContextLogger &ctx) = 0;
-    virtual IRoxieDebugSessionManager* getRoxieDebugSessionManager() const = 0;
-    virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
     virtual IQueryFactory *getQuery(const char *id, const IRoxieContextLogger &logctx) const = 0;
+    virtual IRoxieLibraryLookupContext *getLibraryLookupContext(const char *querySet) const = 0;
 };
 
-extern IRoxieQuerySetManager *createServerManager();
+extern IRoxieDebugSessionManager &queryRoxieDebugSessionManager();
+
+extern IRoxieQuerySetManager *createServerManager(const char *querySet);
 extern IRoxieQuerySetManager *createSlaveManager();
 extern IRoxieQueryPackageManagerSet *createRoxiePackageSetManager(const IQueryDll *standAloneDll);
 extern IRoxieQueryPackageManagerSet *globalPackageSetManager;


### PR DESCRIPTION
This pull request includes a commit from @RichardKChapman and one from myself.

Update roxie to use target as queryset name.

Update ws_workunits publish, querysets, and queryset details to use target as queryset name.

Update ws_ecl to show targets instead of querysets and to use target to locate roxie.

Update eclwatch to show targets instead of querysets when browsing queries.

Fixes gh-3157.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
