### PR TITLE
HPCC-7888 Ensure query dlls in separate dir

### DIFF
--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -396,7 +396,7 @@ int main( int argc, char *argv[]  )
                 globals->getProp("@query_so_dir", str.clear());
             if (str.length())
             {
-                if (globals->getPropBool("Debug/@dllsToSlaves"))
+                if (globals->getPropBool("Debug/@dllsToSlaves", true))
                 {
                     StringBuffer uniqSoPath;
                     if (PATHSEPCHAR == str.charAt(str.length()-1))


### PR DESCRIPTION
In multi slave setups, the query dll must not clash.
Ensure it's in it's own directory.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
