### PR TITLE
HPCC-8977 Clean Warning in mime.cpp

### DIFF
--- a/esp/bindings/http/platform/mime.cpp
+++ b/esp/bindings/http/platform/mime.cpp
@@ -536,11 +536,8 @@ bool CMimeMultiPart::separateMultiParts(MemoryBuffer& firstPart, MemoryBuffer& o
     unsigned firstPartLength = offset;
     while ((firstPartLength > 0) && ((startPos[firstPartLength-1] == '\r') || (startPos[firstPartLength-1] == '\n')))
         firstPartLength--;
-    if(firstPartLength >= 0)
-    {
-        otherParts.append(totalLength - offset, startPos + offset);
-        firstPart.setLength(firstPartLength);
-    }
+    otherParts.append(totalLength - offset, startPos + offset);
+    firstPart.setLength(firstPartLength);
 
     return foundMultiParts;
 }


### PR DESCRIPTION
This fix removes the check of 'if (firstPartLength >= 0)'. The firstPartLength
comes from offset and may be decreased by 1 if > 0 and other conditions.
So, the firstPartLength should never be negative.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
