### PR TITLE
HPCC-8013 Ecl Packagemap add needs to add logical file info to dali

### DIFF
--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -510,6 +510,8 @@ public:
                 }
                 continue;
             }
+            if (iter.matchOption(optDaliIP, ECLOPT_DALIIP))
+                continue;
             if (iter.matchFlag(optActivate, ECLOPT_ACTIVATE)||iter.matchFlag(optActivate, ECLOPT_ACTIVATE_S))
                 continue;
             if (iter.matchFlag(optOverWrite, ECLOPT_OVERWRITE)||iter.matchFlag(optOverWrite, ECLOPT_OVERWRITE_S))
@@ -558,6 +560,8 @@ public:
         request->setTarget(optTarget);
         request->setPackageMap(optFileName);
         request->setProcess(optProcess);
+        request->setDaliIp(optDaliIP);
+        request->setOverWrite(optOverWrite);
 
         Owned<IClientAddPackageResponse> resp = packageProcessClient->AddPackage(request);
         if (resp->getExceptions().ordinality())
@@ -576,6 +580,7 @@ public:
                     " Options:\n"
                     "   -O, --overwrite             overwrite existing information\n"
                     "   -A, --activate              activate the package information\n"
+                    "   --daliip=<ip>               ip of the remote dali to use for logical file lookups"
 // NOT-YET          "  --packageprocessname         if not set use this package process name for all clusters"
                     "   <target>                    name of target to use when adding package map information\n"
                     "   <filename>                  name of file containing package map information\n",
@@ -590,7 +595,7 @@ private:
     bool optActivate;
     bool optOverWrite;
     StringBuffer pkgInfo;
-
+    StringAttr optDaliIP;
 };
 
 

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -27,6 +27,7 @@ ESPrequest AddPackageRequest
     string Target;
     string PackageMap;
     string Process;
+    string DaliIp;
 };
 
 

--- a/esp/services/ws_packageprocess/CMakeLists.txt
+++ b/esp/services/ws_packageprocess/CMakeLists.txt
@@ -22,6 +22,8 @@ set (    SRCS
          ws_packageprocessService.cpp
          ws_packageprocessService.hpp
          packageprocess_errors.h
+         ${HPCC_SOURCE_DIR}/common/roxiemanager/referencedfilelist.cpp
+         ${HPCC_SOURCE_DIR}/common/roxiemanager/referencedfilelist.hpp
     )
 
 include_directories (
@@ -40,6 +42,9 @@ include_directories (
          ${HPCC_SOURCE_DIR}/common/environment
          ${HPCC_SOURCE_DIR}/dali/dfu
          ${HPCC_SOURCE_DIR}/common/remote
+         ${HPCC_SOURCE_DIR}/common/roxiemanager
+         ${HPCC_SOURCE_DIR}/common/workunit
+         ${HPCC_SOURCE_DIR}/rtl/include
     )
 
 ADD_DEFINITIONS( -D_USRDLL )
@@ -54,5 +59,6 @@ target_link_libraries ( ws_packageprocess
          securesocket
          dalibase
          ws_fs
+         roxiemanager
     )
 

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -104,7 +104,10 @@ bool isFileKnownOnCluster(const char *logicalname, const char *lookupDaliIp, con
     Owned<IDistributedFile> dst = queryDistributedFileDirectory().lookup(logicalname, userdesc, true);
     if (dst)
     {
-        if (dst->findCluster(target) != NotFound)
+        Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(target);
+        SCMStringBuffer processName;
+        clusterInfo->getRoxieProcess(processName);
+        if (dst->findCluster(processName.str()) != NotFound)
             return true; // file already known for this cluster
     }
     return false;
@@ -275,7 +278,6 @@ void addPackageMapInfo(IPropertyTree *pkgSetRegistry, const char *target, const 
                     {
                         if (subid[0] == '~')
                             subtree.setProp("@value", subid+1);
-                        StringBuffer msg;
                         if (!isFileKnownOnCluster(subid, lookupDaliIp, target, userdesc))
                             fileNames.append(subid);
                     }
@@ -528,7 +530,6 @@ bool CWsPackageProcessEx::onAddPackage(IEspContext &context, IEspAddPackageReque
     StringAttr target(req.getTarget());
     StringAttr pkgMapName(req.getPackageMap());
     StringAttr processName(req.getProcess());
-    StringAttr daliIp(req.getDaliIp());
 
     Owned<IUserDescriptor> userdesc;
     const char *user = context.queryUserId();
@@ -545,7 +546,7 @@ bool CWsPackageProcessEx::onAddPackage(IEspContext &context, IEspAddPackageReque
 
     Owned<IPropertyTree> packageTree = createPTreeFromXMLString(info.str());
     Owned<IPropertyTree> pkgSetRegistry = getPkgSetRegistry(pkgSetId.str(), processName.get(), false);
-    addPackageMapInfo(pkgSetRegistry, target.get(), pkgMapName.get(), pkgSetId.str(), daliIp.get(), LINK(packageTree), activate, overWrite, userdesc);
+    addPackageMapInfo(pkgSetRegistry, target.get(), pkgMapName.get(), pkgSetId.str(), req.getDaliIp(), LINK(packageTree), activate, overWrite, userdesc);
 
     StringBuffer msg;
     msg.append("Successfully loaded ").append(pkgMapName.get());


### PR DESCRIPTION
In addition to adding the packageset and packagemap information to dali
packagemap add also needs to add the logical file information to dali
if the file is not already known in dali

Signed-off-by: Stuart Ort stuart.ort@lexisnexis.com
