### PR TITLE
HPCC-7852 Display an error when a query is published and suspended

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -666,6 +666,26 @@
                     headerText = "Error reloading cluster";
                     exceptionHtml = "Published to Queryset.<br/>But request to update cluster failed.";
                   }
+                  else {
+                    i = o.responseText.indexOf('<Suspended>1');
+                    if (i > -1) {
+                        headerText = "Query is suspended";
+
+                        var error = "";
+                        var j = o.responseText.indexOf('<ErrorMessage>');
+                        if (j > -1) {
+                            var k = o.responseText.indexOf('</ErrorMessage>');
+                            if (k > j+14) {
+                                error = o.responseText.substring(j+14, k);
+                            }
+                        }
+
+                        if (error.length > 0)
+                            exceptionHtml = "Published to Queryset.<br/>Error: " + error;
+                        else
+                            exceptionHtml = "Published to Queryset.<br/>No error message.";
+                    }
+                  }
                 }
                 var publishDialog =
                      new YAHOO.widget.SimpleDialog("publishDialog",

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1076,6 +1076,8 @@ ESPresponse [exceptions_inline] WUPublishWorkunitResponse
     string QueryName;
     string QueryId;
     bool ReloadFailed;
+    [min_ver("1.39")] bool Suspended;
+    [min_ver("1.39")] string ErrorMessage;
     ESParray<ESPStruct WUCopyLogicalClusterFileSections, Cluster> ClusterFiles;
 };
 
@@ -1291,7 +1293,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.38"), default_client_version("1.38"),
+    version("1.39"), default_client_version("1.39"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -105,7 +105,7 @@ public:
 
     void setPort(unsigned short _port){port=_port;}
 
-    bool isQuerySuspended(const char* query, const char *target, unsigned wait, StringBuffer& errorMessage);
+    bool isQuerySuspended(const char* query, IConstWUClusterInfo *clusterInfo, unsigned wait, StringBuffer& errorMessage);
 
 private:
     unsigned awusCacheMinutes;

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -105,6 +105,8 @@ public:
 
     void setPort(unsigned short _port){port=_port;}
 
+    bool isQuerySuspended(const char* query, const char *target, unsigned wait, StringBuffer& errorMessage);
+
 private:
     unsigned awusCacheMinutes;
     StringBuffer queryDirectory;


### PR DESCRIPTION
A user publishes a workunit to roxie. The query may be suspended due to
some reason. ESP should be able to notify the user about the problem
when the workunit is published. This fix calls a roxie control command
to check whether a query is suspended or not and, if suspended, displays
the error returned by that command.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
