### PR TITLE
HPCC-3153 Filter WU names before showing on Browse Workunits page

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2016,8 +2016,11 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
         SCMStringBuffer parent;
         if (!cw.getParentWuid(parent).length())
         {
+            const char* wuid = cw.getWuid(parent).str();
+            if (!looksLikeAWuid(wuid))
+                continue;
             Owned<IEspECLWorkunit> info = createECLWorkunit("","");
-            WsWuInfo winfo(context, cw.getWuid(parent).str());
+            WsWuInfo winfo(context, wuid);
             winfo.getCommon(*info, 0);
             results.append(*info.getClear());
         }


### PR DESCRIPTION
On some environments, EclWatch Browse Workunits page shows a few items
which are not workunits, such as 'globel', 'Query', etc. Those items
are retrieved from the '/WorkUnits' tree using querySDS().connect().
Now, I filter out those names before showing workunits on Browse
Workunits page.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
