### PR TITLE
HPCC-8897 Pass cacheHint to use paged cache when querying workunits

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_workunits.xslt
@@ -32,6 +32,7 @@
     <xsl:variable name="num" select="/GetDFUWorkunitsResponse/NumWUs"/>
     <xsl:variable name="filters" select="/GetDFUWorkunitsResponse/Filters"/>
     <xsl:variable name="basicquery" select="/GetDFUWorkunitsResponse/BasicQuery"/>
+    <xsl:variable name="cachehint" select="/GetDFUWorkunitsResponse/CacheHint"/>
     <xsl:template match="/GetDFUWorkunitsResponse">
         <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
             <head>
@@ -52,6 +53,7 @@
                     var currentFilters='<xsl:value-of select="$filters"/>';
                     var archived='<xsl:value-of select="$archived"/>';
                     var basicQuery='<xsl:value-of select="$basicquery"/>';
+                    var cacheHint='<xsl:value-of select="$cachehint"/>';
                     <xsl:text disable-output-escaping="yes"><![CDATA[
                             var protectedChecked = 0;
                             var unprotectedChecked = 0;
@@ -138,9 +140,9 @@
                                 startFrom -= 1;
 
                                 if (basicQuery.length > 0)
-                                    document.location.href = '/FileSpray/GetDFUWorkunits?'+ basicQuery + '&PageStartFrom='+startFrom+'&PageSize='+size;
+                                    document.location.href = '/FileSpray/GetDFUWorkunits?'+ basicQuery + '&PageStartFrom='+startFrom+'&PageSize='+size+'&CacheHint=' + cacheHint;
                                 else
-                                    document.location.href = '/FileSpray/GetDFUWorkunits?PageStartFrom='+startFrom+'&PageSize='+size;
+                                    document.location.href = '/FileSpray/GetDFUWorkunits?PageStartFrom='+startFrom+'&PageSize='+size+'&CacheHint=' + cacheHint;
 
                                 return false;
                             }             
@@ -334,25 +336,25 @@
               <xsl:choose>
                 <xsl:when test="string-length($basicquery)">
                   <xsl:if test="$firstpage &lt; 1">
-                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?{$basicquery}&amp;PageSize={$pagesize}')">First</a>
-                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?{$basicquery}&amp;PageStartFrom={$prevpage}&amp;PageSize={$pagesize}')">Prev</a>
+                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?{$basicquery}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">First</a>
+                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?{$basicquery}&amp;PageStartFrom={$prevpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Prev</a>
                   </xsl:if>
                   <xsl:if test="$nextpage &gt; -1">
-                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?{$basicquery}&amp;PageStartFrom={$nextpage}&amp;PageSize={$pagesize}')">Next</a>
+                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?{$basicquery}&amp;PageStartFrom={$nextpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Next</a>
                     <xsl:if test="not(string-length($archived))">
-                      <a href="javascript:go('/FileSpray/GetDFUWorkunits?{$basicquery}&amp;PageStartFrom={$lastpage}&amp;PageSize={$pagesize}')">Last</a>
+                      <a href="javascript:go('/FileSpray/GetDFUWorkunits?{$basicquery}&amp;PageStartFrom={$lastpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Last</a>
                     </xsl:if>
                   </xsl:if>
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:if test="$firstpage &lt; 1">
-                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?PageSize={$pagesize}')">First</a>
-                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?PageStartFrom={$prevpage}&amp;PageSize={$pagesize}')">Prev</a>
+                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?PageSize={$pagesize}&amp;CacheHint={$cachehint}')">First</a>
+                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?PageStartFrom={$prevpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Prev</a>
                   </xsl:if>
                   <xsl:if test="$nextpage &gt; -1">
-                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?PageStartFrom={$nextpage}&amp;PageSize={$pagesize}')">Next</a>
+                    <a href="javascript:go('/FileSpray/GetDFUWorkunits?PageStartFrom={$nextpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Next</a>
                     <xsl:if test="not(string-length($archived))">
-                      <a href="javascript:go('/FileSpray/GetDFUWorkunits?PageStartFrom={$lastpage}&amp;PageSize={$pagesize}')">Last</a>
+                      <a href="javascript:go('/FileSpray/GetDFUWorkunits?PageStartFrom={$lastpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Last</a>
                     </xsl:if>
                   </xsl:if>
                 </xsl:otherwise>

--- a/esp/eclwatch/ws_XSLT/workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/workunits.xslt
@@ -37,6 +37,7 @@
    <xsl:variable name="descending" select="/WUQueryResponse/Descending"/>
    <xsl:variable name="filters" select="/WUQueryResponse/Filters"/>
    <xsl:variable name="basicquery" select="/WUQueryResponse/BasicQuery"/>
+   <xsl:variable name="cachehint" select="/WUQueryResponse/CacheHint"/>
    <xsl:template match="WUQueryResponse">
       <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
          <head>
@@ -54,6 +55,7 @@
                var currentFilters='<xsl:value-of select="$filters"/>';
                var archivedStr='<xsl:value-of select="$archived"/>';
                var basicQuery='<xsl:value-of select="$basicquery"/>';
+               var cacheHint='<xsl:value-of select="$cachehint"/>';
                <xsl:text disable-output-escaping="yes"><![CDATA[
                      var protectedChecked = 0;
                      var unprotectedChecked = 0;
@@ -172,9 +174,9 @@
                         var size = pageEndAt - startFrom + 1;
                         startFrom -= 1;
                         if (basicQuery.length > 0)
-                            document.location.href = '/WsWorkunits/WUQuery?'+ basicQuery + '&PageStartFrom='+startFrom+'&PageSize='+size;
+                            document.location.href = '/WsWorkunits/WUQuery?'+ basicQuery + '&PageStartFrom='+startFrom+'&PageSize='+size+'&CacheHint=' + cacheHint;
                         else
-                            document.location.href = '/WsWorkunits/WUQuery?PageStartFrom='+startFrom+'&PageSize='+size;
+                            document.location.href = '/WsWorkunits/WUQuery?PageStartFrom='+startFrom+'&PageSize='+size+'&CacheHint=' + cacheHint;
 
                         return false;
                      }             
@@ -366,25 +368,25 @@
                         <xsl:choose>
                             <xsl:when test="string-length($basicquery)">
                                 <xsl:if test="$firstpage &lt; 1">
-                                    <a href="javascript:go('/WsWorkunits/WUQuery?{$basicquery}&amp;PageSize={$pagesize}')">First</a>&#160;
-                                    <a href="javascript:go('/WsWorkunits/WUQuery?{$basicquery}&amp;PageStartFrom={$prevpage}&amp;PageSize={$pagesize}')">Prev</a>&#160;
+                                    <a href="javascript:go('/WsWorkunits/WUQuery?{$basicquery}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">First</a>&#160;
+                                    <a href="javascript:go('/WsWorkunits/WUQuery?{$basicquery}&amp;PageStartFrom={$prevpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Prev</a>&#160;
                                 </xsl:if>
                                 <xsl:if test="$nextpage &gt; -1">
-                                    <a href="javascript:go('/WsWorkunits/WUQuery?{$basicquery}&amp;PageStartFrom={$nextpage}&amp;PageSize={$pagesize}')">Next</a>&#160;
+                                    <a href="javascript:go('/WsWorkunits/WUQuery?{$basicquery}&amp;PageStartFrom={$nextpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Next</a>&#160;
                                     <xsl:if test="not(string-length($archived))">
-                                        <a href="javascript:go('/WsWorkunits/WUQuery?{$basicquery}&amp;PageStartFrom={$lastpage}&amp;PageSize={$pagesize}')">Last</a>&#160;
+                                        <a href="javascript:go('/WsWorkunits/WUQuery?{$basicquery}&amp;PageStartFrom={$lastpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Last</a>&#160;
                                     </xsl:if>
                                 </xsl:if>
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:if test="$firstpage &lt; 1">
-                                    <a href="javascript:go('/WsWorkunits/WUQuery?PageSize={$pagesize}')">First</a>&#160;
-                                    <a href="javascript:go('/WsWorkunits/WUQuery?PageStartFrom={$prevpage}&amp;PageSize={$pagesize}')">Prev</a>&#160;
+                                    <a href="javascript:go('/WsWorkunits/WUQuery?PageSize={$pagesize}&amp;CacheHint={$cachehint}')">First</a>&#160;
+                                    <a href="javascript:go('/WsWorkunits/WUQuery?PageStartFrom={$prevpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Prev</a>&#160;
                                 </xsl:if>
                                 <xsl:if test="$nextpage &gt; -1">
-                                    <a href="javascript:go('/WsWorkunits/WUQuery?PageStartFrom={$nextpage}&amp;PageSize={$pagesize}')">Next</a>&#160;
+                                    <a href="javascript:go('/WsWorkunits/WUQuery?PageStartFrom={$nextpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Next</a>&#160;
                                     <xsl:if test="not(string-length($archived))">
-                                        <a href="javascript:go('/WsWorkunits/WUQuery?PageStartFrom={$lastpage}&amp;PageSize={$pagesize}')">Last</a>&#160;
+                                        <a href="javascript:go('/WsWorkunits/WUQuery?PageStartFrom={$lastpage}&amp;PageSize={$pagesize}&amp;CacheHint={$cachehint}')">Last</a>&#160;
                                     </xsl:if>
                                 </xsl:if>
                             </xsl:otherwise>

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -125,6 +125,7 @@ ESPrequest GetDFUWorkunits
     [min_ver("1.01")] int64 PageStartFrom(-1);
     string Sortby;
     bool Descending(false);
+    int64 CacheHint(-1);
 };
 
 ESPresponse [encode(0), exceptions_inline]
@@ -149,7 +150,7 @@ GetDFUWorkunitsResponse
     bool Descending(false);
     string BasicQuery;
     string Filters;
-
+    [min_ver("1.07")] int64 CacheHint;
  };
 
 ESPrequest [exceptions_inline] ProgressRequest
@@ -587,7 +588,7 @@ ESPresponse [exceptions_inline, nil_remove] DeleteDropZoneFilesResponse
 };
 
 ESPservice [
-    version("1.06"), default_client_version("1.06"),
+    version("1.07"), default_client_version("1.07"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
 {
     ESPuses ESPstruct DFUWorkunit;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -350,6 +350,7 @@ ESPrequest [nil_remove] WUQueryRequest
 
     string Sortby;
     bool Descending(false);
+    int64 CacheHint;
 };
 
 
@@ -386,6 +387,7 @@ ESPresponse [nil_remove, exceptions_inline] WUQueryResponse
     bool Descending(false);
     string BasicQuery;
     string Filters;
+    [min_ver("1.41")] int64 CacheHint;
     
     ESParray<ESPstruct ECLWorkunit> Workunits;
 };
@@ -1335,7 +1337,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.40"), default_client_version("1.40"),
+    version("1.41"), default_client_version("1.41"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -871,7 +871,6 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
             } while (clusters->next());
         }
 
-        __int64 cachehint=0;
         __int64 pagesize = req.getPageSize();
         __int64 pagefrom = req.getPageStartFrom();
         __int64 displayFrom = 0;
@@ -949,11 +948,16 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
 
         filters[filterCount] = DFUsf_term;
 
+        __int64 cacheHint = req.getCacheHint();
+        if (cacheHint < 0) //Not set yet
+            cacheHint = 0;
 
         IArrayOf<IEspDFUWorkunit> result;
         Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
         unsigned numWUs = factory->numWorkUnitsFiltered(filters, filterbuf.bufferBase());
-        Owned<IConstDFUWorkUnitIterator> itr = factory->getWorkUnitsSorted(sortorder, filters, filterbuf.bufferBase(), (int) displayFrom, (int) pagesize+1, req.getOwner(), &cachehint);
+        Owned<IConstDFUWorkUnitIterator> itr = factory->getWorkUnitsSorted(sortorder, filters, filterbuf.bufferBase(), (int) displayFrom, (int) pagesize+1, req.getOwner(), &cacheHint);
+        if (version >= 1.07)
+            resp.setCacheHint(cacheHint);
 
         //unsigned actualCount = 0;
         itr->first();

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2036,9 +2036,15 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
 
     filters[filterCount] = WUSFterm;
 
+    __int64 cacheHint = 0;
+    if (!req.getCacheHint_isNull())
+        cacheHint = req.getCacheHint();
+
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
     unsigned numWUs = factory->numWorkUnitsFiltered(filters, filterbuf.bufferBase());
-    Owned<IConstWorkUnitIterator> it = factory->getWorkUnitsSorted(sortorder, filters, filterbuf.bufferBase(), begin, pagesize+1, "", NULL);
+    Owned<IConstWorkUnitIterator> it = factory->getWorkUnitsSorted(sortorder, filters, filterbuf.bufferBase(), begin, pagesize+1, "", &cacheHint);
+    if (version >= 1.41)
+        resp.setCacheHint(cacheHint);
 
     unsigned actualCount = 0;
     ForEach(*it)


### PR DESCRIPTION
Workunit/Dali implements a paged caching mechanism for sorted workunits
and dfu workunit results. To use the caching mechanism, this fix passes
cacheHint as a parameter of getWorkunitSorted() when paging through
workunits/dfu workunits.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
