### PR TITLE
HPCC-2880 Report files currently in use by cluster

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -194,12 +194,15 @@ public:
     {
         CActivityFactory::getActivityMetrics(reply);
     }
-
     IRoxieSlaveContext *createSlaveContext(SlaveContextLogger &logctx, IRoxieQueryPacket *packet) const
     {
         return queryFactory.createSlaveContext(logctx, packet);
     }
-
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        if (datafile)
+            addXrefFileInfo(reply, datafile);
+    }
     IRoxieSlaveContext *createChildQueries(IHThorArg *colocalArg, IArrayOf<IActivityGraph> &childGraphs, IProbeManager *_probeManager, SlaveContextLogger &logctx, IRoxieQueryPacket *packet) const
     {
         if (!childQueries.length())
@@ -220,6 +223,8 @@ public:
         }
         return NULL;
     }
+
+    Owned<const IResolvedFile> datafile;
 
 protected:
 
@@ -908,7 +913,6 @@ class CRoxieDiskBaseActivityFactory : public CSlaveActivityFactory
 protected:
     Owned<IFileIOArray> fileArray;
     Owned<IInMemoryIndexManager> manager;
-    Owned<const IResolvedFile> datafile;
 
 public:
     CRoxieDiskBaseActivityFactory(IPropertyTree &_graphNode, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory)
@@ -2972,7 +2976,6 @@ ISlaveActivityFactory *createRoxieDiskGroupAggregateActivityFactory(IPropertyTre
 class CRoxieKeyedActivityFactory : public CSlaveActivityFactory
 {
 protected:
-    Owned<const IResolvedFile> datafile;
     Owned<IKeyArray> keyArray;
     Owned<TranslatorArray> layoutTranslators;
     Owned<IDefRecordMeta> activityMeta;
@@ -2986,7 +2989,6 @@ public:
     inline IKeyArray *queryKeyArray() const { return keyArray; }
     inline TranslatorArray *queryLayoutTranslators() const { return layoutTranslators; }
     inline IDefRecordMeta *queryActivityMeta() const { return activityMeta; }
-
 };
 
 class CRoxieIndexActivityFactory : public CRoxieKeyedActivityFactory
@@ -4199,7 +4201,6 @@ class CRoxieFetchActivityFactory : public CSlaveActivityFactory
 public:
     IMPLEMENT_IINTERFACE;
     Owned<IFileIOArray> fileArray;
-    Owned<const IResolvedFile> datafile;
 
     CRoxieFetchActivityFactory(IPropertyTree &_graphNode, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory)
         : CSlaveActivityFactory(_graphNode, _subgraphId, _queryFactory, _helperFactory)
@@ -4890,7 +4891,6 @@ class CRoxieKeyedJoinFetchActivityFactory : public CSlaveActivityFactory
 {
 public:
     IMPLEMENT_IINTERFACE;
-    Owned<const IResolvedFile> datafile;
     Owned<IFileIOArray> fileArray;
 
     CRoxieKeyedJoinFetchActivityFactory(IPropertyTree &_graphNode, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory)
@@ -4921,7 +4921,6 @@ public:
     {
         return fileArray->getFilePart(partNo, _base);
     }
-
 };
 
 class CRoxieKeyedJoinFetchActivity : public CRoxieSlaveActivity
@@ -5235,7 +5234,6 @@ class CRoxieDummyActivityFactory : public CSlaveActivityFactory  // not a real a
 {
 protected:
     Owned<const IResolvedFile> indexfile;
-    Owned<const IResolvedFile> datafile;
     Owned<IKeyArray> keyArray;
     Owned<IFileIOArray> fileArray;
     TranslatorArray layoutTranslators;

--- a/roxie/ccd/ccdactivities.hpp
+++ b/roxie/ccd/ccdactivities.hpp
@@ -45,6 +45,7 @@ interface IActivityFactory : extends IInterface
     virtual IQueryFactory &queryQueryFactory() const = 0;
     virtual ThorActivityKind getKind() const = 0;
     virtual void getActivityMetrics(StringBuffer &reply) const = 0;
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const = 0;
 };
 
 interface IRoxieSlaveActivity : extends IInterface

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -112,6 +112,7 @@ interface IQueryFactory : extends IInterface
     virtual void getGraphNames(StringArray &ret) const = 0;
 
     virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
+    virtual void getQueryXrefInfo(StringBuffer &result, const IRoxieContextLogger &logctx) const = 0;
 };
 
 class ActivityArray : public CInterface
@@ -204,9 +205,15 @@ public:
     {
         mystats.toXML(reply);
     }
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        // Default is no additional information
+    }
 
 };
 
+extern void addXrefFileInfo(IPropertyTree &reply, const IResolvedFile *dataFile);
+extern void addXrefLibraryInfo(IPropertyTree &reply, const char *libraryName);
 
 interface IQueryDll : public IInterface
 {

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -606,6 +606,10 @@ public:
         mystats.noteStatistic(statCode, value, count);
     }
 
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        // Most activities have nothing to say...
+    }
 };
 
 class CRoxieServerMultiInputInfo
@@ -15142,6 +15146,11 @@ public:
     }
 
     virtual unsigned numInputs() const { return inputs.ordinality(); }
+
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        addXrefLibraryInfo(reply, extra.libraryName);
+    }
 };
 
 IRoxieServerActivityFactory *createRoxieServerLibraryCallActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, LibraryCallFactoryExtra & _extra)
@@ -20652,6 +20661,11 @@ public:
         throw MakeStringException(ROXIE_SET_INPUT, "Internal error: setInput() should not be called for %s activity", getActivityText(kind));
     }
 
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        if (datafile)
+            addXrefFileInfo(reply, datafile);
+    }
 };
 
 IRoxieServerActivityFactory *createRoxieServerDiskReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, const RemoteActivityId &_remoteId, IPropertyTree &_graphNode)
@@ -21715,6 +21729,12 @@ public:
         delete cache;
     }
 
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        if (indexfile)
+            addXrefFileInfo(reply, indexfile);
+    }
+
     virtual void setInput(unsigned idx, unsigned source, unsigned sourceidx)
     {
         throw MakeStringException(ROXIE_SET_INPUT, "Internal error: setInput() should not be called for indexread activity");
@@ -22613,6 +22633,12 @@ public:
             answer = 0;
     }
 
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        if (datafile)
+            addXrefFileInfo(reply, datafile);
+    }
+
     virtual IRoxieServerActivity *createFunction(IHThorArg &arg, IProbeManager *_probeManager) const
     {
         arg.Release();
@@ -22822,6 +22848,11 @@ public:
         return new CRoxieServerFetchActivity(this, _probeManager, remoteId, map);
     }
 
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        if (datafile)
+            addXrefFileInfo(reply, datafile);
+    }
 };
 
 IRoxieServerActivityFactory *createRoxieServerFetchActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, const RemoteActivityId &_remoteId, IPropertyTree &_graphNode)
@@ -22878,6 +22909,14 @@ public:
     }
 
     virtual IRoxieServerActivity *createActivity(IProbeManager *_probeManager) const { throw MakeStringException(ROXIE_INTERNAL_ERROR, "%s query %s is suspended and cannot be executed - error occurred at %s(%d)", (queryFactory.isQueryLibrary()) ? "Library" : " ", queryFactory.queryQueryName(), __FILE__, __LINE__); }
+
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        if (datafile)
+            addXrefFileInfo(reply, datafile);
+        if (indexfile)
+            addXrefFileInfo(reply, indexfile);
+    }
 };
 
 IRoxieServerActivityFactory *createRoxieServerDummyActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, IPropertyTree &_graphNode, bool isLoadDataOnly)
@@ -24411,6 +24450,13 @@ public:
                 tailId, map, joinFlags, isLocal);
     }
 
+    virtual void getXrefInfo(IPropertyTree &reply, const IRoxieContextLogger &logctx) const
+    {
+        if (datafile)
+            addXrefFileInfo(reply, datafile);
+        if (indexfile)
+            addXrefFileInfo(reply, indexfile);
+    }
 };
 
 IRoxieServerActivityFactory *createRoxieServerKeyedJoinActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, const RemoteActivityId &_remoteId, const RemoteActivityId &_remoteId2, IPropertyTree &_graphNode)

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -753,6 +753,33 @@ protected:
 
     virtual IQueryFactory *loadQueryFromDll(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo, IRoxieLibraryLookupContext *libraryContext) = 0;
 
+    void getQueryInfo(StringBuffer &reply, bool full, const IRoxieContextLogger &logctx) const
+    {
+        HashIterator elems(queries);
+        for (elems.first(); elems.isValid(); elems.next())
+        {
+            IMapping &cur = elems.query();
+            IQueryFactory *query = queries.mapToValue(&cur);
+            if (full)
+            {
+                query->getQueryXrefInfo(reply, logctx);
+            }
+            else
+            {
+                reply.appendf(" <Query id='%s'", query->queryQueryName());
+                if (query->suspended())
+                    reply.append(" suspended='1'");
+                reply.append("/>\n");
+            }
+        }
+        HashIterator aliasIterator(aliases);
+        for (aliasIterator.first(); aliasIterator.isValid(); aliasIterator.next())
+        {
+            IMapping &cur = aliasIterator.query();
+            reply.appendf(" <Alias id='%s' query='%s'/>\n", (const char *) cur.getKey(), aliases.mapToValue(&cur)->queryQueryName());
+        }
+    }
+
 public:
     IMPLEMENT_IINTERFACE;
     CRoxieQuerySetManager(unsigned _channelNo, const char *_querySetName)
@@ -877,24 +904,14 @@ public:
         }
     }
 
-    virtual void getQueries(StringBuffer &reply) const
+    virtual void getQueries(StringBuffer &reply, const IRoxieContextLogger &logctx) const
     {
-        HashIterator elems(queries);
-        for (elems.first(); elems.isValid(); elems.next())
-        {
-            IMapping &cur = elems.query();
-            IQueryFactory *query = queries.mapToValue(&cur);
-            reply.appendf(" <Query id='%s'", query->queryQueryName());
-            if (query->suspended())
-                reply.append(" suspended='1'");
-            reply.append("/>\n");
-        }
-        HashIterator aliasIterator(aliases);
-        for (aliasIterator.first(); aliasIterator.isValid(); aliasIterator.next())
-        {
-            IMapping &cur = aliasIterator.query();
-            reply.appendf(" <Alias id='%s' query='%s'/>\n", (const char *) cur.getKey(), aliases.mapToValue(&cur)->queryQueryName());
-        }
+        getQueryInfo(reply, false, logctx);
+    }
+
+    virtual void getAllQueryXrefInfo(StringBuffer &reply, const IRoxieContextLogger &logctx) const
+    {
+        getQueryInfo(reply, true, logctx);
     }
 
     virtual IQueryFactory * lookupLibrary(const char * libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const
@@ -1183,10 +1200,10 @@ public:
             }
         }
     }
-    void getQueries(StringBuffer &reply) const
+    void getQueries(StringBuffer &reply, const IRoxieContextLogger &logctx) const
     {
         CriticalBlock b2(updateCrit);
-        serverManager->getQueries(reply);
+        serverManager->getQueries(reply, logctx);
     }
 protected:
     void reloadQueryManagers(CRoxieSlaveQuerySetManagerSet *newSlaveManagers, IRoxieQuerySetManager *newServerManager, hash64_t newHash)
@@ -1631,44 +1648,41 @@ private:
             {
                 // MORE - do nothing for now - possibly needed in the future - leave this so no exception is thrown
             }
-            else if (stricmp(queryName, "control:getAllFileNames")==0)
-            {
-                UNIMPLEMENTED;
-            }
-            else if (stricmp(queryName, "control:getAllQueryInfo")==0)
-            {
-                const char* id = control->queryProp("@id");
-                if (!id)
-                    throw MakeStringException(ROXIE_MISSING_PARAMS, "No query name specified");
-                UNIMPLEMENTED;
-            }
             else if (stricmp(queryName, "control:getClusterName")==0)
             {
                 reply.appendf("<clusterName id='%s'/>", roxieName.str());
-            }
-            else if (stricmp(queryName, "control:getFilesUsedByQuery")==0)
-            {
-                UNIMPLEMENTED;
-            }
-            else if (stricmp(queryName, "control:getFileUsageInfo")==0)
-            {
-                UNIMPLEMENTED;
             }
             else if (stricmp(queryName, "control:getKeyInfo")==0)
             {
                 reportInMemoryIndexStatistics(reply, control->queryProp("@id"), control->getPropInt("@count", 10));
             }
-            else if (stricmp(queryName, "control:getLibrariesUsedByQuery")==0)
+            else if (stricmp(queryName, "control:getQueryXrefInfo")==0)
             {
-                UNIMPLEMENTED;
-            }
-            else if (stricmp(queryName, "control:getQueriesUsingFile")==0)
-            {
-                UNIMPLEMENTED;
-            }
-            else if (stricmp(queryName, "control:getQueriesUsingFileList")==0)
-            {
-                UNIMPLEMENTED;
+                // Report on all files and libraries used by a query, set of queries, or all queries
+                Owned<IPropertyTreeIterator> ids = control->getElements("Query");
+                reply.append("<QueryInfo>\n");
+                if (ids->first())
+                {
+                    ForEach(*ids)
+                    {
+                        const char *id = ids->query().queryProp("@id");
+                        if (!id)
+                            throw MakeStringException(ROXIE_MISSING_PARAMS, "Query name missing");
+                        Owned<IQueryFactory> query = getQuery(id, logctx);
+                        if (!query)
+                            throw MakeStringException(ROXIE_MISSING_PARAMS, "Query %s not found", id);
+                        query->getQueryXrefInfo(reply, logctx);
+                    }
+                }
+                else
+                {
+                    ForEachItemIn(idx, allQueryPackages)
+                    {
+                        Owned<IRoxieQuerySetManager> sm = allQueryPackages.item(idx).getRoxieServerManager();
+                        sm->getAllQueryXrefInfo(reply, logctx);
+                    }
+                }
+                reply.append("</QueryInfo>\n");
             }
             else if (stricmp(queryName, "control:getQuery")==0)
             {
@@ -1686,10 +1700,6 @@ private:
                 else
                     throw MakeStringException(ROXIE_UNKNOWN_QUERY, "Unknown query %s", id);
             }
-            else if (stricmp(queryName, "control:getQueriesUsingLibrary")==0)
-            {
-                UNIMPLEMENTED;
-            }
             else if (stricmp(queryName, "control:getQueryWarningTime")==0)
             {
                 const char *id = control->queryProp("Query/@id");
@@ -1701,10 +1711,6 @@ private:
                     unsigned warnLimit = f->getWarnTimeLimit();
                     reply.appendf("<QueryTimeWarning val='%d'/>", warnLimit);
                 }
-            }
-            else if (stricmp(queryName, "control:getSubFiles")==0)
-            {
-                UNIMPLEMENTED;
             }
             else if (stricmp(queryName, "control:getBuildVersion")==0)
             {
@@ -1879,7 +1885,7 @@ private:
                 ForEachItemIn(idx, allQueryPackages)
                 {
                     CRoxieQueryPackageManager &qpm = allQueryPackages.item(idx);
-                    qpm.getQueries(reply);
+                    qpm.getQueries(reply, logctx);
                 }
                 reply.append("</Queries>\n");
             }

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -114,7 +114,8 @@ interface IRoxieQuerySetManager : extends IRoxieLibraryLookupContext
     virtual void resetQueryTimings(const char *queryName, const IRoxieContextLogger &logctx) = 0;
     virtual void resetAllQueryTimings() = 0;
     virtual void getActivityMetrics(StringBuffer &reply) const = 0;
-    virtual void getQueries(StringBuffer &reply) const = 0;
+    virtual void getQueries(StringBuffer &reply, const IRoxieContextLogger &logctx) const = 0;
+    virtual void getAllQueryXrefInfo(StringBuffer &reply, const IRoxieContextLogger &logctx) const = 0;
 };
 
 interface IRoxieDebugSessionManager : extends IInterface


### PR DESCRIPTION
Added a new control message control:getQueryXrefInfo. This can be passed a list of
<Query id='name'/> elements to indicate what queries to return info for, or will return
info for all queries if no query is specified.

Return info is of the form

```
<QueryInfo>
 <Query id='name'>
  <File name='xxx'/>
  <Library name='yyy'/>
 </Query>
</QueryInfo>
```

Client tools can use this information to present information to the user as they see fit.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
