### PR TITLE
HPCC-8386 Fix extraneous or missing parenthesis

### DIFF
--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -2623,8 +2623,8 @@ static ITypeInfo * getPromotedType(ITypeInfo * lType, ITypeInfo * rType, bool is
 
     type_t lcode = l->getTypeCode();
     type_t rcode = r->getTypeCode();
-    if ((lcode == type_any)) return LINK(r);
-    if ((rcode == type_any)) return LINK(l);
+    if (lcode == type_any) return LINK(r);
+    if (rcode == type_any) return LINK(l);
     if ((lcode == type_set) || (rcode == type_set))
         return getPromotedSet(l, r, isCompare);
     if ((lcode == type_unicode) || (rcode == type_unicode))

--- a/common/thorhelper/thorcommon.cpp
+++ b/common/thorhelper/thorcommon.cpp
@@ -1632,7 +1632,7 @@ public:
     {
         Owned<IRowWriter> out = createWriteBlock();
         void * row;
-        while(row = rows->getNextSorted())
+        while((row = rows->getNextSorted()) != NULL)
             out->putRow(row);
     }
     IRowStream *merge(ICompare *icompare, bool partdedup)

--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -150,7 +150,7 @@ public:
     {
         char *p;
 
-        if (p = strstr(urltext, "://"))
+        if ((p = strstr(urltext, "://")) != NULL)
         {
             *p = 0;
             p += 3; // skip past the colon-slash-slash
@@ -160,7 +160,7 @@ public:
         else
             throw MakeStringException(-1, "Malformed URL");
 
-        if (p = strchr(urltext, '@'))
+        if ((p = strchr(urltext, '@')) != NULL)
         {
             // extract username & password
             *p = 0;
@@ -170,7 +170,7 @@ public:
             urltext = p;
         }
 
-        if (p = strchr(urltext, ':'))
+        if ((p = strchr(urltext, ':')) != NULL)
         {
             // extract the port
             *p = 0;
@@ -180,7 +180,7 @@ public:
 
             host.append(urltext);
 
-            if (p = strchr(p, '/'))
+            if ((p = strchr(p, '/')) != NULL)
                 path.append(p);
             else
                 path.append("/");
@@ -195,7 +195,7 @@ public:
             else
                 throw MakeStringException(-1, "Unsupported access method");
 
-            if (p = strchr(urltext, '/'))
+            if ((p = strchr(urltext, '/')) != NULL)
             {
                 *p = 0;
                 p++;
@@ -940,7 +940,7 @@ public:
                 {
                     return outputQ.dequeue();
                 }
-                else if ((done == numRowThreads))
+                else if (done == numRowThreads)
                 {
                     complete = true;
                     if (error.get())

--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -721,10 +721,10 @@ bool CConfigEnvHelper::deleteRoxieServers(const char* xmlArg)
     {
         IPropertyTree* pChild;
         //if atleast one slave, delete all slaves
-        while (pChild = pRoxieCluster->queryPropTree( "RoxieSlave[1]" ))
+        while ((pChild = pRoxieCluster->queryPropTree( "RoxieSlave[1]" )) != NULL)
             pRoxieCluster->removeTree( pChild );
 
-        while (pChild = pRoxieCluster->queryPropTree( XML_TAG_ROXIE_SLAVE "[1]" ))
+        while ((pChild = pRoxieCluster->queryPropTree( XML_TAG_ROXIE_SLAVE "[1]" )) != NULL)
             pRoxieCluster->removeTree( pChild );
 
         break;
@@ -1144,7 +1144,7 @@ bool CConfigEnvHelper::GenerateFullRedConfig(IPropertyTree* pRoxie, int copies, 
 void CConfigEnvHelper::RemoveSlaves(IPropertyTree* pRoxie, bool bLegacySlaves/*=false*/)
 {
     IPropertyTree* pChild;
-    while (pChild = pRoxie->queryPropTree( bLegacySlaves ? XML_TAG_ROXIE_SLAVE "[1]" : "RoxieSlave[1]"))
+    while ((pChild = pRoxie->queryPropTree( bLegacySlaves ? XML_TAG_ROXIE_SLAVE "[1]" : "RoxieSlave[1]")) != NULL)
         pRoxie->removeTree( pChild );
 }
 

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1787,7 +1787,7 @@ bool Cws_machineEx::excludePartition(const char* partition) const
         for (it=itBegin; it != itEnd; it++)
         {
             const string& pattern = *it;
-            if (found = ::WildMatch(partition, partitionLen, pattern.c_str(), pattern.length(), false))
+            if ((found = ::WildMatch(partition, partitionLen, pattern.c_str(), pattern.length(), false)))
                 break;
         }
     }

--- a/system/hrpc/hrpcmp.cpp
+++ b/system/hrpc/hrpcmp.cpp
@@ -551,7 +551,7 @@ HRPCmptransport* MakeHRPCmptransport(MpTransportStateCommon* s)
 // Intra Communication
 IHRPCtransport *MakeClientMpTransport( ICommunicator *comm, rank_t rank, mptag_t tag)
 {
-    if ((comm==NULL))
+    if (comm==NULL)
         THROWHRPCEXCEPTION(HRPCERR_bad_address);
     // line below: check valid rank value is between 0 and ordinatlity-1
     unsigned count  = comm->queryGroup().ordinality();

--- a/system/jhtree/keydiff.cpp
+++ b/system/jhtree/keydiff.cpp
@@ -173,7 +173,7 @@ public:
 
     size32_t buffSize() { return buffsize; }
     size32_t rowSize() { return thisrowsize; }
-    size32_t serializeRowSize() { return thisrowsize+sizeof(offset_t)+isVar?sizeof(size32_t):0; }
+    size32_t serializeRowSize() { return thisrowsize+sizeof(offset_t)+(isVar?sizeof(size32_t):0); }
 
     size32_t serialize(void *dst)
     {

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -186,7 +186,7 @@ static void doSetCompilerPath(const char * path, const char * includes, const ch
     int r = stat(fname.str(), &filestatus);
     if (    (r != 0)
         ||  (!S_ISREG(filestatus.st_mode))
-        ||  (filestatus.st_mode&(S_IXOTH|S_IXGRP|S_IXUSR)==0))
+        ||  ((filestatus.st_mode&(S_IXOTH|S_IXGRP|S_IXUSR))==0))
     {
         if (r == -1) errno = ENOENT;
 #endif

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -4443,7 +4443,7 @@ restart:
         if (ignoreNameSpaces)
         {
             const char *colon;
-            if (colon = strchr(tagName.str(), ':'))
+            if ((colon = strchr(tagName.str(), ':')) != NULL)
                 tagName.remove(0, (size32_t)(colon - tagName.str() + 1));
         }
         iEvent->beginNode(tagName.toCharArray(), startOffset);
@@ -4748,7 +4748,7 @@ public:
                 if (ignoreNameSpaces)
                 {
                     const char *colon;
-                    if (colon = strchr(stateInfo->wnsTag, ':'))
+                    if ((colon = strchr(stateInfo->wnsTag, ':')) != NULL)
                         stateInfo->wnsTag = colon+1;
                 }
                 endOfRoot = false;


### PR DESCRIPTION
Change in 'system/jhtree/keydiff.cpp' have modified the behaviour, needs careful review. I think I've done the intended behaviour (which was not correct, due to operator precedence).

Still three warnings regarding parenthesis, on zcrypt's zip/unzip, but I haven't touched them since they're not originated in HPCC.

The rest is just to silence the warnings.

Signed-off-by: Renato Golin rengolin@hpccsystems.com
