### PR TITLE
HPCC-7808 Fix a few issues with DISTRIBUTE(,SKEW)

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -3325,10 +3325,12 @@ IHqlExpression * NullFolderMixin::foldNullDataset(IHqlExpression * expr)
     case no_distribute:
     case no_distributed:
         {
+            if (isNull(child) || isFail(child))
+                return removeParentNode(expr);
+            if (expr->hasProperty(skewAtom))
+            	break;
             //Careful - distribute also destroys grouping, so don't remove if input is grouped.
             if ((expr->queryType()->queryDistributeInfo() == child->queryType()->queryDistributeInfo()) && !isGrouped(child))
-                return removeParentNode(expr);
-            if (isNull(child) || isFail(child))
                 return removeParentNode(expr);
             break;
         }

--- a/ecl/hql/hqlmeta.cpp
+++ b/ecl/hql/hqlmeta.cpp
@@ -751,6 +751,21 @@ ITypeInfo * getTypeGrouped(ITypeInfo * prev, IHqlExpression * grouping, bool isL
     return makeGroupedTableType(tableType, newGrouping.getClear(), newGroupOrder.getClear());
 }
 
+//NB: This does not handle ALL groups that is handled in createDataset()
+ITypeInfo * getTypeLoseDistributionKeepOrder(ITypeInfo * prev)
+{
+    OwnedITypeInfo prevUngrouped = getTypeUngroup(prev);
+
+    IHqlExpression * distribution = NULL;
+    IHqlExpression * globalOrder = queryGlobalSortOrder(prevUngrouped);
+
+    //If records are moved from one node to the next, the global order will be preserved, and the local order will
+    //only be valid if it matches the global order.
+
+    ITypeInfo * rowType = queryRowType(prevUngrouped);
+    return makeTableType(LINK(rowType), LINK(distribution), LINK(globalOrder), LINK(globalOrder));
+}
+
 ITypeInfo * getTypeGlobalSort(ITypeInfo * prev, IHqlExpression * sortOrder)
 {
     OwnedHqlExpr newSortOrder = normalizeSortlist(sortOrder);

--- a/ecl/hql/hqlmeta.hpp
+++ b/ecl/hql/hqlmeta.hpp
@@ -45,6 +45,7 @@ extern HQL_API ITypeInfo * getTypeGroupSort(ITypeInfo * prev, IHqlExpression * s
 extern HQL_API ITypeInfo * getTypeDistribute(ITypeInfo * prev, IHqlExpression * distribution, IHqlExpression * optMergeOrder);
 extern HQL_API ITypeInfo * getTypeFromMeta(IHqlExpression * record, IHqlExpression * meta, unsigned firstChild);
 extern HQL_API ITypeInfo * getTypeIntersection(ITypeInfo * leftType, ITypeInfo * rightType);
+extern HQL_API ITypeInfo * getTypeLoseDistributionKeepOrder(ITypeInfo * prev);
 extern HQL_API ITypeInfo * getTypeProject(ITypeInfo * prev, IHqlExpression * newRecord, TableProjectMapper & mapper);
 extern HQL_API ITypeInfo * getTypeShuffle(ITypeInfo * prev, IHqlExpression * grouping, IHqlExpression * sortOrder, bool isLocal);
 extern HQL_API ITypeInfo * getTypeCannotProject(ITypeInfo * prev, IHqlExpression * newRecord); // preserve grouping, but that's it.

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -2427,6 +2427,8 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
     case no_keyeddistribute:
     case no_distribute:
         {
+            if (transformed->hasProperty(skewAtom))
+                break;
             //If distribution matches existing and grouped then don't distribute, but still remove grouping.
             IHqlExpression * distn = queryDistribution(transformed);
             if (distn == queryDistribution(child))

--- a/ecl/regress/distribute10.ecl
+++ b/ecl/regress/distribute10.ecl
@@ -1,0 +1,33 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+namesRecord :=
+            RECORD
+integer2        age := 25;
+string20        surname;
+string10        forename;
+            END;
+
+namesTable := dataset('x',namesRecord,FLAT);
+
+sort1 := sort(namesTable, surname, forename);
+
+//Preserves global sort order but not the distribution
+dist2 := ungroup(group(sort1, surname));  // Should this be optimized away or not?
+sort3 := sort(dist2, surname, forename, local); // this should be optimized away
+
+output(sort3);

--- a/ecl/regress/distribute8.ecl
+++ b/ecl/regress/distribute8.ecl
@@ -1,0 +1,40 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+namesRecord :=
+            RECORD
+integer2        age := 25;
+string20        surname;
+string10        forename;
+            END;
+
+namesTable := dataset('x',namesRecord,FLAT);
+
+sort1 := sort(namesTable, surname, forename);
+
+//Preserves global sort order but not the distribution
+dist1 := distribute(sort1, skew(1.0));
+sort2 := sort(dist1, surname, forename, local); // this should be optimized away
+
+
+group3 := group(dist1, surname, forename); //this should not be optimized to a local group
+summed := TABLE(group3, { count(group) });
+
+sequential(
+output(sort2);
+output(summed);
+);

--- a/ecl/regress/distribute9.ecl
+++ b/ecl/regress/distribute9.ecl
@@ -1,0 +1,35 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+namesRecord :=
+            RECORD
+integer2        age := 25;
+string20        surname;
+string10        forename;
+            END;
+
+namesTable := dataset('x',namesRecord,FLAT);
+
+sort1 := sort(namesTable, surname, forename, local);
+
+//Only preserves local sort order if it was globally sorted!
+dist1 := distribute(sort1, skew(1.0));
+
+group3 := group(dist1, surname, LOCAL);
+sort2 := sort(group3, forename); // This should not be optimized away - no longer locally sorted  
+
+output(sort2);


### PR DESCRIPTION
This fixes a couple of issues:
- DISTRIBUTE(,SKEW) wasn't tracked as preserving the global sort order
- DISTRIBUTE(,SKEW) could be optimized away if the input dataset didn't
  have a known distibution.
- Add some more test cases to ensure it is handled correctly

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
