### PR TITLE
HPCC-8101 Access to workunit is denied

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2030,19 +2030,29 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
     unsigned actualCount = 0;
     ForEach(*it)
     {
-        actualCount++;
         IConstWorkUnit& cw = it->query();
         if (chooseWuAccessFlagsByOwnership(context.queryUserId(), cw, accessOwn, accessOthers) < SecAccess_Read)
+        {
+            numWUs--;
             continue;
+        }
+
         if (bDoubleCheckState && (cw.getState() != WUStateSubmitted))
+        {
+            numWUs--;
             continue;
+        }
 
         SCMStringBuffer parent;
         if (!cw.getParentWuid(parent).length())
         {
             const char* wuid = cw.getWuid(parent).str();
             if (!looksLikeAWuid(wuid))
+            {
+                numWUs--;
                 continue;
+            }
+            actualCount++;
             Owned<IEspECLWorkunit> info = createECLWorkunit("","");
             WsWuInfo winfo(context, wuid);
             winfo.getCommon(*info, 0);


### PR DESCRIPTION
A previous fix (HPCC-3153) filters out certain workunits (global,etc), but
it needed to update the workunit count when it does that. This fix updates
the count for this scenario, and 2 other filters already in place.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
