### PR TITLE
HPCC-8086 Complete Monitorinterval setting

### DIFF
--- a/docs/UsingConfigManager/UsingConfigManager.xml
+++ b/docs/UsingConfigManager/UsingConfigManager.xml
@@ -1049,7 +1049,8 @@ sudo configmgr</programlisting>
                     <row>
                       <entry><emphasis>monitorinterval</emphasis></entry>
 
-                      <entry>the interval that the process checks ...</entry>
+                      <entry>Specifies the polling interval for DFU monitoring
+                      (in seconds). Default is 900 (15 minutes)</entry>
                     </row>
 
                     <row>


### PR DESCRIPTION
fix HPCC-8086 completes the description of the
monitorinterval setting in the DFU component
in the using configuration manager document

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
