### PR TITLE
HPCC-3297 Show usage when ecl queries copy is called with no parameter

### DIFF
--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -266,6 +266,12 @@ public:
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
     {
+        if (iter.done())
+        {
+            usage();
+            return false;
+        }
+
         for (; !iter.done(); iter.next())
         {
             const char *arg = iter.query();


### PR DESCRIPTION
Other CLI commands that have required parameters show usage when no
parameters are provided.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
