### PR TITLE
HPCC-7987 Display the return of getQueryMainDefinition in WU Details page

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -597,7 +597,7 @@
         </p>
       </xsl:if>
 
-      <xsl:if test="string-length(Query/Text)">
+      <xsl:if test="string-length(Query/Text) or string-length(Query/QueryMainDefinition)">
         <div>
           <div class="wugroup">
               <div class="WuGroupHdrLeft">
@@ -605,11 +605,18 @@
               </div>
           </div>
           <div id="querysection" class="wusectioncontent">
-            <div>
-              <textarea id="query" readonly="true" wrap="off" rows="10" STYLE="width:600">
-                <xsl:value-of select="Query/Text"/>
-              </textarea>
-            </div>
+              <xsl:if test="string-length(Query/Text)">
+                  <div>
+                      <textarea id="query" readonly="true" wrap="off" rows="10" STYLE="width:600">
+                          <xsl:value-of select="Query/Text"/>
+                      </textarea>
+                  </div>
+              </xsl:if>
+              <xsl:if test="string-length(Query/QueryMainDefinition)">
+                  <div>
+                      <b>QueryMainDefinition: </b><xsl:value-of select="Query/QueryMainDefinition"/>
+                  </div>
+              </xsl:if>
           </div>
         </div>
       </xsl:if>


### PR DESCRIPTION
It is possible for a query to be submitted with no query text, just a
reference to an attribute in a remote repository. This fix displays
the value of getQueryMainDefinition() in the Query section (inside
ECL WU Details page). The value will be shown under the textarea 
of the query text if there is query text.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
