### PR TITLE
HPCC-9419 Pass data2 through ClusterPartDiskMapSpec for overloaded

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -3314,8 +3314,12 @@ public:
         if (cluster!=NotFound) {
             unsigned n;
             unsigned d;
-            clusters.item(cluster).queryPartDiskMapping().calcPartLocation(partno,numParts(),rep,clusters.queryGroup(cluster)?clusters.queryGroup(cluster)->ordinality():numParts(),n,d);
-            setReplicateFilename(path,d);
+            ClusterPartDiskMapSpec& mspec = clusters.item(cluster).queryPartDiskMapping();
+            mspec.calcPartLocation(partno,numParts(),rep,clusters.queryGroup(cluster)?clusters.queryGroup(cluster)->ordinality():numParts(),n,d);
+            if ((d>0) && (mspec.flags&CPDMSF_overloadedConfig) && mspec.defaultReplicateDir.length())
+                path.set(mspec.defaultReplicateDir.get());
+            else
+                setReplicateFilename(path,d);
         }
     }
 

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -3316,7 +3316,7 @@ public:
             unsigned d;
             ClusterPartDiskMapSpec& mspec = clusters.item(cluster).queryPartDiskMapping();
             mspec.calcPartLocation(partno,numParts(),rep,clusters.queryGroup(cluster)?clusters.queryGroup(cluster)->ordinality():numParts(),n,d);
-            if ((d>0) && (mspec.flags&CPDMSF_overloadedConfig) && mspec.defaultReplicateDir.length())
+            if ((d==1) && (mspec.flags&CPDMSF_overloadedConfig) && mspec.defaultReplicateDir.length())
                 path.set(mspec.defaultReplicateDir.get());
             else
                 setReplicateFilename(path,d);

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -102,9 +102,8 @@ void ClusterPartDiskMapSpec::setRoxie (unsigned redundancy, unsigned channelsPer
     defaultCopies = redundancy+1;
     if ((channelsPerNode>1)&&(redundancy==0)) {
         flags |= CPDMSF_wrapToNextDrv;
+        flags |= CPDMSF_overloadedConfig;
         maxDrvs = channelsPerNode;
-        if (_replicateOffset == 1)
-            flags |= CPDMSF_overloadedConfig;
     }
     else
         maxDrvs = (redundancy>1)?(redundancy+1):2;

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -103,6 +103,8 @@ void ClusterPartDiskMapSpec::setRoxie (unsigned redundancy, unsigned channelsPer
     if ((channelsPerNode>1)&&(redundancy==0)) {
         flags |= CPDMSF_wrapToNextDrv;
         maxDrvs = channelsPerNode;
+        if (_replicateOffset == 1)
+            flags |= CPDMSF_overloadedConfig;
     }
     else
         maxDrvs = (redundancy>1)?(redundancy+1):2;

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -96,6 +96,7 @@ public:
 #define CPDMSF_repeatedPart     (0x08)      // if repeated parts included 
 #define CPDMSF_defaultBaseDir   (0x10)      // set if defaultBaseDir present
 #define CPDMSF_defaultReplicateDir  (0x20)      // set if defaultBaseDir present
+#define CPDMSF_overloadedConfig  (0x40)      // set if overloaded mode
 
 
 // ==PART DESCRIPTOR ==============================================================================================

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -522,61 +522,59 @@ bool CFileSprayEx::ParseLogicalPath(const char * pLogicalPath, StringBuffer &tit
     return true;
 }
 
-DFUclusterPartDiskMapping readClusterMappingSettings(const char *cluster, StringBuffer &dir, int& offset, ClusterPartDiskMapSpec& mspec)
+void setClusterPartDiskMapping(const char *clusterName, const char *defaultFolder, const char *defaultReplicateFolder,
+                               bool supercopy, IDFUfileSpec *wuFSpecDest, IDFUoptions *wuOptions)
 {
-    DFUclusterPartDiskMapping mapping = DFUcpdm_c_only;
     Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
     envFactory->validateCache();
 
     StringBuffer dirxpath;
-    dirxpath.appendf("Software/RoxieCluster[@name=\"%s\"]",cluster);
+    dirxpath.appendf("Software/RoxieCluster[@name=\"%s\"]",clusterName);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironmentByFile();
     Owned<IPropertyTree> pEnvRoot = &constEnv->getPTree();
     Owned<IPropertyTreeIterator> processes = pEnvRoot->getElements(dirxpath);
-    if (processes->first()) 
-    {
-        IPropertyTree &process = processes->query();
-        const char *slaveConfig = process.queryProp("@slaveConfig");
-        if (slaveConfig && *slaveConfig)
-        {
-            if (!strnicmp(slaveConfig, "simple", 6))
-            {
-                mapping = DFUcpdm_c_only;
-            }
-            else if (!strnicmp(slaveConfig, "overloaded", 10))
-            {
-                mapping = DFUcpdm_c_then_d;
-                mspec.setRoxie(0, processe.getCount("RoxieSlave[1]/RoxieChannel"));
-            }
-            else if (!strnicmp(slaveConfig, "full", 4))
-            {
-                mapping = DFUcpdm_c_only;
-            }
-            else if (!strnicmp(slaveConfig, "cyclic", 6))
-            {
-                mapping = DFUcpdm_c_replicated_by_d;
-                offset = process.getPropInt("@cyclicOffset");
-            }
-            else
-            {
-                DBGLOG("Failed to get RoxieCluster settings");
-                throw MakeStringException(ECLWATCH_INVALID_CLUSTER_INFO, "Failed to get RoxieCluster settings. The workunit will not be created.");
-            }
-            dir = process.queryProp("@slaveDataDir");
-        }
-        else
-        {
-            DBGLOG("Failed to get RoxieCluster settings");
-            throw MakeStringException(ECLWATCH_INVALID_CLUSTER_INFO, "Failed to get RoxieCluster settings. The workunit will not be created.");
-        }
-    }
-    else
+    if (!processes->first())
     {
         DBGLOG("Failed to get RoxieCluster settings");
         throw MakeStringException(ECLWATCH_INVALID_CLUSTER_INFO, "Failed to get RoxieCluster settings. The workunit will not be created.");
     }
 
-    return mapping;
+    IPropertyTree &processe = processes->query();
+    const char *slaveConfig = processe.queryProp("@slaveConfig");
+    if (!slaveConfig || !*slaveConfig)
+    {
+        DBGLOG("Failed to get RoxieCluster settings");
+        throw MakeStringException(ECLWATCH_INVALID_CLUSTER_INFO, "Failed to get RoxieCluster settings. The workunit will not be created.");
+    }
+
+    ClusterPartDiskMapSpec spec;
+    spec.setDefaultBaseDir(defaultFolder);
+    if (strieq(slaveConfig, "simple"))
+    {
+        spec.setRoxie(0,1);
+        wuOptions->setReplicate(false);
+    }
+    else if (strieq(slaveConfig, "full redundancy"))
+    {
+        spec.setRoxie(1,1,0);
+        wuOptions->setReplicate(true);
+    }
+    else if (strieq(slaveConfig, "overloaded"))
+    {
+        spec.setRoxie(0, processe.getCount("RoxieSlave[1]/RoxieChannel"));
+        spec.setDefaultReplicateDir(defaultReplicateFolder);
+        wuOptions->setReplicate(false);
+    }
+    else //circular redundancy
+    {
+        spec.setRoxie(1, processe.getCount("RoxieSlave[1]/RoxieChannel"), processe.getPropInt("@cyclicOffset", 1));
+        spec.setDefaultReplicateDir(defaultReplicateFolder);
+        wuOptions->setReplicate(true);
+    }
+
+    if (!supercopy)
+        spec.setRepeatedCopies(CPDMSRP_lastRepeated,false);
+    wuFSpecDest->setClusterPartDiskMapSpec(clusterName,spec);
 }
 
 void getClusterFromLFN(const char* lfn, StringBuffer& cluster, const char* username, const char* passwd)
@@ -2398,27 +2396,12 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
         wuFSpecDest->setFileMask(fileMask.str());
         wuOptions->setOverwrite(req.getOverwrite());
 
-        ClusterPartDiskMapSpec mspec;
-        wuFSpecDest->getClusterPartDiskMapSpec(destCluster.str(), mspec);
         if (bRoxie)
         {
-            int offset;
-            StringBuffer baseDir;
-            DFUclusterPartDiskMapping val = readClusterMappingSettings(destCluster.str(), baseDir, offset, mspec);
+            setClusterPartDiskMapping(destCluster.str(), defaultFolder.str(), defaultReplicateFolder.str(), supercopy, wuFSpecDest, wuOptions);
             wuFSpecDest->setWrap(true);                             // roxie always wraps
             if(req.getCompress())
                 wuFSpecDest->setCompressed(true);
-            if (supercopy)
-                wuFSpecDest->setClusterPartDiskMapping(val, baseDir.str(), destCluster.str());
-            else
-                wuFSpecDest->setClusterPartDiskMapping(val, baseDir.str(), destCluster.str(), true);
-            if (val != DFUcpdm_c_replicated_by_d)
-                wuOptions->setReplicate(false);
-            else
-            {
-                wuOptions->setReplicate(true);
-                wuFSpecDest->setReplicateOffset(offset);
-            }
             if (!supercopy)
                 wuOptions->setSuppressNonKeyRepeats(true);            // **** only repeat last part when src kind = key
         }
@@ -2457,11 +2440,13 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
                 wuOptions->setPush(true);
             if (req.getIfnewer())
                 wuOptions->setIfNewer(true);
-        }
 
-        mspec.setDefaultBaseDir(defaultFolder.str());
-        mspec.setDefaultReplicateDir(defaultReplicateFolder.str());
-        wuFSpecDest->setClusterPartDiskMapSpec(destCluster.str(), mspec);
+            ClusterPartDiskMapSpec mspec;
+            wuFSpecDest->getClusterPartDiskMapSpec(destCluster.str(), mspec);
+            mspec.setDefaultBaseDir(defaultFolder.str());
+            mspec.setDefaultReplicateDir(defaultReplicateFolder.str());
+            wuFSpecDest->setClusterPartDiskMapSpec(destCluster.str(), mspec);
+        }
 
         resp.setResult(wu->queryId());
         resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());


### PR DESCRIPTION
When ESP service copies a file to a roxie, the service checks slaveConfig.
If it is 'overloaded', the service calls setRoxie() which is modified to
set a new flag CPDMSF_overloadedConfig into ClusterPartDiskMapSpec. If the
flag is set, a DFUServer copies 'non-primary' file parts into predefined
defaultReplicateDir (data2, ...).

This commit also refactors a part of File Copy method in FileSpray service.
Before a DFU WU is submitted for copying a file to roxie, the existing
code sets the ClusterPartDiskMapSpec in multiple places. This commit
merges the code into one place and calls setRoxie() based on slaveConfig
setting.
