### PR TITLE
HPCC-8491 Git hook giving spurious errors about line length

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -38,7 +38,7 @@ Use git commit -s -t $1 to reopen previous message for editing\n"
   exit 1
 }
 
-[ $(cat "$1" | wc -L ) -le 80 ] || {
+[ $(grep -v '^#' "$1" | wc -L ) -le 80 ] || {
   echo >&2 "\n ERROR: Commit message lines too long (max 80 chars)."
   echo >&2 $usage
   exit 1


### PR DESCRIPTION
The githook that checks line length can be triggered by long filenames in the
comments about untracked files.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
