### PR TITLE
HPCC-7965 Set correct content type for xml/xslt to avoid log failure

### DIFF
--- a/esp/bindings/SOAP/ws_ecl_client/ws_ecl_client_bind.hpp
+++ b/esp/bindings/SOAP/ws_ecl_client/ws_ecl_client_bind.hpp
@@ -622,7 +622,7 @@ public:
                 mimeType = "application/x-www-form-urlencoded";
             }
             else
-                mimeType = "application/xml";
+                mimeType = "text/xml";
         }
         else
             mimeType = "text/html; charset=UTF-8";

--- a/esp/bindings/SOAP/ws_ecl_client/ws_ecl_client_bind.hpp
+++ b/esp/bindings/SOAP/ws_ecl_client/ws_ecl_client_bind.hpp
@@ -622,7 +622,7 @@ public:
                 mimeType = "application/x-www-form-urlencoded";
             }
             else
-                mimeType = "text/xml";
+                mimeType = "application/xml";
         }
         else
             mimeType = "text/html; charset=UTF-8";

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1099,7 +1099,7 @@ int EspHttpBinding::onGetConfig(IEspContext &context, CHttpRequest* request, CHt
         StringBuffer content;
         xmlContentFromFile(m_configFile, "/esp/xslt/xmlformatter.xsl", content);
         response->setContent(content.str());
-        response->setContentType("text/xml; charset=UTF-8");
+        response->setContentType(HTTP_TYPE_APPLICATION_XML_UTF8);
         response->setStatus(HTTP_STATUS_OK);
         response->send();
         return 0;
@@ -1117,7 +1117,7 @@ int EspHttpBinding::onGetVersion(IEspContext &context, CHttpRequest* request, CH
     verxml.appendf("<VersionInfo><Service>%s</Service><Version>%.3f</Version></VersionInfo>", srvQName.str(), m_wsdlVer);
     
     response->setContent(verxml.str());
-    response->setContentType("text/xml; charset=UTF-8");
+    response->setContentType(HTTP_TYPE_APPLICATION_XML_UTF8);
     response->setStatus(HTTP_STATUS_OK);
     response->send();
     return 0;
@@ -1283,7 +1283,7 @@ int EspHttpBinding::getWsdlOrXsd(IEspContext &context, CHttpRequest* request, CH
             }
 
             response->setContent(content.length(), content.str());
-            response->setContentType("text/xml; charset=UTF-8");
+            response->setContentType(HTTP_TYPE_APPLICATION_XML_UTF8);
             response->setStatus(HTTP_STATUS_OK);
         }
     }
@@ -1410,7 +1410,7 @@ void EspHttpBinding::generateSampleXml(bool isRequest, IEspContext &context, CHt
 
             genSampleXml(parent,type, content, element, generateNamespace(context, request, serviceQName.str(), methodQName.str(), nsdecl).append('\"').str());
             response->setContent(content.length(), content.str());
-            response->setContentType("text/xml; charset=UTF-8");
+            response->setContentType(HTTP_TYPE_APPLICATION_XML_UTF8);
             response->setStatus(HTTP_STATUS_OK);
             response->send();
             return;

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -558,7 +558,7 @@ int CEspHttpServer::onGetTitleBar(CHttpRequest* request, CHttpResponse* response
     bool rawXml = request->queryParameters()->hasProp("rawxml_");
     StringBuffer m_headerHtml(m_apport->getTitleBarHtml(*request->queryContext(), rawXml));
     response->setContent(m_headerHtml.length(), m_headerHtml.str());
-    response->setContentType(rawXml ? "text/xml; charset=UTF-8" : "text/html; charset=UTF-8");
+    response->setContentType(rawXml ? HTTP_TYPE_APPLICATION_XML_UTF8 : "text/html; charset=UTF-8");
     response->setStatus(HTTP_STATUS_OK);
     response->send();
     return 0;
@@ -966,7 +966,7 @@ int CEspHttpServer::onGet()
 
         m_response->setVersion(HTTP_VERSION);
         m_response->setContent(content.length(), content.toByteArray());
-        m_response->setContentType("text/xml; charset=UTF-8");
+        m_response->setContentType(HTTP_TYPE_APPLICATION_XML_UTF8);
         m_response->setStatus(HTTP_STATUS_OK);
         m_response->send();
     }

--- a/esp/bindings/http/platform/httptransport.hpp
+++ b/esp/bindings/http/platform/httptransport.hpp
@@ -45,6 +45,7 @@
 #define HTTP_TYPE_TEXT_HTML                     "text/html"
 #define HTTP_TYPE_TEXT_PLAIN                    "text/plain"
 #define HTTP_TYPE_TEXT_XML                      "text/xml"
+#define HTTP_TYPE_APPLICATION_XML               "application/xml"
 #define HTTP_TYPE_IMAGE_JPEG                    "image/jpeg"
 #define HTTP_TYPE_OCTET_STREAM                  "application/octet-stream"
 #define HTTP_TYPE_SOAP                          "application/soap"
@@ -57,6 +58,7 @@
 #define HTTP_TYPE_TEXT_HTML_UTF8                "text/html; charset=UTF-8"
 #define HTTP_TYPE_TEXT_PLAIN_UTF8               "text/plain; charset=UTF-8"
 #define HTTP_TYPE_TEXT_XML_UTF8                 "text/xml; charset=UTF-8"
+#define HTTP_TYPE_APPLICATION_XML_UTF8          "application/xml; charset=UTF-8"
 #define HTTP_TYPE_SOAP_UTF8                     "application/soap; charset=UTF-8"
 
 

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -207,7 +207,7 @@ const StringBuffer &CEspApplicationPort::getNavBarContent(IEspContext &context, 
         if (rawxml)
         {
             content.swapWith(xml);
-            contentType.clear().append("text/xml; charset=UTF-8");
+            contentType.clear().append(HTTP_TYPE_APPLICATION_XML_UTF8);
         }
         else
         {
@@ -247,7 +247,7 @@ const StringBuffer &CEspApplicationPort::getDynNavData(IEspContext &context, IPr
 
     if (!bVolatile)
         bVolatile = navtree->getPropBool("@volatile", false);
-    contentType.clear().append("text/xml; charset=UTF-8");
+    contentType.clear().append(HTTP_TYPE_APPLICATION_XML_UTF8);
     return toXML(navtree.get(), content.clear());
 }
 

--- a/esp/services/ecldirect/EclDirectService.cpp
+++ b/esp/services/ecldirect/EclDirectService.cpp
@@ -389,7 +389,7 @@ inline const char *runEclExFormatMimeType(CRunEclExFormat format)
 {
     if (format == CRunEclExFormat_Table)
         return "text/html; charset=utf-8";
-    return "text/xml; charset=utf-8";
+    return "application/xml; charset=utf-8";
 }
 
 int CEclDirectSoapBindingEx::onGet(CHttpRequest* request, CHttpResponse* response)

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -1890,8 +1890,6 @@ int CWsEclBinding::getXmlTestForm(IEspContext &context, CHttpRequest* request, C
     const char* excludes[] = {"soap_builder_",NULL};
     getEspUrlParams(context,params,excludes);
 
-    StringBuffer header("Content-Type: text/xml; charset=UTF-8");
-
     Owned<IXslProcessor> xslp = getXslProcessor();
     Owned<IXslTransform> xform = xslp->createXslTransform();
     xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/wsecl3_xmltest.xsl").str());
@@ -1902,18 +1900,22 @@ int CWsEclBinding::getXmlTestForm(IEspContext &context, CHttpRequest* request, C
     srcxml.append("]]></soapbody></srcxml>");
     xform->setXmlSource(srcxml.str(), srcxml.length());
 
+    StringBuffer header;
     if (!stricmp(formtype, "roxiexml"))
     {
+        header.append("Content-Type: application/xml; charset=UTF-8");
         xform->setStringParameter("showhttp", "true()");
         pageName.append("ROXIE XML Test");
     }
     else if (!stricmp(formtype, "roxiesoap"))
     {
+        header.append("Content-Type: text/xml; charset=UTF-8");
         xform->setStringParameter("showhttp", "true()");
         pageName.append("ROXIE SOAP Test");
     }
     else
     {
+        header.append("Content-Type: text/xml; charset=UTF-8");
         xform->setStringParameter("showhttp", "true()");
         pageName.append("SOAP Test");
     }
@@ -2361,7 +2363,7 @@ int CWsEclBinding::onSubmitQueryOutputXML(IEspContext &context, CHttpRequest* re
     }
 
     response->setContent(output.str());
-    response->setContentType("text/xml");
+    response->setContentType(HTTP_TYPE_APPLICATION_XML);
     response->setStatus("200 OK");
     response->send();
 
@@ -2520,7 +2522,7 @@ int CWsEclBinding::getWsEclDefinition(CHttpRequest* request, CHttpResponse* resp
         {
             response->setStatus("200 OK");
             response->setContent(blockStr.str());
-            response->setContentType("text/xml");
+            response->setContentType(HTTP_TYPE_APPLICATION_XML);
             response->send();
         }
     }
@@ -2585,7 +2587,7 @@ int CWsEclBinding::getWsEclDefinition(CHttpRequest* request, CHttpResponse* resp
             {
                 response->setStatus("200 OK");
                 response->setContent(output.str());
-                response->setContentType("text/xml");
+                response->setContentType(HTTP_TYPE_APPLICATION_XML);
                 response->send();
             }
         }
@@ -2618,7 +2620,7 @@ int CWsEclBinding::getWsEclExample(CHttpRequest* request, CHttpResponse* respons
             {
                 response->setStatus("200 OK");
                 response->setContent(output.str());
-                response->setContentType("text/xml");
+                response->setContentType(HTTP_TYPE_APPLICATION_XML);
                 response->send();
             }
     }

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -183,7 +183,7 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
         if(requestparams && requestparams->hasProp("rawxml_"))
         {
             response->setContent(xml.str());
-            response->setContentType(HTTP_TYPE_TEXT_XML_UTF8);
+            response->setContentType(HTTP_TYPE_APPLICATION_XML);
         }
         else{
             StringBuffer htmlbuf;

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2646,7 +2646,7 @@ bool CFileSprayEx::onDFUWUFile(IEspContext &context, IEspDFUWUFileRequest &req, 
                 xmlbuf.append("<?xml-stylesheet href=\"../esp/xslt/xmlformatter.xsl\" type=\"text/xsl\"?>");
                 wu->toXML(xmlbuf);
                 resp.setFile(xmlbuf.str());
-                resp.setFile_mimetype(HTTP_TYPE_TEXT_XML);
+                resp.setFile_mimetype(HTTP_TYPE_APPLICATION_XML);
             }
         }
     }

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -563,7 +563,7 @@ bool CWsTopologyEx::onTpXMLFile(IEspContext &context,IEspTpXMLFileRequest  &req,
         MemoryBuffer membuff;
         membuff.setBuffer(strBuff.length(), (void*)strBuff.toCharArray());
 
-        resp.setThefile_mimetype(HTTP_TYPE_TEXT_XML);
+        resp.setThefile_mimetype(HTTP_TYPE_APPLICATION_XML);
         resp.setThefile(membuff);
     }
     catch(IException* e)
@@ -1748,7 +1748,7 @@ bool CWsTopologyEx::onTpGetComponentFile(IEspContext &context,
                         }
                     }
                     resp.setFileContents(buf);
-                    resp.setFileContents_mimetype(HTTP_TYPE_TEXT_XML);
+                    resp.setFileContents_mimetype(HTTP_TYPE_APPLICATION_XML);
                 }
             }
         }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2594,7 +2594,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
             if (strieq(File_ArchiveQuery, req.getType()))
             {
                 winfo.getWorkunitArchiveQuery(mb);
-                openSaveFile(context, opt, "ArchiveQuery.xml", HTTP_TYPE_TEXT_XML, mb, resp);
+                openSaveFile(context, opt, "ArchiveQuery.xml", HTTP_TYPE_APPLICATION_XML, mb, resp);
             }
             else if (strieq(File_Cpp,req.getType()) && notEmpty(req.getName()))
             {
@@ -2640,7 +2640,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
                 if (plainText && (!stricmp(plainText, "yes")))
                     resp.setThefile_mimetype(HTTP_TYPE_TEXT_PLAIN);
                 else
-                    resp.setThefile_mimetype(HTTP_TYPE_TEXT_XML);
+                    resp.setThefile_mimetype(HTTP_TYPE_APPLICATION_XML);
             }
         }
     }
@@ -3095,7 +3095,7 @@ bool CWsWorkunitsEx::onWUExport(IEspContext &context, IEspWUExportRequest &req, 
         MemoryBuffer mb;
         mb.setBuffer(xml.length(),(void*)xml.str());
         resp.setExportData(mb);
-        resp.setExportData_mimetype(HTTP_TYPE_TEXT_XML);
+        resp.setExportData_mimetype(HTTP_TYPE_APPLICATION_XML);
     }
     catch(IException* e)
     {


### PR DESCRIPTION
When ESP loglevel is high and response xml message is logged, the xml
is logged as a SOAP message because the content type is set as 'text/
xml'. This fix changes the content type of xml/xsl/xslt to be
'application/xml'. This fix also adds exception check in to the log
function. When an exception is thrown inside the log function, the
exception and the xml message will be logged into esp.xml.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
