### PR TITLE
HPCC-9535 Rationalize Roxie topology info

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -57,6 +57,7 @@ extern IException *MakeRoxieException(int code, const char *format, ...) __attri
 extern Owned<ISocket> multicastSocket;
 extern size32_t channelWrite(unsigned channel, void const* buf, size32_t size);
 void addEndpoint(unsigned channel, const IpAddress &slaveIp, unsigned port);
+void openMulticastSocket();
 void joinMulticastChannel(unsigned channel);
 
 extern unsigned channels[MAX_CLUSTER_SIZE];     // list of all channel numbers for this node

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -896,10 +896,9 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                     multicastLast.ipset(topology->queryProp("@multicastLast"));
                 else
                     throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - multicastLast not set");
-                joinMulticastChannel(0); // all slaves also listen on channel 0
             }
+            openMulticastSocket();
         }
-
         setDaliServixSocketCaching(true);  // enable daliservix caching
         loadPlugins();
         globalPackageSetManager = createRoxiePackageSetManager(standAloneDll.getClear());


### PR DESCRIPTION
Fix regression in previous commit (not subscribing to multicast channels).

Also fixes HPCC-9566 - failure to recover after catching exception in
multicast layer.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
