### PR TITLE
HPCC-9822 Docs:Add linebreak logic

### DIFF
--- a/docs/BuildTools/fo.xsl
+++ b/docs/BuildTools/fo.xsl
@@ -103,6 +103,10 @@
    <fo:block break-after='page'/>
 </xsl:template>
   
+<xsl:template match="processing-instruction('linebreak')">
+  <fo:block/>
+</xsl:template>  
+  
 <xsl:template match="programlisting[@role='tab']">
   <fo:block xsl:use-attribute-sets="monospace.verbatim.properties">
    <xsl:attribute name="font-family">serif</xsl:attribute>

--- a/docs/BuildTools/fo.xsl.in
+++ b/docs/BuildTools/fo.xsl.in
@@ -103,6 +103,10 @@
    <fo:block break-after='page'/>
 </xsl:template>
   
+<xsl:template match="processing-instruction('linebreak')">
+  <fo:block/>
+</xsl:template>  
+  
 <xsl:template match="programlisting[@role='tab']">
   <fo:block xsl:use-attribute-sets="monospace.verbatim.properties">
    <xsl:attribute name="font-family">serif</xsl:attribute>


### PR DESCRIPTION
Fix HPCC-9822 Docs:Add linebreak logic
Added linebreak logic to fo(pdf) generation
html generation not automated yet.

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com
