### PR TITLE
HPCC-8755 Fix Auto Refresh on ECL WU Details page

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -187,6 +187,7 @@
 
                 thorProcessChanged(thorProcessDropDown.options[thorProcessDropDown.selectedIndex].value);
 
+                UpdateAutoRefresh();
                 return;
             }
 


### PR DESCRIPTION
When ECL WU Details page is opened for a running WU, the page should
be auto-refreshed itself every x minutes. That function was broken
since the call to the auto-refresh function was removed by mistake.
This fix adds the call back when the page is loaded.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
