### PR TITLE
gh-3136 Configmgr - Improper notification of config file change

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -6029,7 +6029,9 @@ bool CWsDeployFileInfo::buildEnvironment(IEspContext &context, IEspBuildEnvironm
   {
     if(!strcmp(sbName.str(), m_userWithLock.str()) || !strcmp(sbUserIp.str(), m_userIp.str()))
     { 
-      buildEnvFromWizard(xml, m_pService->getName(), m_pService->getCfg(), envXml);
+        buildEnvFromWizard(xml, m_pService->getName(), m_pService->getCfg(), envXml);
+        setSkipNotification(true);
+
         if(envXml.length())
         {
           resp.setStatus("true");


### PR DESCRIPTION
- After generating a configuration using the wizard. Selecting
  advanced view will no longer causes a refresh of the configuration.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
