### PR TITLE
HPCC-8566 Fix XML Schema generation skips top level attributes

### DIFF
--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -3654,13 +3654,16 @@ void XmlSchemaBuilder::addSchemaPrefix()
                     "<xs:element name=\"Row\">"
                         "<xs:complexType>"
                             "<xs:sequence>\n");
+    attributes.append(*new StringBufferItem);
 }
 
 
 void XmlSchemaBuilder::addSchemaSuffix()
 {
-    xml.append(             "</xs:sequence>"
-                        "</xs:complexType>"
+    xml.append(             "</xs:sequence>");
+    xml.append(attributes.tos());
+    attributes.pop();
+    xml.append(         "</xs:complexType>"
                     "</xs:element>\n"
                 "</xs:sequence>"
             "</xs:complexType>"


### PR DESCRIPTION
Attributes defined in the top level record structure were being
ignored by the schema generator.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
