### PR TITLE
HPCC-9241 Returns results after action button is clicked on WUs page

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1405,6 +1405,8 @@ void CHttpRequest::parseEspPathInfo()
 
         if (queryParameters()->hasProp("rawxml_"))
             m_context->setResponseFormat(ESPSerializationXML);
+        else if (isSoapMessage())
+            m_context->setResponseFormat(ESPSerializationXML);
 
         size32_t pathlen=m_httpPath.length();
         if (!pathlen)

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -418,6 +418,13 @@ inline bool canRedirect(CHttpRequest &req)
     return true;
 }
 
+inline bool checkRedirect(IEspContext &ctx)
+{
+    if (ctx.getResponseFormat()!=ESPSerializationANY)
+        return false;
+    return true;
+}
+
 inline bool skipXslt(IEspContext &context)
 {
     return (context.getResponseFormat()!=ESPSerializationANY);  //for now

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1637,7 +1637,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
         else
             throw MakeStringException(ECLWATCH_INVALID_ACTION, "Unknown action type %s", action);
 
-        if (bAllSuccess && strcmp(action, "Delete"))
+        if (bAllSuccess && checkRedirect(context) && strcmp(action, "Delete"))
         {
             if (!strcmp(action, "Restore"))
                 resp.setRedirectUrl("/FileSpray/GetDFUWorkunits?Type=archived workunits");

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -88,7 +88,7 @@ protected:
     StringBuffer m_RootFolder;
     Schedule m_sched;
     Owned<IPropertyTree> directories;
-    
+
     void addToQueryString(StringBuffer &queryString, const char *name, const char *value);
     int doFileCheck(const char* mask, const char* netaddr, const char* osStr, const char* path);
     virtual bool doCopyForRoxie(IEspContext &context,   const char * srcName, const char * srcDali, const char * srcUser, 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -982,7 +982,7 @@ bool CWsWorkunitsEx::onWUAction(IEspContext &context, IEspWUActionRequest &req, 
             params->setProp("State",4);
 
         IArrayOf<IConstWUActionResult> results;
-        if (doAction(context, req.getWuids(), *action, params, &results) && *action!=ActionDelete)
+        if (doAction(context, req.getWuids(), *action, params, &results) && *action!=ActionDelete && checkRedirect(context))
         {
             StringBuffer redirect;
             if(req.getPageFrom() && strieq(req.getPageFrom(), "wuid"))


### PR DESCRIPTION
On Browse (ECL or DFU) Workunits page, when an action (Protect,
SetToFailed, etc) button is clicked and the action is finished, the
page will be redirected to updated Browse Workunits page. That does
not work when rawxml_ flag is true (and for SOAP calls). This fix
returns action results if the rawxml_ flag or SOAP calls is detected.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
