### PR TITLE
HPCC-7913 Regression in control:reload caused by HPCC-7897 fix

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1450,7 +1450,7 @@ private:
 
     void _doControlMessage(IPropertyTree *control, StringBuffer &reply, const IRoxieContextLogger &logctx)
     {
-        ReadLockBlock b(packageCrit); // Some of the control activities below need a lock
+        ReadLockBlock readBlock(packageCrit); // Some of the control activities below need a lock
         const char *queryName = control->queryName();
         logctx.CTXLOG("doControlMessage - %s", queryName);
         assertex(memicmp(queryName, "control:", 8) == 0);
@@ -1984,6 +1984,7 @@ private:
         case 'R':
             if (stricmp(queryName, "control:reload")==0)
             {
+                readBlock.clear();
                 reload();
                 if (daliHelper && daliHelper->connected())
                     reply.appendf("<Dali connected='1'/>");

--- a/system/jlib/jmutex.hpp
+++ b/system/jlib/jmutex.hpp
@@ -598,18 +598,34 @@ protected:
 
 class ReadLockBlock
 {
-    ReadWriteLock &lock;
+    ReadWriteLock *lock;
 public:
-    ReadLockBlock(ReadWriteLock &l) : lock(l)       { lock.lockRead(); }
-    ~ReadLockBlock()                                { lock.unlockRead(); }
+    ReadLockBlock(ReadWriteLock &l) : lock(&l)      { lock->lockRead(); }
+    ~ReadLockBlock()                                { if (lock) lock->unlockRead(); }
+    void clear()
+    {
+        if (lock)
+        {
+            lock->unlockRead();
+            lock = NULL;
+        }
+    }
 };
 
 class WriteLockBlock
 {
-    ReadWriteLock &lock;
+    ReadWriteLock *lock;
 public:
-    WriteLockBlock(ReadWriteLock &l) : lock(l)      { lock.lockWrite(); }
-    ~WriteLockBlock()                               { lock.unlockWrite(); }
+    WriteLockBlock(ReadWriteLock &l) : lock(&l)     { lock->lockWrite(); }
+    ~WriteLockBlock()                               { if (lock) lock->unlockWrite(); }
+    void clear()
+    {
+        if (lock)
+        {
+            lock->unlockWrite();
+            lock = NULL;
+        }
+    }
 };
 
 class Barrier


### PR DESCRIPTION
ReadWriteLock is not reentrant the way a criticalsecetion is - you must release
a read lock before you can get a write lock, even if it's on the same thread.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
