### PR TITLE
HPCC-8990 Regression suite failures with no active dali connection avail...

### DIFF
--- a/testing/ecl/apply.ecl
+++ b/testing/ecl/apply.ecl
@@ -20,6 +20,8 @@
 import lib_logging;
 import lib_workunitservices;
 
+#option('slaveDaliClient', true);
+
 export Display := 
     SERVICE
         unsigned4 echo(const string src) : eclrtl,library='eclrtl',entrypoint='rtlDisplay';

--- a/testing/ecl/multilfn.ecl
+++ b/testing/ecl/multilfn.ecl
@@ -21,6 +21,8 @@ import std.system.thorlib;
 import Std.File AS FileServices;
 import std.str;
 
+#option('slaveDaliClient', true);
+
 rec := RECORD, MAXLENGTH(256)
   STRING    album;
   STRING    song;

--- a/testing/ecl/superfile5.ecl
+++ b/testing/ecl/superfile5.ecl
@@ -22,6 +22,8 @@ import Std.System.Thorlib;
 import Std.File AS FileServices;
 import Std.Str;
 
+#option('slaveDaliClient', true);
+
 rec :=
 RECORD
         integer i;

--- a/testing/ecl/superfile6.ecl
+++ b/testing/ecl/superfile6.ecl
@@ -19,6 +19,8 @@ import Std.File AS FileServices;
 // Super File added to itself test
 //noRoxie
 
+#option('slaveDaliClient', true);
+
 string fsuper := '~t6::superfile';
 string fsub := '~t6::subfile';
 ds := DATASET ([{'aaa'}, {'bbb'}, {'ccc'}, {'ddd'}], {string name});


### PR DESCRIPTION
...able

Some tests need to be given permission for Thor Slaves to access dali.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
