### PR TITLE
HPCC-8683 Problems with PLUGIN attribute on a service definition

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -482,7 +482,8 @@ void EclCC::loadOptions()
 #else
         extractOption(compilerPath, globals, "CL_PATH", "compilerPath", "/usr", NULL);
 #endif
-        extractOption(libraryPath, globals, "ECLCC_LIBRARY_PATH", "libraryPath", syspath, "lib");
+        if (!extractOption(libraryPath, globals, "ECLCC_LIBRARY_PATH", "libraryPath", syspath, "lib"))
+            libraryPath.append(ENVSEPCHAR).append(syspath).append("plugins");
         extractOption(cppIncludePath, globals, "ECLCC_INCLUDE_PATH", "includePath", syspath, "componentfiles/cl/include");
         extractOption(pluginsPath, globals, "ECLCC_PLUGIN_PATH", "plugins", syspath, "plugins");
         extractOption(hooksPath, globals, "HPCC_FILEHOOKS_PATH", "filehooks", syspath, "filehooks");

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -3513,7 +3513,7 @@ IHqlExpression* HqlGram::checkServiceDef(IHqlScope* serviceScope,_ATOM name, IHq
                 attrs = createComma(attrs, createAttribute(entrypointAtom, args));
                 hasEntrypoint = true;
             }
-            else if (name == libraryAtom)
+            else if (name == libraryAtom || name == pluginAtom)
             {
                 bool invalid = false;
                 if (attr->numChildren()==0)
@@ -3529,7 +3529,7 @@ IHqlExpression* HqlGram::checkServiceDef(IHqlScope* serviceScope,_ATOM name, IHq
                 }
 
                 if (invalid)
-                    reportError(ERR_SVC_INVALIDLIBRARY,errpos,"Invalid library: can not be empty");
+                    reportError(ERR_SVC_INVALIDLIBRARY,errpos,"Invalid %s: can not be empty", name->getAtomNamePtr());
             }
             else if (name == includeAtom)
             {

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -128,7 +128,7 @@ static void doSetCompilerPath(const char * path, const char * includes, const ch
     for (;;)
     {
         StringBuffer thislib;
-        while (*libs && *libs != ';')
+        while (*libs && *libs != ENVSEPCHAR)
             thislib.append(*libs++);
         if (thislib.length())
         {


### PR DESCRIPTION
Fix a spurious warning when using PLUGIN attribute, and ensure that the
default plugins location is on the libpath for linking to make life easier.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
