### PR TITLE
HPCC-8120 Firstn deadlock

### DIFF
--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -87,10 +87,15 @@ class ThorLookaheadCache: public IThorDataLink, public CSimpleInterface
     } thread;
 
 public:
-    
-
-
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+
+    void doNotify()
+    {
+        if (notify)
+            notify->onInputFinished(count);
+        if (smartbuf)
+            smartbuf->queryWriter()->flush();
+    }
 
     int run()
     {
@@ -161,13 +166,42 @@ public:
         {
             ActPrintLog(&activity, e, "ThorLookaheadCache get exception");
             getexception.setown(e);
-        }   
-        if (notify)
-            notify->onInputFinished(count);
-        if (smartbuf)
-            smartbuf->queryWriter()->flush();
+        }
+
+        // notify and flush async, as these can block, but we do not want to block in->stop()
+        // especially if this is a spilling read ahead, where use case scenarios include not wanting to
+        // block the upstream input.
+        // An example is a firstn which if stop() it not called, it may block
+        // other nodes from pulling because it is blocked upstream on full buffers (which can be discarded
+        // on stop()), and those in turn are blocking other arms of the graph.
+        class CNotifyThread : implements IThreaded
+        {
+            CThreaded threaded;
+            ThorLookaheadCache &owner;
+        public:
+            CNotifyThread(ThorLookaheadCache &_owner) : threaded("Lookahead-CNotifyThread"), owner(_owner)
+            {
+                threaded.init(this);
+            }
+            ~CNotifyThread()
+            {
+                loop
+                {
+                    if (threaded.join(60000))
+                        break;
+                    PROGLOG("Still waiting on lookahead CNotifyThread thread to complete");
+                }
+            }
+        // IThreaded impl.
+            virtual void main()
+            {
+                owner.doNotify();
+            }
+        } notifyThread(*this);
+
         running = false;
-        try {
+        try
+        {
             if (in)
                 in->stop();
         }
@@ -176,7 +210,8 @@ public:
             ActPrintLog(&activity, e, "ThorLookaheadCache stop exception");
             if (!getexception.get())
                 getexception.setown(e);
-        }   
+        }
+        // NB: Will wait on CNotifyThread to finish before returning
         return 0;
     }
         
@@ -249,8 +284,7 @@ public:
         }
         return row.getClear();
     }
-                    
-    
+
     bool isGrouped() { return false; }
             
     void getMetaInfo(ThorDataLinkMetaInfo &info)


### PR DESCRIPTION
FirstN in combination with certain upstream activities can caused
a deadlock. The problem occurs, when the firstN lookahead hits
it's limit on some nodes and attempts to a) signal the next node
and b) wait for the reader to finish processing or signal stop
the rows it has buffered.
Either one can block, which will prevent the lookahead signalling
'stop' to input it has been reading on. In some circumstances
those inputs will be blocked themselves, e.g. because their
buffers are full, waiting for either read or stop signal.

Spin off the signal to next node and local row cache flush to
a separate thread, and allow the input stop to be called.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
