### PR TITLE
HPCC-10096 Use correct queryset name to get Activated status

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2427,11 +2427,11 @@ public:
 
             IPropertyTree* getAllQuerySetQueries(IRemoteConnection* conn, const char *querySet, const char *xPath)
             {
-                Owned<IPropertyTree> queryRegistry = getQueryRegistry(querySet, false);
                 Owned<IPropertyTree> queryTree = createPTree("Queries");
                 IPropertyTree* root = conn->queryRoot();
                 if (querySet && *querySet)
                 {
+                    Owned<IPropertyTree> queryRegistry = getQueryRegistry(querySet, false);
                     VStringBuffer path("QuerySet[@id='%s']/Query%s", querySet, xPath);
                     populateQueryTree(queryRegistry, querySet, root, path.str(), queryTree);
                 }
@@ -2440,12 +2440,13 @@ public:
                     Owned<IPropertyTreeIterator> iter = root->getElements("QuerySet");
                     ForEach(*iter)
                     {
-                        IPropertyTree &querySet = iter->query();
-                        const char* id = querySet.queryProp("@id");
+                        IPropertyTree &querySetTree = iter->query();
+                        const char* id = querySetTree.queryProp("@id");
                         if (id && *id)
                         {
+                            Owned<IPropertyTree> queryRegistry = getQueryRegistry(id, false);
                             VStringBuffer path("Query%s", xPath);
-                            populateQueryTree(queryRegistry, id, &querySet, path.str(), queryTree);
+                            populateQueryTree(queryRegistry, id, &querySetTree, path.str(), queryTree);
                         }
                     }
                 }

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1134,7 +1134,8 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
         if(!cw)
             throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Cannot open workunit %s.",wuid);
 
-        resp.setPriority(getQueryPriorityName(query->getPropInt("@priority")));
+        if (query->hasProp("@priority"))
+            resp.setPriority(getQueryPriorityName(query->getPropInt("@priority")));
         resp.setIsLibrary(query->getPropBool("@isLibrary"));
         SCMStringBuffer s;
         resp.setWUSnapShot(cw->getSnapshot(s).str()); //Label


### PR DESCRIPTION
When no queryet name is specified, WsWorkunits/WUListQueries returns query
information (including Activated status) for all queries by looping through
every querysets. Incorrect activated status is returned because the existing
code uses incorrect queryset name for the querysets. The problem is sloved
by this fix.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
