### PR TITLE
HPCC-9115 Fedora389 LDAP returns NULL errstring

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1224,7 +1224,7 @@ public:
             }
             if(rc != LDAP_SUCCESS)
             {
-                if (user.getPasswordDaysRemaining() == -1 || strstr(ldap_errstring, "data 532"))//80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 532, v1db0.
+                if (user.getPasswordDaysRemaining() == -1 || (ldap_errstring && *ldap_errstring && strstr(ldap_errstring, "data 532")))//80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 532, v1db0.
                 {
                     DBGLOG("ESP Password Expired for user %s", username);
                     user.setAuthenticateStatus(AS_PASSWORD_EXPIRED);


### PR DESCRIPTION
On Fedora, the call to
     ldap_get_option(user_ld, LDAP_OPT_ERROR_STRING, &ldap_errstring);
sets the string pointer to NULL, causing exception to be thrown when
later dereferenced. This fix checks for NULL before deref

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
