### PR TITLE
HPCC-9090 Add base 64 encode/decode functions to the ecllibrary

### DIFF
--- a/ecllibrary/std/Str.ecl
+++ b/ecllibrary/std/Str.ecl
@@ -11,8 +11,6 @@ data DecodeBase64(const string src) :   eclrtl,pure,include,library='eclrtl',ent
 
 EXPORT Str := MODULE
 
-EXPORT STRING EncodeBase64(data value) := externals.EncodeBase64(value);
-EXPORT DATA DecodeBase64(STRING value) := externals.DecodeBase64(value);
 
 /*
   Since this is primarily a wrapper for a plugin, all the definitions for this standard library
@@ -400,5 +398,35 @@ EXPORT string ToHexPairs(data value) := lib_stringlib.StringLib.Data2String(valu
  */
 
 EXPORT data FromHexPairs(string hex_pairs) := lib_stringlib.StringLib.String2Data(hex_pairs);
+
+/*
+ * Encode binary data to base64 string.
+ *
+ * Every 3 data bytes encoded to 4 base64 chars. If the length of binary data is not divisible 
+ * by 3 then extra 1 or 2 bytes with value 0 added into it. 
+ * At the encoded string there is one or two '=' indicates at the end of original data is one or 
+ * two valid byte exists. 
+ *
+ *
+ * @param value         The binary data array to process.
+ * @return              Base 64 encoded string.
+ */
+
+EXPORT STRING EncodeBase64(data value) := externals.EncodeBase64(value);
+
+/*
+ * Decode base64 encoded string to binary data.
+ *
+ * Decoder handles zero length input, input string with '\n' and/or space chars as valid input.
+ *
+ * If the input has length error (not enough valid base 64 char to decode or missing pad '=' char(s))
+ * or the input contains invalid (not base 64) chars then returns with zero length data array. 
+ *
+ *
+ * @param value        The base 64 encoded string.
+ * @return             Decoded binary data if the input is valid else zero length data.
+ */
+
+EXPORT DATA DecodeBase64(STRING value) := externals.DecodeBase64(value);
 
 END;

--- a/ecllibrary/std/Str.ecl
+++ b/ecllibrary/std/Str.ecl
@@ -2,7 +2,17 @@
 ## HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.  All rights reserved.
 ############################################################################## */
 
+
+externals := 
+    SERVICE
+string EncodeBase64(const data src) :   eclrtl,pure,include,library='eclrtl',entrypoint='rtlBase64Encode';
+data DecodeBase64(const string src) :   eclrtl,pure,include,library='eclrtl',entrypoint='rtlBase64Decode';
+    END;
+
 EXPORT Str := MODULE
+
+EXPORT STRING EncodeBase64(data value) := externals.EncodeBase64(value);
+EXPORT DATA DecodeBase64(STRING value) := externals.DecodeBase64(value);
 
 /*
   Since this is primarily a wrapper for a plugin, all the definitions for this standard library

--- a/ecllibrary/teststd/str/TestBase64Codec.ecl
+++ b/ecllibrary/teststd/str/TestBase64Codec.ecl
@@ -1,0 +1,19 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.  All rights reserved.
+############################################################################## */
+IMPORT Std.Str;
+
+EXPORT TestBase64Codec := MODULE
+
+  EXPORT TestConst := MODULE
+    EXPORT Test01 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'ca')) = x'ca');
+    EXPORT Test02 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'cafe')) = x'cafe');
+    EXPORT Test03 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'cafeba')) = x'cafeba');
+    EXPORT Test04 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'cafebabe')) = x'cafebabe');
+    EXPORT Test05 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'cafebabeca')) = x'cafebabeca');
+    EXPORT Test06 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'cafebabecafe')) = x'cafebabecafe');
+  END;
+
+  EXPORT Main := [EVALUATE(TestConst)]; 
+END;
+

--- a/ecllibrary/teststd/str/TestBase64Codec.ecl
+++ b/ecllibrary/teststd/str/TestBase64Codec.ecl
@@ -12,6 +12,63 @@ EXPORT TestBase64Codec := MODULE
     EXPORT Test04 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'cafebabe')) = x'cafebabe');
     EXPORT Test05 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'cafebabeca')) = x'cafebabeca');
     EXPORT Test06 := ASSERT(Str.DecodeBase64(Str.EncodeBase64(x'cafebabecafe')) = x'cafebabecafe');
+    
+    EXPORT Test07 := ASSERT(Str.EncodeBase64(x'ca') = 'yg==');
+    EXPORT Test08 := ASSERT(Str.EncodeBase64(x'cafe') = 'yv4=');
+    EXPORT Test09 := ASSERT(Str.EncodeBase64(x'cafeba') = 'yv66');
+    EXPORT Test10 := ASSERT(Str.EncodeBase64(x'cafebabe') = 'yv66vg==');
+    EXPORT Test11 := ASSERT(Str.EncodeBase64(x'cafebabeca') = 'yv66vso=');
+    EXPORT Test12 := ASSERT(Str.EncodeBase64(x'cafebabecafe') = 'yv66vsr+');
+
+    EXPORT Test13 := ASSERT(Str.DecodeBase64('yg==') = x'ca');
+    EXPORT Test14 := ASSERT(Str.DecodeBase64('yv4=') = x'cafe');
+    EXPORT Test15 := ASSERT(Str.DecodeBase64('yv66') = x'cafeba');
+    EXPORT Test16 := ASSERT(Str.DecodeBase64('yv66vg==') = x'cafebabe');
+    EXPORT Test17 := ASSERT(Str.DecodeBase64('yv66vso=') = x'cafebabeca');
+    EXPORT Test18 := ASSERT(Str.DecodeBase64('yv66vsr+') = x'cafebabecafe');
+
+    /* Invalid printable character e.g.'@' or '#' in the encoded string */	
+    EXPORT Test19 := ASSERT(Str.DecodeBase64('yg@=') = d'') ;
+    EXPORT Test20 := ASSERT(Str.DecodeBase64('#yg=') = d'') ;
+    EXPORT Test21 := ASSERT(Str.DecodeBase64('y#g=') = d'') ;
+    EXPORT Test22 := ASSERT(Str.DecodeBase64('yg#=') = d'') ;
+    EXPORT Test23 := ASSERT(Str.DecodeBase64('yg=#') = d'') ;
+
+    /* Invalid non-printable character e.g.'\t' or '\b' in the encoded string */
+    EXPORT Test24 := ASSERT(Str.DecodeBase64('y'+x'09'+'g=') = d'');
+    EXPORT Test25 := ASSERT(Str.DecodeBase64('y'+x'08'+'g=') = d'');
+
+    /* Missing pad character from encoded string (length error) */	
+    EXPORT Test26 := ASSERT(Str.DecodeBase64('yg=') = d'') ;
+    EXPORT Test27 := ASSERT(Str.DecodeBase64('yv66vg=') = d'');
+
+    /* Length error in encoded string. It doesn't multiple of 4 */	
+    EXPORT Test28 := ASSERT(Str.DecodeBase64('yv66v==') = d'') ;
+    EXPORT Test29 := ASSERT(Str.DecodeBase64('yv66vg=') = d'') ;
+
+    /* Space(s) in the encoded string */	
+    EXPORT Test30 := ASSERT(Str.DecodeBase64('y g==') = x'ca') ;
+    EXPORT Test31 := ASSERT(Str.DecodeBase64('y g = = ') = x'ca') ;
+	
+    /* Long text encoding. Encoder inserts '\n' to break long output lines. */
+    EXPORT DATA text := 
+           d'Man is distinguished, not only by his reason, but by this singular passion from other animals, '
+         + d'which is a lust of the mind, that by a perseverance of delight in the continued and '
+         + d'indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure.';
+
+    EXPORT STRING encodedText :=
+           'TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0'+'\n'
+         + 'aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1'+'\n'
+         + 'c3Qgb2YgdGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0'+'\n'
+         + 'aGUgY29udGludWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdl'+'\n'
+         + 'LCBleGNlZWRzIHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=';
+
+    EXPORT TEST32 := ASSERT(Str.EncodeBase64(text) = encodedText);
+
+    /* Long encoded text decoding. Decoder skips '\n' characters in input string. */
+    EXPORT DATA decodedText := Str.DecodeBase64(encodedText);
+    EXPORT TEST33 := ASSERT(decodedText = text);
+
   END;
 
   EXPORT Main := [EVALUATE(TestConst)]; 

--- a/ecllibrary/teststd/str/TestBase64Codec.ecl
+++ b/ecllibrary/teststd/str/TestBase64Codec.ecl
@@ -69,6 +69,9 @@ EXPORT TestBase64Codec := MODULE
     EXPORT DATA decodedText := Str.DecodeBase64(encodedText);
     EXPORT TEST33 := ASSERT(decodedText = text);
 
+    /* Test encoder for zero length and full zero data input string. */
+    EXPORT TEST34 := ASSERT(Str.DecodeBase64('') = d'');
+    EXPORT TEST35 := ASSERT(Str.DecodeBase64(''+x'00000000') = d'');
   END;
 
   EXPORT Main := [EVALUATE(TestConst)]; 

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -5606,6 +5606,7 @@ IAtom * rtlCreateFieldNameAtom(const char * name)
 void rtlBase64Encode(size32_t & tlen, char * & tgt, size32_t slen, const void * src)
 {
     tlen = 0;
+    tgt = NULL;
     if (0 < slen )
     {
         StringBuffer out;
@@ -5614,7 +5615,7 @@ void rtlBase64Encode(size32_t & tlen, char * & tgt, size32_t slen, const void * 
         tlen = out.length();
         if( 0 < tlen)
         {
-            char * data  = (char *)malloc(tlen);
+            char * data  = (char *)rtlMalloc(tlen);
 
             if(NULL == data)
             {
@@ -5636,11 +5637,11 @@ void rtlBase64Decode(size32_t & tlen, void * & tgt, size32_t slen, const char * 
     {
         StringBuffer out;
         if( JBASE64_Decode(src, slen, out) )
-                    tlen = out.length();
+            tlen = out.length();
 
         if( 0 < tlen)
         {
-            char * data  = (char *)malloc(tlen);
+            char * data  = (char *)rtlMalloc(tlen);
             if(NULL == data)
             {
                 StringBuffer msg;

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -5603,17 +5603,55 @@ IAtom * rtlCreateFieldNameAtom(const char * name)
     return createAtom(name);
 }
 
-
-void rtlBase64Decode(unsigned & tlen, void * & tgt, unsigned slen, const char * src)
+void rtlBase64Encode(size32_t & tlen, char * & tgt, size32_t slen, const void * src)
 {
+    tlen = 0;
+    if (0 < slen )
+    {
+        StringBuffer out;
+        JBASE64_Encode(src, slen, out);
 
+        tlen = out.length();
+        if( 0 < tlen)
+        {
+            char * data  = (char *)malloc(tlen);
 
+            if(NULL == data)
+            {
+                StringBuffer msg;
+                msg.append("Memory allocation error in ").append(__FILE__).append(" at line ").append(__LINE__).append(" for size ");
+                rtlFail(0, msg);
+            }
+
+            out.getChars(0, tlen, data);
+            tgt = data;
+        }
+    }
 }
 
-void rtlBase64Encode(unsigned & tlen, char * & tgt, unsigned slen, const void * src)
+void rtlBase64Decode(size32_t & tlen, void * & tgt, size32_t slen, const char * src)
 {
+    tlen = 0;
+    if( 0 < slen )
+    {
+        StringBuffer out;
+        JBASE64_Decode(src, slen, out);
 
+        tlen = out.length();
+        if( 0 < tlen)
+        {
+            char * data  = (char *)malloc(tlen);
+            if(NULL == data)
+            {
+                StringBuffer msg;
+                msg.append("Memory allocation error in ").append(__FILE__).append(" at line ").append(__LINE__).append(" for size ");
+                rtlFail(0, msg);
+            }
 
+            out.getChars(0, tlen, data);
+            tgt = (void *)data;
+        }
+    }
 }
 
 

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -5616,14 +5616,6 @@ void rtlBase64Encode(size32_t & tlen, char * & tgt, size32_t slen, const void * 
         if( 0 < tlen)
         {
             char * data  = (char *)rtlMalloc(tlen);
-
-            if(NULL == data)
-            {
-                StringBuffer msg;
-                msg.append("Memory allocation error in ").append(__FILE__).append(" at line ").append(__LINE__).append(" for size ");
-                rtlFail(0, msg);
-            }
-
             out.getChars(0, tlen, data);
             tgt = data;
         }
@@ -5636,19 +5628,12 @@ void rtlBase64Decode(size32_t & tlen, void * & tgt, size32_t slen, const char * 
     if( 0 < slen )
     {
         StringBuffer out;
-        if( JBASE64_Decode(src, slen, out) )
+        if( JBASE64_Decode(slen, src, out) )
             tlen = out.length();
 
         if( 0 < tlen)
         {
             char * data  = (char *)rtlMalloc(tlen);
-            if(NULL == data)
-            {
-                StringBuffer msg;
-                msg.append("Memory allocation error in ").append(__FILE__).append(" at line ").append(__LINE__).append(" for size ");
-                rtlFail(0, msg);
-            }
-
             out.getChars(0, tlen, data);
             tgt = (void *)data;
         }

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -5635,9 +5635,9 @@ void rtlBase64Decode(size32_t & tlen, void * & tgt, size32_t slen, const char * 
     if( 0 < slen )
     {
         StringBuffer out;
-        JBASE64_Decode(src, slen, out);
+        if( JBASE64_Decode(src, slen, out) )
+                    tlen = out.length();
 
-        tlen = out.length();
         if( 0 < tlen)
         {
             char * data  = (char *)malloc(tlen);

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -5604,6 +5604,20 @@ IAtom * rtlCreateFieldNameAtom(const char * name)
 }
 
 
+void rtlBase64Decode(unsigned & tlen, void * & tgt, unsigned slen, const char * src)
+{
+
+
+}
+
+void rtlBase64Encode(unsigned & tlen, char * & tgt, unsigned slen, const void * src)
+{
+
+
+}
+
+
+
 //---------------------------------------------------------------------------
 
 void RtlCInterface::Link() const            { atomic_inc(&xxcount); }

--- a/rtl/eclrtl/eclrtl.hpp
+++ b/rtl/eclrtl/eclrtl.hpp
@@ -722,8 +722,8 @@ ECLRTL_API void rtlFreeException(IException * e);
 
 ECLRTL_API IAtom * rtlCreateFieldNameAtom(const char * name);
 
-ECLRTL_API void rtlBase64Decode(unsigned & tlen, void * & tgt, unsigned slen, const char * src);
-ECLRTL_API void rtlBase64Encode(unsigned & tlen, char * & tgt, unsigned slen, const void * src);
+ECLRTL_API void rtlBase64Encode(size32_t & tlen, char * & tgt, size32_t slen, const void * src);
+ECLRTL_API void rtlBase64Decode(size32_t & tlen, void * & tgt, size32_t slen, const char * src);
 
 //Test functions:
 ECLRTL_API void rtlTestGetPrimes(size32_t & len, void * & data);

--- a/rtl/eclrtl/eclrtl.hpp
+++ b/rtl/eclrtl/eclrtl.hpp
@@ -722,7 +722,29 @@ ECLRTL_API void rtlFreeException(IException * e);
 
 ECLRTL_API IAtom * rtlCreateFieldNameAtom(const char * name);
 
+/**
+ * Wrapper function to encode input binary data with base 64 code.
+ *
+ * @param tlen          Encoded string length
+ * @param tgt           Pointer to encoded string
+ * @param slen          Input binary data length
+ * @param src           Pointer to input binary data
+ * @see                 void JBASE64_Encode(const void *data, long length, StringBuffer &out, bool addLineBreaks=true)
+ *                      function in jutil library
+ */
 ECLRTL_API void rtlBase64Encode(size32_t & tlen, char * & tgt, size32_t slen, const void * src);
+
+/**
+ * Wrapper function to decode base 64 encoded string.
+ * It handles when the decoder fails to decode string.
+ *
+ * @param tlen          Decoded data length
+ * @param tgt           Pointer to decoded data
+ * @param slen          Input string length
+ * @param src           Pointer to input string
+ * @see                 bool JBASE64_Decode(const char *in, long length, StringBuffer &out) function
+ *                      in jutil library.
+ */
 ECLRTL_API void rtlBase64Decode(size32_t & tlen, void * & tgt, size32_t slen, const char * src);
 
 //Test functions:

--- a/rtl/eclrtl/eclrtl.hpp
+++ b/rtl/eclrtl/eclrtl.hpp
@@ -722,6 +722,9 @@ ECLRTL_API void rtlFreeException(IException * e);
 
 ECLRTL_API IAtom * rtlCreateFieldNameAtom(const char * name);
 
+ECLRTL_API void rtlBase64Decode(unsigned & tlen, void * & tgt, unsigned slen, const char * src);
+ECLRTL_API void rtlBase64Encode(unsigned & tlen, char * & tgt, unsigned slen, const void * src);
+
 //Test functions:
 ECLRTL_API void rtlTestGetPrimes(size32_t & len, void * & data);
 ECLRTL_API void rtlTestFibList(bool & outAll, size32_t & outSize, void * & outData, bool inAll, size32_t inSize, const void * inData);

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -1145,6 +1145,40 @@ MemoryBuffer &JBASE64_Decode(const char *incs, MemoryBuffer &out)
     return out;
 }
 
+void JBASE64_Decode(const char *incs, long length, StringBuffer &out)
+{
+    out.ensureCapacity(length / 4 * 3);
+
+    unsigned char c1, c2, c3, c4;
+    unsigned char d1, d2, d3, d4;
+
+    for(long index = 0; index < length; index+=4)
+    {
+        c1 = *incs++;
+        if (!isspace(c1))
+        {
+            c2 = *incs++;
+            c3 = *incs++;
+            c4 = *incs++;
+            d1 = BASE64_dec[c1];
+            d2 = BASE64_dec[c2];
+            d3 = BASE64_dec[c3];
+            d4 = BASE64_dec[c4];
+
+            out.append((char)((d1 << 2) | (d2 >> 4)));
+
+            if(c3 == pad)
+                break;
+
+            out.append((char)((d2 << 4) | (d3 >> 2)));
+
+            if(c4 == pad)
+                break;
+
+            out.append((char)((d3 << 6) | d4));
+        }
+    }
+}
 
 static inline void encode5_32(const byte *in,StringBuffer &out)
 {

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -1154,7 +1154,7 @@ bool JBASE64_Decode(const char *incs, long length, StringBuffer &out)
     const char * end = incs + length;
     unsigned char c1;
     unsigned char c[4];
-    unsigned char cIndex = 0;
+    unsigned cIndex = 0;
     unsigned char d1, d2, d3, d4;
     bool fullQuartetDecoded = false;
 
@@ -1162,10 +1162,10 @@ bool JBASE64_Decode(const char *incs, long length, StringBuffer &out)
     {
         c1 = *incs++;
 
-        if( isspace(c1) || ('\n' == c1) )
+        if( isspace(c1) )
             continue;
 
-        if( !BASE64_dec[c1] && (pad != c1)  )
+        if( !BASE64_dec[c1] && ('A' != c1) && (pad != c1)  )
         {
             // Forbidden char
             fullQuartetDecoded = false;
@@ -1183,32 +1183,23 @@ bool JBASE64_Decode(const char *incs, long length, StringBuffer &out)
             d4 = BASE64_dec[c[3]];
 
             out.append((char)((d1 << 2) | (d2 >> 4)));
+            fullQuartetDecoded = true;
 
             if(pad == c[2])
-            {
-                fullQuartetDecoded = true;
                 break;
-            }
 
             out.append((char)((d2 << 4) | (d3 >> 2)));
 
             if( pad == c[3])
-            {
-                fullQuartetDecoded = true;
                 break;
-            }
 
             out.append((char)((d3 << 6) | d4));
 
             cIndex = 0;
-            fullQuartetDecoded = true;
         }
     }
 
-    if(fullQuartetDecoded)
-        return true;
-    else
-        return false;
+    return fullQuartetDecoded;
 }
 
 static inline void encode5_32(const byte *in,StringBuffer &out)

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -1147,7 +1147,7 @@ MemoryBuffer &JBASE64_Decode(const char *incs, MemoryBuffer &out)
 
 
 
-bool JBASE64_Decode(const char *incs, long length, StringBuffer &out)
+bool JBASE64_Decode(size32_t length, const char *incs, StringBuffer &out)
 {
     out.ensureCapacity(((length / 4) + 1) * 3);
 

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -135,12 +135,12 @@ extern jlib_decl MemoryBuffer &JBASE64_Decode(ISimpleReadStream &in, MemoryBuffe
  * It handles forbidden printable and non-printable chars. Space(s) inserted among the valid chars,
  * missing pad chars and invalid length.
  *
- * @param in            Pointer to base64 encoded string
  * @param length        Length of the input string.
+ * @param in            Pointer to base64 encoded string
  * @param out           Decoded string if the input is valid
  * @return              True when success
  */
-extern jlib_decl bool JBASE64_Decode(const char *in, long length, StringBuffer &out);
+extern jlib_decl bool JBASE64_Decode(size32_t length, const char *in, StringBuffer &out);
 
 extern jlib_decl void JBASE32_Encode(const char *in,StringBuffer &out);  // result all lower
 extern jlib_decl void JBASE32_Decode(const char *in,StringBuffer &out);  

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -129,6 +129,7 @@ extern jlib_decl StringBuffer &JBASE64_Decode(const char *in, StringBuffer &out)
 extern jlib_decl MemoryBuffer &JBASE64_Decode(const char *in, MemoryBuffer &out);
 extern jlib_decl StringBuffer &JBASE64_Decode(ISimpleReadStream &in, StringBuffer &out);
 extern jlib_decl MemoryBuffer &JBASE64_Decode(ISimpleReadStream &in, MemoryBuffer &out);
+extern jlib_decl void JBASE64_Decode(const char *in, long length, StringBuffer &out);
 
 extern jlib_decl void JBASE32_Encode(const char *in,StringBuffer &out);  // result all lower
 extern jlib_decl void JBASE32_Decode(const char *in,StringBuffer &out);  

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -129,7 +129,18 @@ extern jlib_decl StringBuffer &JBASE64_Decode(const char *in, StringBuffer &out)
 extern jlib_decl MemoryBuffer &JBASE64_Decode(const char *in, MemoryBuffer &out);
 extern jlib_decl StringBuffer &JBASE64_Decode(ISimpleReadStream &in, StringBuffer &out);
 extern jlib_decl MemoryBuffer &JBASE64_Decode(ISimpleReadStream &in, MemoryBuffer &out);
-extern jlib_decl void JBASE64_Decode(const char *in, long length, StringBuffer &out);
+
+/**
+ * Decode base 64 encoded string.
+ * It handles forbidden printable and non-printable chars. Space(s) inserted among the valid chars,
+ * missing pad chars and invalid length.
+ *
+ * @param in            Pointer to base64 encoded string
+ * @param length        Length of the input string.
+ * @param out           Decoded string if the input is valid
+ * @return              True when success
+ */
+extern jlib_decl bool JBASE64_Decode(const char *in, long length, StringBuffer &out);
 
 extern jlib_decl void JBASE32_Encode(const char *in,StringBuffer &out);  // result all lower
 extern jlib_decl void JBASE32_Decode(const char *in,StringBuffer &out);  


### PR DESCRIPTION
This new feature contains these implementations:
1. Add a new implementation of JBASE64_Decode which takes a pointer to input
   string and the length of it.
2. Add wrapper functions rtlBase64Encode() and rtlBase64Decode() into eclrtl
   (.hpp and .cpp) to call Base 64 encode/decode functions (implemented in
   jutil.cpp).
3. Add implementation to rtlMalloc() and rtlRealloc() functions to handle
   memory allocation fault. Added macros to handle logging exact filename
   and line number if memory allocate fails.
4. Add external references and exports for functions implemented in 1. into
   Str.ecl.
5. Add test code TestBase64Codec.ecl into ecllibrary/teststd/str/ directory.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
