### PR TITLE
HPCC-9106 Incorrect determination of password expiration prompt

### DIFF
--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -128,15 +128,15 @@ const StringBuffer &CEspApplicationPort::getAppFrameHtml(time_t &modified, const
 
     if (needRefresh || embedded_url || !appFrameHtml.length())
     {
-        int passwordDaysRemaining = -1;
+        int passwordDaysRemaining = -1;//-1 means dont display change password screen
 #ifdef _USE_OPENLDAP
         ISecUser* user = ctx->queryUser();
         ISecManager* secmgr = ctx->querySecManager();
         if(user && secmgr)
         {
-            passwordDaysRemaining = user->getPasswordDaysRemaining();
-            unsigned passwordExpirationDays = secmgr->getPasswordExpirationWarningDays();
-            if ((unsigned) passwordDaysRemaining > passwordExpirationDays)
+            passwordDaysRemaining = user->getPasswordDaysRemaining();//-1 if expired, -2 if never expires
+            int passwordExpirationDays = (int)secmgr->getPasswordExpirationWarningDays();
+            if (passwordDaysRemaining==-2 || passwordDaysRemaining > passwordExpirationDays)
                 passwordDaysRemaining = -1;
         }
 #endif


### PR DESCRIPTION
The test for whether or not to set passwordDaysRemaining to -1 incorrectly
casts passwordDaysRemaining to an unsigned. This is incorrect, because it
can be negative (-1 means expired, -2 means never expires). This fix corrects
the problem by treating it as an integer

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
