### PR TITLE
HPCC-9114 XMLParse gives spurious errors on CDATA sections that end ]]]>

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -4259,19 +4259,16 @@ protected:
             readNext();
             while (']' == nextChar)
             {
-                char c1 = nextChar;
                 readNext();
-                if (']' == nextChar)
+                while (']' == nextChar)
                 {
-                    char c2 = nextChar;
                     readNext();
                     if ('>' == nextChar)
                         return;
                     else
-                        text.append(c1).append(c2);
+                        text.append(']');
                 }
-                else
-                    text.append(c1);
+                text.append(']');
             }
             text.append(nextChar);
         }           


### PR DESCRIPTION
The check for termination of a CDATA Section would miss cases with an odd
number of ] at the end.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
