### PR TITLE
HPCC-8454 Roxie leaks rows when exception thrown in child query

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -13388,12 +13388,12 @@ public:
         ActivityTimer t(totalCycles, timeActivities, ctx->queryDebugContext());
         loop
         {
-            const void * in = input->nextInGroup();
+            OwnedConstRoxieRow in = input->nextInGroup();
             if (!in)
             {
                 recordCount = 0;
                 if (numProcessedLastGroup == processed)
-                    in = input->nextInGroup();
+                    in.setown(input->nextInGroup());
                 if (!in)
                 {
                     numProcessedLastGroup = processed;
@@ -13409,7 +13409,6 @@ public:
                     outSize = ((IHThorCountProjectArg &) basehelper).transform(rowBuilder, in, ++recordCount);
                 else
                     outSize = ((IHThorProjectArg &) basehelper).transform(rowBuilder, in);
-                ReleaseRoxieRow(in);
                 if (outSize)
                 {
                     processed++;


### PR DESCRIPTION
A project that triggers an exception in a child query will leak the current
parent row that was being processed at the time.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
