### PR TITLE
HPCC-8178 - Sort job ran out of memory

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -3826,16 +3826,16 @@ void CQuickSorter::performSort()
 
 bool CStableQuickSorter::addRow(const void * next)
 {
-    size32_t capacity = rowsToSort.capacity() + 1;//increment capacity for the row we are about to add
-    if (capacity > indexCapacity)
+    size32_t nextRowCapacity = rowsToSort.rowCapacity() + 1;//increment capacity for the row we are about to add
+    if (nextRowCapacity > indexCapacity)
     {
-        void *** newIndex = (void ***)rowManager->allocate(capacity, activityId);//could force a spill
+        void *** newIndex = (void ***)rowManager->allocate(nextRowCapacity * sizeof(void*), activityId);//could force an OOM callback
         if (newIndex)
         {
-            roxiemem::RoxieOutputRowArrayLock block(getRowArray());//could spill after index is freed but before index,indexCapacity is updated
+            roxiemem::RoxieOutputRowArrayLock block(getRowArray());//could force an OOM callback after index is freed but before index,indexCapacity is updated
             releaseHThorRow(index);
             index = newIndex;
-            indexCapacity = RoxieRowCapacity(index);
+            indexCapacity = RoxieRowCapacity(index) / sizeof(void*);
         }
         else
         {

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -1018,7 +1018,7 @@ public:
     virtual void killSorted() = 0;
     virtual const DynamicOutputRowArray & getRowArray() = 0;
     virtual void flushRows() = 0;
-    virtual unsigned numCommitted() = 0;
+    virtual unsigned numCommitted() const = 0;
     virtual void setActivityId(unsigned _activityId) = 0;
 };
 
@@ -1084,7 +1084,7 @@ public:
     virtual void killSorted()                               { rowsToSort.kill(); finger = 0;}
     virtual const DynamicOutputRowArray & getRowArray()     { return rowsToSort; }
     virtual void flushRows()                                { rowsToSort.flush(); }
-    virtual size32_t numCommitted()                         { return rowsToSort.numCommitted(); }
+    virtual size32_t numCommitted() const                   { return rowsToSort.numCommitted(); }
     virtual void setActivityId(unsigned _activityId)        { activityId = _activityId; }
 
 protected:

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -40,6 +40,8 @@
 #include "eclrtl_imp.hpp"
 #include "rtlds_imp.hpp"
 #include "rtlread_imp.hpp"
+#include "roxiemem.hpp"
+#include "roxierowbuff.hpp"
 
 roxiemem::IRowManager * queryRowManager();
 #define releaseHThorRow(row) ReleaseRoxieRow(row)
@@ -47,6 +49,7 @@ roxiemem::IRowManager * queryRowManager();
 typedef roxiemem::OwnedRoxieRow OwnedHThorRow;
 typedef roxiemem::OwnedConstRoxieRow OwnedConstHThorRow;
 typedef roxiemem::OwnedRoxieRow OwnedRow;
+typedef roxiemem::DynamicRoxieOutputRowArray DynamicOutputRowArray;
 
 //-- Memory allocation helper class
 
@@ -1008,15 +1011,25 @@ class ISorter : public IInterface
 {
 public:
     virtual ~ISorter() {}
-    virtual void addRow(const void * next) = 0;
+    virtual bool addRow(const void * next) = 0;
     virtual void performSort() = 0;
     virtual void spillSortedToDisk(IDiskMerger * merger) = 0;
     virtual const void * getNextSorted() = 0;
     virtual void killSorted() = 0;
+    virtual const DynamicOutputRowArray & getRowArray() = 0;
+    virtual void flushRows() = 0;
+    virtual unsigned numCommitted() = 0;
+    virtual void setActivityId(unsigned _activityId) = 0;
 };
 
-class CHThorGroupSortActivity : public CHThorSimpleActivityBase
+class CHThorGroupSortActivity : public CHThorSimpleActivityBase, implements roxiemem::IBufferedRowCallback
 {
+   enum {
+        InitialSortElements = 0,
+        //The number of rows that can be added without entering a critical section,
+        //and therefore also the max number of rows that wont get freed during a spill
+        CommitStep = 32
+    };
 public:
     CHThorGroupSortActivity(IAgentContext &agent, unsigned _activityId, unsigned _subgraphId, IHThorSortArg &_arg, ThorActivityKind _kind);
 
@@ -1029,15 +1042,18 @@ public:
 
     virtual IOutputMetaData * queryOutputMeta() const { return outputMeta; }
 
+    //interface roxiemem::IBufferedRowCallback
+    virtual unsigned getPriority() const;
+    virtual bool freeBufferedRows(bool critical);
+
 private:
+    bool sortAndSpillRows();
     void createSorter();
     void getSorted();
 
 protected:
     IHThorSortArg &helper;
     bool gotSorted;
-    bool eof;
-    memsize_t spillThreshold;
     Owned<ISorter> sorter;
     bool sorterIsConst;
     Owned<IDiskMerger> diskMerger;
@@ -1047,50 +1063,70 @@ protected:
 class CSimpleSorterBase : public CInterface, public ISorter
 {
 public:
-    CSimpleSorterBase(ICompare * _compare) : compare(_compare), finger(0) {}
-    virtual ~CSimpleSorterBase() { killSorted(); }
+    CSimpleSorterBase(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : compare(_compare), finger(0), rowManager(_rowManager),
+        rowsToSort(_rowManager, _initialSize, _commitDelta) {}
+    virtual ~CSimpleSorterBase()                            { killSorted(); }
     IMPLEMENT_IINTERFACE;
+    virtual bool addRow(const void * next)                  { return rowsToSort.append(next); }
     virtual void spillSortedToDisk(IDiskMerger * merger);
-    virtual const void * getNextSorted();
-    virtual void killSorted();
+    virtual const void * getNextSorted()
+    {
+        if (finger < rowsToSort.numCommitted())
+        {
+            const void * * rows = rowsToSort.getBlock(finger);
+            const void * row = rows[finger];
+            rows[finger++] = NULL;
+            return row;
+        }
+        else
+            return NULL;
+    }
+    virtual void killSorted()                               { rowsToSort.kill(); finger = 0;}
+    virtual const DynamicOutputRowArray & getRowArray()     { return rowsToSort; }
+    virtual void flushRows()                                { rowsToSort.flush(); }
+    virtual size32_t numCommitted()                         { return rowsToSort.numCommitted(); }
+    virtual void setActivityId(unsigned _activityId)        { activityId = _activityId; }
 
 protected:
+    roxiemem::IRowManager * rowManager;
+    unsigned activityId;
     ICompare * compare;
-    ConstPointerArray rows;
+    DynamicOutputRowArray rowsToSort;
     aindex_t finger;
 };
 
 class CQuickSorter : public CSimpleSorterBase
 {
 public:
-    CQuickSorter(ICompare * _compare) : CSimpleSorterBase(_compare) {}
-    virtual void addRow(const void * next) { rows.append(next); }
+    CQuickSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta) {}
     virtual void performSort();
 };
 
 class CStableQuickSorter : public CSimpleSorterBase
 {
 public:
-    CStableQuickSorter(ICompare * _compare) : CSimpleSorterBase(_compare), index(NULL) {}
+    CStableQuickSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta, roxiemem::IBufferedRowCallback * _rowCB) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta), commitDelta(_commitDelta), index(NULL), indexCapacity(0) {}
     virtual ~CStableQuickSorter() { killSorted(); }
     IMPLEMENT_IINTERFACE;
-    virtual void addRow(const void * next) { rows.append(next); }
+    virtual bool addRow(const void * next);
+    virtual void spillSortedToDisk(IDiskMerger * merger);
     virtual void performSort();
     virtual const void * getNextSorted();
     virtual void killSorted();
 
 private:
     void *** index;
+    memsize_t indexCapacity;
+    unsigned commitDelta;
 };
 
 class CHeapSorter :  public CSimpleSorterBase
 {
 public:
-    CHeapSorter(ICompare * _compare) : CSimpleSorterBase(_compare), heapsize(0) {}
+    CHeapSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta), heapsize(0) {}
     virtual ~CHeapSorter() { killSorted(); }
     IMPLEMENT_IINTERFACE;
-    virtual void addRow(const void * next);
-    virtual void performSort() {}
+    virtual void performSort();
     virtual void spillSortedToDisk(IDiskMerger * merger);
     virtual const void * getNextSorted();
     virtual void killSorted();
@@ -1103,17 +1139,15 @@ private:
 class CInsertionSorter : public CSimpleSorterBase
 {
 public:
-    CInsertionSorter(ICompare * _compare) : CSimpleSorterBase(_compare) {}
-    virtual void addRow(const void * next);
-    virtual void performSort() {}
+    CInsertionSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta) {}
+    virtual void performSort();
 };
 
 class CStableInsertionSorter : public CSimpleSorterBase
 {
 public:
-    CStableInsertionSorter(ICompare * _compare) : CSimpleSorterBase(_compare) {}
-    virtual void addRow(const void * next);
-    virtual void performSort() {}
+    CStableInsertionSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta) {}
+    virtual void performSort();
 };
 
 class CHThorGroupedActivity : public CHThorSimpleActivityBase

--- a/roxie/roxiemem/roxierowbuff.hpp
+++ b/roxie/roxiemem/roxierowbuff.hpp
@@ -73,6 +73,7 @@ public:
     const void * query(rowidx_t i) const;
     const void * getClear(rowidx_t i);
     const void * get(rowidx_t i) const;
+    size32_t capacity() { return rows ? RoxieRowCapacity(rows) : 0; }
 
     //A thread calling the following functions must own the lock, or guarantee no other thread will access
     const void * * getBlock(rowidx_t readRows);

--- a/roxie/roxiemem/roxierowbuff.hpp
+++ b/roxie/roxiemem/roxierowbuff.hpp
@@ -73,7 +73,7 @@ public:
     const void * query(rowidx_t i) const;
     const void * getClear(rowidx_t i);
     const void * get(rowidx_t i) const;
-    size32_t capacity() { return rows ? RoxieRowCapacity(rows) : 0; }
+    size32_t rowCapacity() const { return rows ? RoxieRowCapacity(rows)/sizeof(void*) : 0; }
 
     //A thread calling the following functions must own the lock, or guarantee no other thread will access
     const void * * getBlock(rowidx_t readRows);


### PR DESCRIPTION
A large sort was running out of memory instead of spilling because of
an error in calculating the spill threshold. This fix implements a better
solution, which is to register for roxiemem OOM callbacks during sort,
and to spill in the case of a callback.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
