### PR TITLE
HPCC-9006 Soapplus xml comparison issue

### DIFF
--- a/esp/tools/soapplus/xmldiff.cpp
+++ b/esp/tools/soapplus/xmldiff.cpp
@@ -322,7 +322,7 @@ bool CXmlDiff::cmpPtree(const char* xpath, IPropertyTree* t1, IPropertyTree* t2,
     }
 
     StringBuffer keybuf;
-    keybuf.appendf("%s-%s", xpath, xpathFull);
+    keybuf.appendf("%p-%p", t1, t2);
     std::string key = keybuf.str();
     if(m_compcache.getValue(key.c_str()) != NULL)
     {


### PR DESCRIPTION
This is to fix 9006 and 9270. The problem was caused by mistakenly using
full xpath as key for the cache of comparison results. Some xml files
have exact duplicate of xpath entries, but with different contents. Using
memory address of the property tree solves the problem.

Signed-off-by: mayx yanrui.ma@lexisnexis.com
