### PR TITLE
HPCC-9124 Avoid issues with out of date precompiled headers

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1323,7 +1323,7 @@ bool EclCC::generatePrecompiledHeader()
     {
         StringBuffer fullpath;
         fullpath.append(paths.item(idx));
-        addPathSepChar(fullpath).append("eclinclude.hpp");
+        addPathSepChar(fullpath).append("eclinclude4.hpp");
         if (checkFileExists(fullpath))
         {
             foundPath = paths.item(idx);
@@ -1332,10 +1332,10 @@ bool EclCC::generatePrecompiledHeader()
     }
     if (!foundPath)
     {
-        ERRLOG("Cannot find eclinclude.hpp");
+        ERRLOG("Cannot find eclinclude4.hpp");
         return false;
     }
-    Owned<ICppCompiler> compiler = createCompiler("eclinclude.hpp", foundPath, NULL);
+    Owned<ICppCompiler> compiler = createCompiler("eclinclude4.hpp", foundPath, NULL);
     compiler->setDebug(true);  // a precompiled header with debug can be used for no-debug, but not vice versa
     compiler->setPrecompileHeader(true);
     if (compiler->compile())
@@ -1721,7 +1721,7 @@ const char * const helpText[] = {
     "!   -m            Enable leak checking",
 #endif
 #ifndef _WIN32
-    "!   -pch          Generate precompiled header for eclinclude.hpp",
+    "!   -pch          Generate precompiled header for eclinclude4.hpp",
 #endif
     "!   -P <path>     Specify the path of the output files (only with -b option)",
     "    -specs file   Read eclcc configuration from specified file",

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -434,6 +434,7 @@ public:
     }
 };
 
+#ifndef _WIN32
 static void generatePrecompiledHeader()
 {
     try
@@ -454,6 +455,12 @@ static void generatePrecompiledHeader()
         e->Release();
     }
 }
+
+static void removePrecompiledHeader()
+{
+    remove("eclinclude4.hpp.gch");
+}
+#endif
 
 //------------------------------------------------------------------------------------------------------------------
 // Class EclccServer manages a pool of compile threads
@@ -623,8 +630,12 @@ int main(int argc, const char *argv[])
 
     if (globals->getPropBool("@enableSysLog",true))
         UseSysLogForOperatorMessages();
+#ifndef _WIN32
     if (globals->getPropBool("@generatePrecompiledHeader",true))
         generatePrecompiledHeader();
+    else
+        removePrecompiledHeader();
+#endif
 
     const char *daliServers = globals->queryProp("@daliServers");
     if (!daliServers)

--- a/rtl/eclrtl/CMakeLists.txt
+++ b/rtl/eclrtl/CMakeLists.txt
@@ -39,7 +39,7 @@ set (    SRCS
          rtltype.cpp 
          rtlxml.cpp
          
-         eclinclude.hpp
+         eclinclude4.hpp
          eclrtl.hpp
          eclrtl_imp.hpp
          rtlbcd.hpp
@@ -85,7 +85,7 @@ target_link_libraries ( eclrtl
     )
 
 FOREACH( iFILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/eclinclude.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/eclinclude4.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eclrtl.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eclrtl_imp.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rtlbcd.hpp

--- a/rtl/eclrtl/eclinclude4.hpp
+++ b/rtl/eclrtl/eclinclude4.hpp
@@ -15,8 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
-#ifndef eclinclude_incl
-#define eclinclude_incl
+#ifndef eclinclude4_incl
+#define eclinclude4_incl
 
 // Gather all the includes used by generated code into a single file so that we can
 // take advantage of precompiled headers more easily

--- a/rtl/ecltpl/childtpl.cpp
+++ b/rtl/ecltpl/childtpl.cpp
@@ -16,7 +16,7 @@ $?doNotIncludeInGeneratedCode$
 ##############################################################################*/
 
 $?$/* Template for generating a child module for query */
-#include "eclinclude.hpp"
+#include "eclinclude4.hpp"
 @include@
 @prototype@
 

--- a/rtl/ecltpl/thortpl.cpp
+++ b/rtl/ecltpl/thortpl.cpp
@@ -16,7 +16,7 @@ $?doNotIncludeInGeneratedCode$
 ############################################################################## */
 
 $?$/* Template for generating thor/hthor/roxie output */
-#include "eclinclude.hpp"
+#include "eclinclude4.hpp"
 @include@
 @prototype@
 $?multiFile$#include "$headerName$"


### PR DESCRIPTION
Anyone installing 4.0 then downgrading to 3.x may get weird behaviour caused
by out-of-date precompiled headers.

Renaming the base header file should help mitigate this issue.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
