### PR TITLE
HPCC-9682 Add WsWorkunits method to return paged QuerySet Queries

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2409,8 +2409,8 @@ public:
                 ForEach(*iter)
                 {
                     IPropertyTree &query = iter->query();
-                    query.addProp("@querySetId", querySetId);
-                    queryTreeRoot->addPropTree("Query", LINK(&query));
+                    IPropertyTree *queryWithSetId = queryTreeRoot->addPropTree("Query", LINK(&query));
+                    queryWithSetId->addProp("@querySetId", querySetId);
                 }
             }
 

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1027,7 +1027,6 @@ interface IConstWorkUnitIterator : extends IScmIterator
     virtual IConstWorkUnit & query() = 0;
 };
 
-
 //! IWUTimers
 
 interface IWUTimers : extends IInterface
@@ -1085,6 +1084,29 @@ enum WUSortField
     WUSFwild = 2048
 };
 
+enum WUQuerySortField
+{
+    WUQSFId = 1,
+    WUQSFname = 2,
+    WUQSFwuid = 3,
+    WUQSFdll = 4,
+    WUQSFmemoryLimit = 5,
+    WUQSFmemoryLimitHi = 6,
+    WUQSFtimeLimit = 7,
+    WUQSFtimeLimitHi = 8,
+    WUQSFwarnTimeLimit = 9,
+    WUQSFwarnTimeLimitHi = 10,
+    WUQSFpriority = 11,
+    WUQSFpriorityHi = 12,
+    WUQSFQuerySet = 13,
+    WUQSFterm = 0,
+    WUQSFreverse = 256,
+    WUQSFnocase = 512,
+    WUQSFnumeric = 1024,
+    WUQSFwild = 2048
+};
+
+typedef IIteratorOf<IPropertyTree> IConstQuerySetQueryIterator;
 
 
 interface IWorkUnitFactory : extends IInterface
@@ -1105,6 +1127,7 @@ interface IWorkUnitFactory : extends IInterface
     virtual unsigned numWorkUnitsFiltered(WUSortField * filters, const void * filterbuf) = 0;
     virtual void descheduleAllWorkUnits() = 0;
     virtual bool deleteWorkUnitEx(const char * wuid) = 0;
+    virtual IConstQuerySetQueryIterator * getQuerySetQueriesSorted(WUQuerySortField *sortorder, WUQuerySortField *filters, const void *filterbuf, unsigned startoffset, unsigned maxnum, __int64 *cachehint, unsigned *total) = 0;
 };
 
 

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -263,17 +263,22 @@ interface ISortedElementsTreeFilter : extends IInterface
 {
     virtual bool isOK(IPropertyTree &tree) = 0;
 };
-
-extern da_decl IRemoteConnection *getElementsPaged( const char *basexpath, 
-                                     const char *xpath, 
+interface IElementsPager : extends IInterface
+{
+    virtual IRemoteConnection *getElements(IArrayOf<IPropertyTree> &elements) = 0;
+};
+extern da_decl void sortElements( IPropertyTreeIterator* elementsIter,
                                      const char *sortorder, 
+                                     const char *namefilterlo, // if non null filter less than this value
+                                     const char *namefilterhi, // if non null filter greater than this value
+                                     IArrayOf<IPropertyTree> &sortedElements);
+
+extern da_decl IRemoteConnection *getElementsPaged(IElementsPager *elementsPager,
                                      unsigned startoffset, 
                                      unsigned pagesize, 
                                      ISortedElementsTreeFilter *postfilter, // if non-NULL filters before adding to page
                                      const char *owner,
                                      __int64 *hint,                         // if non null points to in/out cache hint
-                                     const char *namefilterlo, // if non null filter less than this value
-                                     const char *namefilterhi, // if non null filter greater than this value
                                      IArrayOf<IPropertyTree> &results,
                                      unsigned *total); // total possible filtered matches, i.e. irrespective of startoffset and pagesize
 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1168,6 +1168,7 @@ ESPStruct [nil_remove] QuerySetQuery
     nonNegativeInteger warnTimeLimit;
     string priority;
     string Comment;
+    [min_ver("1.45")] string QuerySetId;
 };
 
 ESPStruct QuerySetAlias
@@ -1202,6 +1203,37 @@ ESPresponse [exceptions_inline] WUQuerySetDetailsResponse
     [min_ver("1.37")] string  Filter;
     [min_ver("1.37")] ESPenum WUQuerySetFilterType FilterType;
     [min_ver("1.37")] ESParray<string> ClusterNames;
+};
+
+ESPStruct [nil_remove] WUListQueriesFilters
+{
+    string  QuerySetName;
+    string  ClusterName;
+    int64 MemoryLimitLow;
+    int64 MemoryLimitHigh;
+    nonNegativeInteger TimeLimitLow;
+    nonNegativeInteger TimeLimitHigh;
+    nonNegativeInteger WarnTimeLimitLow;
+    nonNegativeInteger WarnTimeLimitHigh;
+    nonNegativeInteger PriorityLow;
+    nonNegativeInteger PriorityHigh;
+};
+
+ESPrequest [nil_remove] WUListQueriesRequest
+{
+    ESPstruct WUListQueriesFilters Filters;
+    nonNegativeInteger PageSize(0);
+    nonNegativeInteger PageStartFrom(0);
+    string SortBy;
+    bool Descending(false);
+    int64 CacheHint;
+};
+
+ESPresponse [exceptions_inline] WUListQueriesResponse
+{
+    int   NumberOfQueries;
+    int64 CacheHint;
+    ESParray<ESPstruct QuerySetQuery> QuerysetQueries;
 };
 
 ESPrequest WUQueryDetailsRequest
@@ -1360,7 +1392,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.44"), default_client_version("1.44"),
+    version("1.45"), default_client_version("1.45"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);
@@ -1427,6 +1459,7 @@ ESPservice [
     ESPmethod WUQuerysetCopyQuery(WUQuerySetCopyQueryRequest, WUQuerySetCopyQueryResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/WUCopyLogicalFiles.xslt")] WUCopyLogicalFiles(WUCopyLogicalFilesRequest, WUCopyLogicalFilesResponse);
     ESPmethod WUQueryConfig(WUQueryConfigRequest, WUQueryConfigResponse);
+    ESPmethod WUListQueries(WUListQueriesRequest, WUListQueriesResponse);
 };
 
 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1205,7 +1205,7 @@ ESPresponse [exceptions_inline] WUQuerySetDetailsResponse
     [min_ver("1.37")] ESParray<string> ClusterNames;
 };
 
-ESPStruct [nil_remove] WUListQueriesFilters
+ESPrequest [nil_remove] WUListQueriesRequest
 {
     string  QuerySetName;
     string  ClusterName;
@@ -1217,14 +1217,10 @@ ESPStruct [nil_remove] WUListQueriesFilters
     nonNegativeInteger WarnTimeLimitHigh;
     nonNegativeInteger PriorityLow;
     nonNegativeInteger PriorityHigh;
-};
 
-ESPrequest [nil_remove] WUListQueriesRequest
-{
-    ESPstruct WUListQueriesFilters Filters;
     nonNegativeInteger PageSize(0);
     nonNegativeInteger PageStartFrom(0);
-    string SortBy;
+    string Sortby;
     bool Descending(false);
     int64 CacheHint;
 };

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -920,7 +920,7 @@ bool addWUQSQueryFilterInt64(WUQuerySortField *filters, unsigned short &count, M
 bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequest & req, IEspWUListQueriesResponse & resp)
 {
     bool descending = req.getDescending();
-    const char *sortBy =  req.getSortBy();
+    const char *sortBy =  req.getSortby();
     WUQuerySortField sortOrder[2] = {WUQSFId, WUQSFterm};
     if(notEmpty(sortBy))
     {
@@ -946,28 +946,27 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
             sortOrder[0] = (WUQuerySortField) (sortOrder[0] | WUQSFreverse);
     }
 
-    IConstWUListQueriesFilters& filterReqs = req.getFilters();
     WUQuerySortField filters[16];
     unsigned short filterCount = 0;
     MemoryBuffer filterBuf;
-    const char* clusterReq = filterReqs.getClusterName();
-    addWUQSQueryFilter(filters, filterCount, filterBuf, filterReqs.getQuerySetName(), WUQSFQuerySet);
-    if (!filterReqs.getMemoryLimitLow_isNull())
-        addWUQSQueryFilterInt64(filters, filterCount, filterBuf, filterReqs.getMemoryLimitLow(), (WUQuerySortField) (WUQSFmemoryLimit | WUQSFnumeric));
-    if (!filterReqs.getMemoryLimitHigh_isNull())
-        addWUQSQueryFilterInt64(filters, filterCount, filterBuf, filterReqs.getMemoryLimitHigh(), (WUQuerySortField) (WUQSFmemoryLimitHi | WUQSFnumeric));
-    if (!filterReqs.getTimeLimitLow_isNull())
-        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getTimeLimitLow(), (WUQuerySortField) (WUQSFtimeLimit | WUQSFnumeric));
-    if (!filterReqs.getTimeLimitHigh_isNull())
-        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getTimeLimitHigh(), (WUQuerySortField) (WUQSFtimeLimitHi | WUQSFnumeric));
-    if (!filterReqs.getWarnTimeLimitLow_isNull())
-        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getWarnTimeLimitLow(), (WUQuerySortField) (WUQSFwarnTimeLimit | WUQSFnumeric));
-    if (!filterReqs.getWarnTimeLimitHigh_isNull())
-        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getWarnTimeLimitHigh(), (WUQuerySortField) (WUQSFwarnTimeLimitHi | WUQSFnumeric));
-    if (!filterReqs.getPriorityLow_isNull())
-        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getPriorityLow(), (WUQuerySortField) (WUQSFpriority | WUQSFnumeric));
-    if (!filterReqs.getPriorityHigh_isNull())
-        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getPriorityHigh(), (WUQuerySortField) (WUQSFpriorityHi | WUQSFnumeric));
+    const char* clusterReq = req.getClusterName();
+    addWUQSQueryFilter(filters, filterCount, filterBuf, req.getQuerySetName(), WUQSFQuerySet);
+    if (!req.getMemoryLimitLow_isNull())
+        addWUQSQueryFilterInt64(filters, filterCount, filterBuf, req.getMemoryLimitLow(), (WUQuerySortField) (WUQSFmemoryLimit | WUQSFnumeric));
+    if (!req.getMemoryLimitHigh_isNull())
+        addWUQSQueryFilterInt64(filters, filterCount, filterBuf, req.getMemoryLimitHigh(), (WUQuerySortField) (WUQSFmemoryLimitHi | WUQSFnumeric));
+    if (!req.getTimeLimitLow_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getTimeLimitLow(), (WUQuerySortField) (WUQSFtimeLimit | WUQSFnumeric));
+    if (!req.getTimeLimitHigh_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getTimeLimitHigh(), (WUQuerySortField) (WUQSFtimeLimitHi | WUQSFnumeric));
+    if (!req.getWarnTimeLimitLow_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getWarnTimeLimitLow(), (WUQuerySortField) (WUQSFwarnTimeLimit | WUQSFnumeric));
+    if (!req.getWarnTimeLimitHigh_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getWarnTimeLimitHigh(), (WUQuerySortField) (WUQSFwarnTimeLimitHi | WUQSFnumeric));
+    if (!req.getPriorityLow_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getPriorityLow(), (WUQuerySortField) (WUQSFpriority | WUQSFnumeric));
+    if (!req.getPriorityHigh_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getPriorityHigh(), (WUQuerySortField) (WUQSFpriorityHi | WUQSFnumeric));
     filters[filterCount] = WUQSFterm;
 
     unsigned numberOfQueries = 0;

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -826,8 +826,6 @@ void retrieveAllQuerysetDetails(IArrayOf<IEspWUQuerySetDetail> &details, const c
     if (!root)
         throw MakeStringException(ECLWATCH_QUERYSET_NOT_FOUND, "QuerySet Registry not found");
     Owned<IPropertyTreeIterator> querysets = root->getElements("QuerySet");
-    if (!root)
-        throw MakeStringException(ECLWATCH_QUERYSET_NOT_FOUND, "QuerySet Registry not found");
     ForEach(*querysets)
         retrieveQuerysetDetails(details, &querysets->query(), type, value);
 }
@@ -890,6 +888,151 @@ bool CWsWorkunitsEx::onWUMultiQuerysetDetails(IEspContext &context, IEspWUMultiQ
         retrieveAllQuerysetDetails(respDetails, req.getFilterTypeAsString(), req.getFilter());
 
     resp.setQuerysets(respDetails);
+
+    return true;
+}
+
+bool addWUQSQueryFilter(WUQuerySortField *filters, unsigned short &count, MemoryBuffer &buff, const char* value, WUQuerySortField name)
+{
+    if (isEmpty(value))
+        return false;
+    filters[count++] = name;
+    buff.append(value);
+    return true;
+}
+
+bool addWUQSQueryFilterInt(WUQuerySortField *filters, unsigned short &count, MemoryBuffer &buff, int value, WUQuerySortField name)
+{
+    VStringBuffer vBuf("%d", value);
+    filters[count++] = name;
+    buff.append(vBuf.str());
+    return true;
+}
+
+bool addWUQSQueryFilterInt64(WUQuerySortField *filters, unsigned short &count, MemoryBuffer &buff, __int64 value, WUQuerySortField name)
+{
+    VStringBuffer vBuf("%ld", value);
+    filters[count++] = name;
+    buff.append(vBuf.str());
+    return true;
+}
+
+bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequest & req, IEspWUListQueriesResponse & resp)
+{
+    bool descending = req.getDescending();
+    const char *sortBy =  req.getSortBy();
+    WUQuerySortField sortOrder[2] = {WUQSFId, WUQSFterm};
+    if(notEmpty(sortBy))
+    {
+        if (strieq(sortBy, "Name"))
+            sortOrder[0] = WUQSFname;
+        else if (strieq(sortBy, "WUID"))
+            sortOrder[0] = WUQSFwuid;
+        else if (strieq(sortBy, "DLL"))
+            sortOrder[0] = WUQSFdll;
+        else if (strieq(sortBy, "MemoryLimit"))
+            sortOrder[0] = (WUQuerySortField) (WUQSFmemoryLimit | WUQSFnumeric);
+        else if (strieq(sortBy, "TimeLimit"))
+            sortOrder[0] = (WUQuerySortField) (WUQSFtimeLimit | WUQSFnumeric);
+        else if (strieq(sortBy, "WarnTimeLimit"))
+            sortOrder[0] = (WUQuerySortField) (WUQSFwarnTimeLimit | WUQSFnumeric);
+        else if (strieq(sortBy, "Priority"))
+            sortOrder[0] = (WUQuerySortField) (WUQSFpriority | WUQSFnumeric);
+        else
+            sortOrder[0] = WUQSFId;
+
+        sortOrder[0] = (WUQuerySortField) (sortOrder[0] | WUQSFnocase);
+        if (descending)
+            sortOrder[0] = (WUQuerySortField) (sortOrder[0] | WUQSFreverse);
+    }
+
+    IConstWUListQueriesFilters& filterReqs = req.getFilters();
+    WUQuerySortField filters[16];
+    unsigned short filterCount = 0;
+    MemoryBuffer filterBuf;
+    const char* clusterReq = filterReqs.getClusterName();
+    addWUQSQueryFilter(filters, filterCount, filterBuf, filterReqs.getQuerySetName(), WUQSFQuerySet);
+    if (!filterReqs.getMemoryLimitLow_isNull())
+        addWUQSQueryFilterInt64(filters, filterCount, filterBuf, filterReqs.getMemoryLimitLow(), (WUQuerySortField) (WUQSFmemoryLimit | WUQSFnumeric));
+    if (!filterReqs.getMemoryLimitHigh_isNull())
+        addWUQSQueryFilterInt64(filters, filterCount, filterBuf, filterReqs.getMemoryLimitHigh(), (WUQuerySortField) (WUQSFmemoryLimitHi | WUQSFnumeric));
+    if (!filterReqs.getTimeLimitLow_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getTimeLimitLow(), (WUQuerySortField) (WUQSFtimeLimit | WUQSFnumeric));
+    if (!filterReqs.getTimeLimitHigh_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getTimeLimitHigh(), (WUQuerySortField) (WUQSFtimeLimitHi | WUQSFnumeric));
+    if (!filterReqs.getWarnTimeLimitLow_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getWarnTimeLimitLow(), (WUQuerySortField) (WUQSFwarnTimeLimit | WUQSFnumeric));
+    if (!filterReqs.getWarnTimeLimitHigh_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getWarnTimeLimitHigh(), (WUQuerySortField) (WUQSFwarnTimeLimitHi | WUQSFnumeric));
+    if (!filterReqs.getPriorityLow_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getPriorityLow(), (WUQuerySortField) (WUQSFpriority | WUQSFnumeric));
+    if (!filterReqs.getPriorityHigh_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, filterReqs.getPriorityHigh(), (WUQuerySortField) (WUQSFpriorityHi | WUQSFnumeric));
+    filters[filterCount] = WUQSFterm;
+
+    unsigned numberOfQueries = 0;
+    unsigned pageSize = req.getPageSize();
+    unsigned pageStartFrom = req.getPageStartFrom();
+    if(pageSize < 1)
+        pageSize = 100;
+    __int64 cacheHint = 0;
+    if (!req.getCacheHint_isNull())
+        cacheHint = req.getCacheHint();
+
+    Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
+    Owned<IConstQuerySetQueryIterator> it = factory->getQuerySetQueriesSorted(sortOrder, filters, filterBuf.bufferBase(), pageStartFrom, pageSize, &cacheHint, &numberOfQueries);
+    resp.setCacheHint(cacheHint);
+
+    IArrayOf<IEspQuerySetQuery> queries;
+    ForEach(*it)
+    {
+        IPropertyTree &query=it->query();
+        Owned<IEspQuerySetQuery> q = createQuerySetQuery();
+        q->setId(query.queryProp("@id"));
+        q->setName(query.queryProp("@name"));
+        q->setQuerySetId(query.queryProp("@querySetId"));
+        q->setDll(query.queryProp("@dll"));
+        q->setWuid(query.queryProp("@wuid"));
+        q->setSuspended(query.getPropBool("@suspended", false));
+        if (query.hasProp("@memoryLimit"))
+        {
+            StringBuffer s;
+            memoryLimitStringFromUInt64(s, query.getPropInt64("@memoryLimit"));
+            q->setMemoryLimit(s);
+        }
+        if (query.hasProp("@timeLimit"))
+            q->setTimeLimit(query.getPropInt("@timeLimit"));
+        if (query.hasProp("@warnTimeLimit"))
+            q->setWarnTimeLimit(query.getPropInt("@warnTimeLimit"));
+        if (query.hasProp("@priority"))
+            q->setPriority(getQueryPriorityName(query.getPropInt("@priority")));
+        if (query.hasProp("@comment"))
+            q->setComment(query.queryProp("@comment"));
+
+        try
+        {
+            const char* cluster = clusterReq;
+            const char* querySetId = query.queryProp("@querySetId");
+            if (isEmpty(cluster))
+                cluster = querySetId;
+            Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(cluster, querySetId);
+            if (queriesOnCluster)
+            {
+                IArrayOf<IEspClusterQueryState> clusters;
+                addClusterQueryStates(queriesOnCluster, cluster, query.queryProp("@id"), clusters);
+                q->setClusters(clusters);
+            }
+        }
+        catch(IException *e)
+        {
+            StringBuffer err;
+            DBGLOG("Get exception in WUListQueries: %s", e->errorMessage(err.append(e->errorCode()).append(' ')).str());
+            e->Release();
+        }
+        queries.append(*q.getClear());
+    }
+    resp.setQuerysetQueries(queries);
+    resp.setNumberOfQueries(numberOfQueries);
 
     return true;
 }

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -108,6 +108,7 @@ public:
     void setPort(unsigned short _port){port=_port;}
 
     bool isQuerySuspended(const char* query, IConstWUClusterInfo *clusterInfo, unsigned wait, StringBuffer& errorMessage);
+    bool onWUListQueries(IEspContext &context, IEspWUListQueriesRequest &req, IEspWUListQueriesResponse &resp);
 
 private:
     unsigned awusCacheMinutes;


### PR DESCRIPTION
This fix adds new WsWorkunits method 'WUListQueries' to return
QuerySet Queries with paging/sorting options.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
