### PR TITLE
HPCC-9011 Check user object before checking its password expiration

### DIFF
--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -323,7 +323,7 @@ int CEspHttpServer::processRequest()
             {
                 if (!rootAuth(ctx))
                     return 0;
-                if (ctx->queryUser()->getAuthenticateStatus() == AS_PASSWORD_EXPIRED)
+                if (ctx->queryUser() && (ctx->queryUser()->getAuthenticateStatus() == AS_PASSWORD_EXPIRED))
                     return 0;//allow user to change password
                 // authenticate optional groups
                 if (authenticateOptionalFailed(*ctx,NULL))


### PR DESCRIPTION
The existing code checks a user's password expiration using the
user object in ESP. If no user authentication is required, the user
object is NULL and we do not need to check user status of
authentication. This fix checks the user object before using it to
checks the password expiration.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
