### PR TITLE
HPCC-9264 - Avoid possible deadlocks if error gathering lookup RHS

### DIFF
--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -547,6 +547,8 @@ void CThreadedPersistent::main()
         }
         catch (IException *e)
         {
+            VStringBuffer errMsg("CThreadedPersistent (%s)", athread.getName());
+            EXCLOG(e, errMsg.str());
             exception.setown(e);
             joinSem.signal(); // leave in running state, signal to join to handle
             continue;


### PR DESCRIPTION
If an exception occurred whilst gathering the RHS, the exception
could be lost by the one of the broadcast or processing threads.
The exception was tucked away waiting for the offending thread to
be joined, which never heappened.
Handle exception, retain and abort the broadcast.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
