### PR TITLE
HPCC-7974 Fix ecl-package commands using incorrect return type

### DIFF
--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -71,7 +71,7 @@ public:
                 else
                 {
                     fprintf(stderr, "\nunrecognized argument %s\n", arg);
-                    return EclCmdOptionCompletion;
+                    return false;
                 }
                 continue;
             }
@@ -158,7 +158,7 @@ public:
                 else
                 {
                     fprintf(stderr, "\nunrecognized argument %s\n", arg);
-                    return EclCmdOptionCompletion;
+                    return false;
                 }
                 continue;
             }
@@ -242,7 +242,7 @@ public:
                 else
                 {
                     fprintf(stderr, "\nunrecognized argument %s\n", arg);
-                    return EclCmdOptionCompletion;
+                    return false;
                 }
                 continue;
             }
@@ -339,7 +339,7 @@ public:
                 else
                 {
                     fprintf(stderr, "\nunrecognized argument %s\n", arg);
-                    return EclCmdOptionCompletion;
+                    return false;
                 }
                 continue;
             }
@@ -415,7 +415,7 @@ public:
                 else
                 {
                     fprintf(stderr, "\nunrecognized argument %s\n", arg);
-                    return EclCmdOptionCompletion;
+                    return false;
                 }
                 continue;
             }
@@ -506,7 +506,7 @@ public:
                 else
                 {
                     fprintf(stderr, "\nunrecognized argument %s\n", arg);
-                    return EclCmdOptionCompletion;
+                    return false;
                 }
                 continue;
             }


### PR DESCRIPTION
parseCommandLineOptions needs to return false rather than
EclCmdOptionCompletion when there is a parameter error and
the command should exit.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
