### PR TITLE
HPCC-8114 Make missing return an error

### DIFF
--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -1209,6 +1209,7 @@ public:
                 id2 = conn->subscribe(*new CCSub(s.str()));
             }
         }
+        throwUnexpected(); // loop never terminates, but some compilers complain about missing return without this line
     }
 
     SubscriptionId id1, id2;

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -2970,6 +2970,7 @@ static bool anyXmlGeneratedForPass(IHqlExpression * expr, unsigned pass)
     default:
         UNIMPLEMENTED;
     }
+    throwUnexpected(); // unreachable, but some compilers will complain about missing return
 }
 
 

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -566,6 +566,7 @@ protected:
             throw MakeStringException(ROXIE_UNIMPLEMENTED_ERROR, "Unimplemented activity %s required", getActivityText(kind));
             break;
         }
+        throwUnexpected(); // unreachable, but some compilers will complain about missing return
     }
 
     IActivityFactory *findActivity(unsigned id) const

--- a/roxie/udplib/uttest.cpp
+++ b/roxie/udplib/uttest.cpp
@@ -134,6 +134,7 @@ public:
                 lastReport = now;
             }
         }
+        throwUnexpected(); // loop never terminates, but some compilers complain about missing return without this line
     }
 };
 


### PR DESCRIPTION
Fix some false positives from a stupid compiler.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
