### PR TITLE
HPCC-3266 Add Clustername to Std.System.Thorlib

### DIFF
--- a/ecl/regress/stdcluster.ecl
+++ b/ecl/regress/stdcluster.ecl
@@ -1,0 +1,20 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+import std;
+
+output(std.System.ThorLib.Cluster());

--- a/ecllibrary/std/system/Thorlib.ecl
+++ b/ecllibrary/std/system/Thorlib.ecl
@@ -62,6 +62,12 @@ export group() := externals.group();
 export getExpandLogicalName(const varstring name) := externals.getExpandLogicalName(name);
 
 /*
+ * Returns the name of the cluster the query is currently executing on.
+ */
+
+export cluster() := externals.cluster();
+
+/*
  * The following are either unused, or should be replaced with a different syntax.
  
 export getenv(const varstring name, const varstring defaultValue) := externals.getenv(name, defaultValue);


### PR DESCRIPTION
Primarily for backward compatability with the legacy system.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
