### PR TITLE
HPCC-9655 Graphs Total Time Missing Sometimes

### DIFF
--- a/esp/files/scripts/GraphsWidget.js
+++ b/esp/files/scripts/GraphsWidget.js
@@ -126,6 +126,9 @@ define([
         refreshGrid: function (args) {
             var context = this;
             this.wu.getInfo({
+                onGetTimers: function (timers) {
+                    //  Required to calculate Graphs Total Time  ---
+                },
                 onGetGraphs: function (graphs) {
                     context.store.setData(graphs);
                     context.grid.refresh();


### PR DESCRIPTION
The graphs total time was only displayed if the timings page had been loaded.

Fixes HPCC-9655

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
