### PR TITLE
HPCC-8138 Set ECL WU Description to blank using WUUpdate

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -840,7 +840,7 @@ bool CWsWorkunitsEx::onWUUpdate(IEspContext &context, IEspWUUpdateRequest &req, 
         if (origValueChanged(req.getJobname(), req.getJobnameOrig(), s))
             wu->setJobName(s.trim().str());
         if (origValueChanged(req.getDescription(), req.getDescriptionOrig(), s.clear()))
-            wu->setDebugValue("description", (req.getDescription()) ? s.trim().str() : NULL, true);
+            wu->setDebugValue("description", (req.getDescription() && *req.getDescription()) ? s.trim().str() : NULL, true);
 
         double version = context.getClientVersion();
         if (version > 1.04)


### PR DESCRIPTION
In the existing code, calling WUUpdate with a Description of ""
will not blank out the description. That is because the existing 
CClientRemoteTree::setProp() cannot set a property to be empty. 
As a workaround, in this fix, I set the property value of ECL WU 
Description to be NULL if a user sets it to be empty. 

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
