### PR TITLE
HPCC-3292 Don't update workunit jobname when publishing from CLI

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -702,7 +702,7 @@
                 alert('The workunit must have a jobname to be published. \r\nEnter a jobname, then publish.');
                 return;
               }
-              var cObj = YAHOO.util.Connect.asyncRequest('GET', '/WsWorkunits/WUPublishWorkunit?rawxml_&Wuid=' + wuid + '&JobName=' + Jobname + '&Activate=1&Wait=5000', publishCallback);
+              var cObj = YAHOO.util.Connect.asyncRequest('GET', '/WsWorkunits/WUPublishWorkunit?rawxml_&Wuid=' + wuid + '&JobName=' + Jobname + '&Activate=1&UpdateWorkUnitName=1&Wait=5000', publishCallback);
             }
 
         /*

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1063,6 +1063,7 @@ ESPrequest WUPublishWorkunitRequest
     bool CopyLocal(0);
     int Wait(10000);
     bool NoReload(0);
+    bool UpdateWorkUnitName(0);
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -311,7 +311,7 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
         throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid cluster name: %s", target.str());
 
     WorkunitUpdate wu(&cw->lock());
-    if (notEmpty(req.getJobName()))
+    if (req.getUpdateWorkUnitName() && notEmpty(req.getJobName()))
         wu->setJobName(req.getJobName());
 
     StringBuffer queryId;


### PR DESCRIPTION
"ecl publish" takes a queryname as a parameter.  When publishing an
existing workunit from the command line, the queryname should not
be used to update the workunit jobname.

The behavior when publishing from EclWatch doesn't change.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
