### PR TITLE
HPCC-9713 Bad installation message when installing on Ubuntu 13.04

### DIFF
--- a/build_utils/cleanDeb.sh
+++ b/build_utils/cleanDeb.sh
@@ -25,6 +25,7 @@ DNAME=$(basename ${FNAME} .deb)
 mkdir -p ${DNAME}/DEBIAN
 fakeroot dpkg-deb -x ${FNAME} ${DNAME}
 fakeroot dpkg-deb -e ${FNAME} ${DNAME}/DEBIAN
+fakeroot chmod 0644 ${DNAME}/DEBIAN/md5sums
 rm ${FNAME}
 fakeroot dpkg-deb -b ${DNAME} ${FNAME}
 rm -rf ${DNAME}


### PR DESCRIPTION
Lintian reports 'bad quality deb file'. This is caused by CMake bugs, but we
can work around them.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
