### PR TITLE
HPCC-9385 - Fix thread pool runningCount()

### DIFF
--- a/system/jlib/jthread.hpp
+++ b/system/jlib/jthread.hpp
@@ -222,6 +222,7 @@ interface IThreadPool : extends IInterface
         virtual unsigned runningCount()=0;                  // number of currently running threads
         virtual PooledThreadHandle startNoBlock(void *param)=0; // starts a new thread if it can do so without blocking, else throws exception
         virtual PooledThreadHandle startNoBlock(void *param,const char *name)=0;    // starts a new thread if it can do so without blocking, else throws exception
+        virtual void setStartDelayTracing(unsigned secs) = 0;        // set start delay tracing period
 };
 
 extern jlib_decl IThreadPool *createThreadPool(

--- a/system/mp/mputil.hpp
+++ b/system/mp/mputil.hpp
@@ -122,6 +122,11 @@ public:
             runname.append(' ').appendhex(*(b++),true);
         pool->start(&mb,runname.str());
     }
+    void setThreadPoolTracing(unsigned secs)
+    {
+        if (pool)
+            pool->setStartDelayTracing(secs);
+    }
 };
 
 


### PR DESCRIPTION
runningCount() was incorrectly tracked
Add optional tracing for pool thread starts and average delay

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
