### PR TITLE
HPCC-10043 Add option to eclcc to restrict compilation to repository

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1241,7 +1241,13 @@ void EclCC::processFile(EclCompileInstance & instance)
         q->setQueryText(queryTxt);
     }
 
-    if (isArchiveQuery(queryTxt))
+    //On a system with userECL not allowed, all compilations must be from checked-in code that has been
+    //deployed to the eclcc machine via other means (typically via a version-control system)
+    if (!allowAccess("userECL") && (!optQueryRepositoryReference || queryText->length()))
+    {
+        instance.errs->reportError(HQLERR_UserCodeNotAllowed, HQLERR_UserCodeNotAllowed_Text, NULL, 1, 0, 0);
+    }
+    else if (isArchiveQuery(queryTxt))
     {
         instance.fromArchive = true;
         processXmlFile(instance, queryTxt);

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -208,6 +208,7 @@
 #define HQLERR_MaximumSizeLessThanMinimum_XY    4188
 #define HQLERR_UnexpectedOptionValue_XY         4189
 #define HQLERR_VariableRowMustBeLinked          4190
+#define HQLERR_UserCodeNotAllowed               4191
 
 //Warnings....
 #define HQLWRN_PersistDataNotLikely             4500
@@ -491,6 +492,7 @@
 #define HQLERR_MaximumSizeLessThanMinimum_XY_Text "Maximum size (%u) for this record is lower than the minimum (%u)"
 #define HQLERR_UnexpectedOptionValue_XY_Text    "Unexpected value for option %s: %s"
 #define HQLERR_VariableRowMustBeLinked_Text     "External function '%s' cannot return a non-linked variable length row"
+#define HQLERR_UserCodeNotAllowed_Text          "Workunit-supplied code is not permitted on this system"
 
 //Warnings.
 #define HQLWRN_CannotRecreateDistribution_Text  "Cannot recreate the distribution for a persistent dataset"


### PR DESCRIPTION
Set --deny=userECL in the eclccserver options to require that all jobs use
only code that is already present on the eclccserver (typically, from an
external repository via eclcc-hook)

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
