### PR TITLE
HPPC-7873 Remove call to reset a workunit which was in the wrong place

### DIFF
--- a/ecl/hqlcpp/hqlecl.cpp
+++ b/ecl/hqlcpp/hqlecl.cpp
@@ -248,8 +248,6 @@ bool HqlDllGenerator::generatePackage(const char * packageName)
 
 bool HqlDllGenerator::generateCode(HqlQueryContext & query)
 {
-    wu->resetBeforeGeneration();
-
     noOutput = true;
     {
         // ensure warnings/errors are available before we do the processing...


### PR DESCRIPTION
There was a call to wu->resetBeforeGeneration() which was there for the
legacy code to allow workunits to be recompiled.  It should be in the
legacy code instead.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
