### PR TITLE
HPCC-9252 Improve the locking contention in roxiemem 

### DIFF
--- a/roxie/roxiemem/roxierowbuff.hpp
+++ b/roxie/roxiemem/roxierowbuff.hpp
@@ -82,10 +82,12 @@ public:
     void kill();
     void transferRows(rowidx_t & outNumRows, const void * * & outRows);
 
+    // also needs to be locked otherwise they could be updated out of sync
+    inline rowidx_t numCommitted() const { return commitRows - firstRow; }
+
     //The block returned is only valid until the critical section is released
 
     inline rowidx_t firstCommitted() const { return firstRow; }
-    inline rowidx_t numCommitted() const { return commitRows - firstRow; }
 
     //Locking functions - use the RoxieOutputRowArrayLock class below.
     inline void lock() const { cs.enter(); }


### PR DESCRIPTION
This pull request contains the following main changes:
- Rename some of the classes to that the heap and heaplet classes have corresponding names
- Add a separate rowcount for huge allocations - previously if a huge allocation had a destructor the page might have been recycled before the destructor could be called.
- Add a flag to a heap to indicate it may contain a completely empty page.  (The idea is to reduce walking long chains of heaplets that cannot be freed.)
- Split the chunked allocation into two - one to allocate the chunk, the next to initialise it.
  This should reduce the window of contention for the spin lock.

The changes appear to have the desired effect, but the timings I am getting out are very variable so it is hard to be 100% sure (sometimes the timings seemed to show no difference).

@richardkchapman @jakesmith please check carefully.
