### PR TITLE
HPCC-3278 Fix File Spray rate displayed in DFU Workunit Details page

### DIFF
--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -398,12 +398,12 @@ public:
                        str.append(' ');
                 }
                 if (kbs!=0)
-                    str.appendf("@%dKB/s",kbs);
+                    str.appendf("@%dKB/sec",kbs);
                 str.append(')');
             }
             kbs = getKbPerSec();
             if (kbs!=0)
-                str.appendf(" current rate=%dKB/s",kbs);
+                str.appendf(" current rate=%dKB/sec",kbs);
         }
         unsigned totnodes=getTotalNodes();
         if (totnodes==0) { // print subdone/done
@@ -431,7 +431,7 @@ public:
             str.appendf("Total time taken %s", getTimeTaken(timetaken).str());
             unsigned kbs = getKbPerSecAve();
             if (kbs!=0)
-                str.appendf(", Average transfer %dKb/sec", kbs);
+                str.appendf(", Average transfer %dKB/sec", kbs);
         }
         return str;
     }


### PR DESCRIPTION
In DFU Workunit Details page, a user found that two different formats
of File Spray speed are displayed . The ProcessMessage shows 253,000KB/s
as 'current rate'. The SummaryMessage shows 253,000Kb/sec as 'average
transfer'. I think both of them should be in 'KB/sec'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
