### PR TITLE
HPCC-8405 Fix warning: format not a string literal in httpbinding

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1461,7 +1461,7 @@ int EspHttpBinding::onStartUpload(IEspContext &ctx, CHttpRequest* request, CHttp
         errMsg.append("Exception in File Upload - Unknown Exception\n");
     }
 
-    WARNLOG(errMsg.str());
+    WARNLOG("%s", errMsg.str());
     StringBuffer content(
         "<html xmlns=\"http://www.w3.org/1999/xhtml\">"
             "<head>"


### PR DESCRIPTION
Linux build shows a warning: 'format not a string literal and no
format arguments' at esp/bindings/http/platform/httpbinding.cpp:1464.
The warning is removed by this fix.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
