### PR TITLE
HPCC-8957 - Compressed files being published with incorrect crc

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1820,7 +1820,6 @@ public:
     void set(IPropertyTree *pt,FileClusterInfoArray &clusters,unsigned maxcluster);
     RemoteFilename &getFilename(RemoteFilename &ret,unsigned copy);
     void renameFile(IFile *file);
-    unsigned getCRC();
     IPropertyTree &queryAttributes();
     bool lockProperties(unsigned timems);
     void unlockProperties(DFTransactionState state);


### PR DESCRIPTION
When block compression files are created, implicitly a crc of
0 is always the result. The published crc should be ~<crc-val>
but in case of compressed files it was publishing 0.

This was noticed only by VerifyFile

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
