### PR TITLE
HPCC-9056 Build break in thor (Windows)

### DIFF
--- a/system/jlib/jsem.hpp
+++ b/system/jlib/jsem.hpp
@@ -48,7 +48,7 @@ public:
         WaitForSingleObject(hSem, INFINITE);
     }
 
-    void reinit(unsigned initialCount)
+    void reinit(unsigned initialCount=0U)
     {
         CloseHandle(hSem);
         hSem = CreateSemaphore(NULL, initialCount, 0x7fffffff, NULL);


### PR DESCRIPTION
Recent addition of call to Semaphore::init() breaks build in Windows.
Linux Signature is
    void reinit(unsigned initialCount=0U)
and Windows sig is
    void reinit(unsigned initialCount)
This fix changes Windows to default to 0 as well

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
