### PR TITLE
HPCC-8001 Stop generating grouped hash aggregate activities

### DIFF
--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -1668,6 +1668,14 @@ bool isLocalActivity(IHqlExpression * expr)
     }
 }
 
+bool isGroupedAggregateActivity(IHqlExpression * expr, IHqlExpression * grouping)
+{
+    if (grouping && !grouping->isAttribute())
+        return false;
+
+    return isGrouped(expr->queryChild(0));
+}
+
 bool isGroupedActivity(IHqlExpression * expr)
 {
     switch (expr->getOperator())
@@ -1701,6 +1709,13 @@ bool isGroupedActivity(IHqlExpression * expr)
     case no_related:
     case no_pipe:
         return isGrouped(expr->queryType());
+    case no_selectfields:
+    case no_usertable:
+        return isGroupedAggregateActivity(expr, expr->queryChild(2));
+    case no_aggregate:
+    case no_newaggregate:
+    case no_newusertable:
+        return isGroupedAggregateActivity(expr, expr->queryChild(3));
     case no_null:
     case no_anon:
     case no_pseudods:

--- a/ecl/regress/aggds4.ecl
+++ b/ecl/regress/aggds4.ecl
@@ -29,3 +29,7 @@ pr2:= table(sqNamesTable2, { surname, forename, aage, unsigned8 seq := (random()
 
 //Filtered Aggregate on a projected table.
 output(table(pr2(seq > 10), { surname, ave(group, aage) }, surname, few, keyed));
+
+//Should not generate a grouped Hash Aggregate
+output(sort(table(group(sort(sqNamesTable1, surname),surname), { surname, ave(group, aage) }, surname, few), record));
+


### PR DESCRIPTION
Hash aggregate activities should always currentlybe global or local.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
