### PR TITLE
HPCC-8194 CRoxiePackageSetManager does not initialize stateHash

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1298,7 +1298,7 @@ class CRoxiePackageSetManager : public CInterface, implements IRoxieQueryPackage
 public:
     IMPLEMENT_IINTERFACE;
     CRoxiePackageSetManager(const IQueryDll *_standAloneDll) :
-        standAloneDll(_standAloneDll)
+        standAloneDll(_standAloneDll), stateHash(0)
     {
         daliHelper.setown(connectToDali(ROXIE_DALI_CONNECT_TIMEOUT));
     }


### PR DESCRIPTION
The initial value of statehash is not set, meaning that the value returned
by control:state and control:reload is fairly meaningless.

This value is only used by operations as a sanity-check that all nodes in
a cluster are in sync - see HPCC-2706

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
