### PR TITLE
HPCC-8927 Lazy open should default to smart mode

### DIFF
--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -562,7 +562,7 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="lazyOpen" use="optional" default="false">
+    <xs:attribute name="lazyOpen" use="optional" default="smart">
         <xs:annotation>
           <xs:appinfo>
             <tooltip>Delay opening files until first use. Select smart to use lazy mode only after a restart</tooltip>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -804,7 +804,7 @@
                 jumboFrames="false"
                 keyedJoinFlowLimit="1000"
                 keyedJoinStable="true"
-                lazyOpen="true"
+                lazyOpen="smart"
                 leafCacheMem="50"
                 linuxYield="false"
                 localFilesExpire="-1"

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -655,9 +655,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         useRemoteResources = topology->getPropBool("@useRemoteResources", true);
         checkFileDate = topology->getPropBool("@checkFileDate", true);
         const char *lazyOpenMode = topology->queryProp("@lazyOpen");
-        if (!lazyOpenMode)
-            lazyOpen = false;
-        else if (stricmp(lazyOpenMode, "smart")==0)
+        if (!lazyOpenMode || stricmp(lazyOpenMode, "smart")==0)
             lazyOpen = (restarts > 0);
         else
             lazyOpen = topology->getPropBool("@lazyOpen", false);


### PR DESCRIPTION
Especially now that the lazy opening of indexes takes account of the lazyOpen
flag, it seems more sensible to default to 'smart' behaviour rather than off.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
