### PR TITLE
HPPC-10010 - Fix race condition in multicore join helper

### DIFF
--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -1620,6 +1620,8 @@ class CMultiCoreJoinHelper: public CMultiCoreJoinHelperBase
             : Thread("CMultiCoreJoinHelper::cWorker"), parent(_parent), work(activity)
         {
             stopped = false;
+            // JCSMORE - could have a spilling variety instead here..
+            rowStream.setown(createSmartInMemoryBuffer(&parent->activity, parent->rowIf, SMALL_SMART_BUFFER_SIZE));
         }
         int run()
         {
@@ -1633,8 +1635,6 @@ class CMultiCoreJoinHelper: public CMultiCoreJoinHelperBase
             roxiemem::IRowManager *rowManager = parent->activity.queryJob().queryRowManager();
             Owned<IEngineRowAllocator> allocator = createRoxieRowAllocator(*rowManager, meta, activityId, 1, (roxiemem::RoxieHeapFlags)(roxiemem::RHFpacked|roxiemem::RHFunique));
 
-            // JCSMORE - could have a spilling variety instead here..
-            rowStream.setown(createSmartInMemoryBuffer(&parent->activity, parent->rowIf, SMALL_SMART_BUFFER_SIZE));
             IRowWriter *rowWriter = rowStream->queryWriter();
             loop
             {

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -1674,6 +1674,7 @@ public:
         : CMultiCoreJoinHelperBase(activity, numthreads, selfJoin, _jhelper, _helper, _rowIf)
     {
         reader.parent = this;
+        stopped = false;
         workers = new cWorker *[numthreads];
         curin = 0;
         curout = 0;


### PR DESCRIPTION
worker threads creating reader pipe stream too late.
Reader could start reading before created by thread.
Move create to worker constructor.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
