### PR TITLE
HPCC-7919 Report errors that prevented loading a Roxie query

### DIFF
--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -968,17 +968,23 @@ public:
             }
         }
     }
-    virtual void getQueryXrefInfo(StringBuffer &reply, const IRoxieContextLogger &logctx) const
+    virtual void getQueryInfo(StringBuffer &reply, bool full, const IRoxieContextLogger &logctx) const
     {
         Owned<IPropertyTree> xref = createPTree("Query", 0);
         xref->setProp("@id", id);
         if (suspended())
-            xref->setPropBool("@suspended", true);
-        HashIterator i(allActivities);
-        ForEach(i)
         {
-            IActivityFactory *f = *allActivities.mapToValue(&i.query());
-            f->getXrefInfo(*xref, logctx);
+            xref->setPropBool("@suspended", true);
+            xref->setProp("@error", errorMessage);
+        }
+        if (full)
+        {
+            HashIterator i(allActivities);
+            ForEach(i)
+            {
+                IActivityFactory *f = *allActivities.mapToValue(&i.query());
+                f->getXrefInfo(*xref, logctx);
+            }
         }
         toXML(xref, reply);
     }

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -112,7 +112,7 @@ interface IQueryFactory : extends IInterface
     virtual void getGraphNames(StringArray &ret) const = 0;
 
     virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
-    virtual void getQueryXrefInfo(StringBuffer &result, const IRoxieContextLogger &logctx) const = 0;
+    virtual void getQueryInfo(StringBuffer &result, bool full, const IRoxieContextLogger &logctx) const = 0;
 };
 
 class ActivityArray : public CInterface

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -114,8 +114,7 @@ interface IRoxieQuerySetManager : extends IRoxieLibraryLookupContext
     virtual void resetQueryTimings(const char *queryName, const IRoxieContextLogger &logctx) = 0;
     virtual void resetAllQueryTimings() = 0;
     virtual void getActivityMetrics(StringBuffer &reply) const = 0;
-    virtual void getQueries(StringBuffer &reply, const IRoxieContextLogger &logctx) const = 0;
-    virtual void getAllQueryXrefInfo(StringBuffer &reply, const IRoxieContextLogger &logctx) const = 0;
+    virtual void getAllQueryInfo(StringBuffer &reply, bool full, const IRoxieContextLogger &logctx) const = 0;
 };
 
 interface IRoxieDebugSessionManager : extends IInterface


### PR DESCRIPTION
In order to present better feedback to users when queries don't deploy
successfully, improve the output of control:queries to return any
associated error message if a query is suspended. Also allow the output
to be limited to a specified set of queries

The incoming message is of the form:

```
<control:queries>
 <Query id='queryname'/>
 ... more queries here if you want ...
</control:getQueryInfo>
```

Code has been refactored to common up the functionality with the just-added
control:getQueryXrefInfo. As a result the output from that query now uses
`<Queries>` rather than `<QueryInfo>` as the surrounding element name.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
