### PR TITLE
HPCC-8310 Verify KeyedJoin,local matches index

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -91,6 +91,10 @@ public:
         {
             unsigned numParts = 0;
             localKey = indexFile->queryAttributes().getPropBool("@local");
+
+            if (container.queryLocal() && !localKey)
+                throw MakeActivityException(this, 0, "Keyed Join cannot be LOCAL unless supplied index is local");
+
             checkFormatCrc(this, indexFile, helper->getIndexFormatCrc(), true);
             Owned<IFileDescriptor> indexFileDesc = indexFile->getFileDescriptor();
             IDistributedSuperFile *superIndex = indexFile->querySuperFile();


### PR DESCRIPTION
Check that the index supplied to a keyedjoin,LOCAL is also
local. Fire an error if not.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
