### PR TITLE
HPCC-9588 - Avoid holding onto lots of open files

### DIFF
--- a/dali/dfuXRefLib/XRefNodeManager.cpp
+++ b/dali/dfuXRefLib/XRefNodeManager.cpp
@@ -322,25 +322,25 @@ static bool deleteEmptyDir(IFile *dir)
 {
     // this is a bit odd - basically we already know no files but there may be empty sub-dirs
     Owned<IDirectoryIterator> iter = dir->directoryFiles(NULL,false,true);
-    IArrayOf<IFile> subdirs;
     bool candelete = true;
-    ForEach(*iter) {
-        if (iter->isDir()) 
-            subdirs.append(iter->get());
+    ForEach(*iter)
+    {
+        if (iter->isDir())
+        {
+            Owned<IFile> file = &iter->get();
+            try
+            {
+                if (!deleteEmptyDir(file))
+                    candelete = false;
+            }
+            catch (IException *e)
+            {
+                EXCLOG(e,"deleteEmptyDir");
+                candelete = false;
+            }
+        }
         else
             candelete = false;
-    }
-    if (!candelete)
-        return false;
-    try {
-        ForEachItemIn(i,subdirs) {
-            if (!deleteEmptyDir(&subdirs.item(i)))
-                candelete = false;
-        }
-    }
-    catch (IException *e) {
-        EXCLOG(e,"deleteEmptyDir");
-        candelete = false;
     }
     if (!candelete)
         return false;


### PR DESCRIPTION
XRef's 'Delete Empty Directories' causes all sub directories to
be collated, then themselves recursed, leaving each open and in
use. This commit, opens and recurses the sub directory then
ensures it's released(closed) before moving on.
This should greatly reduce the # of concurent open files this
process uses, which in environments with many sibling directories
and depth, was causing 1000's of open sockets and handles to
dafilesrv.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
