### PR TITLE
HPCC-9769 Java embed not working on Centos5

### DIFF
--- a/plugins/Rembed/Rembed.cpp
+++ b/plugins/Rembed/Rembed.cpp
@@ -102,7 +102,6 @@ public:
                         {
                             tail[strlen(SharedObjectExtension)] = 0;
                             HINSTANCE h = LoadSharedObject(fullName, false, false);
-                            DBGLOG("LoadSharedObject %s returned %p", fullName, h);
                             break;
                         }
                     }

--- a/plugins/javaembed/CMakeLists.txt
+++ b/plugins/javaembed/CMakeLists.txt
@@ -67,7 +67,7 @@ if (USE_JNI)
 
     target_link_libraries ( javaembed
     #    ${JSIG_LIBRARY}
-        ${JNI_LIBRARIES}
+        ${JAVA_JVM_LIBRARY}
         eclrtl
         jlib
         )

--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -149,7 +149,6 @@ MODULE_INIT(INIT_PRIORITY_STANDARD)
                     {
                         tail[strlen(SharedObjectExtension)] = 0;
                         HINSTANCE h = LoadSharedObject(fullName, false, false);
-                        DBGLOG("LoadSharedObject %s returned %p", fullName, h);
                         break;
                     }
                 }


### PR DESCRIPTION
Remove unneeded and unhelpful references to awt library.

Also remove some unwanted tracing.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
