### PR TITLE
HPCC-9634 Uninitialized members of ThorDataLinkMetaInfo

### DIFF
--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -146,8 +146,7 @@ class NSplitterSlaveActivity : public CSlaveActivity
         virtual void start() { throwUnexpected(); }
         virtual void getMetaInfo(ThorDataLinkMetaInfo &info)
         {
-            info.totalRowsMin=0;
-            info.totalRowsMax=0;
+            ::initMetaInfo(info);
         }
     };
     class CInputWrapper : public CSplitterOutputBase

--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -315,9 +315,7 @@ IThorDataLink *createDataLinkSmartBuffer(CActivityBase *activity, IThorDataLink 
 }
 
 
-
-
-void CThorDataLink::initMetaInfo(ThorDataLinkMetaInfo &info)
+void initMetaInfo(ThorDataLinkMetaInfo &info)
 {
     memset(&info,0,sizeof(info));
     //info.rowsdone = xx;
@@ -325,6 +323,15 @@ void CThorDataLink::initMetaInfo(ThorDataLinkMetaInfo &info)
     info.totalRowsMax = -1; // rely on inputs to set
     info.spilled = (offset_t)-1;
     info.byteTotal = (offset_t)-1;
+    info.rowsOutput = 0;
+}
+
+
+
+
+void CThorDataLink::initMetaInfo(ThorDataLinkMetaInfo &info)
+{
+    ::initMetaInfo(info);
     info.rowsOutput = getDataLinkCount();
     // more
 }

--- a/thorlcr/activities/thactivityutil.ipp
+++ b/thorlcr/activities/thactivityutil.ipp
@@ -87,6 +87,7 @@ IRowStream *createSequentialPartHandler(CPartHandler *partHandler, IArrayOf<IPar
     } \
     const void *nextRowNoCatch()
 
+void initMetaInfo(ThorDataLinkMetaInfo &info);
 class CThorDataLink : implements IThorDataLink
 {
     CActivityBase *owner;
@@ -101,7 +102,6 @@ protected:
     {
         dataLinkStart(NULL, 0);
     }
-
     inline void dataLinkStart(ThorActivityKind kind, activity_id activityId, unsigned outputId = 0)
     {
         dataLinkStart(activityKindStr(kind), activityId, outputId);


### PR DESCRIPTION
If a splitter has a null input (because pruned) the null input
implementation had uninitialized ThorDataLinkMetaInfo members.
I don't think any were of consequence, the critical members
totalRowsMin/Max were initialized.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
