### PR TITLE
HPCC-10040 maxRecordSize value to avoid "End of record not found..."  exception during XML spray

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -1183,7 +1183,7 @@ offset_t XmlSplitter::getFooterLength(BufferedDirectReader & reader, offset_t si
 }
 
 
-CXmlPartitioner::CXmlPartitioner(const FileFormat & _format) : CInputBasePartitioner(_format.maxRecordSize, _format.maxRecordSize), splitter(_format)
+CXmlPartitioner::CXmlPartitioner(const FileFormat & _format) : CInputBasePartitioner( _format.maxRecordSize, (_format.maxRecordSize > 0x100000 ?_format.maxRecordSize: 0x100000)), splitter(_format)
 {
     format.set(_format);
     unitSize = format.getUnitSize();

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -1183,9 +1183,10 @@ offset_t XmlSplitter::getFooterLength(BufferedDirectReader & reader, offset_t si
 }
 
 
-CXmlPartitioner::CXmlPartitioner(const FileFormat & _format) : CInputBasePartitioner(_format.maxRecordSize, _format.maxRecordSize), splitter(_format)
+CXmlPartitioner::CXmlPartitioner(const FileFormat & _format) : CInputBasePartitioner( _format.maxRecordSize, (_format.maxRecordSize > 0x100000 ?_format.maxRecordSize: 0x100000)), splitter(_format)
 {
     format.set(_format);
+    format.maxRecordSize = _format.maxRecordSize > 0x100000 ?_format.maxRecordSize: 0x100000;
     unitSize = format.getUnitSize();
     utfFormat = getUtfFormatType(format.type);
 }

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -1183,10 +1183,9 @@ offset_t XmlSplitter::getFooterLength(BufferedDirectReader & reader, offset_t si
 }
 
 
-CXmlPartitioner::CXmlPartitioner(const FileFormat & _format) : CInputBasePartitioner( _format.maxRecordSize, (_format.maxRecordSize > 0x100000 ?_format.maxRecordSize: 0x100000)), splitter(_format)
+CXmlPartitioner::CXmlPartitioner(const FileFormat & _format) : CInputBasePartitioner(_format.maxRecordSize, _format.maxRecordSize), splitter(_format)
 {
     format.set(_format);
-    format.maxRecordSize = _format.maxRecordSize > 0x100000 ?_format.maxRecordSize: 0x100000;
     unitSize = format.getUnitSize();
     utfFormat = getUtfFormatType(format.type);
 }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -46,6 +46,7 @@
 #define PARTITION_RECOVERY_LIMIT 1000
 #define EXPECTED_RESPONSE_TIME          (60 * 1000)
 #define RESPONSE_TIME_TIMEOUT           (60 * 60 * 1000)
+#define DEFAULT_MAX_XML_RECORD_SIZE 0x100000
 
 //#define CLEANUP_RECOVERY
 
@@ -1241,6 +1242,18 @@ void FileSprayer::checkFormats()
             }
             break;
         }
+    }
+    switch (srcType)
+    {
+        case FFTutf: case FFTutf8: case FFTutf8n: case FFTutf16: case FFTutf16be: case FFTutf16le: case FFTutf32: case FFTutf32be: case FFTutf32le:
+            if (srcFormat.rowTag)
+            {
+                srcFormat.maxRecordSize = srcFormat.maxRecordSize > DEFAULT_MAX_XML_RECORD_SIZE ? srcFormat.maxRecordSize : DEFAULT_MAX_XML_RECORD_SIZE;
+            }
+            break;
+
+        default:
+            break;
     }
 }
 


### PR DESCRIPTION
Increase maxRecordSize value to 0x100000 (1MB) if it is less.

Signed-off-by: Attila.Vamos attila.vamos@gmail.com
