### PR TITLE
HPCC-8601 Debug values being passed as stored values in deployArchive

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3712,7 +3712,7 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
     wu->commit();
     wu.clear();
 
-    submitWsWorkunit(context, wuid.str(), req.getCluster(), NULL, 0, true, false, NULL, NULL, &req.getDebugValues());
+    submitWsWorkunit(context, wuid.str(), req.getCluster(), NULL, 0, true, false, false, NULL, NULL, &req.getDebugValues());
     waitForWorkUnitToCompile(wuid.str(), req.getWait());
 
     WsWuInfo winfo(context, wuid.str());


### PR DESCRIPTION
Missing parameter caused debug values to be passed in the wrong position.

Debug values are probably rarely used in this way so the issue probably
went unnoticed.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
