### PR TITLE
HPCC-7980 Translate remote file dafilesrv access to local

### DIFF
--- a/common/environment/dalienv.hpp
+++ b/common/environment/dalienv.hpp
@@ -51,4 +51,9 @@ extern ENVIRONMENT_API bool getRemoteRunInfo(const char * keyName, const char * 
 
 extern ENVIRONMENT_API bool envGetConfigurationDirectory(const char *category, const char *component,const char *instance, StringBuffer &dirout);
 
+extern ENVIRONMENT_API IPropertyTree *envGetNASConfiguration(); // return NAS config
+extern ENVIRONMENT_API void envInstallNASHooks(); // gets NAS config and sets up
+// like envInstallNASHooksalso but also reutrns which filters were installed
+extern ENVIRONMENT_API IPropertyTree *envGetInstallNASHooks();
+
 #endif

--- a/common/remote/rmtfile.hpp
+++ b/common/remote/rmtfile.hpp
@@ -37,6 +37,14 @@ enum DAFS_OS
 
 extern REMOTE_API void filenameToUrl(StringBuffer & out, const char * filename);
 
+interface IDaFileSrvHook : extends IRemoteFileCreateHook
+{
+    virtual void addSubnetFilter(const char *subnet, const char *mask, const char *dir, bool trace) = 0;
+    virtual IPropertyTree *addSubnetFilters(IPropertyTree *filters, const IpAddress *ipAddress) = 0;
+    virtual IPropertyTree *addMySubnetFilters(IPropertyTree *filters) = 0;
+    virtual void clearSubNetFilters() = 0;
+};
+extern REMOTE_API IDaFileSrvHook *queryDaFileSrvHook();
 extern REMOTE_API unsigned short getDaliServixPort();  // assumed just the one for now
 extern REMOTE_API void setCanAccessDirectly(RemoteFilename & file,bool set);
 extern REMOTE_API void setDaliServixSocketCaching(bool set);

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3256,6 +3256,9 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
             if (getConfigurationDirectory(agentTopology->queryPropTree("Directories"),"mirror","eclagent",agentTopology->queryProp("@name"),baseDir.clear()))
                 setBaseDirectory(baseDir.str(), true);
 
+            if (agentTopology->getPropBool("@useNASTranslation", true))
+                envInstallNASHooks();
+
             if (standAloneWorkUnit)
             {
                 //Stand alone program, but dali is specified => create a workunit in dali, and store the results there....

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -5130,7 +5130,7 @@ bool IpSubNet::set(const char *_net,const char *_mask)
     return true;
 }
 
-bool IpSubNet::test(const IpAddress &ip)
+bool IpSubNet::test(const IpAddress &ip) const
 {
     unsigned i;
     if (ip.getNetAddress(sizeof(i),&i)==sizeof(i)) {
@@ -5148,19 +5148,24 @@ bool IpSubNet::test(const IpAddress &ip)
     return false;
 }
 
-StringBuffer IpSubNet::getNetText(StringBuffer &text)
+StringBuffer IpSubNet::getNetText(StringBuffer &text) const
 {
     char tmp[INET6_ADDRSTRLEN];
-    return text.append(_inet_ntop(isIp4(net)?AF_INET:AF_INET6, &net, tmp, sizeof(tmp)));
+    const char *res  = ::isIp4(net) ? _inet_ntop(AF_INET, &net[3], tmp, sizeof(tmp))
+                                    : _inet_ntop(AF_INET6, &net, tmp, sizeof(tmp));
+    return text.append(res);
 }
 
-StringBuffer IpSubNet::getMaskText(StringBuffer &text)
+StringBuffer IpSubNet::getMaskText(StringBuffer &text) const
 {
     char tmp[INET6_ADDRSTRLEN];
-    return text.append(_inet_ntop(isIp4(net)?AF_INET:AF_INET6, &mask, tmp, sizeof(tmp))); // isIp4(net) is correct here
+    // isIp4(net) is correct here
+    const char *res  = ::isIp4(net) ? _inet_ntop(AF_INET, &mask[3], tmp, sizeof(tmp))
+                                    : _inet_ntop(AF_INET6, &mask, tmp, sizeof(tmp));
+    return text.append(res);
 }
 
-bool IpSubNet::isNull()
+bool IpSubNet::isNull() const
 {
     for (unsigned i=0;i<4;i++)
         if (net[i]||mask[i])

--- a/system/jlib/jsocket.hpp
+++ b/system/jlib/jsocket.hpp
@@ -195,10 +195,16 @@ public:
     IpSubNet(const char *_net,const char *_mask)    { set(_net,_mask); }
     bool set(const char *_net,const char *_mask); // _net NULL means match everything
                                                   // _mask NULL means match exact
-    bool test(const IpAddress &ip);
-    StringBuffer getNetText(StringBuffer &text);
-    StringBuffer getMaskText(StringBuffer &text);
-    bool isNull();
+    bool test(const IpAddress &ip) const;
+    StringBuffer getNetText(StringBuffer &text) const;
+    StringBuffer getMaskText(StringBuffer &text) const;
+    bool isNull() const;
+    bool operator==(IpSubNet const &other) const
+    {
+        if ((0 == memcmp(net, other.net, sizeof(net))) && (0 == memcmp(mask, other.mask, sizeof(mask))))
+            return true;
+        return false;
+    }
 };
 
 

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -606,6 +606,13 @@ int main( int argc, char *argv[]  )
             FLLOG(MCoperatorError, thorJob, "ERROR: Validate failure(s) detected, exiting Thor");
             return globals->getPropBool("@validateDAFSretCode"); // default is no recycle!
         }
+
+        if (globals->getPropBool("@useNASTranslation", true))
+        {
+            Owned<IPropertyTree> filteredNasConfig = envGetInstallNASHooks();
+            if (filteredNasConfig)
+                globals->setPropTree("NAS", filteredNasConfig.getClear()); // for use by slaves
+        }
         
         HardwareInfo hdwInfo;
         getHardwareInfo(hdwInfo);

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -46,6 +46,7 @@
 #include "slave.hpp"
 #include "portlist.h"
 #include "dafdesc.hpp"
+#include "rmtfile.hpp"
 
 #include "slavmain.hpp"
 
@@ -335,6 +336,10 @@ int main( int argc, char *argv[]  )
             }
             setPasswordsFromSDS();
 #endif
+            IDaFileSrvHook *daFileSrvHook = queryDaFileSrvHook();
+            if (daFileSrvHook) // probably always installed
+                daFileSrvHook->addSubnetFilters(globals->queryPropTree("NAS"), NULL);
+
             StringBuffer thorPath;
             globals->getProp("@thorPath", thorPath);
             recursiveCreateDirectory(thorPath.str());


### PR DESCRIPTION
Add a mechanism to spot remote file access that matches a/some
subnets and translate them to local file access.

This is allow separate slaves/nodes to circumvent the use
of dafilesrv access remotely on other nodes, when the FS is always
remote, e.g. a NAS fs attached to all nodes

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
