### PR TITLE
HPCC-8489 Can't initialize child dictionary from inline spec

### DIFF
--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -5146,7 +5146,7 @@ void TempTableTransformer::createTempTableAssign(HqlExprArray & assigns, IHqlExp
                 if (included)
                 {
                     LinkedHqlExpr src = queryRealChild(curRow, col);
-                    if (expr->isDataset())
+                    if (expr->isDataset() || expr->isDictionary())
                     {
                         if (src)
                             col++;


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
