### PR TITLE
HPCC-9460 First Name and Last Name missing from My Account user area

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1050,13 +1050,14 @@ public:
                 m_domainPwdsNeverExpire = true;
 
             const char* sysuser = m_ldapconfig->getSysUser();
+            bool sysUser = false;
             if(sysuser && *sysuser && (strcmp(username, sysuser) == 0))
             {
                 if(strcmp(password, m_ldapconfig->getSysUserPassword()) == 0)
                 {
                     user.setFullName(m_ldapconfig->getSysUserCommonName());
                     user.setAuthenticateStatus(AS_AUTHENTICATED);
-                    return true;
+                    sysUser = true;
                 }
                 else
                 {
@@ -1188,6 +1189,9 @@ public:
             StringBuffer userdnbuf;
             userdnbuf.append(userdn);
             ldap_memfree(userdn);
+
+            if (sysUser)
+                return true;//sysuser authenticated above
 
             StringBuffer hostbuf;
             m_ldapconfig->getLdapHost(hostbuf);


### PR DESCRIPTION
When authenticating the sysuser, the password is verified based on the
value in the config file and not whats stored in LDAP. The early return
from this check means we did not go to LDAP to query the sys user's other
properties such as first/last name. This code change allows the code to
proceed until we get these properties and the returns them

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
