### PR TITLE
HPCC-8866 Allow PackageId match to query name without version

### DIFF
--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -304,11 +304,21 @@ public:
 
     virtual const packageType *matchResolvedPackage(const char *name) const
     {
-        if (name)
+        if (name && *name)
         {
             const packageType *pkg = queryResolvedPackage(name);
             if (pkg)
                 return pkg;
+            const char *tail = name + strlen(name)-1;
+            while (tail>name && isdigit(*tail))
+                tail--;
+            if (*tail=='.' && tail>name)
+            {
+                StringAttr notail(name, tail-name);
+                pkg = queryResolvedPackage(notail);
+                if (pkg)
+                    return pkg;
+            }
             ForEachItemIn(idx, wildMatches)
             {
                 if (WildMatch(name, wildMatches.item(idx), true))


### PR DESCRIPTION
Existing packages use the root query name (without version) as
the PackageId.  Package matching will now use the following logic
to maintain new functionality but still be backward compatible with
package ids that are not query version specific.
1. make exact packageid match against queryname with version.
2. make exact packageid match against queryname without version.
3. fuzzy match using "queries" attribute against queryname with version.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
