### PR TITLE
HPCC-8152 Display Compress option for Spray XML

### DIFF
--- a/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
@@ -624,14 +624,12 @@
                <input type="checkbox" name="nosplit" value="1"/>
             </td>
          </tr>
-         <xsl:if test="$method='SprayFixed' or $submethod='csv'">
-            <tr>
-               <td>Compress:</td>
-               <td>
-                  <input type="checkbox" id="compress" name="compress" value="1"/>
-               </td>
-            </tr>
-         </xsl:if>
+         <tr>
+            <td>Compress:</td>
+            <td>
+               <input type="checkbox" id="compress" name="compress" value="1"/>
+            </td>
+         </tr>
          <xsl:if test="$fullHtml='1'">
             <tr>
                <td/>


### PR DESCRIPTION
dfuplus offers a compress=1 option that works when spraying XML
files. ECLWatch should provide this option also. The existing
code only displays the option when sprayfixed or sprayCSV. This
fix displays the option for all types of file spray.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
