### PR TITLE
HPCC-8905 Fix minisort OOM and deadlock

### DIFF
--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -823,14 +823,22 @@ void CThorExpandingRowArray::partition(ICompare &compare, unsigned num, Unsigned
 
 offset_t CThorExpandingRowArray::serializedSize()
 {
+    IOutputMetaData *meta = rowIf->queryRowMetaData();
+    IOutputMetaData *diskMeta = meta->querySerializedDiskMeta();
     rowidx_t c = ordinality();
-    assertex(serializer);
     offset_t total = 0;
-    for (rowidx_t i=0; i<c; i++)
+    if (diskMeta->isFixedSize())
+        total = c * diskMeta->getFixedSize();
+    else
     {
+        Owned<IOutputRowSerializer> diskSerializer = diskMeta->createDiskSerializer(rowIf->queryCodeContext(), rowIf->queryActivityId());
         CSizingSerializer ssz;
-        serializer->serialize(ssz, (const byte *)rows[i]);
-        total += ssz.size();
+        for (rowidx_t i=0; i<c; i++)
+        {
+            diskSerializer->serialize(ssz, (const byte *)rows[i]);
+            total += ssz.size();
+            ssz.reset();
+        }
     }
     return total;
 }
@@ -838,16 +846,22 @@ offset_t CThorExpandingRowArray::serializedSize()
 
 memsize_t CThorExpandingRowArray::getMemUsage()
 {
+    roxiemem::IRowManager *rM = activity.queryJob().queryRowManager();
+    IOutputMetaData *meta = rowIf->queryRowMetaData();
+    IOutputMetaData *diskMeta = meta->querySerializedDiskMeta(); // GH->JCS - really I want a internalMeta here.
     rowidx_t c = ordinality();
     memsize_t total = 0;
-    roxiemem::IRowManager *rM = activity.queryJob().queryRowManager();
-    IRecordSize *iRecordSize = rowIf->queryRowMetaData();
-    if (iRecordSize->isFixedSize())
-        total = c * rM->getExpectedFootprint(iRecordSize->getFixedSize(), 0);
+    if (diskMeta->isFixedSize())
+        total = c * rM->getExpectedFootprint(diskMeta->getFixedSize(), 0);
     else
     {
+        CSizingSerializer ssz;
         for (rowidx_t i=0; i<c; i++)
-            total += rM->getExpectedFootprint(iRecordSize->getRecordSize(rows[i]), 0);
+        {
+            serializer->serialize(ssz, (const byte *)rows[i]);
+            total += rM->getExpectedFootprint(ssz.size(), 0);
+            ssz.reset();
+        }
     }
     // NB: worst case, when expanding (see ensure method)
     memsize_t sz = rM->getExpectedFootprint(maxRows * sizeof(void *), 0);
@@ -912,7 +926,7 @@ void CThorExpandingRowArray::serializeCompress(MemoryBuffer &mb)
     fastLZCompressToBuffer(mb,exp.length(), exp.toByteArray());
 }
 
-rowidx_t CThorExpandingRowArray::serializeBlock(MemoryBuffer &mb, size32_t dstmax, rowidx_t idx, rowidx_t count)
+rowidx_t CThorExpandingRowArray::serializeBlock(MemoryBuffer &mb, rowidx_t idx, rowidx_t count, size32_t dstmax, bool hardMax)
 {
     assertex(serializer);
     CMemoryRowSerializer out(mb);
@@ -934,13 +948,17 @@ rowidx_t CThorExpandingRowArray::serializeBlock(MemoryBuffer &mb, size32_t dstma
             WARNLOG("CThorExpandingRowArray::serialize ignoring NULL row");
             warnnull = false;
         }
+        // allows at least one
         if (mb.length()>dstmax)
         {
-            if (ln)
-                mb.setLength(ln);   // make sure one row
+            if (hardMax && ln) // remove last if above limit
+                mb.setLength(ln);
+            else
+                ++ret;
             break;
         }
-        ret++;
+        else
+            ++ret;
     }
     return ret;
 }

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -351,7 +351,7 @@ public:
     memsize_t getMemUsage();
     void serialize(MemoryBuffer &mb);
     void serializeCompress(MemoryBuffer &mb);
-    rowidx_t serializeBlock(MemoryBuffer &mb, size32_t dstmax, rowidx_t idx, rowidx_t count);
+    rowidx_t serializeBlock(MemoryBuffer &mb, rowidx_t idx, rowidx_t count, size32_t dstmax, bool hardMax);
     void deserializeRow(IRowDeserializerSource &in); // NB single row not NULL
     void deserialize(size32_t sz, const void *buf);
     void deserializeExpand(size32_t sz, const void *data);


### PR DESCRIPTION
Various problems causing mini sort to miscalculate in-memory
size, run out of memory and potentially deadlock

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
