### PR TITLE
HPCC-9839 Fix regression failing to check crcResources option

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1051,7 +1051,7 @@ public:
         offset_t dfsSize = partProps.getPropInt64("@size", -1);
         bool local = partProps.getPropBool("@local");
         unsigned crc;
-        if (!pdesc->getCrc(crc))
+        if (!crcResources || !pdesc->getCrc(crc))
             crc = 0;
         CDateTime dfsDate;
         if (checkFileDate)


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
