### PR TITLE
HPCC-7999 Invalid syntax reported by OpenLDAP

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -370,8 +370,7 @@ public:
         else if(m_serverType == IPLANET)
             m_sdfieldname.append("aci");
         else if(m_serverType == OPEN_LDAP)
-            m_sdfieldname.append("OpenLDAPaci");
-
+            m_sdfieldname.append("aci");
     }
 
     virtual LdapServerType getServerType()
@@ -585,7 +584,23 @@ public:
         {
             time(&m_lastaccesstime);
             m_connected = true;
-            DBGLOG("Connected to LdapServer %s using protocol %s", ldapserver, protocol);
+            const char * ldap = NULL;
+            switch (m_ldapconfig->getServerType())
+            {
+            case ACTIVE_DIRECTORY:
+                ldap = "Active Directory";
+                break;
+            case OPEN_LDAP:
+                ldap = "OpenLDAP";
+                break;
+            case IPLANET:
+                ldap = "iplanet";
+                break;
+            default:
+                ldap = "unknown";
+                break;
+            }
+            DBGLOG("Connected to '%s' LdapServer %s using protocol %s", ldap, ldapserver, protocol);
         }
         else
         {
@@ -3367,17 +3382,18 @@ public:
         
         attrs[ind++] = &cn_attr;
         attrs[ind++] = &oc_attr;
-        if(m_ldapconfig->getServerType() == OPEN_LDAP)
-        {
-            attrs[ind++] = &member_attr;
-        }
-
         attrs[ind] = NULL;
 
         Owned<ILdapConnection> lconn = m_connections->getConnection();
         LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
         int rc = ldap_add_ext_s(ld, (char*)dn.str(), attrs, NULL, NULL);
-        if ( rc != LDAP_SUCCESS )
+        if ( rc == LDAP_INVALID_SYNTAX  && m_ldapconfig->getServerType() == OPEN_LDAP)//Fedora389 does not 'seem' to need this, openLDAP does
+        {
+            attrs[ind++] = &member_attr;
+            attrs[ind] = NULL;
+            rc = ldap_add_ext_s(ld, (char*)dn.str(), attrs, NULL, NULL);
+        }
+        if ( rc != LDAP_SUCCESS)
         {
             if(rc == LDAP_ALREADY_EXISTS)
             {
@@ -3852,7 +3868,8 @@ private:
 
         if(m_ldapconfig->getServerType() != ACTIVE_DIRECTORY)
         {
-        
+            if (strncmp(dn,"uid=",4))//Fedora389 returns "cn=Directory Administrators"
+                return;
             const char* comma = strchr(dn, ',');
             // DN is in the format of "uid=uuu,ou=ooo,dc=dd"
             uid.append(comma - dn - 4, dn + 4);

--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -358,6 +358,13 @@ public:
                 return LDAP_INVALID_CREDENTIALS;
             }
             int rc = LdapSimpleBind(ld, (char*)userdn, (char*)password);
+            if (rc != LDAP_SUCCESS && server_type == OPEN_LDAP && strchr(userdn,','))
+            {   //Fedora389 is happier without the domain component specified
+                StringBuffer cn(userdn);
+                cn.replace(',',(char)NULL);
+                if (cn.length())//disallow call if no cn
+                    rc = LdapSimpleBind(ld, (char*)cn.str(), (char*)password);
+            }
             if (rc != LDAP_SUCCESS )
             {
                 // For Active Directory, try binding with NT format username


### PR DESCRIPTION
ESP fails to start on newer releases of openLDAP because of numerous
issues relating to schema changes.  Discussed with Flavio and it was
decided to focus on getting it up and running with Fedora389 instead,
since that was a better open source LDAP implementation. With this fix
I am making several tweaks the allow it to start up, create the top level
organizational units, and perform user/group/permission activities.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
