### PR TITLE
HPCC-9473 TOPN activity crashes if LIMIT depends on context

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -6918,9 +6918,6 @@ const void * CHThorEnthActivity::nextInGroup()
 CHThorTopNActivity::CHThorTopNActivity(IAgentContext & _agent, unsigned _activityId, unsigned _subgraphId, IHThorTopNArg & _arg, ThorActivityKind _kind)
     : CHThorSimpleActivityBase(_agent, _activityId, _subgraphId, _arg, _kind), helper(_arg), compare(*helper.queryCompare())
 {
-    limit = helper.getLimit();
-    assertex(limit == (size_t)limit);
-    sorted = (const void * *)checked_calloc((size_t)(limit+1), sizeof(void *), "topn");
     hasBest = helper.hasBest();
     grouped = outputMeta.isGrouped();
     curIndex = 0;
@@ -6937,6 +6934,9 @@ CHThorTopNActivity::~CHThorTopNActivity()
 void CHThorTopNActivity::ready()
 {
     CHThorSimpleActivityBase::ready();
+    limit = helper.getLimit();
+    assertex(limit == (size_t)limit);
+    sorted = (const void * *)checked_calloc((size_t)(limit+1), sizeof(void *), "topn");
     sortedCount = 0;
     curIndex = 0;
     eof = false;

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -6922,6 +6922,8 @@ CHThorTopNActivity::CHThorTopNActivity(IAgentContext & _agent, unsigned _activit
     grouped = outputMeta.isGrouped();
     curIndex = 0;
     sortedCount = 0;
+    limit = 0;
+    sorted = NULL;
 }
 
 CHThorTopNActivity::~CHThorTopNActivity()
@@ -6948,6 +6950,8 @@ void CHThorTopNActivity::done()
     CHThorSimpleActivityBase::done();
     while(curIndex < sortedCount)
         ReleaseRoxieRow(sorted[curIndex++]);
+    free(sorted);
+    sorted = NULL;
 }
 
 const void * CHThorTopNActivity::nextInGroup()


### PR DESCRIPTION
CHThorTopNActivity queries the LIMIT in the constructor. However there are
cases where that limit is computed in a parent activity, so it must be queried
later.
This fix moves the query, and the allocation of the buffer, from the ctor
to the ready() method

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
