### PR TITLE
HPCC-7850 Configmgr - Roxie componenet needs to have LDAP tab

### DIFF
--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -385,6 +385,7 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
+      <xs:attributeGroup ref="LDAP"/>
       <xs:attributeGroup ref="Options"/>
       <xs:attributeGroup ref="Tracing"/>
       <xs:attributeGroup ref="UDP"/>
@@ -397,7 +398,24 @@
       <xs:field xpath="@name"/>
     </xs:key>
   </xs:element>
-  <xs:attributeGroup name="Options">
+ <xs:attributeGroup name="LDAP">
+    <xs:attribute name="ldapUser" type="xs:string" use="optional" default="roxie">
+      <xs:annotation>
+        <xs:appinfo>
+          <tooltip>Specifies the user name for LDAP file access checking.</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ldapPassword" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:appinfo>
+          <viewType>password</viewType>
+          <tooltip>Specifies the password for LDAP file access checking.</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+ </xs:attributeGroup>
+ <xs:attributeGroup name="Options">
     <xs:attribute name="allowRoxieOnDemand" type="xs:boolean" use="optional" default="false">
       <xs:annotation>
         <xs:appinfo>
@@ -578,21 +596,6 @@
           <xs:enumeration value="smart"/>
         </xs:restriction>
       </xs:simpleType>
-    </xs:attribute>
-    <xs:attribute name="ldapUser" type="xs:string" use="optional" default="roxie">
-      <xs:annotation>
-        <xs:appinfo>
-          <tooltip>Specifies the user name for LDAP file access checking.</tooltip>
-        </xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="ldapPassword" type="xs:string" use="optional">
-      <xs:annotation>
-        <xs:appinfo>
-          <viewType>password</viewType>
-          <tooltip>Specifies the password for LDAP file access checking.</tooltip>
-        </xs:appinfo>
-      </xs:annotation>
     </xs:attribute>
     <xs:attribute name="localFilesExpire" type="xs:integer" use="optional" default="-1">
       <xs:annotation>


### PR DESCRIPTION
- Add LDAP tab to Roxie for configmgr.
  - Move ldapUser and ldapPassword to LDAP tab

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
