### PR TITLE
HPCC-9153 UNIMPLEMENTED on OSX

### DIFF
--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -83,8 +83,6 @@ bool safe_ecvt(size_t len, char * buffer, double value, int numDigits, int * dec
 {
 #ifdef _WIN32
     return _ecvt_s(buffer, len, value, numDigits, decimal, sign) == 0;
-#elif defined(__FreeBSD__) || defined (__APPLE__)
-    UNIMPLEMENTED;
 #else
     SpinBlock block(*cvtLock);
     const char * result = ecvt(value, numDigits, decimal, sign);
@@ -99,8 +97,6 @@ bool safe_fcvt(size_t len, char * buffer, double value, int numPlaces, int * dec
 {
 #ifdef _WIN32
     return _fcvt_s(buffer, len, value, numPlaces, decimal, sign) == 0;
-#elif defined(__FreeBSD__) || defined (__APPLE__)
-    UNIMPLEMENTED;
 #else
     SpinBlock block(*cvtLock);
     const char * result = fcvt(value, numPlaces, decimal, sign);


### PR DESCRIPTION
A couple of places in jutil.cpp throw an UNIMPLEMENTED on OSX for no good
reason.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
