### PR TITLE
HPCC-9487 ESP should set IE=edge for certain ECLIDE HTTP responses

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -672,6 +672,7 @@ int EspHttpBinding::onGet(CHttpRequest* request, CHttpResponse* response)
         case sub_serv_index:
             return onGetIndex(context, request, response, serviceName.str());
         case sub_serv_files:
+            checkInitEclIdeResponse(request, response);
             return onGetFile(context, request, response, pathEx.str());
         case sub_serv_itext:
             return onGetItext(context, request, response, pathEx.str());
@@ -1050,11 +1051,13 @@ int EspHttpBinding::onGetFile(IEspContext &context, CHttpRequest* request, CHttp
 {
     return onGetNotFound(context, request,  response, NULL);
 }
+
 int EspHttpBinding::onGetItext(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *path)
 {
     StringBuffer title;
     request->getParameter("text", title);
     StringBuffer content;
+    checkInitEclIdeResponse(request, response, &content);
     content.append("<html><head>");
     if(title.length() > 0)
         content.appendf("<title>%s</title>", title.str());
@@ -1071,6 +1074,7 @@ int EspHttpBinding::onGetIframe(IEspContext &context, CHttpRequest* request, CHt
     StringBuffer title;
     request->getParameter("esp_iframe_title", title);
     StringBuffer content;
+    checkInitEclIdeResponse(request, response, &content);
     content.append("<html><head>");
     if(title.length() > 0)
         content.appendf("<title>%s</title>", title.str());

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1057,7 +1057,8 @@ int EspHttpBinding::onGetItext(IEspContext &context, CHttpRequest* request, CHtt
     StringBuffer title;
     request->getParameter("text", title);
     StringBuffer content;
-    checkInitEclIdeResponse(request, response, &content);
+    if (checkInitEclIdeResponse(request, response))
+        content.append("<!DOCTYPE html>"); //may be safe for all browsers? but better to be safe for now?
     content.append("<html><head>");
     if(title.length() > 0)
         content.appendf("<title>%s</title>", title.str());
@@ -1074,7 +1075,8 @@ int EspHttpBinding::onGetIframe(IEspContext &context, CHttpRequest* request, CHt
     StringBuffer title;
     request->getParameter("esp_iframe_title", title);
     StringBuffer content;
-    checkInitEclIdeResponse(request, response, &content);
+    if (checkInitEclIdeResponse(request, response))
+        content.append("<!DOCTYPE html>"); //may be safe for all browsers? but better to be safe for now?
     content.append("<html><head>");
     if(title.length() > 0)
         content.appendf("<title>%s</title>", title.str());

--- a/esp/bindings/http/platform/httpbinding.hpp
+++ b/esp/bindings/http/platform/httpbinding.hpp
@@ -300,4 +300,23 @@ protected:
     const char* queryAuthMethod() {return m_authmethod.str(); }
 };
 
+inline bool isEclIdeRequest(CHttpRequest *request)
+{
+    StringBuffer userAgent;
+    return strstr(request->getHeader("User-Agent", userAgent), "eclide/") != NULL;
+}
+
+inline void initEclIdeResponse(CHttpResponse* response, StringBuffer *content = NULL)
+{
+    response->addHeader("X-UA-Compatible", "IE=edge");
+    if (content)
+        content->append("<!DOCTYPE html>"); //may be safe for all browsers? but better to be safe for now?
+}
+
+inline void checkInitEclIdeResponse(CHttpRequest *request, CHttpResponse* response, StringBuffer *content = NULL)
+{
+    if (isEclIdeRequest(request))
+        initEclIdeResponse(response, content);
+}
+
 #endif //_SOAPBIND_HPP__

--- a/esp/bindings/http/platform/httpbinding.hpp
+++ b/esp/bindings/http/platform/httpbinding.hpp
@@ -306,17 +306,14 @@ inline bool isEclIdeRequest(CHttpRequest *request)
     return strstr(request->getHeader("User-Agent", userAgent), "eclide/") != NULL;
 }
 
-inline void initEclIdeResponse(CHttpResponse* response, StringBuffer *content = NULL)
-{
-    response->addHeader("X-UA-Compatible", "IE=edge");
-    if (content)
-        content->append("<!DOCTYPE html>"); //may be safe for all browsers? but better to be safe for now?
-}
-
-inline void checkInitEclIdeResponse(CHttpRequest *request, CHttpResponse* response, StringBuffer *content = NULL)
+inline bool checkInitEclIdeResponse(CHttpRequest *request, CHttpResponse* response)
 {
     if (isEclIdeRequest(request))
-        initEclIdeResponse(response, content);
+    {
+        response->addHeader("X-UA-Compatible", "IE=edge");
+        return true;
+    }
+    return false;
 }
 
 #endif //_SOAPBIND_HPP__

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -345,7 +345,10 @@ int CEspHttpServer::processRequest()
                 if (methodName.charAt(methodName.length()-1)=='_')
                     methodName.setCharAt(methodName.length()-1, 0);
                 if (!stricmp(methodName.str(), "files"))
+                {
+                    checkInitEclIdeResponse(m_request, m_response);
                     return onGetFile(m_request.get(), m_response.get(), pathEx.str());
+                }
                 else if (!stricmp(methodName.str(), "xslt"))
                     return onGetXslt(m_request.get(), m_response.get(), pathEx.str());
                 else if (!stricmp(methodName.str(), "body"))


### PR DESCRIPTION
For certain content, ECLIDE needs ESP to set the HTTP header
X-UA-Compatible to "IE=edge" and add <!DOCTYPE html> to the content.

This triggers the IE activex plugin to render in the proper content
mode.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
