### PR TITLE
HPCC-9639 Roxie may segfault on startup if previous 4.0 build used

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -415,7 +415,7 @@ public:
             return NULL;
         if (!fdesc || !fdesc->queryProperties().hasProp("@cloneFrom"))
             return NULL;
-        if (fdesc->queryProperties().hasProp("cloneFromGroup"))
+        if (fdesc->queryProperties().hasProp("cloneFromGroup") && fdesc->queryProperties().hasProp("@cloneFromDir"))
         {
             return recreateCloneSource(fdesc, _lfn);
         }


### PR DESCRIPTION
If files on the dali were copied using an earlier release candidate of 4.0.0,
rc-14 roxie may core on startup.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
