### PR TITLE
HPCC-9646 Compile warning in thorsoapcall.cpp

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -1477,7 +1477,7 @@ private:
                         while (chunkSize)
                         {
                             if (chunkSize > WSCBUFFERSIZE)
-                                DBGLOG("SOAPCALL chunk size %ld", chunkSize);
+                                DBGLOG("SOAPCALL chunk size %d", chunkSize);
 
                             //read chunk data directly into response
                             size32_t count = dataProvider->getBytes(response.reserve(dataLen + chunkSize), chunkSize);


### PR DESCRIPTION
DBGLOG statement specified %ld when the variable type is unsigned.
Changed %ld to %d

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
