### PR TITLE
HPCC-9246 SOAPCALL may lose records in 4.0.0-rc6

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -13813,7 +13813,6 @@ public:
 //=================================================================================
 
 typedef SafeQueueOf<const void, true> SafeRowQueue;
-typedef SimpleInterThreadQueueOf<const void, true> InterThreadRowQueue;
 
 class CRowQueuePseudoInput : public CPseudoRoxieInput
 {

--- a/testing/ecl/roxie/soapcall.ecl
+++ b/testing/ecl/roxie/soapcall.ecl
@@ -54,7 +54,7 @@ END;
 
 output(SORT(SOAPCALL(d, 'http://127.0.0.1:9876|http://127.0.0.1:9875','soapbase', { unkname }, DATASET(ServiceOutRecord), onFail(doError(LEFT)),RETRY(0), log('SOAP: ' + unkname),TIMEOUT(1)), record));
 output(SORT(SOAPCALL('http://127.0.0.1:9876','soapbase', { string unkname := 'FAIL' }, dataset(ServiceOutRecord),onFail(doError2),RETRY(0), LOG(MIN)),record));
-output(SORT(SOAPCALL(d, 'http://127.0.0.1:9876','soapbaseNOSUCHQUERY', { unkname }, DATASET(ServiceOutRecord), onFail(doError(LEFT)),MERGE(25),RETRY(0), LOG(MIN)), record));
+output(SORT(SOAPCALL(d, 'http://127.0.0.1:9876','soapbaseNOSUCHQUERY', { unkname }, DATASET(ServiceOutRecord), onFail(doError(LEFT)),MERGE(25),PARALLEL(1),RETRY(0), LOG(MIN)), record));
 
 childRecord := record
 unsigned            id;


### PR DESCRIPTION
A regression while fixing HPCC-8978 (SOAPCALL in child queries) introduced
a race condition into SOAPCALL that could result in records being lost.

A separate race condition that meant the result of the sopcall.ecl regression
test might be indeterminate in the number of error rows returned was spotted
while tracking down this issue (rows are allocated to caller threads
indeterminately, but exceptions may be reported one per batch).  That one
is not fixed - it's pretty benign - but the test was changed to ensure that
it does not give false positives in the regression suite.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
