### PR TITLE
HPCC-9550 Control:getQueryXrefInfo not showing super keys

### DIFF
--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -118,7 +118,7 @@ interface IResolvedFileCreator : extends IResolvedFile
     virtual void addSubFile(IFileDescriptor *sub, IFileDescriptor *remoteSub) = 0;
 };
 
-extern IResolvedFileCreator *createResolvedFile(const char *lfn, const char *physical);
+extern IResolvedFileCreator *createResolvedFile(const char *lfn, const char *physical, bool isSuperFile);
 extern IResolvedFile *createResolvedFile(const char *lfn, const char *physical, IDistributedFile *dFile, IRoxieDaliHelper *daliHelper, bool cacheIt, bool writeAccess);
 
 interface IRoxiePublishCallback


### PR DESCRIPTION
Remove optimization for single-subfile case.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
