### PR TITLE
HPCC-8379 Show suspended roxie query on EclWatch

### DIFF
--- a/esp/eclwatch/ws_XSLT/WUQueryDetails.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQueryDetails.xslt
@@ -146,6 +146,11 @@
                 </script>
             </head>
             <body class="yui-skin-sam">
+                <xsl:variable name="suspendedOnClusters">
+                    <xsl:for-each select="Clusters/ClusterQueryState[State='Suspended']">
+                        <xsl:if test="position() > 1"><xsl:text>, </xsl:text></xsl:if><xsl:value-of select="Cluster"/>
+                    </xsl:for-each>
+                </xsl:variable>
                 <h3>Query Details for <xsl:value-of select="QueryId"/></h3>
                 <form>
                     <table style="text-align:left;" cellspacing="10">
@@ -179,7 +184,7 @@
                             </tr>
                         </xsl:if>
                         <tr>
-                            <th>Suspended:
+                            <th>Suspended By User:
                         </th>
                             <td>
                                 <input type="checkbox" onclick="toggleQuery();">
@@ -193,6 +198,14 @@
                             <tr>
                                 <th>Suspended By:</th>
                                 <td><xsl:value-of select="SuspendedBy"/></td>
+                            </tr>
+                        </xsl:if>
+                        <xsl:if test="string-length($suspendedOnClusters)">
+                            <tr>
+                                <th>Suspended On Cluster(s):</th>
+                                <td>
+                                    <xsl:value-of select="$suspendedOnClusters"/>
+                                </td>
                             </tr>
                         </xsl:if>
                         <tr>

--- a/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
@@ -82,7 +82,7 @@
                     record = aliasDataTable.getRecord(selectedRows[0]);
                 else
                     record = queryDataTable.getRecord(selectedRows[0]);
-                document.location.href = "/WsWorkunits/WUQueryDetails?QueryId=" + record.getData('Id') + "&QuerySet=" + querySet;
+                document.location.href = "/WsWorkunits/WUQueryDetails?IncludeStateOnClusters=1&QueryId=" + record.getData('Id') + "&QuerySet=" + querySet;
               }
 
               function deleteQueries() {
@@ -220,7 +220,7 @@
                     {key:"Name", sortable:true, resizeable:true},
                     {key:"Wuid", formatter: formatWUIDColumn, sortable:true, resizeable:true},
                     {key:"Dll", sortable:true, resizeable:true},
-                    {key:"Suspended", formatter: formatCheckColumn, sortable:true, resizeable:true}
+                    {key:"Suspended", sortable:true, resizeable:true}
                   ];
                   if (clusterName != '')
                     queryColumnDefs = [
@@ -228,7 +228,7 @@
                         {key:"Name", sortable:true, resizeable:true},
                         {key:"Wuid", formatter: formatWUIDColumn, sortable:true, resizeable:true},
                         {key:"Dll", sortable:true, resizeable:true},
-                        {key:"Suspended", formatter: formatCheckColumn, sortable:true, resizeable:true},
+                        {key:"Suspended", sortable:true, resizeable:true},
                         {key:"Status", sortable:true, resizeable:true}
                       ];
 
@@ -437,12 +437,29 @@
   </xsl:template>
 
   <xsl:template match="QuerySetQuery">
+      <xsl:variable name="suspendedStatus">
+          <xsl:choose>
+              <xsl:when test="Suspended != 0">By User</xsl:when>
+              <xsl:otherwise>
+                  <xsl:for-each select="Clusters/ClusterQueryState[State='Suspended']">
+                      <xsl:choose>
+                          <xsl:when test="position() = 1">
+                              <xsl:text>On Cluster(s): </xsl:text><xsl:value-of select="Cluster"/>
+                          </xsl:when>
+                          <xsl:otherwise>
+                              <xsl:text>, </xsl:text><xsl:value-of select="Cluster"/>
+                          </xsl:otherwise>
+                      </xsl:choose>
+                  </xsl:for-each>
+              </xsl:otherwise>
+          </xsl:choose>
+      </xsl:variable>
       <xsl:choose>
           <xsl:when test="$clusterselected = ''">
-              {Id:'<xsl:value-of select="Id"/>', Name:'<xsl:value-of select="Name"/>', Wuid:'<xsl:value-of select="Wuid"/>', Dll:'<xsl:value-of select="Dll"/>', Suspended:'<xsl:value-of select="Suspended"/>'}<xsl:if test="position()!=last()">,</xsl:if>
+              {Id:'<xsl:value-of select="Id"/>', Name:'<xsl:value-of select="Name"/>', Wuid:'<xsl:value-of select="Wuid"/>', Dll:'<xsl:value-of select="Dll"/>', Suspended:'<xsl:value-of select="$suspendedStatus"/>'}<xsl:if test="position()!=last()">,</xsl:if>
           </xsl:when>
           <xsl:otherwise>
-              {Id:'<xsl:value-of select="Id"/>', Name:'<xsl:value-of select="Name"/>', Wuid:'<xsl:value-of select="Wuid"/>', Dll:'<xsl:value-of select="Dll"/>', Suspended:'<xsl:value-of select="Suspended"/>', Status:'<xsl:value-of select="Clusters/ClusterQueryState[1]/State"/>'}<xsl:if test="position()!=last()">,</xsl:if>
+              {Id:'<xsl:value-of select="Id"/>', Name:'<xsl:value-of select="Name"/>', Wuid:'<xsl:value-of select="Wuid"/>', Dll:'<xsl:value-of select="Dll"/>', Suspended:'<xsl:value-of select="$suspendedStatus"/>', Status:'<xsl:value-of select="Clusters/ClusterQueryState[1]/State"/>'}<xsl:if test="position()!=last()">,</xsl:if>
           </xsl:otherwise>
       </xsl:choose>
   </xsl:template>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1199,6 +1199,7 @@ ESPrequest WUQueryDetailsRequest
 {
     string QueryId;
     string QuerySet;
+    bool   IncludeStateOnClusters(false);
 };
 
 ESPresponse [exceptions_inline] WUQueryDetailsResponse
@@ -1211,6 +1212,7 @@ ESPresponse [exceptions_inline] WUQueryDetailsResponse
     bool Suspended;
     [min_ver("1.42")] bool Activated;
     string SuspendedBy;
+    [min_ver("1.43")] ESParray<ESPstruct ClusterQueryState> Clusters;
     string PublishedBy;
     string Comment;
 
@@ -1252,7 +1254,7 @@ ESPenum QuerySetQueryActionTypes : string
 
 ESPStruct QuerySetQueryClientState
 {
-    bool Suspended;
+    string Suspended;
 };
 
 ESPStruct QuerySetQueryActionItem

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -30,7 +30,8 @@
 
 #define DALI_FILE_LOOKUP_TIMEOUT (1000*15*1)  // 15 seconds
 
-const unsigned roxieQueryRoxieTimeOut = 60000;
+const unsigned ROXIECONNECTIONTIMEOUT = 1000;   //1 second
+const unsigned ROXIECONTROLQUERYTIMEOUT = 3000; //3 second
 
 #define SDS_LOCK_TIMEOUT (5*60*1000) // 5mins, 30s a bit short
 
@@ -588,6 +589,29 @@ bool CWsWorkunitsEx::onWUQuerysets(IEspContext &context, IEspWUQuerysetsRequest 
     return true;
 }
 
+void addClusterQueryStates(IPropertyTree* queriesOnCluster, const char *target, const char *id, IArrayOf<IEspClusterQueryState>& clusterStates)
+{
+    Owned<IEspClusterQueryState> clusterState = createClusterQueryState();
+    clusterState->setCluster(target);
+
+    VStringBuffer xpath("Endpoint/Queries/Query[@id='%s']", id);
+    IPropertyTree *aQuery = queriesOnCluster->getBranch(xpath.str());
+    if (!aQuery)
+    {
+        clusterState->setState("Not Found");
+    }
+    else if (aQuery->getPropBool("@suspended", false))
+    {
+        clusterState->setState("Suspended");
+    }
+    else
+    {
+        clusterState->setState("Available");
+    }
+
+    clusterStates.append(*clusterState.getClear());
+}
+
 void gatherQuerySetQueryDetails(IPropertyTree *query, IEspQuerySetQuery *queryInfo, const char *cluster, IPropertyTree *queriesOnCluster)
 {
     queryInfo->setId(query->queryProp("@id"));
@@ -612,25 +636,7 @@ void gatherQuerySetQueryDetails(IPropertyTree *query, IEspQuerySetQuery *queryIn
     if (queriesOnCluster)
     {
         IArrayOf<IEspClusterQueryState> clusters;
-        Owned<IEspClusterQueryState> clusterState = createClusterQueryState();
-        clusterState->setCluster(cluster);
-
-        VStringBuffer xpath("Endpoint/Queries/Query[@id='%s']", query->queryProp("@id"));
-        IPropertyTree *aQuery = queriesOnCluster->getBranch(xpath.str());
-        if (!aQuery)
-        {
-            clusterState->setState("Not Found");
-        }
-        else if (aQuery->getPropBool("@suspended", false))
-        {
-            clusterState->setState("Suspended");
-        }
-        else
-        {
-            clusterState->setState("Available");
-        }
-
-        clusters.append(*clusterState.getClear());
+        addClusterQueryStates(queriesOnCluster, cluster, query->queryProp("@id"), clusters);
         queryInfo->setClusters(clusters);
     }
 }
@@ -774,24 +780,38 @@ void retrieveQuerysetDetails(IArrayOf<IEspWUQuerySetDetail> &details, const char
     retrieveQuerysetDetails(details, registry, type, value, cluster, queriesOnCluster);
 }
 
-void retrieveQuerysetDetailsByCluster(IArrayOf<IEspWUQuerySetDetail> &details, const char *target, const char *queryset, const char *type, const char *value)
+IPropertyTree* getQueriesOnCluster(const char *target, const char *queryset)
 {
+    if (isEmpty(target))
+        target = queryset;
     Owned<IConstWUClusterInfo> info = getTargetClusterInfo(target);
     if (!info)
         throw MakeStringException(ECLWATCH_CANNOT_RESOLVE_CLUSTER_NAME, "Cluster %s not found", target);
     if (queryset && *queryset && !strieq(target, queryset))
         throw MakeStringException(ECLWATCH_QUERYSET_NOT_ON_CLUSTER, "Target %s and QuerySet %s should match", target, queryset);
+    if (info->getPlatform()!=RoxieCluster)
+        return NULL;
+    const SocketEndpointArray &eps = info->getRoxieServers();
+    if (!eps.length())
+        return NULL;
 
-    Owned<IPropertyTree> queriesOnCluster;
-    if (info->getPlatform()==RoxieCluster)
+    try
     {
-        const SocketEndpointArray &eps = info->getRoxieServers();
-        if (eps.length())
-        {
-            Owned<ISocket> sock = ISocket::connect_timeout(eps.item(0), 10000);
-            queriesOnCluster.setown(sendRoxieControlQuery(sock, "<control:queries/>", 5));
-        }
+        Owned<ISocket> sock = ISocket::connect_timeout(eps.item(0), ROXIECONNECTIONTIMEOUT);
+        return sendRoxieControlQuery(sock, "<control:queries/>", ROXIECONTROLQUERYTIMEOUT);
     }
+    catch(IException* e)
+    {
+        StringBuffer err;
+        DBGLOG("Get exception in control:queries: %s", e->errorMessage(err.append(e->errorCode()).append(' ')).str());
+        e->Release();
+        return NULL;
+    }
+}
+
+void retrieveQuerysetDetailsByCluster(IArrayOf<IEspWUQuerySetDetail> &details, const char *target, const char *queryset, const char *type, const char *value)
+{
+    Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(target, queryset);
     retrieveQuerysetDetails(details, target, type, value, target, queriesOnCluster);
 }
 
@@ -829,7 +849,11 @@ bool CWsWorkunitsEx::onWUQuerysetDetails(IEspContext &context, IEspWUQuerySetDet
 
     if (isEmpty(req.getClusterName()) || isEmpty(req.getFilterTypeAsString()) || !strieq(req.getFilterTypeAsString(), "Status") || isEmpty(req.getFilter()))
     {
-        retrieveQuerysetDetails(registry, req.getFilterTypeAsString(), req.getFilter(), respQueries, respAliases);
+        const char* cluster = req.getClusterName();
+        if (isEmpty(cluster))
+            cluster = req.getQuerySetName();
+        Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(cluster, req.getQuerySetName());
+        retrieveQuerysetDetails(registry, req.getFilterTypeAsString(), req.getFilter(), respQueries, respAliases, cluster, queriesOnCluster);
 
         resp.setQuerysetQueries(respQueries);
         resp.setQuerysetAliases(respAliases);
@@ -869,6 +893,7 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
 {
     const char* querySet = req.getQuerySet();
     const char* queryId = req.getQueryId();
+    bool  includeStateOnClusters = req.getIncludeStateOnClusters();
     if (!querySet || !*querySet)
         throw MakeStringException(ECLWATCH_QUERYSET_NOT_FOUND, "QuerySet not specified");
     if (!queryId || !*queryId)
@@ -911,7 +936,16 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
         else
             resp.setActivated(true);
     }
-
+    if (includeStateOnClusters && (version >= 1.43))
+    {
+        Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(querySet, querySet);
+        if (queriesOnCluster)
+        {
+            IArrayOf<IEspClusterQueryState> clusterStates;
+            addClusterQueryStates(queriesOnCluster, querySet, queryId, clusterStates);
+            resp.setClusters(clusterStates);
+        }
+    }
     return true;
 }
 
@@ -983,7 +1017,13 @@ void expandQueryActionTargetList(IProperties *queryIds, IPropertyTree *queryset,
     {
         const char *itemId = items.item(i).getQueryId();
         if (!isWildString(itemId))
-            queryIds->setProp(itemId, (int) items.item(i).getClientState().getSuspended());
+        {
+            bool suspendedByUser = false;
+            const char *itemSuspendState = items.item(i).getClientState().getSuspended();
+            if (itemSuspendState && (strieq(itemSuspendState, "By User") || strieq(itemSuspendState, "1")))
+                suspendedByUser = true;
+            queryIds->setProp(itemId, suspendedByUser);
+        }
         else
         {
             verifyQueryActionAllowsWild(allowWildChecked, action);


### PR DESCRIPTION
If roxie suspends the query, querysets may not be updated and existing
ECLWatch page shows that it is not suspended. This fix calls roxie for
query state before displaying the suspended status. If a query is
suspended by a roxie, this fix shows that the query is suspended on
the cluster. If a query is suspended by a user, it shows that the
query is suspended by user. The fix works on both QuerySet page and
QueryDetails page.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
