### PR TITLE
HPCC-8059 Memory leaks

### DIFF
--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -295,7 +295,7 @@ public:
 
         ThorDataLinkMetaInfo info;
         inputs.item(0)->getMetaInfo(info);
-        outRowAllocator.set(queryJob().getRowAllocator(helper->queryDiskRecordSize(), container.queryId()));
+        outRowAllocator.setown(queryJob().getRowAllocator(helper->queryDiskRecordSize(), container.queryId()));
         if (refactor)
         {
             assertex(isLocal);

--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -425,7 +425,7 @@ public:
             if (rightpartition)
                 strm1.set(input1.get()); // already ungrouped
             else
-                strm1.set(createUngroupStream(input1));
+                strm1.setown(createUngroupStream(input1));
         }
         else {
             StringBuffer tmpStr;

--- a/thorlcr/activities/piperead/thprslave.cpp
+++ b/thorlcr/activities/piperead/thprslave.cpp
@@ -234,11 +234,15 @@ public:
         flags = helper->getPipeFlags();
         needTransform = false;
 
+        IRowInterfaces *_inrowif;
         if (needTransform)
+        {
             inrowif.setown(createRowInterfaces(helper->queryDiskRecordSize(),queryActivityId(),queryCodeContext()));
+            _inrowif = inrowif;
+        }
         else
-            inrowif.set(this);
-        readTransformer.setown(createReadRowStream(inrowif->queryRowAllocator(), inrowif->queryRowDeserializer(), helper->queryXmlTransformer(), helper->queryCsvTransformer(), helper->queryXmlIteratorPath(), flags));
+            _inrowif = this;
+        readTransformer.setown(createReadRowStream(_inrowif->queryRowAllocator(), _inrowif->queryRowDeserializer(), helper->queryXmlTransformer(), helper->queryCsvTransformer(), helper->queryXmlIteratorPath(), flags));
         appendOutputLinked(this);
     }
     virtual void start()

--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -128,7 +128,7 @@ public:
             if (notify) 
                 notify->onInputStarted(NULL);
             startsem.signal();
-            Linked<IRowWriter> writer = smartbuf->queryWriter();
+            IRowWriter *writer = smartbuf->queryWriter();
             if (preserveLhsGrouping)
             {
                 while (required&&running)

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -799,6 +799,10 @@ public:
     CThorSlaveGraphResults(CSlaveGraph &_graph,unsigned numResults) : CThorGraphResults(numResults), graph(_graph)
     {
     }
+    ~CThorSlaveGraphResults()
+    {
+        clear();
+    }
     virtual void clear()
     {
         CriticalBlock procedure(cs);


### PR DESCRIPTION
Various leaks fixed, none large in terms of memory:

1) IndexWrite outRowAllocator leak
2) local join (left already sorted) input leak
3) lookahead reader, writer leak
4) piperead activity leak unless transformer used
5) minor graph results leak

the most significant is 2) - which as a side-effect caused all
acitivies above the left hand side input of the join to be
leaked also.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
