### PR TITLE
HPCC-9521 Refactor CDfsLogicalFileName to make it purely representationa...

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -858,10 +858,10 @@ public:
         redirection.setown(createDFSredirection());
     }
 
-    IDistributedFile *dolookup(const CDfsLogicalFileName &logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout);
+    IDistributedFile *dolookup(CDfsLogicalFileName &logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout);
 
     IDistributedFile *lookup(const char *_logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout);
-    IDistributedFile *lookup(const CDfsLogicalFileName &logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout);
+    IDistributedFile *lookup(CDfsLogicalFileName &logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout);
     
     IDistributedFile *createNew(IFileDescriptor * fdesc, const char *lname,bool includeports=false);
     IDistributedFile *createNew(IFileDescriptor * fdesc, bool includeports=false)
@@ -1115,17 +1115,17 @@ static void checkLogicalScope(const char *scopename,IUserDescriptor *user,bool r
         throw e;
 }
 
-static bool checkLogicalName(const CDfsLogicalFileName &dlfn,IUserDescriptor *user,bool readreq,bool createreq,bool allowquery,const char *specialnotallowedmsg)
+static bool checkLogicalName(CDfsLogicalFileName &dlfn,IUserDescriptor *user,bool readreq,bool createreq,bool allowquery,const char *specialnotallowedmsg)
 {
     bool ret = true;
     if (dlfn.isMulti()) { //is temporary superFile?
         if (specialnotallowedmsg)
             throw MakeStringException(-1,"cannot %s a multi file name (%s)",specialnotallowedmsg,dlfn.get());
         if (!dlfn.isExpanded())
-            const_cast<CDfsLogicalFileName &>(dlfn).expand(user);
+            dlfn.expand(user);//expand wildcards
         unsigned i = dlfn.multiOrdinality();
         while (--i)//continue looping even when ret is false, in order to check for illegal elements (foreigns/externals), and to check each scope permission
-            ret = checkLogicalName(dlfn.multiItem(i),user,readreq,createreq,allowquery,specialnotallowedmsg)&&ret;
+            ret = checkLogicalName((CDfsLogicalFileName &)dlfn.multiItem(i),user,readreq,createreq,allowquery,specialnotallowedmsg)&&ret;
     }
     else {
         if (specialnotallowedmsg) {
@@ -4666,12 +4666,12 @@ public:
         init(_parent,conn->queryRoot(),_name,user,transaction,timeout);
     }
 
-    CDistributedSuperFile(CDistributedFileDirectory *_parent,const CDfsLogicalFileName &_name, IUserDescriptor* user, IDistributedFileTransaction *transaction)
+    CDistributedSuperFile(CDistributedFileDirectory *_parent, CDfsLogicalFileName &_name, IUserDescriptor* user, IDistributedFileTransaction *transaction)
     {
         // temp super file
         assertex(_name.isMulti());
         if (!_name.isExpanded())
-            const_cast<CDfsLogicalFileName &>(_name).expand(user);
+            _name.expand(user);//expand wildcards
         Owned<IPropertyTree> tree = _name.createSuperTree();
         init(_parent,tree,_name,user,transaction);
     }
@@ -6644,14 +6644,13 @@ IDistributedFile *CDistributedFileDirectory::lookup(const char *_logicalname, IU
     return lookup(logicalname, user, writeattr, hold, transaction, timeout);
 }
 
-IDistributedFile *CDistributedFileDirectory::dolookup(const CDfsLogicalFileName &_logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout)
+IDistributedFile *CDistributedFileDirectory::dolookup(CDfsLogicalFileName &_logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout)
 {
-    const CDfsLogicalFileName *logicalname = &_logicalname;
+    CDfsLogicalFileName *logicalname = &_logicalname;
     if (logicalname->isMulti()) 
     {
-        assertex(_logicalname.isExpanded());
         // don't bother checking because the sub file creation will
-        return new CDistributedSuperFile(this,*logicalname,user,transaction); // temp superfile
+        return new CDistributedSuperFile(this,_logicalname,user,transaction); // temp superfile
     }
     Owned<IDfsLogicalFileNameIterator> redmatch;
     loop {
@@ -6723,7 +6722,7 @@ IDistributedFile *CDistributedFileDirectory::dolookup(const CDfsLogicalFileName 
     return NULL;
 }
 
-IDistributedFile *CDistributedFileDirectory::lookup(const CDfsLogicalFileName &logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout)
+IDistributedFile *CDistributedFileDirectory::lookup(CDfsLogicalFileName &logicalname, IUserDescriptor *user, bool writeattr, bool hold, IDistributedFileTransaction *transaction, unsigned timeout)
 {
     return dolookup(logicalname, user, writeattr, hold, transaction, timeout);
 }
@@ -8453,7 +8452,7 @@ public:
         mb.clear();
         CDfsLogicalFileName dlfn;   
         dlfn.set(lname);
-        const CDfsLogicalFileName *logicalname=&dlfn;   
+        CDfsLogicalFileName *logicalname=&dlfn;
         Owned<IDfsLogicalFileNameIterator> redmatch;
         loop {
             StringBuffer tail;

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1121,6 +1121,8 @@ static bool checkLogicalName(const CDfsLogicalFileName &dlfn,IUserDescriptor *us
     if (dlfn.isMulti()) { //is temporary superFile?
         if (specialnotallowedmsg)
             throw MakeStringException(-1,"cannot %s a multi file name (%s)",specialnotallowedmsg,dlfn.get());
+        if (dlfn.isWild())
+            const_cast<CDfsLogicalFileName &>(dlfn).expand(user);
         unsigned i = dlfn.multiOrdinality();
         while (--i)//continue looping even when ret is false, in order to check for illegal elements (foreigns/externals), and to check each scope permission
             ret = checkLogicalName(dlfn.multiItem(i),user,readreq,createreq,allowquery,specialnotallowedmsg)&&ret;
@@ -4668,6 +4670,8 @@ public:
     {
         // temp super file
         assertex(_name.isMulti());
+        if (_name.isWild())
+            const_cast<CDfsLogicalFileName &>(_name).expand(user);
         Owned<IPropertyTree> tree = _name.createSuperTree();
         init(_parent,tree,_name,user,transaction);
     }
@@ -6644,8 +6648,12 @@ IDistributedFile *CDistributedFileDirectory::dolookup(const CDfsLogicalFileName 
 {
     const CDfsLogicalFileName *logicalname = &_logicalname;
     if (logicalname->isMulti()) 
+    {
+        if (_logicalname.isWild())
+            const_cast<CDfsLogicalFileName &>(_logicalname).expand(user);
         // don't bother checking because the sub file creation will
         return new CDistributedSuperFile(this,*logicalname,user,transaction); // temp superfile
+    }
     Owned<IDfsLogicalFileNameIterator> redmatch;
     loop {
         checkLogicalName(*logicalname,user,true,writeattr,true,NULL);

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1121,7 +1121,7 @@ static bool checkLogicalName(const CDfsLogicalFileName &dlfn,IUserDescriptor *us
     if (dlfn.isMulti()) { //is temporary superFile?
         if (specialnotallowedmsg)
             throw MakeStringException(-1,"cannot %s a multi file name (%s)",specialnotallowedmsg,dlfn.get());
-        if (dlfn.isWild())
+        if (!dlfn.isExpanded())
             const_cast<CDfsLogicalFileName &>(dlfn).expand(user);
         unsigned i = dlfn.multiOrdinality();
         while (--i)//continue looping even when ret is false, in order to check for illegal elements (foreigns/externals), and to check each scope permission
@@ -4670,7 +4670,7 @@ public:
     {
         // temp super file
         assertex(_name.isMulti());
-        if (_name.isWild())
+        if (!_name.isExpanded())
             const_cast<CDfsLogicalFileName &>(_name).expand(user);
         Owned<IPropertyTree> tree = _name.createSuperTree();
         init(_parent,tree,_name,user,transaction);
@@ -6649,8 +6649,7 @@ IDistributedFile *CDistributedFileDirectory::dolookup(const CDfsLogicalFileName 
     const CDfsLogicalFileName *logicalname = &_logicalname;
     if (logicalname->isMulti()) 
     {
-        if (_logicalname.isWild())
-            const_cast<CDfsLogicalFileName &>(_logicalname).expand(user);
+        assertex(_logicalname.isExpanded());
         // don't bother checking because the sub file creation will
         return new CDistributedSuperFile(this,*logicalname,user,transaction); // temp superfile
     }

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -441,7 +441,7 @@ interface IDistributedFileDirectory: extends IInterface
                                         unsigned timeout=INFINITE
                                     ) = 0;  // links, returns NULL if not found
 
-    virtual IDistributedFile *lookup(   const CDfsLogicalFileName &logicalname,
+    virtual IDistributedFile *lookup(   CDfsLogicalFileName &logicalname,
                                         IUserDescriptor *user,
                                         bool writeaccess=false,
                                         bool hold = false,

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -136,11 +136,6 @@ public:
             dlfns.push_back(other.item(i));
     }
 
-    virtual ~CMultiDLFN()
-    {
-        dlfns.clear();
-    }
-
     bool expand(IUserDescriptor *_udesc)
     {
         if (expanded)
@@ -232,8 +227,8 @@ public:
         return dlfns.at(idx);
     }
 
-    inline unsigned ordinality(){ return dlfns.size(); }
-    inline bool isExpanded()    { return expanded; }
+    inline unsigned ordinality() const { return dlfns.size(); }
+    inline bool isExpanded()     const { return expanded; }
 };
 
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -33,6 +33,7 @@
 #include "dadfs.hpp"
 #include "dasds.hpp"
 #include "daclient.hpp"
+#include <vector>
 
 #ifdef _DEBUG
 //#define TEST_DEADLOCK_RELEASE
@@ -90,48 +91,116 @@ inline bool validFNameChar(char c)
  * This helper class is used for temporary inline super-files
  * only.
  */
+
 class CMultiDLFN
 {
-    unsigned count;
-    CDfsLogicalFileName *dlfns;
-
+    std::vector<CDfsLogicalFileName> dlfns;
+    bool anywilds;
+    bool expanded;
+    StringBuffer prefix;
 public:
-    CMultiDLFN(const char *prefix,const StringArray &lfns)
+    CMultiDLFN(const char *_prefix,const StringArray &lfns)
     {
+#ifdef _DEBUG
+        DBGLOG("PREFIX: %s",_prefix);
+        for (unsigned xx=0; xx<lfns.ordinality(); xx++)
+            DBGLOG("lfn[%d]: %s",xx,lfns.item(xx));//@@
+#endif
         unsigned c = lfns.ordinality();
-        count = 0;
-        dlfns = new CDfsLogicalFileName[c];
-        StringBuffer lfn(prefix);
-        size32_t l = lfn.length();
-        for (unsigned i=0;i<c;i++) {
+        StringBuffer lfn(_prefix);
+        size32_t len = lfn.length();
+        anywilds = false;
+        expanded = true;
+        for (unsigned i=0;i<c;i++) {    //Populate CDfsLogicalFileName array with each logical filespec
             const char * s = lfns.item(i);
             skipSp(s);
             if (*s=='~')
-                s++;
+                s++;//scope provided, create CDfsLogicalFileName as-is
             else {
-                lfn.setLength(l);
+                lfn.setLength(len);//scope not specified, append it before creating CDfsLogicalFileName
                 lfn.append(s);
                 s = lfn.str();
             }
-            dlfns[count++].set(s);
+            CDfsLogicalFileName lfn;
+            lfn.set(s);
+            dlfns.push_back(lfn);
+            if (!anywilds && (strchr(s,'*') || strchr(s,'?')))
+            {
+                expanded = false;
+                anywilds = true;
+            }
         }
+        prefix.append(_prefix);
     }
 
     CMultiDLFN(CMultiDLFN &other)
     {
-        count = other.ordinality();
-        dlfns = new CDfsLogicalFileName[count];
-        ForEachItemIn(i,other) {
-            dlfns[i].set(other.item(i));
-        }
+        anywilds = other.anywilds;
+        expanded = other.expanded;
+        prefix = other.prefix;
+        ForEachItemIn(i,other)
+            dlfns.push_back(other.item(i));
     }
 
-    ~CMultiDLFN()
+    virtual ~CMultiDLFN()
     {
-        delete [] dlfns;
+        dlfns.clear();
     }
 
-    static CMultiDLFN *create(const char *_mlfn, IUserDescriptor *_udesc)
+    bool expand(IUserDescriptor *_udesc)
+    {
+        if (expanded || !anywilds)
+            return true;
+        StringArray lfnExpanded;
+        StringBuffer tmp;
+        const char * s = prefix.str();
+        const char *start = strchr(s,'{');
+        for (unsigned idx=0; idx < dlfns.size(); idx++)
+        {
+            const char *suffix = dlfns.at(idx).get();
+            if (strchr(suffix,'*') || strchr(suffix,'?'))
+            {
+                tmp.clear();
+                if (*suffix=='~')
+                    tmp.append((strcmp(suffix+1,"*")==0) ? "?*" : suffix+1);
+                else
+                    tmp.append(suffix);
+                tmp.clip().toLowerCase();
+                Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),_udesc,false,true,NULL);
+                prefix.setLength(start-s);
+                ForEach(*iter)
+                {
+                    IPropertyTree &attr = iter->query();
+                    if (!&attr)
+                        continue;
+                    const char *name = attr.queryProp("@name");
+                    if (!name||!*name)
+                        continue;
+                    if (memicmp(name,prefix.str(),prefix.length())==0) // optimize
+                        lfnExpanded.append(name+prefix.length());
+                    else
+                    {
+                        tmp.clear().append('~').append(name); // need leading ~ otherwise will get two prefixes
+                        lfnExpanded.append(tmp.str());
+                    }
+                }
+            }
+            else
+                lfnExpanded.append(suffix);
+        }
+
+        dlfns.clear();
+        ForEachItemIn(i3,lfnExpanded)
+        {
+            CDfsLogicalFileName item;
+            item.set(lfnExpanded.item(i3));
+            dlfns.push_back(item);
+        }
+        expanded = true;
+        return true;
+    }
+
+    static CMultiDLFN *create(const char *_mlfn)
     {
         StringBuffer mlfn(_mlfn);
         mlfn.trim();
@@ -145,7 +214,7 @@ public:
         const char *start = strchr(s,'{');
         if (!start)
             return NULL;
-        mlfn.setLength(start-s);
+        mlfn.setLength(start-s);//isolate prefix (anything before leading {
         StringArray lfns;
         lfns.appendList(start+1, ",");
         bool anywilds = false;
@@ -156,67 +225,22 @@ public:
                 break;
             }
         }
-        if (anywilds) {
-            StringArray lfnout;
-            StringBuffer tmp;
-            ForEachItemIn(i2,lfns) {
-                const char *suffix = lfns.item(i2);
-                if (strchr(suffix,'*')||strchr(suffix,'?')) {
-                    tmp.clear();
-                    if (*suffix=='~')
-                        tmp.append((strcmp(suffix+1,"*")==0)?"?*":suffix+1);
-                    else
-                        tmp.append(mlfn).append(suffix);
-                    tmp.clip().toLowerCase();
-                    Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),_udesc,false,true,NULL);
-                    mlfn.setLength(start-s);
-                    ForEach(*iter) {
-                        IPropertyTree &attr = iter->query();
-                        if (!&attr)
-                            continue;
-                        const char *name = attr.queryProp("@name");
-                        if (!name||!*name)
-                            continue;
-                        if (memicmp(name,mlfn.str(),mlfn.length())==0) // optimize
-                            lfnout.append(name+mlfn.length());
-                        else {
-                            tmp.clear().append('~').append(name); // need leading ~ otherwise will get two prefixes
-                            lfnout.append(tmp.str());
-                        }
-                    }
-                }
-                else
-                    lfnout.append(suffix);
-            }
-            lfns.kill();
-            ForEachItemIn(i3,lfnout) {
-                lfns.append(lfnout.item(i3));
-            }
-            // if wildcards, create object even if 0 matches,
-            // if 0 matches, the logical file will look like an empty temp. super "{}"
-            return new CMultiDLFN(mlfn.str(),lfns);
-        }
-        if (lfns.ordinality()==0)
-            return NULL;
-        CMultiDLFN *ret =  new CMultiDLFN(mlfn.str(),lfns);
-        if (ret->ordinality())
+        CMultiDLFN *ret =  new CMultiDLFN(mlfn.str(), lfns);
+        if (ret->ordinality() || anywilds)
             return ret;
         delete ret;
         return NULL;
     }
 
-    const CDfsLogicalFileName &item(unsigned idx)
+    CDfsLogicalFileName &item(unsigned idx)
     {
-        assertex(idx<count);
-        return dlfns[idx];
+        assertex(idx < dlfns.size());
+        return dlfns.at(idx);
     }
 
-    unsigned ordinality()
-    {
-        return count;
-    }
-
-
+    inline unsigned ordinality(){ return dlfns.size(); }
+    inline bool anyWildcards()  { return anywilds; }
+    inline bool isExpanded()    { return expanded; }
 };
 
 
@@ -224,7 +248,6 @@ CDfsLogicalFileName::CDfsLogicalFileName()
 {
     allowospath = false;
     multi = NULL;
-    udesc = NULL;
     clear();
 }
 
@@ -250,6 +273,12 @@ bool CDfsLogicalFileName::isSet() const
     return s&&*s;
 }
 
+CDfsLogicalFileName & CDfsLogicalFileName::operator = (CDfsLogicalFileName const &from)
+{
+    set(from);
+    return *this;
+}
+
 void CDfsLogicalFileName::set(const CDfsLogicalFileName &other)
 {
     lfn.set(other.lfn);
@@ -268,52 +297,60 @@ bool CDfsLogicalFileName::isForeign() const
 {
     if (localpos!=0)
         return true;
-    if (multi) {
-        ForEachItemIn(i1,*multi) {
+    if (multi)
+    {
+        if (!multi->isExpanded())
+            throw MakeStringException(-1, "Must call CDfsLogicalFileName::expand() before calling CDfsLogicalFileName::isForeign(), wildcards are specified");
+        ForEachItemIn(i1,*multi)
             if (multi->item(i1).isForeign())        // if any are say all are
                 return true;
-        }
     }
     return false;
 }
 
-void CDfsLogicalFileName::set(const char *name)
+bool CDfsLogicalFileName::isWild() const
 {
-    clear();
-    StringBuffer str;
-    if (!name)
-        return;
-    skipSp(name);
-    try {
-        multi = CMultiDLFN::create(name,udesc);
-    }
-    catch (IException *e) {
-        StringBuffer err;
-        e->errorMessage(err);
-        WARNLOG("CDfsLogicalFileName::set %s",err.str());
-        e->Release();
-    }
-    if (multi) {
-        StringBuffer full;
-        full.append('{');
-        ForEachItemIn(i1,*multi) {
-            if (i1)
-                full.append(',');
-            const CDfsLogicalFileName &item = multi->item(i1);
-            full.append(item.get());
-            if (item.isExternal())
-                external = external || item.isExternal();
+    if (multi)
+        return multi->anyWildcards();
+    return false;
+}
+
+bool CDfsLogicalFileName::expand(IUserDescriptor *user)
+{
+    if (multi && multi->anyWildcards() && !multi->isExpanded())
+    {
+        try
+        {
+            multi->expand(user);//expand wildcard specifications
+            StringBuffer full("{");
+            ForEachItemIn(i1,*multi)
+            {
+                if (i1)
+                    full.append(',');
+                const CDfsLogicalFileName &item = multi->item(i1);
+                StringAttr norm;
+                normalizeName(item.get(), norm);
+                full.append(norm);
+                if (item.isExternal())
+                    external = external || item.isExternal();
+            }
+            full.append('}');
+            lfn.set(full);
         }
-        full.append('}');
-        lfn.set(full);
-        return;
+        catch (IException *e)
+        {
+            StringBuffer err;
+            e->errorMessage(err);
+            WARNLOG("CDfsLogicalFileName::expand %s",err.str());
+            e->Release();
+        }
     }
-    if (allowospath&&(isAbsolutePath(name)||(stdIoHandle(name)>=0)||(strstr(name,"::")==NULL))) {
-        RemoteFilename rfn;
-        rfn.setRemotePath(name);
-        setExternal(rfn);
-        return;
-    }
+    return true;
+}
+
+void CDfsLogicalFileName::normalizeName(const char * name, StringAttr &res)
+{
+    StringBuffer str;
     StringBuffer nametmp;
     const char *s = name;
     const char *ct = NULL;
@@ -335,6 +372,12 @@ void CDfsLogicalFileName::set(const char *name)
         }
         s++;
     }
+    if (wilddetected)
+    {
+        res.set(name);
+        return;
+    }
+
     bool isext = memicmp(name,EXTERNAL_SCOPE "::",sizeof(EXTERNAL_SCOPE "::")-1)==0;
     if (!isext&&wilddetected)
         throw MakeStringException(-1,"Wildcards not allowed in filename (%s)",name);
@@ -377,7 +420,7 @@ void CDfsLogicalFileName::set(const char *name)
                             str.append("::");
                             tailpos = str.length();
                             str.append(s+2);
-                            lfn.set(str);
+                            res.set(str);
                             return;
                         }
 
@@ -421,10 +464,49 @@ void CDfsLogicalFileName::set(const char *name)
     }
     skipSp(s);
     str.append(s).clip().toLowerCase();
-    lfn.set(str);
+    res.set(str);
 }
 
 
+void CDfsLogicalFileName::set(const char *name)
+{
+    clear();
+    StringBuffer str;
+    if (!name)
+        return;
+    skipSp(name);
+    try {
+        multi = CMultiDLFN::create(name);
+    }
+    catch (IException *e) {
+        StringBuffer err;
+        e->errorMessage(err);
+        WARNLOG("CDfsLogicalFileName::set %s",err.str());
+        e->Release();
+    }
+    if (multi) {
+        StringBuffer full;
+        full.append('{');
+        ForEachItemIn(i1,*multi) {
+            if (i1)
+                full.append(',');
+            const CDfsLogicalFileName &item = multi->item(i1);
+            full.append(item.get());
+            if (item.isExternal())
+                external = external || item.isExternal();
+        }
+        full.append('}');
+        lfn.set(full);
+        return;
+    }
+    if (allowospath&&(isAbsolutePath(name)||(stdIoHandle(name)>=0)||(strstr(name,"::")==NULL))) {
+        RemoteFilename rfn;
+        rfn.setRemotePath(name);
+        setExternal(rfn);
+        return;
+    }
+    normalizeName(name, lfn);
+}
 bool CDfsLogicalFileName::setValidate(const char *lfn,bool removeforeign)
 {
     // NB will allows multi
@@ -2736,7 +2818,6 @@ public:
 
     bool init(const char *fname,IUserDescriptor *user,bool onlylocal,bool onlydfs, bool write)
     {
-        lfn.setUserDescriptor(user);
         fileExists = false;
         if (!onlydfs)
             lfn.allowOsPath(true);

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -300,10 +300,10 @@ bool CDfsLogicalFileName::isExpanded() const
 {
     if (multi)
         return multi->isExpanded();
-    return false;
+    return true;
 }
 
-bool CDfsLogicalFileName::expand(IUserDescriptor *user)
+void CDfsLogicalFileName::expand(IUserDescriptor *user)
 {
     if (multi && !multi->isExpanded())
     {
@@ -334,7 +334,6 @@ bool CDfsLogicalFileName::expand(IUserDescriptor *user)
             throw;
         }
     }
-    return true;
 }
 
 void CDfsLogicalFileName::normalizeName(const char * name, StringAttr &res)

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -133,7 +133,7 @@ public:
     const void resolveWild();  // only for multi
     IPropertyTree *createSuperTree() const;
     void allowOsPath(bool allow=true) { allowospath = allow; } // allow local OS path to be specified
-    bool isWild() const;
+    bool isExpanded() const;
     bool expand(IUserDescriptor *user);
     void normalizeName(const char * name, StringAttr &res);
 };

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -134,7 +134,7 @@ public:
     IPropertyTree *createSuperTree() const;
     void allowOsPath(bool allow=true) { allowospath = allow; } // allow local OS path to be specified
     bool isExpanded() const;
-    bool expand(IUserDescriptor *user);
+    void expand(IUserDescriptor *user);
     void normalizeName(const char * name, StringAttr &res);
 };
 

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -59,11 +59,12 @@ class da_decl CDfsLogicalFileName
     CMultiDLFN *multi;   // for temp superfile
     bool external;
     bool allowospath;
-    IUserDescriptor *udesc;
+
 public:
     CDfsLogicalFileName();
     ~CDfsLogicalFileName();
 
+    CDfsLogicalFileName & operator = (CDfsLogicalFileName const &from);
     void set(const char *lfn);
     void set(const CDfsLogicalFileName &lfn);
     bool setValidate(const char *lfn,bool removeforeign=false); // checks for invalid chars
@@ -71,7 +72,6 @@ public:
     bool setFromMask(const char *partmask,const char *rootdir=NULL);
     void clear();
     bool isSet() const;
-    void setUserDescriptor(IUserDescriptor *_udesc) { udesc = _udesc; }
     /*
      * Foreign files are distributed files whose meta data is stored on a foreign
      * Dali Server, so their names are resolved externally.
@@ -133,6 +133,9 @@ public:
     const void resolveWild();  // only for multi
     IPropertyTree *createSuperTree() const;
     void allowOsPath(bool allow=true) { allowospath = allow; } // allow local OS path to be specified
+    bool isWild() const;
+    bool expand(IUserDescriptor *user);
+    void normalizeName(const char * name, StringAttr &res);
 };
 
 // abstract class, define getCmdText to return tracing text of commands

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1553,16 +1553,16 @@ bool FindInStringArray(StringArray& clusters, const char *cluster)
     return bFound;
 }
 
-static void getFilePermission(const CDfsLogicalFileName &dlfn, ISecUser* user, IUserDescriptor* udesc, ISecManager* secmgr, int& permission)
+static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser* user, IUserDescriptor* udesc, ISecManager* secmgr, int& permission)
 {
     if (dlfn.isMulti())
     {
         if (!dlfn.isExpanded())
-            const_cast<CDfsLogicalFileName &>(dlfn).expand(udesc);
+            dlfn.expand(udesc);
         unsigned i = dlfn.multiOrdinality();
         while (i--)
         {
-            getFilePermission(dlfn.multiItem(i), user, udesc, secmgr, permission);
+            getFilePermission((CDfsLogicalFileName &)dlfn.multiItem(i), user, udesc, secmgr, permission);
         }
     }
     else

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1557,7 +1557,7 @@ static void getFilePermission(const CDfsLogicalFileName &dlfn, ISecUser* user, I
 {
     if (dlfn.isMulti())
     {
-        if (dlfn.isWild())
+        if (!dlfn.isExpanded())
             const_cast<CDfsLogicalFileName &>(dlfn).expand(udesc);
         unsigned i = dlfn.multiOrdinality();
         while (i--)

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1557,6 +1557,8 @@ static void getFilePermission(const CDfsLogicalFileName &dlfn, ISecUser* user, I
 {
     if (dlfn.isMulti())
     {
+        if (dlfn.isWild())
+            const_cast<CDfsLogicalFileName &>(dlfn).expand(udesc);
         unsigned i = dlfn.multiOrdinality();
         while (i--)
         {


### PR DESCRIPTION
...l of a logical file, avoid it resolving/looking up

Currently CDfsLogicalFileName resolves any wildcards in logical file names
when it is instantiated. This is unnecessary since in most cases they dont
need to be. This pull request delays the expansion until it is actually
needed, by adding a new "isWild" and "expand" method to the interface.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
