### PR TITLE
HPCC-9328 - fix misue of a queryProp, should be getPropBool

### DIFF
--- a/common/remote/rmtfile.cpp
+++ b/common/remote/rmtfile.cpp
@@ -180,7 +180,7 @@ CDaliServixFilter *createDaliServixFilter(IPropertyTree &filterProps)
     CDaliServixFilter *filter = NULL;
     const char *dir = filterProps.queryProp("@directory");
     const char *sourceRange = filterProps.queryProp("@sourcerange");
-    bool trace = filterProps.queryProp("@trace");
+    bool trace = filterProps.getPropBool("@trace");
     if (filterProps.hasProp("@subnet"))
         filter = new CDaliServixSubnetFilter(filterProps.queryProp("@subnet"), filterProps.queryProp("@mask"), dir, sourceRange, trace);
     else if (filterProps.hasProp("@range"))


### PR DESCRIPTION
(Caused a compiler warning)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
