### PR TITLE
HPCC-8737 Roxie loses queries it it starts before dali is ready

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -557,11 +557,11 @@ public:
                     serverStatus->queryProperties()->setProp("@cluster", roxieName.str());
                     serverStatus->commitProperties();
                     initCache();
+                    isConnected = true;
                     ForEachItemIn(idx, watchers)
                     {
                         watchers.item(idx).onReconnect();
                     }
-                    isConnected = true;
                 }
                 catch(IException *e)
                 {


### PR DESCRIPTION
If roxie starts before Dali is ready, it loads queries from cache (correctly),
but will then get an empty query set if it subsequently manages to connect to
dali.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
