### PR TITLE
HPCC-8102 Rename eclccserver maxCompileThreads option

### DIFF
--- a/docs/UsingConfigManager/UsingConfigManager.xml
+++ b/docs/UsingConfigManager/UsingConfigManager.xml
@@ -1484,9 +1484,9 @@ sudo configmgr</programlisting>
                     </row>
 
                     <row>
-                      <entry><emphasis>maxCompileThreads</emphasis></entry>
+                      <entry><emphasis>maxEclccProcesses</emphasis></entry>
 
-                      <entry>The maximum number of compile threads</entry>
+                      <entry>The maximum number of eclcc processes that will be launched in parallel</entry>
                     </row>
 
                     <row>

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -574,7 +574,10 @@ int main(int argc, const char *argv[])
         getEclCCServerQueueNames(queueNames, globals->queryProp("@name"));
         if (!queueNames.length())
             throw MakeStringException(0, "No clusters found to listen on");
-        EclccServer server(queueNames.str(), globals->getPropInt("@maxCompileThreads", 1));
+        // The option has been renamed to avoid confusion with the similarly-named eclcc option, but
+        // still accept the old name if the new one is not present.
+        unsigned maxThreads = globals->getPropInt("@maxEclccProcesses", globals->getPropInt("@maxCompileThreads", 4));
+        EclccServer server(queueNames.str(), maxThreads);
         // if we got here, eclserver is successfully started and all options are good, so create the "sentinel file" for re-runs from the script
         // put in its own "scope" to force the flush
         writeSentinelFile(sentinelFile);

--- a/initfiles/componentfiles/configxml/eclccserver.xsd
+++ b/initfiles/componentfiles/configxml/eclccserver.xsd
@@ -192,10 +192,10 @@
                 </xs:annotation>
             </xs:attribute>
             <xs:attribute name="traceLevel" type="xs:nonNegativeInteger" use="optional" default="1"/>
-            <xs:attribute name="maxCompileThreads" type="xs:nonNegativeInteger" use="optional" default="4">
+            <xs:attribute name="maxEclccProcesses" type="xs:nonNegativeInteger" use="optional" default="4">
                 <xs:annotation>
                     <xs:appinfo>
-                        <tooltip>Number of compile threads.</tooltip>
+                        <tooltip>Maximum number of instances of eclcc that will be launched in parallel.</tooltip>
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -387,7 +387,7 @@
                     daliServers="mydali"
                     description="EclCCServer process"
                     enableSysLog="true"
-                    maxCompileThreads="4"
+                    maxEclccProcesses="4"
                     name="myeclccserver"
                     traceLevel="1">
    <Instance computer="localhost"


### PR DESCRIPTION
To avoid confusion with the similarly-named option in eclcc, that does
something slightly different, rename the eclccserver option to
maxEclccProcesses.

The old option name will still be accepted if the new is not present.

Also make the default value consistent between the xsd file and the cpp
file - it now defaults to 4 in both places, where previously the cpp
would default to 1 if the value was explicitly deleted from the config
(unlikely).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
