### PR TITLE
HPCC-7836 Changes to docs to remove or replace IE-7

### DIFF
--- a/docs/HPCCClientTools/CT_Mods/CT_Overview.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Overview.xml
@@ -139,7 +139,7 @@
 
       <para>The optional Tutorial Data File is 100 MB.</para>
 
-      <para>In addition, you will need Internet Explorer 7 and have Active
+      <para>In addition, you will need Internet Explorer 8 and have Active
       Scripting support enabled (Javascript). If browser security is set to
       High, you should add the ECLWatch IP (or DNS name) as a Trusted
       Site.</para>

--- a/docs/HPCCClientTools/CT_Mods/CT_Overview_withoutIDE.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Overview_withoutIDE.xml
@@ -14,8 +14,6 @@
       <colspec />
 
       <tbody>
-       
-       
         <row>
           <entry><emphasis role="bold">ECLPlus</emphasis></entry>
 
@@ -99,8 +97,8 @@
       <title><emphasis>Installation</emphasis></title>
 
       <para>The installation program installs all client tools, including the
-      ECLPlus, DFUPlus, and RoxieConfig. The installation program
-      provides the option to select which tools to install.</para>
+      ECLPlus, DFUPlus, and RoxieConfig. The installation program provides the
+      option to select which tools to install.</para>
 
       <itemizedlist mark="bullet">
         <listitem>
@@ -127,7 +125,7 @@
 
       <para>The optional Tutorial Data File is 100 MB.</para>
 
-      <para>In addition, you will need Internet Explorer 7 and have Active
+      <para>In addition, you will need Internet Explorer 8 and have Active
       Scripting support enabled (Javascript). If browser security is set to
       High, you should add the ECLWatch IP (or DNS name) as a Trusted
       Site.</para>
@@ -135,8 +133,8 @@
       <para>Adobe Reader 5 (or higher) is required to view the documentation
       PDF files.</para>
 
-      <para>GVC Viewer is used to display graphs in ECL Watch, and RoxieConfig GUI. 
-      It is installed automatically.</para>
+      <para>GVC Viewer is used to display graphs in ECL Watch, and RoxieConfig
+      GUI. It is installed automatically.</para>
     </sect2>
   </sect1>
 </chapter>

--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -528,7 +528,7 @@
 
           <itemizedlist spacing="compact">
             <listitem>
-              <para>Internet Explorer® 7 (or later)</para>
+              <para>Internet Explorer® 8 (or later)</para>
             </listitem>
 
             <listitem>

--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -139,7 +139,7 @@
         </listitem>
 
         <listitem>
-          <para>Internet Explorer<superscript>®</superscript> 7, Google Chrome
+          <para>Internet Explorer<superscript>®</superscript> 8, Google Chrome
           10, or Firefox™ 3.0 (or later)</para>
         </listitem>
       </itemizedlist>


### PR DESCRIPTION
Changes to the documentation to remove or replace references
in the doc to IE 7 where appropriate will be replaced with IE 8.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
