### PR TITLE
HPCC-8723 Configmr - htpasswdFile is not set

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -423,7 +423,7 @@
               name="myesp"
               perfReportDelay="60"
               portalurl="${PORTALURL}">
-   <Authentication htpasswd="/etc/HPCCSystems/.htpasswd"
+   <Authentication htpasswdFile="/etc/HPCCSystems/.htpasswd"
                    ldapAuthMethod="kerberos"
                    ldapConnections="10"
                    ldapServer=""


### PR DESCRIPTION
- Correct attribute from htpasswd to htpasswdFile

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
