### PR TITLE
HPCC-7937 Throw an error on ambiguous prop tree get

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -1716,13 +1716,7 @@ IPropertyTree *PTree::queryPropTree(const char *xpath) const
     {
         element = &iter->query();
         if (iter->next())
-        {
-#ifdef _DEBUG
             AMBIGUOUS_PATH("getProp",xpath);
-#else
-            LOG(MCoperatorWarning, unknownJob, "getProp: ambiguous xpath '%s', in parent node '%s'", xpath, queryName());
-#endif
-        }
     }
     return element;
 }


### PR DESCRIPTION
Previously, IPropertyTree::get\* used only to throw an exception in
debug builds only. Letting unintented ambiguous nodes go by,
only leads to future confusion/corruption.
This change means it will always throw an exception.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
