### PR TITLE
HPCC-8014 Require IUserDescriptor in all HPCC calls

### DIFF
--- a/common/fileview2/fvrelate.cpp
+++ b/common/fileview2/fvrelate.cpp
@@ -23,6 +23,7 @@
 #include "fvrelate.ipp"
 #include "deftype.hpp"
 #include "fvresultset.ipp"
+#include "dasess.hpp"
 
 //---------------------------------------------------------------------------
 
@@ -425,7 +426,7 @@ ViewFile * ViewFileWeb::walkFile(const char * filename, IDistributedFile * alrea
         options.isExplicitFile = false;
     }
 
-    Owned<IDistributedFile> resolved = alreadyResolved ? LINK(alreadyResolved) : directory.lookup(filename);
+    Owned<IDistributedFile> resolved = alreadyResolved ? LINK(alreadyResolved) : directory.lookup(filename,UNKNOWN_USER);//MORE:Pass IUserDescriptor
     if (!resolved)
         return NULL;
 

--- a/common/roxiemanager/referencedfilelist.cpp
+++ b/common/roxiemanager/referencedfilelist.cpp
@@ -207,9 +207,9 @@ IPropertyTree *ReferencedFile::getForeignOrRemoteFileTree(IUserDescriptor *user,
     IDistributedFileDirectory &dir = queryDistributedFileDirectory();
     Owned<IPropertyTree> tree;
     if (foreignNode)
-        tree.setown(dir.getFileTree(logicalName.get(), foreignNode, user, WF_LOOKUP_TIMEOUT, false, false));
+        tree.setown(dir.getFileTree(logicalName.get(), user, foreignNode, WF_LOOKUP_TIMEOUT, false, false));
     if (!tree && remote)
-        tree.setown(dir.getFileTree(logicalName.get(), remote, user, WF_LOOKUP_TIMEOUT, false, false));
+        tree.setown(dir.getFileTree(logicalName.get(), user, remote, WF_LOOKUP_TIMEOUT, false, false));
     return tree.getClear();
 }
 
@@ -295,7 +295,7 @@ void ReferencedFile::cloneSuperInfo(ReferencedFileList *list, IUserDescriptor *u
             df.clear();
         }
 
-        Owned<IDistributedSuperFile> superfile = dir.createSuperFile(logicalName.get(), true, false, user);
+        Owned<IDistributedSuperFile> superfile = dir.createSuperFile(logicalName.get(),user, true, false);
         flags |= RefFileCloned;
         Owned<IPropertyTreeIterator> subfiles = tree->getElements("SubFile");
         ForEach(*subfiles)

--- a/common/roxiemanager/roxiewuprocessor.cpp
+++ b/common/roxiemanager/roxiewuprocessor.cpp
@@ -423,7 +423,7 @@ private:
                     else
                         fullBaseIndexName.appendf("~%s", baseIndexName.str());
 
-                    Owned<IPropertyTree> df = queryDistributedFileDirectory().getFileTree(baseIndexName, daliNode, processingInfo.queryUserDescriptor(), DALI_FILE_LOOKUP_TIMEOUT);
+                    Owned<IPropertyTree> df = queryDistributedFileDirectory().getFileTree(baseIndexName, processingInfo.queryUserDescriptor(), daliNode, DALI_FILE_LOOKUP_TIMEOUT);
                     if (df)
                         addSubFile(xml, fullBaseIndexName.str(), foreignIP, df, preload, processingInfo, false, true, NULL, useSourceClusterName, daliNode, updateDali);
 
@@ -435,7 +435,7 @@ private:
                     else
                         fullPatchName.appendf("~%s", patchName.str());
 
-                    Owned<IPropertyTree> df = queryDistributedFileDirectory().getFileTree(patchName, daliNode, processingInfo.queryUserDescriptor(), DALI_FILE_LOOKUP_TIMEOUT);
+                    Owned<IPropertyTree> df = queryDistributedFileDirectory().getFileTree(patchName, processingInfo.queryUserDescriptor(), daliNode, DALI_FILE_LOOKUP_TIMEOUT);
                     if (df)
                         addSubFile(xml, fullPatchName.str(), foreignIP, df, preload, processingInfo, true, false, NULL, useSourceClusterName, daliNode, updateDali);
 
@@ -518,7 +518,7 @@ private:
             Owned<IPropertyTree> df;
             try
             {
-                df.setown(queryDistributedFileDirectory().getFileTree(lookupNameInDali.str()+1, daliNode, processingInfo.queryUserDescriptor(), DALI_FILE_LOOKUP_TIMEOUT)); // don't want to pass the ~
+                df.setown(queryDistributedFileDirectory().getFileTree(lookupNameInDali.str()+1, processingInfo.queryUserDescriptor(), daliNode, DALI_FILE_LOOKUP_TIMEOUT)); // don't want to pass the ~
             }
             catch(IException *e)
             {
@@ -625,7 +625,7 @@ private:
                         StringBuffer foreignIP;
                         StringBuffer fullSubName(sub->queryProp("@name"));
                         removeScope(fullSubName, subName, foreignIP, useSourceClusterName, altRoxieClusterName);
-                        Owned<IPropertyTree> subtree = queryDistributedFileDirectory().getFileTree(fullSubName,daliNode, processingInfo.queryUserDescriptor(), DALI_FILE_LOOKUP_TIMEOUT);
+                        Owned<IPropertyTree> subtree = queryDistributedFileDirectory().getFileTree(fullSubName, processingInfo.queryUserDescriptor(),daliNode, DALI_FILE_LOOKUP_TIMEOUT);
 
                         if (subtree)
                         {
@@ -1396,7 +1396,7 @@ public:
             daliNode.setown(createINode(ep));
         }
 
-        Owned<IPropertyTree> df = queryDistributedFileDirectory().getFileTree(src_filename, daliNode, userdesc, DALI_FILE_LOOKUP_TIMEOUT);
+        Owned<IPropertyTree> df = queryDistributedFileDirectory().getFileTree(src_filename, userdesc, daliNode, DALI_FILE_LOOKUP_TIMEOUT);
         if (df)
         {
             StringBuffer mapping(df->queryProp("Attr/@columnMapping"));
@@ -1412,7 +1412,7 @@ public:
     bool validateDataFileInfo(IPropertyTree *xml, unsigned numParts, offset_t file_crc, offset_t recordCount, offset_t totalSize, offset_t formatCrc, StringBuffer &dest_filename, StringBuffer &remoteRoxieClusterName, const char *lookupDaliIp, IUserDescriptor *userdesc)
     {
         bool retval = true;
-        Owned<IPropertyTree> df = queryDistributedFileDirectory().getFileTree(dest_filename.str(), NULL, userdesc, DALI_FILE_LOOKUP_TIMEOUT);
+        Owned<IPropertyTree> df = queryDistributedFileDirectory().getFileTree(dest_filename.str(), userdesc, NULL, DALI_FILE_LOOKUP_TIMEOUT);
 
         if (df)
         {

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -5534,7 +5534,7 @@ void CLocalWorkUnit::deleteTempFiles(const char *graph, bool deleteOwned, bool d
         {
             const char *name = file.queryProp("@name");
             LOG(MCdebugProgress, unknownJob, "Removing workunit file %s from DFS", name);
-            queryDistributedFileDirectory().removePhysical(name, NULL, NULL, queryUserDescriptor());
+            queryDistributedFileDirectory().removePhysical(name, queryUserDescriptor(), NULL, NULL);
             toRemove.append(file);
         }
     }
@@ -5642,7 +5642,7 @@ void CLocalWorkUnit::releaseFile(const char *fileName)
             files->removeTree(file);
             if (!name.isEmpty()&&(1 == usageCount))
             {
-                if (queryDistributedFileDirectory().removePhysical(fileName, NULL, NULL, queryUserDescriptor()))
+                if (queryDistributedFileDirectory().removePhysical(fileName, queryUserDescriptor(), NULL, NULL))
                     LOG(MCdebugProgress, unknownJob, "Removed (released) file %s from DFS", name.get());
             }
         }

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -880,55 +880,55 @@ public:
         return createNew(fdesc,NULL,includeports);
     }
     IDistributedFile *createNew(IPropertyTree *tree,bool ignoregroup);
-    IDistributedSuperFile *createSuperFile(const char *logicalname,bool interleaved,bool ifdoesnotexist,IUserDescriptor *user,IDistributedFileTransaction *transaction=NULL);
+    IDistributedSuperFile *createSuperFile(const char *logicalname,IUserDescriptor *user,bool interleaved,bool ifdoesnotexist,IDistributedFileTransaction *transaction=NULL);
 
     IDistributedFileIterator *getIterator(const char *wildname, bool includesuper,IUserDescriptor *user);
-    IDFAttributesIterator *getDFAttributesIterator(const char *wildname, bool recursive, bool includesuper,INode *foreigndali,IUserDescriptor *user,unsigned foreigndalitimeout);
-    IDFAttributesIterator *getForeignDFAttributesIterator(const char *wildname, bool recursive=true, bool includesuper=false, const char *foreigndali="",IUserDescriptor *user=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT)
+    IDFAttributesIterator *getDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive, bool includesuper,INode *foreigndali,unsigned foreigndalitimeout);
+    IDFAttributesIterator *getForeignDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive=true, bool includesuper=false, const char *foreigndali="", unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT)
     {
         Owned<INode> foreign;
         if (foreigndali&&*foreigndali) {
             SocketEndpoint ep(foreigndali);
             foreign.setown(createINode(ep));
         }
-        return getDFAttributesIterator(wildname, recursive, includesuper,foreign,user,foreigndalitimeout);
+        return getDFAttributesIterator(wildname, user, recursive, includesuper,foreign,foreigndalitimeout);
     }
 
-    IDFScopeIterator *getScopeIterator(const char *subscope,bool recursive,bool includeempty,IUserDescriptor *user);
+    IDFScopeIterator *getScopeIterator(IUserDescriptor *user, const char *subscope,bool recursive,bool includeempty);
     bool loadScopeContents(const char *scopelfn,StringArray *scopes,    StringArray *supers,StringArray *files, bool includeemptyscopes);
 
-    IPropertyTree *getFileTree(const char *lname,const INode *foreigndali,IUserDescriptor *user,unsigned foreigndalitimeout,bool expandnodes=false, bool appendForeign=true);
-    void setFileAccessed(CDfsLogicalFileName &dlfn, const CDateTime &dt,const INode *foreigndali=NULL,IUserDescriptor *user=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
-    IFileDescriptor *getFileDescriptor(const char *lname,const INode *foreigndali=NULL,IUserDescriptor *user=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
-    IDistributedFile *getFile(const char *lname,const INode *foreigndali=NULL,IUserDescriptor *user=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
+    IPropertyTree *getFileTree(const char *lname,IUserDescriptor *user,const INode *foreigndali,unsigned foreigndalitimeout,bool expandnodes=false, bool appendForeign=true);
+    void setFileAccessed(CDfsLogicalFileName &dlfn, IUserDescriptor *user,const CDateTime &dt,const INode *foreigndali=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
+    IFileDescriptor *getFileDescriptor(const char *lname,IUserDescriptor *user,const INode *foreigndali=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
+    IDistributedFile *getFile(const char *lname,IUserDescriptor *user,const INode *foreigndali=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
 
-    bool exists(const char *_logicalname,bool notsuper=false,bool superonly=false,IUserDescriptor *user=NULL);
+    bool exists(const char *_logicalname,IUserDescriptor *user,bool notsuper=false,bool superonly=false);
     bool existsPhysical(const char *_logicalname,IUserDescriptor *user);
 
     void addEntry(CDfsLogicalFileName &lfn,IPropertyTree *root,bool superfile, bool ignoreexists);
     bool removeEntry(const char *_logicalname,IUserDescriptor *user);
-    bool removePhysical(const char *_logicalname,const char *cluster,IMultiException *mexcept,IUserDescriptor *user);
-    bool renamePhysical(const char *oldname,const char *newname,IMultiException *exceptions,IUserDescriptor *user);
+    bool removePhysical(const char *_logicalname,IUserDescriptor *user,const char *cluster,IMultiException *mexcept);
+    bool renamePhysical(const char *oldname,const char *newname,IUserDescriptor *user,IMultiException *exceptions);
     void removeEmptyScope(const char *name);
 
     IDistributedSuperFile *lookupSuperFile(const char *logicalname,IUserDescriptor *user,IDistributedFileTransaction *transaction,unsigned timeout=INFINITE);
 
     int getFilePermissions(const char *lname,IUserDescriptor *user,unsigned auditflags);
     int getNodePermissions(const IpAddress &ip,IUserDescriptor *user,unsigned auditflags);
-    int getFDescPermissions(IFileDescriptor *,IUserDescriptor *user=NULL,unsigned auditflags=0);
+    int getFDescPermissions(IFileDescriptor *,IUserDescriptor *user,unsigned auditflags=0);
     void setDefaultUser(IUserDescriptor *user);
     IUserDescriptor* queryDefaultUser();
 
     bool doRemovePhysical(CDfsLogicalFileName &dlfn,const char *cluster,IMultiException *mexcept,IUserDescriptor *user,bool ignoresub);
     bool doRemoveEntry(CDfsLogicalFileName &dlfn,IUserDescriptor *user,bool ignoresub);
     DistributedFileCompareResult fileCompare(const char *lfn1,const char *lfn2,DistributedFileCompareMode mode,StringBuffer &errstr,IUserDescriptor *user);
-    bool filePhysicalVerify(const char *lfn1,bool includecrc,StringBuffer &errstr,IUserDescriptor *user);
+    bool filePhysicalVerify(const char *lfn1,IUserDescriptor *user,bool includecrc,StringBuffer &errstr);
     void setDefaultPreferredClusters(const char *clusters);
     void fixDates(IDistributedFile *fil);
 
     GetFileClusterNamesType getFileClusterNames(const char *logicalname,StringArray &out); // returns 0 for normal file, 1 for
 
-    bool isSuperFile( const char *logicalname, INode *foreigndali, IUserDescriptor *user, unsigned timeout);
+    bool isSuperFile( const char *logicalname, IUserDescriptor *user, INode *foreigndali, unsigned timeout);
 
     void promoteSuperFiles(unsigned numsf,const char **sfnames,const char *addsubnames,bool delsub,bool createonlyonesuperfile,IUserDescriptor *user, unsigned timeout, StringArray &outunlinked);
     ISimpleSuperFileEnquiry * getSimpleSuperFileEnquiry(const char *logicalname,const char *title,unsigned timeout);
@@ -959,7 +959,7 @@ public:
     IDFProtectedIterator *lookupProtectedFiles(const char *owner=NULL,bool notsuper=false,bool superonly=false);
 
     static bool cannotRemove(CDfsLogicalFileName &name,IUserDescriptor *user,StringBuffer &reason,bool ignoresub, unsigned timeoutms);
-    void setFileProtect(CDfsLogicalFileName &dlfn, const char *owner, bool set, const INode *foreigndali=NULL,IUserDescriptor *user=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
+    void setFileProtect(CDfsLogicalFileName &dlfn,IUserDescriptor *user, const char *owner, bool set, const INode *foreigndali=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
 
     unsigned setDefaultTimeout(unsigned timems)
     {
@@ -1164,7 +1164,7 @@ public:
     {
         try {
             if (remphys) 
-                queryDistributedFileDirectory().removePhysical(lfn.get(),NULL,NULL,user.get());
+                queryDistributedFileDirectory().removePhysical(lfn.get(),user.get(),NULL,NULL);
             else 
                 queryDistributedFileDirectory().removeEntry(lfn.get(),user);
         }
@@ -2011,7 +2011,7 @@ public:
             wildname = "*";
         parent = _dir;
         bool recursive = (stricmp(wildname,"*")==0);
-        Owned<IDFAttributesIterator> attriter = parent->getDFAttributesIterator(wildname,recursive,includesuper,NULL,user);
+        Owned<IDFAttributesIterator> attriter = parent->getDFAttributesIterator(wildname,user,recursive,includesuper,NULL);
         ForEach(*attriter) {
             IPropertyTree &pt = attriter->query();
             list.append(strdup(pt.queryProp("@name")));
@@ -2397,7 +2397,7 @@ public:
     void setProtect(const char *owner, bool protect, unsigned timems)
     {
         if (logicalName.isForeign()) {
-            parent->setFileProtect(logicalName,owner,protect);
+            parent->setFileProtect(logicalName,udesc,owner,protect);
         }
         else {
             bool ret=false;
@@ -3862,7 +3862,7 @@ public:
     virtual void setAccessedTime(const CDateTime &dt)       
     {
         if (logicalName.isForeign()) {
-            parent->setFileAccessed(logicalName,dt);
+            parent->setFileAccessed(logicalName,udesc,dt);
         }
         else {
             DistributedFilePropertyLock lock(this);
@@ -6384,7 +6384,7 @@ IDistributedFile *CDistributedFileDirectory::dolookup(const CDfsLogicalFileName 
         if (logicalname->isExternal()) 
             return createExternal(*logicalname);    // external always works?
         if (logicalname->isForeign()) {
-            IDistributedFile * ret = getFile(logicalname->get(),NULL,user);
+            IDistributedFile * ret = getFile(logicalname->get(),user,NULL);
             if (ret)
                 return ret;
         }
@@ -6465,16 +6465,16 @@ IDistributedSuperFile *CDistributedFileDirectory::lookupSuperFile(const char *_l
 }
 
 bool CDistributedFileDirectory::isSuperFile(    const char *logicalname,
-                                                INode *foreigndali,
                                                 IUserDescriptor *user,
+                                                INode *foreigndali,
                                                 unsigned timeout)
 {
-    Owned<IPropertyTree> tree = getFileTree(logicalname, foreigndali,user,timeout, false);
+    Owned<IPropertyTree> tree = getFileTree(logicalname, user, foreigndali,timeout, false);
     return tree.get()&&(strcmp(tree->queryName(),queryDfsXmlBranchName(DXB_SuperFile))==0);
 }
 
 
-bool CDistributedFileDirectory::exists(const char *_logicalname,bool notsuper,bool superonly,IUserDescriptor *user)
+bool CDistributedFileDirectory::exists(const char *_logicalname,IUserDescriptor *user,bool notsuper,bool superonly)
 {
     // (currently) no check on scope permissions for exists
 
@@ -6599,7 +6599,7 @@ public:
     }
 };
 
-IDistributedSuperFile *CDistributedFileDirectory::createSuperFile(const char *_logicalname, bool _interleaved,bool ifdoesnotexist,IUserDescriptor *user,IDistributedFileTransaction *transaction)
+IDistributedSuperFile *CDistributedFileDirectory::createSuperFile(const char *_logicalname,IUserDescriptor *user, bool _interleaved,bool ifdoesnotexist,IDistributedFileTransaction *transaction)
 {
     CDfsLogicalFileName logicalname;
     logicalname.set(_logicalname);
@@ -6790,7 +6790,7 @@ bool CDistributedFileDirectory::doRemovePhysical(CDfsLogicalFileName &dlfn,const
     return true;
 }
 
-bool CDistributedFileDirectory::removePhysical(const char *_logicalname,const char *cluster,IMultiException *exceptions,IUserDescriptor *user)
+bool CDistributedFileDirectory::removePhysical(const char *_logicalname,IUserDescriptor *user,const char *cluster,IMultiException *exceptions)
 {
     CDfsLogicalFileName dlfn;
     dlfn.set(_logicalname);
@@ -6798,11 +6798,18 @@ bool CDistributedFileDirectory::removePhysical(const char *_logicalname,const ch
 }
 
     
-bool CDistributedFileDirectory::renamePhysical(const char *oldname,const char *newname,IMultiException *exceptions,IUserDescriptor *user)
+bool CDistributedFileDirectory::renamePhysical(const char *oldname,const char *newname,IUserDescriptor *user,IMultiException *exceptions)
 {
     CriticalBlock block(removesect);
     if (!user)
+    {
+#ifdef _DALIUSER_STACKTRACE
+        DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp CDistributedFileDirectory::renamePhysical %d",__LINE__);
+        //following debug code to be removed
+        PrintStackReport();
+#endif
         user = defaultudesc.get();
+    }
     CDfsLogicalFileName oldlogicalname; 
     oldlogicalname.set(oldname);
     checkLogicalName(oldlogicalname,user,true,true,false,"rename");
@@ -6874,7 +6881,7 @@ bool CDistributedFileDirectory::renamePhysical(const char *oldname,const char *n
     }
     if (splitfrom) {
         oldfile->removeCluster(oldcluster.str());
-        file->attach(newlogicalname.get());
+        file->attach(newlogicalname.get(),user);
     }
     else if (mergeinto) {
         ClusterPartDiskMapSpec mspec = file->queryPartDiskMapping(0);
@@ -8346,7 +8353,7 @@ public:
 } *daliDFSServer = NULL;
 
 
-IDFAttributesIterator *CDistributedFileDirectory::getDFAttributesIterator(const char *wildname, bool recursive, bool includesuper,INode *foreigndali,IUserDescriptor *user,unsigned foreigndalitimeout)
+IDFAttributesIterator *CDistributedFileDirectory::getDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive, bool includesuper,INode *foreigndali,unsigned foreigndalitimeout)
 {
     if (!wildname||!*wildname||(strcmp(wildname,"*")==0)) {
         recursive = true;
@@ -8363,7 +8370,7 @@ IDFAttributesIterator *CDistributedFileDirectory::getDFAttributesIterator(const 
     return new CDFAttributeIterator(mb);
 }
 
-IDFScopeIterator *CDistributedFileDirectory::getScopeIterator(const char *basescope, bool recursive,bool includeempty,IUserDescriptor *user)
+IDFScopeIterator *CDistributedFileDirectory::getScopeIterator(IUserDescriptor *user, const char *basescope, bool recursive,bool includeempty)
 {
     return new CDFScopeIterator(this,basescope,recursive,includeempty,defaultTimeout);
 }
@@ -8454,7 +8461,7 @@ bool CDistributedFileDirectory::loadScopeContents(const char *scopelfn,
     return true;
 }
 
-void CDistributedFileDirectory::setFileAccessed(CDfsLogicalFileName &dlfn, const CDateTime &dt, const INode *foreigndali,IUserDescriptor *user,unsigned foreigndalitimeout)
+void CDistributedFileDirectory::setFileAccessed(CDfsLogicalFileName &dlfn,IUserDescriptor *user, const CDateTime &dt, const INode *foreigndali,unsigned foreigndalitimeout)
 {
     // this accepts either a foreign dali node or a foreign lfn
     Owned<INode> fnode;
@@ -8485,7 +8492,7 @@ void CDistributedFileDirectory::setFileAccessed(CDfsLogicalFileName &dlfn, const
     checkDfsReplyException(mb);
 }
 
-void CDistributedFileDirectory::setFileProtect(CDfsLogicalFileName &dlfn, const char *owner, bool set, const INode *foreigndali,IUserDescriptor *user,unsigned foreigndalitimeout)
+void CDistributedFileDirectory::setFileProtect(CDfsLogicalFileName &dlfn,IUserDescriptor *user, const char *owner, bool set, const INode *foreigndali,unsigned foreigndalitimeout)
 {
     // this accepts either a foreign dali node or a foreign lfn
     Owned<INode> fnode;
@@ -8517,7 +8524,7 @@ void CDistributedFileDirectory::setFileProtect(CDfsLogicalFileName &dlfn, const 
     checkDfsReplyException(mb);
 }
 
-IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, const INode *foreigndali,IUserDescriptor *user,unsigned foreigndalitimeout, bool expandnodes, bool appendForeign)
+IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, IUserDescriptor *user, const INode *foreigndali,unsigned foreigndalitimeout, bool expandnodes, bool appendForeign)
 {
     // this accepts either a foreign dali node or a foreign lfn
     Owned<INode> fnode;
@@ -8586,15 +8593,15 @@ IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, const I
     return ret.getClear();
 }
 
-IFileDescriptor *CDistributedFileDirectory::getFileDescriptor(const char *lname,const INode *foreigndali,IUserDescriptor *user,unsigned foreigndalitimeout)
+IFileDescriptor *CDistributedFileDirectory::getFileDescriptor(const char *lname,IUserDescriptor *user,const INode *foreigndali,unsigned foreigndalitimeout)
 {
-    Owned<IPropertyTree> tree = getFileTree(lname,foreigndali,user,foreigndalitimeout,false);
+    Owned<IPropertyTree> tree = getFileTree(lname,user,foreigndali,foreigndalitimeout,false);
     if (!tree)
         return NULL;
     if (strcmp(tree->queryName(),queryDfsXmlBranchName(DXB_SuperFile))==0) {
         CDfsLogicalFileName dlfn;
         dlfn.set(lname);
-        Owned<CDistributedSuperFile> sfile = new CDistributedSuperFile(this,tree, dlfn, NULL);
+        Owned<CDistributedSuperFile> sfile = new CDistributedSuperFile(this,tree, dlfn, user);
         return sfile->getFileDescriptor(NULL);
     }
     if (strcmp(tree->queryName(),queryDfsXmlBranchName(DXB_File))!=0)
@@ -8607,15 +8614,15 @@ IFileDescriptor *CDistributedFileDirectory::getFileDescriptor(const char *lname,
     return fdesc;
 }
 
-IDistributedFile *CDistributedFileDirectory::getFile(const char *lname,const INode *foreigndali,IUserDescriptor *user,unsigned foreigndalitimeout)
+IDistributedFile *CDistributedFileDirectory::getFile(const char *lname,IUserDescriptor *user,const INode *foreigndali,unsigned foreigndalitimeout)
 {
-    Owned<IPropertyTree> tree = getFileTree(lname,foreigndali,user,foreigndalitimeout,false);
+    Owned<IPropertyTree> tree = getFileTree(lname,user,foreigndali,foreigndalitimeout,false);
     if (!tree)
         return NULL;
     if (strcmp(tree->queryName(),queryDfsXmlBranchName(DXB_SuperFile))==0) {
         CDfsLogicalFileName dlfn;
         dlfn.set(lname);
-        return new CDistributedSuperFile(this,tree, dlfn, NULL);
+        return new CDistributedSuperFile(this,tree, dlfn, user);
     }
     if (strcmp(tree->queryName(),queryDfsXmlBranchName(DXB_File))!=0)
         return NULL; // what is it?
@@ -9029,7 +9036,7 @@ DistributedFileCompareResult CDistributedFileDirectory::fileCompare(const char *
     return ret;
 }
 
-bool CDistributedFileDirectory::filePhysicalVerify(const char *lfn,bool includecrc,StringBuffer &errstr,IUserDescriptor *user=NULL)
+bool CDistributedFileDirectory::filePhysicalVerify(const char *lfn,IUserDescriptor *user,bool includecrc,StringBuffer &errstr)
 {
     bool differs = false;
     Owned<IDistributedFile> file = lookup(lfn,user,false,NULL,defaultTimeout);  
@@ -9177,7 +9184,7 @@ public:
         includesub = _includesub;
         CDfsLogicalFileName lfn;
         StringBuffer query;
-        Owned<IDFScopeIterator> siter = queryDistributedFileDirectory().getScopeIterator(NULL,true,false,user);
+        Owned<IDFScopeIterator> siter = queryDistributedFileDirectory().getScopeIterator(user,NULL,true,false);
         ForEach(*siter) {
             lfn.set(siter->query(),"X");
             lfn.makeScopeQuery(query.clear());
@@ -9476,7 +9483,7 @@ void CDistributedFileDirectory::promoteSuperFiles(unsigned numsf,const char **sf
                 files = i;
                 break;
             }
-            Owned<IDistributedSuperFile> sfile = createSuperFile(sfnames[i],false,false,user,transaction);
+            Owned<IDistributedSuperFile> sfile = createSuperFile(sfnames[i],user,false,false,transaction);
             created = true;
         }
     }
@@ -9525,7 +9532,7 @@ void CDistributedFileDirectory::promoteSuperFiles(unsigned numsf,const char **sf
     // MORE - once deletion of logic files are also in transaction we can move this up (and allow promote within transactions)
     if (delsub) {
         ForEachItemIn(j,outunlinked) 
-            removePhysical(outunlinked.item(j),NULL,NULL,user);
+            removePhysical(outunlinked.item(j),user,NULL,NULL);
     }
 }
 
@@ -9844,7 +9851,7 @@ void CDistributedFileDirectory::addFileRelationship(
     if (pfn.isExternal()||pfn.isForeign()||pfn.isQuery())
         throw MakeStringException(-1,"addFileRelationship primary %s not allowed",pfn.get());
     primary = pfn.get();
-    if (!exists(primary))
+    if (!exists(primary,UNKNOWN_USER))//MORE:Pass IUserDescriptor
         throw MakeStringException(-1,"addFileRelationship primary %s does not exist",primary);
     CDfsLogicalFileName sfn;
     if (!sfn.setValidate(secondary))  
@@ -9852,7 +9859,7 @@ void CDistributedFileDirectory::addFileRelationship(
     if (sfn.isExternal()||sfn.isForeign()||sfn.isQuery())
         throw MakeStringException(-1,"addFileRelationship secondary %s not allowed",sfn.get());
     secondary = sfn.get();
-    if (!exists(secondary))
+    if (!exists(secondary,UNKNOWN_USER))//MORE:Pass IUserDescriptor
         throw MakeStringException(-1,"addFileRelationship secondary %s does not exist",secondary);
     if (cardinality&&*cardinality&&!strchr(cardinality,':'))
         throw MakeStringException(-1,"addFileRelationship cardinality %s invalid",cardinality);
@@ -9990,11 +9997,11 @@ void CDistributedFileDirectory::renameFileRelationships(const char *oldname,cons
 
 
 // JCSMORE what was this for, not called by anything afaics
-bool CDistributedFileDirectory::publishMetaFileXML(const CDfsLogicalFileName &logicalname,IUserDescriptor *user=NULL)
+bool CDistributedFileDirectory::publishMetaFileXML(const CDfsLogicalFileName &logicalname,IUserDescriptor *user)
 {
     if (logicalname.isExternal()||logicalname.isForeign()||logicalname.isQuery()) 
         return false;
-    Owned<IPropertyTree> file = getFileTree(logicalname.get(),NULL,user,FOREIGN_DALI_TIMEOUT,true);
+    Owned<IPropertyTree> file = getFileTree(logicalname.get(),user,NULL,FOREIGN_DALI_TIMEOUT,true);
     if (!file.get())
         return false;
     if (strcmp(file->queryName(),queryDfsXmlBranchName(DXB_SuperFile))==0)

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -211,7 +211,7 @@ interface IDistributedFile: extends IInterface
 
     virtual IDistributedFilePartIterator *getIterator(IDFPartFilter *filter=NULL) = 0;
 
-    virtual void rename(const char *logicalname,IUserDescriptor *user=NULL) = 0;// simple rename (no file copy)
+    virtual void rename(const char *logicalname,IUserDescriptor *user) = 0;     // simple rename (no file copy)
 
     virtual IFileDescriptor *getFileDescriptor(const char *clustername=NULL) = 0;   // get file descriptor used for file system access
                                                                                 // if clustername specified makes filedesc for only that cluster
@@ -219,7 +219,7 @@ interface IDistributedFile: extends IInterface
     virtual const char *queryDefaultDir() = 0;                                  // default directory (note primary dir)
     virtual const char *queryPartMask() = 0;                                    // default part name mask
 
-    virtual void attach(const char *logicalname,IUserDescriptor *user=NULL) = 0;// attach to name in DFS
+    virtual void attach(const char *logicalname,IUserDescriptor *user) = 0;     // attach to name in DFS
     virtual void detach() = 0;                                                  // no longer attached to name in DFS
 
     virtual IPropertyTree &queryAttributes() = 0;                               // DFile attributes
@@ -435,14 +435,14 @@ typedef IIteratorOf<IFileRelationship> IFileRelationshipIterator;
 interface IDistributedFileDirectory: extends IInterface
 {
     virtual IDistributedFile *lookup(   const char *logicalname,
-                                        IUserDescriptor *user=NULL,
+                                        IUserDescriptor *user,
                                         bool writeaccess=false,
                                         IDistributedFileTransaction *transaction=NULL, // transaction only used for looking up superfile sub files
                                         unsigned timeout=INFINITE
                                     ) = 0;  // links, returns NULL if not found
 
     virtual IDistributedFile *lookup(   const CDfsLogicalFileName &logicalname,
-                                        IUserDescriptor *user=NULL,
+                                        IUserDescriptor *user,
                                         bool writeaccess=false,
                                         IDistributedFileTransaction *transaction=NULL, // transaction only used for looking up superfile sub files
                                         unsigned timeout=INFINITE
@@ -450,47 +450,47 @@ interface IDistributedFileDirectory: extends IInterface
 
     virtual IDistributedFile *createNew(IFileDescriptor *desc,bool includeports=false) = 0;
 
-    virtual IDistributedFileIterator *getIterator(const char *wildname, bool includesuper, IUserDescriptor *user=NULL) = 0;
+    virtual IDistributedFileIterator *getIterator(const char *wildname, bool includesuper, IUserDescriptor *user) = 0;
             // wildname is in form scope/name and may contain wild components for either
-    virtual IDFAttributesIterator *getDFAttributesIterator(const char *wildname, bool recursive=true, bool includesuper=false, INode *foreigndali=NULL,IUserDescriptor *user=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
-    virtual IDFAttributesIterator *getForeignDFAttributesIterator(const char *wildname, bool recursive=true, bool includesuper=false, const char *foreigndali="",IUserDescriptor *user=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
+    virtual IDFAttributesIterator *getDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive=true, bool includesuper=false, INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
+    virtual IDFAttributesIterator *getForeignDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive=true, bool includesuper=false, const char *foreigndali="", unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
 
-    virtual IDFScopeIterator *getScopeIterator(const char *subscope=NULL,bool recursive=true,bool includeempty=false, IUserDescriptor *user=NULL)=0;
+    virtual IDFScopeIterator *getScopeIterator(IUserDescriptor *user, const char *subscope=NULL,bool recursive=true,bool includeempty=false)=0;
 
-    virtual bool removeEntry(const char *name,IUserDescriptor *user=NULL) = 0;  // equivalent to lookup/detach/release
-    virtual bool removePhysical(const char *name,const char *cluster=NULL,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                           // removes the physical parts as well as entry
-    virtual bool renamePhysical(const char *oldname,const char *newname,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                         // renames the physical parts as well as entry
+    virtual bool removeEntry(const char *name,IUserDescriptor *user) = 0;  // equivalent to lookup/detach/release
+    virtual bool removePhysical(const char *name,IUserDescriptor *user,const char *cluster=NULL,IMultiException *exceptions=NULL) = 0;                           // removes the physical parts as well as entry
+    virtual bool renamePhysical(const char *oldname,const char *newname,IUserDescriptor *user,IMultiException *exceptions=NULL) = 0;                         // renames the physical parts as well as entry
     virtual void removeEmptyScope(const char *scope) = 0;   // does nothing if called on non-empty scope
     
 
-    virtual bool exists(const char *logicalname,bool notsuper=false,bool superonly=false,IUserDescriptor *user=NULL) = 0;                           // logical name exists
-    virtual bool existsPhysical(const char *logicalname,IUserDescriptor *user=NULL) = 0;                                                    // physical parts exists
+    virtual bool exists(const char *logicalname,IUserDescriptor *user,bool notsuper=false,bool superonly=false) = 0;                           // logical name exists
+    virtual bool existsPhysical(const char *logicalname,IUserDescriptor *user) = 0;                                                    // physical parts exists
 
-    virtual IPropertyTree *getFileTree(const char *lname,const INode *foreigndali=NULL,IUserDescriptor *user=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT, bool expandnodes=true, bool appendForeign=true) =0;
-    virtual IFileDescriptor *getFileDescriptor(const char *lname,const INode *foreigndali=NULL,IUserDescriptor *user=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) =0;
+    virtual IPropertyTree *getFileTree(const char *lname, IUserDescriptor *user, const INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT, bool expandnodes=true, bool appendForeign=true) =0;
+    virtual IFileDescriptor *getFileDescriptor(const char *lname,IUserDescriptor *user,const INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) =0;
 
-    virtual IDistributedSuperFile *createSuperFile(const char *logicalname,bool interleaved,bool ifdoesnotexist=false,IUserDescriptor *user=NULL,IDistributedFileTransaction *transaction=NULL) = 0;
-    virtual IDistributedSuperFile *lookupSuperFile(const char *logicalname,IUserDescriptor *user=NULL,
+    virtual IDistributedSuperFile *createSuperFile(const char *logicalname,IUserDescriptor *user,bool interleaved,bool ifdoesnotexist=false,IDistributedFileTransaction *transaction=NULL) = 0;
+    virtual IDistributedSuperFile *lookupSuperFile(const char *logicalname,IUserDescriptor *user,
                                                     IDistributedFileTransaction *transaction=NULL, // transaction only used for looking up sub files
                                                     unsigned timeout=INFINITE
 
                                                 ) = 0;  // NB lookup will also return superfiles 
 
-    virtual int getFilePermissions(const char *lname,IUserDescriptor *user=NULL,unsigned auditflags=0)=0; // see dasess for auditflags values
+    virtual int getFilePermissions(const char *lname,IUserDescriptor *user,unsigned auditflags=0)=0; // see dasess for auditflags values
     virtual void setDefaultUser(IUserDescriptor *user)=0;
     virtual IUserDescriptor* queryDefaultUser()=0;
-    virtual int getNodePermissions(const IpAddress &ip,IUserDescriptor *user=NULL,unsigned auditflags=0)=0;
-    virtual int getFDescPermissions(IFileDescriptor *,IUserDescriptor *user=NULL,unsigned auditflags=0)=0;
+    virtual int getNodePermissions(const IpAddress &ip,IUserDescriptor *user,unsigned auditflags=0)=0;
+    virtual int getFDescPermissions(IFileDescriptor *,IUserDescriptor *user,unsigned auditflags=0)=0;
 
-    virtual DistributedFileCompareResult fileCompare(const char *lfn1,const char *lfn2,DistributedFileCompareMode mode,StringBuffer &errstr,IUserDescriptor *user=NULL)=0;
-    virtual bool filePhysicalVerify(const char *lfn1,bool includecrc,StringBuffer &errstr,IUserDescriptor *user=NULL)=0;
+    virtual DistributedFileCompareResult fileCompare(const char *lfn1,const char *lfn2,DistributedFileCompareMode mode,StringBuffer &errstr,IUserDescriptor *user)=0;
+    virtual bool filePhysicalVerify(const char *lfn1,IUserDescriptor *user,bool includecrc,StringBuffer &errstr)=0;
 
     virtual void setDefaultPreferredClusters(const char *clusters)=0;   // comma separated list of clusters
 
 
     virtual GetFileClusterNamesType getFileClusterNames(const char *logicalname,StringArray &out)=0;
 
-    virtual bool isSuperFile( const char *logicalname, INode *foreigndali=NULL, IUserDescriptor *user=NULL, unsigned timeout=INFINITE) = 0;
+    virtual bool isSuperFile( const char *logicalname, IUserDescriptor *user, INode *foreigndali=NULL, unsigned timeout=INFINITE) = 0;
 
     // Local 'lightweight' routines
     virtual void promoteSuperFiles(unsigned numsf,const char **sfnames,const char *addsubnames,bool delsub,bool createonlyonesuperfile,IUserDescriptor *user,unsigned timeout, StringArray &outunlinked)=0;
@@ -542,7 +542,7 @@ interface IDistributedFileDirectory: extends IInterface
                                 ) = 0; // if scope returns subfiles and subdirs
 
     virtual bool publishMetaFileXML(const CDfsLogicalFileName &logicalname,
-                                    IUserDescriptor *user=NULL) = 0;
+                                    IUserDescriptor *user) = 0;
 
     virtual bool isProtectedFile( // needs no lock on file
                                       const CDfsLogicalFileName &logicalname,
@@ -664,7 +664,7 @@ extern da_decl bool removeClusterSpares(const char *clusterName, const char *typ
 extern da_decl StringBuffer &getClusterGroupName(IPropertyTree &cluster, StringBuffer &groupName);
 extern da_decl StringBuffer &getClusterSpareGroupName(IPropertyTree &cluster, StringBuffer &groupName);
 
-extern da_decl IDistributedFileTransaction *createDistributedFileTransaction(IUserDescriptor *user=NULL);
+extern da_decl IDistributedFileTransaction *createDistributedFileTransaction(IUserDescriptor *user);
 
 extern da_decl const char *normalizeLFN(const char *s, StringBuffer &normalized);
 

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -79,6 +79,8 @@ interface IUserDescriptor: extends serializable
 
 extern da_decl IUserDescriptor *createUserDescriptor();
 
+const static IUserDescriptor * unknownUser = NULL;//use of this should be avoided
+#define UNKNOWN_USER (IUserDescriptor*)unknownUser
 
 interface ISessionNotify: extends IInterface
 {

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -167,7 +167,7 @@ public:
                     else
                         tmp.append(mlfn).append(suffix);
                     tmp.clip().toLowerCase();
-                    Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),false,true,NULL,_udesc);
+                    Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),_udesc,false,true,NULL);
                     mlfn.setLength(start-s);
                     ForEach(*iter) {
                         IPropertyTree &attr = iter->query();
@@ -2025,7 +2025,8 @@ IClusterFileScanIterator *getClusterFileScanIterator(
                       IGroup *group,        // only scans file with nodes in specified group
                       bool exactmatch,          // only files that match group exactly
                       bool anymatch,            // any nodes match
-                      bool loadbranch)
+                      bool loadbranch,
+                      IUserDescriptor *user)
 {
     class cFileScanIterator: public CInterface, implements IClusterFileScanIterator
     {
@@ -2134,7 +2135,7 @@ IClusterFileScanIterator *getClusterFileScanIterator(
             }
         }
     }
-    Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator("*");
+    Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator("*",user);
     StringBuffer chkname;
     StringBuffer gname;
     ForEach(*iter) {
@@ -2178,7 +2179,7 @@ void getLogicalFileSuperSubList(MemoryBuffer &mb)
 {
     // for fileservices
     IsSuperFileMap supermap;
-    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator("*",true,true);
+    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator("*",UNKNOWN_USER,true,true);//MORE:Pass IUserDescriptor
     if (iter) {
         ForEach(*iter) {
             IPropertyTree &attr=iter->query();

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -326,7 +326,9 @@ extern da_decl IClusterFileScanIterator *getClusterFileScanIterator(
                       IGroup *group,        // only scans file with nodes in specified group
                       bool exactmatch,          // only files that match group exactly (if not true includes base subset or wrapped superset)
                       bool anymatch,            // any nodes match (overrides exactmatch)
-                      bool loadbranch);         // whether to load entire branch
+                      bool loadbranch,         // whether to load entire branch
+                      IUserDescriptor *user);
+
 
 class da_decl CheckTime
 {

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -520,7 +520,7 @@ static void dfsfile(const char *lname,IUserDescriptor *userDesc, UnsignedArray *
     CDfsLogicalFileName lfn;
     lfn.set(lname);
     if (!lfn.isExternal()) {
-        Owned<IPropertyTree> tree = queryDistributedFileDirectory().getFileTree(lname,NULL,userDesc,1000*60*5,true); //,userDesc);
+        Owned<IPropertyTree> tree = queryDistributedFileDirectory().getFileTree(lname,userDesc,NULL,1000*60*5,true); //,userDesc);
         if (partslist)
             filterParts(tree,*partslist);
         if (!tree) {
@@ -567,7 +567,7 @@ void dfscsv(const char *dali,IUserDescriptor *udesc)
         foreigndali.setown(createINode(ep));
     }
     unsigned start = msTick();
-    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator("*",true,false,foreigndali,udesc);
+    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator("*",udesc,true,false,foreigndali);
     StringBuffer ln;
     unsigned i;
     for (i=0;fields[i];i++) {
@@ -620,7 +620,7 @@ static void dfsgroup(const char *name)
 
 static void dfsmap(const char *lname)
 {
-    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname);
+    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname,UNKNOWN_USER);
     if (!file) {
         ERRLOG("File %s not found",lname);
         return;
@@ -645,15 +645,15 @@ static void dfsmap(const char *lname)
 
 //=============================================================================
 
-static int dfsexists(const char *lname)
+static int dfsexists(const char *lname,IUserDescriptor *user)
 {
-    return queryDistributedFileDirectory().exists(lname)?0:1;
+    return queryDistributedFileDirectory().exists(lname,user)?0:1;
 }
 //=============================================================================
 
 static void dfsparents(const char *lname)
 {
-    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname);
+    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname,UNKNOWN_USER);
     if (file) {
         Owned<IDistributedSuperFileIterator> iter = file->getOwningSuperFiles();
         ForEach(*iter) 
@@ -666,7 +666,7 @@ static void dfsparents(const char *lname)
 static void dfsunlink(const char *lname)
 {
     loop {
-        Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname);
+        Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname,UNKNOWN_USER);
         if (file) {
             Owned<IDistributedSuperFileIterator> iter = file->getOwningSuperFiles();
             if (!iter->first())
@@ -790,7 +790,7 @@ public:
 static int dfsverify(const char *name,CDateTime *cutoff)
 {
     static CIpTable dafilesrvips;
-    Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(name);
+    Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(name,UNKNOWN_USER);
     if (!file) {
         ERRLOG("VERIFY: cannot find %s",name);
         return 1;
@@ -914,7 +914,7 @@ static void dfsVerifyFiles(const char *grp,unsigned days)
         cutoff.adjustTime(-60*24*days);
     }
 
-    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator("*",true,false);
+    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator("*",UNKNOWN_USER,true,false);//MORE:Pass IUserDescriptor
     ForEach(*iter) {
         StringBuffer lpath;
         IPropertyTree &attr=iter->query();
@@ -929,7 +929,7 @@ static void dfsVerifyFiles(const char *grp,unsigned days)
 
 static void setprotect(const char *filename, const char *callerid)
 {
-    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(filename);
+    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(filename,UNKNOWN_USER);
     file->setProtect(callerid,true);
 }
 
@@ -937,7 +937,7 @@ static void setprotect(const char *filename, const char *callerid)
 
 static void unprotect(const char *filename, const char *callerid)
 {
-    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(filename);
+    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(filename,UNKNOWN_USER);
     file->setProtect((strcmp(callerid,"*")==0)?NULL:callerid,false);
 }
 //=============================================================================
@@ -1273,7 +1273,7 @@ static void checksubfile(const char *lfn)
 
 static void listexpires(const char * lfnmask)
 {
-    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator(lfnmask,true,false);
+    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator(lfnmask,UNKNOWN_USER,true,false);//MORE:Pass IUserDescriptor
     ForEach(*iter) {
         IPropertyTree &attr=iter->query();
         const char * expires = attr.queryProp("@expires");
@@ -1374,7 +1374,7 @@ static offset_t getCompressedSize(IDistributedFile *file)
 
 static void dfscompratio (const char *lname)
 {
-    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname);
+    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lname,UNKNOWN_USER);
     StringBuffer out;
     out.appendf("File %s ",lname);
     if (file) {
@@ -1455,7 +1455,7 @@ static bool countScopeChildren(IPropertyTree *t,unsigned &files, unsigned &sfile
 static void dfsscopes(const char *name)
 {
     bool wild = isWild(name);
-    Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(wild?NULL:name,true,true);
+    Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(UNKNOWN_USER,wild?NULL:name,true,true);//MORE:Pass IUserDescriptor
     StringBuffer ln;
     ForEach(*iter) {
         CDfsLogicalFileName dlfn;
@@ -1508,7 +1508,7 @@ static bool recursiveCheckEmptyScope(IPropertyTree &ct)
 
 static void cleanscopes()
 {
-    Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(NULL,true,true);
+    Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(UNKNOWN_USER, NULL,true,true);//MORE:Pass IUserDescriptor
     CDfsLogicalFileName dlfn;
     StringBuffer s;
     StringArray toremove;
@@ -2241,7 +2241,7 @@ int main(int argc, char* argv[])
             }
             else if (stricmp(cmd,"dfsexist")==0) {
                 CHECKPARAMS(1,1);
-                ret = dfsexists(params.item(1));
+                ret = dfsexists(params.item(1),userDesc);
             }
             else if (stricmp(cmd,"dfsparents")==0) {
                 CHECKPARAMS(1,1);

--- a/dali/dalidiag/dalidiag.cpp
+++ b/dali/dalidiag/dalidiag.cpp
@@ -273,7 +273,7 @@ void dirParts(const char *ip,const char *dir)
 
 void partInfo(const char *name,unsigned copy)
 {
-    Owned<IDistributedFile> f = queryDistributedFileDirectory().lookup(name);
+    Owned<IDistributedFile> f = queryDistributedFileDirectory().lookup(name,UNKNOWN_USER);
     if (f) {
         Owned<IDistributedFilePartIterator> parts = f->getIterator();
         unsigned partno = 0;

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -30,6 +30,7 @@
 #include "dasds.hpp"
 #include "danqs.hpp"
 #include "dautils.hpp"
+#include "dasess.hpp"
 #include "mplog.hpp"
 
 #include "jptree.hpp"
@@ -50,7 +51,7 @@ static unsigned nIter = 1;
 
 static void addTestFile(const char *name,unsigned n)
 {
-    queryDistributedFileDirectory().removeEntry(name);
+    queryDistributedFileDirectory().removeEntry(name,UNKNOWN_USER);
     SocketEndpointArray epa;
     for (unsigned i=0;i<n;i++) {
         StringBuffer ips("192.168.0.");
@@ -82,7 +83,7 @@ static void addTestFile(const char *name,unsigned n)
         t.setPropInt("@recordSize",1);
         t.setProp("ECL","TESTECL();");
     }
-    dfile->attach(name);
+    dfile->attach(name,UNKNOWN_USER);
 }
 
 #define TEST_SUPER_FILE "nhtest::super"
@@ -96,21 +97,21 @@ void Test_SuperFile()
     // first remove if exists
     unsigned i;
     unsigned n;
-    Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction();
+    Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(UNKNOWN_USER);
     Owned<IDistributedSuperFile> sfile;
     Owned<IDistributedFilePartIterator> piter;
     Owned<IDistributedFileIterator> iter;
-    queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"4");
-    queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"3");
-    queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"2");
+    queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"4",UNKNOWN_USER);
+    queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"3",UNKNOWN_USER);
+    queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"2",UNKNOWN_USER);
 #if 1
-    sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"1"));
+    sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"1",UNKNOWN_USER));
     if (sfile) {
         sfile->removeSubFile(NULL,true,false);
         sfile.clear();
-        queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"1");
+        queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"1",UNKNOWN_USER);
     }
-    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"1",true));
+    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"1",UNKNOWN_USER,true));
     for (i = 0;i<3;i++) {
         StringBuffer name(TEST_SUB_FILE);
         name.append(i+1);
@@ -119,7 +120,7 @@ void Test_SuperFile()
     }
     sfile.clear();
 #endif
-    sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"1"));
+    sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"1",UNKNOWN_USER));
     printf("NumSubFiles = %d\n",sfile->numSubFiles());
 #if 1
     i=0;
@@ -156,7 +157,7 @@ void Test_SuperFile()
         i++;
     }
     piter.clear();
-    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"2",true));
+    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"2",UNKNOWN_USER,true));
     transaction->start();
     for (i = 0;i<3;i++) {
         StringBuffer name(TEST_SUB_FILE);
@@ -165,7 +166,7 @@ void Test_SuperFile()
     }
     sfile.clear(); // mustn't have owner open when commit transaction
     transaction->commit();
-    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"3",true));
+    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"3",UNKNOWN_USER,true));
     for (i = 0;i<3;i++) {
         StringBuffer name(TEST_SUB_FILE);
         name.append(i+1);
@@ -173,7 +174,7 @@ void Test_SuperFile()
     }
     sfile.clear();  // mustn't have owner open when commit transaction
     transaction->rollback();
-    sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"2"));
+    sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"2",UNKNOWN_USER));
     transaction->start();
     sfile->removeSubFile(TEST_SUB_FILE"1",false,false,false,transaction);
     StringBuffer name(TEST_SUB_FILE"4");
@@ -181,14 +182,14 @@ void Test_SuperFile()
     sfile->addSubFile(name,false,NULL,false,transaction);
     sfile.clear(); // mustn't have owner open when commit transaction
     transaction->commit();
-    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"4",true));
+    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"4",UNKNOWN_USER,true));
     transaction->start();
     sfile->addSubFile(TEST_SUPER_FILE"1",false,NULL,false,transaction);
     sfile->addSubFile(TEST_SUPER_FILE"2",false,NULL,false,transaction);
     sfile->addSubFile(TEST_SUPER_FILE"3",false,NULL,false,transaction);
     sfile.clear();  // mustn't have owner open when commit transaction
     transaction->commit();
-    sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"4"));
+    sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"4",UNKNOWN_USER));
     i=0;
     iter.setown(sfile->getSubFileIterator());
     ForEach(*iter) {
@@ -241,21 +242,21 @@ void Test_SuperFile2()
     // first remove if exists
     unsigned i;
     Owned<IDistributedSuperFile> sfile;
-    queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"B1");
-    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"B1",true));
+    queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"B1",UNKNOWN_USER);
+    sfile.setown(queryDistributedFileDirectory().createSuperFile(TEST_SUPER_FILE"B1",UNKNOWN_USER,true));
     for (unsigned tst=0;tst<2;tst++) {
         printf("sfile size = %"I64F"d\n",sfile->getFileSize(false,false));
         for (i = 0;i<3;i++) {
             StringBuffer name(TEST_SUB_FILE);
             name.append(i+1);
             addTestFile(name.str(),i+2);
-            Owned<IDistributedFile> sbfile = queryDistributedFileDirectory().lookup(name);
+            Owned<IDistributedFile> sbfile = queryDistributedFileDirectory().lookup(name,UNKNOWN_USER);
             printf("adding size = %"I64F"d\n",sbfile->getFileSize(false,false));
             sfile->addSubFile(name);
             printf("sfile size = %"I64F"d\n",sfile->getFileSize(false,false));
         }
         sfile.clear();
-        sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"B1"));
+        sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"B1",UNKNOWN_USER));
         printf("NumSubFiles = %d\n",sfile->numSubFiles());
         if (tst==1) {
             sfile->removeSubFile(NULL,false,false);
@@ -265,7 +266,7 @@ void Test_SuperFile2()
             for (i = 0;i<3;i++) {
                 StringBuffer name(TEST_SUB_FILE);
                 name.append(i+1);
-                Owned<IDistributedFile> sbfile = queryDistributedFileDirectory().lookup(name);
+                Owned<IDistributedFile> sbfile = queryDistributedFileDirectory().lookup(name,UNKNOWN_USER);
                 printf("removing size = %"I64F"d\n",sbfile->getFileSize(false,false));
                 sfile->removeSubFile(name,false,false);
                 printf("sfile size = %"I64F"d\n",sfile->getFileSize(false,false));
@@ -279,7 +280,7 @@ void Test_SuperFile2()
 void Test_PartIter()
 {
     unsigned start = msTick();
-    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup("nhtest::file_name_ssn20030805");
+    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup("nhtest::file_name_ssn20030805",UNKNOWN_USER);
     Owned<IDistributedFilePartIterator> parts = file->getIterator();
     ForEach(*parts) {
         IDistributedFilePart & thisPart = parts->query(); 
@@ -462,9 +463,9 @@ void Test_DFS()
     pp->setPropInt64("@size",3456);
     fdesc->setPart(2,node,"testfile1.d00._3_of_3",pp);
     node->Release();
-    queryDistributedFileDirectory().removeEntry("nigel::test::testfile1");
+    queryDistributedFileDirectory().removeEntry("nigel::test::testfile1",UNKNOWN_USER);
     IDistributedFile *dfile = queryDistributedFileDirectory().createNew(fdesc);
-    dfile->attach("nigel::test::testfile1");
+    dfile->attach("nigel::test::testfile1",UNKNOWN_USER);
     dfile->Release();
     fdesc->Release();
     fdesc = createFileDescriptor();
@@ -484,9 +485,9 @@ void Test_DFS()
     node = createINode("192.168.0.4");
     fdesc->setPart(1,node,"testfile2.d00._2_of_3");
     node->Release();
-    queryDistributedFileDirectory().removeEntry("nigel::test::testfile2");
+    queryDistributedFileDirectory().removeEntry("nigel::test::testfile2",UNKNOWN_USER);
     dfile = queryDistributedFileDirectory().createNew(fdesc);
-    dfile->attach("nigel::test::testfile2");
+    dfile->attach("nigel::test::testfile2",UNKNOWN_USER);
     dfile->Release();
     fdesc->Release();
     fdesc = createFileDescriptor();
@@ -500,24 +501,24 @@ void Test_DFS()
     node = createINode("192.168.0.3");
     fdesc->setPart(2,node,"testfile3.d00._3_of_3");
     node->Release();
-    queryDistributedFileDirectory().removeEntry("nigel::test::testfile3");
+    queryDistributedFileDirectory().removeEntry("nigel::test::testfile3",UNKNOWN_USER);
     dfile = queryDistributedFileDirectory().createNew(fdesc);
-    dfile->attach("nigel::test::testfile3");
+    dfile->attach("nigel::test::testfile3",UNKNOWN_USER);
     dfile->Release();
     fdesc->Release();
-    IDistributedFile *f = queryDistributedFileDirectory().lookup("nigel::test::testfile2");
+    IDistributedFile *f = queryDistributedFileDirectory().lookup("nigel::test::testfile2",UNKNOWN_USER);
     if (!f)
         printf("failed 1");
     ::Release(f);
-    f = queryDistributedFileDirectory().lookup("nigel::zest::testfile1");
+    f = queryDistributedFileDirectory().lookup("nigel::zest::testfile1",UNKNOWN_USER);
     assertex(!f);
-    f = queryDistributedFileDirectory().lookup("nigel::test::zestfile1");
+    f = queryDistributedFileDirectory().lookup("nigel::test::zestfile1",UNKNOWN_USER);
     assertex(!f);
-    f = queryDistributedFileDirectory().lookup("nigel::test::testfile1");
+    f = queryDistributedFileDirectory().lookup("nigel::test::testfile1",UNKNOWN_USER);
     if (!f)
         printf("failed 2 ");
     ::Release(f);
-    f = queryDistributedFileDirectory().lookup("nigel::test::testfile3");
+    f = queryDistributedFileDirectory().lookup("nigel::test::testfile3",UNKNOWN_USER);
     if (!f)
         printf("failed 3");
     StringBuffer str;
@@ -569,9 +570,9 @@ void Test_DFSU()
     pp->setPropInt64("@size",3456);
     fdesc->setPart(2,node,"testfile1.d00._3_of_3",pp);
     node->Release();
-    queryDistributedFileDirectory().removeEntry("nigel::test::testfile1u");
+    queryDistributedFileDirectory().removeEntry("nigel::test::testfile1u",UNKNOWN_USER);
     IDistributedFile *dfile = queryDistributedFileDirectory().createNew(fdesc);
-    dfile->attach("nigel::test::testfile1u");
+    dfile->attach("nigel::test::testfile1u",UNKNOWN_USER);
     dfile->Release();
     fdesc->Release();
     fdesc = createFileDescriptor();
@@ -591,9 +592,9 @@ void Test_DFSU()
     node = createINode("192.168.0.4");
     fdesc->setPart(1,node,"testfile2.d00._2_of_3");
     node->Release();
-    queryDistributedFileDirectory().removeEntry("nigel::test::testfile2u");
+    queryDistributedFileDirectory().removeEntry("nigel::test::testfile2u",UNKNOWN_USER);
     dfile = queryDistributedFileDirectory().createNew(fdesc);
-    dfile->attach("nigel::test::testfile2u");
+    dfile->attach("nigel::test::testfile2u",UNKNOWN_USER);
     dfile->Release();
     fdesc->Release();
     fdesc = createFileDescriptor();
@@ -607,12 +608,12 @@ void Test_DFSU()
     node = createINode("192.168.0.3");
     fdesc->setPart(2,node,"testfile3.d00._3_of_3");
     node->Release();
-    queryDistributedFileDirectory().removeEntry("nigel::test::testfile3u");
+    queryDistributedFileDirectory().removeEntry("nigel::test::testfile3u",UNKNOWN_USER);
     dfile = queryDistributedFileDirectory().createNew(fdesc);
-    dfile->attach("nigel::test::testfile3u");
+    dfile->attach("nigel::test::testfile3u",UNKNOWN_USER);
     dfile->Release();
     fdesc->Release();
-    IDistributedFile *f = queryDistributedFileDirectory().lookup("nigel::test::testfile2u");
+    IDistributedFile *f = queryDistributedFileDirectory().lookup("nigel::test::testfile2u",UNKNOWN_USER);
     if (!f)
         printf("failed 1");
     StringBuffer str;
@@ -2769,8 +2770,8 @@ void testDaliLog(bool listener)
 
 void testlockprop(const char *lfn)
 {
-    Owned<IDistributedFile> f1 = queryDistributedFileDirectory().lookup(lfn);
-    Owned<IDistributedFile> f2 = queryDistributedFileDirectory().lookup(lfn);
+    Owned<IDistributedFile> f1 = queryDistributedFileDirectory().lookup(lfn,UNKNOWN_USER);
+    Owned<IDistributedFile> f2 = queryDistributedFileDirectory().lookup(lfn,UNKNOWN_USER);
     f1->lockProperties();
     f1->unlockProperties();
     printf("done\n");

--- a/dali/datest/dfuwutest.cpp
+++ b/dali/datest/dfuwutest.cpp
@@ -566,10 +566,10 @@ void testRoxieCopies()
         PROGLOG("E--------------------------");
         StringBuffer fn("testing::file");
         fn.append(i);
-        queryDistributedFileDirectory().removeEntry(fn.str());
-        file->attach(fn.str());
+        queryDistributedFileDirectory().removeEntry(fn.str(),UNKNOWN_USER);
+        file->attach(fn.str(),UNKNOWN_USER);
         file.clear();
-        file.setown(queryDistributedFileDirectory().lookup(fn.str()));
+        file.setown(queryDistributedFileDirectory().lookup(fn.str(),UNKNOWN_USER));
         Owned<IFileDescriptor> fdesc4 = file->getFileDescriptor();
         printDesc(fdesc4);
     }

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -572,7 +572,7 @@ public:
         monitor->getTriggeredList(prev);
         monitor->setCycleCount(monitor->getCycleCount()+1);
         if (lfn.length()) {                                                 // no wild cards so only 0 or 1 prev
-            if (queryDistributedFileDirectory().exists(lfn.str())) {
+            if (queryDistributedFileDirectory().exists(lfn.str(),UNKNOWN_USER)) {//MORE:Pass IUserDescriptor
                 done.append(*new StringAttrItem(lfn.str()));
                 bool isdone = ((prev.ordinality()!=0)&&
                                 (stricmp(prev.item(0).text.get(),lfn.str())==0));
@@ -831,7 +831,7 @@ public:
             slfn.clearForeign();
             srcdali.setown(createINode(ep));
         }
-        Owned<IPropertyTree> ftree = queryDistributedFileDirectory().getFileTree(srclfn,srcdali,ctx.srcuser, FOREIGN_DALI_TIMEOUT, false);
+        Owned<IPropertyTree> ftree = queryDistributedFileDirectory().getFileTree(srclfn,ctx.srcuser,srcdali, FOREIGN_DALI_TIMEOUT, false);
         if (!ftree.get()) {
             StringBuffer s;
             throw MakeStringException(-1,"Source file %s could not be found in Dali %s",slfn.get(),srcdali?srcdali->endpoint().getUrlStr(s).str():"(local)");
@@ -897,7 +897,7 @@ public:
                     ctx.feedback->displayProgress(numtodo?(numdone*100/numtodo):0,0,"unknown",0,0,"",0,0,0);
             }
             // now construct the superfile          
-            Owned<IDistributedSuperFile> sfile = queryDistributedFileDirectory().createSuperFile(dlfn.get(),true,false,ctx.user);
+            Owned<IDistributedSuperFile> sfile = queryDistributedFileDirectory().createSuperFile(dlfn.get(),ctx.user,true,false);
             if (!sfile)
                 throw MakeStringException(-1,"SuperFile %s could not be created",dlfn.get());
             ForEachItemIn(i,subfiles) {
@@ -1116,7 +1116,7 @@ public:
                     }
                     const char * kind;
                     if (foreigncopy) {
-                        foreignfdesc.setown(queryDistributedFileDirectory().getFileDescriptor(tmp.str(),foreigndalinode,foreignuserdesc));
+                        foreignfdesc.setown(queryDistributedFileDirectory().getFileDescriptor(tmp.str(),foreignuserdesc,foreigndalinode));
                         if (!foreignfdesc) {
                             StringBuffer s;
                             throw MakeStringException(-1,"Source file %s could not be found in Dali %s",tmp.str(),foreigndalinode->endpoint().getUrlStr(s).str());
@@ -1227,7 +1227,7 @@ public:
                                     oldfile.clear();
                                     if (!options->getOverwrite())
                                         throw MakeStringException(-1,"Destination file %s already exists and overwrite not specified",tmp.str());
-                                    fdir.removePhysical(tmp.str(),NULL,NULL,userdesc);
+                                    fdir.removePhysical(tmp.str(),userdesc,NULL,NULL);
                                 }
                             }
                             StringBuffer jobname;
@@ -1272,12 +1272,12 @@ public:
                                 newf.set(foreignfdesc);
                             else 
                                 newf.setown(srcFile->getFileDescriptor());
-                            oldf.setown(queryDistributedFileDirectory().getFileDescriptor(diffNameSrc,foreigncopy?foreigndalinode:NULL,foreigncopy?foreignuserdesc:userdesc));
+                            oldf.setown(queryDistributedFileDirectory().getFileDescriptor(diffNameSrc,foreigncopy?foreignuserdesc:userdesc,foreigncopy?foreigndalinode:NULL));
                             if (!oldf.get()) {
                                 StringBuffer s;
                                 throw MakeStringException(-1,"Old key file %s could not be found in source",diffNameSrc.get());
                             }
-                            olddstf.setown(queryDistributedFileDirectory().getFileDescriptor(diffNameDst,NULL,userdesc));
+                            olddstf.setown(queryDistributedFileDirectory().getFileDescriptor(diffNameDst,userdesc,NULL));
                             if (!olddstf.get()) {
                                 StringBuffer s;
                                 throw MakeStringException(-1,"Old key file %s could not be found in destination",diffNameDst.get());
@@ -1388,7 +1388,7 @@ public:
                         if (options->getNoDelete())
                             fdir.removeEntry(tmp.str(),userdesc);
                         else
-                            fdir.removePhysical(tmp.str(),NULL,NULL,userdesc);
+                            fdir.removePhysical(tmp.str(),userdesc,NULL,NULL);
                         Audit("REMOVE",userdesc,tmp.clear(),NULL);
                         runningconn.clear();
                     }
@@ -1426,7 +1426,7 @@ public:
                         newfile.clear();
                         StringBuffer fromname(srcName);
                         srcFile.clear();
-                        if (!queryDistributedFileDirectory().renamePhysical(fromname.str(),toname.str(),NULL,userdesc))
+                        if (!queryDistributedFileDirectory().renamePhysical(fromname.str(),toname.str(),userdesc,NULL))
                             throw MakeStringException(-1,"rename failed"); // could do with better error here
                         StringBuffer timetaken;
                         timetaken.appendf("%dms",msTick()-start);

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -565,7 +565,7 @@ public:
             slfn.clearForeign();
             srcdali.setown(createINode(ep));
         }
-        Owned<IPropertyTree> ftree = fdir->getFileTree(slfn.get(),srcdali,foreignuserdesc, FOREIGN_DALI_TIMEOUT, false);
+        Owned<IPropertyTree> ftree = fdir->getFileTree(slfn.get(),foreignuserdesc,srcdali, FOREIGN_DALI_TIMEOUT, false);
         if (!ftree.get()) {
             StringBuffer s;
             throw MakeStringException(-1,"Source file %s could not be found in Dali %s",slfn.get(),srcdali?srcdali->endpoint().getUrlStr(s).str():"(local)");
@@ -631,7 +631,7 @@ public:
                 subfiles.append(dlfnres.get());
             }
             // now construct the superfile
-            Owned<IDistributedSuperFile> sfile = fdir->createSuperFile(dlfn.get(),true,false,userdesc);
+            Owned<IDistributedSuperFile> sfile = fdir->createSuperFile(dlfn.get(),userdesc,true,false);
             if (!sfile)
                 throw MakeStringException(-1,"SuperFile %s could not be created",dlfn.get());
             ForEachItemIn(i,subfiles) {
@@ -662,7 +662,7 @@ public:
             slfn.clearForeign();
             srcdali.setown(createINode(ep));
         }
-        Owned<IPropertyTree> ftree = fdir->getFileTree(slfn.get(),srcdali,foreignuserdesc, FOREIGN_DALI_TIMEOUT, false);
+        Owned<IPropertyTree> ftree = fdir->getFileTree(slfn.get(), foreignuserdesc, srcdali, FOREIGN_DALI_TIMEOUT, false);
         if (!ftree.get()) {
             StringBuffer s;
             throw MakeStringException(-1,"Source file %s could not be found in Dali %s",slfn.get(),srcdali?srcdali->endpoint().getUrlStr(s).str():"(local)");
@@ -708,7 +708,7 @@ class CDFUhelper: public CInterface, implements IDFUhelper
 public:
     IMPLEMENT_IINTERFACE;
 
-    void addSuper(const char *superfname, unsigned numtoadd, const char **subfiles, const char *before,IUserDescriptor *user)
+    void addSuper(const char *superfname,IUserDescriptor *user, unsigned numtoadd, const char **subfiles, const char *before)
     {
         if (!numtoadd)
             throwError(DFUERR_DNoSubfileToAddToSuperFile);
@@ -718,7 +718,7 @@ public:
 
         Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFile(superfname);
         if (!superfile)
-            superfile.setown(queryDistributedFileDirectory().createSuperFile(superfname,true,false,user,transaction));
+            superfile.setown(queryDistributedFileDirectory().createSuperFile(superfname,user,true,false,transaction));
 
         for (unsigned i=0;i<numtoadd;i++)
         {
@@ -734,7 +734,7 @@ public:
     }
 
 
-    void removeSuper(const char *superfname, unsigned numtodelete, const char **subfiles, bool delsub, bool removesuperfile, IUserDescriptor *user)
+    void removeSuper(const char *superfname, IUserDescriptor *user, unsigned numtodelete, const char **subfiles, bool delsub, bool removesuperfile)
     {
         Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
         // We need this here, since caching only happens with active transactions
@@ -785,7 +785,7 @@ public:
         if (removesuperfile && (superfile->numSubFiles() == 0)) {
             superfile.clear();
             // MORE - add file deletion to transaction
-            queryDistributedFileDirectory().removeEntry(superfname);
+            queryDistributedFileDirectory().removeEntry(superfname,user);
         }
     }
 
@@ -829,7 +829,7 @@ public:
         return out;
     }
 
-    void addFileXML(const char *lfn,const StringBuffer &xml,IUserDescriptor *user=NULL)
+    void addFileXML(const char *lfn,const StringBuffer &xml,IUserDescriptor *user)
     {
         Owned<IPropertyTree> t = createPTreeFromXMLString(xml);
         Owned<IFileDescriptor> fdesc = deserializeFileDescriptorTree(t,&queryNamedGroupStore(),0);
@@ -838,13 +838,13 @@ public:
             file->attach(lfn,user);
     }
 
-    void addFileRemote(const char *lfn,SocketEndpoint &srcdali,const char *srclfn,IUserDescriptor *srcuser=NULL,IUserDescriptor *user=NULL)
+    void addFileRemote(const char *lfn,SocketEndpoint &srcdali,const char *srclfn,IUserDescriptor *user,IUserDescriptor *srcuser=NULL)
     {
         SocketEndpoint daliep = srcdali;
         if (daliep.port==0)
             daliep.port= DALI_SERVER_PORT;
         Owned<INode> node = createINode(daliep);
-        Owned<IFileDescriptor> fdesc = queryDistributedFileDirectory().getFileDescriptor(srclfn,node,srcuser);
+        Owned<IFileDescriptor> fdesc = queryDistributedFileDirectory().getFileDescriptor(srclfn,srcuser,node);
         if (!fdesc) {
             StringBuffer s;
             throw MakeStringException(-1,"Source file %s could not be found in Dali %s",srclfn,daliep.getUrlStr(s).str());
@@ -876,7 +876,7 @@ public:
                 return;
             }
         }
-        Owned<IPropertyTree> ftree = queryDistributedFileDirectory().getFileTree(srclfn,srcnode,srcuser, FOREIGN_DALI_TIMEOUT, false);
+        Owned<IPropertyTree> ftree = queryDistributedFileDirectory().getFileTree(srclfn,srcuser,srcnode, FOREIGN_DALI_TIMEOUT, false);
         if (!ftree.get()) {
             StringBuffer s;
             throw MakeStringException(-1,"Source file %s could not be found in Dali %s",srclfn,daliep.getUrlStr(s).str());
@@ -902,7 +902,7 @@ public:
         }
         if (strcmp(ftree->queryName(),queryDfsXmlBranchName(DXB_File))==0) {
             assertex(copier);
-            if (!copier->copyFile(lfn,daliep,srclfn,user))
+            if (!copier->copyFile(lfn,daliep,srclfn,user,NULL))
                 throw MakeStringException(-1,"File %s could not be copied",lfn);
 
         }
@@ -920,7 +920,7 @@ public:
                 return;
 
             // now construct the superfile
-            Owned<IDistributedSuperFile> sfile = queryDistributedFileDirectory().createSuperFile(lfn,true,false,user);
+            Owned<IDistributedSuperFile> sfile = queryDistributedFileDirectory().createSuperFile(lfn,user,true,false);
             if (!sfile)
                 throw MakeStringException(-1,"SuperFile %s could not be created",lfn);
             ForEachItemIn(i,subfiles) {
@@ -988,7 +988,7 @@ public:
         bool *ex = (bool *)ma.allocate(dstfns.ordinality()*sizeof(bool));
         unsigned i;
         for (i=0;i<n;i++)
-            ex[i] = queryDistributedFileDirectory().exists(dstfns.item(i));
+            ex[i] = queryDistributedFileDirectory().exists(dstfns.item(i),UNKNOWN_USER);//MORE:Pass IUserDescriptor
         for (i=0;i<n;i++) {
             if (!ex[i])
                 continue;

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -25,19 +25,19 @@ interface IUserDescriptor;
 
 interface IDfuFileCopier: extends IInterface
 {
-    virtual bool copyFile(const char *lfn,SocketEndpoint &srcdali,const char *srclfn,IUserDescriptor *srcuser=NULL,IUserDescriptor *user=NULL) = 0;
+    virtual bool copyFile(const char *lfn,SocketEndpoint &srcdali,const char *srclfn,IUserDescriptor *srcuser,IUserDescriptor *user) = 0;
     virtual bool wait()=0; // waits for all outstanding copies to complete
 };
 
 
 interface IDFUhelper: extends IInterface
 {
-    virtual void addSuper(const char *superfname, unsigned numtoadd=0, const char **subfiles=NULL, const char *before=NULL, IUserDescriptor *user=NULL) = 0;
-    virtual void removeSuper(const char *superfname, unsigned numtodelete=0, const char **subfiles=NULL, bool delsub=false, bool removesuperfile=true, IUserDescriptor *user=NULL) = 0;
-    virtual void listSubFiles(const char *superfname,StringAttrArray &out, IUserDescriptor *user=NULL) = 0;
-    virtual StringBuffer &getFileXML(const char *lfn,StringBuffer &out, IUserDescriptor *user=NULL) = 0;
-    virtual void addFileXML(const char *lfn,const StringBuffer &xml, IUserDescriptor *user=NULL) = 0;
-    virtual void addFileRemote(const char *lfn,SocketEndpoint &srcdali,const char *srclfn,IUserDescriptor *srcuser=NULL,IUserDescriptor *user=NULL) = 0;
+    virtual void addSuper(const char *superfname, IUserDescriptor *user, unsigned numtoadd=0, const char **subfiles=NULL, const char *before=NULL) = 0;
+    virtual void removeSuper(const char *superfname, IUserDescriptor *user, unsigned numtodelete=0, const char **subfiles=NULL, bool delsub=false, bool removesuperfile=true) = 0;
+    virtual void listSubFiles(const char *superfname,StringAttrArray &out, IUserDescriptor *user) = 0;
+    virtual StringBuffer &getFileXML(const char *lfn,StringBuffer &out, IUserDescriptor *user) = 0;
+    virtual void addFileXML(const char *lfn,const StringBuffer &xml, IUserDescriptor *user) = 0;
+    virtual void addFileRemote(const char *lfn,SocketEndpoint &srcdali,const char *srclfn,IUserDescriptor *srcuser,IUserDescriptor *user) = 0;
     virtual void superForeignCopy(const char *lfn,SocketEndpoint &srcdali,const char *srclfn,IUserDescriptor *srcuser,IUserDescriptor *user, bool overwrite, IDfuFileCopier *copier) = 0;
 
     virtual void createFileClone(

--- a/dali/dfuXRefLib/XRefFilesNode.cpp
+++ b/dali/dfuXRefLib/XRefFilesNode.cpp
@@ -153,7 +153,7 @@ bool CXRefFilesNode::RemovePhysical(const char *Partmask,IUserDescriptor* udesc,
     bool exists = false;
     StringBuffer lfn;
     if (LogicalNameFromMask(Partmask,lfn)) {
-        if (queryDistributedFileDirectory().exists(lfn.str(),true)) 
+        if (queryDistributedFileDirectory().exists(lfn.str(),udesc,true)) 
             exists = true;
     }
     if (!checkPartsInCluster(Partmask,clustername,subBranch,errstr,exists))
@@ -312,7 +312,7 @@ bool CXRefFilesNode::AttachPhysical(const char *Partmask,IUserDescriptor* udesc,
         return false;
     }
 
-    if (queryDistributedFileDirectory().exists(logicalName.toCharArray()))
+    if (queryDistributedFileDirectory().exists(logicalName.toCharArray(),udesc))
     {
         ERRLOG("Logical File %s already Exists. Can not reattach to Dali",logicalName.str());
         errstr.appendf("Logical File %s already Exists. Can not reattach to Dali",logicalName.str());

--- a/dali/dfuXRefLib/XRefNodeManager.cpp
+++ b/dali/dfuXRefLib/XRefNodeManager.cpp
@@ -369,7 +369,7 @@ static bool recursiveCheckEmptyScope(IPropertyTree &ct)
 static void emptyScopes()
 {
     PROGLOG("Removing empty scopes");
-    Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(NULL,true,true);
+    Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(UNKNOWN_USER,NULL,true,true);//MORE:Pass IUserDescriptor
     CDfsLogicalFileName dlfn;
     StringBuffer s;
     StringArray toremove;

--- a/dali/dfuXRefLib/dfuxreflib.cpp
+++ b/dali/dfuXRefLib/dfuxreflib.cpp
@@ -709,7 +709,7 @@ struct CLogicalNameEntry: public CInterface
     bool remove()
     {
         IDistributedFileDirectory &fdir = queryDistributedFileDirectory();
-        Owned<IDistributedFile> file = fdir.lookup(lname.get());
+        Owned<IDistributedFile> file = fdir.lookup(lname.get(),UNKNOWN_USER);
         if (!file)
             return false;
         file->detach();
@@ -2269,7 +2269,7 @@ class CXRefManager: public CXRefManagerBase
             ForEachItemIn(i,logicalnamelist) {
                 CLogicalNameEntry &item = logicalnamelist.item(i);
                 if (item.unknowngrp||item.mismatchgrp.get()||item.missinggrp) {
-                    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(item.lname.get());
+                    Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(item.lname.get(),UNKNOWN_USER);
                     if (file) {
                         if (item.missinggrp)
                             outf("WARNING: Missing group for %s\n",item.lname.get());

--- a/dali/regress/daregdfs.cpp
+++ b/dali/regress/daregdfs.cpp
@@ -26,6 +26,7 @@
 
 #include "dadfs.hpp"
 #include "dafdesc.hpp"
+#include "dasess.hpp"
 
 //#define COMPAT
 
@@ -80,25 +81,25 @@ void testMultiCluster()
     fdesc->addCluster(grp1,mapping);
     fdesc->addCluster(grp2,mapping);
     fdesc->addCluster(grp3,mapping);
-    queryDistributedFileDirectory().removeEntry("test::testfile1");
+    queryDistributedFileDirectory().removeEntry("test::testfile1",UNKNOWN_USER);
     Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
-    queryDistributedFileDirectory().removeEntry("test::testfile1");
-    file->attach("test::testfile1");
+    queryDistributedFileDirectory().removeEntry("test::testfile1",UNKNOWN_USER);
+    file->attach("test::testfile1",UNKNOWN_USER);
     StringBuffer name;
     unsigned i;
     for (i=0;i<file->numClusters();i++)
         PROGLOG("cluster[%d] = %s",i,file->getClusterName(i,name.clear()).str());
     file.clear();
-    file.setown(queryDistributedFileDirectory().lookup("test::testfile1"));
+    file.setown(queryDistributedFileDirectory().lookup("test::testfile1",UNKNOWN_USER));
     for (i=0;i<file->numClusters();i++)
         PROGLOG("cluster[%d] = %s",i,file->getClusterName(i,name.clear()).str());
     file.clear();
-    file.setown(queryDistributedFileDirectory().lookup("test::testfile1@testgrp1"));
+    file.setown(queryDistributedFileDirectory().lookup("test::testfile1@testgrp1",UNKNOWN_USER));
     for (i=0;i<file->numClusters();i++)
         PROGLOG("cluster[%d] = %s",i,file->getClusterName(i,name.clear()).str());
     file.clear();
-    queryDistributedFileDirectory().removePhysical("test::testfile1@testgrp2");
-    file.setown(queryDistributedFileDirectory().lookup("test::testfile1"));
+    queryDistributedFileDirectory().removePhysical("test::testfile1@testgrp2",UNKNOWN_USER);
+    file.setown(queryDistributedFileDirectory().lookup("test::testfile1",UNKNOWN_USER));
     for (i=0;i<file->numClusters();i++)
         PROGLOG("cluster[%d] = %s",i,file->getClusterName(i,name.clear()).str());
 }
@@ -233,7 +234,7 @@ void checkFiles(const char *fn)
     if (fn) {
         checker.title(1,fn);
         try {
-            Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(fn);
+            Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(fn,UNKNOWN_USER);
             if (!file)
                 printf("file '%s' not found\n",fn);
             else
@@ -247,7 +248,7 @@ void checkFiles(const char *fn)
         }
     }
     else {
-        Owned<IDistributedFileIterator> iter = queryDistributedFileDirectory().getIterator("*",false);
+        Owned<IDistributedFileIterator> iter = queryDistributedFileDirectory().getIterator("*",false,UNKNOWN_USER);
         unsigned i=0;
         unsigned ss = msTick();
         ForEach(*iter) {
@@ -329,33 +330,33 @@ void testDFile(ClusterPartDiskMapSpec &map)
 {
     {   // 1: single part file old method
 #define TN "1"
-        queryDistributedFileDirectory().removeEntry("test::ftest"TN);
+        queryDistributedFileDirectory().removeEntry("test::ftest"TN,UNKNOWN_USER);
         Owned<IFileDescriptor> fdesc = createFileDescriptor();
         RemoteFilename rfn;
         rfn.setRemotePath("//10.150.10.1/c$/thordata/test/ftest"TN"._1_of_1");
         fdesc->setPart(0,rfn);
         fdesc->endCluster(map);
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
-        file->attach("test::ftest"TN);
+        file->attach("test::ftest"TN,UNKNOWN_USER);
 #undef TN
     }
     {   // 2: single part file new method
 #define TN "2"
-        queryDistributedFileDirectory().removeEntry("test::ftest"TN);
+        queryDistributedFileDirectory().removeEntry("test::ftest"TN,UNKNOWN_USER);
         Owned<IFileDescriptor> fdesc = createFileDescriptor();
         fdesc->setPartMask("ftest"TN"._$P$_of_$N$");
         fdesc->setNumParts(1);
         Owned<IGroup> grp = createIGroup("10.150.10.1");
         fdesc->addCluster(grp,map);
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
-        file->attach("test::ftest"TN);
+        file->attach("test::ftest"TN,UNKNOWN_USER);
 #undef TN
     }
     Owned<IGroup> grp3 = createIGroup("10.150.10.1,10.150.10.2,10.150.10.3");
     queryNamedGroupStore().add("__testgroup3__",grp3,true);
     {   // 3: three parts file old method
 #define TN "3"
-        queryDistributedFileDirectory().removeEntry("test::ftest"TN);
+        queryDistributedFileDirectory().removeEntry("test::ftest"TN,UNKNOWN_USER);
         Owned<IFileDescriptor> fdesc = createFileDescriptor();
         RemoteFilename rfn;
         rfn.setRemotePath("//10.150.10.1/c$/thordata/test/ftest"TN"._1_of_3");
@@ -366,18 +367,18 @@ void testDFile(ClusterPartDiskMapSpec &map)
         fdesc->setPart(2,rfn);
         fdesc->endCluster(map);
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
-        file->attach("test::ftest"TN);
+        file->attach("test::ftest"TN,UNKNOWN_USER);
 #undef TN
     }
     {   // 4: three part file new method
 #define TN "4"
-        queryDistributedFileDirectory().removeEntry("test::ftest"TN);
+        queryDistributedFileDirectory().removeEntry("test::ftest"TN,UNKNOWN_USER);
         Owned<IFileDescriptor> fdesc = createFileDescriptor();
         fdesc->setPartMask("ftest"TN"._$P$_of_$N$");
         fdesc->setNumParts(3);
         fdesc->addCluster(grp3,map);
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(fdesc);
-        file->attach("test::ftest"TN);
+        file->attach("test::ftest"TN,UNKNOWN_USER);
 #undef TN
     }
 }
@@ -589,7 +590,7 @@ void testDF1()
         DistributedFilePropertyLock lock(file);
         lock.queryAttributes().setProp("@testing","1");
     }
-    file->attach("testing::propfile2");
+    file->attach("testing::propfile2",UNKNOWN_USER);
 }
 
 void testDF2() // 4*3 superfile

--- a/dali/sasha/saverify.cpp
+++ b/dali/sasha/saverify.cpp
@@ -221,7 +221,7 @@ public:
 
     void verifyFile(const char *name,CDateTime *cutoff)
     {
-        Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(name);
+        Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(name,UNKNOWN_USER);
         if (!file)
             return;
         IPropertyTree &fileprops = file->queryAttributes();
@@ -343,7 +343,7 @@ public:
             }
         }
         if (!stopped) {
-            file.setown(queryDistributedFileDirectory().lookup(name));
+            file.setown(queryDistributedFileDirectory().lookup(name,UNKNOWN_USER));
             if (!file)
                 return;
             if (afor.ok) {
@@ -411,7 +411,7 @@ public:
             try {
                 PROGLOG("VERIFIER: Started");
                 CFileCrcList filelist(stopped);
-                Owned<IDFAttributesIterator> iter = queryDistributedFileDirectory().getDFAttributesIterator("*",true,false);
+                Owned<IDFAttributesIterator> iter = queryDistributedFileDirectory().getDFAttributesIterator("*",UNKNOWN_USER,true,false);//MORE:Pass IUserDescriptor
                 if (iter) {
                     CDateTime mincutoff;
                     mincutoff.setNow();

--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -1201,7 +1201,7 @@ public:
         CDfsLogicalFileName lfn;
         if (lfn.setFromMask(mask.str(),rootdir)) { // orphans are only orphans if there doesn't exist a valid file
             try {
-                if (queryDistributedFileDirectory().exists(lfn.get(),true,false,NULL)) {
+                if (queryDistributedFileDirectory().exists(lfn.get(),NULL,true,false)) {
                     warn(mask.str(),"Orphans ignored as %s exists",lfn.get());
                     return;
                 }
@@ -1488,7 +1488,7 @@ public:
             lfn.set(lostfiles.item(i0));
             Owned<IDistributedFile> file;
             try {
-                file.setown(queryDistributedFileDirectory().lookup(lfn));
+                file.setown(queryDistributedFileDirectory().lookup(lfn,UNKNOWN_USER));
             }
             catch (IException *e) {
                 EXCLOG(e,"CNewXRefManager::listLost");
@@ -2312,7 +2312,7 @@ public:
             return;
         PROGLOG(LOGPFX2 "Started");
         StringArray expirylist;
-        Owned<IDFAttributesIterator> iter = queryDistributedFileDirectory().getDFAttributesIterator("*",true,false);
+        Owned<IDFAttributesIterator> iter = queryDistributedFileDirectory().getDFAttributesIterator("*",UNKNOWN_USER,true,false);//MORE:Pass IUserDescriptor
         ForEach(*iter) {
             IPropertyTree &attr=iter->query();
             const char * expires = attr.queryProp("@expires");
@@ -2344,7 +2344,7 @@ public:
             const char *lfn = expirylist.item(i);
             PROGLOG(LOGPFX2 "Deleting %s",lfn);
             try {
-                queryDistributedFileDirectory().removePhysical(lfn);
+                queryDistributedFileDirectory().removePhysical(lfn,UNKNOWN_USER);//MORE:Pass IUserDescriptor
             }
             catch (IException *e) { // may want to just detach if fails
                 StringBuffer s;

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -356,7 +356,7 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
             filter.append("*");
         }
 
-        Owned<IDFAttributesIterator> fi = queryDistributedFileDirectory().getDFAttributesIterator(filter, true, false, NULL, userdesc.get());
+        Owned<IDFAttributesIterator> fi = queryDistributedFileDirectory().getDFAttributesIterator(filter, userdesc.get(), true, false, NULL);
         if(!fi)
             throw MakeStringException(ECLWATCH_CANNOT_GET_FILE_ITERATOR,"Cannot get information from file system.");
 
@@ -1066,9 +1066,9 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
 
     synchronized block(m_superfilemutex);
     if(strieq(action, "add"))
-        dfuhelper->addSuper(superfile, num, (const char**) subfileArray.getArray(), beforeSubFile, userdesc.get());
+        dfuhelper->addSuper(superfile, userdesc.get(), num, (const char**) subfileArray.getArray(), beforeSubFile);
     else
-        dfuhelper->removeSuper(superfile, num, (const char**) subfileArray.getArray(), deleteFile, removeSuperfile, userdesc.get());
+        dfuhelper->removeSuper(superfile, userdesc.get(), num, (const char**) subfileArray.getArray(), deleteFile, removeSuperfile);
 
     return num;
 }
@@ -2024,7 +2024,7 @@ void CWsDfuEx::getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *di
         filter.append(dirname);
         filter.append("::*");
         
-        Owned<IDFAttributesIterator> fi = queryDistributedFileDirectory().getDFAttributesIterator(filter.toLowerCase().str(), false,true, NULL, udesc);
+        Owned<IDFAttributesIterator> fi = queryDistributedFileDirectory().getDFAttributesIterator(filter.toLowerCase().str(), udesc, false,true, NULL);
         if(fi)
         {
             StringBuffer size;
@@ -2124,7 +2124,7 @@ void CWsDfuEx::getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *di
         }
     }
 
-    Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(dirname,false);
+    Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(udesc,dirname,false);
     if(iter)
     {
         ForEach(*iter) 
@@ -2506,11 +2506,11 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
         if (bNotInSuperfile)
         {
             fi.setown(createSubFileFilter( 
-                      queryDistributedFileDirectory().getDFAttributesIterator(filter.toLowerCase().str(),true,true, NULL, udesc),udesc,false)); // NB wrapper owns wrapped iterator
+                      queryDistributedFileDirectory().getDFAttributesIterator(filter.toLowerCase().str(),udesc,true,true, NULL),udesc,false)); // NB wrapper owns wrapped iterator
         }
         else
         {
-            fi.setown(queryDistributedFileDirectory().getDFAttributesIterator(filter.toLowerCase().str(),true,true, NULL, udesc));
+            fi.setown(queryDistributedFileDirectory().getDFAttributesIterator(filter.toLowerCase().str(), udesc,true,true, NULL));
         }
         if(!fi)
             throw MakeStringException(ECLWATCH_CANNOT_GET_FILE_ITERATOR,"Cannot get information from file system.");
@@ -3099,7 +3099,7 @@ bool CWsDfuEx::onSuperfileAction(IEspContext &context, IEspSuperfileActionReques
         resp.setRetcode(0);
         if (superfile && *superfile && action && strieq(action, "remove"))
         {
-            Owned<IDistributedSuperFile> fp = queryDistributedFileDirectory().lookupSuperFile(superfile,NULL);
+            Owned<IDistributedSuperFile> fp = queryDistributedFileDirectory().lookupSuperFile(superfile,UNKNOWN_USER);
             if (!fp)
                 resp.setRetcode(-1); //Superfile has been removed.
         }

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2410,7 +2410,7 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
             }
             Owned<IUserDescriptor> udesc=createUserDescriptor();
             udesc->set(u.str(),p.str());
-            if (!queryDistributedFileDirectory().isSuperFile(srcname,foreigndali,udesc))
+            if (!queryDistributedFileDirectory().isSuperFile(srcname,udesc,foreigndali))
                 supercopy = false;
         }
 

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -180,7 +180,7 @@ bool copyWULogicalFiles(IEspContext &context, IConstWorkUnit &cw, const char *cl
                             if (copyLocal)
                             {
                                 StringBuffer wuid;
-                                bool supercopy = queryDistributedFileDirectory().isSuperFile(logicalname, NULL, udesc);
+                                bool supercopy = queryDistributedFileDirectory().isSuperFile(logicalname, udesc, NULL);
                                 doWuFileCopy(*fs, *info, logicalname, cluster, isRoxie, supercopy);
                             }
                             notOnCluster.append(*info.getClear());

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -348,7 +348,7 @@ FILESERVICES_API void FILESERVICES_CALL fsDeleteLogicalFile(ICodeContext *ctx, c
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     StringBuffer uname;
     PrintLog("Deleting NS logical file %s for user %s", lfn.str(),udesc?udesc->getUserName(uname).str():"");
-    if (queryDistributedFileDirectory().removePhysical(lfn.str(),NULL,NULL,udesc))
+    if (queryDistributedFileDirectory().removePhysical(lfn.str(),udesc,NULL,NULL))
     {
         StringBuffer s("DeleteLogicalFile ('");         // ** TBD use removephysical (handles cluster)
         s.append(lfn).append("') done");
@@ -462,7 +462,7 @@ FILESERVICES_API void FILESERVICES_CALL fsRenameLogicalFile(ICodeContext *ctx, c
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     Owned<IMultiException> exceptions = MakeMultiException();
 
-    if (queryDistributedFileDirectory().renamePhysical(lfn.str(),nlfn.str(),exceptions,udesc)) {
+    if (queryDistributedFileDirectory().renamePhysical(lfn.str(),nlfn.str(),udesc,exceptions)) {
         StringBuffer s("RenameLogicalFile ('");
         s.append(lfn).append(", '").append(nlfn).append("') done");
         WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
@@ -1025,7 +1025,7 @@ FILESERVICES_API void FILESERVICES_CALL fsCreateSuperFile(ICodeContext *ctx, con
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     StringBuffer lsfn;
     constructLogicalName(ctx, lsuperfn, lsfn);
-    Owned<IDistributedSuperFile> file = queryDistributedFileDirectory().createSuperFile(lsfn,!sequentialparts,ifdoesnotexist,udesc,transaction);
+    Owned<IDistributedSuperFile> file = queryDistributedFileDirectory().createSuperFile(lsfn,udesc,!sequentialparts,ifdoesnotexist,transaction);
     StringBuffer s("CreateSuperFile ('");
     s.append(lsfn).append("') done");
     AuditMessage(ctx,"CreateSuperFile",lsfn.str());
@@ -1504,7 +1504,7 @@ FILESERVICES_API void FILESERVICES_CALL fsLogicalFileList(ICodeContext *ctx, siz
         mask ="*";
     StringBuffer masklower(mask);
     masklower.toLowerCase();
-    Owned<IDFAttributesIterator> iter = queryDistributedFileDirectory().getForeignDFAttributesIterator(masklower.str(),true,includesuper,foreigndali,ctx->queryUserDescriptor());
+    Owned<IDFAttributesIterator> iter = queryDistributedFileDirectory().getForeignDFAttributesIterator(masklower.str(),ctx->queryUserDescriptor(),true,includesuper,foreigndali);
     if (iter) {
         StringBuffer s;
         ForEach(*iter) {
@@ -1646,7 +1646,7 @@ FILESERVICES_API char *  FILESERVICES_CALL fsVerifyFile(ICodeContext *ctx,const 
     constructLogicalName(ctx, name, lfn);
     StringBuffer retstr;
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
-    if (queryDistributedFileDirectory().filePhysicalVerify(lfn.str(),usecrcs,retstr,udesc))
+    if (queryDistributedFileDirectory().filePhysicalVerify(lfn.str(),udesc,usecrcs,retstr))
         retstr.append("OK");
     return retstr.detach();
 }

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1538,7 +1538,7 @@ IFileDescriptor *checkCloneFrom(const char *id, IFileDescriptor *fdesc)
         CDfsLogicalFileName lfn;
         lfn.set(id);
         lfn.setForeign(cloneFrom, false);
-        Owned<IDistributedFile> cloneFile = queryDistributedFileDirectory().lookup(lfn);
+        Owned<IDistributedFile> cloneFile = queryDistributedFileDirectory().lookup(lfn,UNKNOWN_USER);//MORE:Pass IUserDescriptor
         if (cloneFile)
         {
             Owned<IFileDescriptor> cloneFDesc = cloneFile->getFileDescriptor();
@@ -2798,7 +2798,7 @@ private:
 
             Owned<IDistributedFile> publishFile = queryDistributedFileDirectory().createNew(desc); // MORE - we'll create this earlier if we change the locking paradigm
             publishFile->setAccessedTime(modifiedTime);
-            publishFile->attach(dFile->queryLogicalName(), activity ? activity->queryUserDescriptor() : NULL);
+            publishFile->attach(dFile->queryLogicalName(), activity ? activity->queryUserDescriptor() : UNKNOWN_USER);
             // MORE should probably write to the roxielocalstate too in case Dali is down next time I look...
         }
     }

--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -105,7 +105,7 @@ public:
     }
     inline unsigned elapsedMs()
     {
-        return cycle_to_nanosec(elapsedCycles())/1000000;
+        return static_cast<unsigned>(cycle_to_nanosec(elapsedCycles())/1000000);
     }
 };
 

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1630,7 +1630,7 @@ bool CJobMaster::go()
                 queryThorFileManager().addScope(*this, tmpName, newName, true, true);
                 verifyex(file->renamePhysicalPartFiles(newName.str(), NULL, NULL, queryBaseDirectory()));
 
-                file->attach(newName);
+                file->attach(newName,userDesc);
 
                 Owned<IWorkUnit> wu = &queryWorkUnit().lock();
                 wu->addFile(newName, &clusters, entry.queryUsage(), entry.queryKind(), queryGraphName());


### PR DESCRIPTION
Most calls that accept IUserDescriptor do not require it to be specified
(function prototypes specify "IUserDescriptor *user=NULL"). This leads to
many esp/dali calls with a NULL user, forcing it to use the default user.
Need to make all calls require IUserDescriptor
This fix
1) Changes "IUserDescriptor *user=NULL" to "IUserDescriptor *user"
2) Moves "IUserDescriptor *user" in prototype if there are other default args preceding it
3) Modifies all calls to pass user desc if available
4) Passes NULL if user desc not available, and comment with "//More:Pass IUserDescriptor" if it seems necessary
5) Fix an annoying warning in jdegug "CCycleTimer::elapsedMs"

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
