### PR TITLE
gh-3281 getPlatform() should not cache and should be threadsafe 

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1602,20 +1602,16 @@ void EclAgent::getEventExtra(size32_t & outLen, char * & outStr, const char * ta
 
 char *EclAgent::getPlatform()
 {
-    if (0==platform.length())
+    if (!isStandAloneExe)
     {
-        if (!isStandAloneExe)
-        {
-            const char * cluster = clusterNames.tos();
-            Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
-            if (!clusterInfo)
-                throw MakeStringException(-1, "Unknown Cluster '%s'", cluster);
-            platform.append(clusterTypeString(clusterInfo->getPlatform()));
-        }
-        else
-            platform.append("standalone");
+        const char * cluster = clusterNames.tos();
+        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
+        if (!clusterInfo)
+            throw MakeStringException(-1, "Unknown Cluster '%s'", cluster);
+        return strdup(clusterTypeString(clusterInfo->getPlatform()));
     }
-    return strdup(platform.str());
+    else
+        return strdup("standalone");
 }
 
 char *EclAgent::getEnv(const char *name, const char *defaultValue) const 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1610,7 +1610,7 @@ char *EclAgent::getPlatform()
             Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
             if (!clusterInfo)
                 throw MakeStringException(-1, "Unknown Cluster '%s'", cluster);
-            platform.append((char*)clusterTypeString(clusterInfo->getPlatform()));
+            platform.append(clusterTypeString(clusterInfo->getPlatform()));
         }
         else
             platform.append("standalone");

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -387,7 +387,6 @@ private:
     IPropertyTree *config;
     StringAttr agentTempDir;
     Owned<IOrderedOutputSerializer> outputSerializer;
-    StringBuffer platform;
 
 private:
     void doSetResultString(type_t type, const char * stepname, unsigned sequence, int len, const char *val);


### PR DESCRIPTION
The eclagent::getPlatform() method should not cache the selected platform since
it might change, and should be thread safe. This fix and removes the cached entry
and adds a new CriticalSection for that purpose.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
