### PR TITLE
HPCC-9549 Library cannot be resolved unless uses same package as query

### DIFF
--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -144,12 +144,6 @@ public:
         return node;
     }
 
-    virtual IPropertyTree *getQuerySets() const
-    {
-        if (!node)
-            return NULL;
-        return node->getPropTree("QuerySets");
-    }
     virtual bool validate(StringArray &warn, StringArray &err) const;
 };
 

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -852,7 +852,7 @@ public:
 
     virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const
     {
-        return globalPackageSetManager->lookupLibrary(package, libraryName, expectedInterfaceHash, logctx);
+        return globalPackageSetManager->lookupLibrary(libraryName, expectedInterfaceHash, logctx);
     }
 
     virtual void beforeDispose()

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1216,7 +1216,7 @@ public:
         owner->notify(id, xpath, flags, valueLen, valueData);
     }
 
-    IQueryFactory *lookupLibrary(const IRoxiePackage &package, const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const
+    IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const
     {
         ForEachItemIn(idx, allQueryPackages)
         {
@@ -1457,10 +1457,10 @@ public:
         controlSem.signal();
     }
 
-    virtual IQueryFactory *lookupLibrary(const IRoxiePackage &package, const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const
+    virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const
     {
         ReadLockBlock b(packageCrit);
-        return allQueryPackages->lookupLibrary(package, libraryName, expectedInterfaceHash, logctx);
+        return allQueryPackages->lookupLibrary(libraryName, expectedInterfaceHash, logctx);
     }
 
     virtual IQueryFactory *getQuery(const char *id, const IRoxieContextLogger &logctx) const

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -441,14 +441,6 @@ public:
         return createRoxieWriteHandler(daliHelper, ldFile.getClear(), clusters);
     }
 
-    virtual IPropertyTree *getQuerySets() const
-    {
-        if (node)
-            return node->getPropTree("QuerySets");
-        else
-            return NULL;
-    }
-
     //map ambiguous IHpccPackage
     virtual ISimpleSuperFileEnquiry *resolveSuperFile(const char *superFileName) const
     {
@@ -1232,7 +1224,7 @@ public:
             if (sm->isActive())
             {
                 Owned<IQueryFactory> library = sm->getQuery(libraryName, logctx);
-                if (library && (&library->queryPackage() == &package))  // MORE - is this check too restrictive?
+                if (library)
                 {
                     if (library->isQueryLibrary())
                     {
@@ -1247,7 +1239,7 @@ public:
                 }
             }
         }
-        throw MakeStringException(ROXIE_LIBRARY_ERROR, "No compatible library available for %s", libraryName);
+        throw MakeStringException(ROXIE_LIBRARY_ERROR, "No library available for %s", libraryName);
     }
 
     IQueryFactory *getQuery(const char *id, const IRoxieContextLogger &logctx) const

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -60,8 +60,6 @@ interface IRoxiePackage : public IHpccPackage
     virtual IRoxieWriteHandler *createFileName(const char *fileName, bool overwrite, bool extend, const StringArray &clusters, IConstWorkUnit *wu) const = 0;
     // Lookup information in package about what in-memory indexes should be built for file
     virtual IPropertyTreeIterator *getInMemoryIndexInfo(const IPropertyTree &graphNode) const = 0;
-    // Lookup information in package about what in-memory indexes should be built for file
-    virtual IPropertyTree *getQuerySets() const = 0;
     // Remove a resolved file from the cache 
     virtual void removeCache(const IResolvedFile *goer) const = 0; // note that this is const as cache is considered mutable
 };

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -113,7 +113,7 @@ interface IRoxieQueryPackageManagerSet : extends IInterface
     virtual void load() = 0;
     virtual void doControlMessage(IPropertyTree *xml, StringBuffer &reply, const IRoxieContextLogger &ctx) = 0;
     virtual IQueryFactory *getQuery(const char *id, const IRoxieContextLogger &logctx) const = 0;
-    virtual IQueryFactory *lookupLibrary(const IRoxiePackage &package, const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
+    virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
     virtual int getActivePackageCount() const = 0;
 };
 


### PR DESCRIPTION
There is a check in the lookupLibrary code that requires that any library
found use the exact same package as the query that is looking it up.

On reflection I think that this check is over-cautious. It's quite likely that
a library will want to use a separate package. Remove the check.

Also remove some unused code in the package interface.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
