### PR TITLE
HPCC-9473 TOPN activity crashes if LIMIT depends on context

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -6918,13 +6918,12 @@ const void * CHThorEnthActivity::nextInGroup()
 CHThorTopNActivity::CHThorTopNActivity(IAgentContext & _agent, unsigned _activityId, unsigned _subgraphId, IHThorTopNArg & _arg, ThorActivityKind _kind)
     : CHThorSimpleActivityBase(_agent, _activityId, _subgraphId, _arg, _kind), helper(_arg), compare(*helper.queryCompare())
 {
-    limit = helper.getLimit();
-    assertex(limit == (size_t)limit);
-    sorted = (const void * *)checked_calloc((size_t)(limit+1), sizeof(void *), "topn");
     hasBest = helper.hasBest();
     grouped = outputMeta.isGrouped();
     curIndex = 0;
     sortedCount = 0;
+    limit = 0;
+    sorted = NULL;
 }
 
 CHThorTopNActivity::~CHThorTopNActivity()
@@ -6937,6 +6936,9 @@ CHThorTopNActivity::~CHThorTopNActivity()
 void CHThorTopNActivity::ready()
 {
     CHThorSimpleActivityBase::ready();
+    limit = helper.getLimit();
+    assertex(limit == (size_t)limit);
+    sorted = (const void * *)checked_calloc((size_t)(limit+1), sizeof(void *), "topn");
     sortedCount = 0;
     curIndex = 0;
     eof = false;
@@ -6948,6 +6950,8 @@ void CHThorTopNActivity::done()
     CHThorSimpleActivityBase::done();
     while(curIndex < sortedCount)
         ReleaseRoxieRow(sorted[curIndex++]);
+    free(sorted);
+    sorted = NULL;
 }
 
 const void * CHThorTopNActivity::nextInGroup()

--- a/testing/ecl/key/topn.xml
+++ b/testing/ecl/key/topn.xml
@@ -148,3 +148,8 @@
  <Row><_unnamed_cnt_1>2</_unnamed_cnt_1></Row>
  <Row><_unnamed_cnt_1>1</_unnamed_cnt_1></Row>
 </Dataset>
+<Dataset name='Result 29'>
+ <Row><i>1</i><num>1</num><children><Row><i>1</i></Row></children></Row>
+ <Row><i>2</i><num>3</num><children><Row><i>3</i></Row><Row><i>20</i></Row><Row><i>100</i></Row></children></Row>
+ <Row><i>4</i><num>2</num><children><Row><i>12</i></Row><Row><i>50</i></Row></children></Row>
+</Dataset>

--- a/testing/ecl/topn.ecl
+++ b/testing/ecl/topn.ecl
@@ -66,3 +66,18 @@ output(topn(i3, 1, -l, best('d'), local));      // expect {'d',4}
 b1 := topn(g3, 2, l, best('a'));
 output(sort(b1, l, d));     // expect {'a',1},{'a',9'},{'a',6},{'a',8},{'d',11}
 output(table(b1, { count(group) }));        // expect {2,2,1}
+
+
+
+r1 := { unsigned i; };
+r2 := { unsigned i, unsigned num, dataset(r1) children; };
+ds := dataset([
+    { 1, 1, [{1},{2},{3}] },
+    { 2, 3, [{100},{20},{3}] },
+    { 4, 2, [{50},{12},{76}] }], r2);
+r2 t(r2 l) := TRANSFORM
+    SELF.children := TOPN(l.children, l.num, i);
+    SELF := l;
+END;
+p := PROJECT(ds, t(LEFT));
+output(p);					// expect {1,1,{1}} {2,3,{3,20,100}} {4,2,{50}}


### PR DESCRIPTION
CHThorTopNActivity queries the LIMIT in the constructor. However there are
cases where that limit is computed in a parent activity, so it must be queried
later.
This fix moves the query, and the allocation of the buffer, from the ctor
to the ready() method, and moves the delete from the dtor to the done method

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
