### PR TITLE
HPCC-7821 Fix ReferencedFileList handling of SuperFile within SuperFile

### DIFF
--- a/common/roxiemanager/referencedfilelist.hpp
+++ b/common/roxiemanager/referencedfilelist.hpp
@@ -33,6 +33,7 @@
 #define RefFileSuper          0x020
 #define RefSubFile            0x040
 #define RefFileCopyInfoFailed 0x080
+#define RefFileCloned         0x100
 
 interface IReferencedFile : extends IInterface
 {


### PR DESCRIPTION
When cloning remote superfiles, "super subfiles" need to be cloned
before adding as subfile, or the add will not succeed.

When processing local superfiles actual subfiles should be gathered
across all nested superfiles, so that all actual subfiles will be
cloned.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
