### PR TITLE
HPCC-3298 Fix problems accessing SHARED symbols

### DIFF
--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -418,6 +418,7 @@
 #define ERR_COUNTER_NOT_COUNT       2387
 #define HQLERR_CannotSubmitMacroX   2388
 #define HQLERR_CannotBeGrouped      2389
+#define HQLERR_CannotAccessShared   2390
 
 #define ERR_ASSERTION_FAILS         100000
 

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -786,6 +786,8 @@ protected:
     void expandScopeEntries(HqlExprArrayArray & branches, IHqlExpression * scope);
     void processIfScope(const attribute & errpos, IHqlExpression * cond, IHqlExpression * trueScope, IHqlExpression * falseScope);
 
+    unsigned extraLookupFlags(IHqlScope * scope);
+
     void appendTransformOption(IHqlExpression * expr) 
     { 
         if (curTransform)

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -3070,6 +3070,13 @@ IHqlExpression *HqlGram::lookupSymbol(IHqlScope * scope, _ATOM searchName)
     return scope->lookupSymbol(searchName, LSFpublic, lookupCtx);
 }
 
+unsigned HqlGram::extraLookupFlags(IHqlScope * scope)
+{
+    if (scope == containerScope)
+        return LSFsharedOK;
+    return 0;
+}
+
 IHqlExpression *HqlGram::lookupSymbol(_ATOM searchName, const attribute& errpos)
 {
 #if 0
@@ -3123,7 +3130,10 @@ IHqlExpression *HqlGram::lookupSymbol(_ATOM searchName, const attribute& errpos)
 
         if (modScope)
         {
-            return modScope->lookupSymbol(searchName, LSFrequired, lookupCtx);
+            OwnedHqlExpr resolved = modScope->lookupSymbol(searchName, LSFrequired|LSFsharedOK, lookupCtx);
+            if (resolved && (modScope != containerScope) && !isExported(resolved))
+                reportError(HQLERR_CannotAccessShared, errpos, "Cannot access SHARED symbol '%s' in another module", searchName->str());
+            return resolved.getClear();
         }
 
         // Then come implicitly defined fields...
@@ -3220,7 +3230,7 @@ IHqlExpression *HqlGram::lookupSymbol(_ATOM searchName, const attribute& errpos)
         ForEachItemIn(idx2, defaultScopes)
         {
             IHqlScope &plugin = defaultScopes.item(idx2);
-            IHqlExpression *ret = plugin.lookupSymbol(searchName, LSFpublic, lookupCtx);
+            IHqlExpression *ret = plugin.lookupSymbol(searchName, LSFpublic|extraLookupFlags(&plugin), lookupCtx);
             if (ret)
             {
                 recordLookupInTemplateContext(searchName, ret, templateScope);

--- a/ecl/regress/shared.eclxml
+++ b/ecl/regress/shared.eclxml
@@ -1,0 +1,31 @@
+<Archive legacyMode="0">
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <Module name="common">
+  <Attribute name="v1">
+import $ as common;  
+export v1 := common.v2 * 100;
+  </Attribute>
+  <Attribute name="v2">
+SHARED v2 := 100;
+  </Attribute>
+ </Module>
+ <Query>
+    import common;
+ output(common.v1);
+ </Query>
+</Archive>

--- a/ecl/regress/shared2.eclxml
+++ b/ecl/regress/shared2.eclxml
@@ -1,0 +1,31 @@
+<Archive legacyMode="0">
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <Module name="common">
+  <Attribute name="v1">
+import * FROM $;  
+export v1 := v2 * 100;
+  </Attribute>
+  <Attribute name="v2">
+SHARED v2 := 100;
+  </Attribute>
+ </Module>
+ <Query>
+    import common;
+ output(common.v1);
+ </Query>
+</Archive>

--- a/ecl/regress/shared3e.eclxml
+++ b/ecl/regress/shared3e.eclxml
@@ -1,0 +1,34 @@
+<Archive legacyMode="0">
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <Module name="common">
+  <Attribute name="v1">
+import other;  
+//Illegal access to a SHARED in another module.
+export v1 := other.v2 * 100;
+  </Attribute>
+ </Module>
+ <Module name="other">
+  <Attribute name="v2">
+SHARED v2 := 100;
+  </Attribute>
+ </Module>
+ <Query>
+    import common;
+ output(common.v1);
+ </Query>
+</Archive>


### PR DESCRIPTION
The code to access SHARED symbols from a global module/folder wasn't working
correctly.  This fix allows access to SHARED symbols, and reports a better
error message if trying to explicitly access a SHARED symbol in another module.

The test cases shared.eclxml, shared2.eclxml contain code that didn't work,
Shared3.eclxml is an example which reports the better error message.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
