### PR TITLE
GH-524 Add stringMatchBagOfWords to the saltlib plugin

### DIFF
--- a/plugins/proxies/lib_saltlib.eclmod
+++ b/plugins/proxies/lib_saltlib.eclmod
@@ -15,11 +15,12 @@
     limitations under the License.
 ############################################################################## */
 
-/* Proxy service header for (EE-only) saltlib plugin version SALTLIB 1.0.02 */
+/* Proxy service header for (EE-only) saltlib plugin version SALTLIB 1.0.03 */
 
 export SaltLib := SERVICE
   boolean UnicodeLocaleWithinEditN(const unicode left, const unicode right, unsigned4 distance,  const varstring localename) : c, pure,entrypoint='ulUnicodeLocaleWithinEditN', hole;
   integer4 UnicodeLocaleMatchBagofwords(const unicode left, const unicode right, const varstring localename, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords', hole;
   unicode UnicodeLocaleGetRangeOfWords(const unicode text, unsigned4 s_index, unsigned4 e_index, const varstring localename) : c,pure,entrypoint='ulUnicodeLocaleGetRangeOfWords';
+  integer4 StringMatchBagofwords(const string left, const string right, unsigned4 mode, unsigned4 score_mode, unsigned fn, unsigned fn_arg1, unsigned fn_arg2) : c, pure,entrypoint='ulStringMatchBagofwords', hole;
 END;
 

--- a/plugins/stringlib/stringlib.cpp
+++ b/plugins/stringlib/stringlib.cpp
@@ -422,7 +422,7 @@ unsigned editDistanceV2(unsigned leftLen, const char * left, unsigned rightLen, 
 // * special case edit1 - you could use variables for the 6 interesting array elements, and get
 //   rid of the array completely.  You could also unwind the first (and last iterations).
 // * I suspect the early exit condition could be improved depending the lengths of the strings.
-unsigned editDistanceV3(unsigned leftLen, const char * left, unsigned rightLen, const char * right, unsigned radius)
+extern STRINGLIB_API unsigned editDistanceV3(unsigned leftLen, const char * left, unsigned rightLen, const char * right, unsigned radius)
 {
     if (radius >= 255)
         return 255;

--- a/plugins/stringlib/stringlib.hpp
+++ b/plugins/stringlib/stringlib.hpp
@@ -87,4 +87,7 @@ STRINGLIB_API unsigned STRINGLIB_CALL slMatchDate(size32_t lenS, const char * s,
 STRINGLIB_API void STRINGLIB_CALL slFormatDate(size32_t & __lenResult, char * & __result, unsigned date, const char * format);
 }
 
+namespace nsStringlib {
+extern STRINGLIB_API unsigned editDistanceV3(unsigned leftLen, const char * left, unsigned rightLen, const char * right, unsigned radius);
+}
 #endif


### PR DESCRIPTION
Update to match latest saltlib, and export a symbol that it uses.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
