### PR TITLE
HPCC-7976 Regression suite tests have hacks for platform()

### DIFF
--- a/testing/ecl/distmerge.ecl
+++ b/testing/ecl/distmerge.ecl
@@ -15,16 +15,11 @@
     limitations under the License.
 ############################################################################## */
 
-// temporary hack to get around codegen optimizing platform(),once call into global (and therefore hthor) context.
-nononcelib :=
-    SERVICE
-varstring platform() : library='graph', include='eclhelper.hpp', ctxmethod, entrypoint='getPlatform';
-    END;
-
 // Testing DISTRIBUTE,MERGE
 
-unsigned numrecs := 1000000 : stored('numrecs');
+IMPORT std;
 
+unsigned numrecs := 1000000 : stored('numrecs');
 
 rec1 := record
          string20 key;
@@ -61,7 +56,7 @@ rollup_ds := ROLLUP(hdsds,checksort(LEFT, RIGHT),TRUE,LOCAL);
 
 
 SEQUENTIAL(
-  IF (COUNT(rollup_ds) = IF(nononcelib.platform()='roxie',1,CLUSTERSIZE),
+  IF (COUNT(rollup_ds) = IF(Std.System.Thorlib.platform()='roxie',1,CLUSTERSIZE),
      output('Sort order verified'), 
      FAIL('ERROR: rollup count did not match expected!')
   ),

--- a/testing/ecl/fetch.ecl
+++ b/testing/ecl/fetch.ecl
@@ -17,6 +17,9 @@
 
 //UseStandardFiles
 //UseIndexes
+
+IMPORT Std;
+
 recplus := {string45 name, unsigned8 rfpos, DG_FlatFileEvens};
 
 recplus makeRec(DG_FlatFileEvens L, DG_indexFileEvens R, string name) := TRANSFORM
@@ -45,18 +48,12 @@ varrecplus makeVarRecSkip(DG_VarFile L, DG_VarIndex R, string name) := TRANSFORM
     self := L;
 END;
 
-// temporary hack to get around codegen optimizing platform(),once call into global (and therefore hthor) context.
-nononcelib := 
-    SERVICE
-varstring platform() : library='graph', include='eclhelper.hpp', ctxmethod, entrypoint='getPlatform';
-    END;
-
 sortFixed(dataset(recplus) ds) := FUNCTION
-    RETURN IF(nononcelib.platform() = 'thor', SORT(ds, rfpos), ds);
+    RETURN IF(Std.System.Thorlib.platform() = 'thor', SORT(ds, rfpos), ds);
 END;
 
 sortVar(dataset(varrecplus) ds) := FUNCTION
-    RETURN IF(nononcelib.platform() = 'thor', SORT(ds, rfpos), ds);
+    RETURN IF(Std.System.Thorlib.platform() = 'thor', SORT(ds, rfpos), ds);
 END;
 
 SDG_indexFileEvens := SORT(DG_indexFileEvens, filepos);

--- a/testing/ecl/fetch2.ecl
+++ b/testing/ecl/fetch2.ecl
@@ -17,6 +17,8 @@
 
 //UseStandardFiles
 
+IMPORT Std;
+
 //Daft test of fetch retrieving a dataset
 myPeople := sqSimplePersonBookDs(surname <> '');
 
@@ -42,17 +44,11 @@ fetched := fetch(sqSimplePersonBookDs, myPeople, right.filepos, makeRec(left, ri
 fetched2 := fetch(sqSimplePersonBookDs, myPeople, right.filepos, makeRec2(left, right));
 fetched3 := fetch(sqSimplePersonBookDs, myPeople, right.filepos, makeRec3(left, right));
 
-// temporary hack to get around codegen optimizing platform(),once call into global (and therefore hthor) context.
-nononcelib := 
-    SERVICE
-varstring platform() : library='graph', include='eclhelper.hpp', ctxmethod, entrypoint='getPlatform';
-    END;
-
 recordof(sqSimplePersonBookDs) removeFp(recfp l) := TRANSFORM
     SELF := l;
 END;
 sortIt(dataset(recfp) ds) := FUNCTION
-    RETURN IF(nononcelib.platform() = 'thor', PROJECT(SORT(ds, rfpos),removeFp(LEFT)), PROJECT(ds,removeFp(LEFT)));
+    RETURN IF(Std.System.Thorlib.platform() = 'thor', PROJECT(SORT(ds, rfpos),removeFp(LEFT)), PROJECT(ds,removeFp(LEFT)));
 END;
 
 sequential(

--- a/testing/ecl/indexread.ecl
+++ b/testing/ecl/indexread.ecl
@@ -18,6 +18,8 @@
 //UseStandardFiles
 //UseIndexes
 
+IMPORT Std;
+
 // try it with just one limit
 
 o1 := output(LIMIT(DG_FetchIndex1(Lname='Anderson'),1,SKIP), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
@@ -25,17 +27,11 @@ o2 := output(LIMIT(DG_FetchIndex1(Lname='Anderson'),10,SKIP), {Lname,Fname,TRIM(
 o3 := output(LIMIT(DG_FetchIndex1(Lname='Anderson'),1,SKIP,KEYED), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
 o4 := output(LIMIT(DG_FetchIndex1(Lname='Anderson'),10,SKIP,KEYED), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
 
-// hack to get around codegen optimizing platform(),once call into global (and therefore hthor) context.
-nononcelib := 
-    SERVICE
-varstring platform() : library='graph', include='eclhelper.hpp', ctxmethod, entrypoint='getPlatform';
-    END;
-
 iresult := DG_FetchIndex1(Lname IN ['Anderson', 'Taylor']);
 
 lkresult := LIMIT(iresult,10,KEYED);
 lsresult := LIMIT(lkresult,10,SKIP);
-sresult := IF(nononcelib.platform() != 'hthor', SORT(lsresult,Lname), lsresult);
+sresult := IF(Std.System.Thorlib.platform() != 'hthor', SORT(lsresult,Lname), lsresult);
 o5 := output(sresult, {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
 
 // then try with a keyed and unkeyed....

--- a/testing/ecl/keyed_fetch.ecl
+++ b/testing/ecl/keyed_fetch.ecl
@@ -17,22 +17,18 @@
 
 //UseStandardFiles
 //UseIndexes
+IMPORT Std;
+
 TYPEOF(DG_FetchFile) copy(DG_FetchFile l) := TRANSFORM
     SELF.__filepos := 0; // filepos is not consistent between different test modes, so suppress it from output
     SELF := l;
 END;
 
-// hack to get around codegen optimizing platform(),once call into global (and therefore hthor) context.
-nononcelib := 
-    SERVICE
-varstring platform() : library='graph', include='eclhelper.hpp', ctxmethod, entrypoint='getPlatform';
-    END;
-
 TYPEOF(DG_FetchFile) maybesort(TYPEOF(DG_FetchFile) in) :=
 #if (useLocal)
   SORT(in, fname, lname);
 #else
-  IF(nononcelib.platform() = 'thor', SORT(in, fname, lname), in);
+  IF(Std.System.Thorlib.platform() = 'thor', SORT(in, fname, lname), in);
 #end
 
 output(maybesort(FETCH(DG_FetchFile, DG_FetchIndex1(Lname='Anderson'),RIGHT.__filepos, copy(LEFT))));


### PR DESCRIPTION
Remove temporary hacks that are no longer needed

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
