### PR TITLE
HPCC-9466 Set filter for searching 'unknown' state WUs

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2017,9 +2017,13 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
     MemoryBuffer filterbuf;
 
     bool bDoubleCheckState = false;
-    if(req.getState())
+    if(req.getState() && *req.getState())
     {
-        addWUQueryFilter(filters, filterCount, filterbuf, strieq(req.getState(), "unknown") ? "" : req.getState(), WUSFstate);
+        filters[filterCount++] = WUSFstate;
+        if (!strieq(req.getState(), "unknown"))
+            filterbuf.append(req.getState());
+        else
+            filterbuf.append("");
         if (strieq(req.getState(), "submitted"))
             bDoubleCheckState = true;
     }


### PR DESCRIPTION
An empty string '' is used as a filter when searching 'unknown' state
WUs. The existing filter setting function does not set the filter if
an empty string '' is detected. This fix adds new code to set the filter.
