### PR TITLE
HPCC-9539 Expose SuperFile info from WsWorkunits::WUQueryDetails

### DIFF
--- a/esp/eclwatch/ws_XSLT/WUQueryDetails.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQueryDetails.xslt
@@ -256,6 +256,42 @@
                                 </td>
                             </tr>
                         </xsl:if>
+                      <xsl:if test="count(SuperFiles/SuperFile)">
+                        <tr>
+                          <th valign="top">SuperFiles<br/>
+                            <img src="/esp/files/img/expand.gif" alt=" >> "/>SubFiles:
+                            </th>
+                          <td>
+                            <table id="SuperFileTable">
+                              <xsl:for-each select="SuperFiles/SuperFile">
+                                <tr>
+                                  <td>
+                                    <a href="javascript:void(0)" onclick="DFUFileDetails('{.}');">
+                                      <xsl:value-of select="Name"/>
+                                    </a>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <table>
+                                      <xsl:for-each select="SubFiles/File">
+                                        <tr>
+                                          <td>
+                                            <img src="/esp/files/img/expand.gif" alt=" >> "/>
+                                            <a href="javascript:void(0)" onclick="DFUFileDetails('{.}');">
+                                              <xsl:value-of select="."/>
+                                            </a>
+                                          </td>
+                                        </tr>
+                                      </xsl:for-each>
+                                    </table>
+                                  </td>
+                                </tr>
+                              </xsl:for-each>
+                            </table>
+                          </td>
+                        </tr>
+                      </xsl:if>
                     </table>
                 </form>
                 <input id="deleteBtn" type="button" value="Delete" onclick="deleteQuery();"> </input>

--- a/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
@@ -82,7 +82,7 @@
                     record = aliasDataTable.getRecord(selectedRows[0]);
                 else
                     record = queryDataTable.getRecord(selectedRows[0]);
-                document.location.href = "/WsWorkunits/WUQueryDetails?IncludeStateOnClusters=1&QueryId=" + record.getData('Id') + "&QuerySet=" + querySet;
+                document.location.href = "/WsWorkunits/WUQueryDetails?IncludeSuperFiles=1&IncludeStateOnClusters=1&QueryId=" + record.getData('Id') + "&QuerySet=" + querySet;
               }
 
               function deleteQueries() {

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1198,7 +1198,14 @@ ESPrequest WUQueryDetailsRequest
 {
     string QueryId;
     string QuerySet;
-    bool   IncludeStateOnClusters(false);
+    bool IncludeStateOnClusters(false);
+    bool IncludeSuperFiles(false);
+};
+
+ESPStruct QuerySuperFile
+{
+    string Name;
+    ESParray<string, File> SubFiles;
 };
 
 ESPresponse [exceptions_inline] WUQueryDetailsResponse
@@ -1216,6 +1223,8 @@ ESPresponse [exceptions_inline] WUQueryDetailsResponse
     string Comment;
 
     ESParray<string> LogicalFiles;
+    [min_ver("1.44")] ESParray<ESPstruct QuerySuperFile, SuperFile> SuperFiles;
+
 };
 
 ESPrequest WUMultiQuerySetDetailsRequest
@@ -1341,7 +1350,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.42"), default_client_version("1.42"),
+    version("1.44"), default_client_version("1.44"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -41,7 +41,7 @@ public:
     void deploySharedObject(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEspWUDeployWorkunitResponse & resp, const char *dir, const char *xml=NULL);
     void deploySharedObject(IEspContext &context, StringBuffer &wuid, const char *filename, const char *cluster, const char *name, const MemoryBuffer &obj, const char *dir, const char *xml=NULL);
     void checkAndTrimWorkunit(const char* methodName, StringBuffer& input);
-    bool getQueryFiles(const char* query, const char* target, StringArray& logicalFiles);
+    bool getQueryFiles(const char* query, const char* target, StringArray& logicalFiles, IArrayOf<IEspQuerySuperFile> *superFiles);
 
     bool onWUQuery(IEspContext &context, IEspWUQueryRequest &req, IEspWUQueryResponse &resp);
     bool onWUPublishWorkunit(IEspContext &context, IEspWUPublishWorkunitRequest & req, IEspWUPublishWorkunitResponse & resp);


### PR DESCRIPTION
control:getQueryXrefInfo now includes information on the SuperFiles
used by a query.  Operations has asked that it be exposed from
WsWorkunits::WUQueryDetails.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
