### PR TITLE
HPCC-9496 PackageMap Validate not checking RefFileInPackage flag

### DIFF
--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -426,7 +426,10 @@ public:
                 Owned<IReferencedFileIterator> refFiles = filelist->getFiles();
                 ForEach(*refFiles)
                 {
-                    VStringBuffer fullname("%s/%s", queryid, refFiles->query().getLogicalName());
+                    IReferencedFile &rf = refFiles->query();
+                    if (rf.getFlags() & RefFileInPackage)
+                        continue;
+                    VStringBuffer fullname("%s/%s", queryid, rf.getLogicalName());
                     unmatchedFiles.append(fullname);
                 }
 


### PR DESCRIPTION
Currently lists all files in query rather than only those that are
not defined in the given packagemap.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
