### PR TITLE
HPCC-9117 Stopping of dafilesrv generates odd message

### DIFF
--- a/initfiles/bash/etc/init.d/dafilesrv.in
+++ b/initfiles/bash/etc/init.d/dafilesrv.in
@@ -130,7 +130,7 @@ while true ; do
 done
 for arg do arg=$arg; done
 
-if [ -z "$arg" ] || [ $# -ne 1]; then
+if [ -z "$arg" ] || [ $# -ne 1 ]; then
     print_usage
 fi
 


### PR DESCRIPTION
Previous fix did not completely address the issue.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
