### PR TITLE
HPCC-9814 Show N/A when a memory node is not available

### DIFF
--- a/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
+++ b/esp/eclwatch/ws_XSLT/clusterprocesses.xslt
@@ -732,17 +732,22 @@
           <xsl:text disable-output-escaping="yes"><![CDATA[ <br /> ]]></xsl:text>
           <xsl:value-of select="$memNode/Total"/> MB Total
         </xsl:attribute>
-         <xsl:if test="$threshold != 0">
-                <xsl:choose>
-                        <xsl:when test="$thresholdType=0 and $memNode/PercentAvail &lt; $threshold">
-                    <xsl:attribute name="bgcolor">FF8800</xsl:attribute>
-                        </xsl:when>
-                        <xsl:when test="$thresholdType=1 and $memNode/Available &lt; $threshold">
-                    <xsl:attribute name="bgcolor">FF8800</xsl:attribute>
-                        </xsl:when>
-                    </xsl:choose>
-         </xsl:if>
-         <xsl:value-of select="$memNode/PercentAvail"/>%
+        <xsl:choose>
+          <xsl:when test="$memNode/Total=0">N/A</xsl:when>
+          <xsl:otherwise>
+            <xsl:if test="$threshold != 0">
+              <xsl:choose>
+                <xsl:when test="$thresholdType=0 and $memNode/PercentAvail &lt; $threshold">
+                  <xsl:attribute name="bgcolor">FF8800</xsl:attribute>
+                </xsl:when>
+                <xsl:when test="$thresholdType=1 and $memNode/Available &lt; $threshold">
+                  <xsl:attribute name="bgcolor">FF8800</xsl:attribute>
+                </xsl:when>
+              </xsl:choose>
+            </xsl:if>
+            <xsl:value-of select="$memNode/PercentAvail"/>%
+          </xsl:otherwise>
+        </xsl:choose>
       </td>            
    </xsl:template>
   

--- a/esp/services/ws_machine/machines.xslt
+++ b/esp/services/ws_machine/machines.xslt
@@ -647,17 +647,22 @@
           <xsl:text disable-output-escaping="yes"><![CDATA[ <br /> ]]></xsl:text>
           <xsl:value-of select="$memNode/Total"/> MB Total
         </xsl:attribute>
-         <xsl:if test="$threshold != 0">
-                <xsl:choose>
-                        <xsl:when test="$thresholdType=0 and $memNode/PercentAvail &lt; $threshold">
-                    <xsl:attribute name="bgcolor">FF8800</xsl:attribute>
-                        </xsl:when>
-                        <xsl:when test="$thresholdType=1 and $memNode/Available &lt; $threshold">
-                    <xsl:attribute name="bgcolor">FF8800</xsl:attribute>
-                        </xsl:when>
-                    </xsl:choose>
-         </xsl:if>
-         <xsl:value-of select="$memNode/PercentAvail"/>%
+        <xsl:choose>
+          <xsl:when test="$memNode/Total=0">N/A</xsl:when>
+          <xsl:otherwise>
+            <xsl:if test="$threshold != 0">
+              <xsl:choose>
+                <xsl:when test="$thresholdType=0 and $memNode/PercentAvail &lt; $threshold">
+                  <xsl:attribute name="bgcolor">FF8800</xsl:attribute>
+                </xsl:when>
+                <xsl:when test="$thresholdType=1 and $memNode/Available &lt; $threshold">
+                  <xsl:attribute name="bgcolor">FF8800</xsl:attribute>
+                </xsl:when>
+              </xsl:choose>
+            </xsl:if>
+            <xsl:value-of select="$memNode/PercentAvail"/>%
+          </xsl:otherwise>
+        </xsl:choose>
       </td>            
    </xsl:template>
   


### PR DESCRIPTION
Existing code shows '0%' SWAP when a SWAP is not configured on
a system. It caused some misleading. This fix checks the total
memory size for a memory node. If the size is zero, it shows N/A.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
