### PR TITLE
HPCC-7892 Roxie should default to predictable order

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -17682,7 +17682,7 @@ public:
             left = input->nextInGroup();
             matchedLeft = false;
             countForLeft = keepLimit;
-            if((left == NULL))
+            if(left == NULL)
             {
                 eos = true;
                 return NULL;
@@ -21677,7 +21677,7 @@ public:
     {
         Owned<IHThorIndexReadBaseArg> indexHelper = (IHThorIndexReadBaseArg *) helperFactory();
         unsigned flags = indexHelper->getFlags();
-        sorted = (flags & TIRsorted) != 0;
+        sorted = (flags & TIRunsorted) == 0;
         isLocal = _graphNode.getPropBool("att[@name='local']/@value") && queryFactory.queryChannel()!=0;
         rtlDataAttr indexLayoutMeta;
         size32_t indexLayoutSize;

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -1067,6 +1067,7 @@ enum
     TIRdynamicfilename  = 0x00002000,
     TIRunfilteredtransform = 0x00004000,
     TIRorderedmerge     = 0x00008000,
+    TIRunsorted         = 0x00010000,
 };
 
 //flags for thor index write


### PR DESCRIPTION
Indexread in roxie will now default to providing a stable result EXCEPT
where UNSOERTED flag explicitly set, rather than providing a stable
result ONLY when SORTED flag is set.

I have added the TIRunsorted flag, so that the compiler can set it
if we see fit. If it doesn't, we will always default to stable.

This matches behaviour of other Roxie activities like disk read and
keyed join, that are assumed to want stable result orders unless proven
otherwise.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
