### PR TITLE
HPCC-633 Add support for loopagain support

### DIFF
--- a/testing/ecl/key/loopall.xml
+++ b/testing/ecl/key/loopall.xml
@@ -92,3 +92,9 @@
  <Row><surname>X                   </surname><forename>Z         </forename><age>150</age></Row>
  <Row><surname>Salter              </surname><forename>Abi       </forename><age>240</age></Row>
 </Dataset>
+<Dataset name='Result 12'>
+ <Row><parentfield>parent1changed</parentfield><children><Row><surname>Halliday            </surname><forename>Gavin     </forename><age>51</age></Row><Row><surname>Halliday            </surname><forename>Liz       </forename><age>50</age></Row><Row><surname>Salter              </surname><forename>Abi       </forename><age>30</age></Row><Row><surname>X                   </surname><forename>Z         </forename><age>45</age></Row></children></Row>
+</Dataset>
+<Dataset name='Result 13'>
+ <Row><parentfield>parent1changed</parentfield><children><Row><surname>Halliday            </surname><forename>Gavin     </forename><age>62</age></Row><Row><surname>Halliday            </surname><forename>Liz       </forename><age>120</age></Row><Row><surname>X                   </surname><forename>Z         </forename><age>100</age></Row><Row><surname>Salter              </surname><forename>Abi       </forename><age>80</age></Row></children></Row>
+</Dataset>

--- a/testing/ecl/loopall.ecl
+++ b/testing/ecl/loopall.ecl
@@ -74,3 +74,38 @@ output(loop(namesTable2, left.age < 100, exists(rows(left)) and sum(rows(left), 
 
 //case 5: a row filter
 output(loop(namesTable2, left.age < 100, loopBody(rows(left), counter)));
+
+//case 6: loop within a child query, with condition on dataset
+parentRecord := RECORD
+ string parentField;
+ DATASET(namesRecord) children;
+END;
+
+parentDS := DATASET([{'parent1', namesTable2}], parentRecord);
+
+
+addNum(dataset(namesRecord) ds, unsigned num) := FUNCTION
+ dsAdded := project(ds, transform(namesRecord, self.age := left.age+num; self := left));
+ return dsAdded;
+END;
+
+countChildren(dataset(namesRecord) ds, unsigned ageThreshold) := FUNCTION
+ q := ds(age<ageThreshold);
+ return COUNT(q);
+END;
+
+parentRecord childTrans(parentRecord p) := transform
+ self.parentField := p.parentField + 'changed';
+ self.children := loop(p.children, countChildren(rows(left), 50) > 2, addNum(rows(left), 5));
+END;
+
+// loop adding an increment and perform a count condition on the dataset
+output(nofold(project(nofold(parentDS), childTrans(LEFT))));
+
+//case 7: loop within a child query, fixed number of iterations with row filter
+parentRecord childTrans2(parentRecord p) := transform
+ self.parentField := p.parentField + 'changed';
+ self.children := loop(p.children, 10, left.age <= 60, project(rows(left), transform(namesRecord, self.age := left.age*two; self := left)));
+END;
+
+output(nofold(project(nofold(parentDS), childTrans2(LEFT))));

--- a/testing/ecl/loopall.ecl
+++ b/testing/ecl/loopall.ecl
@@ -16,7 +16,6 @@
 ############################################################################## */
 
 //nothor
-//skip type==thorlcr TBD
 #option ('newChildQueries', true)
 
 namesRecord := 

--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -364,7 +364,7 @@ public:
                 unsigned doLoopAgain = (flags & IHThorLoopArg::LFnewloopagain) ? helper->loopAgainResult() : 0;
                 ownedResults.setown(queryGraph().createThorGraphResults(3));
                 // ensures remote results are available, via owning activity (i.e. this loop act)
-                // so that when aggreagate result is fetched from the master, it will retreive from the act, not the (already cleaed) graph localresults
+                // so that when aggreagate result is fetched from the master, it will retreive from the act, not the (already cleaned) graph localresults
                 ownedResults->setOwner(container.queryId());
 
                 boundGraph->prepareLoopResults(*this, ownedResults);

--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -231,6 +231,15 @@ public:
         helper = (IHThorLoopArg *) queryHelper();
         flags = helper->getFlags();
     }
+    void init(MemoryBuffer &data, MemoryBuffer &slaveData)
+    {
+        CLoopSlaveActivityBase::init(data, slaveData);
+        if (!global && (flags & IHThorLoopArg::LFnewloopagain))
+        {
+            if (container.queryOwner().isGlobal())
+                global = true;
+        }
+    }
     virtual void kill()
     {
         CLoopSlaveActivityBase::kill();
@@ -316,22 +325,7 @@ public:
                 switch (container.getKind())
                 {
                 case TAKloopdataset:
-                    throwUnexpected();
-/*
-                    if (!helper->loopAgain(loopCounter, loopPendingCount, loopPending))
-                    {
-                        if (0 == loopPendingCount)
-                        {
-                            eof = true;
-                            return NULL;
-                        }
-
-                        curInput.set(loopPending); // clear loopPending?
-                        sendEndLooping();
-                        finishedLooping = true;
-                        continue;       // back to the input loop again
-                    }
-*/
+                    assertex(flags & IHThorLoopArg::LFnewloopagain);
                     break;
                 case TAKlooprow:
                     if (0 == loopPendingCount)
@@ -364,15 +358,44 @@ public:
                 if (!sendLoopingCount(loopCounter, emptyIterations)) // only if global
                     return NULL;
                 loopPending->flush();
-                curInput.setown(queryContainer().queryLoopGraph()->execute(*this, (flags & IHThorLoopArg::LFcounter)?loopCounter:0, loopPending.getClear(), loopPendingCount, extractBuilder.size(), extractBuilder.getbytes()));
+
+                IThorBoundLoopGraph *boundGraph = queryContainer().queryLoopGraph();
+                unsigned doLoopCounter = (flags & IHThorLoopArg::LFcounter) ? loopCounter:0;
+                unsigned doLoopAgain = (flags & IHThorLoopArg::LFnewloopagain) ? helper->loopAgainResult() : 0;
+                ownedResults.setown(queryGraph().createThorGraphResults(3));
+                // ensures remote results are available, via owning activity (i.e. this loop act)
+                // so that when aggreagate result is fetched from the master, it will retreive from the act, not the (already cleaed) graph localresults
+                ownedResults->setOwner(container.queryId());
+
+                boundGraph->prepareLoopResults(*this, ownedResults);
+                if (doLoopCounter) // cannot be 0
+                    boundGraph->prepareCounterResult(*this, ownedResults, loopCounter, 2);
+                if (doLoopAgain) // cannot be 0
+                    boundGraph->prepareLoopAgainResult(*this, ownedResults, helper->loopAgainResult());
+
+                boundGraph->execute(*this, doLoopCounter, ownedResults, loopPending.getClear(), loopPendingCount, extractBuilder.size(), extractBuilder.getbytes());
+
+                Owned<IThorResult> result0 = ownedResults->getResult(0);
+                curInput.setown(result0->getRowStream());
+
+                if (flags & IHThorLoopArg::LFnewloopagain)
+                {
+                    Owned<IThorResult> loopAgainResult = ownedResults->getResult(helper->loopAgainResult(), !queryGraph().isLocalChild());
+                    assertex(loopAgainResult);
+                    Owned<IRowStream> loopAgainRows = loopAgainResult->getRowStream();
+                    OwnedConstThorRow row = loopAgainRows->nextRow();
+                    assertex(row);
+                    //Result is a row which contains a single boolean field.
+                    if (!((const bool *)row.get())[0])
+                        finishedLooping = true;
+                }
                 loopPending.setown(createOverflowableBuffer(*this, this, false, true));
                 loopPendingCount = 0;
                 ++loopCounter;
                 if ((container.getKind() == TAKloopcount) && (loopCounter > maxIterations))
-                {
-                    sendEndLooping();
                     finishedLooping = true;
-                }
+                if (finishedLooping)
+                    sendEndLooping();
             }
         }
         return NULL;

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -213,15 +213,16 @@ class CThorBoundLoopGraph : public CInterface, implements IThorBoundLoopGraph
     CGraphBase *graph;
     activity_id activityId;
     Linked<IOutputMetaData> resultMeta;
-    Owned<IOutputMetaData> counterMeta;
-    Owned<IRowInterfaces> resultRowIf, countRowIf;
+    Owned<IOutputMetaData> counterMeta, loopAgainMeta;
+    Owned<IRowInterfaces> resultRowIf, countRowIf, loopAgainRowIf;
 
 public:
     IMPLEMENT_IINTERFACE;
 
     CThorBoundLoopGraph(CGraphBase *_graph, IOutputMetaData * _resultMeta, unsigned _activityId) : graph(_graph), resultMeta(_resultMeta), activityId(_activityId)
     {
-        counterMeta.setown(new CThorEclCounterMeta);
+        counterMeta.setown(createFixedSizeMetaData(sizeof(thor_loop_counter_t)));
+        loopAgainMeta.setown(createFixedSizeMetaData(sizeof(bool)));
     }
     virtual void prepareCounterResult(CActivityBase &activity, IThorGraphResults *results, unsigned loopCounter, unsigned pos)
     {
@@ -235,6 +236,12 @@ public:
         Owned<IRowWriter> counterResultWriter = counterResult->getWriter();
         counterResultWriter->putRow(counterRowFinal.getClear());
     }
+    virtual void prepareLoopAgainResult(CActivityBase &activity, IThorGraphResults *results, unsigned pos)
+    {
+        if (!loopAgainRowIf)
+            loopAgainRowIf.setown(createRowInterfaces(loopAgainMeta, activityId, activity.queryCodeContext()));
+        activity.queryGraph().createResult(activity, pos, results, loopAgainRowIf, !activity.queryGraph().isLocalChild(), SPILL_PRIORITY_DISABLE);
+    }
     virtual void prepareLoopResults(CActivityBase &activity, IThorGraphResults *results)
     {
         if (!resultRowIf)
@@ -242,23 +249,14 @@ public:
         IThorResult *loopResult = results->createResult(activity, 0, resultRowIf, !activity.queryGraph().isLocalChild()); // loop output
         IThorResult *inputResult = results->createResult(activity, 1, resultRowIf, !activity.queryGraph().isLocalChild());
     }
-    virtual IRowStream *execute(CActivityBase &activity, unsigned counter, IRowWriterMultiReader *inputStream, rowcount_t rowStreamCount, size32_t parentExtractSz, const byte *parentExtract)
+    virtual void execute(CActivityBase &activity, unsigned counter, IThorGraphResults *results, IRowWriterMultiReader *inputStream, rowcount_t rowStreamCount, size32_t parentExtractSz, const byte *parentExtract)
     {
-        Owned<IThorGraphResults> results = graph->createThorGraphResults(3);
-        prepareLoopResults(activity, results);
         if (counter)
-        {
-            prepareCounterResult(activity, results, counter, 2);
             graph->setLoopCounter(counter);
-        }
         Owned<IThorResult> inputResult = results->getResult(1);
         if (inputStream)
             inputResult->setResultStream(inputStream, rowStreamCount);
         graph->executeChild(parentExtractSz, parentExtract, results, NULL);
-        if (0 == graph->queryJob().queryMyRank())
-            return NULL; // unset and unused on master
-        Owned<IThorResult> result0 = results->getResult(0);
-        return result0->getRowStream();
     }
     virtual void execute(CActivityBase &activity, unsigned counter, IThorGraphResults *graphLoopResults, size32_t parentExtractSz, const byte *parentExtract)
     {
@@ -1835,6 +1833,11 @@ IThorResult *CGraphBase::getGraphLoopResult(unsigned id, bool distributed)
     return graphLoopResults->getResult(id, distributed);
 }
 
+IThorResult *CGraphBase::createResult(CActivityBase &activity, unsigned id, IThorGraphResults *results, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
+{
+    return results->createResult(activity, id, rowIf, distributed, spillPriority);
+}
+
 IThorResult *CGraphBase::createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority)
 {
     return localResults->createResult(activity, id, rowIf, distributed, spillPriority);
@@ -2616,6 +2619,30 @@ roxiemem::IRowManager *CJobBase::queryRowManager() const
     return thorAllocator->queryRowManager();
 }
 
+IThorResult *CJobBase::getOwnedResult(graph_id gid, activity_id ownerId, unsigned resultId)
+{
+    Owned<CGraphBase> graph = getGraph(gid);
+    if (!graph)
+    {
+        Owned<IThorException> e = MakeThorException(0, "getOwnedResult: graph not found");
+        e->setGraphId(gid);
+        throw e.getClear();
+    }
+    Owned<IThorResult> result;
+    if (ownerId)
+    {
+        CGraphElementBase *container = graph->queryElement(ownerId);
+        assertex(container);
+        CActivityBase *activity = container->queryActivity();
+        result.setown(activity->queryResults()->getResult(resultId));
+    }
+    else
+        result.setown(graph->getResult(resultId));
+    if (!result)
+        throw MakeGraphException(graph, 0, "GraphGetResult: result not found: %d", resultId);
+    return result.getClear();
+}
+
 static IThorResource *iThorResource = NULL;
 void setIThorResource(IThorResource &r)
 {
@@ -2652,6 +2679,11 @@ void CActivityBase::abort()
 {
     if (!abortSoon) ActPrintLog("Abort condition set");
     abortSoon = true;
+}
+
+void CActivityBase::kill()
+{
+    ownedResults.clear();
 }
 
 void CActivityBase::ActPrintLog(const char *format, ...)

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -76,6 +76,7 @@ public:
     virtual void start();
     virtual void done();
     virtual void abort(IException *e);
+    IThorResult *createResult(CActivityBase &activity, unsigned id, IThorGraphResults *results, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
     IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
     IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
 
@@ -233,6 +234,7 @@ class graphmaster_decl CMasterActivity : public CActivityBase, implements IThrea
     bool asyncStart;
     MemoryBuffer *data;
     CriticalSection progressCrit;
+
 protected:
     ProgressInfoArray progressInfo;
     CTimingInfo timingInfo;

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -822,7 +822,7 @@ public:
         IThorResult *globalResult = &globalResults.item(id);
         if (!QUERYINTERFACE(globalResult, CThorUninitializedGraphResults))
             return LINK(globalResult);
-        Owned<IThorResult> gr = graph.getGlobalResult(*result->queryActivity(), result->queryRowInterfaces(), id);
+        Owned<IThorResult> gr = graph.getGlobalResult(*result->queryActivity(), result->queryRowInterfaces(), ownerId, id);
         globalResults.replace(*gr.getLink(), id);
         return gr.getClear();
     }
@@ -833,13 +833,14 @@ IThorGraphResults *CSlaveGraph::createThorGraphResults(unsigned num)
     return new CThorSlaveGraphResults(*this, num);
 }
 
-IThorResult *CSlaveGraph::getGlobalResult(CActivityBase &activity, IRowInterfaces *rowIf, unsigned id)
+IThorResult *CSlaveGraph::getGlobalResult(CActivityBase &activity, IRowInterfaces *rowIf, activity_id ownerId, unsigned id)
 {
     mptag_t replyTag = createReplyTag();
     CMessageBuffer msg;
     msg.setReplyTag(replyTag);
     msg.append(smt_getresult);
     msg.append(graphId);
+    msg.append(ownerId);
     msg.append(id);
     msg.append(replyTag);
 

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -105,7 +105,7 @@ public:
     void initWithActData(MemoryBuffer &in, MemoryBuffer &out);
     void getDone(MemoryBuffer &doneInfoMb);
     void serializeDone(MemoryBuffer &mb);
-    IThorResult *getGlobalResult(CActivityBase &activity, IRowInterfaces *rowIf, unsigned id);
+    IThorResult *getGlobalResult(CActivityBase &activity, IRowInterfaces *rowIf, activity_id ownerId, unsigned id);
 
     virtual void executeSubGraph(size32_t parentExtractSz, const byte *parentExtract);
     virtual bool serializeStats(MemoryBuffer &mb);

--- a/thorlcr/master/thactivitymaster.cpp
+++ b/thorlcr/master/thactivitymaster.cpp
@@ -349,14 +349,13 @@ public:
                 break;
             case TAKlooprow:
             case TAKloopcount:
+            case TAKloopdataset:
                 ret = createLoopActivityMaster(this);
                 break;
             case TAKgraphloop:
             case TAKparallelgraphloop:
                 ret = createGraphLoopActivityMaster(this);
                 break;
-            case TAKloopdataset:
-                throw MakeThorException(0, "Thor currently, does not support a dataset loop condition, activity id: %"ACTPF"d", queryId());
             case TAKlocalresultspill:
             case TAKlocalresultwrite:
                 if (!queryOwner().queryOwner() || queryOwner().isGlobal()) // don't need result in master if in local child query

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -360,23 +360,15 @@ public:
                         {
                             graph_id gid;
                             msg.read(gid);
-                            Owned<CGraphBase> graph = job->getGraph(gid);
-                            if (!graph)
-                            {
-                                Owned<IThorException> e = MakeThorException(0, "GraphGetResult: graph not found");
-                                e->setGraphId(gid);
-                                throw e.getClear();
-                            }
+                            activity_id ownerId;
+                            msg.read(ownerId);
                             unsigned resultId;
                             msg.read(resultId);
                             mptag_t replyTag = job->deserializeMPTag(msg);
-                            msg.setReplyTag(replyTag);
-                            Owned<IThorResult> result = graph->getResult(resultId);
-                            if (!result)
-                                throw MakeGraphException(graph, 0, "GraphGetResult: result not found: %d", resultId);
-                            msg.clear();
-
+                            Owned<IThorResult> result = job->getOwnedResult(gid, ownerId, resultId);
                             Owned<IRowStream> resultStream = result->getRowStream();
+                            msg.setReplyTag(replyTag);
+                            msg.clear();
                             sendInChunks(job->queryJobComm(), 0, replyTag, resultStream, result->queryRowInterfaces());
                             doReply = false;
                         }


### PR DESCRIPTION
Add support for LOOP, where the condition is on a dataset.

Part of the work, is being careful that the global condition result is available to all slaves asking and not cleared by next iteration of loop

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
