### PR TITLE
HPCC-9279 REGRESSION - ESP cored when trying to view a file

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -5057,7 +5057,7 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
 
     Owned<IUserDescriptor> udesc;
     ISecUser * secUser = context.queryUser();
-    if(secUser->getName() && *secUser->getName())
+    if(secUser && secUser->getName() && *secUser->getName())
     {
         udesc.setown(createUserDescriptor());
         udesc->set(secUser->getName(), secUser->credentials().getPassword());


### PR DESCRIPTION
Changes for issue HPCC-9178 introduced a core on systems with no
authentication set up.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
