### PR TITLE
HPCC-8721 - Delete workunit temporaries

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -744,6 +744,7 @@ public:
     void clearGraphProgress();
     void resetBeforeGeneration();
     void deleteTempFiles(const char *graph, bool deleteOwned, bool deleteJobOwned);
+    void deleteTemporaries();
     void addDiskUsageStats(__int64 avgNodeUsage, unsigned minNode, __int64 minNodeUsage, unsigned maxNode, __int64 maxNodeUsage, __int64 graphId);
     void setTimeScheduled(const IJlibDateTime &val);
 
@@ -1235,6 +1236,8 @@ public:
             { c->resetBeforeGeneration(); }
     virtual void deleteTempFiles(const char *graph, bool deleteOwned, bool deleteJobOwned)
             { c->deleteTempFiles(graph, deleteOwned, deleteJobOwned); }
+    virtual void deleteTemporaries()
+            { c->deleteTemporaries(); }
     virtual void addDiskUsageStats(__int64 avgNodeUsage, unsigned minNode, __int64 minNodeUsage, unsigned maxNode, __int64 maxNodeUsage, __int64 graphId)
             { c->addDiskUsageStats(avgNodeUsage, minNode, minNodeUsage, maxNode, maxNodeUsage, graphId); }
     virtual IPropertyTree * getDiskUsageStats()
@@ -5370,6 +5373,17 @@ void CLocalWorkUnit::loadTemporaries() const
         }
         temporariesCached = true;
     }
+}
+
+void CLocalWorkUnit::deleteTemporaries()
+{
+    CriticalBlock block(crit);
+    if (temporariesCached)
+    {
+        temporaries.kill();
+        temporariesCached = false;
+    }
+    p->removeProp("Temporaries");
 }
 
 IWUResult* CLocalWorkUnit::createResult()

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -985,6 +985,7 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual void setCodeVersion(unsigned version, const char * buildVersion, const char * eclVersion) = 0;
     virtual void setBilled(bool value) = 0;
     virtual void deleteTempFiles(const char * graph, bool deleteOwned, bool deleteJobOwned) = 0;
+    virtual void deleteTemporaries() = 0;
     virtual void addDiskUsageStats(__int64 avgNodeUsage, unsigned minNode, __int64 minNodeUsage, unsigned maxNode, __int64 maxNodeUsage, __int64 graphId) = 0;
     virtual void setCloneable(bool value) = 0;
     virtual void setIsClone(bool value) = 0;

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1998,7 +1998,11 @@ void EclAgent::doProcess()
         while (clusterNames.ordinality())
             restoreCluster();
         if (!queryResolveFilesLocally())
+        {
             w->deleteTempFiles(NULL, false, deleteJobTemps);
+            if (deleteJobTemps)
+                w->deleteTemporaries();
+        }
 
         wuRead.clear(); // have a write lock still, but don't want to leave dangling unlocked wuRead after releasing write lock
                         // or else something can delete whilst still referenced (e.g. on complete signal)


### PR DESCRIPTION
WorkUnit temporary files were already cleared at end of job
but workunit temporary results were not, and these can be
considerably large, accumulating into many 100's MB in Dali.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
