### PR TITLE
HPCC-9544 ecl-packagemap-add should report unresolved files

### DIFF
--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -576,6 +576,15 @@ public:
         if (resp->getExceptions().ordinality())
             outputMultiExceptions(resp->getExceptions());
 
+        StringArray &notFound = resp->getFilesNotFound();
+        if (notFound.length())
+        {
+            fputs("\nFiles defined in package but not found in DFS:\n", stderr);
+            ForEachItemIn(i, notFound)
+                fprintf(stderr, "  %s\n", notFound.item(i));
+            fputs("\n", stderr);
+        }
+
         return 0;
     }
 

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -34,6 +34,7 @@ ESPrequest AddPackageRequest
 ESPresponse [exceptions_inline] AddPackageResponse
 {
     ESPstruct BasePackageStatus status;
+    ESParray<string, File> FilesNotFound;
 };
 
 ESPrequest DeletePackageRequest


### PR DESCRIPTION
ecl-packagemap-add listing the files it could not locate would
allow this type of packagemap issue to be resolved much more
quickly and no longer one at a time.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
