### PR TITLE
HPCC-8138 Set ECL WU Description to blank using WUUpdate

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4798,8 +4798,11 @@ void CLocalWorkUnit::setDebugValue(const char *propname, const char *value, bool
     if (overwrite || !p->hasProp(prop.str()))
     {
         // MORE - not sure this line should be needed....
-        p->setProp("Debug", ""); 
-        p->setProp(prop.str(), value); 
+        p->setProp("Debug", "");
+        if (value && *value)
+            p->setProp(prop.str(), value);
+        else
+            p->removeProp(prop.str());
     }
 }
 


### PR DESCRIPTION
In the existing code, calling WUUpdate with a Description of ""
will not blank out the description. That is fixed by this change.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
