### PR TITLE
HPCC-9154 Remove logging of daliUser usage

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1043,10 +1043,16 @@ static void setUserDescriptor(Linked<IUserDescriptor> &udesc,IUserDescriptor *us
 {
     if (!user)
     {
-        DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp setUserDescriptor %d",__LINE__);
-#ifdef _DALIUSER_STACKTRACE
-        //following debug code to be removed
-        PrintStackReport();
+#ifndef _NO_DALIUSER_STACKTRACE
+        StringBuffer sb;
+        if (user)
+            user->getUserName(sb);
+        if (sb.length()==0)
+        {
+            DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp setUserDescriptor() %d",__LINE__);
+            //following debug code to be removed
+            PrintStackReport();
+        }
 #endif
         user = queryDistributedFileDirectory().queryDefaultUser();
     }
@@ -1062,9 +1068,9 @@ static int getScopePermissions(const char *scopename,IUserDescriptor *user,unsig
     if (permissionsavail&&scopename&&*scopename&&((*scopename!='.')||scopename[1])) {
         if (!user)
         {
-#ifdef _DALIUSER_STACKTRACE
+#ifndef _NO_DALIUSER_STACKTRACE
+            DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp getScopePermissions() line %d",__LINE__);
             //following debug code to be removed
-            DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp line %d",__LINE__);
             PrintStackReport();
 #endif
             user = queryDistributedFileDirectory().queryDefaultUser();
@@ -1092,6 +1098,14 @@ static void checkLogicalScope(const char *scopename,IUserDescriptor *user,bool r
         auditflags |= (DALI_LDAP_AUDIT_REPORT|DALI_LDAP_READ_WANTED);
     if (createreq)
         auditflags |= (DALI_LDAP_AUDIT_REPORT|DALI_LDAP_WRITE_WANTED);
+#ifndef _NO_DALIUSER_STACKTRACE
+    if (!user)
+    {
+        DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp checkLogicalScope() line %d",__LINE__);
+        PrintStackReport();
+    }
+#endif
+
     int perm = getScopePermissions(scopename,user,auditflags);
     IDFS_Exception *e = NULL;
     if (readreq&&!HASREADPERMISSION(perm)) 
@@ -7141,7 +7155,7 @@ void CDistributedFileDirectory::renamePhysical(const char *oldname,const char *n
 {
     if (!user)
     {
-#ifdef _DALIUSER_STACKTRACE
+#ifndef _NO_DALIUSER_STACKTRACE
         DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp CDistributedFileDirectory::renamePhysical %d",__LINE__);
         //following debug code to be removed
         PrintStackReport();
@@ -8637,6 +8651,14 @@ IDFAttributesIterator *CDistributedFileDirectory::getDFAttributesIterator(const 
     mb.append((int)MDFS_ITERATE_FILES).append(wildname).append(recursive).append("").append(includesuper); // "" is legacy
     if (user)
         user->serialize(mb);
+#ifndef _NO_DALIUSER_STACKTRACE
+    else
+    {
+        DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp getDFAttributesIterator() line %d",__LINE__);
+        PrintStackReport();
+    }
+#endif
+
     if (foreigndali) 
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);
     else
@@ -8760,6 +8782,13 @@ void CDistributedFileDirectory::setFileAccessed(CDfsLogicalFileName &dlfn,IUserD
     dt.serialize(mb);
     if (user)
         user->serialize(mb);
+#ifndef _NO_DALIUSER_STACKTRACE
+    else
+    {
+        DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp setFileAccessed() line %d",__LINE__);
+        PrintStackReport();
+    }
+#endif
     if (foreigndali) 
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);
     else
@@ -8792,6 +8821,13 @@ void CDistributedFileDirectory::setFileProtect(CDfsLogicalFileName &dlfn,IUserDe
     mb.append((int)MDFS_SET_FILE_PROTECT).append(lname).append(owner).append(set);
     if (user)
         user->serialize(mb);
+#ifndef _NO_DALIUSER_STACKTRACE
+    else
+    {
+        DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp setFileProtect() line %d",__LINE__);
+        PrintStackReport();
+    }
+#endif
     if (foreigndali) 
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);
     else
@@ -8820,6 +8856,13 @@ IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, IUserDe
     mb.append(MDFS_GET_FILE_TREE_V2);
     if (user)
         user->serialize(mb);
+#ifndef _NO_DALIUSER_STACKTRACE
+    else
+    {
+        DBGLOG("UNEXPECTED USER (NULL) in dadfs.cpp getFileTree() line %d",__LINE__);
+        PrintStackReport();
+    }
+#endif
     if (foreigndali) 
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);
     else

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -507,14 +507,13 @@ public:
                 StringAttr passwordenc;
                 mb.read(key).read(obj);
                 udesc->deserialize(mb);
-#ifdef _DALIUSER_STACKTRACE
+#ifndef _NO_DALIUSER_STACKTRACE
                 //following debug code to be removed
                 StringBuffer sb;
                 udesc->getUserName(sb);
-                if (0==sb.length() || !stricmp(sb.str(), "daliuser"))
+                if (0==sb.length())
                 {
-                    DBGLOG("UNEXPECTED USER '%s' in dasess.cpp line %d",username.get(), __LINE__);
-                    PrintStackReport();
+                    DBGLOG("UNEXPECTED USER (NULL) in dasess.cpp CSessionRequestServer::processMessage() line %d", __LINE__);
                 }
 #endif
                 unsigned auditflags = 0;
@@ -770,14 +769,14 @@ public:
         CMessageBuffer mb;
         mb.append((int)MSR_LOOKUP_LDAP_PERMISSIONS);
         mb.append(key).append(obj);
-#ifdef _DALIUSER_STACKTRACE
+#ifndef _NO_DALIUSER_STACKTRACE
         //following debug code to be removed
         StringBuffer sb;
         if (udesc)
             udesc->getUserName(sb);
-        if (0==sb.length() || !stricmp(sb.str(), "daliuser"))
+        if (0==sb.length())
         {
-            DBGLOG("UNEXPECTED USER '%s' in dasess.cpp line %d",sb.str(),__LINE__);
+            DBGLOG("UNEXPECTED USER (NULL) in dasess.cpp getPermissionsLDAP() line %d",__LINE__);
             PrintStackReport();
         }
 #endif
@@ -922,6 +921,16 @@ public:
     {
         key.set(_key);
         obj.set(_obj); 
+#ifndef _NO_DALIUSER_STACKTRACE
+        StringBuffer sb;
+        if (udesc)
+            udesc->getUserName(sb);
+        if (sb.length()==0)
+        {
+            DBGLOG("UNEXPECTED USER (NULL) in dasess.cpp CLdapWorkItem::start() line %d",__LINE__);
+            PrintStackReport();
+        }
+#endif
         udesc.set(_udesc);
         flags = _flags;
         ret = CLDAPE_ldapfailure;
@@ -1169,6 +1178,16 @@ public:
 #ifdef _NO_LDAP
         return -1;
 #else
+#ifndef _NO_DALIUSER_STACKTRACE
+        StringBuffer sb;
+        if (udesc)
+            udesc->getUserName(sb);
+        if (sb.length()==0)
+        {
+            DBGLOG("UNEXPECTED USER (NULL) in dasess.cpp CCovenSessionManager::getPermissionsLDAP() line %d",__LINE__);
+            PrintStackReport();
+        }
+#endif
         if ((ldapconn->getLDAPflags()&(DLF_SAFE|DLF_ENABLED))!=(DLF_SAFE|DLF_ENABLED))
             return ldapconn->getPermissions(key,obj,udesc,flags);
         atomic_inc(&ldapwaiting);

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -131,9 +131,9 @@ public:
                 udesc->getPassword(password);
             }
             if (username.length()==0)  {
-#ifdef _DALIUSER_STACKTRACE
+#ifndef _NO_DALIUSER_STACKTRACE
+                DBGLOG("UNEXPECTED USER (NULL) in daldap.cpp getPermissions() line %d", __LINE__);
                 //following debug code to be removed
-                DBGLOG("UNEXPECTED USER (NULL) in daldap.cpp line %d", __LINE__);
                 PrintStackReport();
 #endif
                 username.append(filesdefaultuser);

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1198,11 +1198,11 @@ public:
             {
                 DBGLOG("LdapBind for user %s (retries=%d).", username, retries);
                 {
-#ifdef _DALIUSER_STACKTRACE
+#ifndef _NO_DALIUSER_STACKTRACE
                     //following debug code to be removed
-                    if (!username || !stricmp(username, "daliuser"))
+                    if (!username)
                     {
-                        DBGLOG("UNEXPECTED USER '%s' in ldapconnection.cpp line %d",username, __LINE__);
+                        DBGLOG("UNEXPECTED USER (NULL) in ldapconnection.cpp authenticate() line %d", __LINE__);
                         PrintStackReport();
                     }
 #endif


### PR DESCRIPTION
Currently there is logging code that logs the stack whenever daliuser
or NULL is specified as a user. This fix changes that logic to only
log when the user is NULL. Additionally this change allows the conditional
code to be built in by default, unless the _NO_DALIUSER_STACKTRACE flag
is specified

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
