### PR TITLE
HPCC-9488 Better handling of changes to config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ if (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.1")
 
             set ( CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/initfiles/sbin/prerm" )
             set ( CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/initfiles/bash/sbin/deb/postrm" )
-                else()
+        else()
             message("WARNING: Unsupported package ${packageManagement}.")
         endif ()
 

--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -133,6 +133,9 @@ SECTION=${SECTION:-DEFAULT}
 confToUse="${INSTALL_DIR}${CONFIG_DIR}/${ENV_CONF_FILE}"
 
 if [ -d ${CONFIG_DIR} ]; then
+    if [ -f ${CONFIG_DIR}/installed ] ; then
+        exit 0
+    fi
     if [ -e ${CONFIG_DIR}/${ENV_CONF_FILE} ]; then
         confToUse="${CONFIG_DIR}/${ENV_CONF_FILE}"
     fi
@@ -271,3 +274,7 @@ fi
 chown root:$group ${configs}
 chown -R $user:$group ${configs}/*
 chmod 775 ${configs}
+
+if [ -d ${CONFIG_DIR} ]; then
+    date > ${CONFIG_DIR}/installed
+fi

--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -24,23 +24,29 @@ installConfs ()
 {
     fileName=$1
     configPath=$2
+    mkdir -p ${configPath}
+    mkdir -p ${configPath}/rpmnew
 
     printf "Installing %-44s ..." "${fileName}"
+
     if [ ! -e ${configPath}/${fileName} ]; then
-        if [ -e ${configPath}/rpmnew/${fileName} ]; then
-            cp -f ${configPath}/rpmnew/${fileName} ${configPath}/${fileName}
-            log_success_msg
+        # Always install new files without comment
+        cp -f ${INSTALL_DIR}/${configPath}/rpmnew/${fileName} ${configPath}/${fileName}
+        cp -f ${INSTALL_DIR}/${configPath}/rpmnew/${fileName} ${configPath}/rpmnew/${fileName}
+        log_success_msg
+    elif [ -e ${configPath}/rpmnew/${fileName} ] && ! `diff -q ${configPath}/rpmnew/${fileName} ${INSTALL_DIR}/${configPath}/rpmnew/${fileName} >/dev/null` ; then
+        # There are changes in the default config since last installed
+        if ! `diff -q ${configPath}/rpmnew/${fileName} ${configPath}/${fileName} >/dev/null` ; then
+            # User has made their own changes too, so don't overwrite
+            log_failure_msg "Not overwriting modified configuration file ${fileName}"
         else
-            if [ -e ${INSTALL_DIR}/${configPath}/rpmnew/${fileName} ]; then
-                cp -f ${INSTALL_DIR}/${configPath}/rpmnew/${fileName} ${configPath}/${fileName}
-                cp -f ${INSTALL_DIR}/${configPath}/rpmnew/${fileName} ${configPath}/rpmnew/${fileName}
-                log_success_msg
-            else
-                log_failure_msg "Fail: File doesn't exist in rpmnew"
-            fi
+            # User has NOT made their own changes - ok to update
+            cp -f ${INSTALL_DIR}/${configPath}/rpmnew/${fileName} ${configPath}/${fileName}
+            cp -f ${INSTALL_DIR}/${configPath}/rpmnew/${fileName} ${configPath}/rpmnew/${fileName}
+            log_success_msg "Updated configuration file ${fileName}"
         fi
     else
-        log_success_msg
+        log_success_msg "No changes to configuration file ${fileName}"
     fi
 }
 

--- a/initfiles/bash/sbin/deb/postrm.in
+++ b/initfiles/bash/sbin/deb/postrm.in
@@ -17,7 +17,4 @@
 
 ###<REPLACE>###
 
-if [ -f "${INSTALL_DIR}/etc/init.d/install-init" ]; then
-        ${INSTALL_DIR}/etc/init.d/install-init
-fi
-
+# Nothing to do - we do it all in prerm

--- a/initfiles/bash/sbin/deb/postrm.in
+++ b/initfiles/bash/sbin/deb/postrm.in
@@ -17,4 +17,12 @@
 
 ###<REPLACE>###
 
-# Nothing to do - we do it all in prerm
+# On some systems, when running an update (as opposed to a remove) the postinstall script does
+# not get run. To work around that issue, we run the post-install actions in the post-remove script
+# (which IS run)
+#
+# If the install dir is still present post-removal, must be an update
+
+if [ -f "${INSTALL_DIR}/etc/init.d/install-init" ]; then
+    ${INSTALL_DIR}/etc/init.d/install-init
+fi

--- a/initfiles/etc/DIR_NAME/CMakeLists.txt
+++ b/initfiles/etc/DIR_NAME/CMakeLists.txt
@@ -25,7 +25,7 @@ FOREACH( iFILES
 ENDFOREACH ( iFILES)
 
 Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/environment.xml DESTINATION .${CONFIG_DIR}/rpmnew COMPONENT Runtime ) 	#  Don't delete the "."
-Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/environment.conf DESTINATION ${CONFIG_DIR}/rpmnew COMPONENT Runtime )
-Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/genenvrules.conf DESTINATION ${CONFIG_DIR}/rpmnew COMPONENT Runtime )
+Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/environment.conf DESTINATION .${CONFIG_DIR}/rpmnew COMPONENT Runtime )
+Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/genenvrules.conf DESTINATION .${CONFIG_DIR}/rpmnew COMPONENT Runtime )
 
 ADD_SUBDIRECTORY(configmgr)

--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -1,4 +1,4 @@
-## Default environment configuration file
+## Default environment configuration file for OpenHPCC
 
 [DEFAULT]
 configs=${CONFIG_DIR}

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-## Default environment file single-node hpcc installation
+## Default environment file single-node OpenHPCC installation
 -->
 
 <Environment>

--- a/initfiles/sbin/prerm.in
+++ b/initfiles/sbin/prerm.in
@@ -25,20 +25,27 @@ if [ $configmgr_status -gt 0 ]; then
     exit 1
 fi
 
-
 # Stop all services before cleaning up
 ######################################
 /etc/init.d/hpcc-init stop
 if [ -f "${PID_DIR}/mydafilesrv.pid" ]; then
     /etc/init.d/dafilesrv stop
 fi
-# Removing edits from /etc files
+
+# Remove edits from /etc files
+##############################
 ${INSTALL_DIR}/sbin/rm_conf_settings.sh
 
 
-# Removing symlinks.
+# Remove symlinks
+#################
 ${INSTALL_DIR}/etc/init.d/uninstall-init
 
+# Remove installed flag
+#######################
+if [ -f ${CONFIG_DIR}/installed ] ; then
+    rm ${CONFIG_DIR}/installed
+fi
 
 exit 0
  


### PR DESCRIPTION
When updating a previous installation from a new release that contains changes
to default/initial configuration files such as environment.conf or
environment.xml, update the user's configuration too if they had not made any
modifications from the previous default file.

If they HAVE made alterations, warn that changes in the default have not been
applied.

Remove the spurious additional call to init code called by the post-uninstall
script, which was interfering with this process.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
