### PR TITLE
HPCC-9442 Avoid ensureCapacity call on fixed size disk read

### DIFF
--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -1290,10 +1290,13 @@ void SourceBuilder::buildTransformElements(BuildCtx & ctx, IHqlExpression * expr
                 }
             }
 
-            OwnedHqlExpr ensureSize = adjustValue(bound.expr, virtualSize);
-            s.clear().append("crSelf.ensureCapacity(");
-            translator.generateExprCpp(s, ensureSize).append(", NULL);");
-            ctx.addQuoted(s);
+            if (!isFixedSizeRecord(record))
+            {
+                OwnedHqlExpr ensureSize = adjustValue(bound.expr, virtualSize);
+                s.clear().append("crSelf.ensureCapacity(");
+                translator.generateExprCpp(s, ensureSize).append(", NULL);");
+                ctx.addQuoted(s);
+            }
 
             s.clear().append("memcpy(crSelf.row(), left, ");
             translator.generateExprCpp(s, bound.expr).append(");");


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
