### PR TITLE
HPCC-9178 Remove several references to UNKNOWN_USER

### DIFF
--- a/common/fileview2/fvrelate.cpp
+++ b/common/fileview2/fvrelate.cpp
@@ -255,8 +255,8 @@ unsigned BrowseCreateInfo::getNestingCount(const ViewFile * search)
 
 //---------------------------------------------------------------------------
 
-ViewFileWeb::ViewFileWeb(IResultSetFactory & resultSetFactory, const char * cluster) 
-: viewOptions(resultSetFactory, cluster), directory(queryDistributedFileDirectory())
+ViewFileWeb::ViewFileWeb(IResultSetFactory & resultSetFactory, const char * cluster, IUserDescriptor *user)
+: viewOptions(resultSetFactory, cluster), directory(queryDistributedFileDirectory()), udesc(user)
 {
     nextId = 0;
 }
@@ -373,7 +373,7 @@ void ViewFileWeb::gatherWebFromPattern(const char * filenamePattern, const ViewG
     if (!localOptions.kind)
         localOptions.kind = S_LINK_RELATIONSHIP_KIND;
 
-    Owned<IDistributedFileIterator> iter = queryDistributedFileDirectory().getIterator(filenamePattern, false, UNKNOWN_USER);
+    Owned<IDistributedFileIterator> iter = queryDistributedFileDirectory().getIterator(filenamePattern, false, udesc);
     if (iter->first())
     {
         do
@@ -426,7 +426,7 @@ ViewFile * ViewFileWeb::walkFile(const char * filename, IDistributedFile * alrea
         options.isExplicitFile = false;
     }
 
-    Owned<IDistributedFile> resolved = alreadyResolved ? LINK(alreadyResolved) : directory.lookup(filename,UNKNOWN_USER);//MORE:Pass IUserDescriptor
+    Owned<IDistributedFile> resolved = alreadyResolved ? LINK(alreadyResolved) : directory.lookup(filename,udesc);
     if (!resolved)
         return NULL;
 
@@ -845,9 +845,9 @@ void ViewXgmmlERdiagramVisitor::endCompound()
 }
 
 
-IViewFileWeb * createViewFileWeb(IResultSetFactory & resultSetFactory, const char * cluster)
+IViewFileWeb * createViewFileWeb(IResultSetFactory & resultSetFactory, const char * cluster, IUserDescriptor *user)
 {
-    return new ViewFileWeb(resultSetFactory, cluster);
+    return new ViewFileWeb(resultSetFactory, cluster, user);
 }
 
 void createERdiagram(StringBuffer & xgmml, IViewFileWeb & _web)

--- a/common/fileview2/fvrelate.hpp
+++ b/common/fileview2/fvrelate.hpp
@@ -127,7 +127,7 @@ interface IFileTreeBrowser : public IInterface
     virtual IResultSetFilter * queryRootFilter() = 0;
 };
 
-extern FILEVIEW_API IViewFileWeb * createViewFileWeb(IResultSetFactory & resultSetFactory, const char * cluster);
+extern FILEVIEW_API IViewFileWeb * createViewFileWeb(IResultSetFactory & resultSetFactory, const char * cluster, IUserDescriptor *user);
 extern FILEVIEW_API void createERdiagram(StringBuffer & xgmml, IViewFileWeb & web);
 
 #endif

--- a/common/fileview2/fvrelate.ipp
+++ b/common/fileview2/fvrelate.ipp
@@ -192,7 +192,7 @@ class CRelatedBrowseFile;
 class FILEVIEW_API ViewFileWeb : public CInterface, implements IViewFileWeb
 {
 public:
-    ViewFileWeb(IResultSetFactory & resultSetFactory, const char * cluster);
+    ViewFileWeb(IResultSetFactory & resultSetFactory, const char * cluster, IUserDescriptor *user);
     IMPLEMENT_IINTERFACE
 
     virtual void gatherWeb(const char * rootFilename, const ViewGatherOptions & options);
@@ -218,6 +218,7 @@ protected:
     IDistributedFileDirectory & directory;
     ViewFileArray files;
     ViewRelationArray relations;
+    Owned<IUserDescriptor> udesc;
 };
 
 //---------------------------------------------------------------------------

--- a/common/fileview2/fvtransform.cpp
+++ b/common/fileview2/fvtransform.cpp
@@ -31,6 +31,7 @@
 #include "hqlcollect.hpp"
 #include "hqlrepository.hpp"
 #include "hqlerror.hpp"
+#include "dasess.hpp"
 
 static ViewTransformerRegistry * theTransformerRegistry;
 static ITypeInfo * stringType;

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -906,7 +906,7 @@ public:
         }
         if (strcmp(ftree->queryName(),queryDfsXmlBranchName(DXB_File))==0) {
             assertex(copier);
-            if (!copier->copyFile(lfn,daliep,srclfn,user,UNKNOWN_USER))
+            if (!copier->copyFile(lfn,daliep,srclfn,srcuser,user))
                 throw MakeStringException(-1,"File %s could not be copied",lfn);
 
         }

--- a/dali/dfuXRefLib/dfuxreflib.cpp
+++ b/dali/dfuXRefLib/dfuxreflib.cpp
@@ -706,10 +706,10 @@ struct CLogicalNameEntry: public CInterface
         if (!grp) 
             manager.warn(lname.get(),"No cluster group set");
     }
-    bool remove()
+    bool remove(IUserDescriptor *user)
     {
         IDistributedFileDirectory &fdir = queryDistributedFileDirectory();
-        Owned<IDistributedFile> file = fdir.lookup(lname.get(),UNKNOWN_USER);
+        Owned<IDistributedFile> file = fdir.lookup(lname.get(),user);
         if (!file)
             return false;
         file->detach();

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -5054,17 +5054,26 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
 
     Owned<IResultSetFactory> resultSetFactory = getSecResultSetFactory(context.querySecManager(), context.queryUser(), context.queryUserId(), context.queryPassword());
     Owned<IViewFileWeb> web;
+
+    Owned<IUserDescriptor> udesc;
+    ISecUser * secUser = context.queryUser();
+    if(secUser->getName() && *secUser->getName())
+    {
+        udesc.setown(createUserDescriptor());
+        udesc->set(secUser->getName(), secUser->credentials().getPassword());
+    }
+
     if (cluster && *cluster)
     {
-        web.setown(createViewFileWeb(*resultSetFactory, cluster));
+        web.setown(createViewFileWeb(*resultSetFactory, cluster, udesc.getLink()));
     }
     else if (m_clusterName.length() > 0)
     {
-        web.setown(createViewFileWeb(*resultSetFactory, m_clusterName.str()));
+        web.setown(createViewFileWeb(*resultSetFactory, m_clusterName.str(), udesc.getLink()));
     }
     else
     {
-        web.setown(createViewFileWeb(*resultSetFactory, NULL));
+        web.setown(createViewFileWeb(*resultSetFactory, NULL, udesc.getLink()));
     }
 
     ViewGatherOptions options;


### PR DESCRIPTION
Code analysis identified several places that reference UNKNOWN_USER which
can be updated with the actual user descriptor. This fix does that

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
