### PR TITLE
HPCC-8596 Problems dealing with CSV headers in mixed width supers

### DIFF
--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -273,10 +273,11 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
             bool someLeft=false;
             do
             {
-                if (0 != headerLinesRemaining[which])
-                    someLeft = true;
                 msgMb.append(which);
-                msgMb.append(headerLinesRemaining[which]);
+                unsigned &remaining = getHeaderLines(which);
+                if (0 != remaining)
+                    someLeft = true;
+                msgMb.append(remaining);
                 which = sentHeaderLines->scanInvert(which+1, false);
             }
             while (which < subFiles);


### PR DESCRIPTION
When have read all local parts, need to check unsent part header
counts from previous node.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
