### PR TITLE
HPCC-3286 Provide new helper function to estimate row memory consumption

### DIFF
--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -431,6 +431,7 @@ interface IRowManager : extends IInterface
     virtual void addRowBuffer(IBufferedRowCallback * callback) = 0;
     virtual void removeRowBuffer(IBufferedRowCallback * callback) = 0;
     virtual size_t getExpectedCapacity(size32_t size, unsigned heapFlags) = 0; // what is the expected capacity for a given size allocation
+    virtual size_t getExpectedFootprint(size32_t size, unsigned heapFlags) = 0; // how much memory will a given size allocation actually use.
 };
 
 extern roxiemem_decl void setDataAlignmentSize(unsigned size);


### PR DESCRIPTION
Add a new getExpectedFootprint function to estimate the amount of memory
that an allocation of a given size will actually require.

Also includes a fix to getExpectedCapacity for a packed row (probably
unused at the moment), and remove a VS warning about a double/size32_t
conversion.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
