### PR TITLE
HPCC-9535 Rationalize Roxie topology info

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -7766,9 +7766,8 @@ class CInitGroups
                 // MORE - it's not clear whether this is correct for full redundancy and overloaded clusters
                 {
                     unsigned k;
-                    for (k=0;k<eps.ordinality();k++)
-                        if (eps.item(k).equals(ep))
-                            break;
+                    if (eps.contains(ep))
+                        break;
                     if (k==eps.ordinality())
                         eps.append(ep); // just add (don't care about order and no duplicates)
                     break;

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6036,23 +6036,6 @@ public:
 
 #define GROUP_CACHE_INTERVAL (1000*60)
 
-static const char *translateGroupType(GroupType groupType)
-{
-    switch (groupType)
-    {
-        case grp_thor:
-            return "Thor";
-        case grp_roxie:
-            return "Roxie";
-        case grp_roxiefarm:
-            return "RoxieFarm";
-        case grp_hthor:
-            return "hthor";
-        default:
-            return NULL;
-    }
-}
-
 static GroupType translateGroupType(const char *groupType)
 {
     if (!groupType)
@@ -6061,8 +6044,6 @@ static GroupType translateGroupType(const char *groupType)
         return grp_thor;
     else if (strieq(groupType, "Roxie"))
         return grp_roxie;
-    else if (strieq(groupType, "RoxieFarm"))
-        return grp_roxiefarm;
     else if (strieq(groupType, "hthor"))
         return grp_hthor;
     else
@@ -7762,9 +7743,6 @@ class CInitGroups
                 processName = "ThorSpareProcess";
                 break;
             case grp_roxie:
-                processName = "RoxieSlave";
-                break;
-            case grp_roxiefarm:
                 processName = "RoxieServerProcess";
                 break;
             default:
@@ -7782,7 +7760,10 @@ class CInitGroups
             }
             SocketEndpoint ep = (*m)->ep;
             switch (groupType) {
-                case grp_roxiefarm:
+                case grp_roxie:
+                // Redundant copies are located via the flags.
+                // Old environments may contain duplicated sever information for multiple ports
+                // MORE - it's not clear whether this is correct for full redundancy and overloaded clusters
                 {
                     unsigned k;
                     for (k=0;k<eps.ordinality();k++)
@@ -7790,26 +7771,6 @@ class CInitGroups
                             break;
                     if (k==eps.ordinality())
                         eps.append(ep); // just add (don't care about order and no duplicates)
-                    break;
-                }
-                case grp_roxie:
-                {
-                    Owned<IPropertyTreeIterator> channels;
-                    channels.setown(node.getElements("RoxieChannel"));
-                    unsigned thisNodePrimaryChannel = 0;
-                    ForEach(*channels) {
-                        unsigned channel = channels->query().getPropInt("@number");
-                        unsigned level = channels->query().getPropInt("@level", 0);
-                        if (level == 0)  // level 0 means primary copy
-                            thisNodePrimaryChannel = channel;
-                    }
-                    if (thisNodePrimaryChannel==0) {
-                        ERRLOG("Cannot construct roxie cluster %s, no channel for node",cluster.queryProp("@name"));
-                        return NULL;
-                    }
-                    while (eps.ordinality()<thisNodePrimaryChannel)
-                        eps.append(nullep);
-                    eps.item(thisNodePrimaryChannel-1) = ep;
                     break;
                 }
                 case grp_thor:
@@ -7826,7 +7787,8 @@ class CInitGroups
         unsigned slavesPerNode = 0;
         if (grp_thor == groupType)
             slavesPerNode = cluster.getPropInt("@slavesPerNode");
-        if (slavesPerNode) {
+        if (slavesPerNode)
+        {
             SocketEndpointArray msEps;
             for (unsigned s=0; s<slavesPerNode; s++) {
                 ForEachItemIn(e, eps)
@@ -7871,9 +7833,6 @@ class CInitGroups
                 break;
             case grp_roxie:
                 kind = "Roxie";
-                break;
-            case grp_roxiefarm:
-                kind = "RoxieFarm";
                 break;
             case grp_hthor:
                 kind = "hthor";
@@ -7920,8 +7879,6 @@ class CInitGroups
                 break;
             case grp_roxie:
                 gname.append(cluster.queryProp("@name"));
-                break;
-            case grp_roxiefarm:
                 break;
             default:
                 throwUnexpected();
@@ -7977,19 +7934,6 @@ class CInitGroups
                 }
             }
         }
-    }
-
-    bool constructFarmGroup(IPropertyTree &cluster, IPropertyTree *oldCluster, bool force, StringBuffer &messages)
-    {
-        Owned<IPropertyTreeIterator> farms = cluster.getElements("RoxieFarmProcess");  // probably only one but...
-        bool ret = true;
-        ForEach(*farms) {
-            IPropertyTree &farm = farms->query();
-            VStringBuffer gname("%s__%s", cluster.queryProp("@name"), farm.queryProp("@name"));
-            if (!constructGroup(farm, gname, oldCluster, grp_roxiefarm, force, messages))
-                ret = false;
-        }
-        return ret;
     }
 
     enum CgCmd { cg_null, cg_reset, cg_add, cg_remove };
@@ -8159,7 +8103,6 @@ public:
                     oldCluster = oldEnvironment->queryPropTree(xpath.str());
                 }
                 constructGroup(cluster,NULL,oldCluster,grp_roxie,force,messages);
-                constructFarmGroup(clusters->query(),oldCluster,force,messages);
             }
             clusters.setown(root->getElements("EclAgentProcess"));
             ForEach(*clusters) {

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -570,7 +570,7 @@ extern da_decl IDistributedFileDirectory &queryDistributedFileDirectory();
 
 // ==GROUP STORE=================================================================================================
 
-enum GroupType { grp_thor, grp_thorspares, grp_roxie, grp_roxiefarm, grp_hthor, grp_unknown };
+enum GroupType { grp_thor, grp_thorspares, grp_roxie, grp_hthor, grp_unknown };
 
 interface INamedGroupIterator: extends IInterface
 {

--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -520,8 +520,6 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
       {
         if (!strcmp(pComponent->queryProp("@buildSet"), "roxie") || !strcmp(pComponent->queryProp("@buildSet"), "thor"))
         {
-          StringBuffer sbChildren;
-          bool isMaster = false;
           Owned<IPropertyTreeIterator> itInst = pComponent->getElements("*");
           ForEach(*itInst)
           {
@@ -529,13 +527,9 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
             String instName(pInst->queryName());
             if (!strcmp(instName.toCharArray(), "ThorMasterProcess") || instName.startsWith("RoxieServerProcess"))
             {
-              isMaster = true;
               out.appendf("%s=%s;%s%c%s;%s\n", pComponent->queryProp("@name"), pComponent->queryProp("@buildSet"), out_dirname, PATHSEPCHAR, pComponent->queryProp("@name"),"master");
             }
           }
-
-          if (!isMaster)
-            out.append(sbChildren);
         }
         else
           out.appendf("%s=%s;%s%c%s\n", pComponent->queryProp("@name"), pComponent->queryProp("@buildSet"), out_dirname, PATHSEPCHAR, pComponent->queryProp("@name"));

--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -532,8 +532,6 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
               isMaster = true;
               out.appendf("%s=%s;%s%c%s;%s\n", pComponent->queryProp("@name"), pComponent->queryProp("@buildSet"), out_dirname, PATHSEPCHAR, pComponent->queryProp("@name"),"master");
             }
-            else if (!strcmp(instName.toCharArray(), "RoxieSlaveProcess"))
-              sbChildren.appendf("%s=%s;%s%c%s;%s\n", pComponent->queryProp("@name"), pComponent->queryProp("@buildSet"), out_dirname, PATHSEPCHAR, pComponent->queryProp("@name"),"slave");
           }
 
           if (!isMaster)

--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -1136,7 +1136,7 @@ IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName,
 {
   Owned<IPropertyTree> pSelComps(createPTree("SelectedComponents"));
   Owned<IPropertyTreeIterator> iter = pEnvRoot->getElements("Software/*");
-  const char* instanceNodeNames[] = { "Instance", "RoxieServerProcess", "RoxieSlaveProcess" };
+  const char* instanceNodeNames[] = { "Instance", "RoxieServerProcess" };
   const char* logDirNames[] = { "@logDir", "@LogDir", "@dfuLogDir", "@eclLogDir" };
 
   ForEach(*iter)
@@ -1228,7 +1228,7 @@ IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName,
             for (UINT i=0; i<sizeof(instanceNodeNames) / sizeof(instanceNodeNames[0]); i++)
               if (!strcmp(sb.str(), instanceNodeNames[i]))
               {
-                //allow multiple instances but do not allow either roxie servers or slaves more than once per computer
+                //allow multiple instances but do not allow roxie servers more than once per computer
                 if (listall || sb.str()[0] != 'R' || !pSelComp->queryPropTree(StringBuffer().appendf("*[@computer=\"%s\"]", computer)))
                 {
                   IPropertyTree* pInstance = pSelComp->addPropTree(sb.str(), createPTree());

--- a/deployment/deployutils/configenvhelper.hpp
+++ b/deployment/deployutils/configenvhelper.hpp
@@ -44,7 +44,6 @@ private:
     IPropertyTree* getSoftwareNode(const char* compType, const char* compName);
     bool addRoxieServers(const char* xmlStr);
     bool checkComputerUse(/*IPropertyTree* pComputerNode*/ const char* szComputer, IPropertyTree* pParentNode) const;
-    bool makePlatformSpecificAbsolutePath(const char* computer, StringBuffer& path);
     IPropertyTree* addLegacyServer(const char* name, IPropertyTree* pServer, IPropertyTree*pFarm, const char* roxieClusterName);
     void setComputerState(IPropertyTree* pNode, COMPUTER_STATE state);
     void setAttribute(IPropertyTree* pNode, const char* szName, const char* szValue);
@@ -65,11 +64,9 @@ private:
     bool handleRoxieSlaveConfig(const char* params);
     bool handleReplaceRoxieServer(const char* xmlArg);
     void addSlaveProcessConfig(IPropertyTree *pRoxie, IPropertyTree *pSlaveNode, int channel, int level, const char* netAddress);
-    bool GenerateCyclicRedConfig(IPropertyTree* pRoxie, IPropertyTreePtrArray& computers, const char* copies, const char* pszOffset,
-                                                             const char* dir1, const char* dir2, const char* dir3);
-    bool GenerateOverloadedConfig(IPropertyTree* pRoxie, IPropertyTreePtrArray& computers, const char* copies,
-                                                                const char* dir1, const char* dir2, const char* dir3);
-    bool GenerateFullRedConfig(IPropertyTree* pRoxie, int copies, IPropertyTreePtrArray& computers, const char* dir1);
+    bool GenerateCyclicRedConfig(IPropertyTree* pRoxie, IPropertyTreePtrArray& computers, const char* copies, const char* pszOffset);
+    bool GenerateOverloadedConfig(IPropertyTree* pRoxie, IPropertyTreePtrArray& computers, const char* copies);
+    bool GenerateFullRedConfig(IPropertyTree* pRoxie, int copies, IPropertyTreePtrArray& computers);
     void RemoveSlaves(IPropertyTree* pRoxie, bool bLegacySlaves/*=false*/);
     void RenameThorInstances(IPropertyTree* pThor);
     void UpdateThorAttributes(IPropertyTree* pParentNode);

--- a/esp/eclwatch/ws_XSLT/machines.xslt
+++ b/esp/eclwatch/ws_XSLT/machines.xslt
@@ -340,7 +340,6 @@
                     <xsl:when test="Type='ThorSlaveProcess'">Thor Slave</xsl:when>
                     <xsl:when test="Type='ThorSpareProcess'">Thor Spare</xsl:when>
                     <xsl:when test="Type='RoxieServerProcess'">Roxie Server</xsl:when>
-                    <xsl:when test="Type='RoxieSlaveProcess'">Roxie Slave</xsl:when>
                     <xsl:when test="Type='DropZone'">Drop Zone</xsl:when>
                     <xsl:otherwise>
                         <xsl:value-of select="Type"/>

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -3645,7 +3645,7 @@ bool CWsDeployFileInfo::getDeployableComps(IEspContext &context, IEspGetDeployab
             for (UINT i=0; i<sizeof(instanceNodeNames) / sizeof(instanceNodeNames[0]); i++)
               if (!strcmp(nodeName, instanceNodeNames[i]))
               {
-                if (*nodeName != 'R')// || //neither RoxieServerProcess nor RoxieSlaveProcess
+                if (*nodeName != 'R')// || // neither RoxieServerProcess nor RoxieSlaveProcess
                 {
                   IPropertyTree* pInstanceNode = pCompNode->addPropTree(XML_TAG_INSTANCES, createPTree());
                   const char* directory = pNode->queryProp(*nodeName == 'R' ? XML_ATTR_LEVEL : XML_ATTR_DIRECTORY);

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -64,10 +64,6 @@
 #define eqRoxieServerProcess    "RoxieServerProcess"
 #endif
 
-#ifndef eqRoxieSlaveProcess
-#define eqRoxieSlaveProcess    "RoxieSlaveProcess"
-#endif
-
 static const int THREAD_POOL_SIZE = 40;
 static const int THREAD_POOL_STACK_SIZE = 64000;
 static const char* FEATURE_URL = "MachineInfoAccess";
@@ -660,7 +656,6 @@ void Cws_machineEx::readTargetClusterProcesses(IPropertyTree &processNode, const
     {
         BoolHash uniqueRoxieProcesses;
         getProcesses(constEnv, pClusterProcess, process, eqRoxieServerProcess, dirStr.str(), machineInfoData, uniqueProcesses, &uniqueRoxieProcesses);
-        getProcesses(constEnv, pClusterProcess, process, eqRoxieSlaveProcess, dirStr.str(), machineInfoData, uniqueProcesses, &uniqueRoxieProcesses);
     }
 }
 
@@ -1991,7 +1986,7 @@ const char* Cws_machineEx::getProcessTypeFromMachineType(const char* machineType
     {
         processType = eqThorCluster;
     }
-    else    if (strieq(machineType, eqRoxieServerProcess) || strieq(machineType, eqRoxieSlaveProcess))
+    else    if (strieq(machineType, eqRoxieServerProcess))
     {
         processType = eqRoxieCluster;
     }

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -122,7 +122,6 @@ void CTpWrapper::getClusterMachineList(double clientVersion,
         else if (strcmp(eqROXIEMACHINES,ClusterType) == 0)
         {
             getMachineList("RoxieServerProcess",path.str(),"", ClusterDirectory, MachineList, &machineNames);
-            getMachineList("RoxieSlaveProcess",path.str(),"", ClusterDirectory, MachineList, &machineNames);
         }
         else if (strcmp(eqMACHINES,ClusterType) == 0)
         {

--- a/esp/xslt/ui_configmgr.xslt
+++ b/esp/xslt/ui_configmgr.xslt
@@ -620,7 +620,6 @@
                       rowsServers[rowsServers.length] = i;
                     </xsl:for-each>
                   </xsl:when>
-                    <xsl:when test="(name() = 'RoxieSlaveProcess')"/>
                     <xsl:when test="(name() = 'RoxieServerProcess')"/>
                     <xsl:when test="(name() = 'RoxieSlave')">
                       id = rowsSlaves.length;

--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -25,6 +25,55 @@
     </xs:annotation>
     <xs:complexType>
       <xs:choice maxOccurs="unbounded">
+
+        <xs:element name="RoxieFarmProcess" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <title>Farms</title>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="9876">
+              <xs:annotation>
+                <xs:appinfo>
+                  <required>true</required>
+                  <tooltip>the network port on which the Roxie servers accept connections</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="numThreads" type="xs:nonNegativeInteger" use="optional" default="30">
+              <xs:annotation>
+                <xs:appinfo>
+                  <tooltip>Number of simultaneous queries Roxie servers will accept on this port</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="listenQueue" type="xs:nonNegativeInteger" use="optional" default="200">
+              <xs:annotation>
+                <xs:appinfo>
+                  <tooltip>Number of pending connections that can be accepted</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="requestArrayThreads" type="xs:nonNegativeInteger" use="optional" default="5">
+              <xs:annotation>
+                <xs:appinfo>
+                  <tooltip>Number of simultaneous queries Roxie servers will process using the MERGE option of SOAPCALL</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="aclName" type="xpathType" use="optional">
+              <xs:annotation>
+                <xs:appinfo>
+                  <tooltip>Name of any Access Control List to use</tooltip>
+                  <title>ACL</title>
+                  <xpath>$process/ACL</xpath>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
         <xs:element name="RoxieServerProcess" maxOccurs="unbounded">
           <xs:annotation>
             <xs:appinfo>
@@ -41,78 +90,9 @@
                 </xs:appinfo>
               </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="9876">
-              <xs:annotation>
-                <xs:appinfo>
-                  <required>true</required>
-                  <tooltip>the network port on which the Roxie server accepts connections</tooltip>
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="numThreads" type="xs:nonNegativeInteger" use="optional" default="30">
-              <xs:annotation>
-                <xs:appinfo>
-                  <tooltip>Number of simultaneous queries this Roxie server will accept on this port</tooltip>
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="listenQueue" type="xs:nonNegativeInteger" use="optional" default="200">
-              <xs:annotation>
-                <xs:appinfo>
-                  <tooltip>Number of pending connections that can be accepted</tooltip>
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="requestArrayThreads" type="xs:nonNegativeInteger" use="optional" default="5">
-              <xs:annotation>
-                <xs:appinfo>
-                  <tooltip>Number of simultaneous queries this Roxie server will process using the MERGE option of SOAPCALL</tooltip>
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="aclName" type="xpathType" use="optional">
-              <xs:annotation>
-                <xs:appinfo>
-                  <tooltip>Name of any Access Control List to use</tooltip>
-                  <title>ACL</title>
-                  <xpath>$process/ACL</xpath>
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:attribute>
           </xs:complexType>
         </xs:element>
-        <xs:element name="RoxieSlaveProcess" maxOccurs="unbounded">
-          <xs:annotation>
-            <xs:appinfo>
-              <viewType>RoxieSlaves</viewType>
-              <title>Agents</title>
-            </xs:appinfo>
-          </xs:annotation>
-          <xs:complexType>
-            <xs:attribute name="computer" type="computerType" use="required"/>
-            <xs:attribute name="netAddress" type="ipAddress">
-              <xs:annotation>
-                <xs:appinfo>
-                  <viewType>readonly</viewType>
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="channel" type="xs:nonNegativeInteger" use="required">
-              <xs:annotation>
-                <xs:appinfo>
-                  <tooltip>Channel number for this agent</tooltip>
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="level" type="xs:nonNegativeInteger" use="optional" default="0">
-              <xs:annotation>
-                <xs:appinfo>
-                  <tooltip>Replication level of this slave</tooltip>
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:attribute>
-          </xs:complexType>
-        </xs:element>
+
         <xs:element name="ACL" maxOccurs="unbounded">
           <xs:annotation>
             <xs:appinfo>

--- a/initfiles/componentfiles/configxml/slaves.xsl
+++ b/initfiles/componentfiles/configxml/slaves.xsl
@@ -28,8 +28,8 @@
 </xsl:template>
 
 <xsl:template  match="RoxieCluster">
-   <xsl:for-each select="RoxieServerProcess|RoxieSlaveProcess">
-    <xsl:if test="string(@computer) != '' and not(@computer = preceding-sibling::RoxieServerProcess/@computer) and not(@computer = preceding-sibling::RoxieSlaveProcess/@computer)">
+   <xsl:for-each select="RoxieServerProcess">
+    <xsl:if test="string(@computer) != '' and not(@computer = preceding-sibling::RoxieServerProcess/@computer)">
         <xsl:value-of select="/Environment/Hardware/Computer[@name=current()/@computer]/@netAddress"/>
         <xsl:text>
 </xsl:text>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -768,7 +768,6 @@
              program="${EXEC_PATH}/ftslave"/>
   </FTSlaveProcess>
   <RoxieCluster allFilesDynamic="true"
-                baseDataDir="${RUNTIME_PATH}/hpcc-data/roxie"
                 blindLogging="false"
                 blobCacheMem="0"
                 build="${projname}_${version}-${stagever}"
@@ -894,50 +893,20 @@
                 useMemoryMappedIndexes="false"
                 useRemoteResources="true"
                 useTreeCopy="false">
-   <RoxieFarmProcess 
-                     level="0"
-                     listenQueue="200"
+   <RoxieFarmProcess listenQueue="200"
                      name="farm1"
                      numThreads="30"
                      port="9876"
-                     requestArrayThreads="5">
-    <RoxieServerProcess computer="localhost" name="farm1_s1"/>
-   </RoxieFarmProcess>
-   <RoxieFarmProcess
-                      level="0"
-                      listenQueue="200"
+                     requestArrayThreads="5"/>
+   <RoxieFarmProcess  listenQueue="200"
                       name="farm2"
                       numThreads="30"
                       port="0"
-                      requestArrayThreads="5">
-      <RoxieServerProcess computer="localhost" name="farm2_s1"/>
-    </RoxieFarmProcess>
-    <RoxieServerProcess
-                       computer="localhost"
-                       level="0"
-                       listenQueue="200"
-                       name="farm1_s1"
-                       netAddress="."
-                       numThreads="30"
-                       port="9876"
-                       requestArrayThreads="5"/>
+                      requestArrayThreads="5"/>
    <RoxieServerProcess 
                        computer="localhost"
-                       level="0"
-                       listenQueue="200"
                        name="farm2_s1"
-                       netAddress="."
-                       numThreads="30"
-                       port="0"
-                       requestArrayThreads="5"/>
-   <RoxieSlave computer="localhost" name="s1">
-    <RoxieChannel level="0" number="1"/>
-   </RoxieSlave>
-   <RoxieSlaveProcess channel="1"
-                      computer="localhost"
-                      level="0"
-                      name="s1"
-                      netAddress="."/>
+                       netAddress="."/>
   </RoxieCluster>
   <SashaServerProcess autoRestartInterval="0"
                       build="${projname}_${version}-${stagever}"

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -311,10 +311,8 @@ interface IRoxieQueryPacket : extends IInterface
 interface IQueryDll;
 
 // Global configuration info
-extern bool isMonitor;
 extern bool shuttingDown;
 extern unsigned numChannels;
-extern unsigned numActiveChannels;
 extern unsigned callbackRetries;
 extern unsigned callbackTimeout;
 extern unsigned lowTimeout;
@@ -349,7 +347,6 @@ extern unsigned indexReadChunkSize;
 extern SocketEndpoint ownEP;
 extern unsigned maxBlockSize;
 extern unsigned maxLockAttempts;
-extern SocketEndpointArray allRoxieServers;
 extern bool enableHeartBeat;
 extern bool checkVersion;
 extern unsigned memoryStatsInterval;
@@ -396,6 +393,8 @@ extern PTreeReaderOptions defaultXmlReadFlags;
 extern bool mergeSlaveStatistics;
 extern bool roxieMulticastEnabled;   // enable use of multicast for sending requests to slaves
 extern bool preloadOnceData;
+
+extern unsigned roxiePort;     // If listening on multiple, this is the first. Used for lock cascading
 
 extern unsigned udpMulticastBufferSize;
 extern size32_t diskReadBufferSize;

--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -244,16 +244,11 @@ class CascadeManager : public CInterface
         }
     }
 
-    SocketEndpoint &queryEndpoint(unsigned idx)
-    {
-        return allRoxieServers.item(idx);
-    }
-
     void connectChild(unsigned idx)
     {
-        if (allRoxieServers.isItem(idx))
+        if (idx < getNumNodes())
         {
-            SocketEndpoint &ep = queryEndpoint(idx);
+            SocketEndpoint ep(roxiePort, getNodeAddress(idx));
             try
             {
                 if (traceLevel)
@@ -518,11 +513,11 @@ public:
         if (traceLevel > 5)
             DBGLOG("doLockGlobal got %d locks", locksGot);
         reply.append("<Lock>").append(locksGot).append("</Lock>");
-        reply.append("<NumServers>").append(allRoxieServers.ordinality()).append("</NumServers>");
+        reply.append("<NumServers>").append(getNumNodes()).append("</NumServers>");
         if (lockAll)
-            return locksGot == allRoxieServers.ordinality();
+            return locksGot == getNumNodes();
         else
-            return locksGot > allRoxieServers.ordinality()/2;
+            return locksGot > getNumNodes()/2;
     }
 
     void doControlQuery(SocketEndpoint &ep, const char *queryText, StringBuffer &reply)

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -833,12 +833,13 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
 
         // Generate the slave channels
         unsigned numDataCopies = topology->getPropInt("@numDataCopies", 1);
-        unsigned cyclicOffset = topology->getPropInt("@cyclicOffset", 0);
         unsigned numNodes = getNumNodes();
-        if (cyclicOffset)
+        const char *slaveConfig = topology->queryProp("@slaveConfig");
+        if (strnicmp(slaveConfig, "cyclic", 6) == 0)
         {
             if (numChannels != numNodes)
                 throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - numChannels does not match number of servers");
+            unsigned cyclicOffset = topology->getPropInt("@cyclicOffset", 0);
             for (int i=0; i<numNodes; i++)
             {
                 int channel = i+1;
@@ -851,7 +852,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                 }
             }
         }
-        else if (numChannels > numNodes)   // overloaded mode
+        else if (strnicmp(slaveConfig, "overloaded", 10) == 0)
         {
             if (numChannels != numNodes * numDataCopies)
                 throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - numChannels does not match expected value");

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -3557,7 +3557,7 @@ public:
                 // Need to add first, then send
                 unsigned i;
                 bool allCached = true;
-                for (i = 1; i <= numActiveChannels; i++)
+                for (i = 1; i <= numChannels; i++)
                 {
                     IRoxieQueryPacket *q = p->clonePacket(i);
                     bool thisChannelCached;

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -2121,11 +2121,6 @@ private:
                 ReadLockBlock readBlock(packageCrit);
                 reply.appendf("<State hash='%"I64F"u'/>", (unsigned __int64) allQueryPackages->queryHash());
             }
-            else if (stricmp(queryName, "control:status")==0)
-            {
-                CriticalBlock b(ccdChannelsCrit);
-                toXML(ccdChannels, reply);
-            }
             else if (stricmp(queryName, "control:steppingEnabled")==0)
             {
                 steppingEnabled = control->getPropBool("@val", true);


### PR DESCRIPTION
Ensure that all components use only the information really needed - this will
be backward compatible on all environments that are internally consistent,
i.e. those generated by configmgr. Duplicate nodes in the server list will be
ignored, port information will be taken from RoxieFarmProcess nodes, and
RoxieSlaveProcess and RoxieSlave nodes will be ignored.

This commit does not update configmgr to stop it generating the additional
info (yet).

Remove the creation of the (unused, as far as I can see) 'farm' group for a
roxie when environment is loaded to Dali. All roxie schemes now generate
groups that contain all nodes, just once - as far as I can tell the previous
code would have done so for schemes other than 'full redundancy', which would
have generated a group with most of the servers missing.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
