### PR TITLE
IDE-246 Add warning to getECLPluginDefinition

### DIFF
--- a/docs/ECLLanguageReference/ECLR_mods/ExtrSvcs-ExternalServicesImpl.xml
+++ b/docs/ECLLanguageReference/ECLR_mods/ExtrSvcs-ExternalServicesImpl.xml
@@ -358,6 +358,13 @@
     <para>The function must fill the passed structure with correct information
     for the features of the plug-in. The structure is defined as
     follows:</para>
+    
+    <para><emphasis role="bold">Warning:</emphasis> This function may be called 
+    without the plugin being loaded fully.  It should not make any library 
+    calls or assume that dependent modules have been loaded or that it has been 
+    initialised.  Specifically:  "The system does not call DllMain for process 
+    and thread initialization and termination.  Also, the system does not load 
+    additional executable modules that are referenced by the specified module."</para>
 
     <programlisting>Struct ECLPluginDefinitionBlock
   {

--- a/plugins/examplelib/examplelib.cpp
+++ b/plugins/examplelib/examplelib.cpp
@@ -32,6 +32,14 @@ static const char * EclDefinition =
 
 EXAMPLELIB_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb) 
 {
+    //  Warning:    This function may be called without the plugin being loaded fully.  
+    //              It should not make any library calls or assume that dependent modules
+    //              have been loaded or that it has been initialised.
+    //
+    //              Specifically:  "The system does not call DllMain for process and thread 
+    //              initialization and termination.  Also, the system does not load 
+    //              additional executable modules that are referenced by the specified module."
+
     if (pb->size != sizeof(ECLPluginDefinitionBlock))
         return false;
 


### PR DESCRIPTION
Warn plugin developers that the getECLPluginDefinition call has restrictive
calling rules.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
