### PR TITLE
HPCC-8624 - Ensure activities that read a logical keep lock

### DIFF
--- a/thorlcr/activities/keypatch/thkeypatch.cpp
+++ b/thorlcr/activities/keypatch/thkeypatch.cpp
@@ -31,6 +31,7 @@ class CKeyPatchMaster : public CMasterActivity
     bool local;
     unsigned width;
     StringArray clusters;
+    Owned<IDistributedFile> originalIndexFile, patchFile;
 
 public:
     CKeyPatchMaster(CMasterGraphElement *info) : CMasterActivity(info)
@@ -48,8 +49,8 @@ public:
 
         OwnedRoxieString originalName(helper->getOriginalName());
         OwnedRoxieString patchName(helper->getPatchName());
-        Owned<IDistributedFile> originalIndexFile = queryThorFileManager().lookup(container.queryJob(), originalName);
-        Owned<IDistributedFile> patchFile = queryThorFileManager().lookup(container.queryJob(), patchName);
+        originalIndexFile.setown(queryThorFileManager().lookup(container.queryJob(), originalName));
+        patchFile.setown(queryThorFileManager().lookup(container.queryJob(), patchName));
         
         if (originalIndexFile->numParts() != patchFile->numParts())
             throw MakeActivityException(this, TE_KeyPatchIndexSizeMismatch, "Index %s and patch %s differ in width", originalName.get(), patchName.get());

--- a/thorlcr/activities/msort/thmsort.cpp
+++ b/thorlcr/activities/msort/thmsort.cpp
@@ -56,6 +56,7 @@ class CMSortActivityMaster : public CMasterActivity
     IThorSorterMaster *imaster;
     mptag_t mpTagRPC, barrierMpTag;
     Owned<IBarrier> barrier;
+    Owned<IDistributedFile> coSortFile;
     
 public:
     CMSortActivityMaster(CMasterGraphElement *info)
@@ -139,9 +140,9 @@ protected:
         OwnedRoxieString cosortlogname(helper->getSortedFilename());
         if (cosortlogname&&*cosortlogname) {
 
-            Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), cosortlogname);
-            Owned<IFileDescriptor> fileDesc = file->getFileDescriptor();
-            queryThorFileManager().noteFileRead(container.queryJob(), file);
+            coSortFile.setown(queryThorFileManager().lookup(container.queryJob(), cosortlogname));
+            Owned<IFileDescriptor> fileDesc = coSortFile->getFileDescriptor();
+            queryThorFileManager().noteFileRead(container.queryJob(), coSortFile);
             unsigned o;
             for (o=0; o<fileDesc->numParts(); o++)
             {

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -38,8 +38,8 @@ CDiskReadMasterBase::CDiskReadMasterBase(CMasterGraphElement *info) : CMasterAct
 void CDiskReadMasterBase::init()
 {
     IHThorDiskReadBaseArg *helper = (IHThorDiskReadBaseArg *) queryHelper();
-    OwnedRoxieString fileName(helper->getFileName());
-    Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), fileName, 0 != ((TDXtemporary|TDXjobtemp) & helper->getFlags()), 0 != (TDRoptional & helper->getFlags()), true);
+    fileName.setown(helper->getFileName());
+    file.setown(queryThorFileManager().lookup(container.queryJob(), fileName, 0 != ((TDXtemporary|TDXjobtemp) & helper->getFlags()), 0 != (TDRoptional & helper->getFlags()), true));
 
     if (file)
     {
@@ -97,7 +97,6 @@ void CDiskReadMasterBase::init()
 void CDiskReadMasterBase::serializeSlaveData(MemoryBuffer &dst, unsigned slave)
 {
     IHThorDiskReadBaseArg *helper = (IHThorDiskReadBaseArg *) queryHelper();
-    OwnedRoxieString fileName(helper->getFileName());
     dst.append(fileName);
     dst.append(subfileLogicalFilenames.ordinality());
     if (subfileLogicalFilenames.ordinality())
@@ -118,10 +117,7 @@ void CDiskReadMasterBase::done()
     if (!abortSoon) // in case query has relinquished control of file usage to another query (e.g. perists) 
     {
         if (0 != (helper->getFlags() & TDXupdateaccessed))
-        {
-            OwnedRoxieString fileName(helper->getFileName());
             queryThorFileManager().updateAccessTime(container.queryJob(), fileName);
-        }
     }
 }
 

--- a/thorlcr/activities/thdiskbase.ipp
+++ b/thorlcr/activities/thdiskbase.ipp
@@ -32,6 +32,8 @@ protected:
     Owned<CSlavePartMapping> mapping;
     IHash *hash;
     Owned<ProgressInfo> inputProgress;
+    OwnedRoxieString fileName;
+    Owned<IDistributedFile> file;
 
 public:
     CDiskReadMasterBase(CMasterGraphElement *info);


### PR DESCRIPTION
Not all of the file reader activities were holding onto to the
IDistributed file (and hence the Dali lock). Consequently, it
would be possible for someone to delete a logical file that a
Thor query was actively using.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
