### PR TITLE
HPCC-8130 Loading of profile regression on start of platform

### DIFF
--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -47,6 +47,8 @@ HPCC_CONFIG=${HPCC_CONFIG:-${CONFIG_DIR}/${ENV_CONF_FILE}}
 #SECTION=${1:-DEFAULT}
 SECTION="DEFAULT"
 
+source /etc/profile
+
 PATH_PREFIX=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^path *= *" | sed -e 's/^path *= *//'`
 
 export PID=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^pid *= *" | sed -e 's/^pid *= *//'`
@@ -157,5 +159,3 @@ else
         fi
     fi
 fi
-
-source /etc/profile


### PR DESCRIPTION
Moved location of source call for /etc/profile. The location of the
source call caused a regression in the PATH on debian and SuSE.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
