### PR TITLE
HPCC-8631 Added library for dynamic apr access

### DIFF
--- a/system/security/dynapr/CMakeLists.txt
+++ b/system/security/dynapr/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-#    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+#    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/system/security/dynapr/CMakeLists.txt
+++ b/system/security/dynapr/CMakeLists.txt
@@ -13,12 +13,34 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ################################################################################
-IF (USE_OPENLDAP)
-HPCC_ADD_SUBDIRECTORY (LdapSecurity)
-ENDIF(USE_OPENLDAP)
-HPCC_ADD_SUBDIRECTORY (securesocket)
-HPCC_ADD_SUBDIRECTORY (test "PLATFORM")
-if (USE_ZLIB)
-  HPCC_ADD_SUBDIRECTORY (zcrypt "PLATFORM")
-endif()
-HPCC_ADD_SUBDIRECTORY (dynapr "PLATFORM")
+
+
+# Component: dynapr
+#####################################################
+# Description:
+# ------------
+#    Cmake Input File for dynapr
+#####################################################
+
+project( dynapr )
+
+set (    SRCS
+         apr.cpp
+         aprshared.cpp
+         apushared.cpp
+         dynshared.cpp
+    )
+
+include_directories (
+         .
+         ./../../include
+         ./../../jlib
+    )
+
+ADD_DEFINITIONS( -DDYNAPR_EXPORTS -D_USRDLL )
+
+HPCC_ADD_LIBRARY( dynapr SHARED ${SRCS} )
+install ( TARGETS dynapr RUNTIME DESTINATION ${EXEC_DIR} LIBRARY DESTINATION ${LIB_DIR} )
+target_link_libraries ( dynapr
+         jlib
+    )

--- a/system/security/dynapr/apr.cpp
+++ b/system/security/dynapr/apr.cpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/system/security/dynapr/apr.cpp
+++ b/system/security/dynapr/apr.cpp
@@ -26,6 +26,17 @@
 #define MAX_STRING_LEN 256
 #define SALT_LEN 9
 
+MODULE_INIT(INIT_PRIORITY_STANDARD)
+{
+    newAprObject();
+    return true;
+}
+
+MODULE_EXIT()
+{
+    destroyAprObject();
+}
+
 Apr::Apr()
 {
     setName("Apr");
@@ -94,6 +105,22 @@ extern "C"
 {
     DYNAPR_API Apr * newAprObject()
     {
-        return new Apr();
+        if (slock.lock())
+        {
+            if (!aprInt)
+                aprInt = new Apr();
+            slock.unlock();
+        }
+        return aprInt;
+    }
+
+    DYNAPR_API void destroyAprObject()
+    {
+        if (slock.lock())
+        {
+            delete aprInt;
+            aprInt = NULL;
+            slock.unlock();
+        }
     }
 }

--- a/system/security/dynapr/apr.cpp
+++ b/system/security/dynapr/apr.cpp
@@ -37,26 +37,18 @@ MODULE_EXIT()
     destroyAprObject();
 }
 
-Apr::Apr()
-{
-    setName("Apr");
-    setInit(false);
-}
-
 Apr::~Apr()
 {
-    if (queryInit())
+    if (init_s)
         apr->apr_terminate();
 }
 
 void Apr::init()
 {
-    AprShared *apr_s = new AprShared();
-    ApuShared *apu_s = new ApuShared();
-    apr_s->init();
-    apu_s->init();
-    apr.setown(apr_s);
-    apu.setown(apu_s);
+    apr.setown(new AprShared());
+    apu.setown(new ApuShared());
+    apr->init();
+    apu->init();
     apr->apr_initialize();
     setInit(true);
 }
@@ -66,7 +58,7 @@ void Apr::apr_md5_string(StringBuffer& inpstring, StringBuffer& outstring)
     checkInit();
     char salt[SALT_LEN];
     char saltedAprMd5[MAX_STRING_LEN];
-    rand_salt(salt);
+    rand_salt_string(salt, SALT_LEN);
     apu->apr_md5_encode(inpstring.str(), salt, saltedAprMd5, sizeof(saltedAprMd5));
     outstring.append(saltedAprMd5);
 }
@@ -86,20 +78,22 @@ apr_ret_t Apr::apr_md5_validate(StringBuffer& inpstring, StringBuffer& aprmd5str
     }
 }
 
-void Apr::rand_salt(char * const salt)
+void Apr::rand_salt_string(char * salt, int saltLen)
 {
     int rv;
-    char intSalt[SALT_LEN];
+    char intSalt[saltLen];
     char *b64Salt;
-    int len = apu->apr_base64_encode_len(SALT_LEN);
-    b64Salt = (char*) malloc(len * sizeof(char*));
-    apu->apr_base64_encode(b64Salt, intSalt, SALT_LEN);
-    rv = apu->apr_generate_random_bytes((unsigned char*) intSalt, SALT_LEN - 1);
-    intSalt[SALT_LEN - 1] = '\0';
-    apu->apr_base64_encode(b64Salt, intSalt, SALT_LEN);
-    apu->apr_cpystrn(salt, b64Salt, SALT_LEN);
+    int len = apu->apr_base64_encode_len(saltLen);
+    b64Salt = (char*) malloc(len * sizeof(char));
+    rv = apu->apr_generate_random_bytes((unsigned char*) intSalt, saltLen);
+    intSalt[SALT_LEN] = '\0';
+    apu->apr_base64_encode(b64Salt, intSalt, saltLen);
+    apu->apr_cpystrn(salt, b64Salt, saltLen);
     free(b64Salt);
 }
+
+static Apr *aprInt = NULL;
+static CSingletonLock slock;
 
 extern "C"
 {

--- a/system/security/dynapr/apr.cpp
+++ b/system/security/dynapr/apr.cpp
@@ -1,0 +1,99 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "apr.hpp"
+
+#include "jlib.hpp"
+#include "jstring.hpp"
+#include "dynshared.hpp"
+#include "aprshared.hpp"
+#include "apushared.hpp"
+
+#define MAX_STRING_LEN 256
+#define SALT_LEN 9
+
+Apr::Apr()
+{
+    setName("Apr");
+    setInit(false);
+}
+
+Apr::~Apr()
+{
+    if (queryInit())
+        apr->apr_terminate();
+}
+
+void Apr::init()
+{
+    AprShared *apr_s = new AprShared();
+    ApuShared *apu_s = new ApuShared();
+    apr_s->init();
+    apu_s->init();
+    apr.setown(apr_s);
+    apu.setown(apu_s);
+    apr->apr_initialize();
+    setInit(true);
+}
+
+void Apr::apr_md5_string(StringBuffer& inpstring, StringBuffer& outstring)
+{
+    checkInit();
+    char salt[SALT_LEN];
+    char saltedAprMd5[MAX_STRING_LEN];
+    rand_salt(salt);
+    apu->apr_md5_encode(inpstring.str(), salt, saltedAprMd5, sizeof(saltedAprMd5));
+    outstring.append(saltedAprMd5);
+}
+
+apr_ret_t Apr::apr_md5_validate(StringBuffer& inpstring, StringBuffer& aprmd5string)
+{
+    checkInit();
+    int result;
+    result = apu->apr_password_validate(inpstring.str(), aprmd5string.str());
+    if (result == 0)
+    {
+        return APR_MD5_TRUE;
+    }
+    else
+    {
+        return APR_MD5_FALSE;
+    }
+}
+
+void Apr::rand_salt(char * const salt)
+{
+    int rv;
+    char intSalt[SALT_LEN];
+    char *b64Salt;
+    int len = apu->apr_base64_encode_len(SALT_LEN);
+    b64Salt = (char*) malloc(len * sizeof(char*));
+    apu->apr_base64_encode(b64Salt, intSalt, SALT_LEN);
+    rv = apu->apr_generate_random_bytes((unsigned char*) intSalt, SALT_LEN - 1);
+    intSalt[SALT_LEN - 1] = '\0';
+    apu->apr_base64_encode(b64Salt, intSalt, SALT_LEN);
+    apu->apr_cpystrn(salt, b64Salt, SALT_LEN);
+    free(b64Salt);
+}
+
+extern "C"
+{
+    DYNAPR_API Apr * newAprObject()
+    {
+        return new Apr();
+    }
+}

--- a/system/security/dynapr/apr.hpp
+++ b/system/security/dynapr/apr.hpp
@@ -50,7 +50,7 @@ class DYNAPR_API Apr : public CInterface, public DynInit
 {
 public:
     IMPLEMENT_IINTERFACE;
-    Apr();
+    Apr() :  DynInit("Apr") {}
     virtual ~Apr();
     void init();
     void apr_md5_string(StringBuffer& inpstring, StringBuffer& outstring);
@@ -60,12 +60,9 @@ private:
     Owned<AprShared> apr;
     Owned<ApuShared> apu;
 
-    void rand_salt(char * const salt);
+    void rand_salt_string(char * salt, int saltLen);
 
 };
-
-static Apr *aprInt = NULL;
-static CSingletonLock slock;
 
 extern "C" DYNAPR_API Apr * newAprObject();
 extern "C" DYNAPR_API void destroyAprObject();

--- a/system/security/dynapr/apr.hpp
+++ b/system/security/dynapr/apr.hpp
@@ -19,6 +19,7 @@
 #define APR_H
 
 #include "jlib.hpp"
+#include "jmutex.hpp"
 #include "jstring.hpp"
 #include "dynshared.hpp"
 #include "aprshared.hpp"
@@ -63,6 +64,10 @@ private:
 
 };
 
+static Apr *aprInt = NULL;
+static CSingletonLock slock;
+
 extern "C" DYNAPR_API Apr * newAprObject();
+extern "C" DYNAPR_API void destroyAprObject();
 
 #endif

--- a/system/security/dynapr/apr.hpp
+++ b/system/security/dynapr/apr.hpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/system/security/dynapr/apr.hpp
+++ b/system/security/dynapr/apr.hpp
@@ -1,0 +1,68 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef APR_H
+#define APR_H
+
+#include "jlib.hpp"
+#include "jstring.hpp"
+#include "dynshared.hpp"
+#include "aprshared.hpp"
+#include "apushared.hpp"
+
+#ifndef DYNAPR_API
+#    ifdef _WIN32
+#        ifndef DYNAPR_EXPORTS
+#            define DYNAPR_API __declspec(dllimport)
+#        else
+#            define DYNAPR_API __declspec(dllexport)
+#        endif
+#    else
+#        define DYNAPR_API
+#    endif
+#endif
+
+
+enum apr_enum {
+    APR_MD5_NULL=-1,
+    APR_MD5_FALSE=0,
+    APR_MD5_TRUE=1
+};
+
+typedef apr_enum apr_ret_t;
+
+class DYNAPR_API Apr : public CInterface, public DynInit
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    Apr();
+    virtual ~Apr();
+    void init();
+    void apr_md5_string(StringBuffer& inpstring, StringBuffer& outstring);
+    apr_ret_t apr_md5_validate(StringBuffer& inpstring, StringBuffer& aprmd5string);
+
+private:
+    Owned<AprShared> apr;
+    Owned<ApuShared> apu;
+
+    void rand_salt(char * const salt);
+
+};
+
+extern "C" DYNAPR_API Apr * newAprObject();
+
+#endif

--- a/system/security/dynapr/aprshared.cpp
+++ b/system/security/dynapr/aprshared.cpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/system/security/dynapr/aprshared.cpp
+++ b/system/security/dynapr/aprshared.cpp
@@ -22,12 +22,10 @@
 #include "jutil.hpp"
 #include "dynshared.hpp"
 
-AprShared::AprShared()
+AprShared::AprShared() : DynInit("AprShared")
 {
-    setName("AprShared");
     lib_name.append(SharedObjectPrefix).append(APR).append(SharedObjectExtension);
     so = new SharedObject();
-    setInit(false);
 }
 
 void AprShared::init()

--- a/system/security/dynapr/aprshared.cpp
+++ b/system/security/dynapr/aprshared.cpp
@@ -1,0 +1,54 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "aprshared.hpp"
+#include "jlib.hpp"
+#include "jstring.hpp"
+#include "jexcept.hpp"
+#include "jutil.hpp"
+#include "dynshared.hpp"
+
+AprShared::AprShared()
+{
+    setName("AprShared");
+    lib_name.append(SharedObjectPrefix).append(APR).append(SharedObjectExtension);
+    so = new SharedObject();
+    setInit(false);
+}
+
+void AprShared::init()
+{
+    if( !so->load(lib_name, true))
+    {
+        throw MakeStringException(-1, "load %s failed with code %d", lib_name.str(), GetSharedObjectError());
+    }
+    hndl = so->getInstanceHandle();
+    _initialize.setown(new SharedObjectFunction<apr_initialize_t>(hndl, "apr_initialize"));
+    _terminate.setown(new SharedObjectFunction<apr_terminate_t>(hndl, "apr_terminate"));
+    setInit(true);
+}
+int AprShared::apr_initialize()
+{
+    checkInit();
+    return (_initialize->getFuncPtr())();
+}
+
+int AprShared::apr_terminate()
+{
+    checkInit();
+    return (_terminate->getFuncPtr())();
+}

--- a/system/security/dynapr/aprshared.hpp
+++ b/system/security/dynapr/aprshared.hpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/system/security/dynapr/aprshared.hpp
+++ b/system/security/dynapr/aprshared.hpp
@@ -1,0 +1,54 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef APRSHARED_H
+#define APRSHARED_H
+
+#include "jlib.hpp"
+#include "jstring.hpp"
+#include "jutil.hpp"
+#include "dynshared.hpp"
+
+#define APR "apr-1"
+
+typedef int (*apr_initialize_t)(void);
+typedef int (*apr_terminate_t)(void);
+
+class AprShared : public CInterface, public DynInit
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    AprShared();
+    void init();
+    virtual ~AprShared()
+    {
+        delete so;
+    }
+
+    int apr_initialize();
+    int apr_terminate();
+
+private:
+    SharedObject *so;
+    HINSTANCE hndl;
+    StringBuffer lib_name;
+    Owned<SharedObjectFunction<apr_initialize_t> > _initialize;
+    Owned<SharedObjectFunction<apr_terminate_t> > _terminate;
+
+};
+
+#endif

--- a/system/security/dynapr/apushared.cpp
+++ b/system/security/dynapr/apushared.cpp
@@ -22,12 +22,10 @@
 #include "jutil.hpp"
 #include "dynshared.hpp"
 
-ApuShared::ApuShared()
+ApuShared::ApuShared() : DynInit("ApuShared")
 {
-    setName("ApuShared");
     lib_name.append(SharedObjectPrefix).append(APRUTIL).append(SharedObjectExtension);
     so = new SharedObject();
-    setInit(false);
 }
 
 void ApuShared::init()

--- a/system/security/dynapr/apushared.cpp
+++ b/system/security/dynapr/apushared.cpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/system/security/dynapr/apushared.cpp
+++ b/system/security/dynapr/apushared.cpp
@@ -1,0 +1,83 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "apushared.hpp"
+#include "jlib.hpp"
+#include "jstring.hpp"
+#include "jexcept.hpp"
+#include "jutil.hpp"
+#include "dynshared.hpp"
+
+ApuShared::ApuShared()
+{
+    setName("ApuShared");
+    lib_name.append(SharedObjectPrefix).append(APRUTIL).append(SharedObjectExtension);
+    so = new SharedObject();
+    setInit(false);
+}
+
+void ApuShared::init()
+{
+    if( !so->load(lib_name, true) )
+    {
+        throw MakeStringException(-1, "load %s failed with code %d", lib_name.str(), GetSharedObjectError());
+    }
+    hndl = so->getInstanceHandle();
+    _generate_random_bytes.setown(new SharedObjectFunction<apr_generate_random_bytes_t>(hndl, "apr_generate_random_bytes"));
+    _base64_encode_len.setown(new SharedObjectFunction<apr_base64_encode_len_t>(hndl, "apr_base64_encode_len"));
+    _base64_encode.setown(new SharedObjectFunction<apr_base64_encode_t>(hndl, "apr_base64_encode"));
+    _md5_encode.setown(new SharedObjectFunction<apr_md5_encode_t>(hndl, "apr_md5_encode"));
+    _password_validate.setown(new SharedObjectFunction<apr_password_validate_t>(hndl, "apr_password_validate"));
+    _cpystrn.setown(new SharedObjectFunction<apr_cpystrn_t>(hndl, "apr_cpystrn"));
+    setInit(true);
+}
+
+int ApuShared::apr_generate_random_bytes(unsigned char* a1, size_t a2)
+{
+    checkInit();
+    return (_generate_random_bytes->getFuncPtr())(a1, a2);
+}
+
+int ApuShared::apr_base64_encode_len(int a1)
+{
+    checkInit();
+    return (_base64_encode_len->getFuncPtr())(a1);
+}
+
+int ApuShared::apr_base64_encode(char* a1, const char* a2, int a3)
+{
+    checkInit();
+    return (_base64_encode->getFuncPtr())(a1,a2,a3);
+}
+
+int ApuShared::apr_md5_encode(const char* a1, const char* a2, char* a3, size_t a4)
+{
+    checkInit();
+    return (_md5_encode->getFuncPtr())(a1,a2,a3,a4);
+}
+
+int ApuShared::apr_password_validate(const char* a1, const char* a2)
+{
+    checkInit();
+    return (_password_validate->getFuncPtr())(a1,a2);
+}
+
+char* ApuShared::apr_cpystrn(char* a1, const char* a2, size_t a3)
+{
+    checkInit();
+    return (_cpystrn->getFuncPtr())(a1,a2,a3);
+}

--- a/system/security/dynapr/apushared.hpp
+++ b/system/security/dynapr/apushared.hpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/system/security/dynapr/apushared.hpp
+++ b/system/security/dynapr/apushared.hpp
@@ -1,0 +1,67 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef APUSHARED_H
+#define APUSHARED_H
+
+#include "jlib.hpp"
+#include "jstring.hpp"
+#include "jutil.hpp"
+#include "dynshared.hpp"
+
+#define APRUTIL "aprutil-1"
+
+typedef int (*apr_generate_random_bytes_t)(unsigned char*, size_t);
+typedef int (*apr_base64_encode_len_t)(int);
+typedef int (*apr_base64_encode_t)(char*, const char*, int);
+typedef int (*apr_md5_encode_t)(const char*, const char*, char*, size_t);
+typedef int (*apr_password_validate_t)(const char*, const char*);
+typedef char* (*apr_cpystrn_t)(char*, const char*, size_t);
+
+class ApuShared : public CInterface, public DynInit
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    ApuShared();
+    void init();
+    virtual ~ApuShared()
+    {
+        delete so;
+    }
+
+    int apr_generate_random_bytes(unsigned char* a1, size_t a2);
+    int apr_base64_encode_len(int a1);
+    int apr_base64_encode(char* a1, const char* a2, int a3);
+    int apr_md5_encode(const char* a1, const char* a2, char* a3, size_t a4);
+    int apr_password_validate(const char* a1, const char* a2);
+    char* apr_cpystrn(char* a1, const char* a2, size_t a3);
+
+private:
+    SharedObject *so;
+    HINSTANCE hndl;
+    bool init_s;
+    StringBuffer lib_name;
+    Owned<SharedObjectFunction<apr_generate_random_bytes_t> > _generate_random_bytes;
+    Owned<SharedObjectFunction<apr_base64_encode_len_t> > _base64_encode_len;
+    Owned<SharedObjectFunction<apr_base64_encode_t> > _base64_encode;
+    Owned<SharedObjectFunction<apr_md5_encode_t> > _md5_encode;
+    Owned<SharedObjectFunction<apr_password_validate_t> > _password_validate;
+    Owned<SharedObjectFunction<apr_cpystrn_t> > _cpystrn;
+
+};
+
+#endif

--- a/system/security/dynapr/dynshared.cpp
+++ b/system/security/dynapr/dynshared.cpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/system/security/dynapr/dynshared.cpp
+++ b/system/security/dynapr/dynshared.cpp
@@ -1,0 +1,18 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "dynshared.hpp"

--- a/system/security/dynapr/dynshared.hpp
+++ b/system/security/dynapr/dynshared.hpp
@@ -25,11 +25,17 @@
 class DynInit
 {
 public:
+    DynInit(const char* _name=NULL) : name(_name)
+    {
+        init_s = false;
+    }
+
+    virtual ~DynInit() {}
     virtual void init() = 0;
     inline void checkInit()
     {
         if ( !init_s )
-            throw MakeStringException(-1, "Class not initialized [%s].", name->str());
+            throw MakeStringException(-1, "Class not initialized [%s].", name);
     }
 
     inline void setInit(bool status=false)
@@ -37,19 +43,11 @@ public:
         init_s=status;
     }
 
-    inline bool queryInit()
-    {
-        return init_s;
-    }
-
-    inline void setName(const char* _name)
-    {
-        name= new StringBuffer(_name);
-    }
-
 private:
+    const char *name;
+
+protected:
     bool init_s;
-    StringBuffer *name;
 
 };
 

--- a/system/security/dynapr/dynshared.hpp
+++ b/system/security/dynapr/dynshared.hpp
@@ -1,0 +1,97 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef DYNSHARED_H
+#define DYNSHARED_H
+
+#include "jlib.hpp"
+#include "jutil.hpp"
+#include "jexcept.hpp"
+
+class DynInit
+{
+public:
+    virtual void init() = 0;
+    inline void checkInit()
+    {
+        if ( !init_s )
+            throw MakeStringException(-1, "Class not initialized [%s].", name->str());
+    }
+
+    inline void setInit(bool status=false)
+    {
+        init_s=status;
+    }
+
+    inline bool queryInit()
+    {
+        return init_s;
+    }
+
+    inline void setName(const char* _name)
+    {
+        name= new StringBuffer(_name);
+    }
+
+private:
+    bool init_s;
+    StringBuffer *name;
+
+};
+
+template <typename T>
+class SharedObjectFunction : public CInterface, implements IInterface
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    SharedObjectFunction(HINSTANCE hndl, const char* _funcName);
+    T getFuncPtr();
+    const char* getFuncName();
+
+private:
+    const char *funcName;
+    T funcPtr;
+
+    T GetFuncSym(HINSTANCE hndl, const char *_funcName);
+
+};
+
+template <typename T>
+T SharedObjectFunction<T>::GetFuncSym(HINSTANCE hndl, const char *_funcName)
+{
+    return (T)GetSharedProcedure(hndl, _funcName);
+}
+
+template <typename T>
+SharedObjectFunction<T>::SharedObjectFunction(HINSTANCE hndl, const char* _funcName) : funcName(_funcName)
+{
+    funcPtr = GetFuncSym(hndl, funcName);
+}
+
+template <typename T>
+T SharedObjectFunction<T>::getFuncPtr()
+{
+    return funcPtr;
+}
+
+template <typename T>
+const char*  SharedObjectFunction<T>::getFuncName()
+{
+    return funcName;
+}
+
+#endif

--- a/system/security/dynapr/dynshared.hpp
+++ b/system/security/dynapr/dynshared.hpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Dynamic loading of apr is done by including the dynapr lib
and then creating an object or using newAprObject() followed
by a call to init().

This is designed to be instantiated and then used allowing for
init to prepare the object for use and the deconstructor to
clean up after the object.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
