### PR TITLE
HPCC-8892 - Error on key build, with excessively large key+payload

### DIFF
--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -60,9 +60,12 @@ public:
     {
         dlfn.set(helper->getFileName());
         isLocal = 0 != (TIWlocal & helper->getFlags());
-        unsigned maxSize = helper->queryDiskRecordSize()->getMinRecordSize();
+        unsigned minSize = helper->queryDiskRecordSize()->getMinRecordSize();
+        if (minSize > KEYBUILD_MAXLENGTH)
+            throw MakeActivityException(this, 0, "Index minimum record length (%d) exceeds %d internal limit", minSize, KEYBUILD_MAXLENGTH);
+        unsigned maxSize = helper->queryDiskRecordSize()->getRecordSize(NULL);
         if (maxSize > KEYBUILD_MAXLENGTH)
-            throw MakeActivityException(this, 0, "Index minimum record length (%d) exceeds %d internal limit", maxSize, KEYBUILD_MAXLENGTH);
+            throw MakeActivityException(this, 0, "Index maximum record length (%d) exceeds %d internal limit. Minimum size = %d, try setting index MAXLENGTH", maxSize, KEYBUILD_MAXLENGTH, minSize);
 
         singlePartKey = 0 != (helper->getFlags() & TIWsmall) || dlfn.isExternal();
         clusters.kill();


### PR DESCRIPTION
Due to the internal 32k key+payload limit (impossed by legacy
header definition) - detect and fire an error if key+payload
exceeds the maximum.

Previously, if the keys managed to squeeze into key build process
but exceeded the maximum, then the key header 'length' was
truncated, causing a confusing error that key was larger than
this truncated value.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
