### PR TITLE
HPCC-8026 Fix View Log file in Last N Hours option

### DIFF
--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -531,26 +531,23 @@ bool CWsTopologyEx::findTimestampAndLT(StringBuffer logname, IFile* rFile, ReadL
     return true;
 }
 
-char* CWsTopologyEx::readALogLine(char* dataPtr, size32_t& bytesRemaining, unsigned ltLength, StringBuffer& logLine, bool& hasLineTernimator)
+char* CWsTopologyEx::readALogLine(char* dataPtr, size32_t& bytesRemaining, unsigned ltLength, StringBuffer& logLine, bool& hasLineTerminator)
 {
-    bool inQuote = false;
     char* pTr = dataPtr;
 
-    hasLineTernimator = false;
+    CDateTime dt;
+    hasLineTerminator = false;
     while(bytesRemaining > 0)
     {
-        if (pTr[0] == '\"')
-            inQuote = !inQuote;
-
-        hasLineTernimator = isLineTerminator(pTr, bytesRemaining, ltLength);
-        if (hasLineTernimator && !inQuote) //a log line may be broken into multiple lines
+        hasLineTerminator = isLineTerminator(pTr, bytesRemaining, ltLength);
+        if (hasLineTerminator && (bytesRemaining > ltLength + 27) && readLogTime(pTr+ltLength, 9, 19, dt))
             break;
 
         pTr++;
         bytesRemaining--;
     }
 
-    if (hasLineTernimator)
+    if (hasLineTerminator && (bytesRemaining > 0))
     {
         pTr += ltLength;
         bytesRemaining -= ltLength;

--- a/esp/services/ws_topology/ws_topologyService.hpp
+++ b/esp/services/ws_topology/ws_topologyService.hpp
@@ -99,7 +99,7 @@ private:
     bool findTimestampAndLT(StringBuffer logname, IFile* pFile, ReadLog& readLogReq, CDateTime& latestLogTime);
     unsigned findLineTerminator(const char* dataPtr, const size32_t dataSize);
     bool isLineTerminator(const char* dataPtr, const size32_t dataSize, unsigned ltLength);
-    char* readALogLine(char* dataPtr, size32_t& dataSize, unsigned ltLength, StringBuffer& logLine, bool& hasLineTernimator);
+    char* readALogLine(char* dataPtr, size32_t& dataSize, unsigned ltLength, StringBuffer& logLine, bool& hasLineTerminator);
     void addALogLine(offset_t& readFrom, unsigned& locationFlag, StringBuffer dataRow, ReadLog& readLogReq, StringArray& returnbuff);
     void readTpLogFileRequest(IEspContext &context, const char* fileName, IFile* rFile, IEspTpLogFileRequest  &req, ReadLog& readLogReq);
     void setTpLogFileResponse(IEspContext &context, ReadLog& readLogReq, const char* fileName,


### PR DESCRIPTION
If a log file is large, the code of View Log file will check
timestamp from the last chuck of the log. The Last N Hours option
fails due to incorrectly match quotes when the chuck starts
from the middle of a log line and an open quote is not inside the
chuck. (Quotes may be used to hold a big log line which are broken
into multiple physical log lines). This fix is based on the
following assumption: if a quote is the last character of a physical
line, the quote is a close quote.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
