### PR TITLE
HPCC-8911 - Deadlock adding duplicate subfile to super

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -3950,6 +3950,9 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
             if (!subfile.isEmpty()) {
                 try {
                     sub.setown(transaction->lookupFile(subfile,SDS_SUB_LOCK_TIMEOUT));
+                    // Must validate before locking for update below, to check sub is not already in parent (and therefore locked already)
+                    CDistributedSuperFile *sf = QUERYINTERFACE(parent.get(),CDistributedSuperFile);
+                    sf->validateAddSubFile(sub);
                 }
                 catch (IDFS_Exception *e) {
                     if (e->errorCode()!=DFSERR_LookupConnectionTimout)
@@ -5021,15 +5024,19 @@ public:
     }
 
 private:
-    void doAddSubFile(IDistributedFile *_sub,bool before,const char *other,IDistributedFileTransaction *transaction) // takes ownership of sub
+    void validateAddSubFile(IDistributedFile *sub)
     {
-        Owned<IDistributedFile> sub = _sub;
         if (strcmp(sub->queryLogicalName(),queryLogicalName())==0)
             throw MakeStringException(-1,"addSubFile: Cannot add file %s to itself", queryLogicalName());
         if (subfiles.ordinality())
             checkFormatAttr(sub,"addSubFile");
         if (findSubFile(sub->queryLogicalName())!=NotFound)
             throw MakeStringException(-1,"addSubFile: File %s is already a subfile of %s", sub->queryLogicalName(),queryLogicalName());
+    }
+    void doAddSubFile(IDistributedFile *_sub,bool before,const char *other,IDistributedFileTransaction *transaction) // takes ownership of sub
+    {
+        Owned<IDistributedFile> sub = _sub;
+        validateAddSubFile(sub);
 
         unsigned pos;
         if (other&&*other) {


### PR DESCRIPTION
If an existing subfile was added to a super, the transaction
mechanism would cause a locking deadlock on the 2nd add.
The 2nd add would attempt to gain an exclusive lock, having
already lookup the super+sub for read, thereby locking.
The transaction mechanism needs to check that the subfile
is not part of the super before that happens.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
