### PR TITLE
HPCC-8389 HashDist grouped input regression

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -592,7 +592,7 @@ class CDistributorBase : public CSimpleInterface, implements IHashDistributor, i
                             }
                         }
                     }
-                    const void *row = input->nextRow();
+                    const void *row = input->ungroupedNextRow();
                     if (!row)
                         break;
                     unsigned dest = owner.ihash->hash(row)%owner.numnodes;


### PR DESCRIPTION
Recent refactoring in 3.10.x caused hash distribute to stop early
if the input was grouped

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
