### PR TITLE
HPCC-7979 Ensure persistent settings reset at end of job

### DIFF
--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -986,11 +986,13 @@ public:
         sizeInMem = 0;
         setMemLimit(_memLimit);
     }
-    void setMemLimit(size32_t _memLimit)
+    size32_t setMemLimit(size32_t _memLimit)
     {
+        size32_t oldMemLimit = memLimit;
         memLimit = _memLimit;
         if (full())
             makeSpace();
+        return oldMemLimit;
     }
     virtual void makeSpace()
     {
@@ -1050,28 +1052,33 @@ public:
         return preloadNodes;
     }
 
-    inline void setNodeCachePreload(bool _preload) 
+    inline bool setNodeCachePreload(bool _preload)
     {
+        bool oldPreloadNodes = preloadNodes;
         preloadNodes = _preload;
+        return oldPreloadNodes;
     }
 
-    inline void setNodeCacheMem(size32_t newSize) 
+    inline size32_t setNodeCacheMem(size32_t newSize)
     {
         SpinBlock block(lock);
-        nodeCache.setMemLimit(newSize);
-        cacheNodes = (newSize != 0); 
+        unsigned oldV = nodeCache.setMemLimit(newSize);
+        cacheNodes = (newSize != 0);
+        return oldV;
     }
-    inline void setLeafCacheMem(size32_t newSize) 
+    inline size32_t setLeafCacheMem(size32_t newSize)
     {
         SpinBlock block(lock);
-        leafCache.setMemLimit(newSize);
+        unsigned oldV = leafCache.setMemLimit(newSize);
         cacheLeaves = (newSize != 0); 
+        return oldV;
     }
-    inline void setBlobCacheMem(size32_t newSize) 
+    inline size32_t setBlobCacheMem(size32_t newSize)
     {
         SpinBlock block(lock);
-        blobCache.setMemLimit(newSize);
+        unsigned oldV = blobCache.setMemLimit(newSize);
         cacheBlobs = (newSize != 0); 
+        return oldV;
     }
     void clear()
     {
@@ -1104,11 +1111,10 @@ inline CKeyStore *queryKeyStore()
     return keyStore;
 }
 
-void setKeyIndexCacheSize(unsigned limit)
+unsigned setKeyIndexCacheSize(unsigned limit)
 {
-    queryKeyStore()->setKeyCacheLimit(limit);
+    return queryKeyStore()->setKeyCacheLimit(limit);
 }
-
 
 CKeyStore::CKeyStore() : keyIndexCache(defaultKeyIndexLimit)
 {
@@ -1131,9 +1137,9 @@ CKeyStore::~CKeyStore()
 {
 }
 
-void CKeyStore::setKeyCacheLimit(unsigned limit)
+unsigned CKeyStore::setKeyCacheLimit(unsigned limit)
 {
-    keyIndexCache.setCacheLimit(limit);
+    return keyIndexCache.setCacheLimit(limit);
 }
 
 IKeyIndex *CKeyStore::doload(const char *fileName, unsigned crc, IReplicatedFile *part, IFileIO *iFileIO, IMemoryMappedFile *iMappedFile, bool isTLK, bool allowPreload)
@@ -2061,24 +2067,24 @@ extern jhtree_decl bool isKeyFile(const char *filename)
     return false;
 }
 
-extern jhtree_decl void setNodeCachePreload(bool preload)
+extern jhtree_decl bool setNodeCachePreload(bool preload)
 {
-    queryNodeCache()->setNodeCachePreload(preload);
+    return queryNodeCache()->setNodeCachePreload(preload);
 }
 
-extern jhtree_decl void setNodeCacheMem(size32_t cacheSize)
+extern jhtree_decl size32_t setNodeCacheMem(size32_t cacheSize)
 {
-    queryNodeCache()->setNodeCacheMem(cacheSize);
+    return queryNodeCache()->setNodeCacheMem(cacheSize);
 }
 
-extern jhtree_decl void setLeafCacheMem(size32_t cacheSize)
+extern jhtree_decl size32_t setLeafCacheMem(size32_t cacheSize)
 {
-    queryNodeCache()->setLeafCacheMem(cacheSize);
+    return queryNodeCache()->setLeafCacheMem(cacheSize);
 }
 
-extern jhtree_decl void setBlobCacheMem(size32_t cacheSize)
+extern jhtree_decl size32_t setBlobCacheMem(size32_t cacheSize)
 {
-    queryNodeCache()->setBlobCacheMem(cacheSize);
+    return queryNodeCache()->setBlobCacheMem(cacheSize);
 }
 
 

--- a/system/jhtree/jhtree.hpp
+++ b/system/jhtree/jhtree.hpp
@@ -107,12 +107,13 @@ interface IReplicatedFile;
 
 extern jhtree_decl void clearKeyStoreCache(bool killAll);
 extern jhtree_decl void clearKeyStoreCacheEntry(const char *name);
-extern jhtree_decl void setKeyIndexCacheSize(unsigned limit);
+extern jhtree_decl unsigned setKeyIndexCacheSize(unsigned limit);
 extern jhtree_decl void clearNodeCache();
-extern jhtree_decl void setNodeCachePreload(bool preload);
-extern jhtree_decl void setNodeCacheMem(size32_t cacheSize);
-extern jhtree_decl void setLeafCacheMem(size32_t cacheSize);
-extern jhtree_decl void setBlobCacheMem(size32_t cacheSize);
+// these methods return previous values
+extern jhtree_decl bool setNodeCachePreload(bool preload);
+extern jhtree_decl size32_t setNodeCacheMem(size32_t cacheSize);
+extern jhtree_decl size32_t setLeafCacheMem(size32_t cacheSize);
+extern jhtree_decl size32_t setBlobCacheMem(size32_t cacheSize);
 
 
 extern jhtree_decl IKeyIndex *createKeyIndex(const char *filename, unsigned crc, bool isTLK, bool preloadAllowed);

--- a/system/jhtree/jhtree.ipp
+++ b/system/jhtree/jhtree.ipp
@@ -49,7 +49,7 @@ public:
     IKeyIndex *load(const char *fileName, unsigned crc, IReplicatedFile &part, bool isTLK, bool allowPreload);
     void clearCache(bool killAll);
     void clearCacheEntry(const char *name);
-    void setKeyCacheLimit(unsigned limit);
+    unsigned setKeyCacheLimit(unsigned limit);
     StringBuffer &getMetrics(StringBuffer &xml);
     void resetMetrics();
 };

--- a/system/jhtree/jhutil.hpp
+++ b/system/jhtree/jhutil.hpp
@@ -128,11 +128,13 @@ class CMRUCacheMaxCountOf : public CMRUCacheOf<KEY, ENTRY, MAPPING, TABLE>
     unsigned cacheOverflow; // # to clear if full
 public:
     CMRUCacheMaxCountOf(unsigned _cacheMax) : cacheMax(_cacheMax) { cacheOverflow = 1; }
-    void setCacheLimit(unsigned _cacheMax)
+    unsigned setCacheLimit(unsigned _cacheMax)
     {
         if (SELF::table.count() > _cacheMax)
             this->clear(_cacheMax - SELF::table.count());
+        unsigned oldCacheMax = cacheMax;
         cacheMax = _cacheMax;
+        return oldCacheMax;
     }
     virtual void makeSpace()
     {

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1007,6 +1007,7 @@ CJobSlave::CJobSlave(ISlaveWatchdog *_watchdog, IPropertyTree *_workUnitInfo, co
 
     init();
 
+    oldNodeCacheMem = 0;
     mpJobTag = _mpJobTag;
     slavemptag = _slavemptag;
 
@@ -1071,7 +1072,8 @@ void CJobSlave::startJob()
     unsigned pinterval = globals->getPropInt("@system_monitor_interval",1000*60);
     if (pinterval)
         startPerformanceMonitor(pinterval);
-    if (pinterval) {
+    if (pinterval)
+    {
         perfmonhook.setown(createThorMemStatsPerfMonHook());
         startPerformanceMonitor(pinterval,PerfMonStandard,perfmonhook);
     }
@@ -1094,7 +1096,7 @@ void CJobSlave::startJob()
     unsigned keyNodeCacheMB = (unsigned)getWorkUnitValueInt("keyNodeCacheMB", 0);
     if (keyNodeCacheMB)
     {
-        setNodeCacheMem(keyNodeCacheMB * 0x100000);
+        oldNodeCacheMem = setNodeCacheMem(keyNodeCacheMB * 0x100000);
         PROGLOG("Key node cache size set to: %d MB", keyNodeCacheMB);
     }
     unsigned keyFileCacheLimit = (unsigned)getWorkUnitValueInt("keyFileCacheLimit", 0);
@@ -1109,6 +1111,8 @@ void CJobSlave::endJob()
     stopPerformanceMonitor();
     LOG(MCdebugProgress, thorJob, "Job ended : %s", graphName.get());
     clearKeyStoreCache(true);
+    if (oldNodeCacheMem)
+        setNodeCacheMem(oldNodeCacheMem);
     PrintMemoryStatusLog();
 }
 

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -141,6 +141,7 @@ class graphslave_decl CJobSlave : public CJobBase
     Owned<IPerfMonHook> perfmonhook;
     Owned<IPropertyTree> workUnitInfo;
     CriticalSection graphRunCrit;
+    size32_t oldNodeCacheMem;
 
     void startJob();
     void endJob();


### PR DESCRIPTION
If a job specified a 'keyNodeCacheMB' settin, it remained set
at that settings for all future jobs.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
