### PR TITLE
HPCC-8800 - Potential lookupjoin deadlock

### DIFF
--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -1006,8 +1006,7 @@ public:
     virtual void abort()
     {
         CIndexReadSlaveBase::abort();
-        if (receiving)
-            cancelReceiveMsg(0, mpTag);
+        cancelReceiveMsg(0, mpTag);
     }
 };
 

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -349,8 +349,8 @@ public:
     {
         allDoneWaiting = false;
         allDone = true;
-        sender.stop();
         receiver.stop();
+        sender.stop();
         allDoneSem.signal();
     }
     bool send(CSendItem *sendItem)

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -99,10 +99,6 @@ class CBroadcaster : public CSimpleInterface
         CRecv(CBroadcaster &_broadcaster) : threaded("CBroadcaster::CRecv", this), broadcaster(_broadcaster)
         {
         }
-        ~CRecv()
-        {
-            stop();
-        }
         void start() { threaded.start(); }
         void stop()
         {

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2687,7 +2687,7 @@ IThorResource &queryThor()
 CActivityBase::CActivityBase(CGraphElementBase *_container) : container(*_container), timeActivities(_container->queryJob().queryTimeActivities())
 {
     mpTag = TAG_NULL;
-    abortSoon = cancelledReceive = reInit = false;
+    abortSoon = receiving = cancelledReceive = reInit = false;
     baseHelper.set(container.queryHelper());
     parentExtractSz = 0;
     parentExtract = NULL;


### PR DESCRIPTION
Possible deadlock since refacotring done in HPCC-3326.
The receiver was stopping too early when all slaves are done, which
could mean not all other packets were received and re-broadcast.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
