### PR TITLE
HPCC-10097 Regression test javaembed crashing intermittently

### DIFF
--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -108,6 +108,7 @@ public:
         ForEachItemIn(idx, optionStrings)
         {
             options[idx].optionString = (char *) optionStrings.item(idx);
+            options[idx].extraInfo = NULL;
         }
         vm_args.nOptions = optionStrings.length();
         vm_args.options = options;


### PR DESCRIPTION
I have no proof that it's related to the (unreproducable) occasional crash,
but I did spot that I was not initializing one field passed to the jvm at
startup.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
