### PR TITLE
HPCC-7918 Configmgr - Save As from context menu locks up browser

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -1224,7 +1224,7 @@ function createNavigationTree(navTreeData) {
 
   var oContextMenuItems = {
     "Environment": [{text: "Save Environment", onclick: { fn: onMenuItemClick } },
-                    {text: "Save Environment As...", onclick: { fn: onMenuItemClick } },
+                    {text: "Save Environment As", onclick: { fn: onMenuItemClick } },
                     {text: "Validate Environment", onclick: { fn: onMenuItemClick } },
                     {text: "Copy Hardware To",
                       submenu: {


### PR DESCRIPTION
- Change menu name to 'Save Environment As' from 'Save Environment
  As...' to properly capture context menu click

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
