### PR TITLE
HPCC-9447 If libRembed is present, eclcc malfunctions on some systems

### DIFF
--- a/plugins/Rembed/Rembed.cpp
+++ b/plugins/Rembed/Rembed.cpp
@@ -46,8 +46,8 @@ extern "C" EXPORT bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb)
         return false;
     pb->magicVersion = PLUGIN_VERSION;
     pb->version = version;
-    pb->moduleName = "R";
-    pb->ECL = NULL;
+    pb->moduleName = "+R+"; // Hack - we don't want to export any ECL, but if we don't export something,
+    pb->ECL = "";           // Hack - the dll is unloaded at startup when compiling, and the R runtime closes stdin when unloaded
     pb->flags = PLUGIN_MULTIPLE_VERSIONS;
     pb->description = "R Embed Helper";
     return true;


### PR DESCRIPTION
On some systems, unloading libRembed (and thus unloading the Rcpp, RInside,
and related objects) seems to cause stdin to be closed.

Providing dummy ecl and module name values means that the plugin will not be
unloaded, hopefully avoiding the issue.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
