### PR TITLE
HPCC-9975 Evaluate(module) does not like enum

### DIFF
--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -4204,6 +4204,7 @@ IHqlExpression * ModuleExpander::createExpanded(IHqlExpression * scopeExpr, IHql
             switch (value->getOperator())
             {
             case no_typedef:
+            case no_enum:
                 op = no_none;
                 break;
             }

--- a/ecl/regress/issue9975.ecl
+++ b/ecl/regress/issue9975.ecl
@@ -1,0 +1,12 @@
+x := module
+
+    export e := enum(a,b,c);
+    export t := unsigned2;
+    export pattern p := 'h';
+    export r:= { unsigned id; };
+
+    export f(unsigned i) := i * 10;
+    export hello(string who = 'world') := 'hello ' + who;
+end;
+
+output(x);


### PR DESCRIPTION
Added switch case to hqlutil.cpp to ignore exported enumerated type deffinitions
when declared within a module listed as an output parameter.

Signed-off-by: jamienoss james.noss@lexisnexis.com
