### PR TITLE
HPCC-8819 Allow LOCAL to prefix a definition (like SHARED/EXPORT)

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -1238,6 +1238,7 @@ knownFunction1
 scopeFlag
     : EXPORT            {   $$.setInt(EXPORT_FLAG); $$.setPosition($1); }
     | SHARED            {   $$.setInt(SHARED_FLAG); $$.setPosition($1); }
+    | LOCAL             {   $$.setInt(0); $$.setPosition($1); }
     ;
 
 // scopeflags needs to be explicitly included, rather than using an optScopeFlags production, otherwise you get shift reduce errors - since it is the first item on a line.

--- a/ecl/regress/issue8819.ecl
+++ b/ecl/regress/issue8819.ecl
@@ -1,0 +1,24 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    This program is free software: you can redistribute it and/or modify
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+myfunc(num) := functionmacro
+    local numPlus := num + 1;
+    return numPlus;
+endmacro;
+
+numPlus := 'this will cause syntax error';
+myfunc(5);


### PR DESCRIPTION
There are some situtations e.g., when you are defining a symbol in a
function/function macro, where it is possible for a definition of a symbol
to fail because it clashes with an existing symbol.  Prefixing the
definition with LOCAL allows you to avoid this ambiguity.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
