### PR TITLE
HPCC-9411 Information needed about unloadable roxie queries

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -658,10 +658,10 @@ public:
         ForEach (*queryNames)
         {
             const IPropertyTree &query = queryNames->query();
+            const char *id = query.queryProp("@id");
+            const char *dllName = query.queryProp("@dll");
             try
             {
-                const char *id = query.queryProp("@id");
-                const char *dllName = query.queryProp("@dll");
                 if (!id || !*id || !dllName || !*dllName)
                     throw MakeStringException(ROXIE_QUERY_MODIFICATION, "dll and id must be specified");
                 Owned<const IQueryDll> queryDll = createQueryDll(dllName);
@@ -685,10 +685,17 @@ public:
             catch (IException *E)
             {
                 // we don't want a single bad query in the set to stop us loading all the others
-                StringBuffer msg, qxml;
-                toXML(&query, qxml);
-                msg.appendf("Failed to load query: %s", qxml.str());
+                StringBuffer msg;
+                msg.appendf("Failed to load query %s from %s", id ? id : "(null)", dllName ? dllname : "(null)");
                 EXCLOG(E, msg.str());
+                if (id)
+                {
+                    StringBuffer emsg;
+                    E->errorMessage(emsg);
+                    Owned<IQueryFactory> dummyQuery = loadQueryFromDll(id, NULL, queryRootRoxiePackage(), NULL);
+                    dummyQuery->suspend(true, emsg.str(), "roxie", true);
+                    addQuery(id, dummyQuery.getClear(), hash);
+                }
                 E->Release();
             }
         }


### PR DESCRIPTION
Queries that cannot be loaded for some reason will now be created as dummy
query entries, so that they will still appear in the output from
control:queries.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
