### PR TITLE
HPCC-8908 - Std distributor not reset in child query, lost recs

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -1141,7 +1141,7 @@ Restart:
 
     void startTX()
     {
-        // not used
+        stopping = false;
     }
 };
 


### PR DESCRIPTION
The standard distributor (as opposed to the pull distributor) was
not being fully reset when restarted - which effects distributors
in child queries, e.g. in a LOOP or GRAPH.
As a consequence, after the 1st iteration of LOOP/GRAPH,
distributed rows were received but throw away.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
