### PR TITLE
HPCC-825 Change Resubmit and Restart buttons to be less confusing

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -904,8 +904,8 @@
             </td>
             <td>
               <form action="/WsWorkunits/WUResubmit?Wuids_i1={$wuid}" method="post">
-                <input type="submit" name="Resubmit" value="Resubmit" class="sbutton" title="Resubmit workunit">
-                  <xsl:if test="number(AccessFlag) &lt; 7 or State!='aborted' and State!='failed' and State!='completed' and State!='archived'">
+                <input type="submit" name="Recover" value="Recover" class="sbutton" title="Attempt to resume running workunit from where it stopped">
+                  <xsl:if test="number(AccessFlag) &lt; 7 or State!='aborted' and State!='failed'">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                   </xsl:if>
                 </input>
@@ -913,7 +913,7 @@
             </td>
             <td>
               <form action="/WsWorkunits/WUResubmit?Wuids_i1={$wuid}&amp;ResetWorkflow=1" method="post">
-                <input type="submit" name="RestartWU" value="Restart" title="Clean and rerun the workunit" class="sbutton">
+                <input type="submit" name="Resubmit" value="Resubmit" title="Clean and rerun the workunit" class="sbutton">
                   <xsl:if test="number(AccessFlag) &lt; 7 or State!='aborted' and State!='failed' and State!='completed' and State!='archived'">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                   </xsl:if>


### PR DESCRIPTION
Restart currently does what Resubmit used to do, which was to reset
and restart the workunit from the beginging.  Instead Resubmit now
tries to recover the workunit from where it left off.

First change the Resubmit behavior back to what it was previously.

Also remove "Restart" and add a "Recover" button which will attempt
to begin the workunit from where it previously stopped.

Also improve the tooltip to better explain what will happen.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
