### PR TITLE
HPCC-8174 Global loop regression

### DIFF
--- a/thorlcr/activities/loop/thloop.cpp
+++ b/thorlcr/activities/loop/thloop.cpp
@@ -239,8 +239,11 @@ public:
                     initLoopResults(loopCounter);
                 boundGraph->execute(*this, (flags & IHThorLoopArg::LFcounter)?loopCounter:0, ownedResults, (IRowWriterMultiReader *)NULL, 0, extractBuilder.size(), extractBuilder.getbytes());
                 ++loopCounter;
-                if (!barrier->wait(false))
-                    break;
+                if (flags & IHThorLoopArg::LFnewloopagain)
+                {
+                    if (!barrier->wait(false))
+                        break;
+                }
             }
         }
         else


### PR DESCRIPTION
Missing condition in master could cause non loop again queries
to deadlock

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
