### PR TITLE
HPCC-9189 Disable udpResendEnabled logic

### DIFF
--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -1710,7 +1710,11 @@ public:
         int udpQueueSize = topology->getPropInt("@udpQueueSize", UDP_QUEUE_SIZE);
         int udpSendQueueSize = topology->getPropInt("@udpSendQueueSize", UDP_SEND_QUEUE_SIZE);
         int udpMaxSlotsPerClient = topology->getPropInt("@udpMaxSlotsPerClient", 0x7fffffff);
+#ifdef _DEBUG
         bool udpResendEnabled = topology->getPropBool("@udpResendEnabled", false);
+#else
+        bool udpResendEnabled = false;  // As long as it is known to be broken, we don't want it accidentally enabled in any release version
+#endif
         openReceiveSocket();
         maxPacketSize = sock->get_max_send_size();
         if ((maxPacketSize==0)||(maxPacketSize>65535))


### PR DESCRIPTION
Still seeing some issues even with the behaviour defaulted off, from people
that created environments while the default was still on.

It is definitely broken, so until I have a chance to work out why, disable it.
Allow it to be enabled only in debug builds (so that I can debug why it is
failing).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
