### PR TITLE
HPCC-9935 Add SourceFormat to ESP FileSpray/SprayFixed request

### DIFF
--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -279,7 +279,7 @@ ESPrequest [nil_remove] SprayFixed
     string sourceIP;
     string sourcePath;
     binary srcxml;
-    string sourceFormat;
+    [min_ver("1.09")] string sourceFormat;
     int sourceRecordSize;
 
     string destGroup;
@@ -600,7 +600,7 @@ ESPresponse [exceptions_inline] UploadFilesResponse
 };
 
 ESPservice [
-    version("1.08"), default_client_version("1.08"),
+    version("1.09"), default_client_version("1.09"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
 {
     ESPuses ESPstruct DFUWorkunit;

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -279,6 +279,7 @@ ESPrequest [nil_remove] SprayFixed
     string sourceIP;
     string sourcePath;
     binary srcxml;
+    string sourceFormat;
     int sourceRecordSize;
 
     string destGroup;


### PR DESCRIPTION
In new ECLWatch UI, the SprayFixed Input page may add a Source
Format selection which contains: fixed, recfmv, recfmvb, and
variable. The FileSpray/SprayFixed should read the selection and
forward the selection to DFU workunit.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
