### PR TITLE
HPCC-9184 Roxie queue name not found in /Status/Servers list after re-at...

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -23,6 +23,7 @@
 #include "dllserver.hpp"
 #include "ccddali.hpp"
 #include "ccdfile.hpp"
+#include "ccdlistener.hpp"
 #include "ccd.hpp"
 
 #include "jencrypt.hpp"
@@ -592,6 +593,7 @@ public:
                 ::closedownClientProcess(); // dali client closedown
                 isConnected = false;
                 disconnectSem.signal();
+                disconnectRoxieQueues();
             }
         }
     }

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -529,12 +529,6 @@ public:
         return isConnected;
     }
 
-    virtual void waitConnected()
-    {
-        while (!isConnected)
-            Sleep(ROXIE_DALI_CONNECT_TIMEOUT);
-    }
-
     // connect handles the operations generally performed by Dali clients at startup.
     virtual bool connect(unsigned timeout)
     {

--- a/roxie/ccd/ccddali.hpp
+++ b/roxie/ccd/ccddali.hpp
@@ -51,7 +51,6 @@ interface IRoxieDaliHelper : extends IInterface
     virtual void releaseSubscription(IDaliPackageWatcher *subscription) = 0;
     virtual bool connect(unsigned timeout) = 0;
     virtual void disconnect() = 0;
-    virtual void waitConnected() = 0;
     virtual void noteQueuesRunning(const char *queueNames) = 0;
     virtual void noteWorkunitRunning(const char *wu, bool running) = 0;
 };

--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -917,7 +917,8 @@ public:
             {
                 if (traceLevel)
                     DBGLOG("roxie: Waiting for dali connection before waiting for queue");
-                daliHelper->waitConnected();
+                while (running && !daliHelper->connected())
+                    Sleep(ROXIE_DALI_CONNECT_TIMEOUT);
             }
         }
         return 0;

--- a/roxie/ccd/ccdlistener.hpp
+++ b/roxie/ccd/ccdlistener.hpp
@@ -25,6 +25,7 @@ interface IRoxieListener : extends IInterface
     virtual void start() = 0;
     virtual bool stop(unsigned timeout) = 0;
     virtual void stopListening() = 0;
+    virtual void disconnectQueue() = 0;
     virtual void addAccess(bool allow, bool allowBlind, const char *ip, const char *mask, const char *query, const char *errMsg, int errCode) = 0;
     virtual unsigned queryPort() const = 0;
     virtual const SocketEndpoint &queryEndpoint() const = 0;
@@ -33,10 +34,10 @@ interface IRoxieListener : extends IInterface
     virtual void runOnce(const char *query) = 0;
 };
 
-IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended);
-IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended);
-bool suspendRoxieListener(unsigned port, bool suspended);
+extern IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended);
+extern IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended);
+extern bool suspendRoxieListener(unsigned port, bool suspended);
 extern IArrayOf<IRoxieListener> socketListeners;
-
+extern void disconnectRoxieQueues();
 
 #endif

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -2098,6 +2098,7 @@ private:
             else if (stricmp(queryName, "control:unlockDali")==0)
             {
                 topology->setPropBool("@lockDali", false);
+                // Dali will reattach via the timer that checks every so often if can reattach...
             }
             else if (stricmp(queryName, "control:unsuspend")==0)
             {


### PR DESCRIPTION
...tach

The queue was not detecting that dali had disconnected properly, and was thus
failing to reconnect.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
