### PR TITLE
HPCC-9689 Buffered stderr mode in IPipeProcess doesn't seem to work

### DIFF
--- a/ecl/ecl-bundle/ecl-bundle.cpp
+++ b/ecl/ecl-bundle/ecl-bundle.cpp
@@ -107,7 +107,7 @@ unsigned doEclCommand(StringBuffer &output, const char *cmd, const char *input)
     {
         Owned<IPipeProcess> pipe = createPipeProcess();
         VStringBuffer runcmd("eclcc  --nologfile --nostdinc %s", cmd);
-        pipe->run("eclcc", runcmd, ".", input != NULL, true, true);
+        pipe->run("eclcc", runcmd, ".", input != NULL, true, true, 1024*1024);
         if (optVerbose)
         {
             printf("Running %s\n", runcmd.str());


### PR DESCRIPTION
Fix problem at:
- stderrbufferthread start synchronisation
- error read synchronisation to stderrbufferthread::run().

Signed-off-by: Attila Vamos attila.vamos@gmail.com
