### PR TITLE
HPCC-9245 Packagemap needs to support mixed case package ids

### DIFF
--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -197,7 +197,7 @@ void addPackageMapInfo(IPropertyTree *pkgSetRegistry, const char *target, const 
 
 
     mapTree = root->addPropTree("PackageMap", createPTree());
-    mapTree->addProp("@id", packageMapName);
+    mapTree->addProp("@id", lcName);
 
     StringArray fileNames;
     Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(target);


### PR DESCRIPTION
Signed-off-by: Stuart Ort stuart.ort@lexisnexis.com
