### PR TITLE
HPCC-8732 Core on second embedded javascript query in Roxie

### DIFF
--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -915,10 +915,16 @@ static __thread ThreadTermFunc threadHookChain;
 
 static void releaseContext()
 {
-    delete threadContext;
-    threadContext = NULL;
+    if (threadContext)
+    {
+        delete threadContext;
+        threadContext = NULL;
+    }
     if (threadHookChain)
+    {
         (*threadHookChain)();
+        threadHookChain = NULL;
+    }
 }
 
 class JavaEmbedContext : public CInterfaceOf<IEmbedContext>

--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -226,10 +226,16 @@ static __thread ThreadTermFunc threadHookChain;
 
 static void releaseContext()
 {
-    delete threadContext;
-    threadContext = NULL;
+    if (threadContext)
+    {
+        delete threadContext;
+        threadContext = NULL;
+    }
     if (threadHookChain)
+    {
         (*threadHookChain)();
+        threadHookChain = NULL;
+    }
 }
 
 // Use a global object to ensure that the Python interpreter is initialized on main thread

--- a/plugins/v8embed/v8embed.cpp
+++ b/plugins/v8embed/v8embed.cpp
@@ -481,9 +481,16 @@ static __thread ThreadTermFunc threadHookChain;
 
 static void releaseContext()
 {
-    ::Release(theFunctionContext);
+    if (theFunctionContext)
+    {
+        ::Release(theFunctionContext);
+        theFunctionContext = NULL;
+    }
     if (threadHookChain)
+    {
         (*threadHookChain)();
+        threadHookChain = NULL;
+    }
 }
 
 class V8JavascriptEmbedContext : public CInterfaceOf<IEmbedContext>

--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -267,7 +267,10 @@ int Thread::begin()
     }
 #endif
     if (threadTerminationHook)
+    {
         (*threadTerminationHook)();
+        threadTerminationHook = NULL;
+    }
 #ifdef _WIN32
 #ifndef _DEBUG
     CloseHandle(hThread);   // leak handle when debugging, 
@@ -809,7 +812,10 @@ public:
             }
 #endif
             if (threadTerminationHook)
+            {
                 (*threadTerminationHook)();    // Reset any pre-thread state.
+                threadTerminationHook = NULL;
+            }
         } while (parent.notifyStopped(this));
         return 0;
     }


### PR DESCRIPTION
Interaction with threadpools caused some issues if a second javascript call
was made on a thread that was a member of a threadpool.

Other embed plugins were also affected by a slightly different bug, which
would cause a stack fault on the second call.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
