### PR TITLE
HPCC-8888 Change 'Spray Variable' to 'Spray Delimited'

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -266,22 +266,29 @@
                     <tr><th>Persistent:</th><td><xsl:value-of select="Persistent"/></td></tr>
                 </xsl:if>
                 <xsl:if test="string-length(Format)">
-                    <tr><th>Format:</th><td><xsl:value-of select="Format"/></td></tr>
+                    <tr><th>Format:</th>
+                    <td>
+                        <xsl:choose>
+                            <xsl:when test="Format='csv'">Delimited</xsl:when>
+                            <xsl:otherwise><xsl:value-of select="Format"/></xsl:otherwise>
+                        </xsl:choose>
+                    </td>
+                    </tr>
                 </xsl:if>
                 <xsl:if test="string-length(MaxRecordSize)">
                     <tr><th>MaxRecordSize:</th><td><xsl:value-of select="MaxRecordSize"/></td></tr>
                 </xsl:if>
-                <xsl:if test="string-length(Separators)">
-                    <tr><th>Separators:</th><td><xsl:value-of select="Separators"/></td></tr>
+                <xsl:if test="string-length(CsvSeparate)">
+                    <tr><th>Separators:</th><td><xsl:value-of select="CsvSeparate"/></td></tr>
                 </xsl:if>
-                <xsl:if test="string-length(Quote)">
-                    <tr><th>Quote:</th><td><xsl:value-of select="Quote"/></td></tr>
+                <xsl:if test="string-length(CsvQuote)">
+                    <tr><th>Quote:</th><td><xsl:value-of select="CsvQuote"/></td></tr>
                 </xsl:if>
-                <xsl:if test="string-length(Terminators)">
-                    <tr><th>Terminators:</th><td><xsl:value-of select="Terminators"/></td></tr>
+                <xsl:if test="string-length(CsvTerminate)">
+                    <tr><th>Terminators:</th><td><xsl:value-of select="CsvTerminate"/></td></tr>
                 </xsl:if>
-                <xsl:if test="string-length(Escape)">
-                    <tr><th>Escape:</th><td><xsl:value-of select="Escape"/></td></tr>
+                <xsl:if test="string-length(CsvEscape)">
+                    <tr><th>Escape:</th><td><xsl:value-of select="CsvEscape"/></td></tr>
                 </xsl:if>
                     <xsl:if test="count(Graphs/ECLGraph)">
                         <th>Graphs:</th>

--- a/esp/eclwatch/ws_XSLT/dfu_wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_wuid.xslt
@@ -271,10 +271,10 @@
         <xsl:apply-templates select="RowTag"/>
         <xsl:apply-templates select="SourceNumParts"/>
         <xsl:apply-templates select="SourceDirectory"/>
-        <xsl:apply-templates select="SourceSeparators"/>
-        <xsl:apply-templates select="SourceEscape"/>
-        <xsl:apply-templates select="SourceTerminators"/>
-        <xsl:apply-templates select="SourceQuote"/>
+        <xsl:apply-templates select="SourceCsvSeparate"/>
+        <xsl:apply-templates select="SourceCsvEscape"/>
+        <xsl:apply-templates select="SourceCsvTerminate"/>
+        <xsl:apply-templates select="SourceCsvQuote"/>
         <xsl:apply-templates select="DestLogicalName"/>
         <xsl:apply-templates select="DestGroupName"/>
         <xsl:apply-templates select="DestDirectory"/>
@@ -372,7 +372,7 @@
             <td>
             <xsl:choose>
             <xsl:when test=". = 0">FIXED</xsl:when>
-            <xsl:when test=". = 1">Variable</xsl:when>
+            <xsl:when test=". = 1">Delimited</xsl:when>
             <xsl:when test=". = 2">UTF8</xsl:when>
             <xsl:when test=". = 3">UTF8N</xsl:when>
             <xsl:when test=". = 4">UTF16</xsl:when>
@@ -474,6 +474,34 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </td>
+        </tr>
+    </xsl:template>
+
+    <xsl:template match="SourceCsvSeparate">
+        <tr>
+            <th>SourceSeparators</th><th>:</th>
+            <td><xsl:value-of select="."/></td>
+        </tr>
+    </xsl:template>
+
+    <xsl:template match="SourceCsvEscape">
+        <tr>
+            <th>SourceEscape</th><th>:</th>
+            <td><xsl:value-of select="."/></td>
+        </tr>
+    </xsl:template>
+
+    <xsl:template match="SourceCsvTerminate">
+        <tr>
+            <th>SourceTerminators</th><th>:</th>
+            <td><xsl:value-of select="."/></td>
+        </tr>
+    </xsl:template>
+
+    <xsl:template match="SourceCsvQuote">
+        <tr>
+            <th>SourceQuote</th><th>:</th>
+            <td><xsl:value-of select="."/></td>
         </tr>
     </xsl:template>
 

--- a/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
+++ b/esp/eclwatch/ws_XSLT/fs_sprayForm.xslt
@@ -21,7 +21,7 @@
    <xsl:param name="fullHtml" select="1"/>
    <xsl:param name="includeFormTag" select="1"/>
    <xsl:param name="method" select="'SprayVariable'"/>
-   <xsl:param name="submethod" select="'variable'"/>
+   <xsl:param name="submethod" select="'csv'"/>
    
    <xsl:template match="/Environment">
      <xsl:choose>
@@ -170,9 +170,9 @@
                      if (method == 'SprayVariable')
                      {
                         disable = (document.getElementById('sourceMaxRecordSize') != null && document.getElementById('sourceMaxRecordSize').value == 0) || 
-                                      (document.getElementById('sourceSeparators') != null && document.getElementById('sourceSeparators').value  == '') ||
-                                      (document.getElementById('sourceTerminators') != null && document.getElementById('sourceTerminators').value == '') ||
-                                      (document.getElementById('sourceQuote') != null && document.getElementById('sourceQuote').value == '') ||
+                                      (document.getElementById('sourceCsvSeparate') != null && document.getElementById('sourceCsvSeparate').value  == '') ||
+                                      (document.getElementById('sourceCsvTerminate') != null && document.getElementById('sourceCsvTerminate').value == '') ||
+                                      (document.getElementById('sourceCsvQuote') != null && document.getElementById('sourceCsvQuote').value == '') ||
                                       (document.getElementById('sourceRowTag') != null && document.getElementById('sourceRowTag').value == '');
                      }
                document.getElementById('submitBtn').readonly = disable;
@@ -239,7 +239,7 @@
 
             function setSourceCsvSeparator(noSeparatorCheckbox)
             {
-                var separatorInputField = document.getElementById("sourceSeparators");
+                var separatorInputField = document.getElementById("sourceCsvSeparate");
                 if (separatorInputField == NaN)
                     return;
 
@@ -279,7 +279,7 @@
                <h3>Spray <xsl:choose>
                      <xsl:when test="$method='SprayFixed'">Fixed</xsl:when>
                      <xsl:otherwise>
-                         <xsl:choose><xsl:when test="$submethod='variable'"> Variable</xsl:when><xsl:otherwise> XML</xsl:otherwise></xsl:choose>
+                         <xsl:choose><xsl:when test="$submethod='csv'"> Delimited</xsl:when><xsl:otherwise> XML</xsl:otherwise></xsl:choose>
                     </xsl:otherwise>
                   </xsl:choose>
                </h3>
@@ -374,7 +374,7 @@
                      <select id="sourceFormat" name="sourceFormat" onchange="onChangeFormat()" onblur="onChangeFormat()">
                      -->
                      <select id="sourceFormat" name="sourceFormat">
-                           <xsl:if test="$submethod='variable'">
+                           <xsl:if test="$submethod='csv'">
                            <option value="1">ASCII</option>
                            </xsl:if>
                            <xsl:choose>
@@ -483,35 +483,35 @@
                      <input type="text" id="sourceMaxRecordSize" name="sourceMaxRecordSize" value="{$rsz}" size="6" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
                   </td>
                </tr>
-              <xsl:choose><xsl:when test="$submethod='variable'">
+              <xsl:choose><xsl:when test="$submethod='csv'">
                <tr>
                   <td>Separators:</td>
                   <td>
-                     <input type="text" id="sourceSeparators" name="sourceSeparators" size="6" value="{$sep}" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
+                     <input type="text" id="sourceCsvSeparate" name="sourceCsvSeparate" size="6" value="{$sep}" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
                   </td>
                </tr>
                <tr>
                   <td/>
                   <td>
-                      <input type="checkbox" id="NoSourceSeparator" name="NoSourceSeparator" value="1" onclick="return setSourceCsvSeparator(this)">No Separator</input>
+                      <input type="checkbox" id="NoSourceCsvSeparator" name="NoSourceCsvSeparator" value="1" onclick="return setSourceCsvSeparator(this)">No Separator</input>
                   </td>
                </tr>
                <tr>
                   <td>Escape:</td>
                   <td>
-                     <input type="text" id="sourceEscape" name="sourceEscape" size="6" value="" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
+                     <input type="text" id="sourceCsvEscape" name="sourceCsvEscape" size="6" value="" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
                   </td>
                </tr>
                <tr>
                   <td>Line Terminators:</td>
                   <td>
-                     <input type="text" id="sourceTerminators" name="sourceTerminators" size="6" value="{$term}" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
+                     <input type="text" id="sourceCsvTerminate" name="sourceCsvTerminate" size="6" value="{$term}" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
                   </td>
                </tr>
                <tr>
                   <td>Quote:</td>
                   <td>
-                     <input type="text" id="sourceQuote" name="sourceQuote" size="6" value="{$quote}"  maxlength="1" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
+                     <input type="text" id="sourceCsvQuote" name="sourceCsvQuote" size="6" value="{$quote}"  maxlength="1" onchange="handleSubmitBtn()" onblur="handleSubmitBtn()"/>
                   </td>
                </tr>
                </xsl:when>

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -88,15 +88,10 @@ ESPStruct DFUFileDetail
     string Persistent;
     string Format;
     string MaxRecordSize;
-    [depr_ver("1.21")] string CsvSeparate;
-    [depr_ver("1.21")] string CsvQuote;
-    [depr_ver("1.21")] string CsvTerminate;
-    [min_ver("1.20"), depr_ver("1.21")] string CsvEscape;
-
-    [min_ver("1.21")] string Separators;
-    [min_ver("1.21")] string Quote;
-    [min_ver("1.21")] string Terminators;
-    [min_ver("1.21")] string Escape;
+    string CsvSeparate;
+    string CsvQuote;
+    string CsvTerminate;
+    [min_ver("1.20")] string CsvEscape;
 
     string Modified;
     string Ecl;
@@ -631,7 +626,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.21"), default_client_version("1.21"),
+    version("1.20"), default_client_version("1.20"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -60,15 +60,10 @@ ESPStruct [nil_remove] DFUWorkunit
     bool Overwrite;
     bool Compress;
 
-    [min_ver("1.04"), depr_ver("1.08")] string SourceCsvSeparate;
-    [min_ver("1.04"), depr_ver("1.08")] string SourceCsvQuote;
-    [min_ver("1.04"), depr_ver("1.08")] string SourceCsvTerminate;
-    [min_ver("1.05"), depr_ver("1.08")] string SourceCsvEscape;
-
-    [min_ver("1.08")] string SourceSeparators;
-    [min_ver("1.08")] string SourceQuote;
-    [min_ver("1.08")] string SourceTerminators;
-    [min_ver("1.08")] string SourceEscape;
+    [min_ver("1.04")] string SourceCsvSeparate;
+    [min_ver("1.04")] string SourceCsvQuote;
+    [min_ver("1.04")] string SourceCsvTerminate;
+    [min_ver("1.05")] string SourceCsvEscape;
 
     string TimeStarted;
     string TimeStopped;
@@ -321,16 +316,11 @@ ESPrequest [nil_remove] SprayVariable
     
     int sourceMaxRecordSize;
     int sourceFormat;
-    [depr_ver("1.08")] bool   NoSourceCsvSeparator(false);
-    [depr_ver("1.08")] string sourceCsvSeparate;
-    [depr_ver("1.08")] string sourceCsvTerminate;
-    [depr_ver("1.08")] string sourceCsvQuote;
-    [depr_ver("1.08")] string sourceCsvEscape;
-    [min_ver("1.08")] bool   NoSourceSeparator(false);
-    [min_ver("1.08")] string sourceSeparators;
-    [min_ver("1.08")] string sourceTerminators;
-    [min_ver("1.08")] string sourceQuote;
-    [min_ver("1.08")] string sourceEscape;
+    bool   NoSourceCsvSeparator(false);
+    string sourceCsvSeparate;
+    string sourceCsvTerminate;
+    string sourceCsvQuote;
+    string sourceCsvEscape;
     string sourceRowTag;
 
     string destGroup;
@@ -598,7 +588,7 @@ ESPresponse [exceptions_inline, nil_remove] DeleteDropZoneFilesResponse
 };
 
 ESPservice [
-    version("1.08"), default_client_version("1.08"),
+    version("1.07"), default_client_version("1.07"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
 {
     ESPuses ESPstruct DFUWorkunit;

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1823,43 +1823,28 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     }
     //#17430
 
-   //new (optional) attribute on a logical file (@persistent) 
-   //indicates the ESP page that shows the details of a file.  It indicates 
-   //whether the file was created with a PERSIST() ecl attribute.
+    //new (optional) attribute on a logical file (@persistent)
+    //indicates the ESP page that shows the details of a file.  It indicates
+    //whether the file was created with a PERSIST() ecl attribute.
     FileDetails.setPersistent(df->queryAttributes().queryProp("@persistent"));
 
-   //@format - what format the file is (if not fixed with)
-    const char* format = df->queryAttributes().queryProp("@format");
-    if (format && strieq(format, "csv"))
-        FileDetails.setFormat("variable");
-    else
-        FileDetails.setFormat(format);
+    //@format - what format the file is (if not fixed with)
+    FileDetails.setFormat(df->queryAttributes().queryProp("@format"));
 
-   //@maxRecordSize - what the maximum length of records is
+    //@maxRecordSize - what the maximum length of records is
     FileDetails.setMaxRecordSize(df->queryAttributes().queryProp("@maxRecordSize"));
 
-   //@csvSeparate - separators between fields for a CSV/utf file
-    if (version >= 1.21)
-        FileDetails.setSeparators(df->queryAttributes().queryProp("@csvSeparate"));
-    else
-        FileDetails.setCsvSeparate(df->queryAttributes().queryProp("@csvSeparate"));
+    //@csvSeparate - separators between fields for a CSV/utf file
+    FileDetails.setCsvSeparate(df->queryAttributes().queryProp("@csvSeparate"));
 
-   //@csvQuote - character used to quote fields for a csv/utf file.
-    if (version >= 1.21)
-        FileDetails.setQuote(df->queryAttributes().queryProp("@csvQuote"));
-    else
-        FileDetails.setCsvQuote(df->queryAttributes().queryProp("@csvQuote"));
+    //@csvQuote - character used to quote fields for a csv/utf file.
+    FileDetails.setCsvQuote(df->queryAttributes().queryProp("@csvQuote"));
 
-   //@csvTerminate - characters used to terminate a record in a csv.utf file
-    if (version >= 1.21)
-        FileDetails.setTerminators(df->queryAttributes().queryProp("@csvTerminate"));
-    else
-        FileDetails.setCsvTerminate(df->queryAttributes().queryProp("@csvTerminate"));
+    //@csvTerminate - characters used to terminate a record in a csv.utf file
+    FileDetails.setCsvTerminate(df->queryAttributes().queryProp("@csvTerminate"));
 
-   //@csvEscape - character used to define escape for a csv/utf file.
-    if (version >= 1.21)
-        FileDetails.setEscape(df->queryAttributes().queryProp("@csvEscape"));
-    else if (version >= 1.20)
+    //@csvEscape - character used to define escape for a csv/utf file.
+    if (version >= 1.20)
         FileDetails.setCsvEscape(df->queryAttributes().queryProp("@csvEscape"));
 
   

--- a/esp/services/ws_fs/ws_fsBinding.hpp
+++ b/esp/services/ws_fs/ws_fsBinding.hpp
@@ -62,7 +62,7 @@ public:
         ensureNavLink(*folder, "Browse Logical Files", "/esp/files/stub.htm?Widget=DFUWUQueryWidget", "Browse a list of Logical Files", NULL, NULL, 6);
         ensureNavLink(*folder, "Browse Files by Scope", "/WsDfu/DFUFileView", "Browse a list of Logical Files by Scope", NULL, NULL, 7);
         ensureNavLink(*folder, "Spray Fixed", "/FileSpray/SprayFixedInput", "Spray a fixed width file", NULL, NULL, 8);
-        ensureNavLink(*folder, "Spray Variable", "/FileSpray/SprayVariableInput?submethod=variable", "Spray a variable length file with fields separated by delimiters", NULL, NULL, 9);
+        ensureNavLink(*folder, "Spray Delimited", "/FileSpray/SprayVariableInput?submethod=csv", "Spray a variable length file with fields separated by delimiters", NULL, NULL, 9);
         ensureNavLink(*folder, "Spray XML", "/FileSpray/SprayVariableInput?submethod=xml", "Spray an XML File", NULL, NULL, 10);
         ensureNavLink(*folder, "Remote Copy", "/FileSpray/CopyInput", "Copy a Logical File from one environment to another", NULL, NULL, 11);
         ensureNavLink(*folder, "XRef", "/WsDFUXRef/DFUXRefList", "View Xref result details or run the Xref utility", NULL, NULL, 12);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -358,33 +358,13 @@ static void DeepAssign(IEspContext &context, IConstDFUWorkUnit *src, IEspDFUWork
             StringBuffer separate, terminate, quote, escape;
             file->getCsvOptions(separate,terminate,quote, escape);
             if(separate.length() > 0)
-            {
-                if(version < 1.07)
-                    dest.setSourceCsvSeparate(separate.str());
-                else
-                    dest.setSourceSeparators(separate.str());
-            }
+                dest.setSourceCsvSeparate(separate.str());
             if(terminate.length() > 0)
-            {
-                if(version < 1.07)
-                    dest.setSourceCsvTerminate(terminate.str());
-                else
-                    dest.setSourceTerminators(terminate.str());
-            }
+                dest.setSourceCsvTerminate(terminate.str());
             if(quote.length() > 0)
-            {
-                if(version < 1.07)
-                    dest.setSourceCsvQuote(quote.str());
-                else
-                    dest.setSourceQuote(quote.str());
-            }
+                dest.setSourceCsvQuote(quote.str());
             if((version >= 1.05) && (escape.length() > 0))
-            {
-                if(version < 1.07)
-                    dest.setSourceCsvEscape(escape.str());
-                else
-                    dest.setSourceEscape(escape.str());
-            }
+                dest.setSourceCsvEscape(escape.str());
         }
     }
 
@@ -2052,35 +2032,21 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
         }
         else
         {
-            const char* cs = req.getSourceSeparators();
-            if (!cs || !*cs)
-                cs = req.getSourceCsvSeparate();
-            bool noSourceSeparator = false;
-            if (!req.getNoSourceSeparator_isNull())
-                noSourceSeparator = req.getNoSourceSeparator();
-            else
-                noSourceSeparator = req.getNoSourceCsvSeparator();
-            if (noSourceSeparator)
+            const char* cs = req.getSourceCsvSeparate();
+            if (req.getNoSourceCsvSeparator())
             {
                 cs = "";
             }
             else if(cs == NULL || *cs == '\0')
                 cs = "\\,";
 
-            const char* ct = req.getSourceTerminators();
-            if (!ct || !*ct)
-                ct = req.getSourceCsvTerminate();
+            const char* ct = req.getSourceCsvTerminate();
             if(ct == NULL || *ct == '\0')
                 ct = "\\n,\\r\\n";
-            const char* cq = req.getSourceQuote();
-            if (!cq || !*cq)
-                cq = req.getSourceCsvQuote();
+            const char* cq = req.getSourceCsvQuote();
             if(cq== NULL)
                 cq = "'";
-            const char* ce = req.getSourceEscape();
-            if (!ce || !*ce)
-                ce = req.getSourceCsvEscape();
-            source->setCsvOptions(cs, ct, cq, ce);
+            source->setCsvOptions(cs, ct, cq, req.getSourceCsvEscape());
         }
 
         destination->setLogicalName(destname);


### PR DESCRIPTION
It is suggested that 'Spray delimited' would be more appropriate.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
