### PR TITLE
HPCC-9182 Prevent adding empty block to FlushingStringBuffer queue

### DIFF
--- a/common/thorhelper/roxiehelper.cpp
+++ b/common/thorhelper/roxiehelper.cpp
@@ -893,8 +893,11 @@ void FlushingStringBuffer::flushXML(StringBuffer &current, bool isClosing)
                 queued.append(s.detach());
                 s.ensureCapacity(HTTP_SPLIT_RESERVE);
             }
-            lengths.append(current.length());
-            queued.append(current.detach());
+            if (current.length())
+            {
+                lengths.append(current.length());
+                queued.append(current.detach());
+            }
             if (!isClosing)
                 current.ensureCapacity(HTTP_SPLIT_RESERVE);
         }

--- a/common/thorhelper/roxiehelper.hpp
+++ b/common/thorhelper/roxiehelper.hpp
@@ -158,6 +158,7 @@ public:
     virtual void encodeXML(const char *x, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=false);
     virtual void flushXML(StringBuffer &current, bool isClosing);
     virtual void flush(bool closing) ;
+    virtual void addPayload(StringBuffer &s, unsigned int reserve=0);
     virtual void *getPayload(size32_t &length);
     virtual void startDataset(const char *elementName, const char *resultName, unsigned sequence, bool _extend = false);
     virtual void startScalar(const char *resultName, unsigned sequence);


### PR DESCRIPTION
An empty block in the FlushingStringBuffer queue will be treated
as end of content.  Some cases such as an empty output dataset
could result in invalid xml being returned.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
