### PR TITLE
HPCC-8826 Build errors on java plugin in EE build

### DIFF
--- a/plugins/javaembed/CMakeLists.txt
+++ b/plugins/javaembed/CMakeLists.txt
@@ -42,6 +42,7 @@ include_directories (
          ./../../common/deftype
          ./../../system/jlib
          ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DJAVAEMBED_EXPORTS )


### PR DESCRIPTION
Was not finding generated build-config.h

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
