### PR TITLE
HPCC-8570 Remove Sentinel check to stop process

### DIFF
--- a/initfiles/bin/init_configesp
+++ b/initfiles/bin/init_configesp
@@ -34,6 +34,7 @@ killed() {
     rm -f ${SENTINEL}
     killall -9 configesp 2>/dev/null
     sleep 1
+    rm $PID_NAME
     exit 255
 }
 
@@ -42,6 +43,7 @@ trap "killed" SIGINT SIGTERM SIGKILL
 nohup configesp 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 
 while [ -e ${SENTINEL} ]; do
     sleep 5
@@ -49,6 +51,7 @@ while [ -e ${SENTINEL} ]; do
         nohup configesp 1>/dev/null 2>/dev/null &
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done
 

--- a/initfiles/bin/init_configesp
+++ b/initfiles/bin/init_configesp
@@ -31,10 +31,7 @@ ulimit -n 8192
 SNMPID=$$
 
 killed() {
-    rm -f ${SENTINEL}
-    killall -9 configesp 2>/dev/null
-    rm $PID_NAME
-    sleep 1
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 

--- a/initfiles/bin/init_configesp
+++ b/initfiles/bin/init_configesp
@@ -33,8 +33,8 @@ SNMPID=$$
 killed() {
     rm -f ${SENTINEL}
     killall -9 configesp 2>/dev/null
-    sleep 1
     rm $PID_NAME
+    sleep 1
     exit 255
 }
 

--- a/initfiles/bin/init_dafilesrv.in
+++ b/initfiles/bin/init_dafilesrv.in
@@ -43,8 +43,8 @@ rm -f ${SENTINEL}
 killed(){
     rm -f ${SENTINEL}
     killall -9 dafilesrv 2> /dev/null
-    sleep 2
     rm $PID_NAME
+    sleep 2
     exit 255
 }
 ulimit -n $handlelimit

--- a/initfiles/bin/init_dafilesrv.in
+++ b/initfiles/bin/init_dafilesrv.in
@@ -44,6 +44,7 @@ killed(){
     rm -f ${SENTINEL}
     killall -9 dafilesrv 2> /dev/null
     sleep 2
+    rm $PID_NAME
     exit 255
 }
 ulimit -n $handlelimit
@@ -51,6 +52,7 @@ trap "killed" SIGINT SIGTERM SIGKILL
 dafilesrv -L $log -I ${INSTANCE_NAME} &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 
 while [ -e ${SENTINEL} ]; do
     sleep 5
@@ -58,5 +60,6 @@ while [ -e ${SENTINEL} ]; do
         dafilesrv -L $log -I ${INSTANCE_NAME} &
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done

--- a/initfiles/bin/init_dafilesrv.in
+++ b/initfiles/bin/init_dafilesrv.in
@@ -41,10 +41,7 @@ export SENTINEL="dafilesrv.sentinel"
 rm -f ${SENTINEL}
 
 killed(){
-    rm -f ${SENTINEL}
-    killall -9 dafilesrv 2> /dev/null
-    rm $PID_NAME
-    sleep 2
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 ulimit -n $handlelimit

--- a/initfiles/bin/init_dali
+++ b/initfiles/bin/init_dali
@@ -29,8 +29,7 @@ ulimit -n 8192
 
 killed(){
     dalistop .
-    rm -f ${SENTINEL}
-    rm $PID_NAME
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 

--- a/initfiles/bin/init_dali
+++ b/initfiles/bin/init_dali
@@ -30,6 +30,7 @@ ulimit -n 8192
 killed(){
     dalistop .
     rm -f ${SENTINEL}
+    rm $PID_NAME
     exit 255
 }
 
@@ -37,6 +38,7 @@ trap "killed" SIGINT SIGTERM SIGKILL
 daserver 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 
 while [ -e ${SENTINEL} ]; do
     sleep 5
@@ -44,5 +46,6 @@ while [ -e ${SENTINEL} ]; do
         daserver 1>/dev/null 2>/dev/null &
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done

--- a/initfiles/bin/init_dfuserver
+++ b/initfiles/bin/init_dfuserver
@@ -30,12 +30,11 @@ ulimit -n 8192
 ulimit -s 512
 
 killed() {
-    if [ -e ${SENTINEL} ]; then
-        rm -f ${SENTINEL}
-        dfuserver stop=1
-        sleep 5
-        killall -9 dfuserver
-    fi
+    rm -f ${SENTINEL}
+    dfuserver stop=1
+    sleep 5
+    killall -9 dfuserver
+    rm $PID_NAME
     exit 255
 }
 
@@ -44,6 +43,7 @@ trap "killed" SIGINT SIGTERM SIGKILL
 dfuserver 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 
 while [ -e ${SENTINEL} ]; do
     sleep 5
@@ -51,5 +51,6 @@ while [ -e ${SENTINEL} ]; do
         dfuserver 1>/dev/null 2>/dev/null &
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done

--- a/initfiles/bin/init_dfuserver
+++ b/initfiles/bin/init_dfuserver
@@ -30,11 +30,9 @@ ulimit -n 8192
 ulimit -s 512
 
 killed() {
-    rm -f ${SENTINEL}
     dfuserver stop=1
     sleep 5
-    killall -9 dfuserver
-    rm $PID_NAME
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 

--- a/initfiles/bin/init_eclagent.in
+++ b/initfiles/bin/init_eclagent.in
@@ -36,8 +36,8 @@ killed (){
     killall eclagent
     sleep 2
     killall -9 agentexec eclagent 1>/dev/null 2>&1 
-    sleep 2
     rm $PID_NAME
+    sleep 2
     exit 255
 }
 

--- a/initfiles/bin/init_eclagent.in
+++ b/initfiles/bin/init_eclagent.in
@@ -37,6 +37,7 @@ killed (){
     sleep 2
     killall -9 agentexec eclagent 1>/dev/null 2>&1 
     sleep 2
+    rm $PID_NAME
     exit 255
 }
 
@@ -47,6 +48,7 @@ ulimit -c unlimited
 agentexec 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 
 while [ -e ${SENTINEL} ]; do
     sleep 1
@@ -54,6 +56,7 @@ while [ -e ${SENTINEL} ]; do
         agentexec 1>/dev/null 2>/dev/null &
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done
 

--- a/initfiles/bin/init_eclagent.in
+++ b/initfiles/bin/init_eclagent.in
@@ -30,14 +30,7 @@ rm -f ${SENTINEL}
 rm -f ${PID_DIR}/hthortemp/*
 
 killed (){
-    rm -f ${SENTINEL}
-
-    killall agentexec
-    killall eclagent
-    sleep 2
-    killall -9 agentexec eclagent 1>/dev/null 2>&1 
-    rm $PID_NAME
-    sleep 2
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 

--- a/initfiles/bin/init_eclccserver
+++ b/initfiles/bin/init_eclccserver
@@ -32,8 +32,8 @@ killed() {
 
     rm -f ${SENTINEL}
     pidwait_fn `cat ${PID_NAME}` 3
-    sleep 2
     rm $PID_NAME
+    sleep 2
     exit 255
 }
 

--- a/initfiles/bin/init_eclccserver
+++ b/initfiles/bin/init_eclccserver
@@ -30,13 +30,10 @@ killed() {
     source ${PATH_PRE}
     PID_NAME="$PID/`basename $PWD`.pid"
 
-    if [ -e ${SENTINEL} ]; then
-            rm -f ${SENTINEL}
-            if [ -e ${PID_NAME} ]; then
-                    pidwait_fn `cat ${PID_NAME}` 3
-            fi
-    fi
+    rm -f ${SENTINEL}
+    pidwait_fn `cat ${PID_NAME}` 3
     sleep 2
+    rm $PID_NAME
     exit 255
 }
 
@@ -44,6 +41,7 @@ trap "killed" SIGINT SIGTERM SIGKILL
 eclccserver 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 
 while [ -e ${SENTINEL} ]; do
     sleep 5
@@ -51,6 +49,7 @@ while [ -e ${SENTINEL} ]; do
         eclccserver 1>/dev/null 2>/dev/null & 
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done
 

--- a/initfiles/bin/init_eclccserver
+++ b/initfiles/bin/init_eclccserver
@@ -26,14 +26,7 @@ export SENTINEL="eclccserver.sentinel"
 rm -f ${SENTINEL}
 
 killed() {
-    PATH_PRE=`type -path hpcc_setenv`
-    source ${PATH_PRE}
-    PID_NAME="$PID/`basename $PWD`.pid"
-
-    rm -f ${SENTINEL}
-    pidwait_fn `cat ${PID_NAME}` 3
-    rm $PID_NAME
-    sleep 2
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 

--- a/initfiles/bin/init_eclscheduler
+++ b/initfiles/bin/init_eclscheduler
@@ -26,10 +26,7 @@ export SENTINEL="eclscheduler.sentinel"
 rm -f ${SENTINEL}
 
 killed(){
-    rm -f ${SENTINEL}
-    killall -9 eclscheduler
-    rm $PID_NAME
-    sleep
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 

--- a/initfiles/bin/init_eclscheduler
+++ b/initfiles/bin/init_eclscheduler
@@ -28,8 +28,8 @@ rm -f ${SENTINEL}
 killed(){
     rm -f ${SENTINEL}
     killall -9 eclscheduler
-    sleep
     rm $PID_NAME
+    sleep
     exit 255
 }
 

--- a/initfiles/bin/init_eclscheduler
+++ b/initfiles/bin/init_eclscheduler
@@ -29,6 +29,7 @@ killed(){
     rm -f ${SENTINEL}
     killall -9 eclscheduler
     sleep
+    rm $PID_NAME
     exit 255
 }
 
@@ -36,6 +37,7 @@ trap "killed" SIGINT SIGTERM SIGKILL
 eclscheduler 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 
 while [ -e ${SENTINEL} ]; do
     sleep 5
@@ -43,6 +45,7 @@ while [ -e ${SENTINEL} ]; do
         eclscheduler 1>/dev/null 2>/dev/null &
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done
 

--- a/initfiles/bin/init_esp
+++ b/initfiles/bin/init_esp
@@ -35,6 +35,7 @@ killed() {
     sleep 15
     killall -9 esp 1>/dev/null 2>/dev/null 
     sleep 2
+    rm $PID_NAME
     exit 255
 }
 
@@ -42,11 +43,13 @@ trap "killed" SIGINT SIGTERM SIGKILL
 esp snmpid=$SNMPID 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 while [ -e ${SENTINEL} ]; do
     sleep 5
     if [ -e ${SENTINEL} ]; then
         esp snmpid=$SNMPID 1>/dev/null 2>/dev/null &
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done

--- a/initfiles/bin/init_esp
+++ b/initfiles/bin/init_esp
@@ -30,12 +30,7 @@ ulimit -n 8192
 SNMPID=$$
 
 killed() {
-    rm -f ${SENTINEL}
-    killall esp 1>/dev/null 2>/dev/null
-    sleep 15
-    killall -9 esp 1>/dev/null 2>/dev/null 
-    rm $PID_NAME
-    sleep 2
+    kill_process ${SENTINEL} ${PID_NAME} 15
     exit 255
 }
 

--- a/initfiles/bin/init_esp
+++ b/initfiles/bin/init_esp
@@ -34,8 +34,8 @@ killed() {
     killall esp 1>/dev/null 2>/dev/null
     sleep 15
     killall -9 esp 1>/dev/null 2>/dev/null 
-    sleep 2
     rm $PID_NAME
+    sleep 2
     exit 255
 }
 

--- a/initfiles/bin/init_roxie
+++ b/initfiles/bin/init_roxie
@@ -52,6 +52,7 @@ killed() {
     sleep 5
     killall -9 roxie
     sleep 2
+    rm $PID_NAME
     exit 255
 }
 
@@ -59,6 +60,7 @@ trap "killed" SIGINT SIGTERM SIGKILL
 nohup roxie --topology=RoxieTopology.xml --logfile=$logfilename --restarts=$restarts --stdlog=0 2>>$logfilename.stderr 1>>$logfilename.stdout &
 echo $! > $PID_NAME 
 wait
+rm $PID_NAME
 
 # Automatically restart roxie when it dies
 while [ -e ${SENTINEL} ]; do
@@ -68,5 +70,6 @@ while [ -e ${SENTINEL} ]; do
     nohup roxie --topology=RoxieTopology.xml --logfile=$logfilename --restarts=$restarts --stdlog=0 2>>$logfilename.stderr 1>>$logfilename.stdout &
     echo $! > $PID_NAME
     wait
+    rm $PID_NAME
 done
 

--- a/initfiles/bin/init_roxie
+++ b/initfiles/bin/init_roxie
@@ -51,8 +51,8 @@ killed() {
     killall roxie
     sleep 5
     killall -9 roxie
-    sleep 2
     rm $PID_NAME
+    sleep 2
     exit 255
 }
 

--- a/initfiles/bin/init_roxie
+++ b/initfiles/bin/init_roxie
@@ -47,12 +47,7 @@ killed() {
     if [ -n "$1" ]; then
         cd $1
     fi
-    rm -f ${SENTINEL}
-    killall roxie
-    sleep 5
-    killall -9 roxie
-    rm $PID_NAME
-    sleep 2
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 

--- a/initfiles/bin/init_sasha
+++ b/initfiles/bin/init_sasha
@@ -50,8 +50,8 @@ killed() {
             kill -9 $pid
         fi
     fi
-    sleep 2
     rm $PID_NAME
+    sleep 2
     exit 255
 }
 

--- a/initfiles/bin/init_sasha
+++ b/initfiles/bin/init_sasha
@@ -34,7 +34,6 @@ ulimit -n 8192
 which_pidof
 
 killed() {
-    rm -f ${SENTINEL}
     pid=`${PIDOF} saserver`
     if [ -n "$pid" ]; then
         sasha server=. action=stop
@@ -50,8 +49,7 @@ killed() {
             kill -9 $pid
         fi
     fi
-    rm $PID_NAME
-    sleep 2
+    kill_process ${SENTINEL} ${PID_NAME} 3
     exit 255
 }
 

--- a/initfiles/bin/init_sasha
+++ b/initfiles/bin/init_sasha
@@ -51,6 +51,7 @@ killed() {
         fi
     fi
     sleep 2
+    rm $PID_NAME
     exit 255
 }
 
@@ -58,6 +59,7 @@ trap "killed" SIGINT SIGTERM SIGKILL
 saserver 1>/dev/null 2>/dev/null &
 echo $! > $PID_NAME
 wait
+rm $PID_NAME
 
 while [ -e ${SENTINEL} ]; do
     sleep 5
@@ -65,5 +67,6 @@ while [ -e ${SENTINEL} ]; do
         saserver 1>/dev/null 2>/dev/null &
         echo $! > $PID_NAME
         wait
+        rm $PID_NAME
     fi
 done

--- a/initfiles/bin/init_thor
+++ b/initfiles/bin/init_thor
@@ -23,10 +23,13 @@ PID_NAME="$PID/`basename $PWD`.pid"
 INIT_PID_NAME="$PID/init_`basename $PWD`.pid"
 echo $$ > $INIT_PID_NAME
 
+export SENTINEL="thor.sentinel"
+rm -f ${SENTINEL}
+
 killed() {
         echo "Stopping"
         $deploydir/stop_thor $deploydir
-        rm $PID_NAME
+        kill_process ${SENTINEL} ${PID_NAME} 3
         exit 255
 }
 

--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -22,17 +22,31 @@
 
 ###<REPLACE>###
 
+function kill_process () {
+    SENTINEL=$1
+    PID=$2
+    TIMEOUT=$3
+    if [ -e $SENTINEL ]; then
+        rm -f $SENTINEL
+    fi
+    if [ -e $PID ]; then
+        pidwait_fn $PID $TIMEOUT
+    fi
+}
+
 function pidwait_fn () {
-        WATCH_PID=$1
-        TIMEOUT=$(($2*1000))
-        kill $WATCH_PID
-        while [ -d /proc/$WATCH_PID -a $TIMEOUT -gt 0 ]; do
-                sleep 0.2
-                TIMEOUT=$(($TIMEOUT-200))
-        done
-        if [ $TIMEOUT -le 0 ]; then
-                kill -9 $WATCH_PID
-        fi
+    PID=$1
+    WATCH_PID=`cat $PID`
+    TIMEOUT=$(($2*1000))
+    kill $WATCH_PID
+    while [ -d /proc/$WATCH_PID -a $TIMEOUT -gt 0 ]; do
+            sleep 0.2
+            TIMEOUT=$(($TIMEOUT-200))
+    done
+    if [ $TIMEOUT -le 0 ]; then
+            kill -9 $WATCH_PID
+    fi
+    rm -f $PID
 }
 
 platform='unknown'


### PR DESCRIPTION
If blocks in killed() were causing processes to not stop if
the sentinel file was not created.

Added removal of pid file on process ending following wait.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
