### PR TITLE
HPCC-8149 mark stepping*.ecl tests as Thor TBD

### DIFF
--- a/testing/ecl/stepping.ecl
+++ b/testing/ecl/stepping.ecl
@@ -18,6 +18,9 @@
 //UseStandardFiles
 //nothor
 
+//Stepped global joins unsupported, see issue HPCC-8148
+//skip type==thorlcr TBD
+
 import lib_stringLib;
 
 MaxTerms            := TS_MaxTerms;

--- a/testing/ecl/stepping2.ecl
+++ b/testing/ecl/stepping2.ecl
@@ -18,6 +18,8 @@
 //UseStandardFiles
 //nothor
 
+//Stepped global joins unsupported, see issue HPCC-8148
+//skip type==thorlcr TBD
 
 OUTPUT(SORTED(STEPPED(TS_WordIndex(keyed(kind = TS_kindType.TextEntry and word in ['boy', 'sheep'])), doc, segment, wpos), doc, segment, wpos, assert)) : independent;
 OUTPUT(SORTED(STEPPED(TS_WordIndex(keyed(kind = TS_kindType.TextEntry and word in ['b%%%', 'sheep'])), doc, segment, wpos), doc, segment, wpos, assert)) : independent;

--- a/testing/ecl/stepping3.ecl
+++ b/testing/ecl/stepping3.ecl
@@ -22,5 +22,8 @@
 //varskip trans
 //nothor
 
+//Stepped global joins unsupported, see issue HPCC-8148
+//skip type==thorlcr TBD
+
 // should be equivalent to OUTPUT(SORT(DG_IndexFile(DG_firstname = 'DAVID'), DG_Prange));
 OUTPUT(STEPPED(DG_IndexFile(KEYED(DG_firstname = 'DAVID')), DG_Prange));

--- a/testing/ecl/stepping4.ecl
+++ b/testing/ecl/stepping4.ecl
@@ -22,6 +22,9 @@
 //varskip trans
 //nothor
 
+//Stepped global joins unsupported, see issue HPCC-8148
+//skip type==thorlcr TBD
+
 boy := STEPPED(TS_WordIndex(keyed(kind = TS_kindType.TextEntry and word = 'boy')), doc);
 
 sheep := STEPPED(TS_WordIndex(keyed(kind = TS_kindType.TextEntry and word = 'sheep')), doc);


### PR DESCRIPTION
See HPCC-8148, Global join stepping not currently supported in
Thor

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
