### PR TITLE
HPCC-3116 Deschedule WU even if the WU is not found

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1238,7 +1238,7 @@ extern WORKUNIT_API void associateLocalFile(IWUQuery * query, WUFileType type, c
 
 
 extern WORKUNIT_API const char *getTargetClusterComponentName(const char *clustname, const char *processType, StringBuffer &name);
-
+extern WORKUNIT_API void descheduleWorkunit(char const * wuid);
 #if 0
 void WORKUNIT_API testWorkflow();
 #endif

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -121,7 +121,7 @@ void ensureWsWorkunitAccess(IEspContext& context, const char* wuid, SecAccessFla
     Owned<IWorkUnitFactory> wf = getWorkUnitFactory(context.querySecManager(), context.queryUser());
     Owned<IConstWorkUnit> cw = wf->openWorkUnit(wuid, false);
     if (!cw)
-        throw MakeStringException(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to open workunit %s", wuid);
+        throw MakeStringException(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to open workunit %s when ensuring workunit access", wuid);
     ensureWsWorkunitAccess(context, *cw, minAccess);
 }
 


### PR DESCRIPTION
A user deleted a workunit where the workunit was in the WAIT state. In
the existing code, the workunit cannot be descheduled because the
deschedule() is a member of IWorkunit and the IWorkunit cannot be opened
after the workunit is deleted. In this fix, an extern descheduleWorkunit
is added to deschedule a workunit. Before the descheduleWorkunit is
called, EclWatch verifies that the user has SecAccess_Full right to both
OWN_WU_ACCESS and OTHERS_WU_ACCESS.

This fix also revises the doAction() function which contains the
deschedule code.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
