### PR TITLE
HPCC-9687 Ambiguous xpath error from EclWatch displaying Roxie queries

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -598,19 +598,21 @@ void addClusterQueryStates(IPropertyTree* queriesOnCluster, const char *target, 
     clusterState->setCluster(target);
 
     VStringBuffer xpath("Endpoint/Queries/Query[@id='%s']", id);
-    IPropertyTree *aQuery = queriesOnCluster->getBranch(xpath.str());
-    if (!aQuery)
+    Owned<IPropertyTreeIterator> iter = queriesOnCluster->getElements(xpath.str());
+    bool found = false;
+    bool suspended = false;
+    ForEach (*iter)
     {
+        found = true;
+        if (iter->query().getPropBool("@suspended", false))
+            suspended = true;
+    }
+    if (!found)
         clusterState->setState("Not Found");
-    }
-    else if (aQuery->getPropBool("@suspended", false))
-    {
+    else if (suspended)
         clusterState->setState("Suspended");
-    }
     else
-    {
         clusterState->setState("Available");
-    }
 
     clusterStates.append(*clusterState.getClear());
 }


### PR DESCRIPTION
If a query is in more than one packageset, can get an ambiguous xpath error
when checking the information for whether query is suspended.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
