### PR TITLE
HPCC-7983 Memory leak in CNullSlaveActivity

### DIFF
--- a/thorlcr/activities/null/thnullslave.cpp
+++ b/thorlcr/activities/null/thnullslave.cpp
@@ -48,7 +48,7 @@ public:
 
     CNullSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container), CThorDataLink(this)
     {
-        appendOutputLinked(this);
+        appendOutput(this);
     }
 // IThorSlaveActivity
     virtual void init(MemoryBuffer & data, MemoryBuffer &slaveData)


### PR DESCRIPTION
CNullSlaveActivity constructor creates a circular link to itself by calling
appendOutputLink(this);

As a result it is never freed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
