### PR TITLE
HPCC-2058 Add a ,UNORDERED option to an index read

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -2979,6 +2979,7 @@ indexFlag
                             $$.setExpr(createAttribute(dynamicAtom));
                             $$.setPosition($1);
                         }
+    | UNORDERED         {   $$.setExpr(createAttribute(unorderedAtom)); $$.setPosition($1); }
     | commonAttribute
     ;
 

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -6194,6 +6194,8 @@ void IndexReadBuilderBase::buildFlagsMember(IHqlExpression * expr)
     StringBuffer flags;
     if (tableExpr->hasProperty(sortedAtom))
         flags.append("|TIRsorted");
+    else if (tableExpr->hasProperty(unorderedAtom))
+        flags.append("|TIRunordered");
     if (!monitors.isFiltered())
         flags.append("|TIRnofilter");
     if (isPreloaded)

--- a/ecl/regress/indexread4.ecl
+++ b/ecl/regress/indexread4.ecl
@@ -18,7 +18,7 @@
 #option ('globalFold', false);
 d := dataset('~local::rkc::person', { string15 name, unsigned8 filepos{virtual(fileposition)} }, flat);
 
-i := index(d, { f_name := (string11) name, filepos } ,'\\home\\person.name_first.key');
+i := index(d, { f_name := (string11) name, filepos } ,'\\home\\person.name_first.key', UNORDERED);
 
 string x := '' : stored('x');
 

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -21691,7 +21691,7 @@ public:
     {
         Owned<IHThorIndexReadBaseArg> indexHelper = (IHThorIndexReadBaseArg *) helperFactory();
         unsigned flags = indexHelper->getFlags();
-        sorted = (flags & TIRunsorted) == 0;
+        sorted = (flags & TIRunordered) == 0;
         isLocal = _graphNode.getPropBool("att[@name='local']/@value") && queryFactory.queryChannel()!=0;
         rtlDataAttr indexLayoutMeta;
         size32_t indexLayoutSize;

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -1067,7 +1067,7 @@ enum
     TIRdynamicfilename  = 0x00002000,
     TIRunfilteredtransform = 0x00004000,
     TIRorderedmerge     = 0x00008000,
-    TIRunsorted         = 0x00010000,
+    TIRunordered        = 0x00010000,
 };
 
 //flags for thor index write


### PR DESCRIPTION
Allow ,UNORDERED to be specified on an INDEX as a hint to allow the engines
to potentially optimize the way rows are returned.

I also renamed the flag from unsorted because it has a slightly stronger
meaning.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
