### PR TITLE
HPCC-9628 Eclcc hangs at end if libarchive dynamically unloaded

### DIFF
--- a/common/remote/hooks/git/gitfile.cpp
+++ b/common/remote/hooks/git/gitfile.cpp
@@ -447,11 +447,14 @@ extern GITFILE_API void installFileHook()
 
 extern GITFILE_API void removeFileHook()
 {
-    CriticalBlock b(*cs); // Probably overkill!
-    if (gitRepositoryFileHook)
+    if (cs)
     {
-        removeContainedFileHook(gitRepositoryFileHook);
-        gitRepositoryFileHook = NULL;
+        CriticalBlock b(*cs); // Probably overkill!
+        if (gitRepositoryFileHook)
+        {
+            removeContainedFileHook(gitRepositoryFileHook);
+            gitRepositoryFileHook = NULL;
+        }
     }
 }
 
@@ -471,4 +474,5 @@ MODULE_EXIT()
     }
     ::Release(gitRepositoryFileHook);
     delete cs;
+    cs = NULL;
 }

--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -544,11 +544,14 @@ extern ARCHIVEFILE_API void installFileHook()
 
 extern ARCHIVEFILE_API void removeFileHook()
 {
-    SpinBlock b(*lock); // Probably overkill!
-    if (archiveFileHook)
+    if (lock)
     {
-        removeContainedFileHook(archiveFileHook);
-        archiveFileHook = NULL;
+        SpinBlock b(*lock); // Probably overkill!
+        if (archiveFileHook)
+        {
+            removeContainedFileHook(archiveFileHook);
+            archiveFileHook = NULL;
+        }
     }
 }
 
@@ -569,5 +572,6 @@ MODULE_EXIT()
     }
     delete signature;
     delete lock;
+    lock = NULL;
     ::Release(archiveFileHook);
 }


### PR DESCRIPTION
In my tests setup, I have the libs directory on my plugins path, meaning that
eclcc will try to load libarchive as a plugin, then unload it when it finds it
is not.

This means that MODEXIT gets called before removeFileHook (due to bugs in the
modexit logic - it should really only be called on the last unload, not on any
unload).

Protect against that event by setting lock ptr to NULL.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
