### PR TITLE
HPCC-10078 Return 0 graph when calling WUQueryDetails for hthor query

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -949,8 +949,8 @@ unsigned CWsWorkunitsEx::getGraphIdsByQueryId(const char *target, const char *qu
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Query Id required");
 
     Owned<IConstWUClusterInfo> info = getTargetClusterInfo(target);
-    if (!info || (info->getPlatform()!=RoxieCluster)) //Only support roxie for now
-        throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid Roxie name");
+    if (!info || (info->getPlatform()!=RoxieCluster)) //Only roxie query has query graph.
+        return 0;
 
     const SocketEndpointArray &eps = info->getRoxieServers();
     if (eps.empty())


### PR DESCRIPTION
The existing code throws an exception when a WUQueryDetails is called
for non roxie query. It is because the WUQueryDetails trys to get graph
IDs for the query, but, right now, only roxie supports cumulative stats.
This fix returns 0 graph (not exception) if non roxie query is detected.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
