### PR TITLE
HPCC-9637 - Uninitialized ENTH counter

### DIFF
--- a/thorlcr/activities/enth/thenthslave.cpp
+++ b/thorlcr/activities/enth/thenthslave.cpp
@@ -85,6 +85,7 @@ public:
     {
         ActivityTimer s(totalCycles, timeActivities, NULL);
         IHThorEnthArg *helper = static_cast <IHThorEnthArg *> (queryHelper());
+        counter = 0;
         denominator = validRC(helper->getProportionDenominator());
         numerator = validRC(helper->getProportionNumerator());
         input.set(inputs.item(0));


### PR DESCRIPTION
The ENTH 'counter' could be left uninitialized by
setInitialCounter, if the numerator was 0
Only side-effect was spurious tracing.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
