### PR TITLE
HPCC-8189 JobQueue updating dali too frequently

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -462,7 +462,7 @@ public:
     void startListener(const char *queuename,CSDSServerStatus *serverstatus)
     {
         PROGLOG("DFU server waiting on queue %s",queuename);
-        cDFUlistener *lt = new cDFUlistener(this,queuename,false,serverstatus, 1000*60);
+        cDFUlistener *lt = new cDFUlistener(this,queuename,false,serverstatus);
         listeners.append(*lt);
         lt->start();
     }

--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -147,7 +147,7 @@ int CEclAgentExecutionServer::run()
         while (started)
         {
             PROGLOG("AgentExec: Waiting on queue(s) '%s'", queueNames.str());
-            Owned<IJobQueueItem> item = queue->dequeue(WAIT_FOREVER);
+            Owned<IJobQueueItem> item = queue->dequeue();
             if (item.get())
             {
                 StringAttr wuid;

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -31111,6 +31111,7 @@ private:
 
 class RoxieWorkUnitListener : public RoxieListener
 {
+    Owned<IJobQueue> queue;
 public:
     RoxieWorkUnitListener(unsigned _poolSize, bool _suspended)
       : RoxieListener(_poolSize, _suspended)
@@ -31132,9 +31133,23 @@ public:
         UNIMPLEMENTED;
     }
 
+    virtual bool stop(unsigned timeout)
+    {
+        if (queue)
+        {
+            DBGLOG("RoxieWorkUnitListener::stop");
+            queue->cancelAcceptConversation();
+        }
+        return RoxieListener::stop(timeout);
+    }
+
     virtual void stopListening()
     {
-        // Nothing to do
+        if (queue)
+        {
+            DBGLOG("RoxieWorkUnitListener::stopListening");
+            queue->cancelAcceptConversation();
+        }
     }
 
     virtual int run()
@@ -31154,12 +31169,12 @@ public:
                         DBGLOG("roxie: Waiting on queue(s) '%s'", queueNames.str());
                     try
                     {
-                        Owned<IJobQueue> queue = createJobQueue(queueNames.str());
+                        queue.setown(createJobQueue(queueNames.str()));
                         queue->connect();
                         daliHelper->noteQueuesRunning(queueNames.str());
                         while (running)
                         {
-                            Owned<IJobQueueItem> item = queue->dequeue(5000);
+                            Owned<IJobQueueItem> item = queue->dequeue();
                             if (item.get())
                             {
                                 if (traceLevel)
@@ -31167,6 +31182,7 @@ public:
                                 pool->start((void *) item->queryWUID());
                             }
                         }
+                        queue.clear();
                     }
                     catch (IDaliClient_Exception *E)
                     {
@@ -31174,6 +31190,7 @@ public:
                             EXCLOG(E, "roxie: Dali connection lost");
                         E->Release();
                         daliHelper->disconnect();
+                        queue.clear();
                     }
                 }
             }


### PR DESCRIPTION
Both eclccserver and roxie were setting short timeouts on the call to
jobq.dequeue, in order to ensure they could close down cleanly and quickly.

However, this resulted in frequent writes to dali to update the queue
status (several per second), meaning dali would never be idle and the
inc file would grow unnecessarily large.

Use the async cancelAcceptConversation method means we can close down even
faster, and avoids the dali noise.

There is still a timeout every 900s (in a defualt configuration) on the
dfuserver monitor queue. That cannot be eliminated without more significant
refactoring.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
