### PR TITLE
HPCC-9635 - Ensure LIMIT rowLimit member is initialized

### DIFF
--- a/thorlcr/activities/limit/thlimitslave.cpp
+++ b/thorlcr/activities/limit/thlimitslave.cpp
@@ -46,12 +46,15 @@ public:
 
     CLimitSlaveActivityBase(CGraphElementBase *_container, const char *_msg) : CSlaveActivity(_container), msg(_msg), CThorDataLink(this)
     {
+        helper = (IHThorLimitArg *)queryHelper();
         input = NULL;       
+        resultSent = container.queryLocal(); // i.e. local, so don't send result to master
+        eos = stopped = anyThisGroup = eogNext = false;
+        rowLimit = RCMAX;
     }
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
     {
         appendOutputLinked(this);
-        helper = (IHThorLimitArg *)queryHelper();
 
         if (!container.queryLocal())
             mpTag = container.queryJob().deserializeMPTag(data);
@@ -60,9 +63,8 @@ public:
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
         resultSent = container.queryLocal(); // i.e. local, so don't send result to master
-        eos = stopped = false;
+        eos = stopped = anyThisGroup = eogNext = false;
         input = inputs.item(0);
-        anyThisGroup = eogNext = false;
         startInput(input);
         rowLimit = (rowcount_t)helper->getRowLimit();
         dataLinkStart(msg, container.queryId());


### PR DESCRIPTION
rowLimit was not initialized until start()
getMetaInfo can be called before start, which would have
led to the wrong totalRowsMax being set

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
