### PR TITLE
HPCC-8158 Set maxCompileThreads >1 by default

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -382,7 +382,7 @@
              name="s1"
              netAddress="."/>
   </EclAgentProcess>
-   <EclCCServerProcess build="${projname}_${version}-${stagever}"
+  <EclCCServerProcess build="${projname}_${version}-${stagever}"
                     buildSet="eclccserver"
                     daliServers="mydali"
                     description="EclCCServer process"
@@ -394,6 +394,7 @@
              directory="${RUNTIME_PATH}/myeclccserver"
              name="s1"
              netAddress="."/>
+   <Option name="maxCompileThreads" value="2"/>
   </EclCCServerProcess>
    <EclSchedulerProcess build="${projname}_${version}-${stagever}"
                 buildSet="eclscheduler"


### PR DESCRIPTION
Set the value to 2 in the default enviroment. This will mean that
regression suite runs go fast, users that don't tweak anything get a
decent default, and users that do tweak get a hint about where to
tweak it.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
