### PR TITLE
HPCC-8413 Stepped join don't split results of previous graph iterations

### DIFF
--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -2577,6 +2577,8 @@ static bool isPotentialCompoundSteppedIndexRead(IHqlExpression * expr)
         case no_compound_indexread:
         case no_newkeyindex:
             return true;
+        case no_getgraphloopresult:
+            return true; // Could be an index read in another graph iteration, so don't combine
         case no_keyedlimit:
         case no_preload:
         case no_filter:


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
