### PR TITLE
HPCC-10035 - Expose compressedSize at logical file level

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2061,6 +2061,8 @@ class CDistributedFilePart: public CInterface, implements IDistributedFilePart
     StringAttr overridename;    // may or not be relative to directory
     bool            dirty;      // whether needs updating in tree 
 
+    offset_t getSize(bool checkCompressed);
+
 public:
 
     virtual void Link(void) const;
@@ -2073,7 +2075,7 @@ public:
     void unlockProperties(DFTransactionState state);
     bool isHost(unsigned copy);
     offset_t getFileSize(bool allowphysical,bool forcephysical);
-    offset_t getDiskSize();
+    offset_t getDiskSize(bool allowphysical,bool forcephysical);
     bool getModifiedTime(bool allowphysical,bool forcephysical,CDateTime &dt);
     bool getCrc(unsigned &crc); 
     unsigned getPhysicalCrc();  
@@ -4091,13 +4093,41 @@ public:
     __int64 getFileSize(bool allowphysical,bool forcephysical)
     {
         __int64 ret = (__int64)(forcephysical?-1:queryAttributes().getPropInt64("@size",-1));
-        if (ret==-1) {
+        if (ret==-1)
+        {
             ret = 0;
             unsigned n = numParts();
-            for (unsigned i=0;i<n;i++) {
+            for (unsigned i=0;i<n;i++)
+            {
                 Owned<IDistributedFilePart> part = getPart(i);
                 __int64 ps = part->getFileSize(allowphysical,forcephysical);
-                if (ps == -1) {
+                if (ps == -1)
+                {
+                    ret = ps;
+                    break;
+                }
+                ret += ps;
+            }
+        }
+        return ret;
+    }
+
+    __int64 getDiskSize(bool allowphysical,bool forcephysical)
+    {
+        if (!isCompressed(NULL))
+            return getFileSize(allowphysical, forcephysical);
+
+        __int64 ret = (__int64)(forcephysical?-1:queryAttributes().getPropInt64("@compressedSize",-1));
+        if (ret==-1)
+        {
+            ret = 0;
+            unsigned n = numParts();
+            for (unsigned i=0;i<n;i++)
+            {
+                Owned<IDistributedFilePart> part = getPart(i);
+                __int64 ps = part->getDiskSize(allowphysical,forcephysical);
+                if (ps == -1)
+                {
                     ret = ps;
                     break;
                 }
@@ -5207,14 +5237,34 @@ public:
     __int64 getFileSize(bool allowphysical,bool forcephysical)
     {
         __int64 ret = (__int64)(forcephysical?-1:queryAttributes().getPropInt64("@size",-1));
-        if (ret==-1) {
+        if (ret==-1)
+        {
             ret = 0;
-            ForEachItemIn(i,subfiles) {
+            ForEachItemIn(i,subfiles)
+            {
                 __int64 ps = subfiles.item(i).getFileSize(allowphysical,forcephysical);
-                if (ps == -1) {
-                    ret = ps;
-                    break;
-                }
+                if (ps == -1)
+                    return -1; // i.e. if cannot determine size of any part, total is unknown
+                ret += ps;
+            }
+        }
+        return ret;
+    }
+
+    __int64 getDiskSize(bool allowphysical,bool forcephysical)
+    {
+        if (!isCompressed(NULL))
+            return getFileSize(allowphysical, forcephysical);
+
+        __int64 ret = (__int64)(forcephysical?-1:queryAttributes().getPropInt64("@compressedSize",-1));
+        if (ret==-1)
+        {
+            ret = 0;
+            ForEachItemIn(i,subfiles)
+            {
+                __int64 ps = subfiles.item(i).getDiskSize(allowphysical,forcephysical);
+                if (ps == -1)
+                    return -1; // i.e. if cannot determine size of any part, total is unknown
                 ret += ps;
             }
         }
@@ -5450,6 +5500,7 @@ public:
             return;
         }
         root->removeProp("Attr/@size");
+        root->removeProp("Attr/@compressedSize");
         root->removeProp("Attr/@checkSum");
         root->removeProp("Attr/@recordCount");  // recordCount not currently supported by superfiles
         root->removeProp("Attr/@formatCrc");    // formatCrc set if all consistant
@@ -5458,6 +5509,12 @@ public:
         __int64 fs = getFileSize(false,false);
         if (fs!=-1)
             root->setPropInt64("Attr/@size",fs);
+        if (isCompressed(NULL))
+        {
+            fs = getDiskSize(false,false);
+            if (fs!=-1)
+                root->setPropInt64("Attr/@compressedSize",fs);
+        }
         unsigned checkSum;
         if (getFileCheckSum(checkSum))
             root->setPropInt64("Attr/@checkSum", checkSum);
@@ -5976,6 +6033,42 @@ bool CDistributedFilePart::Release(void) const
     return CInterface::Release(); 
 }
 
+offset_t CDistributedFilePart::getSize(bool checkCompressed)
+{
+    offset_t ret = (offset_t)-1;
+    StringBuffer firstname;
+    bool compressed = ::isCompressed(parent.queryAttributes());
+    unsigned nc=parent.numCopies(partIndex);
+    for (unsigned copy=0;copy<nc;copy++)
+    {
+        RemoteFilename rfn;
+        try
+        {
+            Owned<IFile> partfile = createIFile(getFilename(rfn,copy));
+            if (checkCompressed && compressed)
+            {
+                Owned<ICompressedFileIO> compressedIO = createCompressedFileReader(partfile);
+                if (compressedIO)
+                    ret = compressedIO->size();
+            }
+            else
+                ret = partfile->size();
+            if (ret!=(offset_t)-1)
+                return ret;
+        }
+        catch (IException *e)
+        {
+            StringBuffer s("CDistributedFilePart::getSize ");
+            rfn.getRemotePath(s);
+            EXCLOG(e, s.str());
+            e->Release();
+        }
+        if (copy==0)
+            rfn.getRemotePath(firstname);
+    }
+    throw new CDFS_Exception(DFSERR_CannotFindPartFileSize,firstname.str());;
+}
+
 StringBuffer & CDistributedFilePart::getPartName(StringBuffer &partname)
 {
     if (!overridename.isEmpty()) {
@@ -6152,69 +6245,21 @@ void CDistributedFilePart::unlockProperties(DFTransactionState state=TAS_NONE)
 offset_t CDistributedFilePart::getFileSize(bool allowphysical,bool forcephysical)
 {
     offset_t ret = (offset_t)((forcephysical&&allowphysical)?-1:queryAttributes().getPropInt64("@size", -1));
-    if (allowphysical&&(ret==(offset_t)-1)) {
-        StringBuffer firstname;
-        bool compressed = ::isCompressed(parent.queryAttributes());
-        unsigned nc=parent.numCopies(partIndex);
-        for (unsigned copy=0;copy<nc;copy++) {
-            RemoteFilename rfn;
-            try {
-                Owned<IFile> partfile = createIFile(getFilename(rfn,copy));
-                if (compressed)
-                {
-                    Owned<ICompressedFileIO> compressedIO = createCompressedFileReader(partfile);
-                    if (compressedIO)
-                        ret = compressedIO->size();
-                }
-                else
-                    ret = partfile->size();
-                if (ret!=(offset_t)-1)
-                    return ret;
-            }
-            catch (IException *e)
-            {
-                StringBuffer s("CDistributedFilePart::getFileSize ");
-                rfn.getRemotePath(s);
-                EXCLOG(e, s.str());
-                e->Release();
-            }
-            if (copy==0)
-                rfn.getRemotePath(firstname);
-        }
-        IDFS_Exception *e = new CDFS_Exception(DFSERR_CannotFindPartFileSize,firstname.str());;
-        throw e;
-    }
+    if (allowphysical&&(ret==(offset_t)-1))
+        ret = getSize(true);
     return ret;
 }
 
-offset_t CDistributedFilePart::getDiskSize()
+offset_t CDistributedFilePart::getDiskSize(bool allowphysical,bool forcephysical)
 {
-    // gets size on disk
     if (!::isCompressed(parent.queryAttributes()))
-        return getFileSize(true,false);
-    StringBuffer firstname;
-    unsigned nc=parent.numCopies(partIndex);
-    for (unsigned copy=0;copy<nc;copy++) {
-        RemoteFilename rfn;
-        try {
-            Owned<IFile> partfile = createIFile(getFilename(rfn,copy));
-                offset_t ret = partfile->size();
-            if (ret!=(offset_t)-1)
-                return ret;
-        }
-        catch (IException *e)
-        {
-            StringBuffer s("CDistributedFilePart::getFileSize ");
-            rfn.getRemotePath(s);
-            EXCLOG(e, s.str());
-            e->Release();
-        }
-        if (copy==0)
-            rfn.getRemotePath(firstname);
-    }
-    IDFS_Exception *e = new CDFS_Exception(DFSERR_CannotFindPartFileSize,firstname.str());;
-    throw e;
-    return 0;
+        return getFileSize(allowphysical, forcephysical);
+
+    if (forcephysical && allowphysical)
+        return getSize(false); // i.e. only if force, because all compressed should have @compressedSize attribute
+
+    // NB: compressSize is disk size
+    return queryAttributes().getPropInt64("@compressedSize", -1);
 }
 
 bool CDistributedFilePart::getModifiedTime(bool allowphysical,bool forcephysical, CDateTime &dt)

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -144,8 +144,8 @@ interface IDistributedFilePart: implements IInterface
 
     virtual bool isHost(unsigned copy=0) = 0;                                   // file is located on this machine
 
-    virtual offset_t getFileSize(bool allowphysical,bool forcephysical)=0;                  // gets the part filesize (NB this will be the *expanded* size)
-    virtual offset_t getDiskSize()=0;                                                       // gets the part size on disk (NB this will be the compressed size)
+    virtual offset_t getFileSize(bool allowphysical,bool forcephysical)=0; // gets the part filesize (NB this will be the *expanded* size)
+    virtual offset_t getDiskSize(bool allowphysical,bool forcephysical)=0; // gets the part size on disk (NB this will be the compressed size)
     virtual bool    getModifiedTime(bool allowphysical,bool forcephysical,CDateTime &dt)=0; // gets the part date time
 
     virtual bool getCrc(unsigned &crc) = 0;             // block compressed returns false (not ~0)
@@ -238,6 +238,7 @@ interface IDistributedFile: extends IInterface
 
 
     virtual __int64 getFileSize(bool allowphysical,bool forcephysical)=0;       // gets the total file size (forcephysical doesn't use cached value)
+    virtual __int64 getDiskSize(bool allowphysical,bool forcephysical)=0;       // gets the part size on disk (NB this will be the compressed size)
     virtual bool getFileCheckSum(unsigned &checksum)=0;                         // gets a single checksum for the logical file, based on the part crc's
     virtual unsigned getPositionPart(offset_t pos,offset_t &base)=0;            // get the part for a given position and the base offset of that part
 

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2309,7 +2309,7 @@ void FileSprayer::setSource(IDistributedFile * source)
             next.mirrorFilename.set(curPart->getFilename(rfn,1));
         // don't set the following here - force to check disk
         //next.size = curPart->getFileSize(true,false);
-        //next.psize = curPart->getDiskSize();
+        //next.psize = curPart->getDiskSize(true,false);
         sources.append(next);
     }
 

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -635,7 +635,10 @@ void CHThorDiskWriteActivity::publish()
     if (encrypted)
         properties.setPropBool("@encrypted", true);
     if (blockcompressed)
+    {
+        properties.setPropInt64("@compressedSize", fileSize);
         properties.setPropBool("@blockCompressed", true);
+    }
     if (helper.getFlags() & TDWpersist)
         properties.setPropBool("@persistent", true);
     if (grouped)

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10805,7 +10805,8 @@ public:
         {
             // caller has already set @size from file size...
             fileProps.setPropBool("@blockCompressed", true);
-            partProps.setPropInt64("@compressedSize", partProps.getPropInt64("@size", 0));  // MORE should this be on logical too?
+            fileProps.setPropInt64("@compressedSize", partProps.getPropInt64("@size", 0));
+            partProps.setPropInt64("@compressedSize", partProps.getPropInt64("@size", 0));
             fileProps.setPropInt64("@size", uncompressedBytesWritten);
             partProps.setPropInt64("@size", uncompressedBytesWritten);
         }

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -566,6 +566,12 @@ public:
         __int64 fs = file->getFileSize(false,false);
         if (fs!=-1)
             file->queryAttributes().setPropInt64("@size",fs);
+        if (file->isCompressed())
+        {
+            fs = file->getDiskSize(false,false);
+            if (fs!=-1)
+                file->queryAttributes().setPropInt64("@compressedSize",fs);
+        }
         file->attach(scopedName.str(), job.queryUserDescriptor());
         unsigned c=0;
         for (; c<fileDesc.numClusters(); c++)


### PR DESCRIPTION
Allow getDiskSize to use published meta info on compressed(disk)
part sizes and aggregate in logical file attribute in the same
way @size is currently done.

This will enable fast retreival of compressedSize possible and
expose it through DFS attribute serialization iterator routines
so that eclwatch has a cheap way to display them.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
