### PR TITLE
HPCC-8095 Remove many refs to UNKNOWN_USER

### DIFF
--- a/common/roxiemanager/referencedfilelist.cpp
+++ b/common/roxiemanager/referencedfilelist.cpp
@@ -510,7 +510,7 @@ void ReferencedFileList::cloneRelationships()
             if (refAssoc && !(refAssoc->getFlags() & RefFileCopyInfoFailed))
             {
                 dir.addFileRelationship(file.getLogicalName(), assoc, r.queryPrimaryFields(), r.querySecondaryFields(),
-                    r.queryKind(), r.queryCardinality(), r.isPayload(), r.queryDescription());
+                    r.queryKind(), r.queryCardinality(), r.isPayload(), user, r.queryDescription());
             }
         }
     }

--- a/common/roxiemanager/roxiewuprocessor.cpp
+++ b/common/roxiemanager/roxiewuprocessor.cpp
@@ -839,7 +839,7 @@ public:
 
                 StringBuffer msg;
                 StringBuffer rel_xpath("MetaFileInfo/Relationships/Relationship");
-                addRoxieFileRelationshipsToDali(xml, processingInfo.queryDfsDaliIp(), rel_xpath, true, msg);
+                addRoxieFileRelationshipsToDali(xml, processingInfo.queryDfsDaliIp(), rel_xpath, true, msg, wu->queryUserDescriptor());
 
                 if (me->ordinality())
                     throw me.getClear();
@@ -1035,7 +1035,7 @@ public:
 
 
 //////////////////////////////////////////////////////////////////////////////////////
-    bool addRoxieFileRelationshipsToDali(IPropertyTree *xml, const char *lookupDaliIp, const char *xpath, bool storeResults, StringBuffer &msg)
+    bool addRoxieFileRelationshipsToDali(IPropertyTree *xml, const char *lookupDaliIp, const char *xpath, bool storeResults, StringBuffer &msg, IUserDescriptor *user)
     {
         if (!xml)
             return false;
@@ -1073,7 +1073,8 @@ public:
                     dfuHelper->cloneFileRelationships(lookupDaliIp,// where src relationships are retrieved from (can be NULL for local)
                                                       srcfiles,     // file names on source
                                                       dstfiles,     // corresponding filenames on dest (must exist otherwise ignored)
-                                                      tree  // MORE - add a tree ptr here and process....
+                                                      tree,  // MORE - add a tree ptr here and process....
+                                                      user
                                                      );
 
                     if (tree)
@@ -1337,7 +1338,7 @@ public:
         lookupRelationships(relationshipTree, src_filename, NULL, remoteRoxieClusterName, lookupDaliIp);
         lookupRelationships(relationshipTree, NULL, src_filename, remoteRoxieClusterName, lookupDaliIp);
 
-        return addRoxieFileRelationshipsToDali(tree, lookupDaliIp, "Relationships/Relationship", false, msg);
+        return addRoxieFileRelationshipsToDali(tree, lookupDaliIp, "Relationships/Relationship", false, msg, userdesc);
     }
     
 
@@ -1705,7 +1706,7 @@ public:
 
         StringBuffer msg;
         StringBuffer rel_xpath("MetaFileInfo/Relationships/Relationship");
-        addRoxieFileRelationshipsToDali(remoteQuery, lookupDaliIp, rel_xpath, true, msg);
+        addRoxieFileRelationshipsToDali(remoteQuery, lookupDaliIp, rel_xpath, true, msg, userdesc);
 
         ForEachItemIn(idx, filesToDelete)
         {

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -507,6 +507,7 @@ interface IDistributedFileDirectory: extends IInterface
         const char *kind,
         const char *cardinality,
         bool payload,
+        IUserDescriptor *user,
         const char *description=NULL
     )=0;
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -2175,11 +2175,11 @@ IClusterFileScanIterator *getClusterFileScanIterator(
 
 typedef MapStringTo<bool> IsSuperFileMap;
 
-void getLogicalFileSuperSubList(MemoryBuffer &mb)
+void getLogicalFileSuperSubList(MemoryBuffer &mb, IUserDescriptor *user)
 {
     // for fileservices
     IsSuperFileMap supermap;
-    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator("*",UNKNOWN_USER,true,true);//MORE:Pass IUserDescriptor
+    IDFAttributesIterator *iter = queryDistributedFileDirectory().getDFAttributesIterator("*",user,true,true);
     if (iter) {
         ForEach(*iter) {
             IPropertyTree &attr=iter->query();

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -354,7 +354,7 @@ public:
     }
 };
 
-extern da_decl void getLogicalFileSuperSubList(MemoryBuffer &mb);
+extern da_decl void getLogicalFileSuperSubList(MemoryBuffer &mb, IUserDescriptor *user);
 
 
 interface IDaliMutexNotifyWaiting

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -976,7 +976,8 @@ public:
         const char *foreigndali,     // where src relationships are retrieved from (can be NULL for local)
         StringArray &srcfns,             // file names on source
         StringArray &dstfns,             // corresponding filenames on dest (must exist)
-        IPropertyTree *relationships    // if not NULL, tree will have all relationships filled in
+        IPropertyTree *relationships,    // if not NULL, tree will have all relationships filled in
+        IUserDescriptor *user
     )
     {
         // not a quick routine! (n^2)
@@ -988,7 +989,7 @@ public:
         bool *ex = (bool *)ma.allocate(dstfns.ordinality()*sizeof(bool));
         unsigned i;
         for (i=0;i<n;i++)
-            ex[i] = queryDistributedFileDirectory().exists(dstfns.item(i),UNKNOWN_USER);//MORE:Pass IUserDescriptor
+            ex[i] = queryDistributedFileDirectory().exists(dstfns.item(i),user);
         for (i=0;i<n;i++) {
             if (!ex[i])
                 continue;
@@ -999,7 +1000,7 @@ public:
                 ForEach(*iter) {
                     try {
                         IFileRelationship &r = iter->query();
-                        queryDistributedFileDirectory().addFileRelationship(dstfns.item(i),dstfns.item(j),r.queryPrimaryFields(),r.querySecondaryFields(),r.queryKind(),r.queryCardinality(),r.isPayload(),r.queryDescription());
+                        queryDistributedFileDirectory().addFileRelationship(dstfns.item(i),dstfns.item(j),r.queryPrimaryFields(),r.querySecondaryFields(),r.queryKind(),r.queryCardinality(),r.isPayload(),user,r.queryDescription());
                         if (relationships)
                         {
                             IPropertyTree *tree = iter->query().queryTree(); // relies on this being modifiable

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -72,7 +72,8 @@ interface IDFUhelper: extends IInterface
         const char *foreigndali,        // where src relationships are retrieved from (can be NULL for local)
         StringArray &srcfns,            // file names on source
         StringArray &dstfns,            // corresponding filenames on dest (must exist otherwise ignored)
-        IPropertyTree *relationships    // if not NULL, tree will have all relationships filled in
+        IPropertyTree *relationships,   // if not NULL, tree will have all relationships filled in
+        IUserDescriptor *user
     ) = 0;
 
 };

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -3101,7 +3101,16 @@ bool CWsDfuEx::onSuperfileAction(IEspContext &context, IEspSuperfileActionReques
         resp.setRetcode(0);
         if (superfile && *superfile && action && strieq(action, "remove"))
         {
-            Owned<IDistributedSuperFile> fp = queryDistributedFileDirectory().lookupSuperFile(superfile,UNKNOWN_USER);
+            Owned<IUserDescriptor> udesc;
+            udesc.setown(createUserDescriptor());
+            {
+                StringBuffer userID;
+                StringBuffer pw;
+                context.getUserID(userID);
+                context.getPassword(pw);
+                udesc->set(userID.str(), pw.str());
+            }
+            Owned<IDistributedSuperFile> fp = queryDistributedFileDirectory().lookupSuperFile(superfile,udesc);
             if (!fp)
                 resp.setRetcode(-1); //Superfile has been removed.
         }

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1767,7 +1767,7 @@ FILESERVICES_API char * FILESERVICES_CALL fsfRemotePull(ICodeContext *ctx,
 FILESERVICES_API void FILESERVICES_CALL fsLogicalFileSuperSubList(ICodeContext *ctx, size32_t & __lenResult,void * & __result)
 {
     MemoryBuffer mb;
-    getLogicalFileSuperSubList(mb);
+    getLogicalFileSuperSubList(mb, ctx->queryUserDescriptor());
     __lenResult = mb.length();
     __result = mb.detach();
 }
@@ -1831,7 +1831,7 @@ FILESERVICES_API void FILESERVICES_CALL fsAddFileRelationship(ICodeContext * ctx
     constructLogicalName(ctx, primary, pfn);
     StringBuffer sfn;
     constructLogicalName(ctx, secondary, sfn);
-    queryDistributedFileDirectory().addFileRelationship(pfn.str(),sfn.str(),primflds,secflds,kind,cardinality,payload,description);
+    queryDistributedFileDirectory().addFileRelationship(pfn.str(),sfn.str(),primflds,secflds,kind,cardinality,payload,ctx->queryUserDescriptor(), description);
     StringBuffer s("AddFileRelationship('");
     s.append(pfn.str()).append("','").append(sfn.str()).append("','").append(primflds?primflds:"").append("','").append(secflds?secflds:"").append("','").append(kind?kind:"").append("') done");
     WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());


### PR DESCRIPTION
Remove as many of the UNKNOWN_USER that are commented as "MORE:Pass IUserDescriptor"
Also removed an unused function (dfsVerifyFiles)from daliadmin.cpp

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
