### PR TITLE
HPCC-9041 Quotes around R_INCLUDE_DIRS causing issue with cmake<2.8.8

### DIFF
--- a/plugins/Rembed/CMakeLists.txt
+++ b/plugins/Rembed/CMakeLists.txt
@@ -33,7 +33,7 @@ if ( R_FOUND )
         )
 
     include_directories (
-             "${R_INCLUDE_DIRS}"
+             ${R_INCLUDE_DIRS}
              ./../../system/include
              ./../../rtl/eclrtl
              ./../../rtl/include


### PR DESCRIPTION
Removed Quotes to allow cmake list to work correctly in all versions
of cmake >= 2.6.1.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
