### PR TITLE
HPCC-9827 - Base roxiemem allocator cache on flags as well

### DIFF
--- a/common/thorhelper/roxierow.hpp
+++ b/common/thorhelper/roxierow.hpp
@@ -28,17 +28,16 @@ extern THORHELPER_API IEngineRowAllocator * createCrcRoxieRowAllocator(roxiemem:
 
 interface IRowAllocatorMetaActIdCache : extends roxiemem::IRowAllocatorCache
 {
-    virtual bool add(IEngineRowAllocator *allocator, IOutputMetaData *meta, unsigned activityId) = 0;
-    virtual bool remove(IOutputMetaData *meta, unsigned activityId) = 0;
-    virtual IEngineRowAllocator *lookup(IOutputMetaData *meta, unsigned activityId) const = 0;
-    virtual IEngineRowAllocator *ensure(IOutputMetaData * meta, unsigned activityId) = 0;
+    virtual bool remove(IOutputMetaData *meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) = 0;
+    virtual IEngineRowAllocator *lookup(IOutputMetaData *meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) const = 0;
+    virtual IEngineRowAllocator *ensure(IOutputMetaData * meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) = 0;
     virtual void clear() = 0;
     virtual unsigned items() const = 0;
 };
 
 interface IRowAllocatorMetaActIdCacheCallback
 {
-    virtual IEngineRowAllocator *createAllocator(IOutputMetaData *meta, unsigned activityId, unsigned cacheId) const = 0;
+    virtual IEngineRowAllocator *createAllocator(IOutputMetaData *meta, unsigned activityId, unsigned cacheId, roxiemem::RoxieHeapFlags flags) const = 0;
 };
 
 extern THORHELPER_API IRowAllocatorMetaActIdCache *createRowAllocatorCache(IRowAllocatorMetaActIdCacheCallback *callback);

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -609,7 +609,7 @@ public:
     }
     virtual IEngineRowAllocator * getRowAllocator(IOutputMetaData * meta, unsigned activityId) const
     {
-        return allocatorMetaCache->ensure(meta, activityId);
+        return allocatorMetaCache->ensure(meta, activityId, roxiemem::RHFnone);
     }
     virtual const char *cloneVString(const char *str) const
     {
@@ -633,9 +633,9 @@ public:
     virtual void updateWULogfile();
 
 // roxiemem::IRowAllocatorMetaActIdCacheCallback
-    virtual IEngineRowAllocator *createAllocator(IOutputMetaData *meta, unsigned activityId, unsigned id) const
+    virtual IEngineRowAllocator *createAllocator(IOutputMetaData *meta, unsigned activityId, unsigned id, roxiemem::RoxieHeapFlags flags) const
     {
-        return createRoxieRowAllocator(*rowManager, meta, activityId, id, roxiemem::RHFnone);
+        return createRoxieRowAllocator(*rowManager, meta, activityId, id, flags);
     }
 };
 

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -1210,7 +1210,7 @@ public:
 
     virtual IEngineRowAllocator *getRowAllocator(IOutputMetaData * meta, unsigned activityId) const
     {
-        return allocatorMetaCache->ensure(meta, activityId);
+        return allocatorMetaCache->ensure(meta, activityId, roxiemem::RHFnone);
     }
 
     virtual const char *cloneVString(const char *str) const
@@ -1242,9 +1242,9 @@ public:
     }
 
 // roxiemem::IRowAllocatorMetaActIdCacheCallback
-    virtual IEngineRowAllocator *createAllocator(IOutputMetaData *meta, unsigned activityId, unsigned id) const
+    virtual IEngineRowAllocator *createAllocator(IOutputMetaData *meta, unsigned activityId, unsigned id, roxiemem::RoxieHeapFlags flags) const
     {
-        return createRoxieRowAllocator(*rowManager, meta, activityId, id, roxiemem::RHFnone);
+        return createRoxieRowAllocator(*rowManager, meta, activityId, id, flags);
     }
 
     virtual void getResultRowset(size32_t & tcount, byte * * & tgt, const char * stepname, unsigned sequence, IEngineRowAllocator * _rowAllocator, bool isGrouped, IXmlToRowTransformer * xmlTransformer, ICsvToRowTransformer * csvTransformer)

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -2615,6 +2615,8 @@ public:
         iHash = helper->queryHash();
         appendOutputLinked(this);
         iCompare = helper->queryCompare();
+
+        // JCSMORE - really should ask / lookup what flags the allocator created for extractKey has...
         allocFlags = queryJob().queryThorAllocator()->queryFlags();
 
         // JCSMORE - it may not be worth extracting the key,

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -1625,13 +1625,9 @@ class CMultiCoreJoinHelper: public CMultiCoreJoinHelperBase
         {
             PROGLOG("CMultiCoreJoinHelper::cWorker started");
 
-            // Create an allocator per thread, to avoid heavy contention
-            // JCSMORE - there should be a way to ask the cache for an allocator that is based on flags
-            activity_id activityId = parent->activity.queryContainer().queryId();
+            CJobBase &job = parent->activity.queryJob();
             Owned<IRowInterfaces> rowIf = parent->activity.getRowInterfaces();
-            IOutputMetaData *meta = rowIf->queryRowMetaData();
-            roxiemem::IRowManager *rowManager = parent->activity.queryJob().queryRowManager();
-            Owned<IEngineRowAllocator> allocator = createRoxieRowAllocator(*rowManager, meta, activityId, 1, (roxiemem::RoxieHeapFlags)(roxiemem::RHFpacked|roxiemem::RHFunique));
+            Owned<IEngineRowAllocator> allocator = job.getRowAllocator(rowIf->queryRowMetaData(), parent->activity.queryActivityId(), (roxiemem::RoxieHeapFlags)(roxiemem::RHFpacked|roxiemem::RHFunique));
 
             // JCSMORE - could have a spilling variety instead here..
             rowStream.setown(createSmartInMemoryBuffer(&parent->activity, parent->rowIf, SMALL_SMART_BUFFER_SIZE));
@@ -1830,13 +1826,9 @@ class CMultiCoreUnorderedJoinHelper: public CMultiCoreJoinHelperBase
         }
         int run()
         {
-            // Create an allocator per thread, to avoid heavy contention
-            // JCSMORE - there should be a way to ask the cache for an allocator that is based on flags
-            activity_id activityId = parent->activity.queryContainer().queryId();
+            CJobBase &job = parent->activity.queryJob();
             Owned<IRowInterfaces> rowIf = parent->activity.getRowInterfaces();
-            IOutputMetaData *meta = rowIf->queryRowMetaData();
-            roxiemem::IRowManager *rowManager = parent->activity.queryJob().queryRowManager();
-            Owned<IEngineRowAllocator> allocator = createRoxieRowAllocator(*rowManager, meta, activityId, 1, (roxiemem::RoxieHeapFlags)(roxiemem::RHFpacked|roxiemem::RHFunique));
+            Owned<IEngineRowAllocator> allocator = job.getRowAllocator(rowIf->queryRowMetaData(), parent->activity.queryActivityId(), (roxiemem::RoxieHeapFlags)(roxiemem::RHFpacked|roxiemem::RHFunique));
 
             Owned<IRowWriter> rowWriter = parent->multiWriter->getWriter();
             PROGLOG("CMulticoreUnorderedJoinHelper::cWorker started");

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2728,7 +2728,7 @@ void CJobBase::runSubgraph(CGraphBase &graph, size32_t parentExtractSz, const by
 
 IEngineRowAllocator *CJobBase::getRowAllocator(IOutputMetaData * meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) const
 {
-    return thorAllocator->getRowAllocator(meta, activityId);
+    return thorAllocator->getRowAllocator(meta, activityId, flags);
 }
 
 roxiemem::IRowManager *CJobBase::queryRowManager() const

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -151,6 +151,7 @@ private:
 
 interface IThorAllocator : extends IInterface
 {
+    virtual IEngineRowAllocator *getRowAllocator(IOutputMetaData * meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) const = 0;
     virtual IEngineRowAllocator *getRowAllocator(IOutputMetaData * meta, unsigned activityId) const = 0;
     virtual roxiemem::IRowManager *queryRowManager() const = 0;
     virtual roxiemem::RoxieHeapFlags queryFlags() const = 0;


### PR DESCRIPTION
Previously the roxiemem cache was based on meta and activity id
only, so it couldn't differentiate between allocators of
different types used by the same allocator.
Also ensure that when Thor activities ask for a unique allocator
they bypass the cache.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
