### PR TITLE
HPCC-8060 Add support for jsonp callbacks to ESP responses

### DIFF
--- a/esp/bindings/SOAP/Platform/soapbind.cpp
+++ b/esp/bindings/SOAP/Platform/soapbind.cpp
@@ -270,9 +270,14 @@ void CSoapComplexType::appendContent(IEspContext* ctx, MemoryBuffer& buffer, Str
     StringBuffer content;
     if (ctx && ctx->getResponseFormat()==ESPSerializationJSON)
     {
+        const char *jsonp = ctx->queryRequestParameters()->queryProp("jsonp");
+        if (jsonp && *jsonp)
+            content.append(jsonp).append('(');
         content.append('{');
         serializeStruct(ctx, content, (const char *)NULL);
         content.append('}');
+        if (jsonp && *jsonp)
+            content.append(");");
         mimetype.set("application/json; charset=UTF-8");
     }
     else


### PR DESCRIPTION
Adding callback=name to an ESP json REST URL will wrap the json
response in the jsonp callback.

Example:

http://myesp:8010/WsExample/method.json?callback=myfunction

would return:

myfunction({"jsonp": "callback supported"});

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
