### PR TITLE
HPCC-8236 Avoid spilling callback deadlock

### DIFF
--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1256,6 +1256,10 @@ protected:
         }
 
         {
+            // Ensure existing callback is cleared, before locked section below, which in turn may add a new callback
+            // Otherwise there is potential for deadlock with the callback mechanism, if it is in the midst of calling this callback.
+            clearSpillingCallback();
+
             CThorSpillableRowArray::CThorSpillableRowArrayLock block(spillableRows);
             if (spillableRowSet)
                 instrms.append(*spillableRowSet->createRowStream());
@@ -1303,8 +1307,15 @@ protected:
         totalRows = 0;
         overflowCount = outStreams = 0;
     }
-
     inline bool spillingEnabled() const { return SPILL_PRIORITY_DISABLE != spillPriority; }
+    void clearSpillingCallback()
+    {
+        if (mmRegistered)
+        {
+            activity.queryJob().queryRowManager()->removeRowBuffer(this);
+            mmRegistered = false;
+        }
+    }
 public:
     CThorRowCollectorBase(CActivityBase &_activity, IRowInterfaces *_rowIf, ICompare *_iCompare, bool _isStable, RowCollectorFlags _diskMemMix, unsigned _spillPriority)
         : activity(_activity),
@@ -1329,8 +1340,7 @@ public:
     ~CThorRowCollectorBase()
     {
         reset();
-        if (mmRegistered)
-            activity.queryJob().queryRowManager()->removeRowBuffer(this);
+        clearSpillingCallback();
     }
     void transferRowsOut(CThorExpandingRowArray &out, bool sort)
     {


### PR DESCRIPTION
A race condition in Thor's use of the spilling callback mechanism,
could mean that it deadlocks. A call back occurs whilst it is
preparing to finish and setup a stream of existing spills, at
that point, it sets up another callback, but that will get
blocked whilst in the existing callback = deadlock.

Fix is to clear the existing callback which is finished with,
before entering the lock and setting up the new one.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
