### PR TITLE
HPCC-8087 Add DFU server name into DFU WU xml and display in EclWatch

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -68,11 +68,17 @@ static void LOGXML(const char *trc,const IPropertyTree *pt)
 
 class CDFUengine: public CInterface, implements IDFUengine
 {
+    StringBuffer dfuServerName;
     size32_t defaultTransferBufferSize;
 
     void setDefaultTransferBufferSize(size32_t size)
     {
         defaultTransferBufferSize = size;
+    }
+
+    void setDFUServerName(const char* name)
+    {
+        dfuServerName = name;
     }
 
     void Audit(const char *func,IUserDescriptor *userdesc,const char *lfn1, const char *lfn2)
@@ -985,6 +991,8 @@ public:
             WARNLOG("DFURUN: Workunit %s not found",dfuwuid);
             return DFUstate_unknown;
         }
+        if (dfuServerName.length())
+            wu->setDFUServerName(dfuServerName.str());
         StringBuffer logname;
         if (fileMsgHandler && fileMsgHandler->getLogName(logname))
             wu->setDebugValue("dfulog", logname.str(), true);

--- a/dali/dfu/dfurun.hpp
+++ b/dali/dfu/dfurun.hpp
@@ -31,6 +31,7 @@ interface IDFUengine: extends IInterface
     virtual void abortListeners()=0;
     virtual DFUstate runWU(const char *dfuwuid)=0;
     virtual void setDefaultTransferBufferSize(size32_t size) = 0;
+    virtual void setDFUServerName(const char* name) = 0;
 };
 
 IDFUengine *createDFUengine();

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -145,7 +145,8 @@ int main(int argc, const char *argv[])
         fileMsgHandler = lf->beginLogging();
     }
     StringBuffer ftslogdir;
-    if (getConfigurationDirectory(globals->queryPropTree("Directories"),"log","ftslave",globals->queryProp("@name"),ftslogdir)) // NB instance deliberately dfuserver's
+    const char* name = globals->queryProp("@name");
+    if (getConfigurationDirectory(globals->queryPropTree("Directories"),"log","ftslave",name,ftslogdir)) // NB instance deliberately dfuserver's
         setFtSlaveLogDir(ftslogdir.str());
     setRemoteSpawnSSH(
         globals->queryProp("SSH/@SSHidentityfile"),
@@ -174,6 +175,7 @@ int main(int argc, const char *argv[])
             connectLogMsgManagerToDali();
 
             engine.setown(createDFUengine());
+            engine->setDFUServerName(name);
             addAbortHandler(exitDFUserver);
         }
         const char *q = queue.str();

--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -2199,6 +2199,12 @@ public:
         updatelock.unlock();
     }
 
+    StringBuffer &getDFUServerName(StringBuffer &str) const
+    {
+        root->getProp("@dfuserver",str);
+        return str;
+    }
+
 
     StringBuffer &getClusterName(StringBuffer &str) const
     {
@@ -2475,6 +2481,11 @@ public:
     void protect(bool protectMode)
     {
         root->setPropInt("@protected", protectMode?1:0);
+    }
+
+    void setDFUServerName(const char * val)
+    {
+        root->setProp("@dfuserver",val);
     }
 
     void setClusterName(const char * val)

--- a/dali/dfu/dfuwu.hpp
+++ b/dali/dfu/dfuwu.hpp
@@ -355,6 +355,7 @@ interface IConstDFUWorkUnit : extends IInterface
 {
     virtual const char *queryId() const = 0;
     virtual StringBuffer &getClusterName(StringBuffer &str) const = 0;
+    virtual StringBuffer &getDFUServerName(StringBuffer &str) const = 0;
     virtual StringBuffer &getJobName(StringBuffer &str) const = 0;
     virtual StringBuffer &getQueue(StringBuffer &str) const = 0;
     virtual StringBuffer &getUser(StringBuffer &str) const = 0;
@@ -387,6 +388,7 @@ interface IDFUWorkUnit : extends IConstDFUWorkUnit
     virtual void  rollback() = 0;                           // cancel changes
     virtual void protect(bool protectMode) = 0;
     virtual void setClusterName(const char * value) = 0;
+    virtual void setDFUServerName(const char * value) = 0;
     virtual void setJobName(const char * value) = 0;
     virtual void setQueue(const char * value) = 0;
     virtual void setUser(const char * value) = 0;

--- a/esp/eclwatch/ws_XSLT/dfu_wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_wuid.xslt
@@ -236,6 +236,7 @@
         <xsl:apply-templates select="ID"/>
         <xsl:apply-templates select="ClusterName"/>
         <xsl:apply-templates select="JobName"/>
+        <xsl:apply-templates select="DFUServerName"/>
         <xsl:apply-templates select="Queue"/>
         <xsl:apply-templates select="User"/>
         <xsl:apply-templates select="isProtected"/>

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -19,6 +19,7 @@
 ESPStruct [nil_remove] DFUWorkunit
 {
     string ID;
+    [min_ver("1.06")] string DFUServerName;
     string ClusterName;
     string JobName;
     string Queue;
@@ -586,7 +587,7 @@ ESPresponse [exceptions_inline, nil_remove] DeleteDropZoneFilesResponse
 };
 
 ESPservice [
-    version("1.05"), default_client_version("1.05"),
+    version("1.06"), default_client_version("1.06"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
 {
     ESPuses ESPstruct DFUWorkunit;

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -229,6 +229,9 @@ static void DeepAssign(IEspContext &context, IConstDFUWorkUnit *src, IEspDFUWork
         }
     }
     
+    if ((version > 1.05) && src->getDFUServerName(tmp.clear()).length())
+        dest.setDFUServerName(tmp.str());
+
     if (src->getJobName(tmp.clear()).length()!=0)
         dest.setJobName(tmp.str());
     else


### PR DESCRIPTION
When looking at any of the DFU related jobs, you cannot tell which
DFU server the job is running on. The DFU Workunit XML also doesn't
tell you which DFU it ran on. This fix adds DFU server name into
DFU WU xml. And the DFU server name will be displayed on DFU WU Details
page.
