### PR TITLE
HPCC-8051 Fix warnings caused by implicit cast in jdebug.hpp

### DIFF
--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -105,7 +105,7 @@ public:
     }
     inline unsigned elapsedMs()
     {
-        return cycle_to_nanosec(elapsedCycles())/1000000;
+        return static_cast<unsigned>(cycle_to_nanosec(elapsedCycles())/1000000);
     }
 };
 


### PR DESCRIPTION
jdebug.hpp is causing warnings throughout the windows build.
Doing the cast explicitly fixes the warning.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
