### PR TITLE
HPCC-8999 Move new Features in ECL Watch.

### DIFF
--- a/esp/files/stub.htm
+++ b/esp/files/stub.htm
@@ -31,7 +31,6 @@
     <link href="dojox/grid/enhanced/resources/claro/EnhancedGrid.css" rel="stylesheet">
     <link href="dojox/grid/resources/claroGrid.css" rel="stylesheet">
     <link href="dojox/widget/Toaster/Toaster.css" rel="stylesheet">
-    <link href="dojox/widget/Standby/Standby.css" rel="stylesheet">
     <link href="css/hpcc.css" rel="stylesheet">
     <!-- load dojo and provide config via dojoConfig global -->
     <script>

--- a/esp/services/ws_fs/ws_fsBinding.hpp
+++ b/esp/services/ws_fs/ws_fsBinding.hpp
@@ -52,20 +52,24 @@ public:
 
         IPropertyTree *folder0 = ensureNavFolder(data, "DFU Workunits", NULL, NULL, false, 5);
         ensureNavLink(*folder0, "Search", "/FileSpray/DFUWUSearch", "Search for DFU workunits ", NULL, NULL, 1);
-        ensureNavLink(*folder0, "Browse", "/esp/files/stub.htm?Widget=GetDFUWorkunitsWidget", "Browse a list of DFU workunits", NULL, NULL, 2);
+        ensureNavLink(*folder0, "Browse", "/FileSpray/GetDFUWorkunits", "Browse a list of DFU workunits", NULL, NULL, 2);
         IPropertyTree *folder = ensureNavFolder(data, "DFU Files", NULL, NULL, false, 6);
         ensureNavLink(*folder, "Upload/download File", "/FileSpray/DropZoneFiles", "Upload or download File from a Drop Zone in the environment", NULL, NULL, 1);
         ensureNavLink(*folder, "View Data File", "/WsDfu/DFUGetDataColumns?ChooseFile=1", "Allows you to view the contents of a logical file", NULL, NULL, 2);
         ensureNavLink(*folder, "Search File Relationships", path.str(), "Search File Relationships", NULL, NULL, 3);
         ensureNavLink(*folder, "Browse Space Usage", "/WsDfu/DFUSpace", "View details about Space Usage", NULL, NULL, 4);
         ensureNavLink(*folder, "Search Logical Files", "/WsDfu/DFUSearch", "Search for Logical Files using a variety of search criteria", NULL, NULL, 5);
-        ensureNavLink(*folder, "Browse Logical Files", "/esp/files/stub.htm?Widget=DFUWUQueryWidget", "Browse a list of Logical Files", NULL, NULL, 6);
+        ensureNavLink(*folder, "Browse Logical Files", "/WsDfu/DFUQuery", "Browse a list of Logical Files", NULL, NULL, 6);
         ensureNavLink(*folder, "Browse Files by Scope", "/WsDfu/DFUFileView", "Browse a list of Logical Files by Scope", NULL, NULL, 7);
         ensureNavLink(*folder, "Spray Fixed", "/FileSpray/SprayFixedInput", "Spray a fixed width file", NULL, NULL, 8);
         ensureNavLink(*folder, "Spray Variable", "/FileSpray/SprayVariableInput?submethod=variable", "Spray a variable length file with fields separated by delimiters", NULL, NULL, 9);
         ensureNavLink(*folder, "Spray XML", "/FileSpray/SprayVariableInput?submethod=xml", "Spray an XML File", NULL, NULL, 10);
         ensureNavLink(*folder, "Remote Copy", "/FileSpray/CopyInput", "Copy a Logical File from one environment to another", NULL, NULL, 11);
         ensureNavLink(*folder, "XRef", "/WsDFUXRef/DFUXRefList", "View Xref result details or run the Xref utility", NULL, NULL, 12);
+
+        IPropertyTree *folderTP = CEspBinding::ensureNavFolder(data, "Tech Preview", "Technical Preview");
+        CEspBinding::ensureNavLink(*folderTP, "DFU Workunits", "/esp/files/stub.htm?Widget=GetDFUWorkunitsWidget", "DFU Workunits", NULL, NULL, 2);
+        CEspBinding::ensureNavLink(*folderTP, "Logical Files", "/esp/files/stub.htm?Widget=DFUWUQueryWidget", "Logical Files", NULL, NULL, 3);
     }
 
     int onGetInstantQuery(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method);

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -137,11 +137,14 @@ public:
         {
             IPropertyTree *folder = ensureNavFolder(data, "ECL", "Run Ecl code and review Ecl workunits", NULL, false, 2);
             ensureNavLink(*folder, "Search Workunits", "/WsWorkunits/WUQuery?form_", "Search Workunits", NULL, NULL, 1);
-            ensureNavLink(*folder, "Browse Workunits", "/esp/files/stub.htm?Widget=WUQueryWidget", "Browse Workunits", NULL, NULL, 2);
+            ensureNavLink(*folder, "Browse Workunits", "/WsWorkunits/WUQuery", "Browse Workunits", NULL, NULL, 2);
             ensureNavLink(*folder, "ECL Playground", "/esp/files/stub.htm?Widget=ECLPlaygroundWidget", "ECL Editor, Executor, Graph and Result Viewer", NULL, NULL, 4);
 
             IPropertyTree *folderQueryset = ensureNavFolder(data, "Queries", NULL, NULL, false, 3);
             ensureNavLink(*folderQueryset, "Browse", "/WsWorkunits/WUQuerySets", "Browse Published Queries");
+
+            IPropertyTree *folderTP = CEspBinding::ensureNavFolder(data, "Tech Preview", "Technical Preview");
+            CEspBinding::ensureNavLink(*folderTP, "ECL Workunits", "/esp/files/stub.htm?Widget=WUQueryWidget", "ECL Workunits", NULL, NULL, 1);
         }
     }
 


### PR DESCRIPTION
Separate out the new ECL Watch features and add as new section in navigation
bar.

Fixes HPCC-8999

@afishbeck - I added the "Tech Preview" links directly in espprotocol.cpp, there may be a better spot for it, but in theory it will be temporary.
