### PR TITLE
HPCC-8384 Silence most unused parameter warnings

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -828,7 +828,7 @@ public:
     {
         CMessageBuffer mb;
         mb.append((int)MSR_REGISTER_SESSION).append(tok).append(parentid);
-        if (!queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DALI_SESSION_REQUEST),SESSIONREPLYTIMEOUT)
+        if (!queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DALI_SESSION_REQUEST,SESSIONREPLYTIMEOUT))
             return 0;
         SessionId ret;
         mb.read(ret);

--- a/deployment/deploy/DeployTask.cpp
+++ b/deployment/deploy/DeployTask.cpp
@@ -418,11 +418,13 @@ public:
                }
                catch(IException* e)
                {
-                 DeleteFile(sb.str());
+                 if (!DeleteFile(sb.str()))
+                       WARNLOG("Couldn't delete file %s", sb.str());
                  throw e;
                }
 
-                DeleteFile(sb.str());               
+               if (!DeleteFile(sb.str()))
+                     WARNLOG("Couldn't delete file %s", sb.str());
               }
            }
 
@@ -463,7 +465,8 @@ public:
          e->Release();
 
          //remove incomplete (invalid) output file produced thus far
-         DeleteFile(target);
+         if (!DeleteFile(target))
+               WARNLOG("Couldn't delete file %s", target);
        }
        catch (...)
        {
@@ -471,7 +474,8 @@ public:
          m_errorString.append("Unspecified XSL error");
 
          //remove incomplete (invalid) output file produced thus far
-         DeleteFile(target);
+         if (!DeleteFile(target))
+               WARNLOG("Couldn't delete file %s", target);
        }
        // Prompt to retry on error
        m_errorCode = (DWORD) -1;//don't format m_errorString based on last error

--- a/deployment/deploy/DeployTask.cpp
+++ b/deployment/deploy/DeployTask.cpp
@@ -419,12 +419,12 @@ public:
                catch(IException* e)
                {
                  if (!DeleteFile(sb.str()))
-                       WARNLOG("Couldn't delete file %s", sb.str());
+                   WARNLOG("Couldn't delete file %s", sb.str());
                  throw e;
                }
 
                if (!DeleteFile(sb.str()))
-                     WARNLOG("Couldn't delete file %s", sb.str());
+                 WARNLOG("Couldn't delete file %s", sb.str());
               }
            }
 
@@ -466,7 +466,7 @@ public:
 
          //remove incomplete (invalid) output file produced thus far
          if (!DeleteFile(target))
-               WARNLOG("Couldn't delete file %s", target);
+           WARNLOG("Couldn't delete file %s", target);
        }
        catch (...)
        {
@@ -475,7 +475,7 @@ public:
 
          //remove incomplete (invalid) output file produced thus far
          if (!DeleteFile(target))
-               WARNLOG("Couldn't delete file %s", target);
+           WARNLOG("Couldn't delete file %s", target);
        }
        // Prompt to retry on error
        m_errorCode = (DWORD) -1;//don't format m_errorString based on last error

--- a/deployment/deploy/DeploymentEngine.cpp
+++ b/deployment/deploy/DeploymentEngine.cpp
@@ -2583,7 +2583,8 @@ void CDeploymentEngine::siteCertificate(IPropertyTree& process, const char *inst
         char* pTempFile = tempfile + strlen(tempfile);
 
         strcpy(pTempFile, pszCertFile);
-        DeleteFile(tempfile);
+        if (!DeleteFile(tempfile))
+            WARNLOG("Couldn't delete file %s", tempfile);
         
         //write certificate in this temp file
         Owned<IFile> pFile = createIFile(tempfile);
@@ -2600,7 +2601,8 @@ void CDeploymentEngine::siteCertificate(IPropertyTree& process, const char *inst
         
         //create temp file path to save private key
         strcpy(pTempFile, pszPrivFile);
-        DeleteFile(tempfile);
+        if (!DeleteFile(tempfile))
+            WARNLOG("Couldn't delete file %s", tempfile);
 
         //write private key in this temp file
         pFile.set( createIFile(tempfile) );

--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -113,7 +113,8 @@ public:
         int count = m_tempFiles.length();
         int i;
         for (i = 0; i < count; i++)
-            DeleteFile(m_tempFiles.item(i));
+            if (!DeleteFile(m_tempFiles.item(i)))
+                WARNLOG("Couldn't delete file %s", m_tempFiles.item(i));
         
         count = m_tempDirs.length();
         for (i = 0; i < count; i++)

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -1439,7 +1439,7 @@ const char *getOpString(node_operator op)
     case no_getenv: return "GETENV";
     case no_once: return "ONCE";
     case no_persist_check: return "no_persist_check";
-    case no_create_initializer: "no_create_initializer";
+    case no_create_initializer: return "no_create_initializer";
     case no_owned_ds: return "no_owned_ds";
     case no_complex: return ",";
     case no_assign_addfiles: return "+=";

--- a/esp/bindings/SOAP/xpp/xpp/StartTag.h
+++ b/esp/bindings/SOAP/xpp/xpp/StartTag.h
@@ -87,8 +87,7 @@ namespace xpp {
     }
 
     /** @return DO NOT DEALLOCATE RETURN VALUE! */
-    const SXT_CHAR* getType(int index) const {
-      index = index;
+    const SXT_CHAR* getType(int /*index*/) const {
       return _MYT("CDATA");
     }
 
@@ -106,8 +105,7 @@ namespace xpp {
      * always return "CDATA" 
      * @return DO NOT DEALLOCATE RETURN VALUE! 
      */
-    const SXT_CHAR* getType (const SXT_CHAR* qName_) const {
-      qName_ = qName_;
+    const SXT_CHAR* getType (const SXT_CHAR* /*qName_*/) const {
       return _MYT("CDATA");
     }
     
@@ -115,9 +113,7 @@ namespace xpp {
      * always return "CDATA" 
      * @return DO NOT DEALLOCATE RETURN VALUE! 
      */
-    const SXT_CHAR* getType (const SXT_STRING* uri_, const SXT_CHAR* localName_) const {
-      uri_ = uri_;
-      localName_ = localName_;
+    const SXT_CHAR* getType (const SXT_STRING* /*uri_*/, const SXT_CHAR* /*localName_*/) const {
       return _MYT("CDATA");
     }
 

--- a/esp/bindings/SOAP/xpp/xpp/StartTag.h
+++ b/esp/bindings/SOAP/xpp/xpp/StartTag.h
@@ -88,7 +88,7 @@ namespace xpp {
 
     /** @return DO NOT DEALLOCATE RETURN VALUE! */
     const SXT_CHAR* getType(int index) const {
-        index;
+      index = index;
       return _MYT("CDATA");
     }
 
@@ -107,7 +107,7 @@ namespace xpp {
      * @return DO NOT DEALLOCATE RETURN VALUE! 
      */
     const SXT_CHAR* getType (const SXT_CHAR* qName_) const {
-      qName_;
+      qName_ = qName_;
       return _MYT("CDATA");
     }
     
@@ -116,8 +116,8 @@ namespace xpp {
      * @return DO NOT DEALLOCATE RETURN VALUE! 
      */
     const SXT_CHAR* getType (const SXT_STRING* uri_, const SXT_CHAR* localName_) const {
-      uri_;
-      localName_;
+      uri_ = uri_;
+      localName_ = localName_;
       return _MYT("CDATA");
     }
 

--- a/esp/bindings/SOAP/xpp/xpp/XmlPullParser.h
+++ b/esp/bindings/SOAP/xpp/xpp/XmlPullParser.h
@@ -720,7 +720,7 @@ namespace xpp {
     }
 
     void ensureNsBufSpace(int addSpace) {
-      addSpace;
+      addSpace = addSpace;
     /*
     // NOTE: unfortunately it can not be used as i was storing char* pointers 
     //   to this block of memory, storing relative offsets though will work - but later!

--- a/esp/tools/soapplus/httpproxy.cpp
+++ b/esp/tools/soapplus/httpproxy.cpp
@@ -225,7 +225,6 @@ int COneServerHttpProxyThread::start()
         socket2->write(requestbuf.str(), requestbuf.length());
         StringBuffer respbuf;
         Owned<IByteOutputStream> respstream = createOutputStream(respbuf);
-        isRoxie;
         Http::receiveData(socket2.get(), respstream.get(), true, isRoxie);
         
         if(http_tracelevel >= 5)


### PR DESCRIPTION
- StartTag: not sure this is the correct fix, the parameters seem completely unused and there is no interface or inheritance. Looks like none of those fields are in use anyway, maybe a refactoring is in order, but looks like it was not coded by us in the first place...
- Dali/dasess: the call was wrong, but just enough to compile. Not critical since it was only the timeout that was not being passed.
- hqlexpr: missing a return statement
- DeleteFile: not using the return value. Instead of failing, I'm just logging.

I don't think any of these are critical to go in 3.10.x.

Signed-off-by: Renato Golin rengolin@hpccsystems.com
