### PR TITLE
HPCC-9271 Show 'truncated' message for viewing large file

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -1230,7 +1230,7 @@
       <xsl:if test="Type = 'cpp'">
         <td>
           <a href="/WsWorkunits/WUFile/{Name}?Wuid={$wuid}&amp;Name={Name}&amp;IPAddress={IPAddress}&amp;Description={Description}&amp;Type=cpp" >
-            <xsl:value-of select="Description"/>
+            <xsl:value-of select="Description"/><xsl:if test="number(FileSize)>640000"> (Truncated to 640K bytes)</xsl:if>
           </a>
         </td>
         <td>
@@ -1254,7 +1254,7 @@
         <td>
           <a href="/esp/iframe?esp_iframe_title=ECL Workunit - {$wuid} - {Description}&amp;inner=
                    /WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Name%3d{Name}%26IPAddress%3d{IPAddress}%26Description%3d{Description}%26Type%3dXML" >
-            <xsl:value-of select="Description"/>
+            <xsl:value-of select="Description"/><xsl:if test="number(FileSize)>640000"> (Truncated to 640K bytes)</xsl:if>
           </a>
         </td>
         <td>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -114,6 +114,7 @@ ESPStruct [nil_remove] ECLHelpFile
     string Type;
     [min_ver("1.32")] string IPAddress;
     [min_ver("1.32")] string Description;
+    [min_ver("1.43")] int64 FileSize;
 };
 
 //  ===========================================================================
@@ -1338,7 +1339,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.42"), default_client_version("1.42"),
+    version("1.43"), default_client_version("1.43"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -523,6 +523,12 @@ void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
                 Owned<IEspECLHelpFile> h= createECLHelpFile("","");
                 h->setName(logName.str());
                 h->setType(File_EclAgentLog);
+                if (version >= 1.43)
+                {
+                    offset_t fileSize;
+                    if (getFileSize(logName.str(), NULL, fileSize))
+                        h->setFileSize(fileSize);
+                }
                 helpers.append(*h.getLink());
             }
         }
@@ -539,6 +545,12 @@ void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
                 Owned<IEspECLHelpFile> h= createECLHelpFile("","");
                 h->setName(name.str());
                 h->setType(File_EclAgentLog);
+                if (version >= 1.43)
+                {
+                    offset_t fileSize;
+                    if (getFileSize(name.str(), NULL, fileSize))
+                        h->setFileSize(fileSize);
+                }
                 helpers.append(*h.getLink());
                 break;
             }
@@ -965,6 +977,12 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
                 h->setName(logName.str());
                 h->setDescription(processName.str());
                 h->setType(fileType.str());
+                if (version >= 1.43)
+                {
+                    offset_t fileSize;
+                    if (getFileSize(logName.str(), NULL, fileSize))
+                        h->setFileSize(fileSize);
+                }
                 helpers.append(*h.getLink());
 
                 if (version < 1.38)
@@ -1012,6 +1030,12 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
             Owned<IEspECLHelpFile> h= createECLHelpFile("","");
             h->setName(name.str());
             h->setType(fileType.str());
+            if (version >= 1.43)
+            {
+                offset_t fileSize;
+                if (getFileSize(name.str(), NULL, fileSize))
+                    h->setFileSize(fileSize);
+            }
             helpers.append(*h.getLink());
         }
 
@@ -1467,15 +1491,43 @@ void WsWuInfo::getResults(IEspECLWorkunit &info, unsigned flags)
     }
 }
 
+bool WsWuInfo::getFileSize(const char* fileName, const char* IPAddress, offset_t& fileSize)
+{
+    if (!fileName || !*fileName)
+        return false;
+
+    Owned<IFile> aFile;
+    if (!IPAddress || !*IPAddress)
+    {
+        aFile.setown(createIFile(fileName));
+    }
+    else
+    {
+        RemoteFilename rfn;
+        rfn.setRemotePath(fileName);
+        SocketEndpoint ep(IPAddress);
+        rfn.setIp(ep);
+        aFile.setown(createIFile(rfn));
+    }
+    if (!aFile)
+        return false;
+
+    bool isDir;
+    CDateTime modtime;
+    if (!aFile->getInfo(isDir, fileSize, modtime) || isDir)
+        return false;
+    return true;
+}
+
 void WsWuInfo::getHelpFiles(IConstWUQuery* query, WUFileType type, IArrayOf<IEspECLHelpFile>& helpers)
 {
     if (!query)
         return;
 
-    SCMStringBuffer name, Ip, description;
     Owned<IConstWUAssociatedFileIterator> iter = &query->getAssociatedFiles();
     ForEach(*iter)
     {
+        SCMStringBuffer name, Ip, description;
         IConstWUAssociatedFile & cur = iter->query();
         if (cur.getType() != type)
             continue;
@@ -1489,7 +1541,6 @@ void WsWuInfo::getHelpFiles(IConstWUQuery* query, WUFileType type, IArrayOf<IEsp
         {
             cur.getIp(Ip);
             h->setIPAddress(Ip.str());
-            Ip.clear();
 
             cur.getDescription(description);
             if ((description.length() < 1) && (name.length() > 0))
@@ -1503,11 +1554,14 @@ void WsWuInfo::getHelpFiles(IConstWUQuery* query, WUFileType type, IArrayOf<IEsp
                 description.set("Help File");
 
             h->setDescription(description.str());
-            description.clear();
+            if (version >= 1.43)
+            {
+                offset_t fileSize;
+                if (getFileSize(name.str(), Ip.str(), fileSize))
+                    h->setFileSize(fileSize);
+            }
         }
-
         helpers.append(*h.getLink());
-        name.clear();
     }
 }
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -155,6 +155,7 @@ public:
     void getHelpers(IEspECLWorkunit &info, unsigned flags);
     void getGraphInfo(IEspECLWorkunit &info, unsigned flags);
     void getGraphTimingData(IArrayOf<IConstECLTimingData> &timingData, unsigned flags);
+    bool getFileSize(const char* fileName, const char* IPAddress, offset_t& fileSize);
 
     void getRoxieCluster(IEspECLWorkunit &info, unsigned flags);
     void getWorkflow(IEspECLWorkunit &info, unsigned flags);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2534,7 +2534,13 @@ void openSaveFile(IEspContext &context, int opt, const char* filename, const cha
     {
         StringBuffer headerStr("attachment;");
         if (filename && *filename)
-            headerStr.appendf("filename=%s", filename);
+        {
+            const char* pFileName = strrchr(filename, PATHSEPCHAR);
+            if (pFileName)
+                headerStr.appendf("filename=%s", pFileName+1);
+            else
+                headerStr.appendf("filename=%s", filename);
+        }
 
         MemoryBuffer buf0;
         unsigned i = 0;


### PR DESCRIPTION
There is a 640k limit for viewing a helper file in ECL Workunit
Details page. This fix checks the size of a helper file. If it is
larger than 640k bytes, a message '(Truncated to 640K bytes)' will
be added beside the view file link.

When a helper file is downloaded, the existing code uses 'file path + file
 name' as 'attachment filename'. Internet browser replaces
the Path Separators in the file path with the '_'s and the file
name looks strange. This fix removes the file path from the
'attachment filename'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
