### PR TITLE
HPCC-8767 ESP users should be able to reset expired passwords

### DIFF
--- a/esp/bindings/http/platform/httpservice.hpp
+++ b/esp/bindings/http/platform/httpservice.hpp
@@ -48,6 +48,7 @@ protected:
     int m_MaxRequestEntityLength;
 
     int unsupported();
+    EspHttpBinding* getBinding();
 public:
     IMPLEMENT_IINTERFACE;
 

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -2229,8 +2229,6 @@ void CHttpResponse::sendBasicChallenge(const char* realm, const char* content)
     send();
 }
 
-
-
 int CHttpResponse::processHeaders(IMultiException *me)
 {
     char oneline[MAX_HTTP_HEADER_LEN + 1];

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -617,7 +617,7 @@ unsigned CEspApplicationPort::updatePassword(IEspContext &context, IHttpMessage*
     bool returnFlag = false;
     try
     {
-        returnFlag = secmgr->updateUser(*user, newpass1);
+        returnFlag = secmgr->updateUserPassword(*user, newpass1, oldpass);//provide the entered current password, not the cached one
     }
     catch(IException* e)
     {

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -2533,7 +2533,7 @@ bool Cws_accessEx::onUserResetPass(IEspContext &context, IEspUserResetPassReques
             return false;
         }
 
-        bool ret = ldapsecmgr->updateUser(username, req.getNewPassword());
+        bool ret = ldapsecmgr->updateUserPassword(username, req.getNewPassword());
         if(ret)
         {
             resp.setRetcode(0);

--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -96,7 +96,7 @@ bool Cws_accountEx::onUpdateUser(IEspContext &context, IEspUpdateUserRequest & r
         bool ok = false;
         try
         {
-            ok = secmgr->updateUser(*user, newpass1);
+            ok = secmgr->updateUserPassword(*user, newpass1, oldpass);
         }
         catch(IException* e)
         {

--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -165,9 +165,9 @@ interface ILdapClient : extends IInterface
     virtual void setResourceBasedn(const char* rbasedn, SecResourceType rtype = RT_DEFAULT) = 0;
     virtual ILdapConfig* getLdapConfig() = 0;
     virtual bool userInGroup(const char* userdn, const char* groupdn) = 0;
-    virtual bool updateUser(ISecUser& user, const char* newPassword) = 0;
+    virtual bool updateUserPassword(ISecUser& user, const char* newPassword, const char* currPassword = 0) = 0;
     virtual bool updateUser(const char* type, ISecUser& user) = 0;
-    virtual bool updateUser(const char* username, const char* newPassword) = 0;
+    virtual bool updateUserPassword(const char* username, const char* newPassword) = 0;
     virtual bool getResources(SecResourceType rtype, const char * basedn, const char* prefix, IArrayOf<ISecResource>& resources) = 0;
     virtual bool getResourcesEx(SecResourceType rtype, const char * basedn, const char* prefix, const char* searchstr, IArrayOf<ISecResource>& resources) = 0;
     virtual bool getPermissionsArray(const char* basedn, SecResourceType rtype, const char* name, IArrayOf<CPermission>& permissions) = 0;

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -1078,16 +1078,16 @@ IAuthMap * CLdapSecManager::createFeatureMap(IPropertyTree * authconfig)
     return feature_authmap;
 }
 
-bool CLdapSecManager::updateUser(ISecUser& user, const char* newPassword)
+bool CLdapSecManager::updateUserPassword(ISecUser& user, const char* newPassword, const char* currPassword)
 {
     // Authenticate User first
-    if(!authenticate(&user))
+    if(!authenticate(&user) && user.getAuthenticateStatus() != AS_PASSWORD_EXPIRED)
     {
         return false;
     }
 
     //Update password if authenticated
-    bool ok = m_ldap_client->updateUser(user, newPassword);
+    bool ok = m_ldap_client->updateUserPassword(user, newPassword, currPassword);
     if(ok && m_permissionsCache.isCacheEnabled() && !m_usercache_off)
     {
         m_permissionsCache.removeFromUserCache(user);
@@ -1104,9 +1104,9 @@ bool CLdapSecManager::updateUser(const char* type, ISecUser& user)
     return ok;
 }
 
-bool CLdapSecManager::updateUser(const char* username, const char* newPassword)
+bool CLdapSecManager::updateUserPassword(const char* username, const char* newPassword)
 {
-    return m_ldap_client->updateUser(username, newPassword);
+    return m_ldap_client->updateUserPassword(username, newPassword);
 }
 
 void CLdapSecManager::getAllGroups(StringArray & groups)

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -378,9 +378,9 @@ public:
     virtual IAuthMap * createFeatureMap(IPropertyTree * authconfig);
     virtual IAuthMap * createSettingMap(struct IPropertyTree *){return 0;}
     virtual bool updateSettings(ISecUser & User,ISecPropertyList * settings){return false;}
-    virtual bool updateUser(ISecUser& user, const char* newPassword);
+    virtual bool updateUserPassword(ISecUser& user, const char* newPassword, const char* currPassword = 0);
     virtual bool updateUser(const char* type, ISecUser& user);
-    virtual bool updateUser(const char* username, const char* newPassword);
+    virtual bool updateUserPassword(const char* username, const char* newPassword);
     virtual bool initUser(ISecUser& user){return false;}
 
     virtual bool getResources(SecResourceType rtype, const char * basedn, IArrayOf<ISecResource>& resources);

--- a/system/security/shared/basesecurity.cpp
+++ b/system/security/shared/basesecurity.cpp
@@ -548,7 +548,7 @@ bool CBaseSecurityManager::updateResources(ISecUser & user, ISecResourceList * r
     return true;
 }
 
-bool CBaseSecurityManager::updateUser(ISecUser& user, const char* newPassword)
+bool CBaseSecurityManager::updateUserPassword(ISecUser& user, const char* newPassword, const char* currPassword)
 {
     //("CBaseSecurityManager::updateUser");
     if(!newPassword)

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -242,7 +242,7 @@ public:
     virtual IAuthMap * createFeatureMap(IPropertyTree * authconfig) {return NULL;}
     virtual IAuthMap * createSettingMap(IPropertyTree * authconfig) {return NULL;}
 
-    virtual bool updateUser(ISecUser& user, const char* newPassword);
+    virtual bool updateUserPassword(ISecUser& user, const char* newPassword, const char* currPassword = NULL);
     virtual bool IsPasswordExpired(ISecUser& user){return false;}
     void getAllGroups(StringArray & groups) { UNIMPLEMENTED;}
     

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -283,7 +283,7 @@ interface ISecManager : extends IInterface
     virtual ISecUser * lookupUser(unsigned uid) = 0;
     virtual ISecUserIterator * getAllUsers() = 0;
     virtual void getAllGroups(StringArray & groups) = 0;
-    virtual bool updateUser(ISecUser & user, const char * newPassword) = 0;
+    virtual bool updateUserPassword(ISecUser & user, const char * newPassword, const char* currPassword = 0) = 0;
     virtual bool initUser(ISecUser & user) = 0;
     virtual void setExtraParam(const char * name, const char * value) = 0;
     virtual IAuthMap * createAuthMap(IPropertyTree * authconfig) = 0;

--- a/system/security/test/ldapsecuritytest/ldapsecuritytest.cpp
+++ b/system/security/test/ldapsecuritytest/ldapsecuritytest.cpp
@@ -377,7 +377,7 @@ int main(int argc, char* argv[])
 
             Owned<ISecUser> usr = secmgr->createUser(username);
             usr->credentials().setPassword(passwd);
-            bool ok = secmgr->updateUser(*usr, newpasswd);
+            bool ok = secmgr->updateUserPassword(*usr, newpasswd);
             if(ok)
                 printf("user password changed\n");
             else


### PR DESCRIPTION
Currently ESP (LDAP) users have to have an admin reset expired passwords.
This change allows a user to change it themselves. It is ensured that people
cannot change someone else's password by requiring the "old password."
When passing a valid but expired password to LDAP, the authentication
fails but returns a unique error string that is parsed to detect this scenario

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
