### PR TITLE
HPCC-8159 Prepare for use of precompiled headers in eclcc-generated code

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -226,7 +226,8 @@ protected:
     void applyDebugOptions(IWorkUnit * wu);
     bool checkWithinRepository(StringBuffer & attributePath, const char * sourcePathname);
     IFileIO * createArchiveOutputFile(EclCompileInstance & instance);
-    ICppCompiler * createCompiler(const char * coreName);
+    ICppCompiler *createCompiler(const char * coreName, const char * sourceDir = NULL, const char * targetDir = NULL);
+    bool generatePrecompiledHeader();
     void generateOutput(EclCompileInstance & instance);
     void instantECL(EclCompileInstance & instance, IWorkUnit *wu, const char * queryFullName, IErrorReceiver *errs, const char * outputFile);
     bool isWithinPath(const char * sourcePathname, const char * searchPath);
@@ -252,6 +253,7 @@ protected:
     Owned<IEclRepository> includeRepository;
     const char * programName;
 
+    StringBuffer cppIncludePath;
     StringBuffer pluginsPath;
     StringBuffer hooksPath;
     StringBuffer templatePath;
@@ -292,6 +294,7 @@ protected:
     bool optOnlyCompile;
     bool optSaveQueryText;
     bool optLegacy;
+    bool optGenerateHeader;
     int argc;
     const char **argv;
 };
@@ -419,7 +422,7 @@ void EclCC::loadOptions()
 
     globals.setown(createProperties(optIniFilename, true));
 
-    StringBuffer compilerPath, includePath, libraryPath;
+    StringBuffer compilerPath, libraryPath;
 
     if (globals->hasProp("targetGcc"))
         optTargetCompiler = globals->getPropBool("targetGcc") ? GccCppCompiler : Vs6CppCompiler;
@@ -433,7 +436,7 @@ void EclCC::loadOptions()
         extractOption(compilerPath, globals, "CL_PATH", "compilerPath", "/usr", NULL);
 #endif
         extractOption(libraryPath, globals, "ECLCC_LIBRARY_PATH", "libraryPath", syspath, "lib");
-        extractOption(includePath, globals, "ECLCC_INCLUDE_PATH", "includePath", syspath, "componentfiles/cl/include");
+        extractOption(cppIncludePath, globals, "ECLCC_INCLUDE_PATH", "includePath", syspath, "componentfiles/cl/include");
         extractOption(pluginsPath, globals, "ECLCC_PLUGIN_PATH", "plugins", syspath, "plugins");
         extractOption(hooksPath, globals, "HPCC_FILEHOOKS_PATH", "filehooks", syspath, "filehooks");
         extractOption(templatePath, globals, "ECLCC_TPL_PATH", "templatePath", syspath, "componentfiles");
@@ -458,7 +461,7 @@ void EclCC::loadOptions()
         installFileHooks(hooksPath.str());
 
     if (!optNoCompile)
-        setCompilerPath(compilerPath.str(), includePath.str(), libraryPath.str(), NULL, optTargetCompiler, logVerbose);
+        setCompilerPath(compilerPath.str(), cppIncludePath.str(), libraryPath.str(), NULL, optTargetCompiler, logVerbose);
 }
 
 //=========================================================================================
@@ -496,10 +499,8 @@ void EclCC::applyDebugOptions(IWorkUnit * wu)
 
 //=========================================================================================
 
-ICppCompiler * EclCC::createCompiler(const char * coreName)
+ICppCompiler * EclCC::createCompiler(const char * coreName, const char * sourceDir, const char * targetDir)
 {
-    const char * sourceDir = NULL;
-    const char * targetDir = NULL;
     Owned<ICppCompiler> compiler = ::createCompiler(coreName, sourceDir, targetDir, optTargetCompiler, logVerbose);
     compiler->setOnlyCompile(optOnlyCompile);
     compiler->setCCLogPath(cclogFilename);
@@ -1257,6 +1258,55 @@ void EclCC::processReference(EclCompileInstance & instance, const char * queryAt
     generateOutput(instance);
 }
 
+bool EclCC::generatePrecompiledHeader()
+{
+    if (inputFiles.ordinality() != 0)
+    {
+        ERRLOG("No input files should be specified when generating precompiled header");
+        return false;
+    }
+    StringArray paths;
+    paths.appendList(cppIncludePath, ENVSEPSTR);
+    const char *foundPath = NULL;
+    ForEachItemIn(idx, paths)
+    {
+        StringBuffer fullpath;
+        fullpath.append(paths.item(idx));
+        addPathSepChar(fullpath).append("eclinclude.hpp");
+        if (checkFileExists(fullpath))
+        {
+            foundPath = paths.item(idx);
+            break;
+        }
+    }
+    if (!foundPath)
+    {
+        ERRLOG("Cannot find eclinclude.hpp");
+        return false;
+    }
+    Owned<ICppCompiler> compiler = createCompiler("eclinclude.hpp", foundPath, NULL);
+    compiler->setDebug(true);  // a precompiled header with debug can be used for no-debug, but not vice versa
+    compiler->setPrecompileHeader(true);
+    if (compiler->compile())
+    {
+        try
+        {
+            Owned<IFile> log = createIFile(cclogFilename);
+            log->remove();
+        }
+        catch (IException * e)
+        {
+            e->Release();
+        }
+        return true;
+    }
+    else
+    {
+        ERRLOG("Compilation failed - see %s for details", cclogFilename.str());
+        return false;
+    }
+}
+
 
 bool EclCC::processFiles()
 {
@@ -1265,7 +1315,11 @@ bool EclCC::processFiles()
     {
         processArgvFilename(inputFiles, inputFileNames.item(idx));
     }
-    if (inputFiles.ordinality() == 0)
+    if (optGenerateHeader)
+    {
+        return generatePrecompiledHeader();
+    }
+    else if (inputFiles.ordinality() == 0)
     {
         if (optBatchMode || !optQueryRepositoryReference)
         {
@@ -1431,6 +1485,9 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
         else if (iter.matchFlag(optOutputDirectory, "-P"))
         {
         }
+        else if (iter.matchFlag(optGenerateHeader, "-pch"))
+        {
+        }
         else if (iter.matchFlag(optSaveQueryText, "-q"))
         {
         }
@@ -1531,7 +1588,7 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
 
     if (inputFileNames.ordinality() == 0)
     {
-        if (!optBatchMode && optQueryRepositoryReference)
+        if (optGenerateHeader || (!optBatchMode && optQueryRepositoryReference))
             return true;
         ERRLOG("No input filenames supplied");
         return false;
@@ -1601,6 +1658,9 @@ const char * const helpText[] = {
     "!   --logdetail=n Set the level of detail in the log file",
 #ifdef _WIN32
     "!   -m            Enable leak checking",
+#endif
+#ifndef _WIN32
+    "!   -pch          Generate precompiled header for eclinclude.hpp",
 #endif
     "!   -P <path>     Specify the path of the output files (only with -b option)",
     "    -specs file   Read eclcc configuration from specified file",

--- a/rtl/eclrtl/CMakeLists.txt
+++ b/rtl/eclrtl/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries ( eclrtl
     )
 
 FOREACH( iFILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/eclinclude.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eclrtl.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eclrtl_imp.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rtldistr.hpp

--- a/rtl/eclrtl/eclinclude.hpp
+++ b/rtl/eclrtl/eclinclude.hpp
@@ -1,0 +1,78 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef eclinclude_incl
+#define eclinclude_incl
+
+// Gather all the includes used by generated code into a single file so that we can
+// take advantage of precompiled headers more easily
+
+#ifdef _WIN32
+#define ECL_API __declspec(dllexport)
+#define LOCAL_API
+#define SERVICE_API __declspec(dllimport)
+#define RTL_API __declspec(dllimport)
+#define BCD_API __declspec(dllimport)
+#else
+  #ifdef USE_VISIBILITY
+    #define ECL_API __attribute__ ((visibility("default")))
+    #define LOCAL_API __attribute__ ((visibility("hidden")))
+  #else
+    #define ECL_API
+    #define LOCAL_API
+  #endif
+  #define SERVICE_API
+  #define RTL_API
+  #define BCD_API
+#endif
+
+#include <string.h>
+#include <malloc.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <math.h>
+
+#define CHEAP_UCHAR_DEF
+#if __WIN32
+typedef wchar_t UChar;
+#else //__WIN32
+typedef unsigned short UChar;
+#endif //__WIN32
+
+#ifdef _WIN32
+typedef unsigned int size32_t; // avoid pulling in platform.h (which pulls in windows.h etc) just for this...
+#else
+#include "platform.h"
+#endif
+
+#include "eclrtl.hpp"
+#include "eclhelper.hpp"
+#include "rtlkey.hpp"
+#include "eclrtl_imp.hpp"
+#include "rtlfield_imp.hpp"
+#include "rtlds_imp.hpp"
+#include "eclhelper_base.hpp"
+
+extern __declspec(dllimport) void _fastcall DecLock();
+extern __declspec(dllimport) void _fastcall DecUnlock();
+struct BcdCriticalBlock
+{
+    BcdCriticalBlock()      { DecLock(); }
+    ~BcdCriticalBlock()     { DecUnlock(); }
+};
+
+#endif

--- a/rtl/ecltpl/childtpl.cpp
+++ b/rtl/ecltpl/childtpl.cpp
@@ -16,60 +16,7 @@ $?doNotIncludeInGeneratedCode$
 ##############################################################################*/
 
 $?$/* Template for generating a child module for query */
-#ifdef _WIN32
-#define ECL_API __declspec(dllexport)
-#define LOCAL_API
-#define SERVICE_API __declspec(dllimport)
-#define RTL_API __declspec(dllimport)
-#define BCD_API __declspec(dllimport)
-#else
-  #ifdef USE_VISIBILITY
-    #define ECL_API __attribute__ ((visibility("default")))
-    #define LOCAL_API __attribute__ ((visibility("hidden")))
-  #else
-    #define ECL_API
-    #define LOCAL_API
-  #endif
-  #define SERVICE_API
-  #define RTL_API
-  #define BCD_API
-#endif
-
-#include <string.h>
-#include <malloc.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <math.h>
-
-#define CHEAP_UCHAR_DEF
-#if __WIN32
-typedef wchar_t UChar;
-#else //__WIN32
-typedef unsigned short UChar;
-#endif //__WIN32
-
-#ifdef _WIN32
-typedef unsigned int size32_t; // avoid pulling in platform.h (which pulls in windows.h etc) just for this...
-#else
-#include "platform.h"
-#endif
-
-#include "eclrtl.hpp"
-#include "eclhelper.hpp"
-#include "rtlkey.hpp"
-#include "eclrtl_imp.hpp"
-#include "rtlfield_imp.hpp"
-#include "rtlds_imp.hpp"
-#include "eclhelper_base.hpp"
-
-extern __declspec(dllimport) void _fastcall DecLock();
-extern __declspec(dllimport) void _fastcall DecUnlock();
-struct BcdCriticalBlock
-{
-    BcdCriticalBlock()      { DecLock(); }
-    ~BcdCriticalBlock()     { DecUnlock(); }
-};
-
+#include "eclinclude.hpp"
 @include@
 @prototype@
 

--- a/rtl/ecltpl/thortpl.cpp
+++ b/rtl/ecltpl/thortpl.cpp
@@ -16,60 +16,7 @@ $?doNotIncludeInGeneratedCode$
 ############################################################################## */
 
 $?$/* Template for generating thor/hthor/roxie output */
-#ifdef _WIN32
-#define ECL_API __declspec(dllexport)
-#define LOCAL_API
-#define SERVICE_API __declspec(dllimport)
-#define RTL_API __declspec(dllimport)
-#define BCD_API __declspec(dllimport)
-#else
-  #ifdef USE_VISIBILITY
-    #define ECL_API __attribute__ ((visibility("default")))
-    #define LOCAL_API __attribute__ ((visibility("hidden")))
-  #else
-    #define ECL_API
-    #define LOCAL_API
-  #endif
-  #define SERVICE_API
-  #define RTL_API
-  #define BCD_API
-#endif
-
-#include <string.h>
-#include <malloc.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <math.h>
-
-#define CHEAP_UCHAR_DEF
-#if __WIN32
-typedef wchar_t UChar;
-#else //__WIN32
-typedef unsigned short UChar;
-#endif //__WIN32
-
-#ifdef _WIN32
-typedef unsigned int size32_t; // avoid pulling in platform.h (which pulls in windows.h etc) just for this...
-#else
-#include "platform.h"
-#endif
-
-#include "eclrtl.hpp"
-#include "eclhelper.hpp"
-#include "rtlkey.hpp"
-#include "eclrtl_imp.hpp"
-#include "rtlfield_imp.hpp"
-#include "rtlds_imp.hpp"
-#include "eclhelper_base.hpp"
-
-extern __declspec(dllimport) void _fastcall DecLock();
-extern __declspec(dllimport) void _fastcall DecUnlock();
-struct BcdCriticalBlock
-{
-    BcdCriticalBlock()      { DecLock(); }
-    ~BcdCriticalBlock()     { DecUnlock(); }
-};
-
+#include "eclinclude.hpp"
 @include@
 @prototype@
 $?multiFile$#include "$headerName$"

--- a/system/include/platform.h
+++ b/system/include/platform.h
@@ -126,6 +126,7 @@ typedef memsize_t rowsize_t;
 #define TEXT_TRANS "t"
 #define LLC(NUM) NUM
 #define ENVSEPCHAR ';'
+#define ENVSEPSTR ";"
 
 #define SEPARATE_LIB_DLL_FILES
 #define SharedObjectPrefix         ""
@@ -282,6 +283,7 @@ typedef int socklen_t;
 #define __TIMESTAMP__ "<__TIMESTAMP__ unsupported>"
 #endif
 #define ENVSEPCHAR ':'
+#define ENVSEPSTR ":"
 #define PATHSEPCHAR '/'
 #define PATHSEPSTR "/"
 #define TEXT_TRANS

--- a/system/jlib/jcomp.hpp
+++ b/system/jlib/jcomp.hpp
@@ -61,6 +61,7 @@ public:
     virtual void setMaxCompileThreads(const unsigned max) = 0;
     virtual void setCCLogPath(const char* path) = 0;
     virtual void setSaveTemps(bool _save) = 0;
+    virtual void setPrecompileHeader(bool _pch) = 0;
     virtual void setAbortChecker(IAbortRequestCallback * abortChecker) = 0;
 };
 

--- a/system/jlib/jcomp.ipp
+++ b/system/jlib/jcomp.ipp
@@ -46,6 +46,7 @@ public:
     virtual IPooledThread *createNew();
     virtual void setCCLogPath(const char* path);
     virtual void setSaveTemps(bool _save) { saveTemps = _save; }
+    virtual void setPrecompileHeader(bool _pch);
     virtual void setAbortChecker(IAbortRequestCallback * _abortChecker) {abortChecker = _abortChecker;}
 
 protected:
@@ -78,6 +79,7 @@ protected:
     bool            verbose;
     void _addInclude(StringBuffer &s, const char *paths);
     bool            saveTemps;
+    bool            precompileHeader;
     IAbortRequestCallback * abortChecker;
 };
 


### PR DESCRIPTION
Reorganise the generated code to make it easier to use precompiled headers.
It also has the benefit of making the generated code a little easier to
read.

Modifying jcomp to actually use precompiled headers will follow in a second
commit.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
