### PR TITLE
HPCC-3092 Add ESCAPE option to CSV dataset - RFC

### DIFF
--- a/common/thorhelper/csvsplitter.hpp
+++ b/common/thorhelper/csvsplitter.hpp
@@ -41,8 +41,9 @@ public:
     void addQuote(const char * text);
     void addSeparator(const char * text);
     void addTerminator(const char * text);
+    void addEscape(const char * text);
 
-    void init(unsigned maxColumns, ICsvParameters * csvInfo, const char * dfsQuotes, const char * dfsSeparators, const char * dfsTerminators);
+    void init(unsigned maxColumns, ICsvParameters * csvInfo, const char * dfsQuotes, const char * dfsSeparators, const char * dfsTerminators, const char * dfsEscapes);
     void reset();
     size32_t splitLine(size32_t maxLen, const byte * start);
 
@@ -50,10 +51,10 @@ public:
     inline const byte * * queryData() { return data; }
 
 protected:
-    void setFieldRange(const byte * start, const byte * end, unsigned curColumn, unsigned quoteToStrip);
+    void setFieldRange(const byte * start, const byte * end, unsigned curColumn, unsigned quoteToStrip, bool unescape);
 
 protected:
-    enum { NONE=0, SEPARATOR=1, TERMINATOR=2, WHITESPACE=3, QUOTE=4 };
+    enum { NONE=0, SEPARATOR=1, TERMINATOR=2, WHITESPACE=3, QUOTE=4, ESCAPE=5 };
     unsigned            maxColumns;
     StringMatcher       matcher;
     unsigned            numQuotes;
@@ -83,6 +84,7 @@ protected:
     StringAttr separator;
     StringAttr terminator;
     StringAttr quote;
+    StringAttr escape;
     const char * prefix;
     bool oldOutputFormat;
 };

--- a/common/thorhelper/thorpipe.cpp
+++ b/common/thorhelper/thorpipe.cpp
@@ -163,7 +163,8 @@ public:
         const char * quotes = NULL;
         const char * separators = NULL;
         const char * terminators = NULL;
-        csvSplitter.init(csvTransformer->getMaxColumns(), csvInfo, quotes, separators, terminators);
+        const char * escapes = NULL;
+        csvSplitter.init(csvTransformer->getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
     }
 
     virtual const void * next()

--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -672,7 +672,7 @@ IDataVal & CCsvToRawTransformer::transform(IDataVal & result, size32_t len, cons
 {
     CSVSplitter csvSplitter;
 
-    csvSplitter.init(rowTransformer->getMaxColumns(), rowTransformer->queryCsvParameters(), NULL, NULL, NULL);
+    csvSplitter.init(rowTransformer->getMaxColumns(), rowTransformer->queryCsvParameters(), NULL, NULL, NULL, NULL);
 
     unsigned maxRecordSize = rowTransformer->queryRecordSize()->getRecordSize(NULL);
     const byte *finger = (const byte *) text;

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -8865,7 +8865,7 @@ static void clearAliases(IPropertyTree * queryRegistry, const char * id)
     }
 }
 
-IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll)
+IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll, bool library)
 {
     StringBuffer lcName(name);
     lcName.toLowerCase();
@@ -8893,6 +8893,8 @@ IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, 
     newEntry->setProp("@dll", dll);
     newEntry->setProp("@id", id);
     newEntry->setPropInt("@seq", seq);
+    if (library)
+        newEntry->setPropBool("@isLibrary", true);
     return queryRegistry->addPropTree("Query", newEntry);
 }
 
@@ -9167,7 +9169,7 @@ void addQueryToQuerySet(IWorkUnit *workunit, const char *querySetName, const cha
         }
     }
 
-    IPropertyTree *newEntry = addNamedQuery(queryRegistry, cleanQueryName, wuid.str(), dllName.str());
+    IPropertyTree *newEntry = addNamedQuery(queryRegistry, cleanQueryName, wuid.str(), dllName.str(), isLibrary(workunit));
     newQueryId.append(newEntry->queryProp("@id"));
     workunit->setIsQueryService(true); //will check querysets before delete
     workunit->commit();

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1207,7 +1207,7 @@ enum WUQueryActivationOptions
 };
 
 
-extern WORKUNIT_API IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll);       // result not linked
+extern WORKUNIT_API IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll, bool library);       // result not linked
 extern WORKUNIT_API void removeNamedQuery(IPropertyTree * queryRegistry, const char * id);
 extern WORKUNIT_API void removeWuidFromNamedQueries(IPropertyTree * queryRegistry, const char * wuid);
 extern WORKUNIT_API void removeDllFromNamedQueries(IPropertyTree * queryRegistry, const char * dll);

--- a/dali/dfu/dfuerror.hpp
+++ b/dali/dfu/dfuerror.hpp
@@ -59,6 +59,7 @@
 #define DFUERR_DSuperFileNotEmpty       8301
 #define DFUERR_DSuperFileContainsSub        8302
 #define DFUERR_DSuperFileDoesntContainSub   8303
+#define DFUERR_DNoSubfileToAddToSuperFile   8304
 
 
 //---- Text for all errors (make it easy to internationalise) ---------------------------
@@ -98,5 +99,6 @@
 #define DFUERR_DSuperFileNotEmpty_Text      "SuperFile %s not empty"
 #define DFUERR_DSuperFileContainsSub_Text       "Superfile already contains subfile %s"
 #define DFUERR_DSuperFileDoesntContainSub_Text  "Superfile doesn't contains subfile %s"
+#define DFUERR_DNoSubfileToAddToSuperFile_Text  "No file has been specified to be added to the superfile"
 
 #endif

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -710,31 +710,27 @@ public:
 
     void addSuper(const char *superfname, unsigned numtoadd, const char **subfiles, const char *before,IUserDescriptor *user)
     {
-        Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
-        // We need this here, since caching only happens with active transactions
-        // MORE - abstract this with DFSAccess, or at least enable caching with a flag
-        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFileCached(superfname);
+        if (!numtoadd)
+            throwError(DFUERR_DNoSubfileToAddToSuperFile);
 
-        bool newfile = false;
-        if (!superfile) {
+        Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
+        transaction->start();
+
+        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFile(superfname);
+        if (!superfile)
             superfile.setown(queryDistributedFileDirectory().createSuperFile(superfname,true,false,user,transaction));
-            transaction->addFile(superfile);
-            newfile = true;
+
+        for (unsigned i=0;i<numtoadd;i++)
+        {
+            if (superfile->querySubFileNamed(subfiles[i]))
+                throwError1(DFUERR_DSuperFileContainsSub, subfiles[i]);
+
+            if (before&&*before)
+                superfile->addSubFile(subfiles[i],true,(stricmp(before,"*")==0)?NULL:before,false,transaction);
+            else
+                superfile->addSubFile(subfiles[i],false,NULL,false,transaction);
         }
-        if (numtoadd) {
-            transaction->start();
-            unsigned i;
-            for (i=0;i<numtoadd;i++)
-                if (superfile->querySubFileNamed(subfiles[i]))
-                    throwError1(DFUERR_DSuperFileContainsSub, subfiles[i]);
-            for (i=0;i<numtoadd;i++) {
-                if (before&&*before)
-                    superfile->addSubFile(subfiles[i],true,(stricmp(before,"*")==0)?NULL:before,false,transaction);
-                else
-                    superfile->addSubFile(subfiles[i],false,NULL,false,transaction);
-            }
-            transaction->commit();
-        }
+        transaction->commit();
     }
 
 

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -282,7 +282,7 @@ public:
         }
         if ((optObj.type==eclObjSource || optObj.type==eclObjArchive) && optTargetCluster.isEmpty())
         {
-            fprintf(stderr, "\nCluster must be specified when deploying from ECL Source or Archive\n");
+            fprintf(stderr, "\nTarget must be specified when deploying from ECL Source or Archive\n");
             return false;
         }
         return true;
@@ -400,7 +400,7 @@ public:
         {
             if (optTargetCluster.isEmpty())
             {
-                fprintf(stderr, "\nCluster must be specified when publishing ECL Text or Archive\n");
+                fprintf(stderr, "\nTarget must be specified when publishing ECL Text or Archive\n");
                 return false;
             }
         }
@@ -563,7 +563,7 @@ public:
         {
             if (optTargetCluster.isEmpty())
             {
-                fprintf(stderr, "\nCluster must be specified when running ECL Text or Archive\n");
+                fprintf(stderr, "\nTarget must be specified when running ECL Text or Archive\n");
                 return false;
             }
         }

--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -302,6 +302,7 @@ _ATOM _selectors_Atom;
 _ATOM _selectorSequence_Atom;
 _ATOM selfAtom;
 _ATOM separatorAtom;
+_ATOM escapeAtom;
 _ATOM sequenceAtom;
 _ATOM _sequence_Atom;
 _ATOM sequentialAtom;
@@ -715,6 +716,7 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKEATOM(template);
     MAKEATOM(terminate);
     MAKEATOM(terminator);
+    MAKEATOM(escape);
     MAKEATOM(thor);
     MAKEATOM(threshold);
     MAKEATOM(timeout);

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -341,6 +341,7 @@ extern HQL_API _ATOM tempAtom;
 extern HQL_API _ATOM templateAtom;
 extern HQL_API _ATOM terminateAtom;
 extern HQL_API _ATOM terminatorAtom;
+extern HQL_API _ATOM escapeAtom;
 extern HQL_API _ATOM thorAtom;
 extern HQL_API _ATOM thresholdAtom;
 extern HQL_API _ATOM timeoutAtom;

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -411,6 +411,7 @@ static void eclsyntaxerror(HqlGram * parser, const char * s, short yystate, int 
   TAN
   TANH
   TERMINATOR
+  ESCAPE
   THEN
   THISNODE
   THOR
@@ -9510,6 +9511,12 @@ csvOption
                         {
                             parser->normalizeExpression($3);
                             $$.setExpr(createExprAttribute(terminatorAtom, createComma($3.getExpr(), createAttribute(quoteAtom))));
+                            $$.setPosition($1);
+                        }
+    | ESCAPE '(' expression ')'
+                        {
+                            parser->normalizeExpression($3);
+                            $$.setExpr(createExprAttribute(escapeAtom, $3.getExpr()));
                             $$.setPosition($1);
                         }
     | NOTRIM

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -903,6 +903,7 @@ TABLE               { RETURNSYM(TABLE); }
 TAN                 { RETURNSYM(TAN); }
 TANH                { RETURNSYM(TANH); }
 TERMINATOR          { RETURNSYM(TERMINATOR); }
+ESCAPE              { RETURNSYM(ESCAPE); }
 THEN                { RETURNSYM(THEN); }
 THISNODE            { RETURNSYM(THISNODE); }
 THOR                { RETURNSYM(THOR); }

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -9129,6 +9129,7 @@ void HqlCppTranslator::buildCsvParameters(BuildCtx & subctx, IHqlExpression * cs
     IHqlExpression * headerAttr = queryProperty(headerAtom, attrs);
     IHqlExpression * terminator = queryProperty(terminatorAtom, attrs);
     IHqlExpression * separator = queryProperty(separatorAtom, attrs);
+    IHqlExpression * escape = queryProperty(escapeAtom, attrs);
     if (headerAttr)
     {
         IHqlExpression * header = queryRealChild(headerAttr, 0);
@@ -9187,11 +9188,13 @@ void HqlCppTranslator::buildCsvParameters(BuildCtx & subctx, IHqlExpression * cs
     buildCsvListFunc(classctx, "queryQuote", queryProperty(quoteAtom, attrs), isReading ? "'" : NULL);
     buildCsvListFunc(classctx, "querySeparator", separator, ",");
     buildCsvListFunc(classctx, "queryTerminator", terminator, isReading ? "\r\n|\n" : "\n");
+    buildCsvListFunc(classctx, "queryEscape", escape, "\\");
 
     StringBuffer flags;
     if (!queryProperty(quoteAtom, attrs))       flags.append("|defaultQuote");
     if (!queryProperty(separatorAtom, attrs))   flags.append("|defaultSeparate");
     if (!queryProperty(terminatorAtom, attrs))  flags.append("|defaultTerminate");
+    if (!queryProperty(escapeAtom, attrs))      flags.append("|defaultEscape");
     if (singleHeader)                           flags.append("|singleHeaderFooter");
     if (manyHeader)                             flags.append("|manyHeaderFooter");
     if (queryProperty(noTrimAtom, attrs))       flags.append("|preserveWhitespace");

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -860,6 +860,7 @@ void CHThorCsvWriteActivity::setFormat(IFileDescriptor * desc)
     desc->queryProperties().setProp("@csvSeparate", separator.str());
     desc->queryProperties().setProp("@csvQuote", csvInfo->queryQuote(0));
     desc->queryProperties().setProp("@csvTerminate", csvInfo->queryTerminator(0));
+    desc->queryProperties().setProp("@csvEscape", csvInfo->queryEscape(0));
     desc->queryProperties().setProp("@format","utf8n");
 }
 
@@ -8489,6 +8490,7 @@ void CHThorCsvReadActivity::gatherInfo(IFileDescriptor * fd)
     const char * quotes = NULL;
     const char * separators = NULL;
     const char * terminators = NULL;
+    const char * escapes = NULL;
     IDistributedFile * dFile = ldFile?ldFile->queryDistributedFile():NULL;
     if (dFile)  //only makes sense for distributed (non local) files
     {
@@ -8496,8 +8498,9 @@ void CHThorCsvReadActivity::gatherInfo(IFileDescriptor * fd)
         quotes = options.queryProp("@csvQuote");
         separators = options.queryProp("@csvSeparate");
         terminators = options.queryProp("@csvTerminate");
+        escapes = options.queryProp("@csvEscape");
     }
-    csvSplitter.init(helper.getMaxColumns(), csvInfo, quotes, separators, terminators);
+    csvSplitter.init(helper.getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
 }
 
 void CHThorCsvReadActivity::calcFixedDiskRecordSize()

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -2455,12 +2455,14 @@ public:
         const char * quotes = NULL;
         const char * separators = NULL;
         const char * terminators = NULL;
+        const char * escapes = NULL;
         if (dFile)
         {
             IPropertyTree & options = dFile->queryAttributes();
             quotes = options.queryProp("@csvQuote");
             separators = options.queryProp("@csvSeparate");
             terminators = options.queryProp("@csvTerminate");
+            escapes = options.queryProp("@csvEscape");
             agent.logFileAccess(dFile, "HThor", "READ");
         }
         else
@@ -2471,7 +2473,7 @@ public:
             agent.addWuException(buff.str(), 0, ExceptionSeverityWarning, "hthor");
         }
             
-        csvSplitter.init(_arg.getMaxColumns(), csvInfo, quotes, separators, terminators);
+        csvSplitter.init(_arg.getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
     }
 
     ~CHThorCsvFetchActivity()

--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -123,7 +123,7 @@
             {
                 pos = value.indexOf('@');
                 thorLogDate = value.substring(pos+1);
-                numberOfSlaves = value.substring(0, pos);
+                numberOfSlaves = parseInt(value.substring(0, pos));
                 pos1 = thorLogDate.indexOf('@');
                 thorProcess = thorLogDate.substring(pos1+1);
                 thorLogDate = thorLogDate.substring(0, pos1);
@@ -135,7 +135,7 @@
                 if (el == undefined)
                     return;
 
-                if (numberOfSlaves == '1')
+                if (numberOfSlaves == 1)
                 {
                     el.innerText = '';
                     document.getElementById('SlaveNum').disabled=true;
@@ -152,7 +152,7 @@
             {
                 if (document.getElementById('NumberSlaves') != undefined)
                 {
-                    var slaveNum = document.getElementById('SlaveNum').value;
+                    var slaveNum = parseInt(document.getElementById('SlaveNum').value);
                     if (slaveNum > numberOfSlaves)
                     {
                         alert('Slave Number cannot be greater than ' + numberOfSlaves);

--- a/esp/services/ecldirect/EclDirectService.hpp
+++ b/esp/services/ecldirect/EclDirectService.hpp
@@ -60,6 +60,8 @@ public:
         CEspBinding::addService(name, host, port, service);
     }
 
+    virtual void getNavigationData(IEspContext &context, IPropertyTree & data) {};
+
     virtual int onGet(CHttpRequest* request, CHttpResponse* response);
     int sendRunEclExForm(IEspContext &context, CHttpRequest* request, CHttpResponse* response);
 };

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -328,7 +328,7 @@ void CWsEclBinding::getQueryNames(IPropertyTree* settree, const char *id, const 
 
     VStringBuffer xpath("Query[@id='%s']", id);
     IPropertyTree *query = settree->queryPropTree(xpath.str());
-    if (query->getPropBool("@suspended"))
+    if (query->getPropBool("@isLibrary") || query->getPropBool("@suspended"))
         return;
 
     if (!qname || !*qname)
@@ -362,7 +362,10 @@ void CWsEclBinding::getDynNavData(IEspContext &context, IProperties *params, IPr
         {
             Owned<IPropertyTreeIterator> iter = settree->getElements("Query");
             ForEach(*iter)
-                addQueryNavLink(data, &iter->query(), setname);
+            {
+                if (!iter->query().getPropBool("@isLibrary"))
+                    addQueryNavLink(data, &iter->query(), setname);
+            }
         }
         else
         {

--- a/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
+++ b/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
@@ -25,6 +25,8 @@ WsEclWuInfo::WsEclWuInfo(const char *wuid_, const char *qset, const char *qname,
     wu.setown(wf->openWorkUnit(wuid.sget(), false));
     if (!wu)
         throw MakeStringException(-1, "Could not open workunit: %s", wuid.sget());
+    if (isLibrary(wu))
+        throw MakeStringException(-1, "%s/%s is a library", qset, qname);
 }
 
 bool WsEclWuInfo::getWsResource(const char *name, StringBuffer &out)

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -1451,6 +1451,7 @@ public:
         const char *quotes = NULL;
         const char *separators = NULL;
         const char *terminators = NULL;
+        const char *escapes = NULL;
         CSVSplitter csvSplitter;
         if (datafile)
         {
@@ -1460,9 +1461,10 @@ public:
                 quotes = options->queryProp("@csvQuote");
                 separators = options->queryProp("@csvSeparate");
                 terminators = options->queryProp("@csvTerminate");
+                escapes = options->queryProp("@csvEscape");
             }
         }
-        csvSplitter.init(helper->getMaxColumns(), csvInfo, quotes, separators, terminators);
+        csvSplitter.init(helper->getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
         while (!aborted)
         {
             // MORE - there are rumours of a  csvSplitter that operates on a stream... if/when it exists, this should use it
@@ -4382,6 +4384,7 @@ public:
         const char * quotes = NULL;
         const char * separators = NULL;
         const char * terminators = NULL;
+        const char * escapes = NULL;
 
         const IResolvedFile *fileInfo = varFileInfo ? varFileInfo : factory->datafile;
         if (fileInfo)
@@ -4392,12 +4395,13 @@ public:
                 quotes = options->queryProp("@csvQuote");
                 separators = options->queryProp("@csvSeparate");
                 terminators = options->queryProp("@csvTerminate");
+                escapes = options->queryProp("@csvEscape");
             }
         }
 
         IHThorCsvFetchArg *h = (IHThorCsvFetchArg *) helper;
         ICsvParameters *csvInfo = h->queryCsvParameters();
-        csvSplitter.init(_maxColumns, csvInfo, quotes, separators, terminators);
+        csvSplitter.init(_maxColumns, csvInfo, quotes, separators, terminators, escapes);
     }
 
     virtual size32_t doFetch(ARowBuilder & rowBuilder, offset_t pos, offset_t rawpos, void *inputData)

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1622,7 +1622,8 @@ ILazyFileIO *createDynamicFile(const char *id, IPartDescriptor *pdesc, IPartDesc
     makePhysicalPartName(logicalname, partNo, numParts, localFileName, false, DFD_OSdefault, baseDataDirectory);  // MORE - if we get the dataDirectory we can pass it in and possibly` reuse an existing file
 
     appendRemoteLocations(pdesc, remoteLocations, true);
-    appendRemoteLocations(remotePDesc, remoteLocations, false);
+    if (remotePDesc)
+        appendRemoteLocations(remotePDesc, remoteLocations, false);
 
     return queryFileCache().lookupFile(id, partNo, fileType, localFileName, NULL, NULL, localLocations, remoteLocations, dfsSize, fileDate, false, true, false, false, crcResources ? crc : 0, pdesc->queryOwner().isCompressed(), NULL);
 }

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10917,6 +10917,7 @@ public:
         props.setProp("@csvSeparate", separator.str());
         props.setProp("@csvQuote", csvParameters->queryQuote(0));
         props.setProp("@csvTerminate", csvParameters->queryTerminator(0));
+        props.setProp("@csvEscape", csvParameters->queryEscape(0));
     }
 
     virtual bool isOutputTransformed() const { return true; }
@@ -20027,12 +20028,13 @@ class CRoxieServerCsvReadActivity : public CRoxieServerDiskReadBaseActivity
     const char *quotes;
     const char *separators;
     const char *terminators;
+    const char *escapes;
 public:
     CRoxieServerCsvReadActivity(const IRoxieServerActivityFactory *_factory, IProbeManager *_probeManager, const RemoteActivityId &_remoteId,
                                 unsigned _numParts, bool _isLocal, bool _sorted, bool _maySkip, IInMemoryIndexManager *_manager,
-                                const char *_quotes, const char *_separators, const char *_terminators)
+                                const char *_quotes, const char *_separators, const char *_terminators, const char *_escapes)
         : CRoxieServerDiskReadBaseActivity(_factory, _probeManager, _remoteId, _numParts, _isLocal, _sorted, _maySkip, _manager),
-          quotes(_quotes), separators(_separators), terminators(_terminators)
+          quotes(_quotes), separators(_separators), terminators(_terminators), escapes(_escapes)
     {
         compoundHelper = NULL;
         readHelper = (IHThorCsvReadArg *)&helper;
@@ -20064,9 +20066,10 @@ public:
                         quotes = options->queryProp("@csvQuote");
                         separators = options->queryProp("@csvSeparate");
                         terminators = options->queryProp("@csvTerminate");
+                        escapes = options->queryProp("@csvEscape");
                     }
                 }
-                csvSplitter.init(readHelper->getMaxColumns(), csvInfo, quotes, separators, terminators);
+                csvSplitter.init(readHelper->getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
             }
         }
     }
@@ -20584,6 +20587,7 @@ public:
     const char *quotes;
     const char *separators;
     const char *terminators;
+    const char *escapes;
 
     CRoxieServerDiskReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, const RemoteActivityId &_remoteId, IPropertyTree &_graphNode)
         : CRoxieServerActivityFactory(_id, _subgraphId, _queryFactory, _helperFactory, _kind), remoteId(_remoteId)
@@ -20593,7 +20597,7 @@ public:
         sorted = (helper->getFlags() & TDRunsorted) == 0;
         variableFileName = (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename)) != 0;
         maySkip = (helper->getFlags() & (TDRkeyedlimitskips|TDRkeyedlimitcreates|TDRlimitskips|TDRlimitcreates)) != 0;
-        quotes = separators = terminators = NULL;
+        quotes = separators = terminators = escapes = NULL;
         if (!variableFileName)
         {
             bool isOpt = (helper->getFlags() & TDRoptional) != 0;
@@ -20615,6 +20619,7 @@ public:
                         quotes = options->queryProp("@csvQuote");
                         separators = options->queryProp("@csvSeparate");
                         terminators = options->queryProp("@csvTerminate");
+                        escapes = options->queryProp("@csvEscape");
                     }
                 }
                 else
@@ -20630,7 +20635,7 @@ public:
         {
         case TAKcsvread:
             return new CRoxieServerCsvReadActivity(this, _probeManager, remoteId, numParts, isLocal, sorted, maySkip, manager,
-                                                   quotes, separators, terminators);
+                                                   quotes, separators, terminators, escapes);
         case TAKxmlread:
             return new CRoxieServerXmlReadActivity(this, _probeManager, remoteId, numParts, isLocal, sorted, maySkip, manager);
         case TAKdiskread:

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -1911,7 +1911,17 @@ typedef IHThorLocalResultWriteArg IHThorLocalResultSpillArg;
 
 struct ICsvParameters
 {
-    enum { defaultQuote = 1, defaultSeparate = 2, defaultTerminate = 4, hasUnicode = 8, singleHeaderFooter = 16, preserveWhitespace = 32, manyHeaderFooter = 64, }; // flags values
+    enum
+    {
+        defaultQuote = 1,
+        defaultSeparate = 2,
+        defaultTerminate = 4,
+        hasUnicode = 8,
+        singleHeaderFooter = 16,
+        preserveWhitespace = 32,
+        manyHeaderFooter = 64,
+        defaultEscape = 128
+    }; // flags values
     virtual unsigned     getFlags() = 0;
     virtual bool         queryEBCDIC() = 0;
     virtual const char * queryHeader()              { return NULL; }
@@ -1920,6 +1930,7 @@ struct ICsvParameters
     virtual const char * queryQuote(unsigned idx) = 0;
     virtual const char * querySeparator(unsigned idx) = 0;
     virtual const char * queryTerminator(unsigned idx) = 0;
+    virtual const char * queryEscape(unsigned idx) = 0;
     virtual const char * queryFooter()              { return NULL; }
 };
 

--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -785,6 +785,11 @@ typedef LONG (WINAPI *PROCNTQSI)(UINT,PVOID,ULONG,PULONG);
 typedef LONG (WINAPI *PROCNTQIP)(HANDLE,UINT,PVOID,ULONG,PULONG);
 typedef LONG (WINAPI *PROCNTGST)(LARGE_INTEGER*, LARGE_INTEGER*, LARGE_INTEGER*);
 
+memsize_t getMapInfo(const char *type)
+{
+    return 0; // TODO/UNKNOWN
+}
+
 void getCpuInfo(unsigned &numCPUs, unsigned &CPUSpeed)
 {
     // MORE: Might be a better way to get CPU speed (actual) than the one stored in Registry
@@ -841,6 +846,31 @@ unsigned getAffinityCpus()
 }
 
 #else // linux
+
+memsize_t getMapInfo(const char *type)
+{
+    memsize_t ret = 0;
+    VStringBuffer procMaps("/proc/%d/maps", GetCurrentProcessId());
+    VStringBuffer typeStr("[%s]", type);
+    FILE *diskfp = fopen(procMaps.str(), "r");
+    if (!diskfp)
+        return false;
+    char ln[256];
+    while (fgets(ln, sizeof(ln), diskfp))
+    {
+        if (strstr(ln, typeStr.str()))
+        {
+            unsigned __int64 addrLow, addrHigh;
+            if (2 == sscanf(ln, "%16Lx-%16Lx", &addrLow, &addrHigh))
+            {
+                ret = (memsize_t)(addrHigh-addrLow);
+                break;
+            }
+        }
+    }
+    fclose(diskfp);
+    return ret;
+}
 
 void getCpuInfo(unsigned &numCPUs, unsigned &CPUSpeed)
 {

--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -253,6 +253,7 @@ unsigned jlib_decl setAllocHook(bool on);  // bwd compat returns unsigned
 #endif
 
 extern jlib_decl void getHardwareInfo(HardwareInfo &hdwInfo, const char *primDiskPath = NULL, const char *secDiskPath = NULL);
+extern jlib_decl memsize_t getMapInfo(const char *type);
 extern jlib_decl void getCpuInfo(unsigned &numCPUs, unsigned &CPUSpeed);
 extern jlib_decl unsigned getAffinityCpus();
 extern jlib_decl void printProcMap(const char *fn, bool printbody, bool printsummary, StringBuffer *lnout, MemoryBuffer *mb, bool useprintf);

--- a/testing/ecl/csv-escaped.ecl
+++ b/testing/ecl/csv-escaped.ecl
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+rec := RECORD
+  string foo;
+  integer id;
+  string bar;
+END;
+
+orig := DATASET([{'this is an \\\'escaped\\\' string', 10, 'while this is not'}], rec);
+OUTPUT(orig, , 'regress::csv-escaped', OVERWRITE, CSV);
+
+escaped := DATASET('regress::csv-escaped', rec, CSV(ESCAPE('\\')));
+OUTPUT(escaped);

--- a/testing/ecl/key/csv-escaped.xml
+++ b/testing/ecl/key/csv-escaped.xml
@@ -1,0 +1,5 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><foo>this is an &apos;escaped&apos; string</foo><id>10</id><bar>while this is not</bar></Row>
+</Dataset>

--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -36,7 +36,7 @@
 class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDataLink
 {
     IHThorCsvReadArg *helper;
-    StringAttr csvQuote, csvSeparate, csvTerminate;
+    StringAttr csvQuote, csvSeparate, csvTerminate, csvEscape;
     Owned<IRowStream> out;
     rowcount_t limit;
     rowcount_t stopAfter;
@@ -85,7 +85,7 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
             readFinished = false;
             //Initialise information...
             ICsvParameters * csvInfo = activity.helper->queryCsvParameters();
-            csvSplitter.init(activity.helper->getMaxColumns(), csvInfo, activity.csvQuote, activity.csvSeparate, activity.csvTerminate);
+            csvSplitter.init(activity.helper->getMaxColumns(), csvInfo, activity.csvQuote, activity.csvSeparate, activity.csvTerminate, activity.csvEscape);
         }
         virtual void setPart(IPartDescriptor *partDesc, unsigned partNoSerialized)
         {
@@ -315,6 +315,8 @@ public:
             if (b) data.read(csvSeparate);
             data.read(b);
             if (b) data.read(csvTerminate);
+            data.read(b);
+            if (b) data.read(csvEscape);
         }
         if (headerLines)
         {

--- a/thorlcr/activities/diskwrite/thdiskwrite.cpp
+++ b/thorlcr/activities/diskwrite/thdiskwrite.cpp
@@ -77,6 +77,7 @@ public:
         props.setProp("@csvSeparate", separator.str());
         props.setProp("@csvQuote", csvParameters->queryQuote(0));
         props.setProp("@csvTerminate", csvParameters->queryTerminator(0));
+        props.setProp("@csvEscape", csvParameters->queryEscape(0));
 
         CWriteMasterBase::done(); // will publish
     }

--- a/thorlcr/activities/fetch/thfetchslave.cpp
+++ b/thorlcr/activities/fetch/thfetchslave.cpp
@@ -542,7 +542,8 @@ public:
         const char * quotes = lFProps->hasProp("@csvQuote")?lFProps->queryProp("@csvQuote"):NULL;
         const char * separators = lFProps->hasProp("@csvSeparate")?lFProps->queryProp("@csvSeparate"):NULL;
         const char * terminators = lFProps->hasProp("@csvTerminate")?lFProps->queryProp("@csvTerminate"):NULL;      
-        csvSplitter.init(helper->getMaxColumns(), csvInfo, quotes, separators, terminators);
+        const char * escapes = lFProps->hasProp("@csvEscape")?lFProps->queryProp("@csvEscape"):NULL;
+        csvSplitter.init(helper->getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
     }
     virtual size32_t fetch(ARowBuilder & rowBuilder, const void *keyRow, unsigned filePartIndex, unsigned __int64 localFpos, unsigned __int64 fpos)
     {

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2354,6 +2354,12 @@ void CJobBase::init()
     if (gmemSize && largeMemSize >= gmemSize)
         throw MakeStringException(0, "largeMemSize(%d) can not exceed globalMemorySize(%d)", largeMemSize, gmemSize);
     PROGLOG("Global memory size = %d MB, large mem size = %d MB", gmemSize, largeMemSize);
+    StringBuffer tracing("maxActivityCores = ");
+    if (maxActivityCores)
+        tracing.append(maxActivityCores);
+    else
+        tracing.append("[unbound]");
+    PROGLOG("%s", tracing.str());
     setLargeMemSize(largeMemSize);
     graphExecutor.setown(new CGraphExecutor(*this));
 }
@@ -2368,6 +2374,13 @@ CJobBase::~CJobBase()
     ::Release(userDesc);
     timeReporter->Release();
     delete pluginMap;
+
+    StringBuffer memStatsStr;
+    roxiemem::memstats(memStatsStr);
+    PROGLOG("Roxiemem stats: %s", memStatsStr.str());
+    memsize_t heapUsage = getMapInfo("heap");
+    if (heapUsage) // if 0, assumed to be unavailable
+        PROGLOG("Heap usage : %"I64F"d bytes", (unsigned __int64)heapUsage);
 }
 
 bool CJobBase::queryForceLogging(graph_id graphId, bool def) const


### PR DESCRIPTION
Request For Comment Only, do not pull.

This is the first attempt to get the escaping in CSV tables. It works, but still need some changes to make it good. The implementation of cleaning up the escapes is lacking, don't pay too much attention to that. In particular, ignore the escape flag and the assumptions about ASCii, I need to streamline the whole filtering.

I'm more concerned to know that the places I changed are correct and that the new extension to the language (CSV(ESCAPE)) is meaningful.

Signed-off-by: Renato Golin rengolin@hpccsystems.com
