### PR TITLE
HPCC-8655 Fix ESP crash when running WUGetDependancyTrees

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1586,7 +1586,7 @@ bool CWsWorkunitsEx::onWUGetDependancyTrees(IEspContext& context, IEspWUGetDepen
 
         MemoryBuffer temp;
         MemoryBuffer2IDataVal xmlresult(temp);
-        Owned<IConstWUResult> result = wu->getResultBySequence(0);
+        Owned<IConstWUResult> result = cw->getResultBySequence(0);
         if (result)
         {
             result->getResultRaw(xmlresult, NULL, NULL);


### PR DESCRIPTION
ESP crashes because the code uses a wu pointer which has been cleared.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
