### PR TITLE
HPCC-9205 SprayVariable file fix

### DIFF
--- a/docs/ECLStandardLibraryReference/SLR-Mods/SprayVariable.xml
+++ b/docs/ECLStandardLibraryReference/SLR-Mods/SprayVariable.xml
@@ -56,7 +56,7 @@
   role="bold">]</emphasis> <emphasis role="bold"> [</emphasis>
   <emphasis>,allowoverwrite</emphasis> <emphasis role="bold">] [</emphasis>
   <emphasis>,replicate</emphasis> <emphasis role="bold">] [</emphasis>
-  <emphasis>, compress </emphasis> <emphasis role="bold">]);</emphasis></para>
+  <emphasis>, compress </emphasis> <emphasis role="bold">]);</emphasis>
   <emphasis>, sourceCsvEscape </emphasis> <emphasis role="bold">]);</emphasis></para>
 
   <informaltable colsep="0" frame="none" rowsep="0">


### PR DESCRIPTION
Fix HPCC-9205 SprayVariable file fix
Fix XML Error in ECLStandLibraryReference/
SprayVariable.xml file causing file to be
invalid and downstream processes fail.

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com
