### PR TITLE
HPCC-9028 Roxie not handling OPT flag correctly on dynamically-resolved ...

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -19639,14 +19639,16 @@ public:
             eof = true;
         else
         {
+            numParts = 0;
             if (variableFileName)
             {
                 varFileInfo.setown(resolveLFN(helper.getFileName(), isOpt));
-                Owned<IFilePartMap> map = varFileInfo->getFileMap();
-                if (map)
-                    numParts = map->getNumParts();
-                else
-                    numParts = 0;
+                if (varFileInfo)
+                {
+                    Owned<IFilePartMap> map = varFileInfo->getFileMap();
+                    if (map)
+                        numParts = map->getNumParts();
+                }
             }
             if (!numParts)
             {
@@ -20732,8 +20734,11 @@ protected:
     void setVariableFileInfo()
     {
         varFileInfo.setown(resolveLFN(indexHelper.getFileName(), isOpt));
-        translators.setown(new TranslatorArray) ;
-        keySet.setown(varFileInfo->getKeyArray(factory->queryActivityMeta(), translators, isOpt, isLocal ? factory->queryQueryFactory().queryChannel() : 0, factory->queryQueryFactory().getEnableFieldTranslation()));
+        if (varFileInfo)
+        {
+            translators.setown(new TranslatorArray) ;
+            keySet.setown(varFileInfo->getKeyArray(factory->queryActivityMeta(), translators, isOpt, isLocal ? factory->queryQueryFactory().queryChannel() : 0, factory->queryQueryFactory().getEnableFieldTranslation()));
+        }
         variableInfoPending = false;
     }
 
@@ -22749,7 +22754,8 @@ public:
         if (variableFileName)
         {
             varFileInfo.setown(resolveLFN(fetchContext->getFileName(), isOpt));
-            map.setown(varFileInfo->getFileMap());
+            if (varFileInfo)
+                map.setown(varFileInfo->getFileMap());
         }
         puller.start(parentExtractSize, parentExtract, paused, ctx->fetchPreload(), false, ctx);
     }
@@ -23429,9 +23435,12 @@ public:
         }
         else if (variableIndexFileName)
         {
-            varFileInfo.setown(resolveLFN(helper.getIndexFileName(), false));
-            translators.setown(new TranslatorArray);
-            keySet.setown(varFileInfo->getKeyArray(factory->queryActivityMeta(), translators, false, isLocal ? factory->queryQueryFactory().queryChannel() : 0, factory->queryQueryFactory().getEnableFieldTranslation())); // MORE - isLocal?
+            varFileInfo.setown(resolveLFN(helper.getIndexFileName(), (helper.getJoinFlags() & JFindexoptional) != 0));
+            if (varFileInfo)
+            {
+                translators.setown(new TranslatorArray);
+                keySet.setown(varFileInfo->getKeyArray(factory->queryActivityMeta(), translators, false, isLocal ? factory->queryQueryFactory().queryChannel() : 0, factory->queryQueryFactory().getEnableFieldTranslation())); // MORE - isLocal?
+            }
         }
         puller.start(parentExtractSize, parentExtract, paused, ctx->fullKeyedJoinPreload(), false, ctx);
     }
@@ -24084,8 +24093,10 @@ public:
         CRoxieServerKeyedJoinBase::start(parentExtractSize, parentExtract, paused);
         if (variableFetchFileName)
         {
-            varFetchFileInfo.setown(resolveLFN(helper.getFileName(), false));
-            map.setown(varFetchFileInfo->getFileMap());
+            bool isFetchOpt = (helper.getFetchFlags() & FFdatafileoptional) != 0;
+            varFetchFileInfo.setown(resolveLFN(helper.getFileName(), isFetchOpt));
+            if (varFetchFileInfo)
+                map.setown(varFetchFileInfo->getFileMap());
         }
         puller.start(parentExtractSize, parentExtract, paused, ctx->keyedJoinPreload(), false, ctx);
     }
@@ -24217,9 +24228,12 @@ public:
         }
         else if (variableIndexFileName)
         {
-            varFileInfo.setown(resolveLFN(helper.getIndexFileName(), false));
-            translators.setown(new TranslatorArray);
-            keySet.setown(varFileInfo->getKeyArray(factory->queryActivityMeta(), translators, false, isLocal ? factory->queryQueryFactory().queryChannel() : 0, factory->queryQueryFactory().getEnableFieldTranslation())); 
+            varFileInfo.setown(resolveLFN(helper.getIndexFileName(), (helper.getJoinFlags() & JFindexoptional) != 0));
+            if (varFileInfo)
+            {
+                translators.setown(new TranslatorArray);
+                keySet.setown(varFileInfo->getKeyArray(factory->queryActivityMeta(), translators, false, isLocal ? factory->queryQueryFactory().queryChannel() : 0, factory->queryQueryFactory().getEnableFieldTranslation()));
+            }
         }
         puller.start(parentExtractSize, parentExtract, paused, ctx->keyedJoinPreload(), isSimple, ctx);
 

--- a/testing/ecl/roxie/dynamicoptflag.ecl
+++ b/testing/ecl/roxie/dynamicoptflag.ecl
@@ -1,0 +1,49 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+d := dataset(DYNAMIC('regress::no::such::file'), {string10 f}, FLAT, OPT);
+output(d);
+count(d);
+output(d(f='NOT'));
+count(d(f='NOT'));
+
+p := PRELOAD(dataset(DYNAMIC('regress::no::such::file::either'), {string10 f}, FLAT, OPT));
+output(p);
+count(p);
+output(p(f='NOT'));
+count(p(f='NOT'));
+
+p2 := PRELOAD(dataset(DYNAMIC('regress::no::such::file::again'), {string10 f}, FLAT, OPT), 2);
+output(p2);
+count(p2);
+output(p2(f='NOT'));
+count(p2(f='NOT'));
+
+i := INDEX(d,{f},{},DYNAMIC('regress::nor::this'), OPT);
+output(i);
+count(i);
+output(i(f='NOT'));
+count(i(f='NOT'));
+MAX(i(f>'NOT'), f);
+
+j := JOIN(d, i, KEYED(LEFT.f = right.f));
+output(j);
+
+j1 := JOIN(d(f='NOT'), d, KEYED(LEFT.f = right.f), KEYED(i));
+output(j1);
+
+output(FETCH(d, i(f='not'), 0));

--- a/testing/ecl/roxie/key/dynamicoptflag.xml
+++ b/testing/ecl/roxie/key/dynamicoptflag.xml
@@ -1,0 +1,49 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>0</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>0</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>0</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>0</Result_8></Row>
+</Dataset>
+<Dataset name='Result 9'>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><Result_10>0</Result_10></Row>
+</Dataset>
+<Dataset name='Result 11'>
+</Dataset>
+<Dataset name='Result 12'>
+ <Row><Result_12>0</Result_12></Row>
+</Dataset>
+<Dataset name='Result 13'>
+</Dataset>
+<Dataset name='Result 14'>
+ <Row><Result_14>0</Result_14></Row>
+</Dataset>
+<Dataset name='Result 15'>
+</Dataset>
+<Dataset name='Result 16'>
+ <Row><Result_16>0</Result_16></Row>
+</Dataset>
+<Dataset name='Result 17'>
+ <Row><Result_17>          </Result_17></Row>
+</Dataset>
+<Dataset name='Result 18'>
+</Dataset>
+<Dataset name='Result 19'>
+</Dataset>
+<Dataset name='Result 20'>
+</Dataset>


### PR DESCRIPTION
...files

If OPT is specified on a dynamically-resolved file in Roxie, then it is liable
to core if the file cannot be resolved.

Other cases may incorrectly throw an exception when a file is not resolved,
rather than ignoring it as should be done with ,OPT files.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
