### PR TITLE
HPCC-3328 Increase dafilesrv file handle hard limit

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -383,7 +383,7 @@ createRuntime() {
     chown -cR $user:$group "${dir_return}"  1> /dev/null 2>/dev/null
 
     # setting up ulimit for thor and other component which needs it.
-    ulimit -n 8192
+    ulimit -n 32768
     ulimit -c unlimited
 
 }
@@ -403,7 +403,7 @@ start_dafilesrv() {
 
       noStatusCheck=1
       /etc/init.d/dafilesrv setup 1>/dev/null 2>/dev/null
-      ulimit -n 8192
+      ulimit -n 32768
       ulimit -c unlimited
       startCmd ${compName} ${noStatusCheck}
       return $?

--- a/initfiles/bin/init_dafilesrv.in
+++ b/initfiles/bin/init_dafilesrv.in
@@ -33,6 +33,9 @@ PID_NAME="$PID/`basename $PWD`.pid"
 INIT_PID_NAME="$PID/init_`basename $PWD`.pid"
 echo $$ > $INIT_PID_NAME
 
+# this must match jsocket hard limit
+export handlelimit=32768
+
 export SENTINEL="dafilesrv.sentinel"
 rm -f ${SENTINEL}
 
@@ -42,7 +45,7 @@ killed(){
     sleep 2
     exit 255
 }
-
+ulimit -n $handlelimit
 trap "killed" SIGINT SIGTERM SIGKILL
 dafilesrv -L $log &
 echo $! > $PID_NAME

--- a/initfiles/componentfiles/thor/run_thor
+++ b/initfiles/componentfiles/thor/run_thor
@@ -19,7 +19,7 @@
 thorpid=0
 
 ulimit -c unlimited
-ulimit -n 8192
+ulimit -n $handlelimit
 
 RUN_THOR_PID_NAME="$PID/run_thor.`basename $PWD`.pid"
 # prevent two thors starting together

--- a/initfiles/componentfiles/thor/start_slave
+++ b/initfiles/componentfiles/thor/start_slave
@@ -34,6 +34,9 @@ if [ $# -lt 9 ]; then
   exit 1
 fi
 
+# this must match jsocket hard limit
+export handlelimit=32768
+
 sudo /etc/init.d/hpcc-init -c dafilesrv setup
 mkdir -p $instancedir
 mkdir -p `dirname $logredirect`
@@ -62,7 +65,7 @@ trap "rm -f $lckfile" exit
 echo $$ > $lckfile
 
 ulimit -c unlimited
-ulimit -n 8192
+ulimit -n $handlelimit
 
 echo "slave starting `date`"
 

--- a/initfiles/componentfiles/thor/start_slaves
+++ b/initfiles/componentfiles/thor/start_slaves
@@ -21,7 +21,7 @@ echo starting thorslaves ...
 
 if [ "$localthor" = "true" ]; then
         ulimit -c unlimited
-        ulimit -n 8192
+        ulimit -n $handlelimit
         let "n = 1";
         for slave in $(cat $instancedir/thorgroup); do
             slaveport=${slave/*:/}

--- a/initfiles/componentfiles/thor/start_thor
+++ b/initfiles/componentfiles/thor/start_thor
@@ -28,7 +28,8 @@ source ${PATH_PRE} ""
 export PID_NAME="$PID/`basename $PWD`_master.pid" ## this needed when we use bash_init_system
 export PID_NAME_BASE="$PID/`basename $PWD`.pid"
 
-
+# this must match jsocket hard limit
+export handlelimit=32768
 
 # deploydir = where binaries and scripts live
 if [ -z "$deploydir" ]; then
@@ -45,8 +46,8 @@ $deploydir/stop_thor $deploydir
 
 # ----------------------------
 
-ulimit -n 8192
-if [ `ulimit -n` -lt 8192 ]; then
+ulimit -n $handlelimit
+if [ `ulimit -n` -lt $handlelimit ]; then
     echo 'ulimit -n failed, aborting start_thor (perhaps you are not logged is as super user?)'
     exit 0
 fi

--- a/initfiles/sbin/add_conf_settings.sh.in
+++ b/initfiles/sbin/add_conf_settings.sh.in
@@ -35,7 +35,8 @@ Defaults:${USER_NAME} !requiretty
 %EOF
 
 alter_file /etc/security/limits.conf "^${USER_NAME}" << %EOF
-${USER_NAME}    hard    nofile  8192
+${USER_NAME}    soft    nofile  8192
+${USER_NAME}    hard    nofile  32768
 ${USER_NAME}    soft  core  unlimited
 ${USER_NAME}    hard  core  unlimited
 %EOF

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -312,7 +312,7 @@ struct MCASTREQ
 #define BADSOCKERR(err) ((err==EBADF)||(err==ENOTSOCK))
 #define CHECKSOCKRANGE(s)
 #else
-#define XFD_SETSIZE 8192
+#define XFD_SETSIZE 32768
 struct xfd_set { __fd_mask fds_bits[XFD_SETSIZE / __NFDBITS]; }; // define our own
 // linux 64 bit
 #ifdef __linux__


### PR DESCRIPTION
Increase jlib and script hard file/handle limits.
This was increased in legacy systems some time ago, but never ported across.

Fixes HPCC-3328

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
