### PR TITLE
HPCC-8139 Fix formatting of JSON exceptions in ESP

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -2339,35 +2339,59 @@ int CHttpResponse::sendException(IEspHttpException* e)
     send();
     return 0;
 }
+
+StringBuffer &toJSON(StringBuffer &json, IMultiException *me)
+{
+    IArrayOf<IException> &exs = me->getArray();
+    appendJSONName(json.set("{"), "Exceptions").append("{");
+    appendJSONValue(json, "Source", me->source());
+    appendJSONName(json, "Exception").append("[");
+    ForEachItemIn(i, exs)
+    {
+        IException &e = exs.item(i);
+        if (i>0)
+            json.append(",");
+        StringBuffer msg;
+        appendJSONValue(json.append("{"), "Code", e.errorCode());
+        appendJSONValue(json, "Message", e.errorMessage(msg).str());
+        json.append("}");
+    }
+    json.append("]}}");
+    return json;
+}
+
 bool CHttpResponse::handleExceptions(IXslProcessor *xslp, IMultiException *me, const char *serv, const char *meth, const char *errorXslt)
 {
     IEspContext *context=queryContext();
     if (me->ordinality()>0)
     {
-        StringBuffer text;
-        me->errorMessage(text);
-        text.append('\n');
-        WARNLOG("Exception(s) in %s::%s - %s", serv, meth, text.str());
+        StringBuffer msg;
+        WARNLOG("Exception(s) in %s::%s - %s", serv, meth, me->errorMessage(msg).append('\n').str());
 
-        bool returnXml = context->queryRequestParameters()->hasProp("rawxml_");
-        if (errorXslt || returnXml)
+        StringBuffer content;
+        switch (context->getResponseFormat())
         {
-            me->serialize(text.clear());
-            if (returnXml)
+        case ESPSerializationJSON:
+            setContentType(HTTP_TYPE_APPLICATION_JSON_UTF8);
+            toJSON(content, me);
+            break;
+        case ESPSerializationXML:
+            setContentType(HTTP_TYPE_APPLICATION_XML);
+            me->serialize(content);
+            break;
+        case ESPSerializationANY:
+        default:
             {
-                setContent(text.str());
-                setContentType(HTTP_TYPE_APPLICATION_XML);
+            if (!errorXslt || !*errorXslt)
+                return false;
+            setContentType("text/html");
+            StringBuffer xml;
+            xslTransformHelper(xslp, me->serialize(xml), errorXslt, content, context->queryXslParameters());
             }
-            else
-            {
-                StringBuffer theOutput;
-                xslTransformHelper(xslp, text.str(), errorXslt, theOutput, context->queryXslParameters());
-                setContent(theOutput.str());
-                setContentType("text/html");
-            }
-            send();
-            return true;
         }
+        setContent(content);
+        send();
+        return true;
     }
     return false;
 }

--- a/esp/bindings/http/platform/httptransport.hpp
+++ b/esp/bindings/http/platform/httptransport.hpp
@@ -60,7 +60,7 @@
 #define HTTP_TYPE_TEXT_XML_UTF8                 "text/xml; charset=UTF-8"
 #define HTTP_TYPE_APPLICATION_XML_UTF8          "application/xml; charset=UTF-8"
 #define HTTP_TYPE_SOAP_UTF8                     "application/soap; charset=UTF-8"
-
+#define HTTP_TYPE_APPLICATION_JSON_UTF8         "application/json; charset=UTF-8"
 
 #define HTTP_STATUS_OK_CODE                 200
 #define HTTP_STATUS_NO_CONTENT_CODE         204


### PR DESCRIPTION
When ESP methods are accessed via JSON format exceptions as JSON
rather than HTML or XML as they currently are.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
