### PR TITLE
HPCC-8403  HThor fixes for MAXLENGTH 

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -1039,8 +1039,7 @@ void CHThorIndexWriteActivity::execute()
         buildUserMetadata(metadata);
         buildLayoutMetadata(metadata);
         unsigned nodeSize = metadata ? metadata->getPropInt("_nodeSize", NODESIZE) : NODESIZE;
-        unsigned rawSize = helper.queryDiskRecordSize()->getRecordSize(NULL);
-        Owned<IKeyBuilder> builder = createKeyBuilder(out, flags, rawSize, fileSize, nodeSize, helper.getKeyedSize(), 0);
+        Owned<IKeyBuilder> builder = createKeyBuilder(out, flags, maxDiskRecordSize, fileSize, nodeSize, helper.getKeyedSize(), 0);
         class BcWrapper : implements IBlobCreator
         {
             IKeyBuilder *builder;


### PR DESCRIPTION
CHThorIndexWriteActivity has one remaining call to getRecordSize(NULL) which
is removed by this fix

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
