### PR TITLE
HPCC-9662 Rename 'Virtual Memory' column to 'Swap' in Preflight page

### DIFF
--- a/common/monitoring/preflight
+++ b/common/monitoring/preflight
@@ -72,7 +72,7 @@ if [ "${1:0:1}" == '-' ]; then
     echo ---SpaceUsedAndFree---
     swap=`free | tail -n 1 | awk '{print $3,$4}'`
     echo Physical Memory: $mem
-    echo Virtual Memory: $swap
+    echo Swap: $swap
 
     i=0
     for name in `df $dfOption | tail -n +2 | awk '{if(NF>=4) print $NF}'`; do
@@ -140,7 +140,7 @@ else
     echo ---SpaceUsedAndFree---
     swap=`free | tail -n 1 | awk '{print $3,$4}'`
     echo Physical Memory: $mem
-    echo Virtual Memory: $swap
+    echo Swap: $swap
     for name in `df -l | tail -n +2 | awk '{if(NF>=4) print $NF}'`
     do
         arr0[i]=$name

--- a/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
+++ b/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
@@ -437,11 +437,11 @@
                         </th>
                      </xsl:for-each>
                      <!--process disk storage next-->
-                     <xsl:for-each select="../../../Columns/Item[text()!='Processes' and text()!='Up Time' and not(contains(text(), 'Memory')) and not(starts-with(text(), 'CPU')) and text()!='State' and text()!='Condition' and text()!='UpTime']">
+                     <xsl:for-each select="../../../Columns/Item[text()!='Processes' and text()!='Up Time' and not(contains(text(), 'Memory')) and not(starts-with(text(), 'CPU')) and text()!='State' and text()!='Condition' and text()!='UpTime' and text()!='Swap']">
                         <th align="center"><xsl:value-of select="."/></th>
                      </xsl:for-each>
-                     <!--process physical and virtual memory next-->      
-                     <xsl:for-each select="../../../Columns/Item[text() = 'Physical Memory' or text()='Virtual Memory']">
+                     <!--process physical memory and swap next-->      
+                     <xsl:for-each select="../../../Columns/Item[text() = 'Physical Memory' or text()='Swap']">
                         <th align="center"><xsl:value-of select="."/></th>
                      </xsl:for-each>
                      <!--process CPU Load next -->      
@@ -630,7 +630,7 @@
      
      <xsl:for-each select="/GetTargetClusterInfoResponse/Columns/Item">
           <xsl:variable name="text" select="text()"/>
-          <xsl:if test="$text!='Processes' and $text!='Up Time' and $text!='State' and $text!='Condition' and $text!='UpTime' and not(contains($text, 'Memory')) and not(starts-with($text, 'CPU'))">
+          <xsl:if test="$text!='Processes' and $text!='Up Time' and $text!='State' and $text!='Condition' and $text!='UpTime' and not(contains($text, 'Memory')) and not(starts-with($text, 'CPU')) and $text!='Swap'">
              <xsl:variable name="storageNode" select="$storageInfo[($OS!=0 and Description=$text) or ($OS=0 and starts-with(Description,$text))]"/>
              <xsl:choose>
                 <xsl:when test="$storageNode">
@@ -648,8 +648,8 @@
           </xsl:if>
       </xsl:for-each>      
              
-      <!--process Physical / Virtual memory next -->      
-      <xsl:for-each select="/GetTargetClusterInfoResponse/Columns/Item[text() = 'Physical Memory' or text()='Virtual Memory']">
+      <!--process Physical memory / Swap next -->      
+      <xsl:for-each select="/GetTargetClusterInfoResponse/Columns/Item[text() = 'Physical Memory' or text()='Swap']">
       <!--save:  and not(starts-with(text(), 'CPU') and contains(substring-after(text(), 'CPU'), 'Load'))-->
          <xsl:variable name="label" select="text()"/>
          <xsl:variable name="storageNode" select="$storageInfo[Description=$label]"/>

--- a/esp/services/ws_machine/machines.xslt
+++ b/esp/services/ws_machine/machines.xslt
@@ -327,11 +327,11 @@
                         </th>
                      </xsl:for-each>
                      <!--process disk storage next-->
-                     <xsl:for-each select="../Columns/Item[text()!='Processes' and text()!='Up Time' and not(contains(text(), 'Memory')) and not(starts-with(text(), 'CPU')) and text()!='State' and text()!='Condition' and text()!='UpTime']">
+                     <xsl:for-each select="../Columns/Item[text()!='Processes' and text()!='Up Time' and not(contains(text(), 'Memory')) and not(starts-with(text(), 'CPU')) and text()!='State' and text()!='Condition' and text()!='UpTime' and text()!='Swap']">
                         <th align="center"><xsl:value-of select="."/></th>
                      </xsl:for-each>
-                     <!--process physical and virtual memory next-->      
-                     <xsl:for-each select="../Columns/Item[text() = 'Physical Memory' or text()='Virtual Memory']">
+                     <!--process physical memory and swap next-->      
+                     <xsl:for-each select="../Columns/Item[text() = 'Physical Memory' or text()='Swap']">
                         <th align="center"><xsl:value-of select="."/></th>
                      </xsl:for-each>
                      <!--process CPU Load next -->      
@@ -545,7 +545,7 @@
      
      <xsl:for-each select="/GetMachineInfoResponse/Columns/Item">
           <xsl:variable name="text" select="text()"/>
-          <xsl:if test="$text!='Processes' and $text!='Up Time' and $text!='State' and $text!='Condition' and $text!='UpTime' and not(contains($text, 'Memory')) and not(starts-with($text, 'CPU'))">
+          <xsl:if test="$text!='Processes' and $text!='Up Time' and $text!='State' and $text!='Condition' and $text!='UpTime' and not(contains($text, 'Memory')) and not(starts-with($text, 'CPU')) and $text!='Swap'">
              <xsl:variable name="storageNode" select="$storageInfo[($OS!=0 and Description=$text) or ($OS=0 and starts-with(Description,$text))]"/>
              <xsl:choose>
                 <xsl:when test="$storageNode">
@@ -563,8 +563,8 @@
           </xsl:if>
       </xsl:for-each>      
              
-      <!--process Physical / Virtual memory next -->      
-      <xsl:for-each select="/GetMachineInfoResponse/Columns/Item[text() = 'Physical Memory' or text()='Virtual Memory']">
+      <!--process Physical memory / Swap next -->      
+      <xsl:for-each select="/GetMachineInfoResponse/Columns/Item[text() = 'Physical Memory' or text()='Swap']">
       <!--save:  and not(starts-with(text(), 'CPU') and contains(substring-after(text(), 'CPU'), 'Load'))-->
          <xsl:variable name="label" select="text()"/>
          <xsl:variable name="storageNode" select="$storageInfo[Description=$label]"/>


### PR DESCRIPTION
It is suggested that the 'Virtual Memory' column should be renamed
as 'Swap' in the Preflight result page.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
