### PR TITLE
HPCC-9551 Roxie cannot set thread priorities to positive values

### DIFF
--- a/initfiles/sbin/add_conf_settings.sh.in
+++ b/initfiles/sbin/add_conf_settings.sh.in
@@ -40,5 +40,7 @@ ${USER_NAME}    soft    core      unlimited
 ${USER_NAME}    hard    core      unlimited
 ${USER_NAME}    soft    nproc     4096
 ${USER_NAME}    hard    nproc     8192
+${USER_NAME}    soft    rtprio    0
+${USER_NAME}    hard    rtprio    4
 %EOF
 


### PR DESCRIPTION
This will show up as error messages referencing pthread_setschedparam when
Roxie starts up, but will also interfere a little with the intended operation
of the UDP layer.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
