### PR TITLE
HPCC-9688 Version 4.0 rc14 configmgr cannot display old roxie configurat...

### DIFF
--- a/esp/xslt/ui_configmgr.xslt
+++ b/esp/xslt/ui_configmgr.xslt
@@ -611,9 +611,11 @@
                       setParentIds(i, rowsServers, parentIds);
                       var subTypeKey = '<xsl:value-of select="@name"/>';
                       <xsl:for-each select="@*">
-                        i.<xsl:value-of select="name()"/> = "<xsl:value-of select="."/>";
-                        i.<xsl:value-of select="name()"/>_extra = cS['<xsl:value-of select="name()"/>'+subCompType].extra;
-                        i.<xsl:value-of select="name()"/>_ctrlType = cS['<xsl:value-of select="name()"/>'+subCompType].ctrlType;
+                        try {
+                         i.<xsl:value-of select="name()"/> = "<xsl:value-of select="."/>";
+                         i.<xsl:value-of select="name()"/>_extra = cS['<xsl:value-of select="name()"/>'+subCompType].extra;
+                         i.<xsl:value-of select="name()"/>_ctrlType = cS['<xsl:value-of select="name()"/>'+subCompType].ctrlType;
+                        } catch (err) {}
                       </xsl:for-each>
                       i.params = "pcType=<xsl:value-of select="$Component"/>::pcName=" + cN;
                       i.params +=  "::subType=" + subCompType + "::subTypeKey=" + subTypeKey;


### PR DESCRIPTION
...ions

Any environment.xml where the RoxieFarmProcess has a dataDirectory attribute
(or any other extraneous attribute that is not displayed) causes the entire
Roxie display to fail.

The xslt generates javascript that assumes a column is set up for every
attribute, with no error checking. Adding a try-catch around the generated
js means any unrecognized attribute will not fail.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
