### PR TITLE
HPCC-8632 Reduce multiple SDS connect() calls for environment info

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4240,11 +4240,20 @@ unsigned getEnvironmentClusterInfo(CConstWUClusterInfoArray &clusters)
     Owned<IRemoteConnection> conn = querySDS().connect("Environment", myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
     if (!conn)
         return 0;
-    Owned<IPropertyTreeIterator> clusterIter = conn->queryRoot()->getElements("Software/Topology/Cluster");
+
+    return getEnvironmentClusterInfo(conn->queryRoot(), clusters);
+}
+
+unsigned getEnvironmentClusterInfo(IPropertyTree* environmentRoot, CConstWUClusterInfoArray &clusters)
+{
+    if (!environmentRoot)
+        return 0;
+
+    Owned<IPropertyTreeIterator> clusterIter = environmentRoot->getElements("Software/Topology/Cluster");
     ForEach(*clusterIter)
     {
         IPropertyTree &node = clusterIter->query();
-        Owned<IConstWUClusterInfo> cluster = getTargetClusterInfo(conn->queryRoot(), &node);
+        Owned<IConstWUClusterInfo> cluster = getTargetClusterInfo(environmentRoot, &node);
         clusters.append(*cluster.getClear());
     }
     return clusters.ordinality();

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1150,6 +1150,7 @@ extern WORKUNIT_API bool validateTargetClusterName(const char *clustname);
 extern WORKUNIT_API IConstWUClusterInfo* getTargetClusterInfo(const char *clustname);
 typedef IArrayOf<IConstWUClusterInfo> CConstWUClusterInfoArray;
 extern WORKUNIT_API unsigned getEnvironmentClusterInfo(CConstWUClusterInfoArray &clusters);
+extern WORKUNIT_API unsigned getEnvironmentClusterInfo(IPropertyTree* environmentRoot, CConstWUClusterInfoArray &clusters);
 extern WORKUNIT_API void getRoxieProcessServers(const char *process, SocketEndpointArray &servers);
 
 

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -288,20 +288,20 @@ void CTpWrapper::getTpEclServers(IArrayOf<IConstTpEclServer>& list)
 
 void CTpWrapper::getTpEclCCServers(IArrayOf<IConstTpEclServer>& list, const char* serverName)
 {
-    DBGLOG("CTpWrapper::getTpEclServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
-    Owned<IPropertyTreeIterator> services= root->getElements(eqEclCCServer);
+    getTpEclCCServers(root, list, serverName);
+    return;
+}
+
+void CTpWrapper::getTpEclCCServers(IPropertyTree* environmentSoftware, IArrayOf<IConstTpEclServer>& list, const char* serverName)
+{
+    if (!environmentSoftware)
+        return;
+
+    Owned<IPropertyTreeIterator> services= environmentSoftware->getElements(eqEclCCServer);
     ForEach(*services)
     {
         IPropertyTree& serviceTree = services->query();
@@ -317,7 +317,7 @@ void CTpWrapper::getTpEclCCServers(IArrayOf<IConstTpEclServer>& list, const char
         pService->setBuild(serviceTree.queryProp("@build"));
 
         StringBuffer tmpDir;
-        if (getConfigurationDirectory(root->queryPropTree("Directories"), "log", "eclccserver", name, tmpDir))
+        if (getConfigurationDirectory(environmentSoftware->queryPropTree("Directories"), "log", "eclccserver", name, tmpDir))
         {
             pService->setLogDirectory( tmpDir.str() );
         }

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -166,6 +166,7 @@ public:
     void getTpDaliServers(IArrayOf<IConstTpDali>& list);
     void getTpEclServers(IArrayOf<IConstTpEclServer>& ServiceList);
     void getTpEclCCServers(IArrayOf<IConstTpEclServer>& ServiceList, const char* name = NULL);
+    void getTpEclCCServers(IPropertyTree* environmentSoftware, IArrayOf<IConstTpEclServer>& ServiceList, const char* name = NULL);
     void getTpEclAgents(IArrayOf<IConstTpEclAgent>& list, const char* name = NULL);
     void getTpEclSchedulers(IArrayOf<IConstTpEclScheduler>& ServiceList, const char* name = NULL);
     void getTpEspServers(IArrayOf<IConstTpEspServer>& list);


### PR DESCRIPTION
Existing EclWatch onActivity calls SDS connect() three times in order to
retrieving environment settings. This fix reduces the three calls to one
for better performance.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
