### PR TITLE
HPCC-9190 Roxie should not reconnect to dali if restarts while lockDali

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -452,6 +452,7 @@ inline unsigned getBondedChannel(unsigned partNo)
 
 extern void FatalError(const char *format, ...)  __attribute__((format(printf, 1, 2)));
 extern unsigned getNextInstanceId();
+extern void saveTopology();
 
 #define LOGGING_INTERCEPTED     0x01
 #define LOGGING_TIMEACTIVITIES  0x02

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -90,6 +90,7 @@ unsigned udpMulticastBufferSize = 262142;
 bool roxieMulticastEnabled = true;
 
 IPropertyTree* topology;
+StringBuffer topologyFile;
 CriticalSection ccdChannelsCrit;
 IPropertyTree* ccdChannels;
 StringArray allQuerySetNames;
@@ -432,6 +433,23 @@ public:
     }
 } callbackHook;
 
+void saveTopology()
+{
+    // Write back changes that have been made via certain control:xxx changes, so that they survive a roxie restart
+    // Note that they are overwritten when Roxie is manually stopped/started via hpcc-init service - these changes
+    // are only intended to be temporary for the current session
+    try
+    {
+        saveXML(topologyFile.str(), topology);
+    }
+    catch (IException *E)
+    {
+        // If we can't save the topology, then tough. Carry on without it. Changes will not survive an unexpected roxie restart
+        EXCLOG(E, "Error saving topology file");
+        E->Release();
+    }
+}
+
 int STARTQUERY_API start_query(int argc, const char *argv[])
 {
     InitModuleObjects();
@@ -511,7 +529,6 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         Owned<IFile> sentinelFile = createSentinelTarget();
         removeSentinelFile(sentinelFile);
 
-        StringBuffer topologyFile;
         if (globals->hasProp("--topology"))
             globals->getProp("--topology", topologyFile);
         else

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1633,6 +1633,7 @@ private:
                 topology->setPropBool("@lockDali", true);
                 if (daliHelper)
                     daliHelper->disconnect();
+                saveTopology();
             }
             else if (stricmp(queryName, "control:logfullqueries")==0)
             {
@@ -2106,6 +2107,7 @@ private:
             else if (stricmp(queryName, "control:unlockDali")==0)
             {
                 topology->setPropBool("@lockDali", false);
+                saveTopology();
             }
             else if (stricmp(queryName, "control:unsuspend")==0)
             {


### PR DESCRIPTION
If Roxie has been manually disconnected frmo dali, it needs to stay that way
if if it restarts after a core.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
