### PR TITLE
HPCC-8717 Avoid multiple calls to SDS connect() for JobQueue in EclWatch

### DIFF
--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1143,9 +1143,8 @@ public:
     }
 
 
-    unsigned copyItems(sQueueData &qd,CJobQueueContents &dest)
+    unsigned copyItemsImpl(sQueueData &qd,CJobQueueContents &dest)
     {
-        Cconnlockblock block(this,false);
         unsigned ret=0;
         StringBuffer path;
         for (unsigned i=0;;i++) {
@@ -1158,19 +1157,19 @@ public:
         return ret;
     }
 
+    unsigned copyItems(sQueueData &qd,CJobQueueContents &dest)
+    {
+        Cconnlockblock block(this,false);
+        return copyItemsImpl(qd,dest);
+    }
+
     void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state)
     {
         assertex(qdata);
         Cconnlockblock block(this,false);
         assertex(qdata->root);
 
-        StringBuffer path;
-        for (unsigned i=0;;i++) {
-            IPropertyTree *item = qdata->root->queryPropTree(getItemPath(path.clear(),i).str());
-            if (!item)
-                break;
-            contents.append(*new CJobQueueItem(item));
-        }
+        copyItemsImpl(*qdata,contents);
 
         const char *st = qdata->root->queryProp("@state");
         if (st&&*st)

--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1158,6 +1158,24 @@ public:
         return ret;
     }
 
+    void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state)
+    {
+        assertex(qdata);
+        Cconnlockblock block(this,false);
+        assertex(qdata->root);
+
+        StringBuffer path;
+        for (unsigned i=0;;i++) {
+            IPropertyTree *item = qdata->root->queryPropTree(getItemPath(path.clear(),i).str());
+            if (!item)
+                break;
+            contents.append(*new CJobQueueItem(item));
+        }
+
+        const char *st = qdata->root->queryProp("@state");
+        if (st&&*st)
+            state.set(st);
+    }
 
     unsigned takeItems(sQueueData &qd,CJobQueueContents &dest)
     {
@@ -1956,4 +1974,3 @@ extern bool WORKUNIT_API switchWorkUnitQueue(IWorkUnit* wu, const char *cluster)
 
     return wu->switchThorQueue(cluster, &switcher);
 }
-

--- a/common/workunit/wujobq.hpp
+++ b/common/workunit/wujobq.hpp
@@ -91,6 +91,7 @@ interface IJobQueue: extends IInterface
     virtual unsigned findRank(const char *wuid)=0;
     virtual unsigned copyItems(CJobQueueContents &dest)=0;  // takes a snapshot copy of the entire queue (returns number copied)
     virtual bool getLastDequeuedInfo(StringAttr &wuid, CDateTime &enqueuedt, int &priority)=0;
+    virtual void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state)=0;
 
 
 //manipulation

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -238,7 +238,7 @@ void addQueuedWorkUnits(const char *queueName, CJobQueueContents &contents, IArr
     }
 }
 
-void CWsSMCEx::getQueueState(int runningJobsInQueue, StringBuffer& queueState, int& colorType)
+void CWsSMCEx::getQueueState(int runningJobsInQueue, StringBuffer& queueState, BulletType& bulletType)
 {
     bool queuePausedOrStopped = false;
     if ((queueState.length() > 0) && (strieq(queueState.str(),"stopped") || strieq(queueState.str(),"paused")))
@@ -249,19 +249,19 @@ void CWsSMCEx::getQueueState(int runningJobsInQueue, StringBuffer& queueState, i
     if (NotFound == runningJobsInQueue)
     {
         if (queuePausedOrStopped)
-            colorType = 3; //show bullet_white.png
+            bulletType = bulletWhite; //show bullet_white.png
         else
-            colorType = 5; //show bullet_error.png
+            bulletType = bulletError; //show bullet_error.png
     }
     else if (runningJobsInQueue > 0)
     {
         if (queuePausedOrStopped)
-            colorType = 1; //show bullet_orange.png
+            bulletType = bulletOrange; //show bullet_orange.png
         else
-            colorType = 4; //show bullet_green.png
+            bulletType = bulletGreen; //show bullet_green.png
     }
     else if (queuePausedOrStopped)
-        colorType = 2; //show bullet_yellow.png
+        bulletType = bulletYellow; //show bullet_yellow.png
 
     return;
 }
@@ -510,13 +510,13 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 queue->copyItemsAndState(contents, queueState);
                 addQueuedWorkUnits(queueName, contents, aws, context, "ThorMaster", NULL);
 
-                int colorType = 6; //show bullet_green.png
+                BulletType bulletType = bulletGreen; //show bullet_green.png
                 int serverID = runningQueueNames.find(queueName);
                 int numRunningJobsInQueue = (NotFound != serverID) ? runningJobsInQueue[serverID] : -1;
-                getQueueState(numRunningJobsInQueue, queueState, colorType);
+                getQueueState(numRunningJobsInQueue, queueState, bulletType);
                 returnCluster->setQueueStatus(queueState.str());
                 if (version > 1.06)
-                    returnCluster->setQueueStatus2(colorType);
+                    returnCluster->setQueueStatus2(bulletType);
                 if (version > 1.10)
                     returnCluster->setClusterSize(cluster.getSize());
 
@@ -540,12 +540,12 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                     queue->copyItemsAndState(contents, queueState);
                     addQueuedWorkUnits(queueName, contents, aws, context, "RoxieServer", NULL);
 
-                    int colorType = 6; //show bullet_green.png
+                    BulletType bulletType = bulletGreen; //show bullet_green.png
                     int serverID = runningQueueNames.find(queueName);
                     int numRunningJobsInQueue = (NotFound != serverID) ? runningJobsInQueue[serverID] : -1;
-                    getQueueState(numRunningJobsInQueue, queueState, colorType);
+                    getQueueState(numRunningJobsInQueue, queueState, bulletType);
                     returnCluster->setQueueStatus(queueState.str());
-                    returnCluster->setQueueStatus2(colorType);
+                    returnCluster->setQueueStatus2(bulletType);
                     if (version > 1.10)
                         returnCluster->setClusterSize(cluster.getSize());
 
@@ -567,12 +567,12 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 queue->copyItemsAndState(contents, queueState);
                 addQueuedWorkUnits(queueName, contents, aws, context, "HThorServer", NULL);
 
-                int colorType = 6; //show bullet_green.png
+                BulletType bulletType = bulletGreen; //show bullet_green.png
                 int serverID = runningQueueNames.find(queueName);
                 int numRunningJobsInQueue = (NotFound != serverID) ? runningJobsInQueue[serverID] : -1;
-                getQueueState(numRunningJobsInQueue, queueState, colorType);
+                getQueueState(numRunningJobsInQueue, queueState, bulletType);
                 returnCluster->setQueueStatus(queueState.str());
-                returnCluster->setQueueStatus2(colorType);
+                returnCluster->setQueueStatus2(bulletType);
                 HThorClusters.append(*returnCluster);
             }
         }

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -246,22 +246,23 @@ void CWsSMCEx::getQueueState(int runningJobsInQueue, StringBuffer& queueState, B
     else
         queueState.set("running");
 
+    bulletType = bulletGreen;
     if (NotFound == runningJobsInQueue)
     {
         if (queuePausedOrStopped)
-            bulletType = bulletWhite; //show bullet_white.png
+            bulletType = bulletWhite;
         else
-            bulletType = bulletError; //show bullet_error.png
+            bulletType = bulletError;
     }
     else if (runningJobsInQueue > 0)
     {
         if (queuePausedOrStopped)
-            bulletType = bulletOrange; //show bullet_orange.png
+            bulletType = bulletOrange;
         else
-            bulletType = bulletGreen; //show bullet_green.png
+            bulletType = bulletGreen;
     }
     else if (queuePausedOrStopped)
-        bulletType = bulletYellow; //show bullet_yellow.png
+        bulletType = bulletYellow;
 
     return;
 }
@@ -510,7 +511,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 queue->copyItemsAndState(contents, queueState);
                 addQueuedWorkUnits(queueName, contents, aws, context, "ThorMaster", NULL);
 
-                BulletType bulletType = bulletGreen; //show bullet_green.png
+                BulletType bulletType = bulletGreen;
                 int serverID = runningQueueNames.find(queueName);
                 int numRunningJobsInQueue = (NotFound != serverID) ? runningJobsInQueue[serverID] : -1;
                 getQueueState(numRunningJobsInQueue, queueState, bulletType);
@@ -540,7 +541,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                     queue->copyItemsAndState(contents, queueState);
                     addQueuedWorkUnits(queueName, contents, aws, context, "RoxieServer", NULL);
 
-                    BulletType bulletType = bulletGreen; //show bullet_green.png
+                    BulletType bulletType = bulletGreen;
                     int serverID = runningQueueNames.find(queueName);
                     int numRunningJobsInQueue = (NotFound != serverID) ? runningJobsInQueue[serverID] : -1;
                     getQueueState(numRunningJobsInQueue, queueState, bulletType);
@@ -567,7 +568,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 queue->copyItemsAndState(contents, queueState);
                 addQueuedWorkUnits(queueName, contents, aws, context, "HThorServer", NULL);
 
-                BulletType bulletType = bulletGreen; //show bullet_green.png
+                BulletType bulletType = bulletGreen;
                 int serverID = runningQueueNames.find(queueName);
                 int numRunningJobsInQueue = (NotFound != serverID) ? runningJobsInQueue[serverID] : -1;
                 getQueueState(numRunningJobsInQueue, queueState, bulletType);

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -24,7 +24,7 @@
 
 enum BulletType
 {
-    NONE = 0,
+    bulletNONE = 0,
     bulletOrange = 1,
     bulletYellow = 2,
     bulletWhite = 3,

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -22,6 +22,16 @@
 #include "TpWrapper.hpp"
 #include "WUXMLInfo.hpp"
 
+enum BulletType
+{
+    NONE = 0,
+    bulletOrange = 1,
+    bulletYellow = 2,
+    bulletWhite = 3,
+    bulletGreen = 4,
+    bulletError = 5
+};
+
 class CWsSMCEx : public CWsSMC
 {
     long m_counter;
@@ -69,7 +79,7 @@ private:
     void addToRoxieClusterList(IArrayOf<IEspRoxieCluster>& clusters, IEspRoxieCluster* cluster, const char* sortBy, bool descending);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* queueState, const char* serverName, const char* serverType);
-    void getQueueState(int runningJobsInQueue, StringBuffer& queueState, int& colorType);
+    void getQueueState(int runningJobsInQueue, StringBuffer& queueState, BulletType& colorType);
 };
 
 

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -68,6 +68,8 @@ private:
     void addToThorClusterList(IArrayOf<IEspThorCluster>& clusters, IEspThorCluster* cluster, const char* sortBy, bool descending);
     void addToRoxieClusterList(IArrayOf<IEspRoxieCluster>& clusters, IEspRoxieCluster* cluster, const char* sortBy, bool descending);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
+    void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* queueState, const char* serverName, const char* serverType);
+    void getQueueState(int runningJobsInQueue, StringBuffer& queueState, int& colorType);
 };
 
 


### PR DESCRIPTION
Existing EclWatch onActivity calls SDS connect() 4 times per cluster/
server process in order to retrieve JobQueue information. This fix
reduces them to 2 calls per cluster/server process.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
