### PR TITLE
HPCC-8052 nested ChildDatasets + ECL Playground generated results

### DIFF
--- a/esp/files/scripts/ResultsControl.js
+++ b/esp/files/scripts/ResultsControl.js
@@ -99,7 +99,7 @@ define([
 			var paneID = this.getNextPaneID();
 
 			var grid = EnhancedGrid({
-				result: result,
+				resultIndex: resultIndex,
 				store: result.getObjectStore(),
 				query: { id: "*" },
 				structure: result.getStructure(),


### PR DESCRIPTION
Regression introduced when rolling back "disable paging if child
datasets exists" changes.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
