### PR TITLE
HPCC-8567 ECLPlayground Sample Drop Down Error

### DIFF
--- a/esp/files/scripts/GraphControl.js
+++ b/esp/files/scripts/GraphControl.js
@@ -143,23 +143,27 @@ define([
 		},
 
 		centerOn: function (globalID) {
-			var item = this.obj.getItem(globalID);
-			this.obj.centerOnItem(item, true);
-			var items = [item];
-			this.obj.setSelected(items, true);
+			if (this.obj) {
+				var item = this.obj.getItem(globalID);
+				this.obj.centerOnItem(item, true);
+				var items = [item];
+				this.obj.setSelected(items, true);
+			}
 		},
 
 		watchSelect: function (select) {
-			if (sniff("chrome") && select) {
-				var context = this;
+			if (this.obj) {
+				if (sniff("chrome") && select) {
+					var context = this;
 
-				aspect.before(select, "openDropDown", function () {
-					dojo.style(context.obj, "height", "0px");
-				});
+					aspect.before(select, "openDropDown", function () {
+						dojo.style(context.obj, "height", "0px");
+					});
 
-				aspect.after(select, "closeDropDown", function (focus) {
-					dojo.style(context.obj, "height", "100%");
-				});
+					aspect.after(select, "closeDropDown", function (focus) {
+						dojo.style(context.obj, "height", "100%");
+					});
+				}
 			}
 		},
 


### PR DESCRIPTION
In Chrome, if there is no graph control installed, the drop down sample list will not show.

Fixes HPCC-8567

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
