### PR TITLE
HPCC-8563 XML_CATALOG not being set correctly

### DIFF
--- a/docs/BuildTools/xsltproc.cmake.in
+++ b/docs/BuildTools/xsltproc.cmake.in
@@ -1,6 +1,6 @@
 #set(ENV{XML_DEBUG_CATALOG} 1) Uncomment to add debugging to xsltproc catalogs.
-SET( ENV{SGML_CATALOG_FILES} ${XML_CATALOG})
-SET( ENV{XML_CATALOG_FILES} ${XML_CATALOG})
+SET( ENV{SGML_CATALOG_FILES} @XML_CATALOG@)
+SET( ENV{XML_CATALOG_FILES} @XML_CATALOG@)
 execute_process(COMMAND "@XSLTPROC_EXECUTABLE@" -nonet @xinclude@ -o @_out_dir@/@_out@ @_xsl@ @_in_dir@/@_file@ RESULT_VARIABLE CMDRESULT)
 if(CMDRESULT)
   message(FATAL_ERROR "xsltproc build failure: ${CMDRESULT}")


### PR DESCRIPTION
Moved XML_CATALOG variable geneartion in xsltproc.cmake.in to config
generation time instead of at run time as it runs in a seperate cmake
thread during the build process.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
