### PR TITLE
HPCC-8358 ESP Soap arrays of structures not xml decoding input strings

### DIFF
--- a/esp/bindings/SOAP/Platform/soapparam.cpp
+++ b/esp/bindings/SOAP/Platform/soapparam.cpp
@@ -464,7 +464,11 @@ bool EspBaseArrayParam::unmarshallItems(IEspContext* ctx, CSoapValue *sv, const 
         if (ctx && optGroup)
             ctx->addOptGroup(optGroup);
         ForEachItemIn(i, *children)
-            append(ctx, children->item(i));
+        {
+            CSoapValue &child = children->item(i);
+            child.setEncodeXml(false);
+            append(ctx, child);
+        }
         return true;
     }
     return false;


### PR DESCRIPTION
The flag that tells the ESP SOAP interface handlers not to XML encode
incoming string values needs to be passed down to the child elements
of structure members when they are held in arrays.

This change should only affect the encoding of data retrieved from
incoming XML/SOAP requests, and only those which contain arrays...
especially nested structures inside of arrays.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
