### PR TITLE
HPCC-8395 Avoid MP issue, caused by new lookupjoin

### DIFF
--- a/system/mp/mpcomm.cpp
+++ b/system/mp/mpcomm.cpp
@@ -1024,7 +1024,7 @@ class MultiPacketHandler // TAG_SYS_MULTI
     void logError(unsigned code, MultiPacketHeader &mhdr, CMessageBuffer &msg)
     {
         unsigned ms = msTick();
-        if (lastErrMs-ms > 1000) // avoid logging too much
+        if ((ms-lastErrMs) > 1000) // avoid logging too much
         {
             StringBuffer errorMsg("sender=");
             msg.getSender().getUrlStr(errorMsg).newline();

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -88,7 +88,7 @@ class CBroadcaster : public CSimpleInterface
     Owned<IBitSet> slavesStopped;
     IBCastReceive *recvInterface;
     Semaphore allDoneSem;
-    CriticalSection allDoneLock;
+    CriticalSection allDoneLock, bcastOtherCrit;
     bool allDone, allDoneWaiting, allRequestStop, stopping;
     Owned<IBitSet> slavesDone, slavesStopping;
 
@@ -190,6 +190,7 @@ class CBroadcaster : public CSimpleInterface
         unsigned psuedoNode = (myNode<origin) ? slaves-origin+myNode : myNode-origin;
         CMessageBuffer replyMsg;
         // sends to all in 1st pass, then waits for ack from all
+        CriticalBlock b(bcastOtherCrit);
         for (unsigned sendRecv=0; sendRecv<2 && !activity.queryAbortSoon(); sendRecv++)
         {
             unsigned i = 0;


### PR DESCRIPTION
Lookup join, has a couple of threads, both potentially sending
to the same destination on the same tag at the same time.
If these MP packets are deemed multi-packet by MP (which invariably
they will be), then the MP receiver gets confused and fires
MP protocol errors.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
