### PR TITLE
HPCC-9605 - Remove spurious 20s sleep at slave start

### DIFF
--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -308,7 +308,6 @@ int main( int argc, char *argv[]  )
         markNodeCentral(masterEp);
         if (RegisterSelf(masterEp))
         {
-            MilliSleep(20000);
             if (globals->getPropBool("Debug/@slaveDaliClient"))
                 enableThorSlaveAsDaliClient();
 


### PR DESCRIPTION
Introduced accidentally as part of HPCC-8669 changes

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
