### PR TITLE
HPCC-8080 Correction of command line argument handling

### DIFF
--- a/initfiles/bash/etc/init.d/dafilesrv.in
+++ b/initfiles/bash/etc/init.d/dafilesrv.in
@@ -130,7 +130,7 @@ while true ; do
 done
 for arg do arg=$arg; done
 
-if [ -z $arg ]; then
+if [ -z $arg ] || [ $# -ne 1]; then
     print_usage
 fi
 

--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -56,12 +56,12 @@ function print_usage {
 
 function print_components {
     if [ ! -z ${compList} ];then
-        echo >&2 "Components on this node as defined by ${CONFIG_DIR}/${ENV_CONF_FILE}:"
+        echo >&2 "Components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}:"
         IFS=$'\n'
         echo >&2 "${compList[*]}"
         unset IFS
     else
-        echo >&2 "No components on this node as defined by ${CONFIG_DIR}/${ENV_CONF_FILE}."
+        echo >&2 "No components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}."
     fi
     echo >&2
     exit 0
@@ -69,12 +69,12 @@ function print_components {
 
 function print_types {
     if [ ! -z ${compList} ];then
-        echo >&2 "Components types on this node as defined by ${CONFIG_DIR}/${ENV_CONF_FILE}:"
+        echo >&2 "Components types on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}:"
         IFS=$'\n'
         echo >&2 "${compTypeList[*]}"
         unset IFS
     else
-        echo >&2 "No components on this node as defined by ${CONFIG_DIR}/${ENV_CONF_FILE}."
+        echo >&2 "No components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}."
     fi
     echo >&2
     exit 0
@@ -242,6 +242,10 @@ while true ; do
 done
 for arg do arg=$arg; done
 
+if [ -z $arg ] || [ $# -ne 1 ]; then
+    print_usage
+fi
+
 if [ -z ${component} ]; then
     for (( i=0; i<=${compListLen}; i++ ));do
         component="$component ${compList[$i]}"
@@ -251,10 +255,6 @@ elif strstr ${component} "dafilesrv";then
     component=''
 else
     compDafilesrv=''
-fi
-
-if [ -z $arg ]; then
-    print_usage
 fi
 
 case "$arg" in 


### PR DESCRIPTION
Added check for incorrect number of arguments to command line. (>1)

Corrected output of components on system mentioning .conf instead of .xml

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
