### PR TITLE
HPCC-8182 Removed ownership set of dropzone unless we create it

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -720,9 +720,9 @@ create_dropzone() {
     # Creating DropZone directory
     if [ ! -d ${D} ]; then
          mkdir -p $D > /dev/null 2>&1
+         chown -cR $user:$user $D > /dev/null 2>&1
+	 chmod 777 $D > /dev/null 2>&1
     fi
-      chown -cR $user:$user $D > /dev/null 2>&1
-      chmod 777 $D > /dev/null 2>&1
     done
 }
 

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -721,7 +721,7 @@ create_dropzone() {
     if [ ! -d ${D} ]; then
          mkdir -p $D > /dev/null 2>&1
          chown -cR $user:$user $D > /dev/null 2>&1
-	 chmod 777 $D > /dev/null 2>&1
+         chmod 777 $D > /dev/null 2>&1
     fi
     done
 }


### PR DESCRIPTION
create_dropzone use to do a flat chown/chmod of the dropzone, now
it only does this if we need to create the directory.

Signed-off-by: Philip Marc Schwartz philip.schwartz@lexisnexis.com
