### PR TITLE
HPCC-9483 Valgrind complains about remotefile's hashtable of endpoints

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -1547,6 +1547,17 @@ public:
         }
         return clientCrit.getClear();
     }
+    unsigned getHashFromElement(const void *e) const
+    {
+        const CEndpointCS &elem=*(const CEndpointCS *)e;
+        return getHashFromFindParam(elem.queryFindParam());
+    }
+
+    unsigned getHashFromFindParam(const void *fp) const
+    {
+        return ((const SocketEndpoint *)fp)->hash(0);
+    }
+
     void removeExact(CEndpointCS *clientCrit)
     {
         CriticalBlock b(crit);


### PR DESCRIPTION
Because of uninitialized dead space in the SocketEndpoint structure, must
suply hash functions whenever used as the key to a hash table rather than
relying on the default implementation.

Not sure what effect this would have had - probably means that the critsec
designed to prevent multiple simultaneous transactions on the same remote
socket might sometimes have failed to fully protect.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
