### PR TITLE
HPCC-8079 Compile errors related to IUserDescriptor refactoring

### DIFF
--- a/dali/regress/daregress.cpp
+++ b/dali/regress/daregress.cpp
@@ -306,7 +306,7 @@ static bool setupDFS(const char *scope, unsigned supersToDel=3, unsigned subsToC
     for (unsigned i=1; i<=supersToDel; i++) {
         StringBuffer super = buf;
         super.append("::super").append(i);
-        if (dir.exists(super.str(),false,true) && !dir.removeEntry(super.str(), user)) {
+        if (dir.exists(super.str(),user,false,true) && !dir.removeEntry(super.str(), user)) {
             ERROR1("Can't remove %s", super.str());
             return false;
         }

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -369,7 +369,7 @@ FILESERVICES_API bool FILESERVICES_CALL fsFileExists(ICodeContext *ctx, const ch
     if (physical)
         return queryDistributedFileDirectory().existsPhysical(lfn.str(),ctx->queryUserDescriptor());
 
-    return queryDistributedFileDirectory().exists(lfn.str(),false,false,ctx->queryUserDescriptor());
+    return queryDistributedFileDirectory().exists(lfn.str(),ctx->queryUserDescriptor(),false,false);
 }
 
 FILESERVICES_API bool FILESERVICES_CALL fsFileValidate(ICodeContext *ctx, const char *name)
@@ -1036,7 +1036,7 @@ FILESERVICES_API bool FILESERVICES_CALL fsSuperFileExists(ICodeContext *ctx, con
 {
     StringBuffer lsfn;
     constructLogicalName(ctx, lsuperfn, lsfn);
-    return queryDistributedFileDirectory().exists(lsfn,false,true);
+    return queryDistributedFileDirectory().exists(lsfn,ctx->queryUserDescriptor(),false,true);
 }
 
 FILESERVICES_API void FILESERVICES_CALL fsDeleteSuperFile(ICodeContext *ctx, const char *lsuperfn,bool deletesub)


### PR DESCRIPTION
Some errors preventing compilation under clang - not sure why these were
not picked up by other compilers.

Note that this does not address ALL issues in this area - for example
those that are in the USE_CPPUNIT branches.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
