### PR TITLE
HPCC-8633 Add mutex to control data access for preflight result

### DIFF
--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1414,6 +1414,8 @@ void Cws_machineEx::setMachineInfo(IEspContext& context, CMachineInfoThreadParam
         if (pParam->m_options.getGetSoftwareInfo() && process.getType() && strieq(process.getType(), eqEclAgent))
             pMachineInfo1.setown(static_cast<IEspMachineInfoEx*>(new CMachineInfoEx("")));
         setProcessInfo(context, pParam, response, error, process, idx<1, pMachineInfo, pMachineInfo1);
+
+        synchronized block(mutex_machine_info_table);
         pParam->m_machineInfoTable.append(*pMachineInfo.getLink());
         if (pMachineInfo1)
             pParam->m_machineInfoTable.append(*pMachineInfo1.getLink());

--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -714,6 +714,7 @@ private:
     set<string>                 m_excludePartitionPatterns;
     StringBuffer                m_machineInfoFile;
     BoolHash                    m_legacyFilters;
+    Mutex                       mutex_machine_info_table;
 };
 
 //---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Sometimes, ESP EclWatch crashes when doing a preflight on a big
dev environment. The core dump shows that the problem happens
inside Cws_machineEx::setMachineInfo() with double free memory.
When doing a preflight, WsMachine service creates multiple threads
(one thread per each target computer). Every thread will call the
setMachineInfo() and add its preflight result to a shared array of
result objects. This fix adds a mutex to synchronize the array
access. I did many tests after the fix and no crash happened in
those tests.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
