### PR TITLE
HPCC-9199 Invalid params to control:querystats are not reported

### DIFF
--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -576,7 +576,7 @@ public:
                         CriticalBlock cb(crit);
                         if (mergedStats)
                         {
-                            mergeStats(mergedStats, &meat->query(), 0);
+                            mergeStats(mergedStats, &meat->query());
                         }
                         else
                             toXML(&meat->query(), reply);
@@ -607,7 +607,7 @@ public:
                 if (mergedStats)
                 {
                     Owned<IPropertyTree> xml = createPTreeFromXMLString(myReply);
-                    mergeStats(mergedStats, xml, 0);
+                    mergeStats(mergedStats, xml);
                 }
                 else
                     reply.append(myReply);

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1977,7 +1977,7 @@ private:
                     else if (stricmp(action, "selectGraph") == 0)
                         graphName = control->queryProp("Query/@name");
                     else if (stricmp(action, "allGraphs") != 0)  // if we get here and its NOT allgraphs - then error
-                        throw MakeStringException(ROXIE_CONTROL_MSG_ERROR, "invalid action in control:queryState %s", action);
+                        throw MakeStringException(ROXIE_CONTROL_MSG_ERROR, "invalid action in control:queryStats %s", action);
                 }
                 ReadLockBlock readBlock(packageCrit);
                 allQueryPackages->getStats(reply, id, action, graphName, logctx);
@@ -2498,6 +2498,16 @@ void mergeStats(IPropertyTree *s1, IPropertyTree *s2, unsigned level)
     }
 }
 
+void mergeStats(IPropertyTree *s1, IPropertyTree *s2)
+{
+    Owned<IPropertyTreeIterator> elems = s2->getElements("Exception");
+    ForEach(*elems)
+    {
+        s1->addPropTree("Exception", LINK(&elems->query()));
+    }
+    mergeStats(s1, s2, 0);
+}
+
 #ifdef _USE_CPPUNIT
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -2688,7 +2698,7 @@ protected:
         Owned<IPropertyTree> p1 = createPTreeFromXMLString(g1);
         Owned<IPropertyTree> p2 = createPTreeFromXMLString(g2);
         Owned<IPropertyTree> e = createPTreeFromXMLString(expected);
-        mergeStats(p1, p2, 0);
+        mergeStats(p1, p2);
         StringBuffer s1, s2;
         toXML(p1, s1);
         toXML(e, s2);

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -129,6 +129,7 @@ extern void loadPlugins();
 extern void cleanupPlugins();
 
 extern void mergeStats(IPropertyTree *s1, IPropertyTree *s2, unsigned level);
+extern void mergeStats(IPropertyTree *s1, IPropertyTree *s2);
 
 extern const char *queryNodeFileName(const IPropertyTree &graphNode);
 extern const char *queryNodeIndexName(const IPropertyTree &graphNode);


### PR DESCRIPTION
Extend mergestats capabilities to include exceptions.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
