### PR TITLE
HPCC-1744 Added sub uninstall to match the sub install

### DIFF
--- a/deployment/deploy/CMakeLists.txt
+++ b/deployment/deploy/CMakeLists.txt
@@ -65,4 +65,5 @@ target_link_libraries ( deploy
 
 if ( PLATFORM )
     install ( PROGRAMS configesp.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS configesp.uninstall DESTINATION etc/init.d/uninstall COMPONENT Runtime )
 endif()

--- a/deployment/deploy/configesp.uninstall
+++ b/deployment/deploy/configesp.uninstall
@@ -1,0 +1,1 @@
+removeSymlink "$binPath/configesp"

--- a/ecl/ecl-package/CMakeLists.txt
+++ b/ecl/ecl-package/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries ( ecl-packagemap
     )
 
 if ( UNIX )
-install ( PROGRAMS ecl-package.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS ecl-package.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS ecl-package.uninstall DESTINATION etc/init.d/uninstall COMPONENT Runtime )
 endif ( UNIX )
 

--- a/ecl/ecl-package/ecl-package.uninstall
+++ b/ecl/ecl-package/ecl-package.uninstall
@@ -1,0 +1,1 @@
+removeSymlink "/usr/bin/ecl-packagemap"

--- a/ecl/eclcmd/queries/CMakeLists.txt
+++ b/ecl/eclcmd/queries/CMakeLists.txt
@@ -52,5 +52,6 @@ target_link_libraries ( ecl-queries
     )
 
 if (UNIX)
-install ( PROGRAMS ecl-queries.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS ecl-queries.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS ecl-queries.uninstall DESTINATION etc/init.d/uninstall COMPONENT Runtime )
 endif (UNIX)

--- a/ecl/eclcmd/queries/ecl-queries.uninstall
+++ b/ecl/eclcmd/queries/ecl-queries.uninstall
@@ -1,0 +1,1 @@
+removeSymlink "/usr/bin/ecl-queries"

--- a/ecl/eclcmd/roxie/CMakeLists.txt
+++ b/ecl/eclcmd/roxie/CMakeLists.txt
@@ -52,5 +52,6 @@ target_link_libraries ( ecl-roxie
     )
 
 if (UNIX)
-install ( PROGRAMS ecl-roxie.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS ecl-roxie.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS ecl-roxie.uninstall DESTINATION etc/init.d/uninstall COMPONENT Runtime )
 endif (UNIX)

--- a/ecl/eclcmd/roxie/ecl-roxie.uninstall
+++ b/ecl/eclcmd/roxie/ecl-roxie.uninstall
@@ -1,0 +1,1 @@
+removeSymlink "/usr/bin/ecl-roxie"

--- a/esp/tools/soapplus/CMakeLists.txt
+++ b/esp/tools/soapplus/CMakeLists.txt
@@ -62,4 +62,5 @@ ENDFOREACH ( iFILES )
 
 if ( PLATFORM )
     install ( PROGRAMS soapplus.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS soapplus.uninstall DESTINATION etc/init.d/uninstall COMPONENT Runtime )
 endif()

--- a/esp/tools/soapplus/soapplus.uninstall
+++ b/esp/tools/soapplus/soapplus.uninstall
@@ -1,0 +1,1 @@
+removeSymlink "/usr/bin/soapplus"

--- a/initfiles/bash/etc/init.d/CMakeLists.txt
+++ b/initfiles/bash/etc/init.d/CMakeLists.txt
@@ -35,4 +35,5 @@ ENDFOREACH ( oFILES )
 
 if ( PLATFORM )
     install ( PROGRAMS hpcc-init.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS hpcc-init.uninstall DESTINATION etc/init.d/uninstall COMPONENT Runtime )
 endif()

--- a/initfiles/bash/etc/init.d/hpcc-init.uninstall
+++ b/initfiles/bash/etc/init.d/hpcc-init.uninstall
@@ -1,0 +1,2 @@
+removeSymlink "/etc/init.d/hpcc-init"
+removeSymlink "/etc/init.d/dafilesrv"

--- a/initfiles/bash/etc/init.d/uninstall-init.in
+++ b/initfiles/bash/etc/init.d/uninstall-init.in
@@ -54,3 +54,10 @@ if [ -d ${INSTALL_DIR}/etc/bash_completion.d ] && [ -d /etc/bash_completion.d ];
         removeSymlink /etc/bash_completion.d/$subInstall
     done
 fi
+
+# locate sub uninstall files.
+if [ -d ${INSTALL_DIR}/etc/init.d/uninstall ]; then
+    for subUnInstall in $(ls ${INSTALL_DIR}/etc/init.d/uninstall); do
+        source ${INSTALL_DIR}/etc/init.d/uninstall/${subUnInstall}
+    done
+fi

--- a/tools/testsocket/CMakeLists.txt
+++ b/tools/testsocket/CMakeLists.txt
@@ -39,4 +39,5 @@ install ( TARGETS testsocket RUNTIME DESTINATION ${EXEC_DIR} )
 
 if ( PLATFORM )
     install ( PROGRAMS testsocket.install DESTINATION etc/init.d/install COMPONENT Runtime )
+    install ( PROGRAMS testsocket.uninstall DESTINATION etc/init.d/uninstall COMPONENT Runtime )
 endif()

--- a/tools/testsocket/testsocket.uninstall
+++ b/tools/testsocket/testsocket.uninstall
@@ -1,0 +1,1 @@
+removeSymlink "/usr/bin/testsocket"


### PR DESCRIPTION
Added a loop to the prerm call for uninstall-init, this loop
allows for sub uninstalls to be preformed.

I have also added uninstall files for each install file there is.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
