### PR TITLE
    HPCC-9784 - Fix workunit output limit regression

### DIFF
--- a/thorlcr/activities/wuidwrite/thwuidwrite.cpp
+++ b/thorlcr/activities/wuidwrite/thwuidwrite.cpp
@@ -155,6 +155,7 @@ public:
     }
     void init()
     {
+        CWorkUnitWriteGlobalMasterBase::init();
         if (appendOutput)
         {
             Owned<IWorkUnit> wu = &container.queryJob().queryWorkUnit().lock();


### PR DESCRIPTION
A regression introduced by HPCC-8743 (in 4.0), prevented the limits
on workunit results being checked. Normally an excessively
large (default 10MB) workunit result, results in an error.
Large results should be committed to disk.

Changes in HPCC-8743 inadvertently caused the limit to be turned off.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
