### PR TITLE
HPCC-3198 Remove 'Run ECL' link in EclWatch

### DIFF
--- a/esp/scm/ecldirect.ecm
+++ b/esp/scm/ecldirect.ecm
@@ -52,6 +52,7 @@ ESPenum RunEclExFormat : string
 ESPrequest [nil_remove] RunEclExRequest
 {
     [rows(28), cols(80)] string eclText;
+    string UserName;
     string cluster;
     string snapshot;
     boolean includeResults;

--- a/esp/services/ecldirect/EclDirectService.hpp
+++ b/esp/services/ecldirect/EclDirectService.hpp
@@ -60,12 +60,6 @@ public:
         CEspBinding::addService(name, host, port, service);
     }
 
-    virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
-    {
-        IPropertyTree *folder = ensureNavFolder(data, "ECL", "Run Ecl code and review Ecl workunits", NULL, false, 2);
-        ensureNavLink(*folder, "Run Ecl", "/EclDirect/RunEclEx/Form", "Submit ECL text for execution", NULL, NULL, 3);
-    }
-
     virtual int onGet(CHttpRequest* request, CHttpResponse* response);
     int sendRunEclExForm(IEspContext &context, CHttpRequest* request, CHttpResponse* response);
 };


### PR DESCRIPTION
The 'Run ECL' link is removed from EclWatch since its functionality
has been replaced by 'ECL Playground'. The EclDirect web service is
still available for JDBC client. This fix also allows to set
username as the job owner (submitID) in the web service. If the
username is not set, the job owner will be blank.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
