### PR TITLE
HPCC-8178 - Sort job ran out of memory

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -44,16 +44,15 @@
 #include "jsmartsock.hpp"
 #include "thorstep.hpp"
 #include "eclagent.ipp"
+#include "roxierowbuff.hpp"
 
 #define EMPTY_LOOP_LIMIT 1000
 
 static unsigned const hthorReadBufferSize = 0x10000;
-static memsize_t const defaultHThorSpillThreshold = 512*1024*1024;  // MORE - should increase on 64-bit platform?
 static offset_t const defaultHThorDiskWriteSizeLimit = I64C(10*1024*1024*1024); //10 GB, per Nigel
 static size32_t const spillStreamBufferSize = 0x10000;
 static int const defaultWorkUnitWriteLimit = 10; //10MB as thor
 static unsigned const hthorPipeWaitTimeout = 100; //100ms - fairly arbitrary choice
-static char const * const defaultSortAlgorithm = "stablequick";
 
 using roxiemem::IRowManager;
 using roxiemem::OwnedRoxieRow;
@@ -3618,10 +3617,6 @@ CHThorGroupSortActivity::CHThorGroupSortActivity(IAgentContext &_agent, unsigned
 void CHThorGroupSortActivity::ready()
 {
     CHThorSimpleActivityBase::ready();
-    eof = false;
-    spillThreshold = (memsize_t)agent.queryWorkUnit()->getDebugValueInt64("hthorSpillThreshold", defaultHThorSpillThreshold);
-    memsize_t totalMemoryLimit = roxiemem::getTotalMemoryLimit();
-    spillThreshold = (memsize_t)std::min(spillThreshold, totalMemoryLimit / 3);
     if(!sorter)
         createSorter();
 }
@@ -3629,10 +3624,12 @@ void CHThorGroupSortActivity::ready()
 void CHThorGroupSortActivity::done()
 {
     if(sorter)
+    {
         if(sorterIsConst)
             sorter->killSorted();
         else
             sorter.clear();
+    }
     gotSorted = false;
     diskReader.clear();
     CHThorSimpleActivityBase::done();
@@ -3642,8 +3639,6 @@ const void *CHThorGroupSortActivity::nextInGroup()
 {
     if(!gotSorted)
         getSorted();
-    if(eof)
-        return NULL;
 
     if(diskReader)
     {
@@ -3668,11 +3663,10 @@ const void *CHThorGroupSortActivity::nextInGroup()
 
 void CHThorGroupSortActivity::createSorter()
 {
-    sorterIsConst = true;
     IHThorAlgorithm * algo = static_cast<IHThorAlgorithm *>(helper.selectInterface(TAIalgorithm_1));
     if(!algo)
     {
-        sorter.setown(new CHeapSorter(helper.queryCompare()));
+        sorter.setown(new CHeapSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
         return;
     }
     unsigned flags = algo->getAlgorithmFlags();
@@ -3681,93 +3675,122 @@ void CHThorGroupSortActivity::createSorter()
     if(!algoname)
     {
         if((flags & TAFunstable) != 0)
-            sorter.setown(new CQuickSorter(helper.queryCompare()));
+            sorter.setown(new CQuickSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
         else
-            sorter.setown(new CHeapSorter(helper.queryCompare()));
+            sorter.setown(new CHeapSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
         return;
     }
     if(stricmp(algoname, "quicksort") == 0)
         if((flags & TAFstable) != 0)
-            sorter.setown(new CStableQuickSorter(helper.queryCompare()));
+            sorter.setown(new CStableQuickSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep, this));
         else
-            sorter.setown(new CQuickSorter(helper.queryCompare()));
+            sorter.setown(new CQuickSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
     else if(stricmp(algoname, "heapsort") == 0)
-        sorter.setown(new CHeapSorter(helper.queryCompare()));
+        sorter.setown(new CHeapSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
     else if(stricmp(algoname, "insertionsort") == 0)
         if((flags & TAFstable) != 0)
-            sorter.setown(new CStableInsertionSorter(helper.queryCompare()));
+            sorter.setown(new CStableInsertionSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
         else
-            sorter.setown(new CInsertionSorter(helper.queryCompare()));
+            sorter.setown(new CInsertionSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
     else
     {
         StringBuffer sb;
         sb.appendf("Ignoring unsupported sort order algorithm '%s', using default", algoname);
         agent.addWuException(sb.str(),0,ExceptionSeverityWarning,"hthor");
         if((flags & TAFunstable) != 0)
-            sorter.setown(new CQuickSorter(helper.queryCompare()));
+            sorter.setown(new CQuickSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
         else
-            sorter.setown(new CHeapSorter(helper.queryCompare()));
+            sorter.setown(new CHeapSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
     }
+    sorter->setActivityId(activityId);
 }
 
 void CHThorGroupSortActivity::getSorted()
 {
     diskMerger.clear();
     diskReader.clear();
-    memsize_t grpSize = 0;
+    queryRowManager()->addRowBuffer(this);//register for OOM callbacks
     const void * next;
     while((next = input->nextInGroup()) != NULL)
     {
-        size32_t nextSize = input->queryOutputMeta()->getRecordSize(next);
-        if((grpSize+nextSize) > spillThreshold) //Spill ??
+        if (!sorter->addRow(next))
         {
-            if(!diskMerger)
             {
-                StringBuffer fbase;
-                agent.getTempfileBase(fbase).appendf(".spill_sort_%p", this);
-                PROGLOG("SORT: spilling to disk, filename base %s", fbase.str());
-                class CHThorRowLinkCounter : public CSimpleInterface, implements IRowLinkCounter
-                {
-                public:
-                    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
-                    virtual void releaseRow(const void *row)
-                    {
-                        releaseHThorRow(row);
-                    }
-                    virtual void linkRow(const void *row)
-                    {
-                        linkHThorRow(row);
-                    }
-                };
-                Owned<IRowLinkCounter> linker = new CHThorRowLinkCounter();
-                Owned<IRowInterfaces> rowInterfaces = createRowInterfaces(input->queryOutputMeta(), activityId, agent.queryCodeContext());
-                diskMerger.setown(createDiskMerger(rowInterfaces, linker, fbase.str()));
+                //Unlikely that this code will ever be executed but added for comfort
+                roxiemem::RoxieOutputRowArrayLock block(sorter->getRowArray());
+                sorter->flushRows();
+                sortAndSpillRows();
+                //Ensure new rows are written to the head of the array.  It needs to be a separate call because
+                //performSort() cannot shift active row pointer since it can be called from any thread
+                sorter->flushRows();
             }
-            sorter->performSort();
-            sorter->spillSortedToDisk(diskMerger);
-            grpSize = 0;
+            if (!sorter->addRow(next))
+            {
+                releaseHThorRow(next);
+                throw MakeStringException(0, "Insufficient memory to append sort row");
+            }
         }
-        sorter->addRow(next);
-        grpSize += nextSize;
     }
+    queryRowManager()->removeRowBuffer(this);//unregister for OOM callbacks
+    sorter->flushRows();
 
     if(diskMerger)
     {
-        sorter->performSort();
-        sorter->spillSortedToDisk(diskMerger);
+        sortAndSpillRows();
+        sorter->killSorted();
         ICompare *compare = helper.queryCompare();
-        assertex(compare);
         diskReader.setown(diskMerger->merge(compare));
-    }
-    else if(grpSize)
-    {
-        sorter->performSort();
     }
     else
     {
-        eof = true;
+        sorter->performSort();
     }
     gotSorted = true;
+}
+
+//interface roxiemem::IBufferedRowCallback
+unsigned CHThorGroupSortActivity::getPriority() const
+{
+    return 10;
+}
+
+bool CHThorGroupSortActivity::freeBufferedRows(bool critical)
+{
+    roxiemem::RoxieOutputRowArrayLock block(sorter->getRowArray());
+    return sortAndSpillRows();
+}
+
+
+
+bool CHThorGroupSortActivity::sortAndSpillRows()
+{
+    if (0 == sorter->numCommitted())
+        return false;
+    if(!diskMerger)
+    {
+        StringBuffer fbase;
+        agent.getTempfileBase(fbase).appendf(".spill_sort_%p", this);
+        PROGLOG("SORT: spilling to disk, filename base %s", fbase.str());
+        class CHThorRowLinkCounter : public CSimpleInterface, implements IRowLinkCounter
+        {
+        public:
+            IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+            virtual void releaseRow(const void *row)
+            {
+                releaseHThorRow(row);
+            }
+            virtual void linkRow(const void *row)
+            {
+                linkHThorRow(row);
+            }
+        };
+        Owned<IRowLinkCounter> linker = new CHThorRowLinkCounter();
+        Owned<IRowInterfaces> rowInterfaces = createRowInterfaces(input->queryOutputMeta(), activityId, agent.queryCodeContext());
+        diskMerger.setown(createDiskMerger(rowInterfaces, linker, fbase.str()));
+    }
+    sorter->performSort();
+    sorter->spillSortedToDisk(diskMerger);
+    return true;
 }
 
 // Base for Quick sort and both Insertion sorts
@@ -3780,71 +3803,105 @@ void CSimpleSorterBase::spillSortedToDisk(IDiskMerger * merger)
         const void *row = getNextSorted();
         if (!row)
             break;
-        linkHThorRow(row);
         out->putRow(row);
     }
-    ForEachItemIn(idxx, rows)
-        releaseHThorRow(rows.item(idxx));
-    rows.kill();
-}
-
-const void * CSimpleSorterBase::getNextSorted()
-{
-    if(finger < rows.ordinality())
-        return rows.item(finger++);
-    else
-        return NULL;
-}
-
-void CSimpleSorterBase::killSorted()
-{
-    while(rows.isItem(finger))
-        releaseHThorRow(rows.item(finger++));
-    rows.kill();
+    finger = 0;
+    out->flush();
+    rowsToSort.noteSpilled(rowsToSort.numCommitted());
 }
 
 // Quick sort
 
 void CQuickSorter::performSort()
 {
-    qsortvec((void * *)rows.getArray(), rows.ordinality(), *compare);
-    finger = 0;
+    size32_t numRows = rowsToSort.numCommitted();
+    if (numRows)
+    {
+        const void * * rows = rowsToSort.getBlock(numRows);
+        qsortvec((void * *)rows, numRows, *compare);
+        finger = 0;
+    }
 }
 
 // StableQuick sort
 
+bool CStableQuickSorter::addRow(const void * next)
+{
+    roxiemem::rowidx_t nextRowCapacity = rowsToSort.rowCapacity() + 1;//increment capacity for the row we are about to add
+    if (nextRowCapacity > indexCapacity)
+    {
+        void *** newIndex = (void ***)rowManager->allocate(nextRowCapacity * sizeof(void*), activityId);//could force an OOM callback
+        if (newIndex)
+        {
+            roxiemem::RoxieOutputRowArrayLock block(getRowArray());//could force an OOM callback after index is freed but before index,indexCapacity is updated
+            releaseHThorRow(index);
+            index = newIndex;
+            indexCapacity = RoxieRowCapacity(index) / sizeof(void*);
+        }
+        else
+        {
+            killSorted();
+            releaseHThorRow(next);
+            throw MakeStringException(0, "Insufficient memory to allocate StableQuickSorter index");
+        }
+    }
+    return CSimpleSorterBase::addRow(next);
+}
+
+void CStableQuickSorter::spillSortedToDisk(IDiskMerger * merger)
+{
+    CSimpleSorterBase::spillSortedToDisk(merger);
+    releaseHThorRow(index);
+    index = NULL;
+    indexCapacity = 0;
+}
+
 void CStableQuickSorter::performSort()
 {
-    index = (void ***)realloc(index, rows.ordinality()*sizeof(void**));
-    qsortvecstable((void * *)rows.getArray(), rows.ordinality(), *compare, index);
-    finger = 0;
+    size32_t numRows = rowsToSort.numCommitted();
+    if (numRows)
+    {
+        const void * * rows = rowsToSort.getBlock(numRows);
+        qsortvecstable((void * *)rows, numRows, *compare, index);
+        finger = 0;
+    }
 }
 
 const void * CStableQuickSorter::getNextSorted()
 {
-    if(finger < rows.ordinality())
-        return *(index[finger++]);
+    if(finger < rowsToSort.numCommitted())
+    {
+        const void * row = *(index[finger]);
+        *(index[finger++]) = NULL;//Clear the entry in rowsToSort so it wont get double-released
+        return row;
+    }
     else
         return NULL;
 }
 
 void CStableQuickSorter::killSorted()
 {
-    while(finger < rows.ordinality())
-        releaseHThorRow(*(index[finger++]));
-    rows.kill();
-    free(index);
+    CSimpleSorterBase::killSorted();
+    releaseHThorRow(index);
     index = NULL;
+    indexCapacity = 0;
 }
 
 // Heap sort
 
-void CHeapSorter::addRow(const void * next)
+void CHeapSorter::performSort()
 {
-    heap.append(heapsize);
-    rows.append(next);
-    heap_push_up(heapsize, heap.getArray(), rows.getArray(), compare);
-    ++heapsize;
+    size32_t numRows = rowsToSort.numCommitted();
+    if (numRows)
+    {
+        const void * * rows = rowsToSort.getBlock(numRows);
+        heapsize = numRows;
+        for (unsigned i = 0; i < numRows; i++)
+        {
+            heap.append(i);
+            heap_push_up(i, heap.getArray(), rows, compare);
+        }
+    }
 }
 
 void CHeapSorter::spillSortedToDisk(IDiskMerger * merger)
@@ -3858,39 +3915,57 @@ const void * CHeapSorter::getNextSorted()
 {
     if(heapsize)
     {
-        unsigned top = heap.item(0);
-        --heapsize;
-        heap.replace(heap.item(heapsize), 0);
-        heap_push_down(0, heapsize, heap.getArray(), rows.getArray(), compare);
-        return rows.item(top);
+        size32_t numRows = rowsToSort.numCommitted();
+        if (numRows)
+        {
+            const void * * rows = rowsToSort.getBlock(numRows);
+            unsigned top = heap.item(0);
+            --heapsize;
+            heap.replace(heap.item(heapsize), 0);
+            heap_push_down(0, heapsize, heap.getArray(), rows, compare);
+            const void * row = rows[top];
+            rows[top] = NULL;
+            return row;
+        }
     }
-    else
-    {
-        return NULL;
-    }
+    return NULL;
 }
 
 void CHeapSorter::killSorted()
 {
-    for(unsigned i=0; i<heapsize; ++i)
-        releaseHThorRow(rows.item(heap.item(i)));
-    rows.kill();
+    CSimpleSorterBase::killSorted();
     heap.kill();
     heapsize = 0;
 }
 
 // Insertion sorts
 
-void CInsertionSorter::addRow(const void * next)
+void CInsertionSorter::performSort()
 {
-    rows.append(NULL);
-    binary_vec_insert(next, rows.getArray(), rows.ordinality()-1, *compare);
+    size32_t numRows = rowsToSort.numCommitted();
+    if (numRows)
+    {
+        const void * * rows = rowsToSort.getBlock(numRows);
+        for (unsigned i = 0; i < numRows; i++)
+        {
+            binary_vec_insert(rowsToSort.query(i), rows, i, *compare);
+        }
+        finger = 0;
+    }
 }
 
-void CStableInsertionSorter::addRow(const void * next)
+void CStableInsertionSorter::performSort()
 {
-    rows.append(NULL);
-    binary_vec_insert_stable(next, rows.getArray(), rows.ordinality()-1, *compare);
+    size32_t numRows = rowsToSort.numCommitted();
+    if (numRows)
+    {
+        const void * * rows = rowsToSort.getBlock(numRows);
+        for (unsigned i = 0; i < numRows; i++)
+        {
+            binary_vec_insert_stable(rowsToSort.query(i), rows, i, *compare);
+        }
+        finger = 0;
+    }
 }
 
 //=====================================================================================================

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -40,6 +40,8 @@
 #include "eclrtl_imp.hpp"
 #include "rtlds_imp.hpp"
 #include "rtlread_imp.hpp"
+#include "roxiemem.hpp"
+#include "roxierowbuff.hpp"
 
 roxiemem::IRowManager * queryRowManager();
 #define releaseHThorRow(row) ReleaseRoxieRow(row)
@@ -47,6 +49,7 @@ roxiemem::IRowManager * queryRowManager();
 typedef roxiemem::OwnedRoxieRow OwnedHThorRow;
 typedef roxiemem::OwnedConstRoxieRow OwnedConstHThorRow;
 typedef roxiemem::OwnedRoxieRow OwnedRow;
+typedef roxiemem::DynamicRoxieOutputRowArray DynamicOutputRowArray;
 
 //-- Memory allocation helper class
 
@@ -1008,15 +1011,25 @@ class ISorter : public IInterface
 {
 public:
     virtual ~ISorter() {}
-    virtual void addRow(const void * next) = 0;
+    virtual bool addRow(const void * next) = 0;
     virtual void performSort() = 0;
     virtual void spillSortedToDisk(IDiskMerger * merger) = 0;
     virtual const void * getNextSorted() = 0;
     virtual void killSorted() = 0;
+    virtual const DynamicOutputRowArray & getRowArray() = 0;
+    virtual void flushRows() = 0;
+    virtual unsigned numCommitted() const = 0;
+    virtual void setActivityId(unsigned _activityId) = 0;
 };
 
-class CHThorGroupSortActivity : public CHThorSimpleActivityBase
+class CHThorGroupSortActivity : public CHThorSimpleActivityBase, implements roxiemem::IBufferedRowCallback
 {
+   enum {
+        InitialSortElements = 0,
+        //The number of rows that can be added without entering a critical section,
+        //and therefore also the max number of rows that wont get freed during a spill
+        CommitStep = 32
+    };
 public:
     CHThorGroupSortActivity(IAgentContext &agent, unsigned _activityId, unsigned _subgraphId, IHThorSortArg &_arg, ThorActivityKind _kind);
 
@@ -1029,15 +1042,18 @@ public:
 
     virtual IOutputMetaData * queryOutputMeta() const { return outputMeta; }
 
+    //interface roxiemem::IBufferedRowCallback
+    virtual unsigned getPriority() const;
+    virtual bool freeBufferedRows(bool critical);
+
 private:
+    bool sortAndSpillRows();
     void createSorter();
     void getSorted();
 
 protected:
     IHThorSortArg &helper;
     bool gotSorted;
-    bool eof;
-    memsize_t spillThreshold;
     Owned<ISorter> sorter;
     bool sorterIsConst;
     Owned<IDiskMerger> diskMerger;
@@ -1047,50 +1063,70 @@ protected:
 class CSimpleSorterBase : public CInterface, public ISorter
 {
 public:
-    CSimpleSorterBase(ICompare * _compare) : compare(_compare), finger(0) {}
-    virtual ~CSimpleSorterBase() { killSorted(); }
+    CSimpleSorterBase(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : compare(_compare), finger(0), rowManager(_rowManager),
+        rowsToSort(_rowManager, _initialSize, _commitDelta) {}
+    virtual ~CSimpleSorterBase()                            { killSorted(); }
     IMPLEMENT_IINTERFACE;
+    virtual bool addRow(const void * next)                  { return rowsToSort.append(next); }
     virtual void spillSortedToDisk(IDiskMerger * merger);
-    virtual const void * getNextSorted();
-    virtual void killSorted();
+    virtual const void * getNextSorted()
+    {
+        if (finger < rowsToSort.numCommitted())
+        {
+            const void * * rows = rowsToSort.getBlock(finger);
+            const void * row = rows[finger];
+            rows[finger++] = NULL;
+            return row;
+        }
+        else
+            return NULL;
+    }
+    virtual void killSorted()                               { rowsToSort.kill(); finger = 0;}
+    virtual const DynamicOutputRowArray & getRowArray()     { return rowsToSort; }
+    virtual void flushRows()                                { rowsToSort.flush(); }
+    virtual size32_t numCommitted() const                   { return rowsToSort.numCommitted(); }
+    virtual void setActivityId(unsigned _activityId)        { activityId = _activityId; }
 
 protected:
+    roxiemem::IRowManager * rowManager;
+    unsigned activityId;
     ICompare * compare;
-    ConstPointerArray rows;
+    DynamicOutputRowArray rowsToSort;
     aindex_t finger;
 };
 
 class CQuickSorter : public CSimpleSorterBase
 {
 public:
-    CQuickSorter(ICompare * _compare) : CSimpleSorterBase(_compare) {}
-    virtual void addRow(const void * next) { rows.append(next); }
+    CQuickSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta) {}
     virtual void performSort();
 };
 
 class CStableQuickSorter : public CSimpleSorterBase
 {
 public:
-    CStableQuickSorter(ICompare * _compare) : CSimpleSorterBase(_compare), index(NULL) {}
+    CStableQuickSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta, roxiemem::IBufferedRowCallback * _rowCB) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta), commitDelta(_commitDelta), index(NULL), indexCapacity(0) {}
     virtual ~CStableQuickSorter() { killSorted(); }
     IMPLEMENT_IINTERFACE;
-    virtual void addRow(const void * next) { rows.append(next); }
+    virtual bool addRow(const void * next);
+    virtual void spillSortedToDisk(IDiskMerger * merger);
     virtual void performSort();
     virtual const void * getNextSorted();
     virtual void killSorted();
 
 private:
     void *** index;
+    roxiemem::rowidx_t indexCapacity;
+    unsigned commitDelta;
 };
 
 class CHeapSorter :  public CSimpleSorterBase
 {
 public:
-    CHeapSorter(ICompare * _compare) : CSimpleSorterBase(_compare), heapsize(0) {}
+    CHeapSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta), heapsize(0) {}
     virtual ~CHeapSorter() { killSorted(); }
     IMPLEMENT_IINTERFACE;
-    virtual void addRow(const void * next);
-    virtual void performSort() {}
+    virtual void performSort();
     virtual void spillSortedToDisk(IDiskMerger * merger);
     virtual const void * getNextSorted();
     virtual void killSorted();
@@ -1103,17 +1139,15 @@ private:
 class CInsertionSorter : public CSimpleSorterBase
 {
 public:
-    CInsertionSorter(ICompare * _compare) : CSimpleSorterBase(_compare) {}
-    virtual void addRow(const void * next);
-    virtual void performSort() {}
+    CInsertionSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta) {}
+    virtual void performSort();
 };
 
 class CStableInsertionSorter : public CSimpleSorterBase
 {
 public:
-    CStableInsertionSorter(ICompare * _compare) : CSimpleSorterBase(_compare) {}
-    virtual void addRow(const void * next);
-    virtual void performSort() {}
+    CStableInsertionSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta) {}
+    virtual void performSort();
 };
 
 class CHThorGroupedActivity : public CHThorSimpleActivityBase

--- a/roxie/roxiemem/roxierowbuff.hpp
+++ b/roxie/roxiemem/roxierowbuff.hpp
@@ -73,6 +73,7 @@ public:
     const void * query(rowidx_t i) const;
     const void * getClear(rowidx_t i);
     const void * get(rowidx_t i) const;
+    rowidx_t rowCapacity() const { return rows ? RoxieRowCapacity(rows)/sizeof(void*) : 0; }
 
     //A thread calling the following functions must own the lock, or guarantee no other thread will access
     const void * * getBlock(rowidx_t readRows);


### PR DESCRIPTION
A large sort was running out of memory instead of spilling because of
an error in calculating the spill threshold. This fix implements a better
solution, which is to register for roxiemem OOM callbacks during sort,
and to spill in the case of a callback.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
