### PR TITLE
HPCC-7917 Add CLI support for a --help option

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -279,6 +279,11 @@ StringBuffer &EclObjectParameter::getDescription(StringBuffer &s)
 eclCmdOptionMatchIndicator EclCmdCommon::matchCommandLineOption(ArgvIterator &iter, bool finalAttempt)
 {
     bool boolValue;
+    if (iter.matchFlag(boolValue, ECLOPT_HELP))
+    {
+        usage();
+        return EclCmdOptionCompletion;
+    }
     if (iter.matchFlag(boolValue, ECLOPT_VERSION))
     {
         fprintf(stdout, "%s\n", BUILD_TAG);

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -32,6 +32,9 @@ interface IEclCommand : extends IInterface
 
 typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 
+#define ECLOPT_HELP "--help"
+#define ECLARG_HELP "help"
+
 #define ECLOPT_SERVER "--server"
 #define ECLOPT_SERVER_S "-s"
 #define ECLOPT_SERVER_INI "eclWatchIP"
@@ -182,6 +185,7 @@ public:
     virtual void usage()
     {
         fprintf(stdout,
+            "   --help                 display usage information for the given command\n"
             "   -v, --verbose          output additional tracing information\n"
             "   -s, --server=<ip>      ip of server running ecl services (eclwatch)\n"
             "   --port=<port>          ecl services port\n"

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -156,7 +156,7 @@ bool EclCMDShell::parseCommandLineOptions(ArgvIterator &iter)
     for (; !iter.done(); iter.next())
     {
         const char * arg = iter.query();
-        if (iter.matchFlag(optHelp, "help"))
+        if (iter.matchFlag(optHelp, ECLARG_HELP) || iter.matchFlag(optHelp, ECLOPT_HELP)) //users expect --help to work too
             continue;
         if (*arg!='-')
         {

--- a/ecl/eclcmd/roxie/ecl-roxie.cpp
+++ b/ecl/eclcmd/roxie/ecl-roxie.cpp
@@ -216,7 +216,7 @@ public:
         if (attach)
             fputs("\nUsage:\n"
                 "\n"
-                "The 'roxie attach' command (re)attaches a roxie process cluster to its"
+                "The 'roxie attach' command (re)attaches a roxie process cluster to its\n"
                 "DALI allowing changes to the environment or contents of its assigned\n"
                 "querysets to take effect.\n"
                 "\n"


### PR DESCRIPTION
Support --help in addition to existing "ecl help xxx" command because
many users find it more intuitive, and expect it to work.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
