### PR TITLE
HPCC-9431 Allow constant folder to resolve functions in eclrtl

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -609,7 +609,12 @@ IValue * foldExternalCall(IHqlExpression* expr, unsigned foldOptions, ITemplateC
             throw MakeStringException(ERR_SVC_NOLIBRARY,"Missing library for function folding");
         return NULL;
     }
-    ensureFileExtension(lib, SharedObjectExtension);
+
+    if (!pathExtension(lib))
+    {
+        lib.insert(0, SharedObjectPrefix);
+        ensureFileExtension(lib, SharedObjectExtension);
+    }
 
     const char * entrypoint = entry.toCharArray();
     const char * library = lib.toCharArray();

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -142,6 +142,26 @@ StringBuffer &swapPathDrive(StringBuffer &filename,unsigned fromdrvnum,unsigned 
 }
 
 
+const char *pathTail(const char *path)
+{
+    if (!path)
+        return NULL;
+    const char *tail=path;
+    const char *s = path;
+    while (*s)
+        if (isPathSepChar(*(s++)))
+            tail = s;
+    return tail;
+}
+
+const char * pathExtension(const char * path)
+{
+    const char * tail = pathTail(path);
+    if (tail)
+        return strrchr(tail, '.');
+    return NULL;
+}
+
 bool checkFileExists(const char * filename)
 {
 #ifdef _WIN32

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -529,17 +529,8 @@ inline StringBuffer & addDirectoryPrefix(StringBuffer & target, const char * sou
     return target;
 }
 
-inline const char *pathTail(const char *path)
-{
-    if (!path)
-        return NULL;
-    const char *tail=path;
-    const char *s = path;
-    while (*s) 
-        if (isPathSepChar(*(s++)))
-            tail = s;
-    return tail;
-}
+extern jlib_decl const char *pathTail(const char *path);
+extern jlib_decl const char *pathExtension(const char * path);
 
 inline const char *splitDirTail(const char *path,StringBuffer &dir)
 {
@@ -555,8 +546,6 @@ inline bool isAbsolutePath(const char *path)
         return false;
     return isPathSepChar(path[0])||((path[1]==':')&&(isPathSepChar(path[2])));
 }
-
-
 
 extern jlib_decl StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out,bool mustExist=false);
 extern jlib_decl StringBuffer &makeAbsolutePath(StringBuffer &relpath,bool mustExist=false);


### PR DESCRIPTION
If the extension is missing from the library name, then prefix it with the
default library prefix as well as adding the default filename extension.

(This mirrors the behaviour in LoadSharedObject)

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
