### PR TITLE
HPCC-9708 Hook plugin libarchiveFile cores under windows

### DIFF
--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -35,7 +35,11 @@
  * Installs hooks into createIFile, spotting filenames of the form /my/directory/myfile.zip/{password}/path/within/archive
  */
 
-#define ARCHIVE_SIGNATURE "[.]{zip|tar|tar[.]gz|tgz}{$|"PATHSEPSTR"}"
+#ifdef _WIN32
+#define ARCHIVE_SIGNATURE "[.]{zip|tar|tar[.]gz|tgz}{$|/|\\\\}"
+#else
+#define ARCHIVE_SIGNATURE "[.]{zip|tar|tar[.]gz|tgz}{$|/}"
+#endif
 
 static RegExpr *signature;
 static SpinLock *lock;
@@ -606,5 +610,6 @@ MODULE_EXIT()
     delete signature;
     delete lock;
     lock = NULL;
+    signature = NULL;
     ::Release(archiveFileHook);
 }

--- a/common/remote/rmtfile.cpp
+++ b/common/remote/rmtfile.cpp
@@ -851,10 +851,11 @@ static void installFileHook(const char *hookFile)
         }
         else if (file->isFile() == foundYes)
         {
+            HookInstallFunction *hookInstall;
             SharedObject *so = new SharedObject(); // MORE - this leaks! Kind-of deliberate right now...
-            if (so->load(file->queryFilename(), false))
+            if (so->load(file->queryFilename(), false) &&
+                (hookInstall = (HookInstallFunction *) GetSharedProcedure(so->getInstanceHandle(), "installFileHook")) != NULL)
             {
-                HookInstallFunction *hookInstall = (HookInstallFunction *) GetSharedProcedure(so->getInstanceHandle(), "installFileHook");
                 hookInstall();
                 hookDlls->append(so);
             }


### PR DESCRIPTION
Because of invalid regex. Also, will core if any non-hook dlls are in the
hooks directory.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
