### PR TITLE
HPCC-10106 Rebuild Persists if input files change, ignore other persists

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1802,6 +1802,9 @@ void HqlCppTranslator::postProcessOptions()
     //Probably best to ignore this warning. - possibly configure it based on some other option
     queryWarningProcessor().addGlobalOnWarning(HQLWRN_FoldRemoveKeyed, ignoreAtom);
 
+    //Ensure the settings for the following options are always present in the workunit
+    wu()->setDebugValueInt("expandPersistInputDependencies",options.expandPersistInputDependencies,true);
+
     if (options.forceVariableWuid)
         wu()->setCloneable(true);
 }

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1706,6 +1706,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.traceIR,"traceIR",false),
         DebugOption(options.preserveCaseExternalParameter,"preserveCaseExternalParameter",true),
         DebugOption(options.optimizeParentAccess,"optimizeParentAccess",false),
+        DebugOption(options.expandPersistInputDependencies,"expandPersistInputDependencies",true),
     };
 
     //get options values from workunit

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -721,6 +721,7 @@ struct HqlCppOptions
     bool                traceIR;
     bool                preserveCaseExternalParameter;
     bool                optimizeParentAccess;
+    bool                expandPersistInputDependencies;
 };
 
 //Any information gathered while processing the query should be moved into here, rather than cluttering up the translator class

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -5255,6 +5255,7 @@ WorkflowTransformer::WorkflowTransformer(IWorkUnit * _wu, HqlCppTranslator & _tr
     onceWfid = 0;
     combineAllStored = translator.queryOptions().combineAllStored;
     combineTrivialStored = translator.queryOptions().combineTrivialStored;
+    expandPersistInputDependencies = translator.queryOptions().expandPersistInputDependencies;
     isRootAction = true;
     isRoxie = (translator.getTargetClusterType() == RoxieCluster);
     workflowOut = NULL;
@@ -5417,6 +5418,9 @@ void WorkflowTransformer::extractDependentInputs(UnsignedArray & visited, Depend
         switch (match->workflowOp)
         {
         case no_persist:
+            if (expandPersistInputDependencies)
+                break;
+            continue;
         case no_stored:
             continue;
         }

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -533,6 +533,7 @@ protected:
     bool                      combineTrivialStored;
     bool                      isRootAction;
     bool                      isRoxie;
+    bool                      expandPersistInputDependencies;
     UnsignedArray             cumulativeDependencies;
     UnsignedArray             emptyDependencies;
     UnsignedArray             storedWfids;


### PR DESCRIPTION
Previously persists rebuild if any direct input files, or any persists they
were dependent on changed.  With this change the persist will rebuild if any
direct or indirect input files change.  This allows intermediate persists
to be deleted without causing other persists to rebuild.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
