### PR TITLE
HPCC-8594 - Fix splitter activity timings + missing indexread timing

### DIFF
--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -691,6 +691,7 @@ public:
     }
     CATCH_NEXTROW()
     {
+        ActivityTimer t(totalCycles, timeActivities, NULL);
         if (eoi) 
             return NULL;
         if (RCMAX != keyedLimitCount)

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -263,9 +263,10 @@ unsigned __int64 CSlaveActivity::queryLocalCycles() const
                 break;
         }
     }
-    if (totalCycles < inputCycles) // not sure how/if possible, but guard against
+    unsigned __int64 _totalCycles = queryTotalCycles();
+    if (_totalCycles < inputCycles) // not sure how/if possible, but guard against
         return 0;
-    return totalCycles-inputCycles;
+    return _totalCycles-inputCycles;
 }
 
 unsigned __int64 CSlaveActivity::queryTotalCycles() const

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -70,7 +70,7 @@ public:
 
     unsigned __int64 &getTotalCyclesRef() { return totalCycles; }
     unsigned __int64 queryLocalCycles() const;
-    unsigned __int64 queryTotalCycles() const;
+    virtual unsigned __int64 queryTotalCycles() const; // some acts. may calculate accumulated total from inputs (e.g. splitter)
     virtual void serializeStats(MemoryBuffer &mb);
 };
 


### PR DESCRIPTION
timeMinMs/timeMaxMs were being accumulated based on an uninitialized
member variable, producing spurious results for splitter timings
and effecting the activity immediately downstream from the splitter.

Also, Indexread was accounting for activity timing in nextRow()

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
