### PR TITLE
HPCC-9136 Remove Roxie Queries options from ECLWatch UI

### DIFF
--- a/docs/ECLLanguageReference/ECLR_mods/BltInFunc-ROLLUP.xml
+++ b/docs/ECLLanguageReference/ECLR_mods/BltInFunc-ROLLUP.xml
@@ -99,10 +99,19 @@
   <emphasis>transform </emphasis>function, ROLLUP can keep the LEFT or RIGHT
   record, or any mixture of data from both.</para>
 
-  <para>Record matching is done solely based on the values in adjacent records
-  in the <emphasis>recordset</emphasis>. For the first match, the two matching
-  records from the <emphasis>recordset</emphasis> are passed to the
-  <emphasis>transform</emphasis>. For subsequent matches of the same values,
+  <para>
+  The first form of ROLLUP tests a condition using values from the records that
+  would be passed as LEFT and RIGHT to the <emphasis>transform</emphasis>.  
+  The records are combined if the condition is true.
+  The second form of ROLLUP compares values from adjacent records in the input
+  <emphasis>recordset</emphasis>, and combines them if they are the same.  
+  These two forms will behave differently if the <emphasis>transform</emphasis>
+  modifies some of the fields used in the matching condition (see example below).
+  </para>
+  
+  <para>For the first pair of candidate records, the LEFT record passed to the transform
+  is the first record of the pair, and the RIGHT record is the second.
+  For subsequent matches of the same values,
   the LEFT record passed is the result record from the previous call to the
   <emphasis>transform</emphasis> and the RIGHT record is the next record in
   the <emphasis>recordset</emphasis>, as in this example:</para>
@@ -114,11 +123,18 @@ d t(ds L, ds R) := TRANSFORM
   SELF.n := L.n + R.n;
 END;
 ROLLUP(ds, t(LEFT, RIGHT), r);
-ROLLUP(ds, LEFT.r = RIGHT.r,t(LEFT, RIGHT));
-/* Both ROLLUPs result in:
+/* results in:
    3  60
    3  40
    4  50
+*/
+ROLLUP(ds, LEFT.r = RIGHT.r,t(LEFT, RIGHT));
+/* results in:
+   2  30
+   1  30
+   3  40
+   4  50
+   the third record is not combined because the transform modified the value.
 */</programlisting>
 
   <sect2 id="TRANSFORM_Function_Requirements_Rollup">

--- a/docs/ECLLanguageReference/ECLR_mods/ExpressionsandOperatos.xml
+++ b/docs/ECLLanguageReference/ECLR_mods/ExpressionsandOperatos.xml
@@ -80,8 +80,42 @@
       </tgroup>
     </informaltable>
 
-    <para>Division (all three types) by zero (0) results in zero (0)—there is
-    no “divide by zero” error.</para>
+    <para>Division by zero<indexterm><primary>Division by zero</primary></indexterm>
+	defaults to generating a zero result (0), rather than reporting a “divide by zero” error.  
+	This avoids invalid or unexpected data aborting a long job.
+	The default behaviour can be changed using </para>
+	<programlisting>#option ('divideByZero', ...);</programlisting> 
+	<para>The #option can take the following values:
+	</para>
+     <informaltable colsep="0" frame="none" rowsep="0">
+      <tgroup align="left" cols="2">
+        <colspec colwidth="194.80pt" />
+
+        <colspec />
+
+        <tbody>
+          <row>
+            <entry>'zero'</entry>
+
+            <entry>Evaluate to 0 - the default behaviour.</entry>
+          </row>
+          <row>
+            <entry>'fail'</entry>
+
+            <entry>Stop and report a division by zero error.</entry>
+          </row>
+          <row>
+            <entry>'nan'</entry>
+
+            <entry>This is only currently supported for real numbers.  Division by zero
+			creates a quiet NaN, which will propogate through any real expressions it is used in.
+			You can use NOT ISVALID(x) to test if the value is a NaN.
+			Integer and decimal division by zero continue to return 0.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </informaltable>
+
   </sect2>
 
   <sect2 id="Bitwise_Operators">

--- a/docs/ECLLanguageReference/ECLR_mods/RecordStructure.xml
+++ b/docs/ECLLanguageReference/ECLR_mods/RecordStructure.xml
@@ -38,7 +38,7 @@
       <primary>RECORD structure</primary>
     </indexterm></emphasis></para>
 
-  <informaltable colsep="0" frame="none" rowsep="0">
+  <informaltable colsep="1" frame="all" rowsep="1">
     <tgroup cols="2">
       <colspec align="left" colwidth="122.40pt" />
 
@@ -185,35 +185,75 @@
     <para>All field declarations in a RECORD Structure must use one of the
     following syntaxes:</para>
 
-    <para><emphasis> datatype identifier <emphasis role="bold">[
-    {</emphasis><emphasis>modifier</emphasis><emphasis role="bold">}
-    ]</emphasis> </emphasis><emphasis role="bold">[ :=</emphasis><emphasis>
-    defaultvalue</emphasis><emphasis role="bold">] </emphasis><emphasis
-    role="bold"> ;</emphasis><emphasis> </emphasis></para>
-
-    <para><emphasis> identifier </emphasis><emphasis role="bold"> :=
-    </emphasis><emphasis>defaultvalue</emphasis><emphasis role="bold">
-    ;</emphasis><emphasis> </emphasis></para>
-
-    <para><emphasis> defaultvalue</emphasis><emphasis role="bold">
-    ;</emphasis><emphasis role="bold"> </emphasis><emphasis></emphasis></para>
-
-    <para><emphasis> sourcefield</emphasis><emphasis role="bold">
-    ;</emphasis><emphasis> </emphasis></para>
-
-    <para><emphasis> recstruct</emphasis><emphasis role="bold"> [
-    </emphasis><emphasis>identifier </emphasis><emphasis role="bold">]
-    ;</emphasis><emphasis></emphasis></para>
-
-    <para><emphasis> sourcedataset</emphasis><emphasis role="bold">
-    ;</emphasis><emphasis> </emphasis></para>
-
-    <para><emphasis> childdataset</emphasis><emphasis role="bold">
-    </emphasis><emphasis> identifier </emphasis><emphasis role="bold">[ {
-    </emphasis><emphasis>modifier </emphasis><emphasis role="bold">}
-    ];</emphasis></para>
-
     <informaltable colsep="0" frame="none" rowsep="0">
+      <tgroup cols="2">
+        <colspec align="left" colwidth="50pt" />
+
+        <colspec />
+
+        <tbody>
+          <row>
+            <entry></entry>
+
+            <entry><emphasis> datatype identifier <emphasis role="bold">[
+            {</emphasis><emphasis>modifier</emphasis><emphasis role="bold">}
+            ]</emphasis> </emphasis><emphasis role="bold">[
+            :=</emphasis><emphasis> defaultvalue</emphasis><emphasis
+            role="bold">] </emphasis><emphasis role="bold">
+            ;</emphasis><emphasis> </emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis> identifier </emphasis><emphasis role="bold"> :=
+            </emphasis><emphasis>defaultvalue</emphasis><emphasis role="bold">
+            ;</emphasis><emphasis> </emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis> defaultvalue</emphasis><emphasis role="bold">
+            ;</emphasis><emphasis role="bold">
+            </emphasis><emphasis></emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis> sourcefield</emphasis><emphasis role="bold">
+            ;</emphasis><emphasis> </emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis> recstruct</emphasis><emphasis role="bold"> [
+            </emphasis><emphasis>identifier </emphasis><emphasis role="bold">]
+            ;</emphasis><emphasis></emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis> sourcedataset</emphasis><emphasis role="bold">
+            ;</emphasis><emphasis> </emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis> childdataset</emphasis><emphasis role="bold">
+            </emphasis><emphasis> identifier </emphasis><emphasis
+            role="bold">[ { </emphasis><emphasis>modifier </emphasis><emphasis
+            role="bold">} ];</emphasis></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </informaltable>
+
+  <informaltable colsep="1" frame="all" rowsep="1">
       <tgroup cols="2">
         <colspec align="left" colwidth="122.40pt" />
 
@@ -428,46 +468,95 @@ END;</programlisting>
     <para>The following list of field modifiers are available for use on field
     definitions:</para>
 
-    <para><emphasis role="bold"> { MAXLENGTH<indexterm>
-        <primary>MAXLENGTH</primary>
-      </indexterm>( </emphasis><emphasis>length</emphasis><emphasis
-    role="bold"> ) }</emphasis><emphasis role="bold"> </emphasis></para>
-
-    <para><emphasis role="bold"> { MAXCOUNT<indexterm>
-        <primary>MAXCOUNT</primary>
-      </indexterm>( </emphasis><emphasis>records</emphasis><emphasis
-    role="bold"> ) }</emphasis></para>
-
-    <para><emphasis role="bold"> { XPATH<indexterm>
-        <primary>XPATH</primary>
-      </indexterm>(</emphasis><emphasis role="bold"> </emphasis><emphasis
-    role="bold">'</emphasis><emphasis>tag</emphasis><emphasis role="bold">' )
-    }</emphasis><emphasis role="bold"> </emphasis></para>
-
-    <para><emphasis role="bold"> { XMLDEFAULT<indexterm>
-        <primary>XMLDEFAULT</primary>
-      </indexterm>(</emphasis> <emphasis
-    role="bold">'</emphasis><emphasis>value</emphasis><emphasis role="bold">'
-    ) }</emphasis></para>
-
-    <para><emphasis role="bold"> { DEFAULT<indexterm>
-        <primary>DEFAULT</primary>
-      </indexterm>(</emphasis> <emphasis>value</emphasis><emphasis
-    role="bold"> ) }</emphasis></para>
-
-    <para><emphasis role="bold"> { VIRTUAL<indexterm>
-        <primary>Virtual</primary>
-      </indexterm><indexterm>
-        <primary>Virtual fileposition</primary>
-      </indexterm>(</emphasis><emphasis role="bold"> </emphasis><emphasis
-    role="bold">fileposition ) }</emphasis><emphasis role="bold">
-    </emphasis></para>
-
-    <para><emphasis role="bold"> { VIRTUAL<indexterm>
-        <primary>Virtual localfileposition</primary>
-      </indexterm>( localfileposition ) }</emphasis></para>
-
     <informaltable colsep="0" frame="none" rowsep="0">
+      <tgroup cols="2">
+        <colspec align="left" colwidth="50pt" />
+
+        <colspec />
+
+        <tbody>
+          <row>
+            <entry></entry>
+
+            <entry><emphasis role="bold"> { MAXLENGTH<indexterm>
+                <primary>MAXLENGTH</primary>
+              </indexterm>( </emphasis><emphasis>length</emphasis><emphasis
+            role="bold"> ) }</emphasis><emphasis role="bold">
+            </emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis role="bold"> { MAXCOUNT<indexterm>
+                <primary>MAXCOUNT</primary>
+              </indexterm>( </emphasis><emphasis>records</emphasis><emphasis
+            role="bold"> ) }</emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis role="bold"> { XPATH<indexterm>
+                <primary>XPATH</primary>
+              </indexterm>(</emphasis><emphasis role="bold">
+            </emphasis><emphasis
+            role="bold">'</emphasis><emphasis>tag</emphasis><emphasis
+            role="bold">' ) }</emphasis><emphasis role="bold">
+            </emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis role="bold"> { XMLDEFAULT<indexterm>
+                <primary>XMLDEFAULT</primary>
+              </indexterm>(</emphasis> <emphasis
+            role="bold">'</emphasis><emphasis>value</emphasis><emphasis
+            role="bold">' ) }</emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis role="bold"> { DEFAULT<indexterm>
+                <primary>DEFAULT</primary>
+              </indexterm>(</emphasis> <emphasis>value</emphasis><emphasis
+            role="bold"> ) }</emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis role="bold"> { VIRTUAL<indexterm>
+                <primary>Virtual</primary>
+              </indexterm><indexterm>
+                <primary>Virtual fileposition</primary>
+              </indexterm>(</emphasis><emphasis role="bold">
+            </emphasis><emphasis role="bold">fileposition )
+            }</emphasis><emphasis role="bold"> </emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis role="bold"> { VIRTUAL<indexterm>
+                <primary>Virtual localfileposition</primary>
+              </indexterm>( localfileposition ) }</emphasis></entry>
+          </row>
+
+          <row>
+            <entry></entry>
+
+            <entry><emphasis role="bold"> { BLOB<indexterm>
+                <primary>BLOB in INDEX</primary>
+              </indexterm> }</emphasis></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </informaltable>
+
+  <informaltable colsep="1" frame="all" rowsep="1">
       <tgroup cols="2">
         <colspec align="left" colwidth="200pt" />
 
@@ -554,11 +643,20 @@ END;</programlisting>
             when the file is loaded into memory from disk (hence, the
             “virtual”).</entry>
           </row>
+
+          <row>
+            <entry><emphasis role="bold">{ BLOB }</emphasis></entry>
+
+            <entry>Specifies the field is stored separately from the leaf node
+            entry in the INDEX. This is applicable specifically to fields in
+            the payload of an INDEX to allow more than 32K of data per index
+            entry. The BLOB data is stored within the index file, but not with
+            the rest of the record. Accessing the BLOB data requires an
+            additional seek.</entry>
+          </row>
         </tbody>
       </tgroup>
     </informaltable>
-
-    <para><emphasis role="bold"></emphasis></para>
   </sect2>
 
   <sect2 id="XPATH_Support">
@@ -572,7 +670,7 @@ END;</programlisting>
     <para><emphasis role="bold">node[qualifier] / node[qualifier]
     ...</emphasis></para>
 
-    <informaltable colsep="0" frame="none" rowsep="0">
+  <informaltable colsep="1" frame="all" rowsep="1">
       <tgroup cols="2">
         <colspec align="left" colwidth="122.40pt" />
 

--- a/docs/ECLLanguageReference/ECLR_mods/Recrd-Index.xml
+++ b/docs/ECLLanguageReference/ECLR_mods/Recrd-Index.xml
@@ -37,7 +37,7 @@
   INDEX(</emphasis><emphasis>index,newindexfile</emphasis><emphasis
   role="bold">);</emphasis></para>
 
-  <informaltable colsep="0" frame="none" rowsep="0">
+  <informaltable colsep="1" frame="all" rowsep="1">
     <tgroup cols="2">
       <colspec align="left" colwidth="122.40pt" />
 
@@ -69,9 +69,9 @@
           <emphasis>baserecset</emphasis>. Field names and types must match
           the <emphasis>baserecset</emphasis> fields (REAL and DECIMAL type
           fields are not supported). This may also contain additional fields
-          not present in the <emphasis>baserecset</emphasis>(computed fields).
-          If omitted, all fields in the <emphasis>baserecset</emphasis> are
-          used.</entry>
+          not present in the <emphasis>baserecset</emphasis> (computed
+          fields). If omitted, all fields in the
+          <emphasis>baserecset</emphasis> are used.</entry>
         </row>
 
         <row>
@@ -82,10 +82,13 @@
           <emphasis>baserecset</emphasis> is in the structure, it specifies
           “all other fields not already named in the <emphasis>keys</emphasis>
           parameter.” This may contain fields not present in the
-          <emphasis>baserecordset</emphasis>(computed fields). The
+          <emphasis>baserecordset</emphasis> (computed fields). The
           <emphasis>payload</emphasis> fields do not take up space in the
           non-leaf nodes of the index and cannot be referenced in a KEYED()
-          filter clause.</entry>
+          filter clause. Any field with the {BLOB} modifier (to allow more
+          than 32K of data per index entry) is stored within the
+          <emphasis>indexfile</emphasis>, but not with the rest of the record;
+          accessing the BLOB data requires an additional seek.</entry>
         </row>
 
         <row>
@@ -220,16 +223,21 @@ Bld := BUILDINDEX(AlphaInStateCity);</programlisting>
     <title>Payload INDEX</title>
 
     <para>This form defines an index file containing extra payload fields in
-    addition to the keys. This form is used primarily by “half-key” JOIN
-    operations to eliminate the need to directly access the
-    <emphasis>baserecset</emphasis>, thus increasing performance over the
-    “full-keyed” version of the same operation (done with the KEYED option on
-    the JOIN). By default, payload fields are sorted during the BUILD
-    action<indexterm>
+    addition to the keys. The payload may contain fields with the {BLOB}
+    modifier to allow more than 32K of data per index entry. These BLOB fields
+    are stored within the <emphasis>indexfile</emphasis>, but not with the
+    rest of the record; accessing the BLOB data requires an additional
+    seek.</para>
+
+    <para>This form is used primarily by “half-key” JOIN operations to
+    eliminate the need to directly access the <emphasis>baserecset</emphasis>,
+    thus increasing performance over the “full-keyed” version of the same
+    operation (done with the KEYED option on the JOIN). By default, payload
+    fields are not sorted during the BUILD action<indexterm>
         <primary>BUILD action</primary>
       </indexterm> to minimize space on the leaf nodes of the key. This
-    sorting can be controlled by using <emphasis>sortIndexPayload</emphasis>
-    in a #OPTION statement.</para>
+    sorting behavior can be controlled by using
+    <emphasis>sortIndexPayload</emphasis> in a #OPTION statement.</para>
 
     <para>Example:</para>
 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1820,6 +1820,7 @@ void EclAgent::doProcess()
     try
     {
         LOG(MCrunlock, unknownJob, "Waiting for workunit lock");
+        unsigned eclccCodeVersion;
         {
             WorkunitUpdate w = updateWorkUnit();
             LOG(MCrunlock, unknownJob, "Obtained workunit lock");
@@ -1828,8 +1829,10 @@ void EclAgent::doProcess()
             w->setTracingValue("EclAgentBuild", BUILD_TAG);
             if (agentTopology->hasProp("@name"))
                 w->addProcess("EclAgent", agentTopology->queryProp("@name"), logname.str());
-            if (checkVersion && ((w->getCodeVersion() > ACTIVITY_INTERFACE_VERSION) || (w->getCodeVersion() < MIN_ACTIVITY_INTERFACE_VERSION)))
-                failv(0, "Workunit was compiled for eclagent interface version %d, this eclagent requires version %d..%d", w->getCodeVersion(), MIN_ACTIVITY_INTERFACE_VERSION, ACTIVITY_INTERFACE_VERSION);
+
+            eclccCodeVersion = w->getCodeVersion();
+            if (checkVersion && ((eclccCodeVersion > ACTIVITY_INTERFACE_VERSION) || (eclccCodeVersion < MIN_ACTIVITY_INTERFACE_VERSION)))
+                failv(0, "Workunit was compiled for eclagent interface version %d, this eclagent requires version %d..%d", eclccCodeVersion, MIN_ACTIVITY_INTERFACE_VERSION, ACTIVITY_INTERFACE_VERSION);
             if(noRetry && (w->getState() == WUStateFailed))
                 throw MakeStringException(0, "Ecl agent started in 'no retry' mode for failed workunit, so failing");
             w->setState(WUStateRunning);
@@ -1854,6 +1857,10 @@ void EclAgent::doProcess()
         {
             MTIME_SECTION(timer, "Process");
             Owned<IEclProcess> process = loadProcess();
+
+            if (checkVersion && (process->getActivityVersion() != eclccCodeVersion))
+                failv(0, "Inconsistent interface versions.  Workunit was created using eclcc for version %u, but the c++ compiler used version %u", eclccCodeVersion, process->getActivityVersion());
+
             PrintLog("Starting process");
             runProcess(process);
             failed = false;

--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -278,18 +278,19 @@ void checkEclVersionCompatible(Shared<IErrorReceiver> & errors, const char * ecl
         if (extractVersion(major, minor, subminor, eclVersion))
         {
             if (major != LANGUAGE_VERSION_MAJOR)
-                throwError2(HQLERR_VersionMismatch, eclVersion, LANGUAGE_VERSION);
-            if (minor != LANGUAGE_VERSION_MINOR)
             {
-                StringBuffer msg;
-                msg.appendf("Mismatch in minor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
+                VStringBuffer msg("Mismatch in major version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
+                errors->reportWarning(HQLERR_VersionMismatch, msg.str(), NULL, 0, 0, 0);
+            }
+            else if (minor != LANGUAGE_VERSION_MINOR)
+            {
+                VStringBuffer msg("Mismatch in minor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
                 errors->reportWarning(HQLERR_VersionMismatch, msg.str(), NULL, 0, 0, 0);
             }
             else if (subminor != LANGUAGE_VERSION_SUB)
             {
                 //This adds the warning if any other warnings occur.
-                StringBuffer msg;
-                msg.appendf("Mismatch in subminor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
+                VStringBuffer msg("Mismatch in subminor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
                 Owned<IECLError> warning = createECLWarning(HQLERR_VersionMismatch, msg.str(), NULL, 0, 0);
                 errors.setown(new ErrorInserter(errors, warning));
             }

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -17158,6 +17158,8 @@ void HqlCppTranslator::buildWorkflow(WorkflowArray & workflow)
     BuildCtx classctx(*code, goAtom);
     classctx.addQuotedCompound("struct MyEclProcess : public EclProcess", ";");
 
+    classctx.addQuoted("virtual unsigned getActivityVersion() const { return ACTIVITY_INTERFACE_VERSION; }");
+
     BuildCtx performctx(classctx);
     performctx.addQuotedCompound("virtual int perform(IGlobalCodeContext * gctx, unsigned wfid)");
     performctx.addQuoted("ICodeContext * ctx;");

--- a/ecl/regress/version1.eclxml
+++ b/ecl/regress/version1.eclxml
@@ -1,4 +1,4 @@
-<Archive build="internal_3.0_beta0_Debug" eclVersion="4.0.99">
+<Archive build="internal_3.0_beta0_Debug" eclVersion="4.99.0">
 <!--
 
     HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.

--- a/ecl/regress/version4e.eclxml
+++ b/ecl/regress/version4e.eclxml
@@ -1,4 +1,4 @@
-<Archive build="internal_3.0_beta0_Debug" eclVersion="3.0.9999">
+<Archive build="internal_3.0_beta0_Debug" eclVersion="4.0.9999">
 <!--
 
     HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.

--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -107,11 +107,6 @@
             {
               document.location.href='/FileSpray/DesprayInput?sourceLogicalName='+filename;
             }
-            function showRoxieQueries()
-            {
-              //document.location.href='/WsRoxieQuery/QueriesAction?Type=ListQueries&Cluster='+cluster+'&LogicalName='+filename;
-              document.location.href='/WsSMC/DisabledInThisVersion?form_';
-            }
             var xypos = YAHOO.util.Dom.getXY('mn' + PosId);
             if (oMenu) {
               oMenu.destroy();
@@ -137,15 +132,10 @@
             ]);
             }
 
-            if (roxiecluster != 0) {
-            oMenu.addItems([
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            }
-            else {
-            oMenu.addItems([
-            { text: "Despray", onclick: { fn: desprayDFUFile } }
-            ]);
+            if (roxiecluster == 0) {
+                oMenu.addItems([
+                    { text: "Despray", onclick: { fn: desprayDFUFile } }
+                ]);
             }
 
             //showPopup(menu,(window.event ? window.event.screenX : 0),  (window.event ? window.event.screenY : 0));

--- a/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
@@ -75,10 +75,6 @@
             {
               document.location.href='/FileSpray/DesprayInput?sourceLogicalName='+filename;
             }
-            function showRoxieQueries()
-            {
-              document.location.href='/WsRoxieQuery/QueriesAction?Type=ListQueries&Cluster='+cluster+'&LogicalName='+filename;
-            }
             var xypos = YAHOO.util.Dom.getXY('mn' + PosId);
             if (oMenu) {
               oMenu.destroy();
@@ -87,74 +83,70 @@
             oMenu.clearContent();
 
             if (roxiecluster != 0) {
-            if (browsedata != 0) {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
+                if (browsedata != 0) {
+                    if (replicate != 0) {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "View Data File", onclick: { fn: searchDFUData } },
+                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } }
+                        ]);
+                    } else {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "View Data File", onclick: { fn: searchDFUData } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } }
+                        ]);
+                    }
+                } else {
+                    if (replicate != 0) {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } }
+                        ]);
+                    } else {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } }
+                        ]);
+                    }
+                }
             } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            }
-            } else {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            }
-            }
-            } else {
-            if (browsedata != 0) {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            }
-            } else {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            }
-            }
+                if (browsedata != 0) {
+                    if (replicate != 0) {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "View Data File", onclick: { fn: searchDFUData } },
+                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } },
+                        ]);
+                    } else {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "View Data File", onclick: { fn: searchDFUData } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } },
+                        ]);
+                    }
+                } else {
+                    if (replicate != 0) {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } },
+                        ]);
+                    } else {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } },
+                        ]);
+                    }
+                }
             }
             //showPopup(menu,(window.event ? window.event.screenX : 0),  (window.event ? window.event.screenY : 0));
             oMenu.render("dfulogicalfilemenu");

--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
@@ -50,12 +50,6 @@ public:
 
     virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
     {
-        IPropertyTree *folder = ensureNavFolder(data, "Roxie Queries", NULL, NULL, false, 7);
-        StringBuffer path = "/WsSMC/NotInCommunityEdition?form_";
-        if (m_portalURL.length() > 0)
-            path.appendf("&EEPortal=%s", m_portalURL.str());
-        ensureNavLink(*folder, "Search Roxie Files",path.str(), "Search Roxie Files", NULL, NULL, 2);
-        ensureNavLink(*folder, "View Roxie Files", path.str(), "View Roxie Files", NULL, NULL, 3);
     }
 };
 

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -39,8 +39,8 @@ if the supplied pointer was not from the roxiemem heap. Usually an OwnedRoxieStr
 
 //Should be incremented whenever the virtuals in the context or a helper are changed, so
 //that a work unit can't be rerun.  Try as hard as possible to retain compatibility.
-#define ACTIVITY_INTERFACE_VERSION      148
-#define MIN_ACTIVITY_INTERFACE_VERSION  148             //minimum value that is compatible with current interface - without using selectInterface
+#define ACTIVITY_INTERFACE_VERSION      149
+#define MIN_ACTIVITY_INTERFACE_VERSION  149             //minimum value that is compatible with current interface - without using selectInterface
 
 typedef unsigned char byte;
 
@@ -2745,6 +2745,7 @@ struct IGlobalCodeContext
 struct IEclProcess : public IInterface
 {
     virtual int perform(IGlobalCodeContext * gctx, unsigned wfid) = 0;
+    virtual unsigned getActivityVersion() const = 0;
 };
 
 

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -83,8 +83,6 @@ bool safe_ecvt(size_t len, char * buffer, double value, int numDigits, int * dec
 {
 #ifdef _WIN32
     return _ecvt_s(buffer, len, value, numDigits, decimal, sign) == 0;
-#elif defined(__FreeBSD__) || defined (__APPLE__)
-    UNIMPLEMENTED;
 #else
     SpinBlock block(*cvtLock);
     const char * result = ecvt(value, numDigits, decimal, sign);
@@ -99,8 +97,6 @@ bool safe_fcvt(size_t len, char * buffer, double value, int numPlaces, int * dec
 {
 #ifdef _WIN32
     return _fcvt_s(buffer, len, value, numPlaces, decimal, sign) == 0;
-#elif defined(__FreeBSD__) || defined (__APPLE__)
-    UNIMPLEMENTED;
 #else
     SpinBlock block(*cvtLock);
     const char * result = fcvt(value, numPlaces, decimal, sign);


### PR DESCRIPTION
A 'Queries' section has been added to ECLWatch navigation. Old 'Roxie
Queries' section should be removed. This fix also removes the 'ShowQuery'
from logical file's drop down menu since the 'ShowQuery' for a file has
not been implemented yet.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
