### PR TITLE
HPCC-3017 Configmgr - Context menu display issue on multiselect

### DIFF
--- a/esp/files/scripts/configmgr/navtree.js
+++ b/esp/files/scripts/configmgr/navtree.js
@@ -579,7 +579,7 @@ function createNavigationTree(navTreeData) {
     }
 
     navDT.clearTextSelection();
-    if (oArgs.event.button === 2)
+    if (oArgs.event.button === 2 && navDT.getSelectedRows().length == 1)
       navDT.onEventSelectRow(oArgs);
 
     var selectedRows;


### PR DESCRIPTION
- Right clicking to bring up context menu during multi-select no longer
  will require the shift is depressed.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
