### PR TITLE
HPCC-8301 Major Refactory in DFS Remove

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -185,10 +185,14 @@ interface IDistributedFileTransaction: extends IInterface
     virtual IDistributedSuperFile *lookupSuperFile(const char *slfn,unsigned timeout=INFINITE)=0;
     virtual IDistributedSuperFile *lookupSuperFileCached(const char *slfn,unsigned timeout=INFINITE)=0;
     virtual IUserDescriptor *queryUser()=0;
-    virtual bool addDelayedDelete(const char *lfn,bool remphys,const char*cluster=NULL,unsigned timeoutms=INFINITE)=0; // used internally to delay deletes untill commit
-    virtual void addAction(CDFAction *action)=0; // internal
+    virtual bool addDelayedDelete(const char *lfn,const char*cluster=NULL,unsigned timeoutms=INFINITE)=0; // used internally to delay deletes until commit
+    virtual void descend()=0;  // descend into a recursive call (can't autoCommit if depth is not zero)
+    virtual void ascend()=0;   // ascend back from the deep, one step at a time
+
+    // MORE: These need refactoring
+    virtual void addAction(CDFAction *action)=0; // internal (so why is this on a public interface?)
     virtual void addFile(IDistributedFile *file)=0; // TODO: avoid this being necessary
-    virtual void clearFiles()=0; // internal
+    virtual void clearFiles()=0; // internal (so why is this on a public interface?)
 };
 
 interface IDistributedSuperFileIterator: extends IIteratorOf<IDistributedSuperFile>
@@ -317,10 +321,8 @@ interface IDistributedSuperFile: extends IDistributedFile
                          )=0;
     virtual bool removeSubFile(const char *subfile,         // if NULL removes all
                                 bool remsub,                // if true removes subfiles from DFS
-                                bool remphys,               // if true removes physical parts of sub file
                                 bool remcontents=false,     // if true removes contents of subfile (assuming it is a superfile)
-                                IDistributedFileTransaction *transaction=NULL,
-                                bool delayed = false)=0;
+                                IDistributedFileTransaction *transaction=NULL)=0;
                             // Note does not delete subfile
     virtual bool swapSuperFile( IDistributedSuperFile *_file,               // swaps sub files
                                 IDistributedFileTransaction *transaction)=0;

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -691,7 +691,7 @@ static void dfsunlink(const char *lname, IUserDescriptor *user)
             if (!iter->first())
                 break;
             IDistributedSuperFile *sf = &iter->query();
-            if (sf->removeSubFile(lname,false,false))
+            if (sf->removeSubFile(lname,false))
                 OUTLOG("removed %s from %s",lname,sf->queryLogicalName());
             else
                 ERRLOG("FAILED to remove %s from %s",lname,sf->queryLogicalName());

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -107,7 +107,7 @@ void Test_SuperFile()
 #if 1
     sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"1",UNKNOWN_USER));
     if (sfile) {
-        sfile->removeSubFile(NULL,true,false);
+        sfile->removeSubFile(NULL,true);
         sfile.clear();
         queryDistributedFileDirectory().removeEntry(TEST_SUPER_FILE"1",UNKNOWN_USER);
     }
@@ -176,7 +176,7 @@ void Test_SuperFile()
     transaction->rollback();
     sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"2",UNKNOWN_USER));
     transaction->start();
-    sfile->removeSubFile(TEST_SUB_FILE"1",false,false,false,transaction);
+    sfile->removeSubFile(TEST_SUB_FILE"1",false,false,transaction);
     StringBuffer name(TEST_SUB_FILE"4");
     addTestFile(name.str(),3);
     sfile->addSubFile(name,false,NULL,false,transaction);
@@ -259,7 +259,7 @@ void Test_SuperFile2()
         sfile.setown(queryDistributedFileDirectory().lookupSuperFile(TEST_SUPER_FILE"B1",UNKNOWN_USER));
         printf("NumSubFiles = %d\n",sfile->numSubFiles());
         if (tst==1) {
-            sfile->removeSubFile(NULL,false,false);
+            sfile->removeSubFile(NULL,false);
             printf("sfile size = %"I64F"d\n",sfile->getFileSize(false,false));
         }
         else {
@@ -268,7 +268,7 @@ void Test_SuperFile2()
                 name.append(i+1);
                 Owned<IDistributedFile> sbfile = queryDistributedFileDirectory().lookup(name,UNKNOWN_USER);
                 printf("removing size = %"I64F"d\n",sbfile->getFileSize(false,false));
-                sfile->removeSubFile(name,false,false);
+                sfile->removeSubFile(name,false);
                 printf("sfile size = %"I64F"d\n",sfile->getFileSize(false,false));
             }
         }

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -778,7 +778,7 @@ public:
         if (toremove.ordinality()) {
             transaction->start();
             ForEachItemIn(i2,toremove)
-                superfile->removeSubFile(toremove.item(i2).text.get(),delsub,delsub,false,transaction);
+                superfile->removeSubFile(toremove.item(i2).text.get(),delsub,false,transaction);
             transaction->commit();
         }
         // Delete superfile if empty

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1216,7 +1216,7 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveSuperFile(ICodeContext *ctx, co
     lookupSuperFile(ctx, lsuperfn, file, true, lsfn, false, true);
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
     assertex(transaction);
-    file->removeSubFile(_lfn?lfn.str():NULL,del,del,remcontents,transaction);
+    file->removeSubFile(_lfn?lfn.str():NULL,del,remcontents,transaction);
     StringBuffer s;
     if (_lfn)
         s.append("RemoveSuperFile ('");

--- a/testing/ecl/superfile7.ecl
+++ b/testing/ecl/superfile7.ecl
@@ -65,7 +65,7 @@ SEQUENTIAL(
 
   // Delete Super + Rollback (del subs, not really)
   FileServices.StartSuperFileTransaction(),
-  FileServices.DeleteSuperFile('regress::superfile7'),
+  FileServices.DeleteSuperFile('regress::superfile7', true),
   FileServices.FinishSuperFileTransaction(true),    // rollback
   OUTPUT(FileServices.SuperFileExists('regress::superfile7')), // true
   OUTPUT(FileServices.FileExists('regress::subfile1')), // true

--- a/testing/ecl/superfile8.ecl
+++ b/testing/ecl/superfile8.ecl
@@ -67,7 +67,7 @@ SEQUENTIAL(
   FileServices.AddSuperFile('regress::superfile8','regress::subfile6'),
   FileServices.AddSuperFile('regress::superfile8','regress::subfile7'),
   FileServices.AddSuperFile('regress::superfile8','regress::subfile8'),
-  FileServices.DeleteSuperFile('regress::superfile8'),
+  FileServices.DeleteSuperFile('regress::superfile8', true),
   FileServices.FinishSuperFileTransaction(true),    // rollback
   OUTPUT(FileServices.SuperFileExists('regress::superfile8')), // false
   OUTPUT(FileServices.FileExists('regress::subfile5')), // true


### PR DESCRIPTION
WARNING: The 5 commits should be squashed before pulling this patch.

Following previous commits and the need to merge removeEntry with removeSubFile and RemoveSuperFile, many changes were needed to the DFS:
1. Physically removing super-files is illegal
2. Centralize removal type decision (physical/logical)
   - Avoid actions to call doRemove[Phys/Entry] directly
3. Allow for actions to call other actions
   - Make sure auto-commit doesn't persist changes mid-way through

To implement those features, the following changes were performed:
1. CDelayedDelete class, called only from the end of a transaction, is the sole responsible for deciding which type of delete to use on a file, and all removals must invariably pass through it:
   - doDelete() checks if it's super-file and choose logical/physical
   - everyone else call addDelayedDelete() instead of doRemove*
   - there is no need any more for "remphys" parameter anywhere (all removed)
2. Auto-commit and local transaction logic refactored:
   - To avoid the "local" parameter and changing the action (commit/autoCommit), which was error prone, a new concept was added: _transaction depth_
   - every time one action calls another, it descend its transaction depth, so when the called method calls autoCommit(), it won't do anything
   - at the end of every recursive call, ascend() is called, so autoCommit() can work again
   - this allows for complex lists of actions (including delayed deletes) to still be taken atomically, even though the transaction is inactive
3. Final methods using doRemovePhysical/Entry were migrated to addDelayedDelete()
   - including removeSubFile() and RemoveSuperFile (which calls the former)

Some tests were created (in daregress) and others were fixed (superfile[7,8].ecl), but some changes were needed to make daregress work properly (and enhance the API).

Tests were not properly catching a lock bug that would occur if the transaction was re-used in auto-commit mode (which is expected).

Whenever adding a super-file to the cache (either when the transaction is active or when the user called lookupSuperFileCached), all its subs (recursively) are also cached
