### PR TITLE
HPCC-9700 Warning "Explicit file /opt/HPCCSystems/share/Bundles" not found

### DIFF
--- a/ecl/ecl-bundle/CMakeLists.txt
+++ b/ecl/ecl-bundle/CMakeLists.txt
@@ -67,3 +67,5 @@ if ( UNIX )
     install ( PROGRAMS ecl-bundle.install DESTINATION etc/init.d/install COMPONENT Runtime )
     install ( PROGRAMS ecl-bundle.uninstall DESTINATION etc/init.d/uninstall COMPONENT Runtime )
 endif ( UNIX )
+# Put the bundle-writers guide into the bundles directory - makes sure it's not empty
+install ( FILES BUNDLES.rst DESTINATION ${INSTALL_DIR}/share/bundles COMPONENT Runtime )


### PR DESCRIPTION
Make sure that the default bundles directory is created at install time

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
