### PR TITLE
HPCC-9063 Fix regression handling non dynamic filenames in roxie

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -19561,11 +19561,11 @@ public:
             eof = true;
         else
         {
-            numParts = 0;
             if (variableFileName)
             {
                 OwnedRoxieString fileName(helper.getFileName());
                 varFileInfo.setown(resolveLFN(fileName, isOpt));
+                numParts = 0;
                 if (varFileInfo)
                 {
                     Owned<IFilePartMap> map = varFileInfo->getFileMap();


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
