### PR TITLE
HPCC-7943 Indicate Replicate Optional

### DIFF
--- a/docs/HPCCClientTools/CT_Mods/CT_Comm_Line_DFU.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Comm_Line_DFU.xml
@@ -120,14 +120,17 @@
 
                   <entry>Optional. A boolean flag (0 | 1) indicating whether
                   to overwrite any existing file of the same name. If omitted,
-                  the default is 0.</entry>
+                  the default is 0. </entry>
                 </row>
 
                 <row>
                   <entry><emphasis>replicate</emphasis></entry>
 
-                  <entry>Optional. A boolean flag (1 | 0) indicating whether
-                  to replicate the file. If omitted, the default is 1.</entry>
+                  <entry><para>Optional. A boolean flag (1 | 0) indicating
+                  whether to replicate the file. If omitted, the default is
+                  1.</para><para><emphasis role="bold">This option is only
+                  available on systems where replication has been
+                  enabled.</emphasis></para></entry>
                 </row>
 
                 <row>

--- a/docs/HPCCDataHandling/DataHandling.xml
+++ b/docs/HPCCDataHandling/DataHandling.xml
@@ -149,8 +149,6 @@
       storage location defined in your system's environment. There can be one
       or more of these locations defined. A daemon (DaFileSrv) must be running
       on that server to enable file sprays and desprays.</para>
-
-      <beginpage />
     </sect1>
 
     <sect1 id="Working_with_a_data_file">
@@ -581,12 +579,11 @@
                         role="bold">Replicate</emphasis></entry>
 
                         <entry><para>Check this box to create backup copies of
-                        all file parts that exist in the backup directory (by
-                        convention on the secondary drive of the node
-                        following in the cluster).</para><para><emphasis
-                        role="bold">This option is only available on systems
-                        where replication has been
-                        enabled.</emphasis></para></entry>
+                        all file parts in the backup directory (by convention
+                        on the secondary drive of the node following in the
+                        cluster).</para><para><emphasis role="bold">This
+                        option is only available on systems where replication
+                        has been enabled.</emphasis></para></entry>
                       </row>
 
                       <row>
@@ -762,12 +759,11 @@
                         role="bold">Replicate</emphasis></entry>
 
                         <entry><para>Check this box to create backup copies of
-                        all file parts that exist in the backup directory (by
-                        convention on the secondary drive of the node
-                        following in the cluster).</para><para><emphasis
-                        role="bold">This option is only available on systems
-                        where replication has been
-                        enabled.</emphasis></para></entry>
+                        all file parts in the backup directory (by convention
+                        on the secondary drive of the node following in the
+                        cluster).</para><para><emphasis role="bold">This
+                        option is only available on systems where replication
+                        has been enabled.</emphasis></para></entry>
                       </row>
 
                       <row>
@@ -936,12 +932,11 @@
                         role="bold">Replicate</emphasis></entry>
 
                         <entry><para>Check this box to create backup copies of
-                        all file parts that exist in the backup directory (by
-                        convention on the secondary drive of the node
-                        following in the cluster).</para><para><emphasis
-                        role="bold">This option is only available on systems
-                        where replication has been
-                        enabled.</emphasis></para></entry>
+                        all file parts in the backup directory (by convention
+                        on the secondary drive of the node following in the
+                        cluster).</para><para><emphasis role="bold">This
+                        option is only available on systems where replication
+                        has been enabled.</emphasis></para></entry>
                       </row>
 
                       <row>
@@ -1058,11 +1053,11 @@
                       role="bold">Replicate</emphasis></entry>
 
                       <entry><para>Check this box to create backup copies of
-                      all file parts that exist in the backup directory (by
-                      convention on the secondary drive of the node following
-                      in the cluster).</para><para><emphasis role="bold">This
-                      option is only available on systems where replication
-                      has been enabled.</emphasis></para></entry>
+                      all file parts in the backup directory (by convention on
+                      the secondary drive of the node following in the
+                      cluster).</para><para><emphasis role="bold">This option
+                      is only available on systems where replication has been
+                      enabled.</emphasis></para></entry>
                     </row>
 
                     <row>
@@ -1219,11 +1214,11 @@
                       role="bold">Replicate</emphasis></entry>
 
                       <entry><para>Check this box to create backup copies of
-                      all file parts that exist in the backup directory (by
-                      convention on the secondary drive of the node following
-                      in the cluster).</para><para><emphasis role="bold">This
-                      option is only available on systems where replication
-                      has been enabled.</emphasis></para></entry>
+                      all file parts in the backup directory (by convention on
+                      the secondary drive of the node following in the
+                      cluster).</para><para><emphasis role="bold">This option
+                      is only available on systems where replication has been
+                      enabled.</emphasis></para></entry>
                     </row>
 
                     <row>

--- a/docs/HPCCDataHandling/DataHandling.xml
+++ b/docs/HPCCDataHandling/DataHandling.xml
@@ -580,10 +580,13 @@
                         <entry><emphasis
                         role="bold">Replicate</emphasis></entry>
 
-                        <entry>Check this box to create backup copies of all
-                        file parts exist in the backup directory (by
+                        <entry><para>Check this box to create backup copies of
+                        all file parts that exist in the backup directory (by
                         convention on the secondary drive of the node
-                        following in the cluster).</entry>
+                        following in the cluster).</para><para><emphasis
+                        role="bold">This option is only available on systems
+                        where replication has been
+                        enabled.</emphasis></para></entry>
                       </row>
 
                       <row>
@@ -758,10 +761,13 @@
                         <entry><emphasis
                         role="bold">Replicate</emphasis></entry>
 
-                        <entry>Check this box to create backup copies of all
-                        file parts exist in the backup directory (by
+                        <entry><para>Check this box to create backup copies of
+                        all file parts that exist in the backup directory (by
                         convention on the secondary drive of the node
-                        following in the cluster).</entry>
+                        following in the cluster).</para><para><emphasis
+                        role="bold">This option is only available on systems
+                        where replication has been
+                        enabled.</emphasis></para></entry>
                       </row>
 
                       <row>
@@ -929,10 +935,13 @@
                         <entry><emphasis
                         role="bold">Replicate</emphasis></entry>
 
-                        <entry>Check this box to create backup copies of all
-                        file parts exist in the backup directory (by
-                        convention on the d: drive of the node following in
-                        the cluster).</entry>
+                        <entry><para>Check this box to create backup copies of
+                        all file parts that exist in the backup directory (by
+                        convention on the secondary drive of the node
+                        following in the cluster).</para><para><emphasis
+                        role="bold">This option is only available on systems
+                        where replication has been
+                        enabled.</emphasis></para></entry>
                       </row>
 
                       <row>
@@ -1048,10 +1057,12 @@
                       <entry><emphasis
                       role="bold">Replicate</emphasis></entry>
 
-                      <entry>Check this box to create backup copies of all
-                      file parts exist in the backup directory (by convention
-                      on the second drive of the node following in the
-                      cluster).</entry>
+                      <entry><para>Check this box to create backup copies of
+                      all file parts that exist in the backup directory (by
+                      convention on the secondary drive of the node following
+                      in the cluster).</para><para><emphasis role="bold">This
+                      option is only available on systems where replication
+                      has been enabled.</emphasis></para></entry>
                     </row>
 
                     <row>
@@ -1207,10 +1218,12 @@
                       <entry><emphasis
                       role="bold">Replicate</emphasis></entry>
 
-                      <entry>Check this box to create backup copies of all
-                      file parts exist in the backup directory (by convention
-                      on the d: drive of the node following in the
-                      cluster).</entry>
+                      <entry><para>Check this box to create backup copies of
+                      all file parts that exist in the backup directory (by
+                      convention on the secondary drive of the node following
+                      in the cluster).</para><para><emphasis role="bold">This
+                      option is only available on systems where replication
+                      has been enabled.</emphasis></para></entry>
                     </row>
 
                     <row>

--- a/docs/HPCCDataTutorial/DataTutorial.xml
+++ b/docs/HPCCDataTutorial/DataTutorial.xml
@@ -446,9 +446,8 @@
             role="bold">Replicate</emphasis><emphasis role="bold">
             </emphasis>box is checked.</para>
 
-            <para><emphasis role="bold">Note:</emphasis> If replication is
-            disabled in your Thor settings, this checkbox does not
-            appear.</para>
+            <para><emphasis role="bold">Note:</emphasis> This option is only
+            available on systems where replication has been enabled.</para>
 
             <para><figure>
                 <title>Dropzones and Files</title>

--- a/docs/IMDB/IMDB.xml
+++ b/docs/IMDB/IMDB.xml
@@ -444,6 +444,9 @@ Blankline</programlisting></para>
             <emphasis role="bold">Replicate</emphasis><emphasis role="bold">
             </emphasis>boxes are checked.</para>
 
+            <para><emphasis role="bold">Note:</emphasis> This option is only
+            available on systems where replication has been enabled.</para>
+
             <para><figure>
                 <title>Spray the File</title>
 

--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -1963,6 +1963,10 @@ OUTPUT(L);</programlisting></para>
                   </imageobject>
                 </mediaobject>
               </figure></para>
+
+            <para><emphasis role="bold">Note:</emphasis> The <emphasis
+            role="bold">Replicate</emphasis> option is only available on
+            systems where replication has been enabled.</para>
           </listitem>
 
           <listitem>

--- a/docs/One-Click_HPCCinAWS/One-Click_RuningHPCCinAmazonWebServicesEC2.xml
+++ b/docs/One-Click_HPCCinAWS/One-Click_RuningHPCCinAmazonWebServicesEC2.xml
@@ -1239,6 +1239,10 @@ OUTPUT(L);</programlisting></para>
                   </imageobject>
                 </mediaobject>
               </figure></para>
+
+            <para><emphasis role="bold">Note:</emphasis> The <emphasis
+            role="bold">Replicate</emphasis> option is only available on
+            systems where replication has been enabled.</para>
           </listitem>
 
           <listitem>

--- a/docs/RDDERef/RDDERef.xml
+++ b/docs/RDDERef/RDDERef.xml
@@ -255,10 +255,11 @@
       to the local copy once the copy operation is complete. This provides the
       benefit of quick availability because the query can be active before the
       data is copied, while still taking advantage of the performance benefits
-      of local data. </para>
+      of local data.</para>
 
-      <xi:include href="RDDERef/RDDE_Mods/RoxieCopySettings.xml" xpointer="element(/1)"
-              xmlns:xi="http://www.w3.org/2001/XInclude" />
+      <xi:include href="RDDERef/RDDE_Mods/RoxieCopySettings.xml"
+                  xpointer="element(/1)"
+                  xmlns:xi="http://www.w3.org/2001/XInclude" />
     </sect1>
 
     <sect1 id="Roxie-Data-Backup">
@@ -612,10 +613,12 @@
                     <row>
                       <entry>Replicate</entry>
 
-                      <entry>Check this box to create backup copies of all
-                      file parts exist in the backup directory (by convention
-                      on the d: drive of the node following in the
-                      cluster).</entry>
+                      <entry><para>Check this box to create backup copies of
+                      all file parts in the backup directory (by convention on
+                      the secondary drive of the node following in the
+                      cluster).</para><para><emphasis role="bold">This option
+                      is only available on systems where replication has been
+                      enabled.</emphasis></para></entry>
                     </row>
 
                     <row>
@@ -763,10 +766,12 @@
                     <row>
                       <entry>Replicate</entry>
 
-                      <entry>Check this box to create backup copies of all
-                      file parts exist in the backup directory (by convention
-                      on the d: drive of the node following in the
-                      cluster).</entry>
+                      <entry><para>Check this box to create backup copies of
+                      all file parts in the backup directory (by convention on
+                      the secondary drive of the node following in the
+                      cluster).</para><para><emphasis role="bold">This option
+                      is only available on systems where replication has been
+                      enabled.</emphasis></para></entry>
                     </row>
 
                     <row>

--- a/docs/RuningHPCCinAmazonWebServicesEC2/RuningHPCCinAmazonWebServicesEC2.xml
+++ b/docs/RuningHPCCinAmazonWebServicesEC2/RuningHPCCinAmazonWebServicesEC2.xml
@@ -2708,6 +2708,10 @@ OUTPUT(L);</programlisting></para>
                   </imageobject>
                 </mediaobject>
               </figure></para>
+
+            <para><emphasis role="bold">Note:</emphasis> The <emphasis
+            role="bold">Replicate</emphasis> option is only available on
+            systems where replication has been enabled.</para>
           </listitem>
 
           <listitem>

--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -1032,6 +1032,10 @@ OUTPUT(L);</programlisting></para>
                     </imageobject>
                   </mediaobject>
                 </figure></para>
+
+              <para><emphasis role="bold">Note:</emphasis> The <emphasis
+              role="bold">Replicate</emphasis> option is only available on
+              systems where replication has been enabled.</para>
             </listitem>
 
             <listitem>

--- a/docs/wip/ECL_Watch.xml
+++ b/docs/wip/ECL_Watch.xml
@@ -879,10 +879,12 @@
                       <entry><emphasis
                       role="bold">Replicate</emphasis></entry>
 
-                      <entry>Check this box to create backup copies of all
-                      file parts exist in the backup directory (by convention
-                      on the secondary drive of the node following in the
-                      cluster).</entry>
+                      <entry><para>Check this box to create backup copies of
+                      all file parts in the backup directory (by convention on
+                      the secondary drive of the node following in the
+                      cluster).</para><para><emphasis role="bold">This option
+                      is only available on systems where replication has been
+                      enabled.</emphasis></para></entry>
                     </row>
 
                     <row>
@@ -1049,10 +1051,12 @@
                   <row>
                     <entry><emphasis role="bold">Replicate</emphasis></entry>
 
-                    <entry>Check this box to create backup copies of all file
-                    parts exist in the backup directory (by convention on the
+                    <entry><para>Check this box to create backup copies of all
+                    file parts in the backup directory (by convention on the
                     secondary drive of the node following in the
-                    cluster).</entry>
+                    cluster).</para><para><emphasis role="bold">This option is
+                    only available on systems where replication has been
+                    enabled.</emphasis></para></entry>
                   </row>
 
                   <row>
@@ -1207,9 +1211,12 @@
                   <row>
                     <entry><emphasis role="bold">Replicate</emphasis></entry>
 
-                    <entry>Check this box to create backup copies of all file
-                    parts exist in the backup directory (by convention on the
-                    d: drive of the node following in the cluster).</entry>
+                    <entry><para>Check this box to create backup copies of all
+                    file parts in the backup directory (by convention on the
+                    secondary drive of the node following in the
+                    cluster).</para><para><emphasis role="bold">This option is
+                    only available on systems where replication has been
+                    enabled.</emphasis></para></entry>
                   </row>
 
                   <row>
@@ -1350,9 +1357,12 @@
                 <row>
                   <entry><emphasis role="bold">Replicate</emphasis></entry>
 
-                  <entry>Check this box to create backup copies of all file
-                  parts exist in the backup directory (by convention on the d:
-                  drive of the node following in the cluster).</entry>
+                  <entry><para>Check this box to create backup copies of all
+                  file parts in the backup directory (by convention on the
+                  secondary drive of the node following in the
+                  cluster).</para><para><emphasis role="bold">This option is
+                  only available on systems where replication has been
+                  enabled.</emphasis></para></entry>
                 </row>
 
                 <row>
@@ -1947,18 +1957,14 @@
 
                   <entry><para>Full</para></entry>
                 </row>
+
                 <row>
-                  <entry>
-                    <para>RoxieControlAccess</para>
-                  </entry>
+                  <entry><para>RoxieControlAccess</para></entry>
 
-                  <entry>
-                    <para>Access to Roxie Process Cluster Control</para>
-                  </entry>
+                  <entry><para>Access to Roxie Process Cluster
+                  Control</para></entry>
 
-                  <entry>
-                    <para>Full</para>
-                  </entry>
+                  <entry><para>Full</para></entry>
                 </row>
               </tbody>
             </tgroup>


### PR DESCRIPTION
Fix HPCC-7943 Indicate that the Replicate option is only available when replication has been enabled. Update all docs. where replicate is indicated as an option. 
