### PR TITLE
HPCC-8078 System won't compile under Clang

### DIFF
--- a/dali/base/daclient.hpp
+++ b/dali/base/daclient.hpp
@@ -22,6 +22,7 @@
 #define da_decl __declspec(dllimport)
 #endif
 
+#include "jlib.hpp"
 #include "mpcomm.hpp"
 #include "dasds.hpp"
 

--- a/esp/clients/LoggingClient/LogFailSafe.hpp
+++ b/esp/clients/LoggingClient/LogFailSafe.hpp
@@ -34,7 +34,7 @@
 #endif
 
 
-#include "jiface.hpp"
+#include "jlib.hpp"
 #include "jstring.hpp"
 #include "jutil.hpp" // for StringArray
 #include "LogSerializer.hpp"

--- a/esp/clients/LoggingClient/LogSerializer.hpp
+++ b/esp/clients/LoggingClient/LogSerializer.hpp
@@ -22,7 +22,7 @@
 #ifndef _LOGSERIALIZER_HPP__
 #define _LOGSERIALIZER_HPP__
 
-#include "jiface.hpp"
+#include "jlib.hpp"
 #include "jstring.hpp"
 #include "jutil.hpp" // for StringArray
 #include "jmutex.hpp"

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -34,7 +34,7 @@
 
 
 
-#include "jiface.hpp"
+#include "jlib.hpp"
 #include "mpbase.hpp"
 #include "daclient.hpp"
 #include "dadfs.hpp"

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -19,6 +19,7 @@
 #ifndef JUTIL_HPP
 #define JUTIL_HPP
 
+#include "jlib.hpp"
 #include "jexpdef.hpp"
 #include "jstring.hpp"
 #include "jarray.tpp"

--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -28,13 +28,13 @@
 #endif
 #include <limits.h>
 
+#include "jlib.hpp"
 #include <mpbase.hpp>
 #include <mpcomm.hpp>
 #include "thorport.hpp"
 
 #include "jsocket.hpp"
 #include "jthread.hpp"
-#include "jlib.hpp"
 #include "jsort.hpp"
 
 #include "thexception.hpp"

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -17,13 +17,13 @@
 
 #include "platform.h"
 #include <limits.h>
+#include "jlib.hpp"
 #include <mpbase.hpp>
 #include <mpcomm.hpp>
 #include "thorport.hpp"
 #include "jsocket.hpp"
 #include "jthread.hpp"
 #include "thormisc.hpp"
-#include "jlib.hpp"
 #include "jisem.hpp"
 #include "jsort.hpp"
 #include "tsorts.hpp"

--- a/thorlcr/msort/tsorts1.cpp
+++ b/thorlcr/msort/tsorts1.cpp
@@ -18,6 +18,7 @@
 #include "platform.h"
 #include <limits.h>
 
+#include "jlib.hpp"
 #include "mpbase.hpp"
 #include "mpcomm.hpp"
 #include "thorport.hpp"


### PR DESCRIPTION
System is sensitive to include order.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
