### PR TITLE
HPCC-7838 - stack dump changes break in string function

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1057,7 +1057,7 @@ static int getScopePermissions(const char *scopename,IUserDescriptor *user,unsig
             //following debug code to be removed
             StringBuffer sb;
             user->getUserName(sb);
-            if (0==sb.length() || !strcmpi(sb.str(), "daliuser"))
+            if (0==sb.length() || !stricmp(sb.str(), "daliuser"))
             {
                 DBGLOG("UNEXPECTED USER '%s' in %s line %ld",sb.str(),__FILE__, __LINE__);
                 PrintStackReport();

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -512,7 +512,7 @@ public:
                 //following debug code to be removed
                 StringBuffer sb;
                 udesc->getUserName(sb);
-                if (0==sb.length() || !strcmpi(sb.str(), "daliuser"))
+                if (0==sb.length() || !stricmp(sb.str(), "daliuser"))
                 {
                     DBGLOG("UNEXPECTED USER '%s' in %s line %ld",username,__FILE__, __LINE__);
                     PrintStackReport();
@@ -775,7 +775,7 @@ public:
         //following debug code to be removed
         StringBuffer sb;
         udesc->getUserName(sb);
-        if (0==sb.length() || !strcmpi(sb.str(), "daliuser"))
+        if (0==sb.length() || !stricmp(sb.str(), "daliuser"))
         {
             DBGLOG("UNEXPECTED USER '%s' in %s line %ld",sb.str(),__FILE__, __LINE__);
             PrintStackReport();

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1184,7 +1184,7 @@ public:
                 {
 #ifdef _DALIUSER_STACKTRACE
                     //following debug code to be removed
-                    if (!username || !strcmpi(username, "daliuser"))
+                    if (!username || !stricmp(username, "daliuser"))
                     {
                         DBGLOG("UNEXPECTED USER '%s' in %s line %ld",username,__FILE__, __LINE__);
                         PrintStackReport();


### PR DESCRIPTION
Recent bug fix introduced break in strcmpi, should be using stricmp

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
