### PR TITLE
HPCC-3078 Add preflight option to display usage of mounted disks

### DIFF
--- a/common/monitoring/preflight
+++ b/common/monitoring/preflight
@@ -24,10 +24,11 @@ declare -a arrPIDPath
 declare -a arrDep
 
 if [ $# -lt 2 ]; then
-    echo usage: $0 -p=PIDPath[,PIDPath,...] -n=PIDName[,PIDName,...] [-d=dependency,dependency,...]
+    echo usage: $0 -p=PIDPath[,PIDPath,...] -n=PIDName[,PIDName,...] [-m=YES/NO] [-d=dependency,dependency,...]
     exit 1
 fi
 
+dfOption='-l'
 depAll=0
 for (( i=1;$i<=$#;i=$i+1 )) do
     case ${!i:0:3} in '-p=')
@@ -39,6 +40,11 @@ for (( i=1;$i<=$#;i=$i+1 )) do
                 depAll=1
             else
                 IFS=, read -a arrDep <<< "${!i:3}"
+            fi
+            ;;
+        '-m=')
+            if [ "${!i:3}" == 'YES' ]; then
+                dfOption='-a'
             fi
             ;;
         *)
@@ -68,17 +74,17 @@ echo Physical Memory: $mem
 echo Virtual Memory: $swap
 
 i=0
-for name in `df -l | tail -n +2 | awk '{if(NF>=4) print $NF}'`; do
+for name in `df $dfOption | tail -n +2 | awk '{if(NF>=4) print $NF}'`; do
     arr0[i]=$name
     i=$((i+1))
 done
 i=0
-for used in `df -l | tail -n +2 | awk '{if(NF>=4) print $(NF-3)}'`; do
+for used in `df $dfOption | tail -n +2 | awk '{if(NF>=4) print $(NF-3)}'`; do
     arr1[i]=$used
     i=$((i+1))
 done
 i=0
-for free in `df -l | tail -n +2 | awk '{if(NF>=4) print $(NF-2)}'`; do
+for free in `df $dfOption | tail -n +2 | awk '{if(NF>=4) print $(NF-2)}'`; do
     arr2[i]=$free
     i=$((i+1))
 done

--- a/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
+++ b/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
@@ -306,6 +306,7 @@
                                    <xsl:with-param name="getProcessorInfo" select="boolean(RequestInfo/GetProcessorInfo=1)"/>
                                    <xsl:with-param name="getSoftwareInfo" select="boolean(RequestInfo/GetSoftwareInfo=1)"/>
                                    <xsl:with-param name="getStorageInfo" select="boolean(RequestInfo/GetStorageInfo=1)"/>
+                                   <xsl:with-param name="localFileSystemsOnly" select="boolean(RequestInfo/LocalFileSystemsOnly=1)"/>
                                    <xsl:with-param name="applyProcessFilter" select="boolean(RequestInfo/ApplyProcessFilter=1)"/>
                                    <xsl:with-param name="addProcessesToFilter" select="RequestInfo/AddProcessesToFilter"/>
                                    <xsl:with-param name="securityString" select="RequestInfo/SecurityString"/>

--- a/esp/scm/ws_machine.ecm
+++ b/esp/scm/ws_machine.ecm
@@ -35,6 +35,7 @@ ESPrequest GetMachineInfoRequest
    bool   ApplyProcessFilter;
    bool   GetProcessorInfo;
    bool   GetStorageInfo;
+   [min_ver("1.11")] bool LocalFileSystemsOnly;
    bool   GetSoftwareInfo;
    int    MemThreshold;
    int    DiskThreshold;
@@ -62,6 +63,7 @@ ESPstruct RequestInfoStruct
    bool   ApplyProcessFilter;
    bool   GetProcessorInfo;
    bool   GetStorageInfo;
+   [min_ver("1.11")] bool LocalFileSystemsOnly;
    bool   GetSoftwareInfo;
    int    MemThreshold;
    int    DiskThreshold;
@@ -86,9 +88,9 @@ ESPstruct StorageInfo
 {
    string Description;
    string Type;
-   int    Available;
+   int64  Available;
    int    PercentAvail;
-   int    Total;
+   int64  Total;
    int    Failures;
 };
 
@@ -277,6 +279,7 @@ ESPrequest GetTargetClusterInfoRequest
     bool   ApplyProcessFilter;
     bool   GetProcessorInfo;
     bool   GetStorageInfo;
+    [min_ver("1.11")] bool LocalFileSystemsOnly;
     bool   GetSoftwareInfo;
     int    MemThreshold;
     int    DiskThreshold;
@@ -301,7 +304,7 @@ ESPresponse [encode(0), exceptions_inline] GetTargetClusterInfoResponse
     string TimeStamp;
 };
 //-------- service ---------
-ESPservice [version("1.10"), default_client_version("1.10")] ws_machine
+ESPservice [version("1.11"), default_client_version("1.11")] ws_machine
 {
     ESPuses ESPstruct RequestInfoStruct;
     ESPuses ESPstruct MachineInfoEx;

--- a/esp/services/ws_machine/machines.xslt
+++ b/esp/services/ws_machine/machines.xslt
@@ -269,6 +269,7 @@
                                            <xsl:with-param name="getProcessorInfo" select="boolean(RequestInfo/GetProcessorInfo=1)"/>
                                            <xsl:with-param name="getSoftwareInfo" select="boolean(RequestInfo/GetSoftwareInfo=1)"/>
                                            <xsl:with-param name="getStorageInfo" select="boolean(RequestInfo/GetStorageInfo=1)"/>
+                                           <xsl:with-param name="localFileSystemsOnly" select="boolean(RequestInfo/LocalFileSystemsOnly=1)"/>
                                            <xsl:with-param name="applyProcessFilter" select="boolean(RequestInfo/ApplyProcessFilter=1)"/>
                                            <xsl:with-param name="addProcessesToFilter" select="RequestInfo/AddProcessesToFilter"/>
                                           <xsl:with-param name="enableSNMP" select="number(RequestInfo/EnableSNMP)"/>

--- a/esp/services/ws_machine/preflightControls.xslt
+++ b/esp/services/ws_machine/preflightControls.xslt
@@ -46,12 +46,13 @@
             showPreflightControl(method);
             var cbGetSoftwareInfo = document.getElementById("GetSoftwareInfo");
             onGetSoftwareInfo(cbGetSoftwareInfo);            
+            onGetStorageInfo(document.getElementById("GetStorageInfo"));
          }
          
          function reloadPage() {
              document.forms['listitems'].submit();
          }
-                  
+
          function setReloadTimeout(mins) {
              if (reloadTimeout != mins && allowReloadPage) {
                 if (reloadTimer) {              
@@ -130,6 +131,11 @@
               }
             }
          } 
+
+         function onGetStorageInfo(cb)
+         {
+            document.getElementById("LocalFileSystemsOnly").disabled = !cb.checked;
+         }
          
          function onGetSoftwareInfo(cb)
          {
@@ -297,6 +303,7 @@
     <xsl:param name="getProcessorInfo" select="1"/>
     <xsl:param name="getSoftwareInfo" select="1"/>
     <xsl:param name="getStorageInfo" select="1"/>
+    <xsl:param name="localFileSystemsOnly" select="1"/>
     <xsl:param name="applyProcessFilter" select="1"/>
     <xsl:param name="addProcessesToFilter"/>
     <xsl:param name="enableSNMP"/>
@@ -383,7 +390,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <input type="checkbox" name="GetStorageInfo" align="left" value="1">
+                        <input type="checkbox" id="GetStorageInfo" name="GetStorageInfo" align="left" value="1" onclick="onGetStorageInfo(this)">
                             <xsl:if test="$getStorageInfo">
                                 <xsl:attribute name="checked"/>
                             </xsl:if>
@@ -407,6 +414,15 @@
                                 <xsl:text>MB</xsl:text>
                             </option>
                         </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td col="2" align="center">
+                        <input type="checkbox" id="LocalFileSystemsOnly" name="LocalFileSystemsOnly" value="1">
+                            <xsl:if test="$localFileSystemsOnly">
+                                <xsl:attribute name="checked"/>
+                            </xsl:if>
+                        </input><xsl:text>Local File Systems Only</xsl:text>
                     </td>
                 </tr>
                 <tr>

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -192,7 +192,7 @@ bool Cws_machineEx::onGetMachineInfo(IEspContext &context, IEspGetMachineInfoReq
             throw MakeStringException(ECLWATCH_INVALID_IP_OR_COMPONENT, "No network address specified.");
 
         CGetMachineInfoData machineInfoData;
-        readMachineInfoRequest(context, req.getGetProcessorInfo(), req.getGetStorageInfo(), req.getGetSoftwareInfo(),
+        readMachineInfoRequest(context, req.getGetProcessorInfo(), req.getGetStorageInfo(), req.getLocalFileSystemsOnly(), req.getGetSoftwareInfo(),
             req.getApplyProcessFilter(), addresses, req.getAddProcessesToFilter(), machineInfoData);
         getMachineInfo(context, machineInfoData);
         setMachineInfoResponse(context, req, machineInfoData, resp);
@@ -217,7 +217,7 @@ bool Cws_machineEx::onGetMachineInfoEx(IEspContext &context, IEspGetMachineInfoR
             throw MakeStringException(ECLWATCH_INVALID_IP_OR_COMPONENT, "No network address specified.");
 
         CGetMachineInfoData machineInfoData;
-        readMachineInfoRequest(context, true, true, true, true, addresses, NULL, machineInfoData);
+        readMachineInfoRequest(context, true, true, true, true, true, addresses, NULL, machineInfoData);
         getMachineInfo(context, machineInfoData);
         if (machineInfoData.getMachineInfoTable().ordinality())
             resp.setMachines(machineInfoData.getMachineInfoTable());
@@ -243,7 +243,7 @@ bool Cws_machineEx::onGetTargetClusterInfo(IEspContext &context, IEspGetTargetCl
 
         CGetMachineInfoData machineInfoData;
         Owned<IPropertyTree> targetClustersOut = createPTreeFromXMLString("<Root/>");
-        readMachineInfoRequest(context, req.getGetProcessorInfo(), req.getGetStorageInfo(), req.getGetSoftwareInfo(),
+        readMachineInfoRequest(context, req.getGetProcessorInfo(), req.getGetStorageInfo(), req.getLocalFileSystemsOnly(), req.getGetSoftwareInfo(),
             req.getApplyProcessFilter(), req.getAddProcessesToFilter(), targetClusters, machineInfoData, targetClustersOut);
         getMachineInfo(context, machineInfoData);
         setTargetClusterInfoResponse(context, req, machineInfoData, targetClustersOut, resp);
@@ -259,7 +259,7 @@ bool Cws_machineEx::onGetTargetClusterInfo(IEspContext &context, IEspGetTargetCl
 // Read Machine Infomation request and collect related settings from environment.xml  //
 ////////////////////////////////////////////////////////////////////////////////////////
 
-void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcessorInfo, bool getStorageInfo, bool getSoftwareInfo, bool applyProcessFilter,
+void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcessorInfo, bool getStorageInfo, bool localFileSystemsOnly, bool getSoftwareInfo, bool applyProcessFilter,
                                            StringArray& processes, const char* addProcessesToFilters, CGetMachineInfoData& machineInfoData)
 {
     StringBuffer userID, password;
@@ -270,6 +270,7 @@ void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcess
 
     machineInfoData.getOptions().setGetProcessorInfo(getProcessorInfo);
     machineInfoData.getOptions().setGetStorageInfo(getStorageInfo);
+    machineInfoData.getOptions().setLocalFileSystemsOnly(localFileSystemsOnly);
     machineInfoData.getOptions().setGetSoftwareInfo(getSoftwareInfo);
     machineInfoData.getOptions().setApplyProcessFilter(applyProcessFilter);
 
@@ -300,7 +301,7 @@ void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcess
 }
 
 
-void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcessorInfo, bool getStorageInfo, bool getSoftwareInfo, bool applyProcessFilter,
+void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcessorInfo, bool getStorageInfo, bool localFileSystemsOnly, bool getSoftwareInfo, bool applyProcessFilter,
                                            const char* addProcessesToFilters, StringArray& targetClustersIn, CGetMachineInfoData& machineInfoData, IPropertyTree* targetClusterTreeOut)
 {
     StringBuffer userID, password;
@@ -311,6 +312,7 @@ void Cws_machineEx::readMachineInfoRequest(IEspContext& context, bool getProcess
 
     machineInfoData.getOptions().setGetProcessorInfo(getProcessorInfo);
     machineInfoData.getOptions().setGetStorageInfo(getStorageInfo);
+    machineInfoData.getOptions().setLocalFileSystemsOnly(localFileSystemsOnly);
     machineInfoData.getOptions().setGetSoftwareInfo(getSoftwareInfo);
     machineInfoData.getOptions().setApplyProcessFilter(applyProcessFilter);
 
@@ -913,6 +915,8 @@ void Cws_machineEx::buildPreflightCommand(IEspContext& context, CMachineInfoThre
 
     if (checkDependency || !pParam->m_options.getApplyProcessFilter())
         preflightCommand.append(" -d=ALL");
+    if (pParam->m_options.getGetStorageInfo() && !pParam->m_options.getLocalFileSystemsOnly())
+        preflightCommand.append(" -m=YES");
 }
 
 int Cws_machineEx::runCommand(IEspContext& context, const char* sAddress, const char* sConfigAddress, EnvMachineOS os,
@@ -1824,6 +1828,9 @@ void Cws_machineEx::setMachineInfoResponse(IEspContext& context, IEspGetMachineI
     reqInfo.setSecurityString(req.getSecurityString());
     reqInfo.setGetProcessorInfo(req.getGetProcessorInfo());
     reqInfo.setGetStorageInfo(req.getGetStorageInfo());
+    double version = context.getClientVersion();
+    if (version > 1.10)
+        reqInfo.setLocalFileSystemsOnly(req.getLocalFileSystemsOnly());
     reqInfo.setGetSoftwareInfo(req.getGetSoftwareInfo());
     reqInfo.setAutoRefresh( req.getAutoRefresh() );
     reqInfo.setMemThreshold(req.getMemThreshold());
@@ -1881,6 +1888,9 @@ void Cws_machineEx::setTargetClusterInfoResponse(IEspContext& context, IEspGetTa
 #endif
     reqInfo.setGetProcessorInfo(req.getGetProcessorInfo());
     reqInfo.setGetStorageInfo(req.getGetStorageInfo());
+    double version = context.getClientVersion();
+    if (version > 1.10)
+        reqInfo.setLocalFileSystemsOnly(req.getLocalFileSystemsOnly());
     reqInfo.setGetSoftwareInfo(req.getGetSoftwareInfo());
     reqInfo.setAutoRefresh( req.getAutoRefresh() );
     reqInfo.setMemThreshold(req.getMemThreshold());

--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -493,6 +493,7 @@ class CGetMachineInfoUserOptions : public CInterface
     StringBuffer m_password;
     bool         m_getProcessorInfo;
     bool         m_getStorageInfo;
+    bool         m_localFileSystemsOnly;
     bool         m_getSoftwareInfo;
     bool         m_applyProcessFilter;
     StringArray  m_additionalProcessFilters; //A user may add them using edit box 'Additional processes to filter:'.
@@ -505,6 +506,7 @@ public:
         m_password.clear();
         m_getProcessorInfo = true;
         m_getStorageInfo = true;
+        m_localFileSystemsOnly = true;
         m_getSoftwareInfo = true;
         m_applyProcessFilter = true;
     }
@@ -548,6 +550,16 @@ public:
     const bool getGetStorageInfo()
     {
         return m_getStorageInfo;
+    }
+
+    void setLocalFileSystemsOnly(bool localFileSystemsOnly)
+    {
+        m_localFileSystemsOnly = localFileSystemsOnly;
+    }
+
+    const bool getLocalFileSystemsOnly()
+    {
+        return m_localFileSystemsOnly;
     }
 
     void setGetSoftwareInfo(bool getSoftwareInfo)
@@ -656,8 +668,8 @@ private:
     void getProcessDisplayName(const char* processName, StringBuffer& displayName);
     void readALineFromResult(const char *result, const char *start, StringBuffer& value, bool bTrim = true);
 
-    void readMachineInfoRequest(IEspContext& context, bool getProcessorInfo, bool getStorageInfo, bool getSwInfo, bool applyProcessFilter, StringArray& addresses, const char* addProcessesToFilters, CGetMachineInfoData& machineInfoData);
-    void readMachineInfoRequest(IEspContext& context, bool getProcessorInfo, bool getStorageInfo, bool getSwInfo, bool applyProcessFilter, const char* addProcessesToFilters, StringArray& targetClustersIn, CGetMachineInfoData& machineInfoData, IPropertyTree* targetClustersOut);
+    void readMachineInfoRequest(IEspContext& context, bool getProcessorInfo, bool getStorageInfo, bool localFileSystemsOnly, bool getSwInfo, bool applyProcessFilter, StringArray& addresses, const char* addProcessesToFilters, CGetMachineInfoData& machineInfoData);
+    void readMachineInfoRequest(IEspContext& context, bool getProcessorInfo, bool getStorageInfo, bool localFileSystemsOnly, bool getSwInfo, bool applyProcessFilter, const char* addProcessesToFilters, StringArray& targetClustersIn, CGetMachineInfoData& machineInfoData, IPropertyTree* targetClustersOut);
     void getMachineInfo(IEspContext& context, CGetMachineInfoData& machineInfoData);
     void setMachineInfoResponse(IEspContext& context, IEspGetMachineInfoRequest& req, CGetMachineInfoData& machineInfoData, IEspGetMachineInfoResponse& resp);
     void setTargetClusterInfoResponse(IEspContext& context, IEspGetTargetClusterInfoRequest& req, CGetMachineInfoData& machineInfoData, IPropertyTree* targetClusterTree, IEspGetTargetClusterInfoResponse& resp);


### PR DESCRIPTION
The existing Preflight function does not check (and not display)
the usage of mounted disks. In this fix, preflight script and
EclWatch UI are upgraded, which allows a user to specify whether
the usage of mounted disks is checked or not.

This fix also cleans two compiler warnings in this ESP service.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
