### PR TITLE
HPCC-7944 Add setting, to allow master memory to be specified

### DIFF
--- a/initfiles/componentfiles/configxml/thor.xsd.in
+++ b/initfiles/componentfiles/configxml/thor.xsd.in
@@ -347,10 +347,17 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="masterMemorySize" type="xs:nonNegativeInteger" use="optional">
+        <xs:annotation>
+          <xs:appinfo>
+            <tooltip>Memory (in MB) to use for Link Counted Rows on thor master. It will default to globalMemorySize if unset</tooltip>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="globalMemorySize" type="xs:nonNegativeInteger" use="optional">
         <xs:annotation>
           <xs:appinfo>
-            <tooltip>Memory (in MB) to use for Link Counted Rows</tooltip>
+            <tooltip>Memory (in MB) to use for Link Counted Rows. It will default to physical available memory if unset</tooltip>
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2323,6 +2323,7 @@ CJobBase::CJobBase(const char *_graphName) : graphName(_graphName)
     jobComm.setown(createCommunicator(jobGroup));
     slaveGroup.setown(jobGroup->remove(0));
     myrank = jobGroup->rank(queryMyNode());
+    globalMemorySize = globals->getPropInt("@globalMemorySize"); // in MB
 }
 
 void CJobBase::init()
@@ -2346,7 +2347,6 @@ void CJobBase::init()
     pausing = false;
     resumed = false;
 
-    unsigned gmemSize = globals->getPropInt("@globalMemorySize"); // in MB
 #ifdef _DEBUG
     bool defaultCrcChecking = true;
 #else
@@ -2355,13 +2355,13 @@ void CJobBase::init()
     bool crcChecking = 0 != getWorkUnitValueInt("THOR_ROWCRC", globals->getPropBool("@THOR_ROWCRC", defaultCrcChecking));
     bool usePackedAllocator = 0 != getWorkUnitValueInt("THOR_PACKEDALLOCATOR", globals->getPropBool("@THOR_PACKEDALLOCATOR", false));
     unsigned memorySpillAt = getWorkUnitValueInt("memorySpillAt", globals->getPropInt("@memorySpillAt", 80));
-    thorAllocator.setown(createThorAllocator(((memsize_t)gmemSize)*0x100000, memorySpillAt, crcChecking, usePackedAllocator));
+    thorAllocator.setown(createThorAllocator(((memsize_t)globalMemorySize)*0x100000, memorySpillAt, crcChecking, usePackedAllocator));
 
-    unsigned defaultMemMB = gmemSize*3/4;
+    unsigned defaultMemMB = globalMemorySize*3/4;
     unsigned largeMemSize = getOptInt("@largeMemSize", defaultMemMB);
-    if (gmemSize && largeMemSize >= gmemSize)
-        throw MakeStringException(0, "largeMemSize(%d) can not exceed globalMemorySize(%d)", largeMemSize, gmemSize);
-    PROGLOG("Global memory size = %d MB, memory spill at = %d%%, large mem size = %d MB", gmemSize, memorySpillAt, largeMemSize);
+    if (globalMemorySize && largeMemSize >= globalMemorySize)
+        throw MakeStringException(0, "largeMemSize(%d) can not exceed globalMemorySize(%d)", largeMemSize, globalMemorySize);
+    PROGLOG("Global memory size = %d MB, memory spill at = %d%%, large mem size = %d MB", globalMemorySize, memorySpillAt, largeMemSize);
     StringBuffer tracing("maxActivityCores = ");
     if (maxActivityCores)
         tracing.append(maxActivityCores);

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -811,7 +811,7 @@ protected:
     Owned<IPropertyTree> xgmml;
     Owned<IGraphTempHandler> tmpHandler;
     bool timeActivities;
-    unsigned maxActivityCores;
+    unsigned maxActivityCores, globalMemorySize;
     unsigned forceLogGraphIdMin, forceLogGraphIdMax;
     class CThorPluginCtx : public SimplePluginCtx
     {

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1214,6 +1214,7 @@ CJobMaster::CJobMaster(IConstWorkUnit &_workunit, const char *graphName, const c
     user.append(_user.str());
     token.append(_token.str());
     scope.append(_scope.str());
+    globalMemorySize = globals->getPropInt("@masterMemorySize", globals->getPropInt("@globalMemorySize")); // in MB
     init();
 
     resumed = WUActionResume == workunit->getAction();

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -625,19 +625,26 @@ int main( int argc, char *argv[]  )
 #endif
 #endif
             gmemSize = maxMem * 3 / 4; // default to 75% of total
+            unsigned perSlaveSize = gmemSize;
             unsigned slavesPerNode = globals->getPropInt("@slavesPerNode", 1);
             if (slavesPerNode>1)
             {
-                PROGLOG("Sharing globalMemorySize(%d MB), between %d slave. %d MB each", gmemSize, slavesPerNode, gmemSize / slavesPerNode);
-                gmemSize /= slavesPerNode;
+                PROGLOG("Sharing globalMemorySize(%d MB), between %d slave. %d MB each", perSlaveSize, slavesPerNode, perSlaveSize / slavesPerNode);
+                perSlaveSize /= slavesPerNode;
             }
-            globals->setPropInt("@globalMemorySize", gmemSize);
+            globals->setPropInt("@globalMemorySize", perSlaveSize);
         }
         else if (gmemSize >= hdwInfo.totalMemory)
         {
             // should prob. error here
         }
-        roxiemem::setTotalMemoryLimit(((memsize_t)gmemSize) * 0x100000, 0, NULL);
+        unsigned gmemSizeMaster = globals->getPropInt("@masterMemorySize", gmemSize); // in MB
+
+        // if @masterMemorySize and @globalMemorySize unspecified gmemSize will be default based on h/w
+        globals->setPropInt("@masterMemorySize", gmemSizeMaster);
+
+        PROGLOG("Global memory size = %d MB", gmemSizeMaster);
+        roxiemem::setTotalMemoryLimit(((memsize_t)gmemSizeMaster) * 0x100000, 0, NULL);
 
         const char * overrideBaseDirectory = globals->queryProp("@thorDataDirectory");
         const char * overrideReplicateDirectory = globals->queryProp("@thorReplicateDirectory");

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -610,7 +610,7 @@ void slaveMain()
     HardwareInfo hdwInfo;
     getHardwareInfo(hdwInfo);
     if (hdwInfo.totalMemory < masterMemMB)
-        WARNLOG("Slave has less memory than master node"); // JCSMORE, error?
+        WARNLOG("Slave has less memory than master node");
     unsigned gmemSize = globals->getPropInt("@globalMemorySize");
     if (gmemSize >= hdwInfo.totalMemory)
     {


### PR DESCRIPTION
Also fixes a bug, that if globalMemorySize was left blank
and slavesPerNode was >1, it would limit master memory to the
same calculated memory as each slave
(which is 75% physical / slavesPerNode)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
