### PR TITLE
HPCC-9120 - Fix global rollup early stop deadlock

### DIFF
--- a/thorlcr/activities/rollup/throllupslave.cpp
+++ b/thorlcr/activities/rollup/throllupslave.cpp
@@ -497,6 +497,12 @@ public:
     }
     virtual void stop()
     {
+        if (global && !eos) // if stopped early, ensure next informed
+        {
+            kept.clear();
+            keptTransformed.clear();
+            putNextKept();
+        }
         CDedupRollupBaseActivity::stop();
         dataLinkStop();
     }


### PR DESCRIPTION
If global rollup was stopped before it had process all it's input,
it would stall on a multi slave setup. If stopped, global rollup
was not signalling to the next nodes that it had finished.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
