### PR TITLE
HPCC-8537 Skip title line when parsing space usages in preflight

### DIFF
--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1174,6 +1174,7 @@ void Cws_machineEx::readStorageData(const char* response, CMachineInfoThreadPara
     if (!pStr)
         DBGLOG("Storage information not found on %s", pParam->m_machineData.getNetworkAddress());
 
+    bool isTitleLine = true;
     CIArrayOf<CStorageData>& storage = pParam->m_machineData.getStorage();
     while (pStr)
     {
@@ -1188,6 +1189,12 @@ void Cws_machineEx::readStorageData(const char* response, CMachineInfoThreadPara
         {
             buf.append(pStr);
             pStr = NULL;
+        }
+
+        if (isTitleLine)
+        {
+            isTitleLine = false;
+            continue;
         }
 
         if (buf.length() > 0)


### PR DESCRIPTION
Preflight result contains a Space Usage title line 'SpaceUsedAndFree'
indicating the section. The existing EclWatch Preflight function tries
to parse the line and generates a log line 'Invalid storage information
on x.x.x.x: ---SpaceUsedAndFree---', which confuses the log user. The
code in this fix skips the title line when parsing the preflight result.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
