### PR TITLE
HPCC-9022 Allow testsocket to read query from stdin

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -344,6 +344,7 @@ public:
     {
         if (isConnected)
         {
+            DBGLOG("Dali lookup %s", logicalName);
             CDfsLogicalFileName lfn;
             lfn.set(logicalName);
             Owned<IDistributedFile> dfsFile = queryDistributedFileDirectory().lookup(lfn, userdesc.get(), writeAccess, cacheIt);

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -398,6 +398,7 @@ public:
     {
         StringBuffer fileName;
         expandLogicalFilename(fileName, _fileName, wu, false);
+        DBGLOG("lookupFileName %s", fileName.str());
 
         const IResolvedFile *result = lookupFile(fileName, cache, false, false);
         if (!result)

--- a/tools/testsocket/testsocket.cpp
+++ b/tools/testsocket/testsocket.cpp
@@ -894,7 +894,8 @@ int main(int argc, char **argv)
                             break;
                         fileContents.append(buffer, 0, bytes);
                     }
-                    fclose(in);
+                    if (in != stdin)
+                        fclose(in);
                     ret = sendQuery(ip, socketPort, fileContents.toCharArray());
                 }
                 else


### PR DESCRIPTION
Potentially handy for using testsocket via PIPE, for example for roxie query
regression tests.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
