### PR TITLE
HPCC-3097 Compress internal spill files

### DIFF
--- a/common/thorhelper/thorcommon.cpp
+++ b/common/thorhelper/thorcommon.cpp
@@ -1150,7 +1150,7 @@ class CRowStreamReader : public CSimpleInterface, implements IExtRowStream
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CRowStreamReader(IFileIO *_fileio,IMemoryMappedFile *_mmfile,offset_t _ofs, offset_t _len, IRowInterfaces *rowif,unsigned __int64 _maxrows,bool _tallycrc, bool _grouped)
+    CRowStreamReader(IFileIO *_fileio, IMemoryMappedFile *_mmfile, IRowInterfaces *rowif, offset_t _ofs, offset_t _len, unsigned __int64 _maxrows, bool _tallycrc, bool _grouped)
         : fileio(_fileio), mmfile(_mmfile), allocator(rowif->queryRowAllocator()), prefetchBuffer(NULL) 
     {
 #ifdef TRACE_CREATE
@@ -1287,33 +1287,39 @@ unsigned CRowStreamReader::rdnum;
 
 bool UseMemoryMappedRead = false;
 
-IExtRowStream *createRowStream(IFile *file,IRowInterfaces *rowif,offset_t offset,offset_t len,unsigned __int64 maxrows,bool tallycrc,bool grouped)
+IExtRowStream *createRowStreamEx(IFile *file, IRowInterfaces *rowIf, offset_t offset, offset_t len, unsigned __int64 maxrows, unsigned rwFlags, IExpander *eexp)
 {
-    IExtRowStream *ret;
-    if (UseMemoryMappedRead) {
+    bool compressed = TestRwFlag(rwFlags, rw_compress);
+    if (UseMemoryMappedRead && !compressed)
+    {
         PROGLOG("Memory Mapped read of %s",file->queryFilename());
         Owned<IMemoryMappedFile> mmfile = file->openMemoryMapped();
         if (!mmfile)
             return NULL;
-        ret = new CRowStreamReader(NULL,mmfile,offset,len,rowif,maxrows,tallycrc,grouped);
+        return new CRowStreamReader(NULL, mmfile, rowIf, offset, len, maxrows, TestRwFlag(rwFlags, rw_crc), TestRwFlag(rwFlags, rw_grouped));
     }
-    else {
-        Owned<IFileIO> fileio = file->open(IFOread);
+    else
+    {
+        Owned<IFileIO> fileio;
+        if (compressed)
+        {
+            // JCSMORE should pass in a flag for rw_compressblkcrc I think, doesn't look like it (or anywhere else)
+            // checks the block crc's at the moment.
+            fileio.setown(createCompressedFileReader(file, eexp, UseMemoryMappedRead));
+        }
+        else
+            fileio.setown(file->open(IFOread));
         if (!fileio)
             return NULL;
-        ret = new CRowStreamReader(fileio,NULL,offset,len,rowif,maxrows,tallycrc,grouped);
+        return new CRowStreamReader(fileio, NULL, rowIf, offset, len, maxrows, TestRwFlag(rwFlags, rw_crc), TestRwFlag(rwFlags, rw_grouped));
     }
-    return ret;
 }
 
-IExtRowStream *createCompressedRowStream(IFile *file,IRowInterfaces *rowif,offset_t offset,offset_t len,unsigned __int64 maxrows,bool tallycrc,bool grouped,IExpander *eexp)
+IExtRowStream *createRowStream(IFile *file, IRowInterfaces *rowIf, unsigned rwFlags, IExpander *eexp)
 {
-    Owned<IFileIO> fileio = createCompressedFileReader(file, eexp, UseMemoryMappedRead);
-    if (!fileio)
-        return NULL;
-    IExtRowStream *ret = new CRowStreamReader(fileio,NULL,offset,len,rowif,maxrows,tallycrc,grouped);
-    return ret;
+    return createRowStreamEx(file, rowIf, 0, (offset_t)-1, (unsigned __int64)-1, rwFlags, eexp);
 }
+
 
 void useMemoryMappedRead(bool on)
 {
@@ -1526,20 +1532,44 @@ public:
 unsigned CRowStreamWriter::wrnum=0;
 #endif
 
-IExtRowWriter *createRowWriter(IFile *file,IOutputRowSerializer *serializer,IEngineRowAllocator *allocator,bool grouped, bool tallycrc, bool extend)
+IExtRowWriter *createRowWriter(IFile *iFile, IRowInterfaces *rowIf, unsigned flags, ICompressor *compressor)
 {
-    Owned<IFileIO> fileio = file->open(extend?IFOwrite:IFOcreate);
-    if (!fileio)
+    OwnedIFileIO iFileIO;
+    if (TestRwFlag(flags, rw_compress))
+    {
+        size32_t fixedSize = rowIf->queryRowMetaData()->querySerializedMeta()->getFixedSize();
+        if (fixedSize && TestRwFlag(flags, rw_grouped))
+            ++fixedSize; // row writer will include a grouping byte
+        iFileIO.setown(createCompressedFileWriter(iFile, fixedSize, TestRwFlag(flags, rw_extend), TestRwFlag(flags, rw_compressblkcrc), compressor, TestRwFlag(flags, rw_fastlz)));
+    }
+    else
+        iFileIO.setown(iFile->open((flags & rw_extend)?IFOwrite:IFOcreate));
+    if (!iFileIO)
         return NULL;
-    Owned<IFileIOStream> stream = createIOStream(fileio);
-    if (extend)
-        stream->seek(0,IFSend);
-    return createRowWriter(stream,serializer,allocator,grouped,tallycrc,true);
+    flags &= ~((unsigned)(rw_compress|rw_fastlz|rw_compressblkcrc));
+    return createRowWriter(iFileIO, rowIf, flags);
 }
 
-IExtRowWriter *createRowWriter(IFileIOStream *strm,IOutputRowSerializer *serializer,IEngineRowAllocator *allocator,bool grouped, bool tallycrc, bool autoflush)
+IExtRowWriter *createRowWriter(IFileIO *iFileIO, IRowInterfaces *rowIf, unsigned flags)
 {
-    Owned<CRowStreamWriter> writer = new CRowStreamWriter(strm, serializer, allocator, grouped, tallycrc, autoflush);
+    if (TestRwFlag(flags, rw_compress))
+        throw MakeStringException(0, "Unsupported createRowWriter flags");
+    Owned<IFileIOStream> stream;
+    if (TestRwFlag(flags, rw_buffered))
+        stream.setown(createBufferedIOStream(iFileIO));
+    else
+        stream.setown(createIOStream(iFileIO));
+    if (flags & rw_extend)
+        stream->seek(0, IFSend);
+    flags &= ~((unsigned)(rw_extend|rw_buffered));
+    return createRowWriter(stream, rowIf, flags);
+}
+
+IExtRowWriter *createRowWriter(IFileIOStream *strm, IRowInterfaces *rowIf, unsigned flags)
+{
+    if (0 != (flags & (rw_compress|rw_fastlz|rw_extend|rw_buffered|rw_compressblkcrc)))
+        throw MakeStringException(0, "Unsupported createRowWriter flags");
+    Owned<CRowStreamWriter> writer = new CRowStreamWriter(strm, rowIf->queryRowSerializer(), rowIf->queryRowAllocator(), TestRwFlag(flags, rw_grouped), TestRwFlag(flags, rw_crc), TestRwFlag(flags, rw_autoflush));
     return writer.getClear();
 }
 
@@ -1584,7 +1614,7 @@ public:
         tempname.append('.').append(tempfiles.ordinality()).append('_').append((__int64)GetCurrentThreadId()).append('_').append((unsigned)GetCurrentProcessId());
         IFile *file = createIFile(tempname.str());
         tempfiles.append(*file);
-        return createRowWriter(file,rowInterfaces->queryRowSerializer(),rowInterfaces->queryRowAllocator(),false,false,false); // flushed by close
+        return createRowWriter(file, rowInterfaces, 0); // flushed by close
     }
     void put(const void **rows,unsigned numrows)
     {
@@ -1611,7 +1641,7 @@ public:
         strms = (IRowStream **)calloc(numstrms,sizeof(IRowStream *));
         unsigned i;
         for (i=0;i<numstrms;i++) {
-            strms[i] = createSimpleRowStream(&tempfiles.item(i), rowInterfaces);
+            strms[i] = createRowStream(&tempfiles.item(i), rowInterfaces);
         }
         if (numstrms==1) 
             return LINK(strms[0]);
@@ -1632,9 +1662,7 @@ public:
             ++count;
         }
         return count;
-    }
-
-    
+    }    
 };
 
 IDiskMerger *createDiskMerger(IRowInterfaces *rowInterfaces, IRowLinkCounter *linker, const char *tempnamebase)

--- a/common/thorhelper/thorcommon.hpp
+++ b/common/thorhelper/thorcommon.hpp
@@ -68,6 +68,21 @@ extern THORHELPER_API void useMemoryMappedRead(bool on);
 
 extern THORHELPER_API IRowInterfaces *createRowInterfaces(IOutputMetaData *meta, unsigned actid, ICodeContext *context);
 
+
+enum RowReaderWriterFlags
+{
+    rw_grouped        = 0x1,
+    rw_crc            = 0x2,
+    rw_extend         = 0x4,
+    rw_compress       = 0x8,
+    rw_compressblkcrc = 0x10, // block compression, this sets/checks crc's at block level
+    rw_fastlz         = 0x20, // if rw_compress
+    rw_autoflush      = 0x40,
+    rw_buffered       = 0x80
+};
+#define DEFAULT_RWFLAGS (rw_buffered|rw_autoflush|rw_fastlz|rw_compressblkcrc)
+inline bool TestRwFlag(unsigned flags, RowReaderWriterFlags flag) { return 0 != (flags & flag); }
+
 interface IExtRowStream: extends IRowStream
 {
     virtual offset_t getOffset() = 0;
@@ -77,19 +92,19 @@ interface IExtRowStream: extends IRowStream
     virtual void reinit(offset_t offset,offset_t len,unsigned __int64 maxrows) = 0;
 };
 
-extern THORHELPER_API IExtRowStream *createRowStream(IFile *file,IRowInterfaces *rowif,offset_t offset,offset_t len,unsigned __int64 maxrows,bool tallycrc,bool grouped);
-inline IExtRowStream *createSimpleRowStream(IFile *file,IRowInterfaces *rowif) { return createRowStream(file, rowif,0,(offset_t)-1,(unsigned __int64)-1,false,false); }
-interface IExpander;
-extern THORHELPER_API IExtRowStream *createCompressedRowStream(IFile *file,IRowInterfaces *rowif,offset_t offset,offset_t len,unsigned __int64 maxrows,bool tallycrc,bool grouped,IExpander *eexp);
-
 interface IExtRowWriter: extends IRowWriter
 {
     virtual offset_t getPosition() = 0;
     virtual void flush(CRC32 *crcout=NULL) = 0;
 };
 
-extern THORHELPER_API IExtRowWriter *createRowWriter(IFile *file,IOutputRowSerializer *serializer,IEngineRowAllocator *allocator,bool grouped=false, bool tallycrc=false, bool extend=false); 
-extern THORHELPER_API IExtRowWriter *createRowWriter(IFileIOStream *strm,IOutputRowSerializer *serializer,IEngineRowAllocator *allocator,bool grouped=false, bool tallycrc=false,bool autoflush=true); // strm should be unbuffered
+interface IExpander;
+extern THORHELPER_API IExtRowStream *createRowStream(IFile *file, IRowInterfaces *rowif, unsigned flags=DEFAULT_RWFLAGS, IExpander *eexp=NULL);
+extern THORHELPER_API IExtRowStream *createRowStreamEx(IFile *file, IRowInterfaces *rowif, offset_t offset=0, offset_t len=(offset_t)-1, unsigned __int64 maxrows=(unsigned __int64)-1, unsigned flags=DEFAULT_RWFLAGS, IExpander *eexp=NULL);
+interface ICompressor;
+extern THORHELPER_API IExtRowWriter *createRowWriter(IFile *file, IRowInterfaces *rowIf, unsigned flags=DEFAULT_RWFLAGS, ICompressor *compressor=NULL);
+extern THORHELPER_API IExtRowWriter *createRowWriter(IFileIO *fileIO, IRowInterfaces *rowIf, unsigned flags=DEFAULT_RWFLAGS);
+extern THORHELPER_API IExtRowWriter *createRowWriter(IFileIOStream *strm, IRowInterfaces *rowIf, unsigned flags=DEFAULT_RWFLAGS); // strm should be unbuffered
 
 interface THORHELPER_API IDiskMerger : extends IInterface
 {

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -290,7 +290,7 @@ protected:
     unsigned __int64 numRecords;
     Owned<ClusterWriteHandler> clusterHandler;
     offset_t sizeLimit;
-    Owned<IOutputRowSerializer> rowSerializer;
+    Owned<IRowInterfaces> rowIf;
     StringBuffer mangledHelperFileName;
     OwnedConstHThorRow nextrow; // needed for grouped spill
 

--- a/initfiles/componentfiles/configxml/thor.xsd.in
+++ b/initfiles/componentfiles/configxml/thor.xsd.in
@@ -562,6 +562,13 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="compressInternalSpills" type="xs:boolean" default="true">
+        <xs:annotation>
+          <xs:appinfo>
+            <tooltip>Compress internal writes to disk when spilling</tooltip>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
     </xs:complexType>
     <xs:key name="thorProcessKey1">
       <xs:selector xpath="./ThorMasterProcess|./ThorSlaveProcess"/>

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10744,9 +10744,17 @@ public:
         diskout.setown(createBufferedIOStream(io));
         if (extend)
             diskout->seek(0, IFSend);
-        rowSerializer.setown(input->queryOutputMeta()->createRowSerializer(ctx->queryCodeContext(), activityId)); 
         tallycrc = !factory->queryQueryFactory().getDebugValueBool("skipFileFormatCrcCheck", false) && !(helper.getFlags() & TDRnocrccheck) && !blockcompressed;
-        outSeq.setown(createRowWriter(diskout, rowSerializer, rowAllocator, grouped, tallycrc, true )); 
+        Owned<IRowInterfaces> rowIf = createRowInterfaces(input->queryOutputMeta(), activityId, ctx->queryCodeContext());
+        rowSerializer.set(rowIf->queryRowSerializer());
+        unsigned rwFlags = rw_autoflush;
+        if(grouped)
+            rwFlags |= rw_grouped;
+        if(tallycrc)
+            rwFlags |= rw_crc;
+        if(!factory->queryQueryFactory().getDebugValueBool("skipFileFormatCrcCheck", false) && !(helper.getFlags() & TDRnocrccheck))
+            rwFlags |= rw_crc;
+        outSeq.setown(createRowWriter(diskout, rowIf, rwFlags));
     }
 
     virtual void stop(bool aborting)

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1241,7 +1241,7 @@ public:
         else // local
         {
             if (RCUNSET != rhsTotalCount)
-                rhsRows = rhsTotalCount;
+                rhsRows = (rowidx_t)rhsTotalCount;
             else // all join, or lookup if total count unkown
                 rhsRows = rhs.ordinality();
         }

--- a/thorlcr/activities/loop/thloop.cpp
+++ b/thorlcr/activities/loop/thloop.cpp
@@ -107,7 +107,7 @@ public:
         global = !loopGraph->isLocalOnly();
         if (container.queryLocalOrGrouped())
             return;
-        maxEmptyLoopIterations = (unsigned)container.queryJob().getWorkUnitValueInt("@maxEmptyLoopIterations", 1000);
+        maxEmptyLoopIterations = getOptUInt(THOROPT_LOOP_MAX_EMPTY, 1000);
     }
     void process()
     {

--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -165,7 +165,7 @@ public:
     {
         input = NULL;
         mpTag = TAG_NULL;
-        maxEmptyLoopIterations = (unsigned)container->queryJob().getWorkUnitValueInt("@maxEmptyLoopIterations", 1000);
+        maxEmptyLoopIterations = getOptUInt(THOROPT_LOOP_MAX_EMPTY, 1000);
     }
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
     {

--- a/thorlcr/activities/merge/thmergeslave.cpp
+++ b/thorlcr/activities/merge/thmergeslave.cpp
@@ -316,7 +316,7 @@ public:
         StringBuffer tmpname;
         GetTempName(tmpname,"merge",true); // use alt temp dir
         tmpfile.setown(createIFile(tmpname.str()));
-        Owned<IRowWriter> writer =  createRowWriter(tmpfile,queryRowSerializer(),queryRowAllocator()); 
+        Owned<IRowWriter> writer =  createRowWriter(tmpfile, this);
         CThorKeyArray sample(*this, this, helper->querySerialize(), helper->queryCompare(), helper->queryCompareKey(), helper->queryCompareRowKey());
         sample.setSampling(MERGE_TRANSFER_BUFFER_SIZE);
         ActPrintLog("MERGE: start gather");
@@ -360,7 +360,7 @@ public:
         offset_t end = partitionpos[idx];
         if (pos>=end)
             return 0;
-        Owned<IExtRowStream> rs = createRowStream(tmpfile,queryRowInterfaces(this),pos,end,RCUNBOUND,false,false); // this is not good
+        Owned<IExtRowStream> rs = createRowStreamEx(tmpfile, queryRowInterfaces(this), pos, end); // this is not good
         offset_t so = rs->getOffset();
         size32_t len = 0;
         size32_t chunksize = chunkmaxsize;

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -310,7 +310,7 @@ public:
         ForEachItemIn(o, container.outputs)
             appendOutput(new CDelayedInput(*this));
         IHThorSplitArg *helper = (IHThorSplitArg *)queryHelper();
-        int dV = (int)container.queryJob().getWorkUnitValueInt("splitterSpills", -1);
+        int dV = getOptInt(THOROPT_SPLITTER_SPILL, -1);
         if (-1 == dV)
         {
             spill = !helper->isBalanced();

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -340,7 +340,12 @@ void CDiskWriteSlaveActivityBase::open()
     else
     {
         stream.setown(createIOStream(iFileIO));
-        out.setown(createRowWriter(stream,::queryRowSerializer(input),::queryRowAllocator(input),grouped,calcFileCrc,false)); // flushed by close
+        unsigned rwFlags = 0;
+        if (grouped)
+            rwFlags |= rw_grouped;
+        if (calcFileCrc)
+            rwFlags |= rw_crc;
+        out.setown(createRowWriter(stream, ::queryRowInterfaces(input), rwFlags));
     }
     CDfsLogicalFileName dlfn;
     dlfn.set(logicalFilename);

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -898,8 +898,11 @@ public:
     mptag_t allocateMPTag();
     void freeMPTag(mptag_t tag);
     mptag_t deserializeMPTag(MemoryBuffer &mb);
-    unsigned getOptInt(const char *opt, unsigned dft=0);
+    bool getOptBool(const char *opt, bool dft=false);
+    int getOptInt(const char *opt, int dft=0);
+    unsigned getOptUInt(const char *opt, unsigned dft=0) { return (unsigned)getOptInt(opt, dft); }
     __int64 getOptInt64(const char *opt, __int64 dft=0);
+    unsigned __int64 getOptUInt64(const char *opt, unsigned __int64 dft=0) { return (unsigned __int64)getOptInt64(opt, dft); }
 
     virtual void abort(IException *e);
     virtual IBarrier *createBarrier(mptag_t tag) { UNIMPLEMENTED; return NULL; }
@@ -988,6 +991,12 @@ public:
     virtual IOutputMetaData *queryRowMetaData() { return baseHelper->queryOutputMeta(); }
     virtual unsigned queryActivityId() { return (unsigned)container.queryId(); }
     virtual ICodeContext *queryCodeContext() { return container.queryCodeContext(); }
+
+    bool getOptBool(const char *prop, bool defVal=false) const;
+    int getOptInt(const char *prop, int defVal=0) const;
+    unsigned getOptUInt(const char *prop, unsigned defVal=0) const { return (unsigned)getOptInt(prop, defVal); }
+    __int64 getOptInt64(const char *prop, __int64 defVal=0) const;
+    unsigned __int64 getOptUInt64(const char *prop, unsigned __int64 defVal=0) const { return (unsigned __int64)getOptInt64(prop, defVal); }
 };
 
 interface IFileInProgressHandler : extends IInterface

--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -455,7 +455,7 @@ void CThorKeyArray::calcPositions(IFile *file,CThorKeyArray &sample)
         if (pos==(offset_t)-1) 
             pos = 0;
         // should do bin-chop for fixed length but initially do sequential search
-        Owned<IRowStream> s = createRowStream(file,rowif,pos,(offset_t)-1,RCUNBOUND,false,false);
+        Owned<IRowStream> s = createRowStreamEx(file, rowif, pos);
         loop
         {
             OwnedConstThorRow rowcmp = s->nextRow();

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -416,7 +416,7 @@ public:
 
     //A thread calling the following functions must own the lock, or guarantee no other thread will access
     void sort(ICompare & compare, unsigned maxcores);
-    rowidx_t save(IFile &file, rowidx_t watchRecNum=(rowidx_t)-1, offset_t *watchFilePosResult=NULL);
+    rowidx_t save(IFile &file, bool useCompression);
     const void **getBlock(rowidx_t readRows);
     inline void noteSpilled(rowidx_t spilledRows)
     {

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -45,6 +45,13 @@
     #define graph_decl
 #endif
 
+/// Thor options, that can be hints, workunit options, or global settings
+#define THOROPT_COMPRESS_SPILLS       "compressInternalSpills"
+#define THOROPT_HDIST_SPILL           "hdistSpill"
+#define THOROPT_HDIST_WRITE_POOL_SIZE "hdistSendPoolSize"
+#define THOROPT_SPLITTER_SPILL        "splitterSpill"
+#define THOROPT_LOOP_MAX_EMPTY        "loopMaxEmpty"
+
 #define INITIAL_SELFJOIN_MATCH_WARNING_LEVEL 20000  // max of row matches before selfjoin emits warning
 
 #define THOR_SEM_RETRY_TIMEOUT 2


### PR DESCRIPTION
HPCC-3097 Compress internal spill files

By default, spill all internal spill files.
Configurable via option 'compress_internal_spills',
via hint,workunit or global

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
