### PR TITLE
HPCC-3198 Remove 'Run ECL' link from EclWatch

### DIFF
--- a/esp/services/ecldirect/EclDirectService.hpp
+++ b/esp/services/ecldirect/EclDirectService.hpp
@@ -60,6 +60,8 @@ public:
         CEspBinding::addService(name, host, port, service);
     }
 
+    virtual void getNavigationData(IEspContext &context, IPropertyTree & data) {};
+
     virtual int onGet(CHttpRequest* request, CHttpResponse* response);
     int sendRunEclExForm(IEspContext &context, CHttpRequest* request, CHttpResponse* response);
 };


### PR DESCRIPTION
My previous fix removed the 'Run ECL' link from the ECL menu. But, an
'ECLDirect' menu group is added since default ESP getNavigationData()
is called. This fix adds an empty getNavigationData() into EclDirect
service to avoid the default getNavigationData().

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
