### PR TITLE
HPCC-7859 Fix unity installer

### DIFF
--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -198,7 +198,7 @@ if [ -d ${INSTALL_DIR}/etc/bash_completion.d ] && [ -d /etc/bash_completion.d ];
 fi
 
 # Ubuntu Unity Launcher
-if [ -d ${INSTALL_DIR}/share/hpcc-systems.desktop ] && [ -d /usr/share/applications ]; then
+if [ -f ${INSTALL_DIR}/share/hpcc-systems.desktop ] && [ -d /usr/share/applications ]; then
     installFile ${INSTALL_DIR}/share/hpcc-systems.desktop /usr/share/applications 1 || exit 1
 fi
 


### PR DESCRIPTION
I was testing if a file existed with a directory check. Now it's working
on other machines other than just mine.

Signed-off-by: Renato Golin rengolin@hpccsystems.com
