### PR TITLE
HPCC-8235 Ensure end-of-groups stripped for sorted join input

### DIFF
--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -119,7 +119,7 @@ class JoinSlaveActivity : public CSlaveActivity, public CThorDataLink, implement
         {
             if (firstrow)
                 return firstrow.getClear();
-            return base->nextRow();
+            return base->ungroupedNextRow();
         }
 
         void stop()


### PR DESCRIPTION
A grouped input to a global join, which was presorted by the join
keys, was not stripping the end of group markers off, as a
consequence it would stop reading the input at the first end of group.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
