### PR TITLE
HPCC-7862 Initialize and Terminate JLIB in Treeview executable

### DIFF
--- a/dali/treeview/treeviewdlg.cpp
+++ b/dali/treeview/treeviewdlg.cpp
@@ -191,6 +191,9 @@ CTreeviewDlg::CTreeviewDlg(LPCSTR fn, CWnd* pParent) : CDialog(CTreeviewDlg::IDD
         // NOTE: the ClassWizard will add member initialization here
     //}}AFX_DATA_INIT
     // Note that LoadIcon does not require a subsequent DestroyIcon in Win32
+    InitModuleObjects();
+    queryStderrLogMsgHandler()->setMessageFields(0);
+
     m_hIcon = AfxGetApp()->LoadIcon(IDR_MAINFRAME);
     tooltipCtrl = NULL;
     hAccel = NULL;
@@ -203,6 +206,8 @@ CTreeviewDlg::CTreeviewDlg(LPCSTR fn, CWnd* pParent) : CDialog(CTreeviewDlg::IDD
 
 CTreeviewDlg::~CTreeviewDlg()
 {
+    releaseAtoms();
+
     free(cmdfname);
     if(expander) delete expander;
     delete tooltipCtrl;


### PR DESCRIPTION
While this must have worked in the past, it was not correct, and
changes in JLIB must have made this a fatal issue.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
