### PR TITLE
HPCC-10108 No way to disable quote processing and use the CSV quick partitioning

### DIFF
--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -1337,7 +1337,7 @@ public:
             t->setProp("@csvSeparate",separate);
         if (terminate && *terminate)
             t->setProp("@csvTerminate",terminate);
-        if (quote && *quote)
+        if (quote)  //Enable to pass zero string to override default quote
             t->setProp("@csvQuote",quote);
         if (escape && *escape)
             t->setProp("@csvEscape",escape);

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -575,17 +575,7 @@ CCsvPartitioner::CCsvPartitioner(const FileFormat & _format) : CInputBasePartiti
     maxElementLength = 1;
     format.set(_format);
     addActionList(matcher, format.separate.get() ? format.separate.get() : "\\,", SEPARATOR, &maxElementLength);
-    const char * quote = format.quote.get();
-    if (quote)
-    {
-        if (*quote)
-            // Define new quote char(s)
-            addActionList(matcher, quote, QUOTE, &maxElementLength);
-    }
-    else
-        // Set default quote char
-        addActionList(matcher, "'", QUOTE, &maxElementLength);
-
+    addActionList(matcher, format.quote.get() ? format.quote.get() : "'", QUOTE, &maxElementLength);
     addActionList(matcher, format.terminate.get() ? format.terminate.get() : "\\n,\\r\\n", TERMINATOR, &maxElementLength);
     const char * escape = format.escape.get();
     if (escape && *escape)

--- a/dali/ft/daftformat.ipp
+++ b/dali/ft/daftformat.ipp
@@ -265,19 +265,13 @@ public:
     CCsvQuickPartitioner(const FileFormat & _format, bool _noTranslation) 
         : CCsvPartitioner(_format) 
     { 
-        noTranslation = _noTranslation; 
-        if (_format.quote.get()) { 
+        noTranslation = _noTranslation;
+        const char * quote = _format.quote.get();  
+        if (quote && (*quote == '\0')) { 
             isquoted = false;
-            StringArray csl;
-            csl.appendList(_format.quote, ","); // OTT but catches previous kludge of ","
-            ForEachItemIn(i,csl) {
-                if (strlen(csl.item(i)))
-                isquoted = true;
-            }
         }       
-        else // default is NULL which is quoted
+        else // default is quoted
             isquoted = true;
-        isquoted = (!_format.quote.get()) || (*_format.quote.get()); // sic - null or not empty
     }
 
 protected:


### PR DESCRIPTION
Add quote char overriding with zero ('') string capability.
Fix empty quote handling bug in CCsvQuickPartitioner constructor.
Add extra pass to discover record structure into CCsvQuickPartitioner.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
