### PR TITLE
HPCC-3162 Add jlib_decl to compile on Windows

### DIFF
--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -137,7 +137,7 @@ extern jlib_decl void JBASE32_Decode(const char *in,StringBuffer &out);
 extern jlib_decl StringBuffer& encodeUrlUseridPassword(StringBuffer& out, const char* in);
 extern jlib_decl StringBuffer& decodeUrlUseridPassword(StringBuffer& out, const char* in);
 
-class StringArray : public ArrayOf<const char *, const char *>
+class jlib_decl StringArray : public ArrayOf<const char *, const char *>
 {
 public:
     // Appends a list in a string delimited by 'delim'
@@ -145,7 +145,7 @@ public:
     // Appends a list in a string delimited by 'delim' without duplicates
     void appendListUniq(const char *list, const char *delim);
 };
-class CIStringArray : public StringArray, public CInterface
+class jlib_decl CIStringArray : public StringArray, public CInterface
 {
 };
 


### PR DESCRIPTION
Without the jlib_decl, the classes StringArray and CIStringArray
wouldn't compile under Windows (exportdll-wise).

Signed-off-by: Renato Golin rengolin@hpccsystems.com
