### PR TITLE
HPCC-8889 getEnv cores on roxie when no packages are defined

### DIFF
--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -192,10 +192,11 @@ public:
     {
         if (baseResolution==basesResolved)
             return;
+        if (baseResolution==basesResolving)
+            throw MakeStringExceptionDirect(0, "PACKAGE_ERROR: circular or invalid base package definition");
+        TYPE::loadEnvironment();
         if (packages)
         {
-            if (baseResolution==basesResolving)
-                throw MakeStringExceptionDirect(0, "PACKAGE_ERROR: circular or invalid base package definition");
             Owned<IPropertyTreeIterator> baseIterator = TYPE::node->getElements("Base");
             if (!baseIterator->first())
                 appendBase(TYPE::queryRootPackage());
@@ -346,7 +347,6 @@ public:
                 throw MakeStringException(-1, "Invalid package map - Package element missing id attribute");
             Owned<packageType> package = new packageType(&packageTree);
             packages.setValue(id, package.get());
-            package->loadEnvironment();
             const char *queries = packageTree.queryProp("@queries");
             if (queries && *queries)
             {


### PR DESCRIPTION
Regression in 3.10.4 caused by:
https://github.com/hpcc-systems/HPCC-Platform/pull/3995

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
