### PR TITLE
HPCC-9904 - ensure detach checks if allowed to delete file

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -945,7 +945,6 @@ public:
     bool getProtectedInfo(const CDfsLogicalFileName &logicalname, StringArray &names, UnsignedArray &counts);
     IDFProtectedIterator *lookupProtectedFiles(const char *owner=NULL,bool notsuper=false,bool superonly=false);
 
-    static bool cannotRemove(CDfsLogicalFileName &name,IUserDescriptor *user,StringBuffer &reason,bool ignoresub, unsigned timeoutms);
     void setFileProtect(CDfsLogicalFileName &dlfn,IUserDescriptor *user, const char *owner, bool set, const INode *foreigndali=NULL,unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT);
 
     unsigned setDefaultTimeout(unsigned timems)
@@ -2801,7 +2800,13 @@ protected:
                         ThrowStringException(-1, "Cluster %s not present in file %s", clusterName.str(), logicalName.get());
                 }
             }
-
+            if (removeFile)
+            {
+                // check can remove, e.g. cannot if this is a subfile of a super
+                StringBuffer reason;
+                if (!canRemove(reason))
+                    throw MakeStringException(-1,"detach: %s", reason.str());
+            }
             // detach this IDistributeFile
             writeLock.clear();
             root.setown(closeConnection(removeFile));


### PR DESCRIPTION
Regression introduced by HPCC-8364, allowed logical files to be
deleted by various components (e.g. thor writing to a file) even
if logical file was owned by a superfile.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
