### PR TITLE
HPCC-9443 Race condition can cause roxie to core when updating packages

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1488,9 +1488,10 @@ private:
         // Hold the lock for as little time as we can
         // Note that we must NOT hold the lock during the delete of the old object - or we deadlock.
         // Hence the slightly convoluted code below
-        Owned<CRoxiePackageSetWatcher> oldPackages = allQueryPackages.getLink();  // To ensure that the setown just below does not delete it
+        Owned<CRoxiePackageSetWatcher> oldPackages;  // NB Destroyed outside the WriteLockBlock
         {
             WriteLockBlock b(packageCrit);
+            oldPackages.setown(allQueryPackages.getLink());  // To ensure that the setown just below does not delete it
             allQueryPackages.setown(newPackages.getClear());
         }
     }


### PR DESCRIPTION
If a control:reload and an automatic notify from Dali coincide, a race
condition can cause Roxie to core. The retrieval and linking of the old
packages needs to be inside the WriteLockBlock.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
