### PR TITLE
HPCC-1960 When trying to OUTPUT a file in a standalone I get an error

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -1711,7 +1711,7 @@ void EclAgent::executeThorGraph(const char * graphName)
 void EclAgent::executeGraph(const char * graphName, bool realThor, size32_t parentExtractSize, const void * parentExtract)
 {
     assertex(parentExtractSize == 0);
-    if (realThor)
+    if (realThor && !isStandAloneExe)
     {
         executeThorGraph(graphName);
     }


### PR DESCRIPTION
When running a workunit compiled with 'platform=thor', the generated
process would core when eclagent tried to create a thor job queue.
This fix bypasses the thor execution and executes on hthor instead.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
