### PR TITLE
HPCC-7940 ECLWatch Users screen should be sortable on PWD Expiry columns

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_users.xslt
+++ b/esp/eclwatch/ws_XSLT/access_users.xslt
@@ -61,7 +61,7 @@
                     initSelection('resultsTable');
                     var table = document.getElementById('resultsTable');
                     if (table)
-                        sortableTable = new SortableTable(table, table, ["None", "String", "String", "None"]);
+                        sortableTable = new SortableTable(table, table, ["None", "String", "String", "String", "None"]);
                 }
 
                 function onSubmit(o, theaction)


### PR DESCRIPTION
The new PasswordExpiration column in the eclwatch Users screen should be
sortable like all the other columns

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
