### PR TITLE
HPCC-8025 The complete-uninstall script should not remove unrelated pack...

### DIFF
--- a/initfiles/sbin/complete-uninstall.sh.in
+++ b/initfiles/sbin/complete-uninstall.sh.in
@@ -24,14 +24,8 @@ set_environmentvars
 
 if [ -e /etc/debian_version ]; then
     dpkg --purge hpccsystems-platform
-    dpkg --purge hpccsystems-clienttools
-    dpkg --purge hpccsystems-graphcontrol
-    dpkg --purge hpccsystems-documentation
 elif [ -e /etc/redhat-release -o -e /etc/SuSE-release ]; then
     echo "Removing RPM"
-    rpm -e hpccsystems-clienttools
-    rpm -e hpccsystems-graphcontrol
-    rpm -e hpccsystems-documentation
     rpm -e hpccsystems-platform
 fi
 


### PR DESCRIPTION
...ages

There is now no relationship/dependency between the graphcontrol or clienttools
packages and the platform package, so uninstall of the package should not
imply that the others should be removed too.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
