### PR TITLE
HPCC-8381 agentexec segfaults and doesn't restart

### DIFF
--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -511,22 +511,22 @@ public:
                             pconn.setown(querySDS().connect("/JobQueues",myProcessSession(),RTM_LOCK_WRITE|RTM_CREATE_QUERY,wait));
                             if (!pconn)
                                 throw MakeStringException(-1,"CJobQueue could not create JobQueues");
+                            IPropertyTree *proot = pconn->queryRoot();
+                            StringBuffer cpath;
+                            cpath.appendf("Queue[@name=\"%s\"]",qd->qname.get());
+                            if (!proot->hasProp(cpath.str())) {
+                                IPropertyTree *pt = proot->addPropTree("Queue",createPTree("Queue"));
+                                pt->setProp("@name",qd->qname.get());
+                                pt->setProp("@state","active");
+                                pt->setPropInt("@count", 0);
+                                pt->setPropInt("Edition", 1);
+                            }
                         }
                         catch (ISDSException *e) {
                             if (SDSExcpt_LockTimeout != e->errorCode())
                                 throw;
                             e->Release();
                             timeout = true;
-                        }
-                        IPropertyTree *proot = pconn->queryRoot();
-                        StringBuffer cpath;
-                        cpath.appendf("Queue[@name=\"%s\"]",qd->qname.get());
-                        if (!proot->hasProp(cpath.str())) {
-                            IPropertyTree *pt = proot->addPropTree("Queue",createPTree("Queue"));
-                            pt->setProp("@name",qd->qname.get());
-                            pt->setProp("@state","active");
-                            pt->setPropInt("@count", 0);
-                            pt->setPropInt("Edition", 1);
                         }
                     }
                     if (!timeout)


### PR DESCRIPTION
The common job queue code in connlock cores if there is a timeout because
it later dereferences the NULL pconn object. This fix checks for NULL
before dereferencing

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
