### PR TITLE
HPCC-8837 Correct archive instructions

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -919,7 +919,7 @@
           listed in your environment's topology section.</para>
         </sect3>
 
-        <sect3>
+        <sect3 role="brk">
           <title>Running a basic ECL program from the ECL IDE</title>
 
           <para><orderedlist>

--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -779,7 +779,7 @@
 
                     <mediaobject>
                       <imageobject>
-                        <imagedata fileref="images/GS_1311.JPG"
+                        <imagedata fileref="images/GS_1311.jpg"
                                    vendor="eclwatchSS" />
                       </imageobject>
                     </mediaobject>
@@ -913,7 +913,7 @@
           use the eclcc compiler locally to create an archive to be sent to
           the eclccServer:</para>
 
-          <para><programlisting>eclcc hello.ecl -E | ecl run --target=thor --server=&lt;IP Address of the ESP&gt;:8010</programlisting></para>
+          <para><programlisting>eclcc hello.ecl -E | ecl run - --target=thor --server=&lt;IP Address of the ESP&gt;:8010</programlisting></para>
 
           <para>The target parameter must name a valid target cluster name as
           listed in your environment's topology section.</para>


### PR DESCRIPTION
Fix HPCC-8837 where archive instructions 
Code example is missing a dash required to 
properly run the command. It is also showing 
some pagination issue on the same page. 
