### PR TITLE
HPCC-8233 Fix JSONTest page not populating "set of strings"

### DIFF
--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -414,10 +414,16 @@ inline StringBuffer &appendXMLTag(StringBuffer &xml, const char *tag, const char
     return appendXMLCloseTag(xml, tag, prefix);
 }
 
-inline StringBuffer &delimitJSON(StringBuffer &s)
+inline StringBuffer &delimitJSON(StringBuffer &s, bool addNewline=false, bool escapeNewline=false)
 {
-    if (s.length() && !strchr("{[:", s.charAt(s.length()-1)))
-        s.append(", ");
+    if (s.length() && !strchr("{[:n\n", s.charAt(s.length()-1))) //'n' or '\n' indicates already formatted with optionally escaped newline
+    {
+        s.append(",");
+        if (addNewline)
+            s.append(escapeNewline ? "\\n" : "\n");
+        else
+            s.append(' ');
+    }
     return s;
 }
 


### PR DESCRIPTION
JSONTest will populate a JSON request from the content of a WsECL
test form.  When the input is a stored set of string, the form data
was not populating the JSON request.

This issue only affects generating the sample request.  It doesn't
affect processing of JSON requests once they are submitted.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
