### PR TITLE
HPCC-9072 Fix issue with null act and multiple outputs

### DIFF
--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -113,17 +113,18 @@ CSlaveActivity::~CSlaveActivity()
 void CSlaveActivity::setInput(unsigned index, CActivityBase *inputActivity, unsigned inputOutIdx)
 {
     CActivityBase::setInput(index, inputActivity, inputOutIdx);
-    Owned<CActivityBase> nullAct;
+    Linked<IThorDataLink> outLink;
     if (!inputActivity)
     {
-        nullAct.setown(container.factory(TAKnull));
-        inputActivity = nullAct; // NB: output of nullAct linked, input of this act will own
+        Owned<CActivityBase> nullAct = container.factory(TAKnull);
+        outLink.set(((CSlaveActivity *)(nullAct.get()))->queryOutput(0)); // NB inputOutIdx irrelevant, null has single 'fake' output
+        nullAct->releaseIOs(); // normally done as graph winds up, clear now to avoid circular dependencies with outputs
     }
-
-    IThorDataLink *outLink = ((CSlaveActivity *)inputActivity)->queryOutput(inputOutIdx);
+    else
+        outLink.set(((CSlaveActivity *)inputActivity)->queryOutput(inputOutIdx));
     assertex(outLink);
     while (inputs.ordinality()<=index) inputs.append(NULL);
-    inputs.replace(LINK(outLink), index);
+    inputs.replace(outLink.getClear(), index);
 }
 
 IThorDataLink *CSlaveActivity::queryOutput(unsigned index)


### PR DESCRIPTION
Thor would hit assert(outLink), if it introduced a nullAct
in place of a splitter. The assert was hit when one
of the pulling activities requested an output >0 from the nullAct.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
