### PR TITLE
HPCC-9623 WsEcl xml test message shouldn't close tag prematurely

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -603,7 +603,7 @@ static void buildReqXml(StringStack& parent, IXmlType* type, StringBuffer& out, 
             parent.push_back(typeName);
 
         int startlen = out.length();
-        appendXMLOpenTag(out, tag);
+        appendXMLOpenTag(out, tag, NULL, false);
         if (ns)
             out.append(' ').append(ns);
         out.append(">");


### PR DESCRIPTION
In generated WsECl test soap messages the root tag of an array
element ends up being closed twice, resulting in an extraneous '>'
character.  It is usually harmless but confusing as these messages
are supposed to demonstrate how to correctly format requests.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
