### PR TITLE
HPCC-3312 Support setting per-query memory and time limits from CLI

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1213,9 +1213,14 @@ extern WORKUNIT_API void removeWuidFromNamedQueries(IPropertyTree * queryRegistr
 extern WORKUNIT_API void removeDllFromNamedQueries(IPropertyTree * queryRegistry, const char * dll);
 extern WORKUNIT_API void removeAliasesFromNamedQuery(IPropertyTree * queryRegistry, const char * id);
 extern WORKUNIT_API void setQueryAlias(IPropertyTree * queryRegistry, const char * name, const char * value);
+
+extern WORKUNIT_API IPropertyTree * getQueryById(IPropertyTree * queryRegistry, const char *queryid);
+extern WORKUNIT_API IPropertyTree * getQueryById(const char *queryset, const char *queryid, bool readonly);
 extern WORKUNIT_API IPropertyTree * resolveQueryAlias(IPropertyTree * queryRegistry, const char * alias);
+extern WORKUNIT_API IPropertyTree * resolveQueryAlias(const char *queryset, const char *alias, bool readonly);
 extern WORKUNIT_API IPropertyTree * getQueryRegistry(const char * wsEclId, bool readonly);
 extern WORKUNIT_API IPropertyTree * getQueryRegistryRoot();
+
 extern WORKUNIT_API void setQueryCommentForNamedQuery(IPropertyTree * queryRegistry, const char *id, const char *queryComment);
 
 extern WORKUNIT_API void setQuerySuspendedState(IPropertyTree * queryRegistry, const char * name, bool suspend);

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -104,6 +104,34 @@ static bool looksLikeOnlyAWuid(const char * wuid)
     return true;
 }
 
+bool isValidMemoryValue(const char *value)
+{
+    if (!value || !*value || !isdigit(*value))
+        return false;
+    while (isdigit(*++value));
+
+    if (!*value)
+        return true;
+
+    switch (toupper(*value++))
+    {
+        case 'E':
+        case 'P':
+        case 'T':
+        case 'G':
+        case 'M':
+        case 'K':
+            if (!*value || strieq("B", value))
+                return true;
+            break;
+        case 'B':
+            if (!*value)
+                return true;
+            break;
+    }
+    return false;
+}
+
 //=========================================================================================
 
 #define PE_OFFSET_LOCATION_IN_DOS_SECTION 0x3C

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -75,6 +75,10 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_WAIT_INI "waitTimeout"
 #define ECLOPT_WAIT_ENV "ECL_WAIT_TIMEOUT"
 
+#define ECLOPT_TIME_LIMIT "--timeLimit"
+#define ECLOPT_MEMORY_LIMIT "--memoryLimit"
+#define ECLOPT_WARN_TIME_LIMIT "--warnTimeLimit"
+
 #define ECLOPT_RESULT_LIMIT "--limit"
 #define ECLOPT_RESULT_LIMIT_INI "resultLimit"
 #define ECLOPT_RESULT_LIMIT_ENV "ECL_RESULT_LIMIT"
@@ -111,6 +115,8 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 
 #define ECLOPT_VERBOSE "--verbose"
 #define ECLOPT_VERBOSE_S "-v"
+
+bool isValidMemoryValue(const char *value);
 
 bool extractEclCmdOption(StringBuffer & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);
 bool extractEclCmdOption(StringAttr & option, IProperties * globals, const char * envName, const char * propertyName, const char * defaultPrefix, const char * defaultSuffix);

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1053,7 +1053,7 @@ ESPresponse [exceptions_inline] WUCopyLogicalFilesResponse
 };
 
 
-ESPrequest WUPublishWorkunitRequest
+ESPrequest [nil_remove] WUPublishWorkunitRequest
 {
     string Wuid;
     string Cluster;
@@ -1063,6 +1063,9 @@ ESPrequest WUPublishWorkunitRequest
     int Wait(10000);
     bool NoReload(0);
     bool UpdateWorkUnitName(0);
+    string memoryLimit;
+    nonNegativeInteger TimeLimit(0);
+    nonNegativeInteger WarnTimeLimit(0);
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse
@@ -1074,6 +1077,28 @@ ESPresponse [exceptions_inline] WUPublishWorkunitResponse
     string QueryId;
     bool ReloadFailed;
     ESParray<ESPStruct WUCopyLogicalClusterFileSections, Cluster> ClusterFiles;
+};
+
+ESPrequest [nil_remove] WUQueryConfigRequest
+{
+    string Target;
+    string QueryId;
+    int Wait(10000);
+    bool NoReload(0);
+    string memoryLimit;
+    nonNegativeInteger TimeLimit(0);
+    nonNegativeInteger WarnTimeLimit(0);
+};
+
+ESPStruct WUQueryConfigResult
+{
+    string  QueryId;
+};
+
+ESPresponse [exceptions_inline] WUQueryConfigResponse
+{
+    bool ReloadFailed;
+    ESParray<ESPStruct WUQueryConfigResult, Result> Results;
 };
 
 
@@ -1098,7 +1123,7 @@ ESPStruct ClusterQueryState
     string State;
 };
 
-ESPStruct QuerySetQuery
+ESPStruct [nil_remove] QuerySetQuery
 {
     string Id;
     string Name;
@@ -1106,6 +1131,9 @@ ESPStruct QuerySetQuery
     string Dll;
     bool Suspended;
     ESParray<ESPstruct ClusterQueryState> Clusters;
+    string memoryLimit;
+    nonNegativeInteger timeLimit;
+    nonNegativeInteger warnTimeLimit;
 };
 
 ESPStruct QuerySetAlias
@@ -1241,7 +1269,7 @@ ESPresponse [exceptions_inline] WUQuerySetAliasActionResponse
     ESParray<ESPstruct QuerySetAliasActionResult, Result> Results;
 };
 
-ESPrequest WUQuerySetCopyQueryRequest
+ESPrequest [nil_remove] WUQuerySetCopyQueryRequest
 {
     string Source;
     string Target;
@@ -1252,6 +1280,9 @@ ESPrequest WUQuerySetCopyQueryRequest
     bool DontCopyFiles(false);
     int Wait(10000);
     bool NoReload(0);
+    string memoryLimit;
+    nonNegativeInteger TimeLimit(0);
+    nonNegativeInteger WarnTimeLimit(0);
 };
 
 ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
@@ -1325,6 +1356,7 @@ ESPservice [
     ESPmethod WUQuerysetAliasAction(WUQuerySetAliasActionRequest, WUQuerySetAliasActionResponse);
     ESPmethod WUQuerysetCopyQuery(WUQuerySetCopyQueryRequest, WUQuerySetCopyQueryResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/WUCopyLogicalFiles.xslt")] WUCopyLogicalFiles(WUCopyLogicalFilesRequest, WUCopyLogicalFilesResponse);
+    ESPmethod WUQueryConfig(WUQueryConfigRequest, WUQueryConfigResponse);
 };
 
 

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -49,6 +49,7 @@ public:
     bool onWUMultiQuerysetDetails(IEspContext &context, IEspWUMultiQuerySetDetailsRequest &req, IEspWUMultiQuerySetDetailsResponse &resp);
     bool onWUQuerysetQueryAction(IEspContext &context, IEspWUQuerySetQueryActionRequest & req, IEspWUQuerySetQueryActionResponse & resp);
     bool onWUQuerysetAliasAction(IEspContext &context, IEspWUQuerySetAliasActionRequest &req, IEspWUQuerySetAliasActionResponse &resp);
+    bool onWUQueryConfig(IEspContext &context, IEspWUQueryConfigRequest &req, IEspWUQueryConfigResponse &resp);
     bool onWUQuerysetCopyQuery(IEspContext &context, IEspWUQuerySetCopyQueryRequest &req, IEspWUQuerySetCopyQueryResponse &resp);
     bool onWUCopyLogicalFiles(IEspContext &context, IEspWUCopyLogicalFilesRequest &req, IEspWUCopyLogicalFilesResponse &resp);
 


### PR DESCRIPTION
Create a new ecl command "ecl queries config" supporting the
parameters --memoryLimit, --timeLimit, and --warnTimeLimit to set
the corresponding per query values.

Add the same new parameters to the CLI commands "ecl publish" and
"ecl queries copy".

Show values set for memoryLimit, timeLimit, and warnTime limit
when listing queries via "ecl queries list".

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
