### PR TITLE
HPCC-9249 Return user/IP for paused queue to WsSMC/Activity response

### DIFF
--- a/common/workunit/wujobq.hpp
+++ b/common/workunit/wujobq.hpp
@@ -91,7 +91,7 @@ interface IJobQueue: extends IInterface
     virtual unsigned findRank(const char *wuid)=0;
     virtual unsigned copyItems(CJobQueueContents &dest)=0;  // takes a snapshot copy of the entire queue (returns number copied)
     virtual bool getLastDequeuedInfo(StringAttr &wuid, CDateTime &enqueuedt, int &priority)=0;
-    virtual void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state)=0;
+    virtual void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state, StringBuffer& stateDetails)=0;
 
 
 //manipulation
@@ -112,10 +112,15 @@ interface IJobQueue: extends IInterface
 
 // control:
     virtual void pause()=0;     // marks queue as paused - and subsequent dequeues block until resumed
+    virtual void pause(const char *info)=0;     // marks queue as paused - and subsequent dequeues block until resumed
     virtual bool paused()=0;    // true if paused
+    virtual bool paused(StringBuffer& info)=0;    // true if paused
     virtual void stop()=0;      // sets stopped flags - all current and subsequent dequeues return NULL
+    virtual void stop(const char *info)=0;      // sets stopped flags - all current and subsequent dequeues return NULL
     virtual bool stopped()=0;   // true if stopped
+    virtual bool stopped(StringBuffer& info)=0;   // true if stopped
     virtual void resume()=0;    // removes paused or stopped flag
+    virtual void resume(const char *info)=0;    // removes paused or stopped flag
 
 // conversations:
     virtual IConversation *initiateConversation(IJobQueueItem *item)=0; // does enqueue - take ownership of item

--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -613,6 +613,7 @@
                             <xsl:with-param name="clusterType" select="ServerType"/>
                             <xsl:with-param name="queue" select="QueueName"/>
                             <xsl:with-param name="queueStatus" select="QueueStatus"/>
+                            <xsl:with-param name="statusDetails" select="StatusDetails"/>
                         </xsl:call-template>
                     </xsl:for-each>
 
@@ -623,6 +624,7 @@
                             <xsl:with-param name="clusterType" select="ServerType"/>
                             <xsl:with-param name="queue" select="QueueName"/>
                             <xsl:with-param name="queueStatus" select="QueueStatus"/>
+                            <xsl:with-param name="statusDetails" select="StatusDetails"/>
                         </xsl:call-template>
                     </xsl:for-each>
 
@@ -633,6 +635,7 @@
                             <xsl:with-param name="clusterType" select="ServerType"/>
                             <xsl:with-param name="queue" select="QueueName"/>
                             <xsl:with-param name="queueStatus" select="QueueStatus"/>
+                            <xsl:with-param name="statusDetails" select="StatusDetails"/>
                         </xsl:call-template>
                     </xsl:for-each>
 
@@ -643,6 +646,7 @@
                             <xsl:with-param name="clusterType" select="ServerType"/>
                             <xsl:with-param name="queue" select="QueueName"/>
                             <xsl:with-param name="queueStatus" select="QueueStatus"/>
+                            <xsl:with-param name="statusDetails" select="StatusDetails"/>
                         </xsl:call-template>
                     </xsl:for-each>
                     <xsl:apply-templates select="DFUJobs"/>
@@ -768,15 +772,12 @@
                                 <xsl:choose>
                                     <xsl:when test="$queueStatus='paused'">
                                         <xsl:attribute name="class">thorrunningpausedqueuejobs</xsl:attribute>
-                                        <xsl:attribute name="title">Queue paused</xsl:attribute>
                                     </xsl:when>
                                     <xsl:when test="$queueStatus='stopped'">
                                         <xsl:attribute name="class">thorrunningpausedqueuejobs</xsl:attribute>
-                                        <xsl:attribute name="title">Queue stopped</xsl:attribute>
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <xsl:attribute name="class">thorrunning</xsl:attribute>
-                                        <xsl:attribute name="title">Queue running</xsl:attribute>
                                     </xsl:otherwise>
                                 </xsl:choose>
                             </xsl:when>
@@ -798,11 +799,11 @@
                                         <xsl:attribute name="class">thorrunning</xsl:attribute>
                                     </xsl:otherwise>
                                 </xsl:choose>
-                                <xsl:attribute name="title">
-                                    <xsl:value-of select="$statusDetails"/>
-                                </xsl:attribute>
                             </xsl:otherwise>
                         </xsl:choose>
+                        <xsl:attribute name="title">
+                            <xsl:value-of select="$statusDetails"/>
+                        </xsl:attribute>
                         <xsl:if test="$clusterType = 'THOR'">
                             <xsl:attribute name="href">javascript:go('/WsTopology/TpClusterInfo?Name=<xsl:value-of select="$cluster"/>')</xsl:attribute>
                         </xsl:if>

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -106,6 +106,7 @@ ESPStruct ServerJobQueue
     string ServerName;
     string ServerType;
     string QueueStatus;
+    [min_ver("1.17")] string StatusDetails;
 };
 
 ESPrequest [nil_remove] ActivityRequest
@@ -183,6 +184,7 @@ ESPrequest SMCQueueRequest
     int ClusterType;
     string Cluster;
     string QueueName;
+    string Comment;
 };
 
 
@@ -319,7 +321,7 @@ RoxieControlCmdResponse
     ESParray<ESPstruct RoxieControlEndpointInfo, Endpoint> Endpoints;
 };
 
-ESPservice [noforms, version("1.16"), default_client_version("1.16"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [noforms, version("1.17"), default_client_version("1.17"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1822,11 +1822,10 @@ const char* CWsSMCEx::createQueueActionInfo(IEspContext &context, const char* st
     CDateTime now;
     now.setNow();
     now.getString(currentTime);
+    info.appendf("%s by <%s> at <%s> from <%s>", state, userId, currentTime.str(), peer.str());
     const char* comment = req.getComment();
     if (comment && *comment)
-        info.appendf("'%s' (commented by <%s> at <%s> from <%s>)", comment, userId, currentTime.str(), peer.str());
-    else
-        info.appendf("%s by <%s> at <%s> from <%s>", state, userId, currentTime.str(), peer.str());
+        info.append(": ' ").append(comment).append("'");
     return info.str();
 }
 

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -45,7 +45,7 @@ class CWsSMCQueue
 {
 public:
     SCMStringBuffer queueName;
-    StringBuffer queueState;
+    StringBuffer queueState, queueStateDetails;
     bool foundQueueInStatusServer;
     unsigned countRunningJobs;
     unsigned countQueuedJobs;
@@ -119,8 +119,8 @@ private:
                                  IArrayOf<IEspCapability>& capabilities);
     void addToThorClusterList(IArrayOf<IEspThorCluster>& clusters, IEspThorCluster* cluster, const char* sortBy, bool descending);
     void addToRoxieClusterList(IArrayOf<IEspRoxieCluster>& clusters, IEspRoxieCluster* cluster, const char* sortBy, bool descending);
-    void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
-    void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* queueState, const char* serverName, const char* serverType);
+    void addServerJobQueue(double version, IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType);
+    void addServerJobQueue(double version, IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName, const char* serverType, const char* queueState, const char* queueStateDetails);
     void getQueueState(int runningJobsInQueue, StringBuffer& queueState, BulletType& colorType);
     void readClusterTypeAndQueueName(CConstWUClusterInfoArray& clusters, const char* clusterName, StringBuffer& clusterType, SCMStringBuffer& clusterQueue);
     void addRunningWUs(IEspContext &context, IPropertyTree& node, CConstWUClusterInfoArray& clusters,
@@ -149,6 +149,8 @@ private:
     void getWUsNotOnTargetCluster(IEspContext &context, IPropertyTree* serverStatusRoot, IArrayOf<IEspServerJobQueue>& serverJobQueues, IArrayOf<IEspActiveWorkunit>& aws);
     void getDFUServersAndWUs(IEspContext &context, IPropertyTree* envRoot, IArrayOf<IEspServerJobQueue>& serverJobQueues, IArrayOf<IEspActiveWorkunit>& aws);
     void getDFURecoveryJobs(IEspContext &context, IArrayOf<IEspDFUJob>& jobs);
+    const char* createQueueActionInfo(IEspContext &context, const char* action, IEspSMCQueueRequest &req, StringBuffer& info);
+    void setServerJobQueueStatus(double version, IEspServerJobQueue* jobQueue, const char* status, const char* details);
 };
 
 


### PR DESCRIPTION
This fix allows a user add some comment when the user
pauses/stops/resumes a queue through WsSMC service. The comment, as
well as user name, IP, and time, will be stored and returned as a
part of WsSMC/Activity response.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
