### PR TITLE
HPCC-3286 Minisort could spill and lose records

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -2434,11 +2434,27 @@ protected:
         }
 
         if (heapFlags & RHFpacked)
-            return align_pow2(size + PackedFixedSizeHeaplet::chunkHeaderSize, PACKED_ALIGNMENT);
+            return align_pow2(size + PackedFixedSizeHeaplet::chunkHeaderSize, PACKED_ALIGNMENT) - PackedFixedSizeHeaplet::chunkHeaderSize;
 
         size32_t rounded = roundup(size + FixedSizeHeaplet::chunkHeaderSize);
         size32_t heapSize = ROUNDEDSIZE(rounded);
         return heapSize - FixedSizeHeaplet::chunkHeaderSize;
+    }
+
+    virtual size_t getExpectedFootprint(size32_t size, unsigned heapFlags)
+    {
+        if (size > FixedSizeHeaplet::maxHeapSize())
+        {
+            unsigned numPages = PAGES(size + HugeHeaplet::dataOffset(), HEAP_ALIGNMENT_SIZE);
+            return (numPages * HEAP_ALIGNMENT_SIZE);
+        }
+
+        if (heapFlags & RHFpacked)
+            return align_pow2(size + PackedFixedSizeHeaplet::chunkHeaderSize, PACKED_ALIGNMENT);
+
+        size32_t rounded = roundup(size + FixedSizeHeaplet::chunkHeaderSize);
+        size32_t heapSize = ROUNDEDSIZE(rounded);
+        return heapSize;
     }
 };
 

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -432,6 +432,7 @@ interface IRowManager : extends IInterface
     virtual void addRowBuffer(IBufferedRowCallback * callback) = 0;
     virtual void removeRowBuffer(IBufferedRowCallback * callback) = 0;
     virtual size_t getExpectedCapacity(size32_t size, unsigned heapFlags) = 0; // what is the expected capacity for a given size allocation
+    virtual size_t getExpectedFootprint(size32_t size, unsigned heapFlags) = 0; // how much memory will a given size allocation actually use.
 };
 
 extern roxiemem_decl void setDataAlignmentSize(unsigned size);

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -431,6 +431,7 @@ interface IRowManager : extends IInterface
     virtual IVariableRowHeap * createVariableRowHeap(unsigned activityId, unsigned roxieHeapFlags) = 0;            // should this be passed the initial size?
     virtual void addRowBuffer(IBufferedRowCallback * callback) = 0;
     virtual void removeRowBuffer(IBufferedRowCallback * callback) = 0;
+    virtual size_t getExpectedCapacity(size32_t size, unsigned heapFlags) = 0; // what is the expected capacity for a given size allocation
 };
 
 extern roxiemem_decl void setDataAlignmentSize(unsigned size);

--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -1227,6 +1227,7 @@ public:
         }
         ActPrintLog(activity,"Total recs in mem = %"RCPF"d scaled recs= %"RCPF"d size = %"CF"d bytes, minrecsonnode = %"RCPF"d, maxrecsonnode = %"RCPF"d",total,stotal,totalmem,minrecsonnode,maxrecsonnode);
         if (!usepartitionrow&&!betweensort&&(totalmem<minisortthreshold)&&!overflowed) {
+            ActPrintLog(activity, "Performing minisort of %"RCPF"d records", total);
             sorted = MiniSort(total);
             return;
         }

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -25,6 +25,7 @@
 #include "jthread.hpp"
 #include "thormisc.hpp"
 #include "jlib.hpp"
+#include "jisem.hpp"
 #include "jsort.hpp"
 #include "tsorts.hpp"
 #include "tsorta.hpp"
@@ -46,7 +47,8 @@
 #define MINISORT_PARALLEL_TRANSFER 16
 
 
-inline void traceWait(const char *name,Semaphore &sem,unsigned interval=60*1000)
+template <class T>
+inline void traceWait(const char *name, T &sem,unsigned interval=60*1000)
 {
     while (!sem.wait(interval))
         PROGLOG("Waiting for %s",name);
@@ -433,9 +435,9 @@ public:
         deserializer = rowIf.queryRowDeserializer();
         allocator = rowIf.queryRowAllocator();
     }
-    IRowStream *sort(CThorExpandingRowArray &localRows, ICompare &iCompare, bool isStable, rowcount_t &rowCount)
+    IRowStream *sort(CThorExpandingRowArray &localRows, rowcount_t globalTotal, ICompare &iCompare, bool isStable, rowcount_t &rowCount)
     {
-        PrintLog("Minisort started: %s, totalrows=%"RCPF"d", partNo?"seconday node":"primary node", localRows.ordinality());
+        PrintLog("Minisort started: %s, totalrows=%"RIPF"d", partNo?"seconday node":"primary node", localRows.ordinality());
         size32_t blksize = 0x100000;
 
         // JCSMORE - at the moment, the localsort set is already sorted
@@ -473,8 +475,9 @@ public:
         }
         else
         {
-            collector->setup(&iCompare, isStable, rc_mixed, SPILL_PRIORITY_DISABLE); // must not spill
+            collector->setup(&iCompare, isStable, rc_allMem, SPILL_PRIORITY_DISABLE); // must not spill
             collector->transferRowsIn(localRows);
+            collector->ensure((rowidx_t)globalTotal); // pre-expand row array for efficiency
 
             // JCSMORE - very odd, threaded, but semaphores ensuring sequential writes, why?
             class casyncfor: public CAsyncFor
@@ -580,7 +583,8 @@ class CThorSorter : public CSimpleInterface, implements IThorSorter, implements 
     ICompare *icollateupper; // used in between join
     ISortKeySerializer *keyserializer;      // used on partition calculation
     void *midkeybuf;
-    Semaphore startgathersem, startmergesem, finishedmergesem, closedownsem;
+    Semaphore startgathersem, finishedmergesem, closedownsem;
+    InterruptableSemaphore startmergesem;
     size32_t transferblocksize, midkeybufsize;
 
     void main()
@@ -1032,12 +1036,21 @@ public:
         outbufsize = mb.length();
         outkeybuf = mb.detach();
     }
-    virtual void StartMiniSort(rowcount_t unused) // JCSMORE
+    virtual void StartMiniSort(rowcount_t globalTotal)
     {
         // JCSMORE partno and numnodes should be implicit
         CMiniSort miniSort(*activity, *rowif, *clusterComm, partno, numnodes, mpTagRPC);
 
-        Owned<IRowStream> sortedStream = miniSort.sort(rowArray, *icompare, isstable, totalrows);
+        Owned<IRowStream> sortedStream;
+        try
+        {
+            sortedStream.setown(miniSort.sort(rowArray, globalTotal, *icompare, isstable, totalrows));
+        }
+        catch (IException *e)
+        {
+            startmergesem.interrupt(LINK(e));
+            throw e;
+        }
         merger.setown(sortedStream.getClear());
         startmergesem.signal();
         ActPrintLog(activity, "StartMiniSort output started");
@@ -1181,10 +1194,11 @@ public:
 
         Owned<IThorRowLoader> sortedloader = createThorRowLoader(*activity, rowif, nosort?NULL:icompare, isstable, rc_allDiskOrAllMem, SPILL_PRIORITY_SELFJOIN);
         Owned<IRowStream> overflowstream;
+        memsize_t inMemUsage = 0;
         try
         {
             // if all in memory, rows will be transferred into rowArray when done
-            overflowstream.setown(sortedloader->load(in, abort, false, &rowArray));
+            overflowstream.setown(sortedloader->load(in, abort, false, &rowArray, &inMemUsage));
             ActPrintLog(activity, "Local run sort(s) done");
         }
         catch (IException *e)
@@ -1212,7 +1226,7 @@ public:
             {
                 // unspillable at this point, whilst partitioning (or determining if minisort)
                 overflowinterval = 1;
-                grandtotalsize = rowArray.serializedSize(); // expensive
+                grandtotalsize = inMemUsage;
             }
             ActPrintLog(activity, "Sort done: rows sorted = %"RCPF"d, bytes sorted = %"I64F"d, overflowed to disk %d time%c", grandtotal, grandtotalsize, numOverflows, (numOverflows==1)?' ':'s');
         }

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -771,14 +771,14 @@ memsize_t CThorExpandingRowArray::getMemUsage()
     roxiemem::IRowManager *rM = activity.queryJob().queryRowManager();
     IRecordSize *iRecordSize = rowIf->queryRowMetaData();
     if (iRecordSize->isFixedSize())
-        total = c * rM->getExpectedCapacity(iRecordSize->getFixedSize(), 0);
+        total = c * rM->getExpectedFootprint(iRecordSize->getFixedSize(), 0);
     else
     {
         for (rowidx_t i=0; i<c; i++)
-            total += rM->getExpectedCapacity(iRecordSize->getRecordSize(rows[i]), 0);
+            total += rM->getExpectedFootprint(iRecordSize->getRecordSize(rows[i]), 0);
     }
     // NB: worst case, when expanding (see ensure method)
-    memsize_t sz = rM->getExpectedCapacity(maxRows * sizeof(void *), 0);
+    memsize_t sz = rM->getExpectedFootprint(maxRows * sizeof(void *), 0);
     memsize_t szE = sz / 100 * 125; // don't care if sz v. small
     if (stableSort_none == stableSort)
         total += sz + szE;

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -318,6 +318,7 @@ public:
     void partition(ICompare &compare, unsigned num, UnsignedArray &out); // returns num+1 points
 
     offset_t serializedSize();
+    memsize_t getMemUsage();
     void serialize(MemoryBuffer &mb);
     void serializeCompress(MemoryBuffer &mb);
     rowidx_t serializeBlock(MemoryBuffer &mb, size32_t dstmax, rowidx_t idx, rowidx_t count);
@@ -341,10 +342,6 @@ class graph_decl CThorSpillableRowArray : private CThorExpandingRowArray
     rowidx_t commitRows;  // can only be updated by writing thread within a critical section
     mutable CriticalSection cs;
     ICopyArrayOf<IWritePosCallback> writeCallbacks;
-
-protected:
-    virtual bool ensure(rowidx_t requiredRows);
-
 public:
 
     class CThorSpillableRowArrayLock
@@ -447,6 +444,7 @@ public:
             throwUnexpected();
         return CThorExpandingRowArray::serializedSize();
     }
+    memsize_t getMemUsage() { return CThorExpandingRowArray::getMemUsage(); }
     void serialize(MemoryBuffer &mb)
     {
         if (firstRow > 0)
@@ -455,6 +453,7 @@ public:
     }
     void deserialize(size32_t sz, const void *buf, bool hasNulls){ CThorExpandingRowArray::deserialize(sz, buf); }
     void deserializeRow(IRowDeserializerSource &in) { CThorExpandingRowArray::deserializeRow(in); }
+    virtual bool ensure(rowidx_t requiredRows);
 };
 
 
@@ -467,12 +466,13 @@ interface IThorRowCollectorCommon : extends IInterface
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort=true) = 0;
     virtual void transferRowsIn(CThorExpandingRowArray &src) = 0;
     virtual void setup(ICompare *iCompare, bool isStable=false, RowCollectorFlags diskMemMix=rc_mixed, unsigned spillPriority=50) = 0;
+    virtual void ensure(rowidx_t max) = 0;
 };
 
 interface IThorRowLoader : extends IThorRowCollectorCommon
 {
-    virtual IRowStream *load(IRowStream *in, const bool &abort, bool preserveGrouping=false, CThorExpandingRowArray *allMemRows=NULL) = 0;
-    virtual IRowStream *loadGroup(IRowStream *in, const bool &abort, CThorExpandingRowArray *allMemRows=NULL) = 0;
+    virtual IRowStream *load(IRowStream *in, const bool &abort, bool preserveGrouping=false, CThorExpandingRowArray *allMemRows=NULL, memsize_t *memUsage=NULL) = 0;
+    virtual IRowStream *loadGroup(IRowStream *in, const bool &abort, CThorExpandingRowArray *allMemRows=NULL, memsize_t *memUsage=NULL) = 0;
 };
 
 interface IThorRowCollector : extends IThorRowCollectorCommon


### PR DESCRIPTION
Mini sort is supposed to estimate when all [global] records can fit into
memory, then gather, sort, partition on 1 node. Due to a few reasons and in
particular circumstances, it could spill whilst it was gathering the rows
from nodes 2->n onto node 1, and as a consequence lose records from the
final output.

The main bug was that a spilling flag was being ignored and therefore when
OOM it spilled instead of errored.
The OOM itself was probably mainly as a consequence of the memory manager
issue HPCC-3321, but also in part because the estimate for memory usage for
the minisort was too conservative (wasn't taking into account overheads).

Changes:
- Fix disabled spilling flag conditions.
- If minisort is used, the total row count is known, so pre-expand the large
  row array.
- Improve abort handling.
- Improve size estiamte.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
