### PR TITLE
HPCC-7890 Default to outputting multiple c++ files

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1510,7 +1510,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.checkThorRestrictions,"checkThorRestrictions", true),       // a debug aid for running regression suite
         DebugOption(options.allowCsvWorkunitRead,"allowStoredCsvFormat", false),
         DebugOption(options.evaluateCoLocalRowInvariantInExtract,"evaluateCoLocalRowInvariantInExtract", false),
-        DebugOption(options.spanMultipleCpp,"spanMultipleCpp", false),
+        DebugOption(options.spanMultipleCpp,"spanMultipleCpp", true),
         DebugOption(options.activitiesPerCpp, "<exception>", 0x7fffffff),
         DebugOption(options.allowInlineSpill,"allowInlineSpill", true),
         DebugOption(options.optimizeGlobalProjects,"optimizeGlobalProjects", false),

--- a/ecl/regress/regress.bat
+++ b/ecl/regress/regress.bat
@@ -23,7 +23,7 @@ rd /s /q %regresstgt%
 md %regresstgt% 2>nul
 
 set flags=-P%regresstgt% -legacy -target=thorlcr -fforceGenerate -fdebugNlp=1 -fnoteRecordSizeInGraph -fregressionTest -b -m -S -shared -faddTimingToWorkunit=0 -fshowRecordCountInGraph
-set flags=%flags% %regressinclude% -fshowMetaInGraph
+set flags=%flags% %regressinclude% -fshowMetaInGraph -fspanMultipleCpp-
 
 if NOT '%regressProcesses%'=='' goto multiway
 eclcc %flags% %* > out.log

--- a/ecl/regress/regress.sh
+++ b/ecl/regress/regress.sh
@@ -93,7 +93,7 @@ fi
 if [[ $eclcc != '' ]]; then
     ## Set flags
     default_flags="-P$target_dir -legacy -platform=thorlcr -fforceGenerate -fregressionTest -faddTimingToWorkunit=0 -b -S -shared"
-    flags="$default_flags $include_dir -fshowMetaInGraph $userflags"
+    flags="$default_flags $include_dir -fshowMetaInGraph -fspanMultipleCpp- $userflags"
 
     ## Prepare target directory
     if [[ $query == '' ]]; then

--- a/ecl/regress/regress1.bat
+++ b/ecl/regress/regress1.bat
@@ -19,7 +19,7 @@ rem ############################################################################
 if '%regresstgt%'=='' goto novars
 
 set flags=-P%regresstgt% -legacy -target=thorlcr -fforceGenerate -fdebugNlp=1 -fnoteRecordSizeInGraph -fregressionTest -b -m -S -shared -faddTimingToWorkunit=0 -fshowRecordCountInGraph
-set flags=%flags% %regressinclude% -fshowMetaInGraph
+set flags=%flags% %regressinclude% -fshowMetaInGraph -fspanMultipleCpp-
 
 md %regresstgt% 2>nul
 echo %* >> %regresstgt%\stdout.log


### PR DESCRIPTION
Gcc (and other compilers) have problems on very large queries (e.g., >10,000)
activities, because of the total size of a single c++ file.  This changes the
default to split into multiple c++ files.  The regression suite still
generates single files in most cases since that is much easier to compare.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
