### PR TITLE
HPCC-8299 Fix error modfying a shared rowset

### DIFF
--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -314,6 +314,7 @@ public:
 #define RoxieRowCapacity(row)  roxiemem::HeapletBase::capacity(row)
 #define RoxieRowHasDestructor(row)  roxiemem::HeapletBase::hasDestructor(row)
 #define RoxieRowAllocatorId(row) roxiemem::HeapletBase::getAllocatorId(row)
+#define RoxieRowIsShared(row)  roxiemem::HeapletBase::isShared(row)
 
 class OwnedRoxieRow;
 class OwnedConstRoxieRow


### PR DESCRIPTION
Aggregates have code to optimize appending to a rowset.  In some situations the
target rowset might be shared.  This change ensures the shared rowset is never
modified.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
