### PR TITLE
HPCC-10093 Read compressed file size from DFU attributes

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -45,7 +45,7 @@ ESPStruct DFULogicalFile
     string LongSize;
     string LongRecordCount;
     bool   isSuperfile;
-    bool   isZipfile;
+    [depr_ver("1.22")] bool   isZipfile;
     bool   isDirectory(false);
     bool   Replicate(false);
     [min_ver("1.01")] int64 IntSize;
@@ -53,6 +53,8 @@ ESPStruct DFULogicalFile
     [min_ver("1.02")] bool FromRoxieCluster;
     [min_ver("1.03")] bool BrowseData;
     [min_ver("1.14")] bool IsKeyFile;
+    [min_ver("1.22")] bool IsCompressed;
+    [min_ver("1.22")] int64 CompressedFileSize;
 };
 
 ESPStruct DFUPart
@@ -95,7 +97,7 @@ ESPStruct DFUFileDetail
 
     string Modified;
     string Ecl;
-    bool ZipFile(false);
+    [depr_ver("1.22")] bool ZipFile(false);
     ESPstruct DFUFileStat Stat;
     ESParray<ESPstruct DFUPart> DFUFileParts;
     bool isSuperfile(false);
@@ -106,6 +108,8 @@ ESPStruct DFUFileDetail
     [min_ver("1.07")] ESParray<string, ECLGraph> Graphs;
     [min_ver("1.09")] string UserPermission;
     [min_ver("1.21")] string ContentType;
+    [min_ver("1.22")] int64 CompressedFileSize;
+    [min_ver("1.22")] bool IsCompressed(false);
 };
 
 ESPStruct DFUSpaceItem
@@ -627,7 +631,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.21"), default_client_version("1.21"),
+    version("1.22"), default_client_version("1.22"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1668,7 +1668,14 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
 
     if(df->isCompressed())
     {
-        FileDetails.setZipFile(true);
+        if (version < 1.22)
+            FileDetails.setZipFile(true);
+        else
+        {
+            FileDetails.setIsCompressed(true);
+            if (df->queryAttributes().hasProp("@compressedSize"))
+                FileDetails.setCompressedFileSize(df->queryAttributes().getPropInt64("@compressedSize"));
+        }
     }
 
     comma c2(recordSize);
@@ -1940,9 +1947,9 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
 }
 
 
-void CWsDfuEx::getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *dirname, IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& numFiles, int& numDirs)
+void CWsDfuEx::getLogicalFileAndDirectory(IEspContext &context, IUserDescriptor* udesc, const char *dirname, IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& numFiles, int& numDirs)
 {
-    DBGLOG("CWsDfuEx::getLogicalFileAndDirectory\n");
+    double version = context.getClientVersion();
 
     StringArray roxieClusterNames;
     IArrayOf<IEspTpCluster> roxieclusters;
@@ -2033,13 +2040,13 @@ void CWsDfuEx::getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *di
 
                     __int64 recordSize=attr.getPropInt64("@recordSize",0), size=attr.getPropInt64("@size",-1);
         
-                    if(!isCompressed(attr))
-                    {
-                        File->setIsZipfile(false);
-                    }
+                    if (version < 1.22)
+                        File->setIsZipfile(isCompressed(attr));
                     else
                     {
-                        File->setIsZipfile(true);
+                        File->setIsCompressed(isCompressed(attr));
+                        if (attr.hasProp("@compressedSize"))
+                            File->setCompressedFileSize(attr.getPropInt64("@compressedSize"));
                     }
 
                     StringBuffer buf;
@@ -2103,7 +2110,7 @@ bool CWsDfuEx::onDFUFileView(IEspContext &context, IEspDFUFileViewRequest &req, 
         int numDirs = 0;
         int numFiles = 0;
         IArrayOf<IEspDFULogicalFile> logicalFiles;
-        getLogicalFileAndDirectory(userdesc.get(), req.getScope(), logicalFiles, numFiles, numDirs);
+        getLogicalFileAndDirectory(context, userdesc.get(), req.getScope(), logicalFiles, numFiles, numDirs);
 
         if (numFiles > 0)
             resp.setNumFiles(numFiles);
@@ -2414,7 +2421,7 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
     {
         int numDirs = 0;
         int numFiles = 0;
-        getLogicalFileAndDirectory(udesc, req.getLogicalName(), LogicalFiles, numFiles, numDirs);
+        getLogicalFileAndDirectory(context, udesc, req.getLogicalName(), LogicalFiles, numFiles, numDirs);
     }
     else
     {
@@ -2787,14 +2794,15 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
                 }
                 File->setIsSuperfile(bSuperfile);
 
-                if(!isCompressed(attr))
-                {
-                    File->setIsZipfile(false);
-                }
+                if (version < 1.22)
+                    File->setIsZipfile(isCompressed(attr));
                 else
                 {
-                    File->setIsZipfile(true);
+                    File->setIsCompressed(isCompressed(attr));
+                    if (attr.hasProp("@compressedSize"))
+                        File->setCompressedFileSize(attr.getPropInt64("@compressedSize"));
                 }
+
                 //File->setBrowseData(bKeyFile); //Bug: 39750 - All files should be viewable through ViewKeyFile function
                 if (numSubFiles > 1) //Bug 41379 - ViewKeyFile Cannot handle superfile with multiple subfiles
                     File->setBrowseData(false); 

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -88,7 +88,7 @@ public:
     virtual bool onSuperfileAction(IEspContext &context, IEspSuperfileActionRequest &req, IEspSuperfileActionResponse &resp);
 
 private:
-    void getLogicalFileAndDirectory(IUserDescriptor* udesc, const char *dirname, IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& numFiles, int& numDirs);
+    void getLogicalFileAndDirectory(IEspContext &context, IUserDescriptor* udesc, const char *dirname, IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& numFiles, int& numDirs);
     bool doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc, IEspDFUQueryRequest & req, IEspDFUQueryResponse & resp);
     //bool doLogicalFileSearch(IUserDescriptor* udesc, IEspDFUQueryRequest & req, IEspDFUQueryResponse & resp);
     void doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, const char *name,const char *cluster,


### PR DESCRIPTION
In this fix, WsDFU DFUInfo/DFUQuery reads compressed file size from DFU attributes.
The compressed file size can be shown on EclWatch file browser and details page.

This fix also sets a file to be compressed if the file is an index because all of
indexes are compressed.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
