### PR TITLE
HPCC-7984 ECLWatch 4.0

### DIFF
--- a/esp/files/CMakeLists.txt
+++ b/esp/files/CMakeLists.txt
@@ -30,49 +30,43 @@ add_subdirectory (templates)
 source_group(templates FILES ${TEMPLATES_FILES})
 
 set ( MAIN_FILES 
-    dummy.cpp
-    default.css
-    gen_form.css
-    wsecl2_form.css
-    configmgr.html
-    GraphViewCtl.cab
-    npGraphViewCtl.xpi
-    update.rdf
     base64.js
-    qmalert.html
     calendar.html
     calendar_xs.js
     components.xml
+    configmgr.html
+    default.css
     empty.svg
+    esp_app.html
+    esp_app_tree.html
+    gen_form.css
     gen_form.js
     get_input.js
     graph.js
+    GraphViewCtl.cab
+    groupadd.html
     hashtable.js
     hint.js
     joblist.js
     jobqueue.js
     minus.gif
+    npGraphViewCtl.xpi
     plus.gif
     popup.js
+    qmalert.html
     req_array.js
     select.js
     stack.js
     stringbuffer.js
+    stub.htm
+    stub.js
     submitNavForm.html
     tabularForm.xslt
     transformDlg.html
-    esp_app_tree.html
-    esp_app.html
+    update.rdf
     useradd.html
-    groupadd.html
-    stub.htm
-    stub.js
+    wsecl2_form.css
 )
-source_group("Source Files" FILES ${MAIN_FILES})
-
-set ( SRCS ${MAIN_FILES} ${HTML_FILES} ${IMG_FILES} ${LOGO_FILES} ${CSS_FILES} ${SCRIPTS_FILES} ${TEMPLATES_FILES})
-
-HPCC_ADD_LIBRARY( web_files ${SRCS} )
 
 FOREACH( iFile ${MAIN_FILES} )
     Install( FILES ${iFile} DESTINATION componentfiles/files COMPONENT Runtime )

--- a/esp/files/css/CMakeLists.txt
+++ b/esp/files/css/CMakeLists.txt
@@ -15,19 +15,18 @@
 ################################################################################
 
 set ( CSS_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/espdefault.css
+    ${CMAKE_CURRENT_SOURCE_DIR}/ecl.css
     ${CMAKE_CURRENT_SOURCE_DIR}/eclwatch.css
+    ${CMAKE_CURRENT_SOURCE_DIR}/espdefault.css
     ${CMAKE_CURRENT_SOURCE_DIR}/graph.css
-    ${CMAKE_CURRENT_SOURCE_DIR}/winclassic.css
     ${CMAKE_CURRENT_SOURCE_DIR}/headerFooter.css
+    ${CMAKE_CURRENT_SOURCE_DIR}/hpcc.css
     ${CMAKE_CURRENT_SOURCE_DIR}/list.css
     ${CMAKE_CURRENT_SOURCE_DIR}/rightSideBar.css
     ${CMAKE_CURRENT_SOURCE_DIR}/sortabletable.css
     ${CMAKE_CURRENT_SOURCE_DIR}/tabs.css
-    ${CMAKE_CURRENT_SOURCE_DIR}/hpcc.css
-    ${CMAKE_CURRENT_SOURCE_DIR}/ecl.css
+    ${CMAKE_CURRENT_SOURCE_DIR}/winclassic.css
 )
-set ( CSS_FILES ${CSS_FILES} PARENT_SCOPE)
 
 FOREACH( iFile ${CSS_FILES} )
     Install( FILES ${iFile} DESTINATION componentfiles/files/css COMPONENT Runtime )

--- a/esp/files/dummy.cpp
+++ b/esp/files/dummy.cpp
@@ -1,2 +1,0 @@
-//  Empty File for cmake
-

--- a/esp/files/html/CMakeLists.txt
+++ b/esp/files/html/CMakeLists.txt
@@ -17,6 +17,5 @@
 set ( HTML_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/searchfile.html
 )
-set ( HTML_FILES ${HTML_FILES} PARENT_SCOPE)
 
 Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/searchfile.html DESTINATION componentfiles/files COMPONENT Runtime )

--- a/esp/files/img/CMakeLists.txt
+++ b/esp/files/img/CMakeLists.txt
@@ -15,38 +15,48 @@
 ################################################################################
 
 set ( IMG_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/collapse.gif
-    ${CMAKE_CURRENT_SOURCE_DIR}/expand.gif
-    ${CMAKE_CURRENT_SOURCE_DIR}/save.gif
-    ${CMAKE_CURRENT_SOURCE_DIR}/saveasimg.gif
-    ${CMAKE_CURRENT_SOURCE_DIR}/cloud.jpg
-    ${CMAKE_CURRENT_SOURCE_DIR}/wizard.gif
-    ${CMAKE_CURRENT_SOURCE_DIR}/tooltip.jpg
-    ${CMAKE_CURRENT_SOURCE_DIR}/hpcc_logo.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/favicon.ico
+    ${CMAKE_CURRENT_SOURCE_DIR}/accept.png
     ${CMAKE_CURRENT_SOURCE_DIR}/base.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/blank.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/information.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_error.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_green.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_orange.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_red.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_white.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_yellow.png
     ${CMAKE_CURRENT_SOURCE_DIR}/cal.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/close_wnd.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/cloud.jpg
+    ${CMAKE_CURRENT_SOURCE_DIR}/cog.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/collapse.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/config.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/control_pause_blue.png
     ${CMAKE_CURRENT_SOURCE_DIR}/copyurl.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/delete.png
     ${CMAKE_CURRENT_SOURCE_DIR}/downsimple.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/error-icon.png
     ${CMAKE_CURRENT_SOURCE_DIR}/espbtns_tiled.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/expand.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/favicon.ico
     ${CMAKE_CURRENT_SOURCE_DIR}/folder.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/folderopen.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/folder_table.png
     ${CMAKE_CURRENT_SOURCE_DIR}/form_minus.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/form_more.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/form_plus.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/home.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/hpccsystemsECLWatch.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/hpccsystemsWsECL.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/hpcc_logo.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/information.png
     ${CMAKE_CURRENT_SOURCE_DIR}/join.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/joinbottom.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/keyfile.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/hpccsystemsECLWatch.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/hpccsystemsWsECL.png
     ${CMAKE_CURRENT_SOURCE_DIR}/line.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/loading.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/loadingAnimation.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/locked.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/locked.png
     ${CMAKE_CURRENT_SOURCE_DIR}/menu1.png
     ${CMAKE_CURRENT_SOURCE_DIR}/menudown.png
     ${CMAKE_CURRENT_SOURCE_DIR}/menuup.png
@@ -62,34 +72,37 @@ set ( IMG_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/prev.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/prev_year.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/refresh.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/refresh2.png
     ${CMAKE_CURRENT_SOURCE_DIR}/refreshdisabled.png
     ${CMAKE_CURRENT_SOURCE_DIR}/refreshenabled.png
     ${CMAKE_CURRENT_SOURCE_DIR}/relogin.png
     ${CMAKE_CURRENT_SOURCE_DIR}/reqxml.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/respxml.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/save.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/saveasimg.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/selectall.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/tab_bottom.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/tooltip.jpg
     ${CMAKE_CURRENT_SOURCE_DIR}/topurl.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/unlocked.png
     ${CMAKE_CURRENT_SOURCE_DIR}/unselectall.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/upsimple.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/warning.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/wizard.gif
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit_aborting.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit_completed.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit_deleted.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit_edit.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit_failed.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit_running.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit_submitted.png
+    ${CMAKE_CURRENT_SOURCE_DIR}/workunit_warning.png
     ${CMAKE_CURRENT_SOURCE_DIR}/wsdl.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/xsd.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/zip.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/zipbig.gif
-    ${CMAKE_CURRENT_SOURCE_DIR}/accept.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_green.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_orange.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/cog.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/delete.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/folder_table.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/control_pause_blue.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_error.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_red.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_white.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/bullet_yellow.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/loadingAnimation.gif
 )
-set ( IMG_FILES ${IMG_FILES} PARENT_SCOPE)
 
 FOREACH( iFile ${IMG_FILES} )
     Install( FILES ${iFile} DESTINATION componentfiles/files/img COMPONENT Runtime )

--- a/esp/files/logo/CMakeLists.txt
+++ b/esp/files/logo/CMakeLists.txt
@@ -19,7 +19,6 @@ set ( LOGO_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/seisint_small.gif
     ${CMAKE_CURRENT_SOURCE_DIR}/slogo.gif
 )
-set ( LOGO_FILES ${LOGO_FILES} PARENT_SCOPE)
 
 FOREACH( iFile ${LOGO_FILES} )
     Install( FILES ${iFile} DESTINATION componentfiles/files/logo COMPONENT Runtime )

--- a/esp/files/scripts/CMakeLists.txt
+++ b/esp/files/scripts/CMakeLists.txt
@@ -19,21 +19,24 @@ set ( SCRIPTS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/bpsreport.js
     ${CMAKE_CURRENT_SOURCE_DIR}/builder.js
     ${CMAKE_CURRENT_SOURCE_DIR}/CMultiSelect.js
-
     ${CMAKE_CURRENT_SOURCE_DIR}/controls.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/DFUSearchWidget.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/DFUWUDetailsWidget.js
     ${CMAKE_CURRENT_SOURCE_DIR}/dragdrop.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ECLPlaygroundWidget.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ECLSourceWidget.js
     ${CMAKE_CURRENT_SOURCE_DIR}/effects.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ESPBase.js
     ${CMAKE_CURRENT_SOURCE_DIR}/espdefault.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/ESPDFUWorkunit.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ESPLogicalFile.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ESPResult.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ESPWorkunit.js
-    ${CMAKE_CURRENT_SOURCE_DIR}/ESPDFUWorkunit.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/FilePartsWidget.js
     ${CMAKE_CURRENT_SOURCE_DIR}/fixedTables.js
     ${CMAKE_CURRENT_SOURCE_DIR}/graphgvc.js
     ${CMAKE_CURRENT_SOURCE_DIR}/GraphPageWidget.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/GraphsWidget.js
     ${CMAKE_CURRENT_SOURCE_DIR}/GraphWidget.js
     ${CMAKE_CURRENT_SOURCE_DIR}/InfoGridWidget.js
     ${CMAKE_CURRENT_SOURCE_DIR}/LFDetailsWidget.js
@@ -43,8 +46,8 @@ set ( SCRIPTS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/prototype.js
     ${CMAKE_CURRENT_SOURCE_DIR}/prototype_helpers.js
     ${CMAKE_CURRENT_SOURCE_DIR}/range.js
-    ${CMAKE_CURRENT_SOURCE_DIR}/ResultsControl.js
     ${CMAKE_CURRENT_SOURCE_DIR}/ResultsWidget.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/ResultWidget.js
     ${CMAKE_CURRENT_SOURCE_DIR}/rightSideBar.js
     ${CMAKE_CURRENT_SOURCE_DIR}/SampleSelectControl.js
     ${CMAKE_CURRENT_SOURCE_DIR}/SampleSelectWidget.js
@@ -64,7 +67,6 @@ set ( SCRIPTS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/WsWorkunits.js
     ${CMAKE_CURRENT_SOURCE_DIR}/WUDetailsWidget.js
 )
-set ( SCRIPTS_FILES ${SCRIPTS_FILES} PARENT_SCOPE)
 
 FOREACH( iFile ${SCRIPTS_FILES} )
     Install( FILES ${iFile} DESTINATION componentfiles/files/scripts COMPONENT Runtime )

--- a/esp/files/templates/CMakeLists.txt
+++ b/esp/files/templates/CMakeLists.txt
@@ -14,14 +14,19 @@
 #    limitations under the License.
 ################################################################################
 set ( TEMPLATES_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/DFUSearchWidget.html
+    ${CMAKE_CURRENT_SOURCE_DIR}/DFUWUDetailsWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/ECLPlaygroundWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/ECLSourceWidget.html
+    ${CMAKE_CURRENT_SOURCE_DIR}/FilePartsWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/GraphPageWidget.html
+    ${CMAKE_CURRENT_SOURCE_DIR}/GraphWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/GraphWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/InfoGridWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/LFDetailsWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/LogsWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/ResultsWidget.html
+    ${CMAKE_CURRENT_SOURCE_DIR}/ResultWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/SampleSelectWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/TargetSelectWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/TimingGridWidget.html
@@ -29,7 +34,6 @@ set ( TEMPLATES_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/TimingTreeMapWidget.html
     ${CMAKE_CURRENT_SOURCE_DIR}/WUDetailsWidget.html
 )
-set ( TEMPLATES_FILES ${TEMPLATES_FILES} PARENT_SCOPE)
 
 FOREACH( iFile ${TEMPLATES_FILES} )
     Install( FILES ${iFile} DESTINATION componentfiles/files/templates COMPONENT Runtime )


### PR DESCRIPTION
Fixes master not building issue.

Sync install lists with actual files.
Remove files from being included in the generated project tree.

There must be a better way of doing this - I think css/img/scripts folders should just include everything like we do for yui/dojo etc.?

Maybe just include the entire "files" folder?
