### PR TITLE
HPCC-8937 Add a flag to skip existing superfile check

### DIFF
--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -708,7 +708,7 @@ class CDFUhelper: public CInterface, implements IDFUhelper
 public:
     IMPLEMENT_IINTERFACE;
 
-    void addSuper(const char *superfname,IUserDescriptor *user, unsigned numtoadd, const char **subfiles, const char *before)
+    void addSuper(const char *superfname, IUserDescriptor *user, unsigned numtoadd, const char **subfiles, const char *before, bool autocreatesuper)
     {
         if (!numtoadd)
             throwError(DFUERR_DNoSubfileToAddToSuperFile);
@@ -718,7 +718,11 @@ public:
 
         Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFile(superfname);
         if (!superfile)
+        {
+            if (!autocreatesuper)
+                throwError1(DFUERR_DSuperFileNotFound, superfname);
             superfile.setown(queryDistributedFileDirectory().createSuperFile(superfname,user,true,false,transaction));
+        }
 
         for (unsigned i=0;i<numtoadd;i++)
         {

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -32,7 +32,7 @@ interface IDfuFileCopier: extends IInterface
 
 interface IDFUhelper: extends IInterface
 {
-    virtual void addSuper(const char *superfname, IUserDescriptor *user, unsigned numtoadd=0, const char **subfiles=NULL, const char *before=NULL) = 0;
+    virtual void addSuper(const char *superfname, IUserDescriptor *user, unsigned numtoadd=0, const char **subfiles=NULL, const char *before=NULL, bool autocreatesuper = false) = 0;
     virtual void removeSuper(const char *superfname, IUserDescriptor *user, unsigned numtodelete=0, const char **subfiles=NULL, bool delsub=false, bool removesuperfile=true) = 0;
     virtual void listSubFiles(const char *superfname,StringAttrArray &out, IUserDescriptor *user) = 0;
     virtual StringBuffer &getFileXML(const char *lfn,StringBuffer &out, IUserDescriptor *user) = 0;

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -137,7 +137,7 @@ private:
     bool getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, int& permission);
     void parseStringArray(const char *input, StringArray& strarray);
     int superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
-        const char* beforeSubFile, bool existingSuperfile, bool deleteFile, bool removeSuperfile =  true);
+        const char* beforeSubFile, bool existingSuperfile, bool autocreatesuper, bool deleteFile, bool removeSuperfile =  true);
 private:
     bool         m_disableUppercaseTranslation;
     StringBuffer m_clusterName;


### PR DESCRIPTION
EclWatch has a Radio button on Add to Superfile page. The button
allows a user to specify a subfile is added to an existing superfile
or a new superfile. EclWatch will check whether the superfile exists
or not and show an error message if the user choose a wrong radio
button. But, EclWatch should not do the check if addSuper request
comes from dfuplus/addSuper command (not come from the EclWatch page)
because the existing addSuper command does not specify that a subfile
is added to an existing superfile or a new superfile. This fix adds
a flag to avoid the existing superfile check if the addSuper request
comes from dfuplus/addSuper command. This fix also adds the option of 
creating new superfile into the addSuper() help method. The help method
may check the superfile based on the option.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
