### PR TITLE
HPCC-8418 Schema generation should ignore xpaths that are too long

### DIFF
--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -3826,6 +3826,12 @@ void XmlSchemaBuilder::addSetField(const char * name, const char * itemname, ITy
     StringBuffer elementType;
     getXmlTypeName(elementType, *type.queryChildType());
 
+    if ((!itemname || !*itemname) && name) // xpaths 'Name', '/Name', and 'Name/' seem to be equivalent
+    {
+        itemname = name;
+        name = NULL;
+    }
+
     if (name && *name)
     {
         xml.append("<xs:element name=\"").append(name).append("\"");

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -577,7 +577,11 @@ void fvSplitXPath(const char *xpath, StringBuffer &s, const char *&name, const c
         return;
     const char * slash = strchr(xpath, '/');
     if (!slash)
+    {
         name = xpath;
+        if (childname)
+            *childname = NULL;
+    }
     else
     {
         if (!childname || strchr(slash+1, '/')) //output ignores xpaths that are too deep

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -571,40 +571,31 @@ ITypeInfo * containsSingleSimpleFieldBlankXPath(IResultSetMetaData * meta)
     return NULL;
 }
 
-    
+void fvSplitXPath(const char *xpath, StringBuffer &s, const char *&name, const char **childname=NULL)
+{
+    if (!xpath || !*xpath)
+        return;
+    const char * slash = strchr(xpath, '/');
+    if (!slash)
+        name = xpath;
+    else
+    {
+        if (!childname || strchr(slash+1, '/')) //output ignores xpaths that are too deep
+            return;
+        name = s.clear().append(slash-xpath, xpath).str();
+        *childname = slash+1;
+    }
+}
+
 void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) const
 {
-    StringBuffer prefix, suffix;
+    StringBuffer xname;
     ForEachItemIn(idx, columns)
     {
         CResultSetColumnInfo & column = columns.item(idx);
         unsigned flag = column.flag;
         const char * name = meta->queryName(idx);
         const char * childname = NULL;
-        const char * xname = NULL;
-        if (useXPath)
-        {
-            xname = meta->queryXPath(idx);
-            if (xname)
-            {
-                const char * slash = strchr(xname, '/');
-                if (slash)
-                {
-                    const char * slash2 = strchr(slash+1, '/');
-                    prefix.clear().append(slash-xname, xname);
-                    name = prefix.str();
-                    if (slash2)
-                    {
-                        suffix.clear().append(slash2-(slash+1), slash+1);
-                        childname = suffix.str();
-                    }
-                    else
-                        childname = slash+1;
-                }
-                else
-                    name = xname;
-            }
-        }
 
         switch (flag)
         {
@@ -622,7 +613,9 @@ void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) c
             break;
         case FVFFdataset:
             {
-                if (!childname && (!xname || !*xname)) childname = "Row";
+                childname = "Row";
+                if (useXPath)
+                    fvSplitXPath(meta->queryXPath(idx), xname, name, &childname);
                 ITypeInfo * singleFieldType = (useXPath && name && *name && childname && *childname) ? containsSingleSimpleFieldBlankXPath(column.childMeta.get()) : NULL;
                 if (!singleFieldType || !builder.addSingleFieldDataset(name, childname, *singleFieldType))
                 {
@@ -639,11 +632,17 @@ void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) c
                 ITypeInfo & type = *column.type;
                 if (type.getTypeCode() == type_set)
                 {
-                    if (!childname) childname = "Item";
+                    childname = "Item";
+                    if (useXPath)
+                        fvSplitXPath(meta->queryXPath(idx), xname, name, &childname);
                     builder.addSetField(name, childname, type);
                 }
                 else
+                {
+                    if (useXPath)
+                        fvSplitXPath(meta->queryXPath(idx), xname, name);
                     builder.addField(name, type);
+                }
                 break;
             }
         }


### PR DESCRIPTION
Currently ECL generated XML schemas don't match ECL output when the xpath is longer than needed for a particular element.  I.e. no '/'s for a field, only 1 '/' for a set or dataset.

These XPATHS are used for input record structures but ignored on output.

Schema generation will now ignore these xpaths, matching output.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
