### PR TITLE
HPCC-8180 Roxie issues reloading changed files

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -353,7 +353,9 @@ protected:
         if (variableFileName) // note - in keyed join with dependent index case, kj itself won't have variableFileName but indexread might
         {
             CDateTime cacheDate(serializedCreate);
-            varFileInfo.setown(querySlaveDynamicFileCache()->lookupDynamicFile(logctx, queryDynamicFileName(), cacheDate, &packet->queryHeader(), isOpt, true));
+            unsigned checksum;
+            serializedCreate.read(checksum);
+            varFileInfo.setown(querySlaveDynamicFileCache()->lookupDynamicFile(logctx, queryDynamicFileName(), cacheDate, checksum, &packet->queryHeader(), isOpt, true));
             setVariableFileInfo();
         }
     }

--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -41,10 +41,6 @@ interface ILazyFileIO : extends IFileIO
     virtual IFile *queryTarget() = 0;
     virtual void copyComplete() = 0;
     virtual int getLinkCount() const = 0;
-    virtual void setFileIsMemFile(bool val) = 0;
-    virtual bool getFileIsMemFile() = 0;
-    virtual void setCopyInForeground(bool val) = 0;
-    virtual bool getCopyInForeground() = 0;
     virtual bool createHardFileLink() = 0;
 
     virtual void setBaseIndexFileName(const char *val) =0;
@@ -112,6 +108,7 @@ interface IResolvedFile : extends ISimpleSuperFileEnquiry
     virtual offset_t getFileSize() const = 0;
 
     virtual const CDateTime &queryTimeStamp() const = 0;
+    virtual unsigned queryCheckSum() const = 0;
 
     virtual const char *queryFileName() const = 0;
     virtual void setCache(const IRoxiePackage *cache) = 0;

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -83,7 +83,7 @@ extern IRoxiePackage *createPackage(IPropertyTree *p);
 
 interface ISlaveDynamicFileCache : extends IInterface
 {
-    virtual IResolvedFile *lookupDynamicFile(const IRoxieContextLogger &logctx, const char *lfn, CDateTime &cacheDate, RoxiePacketHeader *header, bool isOpt, bool isLocal) = 0; 
+    virtual IResolvedFile *lookupDynamicFile(const IRoxieContextLogger &logctx, const char *lfn, CDateTime &cacheDate, unsigned checksum, RoxiePacketHeader *header, bool isOpt, bool isLocal) = 0;
 };
 extern ISlaveDynamicFileCache *querySlaveDynamicFileCache();
 extern void releaseSlaveDynamicFileCache();

--- a/system/jlib/jcrc.hpp
+++ b/system/jlib/jcrc.hpp
@@ -37,7 +37,7 @@ class jlib_decl CRC32
 public:
     CRC32(unsigned crc = ~0U) { reset(crc); }
     inline void reset(unsigned _crc = ~0U) { crc = _crc; }
-    inline unsigned get() { return ~crc; }
+    inline unsigned get() const { return ~crc; }
     void skip(offset_t length);
     void tally(unsigned len, const void * buf);
 

--- a/testing/ecl/key/rewrite.xml
+++ b/testing/ecl/key/rewrite.xml
@@ -1,0 +1,15 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><a>1</a></Row>
+</Dataset>
+<Dataset name='Result 3'>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><a>2</a></Row>
+</Dataset>
+<Dataset name='Result 5'>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><a>3</a></Row>
+</Dataset>

--- a/testing/ecl/rewrite.ecl
+++ b/testing/ecl/rewrite.ecl
@@ -1,0 +1,17 @@
+#option ('allowVariableRoxieFilenames', 1);
+string prefix := '' : stored('prefix');
+
+
+d1 := dataset([{1}], { INTEGER a });
+d2 := dataset([{2}], { INTEGER a });
+d3 := dataset([{3}], { INTEGER a });
+i := dataset('regress::outfile'+prefix, { INTEGER a }, FLAT);
+
+sequential(
+  output(d1,,'regress::outfile'+prefix, OVERWRITE),
+  output(i);
+  output(d2,,'regress::outfile'+prefix, OVERWRITE),
+  output(i);
+  output(d3,,'regress::outfile'+prefix, OVERWRITE),
+  output(i);
+);

--- a/testing/ecl/roxie/key/rewrite.xml
+++ b/testing/ecl/roxie/key/rewrite.xml
@@ -1,0 +1,15 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><a>1</a></Row>
+</Dataset>
+<Dataset name='Result 3'>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><a>2</a></Row>
+</Dataset>
+<Dataset name='Result 5'>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><a>3</a></Row>
+</Dataset>


### PR DESCRIPTION
Various issues related to how Roxie caches file references:
1. A memory leak was causing files to be locked longer than they should
2. Using just the file time and not the CRC to determine if the slave
   dynamic file cache entries are valid. Time is only accurate to 1s,
   it seems
3. Files were always being copied regardless of the settings of
   useRemoteResources/copyResources. Some code that was intended to be
   temporary had been left in.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
