### PR TITLE
HPCC-9215 DALI should not check LDAP for non managed scopes

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -188,6 +188,8 @@ interface ILdapClient : extends IInterface
     virtual ILdapConfig* queryConfig() = 0;
     virtual const char* getPasswordStorageScheme() = 0;
     virtual bool createUserScope(ISecUser& user) = 0;
+    virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) = 0;
+    virtual int queryDefaultPermission(ISecUser& user) = 0;
 };
 
 ILdapClient* createLdapClient(IPropertyTree* cfg);

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -247,7 +247,6 @@ public:
     IMPLEMENT_IINTERFACE
 
     CLdapSecResource(const char *name);
-
     void addAccess(int flags);
     void setAccessFlags(int flags);
     virtual void setRequiredAccessFlags(int flags);
@@ -439,6 +438,8 @@ public:
         return m_passwordExpirationWarningDays;
     }
     virtual bool createUserScopes();
+    virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes);
+    virtual int queryDefaultPermission(ISecUser& user);
 };
 
 #endif

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -285,7 +285,8 @@ public:
     }
 
     virtual bool createUserScopes() {UNIMPLEMENTED; return false;}
-
+    virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) {UNIMPLEMENTED; }
+    virtual int queryDefaultPermission(ISecUser& user) {UNIMPLEMENTED; }
 protected:
     const char* getServer(){return m_dbserver.toCharArray();}
     const char* getUser(){return m_dbuser.toCharArray();}

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -137,10 +137,13 @@ public:
 class CPermissionsCache
 {
 public:
-    CPermissionsCache() 
+    CPermissionsCache()
     { 
         m_cacheTimeout = 300;
         m_transactionalEnabled = false;
+        m_secMgr = NULL;
+        m_lastManagedFileScopesRefresh = 0;
+        m_defaultPermission = SecAccess_Unknown;
     }
     virtual ~CPermissionsCache();
 
@@ -165,7 +168,14 @@ public:
     const int getCacheTimeout() { return m_cacheTimeout; }
     bool  isCacheEnabled() { return m_cacheTimeout > 0; }
     void setTransactionalEnabled(bool enable) { m_transactionalEnabled = enable; }
-    bool isTransactionalEnabled() { return m_transactionalEnabled;} 
+    bool isTransactionalEnabled() { return m_transactionalEnabled;}
+
+    bool addManagedFileScopes(IArrayOf<ISecResource>& scopes);
+    void removeManagedFileScopes(IArrayOf<ISecResource>& scopes);
+    void removeAllManagedFileScopes();
+    bool queryPermsManagedFileScope(ISecUser& sec_user, const char * fullScope, StringBuffer& managedScope, int * accessFlags);
+    void setSecManager(ISecManager * secMgr) { m_secMgr = secMgr; }
+    int  queryDefaultPermission(ISecUser& user);
 private:
 
     typedef std::map<string, CResPermissionsCache*> MapResPermissionsCache;
@@ -180,6 +190,14 @@ private:
 
     MapUserCache m_userCache;
     Monitor m_userCacheMonitor;
+
+
+    //Managed File Scope support
+    int                         m_defaultPermission;
+    map<string, ISecResource*>  m_managedFileScopesMap;
+    Monitor                     m_managedFileScopesCacheMonitor;
+    ISecManager *               m_secMgr;
+    time_t                      m_lastManagedFileScopesRefresh;
 };
 
 time_t getThreadCreateTime();

--- a/system/security/shared/defaultsecuritymanager.hpp
+++ b/system/security/shared/defaultsecuritymanager.hpp
@@ -80,6 +80,8 @@ public:
         return true;
     }
     virtual bool createUserScopes() { return false; }
+    virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) { return 0; }
+    virtual int queryDefaultPermission(ISecUser& user) { return SecAccess_Full; }
 };
 
 class CLocalSecurityManager : public CDefaultSecurityManager

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -296,6 +296,8 @@ interface ISecManager : extends IInterface
     virtual const char * getDescription() = 0;
     virtual unsigned getPasswordExpirationWarningDays() = 0;
     virtual bool createUserScopes() = 0;
+    virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) = 0;
+    virtual int queryDefaultPermission(ISecUser& user) = 0;
 };
 
 interface IExtSecurityManager


### PR DESCRIPTION
Currently dali makes time consuming calls to LDAP to check the permissions
for every single file, even when that file not within a managed scope.
This was causing dali to delay workunits that used to run in seconds,
to over an hour or more. Additionally, DALI would call out to LDAP to check
a scope, even if that scope was a child of a scope with known permissions.

This fix corrects behavior in two ways.
First, checks if the scope is managed (if it was added to the ESP "FileScopes"
permissions), and if not, assign the default LDAP permission without a call
to LDAP.
Second, if it is part of a managed scope (exact match or a child of another
managed scope) then returns the cached permissions of the closest parent
scope, with an early exit in case of a DENY permission. If the scope is not
in the cache, a call to LDAP is made and the results are added to the cache
for subsequent calls.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
