### PR TITLE
HPCC-7891 colprefix inx with 0 rows hitting assert

### DIFF
--- a/system/jhtree/ctfile.cpp
+++ b/system/jhtree/ctfile.cpp
@@ -614,6 +614,7 @@ void CJHTreeNode::unpack(const void *node, bool needCopy)
                 keyBuf = expandKeys(keys,keyLen,expandedSize,quick);
             }
         }
+        assertex(keyBuf||rowexp.get());
     }
     else
     {
@@ -708,6 +709,7 @@ void CJHTreeNode::unpack(const void *node, bool needCopy)
                 }
                 expandedSize = keyBufMb.length();
                 keyBuf = (char *)keyBufMb.detach();
+                assertex(keyBuf);
             }
             else {
                 keyBuf = NULL;
@@ -722,7 +724,6 @@ void CJHTreeNode::unpack(const void *node, bool needCopy)
             memcpy(keyBuf, keys, hdr.keyBytes + sizeof( __int64 ));
         }
     }
-    assertex(keyBuf||rowexp.get());
 }
 
 offset_t CJHTreeNode::prevNodeFpos() const


### PR DESCRIPTION
A column prefix compressed index with 0 rows (in a part), was falsely
asserting that there should be key buffer
This is a regression, introduced by HPCC-7891

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
