### PR TITLE
HPCC-2921 eclagent - Not sure about the use of _numResults

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -773,15 +773,12 @@ void EclSubGraph::createFromXGMML(EclGraph * graph, ILoadedDllEntry * dll, IProp
     xgmml.set(node->queryPropTree("att/graph"));
 
     id = node->getPropInt("@id", 0);
-    bool multiInstance = node->getPropBool("@multiInstance");
-    if (multiInstance)
-        agent = &subgraphAgentContext;
 
     isSink = xgmml->getPropBool("att[@name=\"rootGraph\"]/@value", false);
     parentActivityId = node->getPropInt("att[@name=\"_parentActivity\"]/@value", 0);
-    numResults = xgmml->getPropInt("att[@name=\"_numResults\"]/@value", 0);
-    if (multiInstance || numResults)
+    if (xgmml->hasProp("att[@name=\"_numResults\"]/@value"))
     {
+        numResults = xgmml->getPropInt("att[@name=\"_numResults\"]/@value", 0);
         localResults.setown(new GraphResults(numResults));
         resultsGraph = this;
     }


### PR DESCRIPTION
multiInstance is not set at this point so is always false, and if the
following call to getPropInt("_numResults") returned 0 then the localResults
would never get created. This fix removes the useless call to
getPropBool(multiInstance), and ensures that localResults and resultsGraph
get set even if numResults are 0 (localResults are accessed elsewhere in the code)

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
