### PR TITLE
HPCC-8115 Building HPCC-Platform in Ubuntu 12.10

### DIFF
--- a/system/jlib/jarray.hpp
+++ b/system/jlib/jarray.hpp
@@ -135,11 +135,7 @@ public:
     CopyArrayOf() { SELF::_init(); }
     ~CopyArrayOf();
     
-#ifdef __clang__
-    PARAM item(aindex_t pos) const;  // Clang's stricter template checking is not working with inline case. Should revisit for efficiency sometime
-#else
-    inline PARAM item(aindex_t pos) const             { assertex(SELF::isItem(pos)); return Array__Member2Param(((MEMBER *)AllocatorOf<sizeof(MEMBER)>::_head)[pos]);}
-#endif
+    inline PARAM item(aindex_t pos) const;
     PARAM tos(void) const;
     PARAM tos(aindex_t) const;
 
@@ -181,11 +177,7 @@ class ArrayOf : public OwningArrayOf<MEMBER, PARAM>
     typedef ArrayOf<MEMBER,PARAM> SELF;
 
 public:
-#ifdef __clang__
-    PARAM item(aindex_t pos) const;  // Clang's stricter template checking is not working with inline case. Should revisit for efficiency sometime
-#else
-    inline PARAM item(aindex_t pos) const             { assertex(SELF::isItem(pos)); return Array__Member2Param(((MEMBER *)AllocatorOf<sizeof(MEMBER)>::_head)[pos]);}
-#endif
+    inline PARAM item(aindex_t pos) const; 
     PARAM popGet();
     PARAM tos(void) const;
     PARAM tos(aindex_t) const;

--- a/system/jlib/jarray.tpp
+++ b/system/jlib/jarray.tpp
@@ -123,13 +123,11 @@ void BaseArrayOf<MEMBER, PARAM>::sort(CompareFunc cf)
  *                            Master CopyArrays                         *
  ************************************************************************/
 
-#ifdef __clang__
 template <class MEMBER, class PARAM>
 PARAM CopyArrayOf<MEMBER, PARAM>::item(aindex_t pos) const
 {
    assertex(SELF::isItem(pos)); return Array__Member2Param(((MEMBER *)AllocatorOf<sizeof(MEMBER)>::_head)[pos]);
 }
-#endif
 
 template <class MEMBER, class PARAM>
 void CopyArrayOf<MEMBER, PARAM>::replace(PARAM it, aindex_t pos)
@@ -334,13 +332,11 @@ bool OwningArrayOf<MEMBER, PARAM>::zap(PARAM sought, bool nodel)
  *                            Master Ref Array                          *
  ************************************************************************/
 
-#ifdef __clang__
 template <class MEMBER, class PARAM>
 PARAM ArrayOf<MEMBER, PARAM>::item(aindex_t pos) const
 {
    assertex(SELF::isItem(pos)); return Array__Member2Param(((MEMBER *)AllocatorOf<sizeof(MEMBER)>::_head)[pos]);
 }
-#endif
 
 template <class MEMBER, class PARAM>
 PARAM ArrayOf<MEMBER, PARAM>::popGet()


### PR DESCRIPTION
Because jarray.tpp is included as a header, the body of "item" function should be available to be inlined just by adding the "inline" keyword to the prototype (IOW it doesn't _have_ to be physically inline in the source).

(I think).

@ghalliday please review.

(I do have a variant with:

``` c++
#if defined (__clang__) || (__GNUC__ >= 4 && __GNUC_MINOR__ >= 7)
```

If you prefer)
