### PR TITLE
HPCC-8450 WsEcl navigation not checking getQueryRegistry return

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -355,8 +355,9 @@ void CWsEclBinding::getDynNavData(IEspContext &context, IProperties *params, IPr
         const char *setname = params->queryProp("queryset");
         if (!setname || !*setname)
             return;
-
         Owned<IPropertyTree> settree = getQueryRegistry(setname, true);
+        if (!settree)
+            return;
 
         if (params->hasProp("QueryList"))
         {


### PR DESCRIPTION
If the queryset coresponding to a target cluster does not yet exist,
WsEcl will no longer core when tring to expand the navigation menu item.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
