### PR TITLE
HPCC-7834 Temporarily dump stack trace if default dali user

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1052,7 +1052,19 @@ static int getScopePermissions(const char *scopename,IUserDescriptor *user,unsig
     int ret = 255;
     if (permissionsavail&&scopename&&*scopename&&((*scopename!='.')||scopename[1])) {
         if (!user)
+        {
+#ifdef _DALIUSER_STACKTRACE
+            //following debug code to be removed
+            StringBuffer sb;
+            user->getUserName(sb);
+            if (0==sb.length() || !strcmpi(sb.str(), "daliuser"))
+            {
+                DBGLOG("UNEXPECTED USER '%s' in %s line %ld",sb.str(),__FILE__, __LINE__);
+                PrintStackReport();
+            }
+#endif
             user = queryDistributedFileDirectory().queryDefaultUser();
+        }
         ret = querySessionManager().getPermissionsLDAP(queryDfsXmlBranchName(DXB_Scope),scopename,user,auditflags);
         if (ret<0) {
             if (ret==-1) {

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -508,6 +508,16 @@ public:
                 StringAttr passwordenc;
                 mb.read(key).read(obj);
                 udesc->deserialize(mb);
+#ifdef _DALIUSER_STACKTRACE
+                //following debug code to be removed
+                StringBuffer sb;
+                udesc->getUserName(sb);
+                if (0==sb.length() || !strcmpi(sb.str(), "daliuser"))
+                {
+                    DBGLOG("UNEXPECTED USER '%s' in %s line %ld",username,__FILE__, __LINE__);
+                    PrintStackReport();
+                }
+#endif
                 unsigned auditflags = 0;
                 if (mb.length()-mb.getPos()>=sizeof(auditflags))
                     mb.read(auditflags);
@@ -761,6 +771,16 @@ public:
         CMessageBuffer mb;
         mb.append((int)MSR_LOOKUP_LDAP_PERMISSIONS);
         mb.append(key).append(obj);
+#ifdef _DALIUSER_STACKTRACE
+        //following debug code to be removed
+        StringBuffer sb;
+        udesc->getUserName(sb);
+        if (0==sb.length() || !strcmpi(sb.str(), "daliuser"))
+        {
+            DBGLOG("UNEXPECTED USER '%s' in %s line %ld",sb.str(),__FILE__, __LINE__);
+            PrintStackReport();
+        }
+#endif
         udesc->serialize(mb);
         mb.append(auditflags);
         if (!queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DALI_SESSION_REQUEST,SESSIONREPLYTIMEOUT))

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -122,6 +122,11 @@ public:
                 udesc->getPassword(password);
             }
             if (username.length()==0)  {
+#ifdef _DALIUSER_STACKTRACE
+                //following debug code to be removed
+                DBGLOG("UNEXPECTED USER '%s' in %s line %ld",NULL,__FILE__, __LINE__);
+                PrintStackReport();
+#endif
                 username.append(filesdefaultuser);
                 decrypt(password, filesdefaultpassword);
             }

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1182,6 +1182,14 @@ public:
             {
                 DBGLOG("LdapBind for user %s (retries=%d).", username, retries);
                 {
+#ifdef _DALIUSER_STACKTRACE
+                    //following debug code to be removed
+                    if (!username || !strcmpi(username, "daliuser"))
+                    {
+                        DBGLOG("UNEXPECTED USER '%s' in %s line %ld",username,__FILE__, __LINE__);
+                        PrintStackReport();
+                    }
+#endif
                     LDAP* user_ld = LdapUtils::LdapInit(m_ldapconfig->getProtocol(), hostbuf.str(), m_ldapconfig->getLdapPort(), m_ldapconfig->getLdapSecurePort());
                     rc = LdapUtils::LdapBind(user_ld, m_ldapconfig->getDomain(), username, password, userdnbuf.str(), m_ldapconfig->getServerType(), m_ldapconfig->getAuthMethod());
                     ldap_unbind(user_ld);


### PR DESCRIPTION
In order to help trace the source of the spurious usage of the default
"daliuser" credentials, it would be helpful to (temporarily) log a stack
trace of how we get to that point, hoping to narrow in on the offending
code.
This commit introduces checks in key areas, and logs the stack when the
user is NULL or "daliuser".  The intent is that this code be removed in
subsequent builds when the problem is resolved.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
