### PR TITLE
HPCC-8637 - Make thorslave dali connection optional.

### DIFF
--- a/initfiles/componentfiles/configxml/thor.xsd.in
+++ b/initfiles/componentfiles/configxml/thor.xsd.in
@@ -147,6 +147,13 @@
                 </xs:appinfo>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="slaveDaliClient" type="xs:boolean" use="optional" default="false">
+              <xs:annotation>
+                <xs:appinfo>
+                  <tooltip>Set to true if thor slaves require dali connectivity</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
           </xs:complexType>
         </xs:element>
         <xs:element name="SwapNode">


### PR DESCRIPTION
Only register thor slaves with Dali if configuration option
defined (Debug/@slaveDaliClient)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
