### PR TITLE
HPCC-8669 - Extend NAS mapping options

### DIFF
--- a/common/environment/dalienv.cpp
+++ b/common/environment/dalienv.cpp
@@ -464,29 +464,29 @@ IPropertyTree *envGetNASConfiguration()
     return createPTreeFromIPT(conn->queryRoot());
 }
 
-IPropertyTree *envGetInstallNASHooks()
+IPropertyTree *envGetInstallNASHooks(SocketEndpoint *myEp)
 {
     Owned<IPropertyTree> nasPTree = envGetNASConfiguration();
-    return envGetInstallNASHooks(nasPTree);
+    return envGetInstallNASHooks(nasPTree, myEp);
 }
 
-IPropertyTree *envGetInstallNASHooks(IPropertyTree *nasPTree)
+IPropertyTree *envGetInstallNASHooks(IPropertyTree *nasPTree, SocketEndpoint *myEp)
 {
     IDaFileSrvHook *daFileSrvHook = queryDaFileSrvHook();
     if (!daFileSrvHook) // probably always installed
         return NULL;
-    daFileSrvHook->clearSubNetFilters();
+    daFileSrvHook->clearFilters();
     if (!nasPTree)
         return NULL;
-    return daFileSrvHook->addMySubnetFilters(nasPTree);
+    return daFileSrvHook->addMyFilters(nasPTree, myEp);
 }
 
-void envInstallNASHooks()
+void envInstallNASHooks(SocketEndpoint *myEp)
 {
-    Owned<IPropertyTree> installedFilters = envGetInstallNASHooks();
+    Owned<IPropertyTree> installedFilters = envGetInstallNASHooks(myEp);
 }
 
-void envInstallNASHooks(IPropertyTree *nasPTree)
+void envInstallNASHooks(IPropertyTree *nasPTree, SocketEndpoint *myEp)
 {
-    Owned<IPropertyTree> installedFilters = envGetInstallNASHooks(nasPTree);
+    Owned<IPropertyTree> installedFilters = envGetInstallNASHooks(nasPTree, myEp);
 }

--- a/common/environment/dalienv.hpp
+++ b/common/environment/dalienv.hpp
@@ -52,10 +52,11 @@ extern ENVIRONMENT_API bool getRemoteRunInfo(const char * keyName, const char * 
 extern ENVIRONMENT_API bool envGetConfigurationDirectory(const char *category, const char *component,const char *instance, StringBuffer &dirout);
 
 extern ENVIRONMENT_API IPropertyTree *envGetNASConfiguration(); // return NAS config from environment
-extern ENVIRONMENT_API void envInstallNASHooks(); // gets NAS config and sets up NAS hooks from it
-extern ENVIRONMENT_API void envInstallNASHooks(IPropertyTree *nasPTree); // Sets NAS hooks from user-supplied info
+// These methods filter the NAS hooks based on the callers IP, unless 'myEp' is supplied.
+extern ENVIRONMENT_API void envInstallNASHooks(SocketEndpoint *myEp=NULL); // gets NAS config and sets up NAS hooks from it
+extern ENVIRONMENT_API void envInstallNASHooks(IPropertyTree *nasPTree, SocketEndpoint *myEp=NULL); // Sets NAS hooks from user-supplied info
 // like envInstallNASHooks but also returns which filters were installed
-extern ENVIRONMENT_API IPropertyTree *envGetInstallNASHooks();
-extern ENVIRONMENT_API IPropertyTree *envGetInstallNASHooks(IPropertyTree *nasPTree);
+extern ENVIRONMENT_API IPropertyTree *envGetInstallNASHooks(SocketEndpoint *myEp=NULL);
+extern ENVIRONMENT_API IPropertyTree *envGetInstallNASHooks(IPropertyTree *nasPTree, SocketEndpoint *myEp=NULL);
 
 #endif

--- a/common/remote/rmtfile.hpp
+++ b/common/remote/rmtfile.hpp
@@ -39,10 +39,11 @@ extern REMOTE_API void filenameToUrl(StringBuffer & out, const char * filename);
 
 interface IDaFileSrvHook : extends IRemoteFileCreateHook
 {
-    virtual void addSubnetFilter(const char *subnet, const char *mask, const char *dir, bool trace) = 0;
-    virtual IPropertyTree *addSubnetFilters(IPropertyTree *filters, const IpAddress *ipAddress) = 0;
-    virtual IPropertyTree *addMySubnetFilters(IPropertyTree *filters) = 0;
-    virtual void clearSubNetFilters() = 0;
+    virtual void addSubnetFilter(const char *subnet, const char *mask, const char *dir, const char *sourceRange, bool trace) = 0;
+    virtual void addRangeFilter(const char *range, const char *dir, const char *sourceRange, bool trace) = 0;
+    virtual IPropertyTree *addFilters(IPropertyTree *filters, const SocketEndpoint *ipAddress) = 0;
+    virtual IPropertyTree *addMyFilters(IPropertyTree *filters, SocketEndpoint *myEp=NULL) = 0;
+    virtual void clearFilters() = 0;
 };
 extern REMOTE_API IDaFileSrvHook *queryDaFileSrvHook();
 extern REMOTE_API unsigned short getDaliServixPort();  // assumed just the one for now

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -609,9 +609,10 @@ int main( int argc, char *argv[]  )
 
         if (globals->getPropBool("@useNASTranslation", true))
         {
-            Owned<IPropertyTree> filteredNasConfig = envGetInstallNASHooks();
-            if (filteredNasConfig)
-                globals->setPropTree("NAS", filteredNasConfig.getClear()); // for use by slaves
+            Owned<IPropertyTree> nasConfig = envGetNASConfiguration();
+            if (nasConfig)
+                globals->setPropTree("NAS", nasConfig.getClear()); // for use by slaves
+            Owned<IPropertyTree> masterNasFilters = envGetInstallNASHooks(nasConfig, &thorEp);
         }
         
         HardwareInfo hdwInfo;

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -307,12 +307,13 @@ int main( int argc, char *argv[]  )
         markNodeCentral(masterEp);
         if (RegisterSelf(masterEp))
         {
+            MilliSleep(20000);
             if (globals->getPropBool("Debug/@slaveDaliClient"))
                 enableThorSlaveAsDaliClient();
 
             IDaFileSrvHook *daFileSrvHook = queryDaFileSrvHook();
             if (daFileSrvHook) // probably always installed
-                daFileSrvHook->addSubnetFilters(globals->queryPropTree("NAS"), NULL);
+                daFileSrvHook->addFilters(globals->queryPropTree("NAS"), &slfEp);
 
             StringBuffer thorPath;
             globals->getProp("@thorPath", thorPath);


### PR DESCRIPTION
Allow a range as opposed to a subnet/mask to be defined for a
filter and allow a source range to apply also.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
