### PR TITLE
HPCC-8250 Activities derived from disk read asserting on multiway files

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -19654,13 +19654,13 @@ public:
                 if (map)
                     numParts = map->getNumParts();
                 else
-                {
                     numParts = 0;
-                    eof = true;
-                    return;
-                }
             }
-            if (useRemote())
+            if (!numParts)
+            {
+                eof = true;
+            }
+            else if (useRemote())
             {
                 remote->onStart(parentExtractSize, parentExtract);
                 remote->setLimits(rowLimit, (unsigned __int64) -1, stopAfter);
@@ -19999,7 +19999,10 @@ public:
 
     virtual const void *nextInGroup()
     {
-        // Note - in remote case this never gets called as input chain is routed to remoteResultAdaptor
+        if (eof)
+            return NULL;
+        else if (useRemote())
+            return remote->nextInGroup();
         assertex(xmlParser != NULL);
         try
         {
@@ -20104,7 +20107,10 @@ public:
 
     virtual const void *nextInGroup()
     {
-        // Note - in remote case this never gets called as input chain is routed to remoteResultAdaptor
+        if (eof)
+            return NULL;
+        else if (useRemote())
+            return remote->nextInGroup();
         try
         {
             while (!eof)
@@ -20211,6 +20217,8 @@ public:
     {
         if (eof)
             return NULL;
+        else if (useRemote())
+            return remote->nextInGroup();
         RtlDynamicRowBuilder rowBuilder(rowAllocator);
         unsigned transformedSize = 0;
         if (isKeyed)
@@ -20357,7 +20365,7 @@ public:
         done = true;
 
         unsigned __int64 totalCount = 0;
-        if (helper.canMatchAny())
+        if (helper.canMatchAny() && !eof)
         {
             if (useRemote())
             {
@@ -20486,28 +20494,31 @@ public:
         else
         {
             aggregateHelper.clearAggregate(rowBuilder);
-            if (isKeyed)
+            if (helper.canMatchAny() && !eof)
             {
-                loop
+                if (isKeyed)
                 {
-                    const void *next = cursor->nextMatch();
-                    if (!next)
-                        break;
-                    aggregateHelper.processRow(rowBuilder, next);
-                }
-            }
-            else
-            {
-                assertex(reader != NULL);
-                while (!deserializeSource.eos())
-                {
-                    prefetcher->readAhead(deserializeSource);
-                    const byte *nextRec = deserializeSource.queryRow();
-                    if (!cursor || !cursor->isFiltered(nextRec))
+                    loop
                     {
-                        aggregateHelper.processRow(rowBuilder, nextRec);
+                        const void *next = cursor->nextMatch();
+                        if (!next)
+                            break;
+                        aggregateHelper.processRow(rowBuilder, next);
                     }
-                    deserializeSource.finishedRow();
+                }
+                else
+                {
+                    assertex(reader != NULL);
+                    while (!deserializeSource.eos())
+                    {
+                        prefetcher->readAhead(deserializeSource);
+                        const byte *nextRec = deserializeSource.queryRow();
+                        if (!cursor || !cursor->isFiltered(nextRec))
+                        {
+                            aggregateHelper.processRow(rowBuilder, nextRec);
+                        }
+                        deserializeSource.finishedRow();
+                    }
                 }
             }
             finalSize = meta.getRecordSize(rowBuilder.getSelf());
@@ -20570,11 +20581,14 @@ public:
         }
         else
         {
-            Owned<IInMemoryFileProcessor> processor = isKeyed ? 
-                createKeyedGroupAggregateRecordProcessor(cursor, resultAggregator, aggregateHelper) :
-                createUnkeyedGroupAggregateRecordProcessor(cursor, resultAggregator, aggregateHelper, manager->createReader(0, 0, 1),
-                                                           ctx->queryCodeContext(), activityId);
-            processor->doQuery(NULL, 0, 0, 0);
+            if (helper.canMatchAny() && !eof)
+            {
+                Owned<IInMemoryFileProcessor> processor = isKeyed ?
+                    createKeyedGroupAggregateRecordProcessor(cursor, resultAggregator, aggregateHelper) :
+                    createUnkeyedGroupAggregateRecordProcessor(cursor, resultAggregator, aggregateHelper, manager->createReader(0, 0, 1),
+                                                               ctx->queryCodeContext(), activityId);
+                processor->doQuery(NULL, 0, 0, 0);
+            }
         }
         gathered = true;
     }


### PR DESCRIPTION
When reading a multiway file, some activities derived from diskread are
failing with assertion errors due to changes related to the delayed
decision on whether remote read is needed.

Now that the queryOutput never returns the remote adaptor, the redirect
to use remote needs to be added to the nextInGroup methods for csv, xml
and normalize activities

This error was introduced in rc3 and should be addressed before rc4/gold.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
