### PR TITLE
HPCC-7815 Remove redundant/wrong default dir

### DIFF
--- a/thorlcr/slave/backup.cpp
+++ b/thorlcr/slave/backup.cpp
@@ -38,7 +38,6 @@ public:
 class CThorBackupHandler : public CSimpleInterface, implements IBackup, implements IThreaded, implements ICopyFileProgress
 {
     CThreaded threaded;
-    StringAttr dataDir;
     bool aborted, currentAbort;
     Semaphore sem, cancelSem;
     CriticalSection crit;
@@ -149,7 +148,7 @@ class CThorBackupHandler : public CSimpleInterface, implements IBackup, implemen
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CThorBackupHandler(const char *_dataDir) : threaded("CBackupHandler"), dataDir(_dataDir)
+    CThorBackupHandler() : threaded("CBackupHandler")
     {
         aborted = currentAbort = false;
         async = globals->getPropBool("@replicateAsync", true);
@@ -307,8 +306,8 @@ public:
 const char *CThorBackupHandler::formatV = "01\n";
 
 
-IBackup *createBackupHandler(const char *dataDir)
+IBackup *createBackupHandler()
 {
-    return new CThorBackupHandler(dataDir);
+    return new CThorBackupHandler();
 }
 

--- a/thorlcr/slave/backup.hpp
+++ b/thorlcr/slave/backup.hpp
@@ -24,6 +24,6 @@ interface IBackup : extends IInterface
     virtual void cancel(const char *src) = 0;
 };
 
-IBackup *createBackupHandler(const char *dataDir);
+IBackup *createBackupHandler();
 
 #endif

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -585,7 +585,7 @@ public:
 
     CThorResourceSlave()
     {
-        backupHandler.setown(createBackupHandler(queryBaseDirectory()));
+        backupHandler.setown(createBackupHandler());
         fileCache.setown(createFileCache(globals->getPropInt("@fileCacheLimit", 1800)));
         fipHandler.setown(new CFileInProgressHandler());
     }


### PR DESCRIPTION
Spurious call to queryBaseDirectory() in Thor backup handler.
Unused and wrong anyway. It gets the paths for primary/replicates from DFS
file descriptor

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
