### PR TITLE
HPCC-9412 Input fields in dijit.Toolbar lock up the web page

### DIFF
--- a/esp/files/templates/GraphWidget.html
+++ b/esp/files/templates/GraphWidget.html
@@ -1,7 +1,7 @@
 <div class="${baseClass}">
     <div id="${id}BorderContainer" class="${baseClass}BorderContainer" style="width: 100%; height: 100%; padding: 0px; overflow: hidden" data-dojo-props="splitter: false, gutters:false" data-dojo-type="dijit.layout.BorderContainer">
         <div id="${id}ToolbarContentPane" class="${baseClass}ToolbarContentPane" style="padding: 0px; overflow: hidden" data-dojo-props="region: 'top'" data-dojo-type="dijit.layout.ContentPane">
-            <div class="topPanel" data-dojo-type="dijit.Toolbar">
+            <div class="topPanel dijit dijitToolbar" role="toolbar">
                 <b>Zoom:</b>
                 <div data-dojo-attach-event="onClick:_onClickZoomAll" data-dojo-type="dijit.form.Button">All</div>
                 <div data-dojo-attach-event="onClick:_onClickZoomWidth" data-dojo-type="dijit.form.Button">Width</div>


### PR DESCRIPTION
Once a key is pressed the dijit.Toolbar tries to use that key press to set
focus an appropriate button.

Fixes HPCC-9412

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
