### PR TITLE
HPCC-9303 - Use thread pool for DFS requests

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -6191,7 +6191,7 @@ void CCovenSDSManager::loadStore(const char *storeName, const bool *abort)
     Owned<IRemoteConnection> conn = connect("/", 0, RTM_INTERNAL, INFINITE);
     initializeInternals(conn->queryRoot());
     conn.clear();
-    bool forceGroupUpdate = config.getPropBool("@forceGroupUpdate");
+    bool forceGroupUpdate = config.getPropBool("DFS/@forceGroupUpdate");
     StringBuffer response;
     initClusterGroups(forceGroupUpdate, response, oldEnvironment);
     if (response.length())

--- a/initfiles/componentfiles/configxml/dali.xsd
+++ b/initfiles/componentfiles/configxml/dali.xsd
@@ -129,6 +129,7 @@
       <xs:attributeGroup ref="Store"/>
       <xs:attributeGroup ref="Backup"/>
       <xs:attributeGroup ref="LDAP"/>
+      <xs:attributeGroup ref="DFS"/>
       <xs:attribute name="build" type="buildType" use="required">
         <xs:annotation>
           <xs:appinfo>
@@ -285,10 +286,17 @@
     </xs:attribute>
   </xs:attributeGroup>
    <xs:attributeGroup name="DFS">
-    <xs:attribute name="forceGroupUpdate" use="optional" default="false">
+    <xs:attribute name="forceGroupUpdate" type="xs:boolean" use="optional" default="false">
       <xs:annotation>
         <xs:appinfo>
           <tooltip>Force group updates on startup, if environment mismatch</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="numThreads" type="xs:nonNegativeInteger" use="optional" default="30">
+      <xs:annotation>
+        <xs:appinfo>
+          <tooltip>Number of threads to use to process DFS requests</tooltip>
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>

--- a/initfiles/componentfiles/configxml/dali.xsl
+++ b/initfiles/componentfiles/configxml/dali.xsl
@@ -172,9 +172,9 @@
           </xsl:call-template>
         </xsl:attribute>
       </xsl:element>
-      <xsl:element name="DFS">
-        <xsl:copy-of select="@forceGroupUpdate"/>
-      </xsl:element>
+      <DFS>
+      <xsl:copy-of select="@forceGroupUpdate | @numThreads"/>
+      </DFS>
       <xsl:element name="Coven">
         <xsl:attribute name="store">dalicoven.xml</xsl:attribute>
         <xsl:element name="Alerts">

--- a/system/mp/mputil.hpp
+++ b/system/mp/mputil.hpp
@@ -45,12 +45,12 @@ public:
         return CInterface::Release(); 
     }
 
-    CMessageHandler(const char *_name,PARENT *_parent,void (PARENT::*_handler)(CMessageBuffer &_mb), IExceptionHandler *exceptionHandler=NULL, unsigned maxthreads=40, unsigned timeoutOnRelease=INFINITE)
+    CMessageHandler(const char *_name,PARENT *_parent,void (PARENT::*_handler)(CMessageBuffer &_mb), IExceptionHandler *exceptionHandler=NULL, unsigned maxthreads=40, unsigned timeoutOnRelease=INFINITE, unsigned lowThreadsDelay=1000)
     {
         parent = _parent;
         handler = _handler;
         name = strdup(_name);
-        pool = createThreadPool(name,this,exceptionHandler,maxthreads,1000,0,timeoutOnRelease); // this will cause this to be linked
+        pool = createThreadPool(name,this,exceptionHandler,maxthreads,lowThreadsDelay,0,timeoutOnRelease); // this will cause this to be linked
         hasexceptionhandler = exceptionHandler!=NULL;
     }
     ~CMessageHandler()
@@ -122,7 +122,6 @@ public:
             runname.append(' ').appendhex(*(b++),true);
         pool->start(&mb,runname.str());
     }
-
 };
 
 


### PR DESCRIPTION
Use threadpool for DFS server (used to be single threaded)
Allow options to be configured

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
