### PR TITLE
HPCC-8792 - Log disk space at thor startup

### DIFF
--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1103,13 +1103,11 @@ void CJobSlave::startJob()
         startPerformanceMonitor(pinterval,PerfMonStandard,perfmonhook);
     }
     PrintMemoryStatusLog();
-    unsigned __int64 freeSpace = getFreeSpace(queryBaseDirectory());
-    unsigned __int64 freeSpaceRep = getFreeSpace(queryBaseDirectory(true));
-    PROGLOG("Disk space: %s = %"I64F"d, %s = %"I64F"d", queryBaseDirectory(), freeSpace/0x100000, queryBaseDirectory(true), freeSpaceRep/0x100000);
-
+    logDiskSpace();
     unsigned minFreeSpace = (unsigned)getWorkUnitValueInt("MINIMUM_DISK_SPACE", 0);
     if (minFreeSpace)
     {
+        unsigned __int64 freeSpace = getFreeSpace(queryBaseDirectory());
         if (freeSpace < ((unsigned __int64)minFreeSpace)*0x100000)
         {
             SocketEndpoint ep;

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -674,13 +674,15 @@ int main( int argc, char *argv[]  )
             setBaseDirectory(overrideBaseDirectory, false);
         if (overrideReplicateDirectory&&*overrideBaseDirectory)
             setBaseDirectory(overrideReplicateDirectory, true);
-        StringBuffer tempdirstr;
-        const char *tempdir = globals->queryProp("@thorTempDirectory");
-        if (getConfigurationDirectory(globals->queryPropTree("Directories"),"temp","thor",globals->queryProp("@name"),tempdirstr))
-            tempdir = tempdirstr.str();
+        StringBuffer tempDirStr;
+        if (getConfigurationDirectory(globals->queryPropTree("Directories"),"temp","thor",globals->queryProp("@name"), tempDirStr))
+            globals->setProp("@thorTempDirectory", tempDirStr.str());
+        else
+            tempDirStr.append(globals->queryProp("@thorTempDirectory"));
+        logDiskSpace(); // Log before temp space is cleared
         StringBuffer tempPrefix("thtmp");
         tempPrefix.append(getMasterPortBase()).append("_");
-        SetTempDir(tempdir, tempPrefix.str(), true);
+        SetTempDir(tempDirStr.str(), tempPrefix.str(), true);
 
         char thorPath[1024];
         if (!GetCurrentDirectory(1024, thorPath)) {

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -349,13 +349,15 @@ int main( int argc, char *argv[]  )
                 setBaseDirectory(overrideBaseDirectory, false);
             if (overrideReplicateDirectory&&*overrideBaseDirectory)
                 setBaseDirectory(overrideReplicateDirectory, true);
-            StringBuffer tempdirstr;
-            const char *tempdir = globals->queryProp("@thorTempDirectory");
-            if (getConfigurationDirectory(globals->queryPropTree("Directories"),"temp","thor",globals->queryProp("@name"),tempdirstr))
-                tempdir = tempdirstr.str();
+            StringBuffer tempDirStr;
+            if (getConfigurationDirectory(globals->queryPropTree("Directories"),"temp","thor",globals->queryProp("@name"), tempDirStr))
+                globals->setProp("@thorTempDirectory", tempDirStr.str());
+            else
+                tempDirStr.append(globals->queryProp("@thorTempDirectory"));
+            logDiskSpace(); // Log before temp space is cleared
             StringBuffer tempPrefix("thtmp");
             tempPrefix.append(getMachinePortBase()).append("_");
-            SetTempDir(tempdir, tempPrefix.str(), true);
+            SetTempDir(tempDirStr.str(), tempPrefix.str(), true);
 
             useMemoryMappedRead(globals->getPropBool("@useMemoryMappedRead"));
 

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -1232,3 +1232,13 @@ void sendInChunks(ICommunicator &comm, rank_t dst, mptag_t mpTag, IRowStream *in
             break;
     }
 }
+
+void logDiskSpace()
+{
+    StringBuffer diskSpaceMsg("Disk space: ");
+    diskSpaceMsg.append(queryBaseDirectory()).append(" = ").append(getFreeSpace(queryBaseDirectory())/0x100000).append(" MB, ");
+    diskSpaceMsg.append(queryBaseDirectory(true)).append(" = ").append(getFreeSpace(queryBaseDirectory(true))/0x100000).append(" MB, ");
+    const char *tempDir = globals->queryProp("@thorTempDirectory");
+    diskSpaceMsg.append(tempDir).append(" = ").append(getFreeSpace(tempDir)/0x100000).append(" MB");
+    PROGLOG("%s", diskSpaceMsg.str());
+}

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -450,5 +450,7 @@ extern graph_decl IRowStream *createUngroupStream(IRowStream *input);
 interface IRowInterfaces;
 extern graph_decl void sendInChunks(ICommunicator &comm, rank_t dst, mptag_t mpTag, IRowStream *input, IRowInterfaces *rowIf);
 
+extern graph_decl void logDiskSpace();
+
 #endif
 


### PR DESCRIPTION
Useful because in the event of disk full events, it is useful
to see the disk space before Thor clears all the temp files,
that may well have cause the disk to be full in the first place

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
