### PR TITLE
HPCC-8939 Fix problems with <ebcdic-string1> IN ('a','b')

### DIFF
--- a/ecl/regress/issue8939.ecl
+++ b/ecl/regress/issue8939.ecl
@@ -1,0 +1,19 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+ds := DATASET('x', { ebcdic string1 x }, THOR);
+output(ds(x IN ['A', 'B', 'Z']));


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
