### PR TITLE
HPCC-9240 Workunit monitoring is "lumpy" and too aggressive

### DIFF
--- a/esp/files/scripts/ESPUtil.js
+++ b/esp/files/scripts/ESPUtil.js
@@ -63,8 +63,14 @@ define([
     });
 
     var Monitor = declare(null, {
-        startMonitor: function () {
-            this._timerTickCount = 0;
+        isMonitoring: function () {
+            return this._timer && this._timer > 0;
+        },
+        startMonitor: function (aggressive) {
+            if (this.isMonitoring()) 
+                return;
+
+            this._timerTickCount = aggressive ? 0 : Math.floor((Math.random() * 40) + 70);
             this._timer = 1000;
             this.onMonitor();
         },

--- a/esp/files/scripts/ESPWorkunit.js
+++ b/esp/files/scripts/ESPWorkunit.js
@@ -203,7 +203,9 @@ define([
             var context = this;
             WsWorkunits.WUCreate({
                 load: function (response) {
-                    _workunits[response.WUCreateResponse.Workunit.Wuid] = context
+                    _workunits[response.WUCreateResponse.Workunit.Wuid] = context;
+                    context.Wuid = response.WUCreateResponse.Workunit.Wuid;
+                    context.startMonitor(true);
                     context.updateData(response.WUCreateResponse.Workunit);
                     context.onCreate();
                 }


### PR DESCRIPTION
Running workunits not created by the local user should not have the initial
"aggressive" polling pattern.
When polling is started on several WUs at once, the calls should be staggered
a bit to help performance.

Fixes HPCC-9240

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
