### PR TITLE
HPCC-2346 two log directories for dafilesrv created on startup

### DIFF
--- a/initfiles/bin/init_dafilesrv.in
+++ b/initfiles/bin/init_dafilesrv.in
@@ -18,7 +18,7 @@
 ###<REPLACE>###
 
 if [ -z $1 ]; then
-        log=${LOG_DIR}/dafilesrv
+        log=${LOG_DIR}
 else
         log=$1
 fi
@@ -28,6 +28,8 @@ shift
 PATH_PRE=`type -path hpcc_setenv`
 source ${PATH_PRE}
 PID_NAME="$PID/`basename $PWD`.pid"
+
+INSTANCE_NAME="`basename $PWD`"
 
 INIT_PID_NAME="$PID/init_`basename $PWD`.pid"
 echo $$ > $INIT_PID_NAME
@@ -46,14 +48,14 @@ killed(){
 }
 ulimit -n $handlelimit
 trap "killed" SIGINT SIGTERM SIGKILL
-dafilesrv -L $log &
+dafilesrv -L $log -I ${INSTANCE_NAME} &
 echo $! > $PID_NAME
 wait
 
 while [ -e ${SENTINEL} ]; do
     sleep 5
     if [ -e ${SENTINEL} ]; then
-        dafilesrv -L $log &
+        dafilesrv -L $log -I ${INSTANCE_NAME} &
         echo $! > $PID_NAME
         wait
     fi


### PR DESCRIPTION
Dafilesrv was unable to create an instance-specific logfile folder since
it has no config file, and therefore didn't know the instance name. This
code passes the instance name to dafilesrv on the command line, which
dafilesrv then uses to build up the logfile location

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
