### PR TITLE
HPCC-8017 Expand huge allocations into adjacent free blocks on resizeRow

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -463,8 +463,17 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             // MORE - maybe add a 'list' function here?
             for (int name = 2; name < argc; name++)
             {
-                CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry(argv[name]);
-                runner.addTest( registry.makeTest() );
+                if (stricmp(argv[name], "-q")==0)
+                {
+                    traceLevel = 0;
+                    roxiemem::memTraceLevel = 0;
+                    removeLog();
+                }
+                else
+                {
+                    CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry(argv[name]);
+                    runner.addTest( registry.makeTest() );
+                }
             }
         }
         bool wasSucessful = runner.run( "", false );


### PR DESCRIPTION
Calls to resizeRow for a huge (>1Mb) memory block will expand the currently
allocated block where possible, rather than always creating a new one and
copying into it.

This can have a significant impact on the fragmentation of the roxiemem
heap.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
