### PR TITLE
HPCC-8900 cli should allow wu compile state of compiled or completed

### DIFF
--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -201,7 +201,7 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
         if (cmd.optVerbose)
             fprintf(stdout, "Deployed\n   wuid: ");
         const char *state = resp->getWorkunit().getState();
-        bool isCompiled = strieq(state, "compiled");
+        bool isCompiled = (strieq(state, "compiled")||strieq(state, "completed"));
         if (displayWuid || cmd.optVerbose || !isCompiled)
             fprintf(stdout, "%s\n", w);
         if (cmd.optVerbose || !isCompiled)


### PR DESCRIPTION
After a workunit is successfully compiled its state can be either
compiled or completed.  ecl command line was only recognizing the
compiled state.

Legacy eclserver seems to sometimes set compiled workunit state to
completed.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
