### PR TITLE
HPCC-7956 Group Hash Aggregate failure

### DIFF
--- a/testing/ecl/aggds4.ecl
+++ b/testing/ecl/aggds4.ecl
@@ -33,3 +33,6 @@ output(sort(table(pr(aage > 20), { aage, max(group, fullname) }, aage, few), rec
 
 //Filtered Aggregate on a projected table.
 output(sort(table(pr2(seq > 10), { surname, ave(group, aage) }, surname, few), record));
+
+//Grouped Hash Aggregate
+output(sort(table(group(sort(sqNamesTable1, surname),surname), { surname, ave(group, aage) }, surname, few), record));

--- a/testing/ecl/key/aggds4.xml
+++ b/testing/ecl/key/aggds4.xml
@@ -15,3 +15,10 @@
  <Row><surname>Jones               </surname><_unnamed_avg_aage2>49.5</_unnamed_avg_aage2></Row>
  <Row><surname>Windsor             </surname><_unnamed_avg_aage2>80.5</_unnamed_avg_aage2></Row>
 </Dataset>
+<Dataset name='Result 3'>
+ <Row><surname>Flintstone          </surname><_unnamed_avg_aage2>99.0</_unnamed_avg_aage2></Row>
+ <Row><surname>Grabdale            </surname><_unnamed_avg_aage2>68.0</_unnamed_avg_aage2></Row>
+ <Row><surname>Halliday            </surname><_unnamed_avg_aage2>24.66666666666667</_unnamed_avg_aage2></Row>
+ <Row><surname>Jones               </surname><_unnamed_avg_aage2>49.5</_unnamed_avg_aage2></Row>
+ <Row><surname>Windsor             </surname><_unnamed_avg_aage2>80.5</_unnamed_avg_aage2></Row>
+</Dataset>

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2549,8 +2549,10 @@ public:
         appendOutputLinked(this);
 
         if (!container.queryLocalOrGrouped())
+        {
             mptag = container.queryJob().deserializeMPTag(data);
-        ActPrintLog("HASHAGGREGATE: init tags %d",(int)mptag);
+            ActPrintLog("HASHAGGREGATE: init tags %d",(int)mptag);
+        }
     }
     void start()
     {
@@ -2581,7 +2583,7 @@ public:
         stopInput(input);
         if (abortSoon)
             return;
-        if (!container.queryLocal() && container.queryJob().querySlaves()>1)
+        if (!container.queryLocalOrGrouped() && container.queryJob().querySlaves()>1)
         {
             bool ordered = 0 != (TAForderedmerge & helper->getAggregateFlags());
             localAggTable.setown(mergeLocalAggs(*this, *helper, *helper, localAggTable, mptag, ordered));


### PR DESCRIPTION
Hash aggregate was incorrectly testing the grouped state of the activity
As a consequence, it was running global distribute code and hit an assert
upon trying to use a null MP tag.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
