### PR TITLE
gh-3280 Fix problems projecting nested records

### DIFF
--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -291,10 +291,16 @@ IHqlExpression * UsedFieldSet::createFilteredAssign(IHqlExpression * field, IHql
                 {
                     newTransform.setown(match->used.createFilteredTransform(value->queryChild(0), exceptionFields));
                 }
-                else
+                else if (value->getOperator() == no_select)
                 {
                     newTransform.setown(match->used.createRowTransform(value, exceptionFields));
                 }
+                else
+                {
+                    OwnedHqlExpr row = createRow(no_newrow, LINK(value));
+                    newTransform.setown(match->used.createRowTransform(row, exceptionFields));
+                }
+
 
                 newValue.setown(createRow(no_createrow, newTransform.getClear()));
 #if defined(PRESERVE_TRANSFORM_ANNOTATION)
@@ -370,7 +376,7 @@ IHqlExpression * UsedFieldSet::createRowTransform(IHqlExpression * row, const Us
     ForEachItemIn(i, fields)
     {
         IHqlExpression & field = fields.item(i);
-        OwnedHqlExpr value = createNewSelectExpr(LINK(row), LINK(&field));
+        OwnedHqlExpr value = createSelectExpr(LINK(row), LINK(&field));
         OwnedHqlExpr assign = createFilteredAssign(&field, value, self, exceptions);
         if (assign)
             assigns.append(*assign.getClear());

--- a/ecl/regress/nested12.ecl
+++ b/ecl/regress/nested12.ecl
@@ -1,19 +1,18 @@
 /*##############################################################################
 
-    Copyright (C) 2011 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
 
-    All rights reserved. This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 ############################################################################## */
 
 #option ('targetClusterType', 'thorlcr');

--- a/ecl/regress/nested12.ecl
+++ b/ecl/regress/nested12.ecl
@@ -1,0 +1,50 @@
+/*##############################################################################
+
+    Copyright (C) 2011 HPCC Systems.
+
+    All rights reserved. This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################## */
+
+#option ('targetClusterType', 'thorlcr');
+
+level1Rec := RECORD
+    UNSIGNED a;
+    UNSIGNED b;
+    UNSIGNED c;
+END;
+
+level2Rec := RECORD
+    unsigned id;
+    level1Rec a;
+END;
+
+ds1 := DATASET('ds1', level2Rec, thor);
+ds2 := DATASET('ds2', level1Rec, thor);
+
+j := JOIN(ds1, ds2, LEFT.id = right.a, transform(level2Rec, self.a := RIGHT; SELF := LEFT));
+
+d := DEDUP(j, a.b, a.c);
+
+c := table(d, { d, cnt := count(group) },  a.b);
+
+xRec := record
+    unsigned id;
+    unsigned a;
+END;
+
+ds3 := dataset('ds3', xRec, thor);
+
+j2 := JOIN(ds3, c(cnt=1), left.id=right.a.b, transform(xRec, SELF.a := RIGHT.a.c; SELF := LEFT));
+output(j2);
+


### PR DESCRIPTION
The transform for the no_createrow to remove fields from a nested record field
was incorrectly adding a <new> qualifier to no_selects.  When it was later
optimized this caused problems since they weren't spotted as selectors from the
active dataset.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
