### PR TITLE
HPCC-716 Include superfile into addSuper transactions

### DIFF
--- a/dali/dfu/dfuerror.hpp
+++ b/dali/dfu/dfuerror.hpp
@@ -59,6 +59,7 @@
 #define DFUERR_DSuperFileNotEmpty       8301
 #define DFUERR_DSuperFileContainsSub        8302
 #define DFUERR_DSuperFileDoesntContainSub   8303
+#define DFUERR_DNoSubfileToAddToSuperFile   8304
 
 
 //---- Text for all errors (make it easy to internationalise) ---------------------------
@@ -98,5 +99,6 @@
 #define DFUERR_DSuperFileNotEmpty_Text      "SuperFile %s not empty"
 #define DFUERR_DSuperFileContainsSub_Text       "Superfile already contains subfile %s"
 #define DFUERR_DSuperFileDoesntContainSub_Text  "Superfile doesn't contains subfile %s"
+#define DFUERR_DNoSubfileToAddToSuperFile_Text  "No file has been specified to be added to the superfile"
 
 #endif

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -710,31 +710,27 @@ public:
 
     void addSuper(const char *superfname, unsigned numtoadd, const char **subfiles, const char *before,IUserDescriptor *user)
     {
-        Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
-        // We need this here, since caching only happens with active transactions
-        // MORE - abstract this with DFSAccess, or at least enable caching with a flag
-        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFileCached(superfname);
+        if (!numtoadd)
+            throwError(DFUERR_DNoSubfileToAddToSuperFile);
 
-        bool newfile = false;
-        if (!superfile) {
+        Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
+        transaction->start();
+
+        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFile(superfname);
+        if (!superfile)
             superfile.setown(queryDistributedFileDirectory().createSuperFile(superfname,true,false,user,transaction));
-            transaction->addFile(superfile);
-            newfile = true;
+
+        for (unsigned i=0;i<numtoadd;i++)
+        {
+            if (superfile->querySubFileNamed(subfiles[i]))
+                throwError1(DFUERR_DSuperFileContainsSub, subfiles[i]);
+
+            if (before&&*before)
+                superfile->addSubFile(subfiles[i],true,(stricmp(before,"*")==0)?NULL:before,false,transaction);
+            else
+                superfile->addSubFile(subfiles[i],false,NULL,false,transaction);
         }
-        if (numtoadd) {
-            transaction->start();
-            unsigned i;
-            for (i=0;i<numtoadd;i++)
-                if (superfile->querySubFileNamed(subfiles[i]))
-                    throwError1(DFUERR_DSuperFileContainsSub, subfiles[i]);
-            for (i=0;i<numtoadd;i++) {
-                if (before&&*before)
-                    superfile->addSubFile(subfiles[i],true,(stricmp(before,"*")==0)?NULL:before,false,transaction);
-                else
-                    superfile->addSubFile(subfiles[i],false,NULL,false,transaction);
-            }
-            transaction->commit();
-        }
+        transaction->commit();
     }
 
 


### PR DESCRIPTION
When files are added into new superfile and a failure occurs when adding
one of the files, the empty superfile is not deleted. That may mislead
us. This fix moves the superfile creation into the same transaction of
adding the files into the superfile. If there is a failure when adding
the files, the whole transaction will be rolled back so that the empty
superfile will be deleted.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
