### PR TITLE
HPCC-8049 Add Rename Physical to transactions

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -459,7 +459,7 @@ interface IDistributedFileDirectory: extends IInterface
 
     virtual bool removeEntry(const char *name,IUserDescriptor *user, unsigned timeoutms=INFINITE) = 0;  // equivalent to lookup/detach/release
     virtual bool removePhysical(const char *name,IUserDescriptor *user,const char *cluster=NULL,IMultiException *exceptions=NULL) = 0;                           // removes the physical parts as well as entry
-    virtual bool renamePhysical(const char *oldname,const char *newname,IUserDescriptor *user,IMultiException *exceptions=NULL) = 0;                         // renames the physical parts as well as entry
+    virtual void renamePhysical(const char *oldname,const char *newname,IUserDescriptor *user,IDistributedFileTransaction *transaction) = 0;                         // renames the physical parts as well as entry
     virtual void removeEmptyScope(const char *scope) = 0;   // does nothing if called on non-empty scope
     
 

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1443,8 +1443,7 @@ public:
                         newfile.clear();
                         StringBuffer fromname(srcName);
                         srcFile.clear();
-                        if (!queryDistributedFileDirectory().renamePhysical(fromname.str(),toname.str(),userdesc,NULL))
-                            throw MakeStringException(-1,"rename failed"); // could do with better error here
+                        queryDistributedFileDirectory().renamePhysical(fromname.str(),toname.str(),userdesc,NULL);
                         StringBuffer timetaken;
                         timetaken.appendf("%dms",msTick()-start);
                         progress->setDone(timetaken.str(),0,true);

--- a/testing/ecl/key/superfile9.xml
+++ b/testing/ecl/key/superfile9.xml
@@ -1,0 +1,34 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>true</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>true</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>false</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>false</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><Result_7>false</Result_7></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>true</Result_8></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><Result_9>true</Result_9></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><Result_10>false</Result_10></Row>
+</Dataset>
+<Dataset name='Result 11'>
+ <Row><Result_11>false</Result_11></Row>
+</Dataset>
+<Dataset name='Result 12'>
+ <Row><Result_12>true</Result_12></Row>
+</Dataset>

--- a/testing/ecl/superfile9.ecl
+++ b/testing/ecl/superfile9.ecl
@@ -1,0 +1,71 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+import Std.System.Thorlib;
+import Std.File AS FileServices;
+import Std.Str;
+// Super File regression test
+//noRoxie
+
+rec :=
+RECORD
+        integer i;
+    string1 id;
+END;
+
+ds1 := DATASET([{1,'A'}, {1,'B'}, {1,'C'}], rec);
+ds2 := DATASET([{1,'A'}, {1,'B'}, {1,'C'}], rec);
+
+clusterLFNPrefix := thorlib.getExpandLogicalName('regress::');
+
+string stripPrefix(string qlfn) := IF (Str.Find(qlfn, clusterLFNprefix, 1) = 1, Str.FindReplace(qlfn, clusterLFNPrefix, ''), qlfn);
+
+conditionalDelete(string lfn) := FUNCTION
+        RETURN IF(FileServices.FileExists(lfn), FileServices.DeleteLogicalFile(lfn));
+END;
+
+
+SEQUENTIAL(
+  // Prepare
+  conditionalDelete ('regress::subfile12'),
+  conditionalDelete ('regress::subfile13'),
+  OUTPUT(ds1,,'regress::subfile10',overwrite),
+  OUTPUT(ds2,,'regress::subfile11',overwrite),
+  OUTPUT(FileServices.FileExists('regress::subfile10')), // true
+  OUTPUT(FileServices.FileExists('regress::subfile11')), // true
+  OUTPUT(FileServices.FileExists('regress::subfile12')), // false
+  OUTPUT(FileServices.FileExists('regress::subfile13')), // false
+
+  // Rename Auto-commit
+  FileServices.RenameLogicalFile('regress::subfile10','regress::subfile12'),
+  OUTPUT(FileServices.FileExists('regress::subfile10')), // false
+  OUTPUT(FileServices.FileExists('regress::subfile12')), // true
+
+  // Rename + Rollback
+  FileServices.StartSuperFileTransaction(),
+  FileServices.RenameLogicalFile('regress::subfile11','regress::subfile13'),
+  FileServices.FinishSuperFileTransaction(true),    // rollback
+  OUTPUT(FileServices.FileExists('regress::subfile11')), // true
+  OUTPUT(FileServices.FileExists('regress::subfile13')), // false
+
+  // Rename + Commit
+  FileServices.StartSuperFileTransaction(),
+  FileServices.RenameLogicalFile('regress::subfile11','regress::subfile13'),
+  FileServices.FinishSuperFileTransaction(),    // commit
+  OUTPUT(FileServices.FileExists('regress::subfile11')), // false
+  OUTPUT(FileServices.FileExists('regress::subfile13')), // true
+);


### PR DESCRIPTION
Adding RenamePhysical to the list of actions supported by transactions. Also adding engine tests and unit tests.

Commit will rename the file, while rollback/retry will rename back to the original name. Since rollback happens in the reverse order in which they occurred, chained renames should roll back correctly.

Signed-off-by: Renato Golin rengolin@hpccsystems.com
