### PR TITLE
HPCC-9414 Add XML/JSON responses to FileSpray/UploadFile

### DIFF
--- a/esp/bindings/http/platform/httpbinding.hpp
+++ b/esp/bindings/http/platform/httpbinding.hpp
@@ -94,7 +94,7 @@ interface IEspHttpBinding
     virtual int onGetReqSampleXml(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *serv, const char *method)=0;
     virtual int onGetRespSampleXml(IEspContext &context, CHttpRequest* request, CHttpResponse* response,    const char *serv, const char *method)=0;
     virtual int onStartUpload(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *serv, const char *method)=0;
-    virtual int onFinishUpload(IEspContext &context, CHttpRequest* request, CHttpResponse* response,    const char *serv, const char *method)=0;
+    virtual int onFinishUpload(IEspContext &context, CHttpRequest* request, CHttpResponse* response,    const char *serv, const char *method, StringArray& fileNames, IMultiException *me)=0;
 };
 
 typedef MapStringTo<int> wsdlIncludedTable;
@@ -248,7 +248,7 @@ public:
     virtual int onGetRespSampleXml(IEspContext &context, CHttpRequest* request, CHttpResponse* response,    const char *serv, const char *method);
 
     virtual int onStartUpload(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *serv, const char *method);
-    virtual int onFinishUpload(IEspContext &context, CHttpRequest* request, CHttpResponse* response,    const char *serv, const char *method);
+    virtual int onFinishUpload(IEspContext &context, CHttpRequest* request, CHttpResponse* response,    const char *serv, const char *method, StringArray& fileNames, IMultiException *me);
 
 //interface IEspWsdlSections
     StringBuffer & getServiceName(StringBuffer & resp){return resp;}

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1926,8 +1926,11 @@ IFile* CHttpRequest::createUploadFile(StringBuffer netAddress, const char* fileP
 
 int CHttpRequest::readContentToFiles(StringBuffer netAddress, StringBuffer path, StringArray& fileNames)
 {
-    Owned<CMimeMultiPart> multipart = new CMimeMultiPart("1.0", m_content_type.get(), "", "", "");
-    multipart->parseContentType(m_content_type.get());
+    const char* contentType = m_content_type.get();
+    if (!contentType || !*contentType)
+        throw MakeStringException(-1, "Content Type not found.");
+    Owned<CMimeMultiPart> multipart = new CMimeMultiPart("1.0", contentType, "", "", "");
+    multipart->parseContentType(contentType);
 
     MemoryBuffer fileContent, moreContent;
     __int64 bytesNotRead = m_content_length64;

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -587,6 +587,11 @@ ESPresponse [exceptions_inline, nil_remove] DeleteDropZoneFilesResponse
     ESParray<ESPstruct DFUActionResult> DFUActionResults;
 };
 
+ESPresponse [exceptions_inline] UploadFilesResponse
+{
+    ESParray<ESPstruct DFUActionResult> UploadFileResults;
+};
+
 ESPservice [
     version("1.07"), default_client_version("1.07"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray

--- a/esp/services/ws_fs/ws_fsBinding.hpp
+++ b/esp/services/ws_fs/ws_fsBinding.hpp
@@ -74,7 +74,7 @@ public:
     }
 
     int onGetInstantQuery(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method);
-    int onFinishUpload(IEspContext &ctx, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method);
+    int onFinishUpload(IEspContext &ctx, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method, StringArray& fileNames, IMultiException *me);
 
 private:
     IPropertyTree* createPTreeForXslt(const char* method, const char* dfuwuid);


### PR DESCRIPTION
On EclWatch Upload File page, when a file is uploaded, the page will
be redirected to Browse Dropzone File page. That does not work when
rawxml_ flag or JSON flag is true. This fix returns upload file results
if the rawxml_ flag or JSON call is detected.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
