### PR TITLE
HPCC-9326 - onStartCalled not set if nullact causing assert

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -554,16 +554,20 @@ void CGraphElementBase::onCreate()
 
 void CGraphElementBase::onStart(size32_t parentExtractSz, const byte *parentExtract)
 {
-    if (nullAct ||onStartCalled) return;
-    if (haveStartCtx)
-    {
-        baseHelper->onStart(parentExtract, &startCtxMb);
-        startCtxMb.reset();
-        haveStartCtx = false;
-    }
-    else
-        baseHelper->onStart(parentExtract, NULL);
+    if (onStartCalled)
+        return;
     onStartCalled = true;
+    if (!nullAct)
+    {
+        if (haveStartCtx)
+        {
+            baseHelper->onStart(parentExtract, &startCtxMb);
+            startCtxMb.reset();
+            haveStartCtx = false;
+        }
+        else
+            baseHelper->onStart(parentExtract, NULL);
+    }
 }
 
 bool CGraphElementBase::executeDependencies(size32_t parentExtractSz, const byte *parentExtract, int controlId, bool async)


### PR DESCRIPTION
A null act was bypassing normal initialization, but also
bypassing setting onStartCalled to true. As a result a null act
in a child query was hitting an assert during initialization

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
