### PR TITLE
HPCC-8892 - Avoid key max length issues for large key+payloads.

### DIFF
--- a/system/jhtree/ctfile.cpp
+++ b/system/jhtree/ctfile.cpp
@@ -80,6 +80,7 @@ inline void SwapBigEndian(KeyHdr &hdr)
     _WINREV(hdr.version);
     _WINREV(hdr.blobHead);
     _WINREV(hdr.metadataHead);
+    _WINREV(hdr.ulength);
 }
 
 inline void SwapBigEndian(NodeHdr &hdr)
@@ -89,7 +90,7 @@ inline void SwapBigEndian(NodeHdr &hdr)
     _WINREV(hdr.numKeys);
     _WINREV(hdr.keyBytes);
     _WINREV(hdr.crc32);
-//   _WINREV(hdr.memNumber);
+//   _WINREV(hdr.compatVersion);
 //   _WINREV(hdr.leafFlag);
 }
 
@@ -206,6 +207,8 @@ CNodeBase::~CNodeBase()
 CWriteNodeBase::CWriteNodeBase(offset_t _fpos, CKeyHdr *_keyHdr) 
 {
     CNodeBase::load(_keyHdr, _fpos);
+    if (isBigKey()) // if key is bigger than legacy systems, flag in hdr, so legacy builds will reject key
+        hdr.compatVersion = KEYBUILD_VERSION;
     unsigned nodeSize = keyHdr->getNodeSize();
     nodeBuf = (char *) malloc(nodeSize);
     memset(nodeBuf, 0, nodeSize);
@@ -442,18 +445,6 @@ size32_t CMetadataWriteNode::set(const char * &data, size32_t &size)
     data += written;
     size -= written;
     return written;
-}
-
-//=========================================================================================================
-
-CNodeHeader::CNodeHeader() 
-{
-}
-
-void CNodeHeader::load(NodeHdr &_hdr)
-{
-    memcpy(&hdr, &_hdr, sizeof(hdr));
-    SwapBigEndian(hdr);
 }
 
 //=========================================================================================================

--- a/system/jhtree/ctfile.cpp
+++ b/system/jhtree/ctfile.cpp
@@ -162,7 +162,9 @@ void CKeyHdr::write(IFileIOStream *out, CRC32 *crc)
 
 unsigned int CKeyHdr::getMaxKeyLength() 
 {
-    return hdr.length; 
+    if (hdr.flflvr < 2) // ulength introduced in KEYBUILD_VERSION_MINOR(2)
+        return hdr.length;
+    return hdr.ulength;
 }
 
 bool CKeyHdr::isVariable() 

--- a/system/jhtree/ctfile.hpp
+++ b/system/jhtree/ctfile.hpp
@@ -38,7 +38,8 @@
 #define HTREE_COMPRESSED_KEY 0x40
 #define HTREE_QUICK_COMPRESSED_KEY 0x48
 #define KEYBUILD_VERSION 1 // unsigned short. NB: This should upped if a change would make existing keys incompatible with current build.
-#define KEYBUILD_MAXLENGTH 0x7FFF
+#define KEYBUILD_VERSION_MINOR 2 // a minor version change, will not break compatibility with old builds
+#define KEYBUILD_LEGACY_MAXLENGTH 0x7FFF
 
 // structure to be read into - NO VIRTUALS.
 // This header layout corresponds to FairCom cTree layout for compatibility with old systems ...
@@ -57,7 +58,7 @@ struct __declspec(novtable) jhtree_decl KeyHdr
     __int64 servid; /* unique server id         48x */
     short   verson; /* configuration options at create  50x */
     unsigned short  nodeSize;   /* node record size         52x */
-    unsigned short  reclen; /* data record length           54x */
+    unsigned short  reclen; /* data record length           54x */ // JCSMORE - appears to be unused/unset in our system
     unsigned short  extsiz; /* extend file (chunk) size     56x */
     unsigned short  flmode; /* file mode (virtual, etc)     58x */
     unsigned short  logtyp; /* permanent components of file mode    5ax */
@@ -96,6 +97,7 @@ struct __declspec(novtable) jhtree_decl KeyHdr
     short unused[2]; /* unused ecx */
     __int64 blobHead; /* fpos of first blob node f0x */
     __int64 metadataHead; /* fpos of first metadata node f8x */
+    unsigned ulength; // KEYBUILD_VERSION_MINOR>=2 use this 4byte field in place of 2byte 'length'
 };
 
 //#pragma pack(1)

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -60,10 +60,6 @@ public:
     {
         dlfn.set(helper->getFileName());
         isLocal = 0 != (TIWlocal & helper->getFlags());
-        unsigned maxSize = helper->queryDiskRecordSize()->getMinRecordSize();
-        if (maxSize > KEYBUILD_MAXLENGTH)
-            throw MakeActivityException(this, 0, "Index minimum record length (%d) exceeds %d internal limit", maxSize, KEYBUILD_MAXLENGTH);
-
         singlePartKey = 0 != (helper->getFlags() & TIWsmall) || dlfn.isExternal();
         clusters.kill();
         unsigned idx=0;

--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -74,7 +74,7 @@ class IndexWriteSlaveActivity  : public ProcessSlaveActivity, public ISmartBuffe
     bool isLocal, singlePartKey, reportOverflow, fewcapwarned, refactor;
     unsigned __int64 totalCount;
 
-    size32_t maxDiskRecordSize, lastRowSize, firstRowSize;
+    size32_t lastRowSize, firstRowSize;
     MemoryBuffer rowBuff;
     OwnedConstThorRow lastRow, firstRow;
     bool needFirstRow, enableTlkPart0, receivingTag2;
@@ -113,7 +113,6 @@ public:
     {
         helper = static_cast <IHThorIndexWriteArg *> (queryHelper());
         init();
-        maxDiskRecordSize = 0;
         active = false;
         isLocal = false;
         buildTlk = true;
@@ -171,10 +170,6 @@ public:
             }
         }
         assertex(!(helper->queryDiskRecordSize()->getMetaFlags() & MDFneedserialize));
-        maxDiskRecordSize = helper->queryDiskRecordSize()->isVariableSize() ? KEYBUILD_MAXLENGTH : helper->queryDiskRecordSize()->getFixedSize();
-        // NB: the max [ecl] length is not used, other than setting a max field in the header.
-        // However, legacy systems (<=702) check that query rec length == key rec len.
-        maxDiskRecordSize = helper->queryDiskRecordSize()->getRecordSize(NULL);
         reportOverflow = false;
     }
 
@@ -198,6 +193,7 @@ public:
         buildUserMetadata(metadata);                
         buildLayoutMetadata(metadata);
         unsigned nodeSize = metadata ? metadata->getPropInt("_nodeSize", NODESIZE) : NODESIZE;
+        size32_t maxDiskRecordSize = helper->queryDiskRecordSize()->getRecordSize(NULL);
         builder.setown(createKeyBuilder(out, flags, maxDiskRecordSize, fileSize, nodeSize, helper->getKeyedSize(), isTopLevel ? 0 : totalCount));
     }
 


### PR DESCRIPTION
HPCC-8892 - Avoid key max length issues for large key+payloads.

Introduce a new 4byte max length header member to supplant the
exist 2byte length. Previously, a key+payload length that
exceeded the 2byte length, caused a truncated value to make it's
way into the header and the key build process to spuriously
complain that rows were too large adding.

The new member will be used for new keys, the old 'length' value
will still be maintained for backward compatibility.
## 

Add a missing WINREV
Set a compatibility flag, if key size exceeds old max, that will
be detected by 702 builds
