### PR TITLE
HPCC-9857 Configmr - Crashes if referencing a missing HW node

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -3257,6 +3257,9 @@ bool CWsDeployFileInfo::displaySettings(IEspContext &context, IEspDisplaySetting
                   {
                     xpath.clear().appendf("Hardware/Computer/[@name='%s']", pszComputer);
                     IPropertyTree* pComputer= pEnvRoot->queryPropTree(xpath.str());
+
+                    if (pComputer == NULL)
+                      break;
                     const char* pszNetAddr = pComputer->queryProp(XML_ATTR_NETADDRESS);
                     if (pszNetAddr)
                       pSlaveNode->addProp(XML_ATTR_NETADDRESS, pszNetAddr);


### PR DESCRIPTION
Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
