### PR TITLE
HPCC-9225 Allow WsEcl caller to specify jobname

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -2172,7 +2172,11 @@ int CWsEclBinding::submitWsEclWorkunit(IEspContext & context, WsEclWuInfo &wsinf
     workunit->resetWorkflow();
     workunit->setClusterName(wsinfo.qsetname.sget());
     workunit->setUser(context.queryUserId());
-    
+
+    const char *jobname = context.queryRequestParameters()->queryProp("_jobname");
+    if (jobname && *jobname)
+        workunit->setJobName(jobname);
+
     SCMStringBuffer wuid;
     workunit->getWuid(wuid);
 


### PR DESCRIPTION
By default WsEcl gives a result workunit the same jobname as the
published query workunit.  Allow _jobname=<name> to be specified in
the url used to submit the query so that the user can create a
unique jobname each time the query is invoked.

Works for HTTP-GET URL, SOAP, XML POST, FORM POST, JSON POST.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
