### PR TITLE
HPCC-9682 Add WsWorkunits method to return paged QuerySet Queries

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2403,25 +2403,25 @@ public:
             StringAttr xPath;
             StringAttr sortOrder;
 
-            void getQuerySetQueries(const char* querySetId, IPropertyTree* querySetTree, const char *xPath, IPropertyTree* queryTreeRoot)
+            void populateQueryTree(const char* querySetId, IPropertyTree* querySetTree, const char *xPath, IPropertyTree* queryTree)
             {
                 Owned<IPropertyTreeIterator> iter = querySetTree->getElements(xPath);
                 ForEach(*iter)
                 {
                     IPropertyTree &query = iter->query();
-                    IPropertyTree *queryWithSetId = queryTreeRoot->addPropTree("Query", LINK(&query));
+                    IPropertyTree *queryWithSetId = queryTree->addPropTree("Query", LINK(&query));
                     queryWithSetId->addProp("@querySetId", querySetId);
                 }
             }
 
             IPropertyTree* getAllQuerySetQueries(IRemoteConnection* conn, const char *querySet, const char *xPath)
             {
-                Owned<IPropertyTree> queryTreeRoot = createPTree("Queries");
+                Owned<IPropertyTree> queryTree = createPTree("Queries");
                 IPropertyTree* root = conn->queryRoot();
                 if (querySet && *querySet)
                 {
                     VStringBuffer path("QuerySet[@id='%s']/Query%s", querySet, xPath);
-                    getQuerySetQueries(querySet, root, path.str(), queryTreeRoot);
+                    populateQueryTree(querySet, root, path.str(), queryTree);
                 }
                 else
                 {
@@ -2433,11 +2433,11 @@ public:
                         if (id && *id)
                         {
                             VStringBuffer path("Query%s", xPath);
-                            getQuerySetQueries(id, &querySet, path.str(), queryTreeRoot);
+                            populateQueryTree(id, &querySet, path.str(), queryTree);
                         }
                     }
                 }
-                return queryTreeRoot.getClear();
+                return queryTree.getClear();
             }
 
         public:

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1027,7 +1027,6 @@ interface IConstWorkUnitIterator : extends IScmIterator
     virtual IConstWorkUnit & query() = 0;
 };
 
-
 //! IWUTimers
 
 interface IWUTimers : extends IInterface
@@ -1085,6 +1084,29 @@ enum WUSortField
     WUSFwild = 2048
 };
 
+enum WUQuerySortField
+{
+    WUQSFId = 1,
+    WUQSFname = 2,
+    WUQSFwuid = 3,
+    WUQSFdll = 4,
+    WUQSFmemoryLimit = 5,
+    WUQSFmemoryLimitHi = 6,
+    WUQSFtimeLimit = 7,
+    WUQSFtimeLimitHi = 8,
+    WUQSFwarnTimeLimit = 9,
+    WUQSFwarnTimeLimitHi = 10,
+    WUQSFpriority = 11,
+    WUQSFpriorityHi = 12,
+    WUQSFQuerySet = 13,
+    WUQSFterm = 0,
+    WUQSFreverse = 256,
+    WUQSFnocase = 512,
+    WUQSFnumeric = 1024,
+    WUQSFwild = 2048
+};
+
+typedef IIteratorOf<IPropertyTree> IConstQuerySetQueryIterator;
 
 
 interface IWorkUnitFactory : extends IInterface
@@ -1105,6 +1127,7 @@ interface IWorkUnitFactory : extends IInterface
     virtual unsigned numWorkUnitsFiltered(WUSortField * filters, const void * filterbuf) = 0;
     virtual void descheduleAllWorkUnits() = 0;
     virtual bool deleteWorkUnitEx(const char * wuid) = 0;
+    virtual IConstQuerySetQueryIterator * getQuerySetQueriesSorted(WUQuerySortField *sortorder, WUQuerySortField *filters, const void *filterbuf, unsigned startoffset, unsigned maxnum, __int64 *cachehint, unsigned *total) = 0;
 };
 
 

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -263,17 +263,22 @@ interface ISortedElementsTreeFilter : extends IInterface
 {
     virtual bool isOK(IPropertyTree &tree) = 0;
 };
-
-extern da_decl IRemoteConnection *getElementsPaged( const char *basexpath, 
-                                     const char *xpath, 
+interface IElementsPager : extends IInterface
+{
+    virtual IRemoteConnection *getElements(IArrayOf<IPropertyTree> &elements) = 0;
+};
+extern da_decl void sortElements( IPropertyTreeIterator* elementsIter,
                                      const char *sortorder, 
+                                     const char *namefilterlo, // if non null filter less than this value
+                                     const char *namefilterhi, // if non null filter greater than this value
+                                     IArrayOf<IPropertyTree> &sortedElements);
+
+extern da_decl IRemoteConnection *getElementsPaged(IElementsPager *elementsPager,
                                      unsigned startoffset, 
                                      unsigned pagesize, 
                                      ISortedElementsTreeFilter *postfilter, // if non-NULL filters before adding to page
                                      const char *owner,
                                      __int64 *hint,                         // if non null points to in/out cache hint
-                                     const char *namefilterlo, // if non null filter less than this value
-                                     const char *namefilterhi, // if non null filter greater than this value
                                      IArrayOf<IPropertyTree> &results,
                                      unsigned *total); // total possible filtered matches, i.e. irrespective of startoffset and pagesize
 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1169,6 +1169,7 @@ ESPStruct [nil_remove] QuerySetQuery
     nonNegativeInteger warnTimeLimit;
     string priority;
     string Comment;
+    [min_ver("1.45")] string QuerySetId;
 };
 
 ESPStruct QuerySetAlias
@@ -1203,6 +1204,33 @@ ESPresponse [exceptions_inline] WUQuerySetDetailsResponse
     [min_ver("1.37")] string  Filter;
     [min_ver("1.37")] ESPenum WUQuerySetFilterType FilterType;
     [min_ver("1.37")] ESParray<string> ClusterNames;
+};
+
+ESPrequest [nil_remove] WUListQueriesRequest
+{
+    string  QuerySetName;
+    string  ClusterName;
+    int64 MemoryLimitLow;
+    int64 MemoryLimitHigh;
+    nonNegativeInteger TimeLimitLow;
+    nonNegativeInteger TimeLimitHigh;
+    nonNegativeInteger WarnTimeLimitLow;
+    nonNegativeInteger WarnTimeLimitHigh;
+    nonNegativeInteger PriorityLow;
+    nonNegativeInteger PriorityHigh;
+
+    nonNegativeInteger PageSize(0);
+    nonNegativeInteger PageStartFrom(0);
+    string Sortby;
+    bool Descending(false);
+    int64 CacheHint;
+};
+
+ESPresponse [exceptions_inline] WUListQueriesResponse
+{
+    int   NumberOfQueries;
+    int64 CacheHint;
+    ESParray<ESPstruct QuerySetQuery> QuerysetQueries;
 };
 
 ESPrequest WUQueryDetailsRequest
@@ -1362,7 +1390,7 @@ ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
 };
 
 ESPservice [
-    version("1.44"), default_client_version("1.44"),
+    version("1.45"), default_client_version("1.45"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);
@@ -1429,6 +1457,7 @@ ESPservice [
     ESPmethod WUQuerysetCopyQuery(WUQuerySetCopyQueryRequest, WUQuerySetCopyQueryResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/WUCopyLogicalFiles.xslt")] WUCopyLogicalFiles(WUCopyLogicalFilesRequest, WUCopyLogicalFilesResponse);
     ESPmethod WUQueryConfig(WUQueryConfigRequest, WUQueryConfigResponse);
+    ESPmethod WUListQueries(WUListQueriesRequest, WUListQueriesResponse);
 };
 
 

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -108,6 +108,7 @@ public:
     void setPort(unsigned short _port){port=_port;}
 
     bool isQuerySuspended(const char* query, IConstWUClusterInfo *clusterInfo, unsigned wait, StringBuffer& errorMessage);
+    bool onWUListQueries(IEspContext &context, IEspWUListQueriesRequest &req, IEspWUListQueriesResponse &resp);
 
 private:
     unsigned awusCacheMinutes;


### PR DESCRIPTION
This fix adds new WsWorkunits method 'WUListQueries' to return
QuerySet Queries with paging/sorting options.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
