### PR TITLE
HPCC-7939 Confusing code in checkLogicalName

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1095,11 +1095,11 @@ static void checkLogicalScope(const char *scopename,IUserDescriptor *user,bool r
 static bool checkLogicalName(const CDfsLogicalFileName &dlfn,IUserDescriptor *user,bool readreq,bool createreq,bool allowquery,const char *specialnotallowedmsg)
 {
     bool ret = true;
-    if (dlfn.isMulti()) {
+    if (dlfn.isMulti()) { //is temporary superFile?
         if (specialnotallowedmsg)
             throw MakeStringException(-1,"cannot %s a multi file name (%s)",specialnotallowedmsg,dlfn.get());
         unsigned i = dlfn.multiOrdinality();
-        while (--i)
+        while (--i)//continue looping even when ret is false, in order to check for illegal elements (foreigns/externals), and to check each scope permission
             ret = checkLogicalName(dlfn.multiItem(i),user,readreq,createreq,allowquery,specialnotallowedmsg)&&ret;
     }
     else {


### PR DESCRIPTION
Add comment explaining the loop that checks each file in a multi file in checkLogicalName() should continue,
even when it is determined that one of them returns false

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
