### PR TITLE
HPCC-9480 A GROUP ROLLUP was incorrectly marked as having grouped output...

### DIFF
--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -1781,6 +1781,7 @@ public:
 
     virtual void ready();
     virtual bool needsAllocator() const { return true; }    
+    virtual bool isGrouped() { return false; }
 
     //interface IHThorInput
     virtual const void *nextInGroup();

--- a/testing/ecl/countgrouprollup.ecl
+++ b/testing/ecl/countgrouprollup.ecl
@@ -1,0 +1,9 @@
+
+
+ds := DATASET([], { unsigned id; });
+
+g := GROUP(NOFOLD(ds), id);
+
+r := ROLLUP(g, GROUP, TRANSFORM({unsigned i}, SELF.i := COUNT(ROWS(LEFT))));
+
+output(count(r));

--- a/testing/ecl/key/countgrouprollup.xml
+++ b/testing/ecl/key/countgrouprollup.xml
@@ -1,0 +1,3 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>0</Result_1></Row>
+</Dataset>


### PR DESCRIPTION
....

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
