### PR TITLE
HPCC-9242 Can't delete a roxie query using the ECL Watch Queries Browse ...

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1100,7 +1100,8 @@ bool CWsWorkunitsEx::onWUQuerysetQueryAction(IEspContext &context, IEspWUQuerySe
                     break;
             }
             result->setSuccess(true);
-            result->setSuspended(query->getPropBool("@suspended"));
+            if (req.getAction() != CQuerySetQueryActionTypes_Delete)
+                result->setSuspended(query->getPropBool("@suspended"));
         }
         catch(IException *e)
         {


### PR DESCRIPTION
...page

Testing the suspended propery of the query, after it had been deleted.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
