### PR TITLE
HPCC-8490 Can't convert dictionary to dataset in output spec

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -4270,6 +4270,18 @@ fieldDef
                             parser->addFields($1, e, NULL, hasNamedSymbol(e));
                             $$.clear();
                         }
+    | dictionary        {
+                            parser->normalizeExpression($1);
+                            IHqlExpression *value = $1.getExpr();
+
+                            _ATOM name = parser->createFieldNameFromExpr(value);
+
+                            IHqlExpression * attrs = extractAttrsFromExpr(value);
+
+                            ITypeInfo * type = value->queryType();
+                            parser->addField($1, name, LINK(type), value, attrs);
+                            $$.clear();
+                        }
     | dataSet               {
                             OwnedHqlExpr e = $1.getExpr();
                             parser->addFields($1, e->queryRecord(), e, true);

--- a/testing/ecl/dict_dsout.ecl
+++ b/testing/ecl/dict_dsout.ecl
@@ -1,0 +1,15 @@
+d := dataset(
+  [{ '1', '2',
+    [{ '3' => '4'},
+     { 'a' => 'A'},
+     { 'b' => 'B'},
+     { 'c' => 'C'},
+     { 'd' => 'D'},
+     { 'e' => 'E'},
+     { 'f' => 'F'}],
+     '5'
+  }],
+   { string1 a, string1 b, dictionary({string1 c1=>string1 c2}) c, string1 dd });
+
+output(d,{a,b,c,dd});
+output(d,{a,b,cc := DATASET(c),dd});

--- a/testing/ecl/key/dict_dsout.xml
+++ b/testing/ecl/key/dict_dsout.xml
@@ -1,0 +1,6 @@
+<Dataset name='Result 1'>
+ <Row><a>1</a><b>2</b><c><Row><c1>f</c1><c2>F</c2></Row><Row><c1>e</c1><c2>E</c2></Row><Row><c1>d</c1><c2>D</c2></Row><Row><c1>3</c1><c2>4</c2></Row><Row><c1>b</c1><c2>B</c2></Row><Row><c1>a</c1><c2>A</c2></Row><Row><c1>c</c1><c2>C</c2></Row></c><dd>5</dd></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><a>1</a><b>2</b><cc><Row><c1>f</c1><c2>F</c2></Row><Row><c1>e</c1><c2>E</c2></Row><Row><c1>d</c1><c2>D</c2></Row><Row><c1>3</c1><c2>4</c2></Row><Row><c1>b</c1><c2>B</c2></Row><Row><c1>a</c1><c2>A</c2></Row><Row><c1>c</c1><c2>C</c2></Row></cc><dd>5</dd></Row>
+</Dataset>


### PR DESCRIPTION
Add support for listing a dictionary field in a record def for output.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
