### PR TITLE
HPCC-9664 dfu copy of files generating odd names

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2324,9 +2324,9 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
             }
         }
 
+        CDfsLogicalFileName lfn;
         if (!bRoxie)
         {
-            CDfsLogicalFileName lfn;
             if (!lfn.setValidate(dstname))
                 throw MakeStringException(ECLWATCH_INVALID_INPUT, "invalid destination filename");
             dstname = lfn.get();


### PR DESCRIPTION
Move StringBuffer for logical file name outside the local block to keep
its content.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
