### PR TITLE
HPCC-8027 skew percentages not visible in graph

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -2600,8 +2600,8 @@ CThorStats::CThorStats(const char *_prefix)
     {
         labelMin.set("min");
         labelMax.set("max");
-        labelMinSkew.set("minSkew");
-        labelMaxSkew.set("maxSkew");
+        labelMinSkew.set("minskew");
+        labelMaxSkew.set("maxskew");
         labelMinEndpoint.set("minEndpoint");
         labelMaxEndpoint.set("maxEndpoint");
     }


### PR DESCRIPTION
A casing change to minSkew/maxSkew caused the skew percentages
not to show up in the graph control.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
