### PR TITLE
HPCC-7817 Memory leak in Std.Uni.GetNthWord

### DIFF
--- a/plugins/unicodelib/unicodelib.cpp
+++ b/plugins/unicodelib/unicodelib.cpp
@@ -1130,6 +1130,7 @@ UNICODELIB_API void UNICODELIB_CALL ulUnicodeLocaleGetNthWord(unsigned & tgtLen,
     UnicodeString uText(text, textLen);
     uText.trim();
     UnicodeString word = getNthWord(*bi, uText, n);
+    delete bi;
     if(word.length()>0)
     {
         tgtLen = word.length();


### PR DESCRIPTION
The RuleBasedBreakIterator object allocated in the unicode plugin function
ulUnicodeLocaleGetNthWord was not released, resulting in a leak every time the
function is called.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
