### PR TITLE
HPCC-8790 Reversed sequence and maturity in stageVer var

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -271,7 +271,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   if ( "${HPCC_MATURITY}" STREQUAL "release" )
     set(stagever "${HPCC_SEQUENCE}")
   else()
-    set(stagever "${HPCC_SEQUENCE}${HPCC_MATURITY}")
+    set(stagever "${HPCC_MATURITY}${HPCC_SEQUENCE}")
   endif()
   set(version ${majorver}.${minorver}.${point})
 


### PR DESCRIPTION
moved version for non-release builds to:
M.m.p.{Maturity}s from M.m.p.s{Maturity}

This allows the rpm and dpkg version checks to see releases as
a greater version then non-releases.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
