### PR TITLE
HPCC-8666 Submit workunit should reschedule even if workflow not reset

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -214,11 +214,9 @@ void submitWsWorkunit(IEspContext& context, IConstWorkUnit* cw, const char* clus
     }
 
     if (resetWorkflow)
-    {
         wu->resetWorkflow();
-        if (!compile)
-            wu->schedule();
-    }
+    if (!compile)
+        wu->schedule();
 
     if (resetVariables)
     {


### PR DESCRIPTION
Regression was causing resubmitted workunits not to reschedule events.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
