### PR TITLE
HPCC-8773 Add a control:closedown command to Roxie

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -451,6 +451,7 @@ inline unsigned getBondedChannel(unsigned partNo)
 
 extern void FatalError(const char *format, ...)  __attribute__((format(printf, 1, 2)));
 extern unsigned getNextInstanceId();
+extern void closedown();
 
 #define LOGGING_INTERCEPTED     0x01
 #define LOGGING_TIMEACTIVITIES  0x02

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -250,6 +250,13 @@ public:
     }
 } waiter;
 
+void closedown()
+{
+    Owned<IFile> sentinelFile = createSentinelTarget();
+    removeSentinelFile(sentinelFile);
+    waiter.onAbort();
+}
+
 void getAccessList(const char *aclName, IPropertyTree *topology, IPropertyTree *serverInfo)
 {
     StringBuffer xpath;

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1384,6 +1384,10 @@ private:
                 bool clearAll = control->getPropBool("@clearAll", true);
                 clearKeyStoreCache(clearAll);
             }
+            else if (stricmp(queryName, "control:closedown")==0)
+            {
+                closedown();
+            }
             else if (stricmp(queryName, "control:closeExpired")==0)
             {
                 queryFileCache().closeExpired(false);


### PR DESCRIPTION
For ease of debugging, but potentially useful in general, add a
control:closedown message to Roxie that will cause the Roxie node to close
down cleanly.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
