### PR TITLE
gh-2122 Add ability to pause DFU queue

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -596,17 +596,35 @@
                         </xsl:call-template>
                     </xsl:for-each>
 
-                    <xsl:call-template name="show-server">
-                        <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLagent']"/>
-                    </xsl:call-template>
+                    <xsl:for-each select="ServerJobQueues/ServerJobQueue[ServerType='ECLagent']">
+                        <xsl:call-template name="show-queue">
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLagent' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="cluster" select="ServerName"/>
+                            <xsl:with-param name="clusterType" select="ServerType"/>
+                            <xsl:with-param name="queue" select="QueueName"/>
+                            <xsl:with-param name="status" select="QueueStatus"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
 
-                    <xsl:call-template name="show-server">
-                        <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLCCserver']"/>
-                    </xsl:call-template>
+                    <xsl:for-each select="ServerJobQueues/ServerJobQueue[ServerType='ECLCCserver']">
+                        <xsl:call-template name="show-queue">
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLCCserver' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="cluster" select="ServerName"/>
+                            <xsl:with-param name="clusterType" select="ServerType"/>
+                            <xsl:with-param name="queue" select="QueueName"/>
+                            <xsl:with-param name="status" select="QueueStatus"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
 
-                    <xsl:call-template name="show-server">
-                        <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='DFUserver']"/>
-                    </xsl:call-template>
+                    <xsl:for-each select="ServerJobQueues/ServerJobQueue[ServerType='DFUserver']">
+                        <xsl:call-template name="show-queue">
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='DFUserver' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="cluster" select="ServerName"/>
+                            <xsl:with-param name="clusterType" select="ServerType"/>
+                            <xsl:with-param name="queue" select="QueueName"/>
+                            <xsl:with-param name="status" select="QueueStatus"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
                     <xsl:apply-templates select="DFUJobs"/>
                 </form>
                 <xsl:if test="SuperUser">
@@ -707,8 +725,14 @@
                         <xsl:when test="$clusterType = 'HTHOR'">
                             <xsl:value-of select="concat('mn_3_', $pid)"/>
                         </xsl:when>
-                        <xsl:otherwise>
+                        <xsl:when test="$clusterType = 'ECLCCserver'">
                             <xsl:value-of select="concat('mn_4_', $pid)"/>
+                        </xsl:when>
+                        <xsl:when test="$clusterType = 'DFUserver'">
+                            <xsl:value-of select="concat('mn_5_', $pid)"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="concat('mn_6_', $pid)"/>
                         </xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
@@ -722,6 +746,22 @@
                     </xsl:if>
                     <a>
                         <xsl:choose>
+                            <xsl:when test="$clusterType = 'DFUserver' or $clusterType = 'ECLCCserver' or $clusterType = 'ECLagent'">
+                                <xsl:choose>
+                                    <xsl:when test="$status='paused'">
+                                        <xsl:attribute name="class">thorrunningpausedqueuejobs</xsl:attribute>
+                                        <xsl:attribute name="title">Queue paused</xsl:attribute>
+                                    </xsl:when>
+                                    <xsl:when test="$status='stopped'">
+                                        <xsl:attribute name="class">thorrunningpausedqueuejobs</xsl:attribute>
+                                        <xsl:attribute name="title">Queue stopped</xsl:attribute>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:attribute name="class">thorrunning</xsl:attribute>
+                                        <xsl:attribute name="title">Queue running</xsl:attribute>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:when>
                             <xsl:when test="$status2='1'">
                                 <xsl:attribute name="class">thorrunningpausedqueuejobs</xsl:attribute>
                                 <xsl:attribute name="title">Queue paused - Cluster running</xsl:attribute>
@@ -747,11 +787,13 @@
                             <xsl:attribute name="href">javascript:go('/WsTopology/TpClusterInfo?Name=<xsl:value-of select="$cluster"/>')</xsl:attribute>
                         </xsl:if>
                         <xsl:choose>
-                            <xsl:when test="$clusterType = 'ROXIE'">RoxieCluster - </xsl:when>
-                            <xsl:when test="$clusterType = 'THOR'">ThorCluster - </xsl:when>
-                            <xsl:when test="$clusterType = 'HTHOR'">HThorCluster - </xsl:when>
+                            <xsl:when test="$clusterType = 'ROXIE'">RoxieCluster - <xsl:value-of select="$cluster"/></xsl:when>
+                            <xsl:when test="$clusterType = 'THOR'">ThorCluster - <xsl:value-of select="$cluster"/></xsl:when>
+                            <xsl:when test="$clusterType = 'HTHOR'">HThorCluster - <xsl:value-of select="$cluster"/></xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$clusterType"/> - <xsl:value-of select="$queue"/>
+                            </xsl:otherwise>
                         </xsl:choose>
-                        <xsl:value-of select="$cluster"/>
                     </a>
                 </td>
             </tr>

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -84,6 +84,14 @@ ESPStruct DFUJob
     string Command;
 };
 
+ESPStruct ServerJobQueue
+{
+    string QueueName;
+    string ServerName;
+    string ServerType;
+    string QueueStatus;
+};
+
 ESPrequest [nil_remove] ActivityRequest
 {
     string ChatURL;
@@ -117,6 +125,7 @@ ESPresponse [exceptions_inline] ActivityResponse
     [min_ver("1.11")] bool Descending(false);
     [min_ver("1.12")] bool SuperUser(false);
     [min_ver("1.12")] string AccessRight;
+    [min_ver("1.14")] ESParray<ESPstruct ServerJobQueue> ServerJobQueues;
 };
 
 ESPrequest SMCIndexRequest
@@ -291,7 +300,7 @@ RoxieControlCmdResponse
     ESParray<ESPstruct RoxieControlEndpointInfo, Endpoint> Endpoints;
 };
 
-ESPservice [noforms, version("1.13"), default_client_version("1.13"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [noforms, version("1.14"), default_client_version("1.14"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -67,6 +67,7 @@ private:
                                  IArrayOf<IEspCapability>& capabilities);
     void addToThorClusterList(IArrayOf<IEspThorCluster>& clusters, IEspThorCluster* cluster, const char* sortBy, bool descending);
     void addToRoxieClusterList(IArrayOf<IEspRoxieCluster>& clusters, IEspRoxieCluster* cluster, const char* sortBy, bool descending);
+    void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
 };
 
 


### PR DESCRIPTION
Operations is requesting the ability to pause the DFU queue. The
existing code can pause the queue. But, it still shows that the
queue is running. The existing C++ code sends the queue status
using the first workunit inside the queue. If the queue does not
have a workunit, the UI code cannot know the status. The new code
creates a ServerJobQueue object and uses it to pass the queue
status to xslt.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
