### PR TITLE
HPCC-1960 When trying to OUTPUT a file in a standalone I get an error

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -426,7 +426,7 @@ void CHThorDiskWriteActivity::resolve()
                 else
                     throw MakeStringException(99, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", lfn.str());
             }
-            else if (f->exists())
+            else if (f->exists() || agent.queryResolveFilesLocally())
             {
                 // special/local/external file
                 if (f->numParts()!=1)


### PR DESCRIPTION
Diskwrite activity in standalone mode incorrectly builds target filespec
if the specified file does not already exist. This fix ensures the correct
filespec is created in either case

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
