### PR TITLE
HPCC-8485 result_lib.xslt not escaping some xml strings

### DIFF
--- a/esp/eclwatch/ws_XSLT/result_lib.xslt
+++ b/esp/eclwatch/ws_XSLT/result_lib.xslt
@@ -421,6 +421,9 @@
                         </xsl:when>
                         <xsl:otherwise>
                             <data>
+                                <xsl:if test="number($escapeResults) and not(starts-with($rowSchema/@name, '__html__'))">
+                                    <xsl:attribute name="escape">1</xsl:attribute>
+                                </xsl:if>
                                 <xsl:for-each select="$matchingData|$matchingData2">
                                     <xsl:value-of select="."/>
                                     <xsl:if test="position()!=last()">, </xsl:if>


### PR DESCRIPTION
When building preliminary node-set some data elements were not marked
for escaping of values.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
