### PR TITLE
HPCC-7953 Roxiemem unit tests fail if all run together

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -32365,6 +32365,7 @@ extern "C" IHThorArg * localResultActivityTestFactory() { return new LocalResult
 class CcdServerTest : public CppUnit::TestFixture  
 {
     CPPUNIT_TEST_SUITE(CcdServerTest);
+        CPPUNIT_TEST(testSetup);
         CPPUNIT_TEST(testHeapSort);
         CPPUNIT_TEST(testInsertionSort);
         CPPUNIT_TEST(testQuickSort);
@@ -32372,6 +32373,7 @@ class CcdServerTest : public CppUnit::TestFixture
         CPPUNIT_TEST(testMergeDedup);
         CPPUNIT_TEST(testPrefetchProject);
         CPPUNIT_TEST(testMiscellaneous);
+        CPPUNIT_TEST(testCleanup);
     CPPUNIT_TEST_SUITE_END();
 protected:
     SlaveContextLogger logctx;
@@ -32380,14 +32382,18 @@ protected:
     Owned<IRoxieSlaveContext> ctx;
     Owned<IQueryFactory> queryFactory;
 
+    void testSetup()
+    {
+        roxiemem::setTotalMemoryLimit(100 * 1024 * 1024, 0, NULL);
+    }
+
+    void testCleanup()
+    {
+        roxiemem::releaseRoxieHeap();
+    }
+
     void init()
     {
-        static bool heapInitialized = false;
-        if (!heapInitialized)
-        {
-            roxiemem::setTotalMemoryLimit(100 * 1024 * 1024, 0, NULL);
-            heapInitialized = true;
-        }
         package.setown(createPackage(NULL));
         ctx.setown(createSlaveContext(NULL, logctx, 0, 50*1024*1024, NULL));
         queryDll.setown(createExeQueryDll("roxie"));

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -164,6 +164,8 @@ extern void releaseRoxieHeap()
 {
     if (heapBase)
     {
+        if (memTraceLevel)
+            DBGLOG("RoxieMemMgr: releasing heap");
         delete [] heapBitmap;
         heapBitmap = NULL;
         heapBitmapSize = 0;
@@ -3145,6 +3147,7 @@ public:
 class RoxieMemTests : public CppUnit::TestFixture  
 {
     CPPUNIT_TEST_SUITE( RoxieMemTests );
+        CPPUNIT_TEST(testSetup);
         CPPUNIT_TEST(testRoundup);
         CPPUNIT_TEST(testBitmapThreading);
         CPPUNIT_TEST(testAllocSize);
@@ -3156,21 +3159,30 @@ class RoxieMemTests : public CppUnit::TestFixture
         CPPUNIT_TEST(testDatamanagerThreading);
         CPPUNIT_TEST(testCallbacks);
         CPPUNIT_TEST(testRecursiveCallbacks);
+        CPPUNIT_TEST(testCleanup);
     CPPUNIT_TEST_SUITE_END();
     const IContextLogger &logctx;
 
 public:
     RoxieMemTests() : logctx(queryDummyContextLogger())
     {
-        initializeHeap(300, 0, NULL);
     }
 
     ~RoxieMemTests()
     {
-        releaseRoxieHeap();
     }
 
 protected:
+    void testSetup()
+    {
+        initializeHeap(300, 0, NULL);
+    }
+
+    void testCleanup()
+    {
+        releaseRoxieHeap();
+    }
+
     static int mc4(const void *x, const void *y)
     {
         return -memcmp(x, y, sizeof(void*));
@@ -4168,23 +4180,33 @@ const memsize_t memorySize = 0x60000000;
 class RoxieMemStressTests : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE( RoxieMemStressTests );
+    CPPUNIT_TEST(testSetup);
     CPPUNIT_TEST(testFragmenting);
     CPPUNIT_TEST(testSequential);
+    CPPUNIT_TEST(testCleanup);
     CPPUNIT_TEST_SUITE_END();
     const IContextLogger &logctx;
 
 public:
     RoxieMemStressTests() : logctx(queryDummyContextLogger())
     {
-        setTotalMemoryLimit(memorySize, 0, NULL);
     }
 
     ~RoxieMemStressTests()
     {
-        releaseRoxieHeap();
     }
 
 protected:
+    void testSetup()
+    {
+        setTotalMemoryLimit(memorySize, 0, NULL);
+    }
+
+    void testCleanup()
+    {
+        releaseRoxieHeap();
+    }
+
     void testSequential()
     {
         unsigned requestSize = 20;
@@ -4244,22 +4266,32 @@ const memsize_t initialAllocSize = 0x100;
 class RoxieMemHugeTests : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE( RoxieMemHugeTests );
+    CPPUNIT_TEST(testSetup);
     CPPUNIT_TEST(testHuge);
+    CPPUNIT_TEST(testCleanup);
     CPPUNIT_TEST_SUITE_END();
     const IContextLogger &logctx;
 
 public:
     RoxieMemHugeTests() : logctx(queryDummyContextLogger())
     {
-        setTotalMemoryLimit(hugeMemorySize, 0, NULL);
     }
 
     ~RoxieMemHugeTests()
     {
-        releaseRoxieHeap();
     }
 
 protected:
+    void testSetup()
+    {
+        setTotalMemoryLimit(hugeMemorySize, 0, NULL);
+    }
+
+    void testCleanup()
+    {
+        releaseRoxieHeap();
+    }
+
     void testHuge()
     {
         Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);

--- a/roxie/roxiemem/roxierow.cpp
+++ b/roxie/roxiemem/roxierow.cpp
@@ -336,19 +336,19 @@ namespace roxiemem {
 class RoxieRowAllocatorTests : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE( RoxieRowAllocatorTests );
+        CPPUNIT_TEST(testSetup);
         CPPUNIT_TEST(testChecking);
+        CPPUNIT_TEST(testCleanup);
     CPPUNIT_TEST_SUITE_END();
     const IContextLogger &logctx;
 
 public:
     RoxieRowAllocatorTests() : logctx(queryDummyContextLogger())
     {
-        setTotalMemoryLimit(40*HEAP_ALIGNMENT_SIZE, 0, NULL);
     }
 
     ~RoxieRowAllocatorTests()
     {
-        releaseRoxieHeap();
     }
 
 protected:
@@ -442,6 +442,16 @@ protected:
         testAllocator(meta, flags, low, high, 0, true);
         testAllocator(meta, flags, low, high, -1, true);
         testAllocator(meta, flags, low, high, +1, true);
+    }
+
+    void testSetup()
+    {
+        setTotalMemoryLimit(40*HEAP_ALIGNMENT_SIZE, 0, NULL);
+    }
+
+    void testCleanup()
+    {
+        releaseRoxieHeap();
     }
 
     void testChecking()


### PR DESCRIPTION
Running roxie -selftest to execute all unit tests may cause some to fail, as
the roxiemem heap size ends up being set by whichever test executes first, and
this may not be enough for later tests.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
