### PR TITLE
HPCC-10080 Add Activated flag to WUListQueries response

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1185,6 +1185,7 @@ ESPStruct [nil_remove] QuerySetQuery
     string Comment;
     [min_ver("1.45")] string QuerySetId;
     [min_ver("1.46")] bool IsLibrary;
+    [min_ver("1.46")] bool Activated;
     [min_ver("1.46")] string PublishedBy;
 };
 

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1049,6 +1049,7 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
         q->setQuerySetId(query.queryProp("@querySetId"));
         q->setDll(query.queryProp("@dll"));
         q->setWuid(query.queryProp("@wuid"));
+        q->setActivated(query.getPropBool("@activated", false));
         q->setSuspended(query.getPropBool("@suspended", false));
         if (query.hasProp("@memoryLimit"))
         {
@@ -1159,7 +1160,7 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
 
     if (version >= 1.42)
     {
-        xpath.clear().appendf("Alias[@name='%s']", queryName);
+        xpath.clear().appendf("Alias[@id='%s']", queryId);
         IPropertyTree *alias = queryRegistry->queryPropTree(xpath.str());
         if (!alias)
             resp.setActivated(false);


### PR DESCRIPTION
Add Activated flag to WUListQueries response for each
individual query.

Also fix a bug: the Activated flag should be read using @id,
not @name.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
