### PR TITLE
HPCC-8098 Fix seh after unusual syntax error

### DIFF
--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -2222,8 +2222,10 @@ void HqlGram::addToActiveRecord(IHqlExpression * newField)
     //it means fields from ifblocks are inserted twice into the symbol table - and we still need to expose this internal function
     OwnedHqlExpr self = getSelfScope();
     assertex(self);
-    CHqlRecord *currentRecord = QUERYINTERFACE(self.get(), CHqlRecord);
-    if (currentRecord != &topRecord)
+
+    CHqlRecord *currentRecord = QUERYINTERFACE(self->queryRecord(), CHqlRecord);
+    //Protect against adding fields to closed records (can only occur after errors).
+    if ((currentRecord != &topRecord) && !currentRecord->isExprClosed())
         currentRecord->insertSymbols(newField);
 }
 


### PR DESCRIPTION
Currently pushSelf is used differently when processing a record from
when processing a transform.  In the former it is a record, in the latter
a no_self.  This should really be changed in the future and made consistent.

A user had an example query containing a syntax error which caused the
state to become inconsistent, and then crash.  This change fixes the seh by
ensuring the record of the active item is selected.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
