### PR TITLE
HPCC-8817 Fix hthor running WU not shown on Activity page

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -596,16 +596,6 @@
                         </xsl:call-template>
                     </xsl:for-each>
 
-                    <xsl:for-each select="ServerJobQueues/ServerJobQueue[ServerType='ECLagent']">
-                        <xsl:call-template name="show-queue">
-                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLagent' and QueueName=current()/QueueName]"/>
-                            <xsl:with-param name="cluster" select="ServerName"/>
-                            <xsl:with-param name="clusterType" select="ServerType"/>
-                            <xsl:with-param name="queue" select="QueueName"/>
-                            <xsl:with-param name="status" select="QueueStatus"/>
-                        </xsl:call-template>
-                    </xsl:for-each>
-
                     <xsl:for-each select="ServerJobQueues/ServerJobQueue[ServerType='ECLCCserver']">
                         <xsl:call-template name="show-queue">
                             <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ECLCCserver' and QueueName=current()/QueueName]"/>

--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -860,13 +860,14 @@
         <xsl:param name="queue"/>
         <xsl:param name="thorlcr" select="'0'"/>
 
-        <xsl:variable name="active" select="$workunits[State='running']"/>
+        <xsl:variable name="active1" select="$workunits[State='running' and $queue = QueueName]"/>
+        <xsl:variable name="active2" select="$workunits[State='running' and $queue != QueueName]"/>
         <tbody>
             <xsl:choose>
                 <xsl:when test="$workunits[1]">
                     <tr style="border:solid 2 black">
-                        <xsl:if test="count($active)">
-                            <xsl:for-each select="$active">
+                        <xsl:if test="count($active1)">
+                            <xsl:for-each select="$active1">
                                 <xsl:if test="position() > 1">
                                     <xsl:text disable-output-escaping="yes">
                                             <![CDATA[
@@ -895,6 +896,27 @@
                             </xsl:apply-templates>
                         </tr>
                     </xsl:for-each>
+
+                    <tr style="border:solid 2 black">
+                        <xsl:if test="count($active2)">
+                            <xsl:for-each select="$active2">
+                                <xsl:if test="position() > 1">
+                                    <xsl:text disable-output-escaping="yes">
+                                            <![CDATA[
+                                                </tr>
+                                                <tr>
+                                            ]]>
+                                        </xsl:text>
+                                </xsl:if>
+                                <xsl:apply-templates select=".">
+                                    <xsl:with-param name="cluster" select="$cluster"/>
+                                    <xsl:with-param name="clusterType" select="$clusterType"/>
+                                    <xsl:with-param name="queue" select="$queue"/>
+                                    <xsl:with-param name="thorlcr" select="$thorlcr"/>
+                                </xsl:apply-templates>
+                            </xsl:for-each>
+                        </xsl:if>
+                    </tr>
                 </xsl:when>
                 <xsl:otherwise>
                     <td width="1100" colspan='4'>No active workunit</td>
@@ -1005,6 +1027,9 @@
                     </xsl:if>
                 </xsl:otherwise>
             </xsl:choose>
+            <xsl:if test="$queue != QueueName">
+                <b> (on <xsl:value-of select="QueueName"/>)</b>
+            </xsl:if>
         </td>
         <td class="{$active}">
             <xsl:value-of select="Owner"/>&#160;

--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -564,7 +564,7 @@
                     <input type="hidden" name="Wuid" id="Wuid" value=""/>
                     <xsl:for-each select="ThorClusters/ThorCluster">
                         <xsl:call-template name="show-queue">
-                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='ThorMaster' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[(Server='ThorMaster' and QueueName=current()/QueueName) or (ClusterType='Thor' and ClusterQueueName=current()/QueueName)]"/>
                             <xsl:with-param name="cluster" select="ClusterName"/>
                             <xsl:with-param name="clusterType" select="'THOR'"/>
                             <xsl:with-param name="queue" select="QueueName"/>
@@ -576,7 +576,7 @@
 
                     <xsl:for-each select="RoxieClusters/RoxieCluster">
                         <xsl:call-template name="show-queue">
-                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='RoxieServer' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[(Server='RoxieServer' and QueueName=current()/QueueName) or (ClusterType='Roxie' and ClusterQueueName=current()/QueueName)]"/>
                             <xsl:with-param name="cluster" select="ClusterName"/>
                             <xsl:with-param name="clusterType" select="'ROXIE'"/>
                             <xsl:with-param name="queue" select="QueueName"/>
@@ -587,7 +587,7 @@
 
                     <xsl:for-each select="HThorClusters/HThorCluster">
                         <xsl:call-template name="show-queue">
-                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[Server='HThorServer' and QueueName=current()/QueueName]"/>
+                            <xsl:with-param name="workunits" select="//Running/ActiveWorkunit[(Server='HThorServer' and QueueName=current()/QueueName) or (ClusterType='HThor' and ClusterQueueName=current()/QueueName)]"/>
                             <xsl:with-param name="cluster" select="ClusterName"/>
                             <xsl:with-param name="clusterType" select="'HTHOR'"/>
                             <xsl:with-param name="queue" select="QueueName"/>

--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -876,6 +876,29 @@
                         </xsl:if>
                     </tr>
 
+                    <xsl:if test="$clusterType='HTHOR'">
+                        <tr style="border:solid 2 black">
+                            <xsl:if test="count($active2)">
+                                <xsl:for-each select="$active2">
+                                    <xsl:if test="position() > 1">
+                                        <xsl:text disable-output-escaping="yes">
+                                                <![CDATA[
+                                                    </tr>
+                                                    <tr>
+                                                ]]>
+                                            </xsl:text>
+                                    </xsl:if>
+                                    <xsl:apply-templates select=".">
+                                        <xsl:with-param name="cluster" select="$cluster"/>
+                                        <xsl:with-param name="clusterType" select="$clusterType"/>
+                                        <xsl:with-param name="queue" select="$queue"/>
+                                        <xsl:with-param name="thorlcr" select="$thorlcr"/>
+                                    </xsl:apply-templates>
+                                </xsl:for-each>
+                            </xsl:if>
+                        </tr>
+                    </xsl:if>
+
                     <xsl:for-each select="$workunits[State!='running']">
                         <tr>
                             <xsl:apply-templates select=".">
@@ -887,26 +910,28 @@
                         </tr>
                     </xsl:for-each>
 
-                    <tr style="border:solid 2 black">
-                        <xsl:if test="count($active2)">
-                            <xsl:for-each select="$active2">
-                                <xsl:if test="position() > 1">
-                                    <xsl:text disable-output-escaping="yes">
-                                            <![CDATA[
-                                                </tr>
-                                                <tr>
-                                            ]]>
-                                        </xsl:text>
-                                </xsl:if>
-                                <xsl:apply-templates select=".">
-                                    <xsl:with-param name="cluster" select="$cluster"/>
-                                    <xsl:with-param name="clusterType" select="$clusterType"/>
-                                    <xsl:with-param name="queue" select="$queue"/>
-                                    <xsl:with-param name="thorlcr" select="$thorlcr"/>
-                                </xsl:apply-templates>
-                            </xsl:for-each>
-                        </xsl:if>
-                    </tr>
+                    <xsl:if test="$clusterType!='HTHOR'">
+                        <tr style="border:solid 2 black">
+                            <xsl:if test="count($active2)">
+                                <xsl:for-each select="$active2">
+                                    <xsl:if test="position() > 1">
+                                        <xsl:text disable-output-escaping="yes">
+                                                <![CDATA[
+                                                    </tr>
+                                                    <tr>
+                                                ]]>
+                                            </xsl:text>
+                                    </xsl:if>
+                                    <xsl:apply-templates select=".">
+                                        <xsl:with-param name="cluster" select="$cluster"/>
+                                        <xsl:with-param name="clusterType" select="$clusterType"/>
+                                        <xsl:with-param name="queue" select="$queue"/>
+                                        <xsl:with-param name="thorlcr" select="$thorlcr"/>
+                                    </xsl:apply-templates>
+                                </xsl:for-each>
+                            </xsl:if>
+                        </tr>
+                    </xsl:if>
                 </xsl:when>
                 <xsl:otherwise>
                     <td width="1100" colspan='4'>No active workunit</td>

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -39,6 +39,9 @@ ESPStruct ActiveWorkunit
     [min_ver("1.04")] int MemoryBlocked;
     [min_ver("1.09")] bool IsPausing(false);
     [min_ver("1.10")] string Warning;
+    [min_ver("1.15")] ClusterName;
+    [min_ver("1.15")] string ClusterType;
+    [min_ver("1.15")] string ClusterQueueName;
 };
 
 ESPStruct ThorCluster
@@ -300,7 +303,7 @@ RoxieControlCmdResponse
     ESParray<ESPstruct RoxieControlEndpointInfo, Endpoint> Endpoints;
 };
 
-ESPservice [noforms, version("1.14"), default_client_version("1.14"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [noforms, version("1.15"), default_client_version("1.15"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -272,7 +272,7 @@ void CWsSMCEx::getQueueState(int runningJobsInQueue, StringBuffer& queueState, B
     return;
 }
 
-void CWsSMCEx::readClusterTypeAndQueueName(CConstWUClusterInfoArray& clusters, const char* clusterName, SCMStringBuffer& clusterType, SCMStringBuffer& clusterQueue)
+void CWsSMCEx::readClusterTypeAndQueueName(CConstWUClusterInfoArray& clusters, const char* clusterName, StringBuffer& clusterType, SCMStringBuffer& clusterQueue)
 {
     if (!clusterName || !*clusterName)
         return;
@@ -311,10 +311,10 @@ void CWsSMCEx::addRunningWUs(IEspContext &context, IPropertyTree& node, CConstWU
                    StringArray& runningQueueNames, int* runningJobsInQueue)
 {
     StringBuffer instance;
-	StringBuffer qname;
-	int serverID = -1;
-	const char* name = node.queryProp("@name");
-	if (name && *name)
+    StringBuffer qname;
+    int serverID = -1;
+    const char* name = node.queryProp("@name");
+    if (name && *name)
     {
         node.getProp("@queue", qname);
         if (0 == stricmp("ThorMaster", name))
@@ -404,7 +404,8 @@ void CWsSMCEx::addRunningWUs(IEspContext &context, IPropertyTree& node, CConstWU
                         const char* clusterName = wu->getClusterName();
                         if (clusterName && *clusterName)
                         {
-                            SCMStringBuffer clusterType, clusterQueue;
+                            StringBuffer clusterType;
+                            SCMStringBuffer clusterQueue;
                             readClusterTypeAndQueueName(clusters, clusterName, clusterType, clusterQueue);
                             wu->setClusterType(clusterType.str());
                             wu->setClusterQueueName(clusterQueue.str());

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -431,6 +431,24 @@ void CWsSMCEx::addRunningWUs(IEspContext &context, IPropertyTree& node, CConstWU
     return;
 }
 
+// This method reads job information from both /Status/Servers and IJobQueue.
+//
+// Each server component (a thor cluster, a dfuserver, or an eclagent) is one 'Server' branch under
+// /Status/Servers. A 'Server' branch has a @queue which indicates the queue name of the server.
+// A 'Server' branch also contains the information about running WUs on that 'Server'. This
+// method reads the information. Those WUs are displays under that server (identified by its queue name)
+// on Activity page.
+//
+// For the WUs list inside /Status/Servers/Server[@name=ECLagent] but not list under other 'Server', the
+// existing code has to find out WUID and @clusterName of the WU. Then, uses @clusterName to find out the
+// queue name in IConstWUClusterInfo. Those WUs list under that server (identified by its queue name) with
+// a note 'on ECLagent'.
+//
+// In order to get information about queued WUs, this method gets queue names from both IConstWUClusterInfo
+// and other environment functions. Each of those queue names is linked to one IJobQueues. From the
+// IJobQueues, this method reads queued jobs for each server component and list them under the server
+// component (identified by its queue name).
+
 bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspActivityResponse& resp)
 {
     context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, true);

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -442,7 +442,8 @@ void CWsSMCEx::addRunningWUs(IEspContext &context, IPropertyTree& node, CConstWU
 // For the WUs list inside /Status/Servers/Server[@name=ECLagent] but not list under other 'Server', the
 // existing code has to find out WUID and @clusterName of the WU. Then, uses @clusterName to find out the
 // queue name in IConstWUClusterInfo. Those WUs list under that server (identified by its queue name) with
-// a note 'on ECLagent'.
+// a note 'on ECLagent'. TBD: the logic here will be simpler if the /Status/Servers/Server is named the
+// instance and/or cluster.
 //
 // In order to get information about queued WUs, this method gets queue names from both IConstWUClusterInfo
 // and other environment functions. Each of those queue names is linked to one IJobQueues. From the

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -80,7 +80,7 @@ private:
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* queueState, const char* serverName, const char* serverType);
     void getQueueState(int runningJobsInQueue, StringBuffer& queueState, BulletType& colorType);
-    void readClusterTypeAndQueueName(CConstWUClusterInfoArray& clusters, const char* clusterName, SCMStringBuffer& clusterType, SCMStringBuffer& clusterQueue);
+    void readClusterTypeAndQueueName(CConstWUClusterInfoArray& clusters, const char* clusterName, StringBuffer& clusterType, SCMStringBuffer& clusterQueue);
     void addRunningWUs(IEspContext &context, IPropertyTree& node, CConstWUClusterInfoArray& clusters,
                    IArrayOf<IEspActiveWorkunit>& aws, BoolHash& uniqueWUIDs,
                    StringArray& runningQueueNames, int* runningJobsInQueue);

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -80,6 +80,16 @@ private:
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* queueState, const char* serverName, const char* serverType);
     void getQueueState(int runningJobsInQueue, StringBuffer& queueState, BulletType& colorType);
+    void setClusterNameTypeQueueMap(CConstWUClusterInfoArray& clusters, std::map<std::string, std::string>& clusterNameQueueMap, std::map<std::string, std::string>& clusterNameTypeMap);
+    void findQueueNameAndInstance(IPropertyTree& node, StringBuffer& qname, StringBuffer& instance);
+    void addRunningWUs(IEspContext &context, IPropertyTree& node, StringBuffer& qname, StringBuffer& instance,
+                   std::map<std::string, std::string>& clusterNameQueueMap, std::map<std::string, std::string>& clusterNameTypeMap,
+                   IArrayOf<IEspActiveWorkunit>& aws, BoolHash& uniqueWUIDs,
+                   StringArray& runningQueueNames, int* runningJobsInQueue);
+    void addRunningWUs(IEspContext &context, IPropertyTreeIterator* it,
+                   std::map<std::string, std::string>& clusterNameQueueMap, std::map<std::string, std::string>& clusterNameTypeMap,
+                   IArrayOf<IEspActiveWorkunit>& aws, BoolHash& uniqueWUIDs,
+                   StringArray& runningQueueNames, int* runningJobsInQueue, bool fromECLagent);
 };
 
 

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -80,16 +80,10 @@ private:
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* queueState, const char* serverName, const char* serverType);
     void getQueueState(int runningJobsInQueue, StringBuffer& queueState, BulletType& colorType);
-    void setClusterNameTypeQueueMap(CConstWUClusterInfoArray& clusters, std::map<std::string, std::string>& clusterNameQueueMap, std::map<std::string, std::string>& clusterNameTypeMap);
-    void findQueueNameAndInstance(IPropertyTree& node, StringBuffer& qname, StringBuffer& instance);
-    void addRunningWUs(IEspContext &context, IPropertyTree& node, StringBuffer& qname, StringBuffer& instance,
-                   std::map<std::string, std::string>& clusterNameQueueMap, std::map<std::string, std::string>& clusterNameTypeMap,
+    void readClusterTypeAndQueueName(CConstWUClusterInfoArray& clusters, const char* clusterName, SCMStringBuffer& clusterType, SCMStringBuffer& clusterQueue);
+    void addRunningWUs(IEspContext &context, IPropertyTree& node, CConstWUClusterInfoArray& clusters,
                    IArrayOf<IEspActiveWorkunit>& aws, BoolHash& uniqueWUIDs,
                    StringArray& runningQueueNames, int* runningJobsInQueue);
-    void addRunningWUs(IEspContext &context, IPropertyTreeIterator* it,
-                   std::map<std::string, std::string>& clusterNameQueueMap, std::map<std::string, std::string>& clusterNameTypeMap,
-                   IArrayOf<IEspActiveWorkunit>& aws, BoolHash& uniqueWUIDs,
-                   StringArray& runningQueueNames, int* runningJobsInQueue, bool fromECLagent);
 };
 
 


### PR DESCRIPTION
Using existing code, running hthor WU is not shown on EclWatch
Activity page since EclWatch trys to read the WU from /Status/
Servers/Server/@name='a_hthor.agent' and the WU is not list there.
But, the WU is list under /Status/Servers/Server/@name='ECLagent'.
This fix reads a WU from /Status/Servers/Server/@name='ECLagent',
find out whether the WUID has been included on the Activity page.
If not, find out @ClusterName of the WU. Using the ClusterName,
find out the cluster type and queue name, and show the WU under
that cluster.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
