### PR TITLE
HPCC-7856 Include macros with parameters-with-defaults in dependencies

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -41,6 +41,8 @@
 #include "build-config.h"
 #include "rmtfile.hpp"
 
+//#define TEST_LEGACY_DEPENDENCY_CODE
+
 #define INIFILE "eclcc.ini"
 #define SYSTEMCONFDIR CONFIG_DIR
 #define DEFAULTINIFILE "eclcc.ini"
@@ -767,6 +769,13 @@ void EclCC::processSingleQuery(EclCompileInstance & instance,
                                IFileContents * queryContents,
                                const char * queryAttributePath)
 {
+#ifdef TEST_LEGACY_DEPENDENCY_CODE
+    setLegacyEclSemantics(instance.legacyMode);
+    Owned<IPropertyTree> dependencies = gatherAttributeDependencies(instance.dataServer, "");
+    if (dependencies)
+        saveXML("depends.xml", dependencies);
+#endif
+
     Owned<IErrorReceiver> wuErrs = new WorkUnitErrorReceiver(instance.wu, "eclcc");
     Owned<IErrorReceiver> errs = createCompoundErrorReceiver(instance.errs, wuErrs);
 
@@ -835,7 +844,7 @@ void EclCC::processSingleQuery(EclCompileInstance & instance,
                 if (instance.legacyMode)
                     importRootModulesToScope(scope, ctx);
 
-                instance.query.setown(parseQuery(scope, queryContents, ctx, NULL, true));
+                instance.query.setown(parseQuery(scope, queryContents, ctx, NULL, NULL, true));
 
                 if (instance.archive)
                 {

--- a/ecl/hql/hqlerror.hpp
+++ b/ecl/hql/hqlerror.hpp
@@ -88,11 +88,15 @@ class HQL_API NullErrorReceiver : public CInterface, implements IErrorReceiver
 public:
     IMPLEMENT_IINTERFACE;
 
-    void reportError(int errNo, const char *msg,  const char * filename, int _lineno, int _column, int _pos) {}
-    void reportWarning(int warnNo, const char *msg,  const char * filename, int _lineno, int _column, int _pos) {}
-    void report(IECLError*) { }
-    virtual size32_t errCount() { return 0; };
-    virtual size32_t warnCount() { return 0; };
+    void reportError(int errNo, const char *msg,  const char * filename, int _lineno, int _column, int _pos) { numErrors++; }
+    void reportWarning(int warnNo, const char *msg,  const char * filename, int _lineno, int _column, int _pos) { numWarnings++; }
+    void report(IECLError* err) { if (err->isError()) numErrors++; else numWarnings++; }
+    virtual size32_t errCount() { return numErrors; };
+    virtual size32_t warnCount() { return numWarnings; };
+
+private:
+    unsigned numErrors;
+    unsigned numWarnings;
 };
 
 

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1382,7 +1382,7 @@ extern HQL_API IHqlExpression * getCastExpr(IHqlExpression * expr, ITypeInfo * t
 
 extern HQL_API void parseModule(IHqlScope *scope, IFileContents * contents, HqlLookupContext & ctx, IXmlScope *xmlScope, bool loadImplicit);
 extern HQL_API IHqlExpression *parseQuery(IHqlScope *scope, IFileContents * contents, 
-                                          HqlLookupContext & ctx, IXmlScope *xmlScope, bool loadImplicit);
+                                          HqlLookupContext & ctx, IXmlScope *xmlScope, IProperties * macroParams, bool loadImplicit);
 extern HQL_API IHqlExpression *parseQuery(const char *in, IErrorReceiver * errs);
 
 extern HQL_API IPropertyTree * gatherAttributeDependencies(IEclRepository * dataServer, const char * items = NULL);

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -1053,6 +1053,7 @@ class HqlLex
             return sourcePath;
         }
 
+        inline void setMacroParams(IProperties * _macroParams) { macroParms.set(_macroParams); }
         inline void setTokenPosition(YYSTYPE & returnToken)
         {
             returnToken.setPosition(yyLineNo, yyColumn, yyPosition, sourcePath);
@@ -1155,7 +1156,7 @@ private:
         /* to handle recursive macro */
         HqlLex *parentLex;
 
-        IProperties *macroParms;
+        Owned<IProperties> macroParms;
         IIterator *forLoop;
         IHqlExpression *macroExpr;
         StringBuffer forBody;

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -54,6 +54,7 @@ extern HQL_API IHqlExpression * queryLastField(IHqlExpression * record);
 extern HQL_API IHqlExpression * queryLastNonAttribute(IHqlExpression * expr);
 extern HQL_API IHqlExpression * queryNextRecordField(IHqlExpression * recorhqlutid, unsigned & idx);
 extern HQL_API int compareSymbolsByName(IInterface * * pleft, IInterface * * pright);
+extern HQL_API int compareScopesByName(IInterface * * pleft, IInterface * * pright);
 extern HQL_API int compareAtoms(IInterface * * pleft, IInterface * * pright);
 extern HQL_API IHqlExpression * getSizetConstant(unsigned size);
 extern HQL_API IHqlExpression * createIntConstant(__int64 val);
@@ -178,6 +179,7 @@ extern HQL_API bool isConstantDataset(IHqlExpression * expr);
 extern HQL_API bool isSimpleTransformToMergeWith(IHqlExpression * expr);
 extern HQL_API IHqlExpression * queryUncastExpr(IHqlExpression * expr);
 extern HQL_API bool areConstant(const HqlExprArray & args);
+extern HQL_API bool getFoldedConstantText(StringBuffer& ret, IHqlExpression * expr);
 
 extern HQL_API IHqlExpression * createTransformForField(IHqlExpression * field, IHqlExpression * value);
 extern HQL_API IHqlExpression * convertScalarToRow(IHqlExpression * value, ITypeInfo * fieldType);
@@ -655,6 +657,7 @@ extern HQL_API IPropertyTree * queryArchiveAttribute(IPropertyTree * module, con
 extern HQL_API IPropertyTree * createArchiveAttribute(IPropertyTree * module, const char * name);
 
 extern HQL_API IECLError * annotateExceptionWithLocation(IException * e, IHqlExpression * location);
+extern HQL_API IHqlExpression * expandMacroDefinition(IHqlExpression * expr, HqlLookupContext & ctx, bool reportError);
 extern HQL_API IHqlExpression * convertAttributeToQuery(IHqlExpression * expr, HqlLookupContext & ctx);
 extern HQL_API StringBuffer & appendLocation(StringBuffer & s, IHqlExpression * location, const char * suffix = NULL);
 extern HQL_API bool userPreventsSort(IHqlExpression * noSortAttr, node_operator side);

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1360,7 +1360,7 @@ HqlCppTranslator::HqlCppTranslator(IErrorReceiver * _errors, const char * _soNam
             cppSystemScope = createScope();
             Owned<ISourcePath> sysPath = createSourcePath("<system-definitions>");
             Owned<IFileContents> systemContents = createFileContentsFromText(systemText.str(), sysPath);
-            OwnedHqlExpr query = parseQuery(cppSystemScope, systemContents, ctx, NULL, false);
+            OwnedHqlExpr query = parseQuery(cppSystemScope, systemContents, ctx, NULL, NULL, false);
             if (errs.errCount())
             {
                 StringBuffer errtext;

--- a/ecl/regress/macroargs.eclxml
+++ b/ecl/regress/macroargs.eclxml
@@ -1,0 +1,34 @@
+<Archive>
+    <!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+    <Module name="myModule">
+        <Attribute name="mac">
+EXPORT mac(a = true, b = false) := MACRO
+    import myModule;
+    #if(b and a)
+        myModule.good;
+    #else
+        myModule.bad;
+    #end
+ENDMACRO;
+        </Attribute>
+        <Attribute name="good">'good';</Attribute>
+        <Attribute name="bad">'bad';</Attribute>
+        <Attribute name="z">'z';</Attribute>
+    </Module>
+    <Query attributePath="myModule.mac"/>
+</Archive>

--- a/ecl/regress/macroargs2.eclxml
+++ b/ecl/regress/macroargs2.eclxml
@@ -1,0 +1,39 @@
+<Archive>
+    <!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+    <Module name="myModule">
+        <Attribute name="mac">
+EXPORT mac(a = true, b = false) := MACRO
+    import myModule;
+    #if(b and a)
+        myModule.good;
+    #else
+        myModule.bad;
+    #end
+ENDMACRO;
+        </Attribute>
+        <Attribute name="good">'good';</Attribute>
+        <Attribute name="bad">'bad';</Attribute>
+        <Attribute name="mac2">
+EXPORT mac2() := MACRO
+   IMPORT myModule;
+   myModule.mac(true, true)
+ENDMACRO;
+        </Attribute>
+    </Module>
+    <Query attributePath="myModule.mac2"/>
+</Archive>

--- a/ecl/regress/macroargse.eclxml
+++ b/ecl/regress/macroargse.eclxml
@@ -1,0 +1,30 @@
+<Archive>
+    <!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+    <Module name="myModule">
+        <Attribute name="mac">
+EXPORT mac(a = true, b) := MACRO
+    #if(b and a)
+        'good';
+    #else
+        'bad';
+    #end
+ENDMACRO;
+        </Attribute>
+    </Module>
+    <Query attributePath="myModule.mac"/>
+</Archive>


### PR DESCRIPTION
This addresses several issues
- You can now sumbit a macro that has default values for all its parameters as
  a query.
- The same macros are now supported in the legacy dependency generation
- Common up some of the macro processing code between the two.
- Sort the module and symbol lists so dependencies are generated in a
  deterministic order.
- Fix potential caching problems if no error handler provided to the dependency
  gathering code.  (It didn't count the number of errors, so the code couldn't
  tell whether an error had occurred processing a definition.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
