### PR TITLE
HPCC-8580 Update Version.xml

### DIFF
--- a/docs/common/Version.xml
+++ b/docs/common/Version.xml
@@ -5,11 +5,11 @@
   <chapterinfo>
     <date id="DateVer">DEVELOPER NON-GENERATED VERSION</date>
 
-    <releaseinfo id="FooterInfo">© 2012 HPCC Systems. All rights
+    <releaseinfo id="FooterInfo">© 2013 HPCC Systems. All rights
     reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2012 HPCC Systems. All rights reserved</year>
+      <year>2013 HPCC Systems. All rights reserved</year>
     </copyright>
   </chapterinfo>
 
@@ -23,7 +23,7 @@
     serve one purpose and that is to store the chapterinfo the above sections
     that are being used by several other documents.</para>
 
-    <para id="CHMVer">2012 Version 3.x</para>
+    <para id="CHMVer">2013 Version 3.x</para>
 
     <para>The following line is the code to be put into the document you wish
     to include the above version info in:</para>

--- a/docs/common/Version.xml.in
+++ b/docs/common/Version.xml.in
@@ -3,13 +3,13 @@
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <chapter>
   <chapterinfo>
-    <date id="DateVer">2012 Version ${DOC_VERSION}</date>
+    <date id="DateVer">2013 Version ${DOC_VERSION}</date>
 
-    <releaseinfo id="FooterInfo">© 2012 HPCC Systems. All rights
+    <releaseinfo id="FooterInfo">© 2013 HPCC Systems. All rights
     reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2012 HPCC Systems. All rights reserved</year>
+      <year>2013 HPCC Systems. All rights reserved</year>
     </copyright>
   </chapterinfo>
 
@@ -23,7 +23,7 @@
     serve one purpose and that is to store the chapterinfo the above sections
     that are being used by several other documents.</para>
 
-    <para id="CHMVer">2012 Version ${DOC_VERSION}</para>
+    <para id="CHMVer">2013 Version ${DOC_VERSION}</para>
 
     <para>The following line is the code to be put into the document you wish
     to include the above version info in:</para>


### PR DESCRIPTION
Fix HPCC-8580 Update Version.xml
which is the config file that all doc builds use
this will ensure all docs now show copyright 2013
This change should be merged into ALL branches, going forward.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
