### PR TITLE
HPCC-8053 - Timeouts can cause superfile update inconsistencies

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2240,6 +2240,7 @@ protected:
     unsigned transactionnest;
     Linked<IUserDescriptor> udesc;
     unsigned defaultTimeout;
+    bool dirty;
 public:
 
     IPropertyTree *queryRoot() { return root; }
@@ -2250,6 +2251,7 @@ public:
         proplockcount = 0;
         transactionnest = 0;
         defaultTimeout = INFINITE;
+        dirty = false;
     }
 
     ~CDistributedFileBase<INTERFACE>()
@@ -2351,21 +2353,34 @@ public:
         bool reload = false;
         if (timeoutms==INFINITE)
             timeoutms = defaultTimeout;
-        reload = false;
-        if (proplockcount++==0) {
-            if (conn) {
+        if (proplockcount++==0)
+        {
+            if (conn)
+            {
                 conn->rollback(); // changes chouldn't be done outside lock properties
 #ifdef TRACE_LOCKS
                 PROGLOG("lockProperties: pre safeChangeModeWrite(%x)",(unsigned)(memsize_t)conn.get());
 #endif
-                try {
+                try
+                {
                     safeChangeModeWrite(conn,queryLogicalName(),reload,timeoutms);
                 }
                 catch(IException *)
                 {
                     proplockcount--;
                     dfCheckRoot("lockProperties",root,conn);
+                    if (reload)
+                        dirty = true; // safeChangeModeWrite unlocked, and reload will be need if retried
                     throw;
+                }
+                if (dirty) // a previous attempt unlocked and did not reload
+                {
+                    dirty = false;
+                    if (!reload) // if reload=true, safeChangeModeWrite has just reloaded, so no need to again here
+                    {
+                        conn->reload();
+                        reload = true;
+                    }
                 }
 #ifdef TRACE_LOCKS
                 PROGLOG("lockProperties: done safeChangeModeWrite(%x)",(unsigned)(memsize_t)conn.get());
@@ -4243,7 +4258,9 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
         }
         bool refresh() // returns true if any changes
         {
-            return (refresh(parent.get()) || refresh(file.get()));
+            bool pChanged = refresh(parent);
+            bool fChanged = refresh(file);
+            return pChanged || fChanged;
         }
     public:
         cSwapFileAction(IDistributedFileTransaction *_transaction,const char *_parentlname,const char *_filelname)


### PR DESCRIPTION
Locking timeouts in transactions can cause add/remove super file
inconsistencies, resulting in corrupt superfiles (wrong # of files
in meta info and/or subfiles with duplicate @num's)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
