### PR TITLE
HPCC-8103 Fix missing hyperlinks for results in WU Details page

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -1067,7 +1067,7 @@
         <xsl:if test="number(IsSupplied)"> supplied</xsl:if>
       </td>
      <xsl:choose>
-       <xsl:when test="number(ShowFileContent) and string-length(Link)">
+       <xsl:when test="((string-length(FileName) &lt; 1) or number(ShowFileContent)) and string-length(Link)">
           <td>
             <a href="javascript:void(0);" onclick="getLink(document.getElementById('ECL_Result_{position()}'), '/WsWorkunits/WUResult?Wuid={$wuid}&amp;Sequence={Link}');return false;">
               <xsl:value-of select="Value"/>


### PR DESCRIPTION
The existing WU Details page uses the ShowFileContent flag to decide
whether the Result hyperlinks should be displayed or not and the flag
is set to true as default. From 3.10.x, the default value is not set
for HTTP response and the Result hyperlink may not be displayed.

In fact, the ShowFileContent flag is being set only if the result has
a logical file name. If no file name, the WU Details page should not
check the ShowFileContent flag.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
