### PR TITLE
HPCC-8031 Display associated XML files from ECL WU Details page

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -1236,6 +1236,19 @@
           </a>
         </td>
       </xsl:if>
+      <xsl:if test="(Type = 'xml') or (Type = 'hint')">
+        <td>
+          <a href="/esp/iframe?esp_iframe_title=ECL Workunit - {$wuid} - {Description}&amp;inner=
+                   /WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Name%3d{Name}%26IPAddress%3d{IPAddress}%26Description%3d{Description}%26Type%3dXML" >
+            <xsl:value-of select="Description"/>
+          </a>
+        </td>
+        <td>
+          <a href="javascript:void(0)" onclick="getOptions('{Description}', '/WsWorkunits/WUFile/{Name}?Wuid={$wuid}&amp;Name={Name}&amp;IPAddress={IPAddress}&amp;Description={Description}&amp;Type=xml', false); return false;">
+            download
+          </a>
+        </td>
+      </xsl:if>
       <xsl:if test="Type = 'res'">
         <td>
           <a href="/WsWorkunits/WUFile/res.txt?Wuid={$wuid}&amp;Type=res">res.txt</a>

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -436,6 +436,30 @@ void WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
     }
 }
 
+struct mapEnums { int val; const char *str; };
+
+mapEnums queryFileTypes[] = {
+   { FileTypeCpp, "cpp" },
+   { FileTypeDll, "dll" },
+   { FileTypeResText, "res" },
+   { FileTypeHintXml, "hint" },
+   { FileTypeXml, "xml" },
+   { FileTypeSize,  NULL },
+};
+
+const char *getEnumText(int value, mapEnums *map)
+{
+    const char *defval = map->str;
+    while (map->str)
+    {
+        if (value==map->val)
+            return map->str;
+        map++;
+    }
+    assertex(!"Unexpected value in setEnum");
+    return defval;
+}
+
 void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
 {
     try
@@ -478,9 +502,8 @@ void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
         }
 
         IArrayOf<IEspECLHelpFile> helpers;
-        getHelpFiles(query, FileTypeCpp, helpers);
-        getHelpFiles(query, FileTypeDll, helpers);
-        getHelpFiles(query, FileTypeResText, helpers);
+        for (unsigned i = 0; i < FileTypeSize; i++)
+            getHelpFiles(query, (WUFileType) i, helpers);
 
         getWorkunitThorLogInfo(helpers, info);
 
@@ -1458,19 +1481,7 @@ void WsWuInfo::getHelpFiles(IConstWUQuery* query, WUFileType type, IArrayOf<IEsp
         cur.getName(name);
         Owned<IEspECLHelpFile> h= createECLHelpFile("","");
         h->setName(name.str());
-
-        switch (type)
-        {
-            case FileTypeCpp:
-                h->setType("cpp");
-                break;
-            case FileTypeDll:
-                h->setType("dll");
-                break;
-            default:
-                h->setType("res");
-                break;
-        }
+        h->setType(getEnumText(type, queryFileTypes));
 
         if (version > 1.31)
         {
@@ -1903,6 +1914,41 @@ void WsWuInfo::getWorkunitCpp(const char *cppname, const char* description, cons
     OwnedIFileIOStream ios = createBufferedIOStream(rIO);
     if (!ios)
         throw MakeStringException(ECLWATCH_CANNOT_READ_FILE,"Cannot read %s.", description);
+    appendIOStreamContent(buf, ios.get(), forDownload);
+}
+
+void WsWuInfo::getWorkunitAssociatedXml(const char* name, const char* ipAddress, const char* plainText,
+                                        const char* description, bool forDownload, MemoryBuffer& buf)
+{
+    if (isEmpty(description)) //'File Name' as shown in WU Details page
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "File not specified.");
+    if (isEmpty(ipAddress))
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "File location not specified.");
+    if (isEmpty(name)) //file name with full path
+        throw MakeStringException(ECLWATCH_INVALID_FILE_NAME, "File path not specified.");
+
+    RemoteFilename rfn;
+    rfn.setRemotePath(name);
+    SocketEndpoint ep(ipAddress);
+    rfn.setIp(ep);
+
+    Owned<IFile> rFile = createIFile(rfn);
+    if (!rFile)
+        throw MakeStringException(ECLWATCH_CANNOT_OPEN_FILE, "Cannot open %s.", description);
+    OwnedIFileIO rIO = rFile->openShared(IFOread,IFSHfull);
+    if (!rIO)
+        throw MakeStringException(ECLWATCH_CANNOT_READ_FILE,"Cannot read %s.", description);
+    OwnedIFileIOStream ios = createBufferedIOStream(rIO);
+    if (!ios)
+        throw MakeStringException(ECLWATCH_CANNOT_READ_FILE,"Cannot read %s.", description);
+
+    const char* header;
+    if (plainText && (!stricmp(plainText, "yes")))
+        header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+    else
+        header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><?xml-stylesheet href=\"../esp/xslt/xmlformatter.xsl\" type=\"text/xsl\"?>";
+
+    buf.append(strlen(header), header);
     appendIOStreamContent(buf, ios.get(), forDownload);
 }
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -172,6 +172,7 @@ public:
     void getWorkunitArchiveQuery(MemoryBuffer& buf);
     void getWorkunitDll(StringBuffer &name, MemoryBuffer& buf);
     void getWorkunitXml(const char* plainText, MemoryBuffer& buf);
+    void getWorkunitAssociatedXml(const char* name, const char* IPAddress, const char* plainText, const char* description, bool forDownload, MemoryBuffer& buf);
     void getWorkunitCpp(const char* cppname, const char* description, const char* ipAddress, MemoryBuffer& buf, bool forDownload);
     void getEventScheduleFlag(IEspECLWorkunit &info);
     unsigned getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IEspECLWorkunit &info);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2043,7 +2043,7 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
         if (results.length() > (aindex_t)pagesize)
             results.pop();
 
-        if(begin + pagesize < numWUs)
+        if(unsigned (begin + pagesize) < numWUs)
         {
             resp.setNextPage(begin + pagesize);
             resp.setPageEndAt(begin + pagesize);
@@ -2639,6 +2639,18 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
             {
                 winfo.getWorkunitEclAgentLog(req.getProcess(), mb);
                 openSaveFile(context, opt, "eclagent.log", HTTP_TYPE_TEXT_PLAIN, mb, resp);
+            }
+            else if (strieq(File_XML,req.getType()) && notEmpty(req.getName()))
+            {
+                const char* name  = req.getName();
+                const char* ptr = strrchr(name, '/');
+                if (ptr)
+                    ptr++;
+                else
+                    ptr = name;
+
+                winfo.getWorkunitAssociatedXml(name, req.getIPAddress(), req.getPlainText(), req.getDescription(), opt > 0, mb);
+                openSaveFile(context, opt, ptr, HTTP_TYPE_APPLICATION_XML, mb, resp);
             }
             else if (strieq(File_XML,req.getType()))
             {


### PR DESCRIPTION
Currently eclwatch displays associated files for cpp, dll and ResText
in the Ecl Workunit Details page. It should also display all file types. 
This fix upgrades the code to display associated XML files, including
FileTypeHintXml and FileTypeXml.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
