### PR TITLE
HPCC-2558 Fix problems deleting workunit .so/.cpp files

### DIFF
--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -220,6 +220,7 @@ class EclccCompileThread : public CInterface, implements IPooledThread
                     Owned<ILocalWorkUnit> embeddedWU = createLocalWorkUnit();
                     embeddedWU->loadXML(wuXML);
                     queryExtendedWU(workunit)->copyWorkUnit(embeddedWU, true);
+                    workunit->setIsClone(false);
                     SCMStringBuffer jobname;
                     if (embeddedWU->getJobName(jobname).length()) //let ECL win naming job during initial compile
                         workunit->setJobName(jobname.str());

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -426,6 +426,7 @@ bool CppCompiler::compile()
         cclog = queryCcLogName();
     Owned <IFile> dstfile = createIFile(cclog);
     dstfile->remove();
+
     Owned<IFileIO> dstIO = dstfile->open(IFOwrite);
     ForEachItemIn(i2, logFiles)
     {
@@ -436,6 +437,12 @@ bool CppCompiler::compile()
             srcfile->remove();
         }
     }
+
+    //Don't leave lots of blank log files around if the compile was successful
+    bool logIsEmpty = (dstIO->size() == 0);
+    dstIO.clear();
+    if (ret && logIsEmpty)
+        dstfile->remove();
 
     pool->joinAll(true, 1000);
     return ret;


### PR DESCRIPTION
Currently the .so files and other files associated with a workunit are
never deleted.  This is because the representation in the workunit changed
a while back, but the code wasn't updated to match.  This patch fixes the
following:
- empty eclcc.log files are removed
- dll/so files pass the tail name to removeDll.
- workunits created by eclccserver are not marked as clones.
- non dll/so files are deleted directly (they are no longer registered with dll
  server)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
