### PR TITLE
HPCC-9746 Don't match expressions to constant transform values.

### DIFF
--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -732,6 +732,10 @@ IHqlExpression * NewProjectMapper2::doCollapseFields(IHqlExpression * expr, IHql
     unsigned match = sources.find(*expr);
     if (match != NotFound)
     {
+        //Don't collapse expressions that don't depend on the input dataset, since they may be used in contexts where
+        //they aren't dependent on the input dataset (e.g., priorities on stepped criteria).
+        if (!expr->usesSelector(oldParent))
+            return LINK(expr);
         IHqlExpression & collapsed = targets.item(match);
         return replaceSelector(&collapsed, self, newDataset);
     }


### PR DESCRIPTION
If the tranform for a PROJECT contains self.x := 10, and the expression
it is moved over also refers to 10, it should not be substitued with
projected.x.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
