### PR TITLE
HPCC-2309 Configmgr - Entering LDAP ou info is error-prone

### DIFF
--- a/deployment/deploy/XMLTags.h
+++ b/deployment/deploy/XMLTags.h
@@ -31,6 +31,7 @@
 
 #define XML_TAG_ATTRIBUTESERVER        "AttributeServer"
 #define XML_TAG_ATTRSERVERINSTANCE     "AttrServerInstance"
+#define XML_TAG_AUTHENTICATION         "Authentication"
 #define XML_TAG_BUILD                  "Build"
 #define XML_TAG_BUILDSET               "BuildSet"
 #define XML_TAG_CLUSTER                "Cluster"
@@ -128,6 +129,7 @@
 #define XML_ATTR_EXTERNALPROGDIR       "@externalProgDir"
 #define XML_ATTR_FAMILY                "@family"
 #define XML_ATTR_FILENAME              "@filename"
+#define XML_ATTR_FILESBASEDN           "@filesBasedn"
 #define XML_ATTR_FOLDSQL               "@foldSQL"
 #define XML_ATTR_FORCECOMPARECLUSTER   "@forceCompareCluster"
 #define XML_ATTR_FORCETHORCOMPARECLUSTER "@forceThorCompareCluster"
@@ -143,6 +145,7 @@
 #define XML_ATTR_JACKAGENTIP           "@jackAgentIP"
 #define XML_ATTR_KEEPCPP               "@keepCPP"
 #define XML_ATTR_LABEL                 "@label"
+#define XML_ATTR_LDAPSERVER            "@ldapServer"
 #define XML_ATTR_LOADERNAME            "@loaderName"
 #define XML_ATTR_LOADORDER             "@loadOrder"
 #define XML_ATTR_LOCALCACHE            "@localCache"
@@ -269,6 +272,9 @@
 #define TAG_VALUE                       "value"
 #define TAG_ATTRIBUTE                   "Attribute"
 #define TAG_ELEMENT                     "Element"
+#define TAG_DALISERVER                  "daliServer"
+#define TAG_LDAPSERVER                  "ldapServer"
+#define TAG_SERVICE                     "service"
 
 //---------------------------------------------------------------------------
 #endif // !defined(AFX_XMLTAGS_H__57887617_2BDE_4E3E_92CB_43FCDEDD05B8__INCLUDED_)

--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -919,6 +919,12 @@ function handleConfigCellClickEvent(oArgs, caller, isComplex) {
 
     var form = top.window.document.forms['treeForm'];
     top.document.startWait(document);
+
+    if ((record.getData('compType') == 'EspProcess' || record.getData('compType') == "DaliServerProcess") && (record.getData('params').indexOf('subType=EspBinding') != -1 || record.getData('_key') == "ldapServer"))
+      bUpdateFilesBasedn = confirm("If available, proceed with update of filesBasedn value?\n\n(If you are unsure select 'Ok')");
+    else
+      bUpdateFilesBasedn = false;
+
     var xmlArgs = argsToXml(category, params, attrName, oldValue, newValue, recordIndex + 1, record.getData(column.key + '_onChange'));
     YAHOO.util.Connect.asyncRequest('POST', '/WsDeploy/SaveSetting', {
       success: function(o) {
@@ -1019,6 +1025,7 @@ function handleConfigCellClickEvent(oArgs, caller, isComplex) {
               doPageRefresh();
             }
           }
+          top.document.navDT.clickCurrentSelOrName(top.document.navDT); // refresh
         } else {
           alert(r.replyText);
           callback();
@@ -1033,7 +1040,7 @@ function handleConfigCellClickEvent(oArgs, caller, isComplex) {
       },
       scope: this
     },
-    top.document.navDT.getFileName(true) + 'XmlArgs=' + xmlArgs);
+    top.document.navDT.getFileName(true) + 'XmlArgs=' + xmlArgs + '&bUpdateFilesBasedn='  + bUpdateFilesBasedn);
   };
 
   if (typeof (caller.editors) === 'undefined') {

--- a/esp/scm/WsDeploy.ecm
+++ b/esp/scm/WsDeploy.ecm
@@ -137,6 +137,7 @@ ESPresponse [exceptions_inline, encode(0)] DisplaySettingsResponse
 ESPrequest SaveSettingRequest
 {
     string XmlArgs;
+    bool bUpdateFilesBasedn;
     ESPstruct WsDeployReqInfo ReqInfo;
 };
 


### PR DESCRIPTION
- When modifying the 'ldapServer' field under the 'LDAP' tab for
  the 'Dali Server' component, pop-up will ask to update the 'filesBasedn'
  field to match that of the selected LDAP server.
- When modifying the 'ldapServer' field under the 'Authentication' tab for
  the 'Esp' component, a pop-up will ask to update the 'filesBasedn' field
  to match that of the selected LDAP server for all bound esp services
  that contain a filesBasedn field.
- When modifying the 'serverice' field under the 'ESP Service Bindings' tab
  for the 'Esp' component, a pop-up will ask to update the 'filesBasedn'
  field for all bound esp services that contain a filesBasedn field.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
