### PR TITLE
HPCC-9946 Add support for JVM settings in environment.conf

### DIFF
--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -76,7 +76,8 @@ public:
     JavaGlobalState()
     {
         JavaVMInitArgs vm_args; /* JDK/JRE 6 VM initialization arguments */
-        JavaVMOption* options = new JavaVMOption[3];
+
+        StringArray optionStrings;
         const char* origPath = getenv("CLASSPATH");
         StringBuffer newPath;
         newPath.append("-Djava.class.path=").append(origPath);
@@ -89,19 +90,25 @@ public:
             conf->getProp("classpath", newPath);
         }
         newPath.append(ENVSEPCHAR).append(".");
+        optionStrings.append(newPath);
+        if (conf && conf->hasProp("jvmoptions"))
+        {
+            optionStrings.appendList(conf->queryProp("jvmoptions"), ENVSEPSTR);
+        }
 
+        // These may be useful for debugging
+        // optionStrings.append("-Xcheck:jni");
+        // optionStrings.append("-verbose:jni");
 
-        options[0].optionString = (char *) newPath.str();
-        options[1].optionString = (char *) "-Xcheck:jni";
-        options[2].optionString = (char *) "-verbose:jni";
-        vm_args.version = JNI_VERSION_1_6;
-#ifdef _DEBUG
-        vm_args.nOptions = 1;  // set to 3 if you want the verbose...
-#else
-        vm_args.nOptions = 1;
-#endif
+        JavaVMOption* options = new JavaVMOption[optionStrings.length()];
+        ForEachItemIn(idx, optionStrings)
+        {
+            options[idx].optionString = (char *) optionStrings.item(idx);
+        }
+        vm_args.nOptions = optionStrings.length();
         vm_args.options = options;
-        vm_args.ignoreUnrecognized = false;
+        vm_args.ignoreUnrecognized = true;
+        vm_args.version = JNI_VERSION_1_6;
         /* load and initialize a Java VM, return a JNI interface pointer in env */
         JNIEnv *env;       /* receives pointer to native method interface */
         JNI_CreateJavaVM(&javaVM, (void**)&env, &vm_args);


### PR DESCRIPTION
Set using jvmoptions=XXX in environment.conf. Use ENVSEPCHAR to separate

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
