### PR TITLE
HPCC-8910 Rename EclWatch Copy URL menu to View URL

### DIFF
--- a/esp/xslt/espheader.xsl
+++ b/esp/xslt/espheader.xsl
@@ -63,7 +63,7 @@
                 url += '?inner=' + escape('..' + inner.pathname + inner.search);
             }
 
-            var html = '<html><head><title>Copy URLs</title>';
+            var html = '<html><head><title>View URL</title>';
             html += '</head><body ><form>';
                     html += "<table border=\"0\" cellpadding=\"2\" cellspacing=\"2\">";
                     var usequote = "\"";
@@ -72,8 +72,8 @@
             html += '</table></form>';
             html += '</body></html>';
 
-            var windowWidth = 400;
-            var windowHeight = 50;
+            var windowWidth = 800;
+            var windowHeight = 500;
             var centerWidth = (window.screen.width - windowWidth) / 2;
             var centerHeight = (window.screen.height - windowHeight) / 2;
 
@@ -125,7 +125,7 @@
                     <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
                     <img src="files_/img/refresh.png" style="cursor:pointer" onclick="parent.frames['main'].location.reload();" title="Refresh" width="13" height="15"/>
                     <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
-                    <img src="files_/img/copyurl.png" style="cursor:pointer" onclick="copy_url(parent.frames['main'].location)" title="Copy URL" width="13" height="15"/>
+                    <img src="files_/img/copyurl.png" style="cursor:pointer" onclick="copy_url(parent.frames['main'].location)" title="View URL" width="13" height="15"/>
                     <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
                     <img border="0" src="files_/img/topurl.png" title="No Frames" width="13" height="15" style="cursor:pointer"
                     onclick="top.location.href=top.frames['main'].location.href"/>


### PR DESCRIPTION
The EclWatch Copy URL icon was used to copy current EclWatch URL to
clipboard. Since most of browsers does not allow JavaScript to
access clipboard data for security and privacy reasons, the icon is
used to display the URL to a new window and a user may copy the URL
from that window. This fix changes the popup text of the icon from
'Copy URL' to 'View URL'. This fix also changes the window size
from 400 x 50 to 800 x 500 for a better display.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
