### PR TITLE
HPCC-8431 Fix delimiting of JSON string arrays

### DIFF
--- a/esp/bindings/SOAP/Platform/soapbind.cpp
+++ b/esp/bindings/SOAP/Platform/soapbind.cpp
@@ -332,10 +332,7 @@ void CSoapComplexType::serializeJSONStruct(IEspContext* ctx, StringBuffer& s, co
 {
     if (ctx && ctx->getResponseFormat()==ESPSerializationJSON)
     {
-        if (s.length() && !strchr("[{:", s.charAt(s.length()-1)))
-            s.append(", ");
-        if (name && *name)
-            s.append('\"').append(name).append("\": ");
+        appendJSONNameOrDelimit(s, name);
         s.append("{");
         serializeContent(ctx, s);
         s.append("}");

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -416,7 +416,7 @@ inline StringBuffer &appendXMLTag(StringBuffer &xml, const char *tag, const char
 
 inline StringBuffer &delimitJSON(StringBuffer &s, bool addNewline=false, bool escapeNewline=false)
 {
-    if (s.length() && !strchr("{[:n\n", s.charAt(s.length()-1))) //'n' or '\n' indicates already formatted with optionally escaped newline
+    if (s.length() && !strchr("{ [:,n\n", s.charAt(s.length()-1))) //'n' or '\n' indicates already formatted with optionally escaped newline
     {
         s.append(",");
         if (addNewline)
@@ -430,10 +430,17 @@ inline StringBuffer &delimitJSON(StringBuffer &s, bool addNewline=false, bool es
 jlib_decl StringBuffer &encodeJSON(StringBuffer &s, const char *value);
 jlib_decl StringBuffer &appendJSONName(StringBuffer &s, const char *name);
 
+inline StringBuffer &appendJSONNameOrDelimit(StringBuffer &s, const char *name)
+{
+    if (name && *name)
+        return appendJSONName(s, name);
+    return delimitJSON(s);
+}
+
 template <typename type>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, type value)
 {
-    appendJSONName(s, name);
+    appendJSONNameOrDelimit(s, name);
     return s.append(value);
 }
 
@@ -441,14 +448,14 @@ inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, type val
 template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, bool value)
 {
-    appendJSONName(s, name);
+    appendJSONNameOrDelimit(s, name);
     return s.append((value) ? "true" : "false");
 }
 
 template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, const char *value)
 {
-    appendJSONName(s, name);
+    appendJSONNameOrDelimit(s, name);
     if (!value)
         return s.append("null");
     return encodeJSON(s.append('"'), value).append('"');
@@ -457,14 +464,14 @@ inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, const ch
 template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, long value)
 {
-    appendJSONName(s, name);
+    appendJSONNameOrDelimit(s, name);
     return s.appendlong(value);
 }
 
 template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, unsigned long value)
 {
-    appendJSONName(s, name);
+    appendJSONNameOrDelimit(s, name);
     return s.appendulong(value);
 }
 


### PR DESCRIPTION
Simple string arrays will now be properly delimited when output as JSON.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
