### PR TITLE
gh-3281 Fix for exception thrown in helper

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1602,16 +1602,20 @@ void EclAgent::getEventExtra(size32_t & outLen, char * & outStr, const char * ta
 
 char *EclAgent::getPlatform()
 {
-    if (!isStandAloneExe)
+    if (0==platform.length())
     {
-        const char * cluster = clusterNames.tos();
-        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
-        if (!clusterInfo)
-            throw MakeStringException(-1, "Unknown Cluster '%s'", cluster);
-        return (char*)clusterTypeString(clusterInfo->getPlatform());
+        if (!isStandAloneExe)
+        {
+            const char * cluster = clusterNames.tos();
+            Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
+            if (!clusterInfo)
+                throw MakeStringException(-1, "Unknown Cluster '%s'", cluster);
+            platform.append((char*)clusterTypeString(clusterInfo->getPlatform()));
+        }
+        else
+            platform.append("standalone");
     }
-    else
-        return (char *)"standalone";
+    return strdup(platform.str());
 }
 
 char *EclAgent::getEnv(const char *name, const char *defaultValue) const 

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -387,6 +387,7 @@ private:
     IPropertyTree *config;
     StringAttr agentTempDir;
     Owned<IOrderedOutputSerializer> outputSerializer;
+    StringBuffer platform;
 
 private:
     void doSetResultString(type_t type, const char * stepname, unsigned sequence, int len, const char *val);


### PR DESCRIPTION
Helper is releasing the string returned from agent context getPlatform(),
causing an exception. This fix returns a strcpy of that string (and caches
in case getPlatform is called again later) so the caller can take ownership
and later release it.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
