### PR TITLE
HPCC-8918 Payload syntax => should work the same for indexes

### DIFF
--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -961,7 +961,7 @@ protected:
     IHqlExpression *queryCurrentTransformRecord();
     IHqlExpression* queryFieldMap(IHqlExpression* expr);
     IHqlExpression* bindFieldMap(IHqlExpression*, IHqlExpression*);
-    void extractRecordFromExtra(SharedHqlExpr & record, SharedHqlExpr & extra);
+    void extractIndexRecordAndExtra(SharedHqlExpr & record, SharedHqlExpr & extra);
     void transferOptions(attribute & filenameAttr, attribute & optionsAttr);
     IHqlExpression * extractTransformFromExtra(SharedHqlExpr & extra);
     void expandPayload(HqlExprArray & fields, IHqlExpression * payload, IHqlSimpleScope * scope, ITypeInfo * & lastFieldType, const attribute & errpos);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -8326,7 +8326,7 @@ simpleDataSet
                             IHqlExpression *dataset = $3.getExpr();
                             OwnedHqlExpr record = $5.getExpr();
                             OwnedHqlExpr extra = $6.getExpr();
-                            parser->extractRecordFromExtra(record, extra);
+                            parser->extractIndexRecordAndExtra(record, extra);
                             OwnedHqlExpr transform = parser->extractTransformFromExtra(extra);
 
                             parser->inheritRecordMaxLength(dataset, record);
@@ -8354,7 +8354,7 @@ simpleDataSet
                         {
                             OwnedHqlExpr record = $3.getExpr();
                             OwnedHqlExpr extra = $4.getExpr();
-                            parser->extractRecordFromExtra(record, extra);
+                            parser->extractIndexRecordAndExtra(record, extra);
                             $$.setExpr(parser->createIndexFromRecord(record, extra, $3));
                             parser->checkIndexRecordTypes($$.queryExpr(), $1);
                             $$.setPosition($1);

--- a/ecl/regress/index_payload.ecl
+++ b/ecl/regress/index_payload.ecl
@@ -1,0 +1,9 @@
+d := dataset([{1,2,3},{4,5,6}], {unsigned a, unsigned b, unsigned c});
+
+i1 := index(d, { a => b, c}, 'my::index');
+i2 := index(d, { a }, { b, c}, 'my::index');
+
+buildindex(i1);
+buildindex(i2);
+i1[1];
+i2[1];


### PR DESCRIPTION
The => syntax introduced for dictionaries  was accepted as an alternative to
supplying the index payload separately, but was not being correctly
interpreted.

In order to avoid changing the CRCs of existing index structures, migrate the
payload attribute from the record to the index, when used in an index context.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
