### PR TITLE
HPCC-8643 Fix memory leaks in ESP EclWatch services

### DIFF
--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -54,7 +54,7 @@ void Cws_accessEx::init(IPropertyTree *cfg, const char *process, const char *ser
         WARNLOG(-1, "config not found for service %s/%s",process, service);
         return;
     }
-    m_servicecfg.setown(LINK(servicecfg));
+    m_servicecfg.setown(servicecfg);
 
     /* Config is like -
     <Modules basedn="ou=le,ou=ecl,dc=le">

--- a/esp/services/ws_fileio/ws_fileioservice.cpp
+++ b/esp/services/ws_fileio/ws_fileioservice.cpp
@@ -47,7 +47,7 @@ bool CWsFileIOEx::CheckServerAccess(const char* server, const char* relPath, Str
 
     Owned<IPropertyTree> pEnvRoot = &env->getPTree();
     IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
-    IPropertyTree* pRoot = createPTreeFromXMLString("<Environment/>");
+    Owned<IPropertyTree> pRoot = createPTreeFromXMLString("<Environment/>");
     IPropertyTree* pSoftware = pRoot->addPropTree("Software", createPTree("Software"));
     if (pEnvSoftware && pSoftware)
     {

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -323,8 +323,12 @@ static void DeepAssign(IEspContext &context, IConstDFUWorkUnit *src, IEspDFUWork
                     info.setown(file->getFileDescriptor());
                     if(info)
                     {
-                        info->getNode(0)->endpoint().getIpText(socket);
-                        dest.setSourceIP(socket.str());
+                        Owned<INode> node = info->getNode(0);
+                        if (node)
+                        {
+                            node->endpoint().getIpText(socket);
+                            dest.setSourceIP(socket.str());
+                        }
                         const char *defaultdir = info->queryDefaultDir();
                         if (defaultdir&&*defaultdir) 
                             addPathSepChar(dir.append(defaultdir));
@@ -394,8 +398,12 @@ static void DeepAssign(IEspContext &context, IConstDFUWorkUnit *src, IEspDFUWork
                     info.setown(file->getFileDescriptor());
                     if(info)
                     {
-                        info->getNode(0)->endpoint().getIpText(socket);
-                        dest.setDestIP(socket.str());
+                        Owned<INode> node = info->getNode(0);
+                        if (node)
+                        {
+                            node->endpoint().getIpText(socket);
+                            dest.setDestIP(socket.str());
+                        }
                         const char *defaultdir = info->queryDefaultDir();
                         if (defaultdir&&*defaultdir) 
                             addPathSepChar(dir.append(defaultdir));
@@ -992,7 +1000,7 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
                 resultWU->setStateMessage(statemsg.str());
                 resultWU->setPercentDone(prog->getPercentDone());
             }
-            result.append(*LINK(resultWU.getClear()));
+            result.append(*resultWU.getLink());
             itr->next();
         }
 
@@ -1454,7 +1462,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                     res->setResult(failedMsg.str());
                 }
 
-                results.append(*LINK(res.getClear()));
+                results.append(*res.getLink());
             }
         }
         else if (!strcmp(action, "Restore"))
@@ -1509,7 +1517,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                 res->setAction("Restore");
                 res->setResult(msg.str());
 
-                results.append(*LINK(res.getClear()));
+                results.append(*res.getLink());
             }
         }
         else if(!strcmp(action, "Protect"))
@@ -1545,7 +1553,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                     res->setResult(failedMsg.str());
                 }
 
-                results.append(*LINK(res.getClear()));
+                results.append(*res.getLink());
             }
         }
         else if(!strcmp(action, "Unprotect"))
@@ -1581,7 +1589,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                     res->setResult(failedMsg.str());
                 }
 
-                results.append(*LINK(res.getClear()));
+                results.append(*res.getLink());
             }
         }
         else if(!strcmp(action, "SetToFailed"))
@@ -1619,7 +1627,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                     failedMsg.append(eMsg);
                     res->setResult(failedMsg.str());
                 }
-                results.append(*LINK(res.getClear()));
+                results.append(*res.getLink());
             }
         }
         else
@@ -1756,7 +1764,7 @@ bool CFileSprayEx::onGetDFUExceptions(IEspContext &context, IEspGetDFUExceptions
             resultE->setCode(e.errorCode());
             StringBuffer msg;
             resultE->setMessage(e.errorMessage(msg).str());
-            result.append(*LINK(resultE.getClear()));
+            result.append(*resultE.getLink());
             itr->next();
         }
 
@@ -2681,7 +2689,7 @@ int CFileSprayEx::doFileCheck(const char* mask, const char* netaddr, const char*
         Owned<IConstEnvironment> env = factory->openEnvironmentByFile();
         Owned<IPropertyTree> pEnvRoot = &env->getPTree();
         IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
-        IPropertyTree* pRoot = createPTreeFromXMLString("<Environment/>");
+        Owned<IPropertyTree> pRoot = createPTreeFromXMLString("<Environment/>");
         IPropertyTree* pSoftware = pRoot->addPropTree("Software", createPTree("Software"));
         if (pEnvSoftware && pSoftware)
         {
@@ -3226,7 +3234,7 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
                 res->setResult(failedMsg.str());
             }
 
-            results.append(*LINK(res.getClear()));
+            results.append(*res.getLink());
         }
 
         resp.setFirstColumn("File");

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -156,7 +156,7 @@ void Cws_machineEx::init(IPropertyTree *cfg, const char *process, const char *se
     if (!pEnvironmentRoot)
         throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
-    IPropertyTree* pEnvSettings = pEnvironmentRoot->getPropTree("EnvSettings");
+    Owned<IPropertyTree> pEnvSettings = pEnvironmentRoot->getPropTree("EnvSettings");
     if (pEnvSettings)
     {
         pEnvSettings->getProp("configs", environmentConfData.m_configsPath.clear());

--- a/esp/services/ws_machine/ws_machineServiceMetrics.cpp
+++ b/esp/services/ws_machine/ws_machineServiceMetrics.cpp
@@ -657,7 +657,7 @@ bool Cws_machineEx::onGetMetrics(IEspContext &context, IEspMetricsRequest &req,
                 ip[ip0 - ep] = 0;
             }
 
-            CMetricsParam* pMetricsParam = new CMetricsParam(ip);
+            Owned<CMetricsParam> pMetricsParam = new CMetricsParam(ip);
             Owned<IPropertyTreeIterator> metrics = endpoint.getElements("Metrics/Metric");
             ForEach(*metrics)
             {
@@ -705,7 +705,7 @@ bool Cws_machineEx::onGetMetrics(IEspContext &context, IEspMetricsRequest &req,
 
                 processValue(name, value, bShow, fieldInfoMap, pMetricsParam->m_fieldMap);
             }
-            fieldMapArray.append(*::LINK(pMetricsParam));
+            fieldMapArray.append(*pMetricsParam.getLink());
         }
 
         int count=fieldMapArray.ordinality();
@@ -774,7 +774,6 @@ bool Cws_machineEx::onGetMetrics(IEspContext &context, IEspMetricsRequest &req,
         }
 
         resp.setMetrics(xml);
-
 #endif
         double version = context.getClientVersion();
         if (version > 1.05)

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1018,7 +1018,9 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
         StringBuffer logDir;
         Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
-        constEnv->getPTree().getProp("EnvSettings/log", logDir);
+        Owned<IPropertyTree> logTree = &constEnv->getPTree();
+        if (logTree)
+             logTree->getProp("EnvSettings/log", logDir);
         if (logDir.length() > 0)
         {
             Owned<IStringIterator> debugs = cw->getLogs("Thor");

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -1549,7 +1549,7 @@ void CTpWrapper::getMachineList(double clientVersion,
 
         StringBuffer path;
         path.appendf("Software/ThorCluster[@name=\"%s\"]", clusterName);
-        IPropertyTree* cluster= root->getPropTree(path.str());
+        Owned<IPropertyTree> cluster= root->getPropTree(path.str());
         if (!cluster)
             throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -1570,11 +1570,11 @@ void CTpWrapper::getMachineList(double clientVersion,
             return;
 
         unsigned processNumber = 0;
-        INodeIterator &gi = *nodeGroup->getIterator();
-        ForEach(gi)
+        Owned<INodeIterator> gi = nodeGroup->getIterator();
+        ForEach(*gi)
         {
             StringBuffer netAddress;
-            gi.query().endpoint().getIpText(netAddress);
+            gi->query().endpoint().getIpText(netAddress);
             if (netAddress.length() == 0)
             {
                 WARNLOG("Net address not found for a node in node group %s", groupName.str());
@@ -1609,7 +1609,7 @@ void CTpWrapper::getMachineList(double clientVersion,
                         machineInfo.setAvailable("Unknown");
                         break;
                 }
-                IConstDomainInfo * pDomain = pMachineInfo->getDomain();
+                Owned<IConstDomainInfo> pDomain = pMachineInfo->getDomain();
                 if (pDomain != 0)
                 {
                     SCMStringBuffer sName;
@@ -1701,7 +1701,6 @@ void CTpWrapper::getMachineList(const char* MachineType,
                         machineInfo.setDirectory(Directory);
 
                     MachineList.append(machineInfo);
-
                 }
             } while (machines->next());
         }
@@ -1835,7 +1834,7 @@ void CTpWrapper::setMachineInfo(const char* name,const char* type,IEspTpMachine&
                     machine.setAvailable("Unknown");
                     break;
             }
-            IConstDomainInfo * pDomain = pMachineInfo->getDomain();
+            Owned<IConstDomainInfo> pDomain = pMachineInfo->getDomain();
             if (pDomain != 0)
             {
                 SCMStringBuffer sName;


### PR DESCRIPTION
Valgrind shows several memory leaks (4789 bytes in 63 blocks) when
running ESP EclWatch services. This fix solves the leaks in ESP
EclWatch services.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
