### PR TITLE
HPCC-8064 Roxie passing NULL for IUserDescriptor

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -275,18 +275,21 @@ public:
     IMPLEMENT_IINTERFACE;
     CRoxieDaliHelper() : connectWatcher(this), serverStatus(NULL)
     {
+        userdesc.setown(createUserDescriptor());
+        const char *roxieUser;
+        const char *roxiePassword;
         if (topology)
         {
-            const char *roxieUser = topology->queryProp("@ldapUser");
-            const char *roxiePassword = topology->queryProp("@ldapPassword");
-            if (roxieUser && *roxieUser && roxiePassword && *roxiePassword)
-            {
-                StringBuffer password;
-                decrypt(password, roxiePassword);
-                userdesc.setown(createUserDescriptor());
-                userdesc->set(roxieUser, password.str());
-            }
+            roxieUser = topology->queryProp("@ldapUser");
+            roxiePassword = topology->queryProp("@ldapPassword");
         }
+        if (!roxieUser)
+            roxieUser = "roxie";
+        if (!roxiePassword)
+            roxiePassword = "";
+        StringBuffer password;
+        decrypt(password, roxiePassword);
+        userdesc->set(roxieUser, password.str());
         if (fileNameServiceDali.length())
             connectWatcher.start();
         else


### PR DESCRIPTION
If no username and password has been supplied in the topology file, Roxie
currently passes NULL to indicate the default user should be used. However,
as we are trying to get rid of all uses if the defualt user, and tracing
aggressively when they are seen, change Roxie to use the userid "roxie"
and blank password if none is supplied.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
