### PR TITLE
 HPCC-9084 Delimit JSON across multiple Roxie ouputs

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3025,7 +3025,7 @@ public:
                         break;
                     if (needDelimiter)
                     {
-                        StringAttr s(",\n ");
+                        StringAttr s(",\n "); //write() will take ownership of buffer
                         size32_t len = s.length();
                         client->write((void *)s.detach(), len, true);
                         needDelimiter=false;

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3005,11 +3005,12 @@ public:
         StringBuffer responseHead, responseTail;
         appendfJSONName(responseHead, "%sResponse", queryName.get()).append(" {");
         appendJSONValue(responseHead, "sequence", seqNo);
-        appendJSONName(responseHead, "Results").append(" {");
+        appendJSONName(responseHead, "Results").append(" {\n ");
 
         unsigned len = responseHead.length();
         client->write(responseHead.detach(), len, true);
 
+        bool needDelimiter = false;
         ForEachItemIn(seq, resultMap)
         {
             FlushingStringBuffer *result = resultMap.item(seq);
@@ -3022,8 +3023,16 @@ public:
                     void *payload = result->getPayload(length);
                     if (!length)
                         break;
+                    if (needDelimiter)
+                    {
+                        StringAttr s(",\n ");
+                        size32_t len = s.length();
+                        client->write((void *)s.detach(), len, true);
+                        needDelimiter=false;
+                    }
                     client->write(payload, length, true);
                 }
+                needDelimiter=true;
             }
         }
 


### PR DESCRIPTION
New pull request targeting closedown-4.0.x from previous pull request:

https://github.com/hpcc-systems/HPCC-Platform/pull/4195

Roxie JSON/HTTP is not being delimited across multiple outputs. This is a bug in the new
feature added to 4.0 and ideally this fix will be merged into the next release candidate.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
