### PR TITLE
HPCC-8770 Show eclserver in Topology/TargetCluster page

### DIFF
--- a/esp/eclwatch/ws_XSLT/targetclusters.xslt
+++ b/esp/eclwatch/ws_XSLT/targetclusters.xslt
@@ -363,6 +363,14 @@
                       <xsl:with-param name="cluster" select="$name"/>
                     </xsl:call-template>
                   </xsl:if>
+                  <xsl:if test="count(TpEclServers/TpEclServer)">
+                    <xsl:call-template name="showMachines">
+                      <xsl:with-param name="caption" select="'ECL Servers'"/>
+                      <xsl:with-param name="nodes" select="TpEclServers/TpEclServer"/>
+                      <xsl:with-param name="compType" select="'EclServerProcess'"/>
+                      <xsl:with-param name="cluster" select="$name"/>
+                    </xsl:call-template>
+                  </xsl:if>
                   <xsl:if test="count(TpEclAgents/TpEclAgent)">
                     <xsl:call-template name="showMachines">
                       <xsl:with-param name="caption" select="'ECL Agents'"/>
@@ -520,7 +528,7 @@
             <xsl:for-each select="TpMachines/*">
               <xsl:variable name="showDir">
                 <xsl:choose>
-                  <xsl:when test="$compType='EclCCServerProcess' or $compType='EclSchedulerProcess'">
+                  <xsl:when test="$compType='EclCCServerProcess' or $compType='EclServerProcess' or $compType='EclSchedulerProcess'">
                     <xsl:value-of select="Directory"/>
                   </xsl:when>
                   <xsl:when test="$compType='EclAgentProcess'">
@@ -531,6 +539,7 @@
               <xsl:variable name="type4">
                 <xsl:choose>
                   <xsl:when test="$compType='EclCCServerProcess'">Ecl CC Server Process</xsl:when>
+                  <xsl:when test="$compType='EclServerProcess'">Ecl Server Process</xsl:when>
                   <xsl:when test="$compType='EclAgentProcess'">Ecl Agent Process</xsl:when>
                   <xsl:when test="$compType='EclSchedulerProcess'">Ecl Scheduler Process</xsl:when>
                 </xsl:choose>

--- a/esp/scm/ws_topology.ecm
+++ b/esp/scm/ws_topology.ecm
@@ -271,6 +271,7 @@ ESPStruct TpTargetCluster
 
     ESParray<ESPstruct TpCluster>   TpClusters;
     ESParray<ESPstruct TpEclServer> TpEclCCServers;
+    [min_ver("1.19")] ESParray<ESPstruct TpEclServer> TpEclServers;
     ESParray<ESPstruct TpEclAgent>  TpEclAgents;
     [min_ver("1.16")] ESParray<ESPstruct TpEclScheduler>  TpEclSchedulers;
 };
@@ -544,7 +545,7 @@ ESPresponse [exceptions_inline,encode(0)] TpThorStatusResponse
     int AutoRefresh;
 };
 
-ESPservice [noforms, version("1.18"), default_client_version("1.18"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsTopology
+ESPservice [noforms, version("1.19"), default_client_version("1.19"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsTopology
 {
     ESPuses ESPStruct TpBinding;
     ESPuses ESPstruct TpCluster;

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -36,6 +36,10 @@
 #define eqEclCCServer       "EclCCServerProcess"
 #endif
 
+#ifndef eqEclServer
+#define eqEclServer       "EclServerProcess"
+#endif
+
 #ifndef eqEclAgent
 #define eqEclAgent          "EclAgentProcess"
 #endif
@@ -579,6 +583,7 @@ void Cws_machineEx::readSettingsForTargetClusters(IEspContext& context, StringAr
         }
 
         Owned<IPropertyTreeIterator> eclCCServerProcesses= pCluster->getElements(eqEclCCServer);
+        Owned<IPropertyTreeIterator> eclServerProcesses= pCluster->getElements(eqEclServer);
         Owned<IPropertyTreeIterator> eclAgentProcesses= pCluster->getElements(eqEclAgent);
         Owned<IPropertyTreeIterator> eclSchedulerProcesses= pCluster->getElements(eqEclScheduler);
 
@@ -594,6 +599,10 @@ void Cws_machineEx::readSettingsForTargetClusters(IEspContext& context, StringAr
         //Read eclCCServer process
         if (eclCCServerProcesses->first())
             readTargetClusterProcesses(eclCCServerProcesses->query(), eqEclCCServer, uniqueProcesses, machineInfoData, targetClusterOut);
+
+        //Read eclServer process
+        if (eclServerProcesses->first())
+            readTargetClusterProcesses(eclServerProcesses->query(), eqEclServer, uniqueProcesses, machineInfoData, targetClusterOut);
 
         //Read eclAgent process
         if (eclAgentProcesses->first())
@@ -738,6 +747,10 @@ void Cws_machineEx::getProcesses(IConstEnvironment* constEnv, IPropertyTree* env
         StringArray processInstances, directories;
 
         IPropertyTree &process = processes->query();
+        const char* name = process.queryProp("@name");
+        if (!name || !*name || !streq(name, processName))
+            continue;
+
         const char* computerName = process.queryProp("@computer");
         if (computerName && *computerName)
             appendProcessInstance(computerName, directory, NULL, processInstances, directories);

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -241,18 +241,9 @@ void CTpWrapper::getTpDaliServers(IArrayOf<IConstTpDali>& list)
     }
 }
 
-void CTpWrapper::getTpEclServers(IArrayOf<IConstTpEclServer>& list)
+void CTpWrapper::getTpEclServers(IArrayOf<IConstTpEclServer>& list, const char* serverName)
 {
-    DBGLOG("CTpWrapper::getTpEclServers()");
-#if 0
-    Owned<IRemoteConnection> conn = querySDS().connect( "/Environment/Software", myProcessSession(), 
-                                                        RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        throw MakeStringException(0,"Failed to get environment information.");
-    IPropertyTree* root = conn->queryRoot();
-#else
     Owned<IPropertyTree> root = getEnvironment("Software");
-#endif
     if (!root)
         throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
@@ -263,6 +254,9 @@ void CTpWrapper::getTpEclServers(IArrayOf<IConstTpEclServer>& list)
 
         Owned<IEspTpEclServer> pService = createTpEclServer("","");
         const char* name = serviceTree.queryProp("@name");
+        if (serverName && stricmp(name, serverName))
+            continue;
+
         pService->setName(name);
         pService->setDescription(serviceTree.queryProp("@description"));
         pService->setBuild(serviceTree.queryProp("@build"));
@@ -1040,6 +1034,7 @@ void CTpWrapper::queryTargetClusters(double version, const char* clusterType, co
             Owned<IPropertyTreeIterator> thorClusters= cluster.getElements(eqThorCluster);
             Owned<IPropertyTreeIterator> roxieClusters= cluster.getElements(eqRoxieCluster);
             Owned<IPropertyTreeIterator> eclCCServerProcesses= cluster.getElements(eqEclCCServer);
+            Owned<IPropertyTreeIterator> eclServerProcesses= cluster.getElements(eqEclServer);
             Owned<IPropertyTreeIterator> eclSchedulerProcesses= cluster.getElements(eqEclScheduler);
             Owned<IPropertyTreeIterator> eclAgentProcesses= cluster.getElements(eqEclAgent);
 
@@ -1095,6 +1090,18 @@ void CTpWrapper::queryTargetClusters(double version, const char* clusterType, co
                 if (process && *process)
                 {
                     getTpEclCCServers(eclCCServerList, process);
+                }
+            }
+
+            //Read eclServer process
+            if ((version >= 1.19) && eclServerProcesses->first())
+            {
+                IArrayOf<IConstTpEclServer>& eclServerList = clusterInfo->getTpEclServers();
+                IPropertyTree &eclServerProcess = eclServerProcesses->query();
+                const char* process = eclServerProcess.queryProp("@process");
+                if (process && *process)
+                {
+                    getTpEclServers(eclServerList, process);
                 }
             }
 

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -164,7 +164,7 @@ public:
     void getMachineInfo(IEspTpMachine& machineInfo,IPropertyTree& machine,const char* ParentPath,const char* MachineType,const char* nodenametag);
 
     void getTpDaliServers(IArrayOf<IConstTpDali>& list);
-    void getTpEclServers(IArrayOf<IConstTpEclServer>& ServiceList);
+    void getTpEclServers(IArrayOf<IConstTpEclServer>& ServiceList, const char* name = NULL);
     void getTpEclCCServers(IArrayOf<IConstTpEclServer>& ServiceList, const char* name = NULL);
     void getTpEclCCServers(IPropertyTree* environmentSoftware, IArrayOf<IConstTpEclServer>& ServiceList, const char* name = NULL);
     void getTpEclAgents(IArrayOf<IConstTpEclAgent>& list, const char* name = NULL);


### PR DESCRIPTION
The Topology/TargetCluster page shows information about the thor,
eclagent, eclscheduler, but not the eclservers. This fix adds the
eclserver information inside the page.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
