### PR TITLE
HPCC-9277 Excessive tracing in lookupFileName

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -399,7 +399,8 @@ public:
     {
         StringBuffer fileName;
         expandLogicalFilename(fileName, _fileName, wu, false);
-        DBGLOG("lookupFileName %s", fileName.str());
+        if (traceLevel > 5)
+            DBGLOG("lookupFileName %s", fileName.str());
 
         const IResolvedFile *result = lookupFile(fileName, cache, false, false);
         if (!result)


### PR DESCRIPTION
Make it conditional on traceLevel

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
