### PR TITLE
HPCC-9042 Correct Rembed using incorrect variable for found

### DIFF
--- a/plugins/Rembed/CMakeLists.txt
+++ b/plugins/Rembed/CMakeLists.txt
@@ -27,7 +27,7 @@ project( Rembed )
 
 ADD_PLUGIN(Rembed PACKAGES R OPTION MAKE_REMBED)
 
-if ( R_FOUND )
+if ( MAKE_REMBED )
     set (    SRCS
              Rembed.cpp
         )


### PR DESCRIPTION
Move from R_FOUND to MAKE_REMBED for the variable marking dependency
as found.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
