### PR TITLE
HPCC-8809 LdapPassword needs new splash page after

### DIFF
--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -323,6 +323,8 @@ int CEspHttpServer::processRequest()
             {
                 if (!rootAuth(ctx))
                     return 0;
+                if (ctx->queryUser()->getAuthenticateStatus() == AS_PASSWORD_EXPIRED)
+                    return 0;//allow user to change password
                 // authenticate optional groups
                 if (authenticateOptionalFailed(*ctx,NULL))
                     throw createEspHttpException(401,"Unauthorized Access","Unauthorized Access");

--- a/esp/xslt/passwordupdate.xsl
+++ b/esp/xslt/passwordupdate.xsl
@@ -73,15 +73,7 @@
                         </xsl:otherwise>
                     </xsl:choose>
                 </b>
-                <form>
-                    <table>
-                        <tr>
-                            <td>
-                                <input type="button" class="sbutton" value="Close this window" onClick="window.close()"/>
-                            </td>
-                        </tr>
-                    </table>
-                </form>
+                <a href="/">Click here to continue.</a>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:if test="number(Code) = 1">


### PR DESCRIPTION
Currently when a password has expired and user is presented with change
password screen, the application frame is incorrectly loaded along with
the change password screen. This fix will only present the change password
screen, and when they correctly reset it they are presented with a
success message and a link to the main page

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
