### PR TITLE
HPCC-8287 Avoid rsync prompt in thor slave script

### DIFF
--- a/initfiles/componentfiles/thor/start_slaves
+++ b/initfiles/componentfiles/thor/start_slaves
@@ -68,8 +68,8 @@ ulimit -n $handlelimit
 echo "slave(s) starting `date`"
 
 # sync to current master thorgroup
-echo rsync $master:$instancedir/thorgroup $instancedir/thorgroup.slave
-rsync $master:$instancedir/thorgroup $instancedir/thorgroup.slave
+echo rsync -e "ssh -o StrictHostKeyChecking=no" $master:$instancedir/thorgroup $instancedir/thorgroup.slave
+rsync -e "ssh -o StrictHostKeyChecking=no" $master:$instancedir/thorgroup $instancedir/thorgroup.slave
 
 let "slavenum = 1";
 for slave in $(cat $instancedir/thorgroup.slave); do


### PR DESCRIPTION
Add a ssh option to avoid rsync prompting to add ssh key

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
