### PR TITLE
HPCC-9582 New feature: evaluate(module, attribute)

### DIFF
--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -783,7 +783,7 @@ protected:
     void definePatternSymbolProduction(attribute & nameattr, const attribute & assignAttr, attribute & valueAttr, attribute & workflowAttr, const attribute & semiattr);
     void cloneInheritedAttributes(IHqlScope * scope, const attribute & errpos);
 
-    IHqlExpression * createEvaluateOutputModule(const attribute & errpos, IHqlExpression * scopeExpr, IHqlExpression * ifaceExpr, node_operator outputOp);
+    IHqlExpression * createEvaluateOutputModule(const attribute & errpos, IHqlExpression * scopeExpr, IHqlExpression * ifaceExpr, node_operator outputOp, _ATOM name);
     IHqlExpression * createStoredModule(const attribute & errpos, IHqlExpression * scopeExpr);
     void processForwardModuleDefinition(const attribute & errpos);
     void checkNonGlobalModule(const attribute & errpos, IHqlExpression * scopeExpr);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -2585,7 +2585,13 @@ actionStmt
                         {
                             OwnedHqlExpr abstract = $3.getExpr();
                             OwnedHqlExpr concrete = parser->checkConcreteModule($3, abstract);
-                            $$.setExpr(parser->createEvaluateOutputModule($3, concrete, concrete, no_evaluate_stmt), $1);
+                            $$.setExpr(parser->createEvaluateOutputModule($3, concrete, concrete, no_evaluate_stmt, NULL), $1);
+                        }
+    | EVALUATE '(' abstractModule ',' knownOrUnknownId ')'
+                        {
+                            OwnedHqlExpr abstract = $3.getExpr();
+                            OwnedHqlExpr concrete = parser->checkConcreteModule($3, abstract);
+                            $$.setExpr(parser->createEvaluateOutputModule($3, concrete, concrete, no_evaluate_stmt, $5.getName()), $1);
                         }
     | DISTRIBUTION '(' startTopFilter beginList optDistributionFlags ignoreDummyList ')' endTopFilter
                         {
@@ -2621,7 +2627,7 @@ actionStmt
                         {
                             OwnedHqlExpr abstract = $3.getExpr();
                             OwnedHqlExpr concrete = parser->checkConcreteModule($3, abstract);
-                            $$.setExpr(parser->createEvaluateOutputModule($3, concrete, concrete, no_output));
+                            $$.setExpr(parser->createEvaluateOutputModule($3, concrete, concrete, no_output, NULL));
                             $$.setPosition($1);
                         }
     | OUTPUT '(' abstractModule ',' abstractModule ')'
@@ -2629,7 +2635,7 @@ actionStmt
                             OwnedHqlExpr abstract = $3.getExpr();
                             OwnedHqlExpr concrete = parser->checkConcreteModule($3, abstract);
                             OwnedHqlExpr iface = $5.getExpr();
-                            $$.setExpr(parser->createEvaluateOutputModule($3, concrete, iface, no_output));
+                            $$.setExpr(parser->createEvaluateOutputModule($3, concrete, iface, no_output, NULL));
                             $$.setPosition($1);
                         }
     | ALLNODES '(' beginList actionlist ')'

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -9615,11 +9615,11 @@ IHqlExpression * HqlGram::createLibraryInstance(const attribute & errpos, IHqlEx
 
 //==========================================================================================================
 
-IHqlExpression * HqlGram::createEvaluateOutputModule(const attribute & errpos, IHqlExpression * scopeExpr, IHqlExpression * ifaceExpr, node_operator outputOp)
+IHqlExpression * HqlGram::createEvaluateOutputModule(const attribute & errpos, IHqlExpression * scopeExpr, IHqlExpression * ifaceExpr, node_operator outputOp, _ATOM name)
 {
     if (!ifaceExpr->queryType()->assignableFrom(scopeExpr->queryType()))
         reportError(ERR_NOT_BASE_MODULE, errpos, "Module doesn't implement the interface supplied");
-    return ::createEvaluateOutputModule(lookupCtx, scopeExpr, ifaceExpr, lookupCtx.queryExpandCallsWhenBound(), outputOp);
+    return ::createEvaluateOutputModule(lookupCtx, scopeExpr, ifaceExpr, lookupCtx.queryExpandCallsWhenBound(), outputOp, name);
 }
 
 IHqlExpression * HqlGram::createStoredModule(const attribute & errpos, IHqlExpression * scopeExpr)

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -165,7 +165,7 @@ extern HQL_API bool hasOperand(IHqlExpression * expr, IHqlExpression * child);
 
 extern HQL_API unsigned numRealChildren(IHqlExpression * expr);
 
-extern HQL_API IHqlExpression * createEvaluateOutputModule(HqlLookupContext & ctx, IHqlExpression * scopeExpr, IHqlExpression * ifaceExpr, bool expandCallsWhenBound, node_operator outputOp);
+extern HQL_API IHqlExpression * createEvaluateOutputModule(HqlLookupContext & ctx, IHqlExpression * scopeExpr, IHqlExpression * ifaceExpr, bool expandCallsWhenBound, node_operator outputOp, _ATOM name);
 extern HQL_API IHqlExpression * createStoredModule(IHqlExpression * scopeExpr);
 extern HQL_API IHqlExpression * convertScalarAggregateToDataset(IHqlExpression * expr);
 

--- a/testing/ecl/evaluateModule.ecl
+++ b/testing/ecl/evaluateModule.ecl
@@ -1,0 +1,13 @@
+t := MODULE
+  EXPORT a := OUTPUT('a');
+  EXPORT c := OUTPUT('c');
+  EXPORT b := OUTPUT('b');
+  EXPORT d := MODULE
+    EXPORT a := OUTPUT('a1');
+    EXPORT c := OUTPUT('c1');
+    EXPORT b := OUTPUT('b1');
+  END;
+END;
+
+EVALUATE(t);
+EVALUATE(t, c);

--- a/testing/ecl/key/evaluateModule.xml
+++ b/testing/ecl/key/evaluateModule.xml
@@ -1,0 +1,24 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>a</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>b</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>c</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>a1</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>b1</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>c1</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><Result_7>c</Result_7></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>c1</Result_8></Row>
+</Dataset>


### PR DESCRIPTION
Will make writing unit tests much simpler and cleaner if we have a form of
evaluate(module) that only evaluates attributes matching a supplied name.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
