### PR TITLE
HPCC-8539 Add configuration option to specify dali client MP port range

### DIFF
--- a/dali/base/daclient.cpp
+++ b/dali/base/daclient.cpp
@@ -88,14 +88,15 @@ IDaliClient_Exception *createClientException(DaliClientError err, const char *ms
 
 
 
-bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned short mpport, const char *clientVersion, const char *minServerVersion, unsigned timeout)
+bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, const char *clientVersion, const char *minServerVersion, unsigned timeout)
 {
     assertex(servergrp);
     daliClientIsActive = true;
     startMPServer(mpport);
     Owned<ICommunicator> comm(createCommunicator(servergrp,true));
     IGroup * covengrp;
-    if (!registerClientProcess(comm.get(),covengrp,timeout,role)) {
+    if (!registerClientProcess(comm.get(),covengrp,timeout,role))
+    {
         daliClientIsActive = false;
         return false;
     }

--- a/dali/base/daclient.hpp
+++ b/dali/base/daclient.hpp
@@ -26,7 +26,7 @@
 #include "mpcomm.hpp"
 #include "dasds.hpp"
 
-extern da_decl bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned short mpport=0, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER);
+extern da_decl bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport=0, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER);
 extern da_decl bool reinitClientProcess(IGroup *servergrp, DaliClientRole role, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER); 
 extern da_decl void closedownClientProcess();
 extern da_decl bool daliClientActive();

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -15,6 +15,10 @@
   <runtime>${RUNTIME_PATH}</runtime>
   <sourcedir>${CONFIG_SOURCE_PATH}</sourcedir>
   <user>${RUNTIME_USER}</user>
+  <ports>
+   <mpStart>7101</mpStart>
+   <mpEnd>7500</mpEnd>
+  </ports>
  </EnvSettings>
  <Hardware>
   <Computer computerType="linuxmachine"

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -198,7 +198,7 @@ static IPropertyTree *getEnvironment()
             env.setown(createPTreeFromIPT(conn->queryRoot())); // we don't really need to copy here
     }
     if (!env.get())
-        env.setown(getHPCCenvironment());
+        env.setown(getHPCCEnvironment());
     return env.getClear();
 }
 

--- a/system/include/portlist.h
+++ b/system/include/portlist.h
@@ -53,9 +53,9 @@
 
 #define DALI_SERVER_PORT                7070 
 #define DATA_TRANSFER_PORT              7080
-#define DAFILESRV_PORT                  7100 /// aka daliservix
-#define MP_BASE_PORT                    7101 //..7999 (for Dali too)
-#define MP_PORT_RANGE                   400
+#define DAFILESRV_PORT                  7100 // aka daliservix
+#define MP_START_PORT                   7101 // Default range for MP ports
+#define MP_END_PORT                     7500
 
 //ESP SERVICES
 //INSECURE

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -2261,9 +2261,9 @@ StringBuffer & fillConfigurationDirectoryEntry(const char *dir,const char *name,
     return dirout;
 }
 
-IPropertyTree *getHPCCenvironment(const char *confloc)
+IPropertyTree *getHPCCEnvironment(const char *configFileName)
 {
-    StringBuffer configFileSpec(confloc);
+    StringBuffer configFileSpec(configFileName);
     if (!configFileSpec.length())
 #ifdef _WIN32 
         return NULL;
@@ -2271,16 +2271,20 @@ IPropertyTree *getHPCCenvironment(const char *confloc)
         configFileSpec.set(CONFIG_DIR).append(PATHSEPSTR).append("environment.conf");
 #endif  
     Owned<IProperties> props = createProperties(configFileSpec.str());
-    if (props) {
+    if (props)
+    {
         StringBuffer envfile;
-        if (props->getProp("environment",envfile)&&envfile.length()) {
-            if (!isAbsolutePath(envfile.str())) {
+        if (props->getProp("environment",envfile)&&envfile.length())
+        {
+            if (!isAbsolutePath(envfile.str()))
+            {
                 StringBuffer tail(envfile);
                 splitDirTail(configFileSpec.str(),envfile.clear());
                 addPathSepChar(envfile).append(tail);
             }
             Owned<IFile> file = createIFile(envfile.str());
-            if (file) {
+            if (file)
+            {
                 Owned<IFileIO> fileio = file->open(IFOread);
                 if (fileio)
                     return createPTree(*fileio);
@@ -2292,7 +2296,7 @@ IPropertyTree *getHPCCenvironment(const char *confloc)
 
 static IPropertyTree *getOSSdirTree()
 {
-    Owned<IPropertyTree> envtree = getHPCCenvironment();
+    Owned<IPropertyTree> envtree = getHPCCEnvironment();
     if (envtree) {
         IPropertyTree *ret = envtree->queryPropTree("Software/Directories");
         if (ret) 

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -256,7 +256,7 @@ public:
 
 extern jlib_decl StringBuffer passwordInput(const char* prompt, StringBuffer& passwd);
 
-extern jlib_decl IPropertyTree *getHPCCenvironment(const char *confloc=NULL);
+extern jlib_decl IPropertyTree *getHPCCEnvironment(const char *configFileName=NULL);
 extern jlib_decl bool getConfigurationDirectory(const IPropertyTree *dirtree, // NULL to use HPCC config
                                                 const char *category, 
                                                 const char *component,

--- a/system/mp/mpcomm.hpp
+++ b/system/mp/mpcomm.hpp
@@ -89,7 +89,7 @@ extern mp_decl mptag_t createReplyTag(); // creates (short-lived) reply-tag;
 extern mp_decl ICommunicator *createCommunicator(IGroup *group,bool outer=false); // outer allows nodes outside group to send
 extern mp_decl IInterCommunicator &queryWorldCommunicator();
 
-extern mp_decl void startMPServer(unsigned short port,bool paused=false);
+extern mp_decl void startMPServer(unsigned port,bool paused=false);
 extern mp_decl void stopMPServer();
 
 interface IConnectionMonitor: extends IInterface


### PR DESCRIPTION
For clients that use the 'default' port range of 7101-7500, read it from the
environment.xml file (if found).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
