### PR TITLE
HPCC-2960 Configmgr - Navigator multiselect can cause display issues

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -466,7 +466,12 @@ function createNavigationTree(navTreeData) {
 
     if (typeof (selectedRows) !== 'undefined') {
       for (var i = 0; i < selectedRows.length; i++) {
-        xmlStr += "<Component name=\"" + navDT.getRecord(selectedRows[i]).getData('Name');
+        if (navDT.getRecord(selectedRows[i]).getData('Name') == "")
+          continue;
+        if (navDT.getRecord(selectedRows[i]).getData('CompType') == 'Directories')
+          continue;
+        else
+          xmlStr += "<Component name=\"" + navDT.getRecord(selectedRows[i]).getData('Name');
         xmlStr += "\" compType=\"" + navDT.getRecord(selectedRows[i]).getData('CompType');
         xmlStr += "\" build=\"" + navDT.getRecord(selectedRows[i]).getData('Build');
 
@@ -608,7 +613,8 @@ function createNavigationTree(navTreeData) {
         if (compName === "Environment" && document.forms['treeForm'].wizops.value === '3')
           getWaitDlg().show();
           
-        document.getElementById('center1frame').src = '/WsDeploy/DisplaySettings?Cmd=Select&' + getFileName(true) + 'XmlArgs=' + navDT.selectionToXML(record, selectedRows);
+        if (oArgs.event.shiftKey == false && oArgs.event.ctrlKey == false)
+          document.getElementById('center1frame').src = '/WsDeploy/DisplaySettings?Cmd=Select&' + getFileName(true) + 'XmlArgs=' + navDT.selectionToXML(record, selectedRows);
         if (top.document.lastSelectedRow !== 'Hardware' && record.getData('BuildSet') === '')
           top.document.stopWait();
         return;
@@ -1353,6 +1359,7 @@ function createNavigationTree(navTreeData) {
       if (record.getData('Name') === 'Software' || record.getData('Name') === 'Directories'){
         this.getItem(2).cfg.setProperty("disabled", true);
         this.getItem(3).cfg.setProperty("disabled", true);
+        this.getItem(4).cfg.setProperty("disabled", true);
       }
 
       if (record.getData('id') === 0) {

--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -470,8 +470,8 @@ function createNavigationTree(navTreeData) {
           continue;
         if (navDT.getRecord(selectedRows[i]).getData('CompType') == 'Directories')
           continue;
-        else
-          xmlStr += "<Component name=\"" + navDT.getRecord(selectedRows[i]).getData('Name');
+
+        xmlStr += "<Component name=\"" + navDT.getRecord(selectedRows[i]).getData('Name');
         xmlStr += "\" compType=\"" + navDT.getRecord(selectedRows[i]).getData('CompType');
         xmlStr += "\" build=\"" + navDT.getRecord(selectedRows[i]).getData('Build');
 


### PR DESCRIPTION
- When using multi-select no error message will be displayed
- Prevent (skip in multiselect) error message when copying 'Directories'
  because only 1 instance of directories can exist

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
