### PR TITLE
HPCC-9607 IPropertyTree exception on using STD.System.Workunit.

### DIFF
--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -407,6 +407,7 @@ static IPropertyTree *getWorkUnitBranch(ICodeContext *ctx,const char *wuid,const
     if (!wuid||!*wuid)
         return NULL;
     StringBuffer _wuid(wuid);
+    _wuid.trimRight();
     wuid = _wuid.toUpperCase().str();
     StringBuffer query;
     query.append("WorkUnits/").append(wuid);


### PR DESCRIPTION
Trim the value of xpath when request workunit because it contains illegal space characters at the end of path string like 'WorkUnits/W20130617-153029        '.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
