### PR TITLE
HPCC-9221 Deleting package from roxie will cause query to hang

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -87,6 +87,9 @@ public:
     virtual void onReconnect()
     {
         Linked<CDaliPackageWatcher> me = this;  // Ensure that I am not released by the notify call (which would then access freed memory to release the critsec)
+        // It's tempting to think you can avoid holding the critsec during the notify call, and that you only need to hold it while looking up notifier
+        // Despite the danger of deadlocks (that requires careful code in the notifier to avoid), I think it is neccessary to hold the lock during the call,
+        // as otherwise notifier may point to a deleted object.
         CriticalBlock b(crit);
         change = querySDS().subscribe(xpath, *this, true);
         if (notifier)


### PR DESCRIPTION
This is a regression caused by recent changes to package reload code, and does
not affect any released version.

This change will fix the deadlock - however I will revisit the question of
whether the critsec that causes the deadlock is really required.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
