### PR TITLE
HPCC-9417 Fix XPATH being ignored for nested records

### DIFF
--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -610,9 +610,13 @@ void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) c
             builder.endIfBlock();
             break;
         case FVFFbeginrecord:
+            if (useXPath)
+                fvSplitXPath(meta->queryXPath(idx), xname, name);
             builder.beginRecord(name);
             break;
         case FVFFendrecord:
+            if (useXPath)
+                fvSplitXPath(meta->queryXPath(idx), xname, name);
             builder.endRecord(name);
             break;
         case FVFFdataset:


### PR DESCRIPTION
This was a regression in 3.10.8.  XPATHs were no longer being used
for FVFFbeginrecord and FVFFendrecord column types resulting in a
mismatch between output and xml schema that can cause the EclWatch
result viewer xslt to not output records whose field names had
been modified via xpath.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
