### PR TITLE
hpcc-10101 Ensure DESDL ESP is not created by default

### DIFF
--- a/initfiles/etc/DIR_NAME/genenvrules.conf
+++ b/initfiles/etc/DIR_NAME/genenvrules.conf
@@ -1,7 +1,7 @@
 
 [Algorithm]
 max_comps_per_node=4
-do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver,ecldirect
+do_not_generate=SiteCertificate,dfuplus,soapplus,eclplus,ldapServer,ws_account,eclserver,ecldirect,DynamicESDL
 avoid_combo=dali-eclagent,dali-sasha
 comps_on_all_nodes=dafilesrv,ftslave
 exclude_from_comps_on_all_nodes=ldapServer


### PR DESCRIPTION
Add DynamicESDL ESP component to the HPCC-Platform "do_not_generate" list

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
