### PR TITLE
hpcc-9763 - Use newly generated UNORDERED flag for join helper

### DIFF
--- a/testing/ecl/joinmulti.ecl
+++ b/testing/ecl/joinmulti.ecl
@@ -30,7 +30,7 @@ unsigned delay(unsigned d, unsigned us) := BEGINC++ if (us) usleep(us); return d
 // RIGHT.keyn>=delay(RIGHT.keyn) is fake test on field to add some work to match()
 baseJoin := JOIN(bigstream, bigstream, LEFT.key=RIGHT.key AND RIGHT.keyn>=delay(RIGHT.keyn, fakeWorkUs));
 parallelJoin := JOIN(bigstream, bigstream, LEFT.key=RIGHT.key AND RIGHT.keyn>=delay(RIGHT.keyn, fakeWorkUs), HINT(parallel_match));
-parallelUnorderedJoin := JOIN(bigstream, bigstream, LEFT.key=RIGHT.key AND RIGHT.keyn>=delay(RIGHT.keyn, fakeWorkUs), HINT(parallel_match), HINT(unsorted_output));
+parallelUnorderedJoin := JOIN(bigstream, bigstream, LEFT.key=RIGHT.key AND RIGHT.keyn>=delay(RIGHT.keyn, fakeWorkUs), UNORDERED);
 
 
 countGroups(dataset(rec) ds) := FUNCTION

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -3366,8 +3366,8 @@ public:
             {
                 case TAKhashjoin:
                     {
-                        bool hintparallelmatch = container.queryXGMML().getPropInt("hint[@name=\"parallel_match\"]/@value")!=0;
-                        bool hintunsortedoutput = container.queryXGMML().getPropInt("hint[@name=\"unsorted_output\"]/@value")!=0;
+                        bool hintunsortedoutput = getOptBool(THOROPT_UNSORTED_OUTPUT, JFreorderable & joinargs->getJoinFlags());
+                        bool hintparallelmatch = getOptBool(THOROPT_PARALLEL_MATCH, hintunsortedoutput); // i.e. unsorted, implies use parallel by default, otherwise no point
                         joinhelper.setown(createJoinHelper(*this, joinargs, this, hintparallelmatch, hintunsortedoutput));
                     }
                     break;

--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -236,8 +236,8 @@ public:
             joinhelper.setown(createDenormalizeHelper(*this, helperdn, this));
         else
         {
-            bool hintparallelmatch = container.queryXGMML().getPropInt("hint[@name=\"parallel_match\"]/@value")!=0;
-            bool hintunsortedoutput = container.queryXGMML().getPropInt("hint[@name=\"unsorted_output\"]/@value")!=0;
+            bool hintunsortedoutput = getOptBool(THOROPT_UNSORTED_OUTPUT, JFreorderable & helper->getJoinFlags());
+            bool hintparallelmatch = getOptBool(THOROPT_PARALLEL_MATCH, hintunsortedoutput); // i.e. unsorted, implies use parallel by default, otherwise no point
             joinhelper.setown(createJoinHelper(*this, helperjn, this, hintparallelmatch, hintunsortedoutput));
         }
     }

--- a/thorlcr/activities/selfjoin/thselfjoinslave.cpp
+++ b/thorlcr/activities/selfjoin/thselfjoinslave.cpp
@@ -164,8 +164,8 @@ public:
         input = inputs.item(0);
         startInput(input);
         dataLinkStart("SELFJOIN", container.queryId());
-        bool hintparallelmatch = container.queryXGMML().getPropInt("hint[@name=\"parallel_match\"]/@value")!=0;
-        bool hintunsortedoutput = container.queryXGMML().getPropInt("hint[@name=\"unsorted_output\"]/@value")!=0;
+        bool hintunsortedoutput = getOptBool(THOROPT_UNSORTED_OUTPUT, JFreorderable & helper->getJoinFlags());
+        bool hintparallelmatch = getOptBool(THOROPT_PARALLEL_MATCH, hintunsortedoutput); // i.e. unsorted, implies use parallel by default, otherwise no point
 
         if (helper->getJoinFlags()&JFlimitedprefixjoin) {
             CriticalBlock b(joinHelperCrit);

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -46,17 +46,19 @@
 #endif
 
 /// Thor options, that can be hints, workunit options, or global settings
-#define THOROPT_COMPRESS_SPILLS       "compressInternalSpills"
-#define THOROPT_HDIST_SPILL           "hdistSpill"
-#define THOROPT_HDIST_WRITE_POOL_SIZE "hdistSendPoolSize"
-#define THOROPT_SPLITTER_SPILL        "splitterSpill"
-#define THOROPT_LOOP_MAX_EMPTY        "loopMaxEmpty"
-#define THOROPT_SMALLSORT             "smallSortThreshold"
-#define THOROPT_PARALLEL_FUNNEL       "parallelFunnel"
-#define THOROPT_SORT_MAX_DEVIANCE     "sort_max_deviance"
-#define THOROPT_OUTPUT_FLUSH_THRESHOLD "output_flush_threshold"
-#define THOROPT_OUTPUTLIMIT           "outputLimit"
-#define THOROPT_JOINHELPER_THREADS    "joinHelperThreads"
+#define THOROPT_COMPRESS_SPILLS       "compressInternalSpills"  // Compress internal spills, e.g. spills created by lookahead or sort gathering  (default = true)
+#define THOROPT_HDIST_SPILL           "hdistSpill"              // Allow distribute receiver to spill to disk, rather than blocking              (default = true)
+#define THOROPT_HDIST_WRITE_POOL_SIZE "hdistSendPoolSize"       // Distribute send thread pool size                                              (default = 16)
+#define THOROPT_SPLITTER_SPILL        "splitterSpill"           // Force splitters to spill or not, default is to adhere to helper setting       (default = -1)
+#define THOROPT_LOOP_MAX_EMPTY        "loopMaxEmpty"            // Max # of iterations that LOOP can cycle through with 0 results before errors  (default = 1000)
+#define THOROPT_SMALLSORT             "smallSortThreshold"      // Use minisort approach, if estimate size of data to sort is below this setting (default = 0)
+#define THOROPT_PARALLEL_FUNNEL       "parallelFunnel"          // Use parallel funnel impl. if !ordered                                         (default = true)
+#define THOROPT_SORT_MAX_DEVIANCE     "sort_max_deviance"       // Max (byte) variance allowed during sort partitioning                          (default = 10Mb)
+#define THOROPT_OUTPUT_FLUSH_THRESHOLD "output_flush_threshold" // When above limit, workunit result is flushed (committed to Dali)              (default = -1 [off])
+#define THOROPT_OUTPUTLIMIT           "outputLimit"             // OUTPUT Mb limit                                                               (default = 10)
+#define THOROPT_PARALLEL_MATCH        "parallel_match"          // Use multi-threaded join helper (retains sort order without unsorted_output)   (default = false)
+#define THOROPT_UNSORTED_OUTPUT       "unsorted_output"         // Allow Join results to be reodered, implies parallel match                     (default = false)
+#define THOROPT_JOINHELPER_THREADS    "joinHelperThreads"       // Number of threads to use in threaded variety of join helper
 
 #define INITIAL_SELFJOIN_MATCH_WARNING_LEVEL 20000  // max of row matches before selfjoin emits warning
 


### PR DESCRIPTION
Use generated JFreorderable to switch to unordered parallel
version of the join helper

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
