### PR TITLE
HPCC-10113 - Lookup join incorrectly handling KEEP(1)

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -694,7 +694,7 @@ public:
 
                 fuzzyMatch = 0 != (JFmatchrequired & flags);
                 bool maySkip = 0 != (flags & JFtransformMaySkip);
-                dedup = compareRight && !maySkip && !fuzzyMatch && (!returnMany || 1==keepLimit);
+                dedup = compareRight && !maySkip && !fuzzyMatch && !returnMany;
 
                 // code gen should spot invalid constants on KEEP with LOOKUP (without MANY)
                 break;


### PR DESCRIPTION
KEEP(1) in conjunction with MANY and ATMOST could cause
spurious records.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
