### PR TITLE
HPCC-8306 Merge stopping early on groups inputs.

### DIFF
--- a/thorlcr/activities/merge/thmergeslave.cpp
+++ b/thorlcr/activities/merge/thmergeslave.cpp
@@ -286,7 +286,7 @@ public:
         ActivityTimer s(totalCycles, timeActivities, NULL);
         ForEachItemIn(i, inputs) {
             IThorDataLink * input = inputs.item(i);
-            try { 
+            try {
                 startInput(input); 
             }
             catch (CATCHALL) {
@@ -295,7 +295,10 @@ public:
                     streams.item(s).stop();
                 throw;
             }
-            streams.append(*LINK(input));
+            if (input->isGrouped())
+                streams.append(*createUngroupStream(input));
+            else
+                streams.append(*LINK(input));
         }
 #ifndef _STABLE_MERGE
         // shuffle streams otherwise will all be reading in order initially
@@ -445,7 +448,10 @@ public:
                     streams.item(s).stop();
                 throw;
             }
-            streams.append(*LINK(input));
+            if (input->isGrouped())
+                streams.append(*createUngroupStream(input));
+            else
+                streams.append(*LINK(input));
         }
         Owned<IRowLinkCounter> linkcounter = new CThorRowLinkCounter;
         out.setown(createRowStreamMerger(streams.ordinality(), streams.getArray(), helper->queryCompare(), helper->dedup(), linkcounter));


### PR DESCRIPTION
An OSS regression, caused merge to stop at the 1st end of group
marker, if an input was grouped.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
