### PR TITLE
HPCC-2122 Add ability to pause DFU queue

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -597,17 +597,35 @@
                         </xsl:call-template>
                     </xsl:for-each>
 
-                    <xsl:call-template name="show-server">
-                        <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLagent']"/>
-                    </xsl:call-template>
+                    <xsl:for-each select="ServerJobQueues/ServerJobQueue[ServerType='ECLagent']">
+                        <xsl:call-template name="show-queue">
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLagent' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="cluster" select="ServerName"/>
+                            <xsl:with-param name="clusterType" select="ServerType"/>
+                            <xsl:with-param name="queue" select="QueueName"/>
+                            <xsl:with-param name="status" select="QueueStatus"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
 
-                    <xsl:call-template name="show-server">
-                        <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLCCserver']"/>
-                    </xsl:call-template>
+                    <xsl:for-each select="ServerJobQueues/ServerJobQueue[ServerType='ECLCCserver']">
+                        <xsl:call-template name="show-queue">
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLCCserver' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="cluster" select="ServerName"/>
+                            <xsl:with-param name="clusterType" select="ServerType"/>
+                            <xsl:with-param name="queue" select="QueueName"/>
+                            <xsl:with-param name="status" select="QueueStatus"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
 
-                    <xsl:call-template name="show-server">
-                        <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='DFUserver']"/>
-                    </xsl:call-template>
+                    <xsl:for-each select="ServerJobQueues/ServerJobQueue[ServerType='DFUserver']">
+                        <xsl:call-template name="show-queue">
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='DFUserver' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="cluster" select="ServerName"/>
+                            <xsl:with-param name="clusterType" select="ServerType"/>
+                            <xsl:with-param name="queue" select="QueueName"/>
+                            <xsl:with-param name="status" select="QueueStatus"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
                     <xsl:apply-templates select="DFUJobs"/>
                 </form>
                 <xsl:if test="SuperUser">
@@ -708,8 +726,14 @@
                         <xsl:when test="$clusterType = 'HTHOR'">
                             <xsl:value-of select="concat('mn_3_', $pid)"/>
                         </xsl:when>
-                        <xsl:otherwise>
+                        <xsl:when test="$clusterType = 'ECLCCserver'">
                             <xsl:value-of select="concat('mn_4_', $pid)"/>
+                        </xsl:when>
+                        <xsl:when test="$clusterType = 'DFUserver'">
+                            <xsl:value-of select="concat('mn_5_', $pid)"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="concat('mn_6_', $pid)"/>
                         </xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
@@ -723,6 +747,22 @@
                     </xsl:if>
                     <a>
                         <xsl:choose>
+                            <xsl:when test="$clusterType = 'DFUserver' or $clusterType = 'ECLCCserver' or $clusterType = 'ECLagent'">
+                                <xsl:choose>
+                                    <xsl:when test="$status='paused'">
+                                        <xsl:attribute name="class">thorrunningpausedqueuejobs</xsl:attribute>
+                                        <xsl:attribute name="title">Queue paused</xsl:attribute>
+                                    </xsl:when>
+                                    <xsl:when test="$status='stopped'">
+                                        <xsl:attribute name="class">thorrunningpausedqueuejobs</xsl:attribute>
+                                        <xsl:attribute name="title">Queue stopped</xsl:attribute>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:attribute name="class">thorrunning</xsl:attribute>
+                                        <xsl:attribute name="title">Queue running</xsl:attribute>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:when>
                             <xsl:when test="$status2='1'">
                                 <xsl:attribute name="class">thorrunningpausedqueuejobs</xsl:attribute>
                                 <xsl:attribute name="title">Queue paused - Cluster running</xsl:attribute>
@@ -748,11 +788,13 @@
                             <xsl:attribute name="href">javascript:go('/WsTopology/TpClusterInfo?Name=<xsl:value-of select="$cluster"/>')</xsl:attribute>
                         </xsl:if>
                         <xsl:choose>
-                            <xsl:when test="$clusterType = 'ROXIE'">RoxieCluster - </xsl:when>
-                            <xsl:when test="$clusterType = 'THOR'">ThorCluster - </xsl:when>
-                            <xsl:when test="$clusterType = 'HTHOR'">HThorCluster - </xsl:when>
+                            <xsl:when test="$clusterType = 'ROXIE'">RoxieCluster - <xsl:value-of select="$cluster"/></xsl:when>
+                            <xsl:when test="$clusterType = 'THOR'">ThorCluster - <xsl:value-of select="$cluster"/></xsl:when>
+                            <xsl:when test="$clusterType = 'HTHOR'">HThorCluster - <xsl:value-of select="$cluster"/></xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$clusterType"/> - <xsl:value-of select="$queue"/>
+                            </xsl:otherwise>
                         </xsl:choose>
-                        <xsl:value-of select="$cluster"/>
                     </a>
                 </td>
             </tr>

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -85,6 +85,14 @@ ESPStruct DFUJob
     string Command;
 };
 
+ESPStruct ServerJobQueue
+{
+    string QueueName;
+    string ServerName;
+    string ServerType;
+    string QueueStatus;
+};
+
 ESPrequest [nil_remove] ActivityRequest
 {
     string ChatURL;
@@ -118,6 +126,7 @@ ESPresponse [exceptions_inline] ActivityResponse
     [min_ver("1.11")] bool Descending(false);
     [min_ver("1.12")] bool SuperUser(false);
     [min_ver("1.12")] string AccessRight;
+    [min_ver("1.14")] ESParray<ESPstruct ServerJobQueue> ServerJobQueues;
 };
 
 ESPrequest SMCIndexRequest
@@ -259,7 +268,7 @@ BrowseResourcesResponse
     ESParray<ESPstruct HPCCResourceRepository> HPCCResourceRepositories;
 };
 
-ESPservice [noforms, version("1.12"), default_client_version("1.12"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [noforms, version("1.14"), default_client_version("1.14"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPuses ESPStruct Capability;
     ESPuses ESPStruct Permission;

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -586,6 +586,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 resp.setAccessRight("Access_Full");
         }
 
+        IArrayOf<IEspServerJobQueue> serverJobQueues;
         IArrayOf<IConstTpEclServer> eclccservers;
         CTpWrapper dummy;
         dummy.getTpEclCCServers(eclccservers);
@@ -620,10 +621,12 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                     Owned<IEspActiveWorkunit> wu(new CActiveWorkunitWrapper(context, iter->query().queryWUID(),++count));
                     wu->setServer("ECLCCserver");
                     wu->setInstance(serverName);
-                    wu->setQueueName(serverName);
+                    wu->setQueueName(queueName);
 
                     aws.append(*wu.getLink());
                 }
+
+                addServerJobQueue(serverJobQueues, queueName, serverName, "ECLCCserver");
             }
         }
 
@@ -641,6 +644,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
             {
                 IPropertyTree &serviceTree = services->query();
                 const char *queuename = serviceTree.queryProp("@queue");
+                const char *serverName = serviceTree.queryProp("@name");
                 if (queuename && *queuename)
                 {
                     StringArray queues;
@@ -665,9 +669,10 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                     }
                     ForEachItemIn(q, queues)
                     {
-                        const char *queuename = queues.item(q);
+                        const char *queueName = queues.item(q);
+
                         StringAttrArray wulist;
-                        unsigned running = queuedJobs(queuename, wulist);
+                        unsigned running = queuedJobs(queueName, wulist);
                         ForEachItemIn(i, wulist)
                         {
                             const char *wuid = wulist.item(i).text.get();
@@ -686,9 +691,8 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
 
                                     Owned<IEspActiveWorkunit> wu1(new CActiveWorkunitWrapper(wuid, uname.str(), jname.str(), state.str(), "normal"));
                                     wu1->setServer("DFUserver");
-                                    wu1->setInstance(queuename);
-                                    wu1->setQueueName(queuename);
-
+                                    wu1->setInstance(serverName);
+                                    wu1->setQueueName(queueName);
                                     aws.append(*wu1.getLink());
                                 }
                             }
@@ -697,16 +701,19 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                                 StringBuffer msg;
                                 Owned<IEspActiveWorkunit> wu1(new CActiveWorkunitWrapper(wuid, "", "", e->errorMessage(msg).str(), "normal"));
                                 wu1->setServer("DFUserver");
-                                wu1->setInstance(queuename);
-                                wu1->setQueueName(queuename);
+                                wu1->setInstance(serverName);
+                                wu1->setQueueName(queueName);
                                 aws.append(*wu1.getLink());
                             }
                         }
+                        addServerJobQueue(serverJobQueues, queueName, serverName, "DFUserver");
                     }
                 }
             } while (services->next());
         }
         resp.setRunning(aws);
+        if (version > 1.03)
+            resp.setServerJobQueues(serverJobQueues);
 
         IArrayOf<IEspDFUJob> jobs;
         conn.setown(querySDS().connect("DFU/RECOVERY",myProcessSession(),0, INFINITE));
@@ -743,6 +750,27 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
     }
 
     return true;
+}
+
+void CWsSMCEx::addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType)
+{
+    if (!queueName || !*queueName || !serverName || !*serverName || !serverType || !*serverType)
+        return;
+
+    Owned<IEspServerJobQueue> jobQueue = createServerJobQueue("", "");
+    jobQueue->setQueueName(queueName);
+    jobQueue->setServerName(serverName);
+    jobQueue->setServerType(serverType);
+
+    Owned<IJobQueue> queue = createJobQueue(queueName);
+    if (queue->stopped())
+        jobQueue->setQueueStatus("stopped");
+    else if (queue->paused())
+        jobQueue->setQueueStatus("paused");
+    else
+        jobQueue->setQueueStatus("running");
+
+    jobQueues.append(*jobQueue.getClear());
 }
 
 void CWsSMCEx::addToThorClusterList(IArrayOf<IEspThorCluster>& clusters, IEspThorCluster* cluster, const char* sortBy, bool descending)

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -67,6 +67,7 @@ private:
                                  IArrayOf<IEspCapability>& capabilities);
     void addToThorClusterList(IArrayOf<IEspThorCluster>& clusters, IEspThorCluster* cluster, const char* sortBy, bool descending);
     void addToRoxieClusterList(IArrayOf<IEspRoxieCluster>& clusters, IEspRoxieCluster* cluster, const char* sortBy, bool descending);
+    void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
 };
 
 


### PR DESCRIPTION
Operations is requesting the ability to pause the DFU queue. The
existing code can pause the queue. But, it still shows that the
queue is running. The existing C++ code sends the queue status
using the first workunit inside the queue. If the queue does not
have a workunit, the UI code cannot know the status. The new code
creates a ServerJobQueue object and uses it to pass the queue
status to xslt.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
