### PR TITLE
HPCC-9503 Return action results when DFU WU restored

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1663,17 +1663,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
         else
             throw MakeStringException(ECLWATCH_INVALID_ACTION, "Unknown action type %s", action);
 
-        if (bAllSuccess && checkRedirect(context) && strcmp(action, "Delete"))
-        {
-            if (!strcmp(action, "Restore"))
-                resp.setRedirectUrl("/FileSpray/GetDFUWorkunits?Type=archived workunits");
-            else
-                resp.setRedirectUrl("/FileSpray/GetDFUWorkunits");
-        }
-        else
-        {
-            resp.setDFUActionResults(results);
-        }
+        resp.setDFUActionResults(results);
     }
     catch(IException* e)
     {   


### PR DESCRIPTION
In the existing ECLWatch, FileSpray/WorkunitsAction automatically
redirects webpage to Browse DFU Workunits page after a workunit
action is finished. This fix removes the code for the URL redirect.
The FileSpray/WorkunitsAction returns the action results. It allows
the caller to decide how to use the results and/or redirect to
another page.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
