### PR TITLE
HPCC-8514 Fix ESDL parameter defaults not being set properly

### DIFF
--- a/esp/bindings/SOAP/Platform/soapparam.hpp
+++ b/esp/bindings/SOAP/Platform/soapparam.hpp
@@ -107,12 +107,16 @@ private:
 
 public:
     SoapParam(nilBehavior nb=nilIgnore, bool httpNil=true) : BaseEspParam(nb, httpNil), value(0){}
-    SoapParam(inittype val, nilBehavior nb=nilIgnore, bool httpNil=true) : BaseEspParam(nb, httpNil), value(val){}
+    SoapParam(inittype val, nilBehavior nb=nilIgnore, bool httpNil=true) : BaseEspParam(nb, httpNil)
+    {
+        set(val);
+    }
 
     cpptype getValue() const {return value;}
     operator cpptype () {return value;}
     const cpptype * operator ->() const {return &value;}
-    void operator=(cpptype val) { value = val; isNil=false;};
+    void set(cpptype val) { value = val; isNil=false;};
+    void operator=(cpptype val) { set(val); };
 
     void copy(SoapParam<cpptype, inittype> &from)
     {
@@ -227,7 +231,10 @@ private:
 
 public:
     SoapStringParam(nilBehavior nb=nilIgnore) : BaseEspParam(nb, true), encodeNewlines(false) {}
-    SoapStringParam(const char * val, nilBehavior nb=nilIgnore) : BaseEspParam(nb, !val), encodeNewlines(false) {}
+    SoapStringParam(const char * val, nilBehavior nb=nilIgnore) : BaseEspParam(nb, !val), encodeNewlines(false)
+    {
+        set(val);
+    }
 
     virtual ~SoapStringParam(){}
 


### PR DESCRIPTION
A regression in version 3.10 due to refactoring of parameter code
meant that ESDL defined default values were not always being set
properly.  Only 1 small related issue has been reported, so this
change should probably be targeted for 3.10.2 where it can be
properly tested before release.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
