### PR TITLE
HPCC-9961 Expose contents of @kind DFU attribute in WsDFU/DFUInfo

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -105,6 +105,7 @@ ESPStruct DFUFileDetail
     [min_ver("1.06")] bool FromRoxieCluster;
     [min_ver("1.07")] ESParray<string, ECLGraph> Graphs;
     [min_ver("1.09")] string UserPermission;
+    [min_ver("1.21")] string ContentType;
 };
 
 ESPStruct DFUSpaceItem
@@ -626,7 +627,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.20"), default_client_version("1.20"),
+    version("1.21"), default_client_version("1.21"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1747,6 +1747,9 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     //@format - what format the file is (if not fixed with)
     FileDetails.setFormat(df->queryAttributes().queryProp("@format"));
 
+    if ((version >= 1.21) && (df->queryAttributes().hasProp("@kind")))
+        FileDetails.setContentType(df->queryAttributes().queryProp("@kind"));
+
     //@maxRecordSize - what the maximum length of records is
     FileDetails.setMaxRecordSize(df->queryAttributes().queryProp("@maxRecordSize"));
 


### PR DESCRIPTION
It is requested that WsDFU should expose contents of @kind DFU attribute
as new field ContentType. This fix exposes the contents of @kind DFU
attribute.
