### PR TITLE
HPCC-9428 Remove @ sign from Deleting File confirmation

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -97,7 +97,11 @@
                          {
                             if (button == "Delete")
                             {
-                                if (confirm("Are you sure you want to delete "+ filename+ "?"))
+                                var val = filename;
+                                var pt = val.indexOf("@");
+                                if (pt > 0)
+                                    val = val.substring(0, pt);
+                                if (confirm("Are you sure you want to delete "+ val+ "?"))
                                 {
                                     document.location.href="/WsDFU/DFUArrayAction?Type=Delete&LogicalFiles_i0=" + filename;
                                     return true;


### PR DESCRIPTION
A @ sign after a filename is used to pass cluster information to
Delete Logical File function. But. the @ sign should not be shown
inside the confirmation message for deleting the file. This fix
removes the @ sign from the confirmation message.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
