### PR TITLE
HPCC-8000 Improve error message when cannot open a file.

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -7161,6 +7161,9 @@ void CFileContents::ensureLoaded()
         throw MakeStringException(1, "File %s could not be opened", file->queryFilename());
 
     offset_t size = io->size();
+    if (size == (offset_t)-1)
+        throw MakeStringException(1, "File %s could not be read", file->queryFilename());
+
     size32_t sizeToRead = (size32_t)size;
     if (sizeToRead != size)
         throw MakeStringException(1, "File %s is larger than 4Gb", file->queryFilename());


### PR DESCRIPTION
It appears to be possible for file->exists() to succeed, but file->size()
to return -1.  This patch changes the error message to indicate the file
couldn't e read instead of complaining it was > 4Gb.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
