### PR TITLE
HPCC-8909 - Avoid thor recycling if registration error detected

### DIFF
--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -297,7 +297,7 @@ public:
                     if (TE_FailedToRegisterSlave == e->errorCode())
                     {
                         setExitCode(0); // to avoid thor auto-recycling
-                        return 0;
+                        return false;
                     }
                 }
                 registerNode(sender);

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -291,7 +291,15 @@ public:
                 StringBuffer str;
                 PROGLOG("Registration confirmation from %s", queryClusterGroup().queryNode(sender).endpoint().getUrlStr(str).str());
                 if (msg.length())
-                    throw deserializeException(msg);
+                {
+                    Owned<IException> e = deserializeException(msg);
+                    EXCLOG(e, "Registration error");
+                    if (TE_FailedToRegisterSlave == e->errorCode())
+                    {
+                        setExitCode(0); // to avoid thor auto-recycling
+                        return 0;
+                    }
+                }
                 registerNode(sender);
             }
             PROGLOG("Slaves initialized");


### PR DESCRIPTION
Serialize an error code to master and exit thor cleanly
on registration error to avoid scripts causing auto-recycle

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
