### PR TITLE
IDE-272 Embedded IE Pages default to compatability mode

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1055,7 +1055,7 @@ int EspHttpBinding::onGetItext(IEspContext &context, CHttpRequest* request, CHtt
     StringBuffer title;
     request->getParameter("text", title);
     StringBuffer content;
-    content.append("<html><head>");
+    content.append("<!DOCTYPE html><html><head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />");
     if(title.length() > 0)
         content.appendf("<title>%s</title>", title.str());
     content.appendf("</head><body>"
@@ -1071,7 +1071,7 @@ int EspHttpBinding::onGetIframe(IEspContext &context, CHttpRequest* request, CHt
     StringBuffer title;
     request->getParameter("esp_iframe_title", title);
     StringBuffer content;
-    content.append("<html><head>");
+    content.append("<!DOCTYPE html><html><head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />");
     if(title.length() > 0)
         content.appendf("<title>%s</title>", title.str());
     content.append("</head>");

--- a/esp/files/stub.htm
+++ b/esp/files/stub.htm
@@ -18,6 +18,7 @@
 -->
 <html>
 <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="utf-8">
     <title>HPCC: Stub</title>
     <link href="CodeMirror2/lib/codemirror.css" rel="stylesheet">


### PR DESCRIPTION
Embedded IE ActiveX controls default to a compatibility mode which can only be
overridden by a registry edit on the client side:
http://stackoverflow.com/questions/4097593/how-to-put-the-webbrowser-control-into-ie9-into-standards
This can be overridden in the served HTML pages.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
