### PR TITLE
HPCC-9187 Missing check for ecl-queries-copy --overwrite option

### DIFF
--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -345,6 +345,8 @@ public:
                 continue;
             if (iter.matchOption(optComment, ECLOPT_COMMENT))
                 continue;
+            if (iter.matchFlag(optOverwrite, ECLOPT_OVERWRITE)||iter.matchFlag(optOverwrite, ECLOPT_OVERWRITE_S))
+                continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
