### PR TITLE
HPCC-9860 - Avoid holding session crit whilst destroying subs

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -1641,6 +1641,7 @@ protected:
                 try { stub.notify(abort); }
                 catch (IException *e) { e->Release(); } // subscriber session may abort during stopSession
             }
+            tonotify.kill(); // clear whilst sessmanagersect unblocked, as subs may query session manager.
         }
         const CSessionState *state = sessionstates.query(id);
         if (state) {


### PR DESCRIPTION
A destructing subscription can involve other locks/crits.
The session manager should ensure the session crit is released
before their final destruction. Otherwise deadlock can ensure
if another thread is involved in e.g. locking and queries the
session manager.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
