### PR TITLE
HPCC-8554 Combine derived helpers that are split into multiple interface...

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -730,39 +730,19 @@ public:
         logXML = (flags & SOAPFlog) != 0;
         logUserMsg = (flags & SOAPFlogusermsg) != 0;
 
-        IHThorWebServiceCallExtra2 * helperExtra2 = static_cast<IHThorWebServiceCallExtra2*>(helper->selectInterface(TAIsoapcallextra_2));
-        if (helperExtra2)
-        {
-            double dval = helperExtra2->getTimeoutMS();//double, indicating seconds and nanoseconds.
-            if (dval == -1.0)//not provided
-                timeoutMS = 300*1000; // 300 second default
-            else if (dval == 0)
-                timeoutMS = WAIT_FOREVER;
-            else
-                timeoutMS = dval * 1000;
-
-            dval = helperExtra2->getTimeLimitMS();
-            if (dval <= 0.0)
-                timeLimitMS = WAIT_FOREVER;
-            else
-                timeLimitMS = dval * 1000;
-        }
+        double dval = helper->getTimeout(); // In seconds, but may include fractions of a second...
+        if (dval == -1.0) //not provided
+            timeoutMS = 300*1000; // 300 second default
+        else if (dval == 0)
+            timeoutMS = WAIT_FOREVER;
         else
-        {
-            timeoutMS = helper->getTimeout();//get timeout, in seconds
-            if (timeoutMS == (unsigned)-1)
-                timeoutMS = 300*1000; // 300 second default
-            else if (timeoutMS == 0)
-                timeoutMS = WAIT_FOREVER;
-            else
-                timeoutMS *= 1000;
+            timeoutMS = dval * 1000;
 
-            timeLimitMS = helper->getTimeLimit();
-            if (timeLimitMS == 0  ||  timeLimitMS == (unsigned)-1)
-                timeLimitMS = WAIT_FOREVER;	//default
-            else
-                timeLimitMS *= 1000;
-        }
+        dval = helper->getTimeLimit();
+        if (dval <= 0.0)
+            timeLimitMS = WAIT_FOREVER;
+        else
+            timeLimitMS = dval * 1000;
 
         if (wscType == STsoap)
         {

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -16752,17 +16752,11 @@ ABoundActivity * HqlCppTranslator::doBuildActivitySOAP(BuildCtx & ctx, IHqlExpre
     //virtual int numRetries()
     doBuildSignedFunction(instance->classctx, "numRetries", queryPropertyChild(expr, retryAtom, 0));
 
-    //virtual unsigned getTimeout()
-    doBuildUnsignedFunction(instance->classctx, "getTimeout", queryPropertyChild(expr, timeoutAtom, 0));
+    //virtual double getTimeout()
+    doBuildDoubleFunction(instance->classctx, "getTimeout", queryPropertyChild(expr, timeoutAtom, 0));
 
-    //virtual unsigned getTimeLimit()
-    doBuildUnsignedFunction(instance->classctx, "getTimeLimit", queryPropertyChild(expr, timeLimitAtom, 0));
-
-    //virtual double getTimeoutMS()
-    doBuildDoubleFunction(instance->classctx, "getTimeoutMS", queryPropertyChild(expr, timeoutAtom, 0));
-
-    //virtual double getTimeLimitMS()
-    doBuildDoubleFunction(instance->classctx, "getTimeLimitMS", queryPropertyChild(expr, timeLimitAtom, 0));
+    //virtual double getTimeLimit()
+    doBuildDoubleFunction(instance->classctx, "getTimeLimit", queryPropertyChild(expr, timeLimitAtom, 0));
 
     if (namespaceAttr)
     {
@@ -16909,17 +16903,11 @@ ABoundActivity * HqlCppTranslator::doBuildActivityHTTP(BuildCtx & ctx, IHqlExpre
     //virtual int numRetries()
     doBuildSignedFunction(instance->classctx, "numRetries", queryPropertyChild(expr, retryAtom, 0));
 
-    //virtual unsigned getTimeout()
-    doBuildUnsignedFunction(instance->classctx, "getTimeout", queryPropertyChild(expr, timeoutAtom, 0));
+    //virtual double getTimeout()
+    doBuildDoubleFunction(instance->classctx, "getTimeout", queryPropertyChild(expr, timeoutAtom, 0));
 
-    //virtual unsigned getTimeLimit()
-    doBuildUnsignedFunction(instance->classctx, "getTimeLimit", queryPropertyChild(expr, timeLimitAtom, 0));
-
-    //virtual double getTimeoutMS()
-    doBuildDoubleFunction(instance->classctx, "getTimeoutMS", queryPropertyChild(expr, timeoutAtom, 0));
-
-    //virtual double getTimeLimitMS()
-    doBuildDoubleFunction(instance->classctx, "getTimeLimitMS", queryPropertyChild(expr, timeLimitAtom, 0));
+    //virtual double getTimeLimit()
+    doBuildDoubleFunction(instance->classctx, "getTimeLimit", queryPropertyChild(expr, timeLimitAtom, 0));
 
     if (namespaceAttr)
     {

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -30,8 +30,8 @@ It should only contain pure interface definitions or inline functions.
 
 //Should be incremented whenever the virtuals in the context or a helper are changed, so
 //that a work unit can't be rerun.  Try as hard as possible to retain compatibility.
-#define ACTIVITY_INTERFACE_VERSION      141
-#define MIN_ACTIVITY_INTERFACE_VERSION  141             //minimum value that is compatible with current interface - without using selectInterface
+#define ACTIVITY_INTERFACE_VERSION      142
+#define MIN_ACTIVITY_INTERFACE_VERSION  142             //minimum value that is compatible with current interface - without using selectInterface
 
 typedef unsigned char byte;
 
@@ -941,9 +941,6 @@ enum ActivityInterfaceEnum
     TAInwayjoinarg_1,
     TAInwaymergeextra_1,
     TAInwaygraphloopresultreadarg_1,
-    TAIcompoundreadextra_2,
-    TAIcompoundgroupaggregateextra_2,
-    TAIsoapactionarg_2,
     TAInwayselectarg_1,
     TAIalgorithm_1,
     TAInonemptyarg_1,
@@ -960,19 +957,13 @@ enum ActivityInterfaceEnum
     TAIfilterprojectarg_1,
     TAIsteppedsourceextra_1,
     TAIcatcharg_1,
-    TAIsortarg_2,
     TAIsectioninputarg_1,
     TAIwhenactionarg_1,
     TAIcountrowaggregator_1,
-    TAIpipereadarg_2,
     TAIstreamediteratorarg_1,
     TAIexternal_1,
-    TAIpipethrougharg_2,
-    TAIpipewritearg_2,
     TAIinlinetablearg_1,
     TAIshuffleextra_1,
-    TAIhashdeduparg_2,
-    TAIsoapcallextra_2,
     TAIdictionaryworkunitwritearg_1,
     TAIdictionaryresultwritearg_1,
 
@@ -1823,7 +1814,6 @@ struct IHThorHashDedupArg : public IHThorArg
     virtual IOutputMetaData * queryKeySize() = 0;
     virtual size32_t recordToKey(ARowBuilder & rowBuilder, const void * _record) = 0;
     virtual ICompare * queryKeyCompare()=0;
-    //the following are only valid if selectInterface(TAIhashdeduparg_2) returns non-null
     virtual unsigned getFlags() = 0;
     virtual IHash    * queryKeyHash()=0;
     virtual ICompare * queryRowKeyCompare()=0; // lhs is a row, rhs is a key
@@ -2111,14 +2101,14 @@ struct IHThorWebServiceCallActionArg : public IHThorArg
     virtual unsigned numRecordsPerBatch()               { return 0; }
     virtual const char * queryUserName()                { return NULL; }
     virtual const char * queryPassword()                { return NULL; }
-    virtual int numRetries()                            { return -1; }
-    virtual unsigned getTimeout()                       { return (unsigned)-1; }
+    virtual int numRetries()                             { return -1; }
+    virtual double getTimeout()                         { return (double)-1.0; }
+    virtual double getTimeLimit()                       { return (double)0.0; }
     virtual const char * querySoapAction()              { return NULL; }
     virtual const char * queryNamespaceName()           { return NULL; }
     virtual const char * queryNamespaceVar()            { return NULL; }
     virtual const char * queryHttpHeaderName()          { return NULL; }
     virtual const char * queryHttpHeaderValue()         { return NULL; }
-    virtual unsigned     getTimeLimit()                 { return (unsigned)-1; }
     virtual const char * queryProxyAddress()            { return NULL; }
     virtual const char * queryAcceptType()              { return NULL; }
 };
@@ -2135,14 +2125,7 @@ struct IHThorWebServiceCallExtra : public IInterface
 };
 typedef IHThorWebServiceCallExtra IHThorSoapCallExtra;
 
-struct IHThorWebServiceCallExtra2 : public IInterface
-{
-    virtual double getTimeoutMS()   { return (double)-1.0; }//not specified, use default
-    virtual double getTimeLimitMS() { return (double)-1.0; }//not specified, use default
-};
-typedef IHThorWebServiceCallExtra2 IHThorSoapCallExtra2;
-
-struct IHThorWebServiceCallArg : public IHThorWebServiceCallActionArg, public IHThorWebServiceCallExtra, public IHThorWebServiceCallExtra2
+struct IHThorWebServiceCallArg : public IHThorWebServiceCallActionArg, public IHThorWebServiceCallExtra
 {
     COMMON_NEWTHOR_FUNCTIONS
 };

--- a/rtl/include/eclhelper_base.hpp
+++ b/rtl/include/eclhelper_base.hpp
@@ -470,7 +470,6 @@ public:
         {
         case TAIarg:
         case TAIpipereadarg_1:
-        case TAIpipereadarg_2:
             return static_cast<IHThorPipeReadArg *>(this);
         }
         return NULL;
@@ -498,7 +497,6 @@ public:
         {
         case TAIarg:
         case TAIpipewritearg_1:
-        case TAIpipewritearg_2:
             return static_cast<IHThorPipeWriteArg *>(this);
         }
         return NULL;
@@ -524,7 +522,6 @@ public:
         {
         case TAIarg:
         case TAIpipethrougharg_1:
-        case TAIpipethrougharg_2:
             return static_cast<IHThorPipeThroughArg *>(this);
         }
         return NULL;
@@ -1529,7 +1526,6 @@ class CThorSortArg : public CThorArg, implements IHThorSortArg, implements IHTho
         {
         case TAIarg:
         case TAIsortarg_1:
-        case TAIsortarg_2:
             return static_cast<IHThorSortArg *>(this);
         case TAIalgorithm_1:
             return static_cast<IHThorAlgorithm *>(this);
@@ -2025,7 +2021,6 @@ class CThorHashDedupArg : public CThorArg, implements IHThorHashDedupArg
         {
         case TAIarg:
         case TAIhashdeduparg_1:
-        case TAIhashdeduparg_2:
             return static_cast<IHThorHashDedupArg *>(this);
         }
         return NULL;
@@ -2416,7 +2411,7 @@ class CThorXmlWriteArg : public CThorArg, implements IHThorXmlWriteArg
 
 //-- SOAP --
 
-class CThorSoapActionArg : public CThorArg, implements IHThorSoapActionArg, public IHThorWebServiceCallExtra2
+class CThorSoapActionArg : public CThorArg, implements IHThorSoapActionArg
 {
     virtual void Link() const { RtlCInterface::Link(); }
     virtual bool Release() const { return RtlCInterface::Release(); }
@@ -2429,10 +2424,7 @@ class CThorSoapActionArg : public CThorArg, implements IHThorSoapActionArg, publ
         {
         case TAIarg:
         case TAIsoapactionarg_1:
-        case TAIsoapactionarg_2:
             return static_cast<IHThorSoapActionArg *>(this);
-        case TAIsoapcallextra_2:
-            return static_cast<IHThorWebServiceCallExtra2 *>(this);
         }
         return NULL;
     }
@@ -2446,14 +2438,14 @@ class CThorSoapActionArg : public CThorArg, implements IHThorSoapActionArg, publ
     virtual const char * queryUserName()                { return NULL; }
     virtual const char * queryPassword()                { return NULL; }
     virtual int numRetries()                            { return -1; }
-    virtual unsigned getTimeout()                       { return -1; }
+    virtual double getTimeout()                          { return -1.0; }
+    virtual double getTimeLimit()                        { return 0.0; }
     virtual const char * querySoapAction()              { return NULL; }
     virtual const char * queryNamespaceName()           { return NULL; }
     virtual const char * queryNamespaceVar()            { return NULL; }
 
     virtual const char * queryHttpHeaderName()          { return NULL; }
     virtual const char * queryHttpHeaderValue()         { return NULL; }
-    virtual unsigned     getTimeLimit()                 { return 0; }
     virtual const char * queryProxyAddress()            { return NULL; }
     virtual const char * queryAcceptType()              { return NULL; }
     virtual void getLogText(size32_t & lenText, char * & text, const void * left) { lenText =0; text = NULL; }
@@ -2471,12 +2463,9 @@ class CThorSoapCallArg : public CThorArg, implements IHThorSoapCallArg
         {
         case TAIarg:
         case TAIsoapactionarg_1:
-        case TAIsoapactionarg_2:
             return static_cast<IHThorSoapActionArg *>(this);
         case TAIsoapcallextra_1:
             return static_cast<IHThorSoapCallExtra *>(this);
-        case TAIsoapcallextra_2:
-            return static_cast<IHThorWebServiceCallExtra2 *>(this);
         }
 
         return NULL;
@@ -2495,14 +2484,14 @@ class CThorSoapCallArg : public CThorArg, implements IHThorSoapCallArg
     virtual const char * queryUserName()                { return NULL; }
     virtual const char * queryPassword()                { return NULL; }
     virtual int numRetries()                            { return -1; }
-    virtual unsigned getTimeout()                       { return -1; }
+    virtual double getTimeout()                          { return -1.0; }
+    virtual double getTimeLimit()                        { return 0.0; }
     virtual const char * querySoapAction()              { return NULL; }
     virtual const char * queryNamespaceName()           { return NULL; }
     virtual const char * queryNamespaceVar()            { return NULL; }
 
     virtual const char * queryHttpHeaderName()          { return NULL; }
     virtual const char * queryHttpHeaderValue()         { return NULL; }
-    virtual unsigned     getTimeLimit()                 { return 0; }
     virtual const char * queryProxyAddress()            { return NULL; }
     virtual const char * queryAcceptType()              { return NULL; }
     virtual void getLogText(size32_t & lenText, char * & text, const void * left) { lenText =0; text = NULL; }
@@ -2555,7 +2544,6 @@ protected:
             return static_cast<IHThorIndexReadBaseArg *>(this);
         case TAIcompoundextra_1:
         case TAIcompoundreadextra_1:
-        case TAIcompoundreadextra_2:
             return static_cast<IHThorCompoundReadExtra *>(this);
         case TAIsourcelimittransformextra_1:
             return static_cast<IHThorSourceLimitTransformExtra *>(this);
@@ -2724,7 +2712,6 @@ protected:
             return static_cast<IHThorIndexReadBaseArg *>(this);
         case TAIrowaggregator_1:
         case TAIcompoundgroupaggregateextra_1:
-        case TAIcompoundgroupaggregateextra_2:
             return static_cast<IHThorCompoundGroupAggregateExtra *>(this);
         }
         return NULL;
@@ -2760,7 +2747,6 @@ class CThorDiskReadArg : public CThorArg, implements IHThorDiskReadArg, implemen
             return static_cast<IHThorDiskReadBaseArg *>(this);
         case TAIcompoundextra_1:
         case TAIcompoundreadextra_1:
-        case TAIcompoundreadextra_2:
             return static_cast<IHThorCompoundReadExtra *>(this);
         case TAIsourcelimittransformextra_1:
             return static_cast<IHThorSourceLimitTransformExtra *>(this);
@@ -2898,7 +2884,6 @@ class CThorDiskGroupAggregateArg : public CThorArg, implements IHThorDiskGroupAg
             return static_cast<IHThorDiskReadBaseArg *>(this);
         case TAIrowaggregator_1:
         case TAIcompoundgroupaggregateextra_1:
-        case TAIcompoundgroupaggregateextra_2:
             return static_cast<IHThorCompoundGroupAggregateExtra *>(this);
         }
         return NULL;

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2493,10 +2493,7 @@ public:
         // JCSMORE - it may not be worth extracting the key,
         // if there's an upstream activity that holds onto rows for periods of time (e.g. sort)
         IOutputMetaData *km = helper->queryKeySize();
-        if (helper->selectInterface(TAIhashdeduparg_2))
-            extractKey = (0 == (HFDwholerecord & helper->getFlags()));
-        else
-            extractKey = km != NULL;
+        extractKey = (0 == (HFDwholerecord & helper->getFlags()));
         if (extractKey)
         {
             // if key and row are fixed length, check that estimated memory sizes make it worth extracting key per row


### PR DESCRIPTION
...s

Clean up some helpers that were split purely for back-compatibility reasons.
Once that are split for logical functionality reasonas have been left.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
