### PR TITLE
HPCC-9905 Remove unnecessary code from the master branch

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -8705,20 +8705,6 @@ IHqlExpression * HqlLinkedChildRowTransformer::createTransformedBody(IHqlExpress
     case no_embedbody:
         //Don't change the type of an embed body - otherwise result it will become link counted when not expected.
         return LINK(expr);
-    case no_select:
-        {
-            OwnedHqlExpr newDs = transform(expr->queryChild(0));
-            IHqlExpression * record = newDs->queryRecord();
-            IHqlExpression * field = expr->queryChild(1);
-            LinkedHqlExpr newField;
-            if (record)
-                newField.setown(record->querySimpleScope()->lookupSymbol(field->queryId()));
-            HqlExprArray children;
-            children.append(*LINK(newDs));
-            if (newField)
-                children.append(*newField.getClear());
-            return completeTransform(expr, children);
-        }
     }
     return QuickHqlTransformer::createTransformedBody(expr);
 }


### PR DESCRIPTION
The code that was required in 4.0.2 is already present in the base class
on the master branch so it can be removed.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
