### PR TITLE
HPCC-8039 Fix eclcc bash_completion of filenames

### DIFF
--- a/initfiles/etc/bash_completion/eclcc
+++ b/initfiles/etc/bash_completion/eclcc
@@ -38,15 +38,8 @@ _eclcc()
 
     # Options with parameters
     case "${prev}" in
-        -I|-L)
-            local files=$(find . -maxdepth 1 -name ${cur}\* | sed 's/\.\///')
-            COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
-            return 0
-            ;;
-        -o|-logfile|-specs)
-            local files=$(find . -maxdepth 1 -name ${cur}\* | sed 's/\.\///')
-            COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
-            return 0
+        -I|-L|-o|-logfile|-specs)
+            COMPREPLY=( $(compgen -f ${cur}) )
             ;;
         -platform)
             local platforms="roxie thor hthor"
@@ -58,8 +51,7 @@ _eclcc()
     esac
 
     # ECL source filename
-    local files=$(find . -maxdepth 1 -name ${cur}\* | sed 's/\.\///')
-    COMPREPLY=( $(compgen -W "${files}" -- ${cur}) )
+    COMPREPLY=( $(compgen -f ${cur}) )
     return 0
 }
-complete -F _eclcc eclcc
+complete -o nospace -F _eclcc eclcc


### PR DESCRIPTION
eclcc comand line bash_completion will now use the built in file
completion logic of compgen, rather than building its own list of files.

Previously errors were generated when a / was provided in a path for
completion.  Completion should now work for filepaths.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
