### PR TITLE
HPCC-8136 Remove Auto-refresh function for Target Clusters page

### DIFF
--- a/esp/eclwatch/ws_XSLT/targetclusters.xslt
+++ b/esp/eclwatch/ws_XSLT/targetclusters.xslt
@@ -51,7 +51,6 @@
         <html>
             <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-        <meta http-equiv="Refresh" content="100"/>
         <link rel="stylesheet" type="text/css" href="/esp/files/default.css"/>
         <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/fonts/fonts-min.css" />
         <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/menu/assets/skins/sam/menu.css" />


### PR DESCRIPTION
The Target Clusters page is mainly displaying static information. The
auto-refresh function for this page is copied from other page by mistake.
This fix removes the auto-refresh.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
