### PR TITLE
HPCC-8130 Fixed IFS issue related to spaces in path in profile

### DIFF
--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -47,7 +47,10 @@ HPCC_CONFIG=${HPCC_CONFIG:-${CONFIG_DIR}/${ENV_CONF_FILE}}
 #SECTION=${1:-DEFAULT}
 SECTION="DEFAULT"
 
+OIFS="${IFS}"
+unset IFS
 source /etc/profile
+IFS="${OIFS}"
 
 PATH_PREFIX=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^path *= *" | sed -e 's/^path *= *//'`
 


### PR DESCRIPTION
On Centos 6 the qt.sh in profile.d introduced a space to the
PATH variable which due to hpcc-init had a failure related to IFS.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
