### PR TITLE
HPCC-9337 --source-process option to specify where roxie to copy data from

### DIFF
--- a/common/workunit/referencedfilelist.hpp
+++ b/common/workunit/referencedfilelist.hpp
@@ -35,6 +35,7 @@
 #define RefFileCopyInfoFailed 0x080
 #define RefFileCloned         0x100
 #define RefFileInPackage      0x200
+#define RefFileNotOnSource    0x400
 
 interface IReferencedFile : extends IInterface
 {
@@ -56,7 +57,7 @@ interface IReferencedFileList : extends IInterface
     virtual void addFiles(StringArray &files)=0;
 
     virtual IReferencedFileIterator *getFiles()=0;
-    virtual void resolveFiles(const char *process, const char *remoteIP, bool checkLocalFirst, bool addSubFiles)=0;
+    virtual void resolveFiles(const char *process, const char *remoteIP, const char *srcCluster, bool checkLocalFirst, bool addSubFiles)=0;
     virtual void cloneAllInfo(IDFUhelper *helper, bool overwrite, bool cloneSuperInfo)=0;
     virtual void cloneFileInfo(IDFUhelper *helper, bool overwrite, bool cloneSuperInfo)=0;
     virtual void cloneRelationships()=0;

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1155,7 +1155,8 @@ typedef IArrayOf<IConstWUClusterInfo> CConstWUClusterInfoArray;
 extern WORKUNIT_API unsigned getEnvironmentClusterInfo(CConstWUClusterInfoArray &clusters);
 extern WORKUNIT_API unsigned getEnvironmentClusterInfo(IPropertyTree* environmentRoot, CConstWUClusterInfoArray &clusters);
 extern WORKUNIT_API void getRoxieProcessServers(const char *process, SocketEndpointArray &servers);
-
+extern WORKUNIT_API bool isProcessCluster(const char *remoteDali, const char *process);
+extern WORKUNIT_API bool isProcessCluster(const char *process);
 
 extern WORKUNIT_API bool getWorkUnitCreateTime(const char *wuid,CDateTime &time); // based on WUID
 extern WORKUNIT_API bool restoreWorkUnit(const char *base,const char *wuid);

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -56,6 +56,7 @@ interface IDFUhelper: extends IInterface
 
 
     virtual void createSingleFileClone(const char *srcname,             // src LFN (can't be super)
+                         const char *srcCluster,
                          const char *dstname,               // dst LFN
                          const char *cluster1,              // group name of roxie cluster
                          DFUclusterPartDiskMapping clustmap, // how the nodes are mapped

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -529,6 +529,8 @@ public:
                 continue;
             if (iter.matchOption(optDaliIP, ECLOPT_DALIIP))
                 continue;
+            if (iter.matchOption(optSourceProcess, ECLOPT_SOURCE_PROCESS))
+                continue;
             if (iter.matchFlag(optActivate, ECLOPT_ACTIVATE)||iter.matchFlag(optActivate, ECLOPT_ACTIVATE_S))
                 continue;
             if (iter.matchFlag(optOverWrite, ECLOPT_OVERWRITE)||iter.matchFlag(optOverWrite, ECLOPT_OVERWRITE_S))
@@ -589,6 +591,7 @@ public:
         request->setDaliIp(optDaliIP);
         request->setOverWrite(optOverWrite);
         request->setGlobalScope(optGlobalScope);
+        request->setSourceProcess(optSourceProcess);
 
         Owned<IClientAddPackageResponse> resp = packageProcessClient->AddPackage(request);
         if (resp->getExceptions().ordinality())
@@ -619,7 +622,7 @@ public:
                     "   --daliip=<ip>               IP of the remote dali to use for logical file lookups\n"
                     "   --pmid                      Identifier of package map - defaults to filename if not specified\n"
                     "   --global-scope              The specified packagemap can be shared across multiple targets\n"
-// NOT-YET          "  --packageprocessname         if not set use this package process name for all clusters"
+                    "   --source-process            Process cluster to copy files from\n"
                     "   <target>                    Name of target to use when adding package map information\n"
                     "   <filename>                  Name of file containing package map information\n",
                     stdout);
@@ -633,6 +636,7 @@ private:
     StringAttr optProcess;
     StringAttr optDaliIP;
     StringAttr optPackageMapId;
+    StringAttr optSourceProcess;
     bool optActivate;
     bool optOverWrite;
     bool optGlobalScope;

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -132,6 +132,9 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_DALIIP "--daliip"
 #define ECLOPT_PROCESS "--process"
 #define ECLOPT_PROCESS_S "-p"
+#define ECLOPT_SOURCE_PROCESS "--source-process"
+
+
 
 #define ECLOPT_LIB_PATH_S "-L"
 #define ECLOPT_IMP_PATH_S "-I"

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -215,6 +215,8 @@ public:
                 continue;
             if (iter.matchOption(optDaliIP, ECLOPT_DALIIP))
                 continue;
+            if (iter.matchOption(optSourceProcess, ECLOPT_SOURCE_PROCESS))
+                continue;
             if (iter.matchOption(optMsToWait, ECLOPT_WAIT))
                 continue;
             if (iter.matchOption(optTimeLimit, ECLOPT_TIME_LIMIT))
@@ -317,6 +319,7 @@ public:
         if (optTargetCluster.length())
             req->setCluster(optTargetCluster.get());
         req->setRemoteDali(optDaliIP.get());
+        req->setSourceProcess(optSourceProcess);
         req->setWait(optMsToWait);
         req->setNoReload(optNoReload);
         req->setDontCopyFiles(optDontCopyFiles);
@@ -377,6 +380,7 @@ public:
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
             "   --no-files             Do not copy files referenced by query\n"
             "   --daliip=<IP>          The IP of the DALI to be used to locate remote files\n"
+            "   --source-process       Process cluster to copy files from\n"
             "   --timeLimit=<ms>       Value to set for query timeLimit configuration\n"
             "   --warnTimeLimit=<ms>   Value to set for query warnTimeLimit configuration\n"
             "   --memoryLimit=<mem>    Value to set for query memoryLimit configuration\n"
@@ -391,6 +395,7 @@ public:
 private:
     StringAttr optName;
     StringAttr optDaliIP;
+    StringAttr optSourceProcess;
     StringAttr optMemoryLimit;
     StringAttr optPriority;
     StringAttr optComment;

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -323,6 +323,8 @@ public:
             }
             if (iter.matchOption(optDaliIP, ECLOPT_DALIIP))
                 continue;
+            if (iter.matchOption(optSourceProcess, ECLOPT_SOURCE_PROCESS))
+                continue;
             if (iter.matchFlag(optActivate, ECLOPT_ACTIVATE)||iter.matchFlag(optActivate, ECLOPT_ACTIVATE_S))
                 continue;
             if (iter.matchFlag(optNoReload, ECLOPT_NORELOAD))
@@ -383,6 +385,7 @@ public:
         req->setTarget(optTargetCluster.get());
         req->setCluster(optTargetCluster.get());
         req->setDaliServer(optDaliIP.get());
+        req->setSourceProcess(optSourceProcess);
         req->setActivate(optActivate);
         req->setOverwrite(optOverwrite);
         req->setDontCopyFiles(optDontCopyFiles);
@@ -429,6 +432,7 @@ public:
             "   <target>               Name of target cluster to copy the query to\n"
             "   --no-files             Do not copy files referenced by query\n"
             "   --daliip=<ip>          For file copying if remote version < 3.8\n"
+            "   --source-process       Process cluster to copy files from\n"
             "   -A, --activate         Activate the new query\n"
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
             "   -O, --overwrite        Overwrite existing files\n"
@@ -449,6 +453,7 @@ private:
     StringAttr optTargetQuerySet;
     StringAttr optTargetCluster;
     StringAttr optDaliIP;
+    StringAttr optSourceProcess;
     StringAttr optMemoryLimit;
     StringAttr optPriority;
     StringAttr optComment;

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -29,6 +29,7 @@ ESPrequest AddPackageRequest
     string Process;
     string DaliIp;
     bool GlobalScope(0);
+    string SourceProcess;
 };
 
 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1094,6 +1094,7 @@ ESPrequest [nil_remove] WUPublishWorkunitRequest
     string RemoteDali;
     string Comment;
     bool DontCopyFiles(false);
+    string SourceProcess;
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse
@@ -1352,6 +1353,7 @@ ESPrequest [nil_remove] WUQuerySetCopyQueryRequest
     nonNegativeInteger WarnTimeLimit(0);
     string priority;
     string Comment;
+    string SourceProcess;
 };
 
 ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse


### PR DESCRIPTION
Add --source-process cli option to ecl-packagemap-add, ecl-publish,
and ecl-queries-copy to explicitly specify which process cluster
roxie should pull data from when loading a query with
CopyResources=true.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
