### PR TITLE
HPCC-8110 GETENV should fall back to calling OS getenv()

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1603,6 +1603,8 @@ void EclAgent::getEventExtra(size32_t & outLen, char * & outStr, const char * ta
 char *EclAgent::getEnv(const char *name, const char *defaultValue) const 
 {
     const char *val = globals->queryProp(name);
+    if (!val)
+        val = getenv(name);
     if (val)
         return strdup(val);
     else if (defaultValue)

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1027,6 +1027,8 @@ public:
         }
         else
             result = package.queryEnv(name);
+        if (!result)
+            result = getenv(name);
         return strdup(result ? result : defaultValue);
     }
     virtual unsigned getPriority() const

--- a/thorlcr/thorcodectx/thcodectx.hpp
+++ b/thorlcr/thorcodectx/thcodectx.hpp
@@ -74,7 +74,16 @@ public:
     virtual char *getClusterName();
     virtual unsigned getPriority() const { return 0; }
     virtual char *getPlatform() { return strdup("thor"); };
-    virtual char *getEnv(const char *name, const char *defaultValue) const { return strdup(defaultValue); }
+    virtual char *getEnv(const char *name, const char *defaultValue) const
+    {
+        const char *val = getenv(name);
+        if (val)
+            return strdup(val);
+        else if (defaultValue)
+            return strdup(defaultValue);
+        else
+            return strdup("");
+    }
     virtual char *getOS()
     {
 #ifdef _WIN32


### PR DESCRIPTION
At least then there is SOME way to configure what it returns.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
