### PR TITLE
HPCC-9802 Delete logical file using removeEntry(), not detach()

### DIFF
--- a/esp/smc/SMCLib/LogicFileWrapper.cpp
+++ b/esp/smc/SMCLib/LogicFileWrapper.cpp
@@ -67,16 +67,23 @@ bool LogicFileWrapper::doDeleteFile(const char* logicalName,const char *cluster,
 
     try
     {
-        Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(cname.str(), udesc, true) ;
-        if(!df)
+        IDistributedFileDirectory &fdir = queryDistributedFileDirectory();
         {
-            returnStr.appendf("<Message><Value>File %s not found</Value></Message>", cname.str());
-            return false;
+            Owned<IDistributedFile> df = fdir.lookup(cname.str(), udesc, true) ;
+            if(!df)
+            {
+                returnStr.appendf("<Message><Value>File %s not found</Value></Message>", cname.str());
+                return false;
+            }
         }
 
-        df->detach();
-        returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>", cname.str());
-        DBGLOG("%s", returnStr.str());
+        if (!fdir.removeEntry(cname.str(), udesc))
+            returnStr.appendf("<Message><Value>Failed to delete %s</Value></Message>", cname.str());
+        else
+        {
+            returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>", cname.str());
+            DBGLOG("%s", returnStr.str());
+        }
         return true;
     }
     catch (IException *e)


### PR DESCRIPTION
Existing ECLWatch code deletes a logical file using detach(). When
the file is associated with a superfile, the superfile may not be
able to be deleted. This fix calls removeEntry() to delete a file.
The removeEntry() should check whether the file can be deleted or
not if it is a subfile. This fix also cleans the code.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
