### PR TITLE
HPCC-9136 Remove Roxie Queries options from ECLWatch UI

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -107,11 +107,6 @@
             {
               document.location.href='/FileSpray/DesprayInput?sourceLogicalName='+filename;
             }
-            function showRoxieQueries()
-            {
-              //document.location.href='/WsRoxieQuery/QueriesAction?Type=ListQueries&Cluster='+cluster+'&LogicalName='+filename;
-              document.location.href='/WsSMC/DisabledInThisVersion?form_';
-            }
             var xypos = YAHOO.util.Dom.getXY('mn' + PosId);
             if (oMenu) {
               oMenu.destroy();
@@ -137,15 +132,10 @@
             ]);
             }
 
-            if (roxiecluster != 0) {
-            oMenu.addItems([
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            }
-            else {
-            oMenu.addItems([
-            { text: "Despray", onclick: { fn: desprayDFUFile } }
-            ]);
+            if (roxiecluster == 0) {
+                oMenu.addItems([
+                    { text: "Despray", onclick: { fn: desprayDFUFile } }
+                ]);
             }
 
             //showPopup(menu,(window.event ? window.event.screenX : 0),  (window.event ? window.event.screenY : 0));

--- a/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
@@ -75,10 +75,6 @@
             {
               document.location.href='/FileSpray/DesprayInput?sourceLogicalName='+filename;
             }
-            function showRoxieQueries()
-            {
-              document.location.href='/WsRoxieQuery/QueriesAction?Type=ListQueries&Cluster='+cluster+'&LogicalName='+filename;
-            }
             var xypos = YAHOO.util.Dom.getXY('mn' + PosId);
             if (oMenu) {
               oMenu.destroy();
@@ -87,74 +83,70 @@
             oMenu.clearContent();
 
             if (roxiecluster != 0) {
-            if (browsedata != 0) {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
+                if (browsedata != 0) {
+                    if (replicate != 0) {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "View Data File", onclick: { fn: searchDFUData } },
+                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } }
+                        ]);
+                    } else {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "View Data File", onclick: { fn: searchDFUData } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } }
+                        ]);
+                    }
+                } else {
+                    if (replicate != 0) {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } }
+                        ]);
+                    } else {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } }
+                        ]);
+                    }
+                }
             } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            }
-            } else {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "ShowQuery", onclick: { fn: showRoxieQueries } }
-            ]);
-            }
-            }
-            } else {
-            if (browsedata != 0) {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "View Data File", onclick: { fn: searchDFUData } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            }
-            } else {
-            if (replicate != 0) {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            } else {
-            oMenu.addItems([
-            { text: "Details", onclick: { fn: detailsDFUFile } },
-            { text: "Copy", onclick: { fn: copyDFUFile } },
-            { text: "Despray", onclick: { fn: desprayDFUFile } },
-            ]);
-            }
-            }
+                if (browsedata != 0) {
+                    if (replicate != 0) {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "View Data File", onclick: { fn: searchDFUData } },
+                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } },
+                        ]);
+                    } else {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "View Data File", onclick: { fn: searchDFUData } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } },
+                        ]);
+                    }
+                } else {
+                    if (replicate != 0) {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } },
+                        ]);
+                    } else {
+                        oMenu.addItems([
+                            { text: "Details", onclick: { fn: detailsDFUFile } },
+                            { text: "Copy", onclick: { fn: copyDFUFile } },
+                            { text: "Despray", onclick: { fn: desprayDFUFile } },
+                        ]);
+                    }
+                }
             }
             //showPopup(menu,(window.event ? window.event.screenX : 0),  (window.event ? window.event.screenY : 0));
             oMenu.render("dfulogicalfilemenu");

--- a/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_fileview.xslt
@@ -75,6 +75,9 @@
             {
               document.location.href='/FileSpray/DesprayInput?sourceLogicalName='+filename;
             }
+            function renameDFUFile() {
+              document.location.href='/FileSpray/RenameInput?sourceLogicalName='+filename;
+            }
             var xypos = YAHOO.util.Dom.getXY('mn' + PosId);
             if (oMenu) {
               oMenu.destroy();
@@ -82,72 +85,27 @@
             oMenu = new YAHOO.widget.Menu("logicalfilecontextmenu", {position: "dynamic", xy: xypos} );
             oMenu.clearContent();
 
-            if (roxiecluster != 0) {
-                if (browsedata != 0) {
-                    if (replicate != 0) {
-                        oMenu.addItems([
-                            { text: "Details", onclick: { fn: detailsDFUFile } },
-                            { text: "View Data File", onclick: { fn: searchDFUData } },
-                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-                            { text: "Copy", onclick: { fn: copyDFUFile } },
-                            { text: "Despray", onclick: { fn: desprayDFUFile } }
-                        ]);
-                    } else {
-                        oMenu.addItems([
-                            { text: "Details", onclick: { fn: detailsDFUFile } },
-                            { text: "View Data File", onclick: { fn: searchDFUData } },
-                            { text: "Copy", onclick: { fn: copyDFUFile } }
-                        ]);
-                    }
-                } else {
-                    if (replicate != 0) {
-                        oMenu.addItems([
-                            { text: "Details", onclick: { fn: detailsDFUFile } },
-                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-                            { text: "Copy", onclick: { fn: copyDFUFile } }
-                        ]);
-                    } else {
-                        oMenu.addItems([
-                            { text: "Details", onclick: { fn: detailsDFUFile } },
-                            { text: "Copy", onclick: { fn: copyDFUFile } }
-                        ]);
-                    }
-                }
-            } else {
-                if (browsedata != 0) {
-                    if (replicate != 0) {
-                        oMenu.addItems([
-                            { text: "Details", onclick: { fn: detailsDFUFile } },
-                            { text: "View Data File", onclick: { fn: searchDFUData } },
-                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-                            { text: "Copy", onclick: { fn: copyDFUFile } },
-                            { text: "Despray", onclick: { fn: desprayDFUFile } },
-                        ]);
-                    } else {
-                        oMenu.addItems([
-                            { text: "Details", onclick: { fn: detailsDFUFile } },
-                            { text: "View Data File", onclick: { fn: searchDFUData } },
-                            { text: "Copy", onclick: { fn: copyDFUFile } },
-                            { text: "Despray", onclick: { fn: desprayDFUFile } },
-                        ]);
-                    }
-                } else {
-                    if (replicate != 0) {
-                        oMenu.addItems([
-                            { text: "Details", onclick: { fn: detailsDFUFile } },
-                            { text: "Replicate", onclick: { fn: replicateDFUFile } },
-                            { text: "Copy", onclick: { fn: copyDFUFile } },
-                            { text: "Despray", onclick: { fn: desprayDFUFile } },
-                        ]);
-                    } else {
-                        oMenu.addItems([
-                            { text: "Details", onclick: { fn: detailsDFUFile } },
-                            { text: "Copy", onclick: { fn: copyDFUFile } },
-                            { text: "Despray", onclick: { fn: desprayDFUFile } },
-                        ]);
-                    }
-                }
+            oMenu.addItems([
+                { text: "Details", onclick: { fn: detailsDFUFile } },
+                { text: "Copy", onclick: { fn: copyDFUFile } },
+                { text: "Rename", onclick: { fn: renameDFUFile } }
+            ]);
+            if (browsedata != 0) {
+                oMenu.addItems([
+                    { text: "View Data File", onclick: { fn: searchDFUData } }
+                ]);
             }
+            if (replicate != 0) {
+                oMenu.addItems([
+                    { text: "Replicate", onclick: { fn: replicateDFUFile } }
+                ]);
+            }
+            if (roxiecluster == 0) {
+                oMenu.addItems([
+                    { text: "Despray", onclick: { fn: desprayDFUFile } }
+                ]);
+            }
+
             //showPopup(menu,(window.event ? window.event.screenX : 0),  (window.event ? window.event.screenY : 0));
             oMenu.render("dfulogicalfilemenu");
             oMenu.show();

--- a/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
+++ b/esp/services/ws_roxiequery/ws_roxiequeryservice.hpp
@@ -50,12 +50,6 @@ public:
 
     virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
     {
-        IPropertyTree *folder = ensureNavFolder(data, "Roxie Queries", NULL, NULL, false, 7);
-        StringBuffer path = "/WsSMC/NotInCommunityEdition?form_";
-        if (m_portalURL.length() > 0)
-            path.appendf("&EEPortal=%s", m_portalURL.str());
-        ensureNavLink(*folder, "Search Roxie Files",path.str(), "Search Roxie Files", NULL, NULL, 2);
-        ensureNavLink(*folder, "View Roxie Files", path.str(), "View Roxie Files", NULL, NULL, 3);
     }
 };
 


### PR DESCRIPTION
A 'Queries' section has been added to ECLWatch navigation. Old 'Roxie
Queries' section should be removed. This fix also removes the 'ShowQuery'
from logical file's drop down menu since the 'ShowQuery' for a file has
not been implemented yet.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
