### PR TITLE
HPCC-8112 Added support for environment profile to hpcc_setenv

### DIFF
--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -157,3 +157,5 @@ else
         fi
     fi
 fi
+
+source /etc/profile


### PR DESCRIPTION
This allows for os getenv()'s to locate values set by user profile
when components start.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
