### PR TITLE
gh-3274 Add proxies for EE-only plugins to CE builds

### DIFF
--- a/plugins/proxies/CMakeLists.txt
+++ b/plugins/proxies/CMakeLists.txt
@@ -1,4 +1,4 @@
-################################################################################
+###############################################################################
 #    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,14 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ################################################################################
-add_subdirectory (auditlib)
-add_subdirectory (debugservices)
-add_subdirectory (fileservices)
-add_subdirectory (logging)
-add_subdirectory (parselib)
-add_subdirectory (stringlib)
-add_subdirectory (unicodelib)
-add_subdirectory (workunitservices)
-if ("${BUILD_LEVEL}" STREQUAL "COMMUNITY")
-  add_subdirectory (proxies)
-endif ()
+
+install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/lib_saltlib.eclmod DESTINATION plugins COMPONENT Runtime)
+install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/lib_metaphone.eclmod DESTINATION plugins COMPONENT Runtime)
+

--- a/plugins/proxies/lib_metaphone.eclmod
+++ b/plugins/proxies/lib_metaphone.eclmod
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+/* Proxy plugin definition for (EE-only) dmetaphone library version DMETAPHONE 1.1.05 */
+
+export MetaphoneLib := SERVICE
+  string DMetaphone1(const string src) : c,pure,entrypoint='mpDMetaphone1';
+  string DMetaphone2(const string src) : c,pure,entrypoint='mpDMetaphone2';
+  string DMetaphoneBoth(const string src) : c,pure,entrypoint='mpDMetaphoneBoth';
+  string20 DMetaphone1_20(const string src) : c,pure,entrypoint='mpDMetaphone1_20', hole;
+  string20 DMetaphone2_20(const string src) : c,pure,entrypoint='mpDMetaphone2_20', hole;
+  string40 DMetaphoneBoth_40(const string src) : c,pure,entrypoint='mpDMetaphoneBoth_40', hole;
+END;
+

--- a/plugins/proxies/lib_saltlib.eclmod
+++ b/plugins/proxies/lib_saltlib.eclmod
@@ -1,0 +1,25 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+/* Proxy service header for (EE-only) saltlib plugin version SALTLIB 1.0.02 */
+
+export SaltLib := SERVICE
+  boolean UnicodeLocaleWithinEditN(const unicode left, const unicode right, unsigned4 distance,  const varstring localename) : c, pure,entrypoint='ulUnicodeLocaleWithinEditN', hole;
+  integer4 UnicodeLocaleMatchBagofwords(const unicode left, const unicode right, const varstring localename, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords', hole;
+  unicode UnicodeLocaleGetRangeOfWords(const unicode text, unsigned4 s_index, unsigned4 e_index, const varstring localename) : c,pure,entrypoint='ulUnicodeLocaleGetRangeOfWords';
+END;
+


### PR DESCRIPTION
In order for users of EE to be able to do local syntax-checks / archive
creation on systems with CE client tools installed (and in order to remove
the need for multiple versions of the client tools packages), provide 'proxy'
plugins for the EE-only plugins and include them in CE builds.

Fixes gh-3274.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
