### PR TITLE
HPCC-9785 - Optimize the parallel and unsorted join helpers

### DIFF
--- a/testing/ecl/joinmulti.ecl
+++ b/testing/ecl/joinmulti.ecl
@@ -1,0 +1,57 @@
+unsigned numgroups := 10000;
+unsigned largeGroupSize := 500;
+unsigned largeGroupFreq := 30;
+unsigned smallGroupSizeMax := 20;
+unsigned fakeWorkUs := 0; // up to pretent match takes time for parallel timing tests
+
+rec := record
+ unsigned key;
+ unsigned keyn;
+end;
+
+seed := dataset([{0, 0}], rec);
+
+rec gen1(rec L, unsigned4 c) := transform
+ SELF.key := c;
+ SELF.keyn := IF(0=(c%largeGroupFreq), largeGroupSize, 1+((c-1)%smallGroupSizeMax)); // # keys in group, either largeGroupSize or 1-smallGroupSizeMax
+ SELF := L;
+END;
+
+seed2 := DISTRIBUTE(NORMALIZE(seed, numGroups, gen1(LEFT, COUNTER)),key);
+
+rec gen2(rec L, unsigned4 c) := transform
+ SELF := L;
+END;
+
+bigstream := NORMALIZE(seed2, LEFT.keyn, gen2(LEFT, counter));
+
+unsigned delay(unsigned d, unsigned us) := BEGINC++ if (us) usleep(us); return d; ENDC++;
+
+// RIGHT.keyn>=delay(RIGHT.keyn) is fake test on field to add some work to match()
+baseJoin := JOIN(bigstream, bigstream, LEFT.key=RIGHT.key AND RIGHT.keyn>=delay(RIGHT.keyn, fakeWorkUs));
+parallelJoin := JOIN(bigstream, bigstream, LEFT.key=RIGHT.key AND RIGHT.keyn>=delay(RIGHT.keyn, fakeWorkUs), HINT(parallel_match));
+parallelUnorderedJoin := JOIN(bigstream, bigstream, LEFT.key=RIGHT.key AND RIGHT.keyn>=delay(RIGHT.keyn, fakeWorkUs), HINT(parallel_match), HINT(unsorted_output));
+
+
+countGroups(dataset(rec) ds) := FUNCTION
+ t := TABLE(ds, { key, unsigned groupSize := COUNT(GROUP) }, key, FEW);
+ s := SORT(t, key);
+ return s;
+END;
+
+baseJoinGroupCounts := countGroups(baseJoin);
+parallelJoinGroupCounts := countGroups(parallelJoin);
+parallelUnorderedJoinGroupCounts := countGroups(parallelUnorderedJoin);
+
+// although ordering can differ, group sizes from all varieties should match
+cmpj1 := JOIN(baseJoinGroupCounts, parallelJoinGroupCounts, LEFT.key=RIGHT.key AND LEFT.groupSize=RIGHT.groupSize, FULL ONLY);
+cmpj2 := JOIN(baseJoinGroupCounts, parallelUnorderedJoinGroupCounts, LEFT.key=RIGHT.key AND LEFT.groupSize=RIGHT.groupSize, FULL ONLY);
+
+SEQUENTIAL(
+OUTPUT(COUNT(baseJoin)),
+OUTPUT(COUNT(parallelJoin)),
+OUTPUT(COUNT(parallelUnorderedJoin)),
+PARALLEL(OUTPUT(cmpj1), OUTPUT(cmpj2))
+)
+
+

--- a/testing/ecl/key/joinmulti.xml
+++ b/testing/ecl/key/joinmulti.xml
@@ -1,0 +1,13 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>84601900</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>84601900</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>84601900</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+</Dataset>
+<Dataset name='Result 5'>
+</Dataset>

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -3368,12 +3368,12 @@ public:
                     {
                         bool hintparallelmatch = container.queryXGMML().getPropInt("hint[@name=\"parallel_match\"]/@value")!=0;
                         bool hintunsortedoutput = container.queryXGMML().getPropInt("hint[@name=\"unsorted_output\"]/@value")!=0;
-                        joinhelper.setown(createJoinHelper(*this, joinargs, queryRowAllocator(), hintparallelmatch, hintunsortedoutput));
+                        joinhelper.setown(createJoinHelper(*this, joinargs, this, hintparallelmatch, hintunsortedoutput));
                     }
                     break;
                 case TAKhashdenormalize:
                 case TAKhashdenormalizegroup:
-                    joinhelper.setown(createDenormalizeHelper(*this, joinargs, queryRowAllocator()));
+                    joinhelper.setown(createDenormalizeHelper(*this, joinargs, this));
                     break;
                 default:
                     throwUnexpected();

--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -233,11 +233,12 @@ public:
         dataLinkStart(activityName, container.queryId());
         CriticalBlock b(joinHelperCrit);
         if (denorm)
-            joinhelper.setown(createDenormalizeHelper(*this, helperdn, queryRowAllocator()));
-        else {
+            joinhelper.setown(createDenormalizeHelper(*this, helperdn, this));
+        else
+        {
             bool hintparallelmatch = container.queryXGMML().getPropInt("hint[@name=\"parallel_match\"]/@value")!=0;
             bool hintunsortedoutput = container.queryXGMML().getPropInt("hint[@name=\"unsorted_output\"]/@value")!=0;
-            joinhelper.setown(createJoinHelper(*this, helperjn, queryRowAllocator(), hintparallelmatch, hintunsortedoutput));
+            joinhelper.setown(createJoinHelper(*this, helperjn, this, hintparallelmatch, hintunsortedoutput));
         }
     }
 

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -32,6 +32,9 @@
 #include "thorxmlwrite.hpp"
 #include "thexception.hpp"
 
+#include "roxierow.hpp"
+#include "thbufdef.hpp"
+
 //#define TRACEROLLING
 
 //#define TEST_PARALLEL_MATCH
@@ -276,9 +279,10 @@ void swapRows(RtlDynamicRowBuilder &row1, RtlDynamicRowBuilder &row2)
     row1.swapWith(row2);
 }
 
-class CJoinHelper : public IJoinHelper, public CSimpleInterface
+class CJoinHelper : public CSimpleInterface, implements IJoinHelper
 {
     CActivityBase &activity;
+    IRowInterfaces *rowIf;
     ICompare *compareLR;
     ICompare *compareL; 
     ICompare *compareR; 
@@ -352,9 +356,10 @@ class CJoinHelper : public IJoinHelper, public CSimpleInterface
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CJoinHelper(CActivityBase &_activity, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : activity(_activity), allocator(_allocator), denormTmp(NULL), rightgroup(_activity, NULL), denormRows(_activity, NULL)
+    CJoinHelper(CActivityBase &_activity, IHThorJoinArg *_helper, IRowInterfaces *_rowIf)
+        : activity(_activity), rowIf(_rowIf), denormTmp(NULL), rightgroup(_activity, NULL), denormRows(_activity, NULL)
     {
+        allocator.set(rowIf->queryRowAllocator());
         kind = activity.queryContainer().getKind();
         helper = _helper; 
         denormCount = 0;
@@ -745,7 +750,7 @@ public:
             break;
         }
     }
-    const void *nextRow()
+    virtual const void *nextRow()
     {
         OwnedConstThorRow ret;
         RtlDynamicRowBuilder failret(allocator, false);
@@ -911,13 +916,15 @@ public:
         CATCH_MEMORY_EXCEPTIONS
         return ret.getClear();;
     }
+    virtual void stop() { }
     virtual rowcount_t getLhsProgress() const { return lhsProgressCount; }
     virtual rowcount_t getRhsProgress() const { return rhsProgressCount; }
 };
 
-class SelfJoinHelper: public IJoinHelper, public CSimpleInterface
+class SelfJoinHelper: public CSimpleInterface, implements IJoinHelper
 {
     CActivityBase &activity;
+    IRowInterfaces *rowIf;
     ICompare *compare;
     CThorExpandingRowArray curgroup;
     unsigned leftidx;
@@ -953,9 +960,10 @@ class SelfJoinHelper: public IJoinHelper, public CSimpleInterface
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    SelfJoinHelper(CActivityBase &_activity, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : activity(_activity), allocator(_allocator), curgroup(_activity, &_activity)
+    SelfJoinHelper(CActivityBase &_activity, IHThorJoinArg *_helper, IRowInterfaces *_rowIf)
+        : activity(_activity), rowIf(_rowIf), curgroup(_activity, &_activity)
     {
+        allocator.set(rowIf->queryRowAllocator());
         helper = _helper;       
         outputmetaL = NULL;
         mcoreintercept = NULL;
@@ -1046,7 +1054,7 @@ public:
         nextrow.clear();
     }
 
-    const void *nextRow()
+    virtual const void *nextRow()
     {
         OwnedConstThorRow ret;
         RtlDynamicRowBuilder failret(allocator, false);
@@ -1243,13 +1251,14 @@ retry:
         CATCH_MEMORY_EXCEPTIONS
         return ret.getClear();
     }
+    virtual void stop() { }
     virtual rowcount_t getLhsProgress() const { return progressCount; }
     virtual rowcount_t getRhsProgress() const { return progressCount; }
 };
 
-IJoinHelper *createDenormalizeHelper(CActivityBase &activity, IHThorDenormalizeArg *helper, IEngineRowAllocator *allocator)
+IJoinHelper *createDenormalizeHelper(CActivityBase &activity, IHThorDenormalizeArg *helper, IRowInterfaces *rowIf)
 {
-    return new CJoinHelper(activity, helper, allocator);
+    return new CJoinHelper(activity, helper, rowIf);
 }
 
 
@@ -1395,6 +1404,7 @@ class CMultiCoreJoinHelperBase: extends CInterface, implements IJoinHelper, impl
 {
 public:
     CActivityBase &activity;
+    IRowInterfaces *rowIf;
     IJoinHelper *jhelper;
     bool leftouter;  
     bool rightouter;  
@@ -1463,20 +1473,7 @@ public:
         }
     };
 
-    class cOutItem
-    {
-    public:
-        cOutItem(const void *_row,bool _done)
-        {
-            row = _row;
-            done = _done;
-        }
-        const void *row;
-        bool done; 
-    };
-
-
-    void doMatch(cWorkItem &work,SimpleInterThreadQueueOf<cOutItem,false> &outqueue) 
+    void doMatch(cWorkItem &work, IRowWriter &writer, IEngineRowAllocator *theAllocator)
     {
         MemoryBuffer rmatchedbuf;  
         CThorExpandingRowArray &rgroup = selfJoin?work.lgroup:work.rgroup;
@@ -1491,37 +1488,38 @@ public:
             for (unsigned rightidx=0; rightidx<rgroup.ordinality(); rightidx++) {
                 if (helper->match(work.lgroup.query(leftidx),rgroup.query(rightidx))) {
                     lmatched = true;
-                    if (rightouter) 
+                    if (rightouter)
                         rmatched[rightidx] = true;
-                    RtlDynamicRowBuilder ret(allocator);
+                    RtlDynamicRowBuilder ret(theAllocator);
                     size32_t sz = exclude?0:helper->transform(ret,work.lgroup.query(leftidx),rgroup.query(rightidx));
-                    if (sz) 
-                        outqueue.enqueue(new cOutItem(ret.finalizeRowClear(sz),false));
+                    if (sz)
+                        writer.putRow(ret.finalizeRowClear(sz));
 
                 }
             }
             if (!lmatched) {
-                RtlDynamicRowBuilder ret(allocator);
+                RtlDynamicRowBuilder ret(theAllocator);
                 size32_t sz =  helper->transform(ret, work.lgroup.query(leftidx), defaultRight);
-                if (sz) 
-                    outqueue.enqueue(new cOutItem(ret.finalizeRowClear(sz),false));
-            }   
+                if (sz)
+                    writer.putRow(ret.finalizeRowClear(sz));
+            }
         }
         if (rightouter) {
             ForEachItemIn(rightidx2,rgroup) {
                 if (!rmatched[rightidx2]) {
-                    RtlDynamicRowBuilder ret(allocator);
+                    RtlDynamicRowBuilder ret(theAllocator);
                     size32_t sz =  helper->transform(ret, defaultLeft, rgroup.query(rightidx2));
-                    if (sz) 
-                        outqueue.enqueue(new cOutItem(ret.finalizeRowClear(sz),false));
+                    if (sz)
+                        writer.putRow(ret.finalizeRowClear(sz));
                 }
             }
         }
     }
 
-    CMultiCoreJoinHelperBase(CActivityBase &_activity, unsigned numthreads, bool _selfJoin, IJoinHelper *_jhelper, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : activity(_activity), allocator(_allocator)
+    CMultiCoreJoinHelperBase(CActivityBase &_activity, unsigned numthreads, bool _selfJoin, IJoinHelper *_jhelper, IHThorJoinArg *_helper, IRowInterfaces *_rowIf)
+        : activity(_activity), rowIf(_rowIf)
     {
+        allocator.set(rowIf->queryRowAllocator());
         kind = activity.queryContainer().getKind();
         jhelper = _jhelper;
         helper = _helper;
@@ -1559,19 +1557,19 @@ public:
         return true;
     }
 
-    rowcount_t getLhsProgress() const
+// IJoinHelper impl.
+    virtual rowcount_t getLhsProgress() const
     {
         if (jhelper)
             return jhelper->getLhsProgress();
         return 0;
     }
-    rowcount_t getRhsProgress() const
+    virtual rowcount_t getRhsProgress() const
     {
         if (jhelper)
             return jhelper->getRhsProgress();
         return 0;
     }
-
 };
 
 
@@ -1579,8 +1577,8 @@ class CMultiCoreJoinHelper: public CMultiCoreJoinHelperBase
 {
     unsigned curin;         // only updated from cReader thread
     unsigned curout;            // only updated from cReader thread
+    bool stopped;
     
-
     class cReader: public Thread
     {
     public:
@@ -1613,56 +1611,67 @@ class CMultiCoreJoinHelper: public CMultiCoreJoinHelperBase
         cWorkItem work;
         Semaphore workready;
         Semaphore workwait;
-        SimpleInterThreadQueueOf<cOutItem,false> outqueue;
+        Owned<ISmartRowBuffer> rowStream;
+        bool stopped;
 
         cWorker(CActivityBase &activity, CMultiCoreJoinHelper *_parent)
             : Thread("CMultiCoreJoinHelper::cWorker"), parent(_parent), work(activity)
         {
-        }
-
-        ~cWorker()
-        {
-            while (outqueue.ordinality())
-                delete outqueue.dequeue();
+            stopped = false;
         }
         int run()
         {
             PROGLOG("CMultiCoreJoinHelper::cWorker started");
-            MemoryBuffer rmatchedbuf;  
-            loop {
+
+            // Create an allocator per thread, to avoid heavy contention
+            // JCSMORE - there should be a way to ask the cache for an allocator that is based on flags
+            activity_id activityId = parent->activity.queryContainer().queryId();
+            Owned<IRowInterfaces> rowIf = parent->activity.getRowInterfaces();
+            IOutputMetaData *meta = rowIf->queryRowMetaData();
+            roxiemem::IRowManager *rowManager = parent->activity.queryJob().queryRowManager();
+            Owned<IEngineRowAllocator> allocator = createRoxieRowAllocator(*rowManager, meta, activityId, 1, (roxiemem::RoxieHeapFlags)(roxiemem::RHFpacked|roxiemem::RHFunique));
+
+            // JCSMORE - could have a spilling variety instead here..
+            rowStream.setown(createSmartInMemoryBuffer(&parent->activity, parent->rowIf, SMALL_SMART_BUFFER_SIZE));
+            IRowWriter *rowWriter = rowStream->queryWriter();
+            loop
+            {
                 work.clear();
                 workready.signal();
                 workwait.wait();
-                try {
-                    if (work.row) {
-                        outqueue.enqueue(new cOutItem(work.row,false));
-                    }
-                    else {
+                try
+                {
+                    if (work.row)
+                        rowWriter->putRow(work.row);
+                    else
+                    {
                         if (work.lgroup.ordinality()==0)
                             break;
-                        parent->doMatch(work,outqueue);
+                        parent->doMatch(work, *rowWriter, allocator);
                     }
-                    outqueue.enqueue(new cOutItem(NULL,false));
+                    rowWriter->putRow(NULL);
                 }
-                catch (IException *e) {
+                catch (IException *e)
+                {
                     parent->setException(e,"CMultiCoreJoinHelper::cWorker");
                     break;
                 }
             }
-            outqueue.enqueue(new cOutItem(NULL,true));
+            // reader will check stopped, which will only be set once all read, becasue flush() will block until all read
+            rowWriter->putRow(NULL); // end-of-stream
+            rowWriter->flush();
+            stopped = true; // NB: will not get past flush(), until all read
             PROGLOG("CMultiCoreJoinHelper::cWorker exit");
-
-
             return 0;
-
         }
+        bool isStopped() const { return stopped; }
     } **workers;
 
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CMultiCoreJoinHelper(CActivityBase &activity, unsigned numthreads, bool selfJoin, IJoinHelper *_jhelper, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : CMultiCoreJoinHelperBase(activity, numthreads, selfJoin, _jhelper, _helper, _allocator)
+    CMultiCoreJoinHelper(CActivityBase &activity, unsigned numthreads, bool selfJoin, IJoinHelper *_jhelper, IHThorJoinArg *_helper, IRowInterfaces *_rowIf)
+        : CMultiCoreJoinHelperBase(activity, numthreads, selfJoin, _jhelper, _helper, _rowIf)
     {
         reader.parent = this;
         workers = new cWorker *[numthreads];
@@ -1674,6 +1683,7 @@ public:
 
     ~CMultiCoreJoinHelper()
     {
+        stop(); // if hasn't been already
         if (!reader.join(1000*60))
             ERRLOG("~CMultiCoreJoinHelper reader join timed out");
         for (unsigned i=0;i<numworkers;i++) {
@@ -1686,8 +1696,8 @@ public:
         ::Release(jhelper);
     }
 
-
-    bool init(
+// IJoinHelper impl.
+    virtual bool init(
             IRowStream *strmL,
             IRowStream *strmR,      // not used for self join - must be NULL
             IEngineRowAllocator *allocatorL,
@@ -1699,50 +1709,66 @@ public:
     {
         if (!CMultiCoreJoinHelperBase::init(strmL,strmR,allocatorL,allocatorR,outputmetaL,_abort,this))
             return false;
-        for (unsigned i=0;i<numworkers;i++) {
-            workers[i]->outqueue.setLimit(1000);  // shouldn't be that large but just in case
+        stopped = false;
+        for (unsigned i=0;i<numworkers;i++)
             workers[i]->start();
-        }
         reader.start();
         return true;
     }
-
     virtual const void *nextRow()
     {
-        cOutItem * item;
-        loop {
+        /* NB: workers fill and block, they output NULL at end of group
+         * which signals this to move onto next worker.
+         * When all work has been added to workers, a end work item marker is added to the workqueue
+         * which causes the workers to finish, mark stopped and flush their stream.
+         */
+        loop
+        {
             if (eos)
                 return NULL;
-            item = workers[curout]->outqueue.dequeue(); 
-            if (exc.get()) {
+            const void *row = workers[curout]->rowStream->nextRow();
+            if (exc.get())
+            {
+                ::ReleaseThorRow(row);
                 CriticalBlock b(sect);
                 throw exc.getClear();
             }
-            if (item&&item->row)
-                break;
-            eos = item->done;
-            delete item;
+            if (row)
+                return row;
+            else
+            {
+                if (workers[curout]->isStopped())
+                {
+                    eos = true;
+                    return NULL;
+                }
+            }
             curout = (curout+1)%numworkers;
         }
-
-        const void * ret = item->row;
-        delete item;
-        return ret;
+    }
+    virtual void stop()
+    {
+        if (stopped)
+            return;
+        stopped = true;
+        for (unsigned i=0;i<numworkers;i++)
+            workers[i]->rowStream->stop();
     }
 
-    void addWork(CThorExpandingRowArray *lgroup,CThorExpandingRowArray *rgroup)
+// IMulticoreIntercept impl.
+    virtual void addWork(CThorExpandingRowArray *lgroup,CThorExpandingRowArray *rgroup)
     {
-        if (!lgroup||!lgroup->ordinality()) {
-            PROGLOG("hello");
-        }
+        /* NB: This is adds a work item to each worker in sequence
+         * The pull side, also pulls from the workers in sequence
+         * This ensures the output is return in input order.
+         */
         cWorker *worker = workers[curin];
         worker->workready.wait();
         workers[curin]->work.set(lgroup,rgroup);
         worker->workwait.signal();
         curin = (curin+1)%numworkers;
     }
-
-    void addRow(const void *row)
+    virtual void addRow(const void *row)
     {
         cWorker *worker = workers[curin];
         worker->workready.wait();
@@ -1750,13 +1776,11 @@ public:
         worker->workwait.signal();
         curin = (curin+1)%numworkers;
     }
-
 };
+
 
 class CMultiCoreUnorderedJoinHelper: public CMultiCoreJoinHelperBase
 {
-    unsigned stoppedworkers;
-    
     void setException(IException *e,const char *title)
     {
         CriticalBlock b(sect);
@@ -1767,10 +1791,9 @@ class CMultiCoreUnorderedJoinHelper: public CMultiCoreJoinHelperBase
             exc.setown(e);
     }
 
-
     SimpleInterThreadQueueOf<cWorkItem,false> workqueue;
-    SimpleInterThreadQueueOf<cOutItem,false> outqueue;          // used in unordered
-
+    Owned<IRowMultiWriterReader> multiWriter;
+    Owned<IRowWriter> rowWriter;
 
     class cReader: public Thread
     {
@@ -1790,13 +1813,11 @@ class CMultiCoreUnorderedJoinHelper: public CMultiCoreJoinHelperBase
             catch (IException *e) {
                 parent->setException(e,"CMulticoreUnorderedJoinHelper::cReader");
             }
-            for (unsigned i=0;i<parent->numworkers;i++) 
-                parent->workqueue.enqueue(new cWorkItem(parent->activity, NULL, NULL));
+            parent->stopWorkers();
             PROGLOG("CMulticoreUnorderedJoinHelper::cReader exit");
             return 0;
         }
     } reader;
-
 
     class cWorker: public Thread
     {
@@ -1808,40 +1829,50 @@ class CMultiCoreUnorderedJoinHelper: public CMultiCoreJoinHelperBase
         }
         int run()
         {
+            // Create an allocator per thread, to avoid heavy contention
+            // JCSMORE - there should be a way to ask the cache for an allocator that is based on flags
+            activity_id activityId = parent->activity.queryContainer().queryId();
+            Owned<IRowInterfaces> rowIf = parent->activity.getRowInterfaces();
+            IOutputMetaData *meta = rowIf->queryRowMetaData();
+            roxiemem::IRowManager *rowManager = parent->activity.queryJob().queryRowManager();
+            Owned<IEngineRowAllocator> allocator = createRoxieRowAllocator(*rowManager, meta, activityId, 1, (roxiemem::RoxieHeapFlags)(roxiemem::RHFpacked|roxiemem::RHFunique));
+
+            Owned<IRowWriter> rowWriter = parent->multiWriter->getWriter();
             PROGLOG("CMulticoreUnorderedJoinHelper::cWorker started");
-            loop {
+            loop
+            {
                 cWorkItem *work = parent->workqueue.dequeue();
-                if (!work||((work->lgroup.ordinality()==0)&&(work->rgroup.ordinality()==0))) {
+                if (!work||((work->lgroup.ordinality()==0)&&(work->rgroup.ordinality()==0)))
+                {
                     delete work;
                     break;
                 }
-                try {
-                    parent->doMatch(*work,parent->outqueue);
+                try
+                {
+                    parent->doMatch(*work, *rowWriter, allocator);
                     delete work;
                 }
-                catch (IException *e) {
+                catch (IException *e)
+                {
                     parent->setException(e,"CMulticoreUnorderedJoinHelper::cWorker");
                     delete work;
                     break;
                 }
             }
-            parent->outqueue.enqueue(new cOutItem(NULL,true));
             PROGLOG("CMulticoreUnorderedJoinHelper::cWorker exit");
-
-
             return 0;
-
         }
     } **workers;
 
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CMultiCoreUnorderedJoinHelper(CActivityBase &activity, unsigned numthreads, bool selfJoin, IJoinHelper *_jhelper, IHThorJoinArg *_helper, IEngineRowAllocator *_allocator)
-        : CMultiCoreJoinHelperBase(activity, numthreads, selfJoin, _jhelper, _helper, _allocator)
+    CMultiCoreUnorderedJoinHelper(CActivityBase &activity, unsigned numthreads, bool selfJoin, IJoinHelper *_jhelper, IHThorJoinArg *_helper, IRowInterfaces *_rowIf)
+        : CMultiCoreJoinHelperBase(activity, numthreads, selfJoin, _jhelper, _helper, _rowIf)
     {
         reader.parent = this;
-        stoppedworkers = 0;
+        unsigned limit = numworkers*1000; // shouldn't be that large but just in case
+        multiWriter.setown(createSharedWriteBuffer(&activity, rowIf, limit));
         workers = new cWorker *[numthreads];
         for (unsigned i=0;i<numthreads;i++) 
             workers[i] = new cWorker(this);
@@ -1855,18 +1886,23 @@ public:
             if (!workers[i]->join(1000*60))
                 ERRLOG("~CMulticoreUnorderedJoinHelper worker[%d] join timed out",i);
         }
-        while (outqueue.ordinality())
-            delete outqueue.dequeue();
         while (workqueue.ordinality())
             delete workqueue.dequeue();
         for (unsigned i=0;i<numworkers;i++) 
             delete workers[i];
-        delete workers;
+        delete [] workers;
         ::Release(jhelper);
     }
 
+    void stopWorkers()
+    {
+        for (unsigned i=0;i<numworkers;i++)
+            addWork(NULL, NULL);
+        rowWriter.clear();
+    }
 
-    bool init(
+// IJoinHelper impl.
+    virtual bool init(
             IRowStream *strmL,
             IRowStream *strmR,      // not used for self join - must be NULL
             IEngineRowAllocator *allocatorL,
@@ -1879,57 +1915,47 @@ public:
         if (!CMultiCoreJoinHelperBase::init(strmL,strmR,allocatorL,allocatorR,outputmetaL,_abort,this))
             return false;
         workqueue.setLimit(numworkers+1);
-        outqueue.setLimit(numworkers*1000);  // shouldn't be that large but just in case
+        rowWriter.setown(multiWriter->getWriter());
         for (unsigned i=0;i<numworkers;i++)
             workers[i]->start();
         reader.start();
         return true;
     }
-
     virtual const void *nextRow()
     {
-        cOutItem * item;
         if (eos)
             return NULL;
-        loop {
-            if (stoppedworkers==numworkers) {
-                eos = true;
-                return NULL;
-            }
-            item = outqueue.dequeue(); 
-            if (exc.get()) {
-                delete item;
-                CriticalBlock b(sect);
-                throw exc.getClear();
-            }
-            if (item&&item->row)
-                break;
-            delete item;
-            stoppedworkers++;
+        const void *ret = multiWriter->nextRow();
+        if (exc.get())
+        {
+            ::ReleaseThorRow(ret);
+            CriticalBlock b(sect);
+            throw exc.getClear();
         }
-
-        const void * ret = item->row;
-        delete item;
-        return ret;
+        if (ret)
+            return ret;
+        eos = true;
+        return NULL;
+    }
+    virtual void stop()
+    {
     }
 
-    void addWork(CThorExpandingRowArray *lgroup,CThorExpandingRowArray *rgroup)
+// IMulticoreIntercept impl.
+    virtual void addWork(CThorExpandingRowArray *lgroup,CThorExpandingRowArray *rgroup)
     {
         cWorkItem *item = new cWorkItem(activity, lgroup, rgroup);
         workqueue.enqueue(item);
     }
-
-    void addRow(const void *row)
+    virtual void addRow(const void *row)
     {
         assertex(row);
-        cOutItem *item = new cOutItem(row,false);
-        outqueue.enqueue(item);
+        rowWriter->putRow(row);
     }
-
 };
 
 
-IJoinHelper *createJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IEngineRowAllocator *allocator, bool parallelmatch, bool unsortedoutput)
+IJoinHelper *createJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IRowInterfaces *rowIf, bool parallelmatch, bool unsortedoutput)
 {
     // 
 #ifdef TEST_PARALLEL_MATCH
@@ -1938,17 +1964,17 @@ IJoinHelper *createJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IE
 #ifdef TEST_UNSORTED_OUT
     unsortedoutput = true;
 #endif
-    IJoinHelper *jhelper = new CJoinHelper(activity, helper, allocator);
+    IJoinHelper *jhelper = new CJoinHelper(activity, helper, rowIf);
     if (!parallelmatch||helper->getKeepLimit()||((helper->getJoinFlags()&JFslidingmatch)!=0)) // currently don't support betweenjoin or keep and multicore
         return jhelper;
     unsigned numthreads = getAffinityCpus();
     if (unsortedoutput)
-        return new CMultiCoreUnorderedJoinHelper(activity, numthreads, false, jhelper, helper, allocator);
-    return new CMultiCoreJoinHelper(activity, numthreads, false, jhelper, helper, allocator);
+        return new CMultiCoreUnorderedJoinHelper(activity, numthreads, false, jhelper, helper, rowIf);
+    return new CMultiCoreJoinHelper(activity, numthreads, false, jhelper, helper, rowIf);
 }
 
 
-IJoinHelper *createSelfJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IEngineRowAllocator *allocator, bool parallelmatch, bool unsortedoutput)
+IJoinHelper *createSelfJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IRowInterfaces *rowIf, bool parallelmatch, bool unsortedoutput)
 {
 #ifdef TEST_PARALLEL_MATCH
     parallelmatch = true;
@@ -1956,13 +1982,13 @@ IJoinHelper *createSelfJoinHelper(CActivityBase &activity, IHThorJoinArg *helper
 #ifdef TEST_UNSORTED_OUT
     unsortedoutput = true;
 #endif
-    IJoinHelper *jhelper = new SelfJoinHelper(activity, helper, allocator);
+    IJoinHelper *jhelper = new SelfJoinHelper(activity, helper, rowIf);
     if (!parallelmatch||helper->getKeepLimit()||((helper->getJoinFlags()&JFslidingmatch)!=0)) // currently don't support betweenjoin or keep and multicore
         return jhelper;
     unsigned numthreads = getAffinityCpus();
     if (unsortedoutput)
-        return new CMultiCoreUnorderedJoinHelper(activity, numthreads, true, jhelper, helper, allocator);
-    return new CMultiCoreJoinHelper(activity, numthreads, true, jhelper, helper, allocator);
+        return new CMultiCoreUnorderedJoinHelper(activity, numthreads, true, jhelper, helper, rowIf);
+    return new CMultiCoreJoinHelper(activity, numthreads, true, jhelper, helper, rowIf);
 }
 
 

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -1400,9 +1400,11 @@ ILimitedCompareHelper *createLimitedCompareHelper()
 
 //===============================================================
 
-class CMultiCoreJoinHelperBase: extends CInterface, implements IJoinHelper, implements IMulticoreIntercept
+class CMultiCoreJoinHelperBase: extends CSimpleInterface, implements IJoinHelper, implements IMulticoreIntercept
 {
 public:
+    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+
     CActivityBase &activity;
     IRowInterfaces *rowIf;
     IJoinHelper *jhelper;
@@ -1668,8 +1670,6 @@ class CMultiCoreJoinHelper: public CMultiCoreJoinHelperBase
     } **workers;
 
 public:
-    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
-
     CMultiCoreJoinHelper(CActivityBase &activity, unsigned numthreads, bool selfJoin, IJoinHelper *_jhelper, IHThorJoinArg *_helper, IRowInterfaces *_rowIf)
         : CMultiCoreJoinHelperBase(activity, numthreads, selfJoin, _jhelper, _helper, _rowIf)
     {
@@ -1866,8 +1866,6 @@ class CMultiCoreUnorderedJoinHelper: public CMultiCoreJoinHelperBase
     } **workers;
 
 public:
-    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
-
     CMultiCoreUnorderedJoinHelper(CActivityBase &activity, unsigned numthreads, bool selfJoin, IJoinHelper *_jhelper, IHThorJoinArg *_helper, IRowInterfaces *_rowIf)
         : CMultiCoreJoinHelperBase(activity, numthreads, selfJoin, _jhelper, _helper, _rowIf)
     {

--- a/thorlcr/activities/msort/thsortu.hpp
+++ b/thorlcr/activities/msort/thsortu.hpp
@@ -45,7 +45,7 @@ interface IMulticoreIntercept
 };
 
 class CActivityBase;
-interface IJoinHelper: public IInterface
+interface IJoinHelper: public IRowStream
 {
     virtual bool init(
             IRowStream *strmL,
@@ -57,14 +57,15 @@ interface IJoinHelper: public IInterface
             IMulticoreIntercept *mcoreintercept=NULL
         )=0;
 
-    virtual const void *nextRow() = 0;
     virtual rowcount_t getLhsProgress() const = 0;
     virtual rowcount_t getRhsProgress() const = 0;
+    virtual const void *nextRow() = 0;
+    virtual void stop() = 0;
 };
 
-IJoinHelper *createJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IEngineRowAllocator *allocator,bool parallelmatch,bool unsortedoutput);
-IJoinHelper *createSelfJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IEngineRowAllocator *allocator,bool parallelmatch,bool unsortedoutput);
-IJoinHelper *createDenormalizeHelper(CActivityBase &activity, IHThorDenormalizeArg *helper, IEngineRowAllocator *allocator);
+IJoinHelper *createJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IRowInterfaces *rowIf, bool parallelmatch, bool unsortedoutput);
+IJoinHelper *createSelfJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IRowInterfaces *rowIf, bool parallelmatch, bool unsortedoutput);
+IJoinHelper *createDenormalizeHelper(CActivityBase &activity, IHThorDenormalizeArg *helper, IRowInterfaces *rowIf);
 
 
 

--- a/thorlcr/activities/selfjoin/thselfjoinslave.cpp
+++ b/thorlcr/activities/selfjoin/thselfjoinslave.cpp
@@ -170,11 +170,12 @@ public:
         if (helper->getJoinFlags()&JFlimitedprefixjoin) {
             CriticalBlock b(joinHelperCrit);
             // use std join helper (less efficient but implements limited prefix)
-            joinhelper.setown(createJoinHelper(*this, helper, queryRowAllocator(), hintparallelmatch, hintunsortedoutput));
+            joinhelper.setown(createJoinHelper(*this, helper, this, hintparallelmatch, hintunsortedoutput));
         }
-        else {
+        else
+        {
             CriticalBlock b(joinHelperCrit);
-            joinhelper.setown(createSelfJoinHelper(*this, helper, queryRowAllocator(), hintparallelmatch, hintunsortedoutput));
+            joinhelper.setown(createSelfJoinHelper(*this, helper, this, hintparallelmatch, hintunsortedoutput));
         }
         strm.setown(isLightweight? doLightweightSelfJoin() : (isLocal ? doLocalSelfJoin() : doGlobalSelfJoin()));
         assertex(strm);

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -1601,7 +1601,7 @@ class CRowMultiWriterReader : public CSimpleInterface, implements IRowMultiWrite
                         emptySem.signal();
                         readerBlocked = false;
                     }
-                    break;
+                    return;
                 }
                 writersBlocked++;
             }

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -86,9 +86,12 @@ extern graph_decl IRowWriterMultiReader *createOverflowableBuffer(CActivityBase 
 interface IRowMultiWriterReader : extends IRowStream
 {
     virtual IRowWriter *getWriter() = 0;
+    virtual void abort() = 0;
 };
 
-IRowMultiWriterReader *createSharedWriteBuffer(CActivityBase *activity, IRowInterfaces *rowif, unsigned limit);
+#define DEFAULT_WR_READ_GRANULARITY 10000 // Amount reader extracts when empty to avoid contention with writer
+#define DEFAULT_WR_WRITE_GRANULARITY 1000 // Amount writers buffer up before committing to output
+IRowMultiWriterReader *createSharedWriteBuffer(CActivityBase *activity, IRowInterfaces *rowif, unsigned limit, unsigned readGranularity=DEFAULT_WR_READ_GRANULARITY, unsigned writeGranularity=DEFAULT_WR_WRITE_GRANULARITY);
 
 
 #endif

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -61,6 +61,7 @@ extern graph_decl ISmartRowBuffer * createSmartInMemoryBuffer(CActivityBase *act
                                                       IRowInterfaces *rowIf,
                                                       size32_t buffsize);
 
+// Multiple readers, one writer
 interface ISharedSmartBuffer : extends IRowWriter
 {
     virtual IRowStream *queryOutput(unsigned output) = 0;
@@ -80,5 +81,14 @@ interface IRowWriterMultiReader : extends IRowWriter
 
 extern graph_decl IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowif, bool grouped, bool shared=false, unsigned spillPriority=SPILL_PRIORITY_OVERFLOWABLE_BUFFER);
 // NB first write all then read (not interleaved!)
+
+// Multiple writers, one reader
+interface IRowMultiWriterReader : extends IRowStream
+{
+    virtual IRowWriter *getWriter() = 0;
+};
+
+IRowMultiWriterReader *createSharedWriteBuffer(CActivityBase *activity, IRowInterfaces *rowif, unsigned limit);
+
 
 #endif

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -536,7 +536,8 @@ void CThorExpandingRowArray::doSort(rowidx_t n, void **const rows, ICompare &com
         parqsortvec((void **const)rows, n, compare, maxCores);
 }
 
-CThorExpandingRowArray::CThorExpandingRowArray(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _allowNulls, StableSortFlag _stableSort, bool _throwOnOom, rowidx_t initialSize) : activity(_activity)
+CThorExpandingRowArray::CThorExpandingRowArray(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _allowNulls, StableSortFlag _stableSort, bool _throwOnOom, rowidx_t initialSize)
+    : activity(_activity)
 {
     init(initialSize, _stableSort);
     setup(_rowIf, _allowNulls, _stableSort, _throwOnOom);
@@ -624,6 +625,15 @@ void CThorExpandingRowArray::transferRows(rowidx_t & outNumRows, const void * * 
     stableTable = NULL;
 }
 
+void CThorExpandingRowArray::transferRowsCopy(rowidx_t &outNumRows, const void **outRows)
+{
+    outNumRows = numRows;
+    memcpy(outRows, rows, numRows*sizeof(void **));
+    memset(rows, 0, numRows*sizeof(void **));
+    numRows = 0;
+    maxRows = 0;
+}
+
 void CThorExpandingRowArray::transferFrom(CThorExpandingRowArray &donor)
 {
     kill();
@@ -654,6 +664,33 @@ void CThorExpandingRowArray::removeRows(rowidx_t start, rowidx_t n)
     }
 }
 
+bool CThorExpandingRowArray::appendRows(CThorExpandingRowArray &inRows, bool takeOwnership)
+{
+    rowidx_t num = inRows.ordinality();
+    if (0 == num)
+        return true;
+    if (numRows+num >= maxRows)
+    {
+        if (!ensure(numRows + num))
+            return false;
+    }
+    const void **_inRows = inRows.getRowArray();
+    const void **newRows = rows+numRows;
+    inRows.transferRowsCopy(num, newRows);
+    if (!takeOwnership)
+    {
+        const void **lastNewRow = newRows+num-1;
+        do
+        {
+            LinkThorRow(*newRows);
+            newRows++;
+        }
+        while (newRows != lastNewRow);
+    }
+    numRows += num;
+    return true;
+}
+
 void CThorExpandingRowArray::clearUnused()
 {
     if (rows)
@@ -672,7 +709,8 @@ bool CThorExpandingRowArray::ensure(rowidx_t requiredRows)
     if (currentMaxRows < requiredRows) // check, because may have expanded previously, but failed to allocate stableTable and set new maxRows
     {
         capacity = ((memsize_t)getNewSize(requiredRows)) * sizeof(void *);
-        CResizeRowCallback callback(*(void ***)(&rows), capacity, *this);
+
+        CResizeRowCallback callback(*(void ***)(&rows), capacity, queryLock());
         if (!resizeRowTable((void **)rows, capacity, true, callback)) // callback will reset capacity
         {
             if (throwOnOom)
@@ -683,7 +721,7 @@ bool CThorExpandingRowArray::ensure(rowidx_t requiredRows)
     if (stableSort_earlyAlloc == stableSort)
     {
         memsize_t dummy;
-        CResizeRowCallback callback(stableTable, dummy, *this);
+        CResizeRowCallback callback(stableTable, dummy, queryLock());
         if (!resizeRowTable(stableTable, capacity, false, callback))
         {
             if (throwOnOom)
@@ -696,7 +734,7 @@ bool CThorExpandingRowArray::ensure(rowidx_t requiredRows)
     }
 
     // Both row tables updated, only now update maxRows
-    CThorArrayLockBlock block(*this);
+    CThorArrayLockBlock block(queryLock());
     maxRows = capacity / sizeof(void *);
     return true;
 }
@@ -1107,8 +1145,8 @@ void CThorSpillableRowArray::flush()
 {
     CThorArrayLockBlock block(*this);
     dbgassertex(numRows >= commitRows);
-    //This test could be improved...
-    if (firstRow != 0 && firstRow == commitRows)
+    // if firstRow over 50% of commitRows, meaning over half of row array is empty, then reduce
+    if (firstRow != 0 && (firstRow >= commitRows/2))
     {
         //A block of rows was removed - copy these rows to the start of the block.
         memmove(rows, rows+firstRow, (numRows-firstRow) * sizeof(void *));
@@ -1117,6 +1155,39 @@ void CThorSpillableRowArray::flush()
     }
 
     commitRows = numRows;
+}
+
+bool CThorSpillableRowArray::appendRows(CThorExpandingRowArray &inRows, bool takeOwnership)
+{
+    rowidx_t num = inRows.ordinality();
+    if (0 == num)
+        return true;
+    if (numRows+num >= maxRows)
+    {
+        if (!ensure(numRows + num))
+        {
+            flush();
+            if (numRows+num >= maxRows)
+                return false;
+        }
+    }
+    const void **_inRows = inRows.getRowArray();
+    const void **newRows = rows+numRows;
+    inRows.transferRowsCopy(num, newRows);
+    if (!takeOwnership)
+    {
+        const void **lastNewRow = newRows+num-1;
+        do
+        {
+            LinkThorRow(*newRows);
+            newRows++;
+        }
+        while (newRows != lastNewRow);
+    }
+    numRows += num;
+    if (numRows >= commitRows + commitDelta)
+        flush();
+    return true;
 }
 
 void CThorSpillableRowArray::transferFrom(CThorExpandingRowArray &src)

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -239,8 +239,16 @@ public:
     inline ~CThorArrayLockUnblock() { alock.lock(); }
 };
 
-class graph_decl CThorExpandingRowArray : public CSimpleInterface, implements IThorArrayLock
+class graph_decl CThorExpandingRowArray : public CSimpleInterface
 {
+    class CDummyLock : implements IThorArrayLock
+    {
+    public:
+        // IThorArrayLock
+        virtual void lock() const { }
+        virtual void unlock() const {  }
+    } dummyLock;
+
 protected:
     CActivityBase &activity;
     IRowInterfaces *rowIf;
@@ -333,9 +341,11 @@ public:
         swap(from);
     }
     void transferRows(rowidx_t & outNumRows, const void * * & outRows);
+    void transferRowsCopy(rowidx_t & outNumRows, const void **outRows);
     void transferFrom(CThorExpandingRowArray &src);
     void transferFrom(CThorSpillableRowArray &src);
     void removeRows(rowidx_t start, rowidx_t n);
+    bool appendRows(CThorExpandingRowArray &inRows, bool takeOwnership);
     void clearUnused();
     void sort(ICompare &compare, unsigned maxCores);
     void reorder(rowidx_t start, rowidx_t num, rowidx_t *neworder);
@@ -356,9 +366,7 @@ public:
     void deserialize(size32_t sz, const void *buf);
     void deserializeExpand(size32_t sz, const void *data);
     bool ensure(rowidx_t requiredRows);
-// IThorArrayLock
-    virtual void lock() const { }
-    virtual void unlock() const { }
+    virtual IThorArrayLock &queryLock() { return dummyLock; }
 };
 
 interface IWritePosCallback : extends IInterface
@@ -367,7 +375,7 @@ interface IWritePosCallback : extends IInterface
     virtual void filePosition(offset_t pos) = 0;
 };
 
-class graph_decl CThorSpillableRowArray : public CThorExpandingRowArray
+class graph_decl CThorSpillableRowArray : private CThorExpandingRowArray, implements IThorArrayLock
 {
     const size32_t commitDelta;  // How many rows need to be written before they are added to the committed region?
     rowidx_t firstRow; // Only rows firstRow..numRows are considered initialized.  Only read/write within cs.
@@ -378,10 +386,10 @@ public:
 
     CThorSpillableRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, rowidx_t initialSize=InitialSortElements, size32_t commitDelta=CommitStep);
     ~CThorSpillableRowArray();
-    // NB: throwOnOom false
-    void setup(IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none)
+    // NB: default throwOnOom to false
+    void setup(IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=false)
     {
-        CThorExpandingRowArray::setup(rowIf, allowNulls, stableSort, false);
+        CThorExpandingRowArray::setup(rowIf, allowNulls, stableSort, throwOnOom);
     }
     void registerWriteCallback(IWritePosCallback &cb);
     void unregisterWriteCallback(IWritePosCallback &cb);
@@ -406,6 +414,7 @@ public:
             flush();
         return true;
     }
+    bool appendRows(CThorExpandingRowArray &inRows, bool takeOwnership);
 
     //The following can be accessed from the reader without any need to lock
     inline const void *query(rowidx_t i) const
@@ -465,6 +474,8 @@ public:
     void deserialize(size32_t sz, const void *buf, bool hasNulls){ CThorExpandingRowArray::deserialize(sz, buf); }
     void deserializeRow(IRowDeserializerSource &in) { CThorExpandingRowArray::deserializeRow(in); }
     bool ensure(rowidx_t requiredRows) { return CThorExpandingRowArray::ensure(requiredRows); }
+
+    virtual IThorArrayLock &queryLock() { return *this; }
 // IThorArrayLock
     virtual void lock() const { cs.enter(); }
     virtual void unlock() const { cs.leave(); }

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -249,6 +249,10 @@ class graph_decl CThorExpandingRowArray : public CSimpleInterface
         virtual void unlock() const {  }
     } dummyLock;
 
+
+// for direct access by another CThorExpandingRowArray only
+    inline void transferRowsCopy(const void **outRows, bool takeOwnership);
+
 protected:
     CActivityBase &activity;
     IRowInterfaces *rowIf;
@@ -341,7 +345,6 @@ public:
         swap(from);
     }
     void transferRows(rowidx_t & outNumRows, const void * * & outRows);
-    void transferRowsCopy(rowidx_t & outNumRows, const void **outRows);
     void transferFrom(CThorExpandingRowArray &src);
     void transferFrom(CThorSpillableRowArray &src);
     void removeRows(rowidx_t start, rowidx_t n);
@@ -367,6 +370,8 @@ public:
     void deserializeExpand(size32_t sz, const void *data);
     bool ensure(rowidx_t requiredRows);
     virtual IThorArrayLock &queryLock() { return dummyLock; }
+
+friend class CThorSpillableRowArray;
 };
 
 interface IWritePosCallback : extends IInterface

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -56,6 +56,7 @@
 #define THOROPT_SORT_MAX_DEVIANCE     "sort_max_deviance"
 #define THOROPT_OUTPUT_FLUSH_THRESHOLD "output_flush_threshold"
 #define THOROPT_OUTPUTLIMIT           "outputLimit"
+#define THOROPT_JOINHELPER_THREADS    "joinHelperThreads"
 
 #define INITIAL_SELFJOIN_MATCH_WARNING_LEVEL 20000  // max of row matches before selfjoin emits warning
 


### PR DESCRIPTION
The multi threaded join helpers were very inefficient in
processing the match/transform of groups and delivery the
results to the output.

The main 2 changes are:
1) Ensure each thread has it's own allocator, to avoid heavy
contention in the memory manager
2) Implement an efficient interface for multiple threads to
write to and a reader read from (a pipe with multiple writers).
This avoids heavy contetion and delays on mutexs and semaphores
that was being hit inside SimpleInterThreadQueueOf

 Signed-off-by: Jake Smith jake.smith@lexisnexis.com
