### PR TITLE
HPCC-8785 - Distinguish between local execute and local data acts

### DIFF
--- a/thorlcr/activities/indexread/thindexread.cpp
+++ b/thorlcr/activities/indexread/thindexread.cpp
@@ -196,6 +196,12 @@ public:
         index.setown(queryThorFileManager().lookup(container.queryJob(), indexBaseHelper->getFileName(), false, 0 != (TIRoptional & indexBaseHelper->getFlags()), true));
         if (index)
         {
+            bool localKey = index->queryAttributes().getPropBool("@local");
+
+            if (container.queryLocalData() && !localKey)
+                throw MakeActivityException(this, 0, "Index Read cannot be LOCAL unless supplied index is local");
+
+
             nofilter = 0 != (TIRnofilter & indexBaseHelper->getFlags());
             if (index->queryAttributes().getPropBool("@local"))
                 nofilter = true;

--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -92,7 +92,7 @@ public:
             unsigned numParts = 0;
             localKey = indexFile->queryAttributes().getPropBool("@local");
 
-            if (container.queryLocal() && !localKey)
+            if (container.queryLocalData() && !localKey)
                 throw MakeActivityException(this, 0, "Keyed Join cannot be LOCAL unless supplied index is local");
 
             checkFormatCrc(this, indexFile, helper->getIndexFormatCrc(), true);

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -357,7 +357,8 @@ CGraphElementBase::CGraphElementBase(CGraphBase &_owner, IPropertyTree &_xgmml) 
     kind = (ThorActivityKind)xgmml->getPropInt("att[@name=\"_kind\"]/@value", TAKnone);
     sink = isActivitySink(kind);
     bool coLocal = xgmml->getPropBool("att[@name=\"coLocal\"]/@value", false);
-    isLocal = coLocal || xgmml->getPropBool("att[@name=\"local\"]/@value", false);
+    isLocalData = xgmml->getPropBool("att[@name=\"local\"]/@value", false); // local execute + local data access only
+    isLocal = isLocalData || coLocal; // local execute
     isGrouped = xgmml->getPropBool("att[@name=\"grouped\"]/@value", false);
     resultsGraph = NULL;
     ownerId = xgmml->getPropInt("att[@name=\"_parentActivity\"]/@value", 0);

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -253,7 +253,7 @@ protected:
     activity_id id, ownerId;
     StringAttr eclText;
     Owned<IPropertyTree> xgmml;
-    bool isLocal, isGrouped, sink, prepared, onCreateCalled, onStartCalled, onlyUpdateIfChanged, nullAct, log;
+    bool isLocal, isLocalData, isGrouped, sink, prepared, onCreateCalled, onStartCalled, onlyUpdateIfChanged, nullAct, log;
     Owned<CActivityBase> activity;
     CGraphBase *resultsGraph, *owner;
     CGraphDependencyArray dependsOn;
@@ -316,7 +316,12 @@ public:
     bool isSink() const { return sink; }
     inline bool doLogging() const { return log; }
     inline void setLogging(bool _log) { log = _log; }
-    bool queryLocal() const { return isLocal; }
+
+    // NB: in almost all cases queryLocal() == queryLocalData()
+    // an exception is e.g. a locally executing keyedjoin, accessing a global key
+    bool queryLocal() const { return isLocal; }  // executed in isolation on each slave
+    bool queryLocalData() const { return isLocalData; } // activity access local data only
+
     bool queryGrouped() const { return isGrouped; }
     bool queryLocalOrGrouped() { return isLocal || isGrouped; }
     CGraphElementBase *queryInput(unsigned index) const


### PR DESCRIPTION
KeyedJoin within a child query executures locally (no reliance on
master), but accesses data globally (the whole key) unless the
keyedjoin is marked LOCAL. Add a means to distinguis between
local execute and local data access activities.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
