### PR TITLE
HPCC-8335 Option on a field to control the default value

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -2870,7 +2870,6 @@ IHqlExpression * ensureExprType(IHqlExpression * expr, ITypeInfo * type, node_op
     }
 
     node_operator op = expr->getOperator();
-    assertex (op != no_null);
 
     IValue * value = expr->queryValue();
     if (value && type->assignableFrom(exprType))    // this last condition is unnecessary, but changes some persist crcs if removed

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1332,7 +1332,7 @@ extern HQL_API IHqlExpression * createPureVirtual(ITypeInfo * type);
 extern HQL_API IHqlExpression * cloneOrLink(IHqlExpression * expr, HqlExprArray & children);
 extern HQL_API IHqlExpression * createConstantOne();
 extern HQL_API IHqlExpression * createLocalAttribute();
-extern HQL_API bool isNullExpr(IHqlExpression * expr, ITypeInfo * type);
+extern HQL_API bool isNullExpr(IHqlExpression * expr, IHqlExpression * field);
 inline bool isNull(IHqlExpression * expr)       { return expr->getOperator() == no_null; }
 inline bool isNullAction(IHqlExpression * expr) { return isNull(expr) && expr->isAction(); }
 inline bool isFail(IHqlExpression * expr)       { return expr->getOperator() == no_fail; }

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -161,6 +161,7 @@ static void eclsyntaxerror(HqlGram * parser, const char * s, short yystate, int 
   DATASET
   __DEBUG__
   DEDUP
+  DEFAULT
   DEFINE
   DENORMALIZE
   DEPRECATED
@@ -4402,6 +4403,10 @@ fieldAttr
     | XMLDEFAULT '(' constExpression ')'
                         {
                             $$.setExpr(createAttribute(xmlDefaultAtom, $3.getExpr()), $1);
+                        }
+    | DEFAULT '(' constExpression ')'
+                        {
+                            $$.setExpr(createAttribute(defaultAtom, $3.getExpr()), $1);
                         }
     | STRING_CONST
                         {

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -656,6 +656,7 @@ CRON                { RETURNSYM(CRON); }
 CSV                 { RETURNSYM(CSV); }
 DATASET             { RETURNSYM(DATASET); }
 DEDUP               { RETURNSYM(DEDUP); }
+DEFAULT             { RETURNSYM(DEFAULT); }
 DEFINE              { RETURNSYM(DEFINE); }
 DENORMALIZE         { RETURNSYM(DENORMALIZE); }
 DEPRECATED          { RETURNSYM(DEPRECATED); }

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -5278,7 +5278,7 @@ void TempTableTransformer::createTempTableAssign(HqlExprArray & assigns, IHqlExp
                     castValue.setown(ensureExprType(src, type));
                 }
                 else
-                    castValue.setown(createNullExpr(type));
+                    castValue.setown(createNullExpr(expr));
             }
             assigns.append(*createAssign(LINK(target), LINK(castValue)));
             mapper.setMapping(target, castValue);

--- a/ecl/hqlcpp/hqlckey.cpp
+++ b/ecl/hqlcpp/hqlckey.cpp
@@ -362,8 +362,7 @@ void KeyedJoinInfo::buildClearRecord(BuildCtx & ctx, RecordSelectIterator & rawI
         OwnedHqlExpr rawSelect = rawIter.get();
         OwnedHqlExpr keySelect = keyIter.get();
 
-        ITypeInfo * keyFieldType = keySelect->queryType();
-        OwnedHqlExpr null = createNullExpr(keyFieldType);
+        OwnedHqlExpr null = createNullExpr(keySelect);
         OwnedHqlExpr keyNull = (rawIter.isInsideIfBlock() || (rawIter.isInsideNested() && isInPayload())) ? LINK(null) : getHozedKeyValue(null);
         OwnedHqlExpr folded = foldHqlExpression(keyNull);
         translator.buildAssign(ctx, rawSelect, folded);

--- a/ecl/hqlcpp/hqltcppc.cpp
+++ b/ecl/hqlcpp/hqltcppc.cpp
@@ -2619,6 +2619,8 @@ void CXmlColumnInfo::buildColumnAssign(HqlCppTranslator & translator, BuildCtx &
     {
         _ATOM func = NULL;
         IHqlExpression * defaultValue = queryPropertyChild(column, xmlDefaultAtom, 0);
+        if (!defaultValue)
+            defaultValue = queryPropertyChild(column, defaultAtom, 0);
 
         switch (type->getTypeCode())
         {
@@ -2763,6 +2765,8 @@ IHqlExpression * CXmlColumnInfo::getXmlSetExpr(HqlCppTranslator & translator, Bu
     builder->buildDeclare(ctx);
 
     LinkedHqlExpr defaultValue = queryPropertyChild(column, xmlDefaultAtom, 0);
+    if (!defaultValue)
+        defaultValue.set(queryPropertyChild(column, defaultAtom, 0));
     bool defaultIsAllValue = defaultValue && (defaultValue->getOperator() == no_all);
     if (checkForAll)
     {
@@ -2802,6 +2806,8 @@ IHqlExpression * CXmlColumnInfo::getCallExpr(HqlCppTranslator & translator, Buil
     Linked<ITypeInfo> type = queryPhysicalType();
     _ATOM func = NULL;
     IHqlExpression * defaultValue = queryPropertyChild(column, xmlDefaultAtom, 0);
+    if (!defaultValue)
+        defaultValue = queryPropertyChild(column, defaultAtom, 0);
 
     switch (type->getTypeCode())
     {

--- a/ecl/hqlcpp/hqltcppc2.cpp
+++ b/ecl/hqlcpp/hqltcppc2.cpp
@@ -751,7 +751,7 @@ void CChildLinkedDatasetColumnInfo::setColumn(HqlCppTranslator & translator, Bui
     boundTarget.expr.setown(convertAddressToValue(addressData, queryType()));
 
     if (value->getOperator() == no_null)
-        value.setown(createNullExpr(resultType));
+        value.setown(createNullExpr(column));
     
     translator.buildDatasetAssign(ctx, boundTarget, value);
 }

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -4542,7 +4542,7 @@ IHqlExpression * queryNullDsSelect(__int64 & selectIndex, IHqlExpression * value
     IValue * index = ds->queryChild(1)->queryValue();
     if (!index)
         return NULL;
-    if (!isNullExpr(other, value->queryType()))
+    if (!isNullExpr(other, value))
         return NULL;
     selectIndex = index->getIntValue();
     return ds->queryChild(0);

--- a/rtl/eclrtl/rtlds.cpp
+++ b/rtl/eclrtl/rtlds.cpp
@@ -453,7 +453,7 @@ inline void doSerializeRowset(IRowSerializerTarget & out, IOutputRowSerializer *
     for (unsigned i=0; i < count; i++)
     {
         byte *row = rows[i];
-        if (row)   // When serializing a dictionary, there may be nulls in the rowset. These can be skipped (we rehash on deserialize)
+        if (row)
         {
             serializer->serialize(out, rows[i]);
             if (isGrouped)
@@ -461,6 +461,10 @@ inline void doSerializeRowset(IRowSerializerTarget & out, IOutputRowSerializer *
                 byte eogPending = (i+1 < count) && (rows[i+1] == NULL);
                 out.put(1, &eogPending);
             }
+        }
+        else
+        {
+            assert(isGrouped); // should not be seeing NULLs otherwise - should not use this function for DICTIONARY
         }
     }
 }

--- a/testing/ecl/default.ecl
+++ b/testing/ecl/default.ecl
@@ -6,24 +6,24 @@ zero := nofold(0);
 
 ds := DATASET([{ 'A' }], {string1 f {DEFAULT('B')}});
 
-//ds[0];      // should be constant folded
-//ds[zero];   // should NOT be
+ds[0];      // should be constant folded
+ds[zero];   // should NOT be
 
 dsn := DATASET([], {string1 f {DEFAULT('B')}});
-//dsn[0];     // should be constant folded
-//dsn[zero];  // can also be
+dsn[0];     // should be constant folded
+dsn[zero];  // can also be
 
 // 2. when looking up in a dictionary
 
 dict := DICTIONARY([{ 1 => 'A' }], { unsigned1 v => string1 f {DEFAULT('B')}});
 
-//dict[0];      // Might one day be constant folded
-//dict[zero];   // should NOT be
+dict[0];      // Might one day be constant folded
+dict[zero];   // should NOT be
 
 dictn := DICTIONARY([], { unsigned1 v => string1 f {DEFAULT('B')}});   // Bit useless !
 
-//dictn[0];      // Might be constant folded
-//dictn[zero];   // Might be constant folded
+dictn[0];      // Might be constant folded
+dictn[zero];   // Might be constant folded
 
 // 3. When assigning self := []
 

--- a/testing/ecl/default.ecl
+++ b/testing/ecl/default.ecl
@@ -1,0 +1,44 @@
+// Test that default field values are used as many places as I can think of
+
+zero := nofold(0);
+
+// 1. when outputting an out-of-range row
+
+ds := DATASET([{ 'A' }], {string1 f {DEFAULT('B')}});
+
+//ds[0];      // should be constant folded
+//ds[zero];   // should NOT be
+
+dsn := DATASET([], {string1 f {DEFAULT('B')}});
+//dsn[0];     // should be constant folded
+//dsn[zero];  // can also be
+
+// 2. when looking up in a dictionary
+
+dict := DICTIONARY([{ 1 => 'A' }], { unsigned1 v => string1 f {DEFAULT('B')}});
+
+//dict[0];      // Might one day be constant folded
+//dict[zero];   // should NOT be
+
+dictn := DICTIONARY([], { unsigned1 v => string1 f {DEFAULT('B')}});   // Bit useless !
+
+//dictn[0];      // Might be constant folded
+//dictn[zero];   // Might be constant folded
+
+// 3. When assigning self := []
+
+ds t1 := TRANSFORM
+  SELF := [];
+END;
+
+PROJECT(ds, t1);
+
+// 4. In the default rows for outer joins
+
+ds t2(ds L, dsn R) := TRANSFORM
+  SELF.f := R.f;
+END;
+
+j := JOIN(ds, dsn, left.f=right.f, t2(LEFT, RIGHT),  LEFT OUTER);
+
+j[1].f;

--- a/testing/ecl/key/default.xml
+++ b/testing/ecl/key/default.xml
@@ -1,0 +1,30 @@
+<Dataset name='Result 1'>
+ <Row><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><v>0</v><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><v>0</v><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><v>0</v><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><v>0</v><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><f>B</f></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><Result_10>B</Result_10></Row>
+</Dataset>


### PR DESCRIPTION
The default value of a field will be used:
1. When a dictionary lookup does not find a match
2. When a dataset select indexes a non-existent row
3. When assigning SELF := [] in a transform
4. In the default row passed to transforms by a OUTER join
5. When reading from XML and a column is not present

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
