### PR TITLE
HPCC-9924 - Avoid timeout causing HD resend

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -1091,11 +1091,21 @@ public:
     }
     bool sendRecv(ICommunicator &comm, CMessageBuffer &mb, rank_t r, mptag_t tag)
     {
+        mptag_t replyTag = createReplyTag();
         loop
         {
             if (aborted)
                 return false;
-            if (comm.sendRecv(mb, r, tag, MEDIUMTIMEOUT))
+            mb.setReplyTag(replyTag);
+            if (comm.send(mb, r, tag, MEDIUMTIMEOUT))
+                break;
+            // try again
+        }
+        loop
+        {
+            if (aborted)
+                return false;
+            if (comm.recv(mb, r, replyTag, NULL, MEDIUMTIMEOUT))
                 return true;
             // try again
         }


### PR DESCRIPTION
A regression was introduced by HPCC-9618, that caused the
distributor to resend a packet if the receiver had not responded
in 30s. Avoid resending via sendRecv, separate timeout loop for
send and recv.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
