### PR TITLE
HPCC-9663 Dynamically start/stop scope scans

### DIFF
--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -37,7 +37,7 @@ extern void closedownDFS();
 // base is saved in store whenever block exhausted, so replacement coven servers can restart 
 
 // server side versioning.
-#define ServerVersion    "3.9"
+#define ServerVersion    "3.10"
 #define MinClientVersion "1.5"
 
 
@@ -327,7 +327,6 @@ public:
         if (comm)
             comm->cancel(srcrank,tag);
     }
-
 };
 
 

--- a/dali/base/dacoven.hpp
+++ b/dali/base/dacoven.hpp
@@ -50,7 +50,6 @@ interface ICoven: extends ICommunicator // ICoven can be used to communicate wit
     virtual rank_t          chooseServer(DALI_UID uid, int tag=0)=0;    // choose a server deterministically based on UID and tag
 
     inline ICommunicator &queryComm() { return *this; }
-
 };
 
 class da_decl CDaliVersion

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -78,6 +78,7 @@ interface IUserDescriptor: extends serializable
 };
 
 extern da_decl IUserDescriptor *createUserDescriptor();
+extern da_decl IUserDescriptor *createUserDescriptor(MemoryBuffer &mb);
 
 const static IUserDescriptor * unknownUser = NULL;//use of this should be avoided
 #define UNKNOWN_USER (IUserDescriptor*)unknownUser
@@ -111,7 +112,8 @@ interface ISessionManager: extends IInterface
     virtual unsigned getLDAPflags()=0;
     virtual void setLDAPflags(unsigned flags)=0;
     virtual bool clearPermissionsCache(IUserDescriptor *udesc)=0;
-
+    virtual bool queryScopeScansEnabled(IUserDescriptor *udesc, int * err, StringBuffer &retMsg)=0;
+    virtual bool enableScopeScans(IUserDescriptor *udesc, bool enable, int * err, StringBuffer &retMsg)=0;
 };
 
 // the following are getPermissionsLDAP input flags for audit reporting
@@ -127,7 +129,12 @@ extern da_decl ISessionManager &querySessionManager();
 
 #define myProcessSession() (querySessionManager().lookupProcessSession())
 
-
+interface IMessageWrapper
+{
+public:
+    virtual void serializeReq(CMessageBuffer &mb) = 0;
+    virtual void deserializeReq(CMessageBuffer &mb) = 0;
+};
 
 // for server use
 interface IDaliServer;

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -187,6 +187,37 @@ public:
         user->credentials().setPassword(password);
         return ldapsecurity->clearPermissionsCache(*user);
     }
+
+    bool enableScopeScans(IUserDescriptor *udesc, bool enable, int * err)
+    {
+        bool superUser;
+        StringBuffer username;
+        StringBuffer password;
+        udesc->getUserName(username);
+        udesc->getPassword(password);
+        Owned<ISecUser> user = ldapsecurity->createUser(username);
+        user->credentials().setPassword(password);
+        if (!ldapsecurity->authenticateUser(*user,superUser) || !superUser)
+        {
+            *err = -1;
+            return false;
+        }
+        unsigned flags = getLDAPflags();
+        if (enable)
+        {
+            DBGLOG("Scope Scans Enabled by user %s",username.str());
+            flags |= (unsigned)DLF_SCOPESCANS;
+        }
+        else
+        {
+            DBGLOG("Scope Scans Disabled by user %s",username.str());
+            flags &= ~(unsigned)DLF_SCOPESCANS;
+        }
+        setLDAPflags(flags);
+        *err = 0;
+        return true;
+    }
+
     bool checkScopeScans()
     {
         return (ldapflags&DLF_SCOPESCANS)!=0;

--- a/dali/server/daldap.hpp
+++ b/dali/server/daldap.hpp
@@ -31,6 +31,7 @@ interface IDaliLdapConnection: extends IInterface
     virtual unsigned getLDAPflags() = 0;
     virtual void setLDAPflags(unsigned flags) = 0;
     virtual bool clearPermissionsCache(IUserDescriptor *udesc) = 0;
+    virtual bool enableScopeScans(IUserDescriptor *udesc, bool enable, int *err) = 0;
 };
 
 extern IDaliLdapConnection *createDaliLdapConnection(IPropertyTree *proptree);

--- a/esp/eclwatch/ws_XSLT/CMakeLists.txt
+++ b/esp/eclwatch/ws_XSLT/CMakeLists.txt
@@ -139,6 +139,8 @@ FOREACH ( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/access_adduser.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_basedns.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_clearpermissionscache.xslt
+    ${CMAKE_CURRENT_SOURCE_DIR}/access_enablescopescans.xslt
+    ${CMAKE_CURRENT_SOURCE_DIR}/access_disablescopescans.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_filepermission.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_groupadd.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_groupdelete.xslt

--- a/esp/eclwatch/ws_XSLT/access_disablescopescans.xslt
+++ b/esp/eclwatch/ws_XSLT/access_disablescopescans.xslt
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+  <xsl:output method="html"/>
+  <xsl:template match="/">
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+      <head>
+        <script type="text/javascript" src="/esp/files/scripts/espdefault.js">&#160;</script>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <title>Scope Scanning</title>
+      </head>
+      <body class="yui-skin-sam" onload="nof5();">
+        <xsl:apply-templates/>
+      </body>
+    </html>
+  </xsl:template>
+  
+  <xsl:template match="DisableScopeScansResponse/scopeScansStatus">
+    <table>
+      <tbody>
+        <th align="left">
+          <h2>Disable Scope Scans Result</h2>
+        </th>
+        <tr>
+          <td>
+            <xsl:choose>
+              <xsl:when test="retcode=0">
+                Scope Scans Disabled
+              </xsl:when>
+              <xsl:otherwise>
+                Scope Scans Disable failed :
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:value-of select="retmsg"/>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    
+  </xsl:template>
+</xsl:stylesheet>

--- a/esp/eclwatch/ws_XSLT/access_enablescopescans.xslt
+++ b/esp/eclwatch/ws_XSLT/access_enablescopescans.xslt
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+  <xsl:output method="html"/>
+  <xsl:template match="/">
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+      <head>
+        <script type="text/javascript" src="/esp/files/scripts/espdefault.js">&#160;</script>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <title>Scope Scanning</title>
+      </head>
+      <body class="yui-skin-sam" onload="nof5();">
+        <xsl:apply-templates/>
+      </body>
+    </html>
+  </xsl:template>
+  
+  <xsl:template match="EnableScopeScansResponse/scopeScansStatus">
+    <table>
+      <tbody>
+        <th align="left">
+          <h2>Enable Scope Scans Result</h2>
+        </th>
+        <tr>
+          <td>
+            <xsl:choose>
+              <xsl:when test="retcode=0">
+                Scope Scans Enabled
+              </xsl:when>
+              <xsl:otherwise>
+                Scope Scans Enable failed :
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:value-of select="retmsg"/>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    
+  </xsl:template>
+</xsl:stylesheet>

--- a/esp/eclwatch/ws_XSLT/access_resources.xslt
+++ b/esp/eclwatch/ws_XSLT/access_resources.xslt
@@ -193,6 +193,24 @@
                   <input id="clearPermissionsCacheBtn" class="sbutton" type="submit" name="action" value="Clear Permissions Cache" onclick="return confirm('Are you sure you want to clear the DALI and ESP permissions caches? Running workunit performance might degrade significantly until the caches have been refreshed.')"/>
                 </form>
             </td>
+
+            <xsl:if test="scopeScansStatus/retcode=0">
+              <xsl:if test="scopeScansStatus/isEnabled=0">
+                <td>
+                  <form action="/ws_access/EnableScopeScans">
+                    <input id="EnableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Enable Scope Scans" onclick="return confirm('Are you sure you want to enable Scope Scans?')"/>
+                  </form>
+                </td>
+              </xsl:if>
+              <xsl:if test="scopeScansStatus/isEnabled=1">
+                <td>
+                  <form action="/ws_access/DisableScopeScans">
+                    <input id="DisableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Disable Scope Scans" onclick="return confirm('Are you sure you want to disable Scope Scans?')"/>
+                  </form>
+                </td>
+              </xsl:if>
+            </xsl:if>
+
                 </tr>
             </table>
       <form action="/ws_access/ResourceAddInput" id="addform">

--- a/esp/scm/ws_access.ecm
+++ b/esp/scm/ws_access.ecm
@@ -362,6 +362,13 @@ ESPstruct Resource
     bool isSpecial;
 };
 
+ESPstruct ScopeScanStatusStruct
+{
+    bool    isEnabled;
+    int     retcode;
+    string  retmsg;
+};
+
 ESPresponse ResourcesResponse
 {
     string basedn;
@@ -373,6 +380,7 @@ ESPresponse ResourcesResponse
     string default_name;
     string prefix;
     [min_ver("1.05")] bool toomany;
+    [min_ver("1.08")] ESPstruct ScopeScanStatusStruct scopeScansStatus;
 };
 
 ESPrequest ResourceAddInputRequest
@@ -561,6 +569,34 @@ ESPresponse ClearPermissionsCacheResponse
 {
     int retcode;
 };
+
+ESPrequest QueryScopeScansEnabledRequest
+{
+};
+
+ESPresponse QueryScopeScansEnabledResponse
+{
+    [min_ver("1.08")] ESPstruct ScopeScanStatusStruct scopeScansStatus;
+};
+
+ESPrequest EnableScopeScansRequest
+{
+};
+
+ESPresponse EnableScopeScansResponse
+{
+    [min_ver("1.08")] ESPstruct ScopeScanStatusStruct scopeScansStatus;
+};
+
+ESPrequest DisableScopeScansRequest
+{
+};
+
+ESPresponse DisableScopeScansResponse
+{
+    [min_ver("1.08")] ESPstruct ScopeScanStatusStruct scopeScansStatus;
+};
+
 ESPrequest PermissionActionRequest
 {
     string basedn;
@@ -655,7 +691,7 @@ ESPresponse [nil_remove] UserAccountExportResponse
 };
 
 
-ESPservice [version("1.07"), default_client_version("1.07"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
+ESPservice [version("1.08"), default_client_version("1.08"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
 {
     ESPmethod [client_xslt("/esp/xslt/access_users.xslt")] Users(UserRequest, UserResponse);
     ESPmethod [client_xslt("/esp/xslt/access_useredit.xslt")] UserEdit(UserEditRequest, UserEditResponse);
@@ -690,6 +726,9 @@ ESPservice [version("1.07"), default_client_version("1.07"), exceptions_inline("
     ESPmethod [client_xslt("/esp/xslt/access_permissionresetinput.xslt")] PermissionsResetInput(PermissionsResetInputRequest, PermissionsResetInputResponse);
     ESPmethod [client_xslt("/esp/xslt/access_permissionsreset.xslt")] PermissionsReset(PermissionsResetRequest, PermissionsResetResponse);
     ESPmethod [client_xslt("/esp/xslt/access_clearpermissionscache.xslt")] ClearPermissionsCache(ClearPermissionsCacheRequest, ClearPermissionsCacheResponse);
+    ESPmethod QueryScopeScansEnabled(QueryScopeScansEnabledRequest, QueryScopeScansEnabledResponse);
+    ESPmethod [client_xslt("/esp/xslt/access_enablescopescans.xslt")] EnableScopeScans(EnableScopeScansRequest, EnableScopeScansResponse);
+    ESPmethod [client_xslt("/esp/xslt/access_disablescopescans.xslt")] DisableScopeScans(DisableScopeScansRequest, DisableScopeScansResponse);
     //ESPmethod [client_xslt("/esp/xslt/access_useraccountexport.xslt")] UserAccountExport(UserAccountExportRequest, UserAccountExportResponse);
     ESPmethod UserAccountExport(UserAccountExportRequest, UserAccountExportResponse);
 

--- a/esp/services/ws_access/ws_accessService.hpp
+++ b/esp/services/ws_access/ws_accessService.hpp
@@ -77,6 +77,7 @@ class Cws_accessEx : public Cws_access
         bool deny_access, bool deny_read, bool deny_write, bool deny_full);
     void getBaseDNsForAddingPermssionToAccount(CLdapSecManager* secmgr, const char* prefix, const char* accountName, 
         int accountType, StringArray& basednNames);
+    int enableDisableScopeScans(IEspContext &context, bool doEnable, StringBuffer &retMsg);
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -117,6 +118,9 @@ public:
     virtual bool onPermissionsReset(IEspContext &context, IEspPermissionsResetRequest &req, IEspPermissionsResetResponse &resp);
     virtual bool onUserAccountExport(IEspContext &context, IEspUserAccountExportRequest &req, IEspUserAccountExportResponse &resp);
     virtual bool onClearPermissionsCache(IEspContext &context, IEspClearPermissionsCacheRequest &req, IEspClearPermissionsCacheResponse &resp);
+    virtual bool onQueryScopeScansEnabled(IEspContext &context, IEspQueryScopeScansEnabledRequest &req, IEspQueryScopeScansEnabledResponse &resp);
+    virtual bool onEnableScopeScans(IEspContext &context, IEspEnableScopeScansRequest &req, IEspEnableScopeScansResponse &resp);
+    virtual bool onDisableScopeScans(IEspContext &context, IEspDisableScopeScansRequest &req, IEspDisableScopeScansResponse &resp);
 };
 
 #endif //_ESPWIZ_ws_access_HPP__

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -1273,6 +1273,13 @@ bool CLdapSecManager::clearPermissionsCache(ISecUser& user)
     }
     return true;
 }
+bool CLdapSecManager::authenticateUser(ISecUser & user, bool &superUser)
+{
+    if (!authenticate(&user))
+        return false;
+    superUser = isSuperUser(&user);
+    return true;
+}
 
 extern "C"
 {

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -441,6 +441,7 @@ public:
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes);
     virtual int queryDefaultPermission(ISecUser& user);
     virtual bool clearPermissionsCache(ISecUser &user);
+    virtual bool authenticateUser(ISecUser & user, bool &superUser);
 };
 
 #endif

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -288,6 +288,7 @@ public:
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) {UNIMPLEMENTED; }
     virtual int queryDefaultPermission(ISecUser& user) {UNIMPLEMENTED; }
     virtual bool clearPermissionsCache(ISecUser& user) {return false;}
+    virtual bool authenticateUser(ISecUser & user, bool &superUser) {return false;}
 protected:
     const char* getServer(){return m_dbserver.toCharArray();}
     const char* getUser(){return m_dbuser.toCharArray();}

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -299,6 +299,7 @@ interface ISecManager : extends IInterface
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) = 0;
     virtual int queryDefaultPermission(ISecUser& user) = 0;
     virtual bool clearPermissionsCache(ISecUser & user) = 0;
+    virtual bool authenticateUser(ISecUser & user, bool &superUser) = 0;
 };
 
 interface IExtSecurityManager


### PR DESCRIPTION
Currently, to enable or disable scope scans, the admin has to bring down Dali,
modify the configuration file, and restart dali. This is awkward, and can
cause production to be down resulting in lost revenue.
This change allows scope scan status to be queried, and allows it to be
enabled/disabled dynamically by sending a new request from ESP to Dali in
response to the admin clicking a new button on the permissions page of ECLWatch.
If the configured Dali is downlevel (a version that does not support this feature)
then the button is not displayed

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
