### PR TITLE
HPCC-9828 - Resolve package watcher notification/reload deadlock

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -98,9 +98,14 @@ public:
     virtual void notify(SubscriptionId subid, const char *xpath, SDSNotifyFlags flags, unsigned valueLen, const void *valueData)
     {
         Linked<CDaliPackageWatcher> me = this;  // Ensure that I am not released by the notify call (which would then access freed memory to release the critsec)
-        CriticalBlock b(crit);
-        if (notifier)
-            notifier->notify(subid, xpath, flags, valueLen, valueData);
+        Linked<ISDSSubscription> myNotifier;
+        {
+            CriticalBlock b(crit);
+            myNotifier.set(notifier);
+            // allow crit to be released, allowing this to be unsubscribed, to avoid deadlocking when other threads via notify call unsubscribe
+        }
+        if (myNotifier)
+            myNotifier->notify(subid, xpath, flags, valueLen, valueData);
     }
 };
 


### PR DESCRIPTION
Multiple CDaliPackageWatcher's could be notified in parallel
on different threads. Each invoked a reload of all packages in
the manager, which could result in deadlock, if two threads
both tried to unregister a watcher that was already in
it's notify method.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
