### PR TITLE
HPCC-8863 Fix cores generating independent dictionaries.

### DIFF
--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -2972,11 +2972,19 @@ bool hasFewRows(IHqlExpression * expr)
     return (info.magnitude <= RCMfew);
 }
 
-bool spillToWorkunitNotFile(IHqlExpression * expr)
+bool spillToWorkunitNotFile(IHqlExpression * expr, ClusterType platform)
 {
-    //In thor, all rows will get sent to master and written to dali, and then read back on slave 0
-    //not likely to be more efficient unless only a single row.
-    return hasNoMoreRowsThan(expr, 1);
+    if (platform == RoxieCluster)
+        return true;
+
+    if (isThorCluster(platform))
+    {
+        //In thor, all rows will get sent to master and written to dali, and then read back on slave 0
+        //not likely to be more efficient unless only a single row - although the generated code accessing
+        //from a child query is better
+        return hasNoMoreRowsThan(expr, 1);
+    }
+    return hasFewRows(expr);
 }
 
 bool hasSingleRow(IHqlExpression * expr)

--- a/ecl/hql/hqlattr.hpp
+++ b/ecl/hql/hqlattr.hpp
@@ -18,6 +18,7 @@
 #define HQLATTR_HPP
 
 #include "hqlexpr.hpp"
+#include "workunit.hpp"
 
 #define MAX_MAXLENGTH (INFINITE_LENGTH-1)
 
@@ -76,6 +77,6 @@ extern HQL_API void getRecordCountText(StringBuffer & result, IHqlExpression * e
 extern HQL_API IHqlExpression * queryRecordCountInfo(IHqlExpression * expr);
 extern HQL_API IHqlExpression * getRecordCountInfo(IHqlExpression * expr);
 extern HQL_API bool hasNoMoreRowsThan(IHqlExpression * expr, __int64 limit);
-extern HQL_API bool spillToWorkunitNotFile(IHqlExpression * expr);
+extern HQL_API bool spillToWorkunitNotFile(IHqlExpression * expr, ClusterType platform);
 
 #endif

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -10110,7 +10110,11 @@ ABoundActivity * HqlCppTranslator::doBuildActivityOutput(BuildCtx & ctx, IHqlExp
     IHqlExpression * rawFilename = queryRealChild(expr, 1);
 
     if (dataset->isDictionary())
+    {
+        //OUTPUT(dictionary,,'filename') should never be generated - it should go via a dataset
+        assertex(!rawFilename);
         return doBuildActivityDictionaryWorkunitWrite(ctx, expr, isRoot);
+    }
     if (!rawFilename)
         return doBuildActivityOutputWorkunit(ctx, expr, isRoot);
 

--- a/testing/ecl/dict5b.ecl
+++ b/testing/ecl/dict5b.ecl
@@ -1,0 +1,16 @@
+
+
+string s1 := 'one' : stored('s1');
+string s2 := 'five' : stored('s2');
+
+
+d1 := dictionary([{'one'},{'two'},{'three'}], { string name }) : independent(few);
+d2 := dictionary([{'one'},{'two'},{'three'},{'four'}], { string name }) : independent(few);
+d3 := dictionary([{'one' => 1},{'one' => 2},{'two'=>2},{'four'=>4}], { string name => unsigned number }) : independent(few);
+
+s1 in d1;
+s2 not in d1;
+s1 in d2;
+s2 not in d2;
+s1 in d3;
+s2 not in d3;

--- a/testing/ecl/dict5c.ecl
+++ b/testing/ecl/dict5c.ecl
@@ -1,0 +1,16 @@
+
+
+string s1 := 'one' : stored('s1');
+string s2 := 'five' : stored('s2');
+
+
+d1 := dictionary([{'one'},{'two'},{'three'}], { string name }) : independent(many);
+d2 := dictionary([{'one'},{'two'},{'three'},{'four'}], { string name }) : independent(many);
+d3 := dictionary([{'one' => 1},{'one' => 2},{'two'=>2},{'four'=>4}], { string name => unsigned number }) : independent(many);
+
+s1 in d1;
+s2 not in d1;
+s1 in d2;
+s2 not in d2;
+s1 in d3;
+s2 not in d3;

--- a/testing/ecl/key/dict5b.xml
+++ b/testing/ecl/key/dict5b.xml
@@ -1,0 +1,18 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>true</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>true</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>true</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>true</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>true</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>true</Result_6></Row>
+</Dataset>

--- a/testing/ecl/key/dict5c.xml
+++ b/testing/ecl/key/dict5c.xml
@@ -1,0 +1,18 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>true</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>true</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>true</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>true</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>true</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>true</Result_6></Row>
+</Dataset>


### PR DESCRIPTION
This also fixes a bug where a FEW attribute on an expression that
was generated as a global could be mis-interpreted as a FEW attribute
on a GLOBAL() operator.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
