### PR TITLE
HPCC-8678 Add ecl cli support for adding comments published queries

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -82,6 +82,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_MEMORY_LIMIT "--memoryLimit"
 #define ECLOPT_WARN_TIME_LIMIT "--warnTimeLimit"
 #define ECLOPT_PRIORITY "--priority"
+#define ECLOPT_COMMENT "--comment"
 
 #define ECLOPT_RESULT_LIMIT "--limit"
 #define ECLOPT_RESULT_LIMIT_INI "resultLimit"

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -339,6 +339,8 @@ public:
                 continue;
             if (iter.matchOption(optPriority, ECLOPT_PRIORITY))
                 continue;
+            if (iter.matchOption(optComment, ECLOPT_COMMENT))
+                continue;
             if (iter.matchFlag(optNoActivate, ECLOPT_NO_ACTIVATE))
             {
                 activateSet=true;
@@ -417,6 +419,8 @@ public:
             req->setMemoryLimit(optMemoryLimit);
         if (!optPriority.isEmpty())
             req->setPriority(optPriority);
+        if (optComment.get()) //allow empty
+            req->setComment(optComment);
 
         Owned<IClientWUPublishWorkunitResponse> resp = client->WUPublishWorkunit(req);
         const char *id = resp->getQueryId();
@@ -466,6 +470,7 @@ public:
             "                          format <mem> as 500000B, 550K, 100M, 10G, 1T etc.\n"
             "   --priority=<val>       set the priority for this query. Value can be LOW,\n"
             "                          HIGH, SLA, NONE. NONE will clear current setting.\n"
+            "   --comment=<string>     Set the comment associated with this query\n"
             "   --wait=<ms>            Max time to wait in milliseconds\n",
             stdout);
         EclCmdWithEclTarget::usage();
@@ -475,6 +480,7 @@ private:
     StringAttr optDaliIP;
     StringAttr optMemoryLimit;
     StringAttr optPriority;
+    StringAttr optComment;
     unsigned optMsToWait;
     unsigned optTimeLimit;
     unsigned optWarnTimeLimit;

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -204,6 +204,12 @@ public:
                 line.appendN(53 - line.length(), ' ');
             line.append(' ').append(query.getMemoryLimit());
         }
+        if (query.getComment())
+        {
+            if (line.length() < 64)
+                line.appendN(64 - line.length(), ' ');
+            line.append(' ').append(query.getComment());
+        }
         fputs(line.append('\n').str(), stdout);
     }
 
@@ -213,9 +219,9 @@ public:
         if (qs.getQuerySetName())
             fprintf(stdout, "\nQuerySet: %s\n", qs.getQuerySetName());
         fputs("\n", stdout);
-        fputs("                                   Time   Warn   Pri  Memory\n", stdout);
-        fputs("Flags Query Id                     Limit  Limit       Limit\n", stdout);
-        fputs("----- ---------------------------- ------ ------ ---- ----------\n", stdout);
+        fputs("                                   Time   Warn        Memory\n", stdout);
+        fputs("Flags Query Id                     Limit  Limit  Pri  Limit      Comment\n", stdout);
+        fputs("----- ---------------------------- ------ ------ ---- ---------- ------------\n", stdout);
 
         IArrayOf<IConstQuerySetQuery> &queries = qs.getQueries();
         ForEachItemIn(id, queries)
@@ -329,6 +335,8 @@ public:
                 continue;
             if (iter.matchOption(optPriority, ECLOPT_PRIORITY))
                 continue;
+            if (iter.matchOption(optComment, ECLOPT_COMMENT))
+                continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }
@@ -389,6 +397,8 @@ public:
             req->setMemoryLimit(optMemoryLimit);
         if (!optPriority.isEmpty())
             req->setPriority(optPriority);
+        if (optComment.get()) //allow empty
+            req->setComment(optComment);
 
         Owned<IClientWUQuerySetCopyQueryResponse> resp = client->WUQuerysetCopyQuery(req);
         if (resp->getExceptions().ordinality())
@@ -430,6 +440,7 @@ public:
             "                          format <mem> as 500000B, 550K, 100M, 10G, 1T etc.\n"
             "   --priority=<val>       set the priority for this query. Value can be LOW,\n"
             "                          HIGH, SLA, NONE. NONE will clear current setting.\n"
+            "   --comment=<string>     Set the comment associated with this query\n"
             " Common Options:\n",
             stdout);
         EclCmdCommon::usage();
@@ -441,6 +452,7 @@ private:
     StringAttr optDaliIP;
     StringAttr optMemoryLimit;
     StringAttr optPriority;
+    StringAttr optComment;
     unsigned optMsToWait;
     unsigned optTimeLimit;
     unsigned optWarnTimeLimit;
@@ -494,6 +506,8 @@ public:
                 continue;
             if (iter.matchOption(optPriority, ECLOPT_PRIORITY))
                 continue;
+            if (iter.matchOption(optComment, ECLOPT_COMMENT))
+                continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }
@@ -543,6 +557,8 @@ public:
             req->setMemoryLimit(optMemoryLimit);
         if (!optPriority.isEmpty())
             req->setPriority(optPriority);
+        if (optComment.get()) //allow empty
+            req->setComment(optComment);
 
         Owned<IClientWUQueryConfigResponse> resp = client->WUQueryConfig(req);
         if (resp->getExceptions().ordinality())
@@ -575,6 +591,7 @@ public:
             "                          format <mem> as 500000B, 550K, 100M, 10G, 1T etc.\n"
             "   --priority=<val>       set the priority for this query. Value can be LOW,\n"
             "                          HIGH, SLA, NONE. NONE will clear current setting.\n"
+            "   --comment=<string>     Set the comment associated with this query\n"
             " Common Options:\n",
             stdout);
         EclCmdCommon::usage();
@@ -584,6 +601,7 @@ private:
     StringAttr optQueryId;
     StringAttr optMemoryLimit;
     StringAttr optPriority;
+    StringAttr optComment;
     unsigned optMsToWait;
     unsigned optTimeLimit;
     unsigned optWarnTimeLimit;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1072,6 +1072,7 @@ ESPrequest [nil_remove] WUPublishWorkunitRequest
     nonNegativeInteger WarnTimeLimit(0);
     string Priority;
     string RemoteDali;
+    string Comment;
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse
@@ -1097,6 +1098,7 @@ ESPrequest [nil_remove] WUQueryConfigRequest
     nonNegativeInteger TimeLimit(0);
     nonNegativeInteger WarnTimeLimit(0);
     string Priority;
+    string Comment;
 };
 
 ESPStruct WUQueryConfigResult
@@ -1144,6 +1146,7 @@ ESPStruct [nil_remove] QuerySetQuery
     nonNegativeInteger timeLimit;
     nonNegativeInteger warnTimeLimit;
     string priority;
+    string Comment;
 };
 
 ESPStruct QuerySetAlias
@@ -1294,6 +1297,7 @@ ESPrequest [nil_remove] WUQuerySetCopyQueryRequest
     nonNegativeInteger TimeLimit(0);
     nonNegativeInteger WarnTimeLimit(0);
     string priority;
+    string Comment;
 };
 
 ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -531,13 +531,15 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
     StringBuffer queryId;
     WUQueryActivationOptions activate = (WUQueryActivationOptions)req.getActivate();
     addQueryToQuerySet(wu, target.str(), queryName.str(), NULL, activate, queryId);
-    if (req.getMemoryLimit() || !req.getTimeLimit_isNull() || !req.getWarnTimeLimit_isNull() || req.getPriority())
+    if (req.getMemoryLimit() || !req.getTimeLimit_isNull() || !req.getWarnTimeLimit_isNull() || req.getPriority() || req.getComment())
     {
         Owned<IPropertyTree> queryTree = getQueryById(target.str(), queryId, false);
         updateMemoryLimitSetting(queryTree, req.getMemoryLimit());
         updateQuerySetting(req.getTimeLimit_isNull(), queryTree, "@timeLimit", req.getTimeLimit());
         updateQuerySetting(req.getWarnTimeLimit_isNull(), queryTree, "@warnTimeLimit", req.getWarnTimeLimit());
         updateQueryPriority(queryTree, req.getPriority());
+        if (req.getComment())
+            queryTree->setProp("@comment", req.getComment());
     }
     wu->commit();
     wu.clear();
@@ -603,6 +605,8 @@ void gatherQuerySetQueryDetails(IPropertyTree *query, IEspQuerySetQuery *queryIn
         queryInfo->setWarnTimeLimit(query->getPropInt("@warnTimeLimit"));
     if (query->hasProp("@priority"))
         queryInfo->setPriority(getQueryPriorityName(query->getPropInt("@priority")));
+    if (query->hasProp("@comment"))
+        queryInfo->setComment(query->queryProp("@comment"));
     if (queriesOnCluster)
     {
         IArrayOf<IEspClusterQueryState> clusters;
@@ -934,6 +938,8 @@ bool CWsWorkunitsEx::onWUQueryConfig(IEspContext &context, IEspWUQueryConfigRequ
             updateQueryPriority(queryTree, req.getPriority());
             updateQuerySetting(req.getTimeLimit_isNull(), queryTree, "@timeLimit", req.getTimeLimit());
             updateQuerySetting(req.getWarnTimeLimit_isNull(), queryTree, "@warnTimeLimit", req.getWarnTimeLimit());
+            if (req.getComment())
+                queryTree->setProp("@comment", req.getComment());
         }
 
         results.append(*result.getClear());
@@ -1154,6 +1160,8 @@ bool CWsWorkunitsEx::onWUQuerysetCopyQuery(IEspContext &context, IEspWUQuerySetC
         updateQueryPriority(queryTree, req.getPriority());
         updateQuerySetting(req.getTimeLimit_isNull(), queryTree, "@timeLimit", req.getTimeLimit());
         updateQuerySetting(req.getWarnTimeLimit_isNull(), queryTree, "@warnTimeLimit", req.getWarnTimeLimit());
+        if (req.getComment())
+            queryTree->setProp("@comment", req.getComment());
     }
     wu.clear();
 


### PR DESCRIPTION
--comment option will add a comment string to a published query.

Can be used with ecl-publish, ecl-queries-copy, and
ecl-queries-config, and will display via ecl-queries-list.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
