### PR TITLE
HPCC-8215 Regenerate HEADING correctly instead of as HEADER

### DIFF
--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -139,7 +139,7 @@ _ATOM graphAtom;
 _ATOM groupAtom;
 _ATOM groupedAtom;
 _ATOM hashAtom;
-_ATOM headerAtom;
+_ATOM headingAtom;
 _ATOM _hidden_Atom;
 _ATOM hintAtom;
 _ATOM holeAtom;
@@ -519,7 +519,7 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKEATOM(group);
     MAKEATOM(grouped);
     MAKEATOM(hash);
-    MAKEATOM(header);
+    MAKEATOM(heading);
     MAKESYSATOM(hidden);
     MAKEATOM(hint);
     MAKEATOM(hole);

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -143,7 +143,7 @@ extern HQL_API _ATOM _graphLocal_Atom;
 extern HQL_API _ATOM groupAtom;
 extern HQL_API _ATOM groupedAtom;
 extern HQL_API _ATOM hashAtom;
-extern HQL_API _ATOM headerAtom;
+extern HQL_API _ATOM headingAtom;
 extern HQL_API _ATOM _hidden_Atom;
 extern HQL_API _ATOM hintAtom;
 extern HQL_API _ATOM holeAtom;

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -3129,7 +3129,7 @@ soapFlag
                             parser->normalizeExpression($3, type_string, false);
                             if ($4.queryExpr())
                                 parser->normalizeExpression($4, type_string, false);
-                            $$.setExpr(createExprAttribute(headerAtom, $3.getExpr(), $4.getExpr()));
+                            $$.setExpr(createExprAttribute(headingAtom, $3.getExpr(), $4.getExpr()));
                             $$.setPosition($1);
                         }
     | SEPARATOR '(' expression ')'
@@ -9469,7 +9469,7 @@ csvOption
                         }
     | HEADING
                         {
-                            $$.setExpr(createAttribute(headerAtom));
+                            $$.setExpr(createAttribute(headingAtom));
                             $$.setPosition($1);
                         }
     | HEADING '(' startHeadingAttrs headingOptions ')'
@@ -9478,7 +9478,7 @@ csvOption
                             $4.unwindCommaList(args);
                             HqlExprArray orderedArgs;
                             reorderAttributesToEnd(orderedArgs, args);
-                            $$.setExpr(createExprAttribute(headerAtom, orderedArgs), $1);
+                            $$.setExpr(createExprAttribute(headingAtom, orderedArgs), $1);
                             $$.setPosition($1);
                         }
     | MAXLENGTH '(' constExpression ')'
@@ -9572,7 +9572,7 @@ xmlOption
                             parser->normalizeExpression($3, type_string, false);
                             if ($4.queryExpr())
                                 parser->normalizeExpression($4, type_string, false);
-                            $$.setExpr(createExprAttribute(headerAtom, $3.getExpr(), $4.getExpr()));
+                            $$.setExpr(createExprAttribute(headingAtom, $3.getExpr(), $4.getExpr()));
                             $$.setPosition($1);
                         }
     | expression        {

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -9139,7 +9139,7 @@ void HqlCppTranslator::buildCsvParameters(BuildCtx & subctx, IHqlExpression * cs
 
     bool singleHeader = false;
     bool manyHeader = false;
-    IHqlExpression * headerAttr = queryProperty(headerAtom, attrs);
+    IHqlExpression * headerAttr = queryProperty(headingAtom, attrs);
     IHqlExpression * terminator = queryProperty(terminatorAtom, attrs);
     IHqlExpression * separator = queryProperty(separatorAtom, attrs);
     IHqlExpression * escape = queryProperty(escapeAtom, attrs);
@@ -9937,7 +9937,7 @@ void HqlCppTranslator::buildXmlWriteMembers(ActivityInstance * instance, IHqlExp
     IHqlExpression * rowAttr = xmlAttr->queryProperty(rowAtom);
     if (rowAttr)
         doBuildVarStringFunction(instance->startctx, "queryIteratorPath", rowAttr->queryChild(0));
-    IHqlExpression * headerAttr = xmlAttr->queryProperty(headerAtom);
+    IHqlExpression * headerAttr = xmlAttr->queryProperty(headingAtom);
     if (headerAttr)
     {
         doBuildVarStringFunction(instance->startctx, "queryHeader", headerAttr->queryChild(0));
@@ -16455,7 +16455,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivitySOAP(BuildCtx & ctx, IHqlExpre
 
     //virtual const char * queryHeader()
     //virtual const char * queryFooter()
-    IHqlExpression * header = expr->queryProperty(headerAtom);
+    IHqlExpression * header = expr->queryProperty(headingAtom);
     if (header)
     {
         doBuildVarStringFunction(instance->startctx, "queryHeader", header->queryChild(0));


### PR DESCRIPTION
The wrong atom name was being used when the HEADING attribute was
represented in the expression tree which meant it was displayed as
HEADER.  This uses the correct name.

The change has the side-effect of modifying the eclcrc for files with
HEADING which means that OUTPUT,UPDATE will trigger a rebuild.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
