### PR TITLE
HPCC-8419 Support remote file DALI IP when publishing via CLI

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -91,9 +91,6 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 
 #define ECLOPT_NOROOT "--noroot"
 
-#define ECLOPT_DALIIP "--daliip"
-#define ECLOPT_PROCESS "--process"
-
 #define ECLOPT_WUID "--wuid"
 #define ECLOPT_WUID_S "-wu"
 #define ECLOPT_CLUSTER_DEPRECATED "--cluster"

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -327,6 +327,8 @@ public:
                 continue;
             if (iter.matchOption(optName, ECLOPT_NAME)||iter.matchOption(optName, ECLOPT_NAME_S))
                 continue;
+            if (iter.matchOption(optDaliIP, ECLOPT_DALIIP))
+                continue;
             if (iter.matchOption(optMsToWait, ECLOPT_WAIT))
                 continue;
             if (iter.matchOption(optTimeLimit, ECLOPT_TIME_LIMIT))
@@ -396,6 +398,7 @@ public:
             req->setJobName(optName.get());
         if (optTargetCluster.length())
             req->setCluster(optTargetCluster.get());
+        req->setRemoteDali(optDaliIP.get());
         req->setWait(optMsToWait);
         req->setNoReload(optNoReload);
 
@@ -447,6 +450,7 @@ public:
             "   -A, --activate         Activate query when published (default)\n"
             "   -A-, --no-activate     Do not activate query when published\n"
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
+            "   --daliip=<IP>          The IP of the DALI to be used to locate remote files\n"
             "   --timeLimit=<ms>       Value to set for query timeLimit configuration\n"
             "   --warnTimeLimit=<ms>   Value to set for query warnTimeLimit configuration\n"
             "   --memoryLimit=<mem>    Value to set for query memoryLimit configuration\n"
@@ -457,6 +461,7 @@ public:
     }
 private:
     StringAttr optName;
+    StringAttr optDaliIP;
     StringAttr optMemoryLimit;
     unsigned optMsToWait;
     unsigned optTimeLimit;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1070,6 +1070,7 @@ ESPrequest [nil_remove] WUPublishWorkunitRequest
     string memoryLimit;
     nonNegativeInteger TimeLimit(0);
     nonNegativeInteger WarnTimeLimit(0);
+    string RemoteDali;
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -472,7 +472,7 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
     if (!isValidCluster(target.str()))
         throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid cluster name: %s", target.str());
 
-    copyQueryFilesToCluster(context, cw, NULL, target.str(), queryName.str(), false);
+    copyQueryFilesToCluster(context, cw, req.getRemoteDali(), target.str(), queryName.str(), false);
 
     WorkunitUpdate wu(&cw->lock());
     if (req.getUpdateWorkUnitName() && notEmpty(req.getJobName()))

--- a/initfiles/etc/bash_completion/ecl
+++ b/initfiles/etc/bash_completion/ecl
@@ -89,7 +89,7 @@ _ecl_opts_queries()
             echo "--help list copy config"
             ;;
         copy)
-            echo -n "--no-reload --wait= --timeLimit= --warnTimeLimit= --memoryLimit= "
+            echo -n "--no-reload --wait= --timeLimit= --warnTimeLimit= --memoryLimit= --daliip= "
             _ecl_opts_common
             ;;
         config)
@@ -166,7 +166,7 @@ _ecl_opts_core_file()
                 _ecl_opts_common
                 ;;
             publish)
-                echo -n "-A --activate --no-reload --timeLimit= --warnTimeLimit= --memoryLimit= "
+                echo -n "-A --activate --no-reload --timeLimit= --warnTimeLimit= --memoryLimit= --daliip= "
                 _ecl_opts_deploy
                 _ecl_opts_common
                 ;;


### PR DESCRIPTION
Command line "ecl publish" will now accept a --daliip parameter which
can be used to specify where to look for remote file information.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
