### PR TITLE
HPCC-8304 Regression causing spilling hthor sort to lose records

### DIFF
--- a/common/thorhelper/thorcommon.cpp
+++ b/common/thorhelper/thorcommon.cpp
@@ -1593,7 +1593,7 @@ public:
         tempname.append('.').append(tempfiles.ordinality()).append('_').append((__int64)GetCurrentThreadId()).append('_').append((unsigned)GetCurrentProcessId());
         IFile *file = createIFile(tempname.str());
         tempfiles.append(*file);
-        return createRowWriter(file, rowInterfaces, 0); // flushed by close
+        return createRowWriter(file, rowInterfaces);
     }
     void put(const void **rows,unsigned numrows)
     {


### PR DESCRIPTION
Regression caused by HPCC-3097, lost the auto flushing from the
spill stream writer used in hthor's sort spilling

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
