### PR TITLE
HPCC-9047 Replace 'children' property with 'childNodes' in javascript

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_accountpermissions.xslt
+++ b/esp/eclwatch/ws_XSLT/access_accountpermissions.xslt
@@ -42,7 +42,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_basedns.xslt
+++ b/esp/eclwatch/ws_XSLT/access_basedns.xslt
@@ -42,7 +42,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_groupedit.xslt
+++ b/esp/eclwatch/ws_XSLT/access_groupedit.xslt
@@ -48,7 +48,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_groupmembereditinput.xslt
+++ b/esp/eclwatch/ws_XSLT/access_groupmembereditinput.xslt
@@ -47,7 +47,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_groups.xslt
+++ b/esp/eclwatch/ws_XSLT/access_groups.xslt
@@ -49,7 +49,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_permissionresetinput.xslt
+++ b/esp/eclwatch/ws_XSLT/access_permissionresetinput.xslt
@@ -46,7 +46,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);
@@ -65,7 +65,7 @@
                         return o.checked ? '\n'+o.name : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected1(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_resources.xslt
+++ b/esp/eclwatch/ws_XSLT/access_resources.xslt
@@ -50,7 +50,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_useredit.xslt
+++ b/esp/eclwatch/ws_XSLT/access_useredit.xslt
@@ -47,7 +47,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_usergroupeditinput.xslt
+++ b/esp/eclwatch/ws_XSLT/access_usergroupeditinput.xslt
@@ -46,7 +46,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/access_users.xslt
+++ b/esp/eclwatch/ws_XSLT/access_users.xslt
@@ -49,7 +49,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/addto_superfile.xslt
+++ b/esp/eclwatch/ws_XSLT/addto_superfile.xslt
@@ -58,7 +58,7 @@
                             return o.checked ? '\n'+o.name : '';
 
                         var s='';
-                        var ch=o.children;
+                        var ch=o.childNodes;
                         if (ch)
                             for (var i in ch)
                                 s=s+getAllChecked(ch[i]);
@@ -86,19 +86,6 @@
                     {
                         validateInput();
                     }  
-
-                    function getSelected(o)
-                    {
-                        if (o.tagName=='INPUT' && o.type == 'checkbox' && o.value != 'on')
-                            return o.checked ? '\n'+o.value : '';
-
-                        var s='';
-                        var ch=o.children;
-                        if (ch)
-                            for (var i in ch)
-                                s=s+getSelected(ch[i]);
-                        return s;
-                    }
 
                     function toggleElement()
                     {

--- a/esp/eclwatch/ws_XSLT/batchworkunits.xslt
+++ b/esp/eclwatch/ws_XSLT/batchworkunits.xslt
@@ -132,7 +132,7 @@
                                 return;
                             }
 
-                            var ch=o.children;
+                            var ch=o.childNodes;
                             if (ch)
                                 for (var i in ch)
                                     checkSelected(ch[i]);
@@ -147,7 +147,7 @@
                                 return;
                             }
 
-                            var ch=o.children;
+                            var ch=o.childNodes;
                             if (ch)
                                 for (var i in ch)
                                 checkSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -355,7 +355,7 @@
                                     return;
                                 }
 
-                                var ch=o.children;
+                                var ch=o.childNodes;
                                 if (ch)
                                     for (var i in ch)
                                         checkSelected(ch[i]);
@@ -391,7 +391,7 @@
                                 }
                             
                                 var s='';
-                                var ch=o.children;
+                                var ch=o.childNodes;
                                 if (ch)
                                     for (var i in ch)
                                     s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -57,7 +57,7 @@
                                 return o.checked ? '\n'+o.value : '';
 
                             var s='';
-                            var ch=o.children;
+                            var ch=o.childNodes;
                             if (ch)
                                 for (var i in ch)
                                     s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/dfu_file_space.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file_space.xslt
@@ -63,24 +63,6 @@
                     </script>
                     <script language="JavaScript1.2">
                         <xsl:text disable-output-escaping="yes"><![CDATA[
-                            function onRowCheck(checked)
-                            {
-                                document.getElementById("deleteBtn").disabled = checkedCount == 0;
-                            }                            
-                            
-                            function getSelected(o)
-                            {
-                                if (o.tagName=='INPUT')
-                                    return o.checked ? '\n'+o.value : '';
-                            
-                                var s='';
-                                var ch=o.children;
-                                if (ch)
-                                    for (var i in ch)
-                                    s=s+getSelected(ch[i]);
-                                 return s;
-                            }
-
                             var countbySelected = 1;
                             var interval = "Year";
                             function onChangeCountType()
@@ -524,19 +506,6 @@
             </xsl:apply-templates>
          </tbody>
         </table>
-        <!--table id="btnTable" style="margin:20 0 0 0">
-            <colgroup>
-                <col span="8" width="100"/>
-            </colgroup>
-            <tr>
-                <td>
-                    <input type="button" class="sbutton" value="Clear" onclick="selectAll(false)"/>
-                </td>
-                <td>
-                    <input type="submit" class="sbutton" id="deleteBtn" value="Delete" disabled="true" onclick="return confirm('Are you sure you want to delete the following file(s) ?\n\n'+getSelected(document.forms['listitems']).substring(1,1000))"/>
-                </td>
-            </tr>
-        </table-->
     </xsl:template>
     
     <xsl:template match="DFUSpaceItem">

--- a/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
@@ -191,7 +191,7 @@
                             return o.checked ? '\n'+o.value : '';
                     
                         var s='';
-                        var ch=o.children;
+                        var ch=o.childNodes;
                         if (ch)
                             for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/dfu_getdatacolumns.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_getdatacolumns.xslt
@@ -109,7 +109,7 @@
                                 filterBy = len_name + len_value + oname + ovalue; 
                         }
 
-                        var ch=o.children;
+                        var ch=o.childNodes;
                         if (ch)
                             for (var i in ch)
                                 checkTextField(ch[i]);

--- a/esp/eclwatch/ws_XSLT/dfu_searchdata.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_searchdata.xslt
@@ -430,7 +430,7 @@
                                 filterBy = len_name + len_value + oname + ovalue; 
                         }
 
-                        var ch=o.children;
+                        var ch=o.childNodes;
                         if (ch)
                             for (var i in ch)
                                 checkTextField(ch[i]);

--- a/esp/eclwatch/ws_XSLT/dfu_superedit.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_superedit.xslt
@@ -47,7 +47,7 @@
                         return o.checked ? '\n'+o.value : '';
 
                     var s='';
-                    var ch=o.children;
+                    var ch=o.childNodes;
                     if (ch)
                         for (var i in ch)
                             s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/dfu_workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_workunits.xslt
@@ -73,7 +73,7 @@
                                     return;
                                 }
 
-                                var ch=o.children;
+                                var ch=o.childNodes;
                                 if (ch)
                                     for (var i in ch)
                                         checkSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/dropzonefile.xslt
+++ b/esp/eclwatch/ws_XSLT/dropzonefile.xslt
@@ -177,7 +177,7 @@
               }
 
               var s='';
-              var ch=o.children;
+              var ch=o.childNodes;
               if (ch)
                 for (var i in ch)
                   s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/queryfilelist.xslt
+++ b/esp/eclwatch/ws_XSLT/queryfilelist.xslt
@@ -139,7 +139,7 @@
               return;
             }
 
-            var ch=o.children;
+            var ch=o.childNodes;
             if (ch)
               for (var i in ch)
                 checkSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/roxiequery.xslt
+++ b/esp/eclwatch/ws_XSLT/roxiequery.xslt
@@ -134,7 +134,7 @@
                                 return o.checked ? '\n'+o.value : '';
                         
                             var s='';
-                            var ch=o.children;
+                            var ch=o.childNodes;
                             if (ch)
                                 for (var i in ch)
                                 s=s+getSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/scheduledwus.xslt
+++ b/esp/eclwatch/ws_XSLT/scheduledwus.xslt
@@ -50,7 +50,7 @@
                             return;
                         }
 
-                        var ch=o.children;
+                        var ch=o.childNodes;
                         if (ch)
                             for (var i in ch)
                                 checkSelected(ch[i]);

--- a/esp/eclwatch/ws_XSLT/workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/workunits.xslt
@@ -94,7 +94,7 @@
                             return;
                         }
 
-                        var ch=o.children;
+                        var ch=o.childNodes;
                         if (ch)
                             for (var i in ch)
                                 checkSelected(ch[i]);


### PR DESCRIPTION
Using Firefox 19.0.2, open ECLWatch and select a file, or a user, or a
group, etc and click the DELETE button will result in each selected
item being displayed 4 times. The problem is because that the new version
of Firefox does not support the 'children' property as well as its
previous versions. In an HTML form, when a checkbox is checked, Firefox
19.0.2 lists four items being checked if we use the 'children' property
to go through the form items. This fix replaces the 'children' property
with childNodes property which is supported in all major browsers.

This fix also removes three functions which are not being used any more
(the 'children' property is called in those functions).

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
