### PR TITLE
HPCC-9631 - KeyedJoin may miss cached IKeyIndex's

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -1877,7 +1877,7 @@ public:
             do
             {
                 IPartDescriptor &filePart = indexParts.item(ip++);
-                unsigned crc;
+                unsigned crc=0;
                 filePart.getCrc(crc);
                 RemoteFilename rfn;
                 filePart.getFilename(0, rfn);


### PR DESCRIPTION
Due to an uninitialized 'crc' variable, that the key index cache
uses to form a key for caching IKeyIndex's. KeyedJoin would
probably have been missing cache hits and consequently, creating
extra IKeyIndex's unecessarily

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
