### PR TITLE
HPCC-8451 Roxie can core in response to control:getQueryXrefInfo

### DIFF
--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1229,6 +1229,7 @@ public:
         catch (...)
         {
             ::Release(activities);
+            allActivities.kill();
             throw;
         }
         return activities;


### PR DESCRIPTION
If any activities threw exceptions while loading, they can leave the
allactivities hash table in a bad state (full of dangling pointers)
which can cause control:getQueryXrefInfo to core.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
