### PR TITLE
HPCC-8255 Csv headings deadlock

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -838,6 +838,12 @@ bool isGlobalActivity(CGraphElementBase &container)
         }
         case TAKspill:
             return false;
+        case TAKcsvread:
+        {
+            Owned<IHThorCsvReadArg> helper = (IHThorCsvReadArg *)container.helperFactory();
+            // if header lines, then [may] need to co-ordinate across slaves
+            return helper->queryCsvParameters()->queryHeaderLen() > 0;
+        }
 // dependent on child acts?
         case TAKlooprow:
         case TAKloopcount:
@@ -938,7 +944,6 @@ bool isGlobalActivity(CGraphElementBase &container)
 
         case TAKindexread:
         case TAKindexnormalize:
-        case TAKcsvread:
         case TAKxmlread:
         case TAKdiskexists:
         case TAKindexexists:


### PR DESCRIPTION
A csvread with headings wasn't marked global, as a consequence
there was a race, between initalizing on one slave and sending
data from previous instances to next.

Ensure csvread with headings is marked global, since the activity
instances need to coordinate.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
