### PR TITLE
HPCC-8414 Fix schema and display of child datasets using xpath('n')

### DIFF
--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -3869,16 +3869,28 @@ bool XmlSchemaBuilder::beginDataset(const char * name, const char * row)
     if (xml.length() == 0)
         addSchemaPrefix();
 
+    if ((!name || !*name) && row) // xpath("Name") and xpath("/Name") seem to be equivalent
+    {
+        name = row;
+        row = NULL;
+    }
+
     if (name && *name)
     {
         xml.append("<xs:element name=\"").append(name).append("\"");
-        if (optionalNesting)
+        if (!row || !*row)
+            xml.append(" minOccurs=\"0\" maxOccurs=\"unbounded\"");
+        else if (optionalNesting)
             xml.append(" minOccurs=\"0\"");
         xml.append(">").newline();
         xml.append("<xs:complexType>").newline();
     }
 
-    xml.append("<xs:sequence minOccurs=\"0\" maxOccurs=\"unbounded\">").newline();
+    xml.append("<xs:sequence");
+    if (!name || !*name || (row && *row))
+        xml.append(" minOccurs=\"0\" maxOccurs=\"unbounded\"");
+    xml.append('>').newline();
+
     if (row && *row)
     {
         attributes.append(*new StringBufferItem);
@@ -3891,6 +3903,12 @@ bool XmlSchemaBuilder::beginDataset(const char * name, const char * row)
 
 void XmlSchemaBuilder::endDataset(const char * name, const char * row)
 {
+    if ((!name || !*name) && row) // xpath("Name") and xpath("/Name") seem to be equivalent
+    {
+        name = row;
+        row = NULL;
+    }
+
     if (row && *row)
     {
         xml.append("</xs:sequence>").newline();

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -581,9 +581,10 @@ void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) c
         unsigned flag = column.flag;
         const char * name = meta->queryName(idx);
         const char * childname = NULL;
+        const char * xname = NULL;
         if (useXPath)
         {
-            const char * xname = meta->queryXPath(idx);
+            xname = meta->queryXPath(idx);
             if (xname)
             {
                 const char * slash = strchr(xname, '/');
@@ -621,7 +622,7 @@ void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) c
             break;
         case FVFFdataset:
             {
-                if (!childname) childname = "Row";
+                if (!childname && (!xname || !*xname)) childname = "Row";
                 ITypeInfo * singleFieldType = (useXPath && name && *name && childname && *childname) ? containsSingleSimpleFieldBlankXPath(column.childMeta.get()) : NULL;
                 if (!singleFieldType || !builder.addSingleFieldDataset(name, childname, *singleFieldType))
                 {

--- a/esp/eclwatch/ws_XSLT/result_lib.xslt
+++ b/esp/eclwatch/ws_XSLT/result_lib.xslt
@@ -394,6 +394,13 @@
             <xsl:choose>
                 <xsl:when test="$matchingData|$matchingData2">
                     <xsl:choose>
+                        <xsl:when test="$rowSchema/@maxOccurs">
+                              <xsl:call-template name="grab-dataset">
+                                    <xsl:with-param name="level" select="$level"/>
+                                    <xsl:with-param name="schema" select="$rowSchema"/>
+                                    <xsl:with-param name="data" select="$matchingData[1]"/>
+                                </xsl:call-template>
+                        </xsl:when>
                         <xsl:when test="$rowSchema/xs:complexType">
                             <xsl:for-each select="$matchingData|$matchingData2">
                                 <xsl:call-template name="grab-data">


### PR DESCRIPTION
Child datasets using xpath('n') or xpath('/n') produce
dataset xml with no root tag and "inline" rows named 'n'.

The generated schemas and display xslt will now reflect that.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
