### PR TITLE
HPCC-9919 Fix core accessing uncompressed workunit resources

### DIFF
--- a/common/dllserver/thorplugin.hpp
+++ b/common/dllserver/thorplugin.hpp
@@ -44,6 +44,7 @@ extern DLLSERVER_API bool getManifestXMLFromFile(const char *filename, StringBuf
 
 extern DLLSERVER_API bool decompressResource(size32_t len, const void *data, StringBuffer &result);
 extern DLLSERVER_API void compressResource(MemoryBuffer & compressed, size32_t len, const void *data);
+extern DLLSERVER_API void appendResource(MemoryBuffer & mb, size32_t len, const void *data, bool compress);
 
 class DLLSERVER_API SimplePluginCtx : implements IPluginContextEx
 {

--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -435,7 +435,7 @@ void WuWebView::getResource(IPropertyTree *res, StringBuffer &content)
 {
     if (!loadDll())
         return;
-    if (res->hasProp("@id"))
+    if (res->hasProp("@id") && (res->hasProp("@header")||res->hasProp("@compressed")))
     {
         int id = res->getPropInt("@id");
         size32_t len = 0;

--- a/system/jlib/jlzw.cpp
+++ b/system/jlib/jlzw.cpp
@@ -685,6 +685,12 @@ Escape:
     return (size32_t)(in-(const byte *)src);
 }
 
+void appendToBuffer(MemoryBuffer & out, size32_t len, const void * src)
+{
+    out.append(false);
+    out.append(len);
+    out.append(len, src);
+}
 
 void compressToBuffer(MemoryBuffer & out, size32_t len, const void * src)
 {
@@ -696,7 +702,7 @@ void compressToBuffer(MemoryBuffer & out, size32_t len, const void * src)
     Owned<ICompressor> compressor = createLZWCompressor();
     void *newData = out.reserve(newSize);
     compressor->open(newData, newSize);
-    if (compressor->write(src, len)==len)
+    if (len>=32 && compressor->write(src, len)==len)
     {
         compressor->close();
         size32_t compressedLen = compressor->buflen();
@@ -707,9 +713,7 @@ void compressToBuffer(MemoryBuffer & out, size32_t len, const void * src)
     else // all or don't compress
     {
         out.setWritePos(originalLength);
-        out.append(false);
-        out.append(len);
-        out.append(len, src);
+        appendToBuffer(out, len, src);
     }
 }
 

--- a/system/jlib/jlzw.hpp
+++ b/system/jlib/jlzw.hpp
@@ -90,6 +90,8 @@ extern jlib_decl void decompressToBuffer(MemoryBuffer & out, const void * src);
 extern jlib_decl void decompressToBuffer(MemoryBuffer & out, MemoryBuffer & in);
 extern jlib_decl void decompressToAttr(MemoryAttr & out, const void * src);
 extern jlib_decl void decompressToBuffer(MemoryAttr & out, MemoryBuffer & in);
+extern jlib_decl void appendToBuffer(MemoryBuffer & out, size32_t len, const void * src); //format as failed compression
+
 
 #define COMPRESS_METHOD_ROWDIF 1
 #define COMPRESS_METHOD_LZW    2


### PR DESCRIPTION
The technique used to store the size and retrieve the size of stored
resources were not compatible.  As most resources are formatted
with headers designed to support compression this is usually not
noticed.  But resources stored without the headers would fail because
they relied on the size that was stored as an absolute data resource.

Headers will now always be stored with resources whether attempting to
compress them or not.  The size will be retrieved from the headers.

The old size information is still stored as it can be retrieved in
other ways besides the dlopen/dlsym technique used by dllserver.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
