### PR TITLE
HPCC-9146 - Archiving failing to archive generated dlls

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2840,7 +2840,7 @@ bool CLocalWorkUnit::archiveWorkUnit(const char *base,bool del,bool ignoredllerr
     Owned<IPropertyTree> generatedDlls = createPTree("GeneratedDlls");
     ForEach(*iter) {
         IConstWUAssociatedFile & cur = iter->query();
-        cur.getName(name);
+        cur.getNameTail(name);
         if (name.length()) {
             Owned<IDllEntry> entry = queryDllServer().getEntry(name.str());
             if (entry.get()) {


### PR DESCRIPTION
A bug introduced long ago, was causing archiveWorkUnit to fail
to archive both the Dali Generateddll entries and the associated
physical files.
As a consequence Dali has been filling up with orphaned/old
GeneratedDll entries, which overtime has degraded performance

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
