### PR TITLE
HPCC-8876 Not show MoveUp/down menu for queued agentexec job

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -236,7 +236,7 @@
                             return false;
                         }
 
-                        function queuedWUPopup(cluster,clusterType,queue,wuid,prev,next,highpriority)
+                        function queuedWUPopup(cluster,clusterType,queue,eclAgentQueue, wuid,prev,next,highpriority)
                         {
                             function moveupWuid()
                             {
@@ -276,15 +276,20 @@
                             oMenu = new YAHOO.widget.Menu("activitypagemenu", {position: "dynamic", xy: xypos} );
                             oMenu.clearContent();
 
-                            oMenu.addItems([
-                                { text: "Move Up", onclick: { fn: moveupWuid }, disabled: prev ? false : true },
-                                { text: "Move Down", onclick: { fn: movedownWuid }, disabled: next ? false : true },
-                                { text: "Move Top", onclick: { fn: movefrontWuid }, disabled: prev ? false : true },
-                                { text: "Move Bottom", onclick: { fn: movebackWuid }, disabled: next ? false : true },
-                                { text: "Remove", onclick: { fn: removeWuid } },
-                                { text: "High Priority", onclick: { fn: highpriority ? setNormalPriority : setHighPriority }, checked: highpriority ? true : false }
-                            ]);
-
+                            if (eclAgentQueue == '') {
+                                oMenu.addItems([
+                                    { text: "Move Up", onclick: { fn: moveupWuid }, disabled: prev ? false : true },
+                                    { text: "Move Down", onclick: { fn: movedownWuid }, disabled: next ? false : true },
+                                    { text: "Move Top", onclick: { fn: movefrontWuid }, disabled: prev ? false : true },
+                                    { text: "Move Bottom", onclick: { fn: movebackWuid }, disabled: next ? false : true },
+                                    { text: "Remove", onclick: { fn: removeWuid } },
+                                    { text: "High Priority", onclick: { fn: highpriority ? setNormalPriority : setHighPriority }, checked: highpriority ? true : false }
+                                ]);
+                            } else {
+                                oMenu.addItems([
+                                    { text: "Remove", onclick: { fn: removeWuid } }
+                                ]);
+                            }
                             oMenu.render("rendertarget");
                             oMenu.show();
                             return false;
@@ -963,7 +968,7 @@
                     return activeWUPopup('paused', '<xsl:value-of select="$cluster"/>','<xsl:value-of select="$clusterType"/>','<xsl:value-of select="$queue"/>','<xsl:value-of select="Wuid"/>',<xsl:value-of select="Priority='high'"/>);
                 </xsl:when>
                 <xsl:when test="starts-with(State,'queued')">
-                    return queuedWUPopup('<xsl:value-of select="$cluster"/>','<xsl:value-of select="$clusterType"/>','<xsl:value-of select="$queue"/>','<xsl:value-of select="Wuid"/>',<xsl:value-of select="starts-with(preceding-sibling::*[Instance=current()/Instance][position()=1]/State,'queued')"/>,<xsl:value-of select="starts-with(following-sibling::*[Instance=current()/Instance][position()=1]/State,'queued')"/>,<xsl:value-of select="Priority='high'"/>);
+                    return queuedWUPopup('<xsl:value-of select="$cluster"/>','<xsl:value-of select="$clusterType"/>','<xsl:value-of select="$queue"/>','<xsl:value-of select="AgentQueueName"/>','<xsl:value-of select="Wuid"/>',<xsl:value-of select="starts-with(preceding-sibling::*[Instance=current()/Instance][position()=1]/State,'queued')"/>,<xsl:value-of select="starts-with(following-sibling::*[Instance=current()/Instance][position()=1]/State,'queued')"/>,<xsl:value-of select="Priority='high'"/>);
                 </xsl:when>
             </xsl:choose>
         </xsl:variable>

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -42,6 +42,7 @@ ESPStruct ActiveWorkunit
     [min_ver("1.15")] ClusterName;
     [min_ver("1.15")] string ClusterType;
     [min_ver("1.15")] string ClusterQueueName;
+    [min_ver("1.16")] string AgentQueueName;
 };
 
 ESPStruct ThorCluster
@@ -303,7 +304,7 @@ RoxieControlCmdResponse
     ESParray<ESPstruct RoxieControlEndpointInfo, Endpoint> Endpoints;
 };
 
-ESPservice [noforms, version("1.15"), default_client_version("1.15"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [noforms, version("1.16"), default_client_version("1.16"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -211,7 +211,7 @@ bool isInWuList(IArrayOf<IEspActiveWorkunit>& aws, const char* wuid)
     return bFound;
 }
 
-void addQueuedWorkUnits(const char *queueName, CJobQueueContents &contents, IArrayOf<IEspActiveWorkunit> &aws, IEspContext &context, const char *serverName, const char *instanceName)
+void addQueuedWorkUnits(const char *queueName, const char *agentQueueName, CJobQueueContents &contents, IArrayOf<IEspActiveWorkunit> &aws, IEspContext &context, const char *serverName, const char *instanceName)
 {
     Owned<IJobQueueIterator> iter = contents.getIterator();
     unsigned count=0;
@@ -225,6 +225,7 @@ void addQueuedWorkUnits(const char *queueName, CJobQueueContents &contents, IArr
                     wu->setServer(serverName);
                     wu->setInstance(instanceName); // JCSMORE In thor case at least, if queued it is unknown which instance it will run on..
                     wu->setQueueName(queueName);
+                    wu->setAgentQueueName(agentQueueName);
 
                     aws.append(*wu.getLink());
             }
@@ -236,6 +237,7 @@ void addQueuedWorkUnits(const char *queueName, CJobQueueContents &contents, IArr
                 wu->setServer(serverName);
                 wu->setInstance(instanceName);
                 wu->setQueueName(queueName);
+                wu->setAgentQueueName(agentQueueName);
 
                 aws.append(*wu.getLink());
             }
@@ -597,7 +599,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 CJobQueueContents contents;
                 Owned<IJobQueue> queue = createJobQueue(queueName);
                 queue->copyItemsAndState(contents, queueState);
-                addQueuedWorkUnits(queueName, contents, aws, context, "ThorMaster", NULL);
+                addQueuedWorkUnits(queueName, "", contents, aws, context, "ThorMaster", NULL);
 
                 BulletType bulletType = bulletGreen;
                 int serverID = runningQueueNames.find(queueName);
@@ -611,7 +613,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 Owned<IJobQueue> agentQueue = createJobQueue(agentQueueName);
                 agentQueue->copyItemsAndState(agentContents, agentQueueState);
                 //Use the same 'queueName' because the job belongs to the same cluster
-                addQueuedWorkUnits(queueName, agentContents, aws, context, "ThorMaster", NULL);
+                addQueuedWorkUnits(queueName, agentQueueName, agentContents, aws, context, "ThorMaster", NULL);
                 if (bulletType == bulletGreen)
                 {//If ThorQueue is normal, check the AgentQueue
                     serverID = runningQueueNames.find(agentQueueName);
@@ -643,7 +645,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                     CJobQueueContents contents;
                     Owned<IJobQueue> queue = createJobQueue(queueName);
                     queue->copyItemsAndState(contents, queueState);
-                    addQueuedWorkUnits(queueName, contents, aws, context, "RoxieServer", NULL);
+                    addQueuedWorkUnits(queueName, queueName, contents, aws, context, "RoxieServer", NULL);
 
                     BulletType bulletType = bulletGreen;
                     int serverID = runningQueueNames.find(queueName);
@@ -670,7 +672,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
                 CJobQueueContents contents;
                 Owned<IJobQueue> queue = createJobQueue(queueName);
                 queue->copyItemsAndState(contents, queueState);
-                addQueuedWorkUnits(queueName, contents, aws, context, "HThorServer", NULL);
+                addQueuedWorkUnits(queueName, queueName, contents, aws, context, "HThorServer", NULL);
 
                 BulletType bulletType = bulletGreen;
                 int serverID = runningQueueNames.find(queueName);


### PR DESCRIPTION
On EclWatch Activity page, each queued job has a pop up menu
which contains menu items: Move Up/Down/Top/Bottom, set High
Priority, and others. For queued agentexec jobs, MoveUp/Down/Top/
Bottom and set High Priority are not useful because they will be
fired off eclagent quickly in parallel. This fix sets agentQueue
for queued agentexec jobs and uses the agentQueue to identify
those jobs from other queued jobs. For those jobs, Move Up/Down/
Top/Bottom menu items and High Priority menu item will not be
shown inside the pop up menu.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
