### PR TITLE
HPCC-8278 Cache memory allocators

### DIFF
--- a/system/jlib/jsuperhash.hpp
+++ b/system/jlib/jsuperhash.hpp
@@ -348,7 +348,7 @@ public:
     virtual void onRemove(void *et) { ((ET *)et)->Release(); }
 };
 
-// template mapping object for base type to arbitary object
+// template mapping object for base type to arbitrary object
 template <class ET, class FP>
 class HTMapping : public CInterface
 {
@@ -364,11 +364,18 @@ public:
 
 // template mapping object for base type to IInterface object
 template <class ET, class FP>
-class LinkedHTMapping : public HTMapping<ET, FP>
+class OwningHTMapping : public HTMapping<ET, FP>
 {
 public:
-    LinkedHTMapping(ET &et, FP &fp) : HTMapping<ET, FP>(et, fp) { this->et.Link(); }
-    ~LinkedHTMapping() { this->et.Release(); }
+    OwningHTMapping(ET &et, FP &fp) : HTMapping<ET, FP>(et, fp) { }
+    ~OwningHTMapping() { this->et.Release(); }
+};
+
+template <class ET, class FP>
+class LinkedHTMapping : public OwningHTMapping<ET, FP>
+{
+public:
+    LinkedHTMapping(ET &et, FP &fp) : OwningHTMapping<ET, FP>(et, fp) { this->et.Link(); }
 };
 
 // template mapping object for string to arbitrary object


### PR DESCRIPTION
Thor or generated code will ask for allocators during the
lifetime of a query. On the whole these are all requested up
front, e.g. in activity initialization or onCreate() methods.
Some might be requested repeatedly e.g. in transform() methods
Ensure that previously request meta/actid allocators are reused
by introducing a cache.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
