### PR TITLE
HPCC-9791 XML file spray logging improvement

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -294,7 +294,14 @@ void CInputBasePartitioner::findSplitPoint(offset_t splitOffset, PartitionCursor
 CInputBasePartitioner::CInputBasePartitioner(unsigned _headerSize, unsigned expectedRecordSize)
 {
     headerSize = _headerSize;
-    blockSize = 0x40000;
+    if (expectedRecordSize == 8192)
+        // Give room for some extreme large record and to try avoid
+        // "DFURUN Exception:  : End of XML record not found (need to increase maxRecordSize?)!"
+        blockSize = 0x80 * expectedRecordSize; // 1 MB
+    else
+        // User has knowledge/prediction about what is the max record size
+        // use this to create proper size block
+        blockSize = 4 * expectedRecordSize;
     bufferSize = 4 * blockSize + expectedRecordSize;
     doInputCRC = false;
     CriticalBlock block(openfilecachesect);
@@ -1163,6 +1170,7 @@ void CXmlQuickPartitioner::findSplitPoint(offset_t splitOffset, PartitionCursor 
     numInBuffer = bufferOffset = 0;
     if (splitOffset != 0)
     {
+        LOG(MCdebugProgressDetail, unknownJob, "CXmlQuickPartitioner::findSplitPoint(splitOffset:%"I64F"d)", splitOffset);
         unsigned delta = (unsigned)(splitOffset & (unitSize-1));
         if (delta)
             splitOffset += (unitSize - delta);
@@ -1187,7 +1195,10 @@ void CXmlQuickPartitioner::findSplitPoint(offset_t splitOffset, PartitionCursor 
                     break;
                 }
                 if (sizeAvailable >= format.maxRecordSize)
-                    throwError(DFTERR_EndOfRecordNotFound);
+                {
+                    LOG(MCdebugProgressDetail, unknownJob, "CXmlQuickPartitioner::findSplitPoint: record size (>%d bytes) is larger than expected maxRecordSize (%d bytes) [and blockSize (%d bytes)]", sizeRecord, format.maxRecordSize, blockSize);
+                    throwError4(DFTERR_EndOfXmlRecordNotFound, splitOffset+bufferOffset, sizeRecord, format.maxRecordSize, blockSize);
+                }
                 LOG(MCdebugProgress, unknownJob, "Failed to find split after reading %d", ensureSize);
                 ensureSize += blockSize;
                 if (ensureSize > format.maxRecordSize)

--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -71,6 +71,7 @@
 #define DFTERR_CannotFindFirstXmlRecord         8098
 #define DFTERR_CannotFindLastXmlRecord          8099
 #define DFTERR_CouldNotOpenCompressedFile       8100
+#define DFTERR_EndOfXmlRecordNotFound           8101
 
 //Internal errors
 #define DFTERR_UnknownFormatType                8190
@@ -130,6 +131,7 @@
 #define DFTERR_CannotPushAndCompress_Text       "Need to pull the data when compressing the output"
 #define DFTERR_CannotFindFirstXmlRecord_Text    "Could not find the start of the first record"
 #define DFTERR_CouldNotOpenCompressedFile_Text  "Could not open file %s as compressed file"
+#define DFTERR_EndOfXmlRecordNotFound_Text      "End of XML record not found (need to increase maxRecordSize?)!\nCXmlQuickPartitioner::findSplitPoint: at offset:%"I64F"d, record size (>%d bytes) is larger than expected maxRecordSize (%d bytes) [and blockSize (%d bytes)]."
 
 #define DFTERR_UnknownFormatType_Text           "INTERNAL: Save unknown format type"
 #define DFTERR_OutputOffsetMismatch_Text        "INTERNAL: Output offset does not match expected (%"I64F"d expected %"I64F"d) at %s of block %d"


### PR DESCRIPTION
Add
- splitOffset value log at findSplitPoint() call
- log predicted recordsize, maxRecordSize and blockSize when "End of record
  not found (need to increase maxRecordSize?)" exception occurs

Signed-off-by: Attila Vamos attila.vamos@gmail.com
