### PR TITLE
HPCC-9891 Generate meta info even if syntax errors

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1320,7 +1320,7 @@ void EclCC::processFile(EclCompileInstance & instance)
         processSingleQuery(instance, queryText, attributePath.str());
     }
 
-    if (instance.reportErrorSummary() && !instance.archive)
+    if (instance.reportErrorSummary() && !instance.archive && !(optGenerateMeta && instance.generatedMeta))
         return;
 
     generateOutput(instance);


### PR DESCRIPTION
Smart editors like to be able to edit code that is not perfect...

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
