### PR TITLE
HPCC-8960 Uninitialized variable in dadfs (rename physical)

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6874,11 +6874,11 @@ class CRenameFileAction: public CDFAction
     IUserDescriptor *user;
 public:
     CRenameFileAction(IDistributedFileTransaction *_transaction,
-                      CDistributedFileDirectory *parent,
+                      CDistributedFileDirectory *_parent,
                       IUserDescriptor *_user,
                       const char *_flname,
                       const char *_newname)
-        : CDFAction(_transaction), user(_user)
+        : CDFAction(_transaction), user(_user), parent(_parent)
     {
         logicalname.set(_flname);
         // Basic consistency checking


### PR DESCRIPTION
Introduced during 4.0 closedown.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
