### PR TITLE
HPCC-8987 - MoveExternalFile error misleading

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -2033,7 +2033,7 @@ FILESERVICES_API void  FILESERVICES_CALL fsMoveExternalFile(ICodeContext * ctx,c
     torfn.setPath(ep,topath);
     Owned<IFile> fileto = createIFile(torfn);
     if (fileto->exists())
-        throw MakeStringException(-1,"fsMoveExternalFile: Destination %s already exists",frompath);
+        throw MakeStringException(-1,"fsMoveExternalFile: Destination %s already exists", topath);
     fileto.clear();
     Owned<IFile> file = createIFile(fromrfn);
     file->move(topath);


### PR DESCRIPTION
MoveExternalFile gives and error when the target exists,
due to a bug however, when the error traced the source file name.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
