### PR TITLE
HPCC-9545 ecl-packagemap-validate option to check subfiles exist in dfs

### DIFF
--- a/common/workunit/package.cpp
+++ b/common/workunit/package.cpp
@@ -183,20 +183,23 @@ void CHpccPackageSet::load(IPropertyTree *xml)
     }
 }
 
-const IHpccPackageMap *CHpccPackageSet::queryActiveMap(const char *queryset) const
+bool checkPackageMapMatchesTarget(const char *target, const char *match)
 {
+    if (!match || !*match)
+        return false;
+    if (isWildString(match))
+        return WildMatch(target, match);
+    return streq(target, match);
+}
+
+const IHpccPackageMap *CHpccPackageSet::queryActiveMap(const char *target) const
+{
+    if (!target || !*target)
+        return NULL;
     ForEachItemIn(i, packageMaps)
     {
         CHpccPackageMap &pm = packageMaps.item(i);
-        StringAttr &match = pm.querySet;
-        if (!match.length())
-            continue;
-        if (isWildString(match))
-        {
-            if (WildMatch(queryset, match))
-                return &pm;
-        }
-        else if (streq(queryset, match))
+        if (checkPackageMapMatchesTarget(target, pm.querySet.get()))
             return &pm;
     }
     return NULL;
@@ -219,6 +222,8 @@ extern WORKUNIT_API IPropertyTree * getPackageMapById(const char * id, bool read
 
 extern WORKUNIT_API IPropertyTree * getPackageSetById(const char * id, bool readonly)
 {
+    if (!id || !*id)
+        return NULL;
     StringBuffer xpath;
     xpath.append("/PackageSets/PackageSet[@id=\"").append(id).append("\"]");
     Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), readonly ? RTM_LOCK_READ : RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
@@ -227,8 +232,27 @@ extern WORKUNIT_API IPropertyTree * getPackageSetById(const char * id, bool read
     return conn->getRoot();
 }
 
+extern WORKUNIT_API IPropertyTree * resolveActivePackageMap(const char *process, const char *target, bool readonly)
+{
+    if (!target || !*target)
+        return NULL;
+    Owned<IPropertyTree> ps = resolvePackageSetRegistry(process, true);
+    if (!ps)
+        return NULL;
+    Owned<IPropertyTreeIterator> it = ps->getElements("PackageMap[@active='1']");
+    ForEach(*it)
+    {
+        IPropertyTree &pm = it->query();
+        if (checkPackageMapMatchesTarget(target, pm.queryProp("@querySet")))
+            return getPackageMapById(pm.queryProp("@id"), readonly);
+    }
+    return NULL;
+}
+
 extern WORKUNIT_API IPropertyTree * resolvePackageSetRegistry(const char *process, bool readonly)
 {
+    if (!process || !*process)
+        return NULL;
     Owned<IRemoteConnection> globalLock = querySDS().connect("/PackageSets/", myProcessSession(), RTM_LOCK_WRITE|RTM_CREATE_QUERY, SDS_LOCK_TIMEOUT);
     Owned<IPropertyTree> psroot = globalLock->getRoot();
 

--- a/common/workunit/package.h
+++ b/common/workunit/package.h
@@ -62,6 +62,7 @@ extern WORKUNIT_API IHpccPackageSet *createPackageSet(const char *process);
 extern WORKUNIT_API IPropertyTree * getPackageMapById(const char * id, bool readonly);
 extern WORKUNIT_API IPropertyTree * getPackageSetById(const char * id, bool readonly);
 extern WORKUNIT_API IPropertyTree * resolvePackageSetRegistry(const char *process, bool readonly);
+extern WORKUNIT_API IPropertyTree * resolveActivePackageMap(const char *process, const char *target, bool readonly);
 extern WORKUNIT_API hash64_t pkgHash64Data(size32_t len, const void *buf, hash64_t hval);
 
 

--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -127,6 +127,7 @@ public:
     virtual void addFilesFromWorkUnit(IConstWorkUnit *cw);
     virtual void addFilesFromQuery(IConstWorkUnit *cw, const IHpccPackageMap *pm, const char *queryid);
     virtual void addFilesFromQuery(IConstWorkUnit *cw, const IHpccPackage *pkg);
+    virtual void addFilesFromPackageMap(IPropertyTree *pm);
 
     virtual IReferencedFileIterator *getFiles();
     virtual void cloneFileInfo(IDFUhelper *helper, bool overwrite, bool cloneSuperInfo);
@@ -388,6 +389,13 @@ void ReferencedFileList::addFiles(StringArray &files)
 {
     ForEachItemIn(i, files)
         addFile(files.item(i));
+}
+
+void ReferencedFileList::addFilesFromPackageMap(IPropertyTree *pm)
+{
+    Owned<IPropertyTreeIterator> files = pm->getElements("Package/SuperFile/SubFile[@value]");
+    ForEach(*files)
+        addFile(files->query().queryProp("@value"));
 }
 
 void ReferencedFileList::addFilesFromQuery(IConstWorkUnit *cw, const IHpccPackage *pkg)

--- a/common/workunit/referencedfilelist.hpp
+++ b/common/workunit/referencedfilelist.hpp
@@ -50,6 +50,7 @@ interface IReferencedFileList : extends IInterface
     virtual void addFilesFromWorkUnit(IConstWorkUnit *cw)=0;
     virtual void addFilesFromQuery(IConstWorkUnit *cw, const IHpccPackageMap *pm, const char *queryid)=0;
     virtual void addFilesFromQuery(IConstWorkUnit *cw, const IHpccPackage *pkg)=0;
+    virtual void addFilesFromPackageMap(IPropertyTree *pm)=0;
 
     virtual void addFile(const char *ln)=0;
     virtual void addFiles(StringArray &files)=0;

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -82,6 +82,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_DELETE_PREVIOUS_S "-dp"
 #define ECLOPT_DELETE_PREVIOUS_INI "deletePrevDefault"
 #define ECLOPT_DELETE_PREVIOUS_ENV "ACTIVATE_DELETE_PREVIOUS"
+#define ECLOPT_CHECK_DFS "--check-dfs"
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -118,6 +118,7 @@ ESPrequest ValidatePackageRequest
     bool Active;
     string PMID;
     string QueryIdToVerify;
+    bool CheckDFS;
 };
 
 ESPstruct ValidatePackageInfo
@@ -133,6 +134,7 @@ ESPstruct ValidatePackageQueries
 ESPstruct ValidatePackageFiles
 {
     ESParray<string> Unmatched;
+    ESParray<string, File> NotInDFS;
 };
 
 ESPresponse [exceptions_inline] ValidatePackageResponse


### PR DESCRIPTION
Adds a new --check-dfs option to ecl-packagemap-validate which will
verify that all subfiles in the packagemap are defined in the local
dfs.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
