### PR TITLE
HPCC-8133 Ensure thorlib.platform() is consistent

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3843,14 +3843,16 @@ ClusterType getClusterType(const char * platform, ClusterType dft)
     return dft;
 }
 
-const char *clusterTypeString(ClusterType clusterType)
+const char *clusterTypeString(ClusterType clusterType, bool lcrSensitive)
 {
     switch (clusterType)
     {
+    case ThorLCRCluster:
+        if (lcrSensitive)
+            return "thorlcr";
+        // fall through
     case ThorCluster:
         return "thor";
-    case ThorLCRCluster:
-        return "thorlcr";
     case RoxieCluster:
         return "roxie";
     case HThorCluster:

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -535,7 +535,7 @@ interface IConstWUExceptionIterator : extends IScmIterator
 enum ClusterType { NoCluster, ThorCluster, HThorCluster, RoxieCluster, ThorLCRCluster };
 
 extern WORKUNIT_API ClusterType getClusterType(const char * platform, ClusterType dft = NoCluster);
-extern WORKUNIT_API const char *clusterTypeString(ClusterType clusterType);
+extern WORKUNIT_API const char *clusterTypeString(ClusterType clusterType, bool lcrSensitive);
 inline bool isThorCluster(ClusterType type) { return (type == ThorCluster) || (type == ThorLCRCluster); }
 
 //! IClusterInfo

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1608,7 +1608,7 @@ char *EclAgent::getPlatform()
         Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
         if (!clusterInfo)
             throw MakeStringException(-1, "Unknown Cluster '%s'", cluster);
-        return strdup(clusterTypeString(clusterInfo->getPlatform()));
+        return strdup(clusterTypeString(clusterInfo->getPlatform(), false));
     }
     else
         return strdup("standalone");

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -268,7 +268,7 @@ public:
         clusterInfo.clear();
         workunit->setState(WUStateCompiling);
         workunit->commit();
-        bool ok = compile(wuid, clusterTypeString(platform), clusterName.str());
+        bool ok = compile(wuid, clusterTypeString(platform, true), clusterName.str());
         if (ok)
         {
             workunit->setState(WUStateCompiled);


### PR DESCRIPTION
EclAgnent used to return either 'thor' (for legacy thor) or
'thorlcr'. This is an internal/legacy distinction, ensure that
a consistent 'thor' string is returned to ECL callers

NB: the one caller that continues to care about the distinction
is eclccserver when it constructs a eclcc cmdline and supplies
the target platform type as a string

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
