### PR TITLE
HPCC-7870 Convert 'Slave Number' input to integer before comparison

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -123,7 +123,7 @@
             {
                 pos = value.indexOf('@');
                 thorLogDate = value.substring(pos+1);
-                numberOfSlaves = value.substring(0, pos);
+                numberOfSlaves = parseInt(value.substring(0, pos));
                 pos1 = thorLogDate.indexOf('@');
                 thorProcess = thorLogDate.substring(pos1+1);
                 thorLogDate = thorLogDate.substring(0, pos1);
@@ -135,7 +135,7 @@
                 if (el == undefined)
                     return;
 
-                if (numberOfSlaves == '1')
+                if (numberOfSlaves == 1)
                 {
                     el.innerText = '';
                     document.getElementById('SlaveNum').disabled=true;
@@ -152,7 +152,7 @@
             {
                 if (document.getElementById('NumberSlaves') != undefined)
                 {
-                    var slaveNum = document.getElementById('SlaveNum').value;
+                    var slaveNum = parseInt(document.getElementById('SlaveNum').value);
                     if (slaveNum > numberOfSlaves)
                     {
                         alert('Slave Number cannot be greater than ' + numberOfSlaves);


### PR DESCRIPTION
On Ecl Workunit Details page (a system with 100 slave nodes), a user
specifies 39 as a Slave Number and clicks the 'get slave log' button.
An error message shows: 'Slave Number cannot be greater than 100'.
The problem was because javascript identifies the user input using
string and do string comparison. This fix converts 'Slave Number' input
(and total number of slaves) to integer before a comparison.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
