### PR TITLE
HPCC-8626 Add new option GenerateFullFieldUsage

### DIFF
--- a/ecl/hql/hqlusage.hpp
+++ b/ecl/hql/hqlusage.hpp
@@ -63,20 +63,24 @@ public:
     inline void noteAll() { usedAll = true; }
     inline void noteFilepos() { usedFilepos = true; }
 
-    IHqlExpression * queryFilename() const;
+    const char * queryFilenameText() const;
     inline bool matches(IHqlExpression * search) const { return source == search; }
     inline bool seenAll() const { return usedAll; }
 
-    IPropertyTree * createReport() const;
+    IPropertyTree * createReport(bool includeFieldDetail, const IPropertyTree * exclude) const;
 
 protected:
-    void expandSelects(IPropertyTree * xml, IHqlExpression * record, IHqlExpression * selector, bool allUsed, unsigned & numFields, unsigned & numFieldsUsed) const;
+    void expandSelects(IPropertyTree * xml, IHqlExpression * record, IHqlExpression * selector, bool allUsed, bool includeFieldDetail, unsigned & numFields, unsigned & numFieldsUsed) const;
+    IHqlExpression * queryFilename() const;
 
 protected:
     LinkedHqlExpr source;
     HqlExprArray selects;
     bool usedAll;
     bool usedFilepos;
+
+private:
+    mutable StringAttr cachedFilenameEcl;
 };
 
 

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1705,6 +1705,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.implicitGroupHashAggregate,"implicitGroupHashAggregate",false),
         DebugOption(options.implicitGroupHashDedup,"implicitGroupHashDedup",false),
         DebugOption(options.reportFieldUsage,"reportFieldUsage",false),
+        DebugOption(options.reportFileUsage,"reportFileUsage",false),
         DebugOption(options.shuffleLocalJoinConditions,"shuffleLocalJoinConditions",false),
         DebugOption(options.projectNestedTables,"projectNestedTables",true),
         DebugOption(options.showSeqInGraph,"showSeqInGraph",false),  // For tracking down why projects are not commoned up

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -713,6 +713,7 @@ struct HqlCppOptions
     bool                implicitGroupHashAggregate;  // convert aggreate(sort(x,a),{..},a,d) to aggregate(group(sort(x,a),a_,{},d))
     bool                implicitGroupHashDedup;
     bool                reportFieldUsage;
+    bool                reportFileUsage;
     bool                shuffleLocalJoinConditions;
     bool                projectNestedTables;
     bool                showSeqInGraph;
@@ -904,7 +905,7 @@ public:
     void useFunction(IHqlExpression * funcdef);
     void useLibrary(const char * libname);
     void finalizeResources();
-    void generateStatistics(const char * targetDir);
+    void generateStatistics(const char * targetDir, const char * varient);
 
             unsigned getHints()                             { return hints; }
     inline  bool checkForRowOverflow() const                { return options.checkRowOverflow; }
@@ -943,6 +944,9 @@ public:
     //Either isIndependentMaybeShared is set - which case the item inserted into the initctx can have no dependencies
     //or isIndependentMaybeShared is false, and the code that is inserted is never implicitly shared.
     bool getInvariantMemberContext(BuildCtx & ctx, BuildCtx * * declarectx, BuildCtx * * initctx, bool isIndependentMaybeShared, bool invariantEachStart);
+
+    IPropertyTree * gatherFieldUsage(const char * varient, const IPropertyTree * exclude);
+    void writeFieldUsage(const char * targetDir, IPropertyTree * xml, const char * variant);
 
 public:
     BoundRow * bindSelf(BuildCtx & ctx, IHqlExpression * dataset, const char * builder);
@@ -1833,7 +1837,6 @@ protected:
     void initOptions();
     void postProcessOptions();
     SourceFieldUsage * querySourceFieldUsage(IHqlExpression * expr);
-    void reportFieldUsage(const char * filename);
     void noteAllFieldsUsed(IHqlExpression * expr);
 
 public:

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -6972,6 +6972,11 @@ ABoundActivity * HqlCppTranslator::doBuildActivityXmlRead(BuildCtx & ctx, IHqlEx
 
     buildInstancePrefix(instance);
 
+    //MORE: Improve when we support projecting xml instead of reading all
+    SourceFieldUsage * fieldUsage = querySourceFieldUsage(tableExpr);
+    if (fieldUsage && !fieldUsage->seenAll())
+        fieldUsage->noteAll();
+
     //---- virtual const char * getFileName() { return "x.d00"; } ----
     buildFilenameFunction(*instance, instance->startctx, "getFileName", filename, hasDynamicFilename(tableExpr));
     buildEncryptHelper(instance->startctx, tableExpr->queryProperty(encryptAtom));


### PR DESCRIPTION
Can be used in conjunction with reportFieldUsage and/or reportFileUsage
to gather dependency information for each field in a generated output.

reportFileUsage is a new abreviated version of reportFieldUsage which excludes
information on each individual field.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
