### PR TITLE
HPCC-7978 ecl commands should set QueryMain explicitly

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -467,7 +467,7 @@ private:
     };
 };
 
-bool addNamedValue(const char * name, const char * value, IArrayOf<IEspNamedValue> &values)
+void addNamedValue(const char * name, const char * value, IArrayOf<IEspNamedValue> &values)
 {
     Owned<IEspNamedValue> nv = createNamedValue();
     nv->setName(name);
@@ -476,7 +476,7 @@ bool addNamedValue(const char * name, const char * value, IArrayOf<IEspNamedValu
     values.append(*nv.getClear());
 }
 
-bool addNamedValue(const char * arg, IArrayOf<IEspNamedValue> &values)
+void addNamedValue(const char * arg, IArrayOf<IEspNamedValue> &values)
 {
     const char *eq = strchr(arg, '=');
     if (!eq)
@@ -560,11 +560,6 @@ bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
             optObj.set(optManifest.get()); //treat as stand alone manifest that must declare ecl to compile
             optManifest.clear();
         }
-    }
-
-    if (optNoArchive && optAttributePath.length())
-    {
-        addNamedValue("eclcc-main", optAttributePath.get(), debugValues);
     }
 
     if (!optNoArchive && (optObj.type == eclObjSource || optObj.type == eclObjManifest))

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -467,22 +467,33 @@ private:
     };
 };
 
+bool addNamedValue(const char * name, const char * value, IArrayOf<IEspNamedValue> &values)
+{
+    Owned<IEspNamedValue> nv = createNamedValue();
+    nv->setName(name);
+    if (value)
+        nv->setValue(value);
+    values.append(*nv.getClear());
+}
+
+bool addNamedValue(const char * arg, IArrayOf<IEspNamedValue> &values)
+{
+    const char *eq = strchr(arg, '=');
+    if (!eq)
+        addNamedValue(arg, NULL, values);
+    else
+    {
+        StringAttr name(arg, eq - arg);
+        addNamedValue(name.get(),eq+1,values);
+    }
+}
+
 bool matchVariableOption(ArgvIterator &iter, const char prefix, IArrayOf<IEspNamedValue> &values)
 {
     const char *arg = iter.query();
     if (*arg++!='-' || *arg++!=prefix || !*arg)
         return false;
-    Owned<IEspNamedValue> nv = createNamedValue();
-    const char *eq = strchr(arg, '=');
-    if (!eq)
-        nv->setName(arg);
-    else
-    {
-        StringAttr name(arg, eq - arg);
-        nv->setName(name.get());
-        nv->setValue(eq+1);
-    }
-    values.append(*nv.getClear());
+    addNamedValue(arg, values);
     return true;
 }
 eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvIterator &iter, bool finalAttempt)
@@ -524,6 +535,10 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     if (iter.matchOption(optResultLimit, ECLOPT_RESULT_LIMIT))
         return EclCmdOptionMatch;
+    if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
+        return EclCmdOptionMatch;
+    if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
+        return EclCmdOptionMatch;
 
     return EclCmdCommon::matchCommandLineOption(iter, finalAttempt);
 }
@@ -539,16 +554,17 @@ bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
         {
             optNoArchive=true;
             optObj.type = eclObjSource;
-            optObj.value.set(optAttributePath.get());
-            StringBuffer text(optAttributePath.get());
-            text.append("();");
-            optObj.mb.append(text.str());
         }
         else if (optManifest.length())
         {
             optObj.set(optManifest.get()); //treat as stand alone manifest that must declare ecl to compile
             optManifest.clear();
         }
+    }
+
+    if (optNoArchive && optAttributePath.length())
+    {
+        addNamedValue("eclcc-main", optAttributePath.get(), debugValues);
     }
 
     if (!optNoArchive && (optObj.type == eclObjSource || optObj.type == eclObjManifest))
@@ -560,8 +576,25 @@ bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
     if (optResultLimit == (unsigned)-1)
         extractEclCmdOption(optResultLimit, globals, ECLOPT_RESULT_LIMIT_ENV, ECLOPT_RESULT_LIMIT_INI, 0);
 
-    return true;
+    if (optObj.value.isEmpty() && optAttributePath.isEmpty())
+    {
+        fprintf(stderr, "\nMust specify a Query, WUID, ECL File, Archive, or shared object\n");
+        return false;
+    }
 
+    if (optObj.type==eclObjTypeUnknown)
+    {
+        fprintf(stderr, "\nCan't determine content type of argument %s\n", optObj.value.sget());
+        return false;
+    }
+
+    if ((optObj.type==eclObjSource || optObj.type==eclObjArchive) && optTargetCluster.isEmpty())
+    {
+        fprintf(stderr, "\nTarget must be specified when source is ECL Source or Archive\n");
+        return false;
+    }
+
+    return true;
 }
 
 eclCmdOptionMatchIndicator EclCmdWithQueryTarget::matchCommandLineOption(ArgvIterator &iter, bool finalAttempt)

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -225,6 +225,7 @@ public:
         );
     }
 public:
+    StringAttr optTargetCluster;
     EclObjectParameter optObj;
     StringBuffer optLibPath;
     StringBuffer optImpPath;

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -179,6 +179,8 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
     req->setFileName(cmd.optObj.value.sget());
     if ((int)cmd.optResultLimit > 0)
         req->setResultLimit(cmd.optResultLimit);
+    if (cmd.optAttributePath.length())
+        req->setQueryMainDefinition(cmd.optAttributePath);
     if (cmd.debugValues.length())
     {
         req->setDebugValues(cmd.debugValues);

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -249,10 +249,6 @@ public:
         for (; !iter.done(); iter.next())
         {
             const char *arg = iter.query();
-            if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
-                continue;
-            if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
-                continue;
             if (iter.matchOption(optName, ECLOPT_NAME)||iter.matchOption(optName, ECLOPT_NAME_S))
                 continue;
             if (EclCmdWithEclTarget::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
@@ -264,25 +260,10 @@ public:
     {
         if (!EclCmdWithEclTarget::finalizeOptions(globals))
             return false;
-        if (optObj.value.isEmpty())
-        {
-            fprintf(stderr, "\nNo ECL Source, Archive, or DLL specified for deployment\n");
-            return false;
-        }
-        if (optObj.type==eclObjTypeUnknown)
-        {
-            fprintf(stderr, "\nCan't determine content type of argument %s\n", optObj.value.sget());
-            return false;
-        }
         if (optObj.type==eclObjWuid)
         {
             StringBuffer s;
             fprintf(stderr, "\nWUID (%s) cannot be the target for deployment\n", optObj.getDescription(s).str());
-            return false;
-        }
-        if ((optObj.type==eclObjSource || optObj.type==eclObjArchive) && optTargetCluster.isEmpty())
-        {
-            fprintf(stderr, "\nTarget must be specified when deploying from ECL Source or Archive\n");
             return false;
         }
         return true;
@@ -318,7 +299,6 @@ public:
         EclCmdWithEclTarget::usage();
     }
 private:
-    StringAttr optTargetCluster;
     StringAttr optName;
 };
 
@@ -344,10 +324,6 @@ public:
             if (iter.matchOption(optObj.value, ECLOPT_WUID)||iter.matchOption(optObj.value, ECLOPT_WUID_S))
                 continue;
             if (iter.matchOption(optName, ECLOPT_NAME)||iter.matchOption(optName, ECLOPT_NAME_S))
-                continue;
-            if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
-                continue;
-            if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
                 continue;
             if (iter.matchOption(optMsToWait, ECLOPT_WAIT))
                 continue;
@@ -385,24 +361,6 @@ public:
             bool activate;
             if (extractEclCmdOption(activate, globals, ECLOPT_ACTIVATE_ENV, ECLOPT_ACTIVATE_INI, true))
                 optNoActivate=!activate;
-        }
-        if (optObj.value.isEmpty())
-        {
-            fprintf(stderr, "\nMust specify a WUID, ECL File, Archive, or shared object to publish\n");
-            return false;
-        }
-        if (optObj.type==eclObjTypeUnknown)
-        {
-            fprintf(stderr, "\nCan't determine content type of argument %s\n", optObj.value.sget());
-            return false;
-        }
-        if (optObj.type==eclObjArchive || optObj.type==eclObjSource)
-        {
-            if (optTargetCluster.isEmpty())
-            {
-                fprintf(stderr, "\nTarget must be specified when publishing ECL Text or Archive\n");
-                return false;
-            }
         }
         if (optMemoryLimit.length() && !isValidMemoryValue(optMemoryLimit))
         {
@@ -496,7 +454,6 @@ public:
         EclCmdWithEclTarget::usage();
     }
 private:
-    StringAttr optTargetCluster;
     StringAttr optName;
     StringAttr optMemoryLimit;
     unsigned optMsToWait;
@@ -530,10 +487,6 @@ public:
                 continue;
             if (iter.matchOption(optName, ECLOPT_NAME)||iter.matchOption(optName, ECLOPT_NAME_S))
                 continue;
-            if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
-                continue;
-            if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
-                continue;
             if (iter.matchOption(optInput, ECLOPT_INPUT)||iter.matchOption(optInput, ECLOPT_INPUT_S))
                 continue;
             if (iter.matchOption(optWaitTime, ECLOPT_WAIT))
@@ -549,24 +502,6 @@ public:
     {
         if (!EclCmdWithEclTarget::finalizeOptions(globals))
             return false;
-        if (optObj.value.isEmpty())
-        {
-            fprintf(stderr, "\nMust specify a Query, WUID, ECL File, Archive, or shared object to run\n");
-            return false;
-        }
-        if (optObj.type==eclObjTypeUnknown)
-        {
-            fprintf(stderr, "\nCan't determine content type of argument %s\n", optObj.value.sget());
-            return false;
-        }
-        if (optObj.type==eclObjArchive || optObj.type==eclObjSource)
-        {
-            if (optTargetCluster.isEmpty())
-            {
-                fprintf(stderr, "\nTarget must be specified when running ECL Text or Archive\n");
-                return false;
-            }
-        }
         if (optInput.length())
         {
             const char *in = optInput.get();
@@ -675,7 +610,6 @@ public:
         EclCmdWithEclTarget::usage();
     }
 private:
-    StringAttr optTargetCluster;
     StringAttr optName;
     StringAttr optInput;
     IArrayOf<IEspNamedValue> variables;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -304,6 +304,7 @@ ESPrequest [nil_remove] WUDeployWorkunitRequest
     string FileName;
     binary Object;
     int ResultLimit;
+    string QueryMainDefinition;
     ESParray<ESPstruct NamedValue> DebugValues;
 };
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -89,6 +89,14 @@ public:
         Owned<IWUQuery> query=get()->updateQuery();
         query->setQueryText(text);
     }
+
+    void setQueryMain(const char *s)
+    {
+        if (!s || !*s)
+            return;
+        Owned<IWUQuery> query=get()->updateQuery();
+        query->setQueryMainDefinition(s);
+    }
 };
 
 void setWsWuXmlParameters(IWorkUnit *wu, const char *xml, bool setJobname=false)
@@ -3666,6 +3674,8 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
         StringBuffer text(req.getObject().length(), req.getObject().toByteArray());
         wu.setQueryText(text.str());
     }
+    if (req.getQueryMainDefinition())
+        wu.setQueryMain(req.getQueryMainDefinition());
     if (!req.getResultLimit_isNull())
         wu->setResultLimit(req.getResultLimit());
 


### PR DESCRIPTION
Rather than generating code to call the attribute, or setting
debug values specifying the QueryMainDefinition, the command line tools
will explicitly specify the QueryMainDefinition as a parameter to
WsWorkunits.  WsWorkunit will call IWuQuery::setQueryMainDefinition()
to set the value.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
