### PR TITLE
HPCC-8920  Implement challenge/response authentication in DALI & ESP

### DIFF
--- a/dali/base/daclient.cpp
+++ b/dali/base/daclient.cpp
@@ -88,7 +88,7 @@ IDaliClient_Exception *createClientException(DaliClientError err, const char *ms
 
 
 
-bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, const char *clientVersion, const char *minServerVersion, unsigned timeout)
+bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, const char *clientVersion, const char *minServerVersion, unsigned timeout, IPropertyTree *cfg)
 {
     assertex(servergrp);
     daliClientIsActive = true;
@@ -103,6 +103,8 @@ bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, 
     initCoven(covengrp,NULL,clientVersion, minServerVersion);
     covengrp->Release();
     queryLogMsgManager()->setSession(myProcessSession());
+    if (cfg)
+        querySessionManager().processConfig(cfg);
     return true;
 }
 

--- a/dali/base/daclient.hpp
+++ b/dali/base/daclient.hpp
@@ -26,7 +26,7 @@
 #include "mpcomm.hpp"
 #include "dasds.hpp"
 
-extern da_decl bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport=0, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER);
+extern da_decl bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport=0, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER, IPropertyTree *cfg=NULL);
 extern da_decl bool reinitClientProcess(IGroup *servergrp, DaliClientRole role, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER); 
 extern da_decl void closedownClientProcess();
 extern da_decl bool daliClientActive();

--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -37,7 +37,7 @@ extern void closedownDFS();
 // base is saved in store whenever block exhausted, so replacement coven servers can restart 
 
 // server side versioning.
-#define ServerVersion    "3.10"
+#define ServerVersion    "3.11"
 #define MinClientVersion "1.5"
 
 

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -73,7 +73,9 @@ interface IUserDescriptor: extends serializable
 {
     virtual StringBuffer &getUserName(StringBuffer &buf)=0;
     virtual StringBuffer &getPassword(StringBuffer &buf)=0;
-    virtual void set(const char *name,const char *password)=0;
+    virtual bool getTrusted()=0;
+    virtual void setTrusted(bool _trusted)=0;
+    virtual void set(const char *name,const char *password, bool _trusted=false)=0;
     virtual void clear()=0;
 };
 
@@ -114,6 +116,7 @@ interface ISessionManager: extends IInterface
     virtual bool clearPermissionsCache(IUserDescriptor *udesc)=0;
     virtual bool queryScopeScansEnabled(IUserDescriptor *udesc, int * err, StringBuffer &retMsg)=0;
     virtual bool enableScopeScans(IUserDescriptor *udesc, bool enable, int * err, StringBuffer &retMsg)=0;
+    virtual void processConfig(IPropertyTree *cfg)=0;
 };
 
 // the following are getPermissionsLDAP input flags for audit reporting
@@ -142,7 +145,7 @@ interface IPropertyTree;
 interface IFile;
 interface IDaliLdapConnection;
 interface IDaliClientAuthConnection;
-extern da_decl IDaliServer *createDaliSessionServer(); // called for coven members
+extern da_decl IDaliServer *createDaliSessionServer(IPropertyTree *config); // called for coven members
 extern da_decl void setLDAPconnection(IDaliLdapConnection *ldapconn); // called for coven members
 extern da_decl void setClientAuth(IDaliClientAuthConnection *authconn); // called for coven members
 

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -143,6 +143,7 @@ public:
             Owned<ISecUser> user = ldapsecurity->createUser(username);
             if (user) {
                 user->credentials().setPassword(password);
+                user->credentials().setTrusted(udesc->getTrusted());
                 if (filescope)
                     perm=ldapsecurity->authorizeFileScope(*user, obj);
                 else if (wuscope)

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -81,7 +81,7 @@ void setMsgLevel(ILogMsgHandler * fileMsgHandler, unsigned level)
 void AddServers(const char *auditdir)
 {
     // order significant
-    servers.append(*createDaliSessionServer());
+    servers.append(*createDaliSessionServer(serverConfig));
     servers.append(*createDaliPublisherServer());
     servers.append(*createDaliSDSServer(serverConfig));
     servers.append(*createDaliNamedQueueServer());

--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -179,7 +179,7 @@ CEspConfig::CEspConfig(IProperties* inputs, IPropertyTree* envpt, IPropertyTree*
         IPropertyTreeIterator *pt_iter = NULL;
         StringBuffer daliservers;
         if (m_cfg->getProp("@daliServers", daliservers))
-            initDali(daliservers.str());
+            initDali(daliservers.str(), m_cfg);
 
 #ifndef _DEBUG
         startPerformanceMonitor(m_cfg->getPropInt("@perfReportDelay", 60)*1000);
@@ -333,7 +333,7 @@ void CEspConfig::sendAlert(int severity, char const * descr, char const * subjec
 {
 }
 
-void CEspConfig::initDali(const char *servers)
+void CEspConfig::initDali(const char *servers, IPropertyTree *cfg)
 {
     if (servers!=NULL && *servers!=0 && !daliClientActive())
     {
@@ -348,7 +348,7 @@ void CEspConfig::initDali(const char *servers)
             throw MakeStringException(0, "Could not instantiate dali IGroup");
 
         // Initialize client process
-        if (!initClientProcess(serverGroup, DCR_EspServer))
+        if (!initClientProcess(serverGroup, DCR_EspServer, 0, NULL, NULL, MP_WAIT_FOREVER, cfg))
             throw MakeStringException(0, "Could not initialize dali client");
         setPasswordsFromSDS();
 

--- a/esp/platform/espcfg.ipp
+++ b/esp/platform/espcfg.ipp
@@ -154,7 +154,7 @@ public:
     }
 
     void initPtree(const char *location, bool isDali);
-    void initDali(const char *location);
+    void initDali(const char *location, IPropertyTree *cfg);
 
     bool isValid(){return (m_cfg.get() != NULL);}
     IPropertyTree* queryConfigPTree(){return m_cfg.get();}

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -61,6 +61,7 @@ private:
     StringAttr   m_sudoHost;
     StringAttr   m_sudoCommand;
     StringAttr   m_sudoOption;
+    bool         m_trusted;
 
 public:
     IMPLEMENT_IINTERFACE
@@ -144,6 +145,8 @@ public:
     const char* getPassword();
     bool setEncodedPassword(SecPasswordEncoding enc, void * pw, unsigned length, void * salt, unsigned saltlen);
     bool addToken(unsigned type, void * data, unsigned length);
+    void setTrusted(bool trusted);
+    bool getTrusted();
 
 // Posix specific fields
     virtual void setGidnumber(const char* gidnumber)

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -40,13 +40,14 @@ private:
     StringBuffer    m_Peer;
     SecUserStatus   m_status;
     Owned<IProperties> m_parameters;
+    bool            m_trusted;
 
     CriticalSection crit;
 public:
     IMPLEMENT_IINTERFACE
 
     CSecureUser(const char *name, const char *pw) : 
-        m_name(name), m_pw(pw), m_authenticateStatus(AS_UNKNOWN), m_userID(0), m_status(SecUserStatus_Unknown)
+        m_name(name), m_pw(pw), m_authenticateStatus(AS_UNKNOWN), m_userID(0), m_status(SecUserStatus_Unknown), m_trusted(false)
     {
     }
 
@@ -188,6 +189,8 @@ public:
     {
         return m_pw.str();
     }
+    virtual void setTrusted(bool _trusted)  { m_trusted = _trusted; }
+    virtual bool getTrusted()               { return m_trusted; }
 
     bool addToken(unsigned type, void * data, unsigned length)
     {
@@ -215,6 +218,7 @@ public:
         destination.setFqdn(getFqdn());
         destination.setPeer(getPeer());
         destination.credentials().setPassword(credentials().getPassword());
+        destination.credentials().setTrusted(credentials().getTrusted());
         CDateTime tmpTime;
         destination.setPasswordExpiration(getPasswordExpiration(tmpTime));
         destination.setStatus(getStatus());

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -121,6 +121,8 @@ interface ISecCredentials : extends IInterface
 {
     virtual bool setPassword(const char * pw) = 0;
     virtual const char * getPassword() = 0;
+    virtual void setTrusted(bool trusted) = 0;
+    virtual bool getTrusted() = 0;
     virtual bool addToken(unsigned type, void * data, unsigned length) = 0;
     virtual bool setPasswordExpiration(CDateTime & expirationDate) = 0;
     virtual CDateTime & getPasswordExpiration(CDateTime & expirationDate) = 0;


### PR DESCRIPTION
When ESP sends a file permission request to DALI it currently includes the username and password. These credential could be captured by an eavesdropper and used to gain access. 
This change implements a mutual challenge/response handshake where both DALI and ESP are challenged by each other, and if successful, the file permission request is performed.  Successful C/R exchanges are cached for a configurable period of time since it is likely more than one request will come from a given user
New configuration parameters (DALI and ESP)include a flag to indicate whether C/R should be enabled, an encrypted secret large digit that will be used as part of the hash, and a cache timeout. (see HPCC-9886)

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
