### PR TITLE
HPCC-8564 Added override settigns for nproc to limits.conf

### DIFF
--- a/initfiles/sbin/add_conf_settings.sh.in
+++ b/initfiles/sbin/add_conf_settings.sh.in
@@ -34,9 +34,11 @@ Defaults:${USER_NAME} !requiretty
 %EOF
 
 alter_file /etc/security/limits.conf "^${USER_NAME}" << %EOF
-${USER_NAME}    soft    nofile  8192
-${USER_NAME}    hard    nofile  32768
-${USER_NAME}    soft  core  unlimited
-${USER_NAME}    hard  core  unlimited
+${USER_NAME}    soft    nofile    8192
+${USER_NAME}    hard    nofile    32768
+${USER_NAME}    soft    core      unlimited
+${USER_NAME}    hard    core      unlimited
+${USER_NAME}    soft    nproc     4096
+${USER_NAME}    hard    nproc     8192
 %EOF
 


### PR DESCRIPTION
Added a soft of 4096 and hard of 8192 which matchs the default
kernel set values on ubuntu and centos 5.x.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
