### PR TITLE
HPCC-9148 Eclccserver does not support controlling permissions

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1484,9 +1484,9 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
     for (; !iter.done(); iter.next())
     {
         const char * arg = iter.query();
-        if (strnicmp(arg, "--allow=", 8)==0)
+        if (iter.matchOption(tempArg, "--allow"))
         {
-            allowedPermissions.append(arg+8);
+            allowedPermissions.append(tempArg);
         }
         else if (iter.matchFlag(optBatchMode, "-b"))
         {
@@ -1507,13 +1507,12 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
         else if (iter.matchFlag(optCheckEclVersion, "-checkVersion"))
         {
         }
-        else if (stricmp(arg, "--deny=all")==0)
+        else if (iter.matchOption(tempArg, "--deny"))
         {
-            defaultAllowed = false;
-        }
-        else if (strnicmp(arg, "--deny=", 7)==0)
-        {
-            deniedPermissions.append(arg+7);
+            if (stricmp(tempArg, "all")==0)
+                defaultAllowed = false;
+            else
+                deniedPermissions.append(tempArg);
         }
         else if (iter.matchFlag(optArchive, "-E"))
         {

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -264,6 +264,8 @@ class EclccCompileThread : public CInterface, implements IPooledThread, implemen
                     eclccCmd.appendf(" -I%s", valueStr.str());
                 else if (stricmp(optName, "libraryPath") == 0)
                     eclccCmd.appendf(" -L%s", valueStr.str());
+                else if (stricmp(start, "-allow")==0)
+                    ; // Don't allow people to grant themselves permissions
                 else
                     eclccCmd.appendf(" -%s=%s", start, valueStr.str());
             }


### PR DESCRIPTION
Added --deny and --allow options to eclcc.

These can be sepcified in the Options section of eclccserver

Also made sure that they cannot be overriden using the -feclcc-XXX option on
ecl run etc.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
