### PR TITLE
HPCC-9393 ATMOST stats inaccurate

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -23680,6 +23680,7 @@ public:
         activityKind = _factory->getKind();
         indexReadInput = NULL;
         rootIndex = NULL;
+        atmostsTriggered = 0;
         // MORE - code would be easier to read if I got more values from helper rather than passing from factory
     }
 


### PR DESCRIPTION
Uninitialized variable means that the stats reported for keyed joins that are
reset but never started will be random.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
