### PR TITLE
HPCC-8221 ESP wasn't correctly loading plugin definitions

### DIFF
--- a/common/fileview2/fvtransform.cpp
+++ b/common/fileview2/fvtransform.cpp
@@ -297,6 +297,7 @@ void ViewTransformerRegistry::addPlugins(const char * name)
     {
         IHqlScope * scope = &scopes.item(i);
         HqlExprArray symbols;
+        scope->ensureSymbolsDefined(ctx);
         scope->getSymbols(symbols);
 
         ForEachItemIn(j, symbols)


### PR DESCRIPTION
Due to a change in the way scopes are loaded on demand, esp wasn't correctly
picking up symbols defined in plugins because they were still waiting to be
loaded.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
