### PR TITLE
HPCC-8420 Ensure that slaves being killed belong to correct thor

### DIFF
--- a/initfiles/componentfiles/thor/stop_slaves
+++ b/initfiles/componentfiles/thor/stop_slaves
@@ -18,11 +18,26 @@
 
 hpcc_compname=$1
 hpcc_setenv=$2
+master=$3
 
 source ${hpcc_setenv}
 
-for file in $PID/${hpcc_compname}_slave_*.pid
-do
-  kill -9 `cat ${file}` # > /dev/null
-done
+echo PID=${PID}
+echo hpcc_compname=${hpcc_compname}
+echo master=${master}
 
+for file in $(ls $PID/${hpcc_compname}_slave_*.pid)
+do
+  apid=`cat ${file}`
+  echo pid = ${apid}
+  slavecmdline=`cat /proc/${apid}/cmdline`
+  psline=`echo ${slavecmdline} | grep ${master}`
+  if [ ! -z "${psline}" ]
+  then
+    echo Process cmdline = `cat /proc/${apid}/cmdline`
+    echo kill -9 ${apid}
+    kill -9 ${apid} # > /dev/null
+  fi
+done
+echo rm -f $PID/${hpcc_compname}_slave_*.pid
+rm -f $PID/${hpcc_compname}_slave_*.pid

--- a/initfiles/componentfiles/thor/stop_thor
+++ b/initfiles/componentfiles/thor/stop_thor
@@ -91,7 +91,7 @@ else
         fi
     fi
     sort $instancedir/slaves | uniq > $instancedir/uslaves
-    $deploydir/frunssh $instancedir/uslaves "/bin/sh -c '$deploydir/stop_slaves ${comp_base} $PATH_PRE'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1 | egrep -v "no process killed"
+    $deploydir/frunssh $instancedir/uslaves "/bin/sh -c '$deploydir/stop_slaves ${comp_base} $PATH_PRE $THORMASTER:$THORMASTERPORT'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1 | egrep -v "no process killed"
     echo slaves stopped
 fi
 


### PR DESCRIPTION
Check that the pid file pid, is [still] a pid that is associated
with the thor instances being recycled

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
