### PR TITLE
HPCC-2345 Debug fails to build package

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -360,7 +360,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   set(version ${majorver}.${minorver}.${point})
 
   IF ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-    set( stagever "${stagever}-Debug" )
+    set( stagever "${stagever}Debug" )
   ENDIF ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 
   ###########################################################################


### PR DESCRIPTION
The - separator is not allowed in rpms.

Using an underscore SEEMS to work in both Ubuntu and Centos, but without
having tested ever distro version, perhaps no separator at all is safer.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
