### PR TITLE
HPCC-9535 Rationalize Roxie topology info

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -850,10 +850,10 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                 int channel = i+1;
                 for (int copy=0; copy<numDataCopies; copy++)
                 {
-                    channel = channel + cyclicOffset;
                     if (channel > numNodes)
                         channel = channel - numNodes;
                     addChannel(i, channel, copy);
+                    channel = channel + cyclicOffset;
                 }
             }
         }

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -152,6 +152,7 @@ size32_t channelWrite(unsigned channel, void const* buf, size32_t size)
 {
     size32_t minwrote = 0;
     SocketEndpointArray &eps = slaveEndpoints[channel]; // if multicast is enabled, this will have a single multicast endpoint in it.
+    assertex(eps.ordinality());
     ForEachItemIn(idx, eps)
     {
         size32_t wrote = multicastSocket->udp_write_to(eps.item(idx), buf, size);


### PR DESCRIPTION
Cyclic redundancy was allocating channels incorrectly.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
