### PR TITLE
HPCC-9173 Ubuntu 13.04 Build Fails

### DIFF
--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -32,6 +32,7 @@
 #include <sys/wait.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/resource.h>
 #endif
 
 #if defined(_DEBUG) && defined(_WIN32) && !defined(USING_MPATROL)


### PR DESCRIPTION
Missing definition for PRIO_PROCESS

I haven't investigated, why or where the change happened in the sys headers (sys/resource.h could be new?  In which case it may break other builds!!!).
