### PR TITLE
HPCC-716 Include superfile creation into addSuper transaction

### DIFF
--- a/dali/dfu/dfuerror.hpp
+++ b/dali/dfu/dfuerror.hpp
@@ -59,6 +59,7 @@
 #define DFUERR_DSuperFileNotEmpty       8301
 #define DFUERR_DSuperFileContainsSub        8302
 #define DFUERR_DSuperFileDoesntContainSub   8303
+#define DFUERR_DWillNotCreateSuperFile      8304
 
 
 //---- Text for all errors (make it easy to internationalise) ---------------------------
@@ -98,5 +99,6 @@
 #define DFUERR_DSuperFileNotEmpty_Text      "SuperFile %s not empty"
 #define DFUERR_DSuperFileContainsSub_Text       "Superfile already contains subfile %s"
 #define DFUERR_DSuperFileDoesntContainSub_Text  "Superfile doesn't contains subfile %s"
+#define DFUERR_DWillNotCreateSuperFile_Text     "Will not create Superfile"
 
 #endif

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -707,6 +707,9 @@ public:
 
     void addSuper(const char *superfname, unsigned numtoadd, const char **subfiles, const char *before,IUserDescriptor *user)
     {
+        if (!numtoadd)
+            throwError(DFUERR_DWillNotCreateSuperFile);
+
         Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
         // We need this here, since caching only happens with active transactions
         // MORE - abstract this with DFSAccess, or at least enable caching with a flag


### PR DESCRIPTION
When files are added into new superfile and a failure occurs when adding
one of the files, the empty superfile is not deleted. That may mislead
us. This fix moves the superfile creation into the same transaction of
adding the files into the superfile. If there is a failure when adding
the files, the whole transaction will be rolled back so that the empty
superfile will be deleted.

Similar change is also made for removeSuper().

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
