### PR TITLE
HPCC-7935 Use temp_files for regression temp dir

### DIFF
--- a/testing/ecl/Regress/Engine.pm
+++ b/testing/ecl/Regress/Engine.pm
@@ -518,7 +518,8 @@ sub _check_ini_file($)
             'server' => $server,
             'owner' => $username,
             'password' => $passwd,
-            'setup_file_location' => $fileloc,
+            'temp_files' => $fileloc,
+            'setup_file_location' => '',
             'os' => $os,
             'parallel_queries' => $parallel,
             'purge' => $purge,
@@ -623,6 +624,7 @@ sub _set_defaults($)
     $self->{report} = 'Default' unless(defined($self->{report}));
     $self->{time} = _current_time();
     $self->{iamwindows} = $self->_am_i_windows();
+    $self->{temp_files} = '' unless(defined($self->{temp_files}));
     $self->{setup_file_location} = '' unless(defined($self->{setup_file_location}));
 }
 

--- a/testing/ecl/Regress/Prepare.pm
+++ b/testing/ecl/Regress/Prepare.pm
@@ -282,6 +282,8 @@ sub _copy_query($$$;$)
     Regress::Query::print_variant_ecl($variant, \*OUT) if($variant);
     my $setupFileLocation = "$self->{setup_file_location}";
     print(OUT "setupTextFileLocation := '$setupFileLocation';\n");
+    my $tempFiles = "$self->{temp_files}";
+    print(OUT "tempFiles := '$tempFiles';\n");
     my $usesTextSearch = ($variant && $variant->{uts});
     my @paths;
     push(@paths, $self->{setuptxt}) if($variant);

--- a/testing/ecl/runregress
+++ b/testing/ecl/runregress
@@ -58,6 +58,7 @@ GetOptions('help|?' => sub { pod2usage(-exitstatus => 0, -verbose => 2) },
            'variant=s' => \$options->{variant},
            'setup_clusters=s' => \$options->{setup_clusters},
            'setup_file_location=s' => \$options->{setup_file_location},
+           'temp_files=s' => \$options->{temp_files},
            'class|c=s' => \$options->{class},
            'parallel_queries|pq=s' => \$options->{parallel_queries},
            'ecloption=s' => $options->{ecloptions},
@@ -161,6 +162,10 @@ During a setup run, specifies the clusters to use, as a comma- or space-separate
 =item B<-setup_file_location>
 
 During a setup run, defines the location of the text files used to create the additional text searching attributes.
+
+=item B<-temp_files>
+
+During execution, some files need to be used for import/export tests. This is the directory those files will be. The default is the directory where the tests and the import files are.
 
 =item B<-testdir>|B<-t> I<directory>
 

--- a/testing/ecl/spray_test.ecl
+++ b/testing/ecl/spray_test.ecl
@@ -25,7 +25,7 @@ import Std.File AS FileServices;
 //noThor
 
 SrcIP := 'localhost';
-File := setupTextFileLocation + '/spray_test.txt';
+File := tempFiles + '/spray_test.txt';
 RecordSize := 11;
 ClusterName := 'mythor';
 DestFile := '~regress::spray_test.txt';


### PR DESCRIPTION
Previously chosen setup_file_location was not a good choice, and broke
the setup phase of the regressions. Using a separate variable to account
for temporary regression files (not setup files).

Signed-off-by: Renato Golin rengolin@hpccsystems.com
