### PR TITLE
HPCC-9535 Rationalize Roxie topology info

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -966,7 +966,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                     roxieServer.setown(createRoxieWorkUnitListener(numThreads, suspended));
 
                 const char *aclName = roxieFarm.queryProp("@aclName");
-                if (aclName)
+                if (aclName && *aclName)
                 {
                     Owned<IPropertyTree> aclInfo = createPTree("AccessInfo");
                     getAccessList(aclName, topology, aclInfo);

--- a/roxie/udplib/udptrs.cpp
+++ b/roxie/udplib/udptrs.cpp
@@ -1203,7 +1203,7 @@ public:
     virtual IMessagePacker *createMessagePacker(ruid_t ruid, unsigned sequence, const void *messageHeader, unsigned headerSize, unsigned destNodeIndex, int queue)
     {
         if (destNodeIndex >= numNodes)
-            throw MakeStringException(ROXIE_UDP_ERROR, "createMesagePacker: invalid destination node index %i", destNodeIndex);
+            throw MakeStringException(ROXIE_UDP_ERROR, "createMessagePacker: invalid destination node index %i", destNodeIndex);
         return new CMessagePacker(ruid, sequence, messageHeader, headerSize, *this, destNodeIndex, myNodeIndex, getNextMessageSequence(), queue);
     }
 


### PR DESCRIPTION
Fix another regression in previous commit (empty aclName should be accepted).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
