### PR TITLE
HPCC-9218 - Further DFS refactoring solving some superfile issues

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -178,21 +178,11 @@ interface IDistributedFileTransaction: extends IInterface
 {
     virtual void start()=0;
     virtual void commit()=0;
-    virtual void autoCommit()=0; // if transaction not active, commit straight away
     virtual void rollback()=0;
     virtual bool active()=0;
+// TBD: shouldn't really be necessary, lookups should auto-add to transaction
     virtual IDistributedFile *lookupFile(const char *lfn,unsigned timeout=INFINITE)=0;
     virtual IDistributedSuperFile *lookupSuperFile(const char *slfn,unsigned timeout=INFINITE)=0;
-    virtual IDistributedSuperFile *lookupSuperFileCached(const char *slfn,unsigned timeout=INFINITE)=0;
-    virtual IUserDescriptor *queryUser()=0;
-    virtual bool addDelayedDelete(CDfsLogicalFileName &lfn,unsigned timeoutms=INFINITE)=0; // used internally to delay deletes until commit
-    virtual void descend()=0;  // descend into a recursive call (can't autoCommit if depth is not zero)
-    virtual void ascend()=0;   // ascend back from the deep, one step at a time
-
-    // MORE: These need refactoring
-    virtual void addAction(CDFAction *action)=0; // internal (so why is this on a public interface?)
-    virtual void addFile(IDistributedFile *file)=0; // TODO: avoid this being necessary
-    virtual void clearFiles()=0; // internal (so why is this on a public interface?)
 };
 
 interface IDistributedSuperFileIterator: extends IIteratorOf<IDistributedSuperFile>
@@ -224,7 +214,7 @@ interface IDistributedFile: extends IInterface
     virtual const char *queryPartMask() = 0;                                    // default part name mask
 
     virtual void attach(const char *logicalname,IUserDescriptor *user) = 0;     // attach to name in DFS
-    virtual void detach(unsigned timeoutms=INFINITE) = 0;                       // no longer attached to name in DFS
+    virtual void detach(unsigned timeoutms=INFINITE, bool removePhysicalParts=true) = 0;                       // no longer attached to name in DFS
 
     virtual IPropertyTree &queryAttributes() = 0;                               // DFile attributes
 

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -743,7 +743,7 @@ public:
         Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user);
         // We need this here, since caching only happens with active transactions
         // MORE - abstract this with DFSAccess, or at least enable caching with a flag
-        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFileCached(superfname);
+        Owned<IDistributedSuperFile> superfile = transaction->lookupSuperFile(superfname);
 
         if (!superfile)
             throwError1(DFUERR_DSuperFileNotFound, superfname);

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1022,10 +1022,7 @@ static bool lookupSuperFile(ICodeContext *ctx, const char *lsuperfn, Owned<IDist
         if (dlfn.isForeign())
             throw MakeStringException(0, "Foreign superfile not allowed: %s", lsfn.str());
     }
-    if (cacheFiles)
-        file.setown(transaction->lookupSuperFileCached(lsfn.str()));
-    else
-        file.setown(transaction->lookupSuperFile(lsfn.str()));
+    file.setown(transaction->lookupSuperFile(lsfn.str()));
     if (file.get())
         return true;
     if (throwerr)


### PR DESCRIPTION
Remove/Add sequence of same file resolved properly (see HPCC-9202),
(restore check in prepare())
Renaming files then adding them to super resolved.
Renaming merge to existing file on another cluster resolved.
Renaming split from existing file on multiple clusters resolved.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
