### PR TITLE
HPCC-8526 RtlDatasetBuilder wasn't updating self when it was reallocated

### DIFF
--- a/rtl/eclrtl/rtlds.cpp
+++ b/rtl/eclrtl/rtlds.cpp
@@ -63,16 +63,18 @@ void RtlDatasetBuilder::ensure(size32_t required)
     if (required > maxSize)
     {
         maxSize = getNextSize(maxSize, required);
-        buffer = (byte *)realloc(buffer, maxSize);
-        if (!buffer)
+        byte * newbuffer = (byte *)realloc(buffer, maxSize);
+        if (!newbuffer)
             throw MakeStringException(-1, "Failed to allocate temporary dataset (requesting %d bytes)", maxSize);
+        buffer = newbuffer;
     }
+    self = buffer + totalSize;
 }
 
 byte * RtlDatasetBuilder::ensureCapacity(size32_t required, const char * fieldName)
 {
     ensure(totalSize + required);
-    return buffer + totalSize;
+    return self; // self is updated by ensure()
 }
 
 void RtlDatasetBuilder::flushDataset()


### PR DESCRIPTION
Calls to RtlDatasetBuilder::ensureCapacity() were increasing the size of the
target buffer, but not updating the value of self.  This could lead to
accessing invalid memory and other chaos.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
