### PR TITLE
HPCC-9782 Fix ESP core when package set not found from dali

### DIFF
--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -337,6 +337,9 @@ void getPkgInfo(const char *target, const char *process, StringBuffer &info)
     IPropertyTree *root = globalLock->queryRoot();
     Owned<IPropertyTree> tree = createPTree("PackageMaps");
     Owned<IPropertyTree> pkgSetRegistry = getPkgSetRegistry((process && *process) ? process : "*", NULL, true);
+    if (!pkgSetRegistry)
+        throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve package information from dali for process %s", (process && *process) ? process : "*");
+
     StringBuffer xpath("PackageMap[@active='1']");
     if (target && *target)
         xpath.appendf("[@querySet='%s']", target);


### PR DESCRIPTION
When package set is not found from dali, getPkgSetRegistry()
returns a NULL pointer. ESP PackageProcesses service should
check the pointer before using it.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
