### PR TITLE
HPCC-8547 - Interleaved mixed width subfiles exposing mapSubPart bug

### DIFF
--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -1976,7 +1976,7 @@ public:
                     p++;
                     f = 0;
                 }
-                if (p<subfilecounts->item(subfile)) {
+                if (p<subfilecounts->item(f)) {
                     if (!superpartnum) {
                         subfile = f;
                         subpartnum = p;


### PR DESCRIPTION
mapSubPart was testing the wrong subfile when iterating through
parts/subs to determining which subfile and part the logical part index
referred to.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
