### PR TITLE
HPCC-9163 Get cloned remote file descriptor once per CResolvedFile

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -340,6 +340,34 @@ public:
         return ret.getClear();
     }
 
+    IFileDescriptor *checkClonedFromRemote(const char *_lfn, IFileDescriptor *fdesc, bool cacheIt, bool writeAccess)
+    {
+        if (_lfn && !strnicmp(_lfn, "foreign", 7)) //if need to support dali hopping should add each remote location
+            return NULL;
+        if (!fdesc || !fdesc->queryProperties().hasProp("@cloneFrom"))
+            return NULL;
+        SocketEndpoint cloneFrom;
+        cloneFrom.set(fdesc->queryProperties().queryProp("@cloneFrom"));
+        if (cloneFrom.isNull())
+            return NULL;
+        CDfsLogicalFileName lfn;
+        lfn.set(_lfn);
+        lfn.setForeign(cloneFrom, false);
+        if (!connected())
+            return resolveCachedLFN(lfn.get());
+        Owned<IDistributedFile> cloneFile = resolveLFN(lfn.get(), cacheIt, writeAccess);
+        if (cloneFile)
+        {
+            Owned<IFileDescriptor> cloneFDesc = cloneFile->getFileDescriptor();
+            if (cloneFDesc->numParts()==fdesc->numParts())
+                return cloneFDesc.getClear();
+
+            StringBuffer s;
+            DBGLOG(ROXIE_MISMATCH, "File %s cloneFrom(%s) mismatch", _lfn, cloneFrom.getIpText(s).str());
+        }
+        return NULL;
+    }
+
     virtual IDistributedFile *resolveLFN(const char *logicalName, bool cacheIt, bool writeAccess)
     {
         if (isConnected)

--- a/roxie/ccd/ccddali.hpp
+++ b/roxie/ccd/ccddali.hpp
@@ -39,6 +39,7 @@ interface IRoxieDaliHelper : extends IInterface
 {
     virtual void commitCache() = 0;
     virtual bool connected() const = 0;
+    virtual IFileDescriptor *checkClonedFromRemote(const char *id, IFileDescriptor *fdesc, bool cacheIt, bool writeAccess) = 0;
     virtual IDistributedFile *resolveLFN(const char *filename, bool cacheIt, bool writeAccess) = 0;
     virtual IFileDescriptor *resolveCachedLFN(const char *filename) = 0;
     virtual IConstWorkUnit *attachWorkunit(const char *wuid, ILoadedDllEntry *source) = 0;

--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -122,11 +122,11 @@ interface IResolvedFileCreator : extends IResolvedFile
 {
     virtual void addSubFile(const char *localFileName) = 0;
     virtual void addSubFile(const IResolvedFile *sub) = 0;
-    virtual void addSubFile(IFileDescriptor *sub) = 0;
+    virtual void addSubFile(IFileDescriptor *sub, IFileDescriptor *remoteSub) = 0;
 };
 
 extern IResolvedFileCreator *createResolvedFile(const char *lfn, const char *physical);
-extern IResolvedFile *createResolvedFile(const char *lfn, const char *physical, IDistributedFile *dFile);
+extern IResolvedFile *createResolvedFile(const char *lfn, const char *physical, IDistributedFile *dFile, IRoxieDaliHelper *daliHelper, bool cacheIt, bool writeAccess);
 
 interface IRoxiePublishCallback
 {

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -237,7 +237,7 @@ protected:
             if (fileInfo)
             {
                 Owned <IResolvedFileCreator> result = createResolvedFile(fileName, NULL);
-                result->addSubFile(createFileDescriptorFromRoxieXML(fileInfo));
+                result->addSubFile(createFileDescriptorFromRoxieXML(fileInfo), NULL);
                 return result.getClear();
             }
         }
@@ -254,7 +254,7 @@ protected:
             {
                 Owned<IDistributedFile> dFile = daliHelper->resolveLFN(fileName, cacheIt, writeAccess);
                 if (dFile)
-                    return createResolvedFile(fileName, NULL, dFile.getClear());
+                    return createResolvedFile(fileName, NULL, dFile.getClear(), daliHelper, cacheIt, writeAccess);
             }
             else if (!writeAccess)  // If we need write access and expect a dali, but don't have one, we should probably fail
             {
@@ -263,7 +263,8 @@ protected:
                 if (fd)
                 {
                     Owned <IResolvedFileCreator> result = createResolvedFile(fileName, NULL);
-                    result->addSubFile(fd.getClear());
+                    Owned<IFileDescriptor> remoteFDesc = daliHelper->checkClonedFromRemote(fileName, fd, cacheIt, writeAccess);
+                    result->addSubFile(fd.getClear(), remoteFDesc.getClear());
                     return result.getClear();
                 }
             }


### PR DESCRIPTION
For cloned files the remote file descriptor was being retrieved
from dali for each file activity.  The descriptor should be retrieved
only once when the CResolvedFile is created, and should use the
roxie dali helper to avoid issues if dali is down.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
