### PR TITLE
HPCC-9632 - Uninitialized lastCycles

### DIFF
--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -52,6 +52,7 @@ MODULE_INIT(INIT_PRIORITY_STANDARD)
 ProcessSlaveActivity::ProcessSlaveActivity(CGraphElementBase *container) : CSlaveActivity(container), threaded("ProcessSlaveActivity", this)
 {
     processed = 0;
+    lastCycles = 0;
 }
 
 ProcessSlaveActivity::~ProcessSlaveActivity()


### PR DESCRIPTION
'lastCycles' was left uninitialized until sink processes started
If the progress serialization requested timings before the sink
had started, totalMaxMs/totalMinMs timinigs would be wrong

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
