### PR TITLE
HPCC-7972 False positives in roxie regression suite on when6c.ecl

### DIFF
--- a/testing/ecl/key/when6c.xml
+++ b/testing/ecl/key/when6c.xml
@@ -4,12 +4,9 @@
  <Row><s>9</s></Row>
 </Dataset>
 <Dataset name='Result 2'>
- <Row><f1>1</f1></Row>
- <Row><f1>9</f1></Row>
- <Row><f1>3</f1></Row>
+ <Row><c>1</c></Row>
+ <Row><c>1</c></Row>
+ <Row><c>1</c></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><c>1</c></Row>
- <Row><c>1</c></Row>
- <Row><c>1</c></Row>
 </Dataset>

--- a/testing/ecl/when6c.ecl
+++ b/testing/ecl/when6c.ecl
@@ -16,6 +16,7 @@
 ############################################################################## */
 
 //skip type==thorlcr TBD
+//skip type==hthor TBD
 
 r := {unsigned f1, unsigned f2, unsigned f3, unsigned f4 };
 


### PR DESCRIPTION
The when6c.xml key file is incorrect. Roxie actually returns the correct
result.

Hthor does not, and is not likely to any time soon. As this is unlikely to be
fixed before we retire hthor in favour of Roxie, I have disabled the test for
hthor.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
