### PR TITLE
HPCC-9076 Attempt to read temp file that has not yet been registered

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -595,6 +595,9 @@ bool EclGraphElement::prepare(IAgentContext & agent, const byte * parentExtract,
                     return branches.item(whichBranch).prepare(agent, parentExtract, checkDependencies);
                 return true;
             }
+#if 0
+        // This may feel like a worthwhile opimization, but it causes issues with through spill activities.
+        // Unless/until through spill activities get replaced by splitters, this code should be disabled
         case TAKfilter:
         case TAKfiltergroup:
         case TAKfilterproject:
@@ -622,9 +625,10 @@ bool EclGraphElement::prepare(IAgentContext & agent, const byte * parentExtract,
                 }
                 break;
             }
+#endif
 #if 1
         //This doesn't really work - we really need to switch over to a similar create(),start()/stop(),reset() structure as roxie.
-        //Howver that is far from trivial, so for the moment conditional statements won't be supported by hthor.
+        //However that is far from trivial, so for the moment conditional statements won't be supported by hthor.
         case TAKifaction:
             {
                 Owned<IHThorArg> helper = createHelper(agent, NULL);
@@ -671,7 +675,7 @@ bool EclGraphElement::prepare(IAgentContext & agent, const byte * parentExtract,
             }
         }
 
-        if (!isEof)    //dont prepare unnecessary branches
+        if (!isEof)    //don't prepare unnecessary branches
         {
             ForEachItemIn(i1, branches)
             {

--- a/testing/ecl/key/throughspill.xml
+++ b/testing/ecl/key/throughspill.xml
@@ -1,0 +1,5 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><a>hello</a></Row>
+</Dataset>

--- a/testing/ecl/key/throughspill2.xml
+++ b/testing/ecl/key/throughspill2.xml
@@ -1,0 +1,5 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><a>hello</a></Row>
+</Dataset>

--- a/testing/ecl/throughspill.ecl
+++ b/testing/ecl/throughspill.ecl
@@ -1,0 +1,6 @@
+boolean b := false : stored('b');
+
+d := nofold(sort(nofold(dataset([{'hello'}], {string a})),a));
+
+d(b);
+d(a = 'hello');

--- a/testing/ecl/throughspill2.ecl
+++ b/testing/ecl/throughspill2.ecl
@@ -1,0 +1,7 @@
+boolean b := false : stored('b');
+integer c := 0 : stored('c');
+
+d := nofold(sort(nofold(dataset([{'hello'}], {string a})),a));
+
+choosen(d, c);
+d(a = 'hello');


### PR DESCRIPTION
Interaction between filters where canMatchAny() returns false, and through
spill activities, is causing some cases where the through spills are not
properly executed.

Disable part of the optimized handling of canMatchAny() - the gain would have
been small (if any).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
