### PR TITLE
HPCC-9331 - Missing activity logging if local graph

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2549,7 +2549,7 @@ void CJobBase::addDependencies(IPropertyTree *xgmml, bool failIfMissing)
                     subGraph.setGlobal(true);
             }
         }
-        bool log = queryForceLogging(subGraph.queryGraphId(), subGraph.isGlobal());
+        bool log = queryForceLogging(subGraph.queryGraphId(), (NULL == subGraph.queryOwner()) || subGraph.isGlobal());
         subGraph.setLogging(log);
     }
 }


### PR DESCRIPTION
Test designed to suppress child query logging, was also
suppressing local only subgraph activity logging

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
