### PR TITLE
HPCC-8816 Show 'Delete Query' result and redirect to QuerySet

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1207,6 +1207,7 @@ ESPresponse [exceptions_inline] WUQueryDetailsResponse
     string Wuid;
     string Dll;
     bool Suspended;
+    [min_ver("1.42")] bool Activated;
     string SuspendedBy;
     string PublishedBy;
     string Comment;
@@ -1337,7 +1338,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.41"), default_client_version("1.41"),
+    version("1.42"), default_client_version("1.42"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -878,14 +878,15 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
 
     StringBuffer xpath;
     xpath.clear().append("Query[@id='").append(queryId).append("']");
-    IPropertyTree *query = queryRegistry->queryPropTree(xpath);
+    IPropertyTree *query = queryRegistry->queryPropTree(xpath.str());
     if (!query)
     {
         DBGLOG("No matching Query");
         return false;
     }
 
-    resp.setQueryName(query->queryProp("@name"));
+    const char* queryName = query->queryProp("@name");
+    resp.setQueryName(queryName);
     resp.setWuid(query->queryProp("@wuid"));
     resp.setDll(query->queryProp("@dll"));
     resp.setPublishedBy(query->queryProp("@publishedBy"));
@@ -897,6 +898,17 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
     getQueryFiles(queryId, querySet, logicalFiles);
     if (logicalFiles.length())
         resp.setLogicalFiles(logicalFiles);
+
+    double version = context.getClientVersion();
+    if (version >= 1.42)
+    {
+        xpath.clear().appendf("Alias[@name='%s']", queryName);
+        IPropertyTree *alias = queryRegistry->queryPropTree(xpath.str());
+        if (!alias)
+            resp.setActivated(false);
+        else
+            resp.setActivated(true);
+    }
 
     return true;
 }


### PR DESCRIPTION
After a query is deleted using the Delete button on QueryDetails page,
the QueryDetails page becomes invalid which should not be displayed.
This fix redirects the page to Browse Queryset page after the query
has been deleted.

On the Query Details page, a check box is added to indicate the query
is activated or not. The check box is also used for activating and
deactivating the query.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
