### PR TITLE
HPCC-8225 Fix global ENTH deadlock issue

### DIFF
--- a/thorlcr/activities/enth/thenthslave.cpp
+++ b/thorlcr/activities/enth/thenthslave.cpp
@@ -197,6 +197,23 @@ class CEnthSlaveActivity : public BaseEnthActivity
         msg.append(count);
         container.queryJob().queryJobComm().send(msg, container.queryJob().queryMyRank()+1, mpTag);
     }
+    bool getPrev()
+    {
+        if (!firstNode()) // no need if 1st node
+        {
+            CMessageBuffer msg;
+            if (!receiveMsg(msg, container.queryJob().queryMyRank()-1, mpTag))
+                return false;
+            msg.read(prevRecCount);
+        }
+        setInitialCounter(prevRecCount);
+        if (haveLocalCount()) // if local total count known, send total now
+            sendCount(prevRecCount + localRecCount);
+        else
+            prevRecCountSem.signal();
+        return true;
+    }
+
 public:
     CEnthSlaveActivity(CGraphElementBase *container) : BaseEnthActivity(container)
     { 
@@ -226,18 +243,8 @@ public:
         if (first)
         {
             first = false;
-            if (!firstNode()) // no need if 1st node
-            {
-                CMessageBuffer msg;
-                if (!receiveMsg(msg, container.queryJob().queryMyRank()-1, mpTag))
-                    return NULL;
-                msg.read(prevRecCount);
-            }
-            setInitialCounter(prevRecCount);
-            if (haveLocalCount()) // if local total count known, send total now
-                sendCount(prevRecCount + localRecCount);
-            else
-                prevRecCountSem.signal();
+            if (!getPrev())
+                return NULL;
         }
         while (!abortSoon)
         {
@@ -251,6 +258,16 @@ public:
             }
         }
         return NULL;        
+    }
+    virtual void stop()
+    {
+        // Need to ensure sequence continues, in nextRow has never been called.
+        if (first)
+        {
+            first = false;
+            getPrev();
+        }
+        BaseEnthActivity::stop();
     }
     virtual void onInputFinished(rowcount_t localRecCount)
     {


### PR DESCRIPTION
Global Enth can deadlock if the input count is pre-known, and
the activity starts but no records are ever requested (nextRow).
This fix ensures that the get/send calls are made in stop()
if has not occured in nextRow()

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
