### PR TITLE
HPCC-8124 Check for failed malloc

### DIFF
--- a/common/deftype/defvalue.hpp
+++ b/common/deftype/defvalue.hpp
@@ -30,6 +30,9 @@
 #define DEFTYPE_API
 #endif
 
+#define DEFVALUE_MALLOC_FAILED 701  //Unable to allocate requested memory
+
+
 interface IValue : public serializable
 {
 public:


### PR DESCRIPTION
Specifying a large value for DATA[n], STRING[x], etc  such as DATA10000000000 causes ECLCC
to core. This fixes that problem by checking for a failed malloc and
throwing if it happens

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
