### PR TITLE
HPCC-9160 Plugins that don't export pluginDefinition block get unloaded

### DIFF
--- a/common/dllserver/thorplugin.cpp
+++ b/common/dllserver/thorplugin.cpp
@@ -457,6 +457,7 @@ bool SafePluginMap::addPlugin(const char *path, const char *dllname)
     }
     catch (IException * e) // MORE - not sure why we don't throw exceptions back here...
     {
+        EXCLOG(e, "Loading plugin");
         e->Release();
         return false;
     }

--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -282,7 +282,7 @@ bool FileSystemFile::checkValid()
                 {
                     ECLPluginDefinitionBlock pb;
                     pb.size = sizeof(pb);
-                    if (p(&pb) && (pb.magicVersion == PLUGIN_VERSION))
+                    if (p(&pb) && (pb.magicVersion == PLUGIN_VERSION) && pb.ECL)
                     {
                         //Name in the plugin overrides the name of the plugin, and the filename where errors are reported.
                         eclName = createAtom(pb.moduleName);
@@ -298,7 +298,7 @@ bool FileSystemFile::checkValid()
                     }
                     else
                     {
-                        DBGLOG("Plugin %s exports getECLPluginDefinition but fails consistency check - not loading", filename);
+                        DBGLOG("Plugin %s exports getECLPluginDefinition but does not export ECL - not loading", filename);
                         return false;
                     }
                 }

--- a/plugins/Rembed/Rembed.cpp
+++ b/plugins/Rembed/Rembed.cpp
@@ -19,6 +19,7 @@
 #include "RInside.h"
 #include "jexcept.hpp"
 #include "jthread.hpp"
+#include "hqlplugins.hpp"
 #include "deftype.hpp"
 #include "eclrtl.hpp"
 #include "eclrtl_imp.hpp"
@@ -28,6 +29,29 @@
 #else
 #define EXPORT
 #endif
+
+static const char * compatibleVersions[] =
+{ "R Embed Helper 1.0.0", NULL };
+
+static const char *version = "R Embed Helper 1.0.0";
+
+extern "C" EXPORT bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb)
+{
+    if (pb->size == sizeof(ECLPluginDefinitionBlockEx))
+    {
+        ECLPluginDefinitionBlockEx * pbx = (ECLPluginDefinitionBlockEx *) pb;
+        pbx->compatibleVersions = compatibleVersions;
+    }
+    else if (pb->size != sizeof(ECLPluginDefinitionBlock))
+        return false;
+    pb->magicVersion = PLUGIN_VERSION;
+    pb->version = version;
+    pb->moduleName = "R";
+    pb->ECL = NULL;
+    pb->flags = PLUGIN_MULTIPLE_VERSIONS;
+    pb->description = "R Embed Helper";
+    return true;
+}
 
 namespace Rembed
 {

--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -19,6 +19,7 @@
 #include <jni.h>
 #include "jexcept.hpp"
 #include "jthread.hpp"
+#include "hqlplugins.hpp"
 #include "deftype.hpp"
 #include "eclrtl.hpp"
 #include "eclrtl_imp.hpp"
@@ -30,6 +31,30 @@
 #else
 #define EXPORT
 #endif
+
+static const char * compatibleVersions[] = {
+    "Java Embed Helper 1.0.0",
+    NULL };
+
+static const char *version = "Java Embed Helper 1.0.0";
+
+extern "C" EXPORT bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb)
+{
+    if (pb->size == sizeof(ECLPluginDefinitionBlockEx))
+    {
+        ECLPluginDefinitionBlockEx * pbx = (ECLPluginDefinitionBlockEx *) pb;
+        pbx->compatibleVersions = compatibleVersions;
+    }
+    else if (pb->size != sizeof(ECLPluginDefinitionBlock))
+        return false;
+    pb->magicVersion = PLUGIN_VERSION;
+    pb->version = version;
+    pb->moduleName = "java";
+    pb->ECL = NULL;
+    pb->flags = PLUGIN_MULTIPLE_VERSIONS;
+    pb->description = "Java Embed Helper";
+    return true;
+}
 
 namespace javaembed {
 

--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -19,6 +19,7 @@
 #include "Python.h"
 #include "jexcept.hpp"
 #include "jthread.hpp"
+#include "hqlplugins.hpp"
 #include "deftype.hpp"
 #include "eclrtl.hpp"
 #include "eclrtl_imp.hpp"
@@ -28,6 +29,30 @@
 #else
 #define EXPORT
 #endif
+
+static const char * compatibleVersions[] = {
+    "Python2.7 Embed Helper 1.0.0",
+    NULL };
+
+static const char *version = "Python2.7 Embed Helper 1.0.0";
+
+extern "C" EXPORT bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb)
+{
+    if (pb->size == sizeof(ECLPluginDefinitionBlockEx))
+    {
+        ECLPluginDefinitionBlockEx * pbx = (ECLPluginDefinitionBlockEx *) pb;
+        pbx->compatibleVersions = compatibleVersions;
+    }
+    else if (pb->size != sizeof(ECLPluginDefinitionBlock))
+        return false;
+    pb->magicVersion = PLUGIN_VERSION;
+    pb->version = version;
+    pb->moduleName = "python";
+    pb->ECL = NULL;
+    pb->flags = PLUGIN_MULTIPLE_VERSIONS;
+    pb->description = "Python2.7 Embed Helper";
+    return true;
+}
 
 namespace pyembed {
 

--- a/plugins/v8embed/v8embed.cpp
+++ b/plugins/v8embed/v8embed.cpp
@@ -19,6 +19,7 @@
 #include "v8.h"
 #include "jexcept.hpp"
 #include "jthread.hpp"
+#include "hqlplugins.hpp"
 #include "deftype.hpp"
 #include "eclrtl.hpp"
 #include "eclrtl_imp.hpp"
@@ -28,6 +29,30 @@
 #else
 #define EXPORT
 #endif
+
+static const char * compatibleVersions[] = {
+    "V8 JavaScript Embed Helper 1.0.0",
+    NULL };
+
+static const char *version = "V8 JavaScript Embed Helper 1.0.0";
+
+extern "C" EXPORT bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb)
+{
+    if (pb->size == sizeof(ECLPluginDefinitionBlockEx))
+    {
+        ECLPluginDefinitionBlockEx * pbx = (ECLPluginDefinitionBlockEx *) pb;
+        pbx->compatibleVersions = compatibleVersions;
+    }
+    else if (pb->size != sizeof(ECLPluginDefinitionBlock))
+        return false;
+    pb->magicVersion = PLUGIN_VERSION;
+    pb->version = version;
+    pb->moduleName = "javascript";
+    pb->ECL = NULL;
+    pb->flags = PLUGIN_MULTIPLE_VERSIONS;
+    pb->description = "V8 JavaScript Embed Helper";
+    return true;
+}
 
 namespace javascriptLanguageHelper {
 

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1857,7 +1857,7 @@ public:
         if (dFile)
         {
             if (traceLevel > 5)
-                DBGLOG("Roxie server adding information for dynamic file %s", lfn.get());
+                DBGLOG("Roxie server adding information for file %s", lfn.get());
             IDistributedSuperFile *superFile = dFile->querySuperFile();
             if (superFile)
             {


### PR DESCRIPTION
Since we split the ECL definition out of the embedded language libraries, they
are not remaining loaded at startup (see HPCC-9068).

This caused cores in the java embedded code test.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
