### PR TITLE
HPCC-7831 filterprojects fail in child queries

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -908,6 +908,7 @@ bool isGlobalActivity(CGraphElementBase &container)
 // always local
         case TAKcountdisk:
         case TAKfilter:
+        case TAKfilterproject:
         case TAKsplit:
         case TAKpipewrite:
         case TAKdegroup:
@@ -1797,7 +1798,7 @@ StringBuffer &getGlobals(CGraphBase &graph, StringBuffer &str)
 
             ThorActivityKind kind = e.getKind();
             str.append(activityKindStr(kind));
-            str.append("(").append(kind).append(")");
+            str.append("(").append(e.queryId()).append(")");
         }
     }
     if (!first)


### PR DESCRIPTION
Some folded filter projects generated as activity type TAKfilterproject by
the code generator, were causing Thor queries to fail if they appeared in
child queries. Resulting in error "Global child graph? : Global acts = .."

Also update minor logging issue in the "Global child graph" error

Fixes HPCC-7831

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
