### PR TITLE
HPCC-9633 - Watchdog crash if collects after shutdown

### DIFF
--- a/thorlcr/slave/slwatchdog.cpp
+++ b/thorlcr/slave/slwatchdog.cpp
@@ -142,6 +142,8 @@ public:
         while (!stopped)
         {
             Sleep(1000);
+            if (stopped)
+                break;
             if (count--==0)
             {
                 gatherAndSend();


### PR DESCRIPTION
If the watchdog happens to be about to collect progress/stats
when thor is shutting down, it could crash. Check if stopping
after sleep and quit before collecting

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
