### PR TITLE
HPCC-9630 - Clear up some exception handling

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -8593,7 +8593,6 @@ public:
     virtual bool fireException(IException *e)
     {
         EXCLOG(e, "CDaliDFSServer exception");
-        e->Release();
         return true;
     }
 } *daliDFSServer = NULL;

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -447,6 +447,7 @@ class CDistributorBase : public CSimpleInterface, implements IHashDistributor, i
                     {
                         ActPrintLog(owner.activity, e, "HDIST: closeWrite");
                         owner.fireException(e);
+                        e->Release();
                     }
                 }
             }
@@ -656,6 +657,7 @@ class CDistributorBase : public CSimpleInterface, implements IHashDistributor, i
             {
                 ActPrintLog(owner.activity, e, "HDIST: sender.process");
                 owner.fireException(e);
+                e->Release();
             }
 
             ActPrintLog(owner.activity, "Distribute send finishing");
@@ -690,6 +692,7 @@ class CDistributorBase : public CSimpleInterface, implements IHashDistributor, i
     // IExceptionHandler impl.
         virtual bool fireException(IException *e)
         {
+            ActPrintLog(owner.activity, e, "HDIST: CSender");
             if (!aborted)
             {
                 exception.set(e);
@@ -1057,11 +1060,8 @@ public:
     // IExceptionHandler impl.
     virtual bool fireException(IException *e)
     {
-        ActPrintLog(activity, e, "HDIST: sendloop");
         if (!sendException.get())
-            sendException.setown(e);
-        else
-            e->Release();
+            sendException.set(e);
         return true;
     }
 };

--- a/thorlcr/activities/join/thjoin.cpp
+++ b/thorlcr/activities/join/thjoin.cpp
@@ -353,7 +353,7 @@ public:
             }
             return true;
         }
-        return CMasterActivity::fireException(e);
+        return CMasterActivity::fireException(_e);
     }
 };
 

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -678,6 +678,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                 catch (IException *e)
                 {
                     owner.fireException(e);
+                    e->Release();
                 }
                 aborted = true;
                 owner.pendingGroupSem.signal(); // release puller if blocked on fetch groups pending, in case this has stopped early.
@@ -872,6 +873,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                 catch (IException *e)
                 {
                     owner.fireException(e);
+                    e->Release();
                 }
                 aborted = true;
             }
@@ -1132,6 +1134,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
             catch (IException *e)
             {
                 owner.fireException(e);
+                e->Release();
             }
         }
     friend class CKeyedFetchRequestProcessor;

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -410,7 +410,7 @@ public:
         if (e)
         {
             allDoneSem.interrupt(LINK(e));
-            activity.fireException(LINK(e));
+            activity.fireException(e);
         }
         else
             allDoneSem.signal();

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2817,22 +2817,20 @@ void CActivityBase::ActPrintLog(IException *e)
 
 bool CActivityBase::fireException(IException *e)
 {
+    Owned<IThorException> _te;
     IThorException *te = QUERYINTERFACE(e, IThorException);
-    StringBuffer s;
-    Owned<IException> e2;
-    if (!te)
-    {
-        IThorException *_e = MakeActivityException(this, e);
-        _e->setAudience(e->errorAudience());
-        e2.setown(_e);
-    }
-    else
+    if (te)
     {
         if (!te->queryActivityId())
             setExceptionActivityInfo(container, te);
-        e2.set(e);
     }
-    return container.queryOwner().fireException(e2);
+    else
+    {
+        te = MakeActivityException(this, e);
+        te->setAudience(e->errorAudience());
+        _te.setown(te);
+    }
+    return container.queryOwner().fireException(te);
 }
 
 

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1602,7 +1602,7 @@ bool CJobMaster::go()
         }
         virtual bool action()
         {
-            job.fireException(LINK(exception)); 
+            job.fireException(exception);
             return true;
         }
     private:

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -775,10 +775,15 @@ void abortThor(IException *e, bool abortCurrentJob)
 {
     if (-1 == queryExitCode()) setExitCode(1);
     Owned<CJobManager> jM = ((CJobManager *)getJobManager());
+    Owned<IException> _e;
     if (0 == aborting)
     {
         aborting = 1;
-        if (!e) e = MakeThorException(TE_AbortException, "THOR ABORT");
+        if (!e)
+        {
+            e = MakeThorException(TE_AbortException, "THOR ABORT");
+            _e.setown(e);
+        }
         EXCLOG(e,"abortThor");
         LOG(MCdebugProgress, thorJob, "abortThor called");
         if (jM)

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -781,8 +781,8 @@ void abortThor(IException *e, bool abortCurrentJob)
         aborting = 1;
         if (!e)
         {
-            e = MakeThorException(TE_AbortException, "THOR ABORT");
-            _e.setown(e);
+            _e.setown(MakeThorException(TE_AbortException, "THOR ABORT"));
+            e = _e;
         }
         EXCLOG(e,"abortThor");
         LOG(MCdebugProgress, thorJob, "abortThor called");

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -140,12 +140,11 @@ void ProcessSlaveActivity::main()
         exception.setown(MakeThorFatal(NULL, TE_UnknownException, "FATAL: Unknown exception thrown by ProcessThread"));
     }
     try { endProcess(); }
-    catch (IException *_e)
+    catch (IException *e)
     {
-        ActPrintLog(_e, "Exception calling activity endProcess");
-        fireException(_e);
-        exception.set(_e);
-        _e->Release();
+        ActPrintLog(e, "Exception calling activity endProcess");
+        fireException(e);
+        exception.setown(e);
     }
 }
 

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -921,9 +921,9 @@ bool getBestFilePart(CActivityBase *activity, IPartDescriptor &partDesc, OwnedIF
                     location = l;
                     if (0 != l)
                     {
-                        IThorException *e = MakeActivityWarning(activity, 0, "Primary file missing: %s, using remote copy: %s", primaryName.str(), locationName.str());
+                        Owned<IThorException> e = MakeActivityWarning(activity, 0, "Primary file missing: %s, using remote copy: %s", primaryName.str(), locationName.str());
                         if (!eHandler)
-                            throw e;
+                            throw e.getClear();
                         eHandler->fireException(e);
                     }
                     path.append(locationName);


### PR DESCRIPTION
Various places, were incorrectly handling the ownership of an
IException passed to IExceptionHandler::fireException.
In some cases resulting in a leaked exception, or worse, a -ve leak.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
