### PR TITLE
HPCC-8011 xmlsize crash fix

### DIFF
--- a/tools/xmlsize/xmlsize.cpp
+++ b/tools/xmlsize/xmlsize.cpp
@@ -178,6 +178,7 @@ void usage(char *prog)
 
 int main(int argc, char **argv)
 {
+    InitModuleObjects();
     try
     {
         if (argc>=2)


### PR DESCRIPTION
The xmlsize utility was crashing due to a missing call to InitModuleObjects

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
