### PR TITLE
HPCC-9661 Move column names out of html input tags

### DIFF
--- a/esp/services/ws_machine/metrics.xslt
+++ b/esp/services/ws_machine/metrics.xslt
@@ -209,7 +209,8 @@
                   else
                   {
                     var bFF=/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)?1:0;
-                    if (show && bFF && autoUpdateChecked)
+                    var isChrome=/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)?1:0;
+                    if (show && (bFF || isChrome) && autoUpdateChecked)        
                       document.forms[0].submit();
                       //reloadPage();
                   }
@@ -566,8 +567,8 @@
          <xsl:if test="not(Hide=1)">
             <xsl:attribute name="checked">true</xsl:attribute>
          </xsl:if>
-         <xsl:value-of select="Caption"/>
          </input>
+         <xsl:value-of select="Caption"/>
       </td>
    </xsl:template>
    


### PR DESCRIPTION
For some environment, ECLWatch "Get Roxie Metrics" shows no column
names to select. The existng html code has the column name between
an open INPUT tage and a closing INPUT tag. Since the closing tag
is not standard html, the code of column name may be ignored.
Moving the column name out of the INPUT tag fixs the problem.

When a column is checked, the column will be added to display.
Another problem found is that the table header is not refreshed
correctly for Chrome. New code is added to detect Chrome and
force the table to refresh as for Firefox.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
