### PR TITLE
HPCC-7955 Configmgr - Disassociating ldap from esp causes seg fault

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -1273,24 +1273,29 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
         }
       }
 
-      if (bUpdateFilesBasedn == true && strcmp(pszAttrName, TAG_LDAPSERVER) == 0 && strcmp(pszCompType, XML_TAG_DALISERVERPROCESS) == 0 && pComp != NULL && pszNewValue && *pszNewValue)
+      if (bUpdateFilesBasedn == true && strcmp(pszAttrName, TAG_LDAPSERVER) == 0 && strcmp(pszCompType, XML_TAG_DALISERVERPROCESS) == 0 && pComp != NULL)
       {
         Owned<IPropertyTree> pActiveEnvRoot = getEnvTree(context, &req.getReqInfo());
 
         StringBuffer ldapXPath;
-        ldapXPath.appendf("./%s/%s[%s=\"%s\"]", XML_TAG_SOFTWARE, XML_TAG_LDAPSERVERPROCESS, XML_ATTR_NAME, pszNewValue);
+        StringBuffer strFilesBasedn;
 
-        StringBuffer strFilesBasedn(pActiveEnvRoot->queryPropTree(ldapXPath.str())->queryProp(XML_ATTR_FILESBASEDN));
+        if (pszNewValue && *pszNewValue)
+        {
+          ldapXPath.appendf("./%s/%s[%s=\"%s\"]", XML_TAG_SOFTWARE, XML_TAG_LDAPSERVERPROCESS, XML_ATTR_NAME, pszNewValue);
+          strFilesBasedn.appendf("%s",pActiveEnvRoot->queryPropTree(ldapXPath.str())->queryProp(XML_ATTR_FILESBASEDN));
+        }
 
         pComp->setProp(XML_ATTR_FILESBASEDN,strFilesBasedn);
       }
-      else if (bUpdateFilesBasedn == true && pComp != NULL && strcmp(pszCompType, XML_TAG_ESPPROCESS) == 0 && strcmp(pszAttrName, TAG_SERVICE) == 0 && pszNewValue && *pszNewValue)
+      else if (bUpdateFilesBasedn == true && pComp != NULL && strcmp(pszCompType, XML_TAG_ESPPROCESS) == 0 && strcmp(pszAttrName, TAG_SERVICE) == 0 pszNewValue && *pszNewValue)
       {
         Owned<IPropertyTree> pActiveEnvRoot = getEnvTree(context, &req.getReqInfo());
 
         StringBuffer ldapXPath;
         StringBuffer espServiceXPath;
         StringBuffer espProcessXPath;
+        StringBuffer strFilesBasedn;
 
         espServiceXPath.appendf("./%s/%s[%s=\"%s\"]", XML_TAG_SOFTWARE, XML_TAG_ESPSERVICE, XML_ATTR_NAME, pszNewValue);
         espProcessXPath.appendf("./%s/%s/[%s=\"%s\"]/%s", XML_TAG_SOFTWARE, XML_TAG_ESPPROCESS, XML_ATTR_NAME, pszCompName, XML_TAG_AUTHENTICATION);
@@ -1300,12 +1305,9 @@ bool CWsDeployFileInfo::saveSetting(IEspContext &context, IEspSaveSettingRequest
         if (strLDAPName.length() > 0)
         {
           ldapXPath.appendf("./%s/%s[%s=\"%s\"]", XML_TAG_SOFTWARE, XML_TAG_LDAPSERVERPROCESS, XML_ATTR_NAME, strLDAPName.str());
-
-          StringBuffer strFilesBasedn(pActiveEnvRoot->queryPropTree(ldapXPath.str())->queryProp(XML_ATTR_FILESBASEDN));
-
-          if (strFilesBasedn.length() > 0)
-            pActiveEnvRoot->queryPropTree(espServiceXPath.str())->setProp(XML_ATTR_FILESBASEDN, strFilesBasedn);
+          strFilesBasedn.appendf("%s", pActiveEnvRoot->queryPropTree(ldapXPath.str())->queryProp(XML_ATTR_FILESBASEDN));
         }
+        pActiveEnvRoot->queryPropTree(espServiceXPath.str())->setProp(XML_ATTR_FILESBASEDN, strFilesBasedn);
       }
       else if (bUpdateFilesBasedn == true && strcmp(pszAttrName, TAG_LDAPSERVER) == 0 && strcmp(pszCompType, XML_TAG_ESPPROCESS) == 0 && pComp != NULL)
       {


### PR DESCRIPTION
- If selecting no ldap (empty) from dropdown in the ESP, dali, or ESP
  service bindings (with no associated LDAP), the filesBasedn will  be set to
  empty in the esp service(s) upon confirmation.
- Fix seg fault.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
