### PR TITLE
HPCC-8789 - Pausenow could fail to abort and lose spills

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -1546,11 +1546,11 @@ void EclAgent::executeThorGraph(const char * graphName)
                 while (!sem.wait(10000))
                 {
                     wu.forceReload();
-                    if (WUStatePaused != wu.getState())
+                    if (WUStatePaused != wu.getState() || wu.aborting())
                     {
                         SCMStringBuffer str;
                         wu.getStateDesc(str);
-                        PROGLOG("Aborting pause job %s, state changed to : %s", wuid.get(), str.str()); 
+                        PROGLOG("Aborting pause job %s, state : %s", wuid.get(), str.str());
                         ret = false;
                         break;
                     }
@@ -1564,7 +1564,7 @@ void EclAgent::executeThorGraph(const char * graphName)
         if (WUStatePaused == queryWorkUnit()->getState()) // check initial state - and wait if paused
         {
             if (!workunitResumeHandler.wait())
-                return;
+                throw new WorkflowException(0,"User abort requested", 0, WorkflowException::ABORT, MSGAUD_user);
         }
         {
             Owned <IWorkUnit> w = updateWorkUnit();

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -526,7 +526,7 @@ protected:
     Owned<IPropertyTree> node;
     IBarrier *startBarrier, *waitBarrier, *doneBarrier;
     mptag_t mpTag, startBarrierTag, waitBarrierTag, doneBarrierTag;
-    bool created, connected, started, aborted, graphDone, prepared, sequential;
+    bool created, connected, started, aborted, graphDone, prepared, sequential, receiving;
     bool reinit, sentInitData, sentStartCtx;
     CJobBase &job;
     graph_id graphId;
@@ -633,6 +633,8 @@ public:
     virtual void serializeCreateContexts(MemoryBuffer &mb);
     virtual void serializeStartContexts(MemoryBuffer &mb);
     void reset();
+    bool receiveMsg(CMessageBuffer &mb, const rank_t rank, const mptag_t mpTag, rank_t *sender=NULL, unsigned timeout=MP_WAIT_FOREVER);
+    void cancelReceiveMsg(const rank_t rank, const mptag_t mpTag);
     void disconnectActivities()
     {
         CGraphElementIterator iter(containers);

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -103,13 +103,13 @@ class graphmaster_decl CJobMaster : public CJobBase
 {
     Linked<IConstWorkUnit> workunit;
     Owned<IFatalHandler> fatalHandler;
-    bool querySent, sendSo;
+    bool querySent, sendSo, spillsSaved;
     Int64Array nodeDiskUsage;
     bool nodeDiskUsageCached;
     StringArray createdFiles;
     CSlaveMessageHandler *slaveMsgHandler;
     SocketEndpoint agentEp;
-    CriticalSection sendQueryCrit;
+    CriticalSection sendQueryCrit, spillCrit;
 
     void initNodeDUCache();
 
@@ -126,8 +126,9 @@ public:
     IPropertyTree *prepareWorkUnitInfo();
     void sendQuery();
     void jobDone();
+    void saveSpills();
     bool go();
-    void stop(bool abort);
+    void pause(bool abort);
 
     virtual IConstWorkUnit &queryWorkUnit() const
     {

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -363,7 +363,7 @@ void CSlaveGraph::recvStartCtx()
     {
         sentStartCtx = true;
         CMessageBuffer msg;
-        if (!job.queryJobComm().recv(msg, 0, mpTag, NULL, LONGTIMEOUT))
+        if (!receiveMsg(msg, 0, mpTag, NULL, LONGTIMEOUT))
             throw MakeStringException(0, "Error receiving startCtx data for graph: %"GIDPF"d", graphId);
         deserializeStartContexts(msg);
     }
@@ -393,7 +393,7 @@ bool CSlaveGraph::recvActivityInitData(size32_t parentExtractSz, const byte *par
 
         if (syncInitData())
         {
-            if (!job.queryJobComm().recv(msg, 0, mpTag, NULL, LONGTIMEOUT))
+            if (!receiveMsg(msg, 0, mpTag, NULL, LONGTIMEOUT))
                 throw MakeStringException(0, "Error receiving actinit data for graph: %"GIDPF"d", graphId);
             replyTag = msg.getReplyTag();
             msg.read(len);
@@ -555,7 +555,7 @@ void CSlaveGraph::create(size32_t parentExtractSz, const byte *parentExtract)
         {
             CMessageBuffer msg;
             // nothing changed if rerunning, unless conditional branches different
-            if (!job.queryJobComm().recv(msg, 0, mpTag, NULL, LONGTIMEOUT))
+            if (!receiveMsg(msg, 0, mpTag, NULL, LONGTIMEOUT))
                 throw MakeStringException(0, "Error receiving createctx data for graph: %"GIDPF"d", graphId);
             try
             {


### PR DESCRIPTION
The pausenow feature, aborts the current subgraph and preserves
the unconsumed spills of completed subgraphs.
If the abort took too long, thor recycled, before the spills
were saved. Since the job was marked paused and resumable, when
it was resumed, if the spills were missing, it would complain and
fail.

Ensure spills are saved away earlier, abort asynchronously and
only kick off the fatal timeout, once the spills have been saved

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
