### PR TITLE
HPCC-3299 Fix missing export from Std.System.Util

### DIFF
--- a/ecllibrary/std/system/Util.ecl
+++ b/ecllibrary/std/system/Util.ecl
@@ -2,6 +2,8 @@
 ## Copyright (c) 2011 HPCC Systems.  All rights reserved.
 ############################################################################## */
 
+import lib_fileservices;
+
 /**
  * Various utility functions for accessing system function.
  */
@@ -22,7 +24,7 @@ EXPORT string CmdProcess(varstring prog, string src) :=
 /**
  * Returns the host name associated with a particular ip.
  *
- * @param ipaddress     The ip address to resolce.
+ * @param ipaddress     The ip address to resolve.
  * @returns             The host name.
  */
 


### PR DESCRIPTION
Added the missing import, and corrected a typo in one of the comments.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
