### PR TITLE
HPCC-9046 Browse ECLWorkunits: sorting should be case-insensitive

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2279,7 +2279,7 @@ public:
                 if (fmt&WUSFreverse) 
                     so.append('-');
                 if (fmt&WUSFnocase) 
-                    so.append('~');
+                    so.append('?');
                 if (fmt&WUSFnumeric) 
                     so.append('#');
                 so.append(getEnumText(fmt&0xff,sortFields));

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2007,6 +2007,7 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
         else
             sortorder[0] = WUSFwuid;
 
+        sortorder[0] = (WUSortField) (sortorder[0] | WUSFnocase);
         bool descending = req.getDescending();
         if (descending)
             sortorder[0] = (WUSortField) (sortorder[0] | WUSFreverse);


### PR DESCRIPTION
When sorting by the owners, it appears that capitalized usernames
appears before lowercase usernames. This fix changes the sorting
from case-sensitive to case-insensitive.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
