### PR TITLE
HPCC-8364 Move doRemove methods to files

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -185,7 +185,7 @@ interface IDistributedFileTransaction: extends IInterface
     virtual IDistributedSuperFile *lookupSuperFile(const char *slfn,unsigned timeout=INFINITE)=0;
     virtual IDistributedSuperFile *lookupSuperFileCached(const char *slfn,unsigned timeout=INFINITE)=0;
     virtual IUserDescriptor *queryUser()=0;
-    virtual bool addDelayedDelete(const char *lfn,const char*cluster=NULL,unsigned timeoutms=INFINITE)=0; // used internally to delay deletes until commit
+    virtual bool addDelayedDelete(CDfsLogicalFileName &lfn,unsigned timeoutms=INFINITE)=0; // used internally to delay deletes until commit
     virtual void descend()=0;  // descend into a recursive call (can't autoCommit if depth is not zero)
     virtual void ascend()=0;   // ascend back from the deep, one step at a time
 
@@ -225,6 +225,7 @@ interface IDistributedFile: extends IInterface
 
     virtual void attach(const char *logicalname,IUserDescriptor *user) = 0;     // attach to name in DFS
     virtual void detach(unsigned timeoutms=INFINITE) = 0;                       // no longer attached to name in DFS
+    virtual void detachLogical(unsigned timeoutms=INFINITE) = 0;                // INTERNAL ONLY, please do not use!
 
     virtual IPropertyTree &queryAttributes() = 0;                               // DFile attributes
 
@@ -459,7 +460,8 @@ interface IDistributedFileDirectory: extends IInterface
 
     virtual IDFScopeIterator *getScopeIterator(IUserDescriptor *user, const char *subscope=NULL,bool recursive=true,bool includeempty=false)=0;
 
-    virtual bool removeEntry(const char *name, IUserDescriptor *user, IDistributedFileTransaction *transaction=NULL, const char *cluster=NULL, unsigned timeoutms=INFINITE) = 0;
+    // Removes files and super-files with format: context/file@cluster
+    virtual bool removeEntry(const char *name, IUserDescriptor *user, IDistributedFileTransaction *transaction=NULL, unsigned timeoutms=INFINITE) = 0;
     virtual void renamePhysical(const char *oldname,const char *newname,IUserDescriptor *user,IDistributedFileTransaction *transaction) = 0;                         // renames the physical parts as well as entry
     virtual void removeEmptyScope(const char *scope) = 0;   // does nothing if called on non-empty scope
     

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -212,6 +212,7 @@ offset_t CDistributedFileSystem::getSize(IDistributedFile * file, bool forceget,
     return totalSize;
 }
 
+// FIXME: This should NOT call detach / removePhysical directly!
 bool CDistributedFileSystem::remove(IDistributedFile * file,const char *cluster,IMultiException *mexcept, unsigned timeoutms)
 {
     // this is now equivalent to removePhysicalPartFiles as linux uses dafilesrv by default

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1250,7 +1250,7 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                 else
                 {
                     df.clear(); 
-                    deleted = queryDistributedFileDirectory().removeEntry(logicalFileName.str(), userdesc, NULL, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT); // this can remove clusters also
+                    deleted = queryDistributedFileDirectory().removeEntry(logicalFileName.str(), userdesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT); // this can remove clusters also
                     if (deleted)
                         returnStr.appendf("<Message><Value>Detached File %s</Value></Message>", logicalFileName.str());
                 }


### PR DESCRIPTION
Yet another controversial change. The main issue was that simple removal actions were passing through files, actions, transactions, delayed-delete, back to files again and finally on the directory. 

This patch simplifies considerably this confusion and removes from directories, transactions and delayed-delete all the internal logic of removing files. There's no need for checking if the file is a super-file or not, since the "detach()" method will act accordingly, depending on which class it refers to.

In the end, deleting a file via Dir->removeEntry() and file->detach() are now synonymous, with all the logic neatly confined on files/super-files.
### Review

There are many patches, and functionality passed from each of the mentioned classes to another, so I recommend to review **the final change directly**, not each path in sequence. I'm only keeping them un-squashed for reference, and to underline the patches that are changes and those that are bug-fixes.
### Controversy 1

There is one important change, however, that need reviewing. Up until now, removePhysical had the "cluster" parameter, but that was never used (either default to NULL, or explicitly passed NULL).

Upon removing the unused parameter, I realized that it was not even being used to detach files, and the only use was when removing the physical parts, or on a very special case for which I found no real usage. This can be seen on CDistributedFile::detach() on the new lexical block that used to be the old detach.

I could have added the old "(if !cluster || (!findCluster && numClusters==1))" to it, but I couldn't find a good reason to. It looks as though that was fixing a bug created elsewhere, and as usual, I prefer to see them break and fix in the right place than propagate bad design decisions.

Please, make sure this decision is actually correct. The cluster is still being passed to the physical removal by the same means it was before, ie., by getting it from the logical name.
### Controversy 2

I found who was calling remove logical only on files: rename. Since that's an internal functionality, I've added a private method: detachLogical(). For now, it shares the flag with daregress (setting it in the properties), but it must move to an internal flag as soon as daregress::testDFS() is refactored. (comments also added).
### Tests

No functional changes expected, daregress and all regressions tests pass on all three engines.

The commits will be squashed before pulling
