### PR TITLE
HPCC-8297 Provide a callback mechanism when resizing a row

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -1650,7 +1650,7 @@ public:
     }
 
     void * doAllocate(memsize_t _size, unsigned allocatorId);
-    void *expandHeap(void * original, memsize_t copysize, memsize_t oldcapacity, memsize_t newsize, unsigned activityId, memsize_t &capacity);
+    void *expandHeap(void * original, memsize_t copysize, memsize_t oldcapacity, memsize_t newsize, unsigned activityId, memsize_t &capacity, IRowResizeCallback * callback);
 
 protected:
     HugeHeaplet * allocateHeaplet(memsize_t _size, unsigned allocatorId);
@@ -2296,7 +2296,7 @@ public:
             logctx.CTXLOG("RoxieMemMgr: CChunkingRowManager::setMemoryLimit new memlimit=%"I64F"u pageLimit=%u spillLimit=%u rowMgr=%p", (unsigned __int64) bytes, pageLimit, spillPageLimit, this);
     }
 
-    virtual void *resizeRow(void * original, memsize_t copysize, memsize_t newsize, unsigned activityId, memsize_t &capacity)
+    virtual void *resizeRow(void * original, memsize_t copysize, memsize_t newsize, unsigned activityId, memsize_t &capacity, IRowResizeCallback * callback)
     {
         assertex(newsize);
         assertex(!HeapletBase::isShared(original));
@@ -2308,12 +2308,15 @@ public:
             return original;
         }
         if (curCapacity > FixedSizeHeaplet::maxHeapSize())
-            return hugeHeap.expandHeap(original, copysize, curCapacity, newsize, activityId, capacity);
+            return hugeHeap.expandHeap(original, copysize, curCapacity, newsize, activityId, capacity, callback);
 
         void *ret = allocate(newsize, activityId);
         memcpy(ret, original, copysize);
+        memsize_t newCapacity = HeapletBase::capacity(ret);
+        if (callback)
+            callback->atomicUpdate(newCapacity, ret);
         HeapletBase::release(original);
-        capacity = HeapletBase::capacity(ret);
+        capacity = newCapacity;
         return ret;
     }
 
@@ -2683,7 +2686,7 @@ void * CRoxieVariableRowHeap::allocate(memsize_t size, memsize_t & capacity)
 
 void * CRoxieVariableRowHeap::resizeRow(void * original, memsize_t copysize, memsize_t newsize, memsize_t &capacity)
 {
-    return rowManager->resizeRow(original, copysize, newsize, allocatorId, capacity);
+    return rowManager->resizeRow(original, copysize, newsize, allocatorId, capacity, NULL);
 }
 
 void * CRoxieVariableRowHeap::finalizeRow(void *final, memsize_t originalSize, memsize_t finalSize)
@@ -2733,7 +2736,7 @@ void * CHugeChunkingHeap::doAllocate(memsize_t _size, unsigned allocatorId)
     return head->allocateHuge(_size);
 }
 
-void *CHugeChunkingHeap::expandHeap(void * original, memsize_t copysize, memsize_t oldcapacity, memsize_t newsize, unsigned activityId, memsize_t &capacity)
+void *CHugeChunkingHeap::expandHeap(void * original, memsize_t copysize, memsize_t oldcapacity, memsize_t newsize, unsigned activityId, memsize_t &capacity, IRowResizeCallback * callback)
 {
     unsigned newPages = PAGES(newsize + HugeHeaplet::dataOffset(), HEAP_ALIGNMENT_SIZE);
     unsigned oldPages = PAGES(oldcapacity + HugeHeaplet::dataOffset(), HEAP_ALIGNMENT_SIZE);
@@ -2783,6 +2786,11 @@ void *CHugeChunkingHeap::expandHeap(void * original, memsize_t copysize, memsize
                         assert(finger != NULL); // Should always have found it
                     }
                 }
+
+                //Copying data within the block => must lock for the duration
+                if (callback && !release)
+                    callback->lock();
+
                 // MORE - If we were really clever, we could manipulate the page table to avoid moving ANY data here...
                 memmove(realloced, oldbase, copysize + HugeHeaplet::dataOffset());  // NOTE - assumes no trailing data (e.g. end markers)
                 SpinBlock b(crit);
@@ -2791,9 +2799,34 @@ void *CHugeChunkingHeap::expandHeap(void * original, memsize_t copysize, memsize
                 active = head;
             }
             void * ret = (char *) realloced + HugeHeaplet::dataOffset();
-            capacity = head->setCapacity(newsize);
+            memsize_t newCapacity = head->setCapacity(newsize);
             if (release)
+            {
+                //Update the pointer before the old one becomes invalid
+                if (callback)
+                    callback->atomicUpdate(newCapacity, ret);
+
                 subfree_aligned(oldbase, oldPages);
+            }
+            else
+            {
+                if (callback)
+                {
+                    if (realloced != oldbase)
+                    {
+                        //previously locked => update the pointer and then unlock
+                        callback->update(newCapacity, ret);
+                        callback->unlock();
+                    }
+                    else
+                    {
+                        //Extended at the end - update the max capacity
+                        callback->atomicUpdate(newCapacity, ret);
+                    }
+                }
+            }
+
+            capacity = newCapacity;
             return ret;
         }
 
@@ -4498,6 +4531,22 @@ protected:
     }
 };
 
+class CSimpleRowResizeCallback : public IRowResizeCallback
+{
+public:
+    CSimpleRowResizeCallback(memsize_t & _capacity, void * & _row) : capacity(_capacity), row(_row), locks(0) {}
+
+    virtual void lock() { ++locks; }
+    virtual void unlock() { --locks; }
+    virtual void update(memsize_t size, void * ptr) { capacity = size; row = ptr; }
+    virtual void atomicUpdate(memsize_t size, void * ptr) { capacity = size; row = ptr; }
+
+public:
+    memsize_t & capacity;
+    void * & row;
+    unsigned locks;
+};
+
 
 const memsize_t memorySize = 0x60000000;
 class RoxieMemStressTests : public CppUnit::TestFixture
@@ -4635,10 +4684,13 @@ protected:
             loop
             {
                 memsize_t nextSize = (memsize_t)(requestSize*1.25);
-                memsize_t capacity;
-                void *next = rowManager->resizeRow(prev, requestSize, nextSize, 1, capacity);
+                memsize_t capacity = 0;
+                memsize_t curSize = RoxieRowCapacity(prev);
+                CSimpleRowResizeCallback callback(curSize, prev);
+                void *next = rowManager->resizeRow(prev, requestSize, nextSize, 1, capacity, &callback);
+                ASSERT(next == prev);
+                ASSERT(curSize == capacity);
                 requestSize = nextSize;
-                prev = next;
             }
         }
         catch (IException *E)
@@ -4667,10 +4719,16 @@ protected:
             {
                 memsize_t nextSize = (memsize_t)(requestSize*1.25);
                 memsize_t capacity;
-                void *next1 = rowManager->resizeRow(prev1, requestSize, nextSize, 1, capacity);
-                prev1 = next1;
-                void *next2 = rowManager->resizeRow(prev2, requestSize, nextSize, 1, capacity);
-                prev2 = next2;
+                memsize_t newSize1 = RoxieRowCapacity(prev1);
+                memsize_t newSize2 = RoxieRowCapacity(prev2);
+                CSimpleRowResizeCallback callback1(newSize1, prev1);
+                CSimpleRowResizeCallback callback2(newSize2, prev2);
+                void *next1 = rowManager->resizeRow(prev1, requestSize, nextSize, 1, capacity, &callback1);
+                ASSERT(newSize1 == capacity);
+                ASSERT(next1 == prev1);
+                void *next2 = rowManager->resizeRow(prev2, requestSize, nextSize, 1, capacity, &callback2);
+                ASSERT(newSize2 == capacity);
+                ASSERT(next2 == prev2);
                 requestSize = nextSize;
             }
         }
@@ -4734,14 +4792,14 @@ protected:
         ASSERT(rowManager->numPagesAfterCleanup(true)==0);
         memsize_t capacity;
         void *huge1 = rowManager->allocate(initialAllocSize, 1);
-        void *huge2 = rowManager->resizeRow(huge1, initialAllocSize, hugeAllocSize, 1, capacity);
+        void *huge2 = rowManager->resizeRow(huge1, initialAllocSize, hugeAllocSize, 1, capacity, NULL);
         ASSERT(capacity > hugeAllocSize);
         ASSERT(rowManager->numPagesAfterCleanup(true)==4097);
         ReleaseRoxieRow(huge2);
         ASSERT(rowManager->numPagesAfterCleanup(true)==0);
 
         huge1 = rowManager->allocate(hugeAllocSize/2, 1);
-        huge2 = rowManager->resizeRow(huge1, hugeAllocSize/2, hugeAllocSize, 1, capacity);
+        huge2 = rowManager->resizeRow(huge1, hugeAllocSize/2, hugeAllocSize, 1, capacity, NULL);
         ASSERT(capacity > hugeAllocSize);
         ASSERT(rowManager->numPagesAfterCleanup(true)==4097);
         ReleaseRoxieRow(huge2);

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -411,11 +411,29 @@ enum RoxieHeapFlags
     RHFoldfixed         = 0x0008,  // Don't create a special fixed size heap for this
 };
 
+//This interface is here to allow atomic updates to allocations when they are being resized.  There are a few complications:
+//- If a new block is allocated, we just need to update the capacity/pointer atomically
+//  but they need to be updated at the same time, otherwise a spill occuring after the pointer update, but before
+//  the resizeRow returns could lead to an out of date capacity.
+//- If a block is resized by expanding earlier then the pointer needs to be locked while the data is being copied.
+//- If any intermediate function adds extra bytes to the amount to be allocated it will need a local implementation
+//  to apply a delta to the values being passed through.
+//
+//NOTE: update will not be called if the allocation was already large enough => the size must be set to the capacity.
+
+interface IRowResizeCallback
+{
+    virtual void lock() = 0; // prevent access to the row pointer
+    virtual void unlock() = 0; // allow access to the row pointer
+    virtual void update(memsize_t capacity, void * ptr) = 0; // update the capacity, row pointer while a lock is held.
+    virtual void atomicUpdate(memsize_t capacity, void * ptr) = 0; // update the row pointer while no lock is held
+};
+
 // Variable size aggregated link-counted Roxie (etc) row manager
 interface IRowManager : extends IInterface
 {
     virtual void *allocate(memsize_t size, unsigned activityId) = 0;
-    virtual void *resizeRow(void * original, memsize_t copysize, memsize_t newsize, unsigned activityId, memsize_t &capacity) = 0;
+    virtual void * resizeRow(void * original, memsize_t copysize, memsize_t newsize, unsigned activityId, memsize_t &capacity, IRowResizeCallback * callback) = 0;
     virtual void *finalizeRow(void *final, memsize_t originalSize, memsize_t finalSize, unsigned activityId) = 0;
     virtual void setMemoryLimit(memsize_t size, memsize_t spillSize = 0) = 0;
     virtual unsigned allocated() = 0;

--- a/roxie/roxiemem/roxierow.cpp
+++ b/roxie/roxiemem/roxierow.cpp
@@ -216,7 +216,7 @@ protected:
             return rowset;
 
         memsize_t capacity;
-        return (byte * *)rowManager.resizeRow(rowset, oldRowCount * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED, capacity);
+        return (byte * *)rowManager.resizeRow(rowset, oldRowCount * sizeof(void *), newRowCount * sizeof(void *), allocatorId | ACTIVITY_FLAG_ISREGISTERED, capacity, NULL);
     }
 
 protected:


### PR DESCRIPTION
When using resizeRow to resize a buffer which is registered with the memory
manager, there needs to be a way of atomically updating the memory buffer
variables.  Otherwise you can get inconsistent results or deadlock the
system.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
