### PR TITLE
HPCC-8761 Add HTTP 304 support to HTTP requests

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -2102,9 +2102,10 @@ int EspHttpBinding::formatResultsPage(IEspContext &context, const char *serv, co
 
 bool EspHttpBinding::setContentFromFile(IEspContext &context, CHttpResponse &resp, const char *filepath)
 {
-    StringBuffer mimetype;
+    StringBuffer mimetype, etag, lastModified;
     MemoryBuffer content;
-    if (httpContentFromFile(filepath, mimetype, content))
+    bool modified = false;
+    if (httpContentFromFile(filepath, mimetype, content, modified, lastModified, etag))
     {
         resp.setContent(content.length(), content.toByteArray());
         resp.setContentType(mimetype.str());

--- a/esp/bindings/http/platform/httptransport.hpp
+++ b/esp/bindings/http/platform/httptransport.hpp
@@ -97,7 +97,7 @@
 //#define DEBUG_HTTP_
 #endif
 
-bool httpContentFromFile(const char *filepath, StringBuffer &mimetype, MemoryBuffer &fileContents);
+bool httpContentFromFile(const char *filepath, StringBuffer &mimetype, MemoryBuffer &fileContents, bool &checkmodifiedTime, StringBuffer &lastModified, StringBuffer &etag);
 bool xmlContentFromFile(const char *filepath, const char *stylesheet, StringBuffer &fileContents);
 
 

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -401,6 +401,8 @@ public:
     virtual int sendException(IEspHttpException* e);
 
     void setTimeOut(unsigned int timeout);
+    void setLastModified(const char *lastModified, const char *etag);
+    void setNotModified(const char *etag);
 };
 
 inline bool canRedirect(CHttpRequest &req)


### PR DESCRIPTION
This fix adds HTTP 304 support to ESP HTTP requests to improve ESP
performance. When an HTTP GetFile request is received, ESP reads
the timestamp of the file. If the request does not contain an etag
which contains the timestamp, ESP will create the etag and send
the etag with the content of the file. Otherwise, ESP will not
read the file content and send an HTTP 304 'Not Modified' response
to the client.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
