### PR TITLE
HPCC-8976 - Fix suspect code in CSocket::write_multiple

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -1913,7 +1913,7 @@ EintrRetry:
                 cpy = s;
             memcpy(outbuf+os,b,cpy);
             os += cpy;
-            left =- cpy;
+            left -= cpy;
             s -= cpy;
             b += cpy;
             if (left==0)  {


### PR DESCRIPTION
A counter tracking how much left to send was incorrectly
reduced. When it hit zero it should have wrote last write and exited.
But due to a typo' it was not being reduced as intended.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
