### PR TITLE
HPCC-9707 Ensure scalar and set datasets are always hoisted

### DIFF
--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -1354,6 +1354,19 @@ bool ResourcerInfo::okToSpillThrough()
     return (options->allowThroughSpill && !options->createSpillAsDataset);
 }
 
+void ResourcerInfo::noteUsedFromChild(bool _forceHoist)
+{
+    linkedFromChild = true;
+    outputToUseForSpill = NULL;
+    if (_forceHoist)
+        forceHoist = true;
+}
+
+unsigned ResourcerInfo::numInternalUses()
+{
+    return numUses - numExternalUses - aggregates.ordinality();
+}
+
 bool ResourcerInfo::spillSharesSplitter()
 {
     if (outputToUseForSpill || useGraphResult() || useGlobalResult())

--- a/ecl/hqlcpp/hqlresource.ipp
+++ b/ecl/hqlcpp/hqlresource.ipp
@@ -206,8 +206,8 @@ public:
 class CChildDependent : public CInterface
 {
 public:
-    CChildDependent(IHqlExpression * _original, IHqlExpression * _hoisted, bool _alwaysHoist, bool _isSingleNode)
-    : original(_original), hoisted(_hoisted), alwaysHoist(_alwaysHoist), isSingleNode(_isSingleNode)
+    CChildDependent(IHqlExpression * _original, IHqlExpression * _hoisted, bool _alwaysHoist, bool _isSingleNode, bool _forceHoist)
+    : original(_original), hoisted(_hoisted), alwaysHoist(_alwaysHoist), isSingleNode(_isSingleNode), forceHoist(_forceHoist)
     {
         projectedHoisted.set(hoisted);
         projected = NULL;
@@ -217,6 +217,7 @@ public:
     IHqlExpression * original;
     LinkedHqlExpr hoisted;
     LinkedHqlExpr projectedHoisted;
+    bool forceHoist;
     bool alwaysHoist;
     bool isSingleNode;
     IHqlExpression * projected;
@@ -251,7 +252,7 @@ public:
     bool isSplit();
     bool isSpilledWrite();
     bool okToSpillThrough();
-    void noteUsedFromChild()            { linkedFromChild = true; outputToUseForSpill = NULL; }
+    void noteUsedFromChild(bool _forceHoist)            { linkedFromChild = true; outputToUseForSpill = NULL; if (_forceHoist) forceHoist = true; }
     unsigned numInternalUses()          { return numUses - numExternalUses - aggregates.ordinality(); }
     unsigned numSplitPaths();
     void setConditionSource(IHqlExpression * condition, bool isFirst);
@@ -323,6 +324,7 @@ public:
     bool balanced;
     bool isAlreadyInScope;
     bool linkedFromChild;
+    bool forceHoist;
     bool neverSplit;
     byte pathToExpr;
     bool isConditionalFilter;

--- a/ecl/hqlcpp/hqlresource.ipp
+++ b/ecl/hqlcpp/hqlresource.ipp
@@ -252,8 +252,8 @@ public:
     bool isSplit();
     bool isSpilledWrite();
     bool okToSpillThrough();
-    void noteUsedFromChild(bool _forceHoist)            { linkedFromChild = true; outputToUseForSpill = NULL; if (_forceHoist) forceHoist = true; }
-    unsigned numInternalUses()          { return numUses - numExternalUses - aggregates.ordinality(); }
+    void noteUsedFromChild(bool _forceHoist);
+    unsigned numInternalUses();
     unsigned numSplitPaths();
     void setConditionSource(IHqlExpression * condition, bool isFirst);
 


### PR DESCRIPTION
Has quite a big effect on a few complex archived examples.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
