### PR TITLE
HPCC-10083 - Some slave exceptions detected too late

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1286,10 +1286,12 @@ void CGraphBase::doExecute(size32_t parentExtractSz, const byte *parentExtract, 
     }
     try
     {
+        if (!exception && abortException)
+            exception.setown(abortException.getClear());
         if (exception)
         {
             if (NULL == owner || isGlobal())
-                waitBarrier->cancel();
+                waitBarrier->cancel(exception);
             if (!queryOwner())
             {
                 StringBuffer str;
@@ -1611,7 +1613,7 @@ bool CGraphBase::wait(unsigned timeout)
     {
         if (INFINITE != timeout && tm.timedout(&remaining))
             waitException.throwException();
-        if (!waitBarrier->wait(false, remaining))
+        if (!waitBarrier->wait(true, remaining))
             return false;
     }
     return true;
@@ -1647,11 +1649,11 @@ void CGraphBase::abort(IException *e)
             iter->query().abort(e); // JCSMORE - could do in parallel, they can take some time to timeout
         }
         if (startBarrier)
-            startBarrier->cancel();
+            startBarrier->cancel(e);
         if (waitBarrier)
-            waitBarrier->cancel();
+            waitBarrier->cancel(e);
         if (doneBarrier)
-            doneBarrier->cancel();
+            doneBarrier->cancel(e);
     }
 }
 

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -103,7 +103,7 @@ interface IBarrier : extends IInterface
 {
     virtual const mptag_t queryTag() const = 0;
     virtual bool wait(bool exception, unsigned timeout=INFINITE) = 0;
-    virtual void cancel() = 0;
+    virtual void cancel(IException *e=NULL) = 0;
 };
 
 graph_decl IThorResource &queryThor();

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -594,6 +594,7 @@ public:
     virtual const mptag_t queryTag() const { return tag; }
     virtual bool wait(bool exception, unsigned timeout)
     {
+        Owned<IException> e;
         CTimeMon tm(timeout);
         unsigned s=comm->queryGroup().ordinality()-1;
         bool aborted = false;
@@ -617,6 +618,10 @@ public:
                     break;
             }
             msg.read(aborted);
+            bool hasExcept;
+            msg.read(hasExcept);
+            if (hasExcept && !e.get())
+                e.setown(deserializeException(msg));
             sender = sender - 1; // 0 = master
             if (raisedSet->testSet(sender, true) && !aborted)
                 WARNLOG("CBarrierMaster, raise barrier message on tag %d, already received from slave %d", tag, sender);
@@ -624,6 +629,13 @@ public:
         }
         msg.clear();
         msg.append(aborted);
+        if (e)
+        {
+            msg.append(true);
+            serializeException(e, msg);
+        }
+        else
+            msg.append(false);
         if (INFINITE != timeout && tm.timedout(&remaining))
         {
             if (exception)
@@ -635,19 +647,28 @@ public:
             throw MakeStringException(0, "CBarrierMaster::wait - Timeout sending to slaves");
         if (aborted)
         {
-            if (exception)
-                throw createBarrierAbortException();
-            else
+            if (!exception)
                 return false;
+            if (e)
+                throw e.getClear();
+            else
+                throw createBarrierAbortException();
         }
         return true;
     }
-    virtual void cancel()
+    virtual void cancel(IException *e)
     {
         if (receiving)
             comm->cancel(RANK_ALL, tag);
         CMessageBuffer msg;
         msg.append(true);
+        if (e)
+        {
+            msg.append(true);
+            serializeException(e, msg);
+        }
+        else
+            msg.append(false);
         if (!comm->send(msg, RANK_ALL_OTHER, tag, LONGTIMEOUT))
             throw MakeStringException(0, "CBarrierMaster::cancel - Timeout sending to slaves");
     }
@@ -2025,8 +2046,11 @@ bool CMasterGraph::fireException(IException *e)
             reportExceptionToWorkunit(job.queryWorkUnit(), e);
             break;
         case tea_abort:
+        {
+            EXCLOG(e, NULL);
             abort(e);
             // fall through
+        }
         default:
         {
             LOG(MCerror, thorJob, e);
@@ -2417,7 +2441,7 @@ bool CMasterGraph::preStart(size32_t parentExtractSz, const byte *parentExtract)
     CGraphBase::preStart(parentExtractSz, parentExtract);
     if (isGlobal())
     {
-        if (!startBarrier->wait(false)) // ensure all graphs are at start point at same time, as some may request data from each other.
+        if (!startBarrier->wait(true)) // ensure all graphs are at start point at same time, as some may request data from each other.
             return false;
     }
     if (!queryOwner())

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -46,10 +46,12 @@ public:
     }
     virtual bool wait(bool exception, unsigned timeout)
     {
+        Owned<IException> e;
         CTimeMon tm(timeout);
         unsigned remaining = timeout;
         CMessageBuffer msg;
         msg.append(false);
+        msg.append(false); // no exception
         if (INFINITE != timeout && tm.timedout(&remaining))
         {
             if (exception)
@@ -74,21 +76,34 @@ public:
         }
         bool aborted;
         msg.read(aborted);
+        bool hasExcept;
+        msg.read(hasExcept);
+        if (hasExcept)
+            e.setown(deserializeException(msg));
         if (aborted)
         {
-            if (exception)
-                throw createBarrierAbortException();
-            else
+            if (!exception)
                 return false;
+            if (e)
+                throw e.getClear();
+            else
+                throw createBarrierAbortException();
         }   
         return true;
     }
-    virtual void cancel()
+    virtual void cancel(IException *e)
     {
         if (receiving)
             comm->cancel(comm->queryGroup().rank(), tag);
         CMessageBuffer msg;
         msg.append(true);
+        if (e)
+        {
+            msg.append(true);
+            serializeException(e, msg);
+        }
+        else
+            msg.append(false);
         if (!comm->send(msg, 0, tag, LONGTIMEOUT))
             throw MakeStringException(0, "CBarrierSlave::cancel - Timeout sending to master");
     }


### PR DESCRIPTION
When a slave aborts and sends an exception, it aborts the
local graph, aborting some barrier points in the process.
As a consequence, the master can proceed beyond the barrier
point without directly knowing what the exception was.
If the timings is unlucky, the master will proceed on to the
next subgraph before being receiving the original exception
from the slave(s).

Change so that the exception is transmitted with the barrier
cancel, so the master can abort with the relevant exception
immediately.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
