### PR TITLE
HPCC-9010 Check query tree branch before using it

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1081,13 +1081,15 @@ bool CWsWorkunitsEx::onWUQuerysetQueryAction(IEspContext &context, IEspWUQuerySe
                     break;
                 case CQuerySetQueryActionTypes_Delete:
                     removeNamedQuery(queryset, id);
+                    query = NULL;
                     break;
                 case CQuerySetQueryActionTypes_RemoveAllAliases:
                     removeAliasesFromNamedQuery(queryset, id);
                     break;
             }
             result->setSuccess(true);
-            result->setSuspended(query->getPropBool("@suspended"));
+            if (query)
+                result->setSuspended(query->getPropBool("@suspended"));
         }
         catch(IException *e)
         {


### PR DESCRIPTION
When a query is deleted, it's tree branch is removed from the
'queryset' tree. The existing code tries to set the 'suspended'
attribute for the tree branch, which causes the core. This fix
checks the query branch before setting the 'suspended' attribute.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
