### PR TITLE
HPCC-8050 RemoveEntry/Physical in transactions

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -5581,7 +5581,7 @@ void CLocalWorkUnit::deleteTempFiles(const char *graph, bool deleteOwned, bool d
         {
             const char *name = file.queryProp("@name");
             LOG(MCdebugProgress, unknownJob, "Removing workunit file %s from DFS", name);
-            queryDistributedFileDirectory().removePhysical(name, queryUserDescriptor(), NULL, NULL);
+            queryDistributedFileDirectory().removePhysical(name, queryUserDescriptor());
             toRemove.append(file);
         }
     }
@@ -5689,7 +5689,7 @@ void CLocalWorkUnit::releaseFile(const char *fileName)
             files->removeTree(file);
             if (!name.isEmpty()&&(1 == usageCount))
             {
-                if (queryDistributedFileDirectory().removePhysical(fileName, queryUserDescriptor(), NULL, NULL))
+                if (queryDistributedFileDirectory().removePhysical(fileName, queryUserDescriptor()))
                     LOG(MCdebugProgress, unknownJob, "Removed (released) file %s from DFS", name.get());
             }
         }

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -185,7 +185,7 @@ interface IDistributedFileTransaction: extends IInterface
     virtual IDistributedSuperFile *lookupSuperFile(const char *slfn,unsigned timeout=INFINITE)=0;
     virtual IDistributedSuperFile *lookupSuperFileCached(const char *slfn,unsigned timeout=INFINITE)=0;
     virtual IUserDescriptor *queryUser()=0;
-    virtual bool addDelayedDelete(const char *lfn,bool remphys,IUserDescriptor *user)=0; // used internally to delay deletes untill commit 
+    virtual bool addDelayedDelete(const char *lfn,bool remphys,IUserDescriptor *user,unsigned timeoutms=INFINITE,const char*cluster=NULL)=0; // used internally to delay deletes untill commit
     virtual void addAction(CDFAction *action)=0; // internal
     virtual void addFile(IDistributedFile *file)=0; // TODO: avoid this being necessary
     virtual void clearFiles()=0; // internal
@@ -457,8 +457,8 @@ interface IDistributedFileDirectory: extends IInterface
 
     virtual IDFScopeIterator *getScopeIterator(IUserDescriptor *user, const char *subscope=NULL,bool recursive=true,bool includeempty=false)=0;
 
-    virtual bool removeEntry(const char *name,IUserDescriptor *user, unsigned timeoutms=INFINITE) = 0;  // equivalent to lookup/detach/release
-    virtual bool removePhysical(const char *name,IUserDescriptor *user,const char *cluster=NULL,IMultiException *exceptions=NULL) = 0;                           // removes the physical parts as well as entry
+    virtual bool removeEntry(const char *name,IUserDescriptor *user, unsigned timeoutms=INFINITE, IDistributedFileTransaction *transaction=NULL) = 0;  // equivalent to lookup/detach/release
+    virtual bool removePhysical(const char *name,IUserDescriptor *user,const char *cluster=NULL,unsigned timeoutms=INFINITE,IDistributedFileTransaction *transaction=NULL) = 0;                           // removes the physical parts as well as entry
     virtual void renamePhysical(const char *oldname,const char *newname,IUserDescriptor *user,IDistributedFileTransaction *transaction) = 0;                         // renames the physical parts as well as entry
     virtual void removeEmptyScope(const char *scope) = 0;   // does nothing if called on non-empty scope
     

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -345,13 +345,18 @@ FILESERVICES_API void FILESERVICES_CALL fsDeleteLogicalFile(ICodeContext *ctx, c
     StringBuffer lfn;
     constructLogicalName(ctx, name, lfn);
 
+    IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     StringBuffer uname;
     PrintLog("Deleting NS logical file %s for user %s", lfn.str(),udesc?udesc->getUserName(uname).str():"");
-    if (queryDistributedFileDirectory().removePhysical(lfn.str(),udesc,NULL,NULL))
+    if (queryDistributedFileDirectory().removePhysical(lfn.str(),udesc,NULL,INFINITE,transaction))
     {
         StringBuffer s("DeleteLogicalFile ('");         // ** TBD use removephysical (handles cluster)
-        s.append(lfn).append("') done");
+        s.append(lfn);
+        if (transaction->active())
+            s.append("') added to transaction");
+        else
+            s.append("') done");
         WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
         AuditMessage(ctx,"DeleteLogicalFile",lfn.str());
 

--- a/testing/ecl/key/superfile10.xml
+++ b/testing/ecl/key/superfile10.xml
@@ -1,0 +1,28 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>true</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>true</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>false</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>true</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><Result_7>false</Result_7></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>true</Result_8></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><Result_9>false</Result_9></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><Result_10>false</Result_10></Row>
+</Dataset>

--- a/testing/ecl/superfile10.ecl
+++ b/testing/ecl/superfile10.ecl
@@ -1,0 +1,69 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+import Std.System.Thorlib;
+import Std.File AS FileServices;
+import Std.Str;
+// Super File regression test
+//noRoxie
+
+rec :=
+RECORD
+        integer i;
+    string1 id;
+END;
+
+ds1 := DATASET([{1,'A'}, {1,'B'}, {1,'C'}], rec);
+ds2 := DATASET([{1,'A'}, {1,'B'}, {1,'C'}], rec);
+
+clusterLFNPrefix := thorlib.getExpandLogicalName('regress::');
+
+string stripPrefix(string qlfn) := IF (Str.Find(qlfn, clusterLFNprefix, 1) = 1, Str.FindReplace(qlfn, clusterLFNPrefix, ''), qlfn);
+
+conditionalDelete(string lfn) := FUNCTION
+        RETURN IF(FileServices.FileExists(lfn), FileServices.DeleteLogicalFile(lfn));
+END;
+
+
+SEQUENTIAL(
+  // Prepare
+  conditionalDelete ('regress::subfile14'),
+  conditionalDelete ('regress::subfile15'),
+  OUTPUT(ds1,,'regress::subfile14',overwrite),
+  OUTPUT(ds2,,'regress::subfile15',overwrite),
+  OUTPUT(FileServices.FileExists('regress::subfile14')), // true
+  OUTPUT(FileServices.FileExists('regress::subfile15')), // true
+
+  // Remove Auto-commit
+  FileServices.DeleteLogicalFile('regress::subfile14'),
+  OUTPUT(FileServices.FileExists('regress::subfile14')), // false
+  OUTPUT(FileServices.FileExists('regress::subfile15')), // true
+
+  // Remove + Rollback
+  FileServices.StartSuperFileTransaction(),
+  FileServices.DeleteLogicalFile('regress::subfile15'),
+  FileServices.FinishSuperFileTransaction(true),    // rollback
+  OUTPUT(FileServices.FileExists('regress::subfile14')), // false
+  OUTPUT(FileServices.FileExists('regress::subfile15')), // true
+
+  // Remove + Commit
+  FileServices.StartSuperFileTransaction(),
+  FileServices.DeleteLogicalFile('regress::subfile15'),
+  FileServices.FinishSuperFileTransaction(),    // commit
+  OUTPUT(FileServices.FileExists('regress::subfile14')), // false
+  OUTPUT(FileServices.FileExists('regress::subfile15')), // false
+);


### PR DESCRIPTION
After the fourth attempt failed, I decided to postpone the internal re-factory and focus on getting removal on transactions.

The current request is incomplete, as that it only deal with logical removal, not physical. But, since the functions are similar and DelayedDelete can cope with both physical and logical removal, there shouldn't be many problems for the physical part.

I've added some tests in daregress, will add more and when physical deletion is complete, I'll add them to the regression suite. Please, note that, as usual with transaction refactories, I can't guarantee that the actions will be much safer than they already are in case of disaster. We're just not there yet.

The main problem (that I was trying to avoid and failed), is that removal of files is an unwritten contract between the transaction, the files/superfiles and the directory, that must happen on a very special chain of events, or deletion simply won't occur. For that reason, I left doRemove\* inside directories and haven't changed the internal workings so far.

I'll merge the commits into one once everyone's happy with the changes.

@richardkchapman @ghalliday @jakesmith

Signed-off-by: Renato Golin rengolin@hpccsystems.com
