### PR TITLE
HPCC-9135 multi-part boundary line check should include extra '-'

### DIFF
--- a/esp/bindings/http/platform/mime.cpp
+++ b/esp/bindings/http/platform/mime.cpp
@@ -509,8 +509,9 @@ bool CMimeMultiPart::separateMultiParts(MemoryBuffer& firstPart, MemoryBuffer& r
     int offset = 0;
     while(offset < totalLength)
     {
-        if (totalLength - offset < boundaryLen)
+        if ((totalLength - offset) < (boundaryLen + 2))
         {//Do not check this line now since buffer size is not longer than boundary line.
+         //The boundary line has two extra '-'s before the boundary ID
             if (contentNotRead > 0)
             {
                 boundaryCheckState = PossibleBoundary;//a boundary line may be cut into two parts


### PR DESCRIPTION
When uploading a file, we need to check possible mime boundary line
using the length of mime boundary ID. Browser adds two extra '-'s
in the front of mime boundary ID. If the length of the last line
inside a file content block is less than the length of mime boundary
ID plus two, the last line may still be a mime boundary line separated
by the content block.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
