### PR TITLE
HPCC-10070 Change to eclcc regression test instructions in sourcedoc.xml

### DIFF
--- a/sourcedoc.xml
+++ b/sourcedoc.xml
@@ -358,11 +358,11 @@
                 </para>
                 <para>
                     Step 3: Step 2 only listed the differences, now you need to see what they are.
-                    For that, re-run the regressing script, with the no-run option (-r). You can omit
-                    the compiler, since the only thing we'll do is to compare verbosely.
+                    For that, re-run the regressing script omitting the compiler, since the only
+                    thing we'll do is to compare verbosely.
 
                     <programlisting>
-                        ./regress.sh -t my_branch -c golden -r
+                        ./regress.sh -t my_branch -c golden
                     </programlisting>
 
                     This will show you all differences, using the same ignore filters as before,


### PR DESCRIPTION
Instructions in sourcedoc.xml state -r syntax for regress.sh that is no
longer supported.

Signed-off-by: jamienoss james.noss@lexisnexis.com
