### PR TITLE
HPCC-7866 - Use CInterfaceOf instead of double inheritance

### DIFF
--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -573,7 +573,7 @@ void CClientRemoteTree::beforeDispose()
 void CClientRemoteTree::Link() const
 {
     connection.Link(); // inc ref count on connection
-    CInterface::Link();
+    CRemoteTreeBase::Link();
 }
 
 bool CClientRemoteTree::Release() const
@@ -581,12 +581,12 @@ bool CClientRemoteTree::Release() const
     //Note: getLinkCount() is not thread safe.
     if (1 < getLinkCount())  //NH -> JCS - you sure this is best way to do this?
     {           
-        bool res = CInterface::Release();
+        bool res = CRemoteTreeBase::Release();
         connection.Release(); // if this tree is not being destroyed then decrement usage count on connection
         return res;
     }
     else
-        return CInterface::Release();
+        return CRemoteTreeBase::Release();
 }
 
 void CClientRemoteTree::deserializeSelfRT(MemoryBuffer &mb)
@@ -766,7 +766,7 @@ ChildMap *CClientRemoteTree::_checkChildren()
 IPropertyTree *CClientRemoteTree::ownPTree(IPropertyTree *tree)
 {
     // if taking ownership of an orphaned clientremote tree need to reset it's attributes.
-    if ((connection.queryStateChanges()) && isEquivalent(tree) && (!QUERYINTERFACE(tree, CInterface)->IsShared()))
+    if ((connection.queryStateChanges()) && isEquivalent(tree) && (!QUERYINTERFACE(tree, CClientRemoteTree)->IsShared()))
     {
         ((CClientRemoteTree *)tree)->reset(CPS_Changed, true);
         return tree;

--- a/dali/base/dasds.ipp
+++ b/dali/base/dasds.ipp
@@ -234,8 +234,6 @@ class CSubscriberContainerList;
 class CRemoteTreeBase : public PTree
 {
 public:
-    IMPLEMENT_IINTERFACE;
-
     CRemoteTreeBase(MemoryBuffer &mb, CPState _state=CPS_Unchanged);
     CRemoteTreeBase(const char *name=NULL, IPTArrayValue *value=NULL, ChildMap *children=NULL, CPState _state=CPS_Unchanged);
     void reset(unsigned state, bool sub=false);

--- a/system/jlib/jptree.ipp
+++ b/system/jlib/jptree.ipp
@@ -307,7 +307,7 @@ public:
 };
 
 
-class jlib_decl PTree : public CInterface, implements IPropertyTree
+class jlib_decl PTree : public CInterfaceOf<IPropertyTree>
 {
 friend class SingleIdIterator;
 friend class PTLocalIteratorBase;
@@ -315,9 +315,6 @@ friend class PTIdMatchIterator;
 friend class ChildMap;
 
 public:
-    IMPLEMENT_IINTERFACE;
-    virtual bool IsShared() const { return CInterface::IsShared(); }
-
     PTree(MemoryBuffer &mb);
     PTree(const char *_name=NULL, byte _flags=0, IPTArrayValue *_value=NULL, ChildMap *_children=NULL);
     ~PTree();


### PR DESCRIPTION
Saves a few % points of memory

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
