### PR TITLE
HPCC-8867 - Fill in @kind file attribute for all files

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1259,7 +1259,7 @@ public:
                                 fdesc->queryProperties().setProp("@roxiePrefix", newroxieprefix.str());
                             if (iskey)
                                 fdesc->queryProperties().setProp("@kind", "key");
-                            else if (kind.length()) // JCSMORE may not really need seperate if (iskey) line above
+                            else if (kind.length()) // JCSMORE may not really need separate "if (iskey)" line above
                                 fdesc->queryProperties().setProp("@kind", kind);
                             if (multiclusterinsert||multiclustermerge) 
                                 multifdesc.setown(fdesc.getClear());

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -735,6 +735,7 @@ void CHThorDiskWriteActivity::setFormat(IFileDescriptor * desc)
     const char *recordECL = helper.queryRecordECL();
     if (recordECL && *recordECL)
         desc->queryProperties().setProp("ECL", recordECL);
+    desc->queryProperties().setProp("@kind", "flat");
 }
 
 void CHThorDiskWriteActivity::checkSizeLimit()
@@ -867,6 +868,7 @@ void CHThorCsvWriteActivity::setFormat(IFileDescriptor * desc)
     desc->queryProperties().setProp("@csvTerminate", rs.setown(csvInfo->getTerminator(0)));
     desc->queryProperties().setProp("@csvEscape", rs.setown(csvInfo->getEscape(0)));
     desc->queryProperties().setProp("@format","utf8n");
+    desc->queryProperties().setProp("@kind", "csv");
 }
 
 //=====================================================================================================
@@ -929,6 +931,7 @@ void CHThorXmlWriteActivity::setFormat(IFileDescriptor * desc)
 {
     desc->queryProperties().setProp("@format","utf8n");
     desc->queryProperties().setProp("@rowTag",rowTag.str());
+    desc->queryProperties().setProp("@kind", "xml");
 }
 
 //=====================================================================================================

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10852,6 +10852,7 @@ public:
         const char *recordECL = helper.queryRecordECL();
         if (recordECL && *recordECL)
             fileProps.setProp("ECL", recordECL);
+        fileProps.setProp("@kind", "flat"); // default, derivitives may override
     }
 
     virtual IUserDescriptor *queryUserDescriptor() const
@@ -10937,6 +10938,7 @@ public:
         props.setProp("@csvQuote", rs.setown(csvParameters->getQuote(0)));
         props.setProp("@csvTerminate", rs.setown(csvParameters->getTerminator(0)));
         props.setProp("@csvEscape", rs.setown(csvParameters->getEscape(0)));
+        props.setProp("@kind", "csv");
     }
 
     virtual bool isOutputTransformed() const { return true; }
@@ -11008,6 +11010,7 @@ public:
         CRoxieServerDiskWriteActivity::setFileProperties(desc);
         desc->queryProperties().setProp("@format","utf8n");
         desc->queryProperties().setProp("@rowTag",rowTag.get());
+        desc->queryProperties().setProp("@kind", "xml");
     }
 
     virtual bool isOutputTransformed() const { return true; }

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -507,7 +507,7 @@ extern jlib_decl bool endsWithIgnoreCase(const char* src, const char* dst);
 
 inline bool strieq(const char* s, const char* t) { return stricmp(s,t)==0; }
 inline bool streq(const char* s, const char* t) { return strcmp(s,t)==0; }
-inline bool strsame(const char* s, const char* t) { return (s == t) || (!s && !t && strcmp(s,t)==0); }  // also allow nulls
+inline bool strsame(const char* s, const char* t) { return (s == t) || (s && t && strcmp(s,t)==0); }  // also allow nulls
 
 extern jlib_decl char *j_strtok_r(char *str, const char *delim, char **saveptr);
 extern jlib_decl int j_memicmp (const void *s1, const void *s2, size32_t len); 

--- a/thorlcr/activities/diskwrite/thdiskwrite.cpp
+++ b/thorlcr/activities/diskwrite/thdiskwrite.cpp
@@ -60,8 +60,8 @@ public:
     void done()
     {
         IPropertyTree &props = fileDesc->queryProperties();
-        props.setPropBool("@csv", true);
         props.setProp("@format", "utf8n");
+        props.setProp("@kind", "csv");
         IHThorCsvWriteArg *helper=(IHThorCsvWriteArg *)queryHelper();
         ICsvParameters *csvParameters = helper->queryCsvParameters();
         StringBuffer separator;

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -76,6 +76,7 @@ public:
         OwnedRoxieString outputName(helper->getOutputName());
         fillClusterArray(container.queryJob(), outputName, clusters, groups);
         patchDesc.setown(queryThorFileManager().create(container.queryJob(), outputName, clusters, groups, 0 != (KDPoverwrite & helper->getFlags()), 0, !local, width));
+        patchDesc->queryProperties().setProp("@kind", "keydiff");
     }
     void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {

--- a/thorlcr/activities/spill/thspill.cpp
+++ b/thorlcr/activities/spill/thspill.cpp
@@ -57,7 +57,7 @@ public:
             props.setPropBool("@blockCompressed", true);        
         if (0 != (helper->getFlags() & TDXgrouped))
             fileDesc->queryProperties().setPropBool("@grouped", true);
-
+        props.setProp("@kind", "flat");
         if (container.queryOwner().queryOwner() && (!container.queryOwner().isGlobal())) // I am in a child query
         { // do early, because this will be local act. and will not come back to master until end of owning graph.
             container.queryTempHandler()->registerFile(fname, container.queryOwner().queryGraphId(), helper->getTempUsageCount(), TDXtemporary & helper->getFlags(), getDiskOutputKind(helper->getFlags()), &clusters);

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -283,6 +283,7 @@ void CWriteMasterBase::init()
             blockCompressed = true;
         if (blockCompressed)
             props.setPropBool("@blockCompressed", true);
+        props.setProp("@kind", "flat");
         if (TAKdiskwrite == container.getKind() && (0 != (diskHelperBase->getFlags() & TDXtemporary)) && container.queryOwner().queryOwner() && (!container.queryOwner().isGlobal())) // I am in a child query
         { // do early, because this will be local act. and will not come back to master until end of owning graph.
             publish();

--- a/thorlcr/activities/xmlwrite/thxmlwrite.cpp
+++ b/thorlcr/activities/xmlwrite/thxmlwrite.cpp
@@ -52,6 +52,7 @@ public:
         }
         props.setProp("@rowTag", rowTag.str());
         props.setProp("@format", "utf8n");
+        props.setProp("@kind", "xml");
     }
 };
 

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1470,6 +1470,7 @@ void CJobMaster::saveSpills()
             fillClusterArray(*this, tmpName, clusters, groups);
             Owned<IFileDescriptor> fileDesc = queryThorFileManager().create(*this, tmpName, clusters, groups, true, TDXtemporary|TDWnoreplicate);
             fileDesc->queryProperties().setPropBool("@pausefile", true); // JCSMORE - mark to keep, may be able to distinguish via other means
+            fileDesc->queryProperties().setProp("@kind", "flat");
 
             IPropertyTree &props = fileDesc->queryProperties();
             props.setPropBool("@owned", true);


### PR DESCRIPTION
The @kind meta field was only filled for keys.
Useful also to be able to distinguis between flag,xml & csv

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
