### PR TITLE
HPCC-3263 Flag libraries when published to QuerySets

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -8865,7 +8865,7 @@ static void clearAliases(IPropertyTree * queryRegistry, const char * id)
     }
 }
 
-IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll)
+IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll, bool library)
 {
     StringBuffer lcName(name);
     lcName.toLowerCase();
@@ -8893,6 +8893,8 @@ IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, 
     newEntry->setProp("@dll", dll);
     newEntry->setProp("@id", id);
     newEntry->setPropInt("@seq", seq);
+    if (library)
+        newEntry->setPropBool("@isLibrary", true);
     return queryRegistry->addPropTree("Query", newEntry);
 }
 
@@ -9167,7 +9169,7 @@ void addQueryToQuerySet(IWorkUnit *workunit, const char *querySetName, const cha
         }
     }
 
-    IPropertyTree *newEntry = addNamedQuery(queryRegistry, cleanQueryName, wuid.str(), dllName.str());
+    IPropertyTree *newEntry = addNamedQuery(queryRegistry, cleanQueryName, wuid.str(), dllName.str(), isLibrary(workunit));
     newQueryId.append(newEntry->queryProp("@id"));
     workunit->setIsQueryService(true); //will check querysets before delete
     workunit->commit();

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1207,7 +1207,7 @@ enum WUQueryActivationOptions
 };
 
 
-extern WORKUNIT_API IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll);       // result not linked
+extern WORKUNIT_API IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll, bool library);       // result not linked
 extern WORKUNIT_API void removeNamedQuery(IPropertyTree * queryRegistry, const char * id);
 extern WORKUNIT_API void removeWuidFromNamedQueries(IPropertyTree * queryRegistry, const char * wuid);
 extern WORKUNIT_API void removeDllFromNamedQueries(IPropertyTree * queryRegistry, const char * dll);

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -328,7 +328,7 @@ void CWsEclBinding::getQueryNames(IPropertyTree* settree, const char *id, const 
 
     VStringBuffer xpath("Query[@id='%s']", id);
     IPropertyTree *query = settree->queryPropTree(xpath.str());
-    if (query->getPropBool("@suspended"))
+    if (query->getPropBool("@isLibrary") || query->getPropBool("@suspended"))
         return;
 
     if (!qname || !*qname)
@@ -362,7 +362,10 @@ void CWsEclBinding::getDynNavData(IEspContext &context, IProperties *params, IPr
         {
             Owned<IPropertyTreeIterator> iter = settree->getElements("Query");
             ForEach(*iter)
-                addQueryNavLink(data, &iter->query(), setname);
+            {
+                if (!iter->query().getPropBool("@isLibrary"))
+                    addQueryNavLink(data, &iter->query(), setname);
+            }
         }
         else
         {

--- a/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
+++ b/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
@@ -25,6 +25,8 @@ WsEclWuInfo::WsEclWuInfo(const char *wuid_, const char *qset, const char *qname,
     wu.setown(wf->openWorkUnit(wuid.sget(), false));
     if (!wu)
         throw MakeStringException(-1, "Could not open workunit: %s", wuid.sget());
+    if (isLibrary(wu))
+        throw MakeStringException(-1, "%s/%s is a library", qset, qname);
 }
 
 bool WsEclWuInfo::getWsResource(const char *name, StringBuffer &out)


### PR DESCRIPTION
WsEcl needs an efficient way of being able to recognize library
entries in querysets.

When libraries are published add an "@isLibrary" attribute to the
Query element in the QuerySet.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
