### PR TITLE
HPCC-7864 Standalone mode broken in Roxie in 3.10

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1420,12 +1420,14 @@ private:
     void reload()
     {
         CriticalBlock b(packageCrit);
-        ForEachItemIn(idx, allQuerySetNames)
+        if (standAloneDll)
+            loadStandaloneQuery(standAloneDll, numChannels, "roxie");
+        else
         {
-            if (standAloneDll)
-                loadStandaloneQuery(standAloneDll, numChannels, allQuerySetNames.item(idx));
-            else
+            ForEachItemIn(idx, allQuerySetNames)
+            {
                 createQueryPackageManagers(numChannels, allQuerySetNames.item(idx));
+            }
         }
     }
 


### PR DESCRIPTION
A regression introduced while refactoring the QuerySet handling code
means that any standalone ECL program compiled with --target=roxie
would fail at startup.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
