### PR TITLE
HPCC-9094 Ensure space is allocated for the length of a child dataset

### DIFF
--- a/rtl/eclrtl/rtlds.cpp
+++ b/rtl/eclrtl/rtlds.cpp
@@ -921,6 +921,7 @@ public:
     {
         unsigned pos = offset;
         offset += sizeof(size32_t);
+        builder.ensureCapacity(offset, "");
         return pos;
     }
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
