### PR TITLE
HPCC-7820 Add LDAP scope for the per-user temp file location

### DIFF
--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -24,6 +24,8 @@
 
 #include "dasds.hpp"
 #include "daldap.hpp"
+#include "mpbase.hpp"
+#include "dautils.hpp"
 
 #ifndef _NO_LDAP
 #include "seclib.hpp"
@@ -54,6 +56,14 @@ class CDaliLdapConnection: public CInterface, implements IDaliLdapConnection
             ISecUser* user = NULL;
             if (ldapsecurity->addResourceEx(RT_FILE_SCOPE, *user, "file",PT_ADMINISTRATORS_ONLY, NULL))
                 PROGLOG("LDAP: Created default 'file' scope");
+            else
+                throw MakeStringException(-1, "Error adding LDAP resource 'file'");
+
+            StringBuffer userTempFileScope(queryDfsXmlBranchName(DXB_Internal));
+            if (ldapsecurity->addResourceEx(RT_FILE_SCOPE, *user, userTempFileScope.str(),PT_ADMINISTRATORS_ONLY, NULL))
+                PROGLOG("LDAP: Created default '%s' scope", userTempFileScope.str());
+            else
+                throw MakeStringException(-1, "Error adding LDAP resource '%s'",userTempFileScope.str());
         }
         catch (IException *e) {
             EXCLOG(e,"LDAP createDefaultScopes");

--- a/system/security/LdapSecurity/CMakeLists.txt
+++ b/system/security/LdapSecurity/CMakeLists.txt
@@ -41,6 +41,8 @@ include_directories (
          ./../shared 
          ./../../jlib 
          ./../../../esp/platform 
+	     ./../../../dali/base
+	     ./../../../system/mp
          ${OPENLDAP_INCLUDE_DIR}
     )
 
@@ -50,6 +52,7 @@ HPCC_ADD_LIBRARY( LdapSecurity SHARED ${SRCS} )
 install ( TARGETS LdapSecurity DESTINATION ${OSSDIR}/lib )
 target_link_libraries ( LdapSecurity
          jlib
+         dalibase
          ${OPENLDAP_LIBRARIES}
     )
 

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -27,6 +27,8 @@
 #include "ldapsecurity.ipp"
 #include "jsmartsock.hpp"
 #include "jrespool.tpp"
+#include "mpbase.hpp"
+#include "dautils.hpp"
 
 #undef new
 #include <map>
@@ -3215,6 +3217,11 @@ public:
                 continue;
             changeUserGroup("delete", username, grp);
         }
+
+        //Remove tempfile scope for this user
+        StringBuffer resName(queryDfsXmlBranchName(DXB_Internal));
+        resName.append("::").append(username);
+        deleteResource(RT_FILE_SCOPE, resName.str(), m_ldapconfig->getResourceBasedn(RT_FILE_SCOPE));
         
         return true;
     }
@@ -4858,6 +4865,13 @@ private:
             passwd = "password";
 
         updateUser(*tmpuser, passwd);
+
+        //Add tempfile scope for this user (spill, paused and checkpoint
+        //will be created under this user specific scope)
+        StringBuffer resName(queryDfsXmlBranchName(DXB_Internal));
+        resName.append("::").append(tmpuser->getName());
+        Owned<ISecResource> resource = new CLdapSecResource(resName.str());
+        addResource(RT_FILE_SCOPE, *tmpuser, resource, PT_ADMINISTRATORS_AND_USER, m_ldapconfig->getResourceBasedn(RT_FILE_SCOPE));
 
         return true;
     }

--- a/system/security/LdapSecurity/permissions.cpp
+++ b/system/security/LdapSecurity/permissions.cpp
@@ -1480,6 +1480,7 @@ CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser& user, const 
         MemoryBuffer umb, gmb;
         if(&user != NULL && DEFAULT_OWNER_PERMISSION != SecAccess_None)
         {
+            //Add SD for given user
             lookupSid(user.getName(), umb);
             psid = (PSID)(umb.toByteArray());
             if(psid != NULL)
@@ -1493,8 +1494,9 @@ CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser& user, const 
             }
         }
 
-        if(DEFAULT_AUTHENTICATED_USERS_PERMISSION != SecAccess_None)
+        if(ptype != PT_ADMINISTRATORS_AND_USER  &&  DEFAULT_AUTHENTICATED_USERS_PERMISSION != SecAccess_None)
         {
+            //Add SD for Authenticated users
             au_psid = (PSID)(authenticated_users_sid);
             unsigned permission = sec2ldap(DEFAULT_AUTHENTICATED_USERS_PERMISSION);
             rc = AddAccessAllowedAce(pacl, ACL_REVISION, permission, au_psid);

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -85,7 +85,8 @@ const char* resTypeDesc(SecResourceType type);
 enum SecPermissionType
 {
     PT_DEFAULT = 0,
-    PT_ADMINISTRATORS_ONLY = 1
+    PT_ADMINISTRATORS_ONLY = 1,
+    PT_ADMINISTRATORS_AND_USER = 2  //excludes Authenticated users
 };
 
 


### PR DESCRIPTION
Temporary files need to be differentiated by user, with separate scopes
restricting access to another user's files. This fix queries DFU for a
tempFiles scope name (HpccInternal), and creates a user-specific scope
(HpccInternal::user) whenever a new user is added. Permissions for that
scope are granted to Administrators and that user only. That scope is
deleted when the user account is deleted.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
