### PR TITLE
HPCC-9334 Graph view shows odd characters

### DIFF
--- a/esp/eclwatch/ws_XSLT/GvcGraph.xslt
+++ b/esp/eclwatch/ws_XSLT/GvcGraph.xslt
@@ -22,7 +22,7 @@
   <xsl:template match="GVCAjaxGraphResponse">
     <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
       <head>
-        <!--meta http-equiv="Content-Type" content="text/html; charset=utf-8"/-->
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <title>
           <xsl:value-of select="Name"/> GVC Graph.
         </title>


### PR DESCRIPTION
Add meta type with content charset of UTF-8 for Internet Explorer.

Signed-off-by: Miguel Vazquez miguel.vazquez@lexisnexis.com
