### PR TITLE
HPCC-9012 Minimum version of python changed to 2.6

### DIFF
--- a/plugins/pyembed/CMakeLists.txt
+++ b/plugins/pyembed/CMakeLists.txt
@@ -27,7 +27,7 @@ set ( debug_python Off )   # A lot slower but can assist in debugging...
 
 project( pyembed )
 
-ADD_PLUGIN(pyembed PACKAGES PythonLibs OPTION MAKE_PYEMBED MINVERSION 2.7 MAXVERSION 2.7)
+ADD_PLUGIN(pyembed PACKAGES PythonLibs OPTION MAKE_PYEMBED MINVERSION 2.6 MAXVERSION 2.7)
 
 if ( MAKE_PYEMBED )
 


### PR DESCRIPTION
API calls used in pyembed are preset in >=2.6 and does not require
a minimum setting of 2.7.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
