### PR TITLE
HPCC-9869 Make packages easier to manage on multiple targets

### DIFF
--- a/common/workunit/package.cpp
+++ b/common/workunit/package.cpp
@@ -222,11 +222,14 @@ extern WORKUNIT_API IPropertyTree * getPackageMapById(const char * id, bool read
 
 extern WORKUNIT_API IPropertyTree * getPackageMapById(const char *target, const char * id, bool readonly)
 {
-    VStringBuffer xpath("/PackageMaps/PackageMap[@id='%s::%s']", target, id);
-    Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), readonly ? RTM_LOCK_READ : RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
-    if (!conn)
-        return getPackageMapById(id, readonly);
-    return conn->getRoot();
+    if (target && *target)
+    {
+        VStringBuffer xpath("/PackageMaps/PackageMap[@id='%s::%s']", target, id);
+        Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), readonly ? RTM_LOCK_READ : RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
+        if (conn)
+            return conn->getRoot();
+    }
+    return getPackageMapById(id, readonly);
 }
 
 extern WORKUNIT_API IPropertyTree * getPackageSetById(const char * id, bool readonly)

--- a/common/workunit/package.cpp
+++ b/common/workunit/package.cpp
@@ -220,6 +220,15 @@ extern WORKUNIT_API IPropertyTree * getPackageMapById(const char * id, bool read
     return conn->getRoot();
 }
 
+extern WORKUNIT_API IPropertyTree * getPackageMapById(const char *target, const char * id, bool readonly)
+{
+    VStringBuffer xpath("/PackageMaps/PackageMap[@id='%s::%s']", target, id);
+    Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), readonly ? RTM_LOCK_READ : RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
+    if (!conn)
+        return getPackageMapById(id, readonly);
+    return conn->getRoot();
+}
+
 extern WORKUNIT_API IPropertyTree * getPackageSetById(const char * id, bool readonly)
 {
     if (!id || !*id)

--- a/common/workunit/package.cpp
+++ b/common/workunit/package.cpp
@@ -212,6 +212,8 @@ extern WORKUNIT_API IHpccPackageSet *createPackageSet(const char *process)
 
 extern WORKUNIT_API IPropertyTree * getPackageMapById(const char * id, bool readonly)
 {
+    if (!id || !*id)
+        return NULL;
     StringBuffer xpath;
     xpath.append("/PackageMaps/PackageMap[@id=\"").append(id).append("\"]");
     Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), readonly ? RTM_LOCK_READ : RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
@@ -222,6 +224,8 @@ extern WORKUNIT_API IPropertyTree * getPackageMapById(const char * id, bool read
 
 extern WORKUNIT_API IPropertyTree * getPackageMapById(const char *target, const char * id, bool readonly)
 {
+    if (!id || !*id)
+        return NULL;
     if (target && *target)
     {
         VStringBuffer xpath("/PackageMaps/PackageMap[@id='%s::%s']", target, id);

--- a/common/workunit/package.h
+++ b/common/workunit/package.h
@@ -60,6 +60,7 @@ extern WORKUNIT_API IHpccPackageMap *createPackageMapFromPtree(IPropertyTree *t,
 
 extern WORKUNIT_API IHpccPackageSet *createPackageSet(const char *process);
 extern WORKUNIT_API IPropertyTree * getPackageMapById(const char * id, bool readonly);
+extern WORKUNIT_API IPropertyTree * getPackageMapById(const char *target, const char * id, bool readonly);
 extern WORKUNIT_API IPropertyTree * getPackageSetById(const char * id, bool readonly);
 extern WORKUNIT_API IPropertyTree * resolvePackageSetRegistry(const char *process, bool readonly);
 extern WORKUNIT_API IPropertyTree * resolveActivePackageMap(const char *process, const char *target, bool readonly);

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -49,7 +49,7 @@ IClientWsPackageProcess *getWsPackageSoapService(const char *server, const char 
 class EclCmdPackageActivate : public EclCmdCommon
 {
 public:
-    EclCmdPackageActivate()
+    EclCmdPackageActivate() : optGlobalScope(false)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -76,6 +76,8 @@ public:
                 }
                 continue;
             }
+            if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
+                continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }
@@ -109,6 +111,7 @@ public:
         request->setTarget(optTarget);
         request->setPackageMap(optPackageMap);
         request->setProcess(optProcess);
+        request->setGlobalScope(optGlobalScope);
 
         Owned<IClientActivatePackageResponse> resp = packageProcessClient->ActivatePackage(request);
         if (resp->getExceptions().ordinality())
@@ -126,7 +129,8 @@ public:
                     "ecl packagemap activate <target> <packagemap>\n"
                     " Options:\n"
                     "   <target>               Name of target containing package map to activate\n"
-                    "   <packagemap>           Packagemap to activate\n",
+                    "   <packagemap>           Packagemap to activate\n"
+                    "   --global-scope         The specified packagemap can be shared across multiple targets\n",
                     stdout);
         EclCmdCommon::usage();
     }
@@ -135,12 +139,13 @@ private:
     StringAttr optTarget;
     StringAttr optPackageMap;
     StringAttr optProcess;
+    bool optGlobalScope;
 };
 
 class EclCmdPackageDeActivate : public EclCmdCommon
 {
 public:
-    EclCmdPackageDeActivate()
+    EclCmdPackageDeActivate() : optGlobalScope(false)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -167,6 +172,8 @@ public:
                 }
                 continue;
             }
+            if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
+                continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }
@@ -200,6 +207,7 @@ public:
         request->setTarget(optTarget);
         request->setPackageMap(optPackageMap);
         request->setProcess(optProcess);
+        request->setGlobalScope(optGlobalScope);
 
         Owned<IClientDeActivatePackageResponse> resp = packageProcessClient->DeActivatePackage(request);
         if (resp->getExceptions().ordinality())
@@ -216,7 +224,8 @@ public:
                     "ecl packagemap deactivate <target> <packagemap>\n"
                     " Options:\n"
                     "   <target>               Name of target containing package map to activate\n"
-                    "   <packagemap>           Packagemap to activate\n",
+                    "   <packagemap>           Packagemap to activate\n"
+                    "   --global-scope         The specified packagemap can be shared across multiple targets\n",
                     stdout);
         EclCmdCommon::usage();
     }
@@ -225,6 +234,7 @@ private:
     StringAttr optTarget;
     StringAttr optPackageMap;
     StringAttr optProcess;
+    bool optGlobalScope;
 };
 
 class EclCmdPackageList : public EclCmdCommon
@@ -413,6 +423,8 @@ public:
                 }
                 continue;
             }
+            if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
+                continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }
@@ -451,6 +463,7 @@ public:
         request->setTarget(optTarget);
         request->setPackageMap(optPackageMap);
         request->setProcess(optProcess);
+        request->setGlobalScope(optGlobalScope);
 
         Owned<IClientDeletePackageResponse> resp = packageProcessClient->DeletePackage(request);
         if (resp->getExceptions().ordinality())
@@ -470,7 +483,8 @@ public:
                     "ecl packagemap delete <target> <packagemap>\n"
                     " Options:\n"
                     "   <target>               Name of the target to use \n"
-                    "   <packagemap>           Name of the package map to delete\n",
+                    "   <packagemap>           Name of the package map to delete\n"
+                    "   --global-scope         The specified packagemap is sharable across multiple targets\n",
                     stdout);
         EclCmdCommon::usage();
     }
@@ -478,12 +492,13 @@ private:
     StringAttr optPackageMap;
     StringAttr optTarget;
     StringAttr optProcess;
+    bool optGlobalScope;
 };
 
 class EclCmdPackageAdd : public EclCmdCommon
 {
 public:
-    EclCmdPackageAdd() : optActivate(false), optOverWrite(false)
+    EclCmdPackageAdd() : optActivate(false), optOverWrite(false), optGlobalScope(false)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -517,6 +532,8 @@ public:
             if (iter.matchFlag(optActivate, ECLOPT_ACTIVATE)||iter.matchFlag(optActivate, ECLOPT_ACTIVATE_S))
                 continue;
             if (iter.matchFlag(optOverWrite, ECLOPT_OVERWRITE)||iter.matchFlag(optOverWrite, ECLOPT_OVERWRITE_S))
+                continue;
+            if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
                 continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
@@ -571,6 +588,7 @@ public:
         request->setProcess(optProcess);
         request->setDaliIp(optDaliIP);
         request->setOverWrite(optOverWrite);
+        request->setGlobalScope(optGlobalScope);
 
         Owned<IClientAddPackageResponse> resp = packageProcessClient->AddPackage(request);
         if (resp->getExceptions().ordinality())
@@ -599,7 +617,8 @@ public:
                     "   -O, --overwrite             Overwrite existing information\n"
                     "   -A, --activate              Activate the package information\n"
                     "   --daliip=<ip>               IP of the remote dali to use for logical file lookups\n"
-                   "   --pmid                       Identifier of package map - defaults to filename if not specified."
+                    "   --pmid                      Identifier of package map - defaults to filename if not specified\n"
+                    "   --global-scope              The specified packagemap can be shared across multiple targets\n"
 // NOT-YET          "  --packageprocessname         if not set use this package process name for all clusters"
                     "   <target>                    Name of target to use when adding package map information\n"
                     "   <filename>                  Name of file containing package map information\n",
@@ -608,20 +627,21 @@ public:
         EclCmdCommon::usage();
     }
 private:
+    StringBuffer pkgInfo;
     StringAttr optFileName;
     StringAttr optTarget;
     StringAttr optProcess;
-    bool optActivate;
-    bool optOverWrite;
-    StringBuffer pkgInfo;
     StringAttr optDaliIP;
     StringAttr optPackageMapId;
+    bool optActivate;
+    bool optOverWrite;
+    bool optGlobalScope;
 };
 
 class EclCmdPackageValidate : public EclCmdCommon
 {
 public:
-    EclCmdPackageValidate() : optValidateActive(false), optCheckDFS(false)
+    EclCmdPackageValidate() : optValidateActive(false), optCheckDFS(false), optGlobalScope(false)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -655,6 +675,8 @@ public:
             if (iter.matchOption(optPMID, ECLOPT_PMID) || iter.matchOption(optPMID, ECLOPT_PMID_S))
                 continue;
             if (iter.matchOption(optQueryId, ECLOPT_QUERYID))
+                continue;
+            if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
                 continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
@@ -709,6 +731,7 @@ public:
         request->setTarget(optTarget);
         request->setQueryIdToVerify(optQueryId);
         request->setCheckDFS(optCheckDFS);
+        request->setGlobalScope(optGlobalScope);
 
         bool validateMessages = false;
         Owned<IClientValidatePackageResponse> resp = packageProcessClient->ValidatePackage(request);
@@ -783,7 +806,8 @@ public:
                     "   <filename>                  Name of file containing package map information\n"
                     "   --active                    Validate the active packagemap\n"
                     "   --check-dfs                 Verify that subfiles exist in DFS\n"
-                    "   -pm, --pmid                 Identifier of packagemap to validate\n",
+                    "   -pm, --pmid                 Identifier of packagemap to validate\n"
+                    "   --global-scope              The specified packagemap can be shared across multiple targets\n",
                     stdout);
 
         EclCmdCommon::usage();
@@ -795,12 +819,13 @@ private:
     StringAttr optQueryId;
     bool optValidateActive;
     bool optCheckDFS;
+    bool optGlobalScope;
 };
 
 class EclCmdPackageQueryFiles : public EclCmdCommon
 {
 public:
-    EclCmdPackageQueryFiles()
+    EclCmdPackageQueryFiles() : optGlobalScope(false)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -828,6 +853,8 @@ public:
                 continue;
             }
             if (iter.matchOption(optPMID, ECLOPT_PMID) || iter.matchOption(optPMID, ECLOPT_PMID_S))
+                continue;
+            if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
                 continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
@@ -863,6 +890,7 @@ public:
         request->setTarget(optTarget);
         request->setQueryName(optQueryId);
         request->setPMID(optPMID);
+        request->setGlobalScope(optGlobalScope);
 
         Owned<IClientGetQueryFileMappingResponse> resp = packageProcessClient->GetQueryFileMapping(request);
         if (resp->getExceptions().ordinality()>0)
@@ -911,7 +939,8 @@ public:
                     " Options:\n"
                     "   <target>                    Name of target to use when validating package map information\n"
                     "   <queryid>                   Name of query to get file mappings for\n"
-                    "   -pm, --pmid                 Optional id of packagemap to validate, defaults to active\n",
+                    "   -pm, --pmid                 Optional id of packagemap to validate, defaults to active\n"
+                    "   --global-scope              The specified packagemap can be shared across multiple targets\n",
                     stdout);
 
         EclCmdCommon::usage();
@@ -920,6 +949,7 @@ private:
     StringAttr optTarget;
     StringAttr optQueryId;
     StringAttr optPMID;
+    bool optGlobalScope;
 };
 
 IEclCommand *createPackageSubCommand(const char *cmdname)

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -83,6 +83,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_DELETE_PREVIOUS_INI "deletePrevDefault"
 #define ECLOPT_DELETE_PREVIOUS_ENV "ACTIVATE_DELETE_PREVIOUS"
 #define ECLOPT_CHECK_DFS "--check-dfs"
+#define ECLOPT_GLOBAL_SCOPE "--global-scope"
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -28,6 +28,7 @@ ESPrequest AddPackageRequest
     string PackageMap;
     string Process;
     string DaliIp;
+    bool GlobalScope(0);
 };
 
 
@@ -42,6 +43,7 @@ ESPrequest DeletePackageRequest
     string Target;
     string PackageMap;
     string Process;
+    bool GlobalScope(0);
 };
 
 ESPresponse [exceptions_inline] DeletePackageResponse
@@ -54,6 +56,7 @@ ESPrequest ActivatePackageRequest
     string Target;
     string PackageMap;
     string Process;
+    bool GlobalScope(0);
 };
 
 ESPresponse [exceptions_inline] ActivatePackageResponse
@@ -66,6 +69,7 @@ ESPrequest DeActivatePackageRequest
     string Target;
     string PackageMap;
     string Process;
+    bool GlobalScope(0);
 };
 
 ESPresponse [exceptions_inline] DeActivatePackageResponse
@@ -119,6 +123,7 @@ ESPrequest ValidatePackageRequest
     string PMID;
     string QueryIdToVerify;
     bool CheckDFS;
+    bool GlobalScope(0);
 };
 
 ESPstruct ValidatePackageInfo
@@ -153,6 +158,7 @@ ESPrequest GetQueryFileMappingRequest
     string Target;
     string PMID;
     string QueryName;
+    bool GlobalScope(0);
 };
 
 ESPstruct SuperFile

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -55,33 +55,45 @@ bool CWsPackageProcessEx::onEcho(IEspContext &context, IEspEchoRequest &req, IEs
     return true;
 }
 
-IPropertyTree *getPkgSetRegistry(const char *id, const char *process, bool readonly)
+inline StringBuffer &buildPkgSetId(StringBuffer &id, const char *process)
+{
+    if (!process || !*process)
+        process = "*";
+    return id.append("default_").append(process).replace('*', '#').replace('?', '~');
+}
+
+IPropertyTree *getPkgSetRegistry(const char *process, bool readonly)
 {
     Owned<IRemoteConnection> globalLock = querySDS().connect("/PackageSets/", myProcessSession(), RTM_LOCK_WRITE|RTM_CREATE_QUERY, SDS_LOCK_TIMEOUT);
+    if (!globalLock)
+        throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to connect to PackageSet information in dali /PackageSets");
+    IPropertyTree *pkgSets = globalLock->queryRoot();
+    if (!pkgSets)
+        throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to open PackageSet information in dali /PackageSets");
+
+    if (!process || !*process)
+        process = "*";
+    StringBuffer id;
+    buildPkgSetId(id, process);
 
     //Only lock the branch for the target we're interested in.
-    StringBuffer xpath;
-    xpath.append("/PackageSets/PackageSet[@id=\"").append(id).append("\"]");
+    VStringBuffer xpath("/PackageSets/PackageSet[@id='%s']", id.str());
     Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), readonly ? RTM_LOCK_READ : RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
     if (!conn)
     {
         if (readonly)
             return NULL;
-        Owned<IPropertyTree> querySet = createPTree();
-        querySet->setProp("@id", id);
-        if (!process || !*process)
-            querySet->setProp("@process", "*");
-        else
-            querySet->setProp("@process", process);
-        globalLock->queryRoot()->addPropTree("PackageSet", querySet.getClear());
+
+        Owned<IPropertyTree> pkgSet = createPTree();
+        pkgSet->setProp("@id", id.str());
+        pkgSet->setProp("@process", process);
+        pkgSets->addPropTree("PackageSet", pkgSet.getClear());
         globalLock->commit();
 
         conn.setown(querySDS().connect(xpath.str(), myProcessSession(), RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT));
-        if (!conn)
-            throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve package information from dali %s", xpath.str());
     }
 
-    return conn->getRoot();
+    return (conn) ? conn->getRoot() : NULL;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -160,42 +172,35 @@ void cloneFileInfoToDali(StringArray &notFound, StringArray &fileNames, const ch
 }
 
 
-void makePackageActive(IPropertyTree *pkgSetRegistry, IPropertyTree *pkgSetTree, const char *setName)
+void makePackageActive(IPropertyTree *pkgSetRegistry, IPropertyTree *pkgSetTree, const char *target, bool activate)
 {
-    VStringBuffer xpath("PackageMap[@querySet='%s'][@active='1']", setName);
-    Owned<IPropertyTreeIterator> iter = pkgSetRegistry->getElements(xpath.str());
-    ForEach(*iter)
+    if (activate)
     {
-        iter->query().setPropBool("@active", false);
+        VStringBuffer xpath("PackageMap[@querySet='%s'][@active='1']", target);
+        Owned<IPropertyTreeIterator> iter = pkgSetRegistry->getElements(xpath.str());
+        ForEach(*iter)
+            iter->query().setPropBool("@active", false);
     }
-    pkgSetTree->setPropBool("@active", true);
-}
-
-const char *buildPkgSetId(StringBuffer &pkgSetId, const char *processName)
-{
-    pkgSetId.appendf("default_%s", processName);
-    pkgSetId.replace('*', '#');
-    pkgSetId.replace('?', '~');
-    return pkgSetId.str();
+    pkgSetTree->setPropBool("@active", activate);
 }
 
 //////////////////////////////////////////////////////////
 
-void addPackageMapInfo(StringArray &filesNotFound, IPropertyTree *pkgSetRegistry, const char *target, const char *packageMapName, const char *packageSetName, const char *lookupDaliIp, IPropertyTree *packageInfo, bool active, bool overWrite, IUserDescriptor* userdesc)
+void addPackageMapInfo(StringArray &filesNotFound, IPropertyTree *pkgSetRegistry, const char *target, const char *pmid, const char *packageSetName, const char *lookupDaliIp, IPropertyTree *packageInfo, bool activate, bool overWrite, IUserDescriptor* userdesc)
 {
     Owned<IRemoteConnection> globalLock = querySDS().connect("/PackageMaps/", myProcessSession(), RTM_LOCK_WRITE|RTM_CREATE_QUERY, SDS_LOCK_TIMEOUT);
 
-    StringBuffer lcName(packageMapName);
-    lcName.toLowerCase();
-    StringBuffer xpath;
-    xpath.append("PackageMap[@id='").append(lcName).append("']");
+    StringBuffer lcPmid(pmid);
+    pmid = lcPmid.toLowerCase().str();
+
+    VStringBuffer xpath("PackageMap[@id='%s']", pmid);
 
     IPropertyTree *pkgRegTree = pkgSetRegistry->queryPropTree(xpath.str());
     IPropertyTree *root = globalLock->queryRoot();
     IPropertyTree *mapTree = root->queryPropTree(xpath);
 
     if (!overWrite && (pkgRegTree || mapTree))
-        throw MakeStringException(PKG_NAME_EXISTS, "Package name %s already exists, either delete it or specify overwrite", lcName.str());
+        throw MakeStringException(PKG_NAME_EXISTS, "Package name %s already exists, either delete it or specify overwrite", pmid);
 
     if (mapTree)
         root->removeTree(mapTree);
@@ -205,7 +210,7 @@ void addPackageMapInfo(StringArray &filesNotFound, IPropertyTree *pkgSetRegistry
 
 
     mapTree = root->addPropTree("PackageMap", createPTree());
-    mapTree->addProp("@id", lcName);
+    mapTree->addProp("@id", pmid);
 
     StringArray fileNames;
     Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(target);
@@ -257,12 +262,10 @@ void addPackageMapInfo(StringArray &filesNotFound, IPropertyTree *pkgSetRegistry
     globalLock->commit();
 
     IPropertyTree *pkgSetTree = pkgSetRegistry->addPropTree("PackageMap", createPTree("PackageMap"));
-    pkgSetTree->setProp("@id", lcName);
+    pkgSetTree->setProp("@id", pmid);
     pkgSetTree->setProp("@querySet", target);
-    if (active)
-        makePackageActive(pkgSetRegistry, pkgSetTree, target);
-    else
-        pkgSetTree->setPropBool("@active", false);
+
+    makePackageActive(pkgSetRegistry, pkgSetTree, target, activate);
 }
 
 void getPackageListInfo(IPropertyTree *mapTree, IEspPackageListMapData *pkgList)
@@ -305,7 +308,7 @@ void listPkgInfo(const char *target, const char *process, IArrayOf<IConstPackage
     if (!globalLock)
         throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve package information from dali /PackageMaps");
     IPropertyTree *root = globalLock->queryRoot();
-    Owned<IPropertyTree> pkgSetRegistry = getPkgSetRegistry((process && *process) ? process : "*", NULL, true);
+    Owned<IPropertyTree> pkgSetRegistry = getPkgSetRegistry(process, true);
     if (!pkgSetRegistry)
         throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve package information from dali for process %s", (process && *process) ? process : "*");
 
@@ -339,7 +342,6 @@ void getPkgInfo(const char *target, const char *process, StringBuffer &info)
     Owned<IPropertyTree> pkgSetRegistry = getPkgSetRegistry((process && *process) ? process : "*", NULL, true);
     if (!pkgSetRegistry)
         throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve package information from dali for process %s", (process && *process) ? process : "*");
-
     StringBuffer xpath("PackageMap[@active='1']");
     if (target && *target)
         xpath.appendf("[@querySet='%s']", target);
@@ -361,13 +363,13 @@ void getPkgInfo(const char *target, const char *process, StringBuffer &info)
     toXML(tree, info);
 }
 
-bool deletePkgInfo(const char *packageMap, const char *target, const char *process)
+bool deletePkgInfo(const char *name, const char *target, const char *process)
 {
-    Owned<IRemoteConnection> pkgSet = querySDS().connect("/PackageSets/", myProcessSession(), RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
-    if (!pkgSet)
+    Owned<IRemoteConnection> pkgSetsConn = querySDS().connect("/PackageSets/", myProcessSession(), RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
+    if (!pkgSetsConn)
         throw MakeStringException(PKG_NONE_DEFINED, "No package sets defined");
 
-    IPropertyTree* packageSets = pkgSet->queryRoot();
+    IPropertyTree* packageSets = pkgSetsConn->queryRoot();
 
     StringBuffer pkgSetId;
     buildPkgSetId(pkgSetId, process);
@@ -376,43 +378,57 @@ bool deletePkgInfo(const char *packageMap, const char *target, const char *proce
     if (!pkgSetRegistry)
         throw MakeStringException(PKG_TARGET_NOT_DEFINED, "No package sets defined for %s", process);
 
-    StringBuffer lcName(packageMap);
-    lcName.toLowerCase();
-    VStringBuffer xpath("PackageMap[@id='%s'][@querySet='%s']", lcName.str(), target);
-    IPropertyTree *pm = pkgSetRegistry->getPropTree(xpath.str());
-    if (pm)
-        pkgSetRegistry->removeTree(pm);
-    else
-        throw MakeStringException(PKG_DELETE_NOT_FOUND, "Unable to delete %s - information not found", lcName.str());
+    StringBuffer lcTarget(target);
+    target = lcTarget.toLowerCase().str();
 
-    VStringBuffer ps_xpath("PackageSet/PackageMap[@id='%s']", lcName.str());
+    StringBuffer lcName(name);
+    name = lcName.toLowerCase().str();
 
-    if (!packageSets->hasProp(ps_xpath))
+    VStringBuffer xpath("PackageMap[@id='%s::%s'][@querySet='%s']", target, name, target);
+    IPropertyTree *mapEntry = pkgSetRegistry->getPropTree(xpath.str());
+    if (!mapEntry)
     {
-        Owned<IRemoteConnection> pkgMap = querySDS().connect("/PackageMaps/", myProcessSession(), RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
-        if (pkgMap)
-        {
-            VStringBuffer map_xpath("PackageMap[@id='%s']", lcName.str());
-            IPropertyTree *pkgMaproot = pkgMap->queryRoot();
-            IPropertyTree *pm = pkgMaproot->getPropTree(map_xpath.str());
-            if (pm)
-                pkgMaproot->removeTree(pm);
-        }
+        xpath.clear().appendf("PackageMap[@id='%s'][@querySet='%s']", name, target);
+        mapEntry = pkgSetRegistry->getPropTree(xpath.str());
+        if (!mapEntry)
+            throw MakeStringException(PKG_DELETE_NOT_FOUND, "Unable to delete %s - information not found", lcName.str());
+    }
+    StringAttr pmid(mapEntry->queryProp("@id"));
+    pkgSetRegistry->removeTree(mapEntry);
+
+    xpath.clear().appendf("PackageSet/PackageMap[@id='%s']", pmid.get());
+    if (!packageSets->hasProp(xpath))
+    {
+        Owned<IRemoteConnection> pkgMapsConn = querySDS().connect("/PackageMaps/", myProcessSession(), RTM_LOCK_WRITE, SDS_LOCK_TIMEOUT);
+        if (!pkgMapsConn)
+            throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve PackageMaps information from dali [/PackageMaps]");
+        IPropertyTree *pkgMaps = pkgMapsConn->queryRoot();
+        if (!pkgMaps)
+            throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve PackageMaps information from dali [/PackageMaps]");
+        IPropertyTree *mapTree = pkgMaps->getPropTree(xpath.clear().appendf("PackageMap[@id='%s']", pmid.get()).str());
+        if (mapTree)
+            pkgMaps->removeTree(mapTree);
     }
     return true;
 }
 
-void activatePackageMapInfo(const char *target, const char *packageMap, const char *process, bool activate)
+void activatePackageMapInfo(const char *target, const char *name, const char *process, bool activate)
 {
     if (!target || !*target)
-        throw MakeStringException(PKG_TARGET_NOT_DEFINED, "No target defined");
+        throw MakeStringExceptionDirect(PKG_TARGET_NOT_DEFINED, "No target defined");
+
+    if (!name || !*name)
+        throw MakeStringExceptionDirect(PKG_MISSING_PARAM, "No pmid specified");
 
     Owned<IRemoteConnection> globalLock = querySDS().connect("PackageSets", myProcessSession(), RTM_LOCK_WRITE|RTM_CREATE_QUERY, SDS_LOCK_TIMEOUT);
     if (!globalLock)
         throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve PackageSets information from dali /PackageSets");
 
-    StringBuffer lcName(target);
-    lcName.toLowerCase();
+    StringBuffer lcTarget(target);
+    target = lcTarget.toLowerCase().str();
+
+    StringBuffer lcName(name);
+    name = lcName.toLowerCase().str();
 
     IPropertyTree *root = globalLock->queryRoot();
     if (!root)
@@ -420,32 +436,40 @@ void activatePackageMapInfo(const char *target, const char *packageMap, const ch
 
     StringBuffer pkgSetId;
     buildPkgSetId(pkgSetId, process);
-    VStringBuffer pkgSet_xpath("PackageSet[@id='%s']", pkgSetId.str());
-    IPropertyTree *pkgSetTree = root->queryPropTree(pkgSet_xpath.str());
+    VStringBuffer xpath("PackageSet[@id='%s']", pkgSetId.str());
+    IPropertyTree *pkgSetTree = root->queryPropTree(xpath);
     if (pkgSetTree)
     {
-        if (packageMap && *packageMap)
+        xpath.clear().appendf("PackageMap[@querySet='%s'][@id='%s::%s']", target, target, name);
+        IPropertyTree *mapTree = pkgSetTree->queryPropTree(xpath);
+        if (!mapTree)
         {
-            StringBuffer lcMapName(packageMap);
-            lcMapName.toLowerCase();
-            VStringBuffer xpath_map("PackageMap[@id=\"%s\"]", lcMapName.str());
-            IPropertyTree *mapTree = pkgSetTree->queryPropTree(xpath_map);
-            if (activate)
-                makePackageActive(pkgSetTree, mapTree, lcName.str());
-            else
-                mapTree->setPropBool("@active", false);
+            xpath.clear().appendf("PackageMap[@querySet='%s'][@id='%s']", target, name);
+            mapTree = pkgSetTree->queryPropTree(xpath);
         }
+        if (!mapTree)
+            throw MakeStringException(PKG_ACTIVATE_NOT_FOUND, "PackageMap %s not found on target %s", name, target);
+        makePackageActive(pkgSetTree, mapTree, target, activate);
     }
 }
 
 bool CWsPackageProcessEx::onAddPackage(IEspContext &context, IEspAddPackageRequest &req, IEspAddPackageResponse &resp)
 {
     resp.updateStatus().setCode(0);
+
+    StringAttr target(req.getTarget());
+    StringAttr name(req.getPackageMap());
+
+    if (target.isEmpty())
+        throw MakeStringExceptionDirect(PKG_MISSING_PARAM, "Target cluster parameter required");
+    if (name.isEmpty())
+        throw MakeStringExceptionDirect(PKG_MISSING_PARAM, "PackageMap name parameter required");
+
+    VStringBuffer pmid("%s::%s", target.get(), name.get());
+
     StringBuffer info(req.getInfo());
     bool activate = req.getActivate();
     bool overWrite = req.getOverWrite();
-    StringAttr target(req.getTarget());
-    StringAttr pkgMapName(req.getPackageMap());
     StringAttr processName(req.getProcess());
 
     Owned<IUserDescriptor> userdesc;
@@ -457,17 +481,16 @@ bool CWsPackageProcessEx::onAddPackage(IEspContext &context, IEspAddPackageReque
         userdesc->set(user, password);
     }
 
+    Owned<IPropertyTree> packageTree = createPTreeFromXMLString(info.str());
+    Owned<IPropertyTree> pkgSetRegistry = getPkgSetRegistry(processName.get(), false);
+    StringArray filesNotFound;
     StringBuffer pkgSetId;
     buildPkgSetId(pkgSetId, processName.get());
-
-    Owned<IPropertyTree> packageTree = createPTreeFromXMLString(info.str());
-    Owned<IPropertyTree> pkgSetRegistry = getPkgSetRegistry(pkgSetId.str(), processName.get(), false);
-    StringArray filesNotFound;
-    addPackageMapInfo(filesNotFound, pkgSetRegistry, target.get(), pkgMapName.get(), pkgSetId.str(), req.getDaliIp(), LINK(packageTree), activate, overWrite, userdesc);
+    addPackageMapInfo(filesNotFound, pkgSetRegistry, target.get(), pmid.str(), pkgSetId.str(), req.getDaliIp(), LINK(packageTree), activate, overWrite, userdesc);
     resp.setFilesNotFound(filesNotFound);
 
     StringBuffer msg;
-    msg.append("Successfully loaded ").append(pkgMapName.get());
+    msg.append("Successfully loaded ").append(name.get());
     resp.updateStatus().setDescription(msg.str());
     return true;
 }
@@ -554,7 +577,7 @@ bool CWsPackageProcessEx::onValidatePackage(IEspContext &context, IEspValidatePa
     }
     else if (pmid && *pmid)
     {
-        mapTree.setown(getPackageMapById(pmid, true));
+        mapTree.setown(getPackageMapById(target, pmid, true));
         if (!mapTree)
             throw MakeStringException(PKG_PACKAGEMAP_NOT_FOUND, "Package map %s not found", req.getPMID());
     }
@@ -619,7 +642,7 @@ bool CWsPackageProcessEx::onGetQueryFileMapping(IEspContext &context, IEspGetQue
     const char *pmid = req.getPMID();
     if (pmid && *pmid)
     {
-        ownedmap.setown(createPackageMapFromPtree(getPackageMapById(pmid, true), target, pmid));
+        ownedmap.setown(createPackageMapFromPtree(getPackageMapById(target, pmid, true), target, pmid));
         if (!ownedmap)
             throw MakeStringException(PKG_LOAD_PACKAGEMAP_FAILED, "Error loading package map %s", req.getPMID());
         map = ownedmap;


### PR DESCRIPTION
Adds the target name as a scope in front of the pmid.. keeping packagemaps
unique per target cluster.  This protects users from accidently
overwriting shared packagemaps.  Also fix bugs that would deactivate or
activate the wrong packagemap, and some bugs that wouldn't support
PackageSets with process masks other than "*".
