### PR TITLE
HPCC-9467 Thor needs to provide user credentials

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -153,9 +153,10 @@ static IPropertyTree *addNamedPropTree(IPropertyTree *parent,const char *sub,con
     return LINK(ret);
 }
 
-const char *normalizeLFN(const char *s,StringBuffer &tmp)
+const char *normalizeLFN(const char *s,StringBuffer &tmp, IUserDescriptor *user)
 { 
     CDfsLogicalFileName dlfn;
+    dlfn.setUserDescriptor(user);
     dlfn.set(s);
     return dlfn.get(tmp).str();
 }
@@ -943,7 +944,7 @@ public:
     bool isSuperFile( const char *logicalname, IUserDescriptor *user, INode *foreigndali, unsigned timeout);
 
     void promoteSuperFiles(unsigned numsf,const char **sfnames,const char *addsubnames,bool delsub,bool createonlyonesuperfile,IUserDescriptor *user, unsigned timeout, StringArray &outunlinked);
-    ISimpleSuperFileEnquiry * getSimpleSuperFileEnquiry(const char *logicalname,const char *title,unsigned timeout);
+    ISimpleSuperFileEnquiry * getSimpleSuperFileEnquiry(const char *logicalname,const char *title,IUserDescriptor *udesc,unsigned timeout);
     bool getFileSuperOwners(const char *logicalname, StringArray &owners);
 
     IDFSredirection & queryRedirection() { return *redirection; }
@@ -1346,7 +1347,7 @@ class CDistributedFileTransaction: public CInterface, implements IDistributedFil
         if (!trackedFile)
         {
             StringBuffer tmp;
-            name = normalizeLFN(name, tmp);
+            name = normalizeLFN(name, tmp, udesc);
             trackedFile.setown(new CTransactionFile(*this, tmp.str(), file));
             trackedFiles.replace(*trackedFile.getLink());
             trackedFilesByName.replace(*trackedFile.getLink());
@@ -1565,7 +1566,7 @@ public:
     IDistributedFile *findFile(const char *name)
     {
         StringBuffer tmp;
-        name = normalizeLFN(name, tmp);
+        name = normalizeLFN(name, tmp, udesc);
         CTransactionFile *trackedFile = trackedFilesByName.find(tmp.str());
         if (!trackedFile)
             return NULL;
@@ -4843,7 +4844,7 @@ public:
     unsigned findSubFile(const char *name)
     {
         StringBuffer lfn;
-        normalizeLFN(name,lfn);
+        normalizeLFN(name,lfn, udesc);
         ForEachItemIn(i,subfiles) 
             if (stricmp(subfiles.item(i).queryLogicalName(),lfn.str())==0)
                 return i;
@@ -9990,6 +9991,7 @@ class CLightWeightSuperFileConn: public CInterface, implements ISimpleSuperFileE
     bool readonly;
     IArrayOf<IRemoteConnection> children;
     unsigned defaultTimeout;
+    Owned<IUserDescriptor> udesc;
 
     static StringBuffer &getSubPath(StringBuffer &path,unsigned idx)
     {
@@ -10071,10 +10073,11 @@ public:
 
     IMPLEMENT_IINTERFACE;
     
-    CLightWeightSuperFileConn(unsigned _defaultTimeout)
+    CLightWeightSuperFileConn(unsigned _defaultTimeout, IUserDescriptor *_udesc)
     {
         defaultTimeout = _defaultTimeout;
         readonly = false;
+        udesc.setown(_udesc);
     }
 
     bool connect(CDistributedFileDirectory *parent,const char *title, const char *name, bool _readonly, bool *autocreate, unsigned timeout)
@@ -10152,7 +10155,7 @@ public:
         if (n!=NotFound)
             return n;
         StringBuffer lfn;
-        normalizeLFN(subname,lfn);
+        normalizeLFN(subname,lfn, udesc);
         Owned<IPropertyTreeIterator> iter = lock.queryRoot()->getElements("SubFile");
         ForEach(*iter) {
             if (stricmp(iter->query().queryProp("@name"),lfn.str())==0) {
@@ -10274,9 +10277,9 @@ void CDistributedFileDirectory::promoteSuperFiles(unsigned numsf,const char **sf
 }
 
 
-ISimpleSuperFileEnquiry * CDistributedFileDirectory::getSimpleSuperFileEnquiry(const char *logicalname,const char *title,unsigned timeout)
+ISimpleSuperFileEnquiry * CDistributedFileDirectory::getSimpleSuperFileEnquiry(const char *logicalname,const char *title,IUserDescriptor *udesc,unsigned timeout)
 {
-    Owned<CLightWeightSuperFileConn> ret = new CLightWeightSuperFileConn(defaultTimeout);
+    Owned<CLightWeightSuperFileConn> ret = new CLightWeightSuperFileConn(defaultTimeout,udesc);
     if (ret->connect(this,title,logicalname,true,NULL,timeout))
         return ret.getClear();
     return NULL;

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -488,7 +488,7 @@ interface IDistributedFileDirectory: extends IInterface
     // Local 'lightweight' routines
     virtual void promoteSuperFiles(unsigned numsf,const char **sfnames,const char *addsubnames,bool delsub,bool createonlyonesuperfile,IUserDescriptor *user,unsigned timeout, StringArray &outunlinked)=0;
     virtual bool getFileSuperOwners(const char *logicalname, StringArray &owners)=0; // local only
-    virtual ISimpleSuperFileEnquiry * getSimpleSuperFileEnquiry(const char *logicalname,const char *dbgtitle,unsigned timeout=INFINITE)=0; // NB must be local!
+    virtual ISimpleSuperFileEnquiry * getSimpleSuperFileEnquiry(const char *logicalname,const char *dbgtitle,IUserDescriptor *udesc,unsigned timeout=INFINITE)=0; // NB must be local!
 
     virtual IDFSredirection & queryRedirection()=0;
 
@@ -657,7 +657,7 @@ extern da_decl StringBuffer &getClusterSpareGroupName(IPropertyTree &cluster, St
 
 extern da_decl IDistributedFileTransaction *createDistributedFileTransaction(IUserDescriptor *user);
 
-extern da_decl const char *normalizeLFN(const char *s, StringBuffer &normalized);
+extern da_decl const char *normalizeLFN(const char *s, StringBuffer &normalized, IUserDescriptor *user);
 
 extern da_decl IDFAttributesIterator *createSubFileFilter(IDFAttributesIterator *_iter,IUserDescriptor* _user, bool includesub, unsigned timems=INFINITE); // takes ownership of iter
 

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1038,7 +1038,7 @@ static ISimpleSuperFileEnquiry *getSimpleSuperFileEnquiry(ICodeContext *ctx, con
         return NULL;
     StringBuffer lsfn;
     constructLogicalName(ctx, lsuperfn, lsfn);
-    return queryDistributedFileDirectory().getSimpleSuperFileEnquiry(lsfn.str(),"Fileservices");
+    return queryDistributedFileDirectory().getSimpleSuperFileEnquiry(lsfn.str(),"Fileservices",ctx->queryUserDescriptor());
 }
 
 static void CheckNotInTransaction(ICodeContext *ctx, const char *fn)

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -185,6 +185,7 @@ CWriteMasterBase::CWriteMasterBase(CMasterGraphElement *info) : CMasterActivity(
     replicateProgress.setown(new ProgressInfo);
     diskHelperBase = (IHThorDiskWriteArg *)queryHelper();
     targetOffset = 0;
+    dlfn.setUserDescriptor(container.queryJob().queryUserDescriptor());
 }
 
 void CWriteMasterBase::deserializeStats(unsigned node, MemoryBuffer &mb)

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -226,7 +226,7 @@ public:
             }
             tmp.append(logicalname).clip();
         }
-        normalizeLFN(tmp.str(), ret);
+        normalizeLFN(tmp.str(), ret, job.queryUserDescriptor());
         return ret;
     }
 


### PR DESCRIPTION
Running regression test multilfn.ecl results in UNEXPECTED USER error
in message sent from THOR to DALI. This fix ensures a populated user
descriptor is provided to the normalizeLFN method

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
