### PR TITLE
HPCC-8697 Build errors on EE on Ubuntu 12.10

### DIFF
--- a/system/jlib/javahash.tpp
+++ b/system/jlib/javahash.tpp
@@ -33,7 +33,7 @@ void JavaHashTableOf<ELEMENT>::onRemove(void * et)
 template <class ELEMENT>
 bool JavaHashTableOf<ELEMENT>::addOwn(ELEMENT & donor)
 {
-    if(add(donor))
+    if(this->add(donor))
     {
         donor.Release();
         return true;
@@ -44,7 +44,7 @@ bool JavaHashTableOf<ELEMENT>::addOwn(ELEMENT & donor)
 template <class ELEMENT>
 bool JavaHashTableOf<ELEMENT>::replaceOwn(ELEMENT & donor)
 {
-    if(replace(donor))
+    if(this->replace(donor))
     {
         donor.Release();
         return true;


### PR DESCRIPTION
Stricter template checking is giving errors in javahash.tpp. This only affects
legacy thor builds, it seems.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
