### PR TITLE
HPCC-9525 Segmentation fault when remote copy

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6055,6 +6055,8 @@ static const char *translateGroupType(GroupType groupType)
 
 static GroupType translateGroupType(const char *groupType)
 {
+    if (!groupType)
+        return grp_unknown;
     if (strieq(groupType, "Thor"))
         return grp_thor;
     else if (strieq(groupType, "Roxie"))


### PR DESCRIPTION
This was a regression introduced since candidate-4.0.0 rc9, and not in any
released build.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
