### PR TITLE
HPCC-8300 Allow stringlib.hpp to be included by other plugins

### DIFF
--- a/plugins/stringlib/stringlib.hpp
+++ b/plugins/stringlib/stringlib.hpp
@@ -34,8 +34,12 @@
 #include "hqlplugins.hpp"
 
 extern "C" {
+
+#ifdef STRINGLIB_EXPORTS
 STRINGLIB_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb);
 STRINGLIB_API void setPluginContext(IPluginContext * _ctx);
+#endif
+
 STRINGLIB_API void STRINGLIB_CALL slStringFilterOut(unsigned & tgtLen, char * & tgt, unsigned srcLen, const char * src, unsigned hitLen, const char * hit);
 STRINGLIB_API void STRINGLIB_CALL slStringFilter(unsigned & tgtLen, char * & tgt, unsigned srcLen, const char * src, unsigned hitLen, const char * hit);
 STRINGLIB_API void STRINGLIB_CALL slStringSubsOut(unsigned & tgtLen, char * & tgt, unsigned srcLen, const char * src, unsigned hitLen, const char * hit, unsigned newCharLen, const char * newChar);


### PR DESCRIPTION
Conditionally include plugin definition and context functions in the header
so they don't clash with definitions in other plugins.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
