### PR TITLE
HPCC-9078 The default system will not start on a 32-bit VM with 10 GB RAM

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -172,8 +172,27 @@ static void initializeHeap(bool allowHugePages, unsigned pages, unsigned largeBl
     {
         int ret;
         if ((ret = posix_memalign((void **) &heapBase, HEAP_ALIGNMENT_SIZE, memsize)) != 0) {
-            DBGLOG("RoxieMemMgr: posix_memalign (alignment=%"I64F"u, size=%"I64F"u) failed - ret=%d", 
-                    (unsigned __int64) HEAP_ALIGNMENT_SIZE, (unsigned __int64) memsize, ret);
+
+        	switch (ret)
+        	{
+        	case EINVAL:
+        		DBGLOG("RoxieMemMgr: posix_memalign (alignment=%"I64F"u, size=%"I64F"u) failed - ret=%d "
+        				"(EINVAL The alignment argument was not a power of two, or was not a multiple of sizeof(void *)!)",
+        		                    (unsigned __int64) HEAP_ALIGNMENT_SIZE, (unsigned __int64) memsize, ret);
+        		break;
+
+        	case ENOMEM:
+        		DBGLOG("RoxieMemMgr: posix_memalign (alignment=%"I64F"u, size=%"I64F"u) failed - ret=%d "
+        				"(ENOMEM There was insufficient memory to fulfill the allocation request.)",
+        		        		                    (unsigned __int64) HEAP_ALIGNMENT_SIZE, (unsigned __int64) memsize, ret);
+        		break;
+
+        	default:
+        		DBGLOG("RoxieMemMgr: posix_memalign (alignment=%"I64F"u, size=%"I64F"u) failed - ret=%d",
+        		                    (unsigned __int64) HEAP_ALIGNMENT_SIZE, (unsigned __int64) memsize, ret);
+        		break;
+
+        	}
             HEAPERROR("RoxieMemMgr: Unable to create heap");
         }
     }

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -635,8 +635,11 @@ int main( int argc, char *argv[]  )
                 maxMem = 2048;
 #else
 #ifndef __64BIT__
-            if (maxMem > 4096)
-                maxMem = 4096;
+            if (maxMem > 2048)
+            {
+            	// 32 bit OS doesn't handle whole physically installed RAM
+                maxMem = 2048;
+            }
 #endif
 #endif
             gmemSize = maxMem * 3 / 4; // default to 75% of total


### PR DESCRIPTION
Signed-off-by: Attila Vamos attila.vamos@gmail.com

This change prevent to crash Thor component on a 32 bit environment when
more than 2 GB physical RAM exits.

Originally the condition was more than 4GB, but in 32 bit OS environment
only 3 GB or less memory can use by application.

This change improves the Roxie memory allocation error handling (it used by Thor heap allocation too). Beyond the pure error code value this change logging human readable error explanation, too.
