### PR TITLE
HPCC-9100 Ignore foreign info when resolving file in package

### DIFF
--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -85,6 +85,7 @@ protected:
 
     inline StringBuffer makeSuperFileXPath(StringBuffer &xpath, const char *superFileName) const
     {
+        superFileName = skipForeign(superFileName);
         return xpath.append("SuperFile[@id='").appendLower(strlen(superFileName), superFileName).append("']");
     }
 
@@ -244,8 +245,6 @@ public:
         if (!superFileName || !*superFileName || !TYPE::node)
             return false;
 
-        if (*superFileName=='~')
-            superFileName++;
         StringBuffer xpath;
         if (TYPE::hasProp(TYPE::makeSuperFileXPath(xpath, superFileName)))
             return true;

--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -35,7 +35,7 @@ bool getIsOpt(const IPropertyTree &graphNode)
         return graphNode.getPropBool("att[@name='_isIndexOpt']/@value", false);
 }
 
-const char *skipForeign(const char *name, StringBuffer *ip=NULL)
+const char *skipForeign(const char *name, StringBuffer *ip)
 {
     if (*name=='~')
         name++;

--- a/common/workunit/referencedfilelist.hpp
+++ b/common/workunit/referencedfilelist.hpp
@@ -59,6 +59,8 @@ interface IReferencedFileList : extends IInterface
     virtual void cloneRelationships()=0;
 };
 
+extern WORKUNIT_API const char *skipForeign(const char *name, StringBuffer *ip=NULL);
+
 extern WORKUNIT_API IReferencedFileList *createReferencedFileList(const char *user, const char *pw);
 
 #endif //REFFILE_LIST_HPP

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -3960,6 +3960,8 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
                 try
                 {
                     sub.setown(transaction->lookupFile(subfile,SDS_SUB_LOCK_TIMEOUT));
+                    if (!sub)
+                        throw MakeStringException(-1,"cAddSubFileAction: sub file %s not found", subfile.sget());
                     // Must validate before locking for update below, to check sub is not already in parent (and therefore locked already)
                     CDistributedSuperFile *sf = dynamic_cast<CDistributedSuperFile *>(parent.get());;
                     sf->validateAddSubFile(sub);


### PR DESCRIPTION
Also fix core in dadfs when subfile information not found.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
