### PR TITLE
HPCC-9157 - Dfu server partition calculation not efficient when more tha...

### DIFF
--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -258,6 +258,8 @@ protected:
     bool usePullOperation();
     void updateSizeRead();
     void waitForTransferSem(Semaphore & sem);
+    void addPrefix(size32_t len, const void * data, unsigned idx);
+    void publishHeaders();
 
 private:
     bool calcUsePull();
@@ -312,6 +314,7 @@ protected:
     size32_t                transferBufferSize;
     StringAttr              encryptKey;
     StringAttr              decryptKey;
+    PartitionPointArray     partitionWork;
 };
 
 

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -258,9 +258,8 @@ protected:
     bool usePullOperation();
     void updateSizeRead();
     void waitForTransferSem(Semaphore & sem);
-    void addPrefix(size32_t len, const void * data, unsigned idx);
-    void publishHeaders();
-
+    void addPrefix(size32_t len, const void * data, unsigned idx, PartitionPointArray & partitionWork);
+    
 private:
     bool calcUsePull();
 
@@ -314,7 +313,6 @@ protected:
     size32_t                transferBufferSize;
     StringAttr              encryptKey;
     StringAttr              decryptKey;
-    PartitionPointArray     partitionWork;
 };
 
 


### PR DESCRIPTION
...n 2M file sprayed

This improvement impact the partition calculation speed if any prefix defined
in dfuplus spray command.

The original version inserted the prefix headers into the existing partition
data. With large amount of data it takes long time (322 sec for 1M,
1445 sec for 2M and 9739 sec for 4M files).

The new approach merges original partition items with prefix headers into a
new array. At the end it copies the merged items into the original partition
array. 

Comparison between old and new partition calculation time consumption:

Number
of files           Old solution             New
32k                      < 1s                 < 1s
64k                         2s                 < 1s
128k                       5s                    1s
256k                     22s                    2s
512k                     82s                    7s
1M                      322s                  14s
2M                    1445s                  17s
4M                    9739s                  32s

Signed-off-by: Attila Vamos attila.vamos@gmail.com
