### PR TITLE
HPCC-7812 DFS loadDefaultBases race condition

### DIFF
--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -2183,8 +2183,14 @@ static StringAttr unixreplicatedir;
 
 static StringAttr defaultpartmask("$L$._$P$_of_$N$");
 
+static SpinLock ldbSpin;
+static bool ldbDone = false;
 void loadDefaultBases()
 {
+    SpinBlock b(ldbSpin);
+    if (ldbDone)
+        return;
+    ldbDone = true;
     // assumed default first thor
     // first set 
     if (winreplicatedir.isEmpty())


### PR DESCRIPTION
Thread unsafe access to loadDefaultBases can cause issues, e.g. double mem.
free.

Fixes [HPCC-7812](http://track.hpccsystems.com/browse/HPCC-7812)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
