### PR TITLE
HPCC-7991 Avoid uninitialized valgrind warning

### DIFF
--- a/thorlcr/slave/slwatchdog.cpp
+++ b/thorlcr/slave/slwatchdog.cpp
@@ -40,6 +40,8 @@ class CGraphProgressHandlerBase : public CSimpleInterface, implements ISlaveWatc
     {
         MemoryBuffer sendMb, progressMb;
         HeartBeatPacketHeader hb;
+        //clear struct, to avoid spurious warnings when serializing raw [unpacked] struct
+        memset(&hb, 0, sizeof(HeartBeatPacketHeader));
         hb.sender = self;
         hb.tick++;
         size32_t progressSizePos = (byte *)&hb.progressSize - (byte *)&hb;


### PR DESCRIPTION
A raw (unpacked) struct that was serialized to between slave
and master, caused valgrind warnings regarding uninitialized
data, because of the uninitialized padding between fields
Avoid warning, by memsetting to empty.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
