### PR TITLE
HPCC-8412 XREF memory configuration regression

### DIFF
--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -479,7 +479,10 @@ public:
         StringBuffer line;
         line.valist_appendf(format, args);
         va_end(args);
-        PROGLOG(LOGPFX "[%s] %s",clustname.get(),line.str());
+        if (clustname.get())
+            PROGLOG(LOGPFX "[%s] %s",clustname.get(),line.str());
+        else
+            PROGLOG(LOGPFX "%s",line.str());
         if (logconn) {
             logcache.set(line.str());
             updateStatus(false);
@@ -675,7 +678,7 @@ public:
 
 
     CNewXRefManager(unsigned maxMb=DEFAULT_MAXMEMORY)
-        : mem(0x100000*maxMb,0x10000,true)
+        : mem(0x100000*((memsize_t)maxMb),0x10000,true)
     {
         iswin = false; // set later
         root = new cDirDesc(mem,"");

--- a/initfiles/componentfiles/configxml/sasha.xsd
+++ b/initfiles/componentfiles/configxml/sasha.xsd
@@ -421,7 +421,7 @@
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="memoryLimit" type="xs:nonNegativeInteger" use="optional" default="4096">
+        <xs:attribute name="xrefMaxMemory" type="xs:nonNegativeInteger" use="optional" default="4096">
             <xs:annotation>
                 <xs:appinfo>
                     <tooltip>The upper memory limit that xref can use.</tooltip>

--- a/initfiles/componentfiles/configxml/sasha.xsl
+++ b/initfiles/componentfiles/configxml/sasha.xsl
@@ -201,7 +201,7 @@
                    </xsl:call-template>
                 </xsl:attribute>
                 <xsl:attribute name="memoryLimit">
-                   <xsl:value-of select="@memoryLimit"/>
+                   <xsl:value-of select="@xrefMaxMemory"/>
                 </xsl:attribute>
             </xsl:element>
             <xsl:element name="DfuExpiry">


### PR DESCRIPTION
A regression introduced in HPCC-7904, caused the default memory
configuration for XREF to become 0MB.

There was also a mismatch between the xsd/xsl and the envionment
variable name for the xrefMaxMemory. The default environment had
"xrefMaxMemory", but the xsl was expecting "memoryLimit".
Have changed to be consistent.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
