### PR TITLE
HPCC-8577 - Unecessarily slow thor start/stop times

### DIFF
--- a/initfiles/componentfiles/thor/run_thor
+++ b/initfiles/componentfiles/thor/run_thor
@@ -51,7 +51,8 @@ while [ 1 ]; do
     if [ "$localthor" = "true" ]; then
         $deploydir/start_slaves $THORMASTER thorslave${LCR} $THORMASTER $THORMASTERPORT $logdir $instancedir $THORNAME $PATH_PRE $logredirect
     else
-        $deploydir/frunssh $instancedir/uslaves.start "/bin/sh -c '$deploydir/start_slaves %a thorslave${LCR} $THORMASTER $THORMASTERPORT $logdir $instancedir $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1
+        nslaves=`cat $instancedir/uslaves.start | wc -l`
+        $deploydir/frunssh $instancedir/uslaves.start "/bin/sh -c '$deploydir/start_slaves %a thorslave${LCR} $THORMASTER $THORMASTERPORT $logdir $instancedir $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries -n:$nslaves 2>&1
     fi
 
     echo thormaster cmd : $instancedir/thormaster_$THORNAME MASTER=$THORMASTER:$THORMASTERPORT

--- a/initfiles/componentfiles/thor/stop_thor
+++ b/initfiles/componentfiles/thor/stop_thor
@@ -90,7 +90,8 @@ else
         fi
     fi
     sort $instancedir/slaves | uniq > $instancedir/uslaves
-    $deploydir/frunssh $instancedir/uslaves "/bin/sh -c '$deploydir/stop_slaves ${comp_base} $PATH_PRE $THORMASTER:$THORMASTERPORT'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries 2>&1 | egrep -v "no process killed"
+    nslaves=`cat $instancedir/uslaves.start | wc -l`
+    $deploydir/frunssh $instancedir/uslaves "/bin/sh -c '$deploydir/stop_slaves ${comp_base} $PATH_PRE $THORMASTER:$THORMASTERPORT'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries -n:$nslaves 2>&1 | egrep -v "no process killed"
     echo slaves stopped
 fi
 


### PR DESCRIPTION
The default frunssh behaviour is to limit concurrent threads to 10
This means the starting process needs to wait until some of the
start slave script complete, before beginning to start others.
There is no good reason the limit is 10 and in general it should
start all in parallel, via option to frunssh.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
