### PR TITLE
HPCC-8621 Reinstate typedef for hash64_t when compiling on windows

### DIFF
--- a/rtl/eclrtl/eclinclude.hpp
+++ b/rtl/eclrtl/eclinclude.hpp
@@ -55,6 +55,7 @@ typedef unsigned short UChar;
 
 #ifdef _WIN32
 typedef unsigned int size32_t; // avoid pulling in platform.h (which pulls in windows.h etc) just for this...
+typedef unsigned __int64 hash64_t;
 #else
 #include "platform.h"
 #endif


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
