### PR TITLE
HPCC-8764 - Ensure temps don't clash if sharing filing system

### DIFF
--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -670,7 +670,9 @@ int main( int argc, char *argv[]  )
         const char *tempdir = globals->queryProp("@thorTempDirectory");
         if (getConfigurationDirectory(globals->queryPropTree("Directories"),"temp","thor",globals->queryProp("@name"),tempdirstr))
             tempdir = tempdirstr.str();
-        SetTempDir(tempdir,true);
+        StringBuffer tempPrefix("thtmp");
+        tempPrefix.append(getMasterPortBase()).append("_");
+        SetTempDir(tempdir, tempPrefix.str(), true);
 
         char thorPath[1024];
         if (!GetCurrentDirectory(1024, thorPath)) {

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -353,7 +353,9 @@ int main( int argc, char *argv[]  )
             const char *tempdir = globals->queryProp("@thorTempDirectory");
             if (getConfigurationDirectory(globals->queryPropTree("Directories"),"temp","thor",globals->queryProp("@name"),tempdirstr))
                 tempdir = tempdirstr.str();
-            SetTempDir(tempdir,true);
+            StringBuffer tempPrefix("thtmp");
+            tempPrefix.append(getMachinePortBase()).append("_");
+            SetTempDir(tempdir, tempPrefix.str(), true);
 
             useMemoryMappedRead(globals->getPropBool("@useMemoryMappedRead"));
 

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -396,7 +396,7 @@ extern graph_decl IThorException *ThorWrapException(IException *e, const char *m
 extern graph_decl void setExceptionActivityInfo(CGraphElementBase &container, IThorException *e);
 
 extern graph_decl void GetTempName(StringBuffer &name, const char *prefix=NULL,bool altdisk=false);
-extern graph_decl void SetTempDir(const char *name,bool clear);
+extern graph_decl void SetTempDir(const char *name, const char *tempPrefix, bool clear);
 extern graph_decl void ClearDir(const char *dir);
 extern graph_decl void ClearTempDirs();
 extern graph_decl const char *queryTempDir(bool altdisk=false);  


### PR DESCRIPTION
Prefix temporaries with slave port, to ensure that slaves
running on different machines, sharing a commong filing system
don't use clashing temp. names

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
