### PR TITLE
HPCC-8426 Support DICTIONARYs created in child queries

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -263,6 +263,8 @@ static IHThorActivity * createActivity(IAgentContext & agent, unsigned activityI
         return createLocalResultReadActivity(agent, activityId, subgraphId, (IHThorLocalResultReadArg &)arg, kind, graphId);
     case TAKlocalresultwrite:
         return createLocalResultWriteActivity(agent, activityId, subgraphId, (IHThorLocalResultWriteArg &)arg, kind, graphId);
+    case TAKdictionaryresultwrite:
+        return createDictionaryResultWriteActivity(agent, activityId, subgraphId, (IHThorDictionaryResultWriteArg &)arg, kind, graphId);
     case TAKlocalresultspill:
         return createLocalResultSpillActivity(agent, activityId, subgraphId, (IHThorLocalResultSpillArg &)arg, kind, graphId);
     case TAKcombine:

--- a/ecl/hthor/hthor.hpp
+++ b/ecl/hthor/hthor.hpp
@@ -182,6 +182,7 @@ extern HTHOR_API IHThorActivity *createXmlReadActivity(IAgentContext &, unsigned
 extern HTHOR_API IHThorActivity *createLocalResultReadActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorLocalResultReadArg &arg, ThorActivityKind kind, __int64 graphId);
 extern HTHOR_API IHThorActivity *createLocalResultWriteActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorLocalResultWriteArg &arg, ThorActivityKind kind, __int64 graphId);
 extern HTHOR_API IHThorActivity *createLocalResultSpillActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorLocalResultSpillArg &arg, ThorActivityKind kind, __int64 graphId);
+extern HTHOR_API IHThorActivity *createDictionaryResultWriteActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorDictionaryResultWriteArg &arg, ThorActivityKind kind, __int64 graphId);
 extern HTHOR_API IHThorActivity *createCombineActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorCombineArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createRollupGroupActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorRollupGroupArg &arg, ThorActivityKind kind);
 extern HTHOR_API IHThorActivity *createRegroupActivity(IAgentContext &, unsigned _activityId, unsigned _subgraphId, IHThorRegroupArg &arg, ThorActivityKind kind);

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -2494,6 +2494,18 @@ public:
     virtual bool needsAllocator() const { return true; }
 };
 
+class CHThorDictionaryResultWriteActivity : public CHThorActivityBase
+{
+    IHThorDictionaryResultWriteArg &helper;
+    ILocalGraphEx * graph;
+
+public:
+    IMPLEMENT_SINKACTIVITY;
+
+    CHThorDictionaryResultWriteActivity (IAgentContext &agent, unsigned _activityId, unsigned _subgraphId, IHThorDictionaryResultWriteArg &_arg, ThorActivityKind _kind, __int64 graphId);
+    virtual void execute();
+    virtual bool needsAllocator() const { return true; }
+};
 
 class CHThorLocalResultSpillActivity : public CHThorSimpleActivityBase
 {

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -491,6 +491,11 @@ protected:
                 unsigned graphId = getGraphId(node);
                 return createRoxieServerLocalResultWriteActivityFactory(id, subgraphId, *this, helperFactory, kind, usageCount(node), graphId, isRootAction(node));
             }
+        case TAKdictionaryresultwrite:
+            {
+                unsigned graphId = getGraphId(node);
+                return createRoxieServerDictionaryResultWriteActivityFactory(id, subgraphId, *this, helperFactory, kind, usageCount(node), graphId, isRootAction(node));
+            }
         case TAKloopcount:
         case TAKlooprow:
         case TAKloopdataset:

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -6062,7 +6062,6 @@ public:
             builder.appendOwn(row);
             processed++;
         }
-        IOutputMetaData *outputMeta = input->queryOutputMeta();
         Owned<CGraphResult> result = new CGraphResult(builder.getcount(), builder.linkrows());
         graph->setResult(helper.querySequence(), result);
     }

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -303,7 +303,6 @@ interface IRoxieServerActivityFactory : extends IActivityFactory
 };
 interface IGraphResult : public IInterface
 {
-    virtual void getResult(unsigned & lenResult, void * & result) = 0;
     virtual void getLinkedResult(unsigned & countResult, byte * * & result) = 0;
     virtual IRoxieInput * createIterator() = 0;
 };
@@ -430,6 +429,7 @@ extern IRoxieServerActivityFactory *createRoxieServerWorkUnitReadActivityFactory
 extern IRoxieServerActivityFactory *createRoxieServerLocalResultReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, unsigned graphId);
 extern IRoxieServerActivityFactory *createRoxieServerLocalResultStreamReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerLocalResultWriteActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, unsigned _usageCount, unsigned _graphId, bool _isRoot);
+extern IRoxieServerActivityFactory *createRoxieServerDictionaryResultWriteActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, unsigned _usageCount, unsigned _graphId, bool _isRoot);
 extern IRoxieServerActivityFactory *createRoxieServerGraphLoopResultReadActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, unsigned graphId);
 extern IRoxieServerActivityFactory *createRoxieServerGraphLoopResultWriteActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, unsigned _usageCount, unsigned _graphId);
 extern IRoxieServerActivityFactory *createRoxieServerDedupActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -189,6 +189,7 @@ interface IRoxieInput : extends IInterface, extends IInputBase
     virtual unsigned queryId() const = 0;
 
     virtual bool nextGroup(ConstPointerArray & group);
+    virtual void readAll(RtlLinkedDatasetBuilder &builder);
     virtual unsigned __int64 queryTotalCycles() const = 0;
     virtual unsigned __int64 queryLocalCycles() const = 0;
     virtual const void * nextSteppedGE(const void * seek, unsigned numFields, bool &wasCompleteMatch, const SmartStepExtra & stepExtra) { throwUnexpected(); }  // can only be called on stepping fields.

--- a/rtl/eclrtl/rtlds.cpp
+++ b/rtl/eclrtl/rtlds.cpp
@@ -329,6 +329,16 @@ RtlLinkedDatasetBuilder::~RtlLinkedDatasetBuilder()
     ::Release(rowAllocator);
 }
 
+void RtlLinkedDatasetBuilder::clear()
+{
+    builder.clear();
+    if (rowset)
+        rowAllocator->releaseRowset(count, rowset);
+    rowset = NULL;
+    count = 0;
+    max = 0;
+}
+
 void RtlLinkedDatasetBuilder::append(const void * source)
 {
     if (count < choosenLimit)

--- a/rtl/eclrtl/rtlds_imp.hpp
+++ b/rtl/eclrtl/rtlds_imp.hpp
@@ -369,6 +369,7 @@ public:
     void resize(size32_t required);
     void finalizeRows();
     void finalizeRow(size32_t len);
+    void clear();
 
     inline RtlDynamicRowBuilder & rowBuilder() { return builder; }
     inline void ensure(size32_t required) { if (required > max) expand(required); }

--- a/testing/ecl/key/dict17.xml
+++ b/testing/ecl/key/dict17.xml
@@ -1,0 +1,6 @@
+<Dataset name='Result 1'>
+ <Row><search>1</search><ids><Row><id>2</id></Row></ids></Row>
+ <Row><search>3</search><ids><Row><id>2</id></Row><Row><id>3</id></Row><Row><id>4</id></Row></ids></Row>
+ <Row><search>10</search><ids><Row><id>10</id></Row><Row><id>11</id></Row></ids></Row>
+ <Row><search>11</search><ids><Row><id>10</id></Row><Row><id>11</id></Row></ids></Row>
+</Dataset>


### PR DESCRIPTION
Support dictionary results in child query in roxie. Refactor to use
roxiemem-allocated rowsets for dictionary, dataset, and loop results
in child queries and graphs.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
