### PR TITLE
HPCC-8673 Fix memory leaks when running Get Roxie Metrics

### DIFF
--- a/common/roxiecommlib/roxiecommunicationclient.cpp
+++ b/common/roxiecommlib/roxiecommunicationclient.cpp
@@ -405,9 +405,9 @@ public:
                 if (strchr(ip.str(), ':') == 0)
                     ip.appendf(":%d", ROXIE_SERVER_PORT);
 
-                IPropertyTree *t = sendRoxieControlQuery(xpath.str(), false, ip.str());
+                Owned<IPropertyTree> t = sendRoxieControlQuery(xpath.str(), false, ip.str());
                 if (t)
-                    tree->addPropTree("Endpoint", t->queryPropTree("Endpoint"));
+                    tree->addPropTree("Endpoint", t->getBranch("Endpoint"));
             }
             return tree;
         }


### PR DESCRIPTION
Valgrind reported memory leaks when running EclWatch Get Roxie
Metrics. I found that the leaks happened inside roxiecommlib.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
