### PR TITLE
HPCC-9349 - HTTPCALL still failing due to missing line in commit

### DIFF
--- a/thorlcr/master/thactivitymaster.cpp
+++ b/thorlcr/master/thactivitymaster.cpp
@@ -150,6 +150,7 @@ public:
             case TAKsoap_rowaction:
             case TAKsoap_datasetdataset:
             case TAKsoap_datasetaction:
+            case TAKhttp_rowdataset:
                 ret = new CMasterActivity(this);
                 break;
             case TAKskipcatch:


### PR DESCRIPTION
Previous commit (gh-4402) had a missing line in the the thor
master code that create the activity type, causing HTTPCALL still
to fail with 'unsupported acitivty kind'

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
