### PR TITLE
HPCC-8228 Use countX instead of lenX for a link counted dataset parameter

### DIFF
--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -812,7 +812,12 @@ void HqlCppWriter::generateParamCpp(IHqlExpression * param)
             if (isOut)
                 out.append(" &");
             if (paramName)
-                appendCapital(out.append(" len"), paramNameText);
+            {
+                if (hasOutOfLineModifier(paramType) || hasLinkCountedModifier(paramType))
+                    appendCapital(out.append(" count"), paramNameText);
+                else
+                    appendCapital(out.append(" len"), paramNameText);
+            }
             out.append(",");
         }
         break;

--- a/testing/ecl/externalfunc.ecl
+++ b/testing/ecl/externalfunc.ecl
@@ -1,0 +1,39 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+inRec := { unsigned id };
+doneRec := { unsigned4 execid };
+out1rec := { unsigned id; };
+out2rec := { real id; };
+
+unsigned4 count1(DATASET(inRec) input) := BEGINC++
+  return lenInput / sizeof(unsigned __int64);
+ENDC++;
+
+unsigned4 count2(_LINKCOUNTED_ DATASET(inRec) input) := BEGINC++
+  return countInput;
+ENDC++;
+
+unsigned4 count3(_ARRAY_ DATASET(inRec) input) := BEGINC++
+  return countInput;
+ENDC++;
+
+
+ds1 := DATASET([1,2,3,4,5],inRec);
+output(count1(ds1));
+output(count2(ds1));
+output(count3(ds1));

--- a/testing/ecl/key/externalfunc.xml
+++ b/testing/ecl/key/externalfunc.xml
@@ -1,0 +1,9 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>5</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>5</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>5</Result_3></Row>
+</Dataset>


### PR DESCRIPTION
A link counted dataset is passed as a (count, byt \* *) pair - so name the count
paramater consistently with a return types (and avoid potential confusion).

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
