### PR TITLE
HPCC-9364 Fix assert(mergeOrder) on stepped index read in a child query

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -3799,8 +3799,8 @@ public:
             ctx->addSlavesReplyLen(mc->queryBytesReceived());
         mc.clear(); // Or we won't free memory for graphs that get recreated
         mu.clear(); //ditto
-        mergeOrder = NULL; // MORE - is that needed?
         deferredStart = false;
+        // NOTE: do NOT clear mergeOrder - this is set at create time not per child query
     }
 
     virtual IOutputMetaData * queryOutputMeta() const

--- a/testing/ecl/key/mergechild.xml
+++ b/testing/ecl/key/mergechild.xml
@@ -1,0 +1,4 @@
+<Dataset name='Result 1'>
+ <Row><_unnamed_1>128</_unnamed_1></Row>
+ <Row><_unnamed_1>199</_unnamed_1></Row>
+</Dataset>

--- a/testing/ecl/mergechild.ecl
+++ b/testing/ecl/mergechild.ecl
@@ -1,0 +1,39 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+//UseStandardFiles
+//UseIndexes
+//varskip payload
+//varskip varload
+//varskip trans
+//varskip dynamic
+
+//Multi level smart stepping, with priorities in the correct order
+
+words := DATASET(['a','the'], { string searchWord; });
+
+p(STRING searchWord) := FUNCTION
+
+    i2 := STEPPED(TS_searchIndex(kind=1 AND word=searchWord), doc, PRIORITY(3),HINT(maxseeklookahead(50)));
+    i1 := STEPPED(TS_searchIndex(kind=1 AND word='walls'), doc, PRIORITY(2),HINT(maxseeklookahead(50)));
+
+    j1 := MERGEJOIN([i1, i2], STEPPED(LEFT.doc =RIGHT.doc ), SORTED(doc));
+    RETURN TABLE(j1, {src := TS_docid2source(doc); UNSIGNED doc := TS_docid2doc(doc), cnt := COUNT(GROUP)},doc);
+END;
+
+
+OUTPUT(NOFOLD(words), { COUNT(p(searchWord)); });


### PR DESCRIPTION
mergeOrder incorrectly cleared per child query (but only set at activity
creation time).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
