### PR TITLE
HPCC-8638 Allow the internal CSV buffer to dynamically resize

### DIFF
--- a/common/thorhelper/csvsplitter.hpp
+++ b/common/thorhelper/csvsplitter.hpp
@@ -90,8 +90,9 @@ protected:
     unsigned *          lengths;
     const byte * *      data;
     byte *              internalBuffer;
-    byte *              curUnquoted;
-    unsigned            maxCsvSize;
+    size32_t            internalOffset;
+    size32_t            sizeInternal;
+    size32_t            maxCsvSize;
 };
 
 class THORHELPER_API CSVOutputStream : public StringBuffer, implements ITypedOutputStream

--- a/testing/ecl/csv-escaped.ecl
+++ b/testing/ecl/csv-escaped.ecl
@@ -78,3 +78,14 @@ orig9 := DATASET([{'\'escaping\'\'the quote\'', 10, 'with user defined escape'}]
 OUTPUT(orig9, ,'regress::csv-escaped-escaped2'+EmptyString, OVERWRITE, CSV);
 escaped9 := DATASET('regress::csv-escaped-escaped2'+EmptyString, rec, CSV(ESCAPE('\\')));
 OUTPUT(escaped9);
+
+// Default is no escape
+orig10 := DATASET([
+    {'this is a line with new lines \n\n in it', 10, 'while this is not'},
+    {'this is a line with new lines \r\n\r\n in it', 10, 'while this is not'},
+    {'this is a line with "quotes" \n\n in it', 10, 'while this is not'},
+    {'',0,''}
+    ], rec);
+OUTPUT(orig10, ,'regress::csv-orig10'+EmptyString, OVERWRITE, CSV(QUOTE('"')));
+escaped10 := DATASET('regress::csv-orig10'+EmptyString, rec, CSV(QUOTE('"'),MAXLENGTH(1)));
+OUTPUT(escaped10);

--- a/testing/ecl/key/csv-escaped.xml
+++ b/testing/ecl/key/csv-escaped.xml
@@ -43,3 +43,15 @@
 <Dataset name='Result 18'>
  <Row><foo>escaping&apos;the quote</foo><id>10</id><bar>with user defined escape</bar></Row>
 </Dataset>
+<Dataset name='Result 19'>
+</Dataset>
+<Dataset name='Result 20'>
+ <Row><foo>this is a line with new lines 
+
+ in it</foo><id>10</id><bar>while this is not</bar></Row>
+ <Row><foo>this is a line with new lines 
+
+ in it</foo><id>10</id><bar>while this is not</bar></Row>
+ <Row><foo>this is a line with &quot;quotes&quot; </foo><id>10</id><bar>while this is not</bar></Row>
+ <Row><foo></foo><id>0</id><bar></bar></Row>
+</Dataset>


### PR DESCRIPTION
Also clean up the quote processing code by including it in the same loop
as the quote processing.  This avoids copying the strings more than once.
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
