### PR TITLE
HPCC-9612 Roxie is ignoring slaveThreads setting

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -618,8 +618,6 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             }
         }
 
-        bool isCCD = false;
-
         headRegionSize = topology->getPropInt("@headRegionSize", 50);
         numChannels = topology->getPropInt("@numChannels", 0);
         statsExpiryTime = topology->getPropInt("@statsExpiryTime", 3600);
@@ -910,7 +908,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         globalPackageSetManager = createRoxiePackageSetManager(standAloneDll.getClear());
         globalPackageSetManager->load();
         unsigned snifferChannel = numChannels+2; // MORE - why +2 not +1 ??
-        ROQ = createOutputQueueManager(snifferChannel, isCCD ? numSlaveThreads : 1);
+        ROQ = createOutputQueueManager(snifferChannel, numSlaveThreads);
         ROQ->setHeadRegionSize(headRegionSize);
         ROQ->start();
         Owned<IPacketDiscarder> packetDiscarder = createPacketDiscarder();


### PR DESCRIPTION
The refactoring of roxie topology in rc13 introduced a regression where the
roxieSlaveThreads setting would be ignored, and only one slave thread would
be allocated.

This could lead to lockups in cases where a slave thread tried to make remote
calls, such as sqfilt.ecl in the regression suite.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
