### PR TITLE
HPCC-8938 - Exception can cause sort partition deadlock

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -2682,6 +2682,7 @@ public:
                     if (numHeapPages == atomic_read(&totalHeapPages))
                     {
                         logctx.CTXLOG("RoxieMemMgr: Memory limit exceeded - current %u, requested %u, limit %u", pageCount, numRequested, pageLimit);
+                        PrintStackReport();
                         throw MakeStringException(ROXIEMM_MEMORY_LIMIT_EXCEEDED, "memory limit exceeded");
                     }
                 }


### PR DESCRIPTION
Need to ensure next in asyncfor loop is signalled to continue
to avoid deadlock.
Also add a stack trace when roxiemem runs out of memory.
