### PR TITLE
HPCC-9338 Add --no-files option to ecl-publish

### DIFF
--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -305,7 +305,7 @@ private:
 class EclCmdPublish : public EclCmdWithEclTarget
 {
 public:
-    EclCmdPublish() : optNoActivate(false), activateSet(false), optNoReload(false), optMsToWait(10000)
+    EclCmdPublish() : optNoActivate(false), activateSet(false), optNoReload(false), optDontCopyFiles(false), optMsToWait(10000)
     {
         optObj.accept = eclObjWuid | eclObjArchive | eclObjSharedObject;
         optTimeLimit = (unsigned) -1;
@@ -338,6 +338,8 @@ public:
             if (iter.matchOption(optPriority, ECLOPT_PRIORITY))
                 continue;
             if (iter.matchOption(optComment, ECLOPT_COMMENT))
+                continue;
+            if (iter.matchFlag(optDontCopyFiles, ECLOPT_DONT_COPY_FILES))
                 continue;
             if (iter.matchFlag(optNoActivate, ECLOPT_NO_ACTIVATE))
             {
@@ -403,6 +405,7 @@ public:
         req->setRemoteDali(optDaliIP.get());
         req->setWait(optMsToWait);
         req->setNoReload(optNoReload);
+        req->setDontCopyFiles(optDontCopyFiles);
 
         if (optTimeLimit != (unsigned) -1)
             req->setTimeLimit(optTimeLimit);
@@ -456,6 +459,7 @@ public:
             "   -A, --activate         Activate query when published (default)\n"
             "   -A-, --no-activate     Do not activate query when published\n"
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
+            "   --no-files             Do not copy files referenced by query\n"
             "   --daliip=<IP>          The IP of the DALI to be used to locate remote files\n"
             "   --timeLimit=<ms>       Value to set for query timeLimit configuration\n"
             "   --warnTimeLimit=<ms>   Value to set for query warnTimeLimit configuration\n"
@@ -480,6 +484,7 @@ private:
     bool optNoActivate;
     bool activateSet;
     bool optNoReload;
+    bool optDontCopyFiles;
 };
 
 class EclCmdRun : public EclCmdWithEclTarget

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1083,6 +1083,7 @@ ESPrequest [nil_remove] WUPublishWorkunitRequest
     string Priority;
     string RemoteDali;
     string Comment;
+    bool DontCopyFiles(false);
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -523,7 +523,8 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
     if (!isValidCluster(target.str()))
         throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid cluster name: %s", target.str());
 
-    copyQueryFilesToCluster(context, cw, req.getRemoteDali(), target.str(), queryName.str(), false);
+    if (!req.getDontCopyFiles())
+        copyQueryFilesToCluster(context, cw, req.getRemoteDali(), target.str(), queryName.str(), false);
 
     WorkunitUpdate wu(&cw->lock());
     if (req.getUpdateWorkUnitName() && notEmpty(req.getJobName()))


### PR DESCRIPTION
Add --no-files option to prevent ecl-publish from copying DFU file
information used by the query to the target cluster.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
