### PR TITLE
HPCC-8824 Remove compile warning reported from gcc

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -291,7 +291,6 @@ void CDfsLogicalFileName::set(const char *name)
         e->errorMessage(err);
         WARNLOG("CDfsLogicalFileName::set %s",err.str());
         e->Release();
-        multi = false;
     }
     if (multi) {
         StringBuffer full;


### PR DESCRIPTION
multi is a pointer, not a boolean, and has already been cleared in the clear()
call above.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
