### PR TITLE
HPCC-1960 When trying to OUTPUT a file in a standalone I get an error

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -1713,6 +1713,8 @@ void EclAgent::executeGraph(const char * graphName, bool realThor, size32_t pare
     assertex(parentExtractSize == 0);
     if (realThor)
     {
+        if (isStandAloneExe)
+            throw MakeStringException(0, "Cannot execute Thor Graph in standalone mode");
         executeThorGraph(graphName);
     }
     else


### PR DESCRIPTION
When running a workunit compiled with 'platform=thor', the generated
process would core when eclagent tried to create a thor job queue (in
standalone mode). Thor graph are not meant to be run on hThor, so this
fix throws an exception in that case

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
