### PR TITLE
HPCC-7843 Temporarily dump stack trace dereferencing NULL user

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1055,13 +1055,8 @@ static int getScopePermissions(const char *scopename,IUserDescriptor *user,unsig
         {
 #ifdef _DALIUSER_STACKTRACE
             //following debug code to be removed
-            StringBuffer sb;
-            user->getUserName(sb);
-            if (0==sb.length() || !stricmp(sb.str(), "daliuser"))
-            {
-                DBGLOG("UNEXPECTED USER '%s' in %s line %ld",sb.str(),__FILE__, __LINE__);
-                PrintStackReport();
-            }
+            DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp line %d",__LINE__);
+            PrintStackReport();
 #endif
             user = queryDistributedFileDirectory().queryDefaultUser();
         }

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -514,7 +514,7 @@ public:
                 udesc->getUserName(sb);
                 if (0==sb.length() || !stricmp(sb.str(), "daliuser"))
                 {
-                    DBGLOG("UNEXPECTED USER '%s' in %s line %ld",username,__FILE__, __LINE__);
+                    DBGLOG("UNEXPECTED USER '%s' in dasess.cpp line %d",username.get(), __LINE__);
                     PrintStackReport();
                 }
 #endif
@@ -774,10 +774,11 @@ public:
 #ifdef _DALIUSER_STACKTRACE
         //following debug code to be removed
         StringBuffer sb;
-        udesc->getUserName(sb);
+        if (udesc)
+            udesc->getUserName(sb);
         if (0==sb.length() || !stricmp(sb.str(), "daliuser"))
         {
-            DBGLOG("UNEXPECTED USER '%s' in %s line %ld",sb.str(),__FILE__, __LINE__);
+            DBGLOG("UNEXPECTED USER '%s' in dasess.cpp line %d",sb.str(),__LINE__);
             PrintStackReport();
         }
 #endif

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -124,7 +124,7 @@ public:
             if (username.length()==0)  {
 #ifdef _DALIUSER_STACKTRACE
                 //following debug code to be removed
-                DBGLOG("UNEXPECTED USER '%s' in %s line %ld",NULL,__FILE__, __LINE__);
+                DBGLOG("UNEXPECTED USER (NULL) in daldap.cpp line %d", __LINE__);
                 PrintStackReport();
 #endif
                 username.append(filesdefaultuser);

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1186,7 +1186,7 @@ public:
                     //following debug code to be removed
                     if (!username || !stricmp(username, "daliuser"))
                     {
-                        DBGLOG("UNEXPECTED USER '%s' in %s line %ld",username,__FILE__, __LINE__);
+                        DBGLOG("UNEXPECTED USER '%s' in ldapconnection.cpp line %d",username, __LINE__);
                         PrintStackReport();
                     }
 #endif


### PR DESCRIPTION
Fix deref of NULL user in temp stack trace code

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
