### PR TITLE
HPCC-8760 Upgrade ESP to upload multiple files per http request

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1447,7 +1447,8 @@ int EspHttpBinding::onStartUpload(IEspContext &ctx, CHttpRequest* request, CHttp
         if ((netAddress.length() < 1) || (path.length() < 1))
             throw MakeStringException(-1, "Upload destination not specified.");
 
-        request->readContentToFile(netAddress, path);
+        StringArray fileNames;
+        request->readContentToFile(netAddress, path, fileNames);
         return onFinishUpload(ctx, request, response, serv, method);
     }
     catch (IException* e)

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1448,7 +1448,7 @@ int EspHttpBinding::onStartUpload(IEspContext &ctx, CHttpRequest* request, CHttp
             throw MakeStringException(-1, "Upload destination not specified.");
 
         StringArray fileNames;
-        request->readContentToFile(netAddress, path, fileNames);
+        request->readContentToFiles(netAddress, path, fileNames);
         return onFinishUpload(ctx, request, response, serv, method);
     }
     catch (IException* e)

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1833,181 +1833,133 @@ int CHttpRequest::processHeaders(IMultiException *me)
     return 0;
 }
 
-int CHttpRequest::readContentToFile(StringBuffer netAddress, StringBuffer path)
+bool CHttpRequest::readContentToBuffer(MemoryBuffer& buffer, __int64& bytesNotRead)
 {
     char buf[1024 + 1];
     int buflen = 1024;
-    int readlen = 0;    
-    __int64 totallen = m_content_length64;
-    if(buflen > totallen)
-        buflen = (int) totallen;
+    if (buflen > bytesNotRead)
+        buflen = bytesNotRead;
 
-    StringBuffer lengthStr;
-    lengthStr.append(m_content_length64);
+    int readlen = m_bufferedsocket->read(buf, buflen);
+    if(readlen < 0)
+        DBGLOG("Failed to read from socket");
 
-    Owned<CMimeMultiPart> m_multipart = new CMimeMultiPart("1.0", m_content_type.get(), "", "", "");
-    m_multipart->parseContentType(m_content_type.get());
+    if(readlen <= 0)
+       return false;
 
-    //Read the first one of data to find out the file name, as well as the beginning of the file content
-    bool lastChuck = false;
-    MemoryBuffer fileContent;
-    StringBuffer fileName;
-    while(fileName.length() < 1)
+    buf[readlen] = 0;
+    buffer.append(readlen, buf);//'buffer' may have some left-over from previous read
+
+    bytesNotRead -= readlen;
+    return true;
+}
+
+bool CHttpRequest::readUploadFileName(CMimeMultiPart* mimemultipart, StringBuffer& fileName, MemoryBuffer& contentBuffer, __int64& bytesNotRead)
+{
+    if (contentBuffer.length())
+        mimemultipart->readUploadFileName(contentBuffer, fileName);
+
+    while((fileName.length() < 1) && (bytesNotRead > 0))
     {
-        readlen = m_bufferedsocket->read(buf, buflen);
-        if(readlen < 0)
-        {
-            DBGLOG(">> Socket timed out because of incorrect Content-Length passed in from the other side");
+        if (!readContentToBuffer(contentBuffer, bytesNotRead))
             break;
-        }
-        if(readlen == 0)
-            break;
-        
-        buf[readlen] = 0;
 
-        fileContent.append(readlen, buf);
-
-        //find out the file name, as well as the beginning of the file content
-        m_multipart->readUploadFile(fileContent, fileName);
-
-        totallen -= readlen;
-        if(totallen <= 0)
-            break;
-        if(buflen > totallen)
-            buflen = (int) totallen;
+        mimemultipart->readUploadFileName(contentBuffer, fileName);
     }
 
-    if (fileName.length() < 1)
-    {
-        DBGLOG(">> File cannot be uploaded.");
-        return 0;
-    }
+    return (fileName.length() > 0);
+}
 
-    //Create IFile to store the file
-    StringBuffer name0(fileName), name1(fileName), fileToSave, fileToUse;
-    char* str = (char*) name1.reverse().str();
+IFile* CHttpRequest::createUploadFile(StringBuffer netAddress, const char* filePath, StringBuffer& fileName)
+{
+    StringBuffer name(fileName), tmpFileName;
+    char* str = (char*) name.reverse().str();
     char* pStr = (char*) strchr(str, '\\');
     if (!pStr)
         pStr = strchr(str, '/');
     if (pStr)
     {
         pStr[0] = 0;
-        name0.clear().append(str).reverse();
+        fileName.clear().append(str).reverse();
     }
-
-    fileToSave.appendf("%s/%s.part", path.str(), name0.str());
-    fileToUse.appendf("%s/%s", path.str(), name0.str());
+    tmpFileName.appendf("%s/%s.part", filePath, fileName.str());
 
     RemoteFilename rfn;
     SocketEndpoint ep;
     ep.set(netAddress.str());
-    rfn.setPath(ep, fileToSave.str());
-    Owned<IFile> file = createIFile(rfn);
-    if (!file)
-    {
-        DBGLOG(">> File %s cannot be uploaded.", name0.str());
-        return 0;
-    }
+    rfn.setPath(ep, tmpFileName.str());
 
-    Owned<IFileIO> fileio = file->open(IFOcreate);
-    if (!fileio)
-    {
-        DBGLOG(">> File %s cannot be uploaded.", name0.str());
-        return 0;
-    }
+    return createIFile(rfn);
+}
 
-    //If this is the last chuck of data, we need to remove the boundry line at the end of data
-    if(totallen <= 0)
-        lastChuck = true;
-    else if(totallen < 1024) 
-    { //if there is only one chuck left, the boundry line may be broken in the first chuck and the last chuck.
-        lastChuck = true;
-        readlen = m_bufferedsocket->read(buf, buflen);
-        if(readlen < 0)
+int CHttpRequest::readContentToFile(StringBuffer netAddress, StringBuffer path, StringArray& fileNames)
+{
+    Owned<CMimeMultiPart> multipart = new CMimeMultiPart("1.0", m_content_type.get(), "", "", "");
+    multipart->parseContentType(m_content_type.get());
+
+    MemoryBuffer fileContent, moreContent;
+    __int64 bytesNotRead = m_content_length64;
+    while (1)
+    {
+        StringBuffer fileName;
+        if (!readUploadFileName(multipart, fileName, fileContent, bytesNotRead))
         {
-            DBGLOG(">> Socket timed out because of incorrect Content-Length passed in from the other side");
-            return 0;
-        }
-        if(readlen == 0)
-            return 0;
-
-        buf[readlen] = 0;
-        fileContent.append(readlen, buf);
-    }
-
-    //remove the boundry line at the end of data
-    if (lastChuck)
-        m_multipart->checkEndOfFile(fileContent);
-
-    //Save the data into the file
-    if (fileio->write(0, fileContent.length(), fileContent.toByteArray()) != fileContent.length())
-    {
-        DBGLOG(">> File %s cannot be uploaded.", name0.str());
-        return 0;
-    }
-
-    if(lastChuck)
-    {
-        file->rename(fileToUse.str());
-        return 0;
-    }
-
-    //The file has more than two chucks. Now, look though the rest of the chucks.
-    __int64 offset = fileContent.length();
-    for(;;)
-    {
-        readlen = m_bufferedsocket->read(buf, buflen);
-        if(readlen < 0)
-        {
-            DBGLOG(">> Socket timed out because of incorrect Content-Length passed in from the other side");
+            DBGLOG("No file name found for upload");
             break;
         }
-        if(readlen == 0)
-            break;
-        
-        buf[readlen] = 0;
-        fileContent.clear().append(readlen, buf);
-            
-        //For the last one or two chucks, remove the boundry line at the end of data. 
-        totallen -= readlen;
-        if(totallen <= 0)
-            lastChuck = true;
-        else if(totallen < 1024)
+
+        fileNames.append(fileName);
+        Owned<IFile> file = createUploadFile(netAddress, path, fileName);
+        if (!file)
         {
-            lastChuck = true;
-            buflen = (int) totallen;
-            readlen = m_bufferedsocket->read(buf, buflen);
-            if(readlen < 0)
+            DBGLOG("Uploaded file %s cannot be created", fileName.str());
+            break;
+        }
+        Owned<IFileIO> fileio = file->open(IFOcreate);
+        if (!fileio)
+        {
+            DBGLOG("Uploaded file %s cannot be opened", fileName.str());
+            break;
+        }
+
+        __int64 writeOffset = 0;
+        bool writeError = false;
+        bool foundAnotherFile = false;
+        while (1)
+        {
+            foundAnotherFile = multipart->separateMultiParts(fileContent, moreContent, bytesNotRead);
+            if (fileContent.length() > 0)
             {
-                DBGLOG(">> Socket timed out because of incorrect Content-Length passed in from the other side");
-                break;
+                if (fileio->write(writeOffset, fileContent.length(), fileContent.toByteArray()) != fileContent.length())
+                {
+                    DBGLOG("Failed to write Uploaded file %s", fileName.str());
+                    writeError = true;
+                    break;
+                }
+                writeOffset += fileContent.length();
             }
-            if(readlen == 0)
+
+            fileContent.clear();
+            if (moreContent.length() > 0)
+            {
+                fileContent.append(moreContent.length(), (void*) moreContent.toByteArray());
+                moreContent.clear();
+            }
+
+            if(foundAnotherFile || (bytesNotRead <= 0) || !readContentToBuffer(fileContent, bytesNotRead))
                 break;
-
-            buf[readlen] = 0;
-            fileContent.append(readlen, buf);
         }
 
-        if (lastChuck)
-        {
-            m_multipart->checkEndOfFile(fileContent);
-            DBGLOG(">> The length of the last chuck=<%d>", fileContent.length());
-        }
-
-        if (fileio->write(offset, fileContent.length(), fileContent.toByteArray()) != fileContent.length())
-        {
-            DBGLOG(">> File %s cannot be uploaded.", name0.str());
-            break;
-        }
-
-        if (lastChuck)
+        if (writeError)
             break;
 
-        offset += readlen;
+        StringBuffer fileNameWithPath;
+        fileNameWithPath.appendf("%s/%s", path.str(), fileName.str());
+        file->rename(fileNameWithPath.str());
+
+        if (!foundAnotherFile)
+            break;
     }
-
-    file->rename(fileToUse.str());
     return 0;
 }
 

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1836,11 +1836,11 @@ int CHttpRequest::processHeaders(IMultiException *me)
 bool CHttpRequest::readContentToBuffer(MemoryBuffer& buffer, __int64& bytesNotRead)
 {
     char buf[1024 + 1];
-    int buflen = 1024;
+    __int64 buflen = 1024;
     if (buflen > bytesNotRead)
         buflen = bytesNotRead;
 
-    int readlen = m_bufferedsocket->read(buf, buflen);
+    int readlen = m_bufferedsocket->read(buf, (int) buflen);
     if(readlen < 0)
         DBGLOG("Failed to read from socket");
 
@@ -1892,7 +1892,7 @@ IFile* CHttpRequest::createUploadFile(StringBuffer netAddress, const char* fileP
     return createIFile(rfn);
 }
 
-int CHttpRequest::readContentToFile(StringBuffer netAddress, StringBuffer path, StringArray& fileNames)
+int CHttpRequest::readContentToFiles(StringBuffer netAddress, StringBuffer path, StringArray& fileNames)
 {
     Owned<CMimeMultiPart> multipart = new CMimeMultiPart("1.0", m_content_type.get(), "", "", "");
     multipart->parseContentType(m_content_type.get());

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -355,7 +355,10 @@ public:
     virtual void setMaxRequestEntityLength(int len) {m_MaxRequestEntityLength = len;}
     virtual int getMaxRequestEntityLength() { return m_MaxRequestEntityLength; }
 
-    virtual int readContentToFile(StringBuffer netAddress, StringBuffer path);
+    bool readContentToBuffer(MemoryBuffer& fileContent, __int64& bytesNotRead);
+    bool readUploadFileName(CMimeMultiPart* mimemultipart, StringBuffer& fileName, MemoryBuffer& contentBuffer, __int64& bytesNotRead);
+    IFile* createUploadFile(StringBuffer netAddress, const char* filePath, StringBuffer& fileName);
+    virtual int readContentToFile(StringBuffer netAddress, StringBuffer path, StringArray& fileNames);
 };
 
 class CHttpResponse : public CHttpMessage

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -358,7 +358,7 @@ public:
     bool readContentToBuffer(MemoryBuffer& fileContent, __int64& bytesNotRead);
     bool readUploadFileName(CMimeMultiPart* mimemultipart, StringBuffer& fileName, MemoryBuffer& contentBuffer, __int64& bytesNotRead);
     IFile* createUploadFile(StringBuffer netAddress, const char* filePath, StringBuffer& fileName);
-    virtual int readContentToFile(StringBuffer netAddress, StringBuffer path, StringArray& fileNames);
+    virtual int readContentToFiles(StringBuffer netAddress, StringBuffer path, StringArray& fileNames);
 };
 
 class CHttpResponse : public CHttpMessage

--- a/esp/bindings/http/platform/mime.cpp
+++ b/esp/bindings/http/platform/mime.cpp
@@ -534,9 +534,9 @@ bool CMimeMultiPart::separateMultiParts(MemoryBuffer& firstPart, MemoryBuffer& o
 
     // Get rid of CR/LF at the end of the content
     unsigned firstPartLength = offset;
-    if ((firstPartLength > 1) && (startPos[firstPartLength-2] == '\r') && (startPos[firstPartLength-1] == '\n'))
-        firstPartLength -= 2;
-    else if ((firstPartLength > 0) && ((startPos[firstPartLength-1] == '\r') || (startPos[firstPartLength-1] == '\n')))
+    if ((firstPartLength > 0) && (startPos[firstPartLength-1] == '\n'))
+        firstPartLength--;
+    if ((firstPartLength > 0) && (startPos[firstPartLength-1] == '\r'))
         firstPartLength--;
     if(firstPartLength >= 0)
     {

--- a/esp/bindings/http/platform/mime.cpp
+++ b/esp/bindings/http/platform/mime.cpp
@@ -534,9 +534,7 @@ bool CMimeMultiPart::separateMultiParts(MemoryBuffer& firstPart, MemoryBuffer& o
 
     // Get rid of CR/LF at the end of the content
     unsigned firstPartLength = offset;
-    if ((firstPartLength > 0) && (startPos[firstPartLength-1] == '\n'))
-        firstPartLength--;
-    if ((firstPartLength > 0) && (startPos[firstPartLength-1] == '\r'))
+    while ((firstPartLength > 0) && ((startPos[firstPartLength-1] == '\r') || (startPos[firstPartLength-1] == '\n')))
         firstPartLength--;
     if(firstPartLength >= 0)
     {

--- a/esp/bindings/http/platform/mime.hpp
+++ b/esp/bindings/http/platform/mime.hpp
@@ -76,8 +76,8 @@ public:
     void setContentType(const char* content_type);
 
     void parseContentType(const char* contenttype);
-    void checkEndOfFile(MemoryBuffer& fileContent);
-    void readUploadFile(MemoryBuffer& fileContent, StringBuffer& fileName);
+    bool separateMultiParts(MemoryBuffer& firstPart, MemoryBuffer& otherParts, __int64 contentNotRead);
+    void readUploadFileName(MemoryBuffer& fileContent, StringBuffer& fileName);
 
     void serialize(StringBuffer& contenttype, StringBuffer & buffer);
     void unserialize(const char* contenttype, int text_length, const char* text);


### PR DESCRIPTION
Existing ESP can only upload one file per HTTP request. Now, the
function is revised to support multiple file upload per request.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
