### PR TITLE
HPCC-8679 Add ecl cli support for specifying a repository snapshot

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -546,6 +546,8 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     if (iter.matchOption(optAttributePath, ECLOPT_MAIN) || iter.matchOption(optAttributePath, ECLOPT_MAIN_S))
         return EclCmdOptionMatch;
+    if (iter.matchOption(optSnapshot, ECLOPT_SNAPSHOT) || iter.matchOption(optSnapshot, ECLOPT_SNAPSHOT_S))
+        return EclCmdOptionMatch;
     if (iter.matchFlag(optNoArchive, ECLOPT_ECL_ONLY))
         return EclCmdOptionMatch;
     if (iter.matchOption(optResultLimit, ECLOPT_RESULT_LIMIT))

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -72,6 +72,8 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format
+#define ECLOPT_SNAPSHOT "--snapshot"
+#define ECLOPT_SNAPSHOT_S "-sn"
 #define ECLOPT_ECL_ONLY "--ecl-only"
 
 #define ECLOPT_WAIT "--wait"
@@ -214,6 +216,7 @@ public:
         EclCmdCommon::usage();
         fprintf(stdout,
             "   --main=<definition>    definition to use from legacy ECL repository\n"
+            "   --snapshot,-sn=<label> snapshot label to use from legacy ECL repository\n"
             "   --ecl-only             send ecl text to hpcc without generating archive\n"
             "   --limit=<limit>        sets the result limit for the query, defaults to 100\n"
             "   -f<option>[=value]     set an ECL option (equivalent to #option)\n"
@@ -230,6 +233,7 @@ public:
     StringBuffer optImpPath;
     StringAttr optManifest;
     StringAttr optAttributePath;
+    StringAttr optSnapshot;
     IArrayOf<IEspNamedValue> debugValues;
     unsigned optResultLimit;
     bool optNoArchive;

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -181,6 +181,8 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
         req->setResultLimit(cmd.optResultLimit);
     if (cmd.optAttributePath.length())
         req->setQueryMainDefinition(cmd.optAttributePath);
+    if (cmd.optSnapshot.length())
+        req->setSnapshot(cmd.optSnapshot);
     if (cmd.debugValues.length())
     {
         req->setDebugValues(cmd.debugValues);

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -306,6 +306,7 @@ ESPrequest [nil_remove] WUDeployWorkunitRequest
     binary Object;
     int ResultLimit;
     string QueryMainDefinition;
+    string Snapshot;
     ESParray<ESPstruct NamedValue> DebugValues;
 };
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3707,6 +3707,8 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
     }
     if (req.getQueryMainDefinition())
         wu.setQueryMain(req.getQueryMainDefinition());
+    if (req.getSnapshot())
+        wu->setSnapshot(req.getSnapshot());
     if (!req.getResultLimit_isNull())
         wu->setResultLimit(req.getResultLimit());
 

--- a/initfiles/etc/bash_completion/ecl
+++ b/initfiles/etc/bash_completion/ecl
@@ -150,7 +150,7 @@ _ecl_opts_packagemap()
 
 _ecl_opts_deploy()
 {
-    echo -n "-t= --target= -n= --name= --main= --ecl-only --limit= "
+    echo -n "-t= --target= -n= --name= --main= --ecl-only --limit= --snapshot= -sn="
     echo -n "--wait= --manifest= "
 }
 


### PR DESCRIPTION
Add --snapshot=<label> and -sn=<label> options to the ecl command line
to specify which repository label to use when compiling
ecl from a legacy ecl source repository.

Can be used with ecl-deploy, ecl-run, ecl-publish.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
