### PR TITLE
HPCC-8550 Spurious warnings using #option ('compileOptions')

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -248,8 +248,6 @@ static bool isOptionTooLate(const char * name)
     if (stricmp(name, "importAllModules") == 0) return true;
     if (stricmp(name, "importImplicitModules") == 0) return true;
     if (stricmp(name, "noCache") == 0) return true;
-    if (stricmp(name, "linkOptions") == 0) return true;
-    if (stricmp(name, "compileOptions") == 0) return true;
     return false;
 }
 


### PR DESCRIPTION
Kill the warning,as it does not appear to be true.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
