### PR TITLE
HPCC-10052 - Add missing stop in previous commit.

### DIFF
--- a/thorlcr/activities/funnel/thfunnelslave.cpp
+++ b/thorlcr/activities/funnel/thfunnelslave.cpp
@@ -892,6 +892,7 @@ public:
     }
     void stop()
     {
+        stopInput(inputs.item(0));
         if (selectedInput)
             selectedInput->stop();
         dataLinkStop();


### PR DESCRIPTION
I think only side-effect was a warning on stop() from the
NWaySelect activity.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
