### PR TITLE
HPCC-8930 Child graph could have missing progress data

### DIFF
--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -318,6 +318,8 @@ void CSlaveGraph::initWithActData(MemoryBuffer &in, MemoryBuffer &out)
 {
     CriticalBlock b(progressCrit);
     initialized = true;
+    if (0 == in.length())
+        return;
     activity_id id;
     loop
     {
@@ -422,12 +424,11 @@ bool CSlaveGraph::recvActivityInitData(size32_t parentExtractSz, const byte *par
         }
         try
         {
+            MemoryBuffer actInitData;
             if (len)
-            {
-                MemoryBuffer actInitData;
                 actInitData.append(len, msg.readDirect(len));
-                initWithActData(actInitData, actInitRtnData);
-            }
+            initWithActData(actInitData, actInitRtnData);
+
             if (queryOwner() && !isGlobal())
             {
                 // initialize any for which no data was sent


### PR DESCRIPTION
If a child graph had no activity initialization data serialized
to it from the master, the 'initialized' field was not set, with
the consequence that no graph progress stats were serialized
from the slaves to the master for those child graphs

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
