### PR TITLE
HPCC-9266 DFU server creates too much partition related logs during spray large amount of files

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2723,7 +2723,8 @@ void FileSprayer::spray()
     addEmptyFilesToPartition();
     
     derivePartitionExtra();
-    displayPartition();
+    if( partition.ordinality() < 10 )
+        displayPartition();
     if (isRecovering)
         displayProgress(progress);
 


### PR DESCRIPTION
Remove displayPartition() call from FileSprayer::spray() to avoid too big log
file generation when large sets of files sprayed using wildcard.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
