### PR TITLE
HPCC-8018 - Dynamic array causes Windows build failure

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -3902,7 +3902,7 @@ struct SuperFileSubTreeCache
         if (!name)
             name = "UNKNOWN";
         // HACK: This is temporary and should not linger beyond 3.8.x
-        unsigned subList[n];
+        unsigned *subList = (unsigned *) alloca(n * sizeof(unsigned));
         memset(subList, 0, n * sizeof(unsigned));
         // HACKEND
         ForEach (*subit) {


### PR DESCRIPTION
Replace dynamic array variable with alloca, as a 'quick fix' for compilation
errors under Windows.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
