### PR TITLE
HPCC-3162 Hide DelimToStringArray

### DIFF
--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -427,7 +427,7 @@ public:
         : subs(this)
     {
         StringArray qlist;
-        CslToStringArray(_qname, qlist, true);
+        qlist.appendListUniq(_qname, ",");
         sQueueData *last = NULL;
         ForEachItemIn(i,qlist) {
             sQueueData *qd = new sQueueData;

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -9495,7 +9495,7 @@ void CDistributedFileDirectory::promoteSuperFiles(unsigned numsf,const char **sf
     Owned<IDistributedSuperFile> first = transaction->lookupSuperFile(sfnames[0]);
     assertex(first.get());
     StringArray toadd;
-    CslToStringArray(addsubnames, toadd, true);
+    toadd.appendListUniq(addsubnames, ",");
     ForEachItemIn(i,toadd) {
         CDfsLogicalFileName lfn;
         if (!lfn.setValidate(toadd.item(i)))

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -145,7 +145,7 @@ public:
             return NULL;
         mlfn.setLength(start-s);
         StringArray lfns;
-        CslToStringArray(start+1, lfns);
+        lfns.appendList(start+1, ",");
         bool anywilds = false;
         ForEachItemIn(i1,lfns) {
             const char *suffix = lfns.item(i1);

--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -1527,7 +1527,7 @@ void CDfuPlusHelper::info(const char *fmt, ...)
     va_end(args);
     if (msgintercept) {
         StringArray strs;
-        DelimToStringArray(buf.str(), strs, "\n");
+        strs.appendList(buf.str(), "\n");
         ForEachItemIn(i,strs) {
             const char *s = strs.item(i);
             if (*s)
@@ -1547,7 +1547,7 @@ void CDfuPlusHelper::progress(const char *fmt, ...)
     va_end(args);
     if (msgintercept) {
         StringArray strs;
-        DelimToStringArray(buf.str(), strs, "\n");
+        strs.appendList(buf.str(), "\n");
         ForEachItemIn(i,strs) {
             const char *s = strs.item(i);
             if (*s)

--- a/dali/ft/daftformat.ipp
+++ b/dali/ft/daftformat.ipp
@@ -256,7 +256,7 @@ public:
         if (_format.quote.get()) { 
             isquoted = false;
             StringArray csl;
-            CslToStringArray(_format.quote,csl); // OTT but catches previous kludge of ","
+            csl.appendList(_format.quote, ","); // OTT but catches previous kludge of ","
             ForEachItemIn(i,csl) {
                 if (strlen(csl.item(i)))
                 isquoted = true;

--- a/dali/fuse/dafuse.cpp
+++ b/dali/fuse/dafuse.cpp
@@ -467,7 +467,7 @@ class CFuseDaliDFS: public CFuseBase
     {
         StringBuffer fn;
         StringArray dirs;
-        DelimToStringArray(path,dirs,"/",false);
+        dirs.appendList(path, "/");
         ForEachItemIn(i,dirs) {
             const char *dir = dirs.item(i);
             if (dir&&*dir) {

--- a/dali/sasha/saqmon.cpp
+++ b/dali/sasha/saqmon.cpp
@@ -69,7 +69,7 @@ public:
         if (!qinitdone) {
             qinitdone = true;
             StringArray qs;
-            CslToStringArray(qlist, qs, true);
+            qs.appendListUniq(qlist, ",");
             if (!qs.ordinality())
                 return false;
             StringArray cna;
@@ -188,7 +188,7 @@ public:
                             const char *allowedclusters = ptree->queryProp("Debug/allowedclusters");
                             if (allowedclusters&&*allowedclusters) {
                                 StringArray acs;
-                                CslToStringArray(allowedclusters, acs, true);
+                                acs.appendListUniq(allowedclusters, ",");
                                 bool found = true;
                                 ForEachItemIn(i,acs) {
                                     if (strcmp(cnames.item(qi),acs.item(i))==0) 

--- a/deployment/deploy/DeploymentEngine.cpp
+++ b/deployment/deploy/DeploymentEngine.cpp
@@ -2323,7 +2323,7 @@ void CDeploymentEngine::addDeploymentFile(StringBuffer &ret, const char *in, IXs
 {
     //input is of the format <method>+<file name>+<source dir>+<dest filename>[+<dest subdir>]
     StringArray tokens;
-    DelimToStringArray(in, tokens, "+");
+    tokens.appendList(in, "+");
     
     int len = tokens.length();
     if (len < 4)
@@ -2359,7 +2359,7 @@ void CDeploymentEngine::siteCertificateFunction(StringBuffer &ret, const char *i
 {
     //input is of the format <processType>+<process name>+<instance name>+<output path>
     StringArray tokens;
-    DelimToStringArray(in, tokens, "+");
+    tokens.appendList(in, "+");
     
     int len = tokens.length();
     if (len < 4)

--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -534,7 +534,7 @@ public:
         //type is either 'error' or 'warning' and any of the other parts may be empty strings
         //
         StringArray sArray;
-        DelimToStringArray(in, sArray, ":");
+        sArray.appendList(in, ":");
 
         if (sArray.ordinality() != 4)
         {

--- a/deployment/deployutils/deployutils.cpp
+++ b/deployment/deployutils/deployutils.cpp
@@ -1815,7 +1815,7 @@ IPropertyTree* generateTreeFromXsd(const IPropertyTree* pEnv, IPropertyTree* pSc
     GenOptional genOpt = GENOPTIONAL_COMPS;
     algProp->getProp("do_not_gen_optional", prop);
     StringArray doNotGenOpt;
-    DelimToStringArray(prop.str(), doNotGenOpt, ",");
+    doNotGenOpt.appendList(prop.str(), ",");
 
     if (doNotGenOpt.length() == 0)
       genOpt = GENOPTIONAL_ALL;
@@ -3199,7 +3199,7 @@ void formIPList(const char* ip, StringArray& formattedIpList)
          ipList.setCharAt((ipList.length()-1),' ');
 
     StringArray sArray;
-    DelimToStringArray(ipList, sArray, ";");
+    sArray.appendList(ipList, ";");
 
     if(sArray.ordinality() > 0 )
     {
@@ -3212,13 +3212,13 @@ void formIPList(const char* ip, StringArray& formattedIpList)
               {
                 StringArray rangeArr, commIPPart ;
                 StringBuffer comip;
-                DelimToStringArray(ip, rangeArr ,"-");
+                rangeArr.appendList(ip, "-");
 
                 if( rangeArr.ordinality() == 2 )
                 {
                    unsigned endAddr = atoi(rangeArr.item(1));
                    //to get common part of IP
-                   DelimToStringArray(rangeArr.item(0),commIPPart,".");
+                   commIPPart.appendList(rangeArr.item(0),".");
                    StringBuffer newip;
                    if(commIPPart.ordinality() == 4)
                    {
@@ -3475,7 +3475,7 @@ void getSummary(const IPropertyTree* pEnvRoot, StringBuffer& respXmlStr, bool pr
          {
            linkString.clear().append(espServiceArr.item(x));
            StringArray sArray;
-           DelimToStringArray(linkString.str(), sArray, "-");
+           sArray.appendList(linkString.str(), "-");
            if(sArray.ordinality() == 3)
            {
              IPropertyTree* pEspServiceType = pSummaryTree->addPropTree("Component", createPTree("Component"));

--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -169,13 +169,13 @@ void CWizardInputs::setWizardRules()
        else if(!strcmp(iter->getPropKey(), "avoid_combo"))
        {
          StringArray pairValue;
-         DelimToStringArray(prop.str(), pairValue, ",");
+         pairValue.appendList(prop.str(), ",");
          if( pairValue.ordinality() > 0)
          {
            for( unsigned i = 0; i < pairValue.ordinality() ; i++)
            {
              StringArray eachpair;
-             DelimToStringArray(pairValue.item(i), eachpair, "-");
+             eachpair.appendList(pairValue.item(i), "-");
              if(eachpair.ordinality() == 2 )
              {
                StringArray* serverCompArr = 0;
@@ -199,15 +199,15 @@ void CWizardInputs::setWizardRules()
          }
        }
        else if(!strcmp (iter->getPropKey(),"do_not_generate"))
-          DelimToStringArray(prop.str(), m_doNotGenComp, ",");
+           m_doNotGenComp.appendList(prop.str(), ",");
        else if(!strcmp (iter->getPropKey(),"comps_on_all_nodes"))
-          DelimToStringArray(prop.str(), m_compOnAllNodes, ",");
+           m_compOnAllNodes.appendList(prop.str(), ",");
        else if(!strcmp(iter->getPropKey(), "topology_for_comps"))
-        DelimToStringArray(prop.str(), m_clusterForTopology, ",");
+           m_clusterForTopology.appendList(prop.str(), ",");
        else if (!strcmp(iter->getPropKey(), "roxie_agent_redundancy"))
        {
          StringArray sbarr;
-         DelimToStringArray(prop.str(), sbarr, ",");
+         sbarr.appendList(prop.str(), ",");
          if (sbarr.length() > 1)
          {
           int type = atoi(sbarr.item(0));
@@ -1069,7 +1069,7 @@ void CWizardInputs::checkAndAddDependComponent(const char* key)
     if(m_algProp->hasProp(paramEntry.str()))
     {
       StringArray sArray;
-      DelimToStringArray(m_algProp->queryProp(paramEntry.str()), sArray, ";");
+      sArray.appendList(m_algProp->queryProp(paramEntry.str()), ";");
       ForEachItemIn(x, sArray)
       {
         if(m_doNotGenComp.find(sArray.item(x)) == NotFound)
@@ -1108,7 +1108,7 @@ void CWizardInputs::setTopologyParam()
         StringArray* compClusterArr = new StringArray();
        
         StringArray clusterElemArr;
-        DelimToStringArray( elemForCluster, clusterElemArr, ",");
+        clusterElemArr.appendList(elemForCluster, ",");
         ForEachItemIn(y, clusterElemArr)
           compClusterArr->append(clusterElemArr.item(y));
         m_compForTopology.setValue(m_clusterForTopology.item(x),compClusterArr);

--- a/deployment/envgen/main.cpp
+++ b/deployment/envgen/main.cpp
@@ -205,7 +205,7 @@ int main(int argc, char** argv)
     {
       i++;
       StringArray sbarr;
-      DelimToStringArray(argv[i++], sbarr, "=");
+      sbarr.appendList(argv[i++], "=");
       if (sbarr.length() != 2)
        continue;
 
@@ -269,7 +269,7 @@ int main(int argc, char** argv)
         for(unsigned i = 0; i < overrides.ordinality() ; i++)
         {
           StringArray sbarr;
-          DelimToStringArray(overrides.item(i), sbarr, ",");
+          sbarr.appendList(overrides.item(i), ",");
 
           if (sbarr.length() != 3)
           {

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -579,7 +579,7 @@ void getEspUrlParams(IEspContext& ctx, StringBuffer& params, const char* exclude
         if (querystr)
         {
             StringArray ps;
-            DelimToStringArray(querystr,ps,"&",true);
+            ps.appendListUniq(querystr, "&");
             for (unsigned int i=0; i<ps.ordinality(); i++)
             {
                 const char* item = ps.item(i);

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -2697,7 +2697,7 @@ bool CWsDeployFileInfo::getValue(IEspContext &context, IEspGetValueRequest &req,
     if(pszparams && *pszparams)
     {
       StringArray sArray;
-      DelimToStringArray(pszparams, sArray, ",");
+      sArray.appendList(pszparams, ",");
       for(unsigned i = 0; i < sArray.ordinality() ; i++)
       {
         if(!strcmp(sArray.item(i), "checklock"))
@@ -6531,7 +6531,7 @@ bool CWsDeployExCE::onGetValue(IEspContext &context, IEspGetValueRequest &req, I
     if(pszparams && *pszparams)
     {
       StringArray sArray;
-      DelimToStringArray(pszparams, sArray, ",");
+      sArray.appendList(pszparams, ",");
       for(unsigned i = 0; i < sArray.ordinality() ; i++)
       {
         if(!strcmp(sArray.item(i), "environment"))
@@ -6583,7 +6583,7 @@ bool CWsDeployExCE::onGetValue(IEspContext &context, IEspGetValueRequest &req, I
           if(pszAttrValue && *pszAttrValue)
           {
             StringArray sArray;
-            DelimToStringArray(pszAttrValue, sArray, ",");
+            sArray.appendList(pszAttrValue, ",");
             ForEachItemIn(x, sArray)
             {
               StringBuffer encryptedPasswd ;
@@ -7127,7 +7127,7 @@ bool CWsDeployEx::onGetValue(IEspContext &context, IEspGetValueRequest &req, IEs
     if(pszparams && *pszparams)
     {
       StringArray sArray;
-      DelimToStringArray(pszparams, sArray, ",");
+      sArray.appendList(pszparams, ",");
       for(unsigned i = 0; i < sArray.ordinality() ; i++)
       {
         if(!strcmp(sArray.item(i), "wizops"))
@@ -7245,8 +7245,8 @@ bool CWsDeployFileInfo::checkForRequiredComponents(IPropertyTree* pEnvRoot, cons
       algProps->getProp("comps_on_all_nodes", prop);
       algProps->getProp("exclude_from_comps_on_all_nodes", prop2);
 
-      DelimToStringArray(prop.str(), compOnAllNodes, ",");
-      DelimToStringArray(prop2.str(), compExcludeOnAllNodes, ",");
+      compOnAllNodes.appendList(prop.str(), ",");
+      compExcludeOnAllNodes.appendList(prop2.str(), ",");
 
       for (unsigned i = 0; buildSet != NULL && i < compExcludeOnAllNodes.ordinality(); i++)
       {

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -606,7 +606,7 @@ static void buildReqXml(StringStack& parent, IXmlType* type, StringBuffer& out, 
                 if (s && *s)
                 {
                     StringArray items;
-                    DelimToStringArray(s, items, "\n", false);
+                    items.appendList(s, "\n");
                     ForEachItemIn(i, items)
                         appendXMLTag(out, itemName, items.item(i));
                 }

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -125,7 +125,7 @@ void Cws_machineEx::init(IPropertyTree *cfg, const char *process, const char *se
     if (pchExcludePartitions && *pchExcludePartitions)
     {
         StringArray sPartitions;
-        DelimToStringArray(pchExcludePartitions, sPartitions, ", ;");
+        sPartitions.appendList(pchExcludePartitions, ", ;");
         unsigned int numOfPartitions = sPartitions.ordinality();
         for (unsigned int i=0; i<numOfPartitions; i++)
         {
@@ -273,13 +273,13 @@ void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcess
     machineInfoData.getOptions().setGetSoftwareInfo(getSoftwareInfo);
     machineInfoData.getOptions().setApplyProcessFilter(applyProcessFilter);
 
-    DelimToStringArray(addProcessesToFilters, machineInfoData.getOptions().getAdditionalProcessFilters(), " ,\t");
+    machineInfoData.getOptions().getAdditionalProcessFilters().appendList(addProcessesToFilters, " ,\t");
 
     BoolHash uniqueProcesses;
     for (unsigned i=0; i<processes.ordinality(); i++)
     {
         StringArray address;
-        DelimToStringArray(processes.item(i), address, ":");
+        address.appendList(processes.item(i), ":");
 
         StringBuffer address1, address2, processType, compName, path;
         unsigned processNumber = 0;
@@ -314,7 +314,7 @@ void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcess
     machineInfoData.getOptions().setGetSoftwareInfo(getSoftwareInfo);
     machineInfoData.getOptions().setApplyProcessFilter(applyProcessFilter);
 
-    DelimToStringArray(addProcessesToFilters, machineInfoData.getOptions().getAdditionalProcessFilters(), " ,\t");
+    machineInfoData.getOptions().getAdditionalProcessFilters().appendList(addProcessesToFilters, " ,\t");
 
     readSettingsForTargetClusters(context, targetClustersIn, machineInfoData, targetClusterTreeOut);
 }

--- a/esp/services/ws_machine/ws_machineServiceRexec.cpp
+++ b/esp/services/ws_machine/ws_machineServiceRexec.cpp
@@ -513,7 +513,7 @@ void Cws_machineEx::ConvertAddress( const char* originalAddress, StringBuffer& n
         throw MakeStringException(ECLWATCH_INVALID_IP_OR_COMPONENT, "No network address or computer name specified!");
 
     StringArray sArray;
-    DelimToStringArray(originalAddress, sArray, ":");
+    sArray.appendList(originalAddress, ":");
 
     if (sArray.ordinality() < 4)
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Incomplete arguments");
@@ -626,7 +626,7 @@ bool Cws_machineEx::doStartStop(IEspContext &context, StringArray& addresses, ch
 
         //address passed in is of the form "192.168.1.4:EspProcess:2:path1"
         StringArray sArray;
-        DelimToStringArray(addresses.item(index), sArray, ":");
+        sArray.appendList(addresses.item(index), ":");
 
         if (sArray.ordinality() < 4)
             throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Incomplete arguments");
@@ -775,7 +775,7 @@ void Cws_machineEx::updatePathInAddress(const char* address, StringBuffer& addrS
     addrStr.append(address);
 
     StringArray sArray;
-    DelimToStringArray(address, sArray, ":");
+    sArray.appendList(address, ":");
     const char* OS    = sArray.item(3);
     const char* Dir  = sArray.item(4);
     if (OS && *OS && Dir && *Dir)

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -411,7 +411,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 if (qname.length() > 0)
                 {
                     StringArray qlist;
-                    CslToStringArray(qname.str(), qlist, true);
+                    qlist.appendListUniq(qname.str(), ",");
                     ForEachItemIn(q, qlist)
                     {
                         const char *_qname = qlist.item(q);

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -1306,7 +1306,7 @@ bool CWsTopologyEx::onTpClusterInfo(IEspContext &context, IEspTpClusterInfoReque
             clusterInfo->getThorQueue(thorQueues);
             resp.setName(req.getName());
             StringArray qlist;
-            CslToStringArray(thorQueues.str(), qlist, true);
+            qlist.appendListUniq(thorQueues.str(), ",");
             IArrayOf<IEspTpQueue> Queues;
             // look for the thor processes which are listening to this clusters queue, some may be listening to other clusters queues as well.
             ForEachItemIn(q, qlist)
@@ -1319,7 +1319,7 @@ bool CWsTopologyEx::onTpClusterInfo(IEspContext &context, IEspTpClusterInfoReque
                     IPropertyTree &server = iter->query();
                     const char *queues = server.queryProp("@queue");
                     StringArray thorqlist;
-                    CslToStringArray(queues, thorqlist, true);
+                    thorqlist.appendListUniq(queues, ",");
                     if (NotFound != thorqlist.find(queueName))
                     {
                         IEspTpQueue* pQueue = createTpQueue("","");

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2220,7 +2220,7 @@ void doWUQueryFromArchive(IEspContext &context, ArchivedWuCache &archivedWuCache
                         continue;
 
                     StringArray wuidArray;
-                    CslToStringArray(csline, wuidArray, false);
+                    wuidArray.appendList(csline, ",");
 
                     if (chooseWuAccessFlagsByOwnership(context.queryUserId(), cmd->queryOwner(), accessOwn, accessOthers) < SecAccess_Read)
                         continue;

--- a/esp/tools/soapplus/EspLogDeserializer.cpp
+++ b/esp/tools/soapplus/EspLogDeserializer.cpp
@@ -163,7 +163,7 @@ static void LoadMethodMappings()
         else if (*p)
         {
             strArray.kill();
-            DelimToStringArray(p, strArray, "= \t()");
+            strArray.appendList(p, "= \t()");
 
             const unsigned int ord = strArray.ordinality();
             if (ord == 0)
@@ -218,7 +218,7 @@ static bool lookupMethod(const char* config, StringBuffer& service, StringBuffer
         else
         {
             StringArray strArray;
-            DelimToStringArray(s.str(), strArray, "/");
+            strArray.appendList(s.str(), "/");
             if (strArray.ordinality() < 2)
                 printf("Invalid configuration: %s", s.str());
             else

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1814,7 +1814,7 @@ FILESERVICES_API  char * FILESERVICES_CALL fsfPromoteSuperFileList(ICodeContext 
     }
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     StringArray toadd;
-    CslToStringArray(addhead,toadd,true);
+    toadd.appendListUniq(addhead, ",");
     StringBuffer addlist;
     ForEachItemIn(i1,toadd) {
         if (addlist.length())

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -835,7 +835,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
 #else
         topology->addPropBool("@linuxOS", true);
 #endif
-        CslToStringArray(topology->queryProp("@querySets"), allQuerySetNames, true);
+        allQuerySetNames.appendListUniq(topology->queryProp("@querySets"), ",");
         if (!numChannels)
             throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - numChannels attribute must be specified");
 

--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -1138,7 +1138,7 @@ static void CheckAllowedProgram(const char *prog,const char *allowed)
         head.append(*(prog++));
     }
     StringArray list;
-    CslToStringArray(allowed, list);
+    list.appendList(allowed, ",");
     ForEachItemIn(i,list) {
         if (WildMatch(head.str(),list.item(i)))
             return;

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -1219,7 +1219,7 @@ void JBASE32_Decode(const char *bi,StringBuffer &out)
 }
 
 
-void DelimToStringArray(const char *csl, StringArray &dst, const char * delim,bool deldup)
+static void DelimToStringArray(const char *csl, StringArray &dst, const char *delim, bool deldup)
 {
     if (!csl)
         return;
@@ -1266,9 +1266,14 @@ void DelimToStringArray(const char *csl, StringArray &dst, const char * delim,bo
     }
 }
 
-void CslToStringArray(const char *csl, StringArray &dst,bool deldup)
+void StringArray::appendList(const char *list, const char *delim)
 {
-    DelimToStringArray(csl, dst, NULL , deldup);
+    DelimToStringArray(list, *this, delim, false);
+}
+
+void StringArray::appendListUniq(const char *list, const char *delim)
+{
+    DelimToStringArray(list, *this, delim, true);
 }
 
 #ifdef _WIN32

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -139,14 +139,15 @@ extern jlib_decl StringBuffer& decodeUrlUseridPassword(StringBuffer& out, const 
 
 class StringArray : public ArrayOf<const char *, const char *>
 {
+public:
+    // Appends a list in a string delimited by 'delim'
+    void appendList(const char *list, const char *delim);
+    // Appends a list in a string delimited by 'delim' without duplicates
+    void appendListUniq(const char *list, const char *delim);
 };
 class CIStringArray : public StringArray, public CInterface
 {
 };
-
-// separated list to array
-extern jlib_decl void DelimToStringArray(const char *csl, StringArray &dst, const char * delim, bool deldup=false);
-extern jlib_decl void CslToStringArray(const char *csl, StringArray &dst, bool deldup=false);
 
 extern jlib_decl unsigned msTick();
 extern jlib_decl unsigned usTick();


### PR DESCRIPTION
Marking this global function static and adding a method (that uses it)
on StringArray class. This makes it easier for developers to find a way
to populate the array with a CSV list, since it follows the rest of the
ArrayOf<> API style.

Signed-off-by: Renato Golin rengolin@hpccsystems.com
