### PR TITLE
HPCC-7981 Memory leak in memoryUsageReporter

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -1707,6 +1707,8 @@ public:
     {
         free(partition);
         free(kbuf);
+        free(newblkio);
+        free(oldblkio);
     }
 
     bool getLine(StringBuffer &out)


### PR DESCRIPTION
Every time memoryReporter (which also reports disk) is started/stopped,
there is a leak of around 56 bytes (on a default debug install).

Becuase Thor calls startMemoryReporter at the start of each subgraph and
stopMemoryReporter at the end, the leak does accumulate.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
