### PR TITLE
HPCC-9369 Disable Delete button when a WU is running/aborting

### DIFF
--- a/esp/eclwatch/ws_XSLT/workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/workunits.xslt
@@ -62,6 +62,7 @@
                      var scheduleChecked = 0;
                      var descheduleChecked = 0;
                      var noscheduleChecked = 0;
+                     var cannotDelete = false;
                      function checkSelected(o)
                      {
                         if (o.tagName=='INPUT' && o.id!='All2'  && o.id!='All1'  && o.checked)
@@ -75,6 +76,10 @@
                                 unprotectedChecked++;
                             }
 
+                            if (document.getElementById(o.value + "_NoDelete"))
+                            {
+                                cannotDelete = true;
+                            }
                             var v1 = o.value + "_S";
                             var v2 = o.value + "_D";
                             var v1v2 = false;
@@ -122,6 +127,7 @@
             scheduleChecked = 0;
                         descheduleChecked = 0;
                         noscheduleChecked = 0;
+                        cannotDelete = false;
                         checkSelected(document.forms['listitems']);
                         if (protectedChecked + unprotectedChecked > 0)
                         {
@@ -134,7 +140,7 @@
                         }
                         else if (unprotectedChecked > 0 && protectedChecked == 0)
                         {
-                            if (document.getElementById("deleteBtn"))
+                            if (!cannotDelete && document.getElementById("deleteBtn"))
                                 document.getElementById("deleteBtn").disabled = false;
                             if (document.getElementById("protectBtn"))
                                 document.getElementById("protectBtn").disabled = false;
@@ -623,6 +629,10 @@
          </td>
          </xsl:if>
          <td>
+             <xsl:if test="number(IsPausing) or (State='running') or (State='aborting') or (State='compiling') or (State='debug_running')
+                     or (State='uploading_files') or (State='debugging') or (State='scheduled' and number(Aborting))">
+                 <input type="hidden" id="{Wuid}_NoDelete"/>
+             </xsl:if>
          <xsl:choose>
            <xsl:when test="number(IsPausing)">
              Pausing

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -825,7 +825,8 @@
                   </xsl:if>
                 </input>
                 <input type="submit" name="ActionType" value="Delete" class="sbutton" title="Delete workunit" onclick="return confirm('Delete workunit?')">
-                  <xsl:if test="number(AccessFlag) &lt; 7 or number(Protected)">
+                  <xsl:if test="number(AccessFlag) &lt; 7 or number(Protected) or State='aborting' or State='running' or State='compiling'
+                          or State='debug_running' or State='debugging' or ($ScheduledAborting!=0)">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                   </xsl:if>
                 </input>
@@ -882,7 +883,8 @@
                   </xsl:if>
                 </input>
                 <input type="submit" name="ActionType" value="Delete" class="sbutton" title="Delete workunit" onclick="return confirm('Delete workunit?')">
-                  <xsl:if test="number(AccessFlag) &lt; 7 or number(Protected)">
+                  <xsl:if test="number(AccessFlag) &lt; 7 or number(Protected) or State='aborting' or State='running' or State='compiling'
+                          or State='debug_running' or State='debugging' or ($ScheduledAborting!=0)">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                   </xsl:if>
                 </input>


### PR DESCRIPTION
A problem is reported when a user deleted an ECL workunit that was in
an "aborting" state. This fix disables the Delete button on both
Browse ECL WUs page and ECL WU Details page if the workunit is in one
of the following states: aborting, running, compiling, debug_running,
and debugging.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
