### PR TITLE
HPCC-9900 DFUPlus does not support escape option for CSV spray

### DIFF
--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -384,6 +384,9 @@ bool CDfuPlusHelper::variableSpray(const char* srcxml,const char* srcip,const ch
             // even it is empty to override default value
             req->setSourceCsvQuote(quote);
         }
+        const char* escape = globals->queryProp("escape");
+        if(escape && *escape)
+            req->setSourceCsvEscape(escape);
     }
     else 
         encoding = format; // may need extra later

--- a/dali/dfuplus/main.cpp
+++ b/dali/dfuplus/main.cpp
@@ -73,6 +73,7 @@ void handleSyntax()
     out.append("            separator=<separator> -- optional, default is \\,\n");
     out.append("            terminator=<terminator> -- optional, default is \\r,\\r\\n\n");
     out.append("            quote=<quote> -- optional, default is '\n");
+    out.append("            escape=<escape> -- optional, no default value \n");
     out.append("        options for xml:\n");
     out.append("            rowtag=rowTag -- required\n");
     out.append("            encoding=utf8|utf8n|utf16|utf16le|utf16be|utf32|utf32le|utf32be -- optional, default is utf8\n");


### PR DESCRIPTION
Add missing code and extend usage info.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
