### PR TITLE
HPCC-8920 Implement challenge/response authentication in DALI & ESP

### DIFF
--- a/dali/base/daclient.cpp
+++ b/dali/base/daclient.cpp
@@ -88,7 +88,7 @@ IDaliClient_Exception *createClientException(DaliClientError err, const char *ms
 
 
 
-bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, const char *clientVersion, const char *minServerVersion, unsigned timeout)
+bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, const char *clientVersion, const char *minServerVersion, unsigned timeout, IPropertyTree *cfg)
 {
     assertex(servergrp);
     daliClientIsActive = true;
@@ -103,6 +103,8 @@ bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, 
     initCoven(covengrp,NULL,clientVersion, minServerVersion);
     covengrp->Release();
     queryLogMsgManager()->setSession(myProcessSession());
+    if (cfg)
+        querySessionManager().processConfig(cfg);
     return true;
 }
 

--- a/dali/base/daclient.hpp
+++ b/dali/base/daclient.hpp
@@ -26,7 +26,7 @@
 #include "mpcomm.hpp"
 #include "dasds.hpp"
 
-extern da_decl bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport=0, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER);
+extern da_decl bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport=0, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER, IPropertyTree *cfg=NULL);
 extern da_decl bool reinitClientProcess(IGroup *servergrp, DaliClientRole role, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER); 
 extern da_decl void closedownClientProcess();
 extern da_decl bool daliClientActive();

--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -37,7 +37,7 @@ extern void closedownDFS();
 // base is saved in store whenever block exhausted, so replacement coven servers can restart 
 
 // server side versioning.
-#define ServerVersion    "3.10"
+#define ServerVersion    "3.11"
 #define MinClientVersion "1.5"
 
 

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -76,7 +76,7 @@ interface ISessionManagerServer: implements IConnectionMonitor
     virtual void addSession(SessionId id) = 0;
     virtual SessionId lookupProcessSession(INode *node) = 0;
     virtual INode *getProcessSessionNode(SessionId id) =0;
-    virtual int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned flags, int *err)=0;
+    virtual int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned flags, int *err, bool allowChallengeResponse=true)=0;
     virtual bool clearPermissionsCache(IUserDescriptor *udesc) = 0;
     virtual void stopSession(SessionId sessid,bool failed) = 0;
     virtual void setClientAuth(IDaliClientAuthConnection *authconn) = 0;
@@ -98,8 +98,12 @@ static CriticalSection sessionCrit;
 #define SESSIONREPLYTIMEOUT (3*60*1000)
 
 
-#define CLDAPE_getpermtimeout (-1)
-#define CLDAPE_ldapfailure    (-2)
+#define CLDAPE_getpermtimeout            (-1)
+#define CLDAPE_ldapfailure               (-2)
+#define CLDAPE_challengeresponseDisabled (-3)
+#define CLDAPE_challengeresponseFailure  (-4)
+
+#define MAKEHASH(h,i) { StringBuffer val; val.append(val); hash = hashc((const unsigned char *)val.str(), val.length(), i); }
 
 class CDaliLDAP_Exception: public CInterface, implements IException
 {
@@ -356,6 +360,26 @@ public:
     }
 };
 
+//manages attributes of a trusted user (verified via challenge/response
+class CTrustedUser : public CInterface
+{
+public:
+    IMPLEMENT_IINTERFACE;
+
+    CTrustedUser(StringBuffer &_username, StringBuffer _sender, unsigned _clientToken, unsigned _serverToken, CDateTime &_whenExpires)
+        : username(_username), sender(_sender), clientToken(_clientToken), serverToken(_serverToken), whenExpires(_whenExpires)
+    {
+        key.append(sender).append('/').append(username);
+    }
+    StringBuffer key;
+    StringAttr  username;
+    StringAttr  sender;
+    unsigned    clientToken;
+    unsigned    serverToken;
+    CDateTime   whenExpires;
+};
+typedef CTrustedUser *CTrustedUserPtr;
+typedef MapStringTo<CTrustedUserPtr> CTrustedUserMap;
 
 
 enum MSessionRequestKind { 
@@ -370,7 +394,12 @@ enum MSessionRequestKind {
     MSR_CLEAR_PERMISSIONS_CACHE,
     MSR_EXIT, // TBD
     MSR_QUERY_SCOPE_SCANS_ENABLED,
-    MSR_ENABLE_SCOPE_SCANS
+    MSR_ENABLE_SCOPE_SCANS,
+    MSR_CR_LOOKUP_LDAP_PERMISSIONS,
+    MSR_CR_SERVER_CHALLENGE,
+    MSR_CR_CLIENT_RESPONSE,
+    MSR_CR_SERVER_RESPONSE,
+    MSR_CR_CONFIRMED
 };
 
 class CQueryScopeScansEnabledReq : implements IMessageWrapper
@@ -417,17 +446,111 @@ public:
     }
 };
 
+class CCRServerChallengeMsg : implements IMessageWrapper//sent from server to client
+{
+public:
+    mptag_t crTag;//tag to be used for C/R exchange
+    unsigned sc;//server challenge
+
+    CCRServerChallengeMsg(mptag_t _crTag, unsigned &_sc) : crTag(_crTag), sc(_sc) {}
+    CCRServerChallengeMsg() {}
+
+    void serializeReq(CMessageBuffer &mb)
+    {
+        mb.append((unsigned)MSR_CR_SERVER_CHALLENGE);
+        serializeMPtag(mb, crTag);
+        mb.append(sc);
+    }
+    void deserializeReq(CMessageBuffer &mb)
+    {
+        deserializeMPtag(mb, crTag);
+        mb.read(sc);
+    }
+};
+
+class CCRClientResponseMsg : implements IMessageWrapper//sent from client to server
+{
+public:
+    unsigned  cr;//client response to server challenge
+    unsigned  cc;//client challenge to server
+
+    CCRClientResponseMsg(unsigned &_ClientResponse, unsigned &_ClientChallenge) : cr(_ClientResponse), cc(_ClientChallenge) {}
+    CCRClientResponseMsg() {}
+
+    void serializeReq(CMessageBuffer &mb)   { mb.append((unsigned)MSR_CR_CLIENT_RESPONSE).append(cr).append(cc); }
+    void deserializeReq(CMessageBuffer &mb) { mb.read(cr).read(cc); }
+};
+
+class CCRServerResponseMsg : implements IMessageWrapper//sent from server to client
+{
+public:
+    unsigned    sr;//server response to client challenge
+    unsigned    crClientToken;
+
+    CCRServerResponseMsg(unsigned &_sr, unsigned _crClientToken) : sr(_sr), crClientToken(_crClientToken) {}
+    CCRServerResponseMsg() {}
+
+    void serializeReq(CMessageBuffer &mb)   { mb.append((unsigned)MSR_CR_SERVER_RESPONSE).append(sr).append(crClientToken); }
+    void deserializeReq(CMessageBuffer &mb) { mb.read(sr).read(crClientToken); }
+};
+
+//Concludes the Challenge/Response exchange
+class CCRConfirmed : implements IMessageWrapper//sent from client to server
+{
+public:
+    unsigned    crServerToken;
+    unsigned    crClientToken;
+
+    CCRConfirmed(unsigned _crClientToken, unsigned _crServerToken) : crClientToken(_crClientToken), crServerToken(_crServerToken) {}
+    CCRConfirmed() {}
+
+    void serializeReq(CMessageBuffer &mb)   { mb.append((unsigned)MSR_CR_CONFIRMED).append(crClientToken).append(crServerToken); }
+    void deserializeReq(CMessageBuffer &mb) { mb.read(crClientToken).read(crServerToken); }
+};
+
+
+
+
 class CSessionRequestServer: public Thread
 {
     bool stopped;
     ISessionManagerServer &manager;
     Semaphore acceptConnections;
 
+    bool useChallengeResponse;
+    CTrustedUserMap trustedUsersMap;
+    CriticalSection trustedUsersMapCrit;
+    CDateTime nextTrustedUserMapFlush;
+    unsigned trustedUserCacheTimeout;//in minutes
+    unsigned crKey;
 public:
-    CSessionRequestServer(ISessionManagerServer &_manager) 
+    CSessionRequestServer(ISessionManagerServer &_manager, IPropertyTree *_config)
         : Thread("Session Manager, CSessionRequestServer"), manager(_manager)
     {
         stopped = true;
+        useChallengeResponse = false;
+        if (_config)
+        {
+            IPropertyTree *crCfg = _config->getPropTree("Coven/challengeResponse");
+            if (crCfg)
+            {
+                useChallengeResponse = crCfg->getPropBool("@enabled",false);
+                if (useChallengeResponse)
+                {
+                    if (queryDaliServerVersion().compare("3.11") < 0)
+                        throw MakeStringException(-1, "challengeResponse enabled but DALI version not 3.11 or newer");
+                    trustedUserCacheTimeout = crCfg->getPropInt("@userCacheTimeout",5);
+                    StringBuffer ecrKey(crCfg->queryProp("@key"));
+                    StringBuffer dcrKey;
+                    decrypt(dcrKey, ecrKey);
+                    crKey = atoi(dcrKey.str());
+
+                    nextTrustedUserMapFlush.setNow();
+                    nextTrustedUserMapFlush.adjustTime(trustedUserCacheTimeout);
+                }
+            }
+        }
+        PROGLOG("Challenge/Response %s", useChallengeResponse ? "enabled" : "disabled" );
     }
 
     int run()
@@ -452,6 +575,151 @@ public:
             }
         }
         return 0;
+    }
+
+    //------------------------------------------------------------------------------------
+    // In response to a request from an ESP client, Dali replies back with a server challenge SC.
+    // ESP responds with a client response CR to the SC, and issues a client challenge CC to the
+    // Dali server. Dali verifies the CR, and sends a unique client token and a server response
+    // SR to the CC. ESP will verify the CR, and respond to Dali which will register the user as being trusted
+    //------------------------------------------------------------------------------------
+    int exchangeChallengeResponse(ICoven &coven, CMessageBuffer &mb, StringBuffer &_username)
+    {
+        #define CR_SUCCESS   0
+        #define CR_FAIL      1
+
+        CDateTime now;
+        now.setNow();
+        if (now.compare(nextTrustedUserMapFlush) >= 0)
+        {
+            //flush expired entries
+            HashIterator iter(trustedUsersMap);
+            StringArray expired;
+            CriticalBlock block(trustedUsersMapCrit);
+            ForEach(iter)
+            {
+                IMapping &cur = iter.query();
+                CTrustedUser *us = *(trustedUsersMap.mapToValue(&cur));
+                if (now.compare(us->whenExpires) >= 0)
+                {
+                    expired.append(us->key);
+                    us->Release();
+                }
+            }
+            for (aindex_t i=0; i<expired.ordinality(); i++)
+                trustedUsersMap.remove(expired.item(i));
+            expired.kill();
+            nextTrustedUserMapFlush.setNow();
+            nextTrustedUserMapFlush.adjustTime(trustedUserCacheTimeout);
+        }
+
+        StringBuffer key;
+        mb.getSender().getIpText(key);
+        key.append('/').append(_username);
+
+        {   //protected block
+            CriticalBlock block(trustedUsersMapCrit);
+            CTrustedUserPtr *trustedUser = trustedUsersMap.getValue(key.str());
+            if (trustedUser)
+            {
+                if (now.compare((*trustedUser)->whenExpires) > 0)
+                {
+                    StringAttr key((*trustedUser)->key);
+                    (*trustedUser)->Release();
+                    trustedUsersMap.remove(key);
+                }
+                else
+                    return 0;//previously verified
+            }
+        }
+
+        //send challenge to client
+        mb.clear().append(CR_SUCCESS);
+        mptag_t crTag = createReplyTag();//C/R communications on this mptag_t
+        unsigned serverChallenge = getRandom() + crKey;//create unique server challenge SC
+        CCRServerChallengeMsg msgSC(crTag, serverChallenge);
+        msgSC.serializeReq(mb);
+        coven.reply(mb);
+
+        unsigned clientToken = -1;
+        StringBuffer sb;
+        while (true)
+        {
+            if (!coven.recv(mb, RANK_ALL, crTag))
+            {
+                PROGLOG("Challenge/Response failed to receive response from client %s for user %s", mb.getSender().getUrlStr(sb).str(), _username.str());
+                mb.clear().append(CR_FAIL);
+                coven.reply(mb);
+                return CLDAPE_challengeresponseFailure;
+            }
+            unsigned retCode;
+            mb.read(retCode);
+            if (retCode != CR_SUCCESS)
+            {
+                PROGLOG("Challenge/Response error %d received from client %s for user %s", retCode, mb.getSender().getUrlStr(sb).str(), _username.str());
+                mb.clear().append(CR_FAIL);
+                coven.reply(mb);
+                return CLDAPE_challengeresponseFailure;
+            }
+            unsigned reqType;
+            mb.read(reqType);
+            switch (reqType)
+            {
+            case MSR_CR_CLIENT_RESPONSE:
+                {
+                    CCRClientResponseMsg msgCR;
+                    msgCR.deserializeReq(mb);
+
+                    unsigned hash;
+                    MAKEHASH(serverChallenge + msgCR.cc + crKey, crKey/2);
+                    if (msgCR.cr != hash)
+                    {
+                        PROGLOG("Challenge/Response error : Client %s response does not match expected for user %s", mb.getSender().getUrlStr(sb).str(), _username.str());
+                        mb.clear().append(CR_FAIL);
+                        coven.reply(mb);
+                        return CLDAPE_challengeresponseFailure;
+                    }
+
+                    mb.clear().append(CR_SUCCESS);
+                    MAKEHASH(serverChallenge + msgCR.cc + crKey, crKey/2);//Compute SR to CC (sr = hash(sc + cc + crKey))
+
+                    clientToken = getRandom() + crKey;
+                    CCRServerResponseMsg srMsg(hash, clientToken);
+                    srMsg.serializeReq(mb);
+                    coven.reply(mb);
+                    break;
+                }
+            case MSR_CR_CONFIRMED:
+                {
+                    CCRConfirmed msgConf;
+                    msgConf.deserializeReq(mb);
+                    if (msgConf.crClientToken != clientToken)
+                    {
+                        PROGLOG("Challenge/Response error : Client %s token mismatch for user %s", mb.getSender().getUrlStr(sb).str(), _username.str());
+                        mb.clear().append(CR_FAIL);
+                        coven.reply(mb);
+                        return CLDAPE_challengeresponseFailure;
+                    }
+                    //Add to map of trusted users
+                    CDateTime whenExpires;
+                    whenExpires.setNow();
+                    whenExpires.adjustTime(5);//expires in 5 minutes
+                    StringBuffer sender;
+                    mb.getSender().getIpText(sender);
+                    CTrustedUser * trustedUser = new CTrustedUser(_username, sender, clientToken, msgConf.crServerToken, whenExpires);
+                    CriticalBlock block(trustedUsersMapCrit);
+                    trustedUsersMap.setValue(trustedUser->key.str(), trustedUser);
+                    return 0;
+                }
+            default:
+                StringBuffer eps;
+                PROGLOG("Challenge/Response error : Unexpected message type %d from client %s for user %s", reqType, mb.getSender().getUrlStr(eps).str(), _username.str());
+                mb.clear().append(CR_FAIL);
+                coven.reply(mb);
+                return CLDAPE_challengeresponseFailure;
+            }
+        }
+        return CLDAPE_challengeresponseFailure;//unreachable
     }
 
     void processMessage(CMessageBuffer &mb)
@@ -483,7 +751,7 @@ public:
                     PROGLOG("Connection to %s authorized",mb.getSender().getUrlStr(eps).str());
 #endif
                 }
-                
+
                 IGroup *covengrp;
                 id = manager.registerClientProcess(node.get(),covengrp,(DaliClientRole)role);
                 mb.clear().append(id);
@@ -549,19 +817,19 @@ public:
                 coven.reply(mb);
             }
             break;
-        case MSR_LOOKUP_LDAP_PERMISSIONS: {
+        case MSR_LOOKUP_LDAP_PERMISSIONS:
+        case MSR_CR_LOOKUP_LDAP_PERMISSIONS:{
                 StringAttr key;
                 StringAttr obj;
                 Owned<IUserDescriptor> udesc=createUserDescriptor();
-                StringAttr username;
-                StringAttr passwordenc;
+                StringBuffer username;
+                udesc->getUserName(username);
                 mb.read(key).read(obj);
                 udesc->deserialize(mb);
 #ifndef _NO_DALIUSER_STACKTRACE
                 //following debug code to be removed
-                StringBuffer sb;
-                udesc->getUserName(sb);
-                if (0==sb.length())
+                udesc->getUserName(username);
+                if (0==username.length())
                 {
                     DBGLOG("UNEXPECTED USER (NULL) in dasess.cpp CSessionRequestServer::processMessage() line %d", __LINE__);
                 }
@@ -569,9 +837,27 @@ public:
                 unsigned auditflags = 0;
                 if (mb.length()-mb.getPos()>=sizeof(auditflags))
                     mb.read(auditflags);
+                int perms = 0;
                 int err = 0;
-                int ret=manager.getPermissionsLDAP(key,obj,udesc,auditflags,&err);
-                mb.clear().append(ret);
+                if (fn == MSR_CR_LOOKUP_LDAP_PERMISSIONS)
+                {
+                    if (!useChallengeResponse)
+                    {
+                        StringBuffer sb;
+                        DBGLOG("MSR_CR_LOOKUP_LDAP_PERMISSIONS requested by client %s for user %s but Challenge/Response disabled", mb.getSender().getUrlStr(sb).str(), username.str());
+                        mb.clear().append(CLDAPE_challengeresponseDisabled);
+                        coven.reply(mb);
+                        break;
+                    }
+                    err = exchangeChallengeResponse(coven, mb, username);
+                    if (0 == err)
+                        udesc->setTrusted(true);
+                    else
+                        break;
+                }
+                if (0 == err)
+                    perms = manager.getPermissionsLDAP(key,obj,udesc,auditflags,&err);
+                mb.clear().append(perms);
                 if (err)
                     mb.append(err);
                 coven.reply(mb);
@@ -806,12 +1092,34 @@ public:
 class CClientSessionManager: public CSessionManagerBase, implements IConnectionMonitor
 {
     bool securitydisabled;
+    bool useChallengeResponse;
+    unsigned crKey;
+
+    class CNonCRDali : public CInterface//represents a DALI that either doesn't support C/R, or where it is not enabled
+    {
+    public:
+        StringBuffer ip;
+        CDateTime whenExpires;
+
+        IMPLEMENT_IINTERFACE;
+        CNonCRDali(const char *_ip, CDateTime &_whenExpires) : ip(_ip), whenExpires(_whenExpires) {}
+    };
+    typedef CNonCRDali *CNonCRDaliPtr;
+    MapStringTo<CNonCRDaliPtr> nonCRDaliMap;//map of DALIs that don't utilize C/R
+    CDateTime nextNonCRDaliMapFlush;
+    CriticalSection nonCRDaliMapCrit;
+
 public:
     IMPLEMENT_IINTERFACE;
 
     CClientSessionManager()
     {
         securitydisabled = false;
+
+        CDateTime now;
+        now.setNow();
+        nextNonCRDaliMapFlush.setNow();
+        nextNonCRDaliMapFlush.adjustTime(30);
     }
     virtual ~CClientSessionManager()
     {
@@ -849,7 +1157,7 @@ public:
     }
 
 
-    int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags,int *err)
+    int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags,int *err, bool allowChallengeResponse)
     {
         if (err)
             *err = 0;
@@ -859,8 +1167,68 @@ public:
             securitydisabled = true;
             return -1;
         }
+
+        if (allowChallengeResponse && useChallengeResponse)
+        {
+            CDateTime now;
+            now.setNow();
+            if (now.compare(nextNonCRDaliMapFlush) >= 0)
+            {
+                //flush expired entries
+                HashIterator iter(nonCRDaliMap);
+                StringArray expired;
+                CriticalBlock block(nonCRDaliMapCrit);
+                ForEach(iter)
+                {
+                    IMapping &cur = iter.query();
+                    CNonCRDali *item = *(nonCRDaliMap.mapToValue(&cur));
+                    if (now.compare(item->whenExpires) >= 0)
+                    {
+                        expired.append(item->ip);
+                        item->Release();
+                    }
+                }
+                for (aindex_t i=0; i<expired.ordinality(); i++)
+                    nonCRDaliMap.remove(expired.item(i));
+                expired.kill();
+                nextNonCRDaliMapFlush.setNow();
+                nextNonCRDaliMapFlush.adjustTime(30);
+            }
+
+            SocketEndpointArray sea;
+            queryCoven().getGroup()->getSocketEndpoints(sea);
+            SocketEndpoint ep = sea.item(0);//JAKE is this the right way to get dali IP?  Seems weird
+            StringBuffer ip;
+            ep.getUrlStr(ip);
+            ip.replace(':', (char)NULL);
+            {   //protected block
+                //Check whether or not we know if this DALI has C/R disabled
+                CriticalBlock block(nonCRDaliMapCrit);
+                CNonCRDaliPtr *item = nonCRDaliMap.getValue(ip.str());
+                if (item)
+                {
+                    if (now.compare((*item)->whenExpires) > 0)//make sure not stale entry
+                    {
+                        StringAttr key((*item)->ip);
+                        (*item)->Release();
+                        nonCRDaliMap.remove(key);
+                    }
+                    else
+                        allowChallengeResponse = false;//Target DALI does not have C/R enabled
+                }
+            }
+        }
+
         CMessageBuffer mb;
-        mb.append((int)MSR_LOOKUP_LDAP_PERMISSIONS);
+        if (allowChallengeResponse && useChallengeResponse && queryDaliServerVersion().compare("3.11") >= 0)
+        {
+            StringBuffer usr;
+            udesc->getUserName(usr);
+            udesc->set(usr.str(), NULL, true);//clear password, flag as trusted
+            mb.append((int)MSR_CR_LOOKUP_LDAP_PERMISSIONS);
+        }
+        else
+            mb.append((int)MSR_LOOKUP_LDAP_PERMISSIONS);
         mb.append(key).append(obj);
 #ifndef _NO_DALIUSER_STACKTRACE
         //following debug code to be removed
@@ -875,7 +1243,93 @@ public:
 #endif
         udesc->serialize(mb);
         mb.append(auditflags);
-        if (!queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DALI_SESSION_REQUEST,SESSIONREPLYTIMEOUT))
+        bool challenged = true;
+        if (allowChallengeResponse && useChallengeResponse && queryDaliServerVersion().compare("3.11") >= 0)
+        {
+            unsigned clientToken = -1;
+            unsigned serverToken = -1;
+            unsigned clientChallenge = -1;
+            unsigned serverChallenge = -1;
+
+            mptag_t crTag = MPTAG_DALI_SESSION_REQUEST;//initially send on this tag, server will provide tag for C/R communication
+            while (challenged)
+            {
+                if (!queryCoven().sendRecv(mb, RANK_RANDOM, crTag, SESSIONREPLYTIMEOUT))
+                    return 0;
+                unsigned retCode;
+                mb.read(retCode);
+                if (retCode == CLDAPE_challengeresponseDisabled)
+                {
+                    {//Remember DALIs that don't support C/R
+                        StringBuffer ip;
+                        mb.getSender().getIpText(ip);
+                        CDateTime now;
+                        now.setNow();
+                        now.adjustTime(30);
+                        CNonCRDali * p = new CNonCRDali(ip.str(), now);
+                        CriticalBlock block(nonCRDaliMapCrit);
+                        nonCRDaliMap.setValue(ip, p);
+                    }
+
+                    //Challenge/Response disabled at dali, retry using legacy message
+                    return getPermissionsLDAP(key, obj, udesc, auditflags, err, false);
+                }
+                if (retCode != CR_SUCCESS)
+                {
+                    StringBuffer eps;
+                    StringBuffer user;
+                    udesc->getUserName(user);
+                    DBGLOG("Challenge/Response error : received error %d from server %s for user %s", retCode,mb.getSender().getUrlStr(eps).str(), user.str());
+                    return 0;
+                }
+
+                unsigned reqType;
+                mb.read(reqType);
+                switch (reqType)
+                {
+                case MSR_CR_SERVER_CHALLENGE://respond to server challenge with server response and issue client challenge
+                    {
+                        CCRServerChallengeMsg msgSC;
+                        msgSC.deserializeReq(mb);
+                        crTag = msgSC.crTag;//use this tag for future C/R communication
+                        serverChallenge = msgSC.sc;
+                        clientChallenge = getRandom() + crKey;
+
+                        unsigned hash;
+                        MAKEHASH(clientChallenge + msgSC.sc + crKey, crKey/2);//compute CR to SC = hash(cc + sc + crKey)
+
+                        mb.clear().append(CR_SUCCESS);
+                        CCRClientResponseMsg msgCR(hash, clientChallenge);
+                        msgCR.serializeReq(mb);
+                        break;
+                    }
+                case MSR_CR_SERVER_RESPONSE://Verify server response to client challenge
+                    {
+                        CCRServerResponseMsg msgSR;
+                        msgSR.deserializeReq(mb);
+
+                        unsigned hash;
+                        MAKEHASH(serverChallenge + clientChallenge + crKey, crKey/2);
+                        if (msgSR.sr != hash)
+                        {
+                            PROGLOG("Challenge/Response error : Server %s response does not match expected", mb.getSender().getUrlStr(sb).str());
+                            mb.clear().append(CR_FAIL);
+                            queryCoven().sendRecv(mb, RANK_RANDOM, crTag, SESSIONREPLYTIMEOUT);
+                            return 0;
+                        }
+                        clientToken = msgSR.crClientToken;
+                        serverToken = getRandom() + crKey;//generate server token
+                        mb.clear().append(CR_SUCCESS);
+                        CCRConfirmed msgGetPerms(clientToken, serverToken);
+                        msgGetPerms.serializeReq(mb);
+                        queryCoven().sendRecv(mb, RANK_RANDOM, crTag, SESSIONREPLYTIMEOUT);
+                        challenged = false;
+                        break;
+                    }
+                }
+            } 
+        }
+        else if (!queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DALI_SESSION_REQUEST,SESSIONREPLYTIMEOUT))
             return 0;
         int ret=-1;
         if (mb.remaining()>=sizeof(ret)) {
@@ -1011,6 +1465,26 @@ public:
         return true;
     }
 
+    void processConfig(IPropertyTree *cfg)
+    {
+        useChallengeResponse = false;
+        if (cfg)
+        {
+            IPropertyTree *crCfg = cfg->getPropTree("challengeResponse");
+            if (crCfg)
+            {
+                useChallengeResponse = crCfg->getPropBool("@enabled",false);
+                if (useChallengeResponse)
+                {
+                    StringBuffer ecrKey(crCfg->queryProp("@key"));
+                    StringBuffer dcrKey;
+                    decrypt(dcrKey, ecrKey);
+                    crKey = atoi(dcrKey.str());
+                }
+            }
+        }
+        PROGLOG("Challenge/Response %s", useChallengeResponse ? "enabled" : "disabled" );
+    }
 
     SessionId startSession(SecurityToken tok, SessionId parentid)
     {
@@ -1214,8 +1688,8 @@ class CCovenSessionManager: public CSessionManagerBase, implements ISessionManag
 public:
     IMPLEMENT_IINTERFACE;
 
-    CCovenSessionManager()
-        : sessionrequestserver(*this)
+    CCovenSessionManager(IPropertyTree *_config)
+        : sessionrequestserver(*this, _config)
     {
         mySessionId = queryCoven().getUniqueId(); // tell others in coven TBD
         registerSubscriptionManager(SESSION_PUBLISHER,this);
@@ -1358,7 +1832,7 @@ public:
         return NULL;
     }
 
-    virtual int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned flags, int *err)
+    virtual int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned flags, int *err, bool allowChallengeResponse)
     {
         if (err)
             *err = 0;
@@ -1542,7 +2016,9 @@ public:
     {
         UNIMPLEMENTED; // TBD
     }
-
+    void processConfig(IPropertyTree *cfg)
+    {
+    }
 protected:
 
     class CSessionSubscriptionStub: public CInterface
@@ -1723,10 +2199,11 @@ ISessionManager &querySessionManager()
 
 class CDaliSessionServer: public CInterface, public IDaliServer
 {
+    IPropertyTree *config;
 public:
     IMPLEMENT_IINTERFACE;
 
-    CDaliSessionServer()
+    CDaliSessionServer(IPropertyTree *_config) : config(_config)
     {
     }
 
@@ -1734,7 +2211,9 @@ public:
     {
         CriticalBlock block(sessionCrit);
         assertex(queryCoven().inCoven()); // must be member of coven
-        CCovenSessionManager *serv = new CCovenSessionManager();
+        CCovenSessionManager *serv = new CCovenSessionManager(config);
+        if (config)
+            serv->processConfig(config);
         SessionManagerServer = serv;
         SessionManager = serv;
         SessionManagerServer->start();
@@ -1765,9 +2244,9 @@ public:
 
 };
 
-IDaliServer *createDaliSessionServer()
+IDaliServer *createDaliSessionServer(IPropertyTree *_config)
 {
-    return new CDaliSessionServer();
+    return new CDaliSessionServer(_config);
 }
 
 void setLDAPconnection(IDaliLdapConnection *ldapconn)
@@ -1915,8 +2394,11 @@ class CUserDescriptor: public CInterface, implements IUserDescriptor
 {
     StringAttr username;
     StringAttr passwordenc;
+    bool    trusted;
 public:
     IMPLEMENT_IINTERFACE;
+
+    CUserDescriptor() { trusted = false; }
     StringBuffer &getUserName(StringBuffer &buf)
     {
         return buf.append(username);
@@ -1926,12 +2408,15 @@ public:
         decrypt(buf,passwordenc);
         return buf;
     }
-    virtual void set(const char *name,const char *password)
+    virtual bool getTrusted() { return trusted; }
+    virtual void setTrusted(bool _trusted) { trusted = _trusted; }
+    virtual void set(const char *name,const char *password, bool _trusted)
     {
         username.set(name);
         StringBuffer buf;
         encrypt(buf,password);
         passwordenc.set(buf.str());
+        trusted = _trusted;
     }
     virtual void clear()
     {

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -73,7 +73,9 @@ interface IUserDescriptor: extends serializable
 {
     virtual StringBuffer &getUserName(StringBuffer &buf)=0;
     virtual StringBuffer &getPassword(StringBuffer &buf)=0;
-    virtual void set(const char *name,const char *password)=0;
+    virtual bool getTrusted()=0;
+    virtual void setTrusted(bool _trusted)=0;
+    virtual void set(const char *name,const char *password, bool _trusted=false)=0;
     virtual void clear()=0;
 };
 
@@ -107,13 +109,14 @@ interface ISessionManager: extends IInterface
     virtual StringBuffer &getClientProcessEndpoint(SessionId id,StringBuffer &buf)=0; // for diagnostics
     virtual unsigned queryClientCount() = 0; // for SNMP
 
-    virtual int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags, int *err=NULL)=0;
+    virtual int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags, int *err=NULL, bool allowChallengeResponse=true)=0;
     virtual bool checkScopeScansLDAP()=0;
     virtual unsigned getLDAPflags()=0;
     virtual void setLDAPflags(unsigned flags)=0;
     virtual bool clearPermissionsCache(IUserDescriptor *udesc)=0;
     virtual bool queryScopeScansEnabled(IUserDescriptor *udesc, int * err, StringBuffer &retMsg)=0;
     virtual bool enableScopeScans(IUserDescriptor *udesc, bool enable, int * err, StringBuffer &retMsg)=0;
+    virtual void processConfig(IPropertyTree *cfg)=0;
 };
 
 // the following are getPermissionsLDAP input flags for audit reporting
@@ -142,7 +145,7 @@ interface IPropertyTree;
 interface IFile;
 interface IDaliLdapConnection;
 interface IDaliClientAuthConnection;
-extern da_decl IDaliServer *createDaliSessionServer(); // called for coven members
+extern da_decl IDaliServer *createDaliSessionServer(IPropertyTree *config); // called for coven members
 extern da_decl void setLDAPconnection(IDaliLdapConnection *ldapconn); // called for coven members
 extern da_decl void setClientAuth(IDaliClientAuthConnection *authconn); // called for coven members
 

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -143,6 +143,7 @@ public:
             Owned<ISecUser> user = ldapsecurity->createUser(username);
             if (user) {
                 user->credentials().setPassword(password);
+                user->credentials().setTrusted(udesc->getTrusted());
                 if (filescope)
                     perm=ldapsecurity->authorizeFileScope(*user, obj);
                 else if (wuscope)

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -81,7 +81,7 @@ void setMsgLevel(ILogMsgHandler * fileMsgHandler, unsigned level)
 void AddServers(const char *auditdir)
 {
     // order significant
-    servers.append(*createDaliSessionServer());
+    servers.append(*createDaliSessionServer(serverConfig));
     servers.append(*createDaliPublisherServer());
     servers.append(*createDaliSDSServer(serverConfig));
     servers.append(*createDaliNamedQueueServer());

--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -179,7 +179,7 @@ CEspConfig::CEspConfig(IProperties* inputs, IPropertyTree* envpt, IPropertyTree*
         IPropertyTreeIterator *pt_iter = NULL;
         StringBuffer daliservers;
         if (m_cfg->getProp("@daliServers", daliservers))
-            initDali(daliservers.str());
+            initDali(daliservers.str(), m_cfg);
 
 #ifndef _DEBUG
         startPerformanceMonitor(m_cfg->getPropInt("@perfReportDelay", 60)*1000);
@@ -333,7 +333,7 @@ void CEspConfig::sendAlert(int severity, char const * descr, char const * subjec
 {
 }
 
-void CEspConfig::initDali(const char *servers)
+void CEspConfig::initDali(const char *servers, IPropertyTree *cfg)
 {
     if (servers!=NULL && *servers!=0 && !daliClientActive())
     {
@@ -348,7 +348,7 @@ void CEspConfig::initDali(const char *servers)
             throw MakeStringException(0, "Could not instantiate dali IGroup");
 
         // Initialize client process
-        if (!initClientProcess(serverGroup, DCR_EspServer))
+        if (!initClientProcess(serverGroup, DCR_EspServer, 0, NULL, NULL, MP_WAIT_FOREVER, cfg))
             throw MakeStringException(0, "Could not initialize dali client");
         setPasswordsFromSDS();
 

--- a/esp/platform/espcfg.ipp
+++ b/esp/platform/espcfg.ipp
@@ -154,7 +154,7 @@ public:
     }
 
     void initPtree(const char *location, bool isDali);
-    void initDali(const char *location);
+    void initDali(const char *location, IPropertyTree *cfg);
 
     bool isValid(){return (m_cfg.get() != NULL);}
     IPropertyTree* queryConfigPTree(){return m_cfg.get();}

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -61,6 +61,7 @@ private:
     StringAttr   m_sudoHost;
     StringAttr   m_sudoCommand;
     StringAttr   m_sudoOption;
+    bool         m_trusted;
 
 public:
     IMPLEMENT_IINTERFACE
@@ -144,6 +145,8 @@ public:
     const char* getPassword();
     bool setEncodedPassword(SecPasswordEncoding enc, void * pw, unsigned length, void * salt, unsigned saltlen);
     bool addToken(unsigned type, void * data, unsigned length);
+    void setTrusted(bool trusted);
+    bool getTrusted();
 
 // Posix specific fields
     virtual void setGidnumber(const char* gidnumber)

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -40,13 +40,14 @@ private:
     StringBuffer    m_Peer;
     SecUserStatus   m_status;
     Owned<IProperties> m_parameters;
+    bool            m_trusted;
 
     CriticalSection crit;
 public:
     IMPLEMENT_IINTERFACE
 
     CSecureUser(const char *name, const char *pw) : 
-        m_name(name), m_pw(pw), m_authenticateStatus(AS_UNKNOWN), m_userID(0), m_status(SecUserStatus_Unknown)
+        m_name(name), m_pw(pw), m_authenticateStatus(AS_UNKNOWN), m_userID(0), m_status(SecUserStatus_Unknown), m_trusted(false)
     {
     }
 
@@ -188,6 +189,8 @@ public:
     {
         return m_pw.str();
     }
+    virtual void setTrusted(bool _trusted)  { m_trusted = _trusted; }
+    virtual bool getTrusted()               { return m_trusted; }
 
     bool addToken(unsigned type, void * data, unsigned length)
     {
@@ -215,6 +218,7 @@ public:
         destination.setFqdn(getFqdn());
         destination.setPeer(getPeer());
         destination.credentials().setPassword(credentials().getPassword());
+        destination.credentials().setTrusted(credentials().getTrusted());
         CDateTime tmpTime;
         destination.setPasswordExpiration(getPasswordExpiration(tmpTime));
         destination.setStatus(getStatus());

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -121,6 +121,8 @@ interface ISecCredentials : extends IInterface
 {
     virtual bool setPassword(const char * pw) = 0;
     virtual const char * getPassword() = 0;
+    virtual void setTrusted(bool trusted) = 0;
+    virtual bool getTrusted() = 0;
     virtual bool addToken(unsigned type, void * data, unsigned length) = 0;
     virtual bool setPasswordExpiration(CDateTime & expirationDate) = 0;
     virtual CDateTime & getPasswordExpiration(CDateTime & expirationDate) = 0;


### PR DESCRIPTION
When ESP sends a file permission request to DALI it currently includes the username and password. These credential could be captured by an eavesdropper and used to gain access.
This change implements a mutual challenge/response handshake where both DALI and ESP are challenged by each other, and if successful, the file permission request is performed. Successful C/R exchanges are cached for a configurable period of time since it is likely more than one request will come from a given user
New configuration parameters (DALI and ESP)include a flag to indicate whether C/R should be enabled, an encrypted secret large digit that will be used as part of the hash, and a cache timeout. (see HPCC-9886)

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
