### PR TITLE
HPCC-8104 Fix duplicated log link and empty log view in ECL WU Details

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -1246,25 +1246,25 @@
       </xsl:if>
       <xsl:if test="starts-with(Type, 'ThorLog')">
         <td>
-          <a href="/WsWorkunits/WUFile/ThorLog?Wuid={$wuid}&amp;Process={Description}&amp;Type={Type}"
+          <a href="/WsWorkunits/WUFile/ThorLog?Wuid={$wuid}&amp;Name={Name}&amp;Type={Type}"
                         >
             thormaster.log: <xsl:value-of select="Name"/>
           </a>
         </td>
         <td>
-          <a href="javascript:void(0)" onclick="getOptions('thormaster.log', '/WsWorkunits/WUFile/ThorLog?Wuid={$wuid}&amp;Process={Description}&amp;Type={Type}', false); return false;">
+          <a href="javascript:void(0)" onclick="getOptions('thormaster.log', '/WsWorkunits/WUFile/ThorLog?Wuid={$wuid}&amp;Name={Name}&amp;Type={Type}', false); return false;">
             download
           </a>
         </td>
       </xsl:if>
       <xsl:if test="Type = 'EclAgentLog'">
         <td>
-          <a href="/WsWorkunits/WUFile/EclAgentLog?Wuid={$wuid}&amp;Process={Description}&amp;Type=EclAgentLog">
+          <a href="/WsWorkunits/WUFile/EclAgentLog?Wuid={$wuid}&amp;Name={Name}&amp;Type=EclAgentLog">
               eclagent.log: <xsl:value-of select="Name"/>
           </a>
         </td>
         <td>
-          <a href="javascript:void(0)" onclick="getOptions('eclagent.log', '/WsWorkunits/WUFile/EclAgentLog?Wuid={$wuid}&amp;Process={Description}&amp;Type=EclAgentLog', false); return false;">
+          <a href="javascript:void(0)" onclick="getOptions('eclagent.log', '/WsWorkunits/WUFile/EclAgentLog?Wuid={$wuid}&amp;Name={Name}&amp;Type=EclAgentLog', false); return false;">
             download
           </a>
         </td>

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2633,7 +2633,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
             }
             else if (strncmp(req.getType(), File_ThorLog, 7) == 0)
             {
-                winfo.getWorkunitThorLog(req.getProcess(), mb);
+                winfo.getWorkunitThorLog(req.getName(), mb);
                 openSaveFile(context, opt, "thormaster.log", HTTP_TYPE_TEXT_PLAIN, mb, resp);
             }
             else if (strieq(File_ThorSlaveLog,req.getType()))
@@ -2646,7 +2646,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
             }
             else if (strieq(File_EclAgentLog,req.getType()))
             {
-                winfo.getWorkunitEclAgentLog(req.getProcess(), mb);
+                winfo.getWorkunitEclAgentLog(req.getName(), mb);
                 openSaveFile(context, opt, "eclagent.log", HTTP_TYPE_TEXT_PLAIN, mb, resp);
             }
             else if (strieq(File_XML,req.getType()))


### PR DESCRIPTION
This fix solves three problems found in the Helpers section of ECL WU
Details page. 1. duplicated log files are displayed; 2. The first
thormaster log is displayed when web link to second thormaster log is
selected from the section; 3. A blank page shows when an EclAgent Log
link is selected from the section. The existing code assumes only one
thormaster log (and one eclagent log) per workunit. When more than one
thormaster log entries occur in WU XML, the entries causes extra loops
to generate duplicated links. The existing links contain process name
as an identifier. When a user clicks one of the links, the code always
picks up the first log file based on the process name. Since no related
log line is found from the first log file, a plank page is displayed.

This fix modifies the code to avoid the extra loops. Inside the web link,
the process name is replaced by log file name. If no related log line
can be found in a log file, the page will display: (Not found a log line
related to this workunit).

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
