### PR TITLE
HPCC-9602 Avoid temporary variables when returing simple expressions

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -3419,10 +3419,8 @@ void HqlCppTranslator::buildReturn(BuildCtx & ctx, IHqlExpression * expr, ITypeI
     else
     {
         CHqlBoundExpr ret;
-        // A very temporary work around for potential gpf using variable length strings
         OwnedHqlExpr castExpr = ensureExprType(expr, retType);
-        buildSimpleExpr(ctx, castExpr, ret);
-        ctx.setNextDestructor();
+        buildExpr(ctx, castExpr, ret);
         ctx.addReturn(ret.expr);
     }
 }


### PR DESCRIPTION
The "very temporary" fix has been in there for many many years, and has
been redundant for most of them.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
