### PR TITLE
HPCC-9817 Fix issues comparing against a NULL unicode string

### DIFF
--- a/ecl/regress/issue9817.ecl
+++ b/ecl/regress/issue9817.ecl
@@ -1,0 +1,35 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+f := false : stored('f');
+
+output((unicode0)U'X' != U'X');
+output(U'' + U'' + U'' != U'Y');
+output(IF(1 = 2, U'', U'') != U'Z');
+output(IF(f, U'', U'') != U'A');
+
+output(U'Xabcdefhehe' != (unicode0)U'X');
+output(U'Y' != U'' + U'' + U'');
+output(U'Z' != IF(1 = 2, U'', U''));
+output(U'A' != IF(f, U'', U''));
+
+ne(unicode x, unicode y) := x != y;
+
+output(ne(U'Xabcdefhehe', (unicode0)U'X'));
+output(ne(U'Y', U'' + U'' + U''));
+output(ne(U'Z', IF(1 = 2, U'', U'')));
+output(ne(U'A', IF(f, U'', U'')));

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -2476,10 +2476,13 @@ int rtlCompareEStrEStr(unsigned l1, const char * p1, unsigned l2, const char * p
     return diff;
 }
 
+const static UChar nullUStr = 0;
 int rtlCompareUnicodeUnicode(unsigned l1, UChar const * p1, unsigned l2, UChar const * p2, char const * locale)
 {
     while(l1 && u_isUWhiteSpace(p1[l1-1])) l1--;
     while(l2 && u_isUWhiteSpace(p2[l2-1])) l2--;
+    if (!p1) p1 = &nullUStr;
+    if (!p2) p2 = &nullUStr;
     return ucol_strcoll(queryRTLLocale(locale)->queryCollator(), p1, l1, p2, l2);
 }
 
@@ -2487,6 +2490,8 @@ int rtlCompareUnicodeUnicodeStrength(unsigned l1, UChar const * p1, unsigned l2,
 {
     while(l1 && u_isUWhiteSpace(p1[l1-1])) l1--;
     while(l2 && u_isUWhiteSpace(p2[l2-1])) l2--;
+    if (!p1) p1 = &nullUStr;
+    if (!p2) p2 = &nullUStr;
     return ucol_strcoll(queryRTLLocale(locale)->queryCollator(strength), p1, l1, p2, l2);
 }
 
@@ -2760,6 +2765,7 @@ int rtlNewSearchUnicodeTable(unsigned count, unsigned elemlen, UChar * * table, 
     int left = 0;
     int right = count;
     
+    if (!search) search = &nullUStr;
     size32_t trimWidth = rtlQuickTrimUnicode(width, search);
 
     do


### PR DESCRIPTION
Strange as it may seem, the ICU compare functions check for NULL
pointers as parameters, and sometimes abort early giving the wrong result.

See http://bugs.icu-project.org/trac/ticket/9396

(Based on 4.0.0, but pull request against 4.0.2).

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
