### PR TITLE
HPCC-9438 Fix problem with unusual joins against null datasets.

### DIFF
--- a/ecl/hql/hqlmeta.cpp
+++ b/ecl/hql/hqlmeta.cpp
@@ -1462,6 +1462,10 @@ bool matchDedupDistribution(IHqlExpression * distn, const HqlExprArray & equalit
     return !includesFieldsOutsideGrouping(distn, cloned);
 }
 
+bool matchesAnyDistribution(IHqlExpression * distn)
+{
+    return distn == queryAnyDistributionAttribute();
+}
 
 //---------------------------------------------------------------------------
 
@@ -1539,16 +1543,21 @@ IHqlExpression * createMatchingDistribution(IHqlExpression * expr, const HqlExpr
         break;
     case no_attr:
     case no_attr_expr:
-        if (expr->queryName() == internalAtom)
         {
-            //HASH,internal - only valid if the types of the old and new sorts match exactly
-            ForEachItemIn(i, oldSort)
+            _ATOM name = expr->queryName();
+            if (name == internalAtom)
             {
-                if (oldSort.item(i).queryType() != newSort.item(i).queryType())
-                    return NULL;
+                //HASH,internal - only valid if the types of the old and new sorts match exactly
+                ForEachItemIn(i, oldSort)
+                {
+                    if (oldSort.item(i).queryType() != newSort.item(i).queryType())
+                        return NULL;
+                }
             }
+            else if (expr == cacheAnyAttribute)
+                return NULL;
+            break;
         }
-        break;
     default:
         return NULL;
     }

--- a/ecl/hql/hqlmeta.hpp
+++ b/ecl/hql/hqlmeta.hpp
@@ -69,6 +69,7 @@ extern HQL_API bool isSortedForGroup(IHqlExpression * table, IHqlExpression *sor
 extern HQL_API IHqlExpression * ensureSortedForGroup(IHqlExpression * table, IHqlExpression *sortList, bool isLocal, bool alwaysLocal, bool allowSubSort);
 
 extern HQL_API bool matchDedupDistribution(IHqlExpression * distn, const HqlExprArray & equalities);
+extern HQL_API bool matchesAnyDistribution(IHqlExpression * distn);
 
 extern HQL_API bool appearsToBeSorted(ITypeInfo * type, bool isLocal, bool ignoreGrouping);
 extern HQL_API bool isAlreadySorted(IHqlExpression * dataset, HqlExprArray & newSort, bool isLocal, bool ignoreGrouping);

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -2695,6 +2695,9 @@ IHqlExpression * ThorHqlTransformer::normalizeJoinOrDenormalize(IHqlExpression *
             //Be careful about the persist scaling factors though.
             //SORT partitions should be supported once they are persisted by the system
             IHqlExpression * leftDistribution = queryDistribution(leftDs);
+            if (matchesAnyDistribution(leftDistribution))
+                return appendOwnedOperand(expr, createLocalAttribute());
+
             if (!isPersistDistribution(leftDistribution) && !isSortedDistribution(leftDistribution) && isPartitionedForGroup(leftDs, leftSorts, true))
             {
                 //MORE: May need a flag to stop this - to prevent issues with skew.


### PR DESCRIPTION
Regression introduced by HPCC-9239 (pull #4405)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
