### PR TITLE
HPCC-3130 changing perms on eclwatch takes 5 minutes to take affect

### DIFF
--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -110,6 +110,7 @@ interface ISessionManager: extends IInterface
     virtual bool checkScopeScansLDAP()=0;
     virtual unsigned getLDAPflags()=0;
     virtual void setLDAPflags(unsigned flags)=0;
+    virtual bool clearPermissionsCache(IUserDescriptor *udesc)=0;
 
 };
 

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -175,6 +175,18 @@ public:
         return 255;
     }
 
+    bool clearPermissionsCache(IUserDescriptor *udesc)
+    {
+        if (!ldapsecurity || ((getLDAPflags() & DLF_ENABLED) == 0))
+            return true;
+        StringBuffer username;
+        StringBuffer password;
+        udesc->getUserName(username);
+        udesc->getPassword(password);
+        Owned<ISecUser> user = ldapsecurity->createUser(username);
+        user->credentials().setPassword(password);
+        return ldapsecurity->clearPermissionsCache(*user);
+    }
     bool checkScopeScans()
     {
         return (ldapflags&DLF_SCOPESCANS)!=0;

--- a/dali/server/daldap.hpp
+++ b/dali/server/daldap.hpp
@@ -30,7 +30,7 @@ interface IDaliLdapConnection: extends IInterface
     virtual bool checkScopeScans() = 0;
     virtual unsigned getLDAPflags() = 0;
     virtual void setLDAPflags(unsigned flags) = 0;
-
+    virtual bool clearPermissionsCache(IUserDescriptor *udesc) = 0;
 };
 
 extern IDaliLdapConnection *createDaliLdapConnection(IPropertyTree *proptree);

--- a/esp/eclwatch/ws_XSLT/CMakeLists.txt
+++ b/esp/eclwatch/ws_XSLT/CMakeLists.txt
@@ -138,6 +138,7 @@ FOREACH ( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/access_accountpermissions.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_adduser.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_basedns.xslt
+    ${CMAKE_CURRENT_SOURCE_DIR}/access_clearpermissionscache.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_filepermission.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_groupadd.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_groupdelete.xslt

--- a/esp/eclwatch/ws_XSLT/access_clearpermissionscache.xslt
+++ b/esp/eclwatch/ws_XSLT/access_clearpermissionscache.xslt
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+  <xsl:output method="html"/>
+  <xsl:template match="/">
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+      <head>
+        <script type="text/javascript" src="/esp/files/scripts/espdefault.js">&#160;</script>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <title>Permissions Cache</title>
+      </head>
+      <body class="yui-skin-sam" onload="nof5();">
+        <xsl:apply-templates/>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="ClearPermissionsCacheResponse">
+    <table>
+      <tbody>
+        <th align="left">
+          <h2>Clear Permissions Cache Result</h2>
+        </th>
+        <tr>
+          <td>
+            <xsl:choose>
+              <xsl:when test="retcode=0">
+                Permissions cache cleared.
+              </xsl:when>
+              <xsl:otherwise>
+                Permissions cache clear unsuccessful
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:value-of select="retmsg"/>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  </xsl:template>
+</xsl:stylesheet>

--- a/esp/eclwatch/ws_XSLT/access_resources.xslt
+++ b/esp/eclwatch/ws_XSLT/access_resources.xslt
@@ -188,6 +188,11 @@
               </form>
             </td>
           </xsl:if>
+            <td>
+                <form action="/ws_access/ClearPermissionsCache">
+                  <input id="clearPermissionsCacheBtn" class="sbutton" type="submit" name="action" value="Clear Permissions Cache" onclick="return confirm('Are you sure you want to clear the DALI and ESP permissions caches? Running workunit performance might degrade significantly until the caches have been refreshed.')"/>
+                </form>
+            </td>
                 </tr>
             </table>
       <form action="/ws_access/ResourceAddInput" id="addform">

--- a/esp/scm/ws_access.ecm
+++ b/esp/scm/ws_access.ecm
@@ -553,6 +553,14 @@ ESPresponse PermissionsResetResponse
     string retmsg;
 };
 
+ESPrequest ClearPermissionsCacheRequest
+{
+};
+
+ESPresponse ClearPermissionsCacheResponse
+{
+    int retcode;
+};
 ESPrequest PermissionActionRequest
 {
     string basedn;
@@ -681,6 +689,7 @@ ESPservice [version("1.07"), default_client_version("1.07"), exceptions_inline("
     ESPmethod [client_xslt("/esp/xslt/access_filepermission.xslt")] FilePermission(FilePermissionRequest, FilePermissionResponse);
     ESPmethod [client_xslt("/esp/xslt/access_permissionresetinput.xslt")] PermissionsResetInput(PermissionsResetInputRequest, PermissionsResetInputResponse);
     ESPmethod [client_xslt("/esp/xslt/access_permissionsreset.xslt")] PermissionsReset(PermissionsResetRequest, PermissionsResetResponse);
+    ESPmethod [client_xslt("/esp/xslt/access_clearpermissionscache.xslt")] ClearPermissionsCache(ClearPermissionsCacheRequest, ClearPermissionsCacheResponse);
     //ESPmethod [client_xslt("/esp/xslt/access_useraccountexport.xslt")] UserAccountExport(UserAccountExportRequest, UserAccountExportResponse);
     ESPmethod UserAccountExport(UserAccountExportRequest, UserAccountExportResponse);
 

--- a/esp/services/ws_access/CMakeLists.txt
+++ b/esp/services/ws_access/CMakeLists.txt
@@ -46,6 +46,8 @@ include_directories (
          ${HPCC_SOURCE_DIR}/esp/bindings
          ${HPCC_SOURCE_DIR}/esp/bindings/SOAP/xpp
          ${HPCC_SOURCE_DIR}/esp/smc/SMCLib
+         ${HPCC_SOURCE_DIR}/dali/base
+         ${HPCC_SOURCE_DIR}/system/mp
     )
 
 # NOTE - this should not be needed, it's the result of poor encapsulation and using CLdapSecManager directly 

--- a/esp/services/ws_access/ws_accessService.hpp
+++ b/esp/services/ws_access/ws_accessService.hpp
@@ -116,6 +116,7 @@ public:
     virtual bool onPermissionsResetInput(IEspContext &context, IEspPermissionsResetInputRequest &req, IEspPermissionsResetInputResponse &resp);
     virtual bool onPermissionsReset(IEspContext &context, IEspPermissionsResetRequest &req, IEspPermissionsResetResponse &resp);
     virtual bool onUserAccountExport(IEspContext &context, IEspUserAccountExportRequest &req, IEspUserAccountExportResponse &resp);
+    virtual bool onClearPermissionsCache(IEspContext &context, IEspClearPermissionsCacheRequest &req, IEspClearPermissionsCacheResponse &resp);
 };
 
 #endif //_ESPWIZ_ws_access_HPP__

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1325,21 +1325,7 @@ public:
 
         if(rtype == RT_FILE_SCOPE)
         {
-            int defaultFileScopePermission = -2;
-            //if(m_defaultFileScopePermission == -2)
-            {
-                const char* basebasedn = strchr(basedn, ',') + 1;
-                StringBuffer baseresource;
-                baseresource.append(basebasedn-basedn-4, basedn+3);
-                IArrayOf<ISecResource> base_resources;
-                base_resources.append(*(new CLdapSecResource(baseresource.str())));
-                bool baseok = authorizeScope(user, base_resources, basebasedn);
-                if(baseok)
-                {
-                    //m_defaultFileScopePermission = base_resources.item(0).getAccessFlags();
-                    defaultFileScopePermission = base_resources.item(0).getAccessFlags();
-                }
-            }
+            int defaultFileScopePermission = queryDefaultPermission(user);
             IArrayOf<ISecResource> non_emptylist;
             ForEachItemIn(x, resources)
             {

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -1255,6 +1255,16 @@ int CLdapSecManager::queryDefaultPermission(ISecUser& user)
     return m_ldap_client->queryDefaultPermission(user);
 }
 
+bool CLdapSecManager::clearPermissionsCache(ISecUser& user)
+{
+    if(m_permissionsCache.isCacheEnabled())
+    {
+        if (!authenticate(&user))
+            return false;
+        m_permissionsCache.flush();
+    }
+    return true;
+}
 
 extern "C"
 {

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -1260,7 +1260,15 @@ bool CLdapSecManager::clearPermissionsCache(ISecUser& user)
     if(m_permissionsCache.isCacheEnabled())
     {
         if (!authenticate(&user))
+        {
+            PROGLOG("User %s not authorized to clear permissions cache", user.getName());
             return false;
+        }
+        if (!isSuperUser(&user))
+        {
+            PROGLOG("User %s denied, only a superuser can clear permissions cache", user.getName());
+            return false;
+        }
         m_permissionsCache.flush();
     }
     return true;

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -440,6 +440,7 @@ public:
     virtual bool createUserScopes();
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes);
     virtual int queryDefaultPermission(ISecUser& user);
+    virtual bool clearPermissionsCache(ISecUser &user);
 };
 
 #endif

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -287,6 +287,7 @@ public:
     virtual bool createUserScopes() {UNIMPLEMENTED; return false;}
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) {UNIMPLEMENTED; }
     virtual int queryDefaultPermission(ISecUser& user) {UNIMPLEMENTED; }
+    virtual bool clearPermissionsCache(ISecUser& user) {return false;}
 protected:
     const char* getServer(){return m_dbserver.toCharArray();}
     const char* getUser(){return m_dbuser.toCharArray();}

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -169,7 +169,7 @@ public:
     bool  isCacheEnabled() { return m_cacheTimeout > 0; }
     void setTransactionalEnabled(bool enable) { m_transactionalEnabled = enable; }
     bool isTransactionalEnabled() { return m_transactionalEnabled;}
-
+    void flush();
     bool addManagedFileScopes(IArrayOf<ISecResource>& scopes);
     void removeManagedFileScopes(IArrayOf<ISecResource>& scopes);
     void removeAllManagedFileScopes();

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -298,6 +298,7 @@ interface ISecManager : extends IInterface
     virtual bool createUserScopes() = 0;
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) = 0;
     virtual int queryDefaultPermission(ISecUser& user) = 0;
+    virtual bool clearPermissionsCache(ISecUser & user) = 0;
 };
 
 interface IExtSecurityManager


### PR DESCRIPTION
Currently if you change permissions via ECLWatch, the ESP cache is updated
but the DALI cache does not update until the timeout period (default 5
minutes, configurable via configmgr). This makes it difficult to test things
like file permissions which are verified by DALI.
This commit adds a new "Flush Permissions Cache" button to the permissions
screens in ECLWatch, and when selected, after presenting a scary prompt,
if the admin user chooses to continue the local (ESP) cache is cleared,
and a message is sent to DALI requesting it to do the same

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
