### PR TITLE
HPCC-8814 OUTPUT(dictionary) was not working

### DIFF
--- a/testing/ecl/dict_matrix.ecl
+++ b/testing/ecl/dict_matrix.ecl
@@ -1,0 +1,7 @@
+// Using a dictionary to implement a sparse matrix
+
+matrix := { integer4 X, integer4 Y => real8 V { default(0.0)} };
+m1 := DICTIONARY([ { 1,1 => 1 }, { 2,2 => 1}, { 3,3 => 1 }],  matrix) : global;
+m1;
+output(m1);
+output(dataset(m1));

--- a/testing/ecl/key/dict_matrix.xml
+++ b/testing/ecl/key/dict_matrix.xml
@@ -1,0 +1,15 @@
+<Dataset name='Result 1'>
+ <Row><x>1</x><y>1</y><v>1.0</v></Row>
+ <Row><x>2</x><y>2</y><v>1.0</v></Row>
+ <Row><x>3</x><y>3</y><v>1.0</v></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><x>1</x><y>1</y><v>1.0</v></Row>
+ <Row><x>2</x><y>2</y><v>1.0</v></Row>
+ <Row><x>3</x><y>3</y><v>1.0</v></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><x>1</x><y>1</y><v>1.0</v></Row>
+ <Row><x>2</x><y>2</y><v>1.0</v></Row>
+ <Row><x>3</x><y>3</y><v>1.0</v></Row>
+</Dataset>


### PR DESCRIPTION
Add OUTPUT(dictionary) and dictionary (implying output) to grammar.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
