### PR TITLE
HPCC-9955 ECL Rec Layout metadata is not reported for CSV files in hthor

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -869,6 +869,9 @@ void CHThorCsvWriteActivity::setFormat(IFileDescriptor * desc)
     desc->queryProperties().setProp("@csvEscape", rs.setown(csvInfo->getEscape(0)));
     desc->queryProperties().setProp("@format","utf8n");
     desc->queryProperties().setProp("@kind", "csv");
+    const char *recordECL = helper.queryRecordECL();
+    if (recordECL && *recordECL)
+        desc->queryProperties().setProp("ECL", recordECL);
 }
 
 //=====================================================================================================


### PR DESCRIPTION
HThor is currently not writing the ECL record layout for CSV files. This
fix checks to see if that information is available and if so, writes it
along with the other file properties

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
