### PR TITLE
HPCC-9984 Compile direct from a version control system

### DIFF
--- a/common/remote/hooks/git/gitfile.cpp
+++ b/common/remote/hooks/git/gitfile.cpp
@@ -81,7 +81,7 @@ public:
     IMPLEMENT_IINTERFACE;
     GitRepositoryFileIO(const char * gitDirectory, const char * revision, const char * relFileName)
     {
-        VStringBuffer gitcmd("git --git-dir=%s show %s:%s", gitDirectory, revision ? revision : "HEAD", relFileName);
+        VStringBuffer gitcmd("git --git-dir=%s show %s:%s", gitDirectory, (revision && *revision) ? revision : "HEAD", relFileName);
         Owned<IPipeProcess> pipe = createPipeProcess();
         if (pipe->run("git", gitcmd, ".", false, true, false, 0))
         {

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1686,10 +1686,9 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
     for (; !iter.done(); iter.next())
     {
         const char * arg = iter.query();
-        if (memcmp(arg, "-a", 2)==0)
+        if (iter.matchFlag(tempArg, "-a"))
         {
-            if (arg[2])
-                applicationOptions.append(arg+2);
+            applicationOptions.append(tempArg);
         }
         else if (iter.matchOption(tempArg, "--allow"))
         {
@@ -1724,10 +1723,9 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
         else if (iter.matchFlag(optArchive, "-E"))
         {
         }
-        else if (memcmp(arg, "-f", 2)==0)
+        else if (iter.matchFlag(tempArg, "-f"))
         {
-            if (arg[2])
-                debugOptions.append(arg+2);
+            debugOptions.append(tempArg);
         }
         else if (iter.matchFlag(tempBool, "-g"))
         {

--- a/ecl/eclccserver/CMakeLists.txt
+++ b/ecl/eclccserver/CMakeLists.txt
@@ -52,3 +52,5 @@ target_link_libraries ( eclccserver
          workunit
     )
 
+HPCC_ADD_SUBDIRECTORY (vchooks "PLATFORM")
+

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -233,7 +233,10 @@ class EclccCompileThread : public CInterface, implements IPooledThread, implemen
         }
         else if (strchr(option, '-'))
         {
-            StringBuffer envVar(option);
+            StringBuffer envVar;
+            if (isLocal)
+                envVar.append("WU_");
+            envVar.append(option);
             envVar.toUpperCase();
             envVar.replace('-','_');
             pipe.setenv(envVar, value);

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -300,7 +300,7 @@ class EclccCompileThread : public CInterface, implements IPooledThread, implemen
             unsigned time = msTick();
             Owned<ErrorReader> errorReader = new ErrorReader(pipe, this);
             eclccCmd.insert(0, eclccProgName);
-            pipe->run("eclccProgName", eclccCmd, ".", true, false, true, 0);
+            pipe->run(eclccProgName, eclccCmd, ".", true, false, true, 0);
             errorReader->start();
             try
             {

--- a/ecl/eclccserver/vchooks/CMakeLists.txt
+++ b/ecl/eclccserver/vchooks/CMakeLists.txt
@@ -1,0 +1,21 @@
+################################################################################
+#    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+################################################################################
+
+FOREACH( iFILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/git.sh
+)
+    install ( PROGRAMS ${iFILES} DESTINATION ${EXEC_DIR} COMPONENT Runtime )
+ENDFOREACH ( iFILES )

--- a/ecl/eclccserver/vchooks/git.sh
+++ b/ecl/eclccserver/vchooks/git.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+################################################################################
+#    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+################################################################################
+
+################################################################################
+# Hook to use a git repository for eclcc compilation
+# Files will be fetched from the remote repo before each compile
+#
+# This hook expecte environment variables to be set as follows:
+# GIT_URL       - The remote repository location
+# GIT_BRANCH    - The branch/commit/tag to use  (if ommitted, master is assumed)
+# GIT_DIRECTORY - can be set to allow the dir to be maintained separately - it is
+#                 assumed (at present) that it will refer to a 'bare' repository
+################################################################################
+
+originalDir=$PWD
+if [ -z "$GIT_URL" ]; then
+    echo "Need to set GIT_URL" 1>&2
+    exit 2
+fi
+
+if [ -z "$GIT_BRANCH" ]; then
+    GIT_BRANCH=master
+    if [ -n "$GIT_VERBOSE" ]; then
+        echo "GIT: No branch specified - assuming master"
+    fi
+else
+    if [ -n "$GIT_VERBOSE" ]; then
+        echo "GIT: using branch $GIT_BRANCH" 1>&2
+    fi
+fi
+
+if [ -z "$GIT_DIRECTORY" ]; then
+    # We are executed in the eclccserver's home dir - typically /var/lib/HPCCSystems/myeclccserver
+    mkdir -p $PWD/repos/
+    if [ $? -ne 0 ]; then
+        echo "Unable to create directory $PWD/repos/" 1>&2
+        exit 2
+    fi
+    cd $PWD/repos/
+
+    # URL is likely to be of the form git@github.com:path/to/dir.git
+    # MORE - we could check it is of the expected form...
+    splitURL=(${GIT_URL//[:\/]/ })
+    splitLen=${#splitURL[@]}
+    tail=${splitURL[$splitLen-1]}
+
+    # tail is now the directory that git clone would create for this url
+    GIT_DIRECTORY=$PWD/$tail
+
+    if [ ! -d $GIT_DIRECTORY ] ; then
+        if [ -n "$GIT_VERBOSE" ]; then
+            echo "GIT: performing initial clone"
+            git clone --bare $GIT_URL 1>&2 || exit $?
+        else
+            git clone --bare $GIT_URL 2>&1 /dev/null
+            if [ $? -ne 0 ]; then
+                echo "Failed to run git clone $GIT_URL" 1>&2
+                exit 2
+            fi
+        fi
+    fi
+fi
+
+cd $GIT_DIRECTORY
+# MORE - may want to not do every time? Add option to check time since last fetched?
+if [ -n "$GIT_VERBOSE" ]; then
+    echo "GIT: using directory $GIT_DIRECTORY" 1>&2
+    git fetch $GIT_URL ${GIT_BRANCH}  1>&2 || exit $?
+else
+    git fetch $GIT_URL ${GIT_BRANCH} 2>&1 >/dev/null || exit $?
+    if [ $? -ne 0 ]; then
+        echo "Failed to run git fetch $GIT_URL ${GIT_BRANCH}" 1>&2
+        exit 2
+    fi
+fi
+
+cd $originalDir
+if [ -n "$GIT_VERBOSE" ]; then
+    echo GIT: calling eclcc -I$GIT_DIRECTORY/{$GIT_BRANCH}/ "$@"  1>&2
+fi
+eclcc -I$GIT_DIRECTORY/{$GIT_BRANCH}/ "$@"

--- a/ecl/eclccserver/vchooks/git.sh
+++ b/ecl/eclccserver/vchooks/git.sh
@@ -79,7 +79,7 @@ if [ -z "$GIT_DIRECTORY" ]; then
             echo "GIT: performing initial clone"
             git clone --bare $GIT_URL 1>&2 || exit $?
         else
-            git clone --bare $GIT_URL 2>&1 /dev/null
+            git clone --bare $GIT_URL 2>&1 >/dev/null
             if [ $? -ne 0 ]; then
                 echo "Failed to run git clone $GIT_URL" 1>&2
                 exit 2

--- a/ecl/eclccserver/vchooks/git.sh
+++ b/ecl/eclccserver/vchooks/git.sh
@@ -51,7 +51,7 @@ function fetch_repo {
     fi
 
     if [ -n "$wu_git_branch" ]; then
-        if [ -z git_branch_locked ]; then
+        if [ -z "$git_branch_locked" ]; then
             echo "GIT: Overriding branch is not allowed" 1>&2
             exit 2
         else

--- a/ecl/eclccserver/vchooks/git.sh
+++ b/ecl/eclccserver/vchooks/git.sh
@@ -27,82 +27,105 @@
 ################################################################################
 
 originalDir=$PWD
-if [ -z "$GIT_URL" ]; then
-    echo "Need to set GIT_URL" 1>&2
-    exit 2
-fi
-
 if [ -n "$WU_GIT_VERBOSE" ]; then
     GIT_VERBOSE=1
 fi
 
-if [ -n "$WU_GIT_BRANCH" ]; then
-    if [ -z GIT_BRANCH_LOCKED ]; then
-        echo "GIT: Overrideing branch is not allowed" 1>&2
-        exit 2
-    else
-        GIT_BRANCH=$WU_GIT_BRANCH
-    fi
-fi
+function fetch_repo {
+    repo=$1
+    prefix="$(echo $repo | tr '[a-z]' '[A-Z]')"
+    eval git_url=\${${prefix}_URL}
+    eval wu_git_branch=\${WU_${prefix}_BRANCH}
+    eval git_branch=\${${prefix}_BRANCH}
+    eval git_branch_locked=\${${prefix}_BRANCH_LOCKED}
+    eval git_directory=\${${prefix}_DIRECTORY}
 
-if [ -z "$GIT_BRANCH" ]; then
-    GIT_BRANCH=master
-    if [ -n "$GIT_VERBOSE" ]; then
-        echo "GIT: No branch specified - assuming master" 1>&2
-    fi
-else
-    if [ -n "$GIT_VERBOSE" ]; then
-        echo "GIT: using branch $GIT_BRANCH" 1>&2
-    fi
-fi
-
-if [ -z "$GIT_DIRECTORY" ]; then
-    # We are executed in the eclccserver's home dir - typically /var/lib/HPCCSystems/myeclccserver
-    mkdir -p $PWD/repos/
-    if [ $? -ne 0 ]; then
-        echo "Unable to create directory $PWD/repos/" 1>&2
+    if [ -z "$git_url" ]; then
+        echo "Need to set ${prefix}_URL" 1>&2
         exit 2
     fi
-    cd $PWD/repos/
 
-    # URL is likely to be of the form git@github.com:path/to/dir.git
-    # MORE - we could check it is of the expected form...
-    splitURL=(${GIT_URL//[:\/]/ })
-    splitLen=${#splitURL[@]}
-    tail=${splitURL[$splitLen-1]}
-
-    # tail is now the directory that git clone would create for this url
-    GIT_DIRECTORY=$PWD/$tail
-
-    if [ ! -d $GIT_DIRECTORY ] ; then
-        if [ -n "$GIT_VERBOSE" ]; then
-            echo "GIT: performing initial clone"
-            git clone --bare $GIT_URL 1>&2 || exit $?
+    if [ -n "$wu_git_branch" ]; then
+        if [ -z git_branch_locked ]; then
+            echo "GIT: Overriding branch is not allowed" 1>&2
+            exit 2
         else
-            git clone --bare $GIT_URL 2>&1 >/dev/null
-            if [ $? -ne 0 ]; then
-                echo "Failed to run git clone $GIT_URL" 1>&2
-                exit 2
+            git_branch=$wu_git_branch
+        fi
+    fi
+
+    if [ -z "$git_branch" ]; then
+        git_branch=master
+        if [ -n "$GIT_VERBOSE" ]; then
+            echo "GIT: No branch specified for $git_url - assuming master" 1>&2
+        fi
+    else
+        if [ -n "$GIT_VERBOSE" ]; then
+            echo "GIT: using branch $git_branch for $git_url" 1>&2
+        fi
+    fi
+
+    if [ -z "$git_directory" ]; then
+        # We are executed in the eclccserver's home dir - typically /var/lib/HPCCSystems/myeclccserver
+        mkdir -p $PWD/repos/
+        if [ $? -ne 0 ]; then
+            echo "Unable to create directory $PWD/repos/" 1>&2
+            exit 2
+        fi
+        cd $PWD/repos/
+
+        # URL is likely to be of the form git@github.com:path/to/dir.git
+        # MORE - we could check it is of the expected form...
+        splitURL=(${git_url//[:\/]/ })
+        splitLen=${#splitURL[@]}
+        tail=${splitURL[$splitLen-1]}
+
+        # tail is now the directory that git clone would create for this url
+        git_directory=$PWD/$tail
+
+        if [ ! -d $git_directory ] ; then
+            if [ -n "$GIT_VERBOSE" ]; then
+                echo "GIT: performing initial clone"
+                git clone --bare $git_url 1>&2 || exit $?
+            else
+                git clone --bare $git_url 2>&1 >/dev/null
+                if [ $? -ne 0 ]; then
+                    echo "Failed to run git clone $git_url" 1>&2
+                    exit 2
+                fi
             fi
         fi
     fi
-fi
-
-cd $GIT_DIRECTORY
-# MORE - may want to not do every time? Add option to check time since last fetched?
-if [ -n "$GIT_VERBOSE" ]; then
-    echo "GIT: using directory $GIT_DIRECTORY" 1>&2
-    git fetch $GIT_URL ${GIT_BRANCH}  1>&2 || exit $?
-else
-    git fetch $GIT_URL ${GIT_BRANCH} 2>&1 >/dev/null || exit $?
+    cd $git_directory
+    # MORE - may want to not do every time? Add option to check time since last fetched?
+    if [ -n "$GIT_VERBOSE" ]; then
+        echo "GIT: using directory $git_directory" 1>&2
+        echo "GIT: Running git fetch $git_url" 1>&2
+        git fetch $git_url 2>&1 >/dev/null
+    else
+        git fetch $git_url >/dev/null
+    fi
     if [ $? -ne 0 ]; then
-        echo "Failed to run git fetch $GIT_URL ${GIT_BRANCH}" 1>&2
+        echo "Failed to run git fetch $git_url" 1>&2
         exit 2
     fi
-fi
+    # Map the branch to a SHA, to avoid issues with the branch being updated by another eclcc process
+    # while this one is compiling (not 100% failsafe, but good enough)
+    last_commit=$(git rev-parse --short $git_branch)
+    if [ $? -ne 0 ]; then
+        echo "Failed to run git rev-parse $git_branch" 1>&2
+        exit 2
+    fi
+    export GIT_INCLUDE_PATH="${GIT_INCLUDE_PATH} -I${git_directory}/{$last_commit}/ -a${repo}_commit=${last_commit}"
+}
+
+repositories=(${GIT_REPOSITORIES//:/ })
+for repo in ${repositories[@]} ; do
+  fetch_repo $repo
+done
 
 cd $originalDir
 if [ -n "$GIT_VERBOSE" ]; then
-    echo GIT: calling eclcc -I$GIT_DIRECTORY/{$GIT_BRANCH}/ "$@"  1>&2
+    echo GIT: calling eclcc $GIT_INCLUDE_PATH "$@"  1>&2
 fi
-eclcc -I$GIT_DIRECTORY/{$GIT_BRANCH}/ "$@"
+eclcc $GIT_INCLUDE_PATH "$@"

--- a/ecl/eclccserver/vchooks/git.sh
+++ b/ecl/eclccserver/vchooks/git.sh
@@ -32,10 +32,23 @@ if [ -z "$GIT_URL" ]; then
     exit 2
 fi
 
+if [ -n "$WU_GIT_VERBOSE" ]; then
+    GIT_VERBOSE=1
+fi
+
+if [ -n "$WU_GIT_BRANCH" ]; then
+    if [ -z GIT_BRANCH_LOCKED ]; then
+        echo "GIT: Overrideing branch is not allowed" 1>&2
+        exit 2
+    else
+        GIT_BRANCH=$WU_GIT_BRANCH
+    fi
+fi
+
 if [ -z "$GIT_BRANCH" ]; then
     GIT_BRANCH=master
     if [ -n "$GIT_VERBOSE" ]; then
-        echo "GIT: No branch specified - assuming master"
+        echo "GIT: No branch specified - assuming master" 1>&2
     fi
 else
     if [ -n "$GIT_VERBOSE" ]; then

--- a/system/jlib/jthread.hpp
+++ b/system/jlib/jthread.hpp
@@ -266,6 +266,7 @@ interface IPipeProcess: extends IInterface
     virtual void abort() = 0;
     virtual void notifyTerminated(HANDLE pid,unsigned retcode) = 0; // internal
     virtual HANDLE getProcessHandle() = 0;                          // used to auto kill
+    virtual void setenv(const char *var, const char *value) = 0;  // Set a value to be passed in the called process environment
 };
 
 extern jlib_decl IPipeProcess *createPipeProcess(const char *allowedprograms=NULL);


### PR DESCRIPTION
Add code to eclccserver to support installation of hooks in place of eclcc,
and to pass values to those hooks via the environment.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
