### PR TITLE
HPCC-3208 Report a warning if a scalar output is used in an APPLY

### DIFF
--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -204,6 +204,7 @@
 #define HQLERR_OutsideGroupAggregate            4182
 #define HQLERR_ResourceAddAfterFinalManifest    4183
 #define HQLERR_SkipInsideCreateRow              4184
+#define HQLERR_ScalarOutputWithinApply          4185
 
 //Warnings....
 #define HQLWRN_PersistDataNotLikely             4500
@@ -480,6 +481,7 @@
 #define HQLERR_OutsideGroupAggregate_Text       "%s used outside of a TABLE aggregation"
 #define HQLERR_ResourceAddAfterFinalManifest_Text "%s resource added after manifest was finalized"
 #define HQLERR_SkipInsideCreateRow_Text         "SKIP inside a ROW(<transform>) not supported.  It is only allowed in a DATASET transform."
+#define HQLERR_ScalarOutputWithinApply_Text     "A scalar output within an APPLY is undefined and may fail.  Use OUTPUT(dataset,EXTEND) instead."
 
 //Warnings.
 #define HQLWRN_CannotRecreateDistribution_Text  "Cannot recreate the distribution for a persistent dataset"

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -155,7 +155,7 @@ private:
 class SequenceNumberAllocator : public NewHqlTransformer
 {
 public:
-    SequenceNumberAllocator();
+    SequenceNumberAllocator(HqlCppTranslator & _translator);
 
     virtual IHqlExpression * createTransformed(IHqlExpression * expr);
     virtual ANewTransformInfo * createTransformInfo(IHqlExpression * expr) { return CREATE_NEWTRANSFORMINFO(SequenceNumberInfo, expr); }
@@ -172,6 +172,8 @@ protected:
     IHqlExpression * attachSequenceNumber(IHqlExpression * expr);
 
 protected:
+    HqlCppTranslator & translator; // should really be an error handler - could do with refactoring.
+    unsigned applyDepth;
     unsigned sequence;
     MapOwnedHqlToOwnedHql namedMap;
 };

--- a/ecl/regress/issue3208.ecl
+++ b/ecl/regress/issue3208.ecl
@@ -1,0 +1,22 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+test := DATASET([1,2,3,4], {INTEGER N});
+
+APPLY(test,
+    OUTPUT(n)
+    ) ;


### PR DESCRIPTION
It doesn't make sense to use a scalar output within an apply since a
scalar output can only output a single value.
It also causse Thor to generate an internal error since the output code is
executed on the slave which Thor doesn't support.

It isn't made an error because there are some existing queries which use it.
(They should be modified.)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
