### PR TITLE
HPCC-7995 - Various minor valgrind-reported issues

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2378,6 +2378,7 @@ public:
         iCompare = helper->queryCompare();
         numHashTables = 0;
         hashTables = NULL;
+        allocFlags = queryJob().queryThorAllocator()->queryFlags();
 
         // JCSMORE - it may not be worth extracing the key,
         // if there's an upstream activity that holds onto rows for periods of time (e.g. sort)
@@ -2413,7 +2414,6 @@ public:
             rowKeyCompare = iCompare;
             iKeyHash = iHash;
         }
-        allocFlags = queryJob().queryThorAllocator()->queryFlags();
     }
     void start()
     {

--- a/thorlcr/activities/indexread/thindexread.cpp
+++ b/thorlcr/activities/indexread/thindexread.cpp
@@ -146,7 +146,7 @@ protected:
                     {
                         StringBuffer remotePath;
                         rfn.getRemotePath(remotePath);
-                        unsigned crc;
+                        unsigned crc = 0;
                         part->getCrc(crc);
                         keyIndex.setown(createKeyIndex(remotePath.str(), crc, false, false));
                         break;

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -56,7 +56,7 @@ static IKeyIndex *openKeyPart(CActivityBase *activity, const char *logicalFilena
         EXCLOG(e, NULL);
         throw e;
     }
-    unsigned crc;
+    unsigned crc=0;
     partDesc.getCrc(crc);
     return createKeyIndex(filePath.str(), crc, false, false);
 }

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -115,7 +115,14 @@ private:
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CInlineTableSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container), CThorDataLink(this) { }
+    CInlineTableSlaveActivity(CGraphElementBase *_container)
+    : CSlaveActivity(_container), CThorDataLink(this)
+    {
+        helper = NULL;
+        startRow = 0;
+        currentRow = 0;
+        maxRow = 0;
+    }
     virtual bool isGrouped() { return false; }
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
     {

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -70,6 +70,8 @@ CDiskPartHandlerBase::CDiskPartHandlerBase(CDiskReadSlaveActivityBase &_activity
     which = 0;
     eoi = false;
     kindStr = activityKindStr(activity.queryContainer().getKind());
+    compressed = blockCompressed = firstInGroup = checkFileCrc = false;
+
 }
 
 void CDiskPartHandlerBase::setPart(IPartDescriptor *_partDesc, unsigned partNoSerialized)

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -441,6 +441,7 @@ int main( int argc, char *argv[]  )
 
     if (multiThorMemoryThreshold)
         setMultiThorMemoryNotify(0,NULL);
+    roxiemem::releaseRoxieHeap();
 
 #ifdef ISDALICLIENT
     closeEnvironment();


### PR DESCRIPTION
Running valgrind on thorslave (while running the thor regression suite) reports
various uninitialized memory accesses.

This fixes the first batch of them.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
