### PR TITLE
HPCC-8925 XMLDECODE decodes & to nothing

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -4125,7 +4125,7 @@ protected:
                                 ref.append(nextChar);
                             }
                             ref.append(";");
-                            decodeXML(ref, refValue, ref.length());
+                            decodeXML(ref, refValue);
                         }
                         else
                         {
@@ -4136,7 +4136,7 @@ protected:
                             {
                                 StringBuffer _ref("&");
                                 _ref.append(ref).append(';');
-                                decodeXML(ref, refValue, ref.length()); // try inbuilts
+                                decodeXML(ref, refValue); // try inbuilts
                             }
                         }
                     }
@@ -4349,10 +4349,10 @@ protected:
         }
         error("Bad comment syntax");
     }
-    const char *_decodeXML(unsigned read, const char *startMark, StringBuffer &ret, unsigned len)
+    const char *_decodeXML(unsigned read, const char *startMark, StringBuffer &ret)
     {
         const char *errMark = NULL;
-        try { return decodeXML(startMark, ret, len, &errMark, this); }
+        try { return decodeXML(startMark, ret, &errMark, this); }
         catch (IException *e)
         {
             if (errMark)
@@ -4565,7 +4565,7 @@ restart:
             else 
                 error();
 
-            _decodeXML(0, attrval.str(), tmpStr.clear(), attrval.length());
+            _decodeXML(0, attrval.str(), tmpStr.clear());
 
             if (0 == strcmp(attrName.str(), "@xsi:type") &&
                (0 == stricmp(tmpStr.str(),"SOAP-ENC:base64")))
@@ -4603,7 +4603,7 @@ restart:
                                 mark.setLength(l+1);
                             }
                             tagText.ensureCapacity(mark.length());
-                            _decodeXML(r, mark.toCharArray(), tagText, mark.length());
+                            _decodeXML(r, mark.toCharArray(), tagText);
                         }
                         readNext();
                         if ('!' == nextChar)
@@ -4899,7 +4899,7 @@ public:
                     else 
                         error();
 
-                    _decodeXML(0, attrval.str(), tmpStr.clear(), attrval.length());
+                    _decodeXML(0, attrval.str(), tmpStr.clear());
 
                     if (0 == strcmp(attrName.str(), "@xsi:type") &&
                        (0 == stricmp(tmpStr.str(),"SOAP-ENC:base64")))
@@ -4959,7 +4959,7 @@ public:
                                 }
                             }   
                             stateInfo->tagText.ensureCapacity(mark.length());
-                            _decodeXML(r, mark.toCharArray(), stateInfo->tagText, mark.length());
+                            _decodeXML(r, mark.toCharArray(), stateInfo->tagText);
                         }
                         if (endOfRoot && mark.length())
                         {

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -364,7 +364,7 @@ extern jlib_decl StringBuffer & appendStringAsQuotedECL(StringBuffer &out, unsig
 extern jlib_decl const char *decodeJSON(const char *x, StringBuffer &ret, unsigned len=(unsigned)-1, const char **errMark=NULL);
 extern jlib_decl void extractItem(StringBuffer & res, const char * src, const char * sep, int whichItem, bool caps);
 extern jlib_decl const char *encodeXML(const char *x, StringBuffer &ret, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=false);
-extern jlib_decl const char *decodeXML(const char *x, StringBuffer &ret, unsigned len=(unsigned)-1, const char **errMark=NULL, IEntityHelper *entityHelper=NULL);
+extern jlib_decl const char *decodeXML(const char *x, StringBuffer &ret, const char **errMark=NULL, IEntityHelper *entityHelper=NULL, bool strict = true);
 extern jlib_decl const char *encodeXML(const char *x, IIOStream &out, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=false);
 extern jlib_decl void decodeXML(ISimpleReadStream &in, StringBuffer &out, unsigned len=(unsigned)-1);
 

--- a/testing/ecl/key/xmldecode.xml
+++ b/testing/ecl/key/xmldecode.xml
@@ -1,0 +1,90 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>Cats &amp; dogs</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>&lt;html&gt;</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>Cats &quot;love&quot; dog&apos;s dinner</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>A is ascii for A</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>B is ascii for B</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>This ---&gt;&#194;&#160;&lt;---- is a non-breaking space</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><Result_7>Cats &amp; dogs</Result_7></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>&amp;amp</Result_8></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><Result_9>&amp;nosuch</Result_9></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><Result_10>&amp;#;</Result_10></Row>
+</Dataset>
+<Dataset name='Result 11'>
+ <Row><Result_11>&amp;#65 is not valid</Result_11></Row>
+</Dataset>
+<Dataset name='Result 12'>
+ <Row><Result_12>&amp;#d;</Result_12></Row>
+</Dataset>
+<Dataset name='Result 13'>
+ <Row><Result_13>&amp;AMP;</Result_13></Row>
+</Dataset>
+<Dataset name='Result 14'>
+ <Row><Result_14>&amp;;</Result_14></Row>
+</Dataset>
+<Dataset name='Result 15'>
+ <Row><Result_15>&amp;</Result_15></Row>
+</Dataset>
+<Dataset name='Result 16'>
+ <Row><Result_16>Cats &amp; dogs</Result_16></Row>
+</Dataset>
+<Dataset name='Result 17'>
+ <Row><Result_17>&lt;html&gt;</Result_17></Row>
+</Dataset>
+<Dataset name='Result 18'>
+ <Row><Result_18>Cats &quot;love&quot; dog&apos;s dinner</Result_18></Row>
+</Dataset>
+<Dataset name='Result 19'>
+ <Row><Result_19>A is ascii for A</Result_19></Row>
+</Dataset>
+<Dataset name='Result 20'>
+ <Row><Result_20>B is ascii for B</Result_20></Row>
+</Dataset>
+<Dataset name='Result 21'>
+ <Row><Result_21>This ---&gt; &lt;---- is a non-breaking space</Result_21></Row>
+</Dataset>
+<Dataset name='Result 22'>
+ <Row><Result_22>Cats &amp; dogs</Result_22></Row>
+</Dataset>
+<Dataset name='Result 23'>
+ <Row><Result_23>&amp;amp</Result_23></Row>
+</Dataset>
+<Dataset name='Result 24'>
+ <Row><Result_24>&amp;nosuch</Result_24></Row>
+</Dataset>
+<Dataset name='Result 25'>
+ <Row><Result_25>&amp;#;</Result_25></Row>
+</Dataset>
+<Dataset name='Result 26'>
+ <Row><Result_26>&amp;#65 is not valid</Result_26></Row>
+</Dataset>
+<Dataset name='Result 27'>
+ <Row><Result_27>&amp;#d;</Result_27></Row>
+</Dataset>
+<Dataset name='Result 28'>
+ <Row><Result_28>&amp;AMP;</Result_28></Row>
+</Dataset>
+<Dataset name='Result 29'>
+ <Row><Result_29>&amp;;</Result_29></Row>
+</Dataset>
+<Dataset name='Result 30'>
+ <Row><Result_30>&amp;</Result_30></Row>
+</Dataset>

--- a/testing/ecl/xmldecode.ecl
+++ b/testing/ecl/xmldecode.ecl
@@ -1,0 +1,39 @@
+// Some non-error cases
+XMLDECODE('Cats &amp; dogs');
+XMLDECODE('&lt;html&gt;');
+XMLDECODE('Cats &quot;love&quot; dog&apos;s dinner');
+XMLDECODE('&#65; is ascii for A');
+XMLDECODE('&#x42; is ascii for B');
+XMLDECODE('This ---&gt;&nbsp;&lt;---- is a non-breaking space');
+
+// Some error cases - leave the original unchanged
+XMLDECODE('Cats & dogs');
+XMLDECODE('&amp');  // missing ;
+XMLDECODE('&nosuch');  // missing ; on unknown entity
+XMLDECODE('&#;');  // missing digits
+XMLDECODE('&#65 is not valid');  // missing semi
+XMLDECODE('&#d;');  // invalid digits
+XMLDECODE(u'&AMP;');  // invalid entity
+XMLDECODE('&;');  // missing contents
+XMLDECODE('&');  // missing contents
+
+// Now the same in unicode
+
+// Some non-error cases
+XMLDECODE(u'Cats &amp; dogs');
+XMLDECODE(u'&lt;html&gt;');
+XMLDECODE(u'Cats &quot;love&quot; dog&apos;s dinner');
+XMLDECODE(u'&#65; is ascii for A');
+XMLDECODE(u'&#x42; is ascii for B');
+XMLDECODE(u'This ---&gt;&nbsp;&lt;---- is a non-breaking space');
+
+// Some error cases - leave the original unchanged
+XMLDECODE(u'Cats & dogs');
+XMLDECODE(u'&amp');  // missing ;
+XMLDECODE(u'&nosuch');  // missing ; on unknown entity
+XMLDECODE(u'&#;');  // missing digits
+XMLDECODE(u'&#65 is not valid');  // missing semi
+XMLDECODE(u'&#d;');  // invalid digits
+XMLDECODE(u'&AMP;');  // invalid entity
+XMLDECODE(u'&;');  // missing contents
+XMLDECODE(u'&');  // missing contents


### PR DESCRIPTION
Various issues with the way XMLDECODE (and xml read) handle invalid escape
sequences.
1. XMLDECODE should be leave invalid escape sequences unchanged. At present
   the unicode version strips them (sometimes) and the ascii version throws an
   exception
2. Potential reads off the end of the input string in both cases
3. Incorrectly accepting upper-case variants of escape sequences
4. Unicode version was missing &nbsp. Strictly speaking that is an HTML escape
   sequence not an XML one, but since the ascii version accepted it the unicode
   one should too.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
