### PR TITLE
HPCC-8515 Running standalone with dalisrvers=... has issues.

### DIFF
--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -363,6 +363,7 @@ private:
     bool isRemoteWorkunit;
     bool resolveFilesLocally;
     bool writeResultsToStdout;
+    Owned<IUserDescriptor> standAloneUDesc;
     outputFmts outputFmt;
     unsigned __int64 stopAfter;
     CriticalSection wusect;
@@ -454,7 +455,7 @@ public:
     void setDebugPaused();
     void setDebugRunning();
     void setBlockedOnPersist(const char * logicalName);
-    void setStandAloneOptions(bool _isStandAloneExe, bool _isRemoteWorkunit, bool _resolveFilesLocally, bool _writeResultsToStdout, outputFmts _outputFmt);
+    void setStandAloneOptions(bool _isStandAloneExe, bool _isRemoteWorkunit, bool _resolveFilesLocally, bool _writeResultsToStdout, outputFmts _outputFmt, IUserDescriptor *_standAloneUDesc);
     inline bool needToLockWorkunit() { return !isStandAloneExe; }           //If standalone exe then either no dali, or a unique remote workunit.
 
     virtual void setResultInt(const char * stepname, unsigned sequence, __int64);


### PR DESCRIPTION
Currently when running a standalone workunit and specifying a DALI, a
workunit is created but is missing some information. Also, there is not
user credentials, so calls to dali pass a NULL user descriptor.
This fix updates the workunit with the missing Owner (which can now be
specified on the command line), job name ( which is argv[0]) and cluster
"StandAloneHThor".  I added a new "-USER=username:password" command line
argument, which will provide the credentials for DALI access.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
