### PR TITLE
HPCC-9213 Remove unused css links

### DIFF
--- a/esp/xslt/wsecl_tabview.xsl
+++ b/esp/xslt/wsecl_tabview.xsl
@@ -66,9 +66,7 @@
                 <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/reset-fonts-grids/reset-fonts-grids.css"/>
                 <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/resize/assets/skins/sam/resize.css"/>
                 <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/button/assets/skins/sam/button.css"/>
-                <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/menu/assets/skins/sam/menu.css"/>
                 <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/tabview/assets/skins/sam/tabview.css"/>
-                <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/treeview/assets/skins/sam/treeview.css"/>
                 <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/paginator/assets/skins/sam/paginator.css"/>
                 <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/datatable/assets/skins/sam/datatable.css"/>
                 <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/container/assets/skins/sam/container.css"/>


### PR DESCRIPTION
On Chrome, WsECL Query tree collapses after a user refreshes the
page. This fix removes two unused css links inside the WsECL xsl
file. After those links are removed, the Query tree does not
collapse any more.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
