### PR TITLE
HPCC-9728 Unordered multi core join helper not working

### DIFF
--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -1817,7 +1817,7 @@ class CMultiCoreUnorderedJoinHelper: public CMultiCoreJoinHelperBase
                     break;
                 }
                 try {
-                    parent->doMatch(*work,outqueue);
+                    parent->doMatch(*work,parent->outqueue);
                     delete work;
                 }
                 catch (IException *e) {


### PR DESCRIPTION
Due to a simple bug, the unordered version of the multi core
join helper output no rows.
[As enabled with ,HINT(parallel_match), HINT(unsorted_output)]

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
