### PR TITLE
HPCC-8216 Csvread,opt heading crash

### DIFF
--- a/thorlcr/activities/csvread/thcsvread.cpp
+++ b/thorlcr/activities/csvread/thcsvread.cpp
@@ -51,8 +51,12 @@ public:
         if (headerLines)
         {
             dst.append((int)mpTag);
-            ISuperFileDescriptor *superFDesc = fileDesc->querySuperFileDescriptor();
-            unsigned subFiles = superFDesc ? superFDesc->querySubFiles() : 1;
+            unsigned subFiles = 0;
+            if (fileDesc)
+            {
+                ISuperFileDescriptor *superFDesc = fileDesc->querySuperFileDescriptor();
+                subFiles = superFDesc ? superFDesc->querySubFiles() : 1;
+            }
             dst.append(subFiles);
         }
     }


### PR DESCRIPTION
If a csv read has OPT and HEADING attributes and the logical file
is missing, a crash will occur inside the master serialization
code for the activity

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
