### PR TITLE
HPCC-9341 Add ecl-publish support for suspend and delete previous

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -9440,15 +9440,14 @@ void addQueryToQuerySet(IWorkUnit *workunit, const char *querySetName, const cha
 
     if (activateOption == ACTIVATE_SUSPEND_PREVIOUS|| activateOption == ACTIVATE_DELETE_PREVIOUS)
     {
-        Owned<IPropertyTree> aliasTree = resolveQueryAlias(queryRegistry, cleanQueryName);
+        Owned<IPropertyTree> prevQuery = resolveQueryAlias(queryRegistry, cleanQueryName);
         setQueryAlias(queryRegistry, cleanQueryName, newQueryId);
-
-        if (aliasTree)
+        if (prevQuery)
         {
             if (activateOption == ACTIVATE_SUSPEND_PREVIOUS)
-                setQuerySuspendedState(queryRegistry, cleanQueryName, true, userid);
+                setQuerySuspendedState(queryRegistry, prevQuery->queryProp("@id"), true, userid);
             else 
-                removeNamedQuery(queryRegistry, aliasTree->queryProp("@id"));
+                removeNamedQuery(queryRegistry, prevQuery->queryProp("@id"));
         }
     }
     else if (activateOption == MAKE_ACTIVATE || activateOption == MAKE_ACTIVATE_LOAD_DATA_ONLY)

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -74,6 +74,14 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_ACTIVATE_S "-A"
 #define ECLOPT_ACTIVATE_INI "activateDefault"
 #define ECLOPT_ACTIVATE_ENV NULL
+#define ECLOPT_SUSPEND_PREVIOUS "--suspend-prev"
+#define ECLOPT_SUSPEND_PREVIOUS_S "-sp"
+#define ECLOPT_SUSPEND_PREVIOUS_INI "suspendPrevDefault"
+#define ECLOPT_SUSPEND_PREVIOUS_ENV "ACTIVATE_SUSPEND_PREVIOUS"
+#define ECLOPT_DELETE_PREVIOUS "--delete-prev"
+#define ECLOPT_DELETE_PREVIOUS_S "-dp"
+#define ECLOPT_DELETE_PREVIOUS_INI "deletePrevDefault"
+#define ECLOPT_DELETE_PREVIOUS_ENV "ACTIVATE_DELETE_PREVIOUS"
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1069,6 +1069,14 @@ ESPresponse [exceptions_inline] WUCopyLogicalFilesResponse
 };
 
 
+ESPenum WUQueryActivationMode : int
+{
+    NoActivate(0, "Do not activate query"),
+    Activate(1, "Activate query"),
+    ActivateSuspendPrevious(2, "Activate query, suspend previous"),
+    ActivateDeletePrevious(3, "Activate query, delete previous")
+};
+
 ESPrequest [nil_remove] WUPublishWorkunitRequest
 {
     string Wuid;


### PR DESCRIPTION
Adds command line support for suspending or deleting the previously
active query when publishing a query.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
