### PR TITLE
HPCC-9013 enter bad pwd for expired user still prompts for pwd change

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -564,7 +564,7 @@ bool EspHttpBinding::basicAuth(IEspContext* ctx)
     bool authenticated = m_secmgr->authorize(*user, rlist);
     if(!authenticated)
     {
-        if (user->getAuthenticateStatus() == AS_PASSWORD_EXPIRED)
+        if (user->getAuthenticateStatus() == AS_PASSWORD_EXPIRED || user->getAuthenticateStatus() == AS_PASSWORD_VALID_BUT_EXPIRED)
             ctx->AuditMessage(AUDIT_TYPE_ACCESS_FAILURE, "Authentication", "ESP password is expired");
         else
             ctx->AuditMessage(AUDIT_TYPE_ACCESS_FAILURE, "Authentication", "Access Denied: User or password invalid");

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -162,7 +162,7 @@ bool CEspHttpServer::rootAuth(IEspContext* ctx)
         else
         {
             ISecUser *user = ctx->queryUser();
-            if (user && user->getAuthenticateStatus() == AS_PASSWORD_EXPIRED)
+            if (user && user->getAuthenticateStatus() == AS_PASSWORD_VALID_BUT_EXPIRED)
             {
                 m_response->redirect(*m_request.get(), "/esp/updatepasswordinput");
                 ret = true;
@@ -323,7 +323,8 @@ int CEspHttpServer::processRequest()
             {
                 if (!rootAuth(ctx))
                     return 0;
-                if (ctx->queryUser() && (ctx->queryUser()->getAuthenticateStatus() == AS_PASSWORD_EXPIRED))
+
+                if (ctx->queryUser() && ctx->queryUser()->getAuthenticateStatus() == AS_PASSWORD_VALID_BUT_EXPIRED)
                     return 0;//allow user to change password
                 // authenticate optional groups
                 if (authenticateOptionalFailed(*ctx,NULL))
@@ -436,7 +437,7 @@ int CEspHttpServer::processRequest()
             if (authState==authRequired)
             {
                 ISecUser *user = ctx->queryUser();
-                if (user && user->getAuthenticateStatus() == AS_PASSWORD_EXPIRED)
+                if (user && (user->getAuthenticateStatus() == AS_PASSWORD_EXPIRED || user->getAuthenticateStatus() == AS_PASSWORD_VALID_BUT_EXPIRED))
                 {
                     DBGLOG("ESP password expired for %s", user->getName());
                     m_response->setContentType(HTTP_TYPE_TEXT_PLAIN);

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -128,15 +128,15 @@ const StringBuffer &CEspApplicationPort::getAppFrameHtml(time_t &modified, const
 
     if (needRefresh || embedded_url || !appFrameHtml.length())
     {
-        int passwordDaysRemaining = -1;
+        int passwordDaysRemaining = -1;//-1 means dont display change password screen
 #ifdef _USE_OPENLDAP
         ISecUser* user = ctx->queryUser();
         ISecManager* secmgr = ctx->querySecManager();
         if(user && secmgr)
         {
-            passwordDaysRemaining = user->getPasswordDaysRemaining();
-            unsigned passwordExpirationDays = secmgr->getPasswordExpirationWarningDays();
-            if ((unsigned) passwordDaysRemaining > passwordExpirationDays)
+            passwordDaysRemaining = user->getPasswordDaysRemaining();//-1 if expired, -2 if never expires
+            int passwordExpirationDays = (int)secmgr->getPasswordExpirationWarningDays();
+            if (passwordDaysRemaining==-2 || passwordDaysRemaining > passwordExpirationDays)
                 passwordDaysRemaining = -1;
         }
 #endif

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1224,15 +1224,36 @@ public:
             }
             if(rc != LDAP_SUCCESS)
             {
-                if (user.getPasswordDaysRemaining() == -1 || strstr(ldap_errstring, "data 532"))//80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 532, v1db0.
+                if (strstr(ldap_errstring, " data "))//if extended error strings are available (they are not in windows clients)
                 {
-                    DBGLOG("ESP Password Expired for user %s", username);
-                    user.setAuthenticateStatus(AS_PASSWORD_EXPIRED);
+#ifdef _DEBUG
+                    DBGLOG("LDAPBIND ERR: RC=%d, - '%s'",  rc, ldap_errstring);
+#endif
+                    if (strstr(ldap_errstring, "data 532"))//80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 532, v1db0.
+                    {
+                        DBGLOG("LDAP: Password Expired(1) for user %s", username);
+                        user.setAuthenticateStatus(AS_PASSWORD_VALID_BUT_EXPIRED);
+                    }
+                    else
+                    {
+                        DBGLOG("LDAP: Authentication(1) for user %s failed - %s", username, ldap_err2string(rc));
+                        user.setAuthenticateStatus(AS_INVALID_CREDENTIALS);
+                    }
                 }
                 else
                 {
-                    DBGLOG("LDAP: Authentication for user %s failed - %s", username, ldap_err2string(rc));
-                    user.setAuthenticateStatus(AS_INVALID_CREDENTIALS);
+                    //This path is typical if running ESP on Windows. We have no way
+                    //to determine if password entered is valid but expired
+                    if (user.getPasswordDaysRemaining() == -1)
+                    {
+                        DBGLOG("LDAP: Password Expired(2) for user %s", username);
+                        user.setAuthenticateStatus(AS_PASSWORD_EXPIRED);
+                    }
+                    else
+                    {
+                        DBGLOG("LDAP: Authentication(2) for user %s failed - %s", username, ldap_err2string(rc));
+                        user.setAuthenticateStatus(AS_INVALID_CREDENTIALS);
+                    }
                 }
                 return false;
             }

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -1081,7 +1081,7 @@ IAuthMap * CLdapSecManager::createFeatureMap(IPropertyTree * authconfig)
 bool CLdapSecManager::updateUserPassword(ISecUser& user, const char* newPassword, const char* currPassword)
 {
     // Authenticate User first
-    if(!authenticate(&user) && user.getAuthenticateStatus() != AS_PASSWORD_EXPIRED)
+    if(!authenticate(&user) && user.getAuthenticateStatus() != AS_PASSWORD_VALID_BUT_EXPIRED)
     {
         return false;
     }

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -134,7 +134,8 @@ enum authStatus
     AS_UNKNOWN = 1,//have not attempted to authenticate
     AS_UNEXPECTED_ERROR = 2,
     AS_INVALID_CREDENTIALS = 3,
-    AS_PASSWORD_EXPIRED = 4
+    AS_PASSWORD_EXPIRED = 4,
+    AS_PASSWORD_VALID_BUT_EXPIRED = 5//user entered valid password, but authentication failed because it is expired
 };
 
 class CDateTime;


### PR DESCRIPTION
Current code displays ChangePassword screen if user tries to log on and password
is expired, even when invalid password provided. This change makes the user
enter valid UN/PW before they are allowed to change their PW

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
