### PR TITLE
HPCC-9463 Use CInterfaceOf for a hashtable base class

### DIFF
--- a/system/jlib/jhash.ipp
+++ b/system/jlib/jhash.ipp
@@ -46,11 +46,9 @@ class jlib_decl MappingKey
     void    *key;               /* points to the key for this element */
 };
 
-class jlib_decl MappingBase : implements IMapping, public CInterface
+class jlib_decl MappingBase : public CInterfaceOf<IMapping>
 {
   public:
-    IMPLEMENT_IINTERFACE
-
     virtual unsigned            getHash() const;
     virtual void                setHash(unsigned);
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
