### PR TITLE
HPCC-9909 Typos in compiler error messages

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -11627,7 +11627,7 @@ pattern0
                         {
                             parser->checkPattern($3, true);
                             if ($3.queryExpr()->queryRecord())
-                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use REPEAT on a rule with associated an row");
+                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use REPEAT on a rule with an associated row");
 
                             IHqlExpression * pattern = $3.getExpr();
                             $$.setExpr(createValue(no_pat_repeat, parser->getCompoundRuleType(pattern), pattern, $4.getExpr()));
@@ -11637,7 +11637,7 @@ pattern0
                             parser->checkPattern($3, true);
                             parser->normalizeExpression($5, type_int, true);
                             if ($3.queryExpr()->queryRecord())
-                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use REPEAT on a rule with associated an row");
+                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use REPEAT on a rule with an associated row");
 
                             IHqlExpression * pattern = $3.getExpr();
                             $$.setExpr(createValue(no_pat_repeat, parser->getCompoundRuleType(pattern), pattern, $5.getExpr(), $6.getExpr()));
@@ -11647,7 +11647,7 @@ pattern0
                             parser->checkPattern($3, true);
                             parser->normalizeExpression($5, type_int, true);
                             if ($3.queryExpr()->queryRecord())
-                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use REPEAT on a rule with associated an row");
+                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use REPEAT on a rule with an associated row");
 
                             IHqlExpression * pattern = $3.getExpr();
                             $$.setExpr(createValue(no_pat_repeat, parser->getCompoundRuleType(pattern), pattern, $5.getExpr(), createValue(no_any, makeNullType()), $8.getExpr()));
@@ -11658,7 +11658,7 @@ pattern0
                             parser->normalizeExpression($5, type_int, true);
                             parser->normalizeExpression($7, type_int, true);
                             if ($3.queryExpr()->queryRecord())
-                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use REPEAT on a rule with associated an row");
+                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use REPEAT on a rule with an associated row");
 
                             IHqlExpression * pattern = $3.getExpr();
                             $$.setExpr(createValue(no_pat_repeat, parser->getCompoundRuleType(pattern), pattern, $5.getExpr(), $7.getExpr(), $8.getExpr()));
@@ -11667,7 +11667,7 @@ pattern0
                         {
                             parser->checkPattern($3, true);
                             if ($4.queryExpr() && $3.queryExpr()->queryRecord())
-                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use OPT with count on a rule with associated an row");
+                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use OPT with count on a rule with an associated row");
 
                             IHqlExpression * pattern = $3.getExpr();
                             IHqlExpression * max = $4.getExpr();
@@ -11678,7 +11678,7 @@ pattern0
     | pattern0 '*'      {
                             parser->checkPattern($1, true);
                             if ($1.queryExpr()->queryRecord())
-                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use * on a rule with associated an row");
+                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use * on a rule with an associated row");
 
                             IHqlExpression * pattern = $1.getExpr();
                             $$.setExpr(createValue(no_pat_repeat, parser->getCompoundRuleType(pattern), pattern));
@@ -11686,7 +11686,7 @@ pattern0
     | pattern0 '+'      {
                             parser->checkPattern($1, true);
                             if ($1.queryExpr()->queryRecord())
-                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use + on a rule with associated an row");
+                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use + on a rule with an associated row");
 
                             IHqlExpression * pattern = $1.getExpr();
                             $$.setExpr(createValue(no_pat_repeat, parser->getCompoundRuleType(pattern), pattern, createConstantOne(), createValue(no_any, makeNullType())));
@@ -11710,7 +11710,7 @@ pattern0
                             parser->normalizeExpression($3, type_int, true);
                             parser->checkPattern($1, true);
                             if ($1.queryExpr()->queryRecord())
-                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use * on a rule with associated an row");
+                                parser->reportError(ERR_AMBIGUOUS_PRODUCTION, $1, "Cannot use * on a rule with an associated row");
 
                             IHqlExpression * pattern = $1.getExpr();
                             IHqlExpression * count = $3.getExpr();

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -8778,7 +8778,7 @@ IHqlExpression * HqlGram::associateSideEffects(IHqlExpression * expr, const ECLl
         }
         else
         {
-            reportError(ERR_RESULT_IGNORED, errpos, "WHEN must be used to associated an action with a definition");
+            reportError(ERR_RESULT_IGNORED, errpos, "WHEN must be used to associate an action with a definition");
         }
         clearSideEffects();
     }


### PR DESCRIPTION
Corrects spelling and grammar in the files ecl/hql/hqlgram.y and
ecl/hql/hqlgram2.cpp regarding several error messages.

Signed-off-by: jamienoss james.noss@lexisnexis.com
