### PR TITLE
HPCC-9251 Incorrect check of dali UNKNOWN USER

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -923,8 +923,8 @@ public:
         obj.set(_obj); 
 #ifndef _NO_DALIUSER_STACKTRACE
         StringBuffer sb;
-        if (udesc)
-            udesc->getUserName(sb);
+        if (_udesc)
+            _udesc->getUserName(sb);
         if (sb.length()==0)
         {
             DBGLOG("UNEXPECTED USER (NULL) in dasess.cpp CLdapWorkItem::start() line %d",__LINE__);


### PR DESCRIPTION
In dasess.cpp, CLdapWorkItem::start incorrect examines member "udesc"
when it should be checking "_udesc"

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
