### PR TITLE
HPCC-8842 Delete spurious semicolon after an if condition

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -8645,7 +8645,7 @@ IHqlScope * CHqlVirtualScope::clone(HqlExprArray & children, HqlExprArray & symb
 extern HQL_API bool isVirtualSymbol(IHqlExpression * expr)
 {
     IHqlNamedAnnotation * symbol = static_cast<IHqlNamedAnnotation *>(expr->queryAnnotation());
-    if (symbol && symbol->getAnnotationKind() == annotate_symbol);
+    if (symbol && symbol->getAnnotationKind() == annotate_symbol)
         return symbol->isVirtual();
     return false;
 }


### PR DESCRIPTION
This wasn't causing any problems - since the condition was always true,
however it would have cored if the input wasn't valid.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
