### PR TITLE
HPCC-7997 Fix retrieveWebServicesInfo support for QueryMainDefinition

### DIFF
--- a/ecl/hql/hqlesp.cpp
+++ b/ecl/hql/hqlesp.cpp
@@ -404,12 +404,8 @@ bool retrieveWebServicesInfo(IWorkUnit *workunit, const char * queryText, HqlLoo
     return true;
 }
 
-
-IPropertyTree * retrieveWebServicesInfo(const char * queryText, HqlLookupContext & ctx)
+IPropertyTree * retrieveWebServicesInfo(WebServicesExtractor &extractor, HqlLookupContext & ctx)
 {
-    WebServicesExtractor extractor(ctx);
-    extractor.addRootText(queryText);
-
     if (!extractor.extractWebServiceInfo())
         return NULL;
 
@@ -425,4 +421,18 @@ IPropertyTree * retrieveWebServicesInfo(const char * queryText, HqlLookupContext
 
     result->setPropInt("@crc", extractor.getVersion());
     return result.getClear();
+}
+
+IPropertyTree * retrieveWebServicesInfo(const char * queryText, HqlLookupContext & ctx)
+{
+    WebServicesExtractor extractor(ctx);
+    extractor.addRootText(queryText);
+    return retrieveWebServicesInfo(extractor, ctx);
+}
+
+IPropertyTree * retrieveMainWebServicesInfo(const char * mainDefinition, HqlLookupContext & ctx)
+{
+    WebServicesExtractor extractor(ctx);
+    extractor.addRootReference(mainDefinition);
+    return retrieveWebServicesInfo(extractor, ctx);
 }

--- a/ecl/hql/hqlesp.hpp
+++ b/ecl/hql/hqlesp.hpp
@@ -22,5 +22,6 @@
 extern HQL_API bool retrieveWebServicesInfo(IWorkUnit *workunit, HqlLookupContext & ctx);
 extern HQL_API bool retrieveWebServicesInfo(IWorkUnit *workunit, const char * queryText, HqlLookupContext & ctx);
 extern HQL_API IPropertyTree * retrieveWebServicesInfo(const char * queryText, HqlLookupContext & ctx);
+extern HQL_API IPropertyTree * retrieveMainWebServicesInfo(const char * mainDefinition, HqlLookupContext & ctx);
 
 #endif


### PR DESCRIPTION
Add a version of retrieveWebServicesInfo  that resolves the info using
an attributePath.

WebService resources are currenlty not being loaded when a query is
compiled based on a MainDefiniton.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
