### PR TITLE
HPCC-559 Set time out value for deleting logical file

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -220,7 +220,7 @@ interface IDistributedFile: extends IInterface
     virtual const char *queryPartMask() = 0;                                    // default part name mask
 
     virtual void attach(const char *logicalname,IUserDescriptor *user=NULL) = 0;// attach to name in DFS
-    virtual void detach() = 0;                                                  // no longer attached to name in DFS
+    virtual void detach(unsigned timeoutms=INFINITE) = 0;                     // no longer attached to name in DFS
 
     virtual IPropertyTree &queryAttributes() = 0;                               // DFile attributes
 
@@ -457,7 +457,7 @@ interface IDistributedFileDirectory: extends IInterface
 
     virtual IDFScopeIterator *getScopeIterator(const char *subscope=NULL,bool recursive=true,bool includeempty=false, IUserDescriptor *user=NULL)=0;
 
-    virtual bool removeEntry(const char *name,IUserDescriptor *user=NULL) = 0;  // equivalent to lookup/detach/release
+    virtual bool removeEntry(const char *name,IUserDescriptor *user=NULL, unsigned timeoutms=INFINITE) = 0;  // equivalent to lookup/detach/release
     virtual bool removePhysical(const char *name,const char *cluster=NULL,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                           // removes the physical parts as well as entry
     virtual bool renamePhysical(const char *oldname,const char *newname,IMultiException *exceptions=NULL,IUserDescriptor *user=NULL) = 0;                         // renames the physical parts as well as entry
     virtual void removeEmptyScope(const char *scope) = 0;   // does nothing if called on non-empty scope

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -212,12 +212,12 @@ offset_t CDistributedFileSystem::getSize(IDistributedFile * file, bool forceget,
     return totalSize;
 }
 
-bool CDistributedFileSystem::remove(IDistributedFile * file,const char *cluster,IMultiException *mexcept)
+bool CDistributedFileSystem::remove(IDistributedFile * file,const char *cluster,IMultiException *mexcept, unsigned timeoutms)
 {
     // this is now equivalent to removePhysicalPartFiles as linux uses dafilesrv by default
     if (!cluster||((file->findCluster(cluster)==0)&&(file->numClusters()==1))) {
         cluster = NULL; // deleting the last cluster removes the file
-        file->detach(); 
+        file->detach(timeoutms);
     }
     return file->removePhysicalPartFiles(cluster,mexcept); // this is bit cavalier with errors - but better orphans than inconsistant DFS
 }

--- a/dali/ft/daft.hpp
+++ b/dali/ft/daft.hpp
@@ -72,7 +72,7 @@ interface IDistributedFileSystem : public IInterface
     virtual offset_t getSize(IDistributedFile * file,
                              bool forceget=false,                               // if true gets physical size (ignores cached attribute)
                              bool dontsetattr=true) = 0;                        // if true doesn't set attribute when physical size got
-    virtual bool remove(IDistributedFile * file,const char *clustername=NULL,IMultiException *mexcept=NULL) = 0;
+    virtual bool remove(IDistributedFile * file,const char *clustername=NULL,IMultiException *mexcept=NULL, unsigned timeoutms=INFINITE) = 0;
     virtual bool compress(IDistributedFile * file) = 0;                                                  
     virtual offset_t getCompressedSize(IDistributedFile * part) = 0;
 

--- a/dali/ft/daft.ipp
+++ b/dali/ft/daft.ipp
@@ -42,7 +42,7 @@ public:
 
 //operations on a single file.
     virtual offset_t getSize(IDistributedFile * file,bool forceget,bool dontsetattr);
-    virtual bool remove(IDistributedFile * file,const char *cluster=NULL,IMultiException *mexcept=NULL);
+    virtual bool remove(IDistributedFile * file,const char *cluster=NULL,IMultiException *mexcept=NULL, unsigned timeoutms=INFINITE);
     virtual bool compress(IDistributedFile * file);                                                  
     virtual offset_t getCompressedSize(IDistributedFile * part);
 

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -68,6 +68,8 @@ static const char* FEATURE_URL="DfuAccess";
 #define     COUNTBY_MONTH   "Month"
 #define     COUNTBY_DAY     "Day"
 
+#define REMOVE_FILE_SDS_CONNECT_TIMEOUT (1000*15)  // 15 seconds
+
 const int DESCRIPTION_DISPLAY_LENGTH = 12;
 const unsigned MAX_VIEWKEYFILE_ROWS = 1000;
 const unsigned MAX_KEY_ROWS = 20;
@@ -1231,7 +1233,7 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                 if(!req.getNoDelete() && !df->querySuperFile())
                 {
                     Owned<IMultiException> pExceptionHandler = MakeMultiException();
-                    deleted = queryDistributedFileSystem().remove(df,cname.length()?cname.str():NULL,pExceptionHandler);
+                    deleted = queryDistributedFileSystem().remove(df,cname.length()?cname.str():NULL,pExceptionHandler, REMOVE_FILE_SDS_CONNECT_TIMEOUT);
                     StringBuffer errorStr;
                     pExceptionHandler->errorMessage(errorStr);
                     if (errorStr.length() > 0)
@@ -1248,7 +1250,7 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                 else
                 {
                     df.clear(); 
-                    deleted = queryDistributedFileDirectory().removeEntry(logicalFileName.str(),userdesc); // this can remove clusters also
+                    deleted = queryDistributedFileDirectory().removeEntry(logicalFileName.str(),userdesc, REMOVE_FILE_SDS_CONNECT_TIMEOUT); // this can remove clusters also
                     if (deleted)
                         returnStr.appendf("<Message><Value>Detached File %s</Value></Message>", logicalFileName.str());
                 }


### PR DESCRIPTION
When a file cannot be deleted because it is locked, the existing code
blocks the process until SDS connection reaches a default time out.
The default time out is 2 hours. This fix allows a time out value (15
seconds) being set in ESP Ws_dfu service. If the the SDS connection
reaches the time out value. an exception will be thrown and returned
by the ESP service.

This fix changes several daft/dfdfs methods in order to pass the time
out value to the file operation. If the time out value is not set,
those methods uses the default time out value (INFINITE) which is used
before this fix.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
