### PR TITLE
HPCC-9214 Include remoteSubFiles when replicating CResolvedFile on slave

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1914,6 +1914,23 @@ public:
         }
         return fileMap.getLink();
     }
+    virtual void serializeFDesc(MemoryBuffer &mb, IFileDescriptor *fdesc, unsigned channel, bool isLocal) const
+    {
+        // Find all the partno's that go to this channel
+        unsigned numParts = fdesc->numParts();
+        if (numParts > 1 && fileType==ROXIE_KEY && isLocal)
+            numParts--; // don't want to send TLK
+        UnsignedArray partNos;
+        for (unsigned i = 1; i <= numParts; i++)
+        {
+            IPartDescriptor *pdesc = fdesc->queryPart(i-1);
+            if (getBondedChannel(i)==channel || !isLocal)
+            {
+                partNos.append(i-1);
+            }
+        }
+        fdesc->serializeParts(mb, partNos);
+    }
     virtual void serializePartial(MemoryBuffer &mb, unsigned channel, bool isLocal) const
     {
         if (traceLevel > 6)
@@ -1929,20 +1946,15 @@ public:
         {
             mb.append(subNames.item(idx));
             IFileDescriptor *fdesc = subFiles.item(idx);
-            // Find all the partno's that go to this channel
-            unsigned numParts = fdesc->numParts();
-            if (numParts > 1 && fileType==ROXIE_KEY && isLocal)
-                numParts--; // don't want to send TLK
-            UnsignedArray partNos;
-            for (unsigned i = 1; i <= numParts; i++)
+            serializeFDesc(mb, fdesc, channel, isLocal);
+            IFileDescriptor *remoteFDesc = remoteSubFiles.item(idx);
+            if (remoteFDesc)
             {
-                IPartDescriptor *pdesc = fdesc->queryPart(i-1);
-                if (getBondedChannel(i)==channel || !isLocal) 
-                {
-                    partNos.append(i-1);
-                }
+                mb.append(true);
+                serializeFDesc(mb, remoteFDesc, channel, isLocal);
             }
-            fdesc->serializeParts(mb, partNos);
+            else
+                mb.append(false);
             if (fileType == ROXIE_KEY) // for now we only support translation on index files
             {
                 IDefRecordMeta *meta = diskMeta.item(idx);
@@ -2058,9 +2070,9 @@ public:
                         if (fdesc) // NB there may be no parts for this channel 
                         {
                             IPartDescriptor *pdesc = fdesc->queryPart(partNo-1);
-                            IPartDescriptor *remotePDesc = queryMatchingRemotePart(pdesc, remoteFDesc, partNo-1);
                             if (pdesc)
                             {
+                                IPartDescriptor *remotePDesc = queryMatchingRemotePart(pdesc, remoteFDesc, partNo-1);
                                 part.setown(createDynamicFile(subNames.item(idx), pdesc, remotePDesc, ROXIE_KEY, fdesc->numParts(), cached != NULL));
                                 pdesc->getCrc(crc);
                             }
@@ -2309,16 +2321,13 @@ public:
                     StringBuffer subName;
                     serverData.read(subName);
                     subNames.append(subName.str());
-                    IArrayOf<IPartDescriptor> parts;
-                    deserializePartFileDescriptors(serverData, parts);
-                    if (parts.length())
-                        subFiles.append(LINK(&parts.item(0).queryOwner()));
+                    deserializeFilePart(serverData, subFiles, fileNo, false);
+                    bool remotePresent;
+                    serverData.read(remotePresent);
+                    if (remotePresent)
+                        deserializeFilePart(serverData, remoteSubFiles, fileNo, true);
                     else
-                    { 
-                        if (traceLevel > 6)
-                            DBGLOG("No information for subFile %d of file %s", fileNo, lfn.get());
-                        subFiles.append(NULL);
-                    }
+                        remoteSubFiles.append(NULL);
                     if (fileType==ROXIE_KEY)
                     {
                         bool diskMetaPresent;
@@ -2343,6 +2352,22 @@ public:
             throw;
         }
         ROQ->removePendingCallback(callback);
+    }
+private:
+    void deserializeFilePart(MemoryBuffer &serverData, PointerIArrayOf<IFileDescriptor> &files, unsigned fileNo, bool remote)
+    {
+        IArrayOf<IPartDescriptor> parts;
+        deserializePartFileDescriptors(serverData, parts);
+        if (parts.length())
+        {
+            files.append(LINK(&parts.item(0).queryOwner()));
+        }
+        else
+        {
+            if (traceLevel > 6)
+                DBGLOG("No information for %s subFile %d of file %s", remote ? "remote" : "", fileNo, lfn.get());
+            files.append(NULL);
+        }
     }
 };
 


### PR DESCRIPTION
Remote sub files were not being serialized/deserialized when
CResolvedFiles were copied to slaves as CSlaveDynamicFile.

subFiles and remoteSubFiles must have the same number of items or
issues will arise when invalid item numbers are accessed.  The remote
file descriptors were also not accessible on the slave nodes.

Also move a call to queryMatchingRemotePart to inside the if block where
the result is used.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
