### PR TITLE
HPCC-8213 Disable sub-file checking on internal build

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -51,7 +51,11 @@
 #define DFSSERVER_THROTTLE_COUNT 20
 #define DFSSERVER_THROTTLE_TIME 1000
 
+#if _INTERNAL_EDITION == 1
+#warning Disabling Sub-file compatibility checking
+#else
 #define SUBFILE_COMPATIBILITY_CHECKING
+#endif
 
 //#define PACK_ECL
 


### PR DESCRIPTION
Needs equivalent pull request in internal repository to enable -D_INTERNAL_BUILD on CMake files.

Signed-off-by: Renato Golin rengolin@hpccsystems.com
