### PR TITLE
HPCC-8159 Add option to generate precompiled header for eclcc-generated ...

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -205,6 +205,7 @@ public:
         optOnlyCompile = false;
         optBatchMode = false;
         optSaveQueryText = false;
+        optGenerateHeader = false;
         optTargetClusterType = HThorCluster;
         optTargetCompiler = DEFAULT_COMPILER;
         optThreads = 0;


### PR DESCRIPTION
...code

Previous commit had an unitialized variable causing many compiles to fail.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
