### PR TITLE
HPCC-8129 Fix bug generating an optimized hash function on a child datas...

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -8727,9 +8727,11 @@ void HqlCppTranslator::doBuildAssignHashElement(BuildCtx & ctx, HashCodeCreator 
             //fallthrough
             if (creator.optimize() && hasOutOfLineRows(elem->queryType()))
             {
+                creator.beginCondition(ctx);
                 BuildCtx iterctx(ctx);
                 BoundRow * row = buildDatasetIterate(iterctx, elem, false);
                 doBuildAssignHashElement(iterctx, creator, elem->queryNormalizedSelector(), elem->queryRecord());
+                creator.endCondition(iterctx);
                 return;
             }
             else

--- a/ecl/regress/dedupall5.ecl
+++ b/ecl/regress/dedupall5.ecl
@@ -1,0 +1,33 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+idRecord := { unsigned id; };
+
+namesRecord :=
+            RECORD
+string        surname;
+string        forename;
+dataset(idRecord) ids;
+            END;
+
+namesTable := dataset([
+    {'Fred', 'Smith', [1,2,3]},
+    {'Fred', 'Smith', [1,2,4]},
+    {'John', 'Smith', [4,5,6]},
+    {'John', 'Smith', [4,5,6]}], namesRecord);
+
+output(dedup(NOFOLD(namesTable), ALL));


### PR DESCRIPTION
...et

For DEDUP(ds, x,y,z), if the list of fields contained a child dataset the
hash function generated when targetting Thor was incorrect, and could
cause thor to crash.  It could possibly be triggered in other situations
as well.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
