### PR TITLE
HPCC-8002 Refactor hashdist(send) to use thread pool of senders

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -591,10 +591,12 @@ ITimeReporter *timer;
 ITimeReporter *createStdTimeReporter() { return new DefaultTimeReporter(); }
 ITimeReporter *createStdTimeReporter(MemoryBuffer &mb) { return new DefaultTimeReporter(mb); }
 
+cycle_t oneSecInCycles;
 MODULE_INIT(INIT_PRIORITY_JDEBUG1)
 {
     // perform v. early in process startup, ideally this would grab process exclusively for the 2 100ths of a sec it performs calc.
     calibrate_timing();
+    oneSecInCycles = nanosec_to_cycle(1000000000);
     return 1;
 }
 

--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -87,6 +87,7 @@ struct ITimeReporter : public IInterface
   virtual void serialize(MemoryBuffer &mb) = 0;
 };
 
+extern jlib_decl cycle_t oneSecInCycles;
 class CCycleTimer
 {
     cycle_t start_time;
@@ -108,6 +109,7 @@ public:
         return static_cast<unsigned>(cycle_to_nanosec(elapsedCycles())/1000000);
     }
 };
+inline cycle_t queryOneSecCycles() { return oneSecInCycles; }
 
 class jlib_decl TimeSection
 {

--- a/thorlcr/activities/fetch/thfetchslave.cpp
+++ b/thorlcr/activities/fetch/thfetchslave.cpp
@@ -199,7 +199,6 @@ public:
             keyOutStream.clear();
         }
         distributor->disconnect(true);  
-        distributor->removetemp();
         distributor->join();
         stopInput();
     }

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.ipp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.ipp
@@ -31,7 +31,6 @@ interface IRowStreamWithMetaData: extends IRowStream
 interface IHashDistributor: extends IInterface
 {
     virtual IRowStream *connect(IRowStream *in, IHash *_ihash, ICompare *_icompare)=0;
-    virtual IRowStreamWithMetaData *connect(IRowStreamWithMetaData *in, size32_t sizemeta, IHash *_ihash, ICompare *_icompare)=0;
     virtual void disconnect(bool stop)=0;
     virtual void removetemp()=0;
     virtual void join()=0;

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.ipp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.ipp
@@ -32,7 +32,6 @@ interface IHashDistributor: extends IInterface
 {
     virtual IRowStream *connect(IRowStream *in, IHash *_ihash, ICompare *_icompare)=0;
     virtual void disconnect(bool stop)=0;
-    virtual void removetemp()=0;
     virtual void join()=0;
     virtual void setBufferSizes(unsigned _sendBufferSize, unsigned _outputBufferSize, unsigned _pullBufferSize) = 0;
 };

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.ipp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.ipp
@@ -30,10 +30,10 @@ interface IRowStreamWithMetaData: extends IRowStream
 
 interface IHashDistributor: extends IInterface
 {
-    virtual IRowStream *connect(IRowStream *in, IHash *_ihash, ICompare *_icompare)=0;
+    virtual IRowStream *connect(IRowStream *in, IHash *ihash, ICompare *icompare)=0;
     virtual void disconnect(bool stop)=0;
     virtual void join()=0;
-    virtual void setBufferSizes(unsigned _sendBufferSize, unsigned _outputBufferSize, unsigned _pullBufferSize) = 0;
+    virtual void setBufferSizes(unsigned sendBufferSize, unsigned outputBufferSize, unsigned pullBufferSize) = 0;
 };
 
 interface IStopInput;

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2754,6 +2754,12 @@ IOutputRowDeserializer * CActivityBase::queryRowDeserializer()
     return rowDeserializer;
 }
 
+IRowInterfaces *CActivityBase::getRowInterfaces()
+{
+    // create an independent instance, to avoid circular link dependency problems
+    return createRowInterfaces(queryRowMetaData(), container.queryId(), queryCodeContext());
+}
+
 bool CActivityBase::receiveMsg(CMessageBuffer &mb, const rank_t rank, const mptag_t mpTag, rank_t *sender, unsigned timeout)
 {
     BooleanOnOff onOff(receiving);

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -879,6 +879,7 @@ public:
     virtual void markWuDirty() { };
     virtual __int64 getWorkUnitValueInt(const char *prop, __int64 defVal) const = 0;
     virtual StringBuffer &getWorkUnitValue(const char *prop, StringBuffer &str) const = 0;
+    virtual bool getWorkUnitValueBool(const char *prop, bool defVal) const = 0;
     const char *queryWuid() const { return wuid.str(); }
     const char *queryUser() const { return user.str(); }
     const char *queryScope() const { return scope.str(); }

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -960,7 +960,7 @@ public:
     bool firstNode() { return 1 == container.queryJob().queryMyRank(); }
     bool lastNode() { return container.queryJob().querySlaves() == container.queryJob().queryMyRank(); }
     unsigned queryMaxCores() const { return maxCores; }
-
+    IRowInterfaces *getRowInterfaces();
 
     virtual void setInput(unsigned index, CActivityBase *inputActivity, unsigned inputOutIdx) { }
     virtual void clearConnections() { }

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1706,6 +1706,11 @@ __int64 CJobMaster::getWorkUnitValueInt(const char *prop, __int64 defVal) const
     return queryWorkUnit().getDebugValueInt64(prop, defVal);
 }
 
+bool CJobMaster::getWorkUnitValueBool(const char *prop, bool defVal) const
+{
+    return queryWorkUnit().getDebugValueBool(prop, defVal);
+}
+
 StringBuffer &CJobMaster::getWorkUnitValue(const char *prop, StringBuffer &str) const
 {
     SCMStringBuffer scmStr;

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -166,7 +166,7 @@ public:
 
     virtual __int64 getWorkUnitValueInt(const char *prop, __int64 defVal) const;
     virtual StringBuffer &getWorkUnitValue(const char *prop, StringBuffer &str) const;
-    
+    virtual bool getWorkUnitValueBool(const char *prop, bool defVal) const;
     virtual IBarrier *createBarrier(mptag_t tag);
 
 // IExceptionHandler

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1121,8 +1121,15 @@ __int64 CJobSlave::getWorkUnitValueInt(const char *prop, __int64 defVal) const
 
 StringBuffer &CJobSlave::getWorkUnitValue(const char *prop, StringBuffer &str) const
 {
-    workUnitInfo->queryPropTree("Debug")->getProp(prop, str);
+    StringBuffer propName(prop);
+    workUnitInfo->queryPropTree("Debug")->getProp(propName.toLowerCase().str(), str);
     return str;
+}
+
+bool CJobSlave::getWorkUnitValueBool(const char *prop, bool defVal) const
+{
+    StringBuffer propName(prop);
+    return workUnitInfo->queryPropTree("Debug")->getPropBool(propName.toLowerCase().str(), defVal);
 }
 
 IBarrier *CJobSlave::createBarrier(mptag_t tag)

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -157,6 +157,7 @@ public:
 
     virtual __int64 getWorkUnitValueInt(const char *prop, __int64 defVal) const;
     virtual StringBuffer &getWorkUnitValue(const char *prop, StringBuffer &str) const;
+    virtual bool getWorkUnitValueBool(const char *prop, bool defVal) const;
     virtual IGraphTempHandler *createTempHandler(bool errorOnMissing);
     virtual CGraphBase *createGraph()
     {

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -57,19 +57,10 @@ extern graph_decl ISmartRowBuffer * createSmartBuffer(CActivityBase *activity, c
                                                       ); 
 
 
-interface ISRBRowInterface: extends IInterface  
-{
-    virtual size32_t rowMemSize(const void *r)=0;
-    virtual void releaseRow(const void *row)=0;
-};
-
-
-
 extern graph_decl ISmartRowBuffer * createSmartInMemoryBuffer(CActivityBase *activity,
                                                       IRowInterfaces *rowIf,
-                                                      size32_t buffsize, 
-                                                      ISRBRowInterface *srbrowif=NULL // only needed if not thor rows
-                                                      ); 
+                                                      size32_t buffsize);
+
 interface ISharedSmartBuffer : extends IRowWriter
 {
     virtual IRowStream *queryOutput(unsigned output) = 0;


### PR DESCRIPTION
- Tidy/remove legacy HDD meta scheme
- Add option to allow receiver to spill disk
- Refactor hashdist(send) to use thread pool of senders

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
