### PR TITLE
HPCC-7934 Disable udpResendEnabled by default

### DIFF
--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -893,13 +893,6 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="udpResendEnabled" type="xs:boolean" use="optional" default="true">
-            <xs:annotation>
-                <xs:appinfo>
-                    <tooltip>UDP transport layer packet resend ability</tooltip>
-                </xs:appinfo>
-            </xs:annotation>
-        </xs:attribute>
     <xs:attribute name="udpOutQsPriority" type="xs:nonNegativeInteger" use="optional" default="0">
       <xs:annotation>
         <xs:appinfo>
@@ -921,7 +914,7 @@
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
-    <xs:attribute name="udpResendEnabled" type="xs:boolean" use="optional" default="true">
+    <xs:attribute name="udpResendEnabled" type="xs:boolean" use="optional" default="false">
       <xs:annotation>
         <xs:appinfo>
           <tooltip>UDP transport layer packet resend ability</tooltip>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -876,7 +876,7 @@
                 udpOutQsPriority="0"
                 udpQueueSize="100"
                 udpRequestToSendTimeout="5"
-                udpResendEnabled="true"
+                udpResendEnabled="false"
                 udpRetryBusySenders="0"
                 udpSendCompletedInData="false"
                 udpSendQueueSize="50"

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -1716,7 +1716,7 @@ public:
         int udpQueueSize = topology->getPropInt("@udpQueueSize", UDP_QUEUE_SIZE);
         int udpSendQueueSize = topology->getPropInt("@udpSendQueueSize", UDP_SEND_QUEUE_SIZE);
         int udpMaxSlotsPerClient = topology->getPropInt("@udpMaxSlotsPerClient", 0x7fffffff);
-        bool udpResendEnabled = topology->getPropBool("@udpResendEnabled", true);
+        bool udpResendEnabled = topology->getPropBool("@udpResendEnabled", false);
         openReceiveSocket();
         maxPacketSize = sock->get_max_send_size();
         if ((maxPacketSize==0)||(maxPacketSize>65535))


### PR DESCRIPTION
It's not clear there is any benefit from this code in most situations, and there
is at least one outstanding issue HPCC-3028 - as yet unreproduced - where it
seemed to be cuaseing a core under load.

Disable by default until proven to work and help.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
