### PR TITLE
HPCC-7904 Allow xref max memory to be configured

### DIFF
--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -25,6 +25,7 @@
 #include "sacmd.hpp"
 
 #define DEFAULT_MAXDIRTHREADS 500
+#define DEFAULT_MAXMEMORY 4096
 
 #define SDS_CONNECT_TIMEOUT  (1000*60*60*2)     // better than infinite
 #define SDS_LOCK_TIMEOUT 300000
@@ -673,8 +674,8 @@ public:
     bool verbose;
 
 
-    CNewXRefManager()
-        : mem(0x100000*1000,0x10000,true)
+    CNewXRefManager(unsigned maxMb=DEFAULT_MAXMEMORY)
+        : mem(0x100000*maxMb,0x10000,true)
     {
         iswin = false; // set later
         root = new cDirDesc(mem,"");
@@ -685,6 +686,7 @@ public:
         lostbranch.setown(createPTree("Lost"));
         orphansbranch.setown(createPTree("Orphans"));
         dirbranch.setown(createPTree("Directories"));
+        log("Max memory = %d MB", maxMb);
     }
 
     ~CNewXRefManager()
@@ -2084,7 +2086,8 @@ public:
             continue;
 #endif          
             const char *gname = groups.item(i);
-            CNewXRefManager manager;
+            unsigned maxMb = serverConfig->getPropInt("DfuXRef/@memoryLimit", DEFAULT_MAXMEMORY);
+            CNewXRefManager manager(maxMb);
             if (!manager.setGroup(cnames.item(i),gname,groupsdone,dirsdone)) 
                 continue;
             manager.start(updateeclwatch);

--- a/initfiles/componentfiles/configxml/sasha.xsd
+++ b/initfiles/componentfiles/configxml/sasha.xsd
@@ -422,6 +422,13 @@
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="memoryLimit" type="xs:nonNegativeInteger" use="optional" default="4096">
+            <xs:annotation>
+                <xs:appinfo>
+                    <tooltip>The upper memory limit that xref can use.</tooltip>
+                </xs:appinfo>
+            </xs:annotation>
+        </xs:attribute>
     </xs:attributeGroup>
     <xs:attributeGroup name="DfuExpiry">
         <xs:attribute name="ExpiryInterval" type="xs:nonNegativeInteger" default="24">

--- a/initfiles/componentfiles/configxml/sasha.xsl
+++ b/initfiles/componentfiles/configxml/sasha.xsl
@@ -201,6 +201,9 @@
                       <xsl:with-param name="val" select="@xrefEclWatchProvider"/>
                    </xsl:call-template>
                 </xsl:attribute>
+                <xsl:attribute name="memoryLimit">
+                   <xsl:value-of select="@memoryLimit"/>
+                </xsl:attribute>
             </xsl:element>
             <xsl:element name="DfuExpiry">
                 <xsl:attribute name="interval">

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -1106,7 +1106,8 @@
                       xrefCutoff="1"
                       xrefEclWatchProvider="true"
                       xrefInterval="0"
-                      xrefList="*">
+                      xrefList="*"
+                      xrefMaxMemory="4096">
    <Instance computer="localhost"
              directory="${RUNTIME_PATH}/mysasha"
              name="s1"


### PR DESCRIPTION
Previously xref was hard-coded to use a maximum of 1GB
There is now a configuration setting to set, the default is now 4GB
On machines with less, it will trigger a out of memory exception, rather
than the forced internal hard limit

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
