### PR TITLE
HPCC-9045 WSFileIO is not accessible by non-admin users

### DIFF
--- a/esp/services/ws_fileio/ws_fileioservice.cpp
+++ b/esp/services/ws_fileio/ws_fileioservice.cpp
@@ -26,7 +26,7 @@
 #endif
 
 ///#define FILE_DESPRAY_URL "FileDesprayAccess"
-#define FILE_IO_URL     "FileIO"
+#define FILE_IO_URL     "FileIOAccess"
 
 void CWsFileIOEx::init(IPropertyTree *cfg, const char *process, const char *service)
 {

--- a/esp/services/ws_smc/espsmc_permissions.txt
+++ b/esp/services/ws_smc/espsmc_permissions.txt
@@ -57,9 +57,8 @@ ws_fs:
         Write - Access to DKC key files
 
 ws_fileio:
-    FileIO: Not defined in esp.xml but used by service.
+    FileIOAccess:
         Write - Access to files in dropzone... CreateFile, ReadFileData, WriteFileData
-    FileIOAccess: Defined in esp.xml but not used by service.
 
 ws_topology:
     ClusterTopologyAccess: 


### PR DESCRIPTION
Security descriptors for "FileIOAccess" were incorrectly validated in
ws_fileioservice.cpp against the string "FileIO", resulting in failures
every time (unless requested by an admin). This fix corrects the string
in ws_fileioservice.cpp to the same one that is provided in the request

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
