### PR TITLE
HPCC-7819 Create temp files in per-user directory

### DIFF
--- a/common/roxiehelper/roxiehelper.cpp
+++ b/common/roxiehelper/roxiehelper.cpp
@@ -27,6 +27,9 @@
 #include "dafdesc.hpp"
 #include "dadfs.hpp"
 
+#include "mpbase.hpp"
+#include "dautils.hpp"
+
 unsigned traceLevel = 0;
 
 //OwnedRowArray
@@ -1324,11 +1327,25 @@ ROXIEHELPER_API IOrderedOutputSerializer * createOrderedOutputSerializer(FILE * 
 
 //=====================================================================================================
 
-ROXIEHELPER_API StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, const char * wuid, unsigned int flags)
+ROXIEHELPER_API StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, const char * wuid, IUserDescriptor *userDesc, unsigned int flags)
 {
-    out = in;
     if (flags & (TDXtemporary | TDXjobtemp))
-        out.append("__").append(wuid);
+    {
+        if (in && *in=='~')
+            in++;
+        StringBuffer sb(queryDfsXmlBranchName(DXB_Internal));
+        out.append("~").append(sb.str()).append("::");
+        if (userDesc)
+        {
+            sb.clear();
+            userDesc->getUserName(sb);
+            if (sb.length())
+                out.append(sb.str()).append("::");
+        }
+        out.append(in).append("__").append(wuid);
+    }
+    else
+        out = in;
     return out;
 }
 

--- a/common/roxiehelper/roxiehelper.hpp
+++ b/common/roxiehelper/roxiehelper.hpp
@@ -210,7 +210,7 @@ private:
 
 //==============================================================================================================
 
-ROXIEHELPER_API StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, const char * wuid, unsigned int flags);
+ROXIEHELPER_API StringBuffer & mangleHelperFileName(StringBuffer & out, const char * in, const char * wuid, IUserDescriptor *userDesc, unsigned int flags);
 ROXIEHELPER_API StringBuffer & mangleLocalTempFilename(StringBuffer & out, char const * in);
 ROXIEHELPER_API StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fname, IConstWorkUnit * wu, bool resolveLocally);
 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1498,7 +1498,7 @@ __int64 EclAgent::countDiskFile(__int64 id, IHThorCountFileArg & arg)
     }
 
     StringBuffer mangled;
-    mangleHelperFileName(mangled, arg.getFileName(), queryWuid(), arg.getFlags());
+    mangleHelperFileName(mangled, arg.getFileName(), queryWuid(), queryUserDescriptor(), arg.getFlags());
     Owned<ILocalOrDistributedFile> ldFile = resolveLFN(mangled, "CountDisk", 0 != (arg.getFlags() & TDRoptional));
     if (ldFile) 
     {

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -401,7 +401,7 @@ void CHThorDiskWriteActivity::done()
 
 void CHThorDiskWriteActivity::resolve()
 {
-    mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent.queryWuid(), helper.getFlags());
+    mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent.queryWuid(),agent.queryCodeContext()->queryUserDescriptor(), helper.getFlags());
     assertex(mangledHelperFileName.str());
     if((helper.getFlags() & (TDXtemporary | TDXjobtemp)) == 0)
     {
@@ -7567,7 +7567,7 @@ void CHThorDiskReadBaseActivity::done()
 
 void CHThorDiskReadBaseActivity::resolve()
 {
-    mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent.queryWuid(), helper.getFlags());
+    mangleHelperFileName(mangledHelperFileName, helper.getFileName(), agent.queryWuid(), agent.queryCodeContext()->queryUserDescriptor(), helper.getFlags());
     if (helper.getFlags() & (TDXtemporary | TDXjobtemp))
     {
         StringBuffer mangledFilename;


### PR DESCRIPTION
In order to prevent other users from seeing a particular user's temp files,
place them in a private scope that can be restricted via LDAP permissions

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
