### PR TITLE
HPCC-3210 Ensure temp files are under user scope

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -51,6 +51,7 @@ extern da_decl const char *queryDfsXmlBranchName(DfsXmlBranchKind kind)
     case DXB_SuperFile:     return "SuperFile";
     case DXB_Collection:    return "Collection";
     case DXB_Scope:         return "Scope";
+    case DXB_Internal:      return "HpccInternal";
     }
     assertex(!"unknown DFS XML branch name");
     return "UNKNOWN";

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -39,7 +39,8 @@ enum DfsXmlBranchKind
     DXB_File,
     DXB_SuperFile,
     DXB_Collection,
-    DXB_Scope
+    DXB_Scope,
+    DXB_Internal // intended as branch for engines to place per user transient files
 };
 
 

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -195,6 +195,10 @@ public:
         if (temporary)
         {
             StringBuffer tail;
+            tmp.append(queryDfsXmlBranchName(DXB_Internal)).append("::");
+            const char *user = job.queryUser();
+            if (user && *user)
+                tmp.append(user).append("::");
             if (paused)
             {
                 tmp.append(PAUSETMPSCOPE);


### PR DESCRIPTION
Redirect all transient files to an internal per user scope.
This will enable security to be enabled on a per user basis and prevent
unauthorised users from seeing each others temp files

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
