### PR TITLE
HPCC-9255 WsEcl should use IWorkUnit::setXmlParams to set stored values

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -2096,70 +2096,6 @@ int CWsEclBinding::getWsEcl2Form(CHttpRequest* request, CHttpResponse* response,
     return 0;
 }
 
-void CWsEclBinding::addParameterToWorkunit(IWorkUnit * workunit, IConstWUResult &vardef, IResultSetMetaData &metadef, const char *varname, IPropertyTree *valtree)
-{
-    if (!varname || !*varname)
-        return;
-
-    Owned<IWUResult> var = workunit->updateVariableByName(varname);
-    if (!vardef.isResultScalar())
-    {
-        StringBuffer ds;
-        if (valtree->hasChildren())
-            toXML(valtree, ds);
-        else
-        {
-            const char *val = valtree->queryProp(NULL);
-            if (val)
-                decodeXML(val, ds);
-        }
-        if (ds.length())
-            var->setResultRaw(ds.length(), ds.str(), ResultFormatXml);
-    }
-    else
-    {
-        const char *val = valtree->queryProp(NULL);
-        if (val && *val)
-        {
-            switch (metadef.getColumnDisplayType(0))
-            {
-                case TypeBoolean:
-                    var->setResultBool(strieq(val, "1") || strieq(val, "true") || strieq(val, "on"));
-                    break;
-                case TypeInteger:
-                    var->setResultInt(_atoi64(val));
-                    break;
-                case TypeUnsignedInteger:
-                    var->setResultInt(_atoi64(val));
-                    break;
-                case TypeReal:
-                    var->setResultReal(atof(val));
-                    break;
-                case TypeSet:
-                case TypeDataset:
-                case TypeData:
-                    var->setResultRaw(strlen(val), val, ResultFormatRaw);
-                    break;
-                case TypeUnicode: {
-                    MemoryBuffer target;
-                    convertUtf(target, UtfReader::Utf16le, strlen(val), val, UtfReader::Utf8);
-                    var->setResultUnicode(target.toByteArray(), (target.length()>1) ? target.length()/2 : 0);
-                    }
-                    break;
-                case TypeString:
-                case TypeUnknown:
-                default:
-                    var->setResultString(val, strlen(val));
-                    break;
-                    break;
-            }
-
-            var->setResultStatus(ResultStatusSupplied);
-        }
-    }
-}
-
-
 int CWsEclBinding::submitWsEclWorkunit(IEspContext & context, WsEclWuInfo &wsinfo, const char *xml, StringBuffer &out, unsigned flags, const char *viewname, const char *xsltname)
 {
     Owned <IWorkUnitFactory> factory = getSecWorkUnitFactory(*context.querySecManager(), *context.queryUser());
@@ -2188,22 +2124,7 @@ int CWsEclBinding::submitWsEclWorkunit(IEspContext & context, WsEclWuInfo &wsinf
         start=start->queryPropTree("Envelope");
     if (start->hasProp("Body"))
         start=start->queryPropTree("Body/*[1]");
-
-    Owned<IResultSetFactory> resultSetFactory(getResultSetFactory(context.queryUserId(), context.queryPassword()));
-    Owned<IPropertyTreeIterator> it = start->getElements("*");
-    ForEach(*it)
-    {
-        IPropertyTree &eclparm=it->query();
-        const char *varname = eclparm.queryName();
-
-        IConstWUResult *vardef = wsinfo.wu->getVariableByName(varname);
-        if (vardef)
-        {
-            Owned<IResultSetMetaData> metadef = resultSetFactory->createResultSetMeta(vardef);
-            if (metadef)
-                addParameterToWorkunit(workunit.get(), *vardef, *metadef, varname, &eclparm);
-        }
-    }
+    workunit->setXmlParams(LINK(start));
 
     workunit->schedule();
     workunit.clear();

--- a/esp/services/ws_ecl/ws_ecl_service.hpp
+++ b/esp/services/ws_ecl/ws_ecl_service.hpp
@@ -170,8 +170,6 @@ public:
 
     int submitWsEclWorkunit(IEspContext & context, WsEclWuInfo &wsinfo, const char *xml, StringBuffer &out, unsigned flags, const char *viewname=NULL, const char *xsltname=NULL);
 
-    void addParameterToWorkunit(IWorkUnit * workunit, IConstWUResult &vardef, IResultSetMetaData &metadef, const char *varname, IPropertyTree *valtree);
-    
     void handleHttpPost(CHttpRequest *request, CHttpResponse *response);
     void handleJSONPost(CHttpRequest *request, CHttpResponse *response);
 


### PR DESCRIPTION
This will simplify the implementation and solve issues related to empty
vs non-existent elements.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
