### PR TITLE
HPCC-7910 Fix building unittests under windows

### DIFF
--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -46,7 +46,7 @@ install ( TARGETS unittests DESTINATION ${OSSDIR}/bin )
 target_link_libraries ( unittests
          jlib
          remote
-         cppunit
+         ${CPPUNIT_LIBRARIES}
     )
 
 endif ()


### PR DESCRIPTION
The cmake file contained a reference to the linux .so instead of a symbolic
reference.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
