### PR TITLE
HPCC-8811 Return WUIDs in WsWorkunits/WUResubmit soap response

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -287,6 +287,12 @@ ESPStruct [nil_remove] ThorQueue
     string RunningWU2;
 };
 
+ESPStruct [nil_remove] ResubmittedWU
+{
+    string WUID;
+    string ParentWUID;
+};
+
 ESPrequest [nil_remove] WUCreateRequest
 {
 };
@@ -494,6 +500,7 @@ ESPrequest WUResubmitRequest
 
 ESPresponse [exceptions_inline] WUResubmitResponse
 {
+    [min_ver("1.40")] ESParray<ESPstruct ResubmittedWU, WU> WUs;
 };
 
 ESPrequest WURunRequest
@@ -1328,7 +1335,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.39"), default_client_version("1.39"),
+    version("1.40"), default_client_version("1.40"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1088,12 +1088,12 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
         IArrayOf<IEspResubmittedWU> resubmittedWUs;
         for(aindex_t i=0; i<req.getWuids().length();i++)
         {
-            StringBuffer wuidStr = req.getWuids().item(i);
-            checkAndTrimWorkunit("WUResubmit", wuidStr);
+            StringBuffer requestWuid = req.getWuids().item(i);
+            checkAndTrimWorkunit("WUResubmit", requestWuid);
 
-            ensureWsWorkunitAccess(context, wuidStr.str(), SecAccess_Write);
+            ensureWsWorkunitAccess(context, requestWuid.str(), SecAccess_Write);
 
-            wuid.set(wuidStr.str());
+            wuid.set(requestWuid.str());
 
             try
             {
@@ -1122,8 +1122,8 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
 
                 Owned<IEspResubmittedWU> resubmittedWU = createResubmittedWU();
                 resubmittedWU->setWUID(wuid.str());
-                if (!streq(wuidStr.str(), wuid.str()))
-                    resubmittedWU->setParentWUID(wuidStr.str());
+                if (!streq(requestWuid.str(), wuid.str()))
+                    resubmittedWU->setParentWUID(requestWuid.str());
                 resubmittedWUs.append(*resubmittedWU.getClear());
             }
             catch (IException *E)
@@ -1146,7 +1146,7 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
                 waitForWorkUnitToComplete(wuids.item(i), timeToWait);
         }
 
-        if (version > 1.39)
+        if (version >= 1.40)
             resp.setWUs(resubmittedWUs);
 
         if(wuids.length()==1)


### PR DESCRIPTION
The existing soap response of WsWorkunits/WUResubmit returns an
empty response. This fix adds WUIDs into the response. If a new
WU is created by a Resubmit, the response returns both original
WUID and new WUID.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
