### PR TITLE
HPCC-8605 - Ensure log files are recorded to the workunit

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -2343,6 +2343,8 @@ void CMasterGraph::executeSubGraph(size32_t parentExtractSz, const byte *parentE
             fatalHandler->clear();
     }
     fatalHandler.clear();
+    Owned<IWorkUnit> wu = &job.queryWorkUnit().lock();
+    queryJobManager().updateWorkUnitLog(*wu);
 }
 
 void CMasterGraph::sendGraph()

--- a/thorlcr/graph/thgraphmaster.hpp
+++ b/thorlcr/graph/thgraphmaster.hpp
@@ -53,6 +53,7 @@ interface IJobManager : extends IInterface
     virtual IDeMonServer *queryDeMonServer() = 0;
     virtual void fatal(IException *e) = 0;
     virtual void addCachedSo(const char *name) = 0;
+    virtual void updateWorkUnitLog(IWorkUnit &workunit) = 0;
 };
 
 interface ILoadedDllEntry;


### PR DESCRIPTION
If the log rollover to a new log file (at midnighg) during
a Thor job, only the initial log was recorded in the wuid.
Update at end of each subgraph.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
