### PR TITLE
HPCC-9430 Remove incorrect active datasets for unusual cases

### DIFF
--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -3426,6 +3426,9 @@ ITypeInfo * replaceChildType(ITypeInfo * type, ITypeInfo * newChild)
     case type_sortlist:
         newType.setown(makeSortListType(LINK(newChild)));
         break;
+    case type_rule:
+        newType.setown(makeRuleType(LINK(newChild)));
+        break;
     default:
         throwUnexpected();
     }

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1049,6 +1049,7 @@ interface IHqlRemoteScope : public IInterface
 
 interface IHqlDataset : public IInterface
 {
+    virtual IHqlExpression * queryExpression() = 0;
     virtual IHqlDataset* queryTable() = 0;
     virtual IHqlDataset * queryRootTable() = 0;         // get DATASET definition.
     virtual IHqlExpression * queryContainer() = 0;          // this shouldn't really be used - won't extent to more arbitrary relation trees.

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -97,6 +97,8 @@ public:
     void addActiveTable(IHqlExpression * expr);
     void cleanupProduction();
     inline void removeActive(IHqlExpression * expr) { inScopeTables.zap(*expr); }
+    void removeParent(IHqlExpression * expr);
+    void removeActiveRecords();
     void removeRows(IHqlExpression * expr, IHqlExpression * left, IHqlExpression * right);
     void set(CUsedTables & tables) { tables.set(inScopeTables, newScopeTables); }
 
@@ -783,6 +785,7 @@ class CHqlExternalDatasetCall: public CHqlExternalCall, implements IHqlDataset
 
     virtual IHqlExpression *clone(HqlExprArray &newkids);
     virtual IHqlDataset *queryDataset() { return this; }
+    virtual IHqlExpression * queryExpression() { return this; }
 
 //interface IHqlDataset
     virtual IHqlDataset* queryTable()               { return this; }
@@ -917,6 +920,7 @@ class CHqlDelayedDatasetCall: public CHqlDelayedCall, implements IHqlDataset
     IMPLEMENT_IINTERFACE_USING(CHqlDelayedCall)
 
     virtual IHqlDataset *queryDataset() { return this; }
+    virtual IHqlExpression * queryExpression() { return this; }
 
 //interface IHqlDataset
     virtual IHqlDataset* queryTable()               { return this; }
@@ -1304,6 +1308,7 @@ public:
 //IHqlExpression
     virtual bool assignableFrom(ITypeInfo * source) { type_t tc = source->getTypeCode(); return tc==type_table; }
     virtual IHqlDataset *queryDataset() { return this; }
+    virtual IHqlExpression * queryExpression() { return this; }
 
 //CHqlParameter
 
@@ -1331,6 +1336,7 @@ public:
 //IHqlExpression
     virtual bool assignableFrom(ITypeInfo * source) { type_t tc = source->getTypeCode(); return tc==type_dictionary; }
     virtual IHqlDataset *queryDataset() { return this; }
+    virtual IHqlExpression * queryExpression() { return this; }
 
 //CHqlParameter
 
@@ -1627,6 +1633,7 @@ public:
     static CHqlDataset *makeDataset(node_operator op, ITypeInfo *type, HqlExprArray &operands);
 
     virtual IHqlDataset *queryDataset() { return this; };
+    virtual IHqlExpression * queryExpression() { return this; }
     virtual IHqlSimpleScope *querySimpleScope();
     virtual IHqlDataset* queryTable();
     virtual IHqlExpression *queryNormalizedSelector(bool skipIndex);

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -251,6 +251,7 @@
 #define HQLWRN_GroupedGlobalFew                 4540
 #define HQLWRN_AmbiguousRollupCondition         4541
 #define HQLWRN_AmbiguousRollupNoGroup           4542
+#define HQLWRN_GlobalActionDependendOnScope     4543
 
 //Temporary errors
 #define HQLERR_OrderOnVarlengthStrings          4601
@@ -523,6 +524,7 @@
 #define HQLWRN_GroupedGlobalFew_Text            "Global few expression is grouped"
 #define HQLWRN_AmbiguousRollupCondition_Text    "ROLLUP condition on '%s' is also modified in the transform"
 #define HQLWRN_AmbiguousRollupNoGroup_Text      "ROLLUP condition - no fields are preserved in the transform - not converted to GROUPed ROLLUP"
+#define HQLWRN_GlobalActionDependendOnScope_Text "Global action appears to be context dependent - this may cause a dataset not active error"
 
 #define HQLERR_OrderOnVarlengthStrings_Text     "Rank/Ranked not supported on variable length strings"
 #define HQLERR_DistributionNoSequence_Text      "DISTRIBUTION() only supported at the outer level"


### PR DESCRIPTION
- INDEX, DISTRIBUTED() could have a dependency on activeTable
- Any expression could have a dependency on parent from parent.child
- The record types of RULES weren't normalized to remove defaults
- Some symbols weren't removed from maxlength attributes
- Some other minor discrepancies

Has the effect of removing some incorrect warnings and removing some
duplicate meta classes for a couple of queries.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
