### PR TITLE
HPCC-8898 #EXPORT not handling decimal types correctly

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -13213,6 +13213,11 @@ void PrintLogExprTree(IHqlExpression *expr, const char *caption, bool full)
 static unsigned exportRecord(IPropertyTree *dataNode, IHqlExpression * record, unsigned & offset, bool flatten);
 static unsigned exportRecord(IPropertyTree *dataNode, IHqlExpression * record, bool flatten);
 
+static inline bool isdigit_or_underbar(unsigned char c)
+{
+    return isdigit(c) || c=='_';
+}
+
 unsigned exportField(IPropertyTree *table, IHqlExpression *field, unsigned & offset, bool flatten)
 {
     if (field->isAttribute())
@@ -13246,7 +13251,7 @@ unsigned exportField(IPropertyTree *table, IHqlExpression *field, unsigned & off
     if (!queryOriginalName(type, typeName))
         type->getECLType(typeName);
     f->setProp("@ecltype", typeName.str());
-    while (isdigit((unsigned char)typeName.charAt(typeName.length()-1)))
+    while (isdigit_or_underbar((unsigned char)typeName.charAt(typeName.length()-1)))
         typeName.remove(typeName.length()-1, 1);
     f->setProp("@type", typeName.str());
     f = table->addPropTree(f->queryName(), f);

--- a/ecl/regress/export4.ecl
+++ b/ecl/regress/export4.ecl
@@ -1,0 +1,8 @@
+decimalRec := RECORD
+DECIMAL3 A;
+DECIMAL3_1 B;
+END;
+LOADXML('<xml/>'); //"dummy" just to open an XML scope
+#DECLARE(out);
+#EXPORT(out, decimalRec);
+OUTPUT(%'out'%);


### PR DESCRIPTION
The code for outputting basic type when exporting records to XML was weird.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
