### PR TITLE
HPCC-8881 Move roxierow into thorhelper dll

### DIFF
--- a/common/thorhelper/roxierow.cpp
+++ b/common/thorhelper/roxierow.cpp
@@ -507,7 +507,8 @@ IRowAllocatorMetaActIdCache *createRowAllocatorCache(IRowAllocatorMetaActIdCache
 #ifdef _USE_CPPUNIT
 #include "unittests.hpp"
 
-namespace roxiemem {
+namespace roxierowtests {
+using namespace roxiemem;
 
 class RoxieRowAllocatorTests : public CppUnit::TestFixture
 {

--- a/common/thorhelper/roxierow.hpp
+++ b/common/thorhelper/roxierow.hpp
@@ -22,8 +22,6 @@
 #include "roxiemem.hpp"
 #include "eclhelper.hpp"
 
-#define ALLOCATORID_CHECK_MASK  0x00300000
-#define ALLOCATORID_MASK                0x000fffff
 
 extern THORHELPER_API IEngineRowAllocator * createRoxieRowAllocator(roxiemem::IRowManager & _rowManager, IOutputMetaData * _meta, unsigned _activityId, unsigned _allocatorId, roxiemem::RoxieHeapFlags flags);
 extern THORHELPER_API IEngineRowAllocator * createCrcRoxieRowAllocator(roxiemem::IRowManager & rowManager, IOutputMetaData * meta, unsigned activityId, unsigned allocatorId, roxiemem::RoxieHeapFlags flags);

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -52,6 +52,9 @@
 #define ACTIVITY_FLAG_NEEDSDESTRUCTOR   0x00800000
 #define ACTIVITY_FLAG_ISREGISTERED      0x00400000
 #define MAX_ACTIVITY_ID                 0x003fffff
+// MAX_ACTIVITY_ID is further subdivided:
+#define ALLOCATORID_CHECK_MASK          0x00300000
+#define ALLOCATORID_MASK                0x000fffff
 
 #define ALLOC_ALIGNMENT                 sizeof(void *)          // Minimum alignment of data allocated from the heap manager
 #define PACKED_ALIGNMENT                4                       // Minimum alignment of packed blocks


### PR DESCRIPTION
Fix confusing namespace, and move a couple of defines back to roxiemem

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
