### PR TITLE
HPCC-8979 - daliadmin dalilocks misreporting superfiles

### DIFF
--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -2168,7 +2168,7 @@ static void dodalilocks(const char *pattern,const char *obj,Int64Array *conn,boo
                     while (*x)
                         curxpath.append(*(x++));
                     if (begins(ln,"/Files")) {
-                        while (*ln&&(begins(ln,"/Scope[@name=\"")||begins(ln,"/File[@name=\""))) {
+                        while (*ln&&(begins(ln,"/Scope[@name=\"")||begins(ln,"/File[@name=\"")||begins(ln,"/SuperFile[@name=\""))) {
                             if (curfile.length())
                                 curfile.append("::");
                             while (*ln&&(*ln!='"'))


### PR DESCRIPTION
Parsing the lock info, did not take account of SuperFiles.
As a cosequence, superfiles were listed as locks on their
parent scope.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
