### PR TITLE
HPCC-2284 Reduce size of the continuation info for Roxie indexes

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -3574,7 +3574,9 @@ public:
                             }
                             else
                             {
-                                // MORE - this is actually pretty fatal fo smart-stepping case
+                                // This is actually pretty fatal for smart-stepping case
+                                if (logctx.queryTraceLevel())
+                                    logctx.CTXLOG("Indexread unable to return partial result set");
                                 continuationFailed = true;
                             }
                         }

--- a/system/jhtree/jhtree.hpp
+++ b/system/jhtree/jhtree.hpp
@@ -49,7 +49,7 @@ interface jhtree_decl IKeyCursor : public IInterface
     virtual size32_t getSize() = 0;
     virtual offset_t getFPos() = 0;
     virtual void serializeCursorPos(MemoryBuffer &mb) = 0;
-    virtual void deserializeCursorPos(MemoryBuffer &mb) = 0;
+    virtual void deserializeCursorPos(MemoryBuffer &mb, char *keyBuffer) = 0;
     virtual unsigned __int64 getSequence() = 0;
     virtual const byte *loadBlob(unsigned __int64 blobid, size32_t &blobsize) = 0;
     virtual void releaseBlobs() = 0;

--- a/system/jhtree/jhtree.ipp
+++ b/system/jhtree/jhtree.ipp
@@ -179,7 +179,7 @@ public:
     virtual size32_t getSize();
     virtual offset_t getFPos(); 
     virtual void serializeCursorPos(MemoryBuffer &mb);
-    virtual void deserializeCursorPos(MemoryBuffer &mb);
+    virtual void deserializeCursorPos(MemoryBuffer &mb, char *keyBuffer);
     virtual unsigned __int64 getSequence(); 
     virtual const byte *loadBlob(unsigned __int64 blobid, size32_t &blobsize);
     virtual void releaseBlobs();


### PR DESCRIPTION
No need to serialize the key buffer contents - can be retrieved from the index

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
