### PR TITLE
HPCC-8090 Remove LD_LIBRARY_PATH

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -2711,7 +2711,7 @@ OUTPUT(ValidWords)
 
 sudo /sbin/service dafilesrv start</programlisting><property><!--*** not for publication
 cd /var/lib/HPCCSystems/mythor
-source /opt/HPCCSystems/sbin/hpcc_setenv 
+...
 init_stop_thor
 init_start_thor--></property></para>
         </listitem>

--- a/docs/RuningHPCCinAmazonWebServicesEC2/RuningHPCCinAmazonWebServicesEC2.xml
+++ b/docs/RuningHPCCinAmazonWebServicesEC2/RuningHPCCinAmazonWebServicesEC2.xml
@@ -464,10 +464,9 @@
             </listitem>
 
             <listitem>
-              <para>Start Configuration Manager using these commands:</para>
+              <para>Start Configuration Manager using this command:</para>
 
-              <programlisting>source /opt/HPCCSystems/sbin/hpcc_setenv
-sudo /opt/HPCCSystems/sbin/configmgr</programlisting>
+              <programlisting>sudo /opt/HPCCSystems/sbin/configmgr</programlisting>
             </listitem>
 
             <listitem>
@@ -1784,11 +1783,10 @@ sudo /opt/HPCCSystems/sbin/configmgr</programlisting>
           </listitem>
 
           <listitem>
-            <para>At the command prompt, enter the following commands to start
+            <para>At the command prompt, enter the following command to start
             Configuration Manager.</para>
 
-            <para><emphasis></emphasis><programlisting>source /opt/HPCCSystems/sbin/hpcc_setenv
-sudo /opt/HPCCSystems/sbin/configmgr</programlisting><emphasis></emphasis></para>
+            <para><emphasis></emphasis><programlisting>sudo /opt/HPCCSystems/sbin/configmgr</programlisting><emphasis></emphasis></para>
           </listitem>
 
           <listitem>

--- a/docs/UsingConfigManager/UsingConfigManager.xml
+++ b/docs/UsingConfigManager/UsingConfigManager.xml
@@ -415,8 +415,7 @@ sudo -u hpcc cp /etc/HPCCSystems/source/NewEnvironment.xml /etc/HPCCSystems/envi
             the first node is considered the head node and is used for this
             task, but this is up to you).</para>
 
-            <programlisting>source /opt/HPCCSystems/sbin/hpcc_setenv
-sudo configmgr</programlisting>
+            <programlisting>sudo configmgr</programlisting>
 
             <para><graphic
             fileref="images/gs_img_configmgrStart.jpg" /></para>


### PR DESCRIPTION
Fix HPCC-8090 Remove all references to LD_LIBRARY_PATH
meaning the command, source /opt/HPCCSystems/sbin/hpcc_setenv
From all instances in the documentation

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
