### PR TITLE
HPCC-9304 Add PID into Process/eclagent entries of ECL WU xml

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -640,7 +640,7 @@ public:
     virtual unsigned __int64 getHash() const;
     virtual IStringIterator *getLogs(const char *type, const char *component) const;
     virtual IStringIterator *getProcesses(const char *type) const;
-    virtual IPropertyTreeIterator& getProcesses(const char *type, const char *component) const;
+    virtual IPropertyTreeIterator& getProcesses(const char *type, const char *instance) const;
 
     virtual bool getWuDate(unsigned & year, unsigned & month, unsigned& day);
     virtual IStringVal & getSnapshot(IStringVal & str) const;
@@ -706,7 +706,6 @@ public:
     void setState(WUState state);
     void setStateEx(const char * text);
     void setAgentSession(__int64 sessionId);
-    void setAgentPID(unsigned pid);
     void setSecurityToken(const char *value);
     void setTimerInfo(const char * name, const char * instance, unsigned ms, unsigned count, unsigned __int64 max);
     void setTracingValue(const char * propname, const char * value);
@@ -1169,8 +1168,6 @@ public:
             { c->setStateEx(text); }
     virtual void setAgentSession(__int64 sessionId)
             { c->setAgentSession(sessionId); }
-    virtual void setAgentPID(unsigned pid)
-            { c->setAgentPID(pid); }
     virtual void setTimerInfo(const char * name, const char * instance, unsigned ms, unsigned count, unsigned __int64 max)
             { c->setTimerInfo(name, instance, ms, count, max); }
     virtual void setTracingValue(const char * propname, const char * value)
@@ -3664,12 +3661,6 @@ void CLocalWorkUnit::setAgentSession(__int64 sessionId)
 {
     CriticalBlock block(crit);
     p->setPropInt64("@agentSession", sessionId);
-}
-
-void CLocalWorkUnit::setAgentPID(unsigned pid)
-{
-    CriticalBlock block(crit);
-    p->setPropInt("@agentPID", pid);
 }
 
 bool CLocalWorkUnit::aborting() const 

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -923,6 +923,7 @@ interface IConstWorkUnit : extends IInterface
     virtual unsigned __int64 getHash() const = 0;
     virtual IStringIterator *getLogs(const char *type, const char *instance=NULL) const = 0;
     virtual IStringIterator *getProcesses(const char *type) const = 0;
+    virtual IPropertyTreeIterator& getProcesses(const char *type, const char *instance) const = 0;
 };
 
 
@@ -935,7 +936,7 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual IWUException * createException() = 0;
     virtual void setTimeStamp(const char * name, const char * instance, const char * event) = 0;
     virtual void addTimeStamp(const char * name, const char * instance, const char * event) = 0;
-    virtual void addProcess(const char *type, const char *instance, const char *log=NULL) = 0;
+    virtual void addProcess(const char *type, const char *instance, unsigned pid, const char *log=NULL) = 0;
     virtual void setAction(WUAction action) = 0;
     virtual void setApplicationValue(const char * application, const char * propname, const char * value, bool overwrite) = 0;
     virtual void setApplicationValueInt(const char * application, const char * propname, int value, bool overwrite) = 0;

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -957,7 +957,6 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual void setState(WUState state) = 0;
     virtual void setStateEx(const char * text) = 0;
     virtual void setAgentSession(__int64 sessionId) = 0;
-    virtual void setAgentPID(unsigned pid) = 0;
     virtual void setTimerInfo(const char * name, const char * instance, unsigned ms, unsigned count, unsigned __int64 max) = 0;
     virtual void setTracingValue(const char * propname, const char * value) = 0;
     virtual void setTracingValueInt(const char * propname, int value) = 0;

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1837,7 +1837,6 @@ void EclAgent::doProcess()
                 throw MakeStringException(0, "Ecl agent started in 'no retry' mode for failed workunit, so failing");
             w->setState(WUStateRunning);
             w->addTimeStamp("EclAgent", GetCachedHostName(), "Started");
-            w->setAgentPID(GetCurrentProcessId());
             if (isRemoteWorkunit)
             {
                 w->setAgentSession(myProcessSession());

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1828,7 +1828,7 @@ void EclAgent::doProcess()
                 traceLevel = w->getDebugValueInt("traceLevel", 10);
             w->setTracingValue("EclAgentBuild", BUILD_TAG);
             if (agentTopology->hasProp("@name"))
-                w->addProcess("EclAgent", agentTopology->queryProp("@name"), logname.str());
+                w->addProcess("EclAgent", agentTopology->queryProp("@name"), GetCurrentProcessId(), logname.str());
 
             eclccCodeVersion = w->getCodeVersion();
             if (checkVersion && ((eclccCodeVersion > ACTIVITY_INTERFACE_VERSION) || (eclccCodeVersion < MIN_ACTIVITY_INTERFACE_VERSION)))

--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -1690,7 +1690,7 @@ void EclAgent::updateWULogfile()
             rlf.getRemotePath(logname.clear());
 
             Owned <IWorkUnit> w = updateWorkUnit();
-            w->addProcess("EclAgent", config->queryProp("@name"), logname.str());
+            w->addProcess("EclAgent", config->queryProp("@name"), GetCurrentProcessId(), logname.str());
         }
         else
         {

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -1286,7 +1286,7 @@
       </xsl:if>
       <xsl:if test="Type = 'EclAgentLog'">
         <td>
-          <a href="/WsWorkunits/WUFile/EclAgentLog?Wuid={$wuid}&amp;Name={Name}&amp;Type=EclAgentLog">
+          <a href="/WsWorkunits/WUFile/EclAgentLog?Wuid={$wuid}&amp;Name={Name}&amp;Process={PID}&amp;Type=EclAgentLog">
               eclagent.log: <xsl:value-of select="Name"/>
           </a>
         </td>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -115,6 +115,7 @@ ESPStruct [nil_remove] ECLHelpFile
     [min_ver("1.32")] string IPAddress;
     [min_ver("1.32")] string Description;
     [min_ver("1.43")] int64 FileSize;
+    [min_ver("1.44")] string PID;
 };
 
 //  ===========================================================================
@@ -1340,7 +1341,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.43"), default_client_version("1.43"),
+    version("1.44"), default_client_version("1.44"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -115,7 +115,7 @@ ESPStruct [nil_remove] ECLHelpFile
     [min_ver("1.32")] string IPAddress;
     [min_ver("1.32")] string Description;
     [min_ver("1.43")] int64 FileSize;
-    [min_ver("1.44")] string PID;
+    [min_ver("1.44")] unsigned PID(0);
 };
 
 //  ===========================================================================

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -512,12 +512,12 @@ void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
 
         if (cw->getWuidVersion() > 0)
         {
-            Owned<IStringIterator> eclAgentLogs = cw->getLogs("EclAgent");
-            ForEach (*eclAgentLogs)
+            IPropertyTreeIterator& eclAgents = cw->getProcesses("EclAgent", NULL);
+            ForEach (eclAgents)
             {
-                SCMStringBuffer logName;
-                eclAgentLogs->str(logName);
-                if (logName.length() < 1)
+                StringBuffer logName, agentPID;
+                eclAgents.query().getProp("@log",logName);
+                if (!logName.length())
                     continue;
 
                 Owned<IEspECLHelpFile> h= createECLHelpFile("","");
@@ -528,6 +528,14 @@ void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
                     offset_t fileSize;
                     if (getFileSize(logName.str(), NULL, fileSize))
                         h->setFileSize(fileSize);
+                    if (version >= 1.44)
+                    {
+                        eclAgents.query().getProp("@pid",agentPID);
+                        if (!agentPID.length())
+                            agentPID.append(cw->getAgentPID());
+                        if (agentPID.length())
+                            h->setPID(agentPID.str());
+                    }
                 }
                 helpers.append(*h.getLink());
             }
@@ -1671,7 +1679,7 @@ void appendIOStreamContent(MemoryBuffer &mb, IFileIOStream *ios, bool forDownloa
     }
 }
 
-void WsWuInfo::getWorkunitEclAgentLog(const char* fileName, MemoryBuffer& buf)
+void WsWuInfo::getWorkunitEclAgentLog(const char* fileName, const char* agentPid, MemoryBuffer& buf)
 {
     if(!fileName || !*fileName)
         throw MakeStringException(ECLWATCH_ECLAGENT_LOG_NOT_FOUND,"Log file not specified");
@@ -1687,8 +1695,11 @@ void WsWuInfo::getWorkunitEclAgentLog(const char* fileName, MemoryBuffer& buf)
     bool eof = false;
     bool wuidFound = false;
 
-    unsigned pid = cw->getAgentPID();
-    VStringBuffer pidstr(" %5d ", pid);
+    StringBuffer pidstr;
+    if (agentPid && *agentPid)
+        pidstr.appendf(" %s ", agentPid);
+    else
+        pidstr.appendf(" %5d ", cw->getAgentPID());
     char const * pidchars = pidstr.str();
     while(!eof)
     {

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -530,11 +530,10 @@ void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned flags)
                         h->setFileSize(fileSize);
                     if (version >= 1.44)
                     {
-                        eclAgents.query().getProp("@pid",agentPID);
-                        if (!agentPID.length())
-                            agentPID.append(cw->getAgentPID());
-                        if (agentPID.length())
-                            h->setPID(agentPID.str());
+                        if (eclAgents.query().hasProp("@pid"))
+                            h->setPID(eclAgents.query().getPropInt("@pid"));
+                        else
+                            h->setPID(cw->getAgentPID());
                     }
                 }
                 helpers.append(*h.getLink());

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -168,7 +168,7 @@ public:
     bool getResultEclSchemas(IConstWUResult &r, IArrayOf<IEspECLSchemaItem>& schemas);
     void getResult(IConstWUResult &r, IArrayOf<IEspECLResult>& results, unsigned flags);
 
-    void getWorkunitEclAgentLog(const char* eclAgentInstance, MemoryBuffer& buf);
+    void getWorkunitEclAgentLog(const char* eclAgentInstance, const char* agentPid, MemoryBuffer& buf);
     void getWorkunitThorLog(const char *processName, MemoryBuffer& buf);
     void getWorkunitThorSlaveLog(const char *groupName, const char *ipAddress, const char* logDate, const char* logDir, int slaveNum, MemoryBuffer& buf, bool forDownload);
     void getWorkunitResTxt(MemoryBuffer& buf);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2682,7 +2682,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
             }
             else if (strieq(File_EclAgentLog,req.getType()))
             {
-                winfo.getWorkunitEclAgentLog(req.getName(), mb);
+                winfo.getWorkunitEclAgentLog(req.getName(), req.getProcess(), mb);
                 openSaveFile(context, opt, "eclagent.log", HTTP_TYPE_TEXT_PLAIN, mb, resp);
             }
             else if (strieq(File_XML,req.getType()) && notEmpty(req.getName()))

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -171,7 +171,7 @@ void CJobManager::updateWorkUnitLog(IWorkUnit &workunit)
     StringBuffer log, logUrl;
     logHandler->getLogName(log);
     createUNCFilename(log, logUrl, false);
-    workunit.addProcess("Thor", globals->queryProp("@name"), logUrl.str());
+    workunit.addProcess("Thor", globals->queryProp("@name"), 0, logUrl.str());
 }
 
 


### PR DESCRIPTION
Existing ECL WU xml contains only one agentPID. EclWatch uses the
agentPID to identify the log lines for the workunit from eclagent
log. When a WU runs on two different eclagents, EclWatch can only
find out the log lines in one eclagent log using the agentPID. In
this fix, the agentPID of each eclagent is added into the /Process/
/EclAgent/eclagent/ entry of the WU xml. EclWatch uses the agentPID
and the log name to read WU log lines from each eclagent log.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
