### PR TITLE
HPCC-9127 - Fix global merge regression

### DIFF
--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -131,8 +131,18 @@ void CThorKeyArray::add(const void *row)
     }
     if (maxsamplesize)
     {
+        bool splitDone=false;
         while (keys.ordinality()&&(totalserialsize+keySz>maxsamplesize))
+        {
             split();
+            splitDone = true;
+        }
+        // if split, current rec may well be candidate to filter out now.
+        if (splitDone && ((filerecnum-1)%divisor != 0))
+        {
+            ReleaseThorRow(row);
+            return;
+        }
     }
     if (filepos)
         filepos->append(totalfilesize);


### PR DESCRIPTION
Fixes for HPCC-8992, introduced a new issue.
When splitting the sample, the pending row was added
unconditionally. For the fpos' to be correct, it needed to check
if candidate to skip following a split.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
