### PR TITLE
HPCC-9165 - Allow XREF to run without suspending coalescer

### DIFF
--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -1985,8 +1985,7 @@ class CSashaXRefServer: public ISashaServer, public Thread
     bool stopped;
     Semaphore stopsem;
     Mutex runmutex;
-    Owned<IRemoteConnection> statusconn;
-    bool ignorelazylost;
+    bool ignorelazylost, suspendCoalescer;
 
     class cRunThread: public Thread
     {
@@ -2002,7 +2001,6 @@ class CSashaXRefServer: public ISashaServer, public Thread
             parent.runXRef(servers,false,false);
             return 0;
         }
-    
     }; 
 
 
@@ -2012,6 +2010,7 @@ public:
     CSashaXRefServer()
         : Thread("CSashaXRefServer")
     {
+        suspendCoalescer = true; // can be overridden by configuration setting
         stopped = false;
     }
 
@@ -2043,23 +2042,23 @@ public:
     {
         if (stopped||!clustcsl||!*clustcsl)
             return;
-        struct cSuspendResume
+        class CSuspendResume : public CSimpleInterface
         {
-            Owned<IRemoteConnection> &statusconn;
-            cSuspendResume(Owned<IRemoteConnection> &_statusconn) 
-                : statusconn(_statusconn)
+        public:
+            CSuspendResume()
             {
-                statusconn.clear();
                 PROGLOG(LOGPFX "suspending coalesce");
                 suspendCoalescingServer();
             }
-            ~cSuspendResume() 
+            ~CSuspendResume()
             {
-                statusconn.clear();
                 PROGLOG(LOGPFX "resuming coalesce");
                 resumeCoalescingServer();
             }
-        } suspendresume(statusconn);
+        };
+        Owned<CSimpleInterface> suspendresume;
+        if (suspendCoalescer)
+            suspendresume.setown(new CSuspendResume());
         synchronized block(runmutex);
         if (stopped)
             return;
@@ -2162,28 +2161,6 @@ public:
             conn->queryRoot()->setPropBool("@useSasha",on);
     }
 
-    void initStatus(const char *cluster)
-    {
-        StringBuffer xpath;
-        xpath.appendf("/DFU/XREF/Cluster[@name=\"%s\"]",cluster);
-        loop {
-            statusconn.setown(querySDS().connect(xpath.str(),myProcessSession(),RTM_NONE,INFINITE));
-            if (statusconn)
-                break;
-            Owned<IRemoteConnection> conn = querySDS().connect("/DFU/XREF",myProcessSession(),RTM_CREATE_QUERY|RTM_LOCK_WRITE ,INFINITE);
-            StringBuffer xpath2;
-            xpath2.appendf("Cluster[@name=\"%s\"]",cluster);
-            if (!conn->queryRoot()->hasProp(xpath2.str()))
-                conn->queryRoot()->addPropTree("Cluster",createPTree("Cluster"))->setProp("@name",cluster);
-        }
-    }
-
-    void setStatus(const char *string) 
-    {
-        statusconn->queryRoot()->setProp("@status",string);
-        statusconn->commit();
-    }
-
     int run()
     {
         Owned<IPropertyTree> props = serverConfig->getPropTree("DfuXRef");
@@ -2202,6 +2179,7 @@ public:
         if (!interval)
             stopped = !eclwatchprovider;
         setSubmittedOk(eclwatchprovider);
+        suspendCoalescer = props->getPropBool("@suspendCoalescerDuringXref", true);
         ignorelazylost = props->getPropBool("@ignoreLazyLost",true);
         PROGLOG(LOGPFX "min interval = %d hr", interval);
         unsigned initinterval = (interval-1)/2+1;  // wait a bit til dali has started
@@ -2270,10 +2248,6 @@ class CSashaExpiryServer: public ISashaServer, public Thread
     bool stopped;
     Semaphore stopsem;
     Mutex runmutex;
-    Owned<IRemoteConnection> statusconn;
-
-    
-
 
 public:
     IMPLEMENT_IINTERFACE;

--- a/initfiles/componentfiles/configxml/sasha.xsd
+++ b/initfiles/componentfiles/configxml/sasha.xsd
@@ -428,6 +428,13 @@
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="suspendCoalescerDuringXref" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:appinfo>
+                    <tooltip>Suspend the coalescer whilst xrefing.</tooltip>
+                </xs:appinfo>
+            </xs:annotation>
+        </xs:attribute>
     </xs:attributeGroup>
     <xs:attributeGroup name="DfuExpiry">
         <xs:attribute name="ExpiryInterval" type="xs:nonNegativeInteger" default="24">

--- a/initfiles/componentfiles/configxml/sasha.xsl
+++ b/initfiles/componentfiles/configxml/sasha.xsl
@@ -203,6 +203,11 @@
                 <xsl:attribute name="memoryLimit">
                    <xsl:value-of select="@xrefMaxMemory"/>
                 </xsl:attribute>
+                <xsl:if test="string(@suspendCoalescerDuringXref) != ''">
+                 <xsl:attribute name="suspendCoalescerDuringXref">
+                   <xsl:value-of select="@suspendCoalescerDuringXref"/>
+                 </xsl:attribute>
+                </xsl:if>
             </xsl:element>
             <xsl:element name="DfuExpiry">
                 <xsl:attribute name="interval">


### PR DESCRIPTION
Add configuration option to allow XREF to run without suspending/
resuming the coalescer.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
