### PR TITLE
HPCC-8123 Fix the Fo.xsl

### DIFF
--- a/docs/BuildTools/fo.xsl
+++ b/docs/BuildTools/fo.xsl
@@ -332,13 +332,13 @@
 
 <!--NEW-inline_monospace-8-12-->
 <xsl:template match="emphasis[@role='code']">
-       <fo:inline font-family="courier">
+       <fo:inline font-family="monospace">
          <xsl:apply-templates/>
        </fo:inline>
 </xsl:template>
 
 <xsl:template match="emphasis[@role='codebold']">
-       <fo:inline font-family="courier" font-weight="bold">
+       <fo:inline font-family="monospace" font-weight="bold">
          <xsl:apply-templates/>
        </fo:inline>
 </xsl:template>

--- a/docs/BuildTools/fo.xsl.in
+++ b/docs/BuildTools/fo.xsl.in
@@ -332,13 +332,13 @@
 
 <!--NEW-inline_monospace-8-12-->
 <xsl:template match="emphasis[@role='code']">
-       <fo:inline font-family="courier">
+       <fo:inline font-family="monospace">
          <xsl:apply-templates/>
        </fo:inline>
 </xsl:template>
 
 <xsl:template match="emphasis[@role='codebold']">
-       <fo:inline font-family="courier" font-weight="bold">
+       <fo:inline font-family="monospace" font-weight="bold">
          <xsl:apply-templates/>
        </fo:inline>
 </xsl:template>


### PR DESCRIPTION
Fix HPCC-8123 Fix the Fo.xsl file
to have it specify the appropriate
font call for monospace font.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
