### PR TITLE
HPCC-7954 Configmgr - improper popup when changing ESP service bindings

### DIFF
--- a/esp/files/scripts/configmgr/configmgr.js
+++ b/esp/files/scripts/configmgr/configmgr.js
@@ -920,7 +920,7 @@ function handleConfigCellClickEvent(oArgs, caller, isComplex) {
     var form = top.window.document.forms['treeForm'];
     top.document.startWait(document);
 
-    if ((record.getData('compType') == 'EspProcess' || record.getData('compType') == "DaliServerProcess") && (record.getData('params').indexOf('subType=EspBinding') != -1 || record.getData('_key') == "ldapServer"))
+    if ((record.getData('compType') == 'EspProcess' || record.getData('compType') == "DaliServerProcess") && (record.getData('params').indexOf('subType=EspBinding') != -1 || record.getData('_key') == "ldapServer") && (typeof(column.field) !== 'undefined' && column.field == 'service'))
       bUpdateFilesBasedn = confirm("If available, proceed with update of filesBasedn value?\n\n(If you are unsure select 'Ok')");
     else
       bUpdateFilesBasedn = false;


### PR DESCRIPTION
- Ensure that user is modifying the service field before triggering
  confirmation pop-up

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
