### PR TITLE
HPCC-10049 Retrieve data for displaying cumulative Roxie graphs

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -853,11 +853,24 @@ ESPresponse [encode(0), exceptions_inline] WUProcessGraphResponse
 ESPrequest WUGetGraphRequest
 {
     string Wuid;
-    [min_ver("1.19")] string GraphName; 
+    [min_ver("1.19")] string GraphName;
     [min_version("1.21")] string SubGraphId;
 };
 
 ESPresponse [exceptions_inline] WUGetGraphResponse
+{
+    ESParray<ESPstruct ECLGraphEx> Graphs;
+};
+
+ESPrequest WUQueryGetGraphRequest
+{
+    string Target;
+    string QueryId;
+    [min_ver("1.19")] string GraphName;
+    [min_version("1.21")] string SubGraphId;
+};
+
+ESPresponse [exceptions_inline] WUQueryGetGraphResponse
 {
     ESParray<ESPstruct ECLGraphEx> Graphs;
 };
@@ -1440,6 +1453,7 @@ ESPservice [
     ESPmethod WUFile(WULogFileRequest, WULogFileResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/graphStats.xslt")] WUProcessGraph(WUProcessGraphRequest, WUProcessGraphResponse); 
     ESPmethod WUGetGraph(WUGetGraphRequest, WUGetGraphResponse);
+    ESPmethod WUQueryGetGraph(WUQueryGetGraphRequest, WUQueryGetGraphResponse);
     ESPmethod WUGetDependancyTrees(WUGetDependancyTreesRequest, WUGetDependancyTreesResponse);
 
     ESPmethod WUListLocalFileRequired(WUListLocalFileRequiredRequest, WUListLocalFileRequiredResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -42,6 +42,7 @@ public:
     void deploySharedObject(IEspContext &context, StringBuffer &wuid, const char *filename, const char *cluster, const char *name, const MemoryBuffer &obj, const char *dir, const char *xml=NULL);
     void checkAndTrimWorkunit(const char* methodName, StringBuffer& input);
     bool getQueryFiles(const char* query, const char* target, StringArray& logicalFiles, IArrayOf<IEspQuerySuperFile> *superFiles);
+    void getGraphsByQueryId(const char *target, const char *queryId, const char *graphName, const char *subGraphId, IArrayOf<IEspECLGraphEx>& ECLGraphs);
 
     bool onWUQuery(IEspContext &context, IEspWUQueryRequest &req, IEspWUQueryResponse &resp);
     bool onWUPublishWorkunit(IEspContext &context, IEspWUPublishWorkunitRequest & req, IEspWUPublishWorkunitResponse & resp);
@@ -90,6 +91,7 @@ public:
     bool onWUSyntaxCheckECL(IEspContext &context, IEspWUSyntaxCheckRequest &req, IEspWUSyntaxCheckResponse &resp);
     bool onWUCompileECL(IEspContext &context, IEspWUCompileECLRequest &req, IEspWUCompileECLResponse &resp);
     bool onWUJobList(IEspContext &context, IEspWUJobListRequest &req, IEspWUJobListResponse &resp);
+    bool onWUQueryGetGraph(IEspContext& context, IEspWUQueryGetGraphRequest& req, IEspWUQueryGetGraphResponse& resp);
     bool onWUGetGraph(IEspContext& context, IEspWUGetGraphRequest& req, IEspWUGetGraphResponse& resp);
     bool onWUGraphTiming(IEspContext& context, IEspWUGraphTimingRequest& req, IEspWUGraphTimingResponse& resp);
     bool onWUGetDependancyTrees(IEspContext& context, IEspWUGetDependancyTreesRequest& req, IEspWUGetDependancyTreesResponse& resp);


### PR DESCRIPTION
This fix adds the code to allow the existing WsWorkunits/WUGetGraph method
to retrieve data for displaying cumulative Roxie graphs. Two new input
parameters (target and query id) have been added to the method. If the
parameters are set, the method calls control:queryStats to get the data
for displaying cumulative Roxie graphs. If they are not set, the method
uses the exist code to get the data for ECL WU graphs.

And two small fixes: a. a compiling warning; b. a better time out for using
control:getQueryXrefInfo.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
