### PR TITLE
HPCC-10131: Add support for optional 'jvmlibpath' property in environment.conf; add additional error checking to JVM initialization.

### DIFF
--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -80,21 +80,34 @@ public:
         StringArray optionStrings;
         const char* origPath = getenv("CLASSPATH");
         StringBuffer newPath;
-        newPath.append("-Djava.class.path=").append(origPath);
+        newPath.append("-Djava.class.path=");
+        if (origPath && *origPath)
+        {
+            newPath.append(origPath).append(ENVSEPCHAR);
+        }
         StringBuffer envConf;
         envConf.append(CONFIG_DIR).append(PATHSEPSTR).append("environment.conf");
         Owned<IProperties> conf = createProperties(envConf.str(), true);
         if (conf && conf->hasProp("classpath"))
         {
-            newPath.append(ENVSEPCHAR);
             conf->getProp("classpath", newPath);
+            newPath.append(ENVSEPCHAR);
         }
         else
         {
-            newPath.append(ENVSEPCHAR).append(INSTALL_DIR).append(PATHSEPCHAR).append("classes");
+            newPath.append(INSTALL_DIR).append(PATHSEPCHAR).append("classes").append(ENVSEPCHAR);
         }
-        newPath.append(ENVSEPCHAR).append(".");
+        newPath.append(".");
         optionStrings.append(newPath);
+        
+        if (conf && conf->hasProp("jvmlibpath"))
+        {
+            StringBuffer libPath;
+            libPath.append("-Djava.library.path=");
+            conf->getProp("jvmlibpath", libPath);
+            optionStrings.append(libPath);
+        }
+        
         if (conf && conf->hasProp("jvmoptions"))
         {
             optionStrings.appendList(conf->queryProp("jvmoptions"), ENVSEPSTR);
@@ -107,7 +120,9 @@ public:
         JavaVMOption* options = new JavaVMOption[optionStrings.length()];
         ForEachItemIn(idx, optionStrings)
         {
+            DBGLOG("javaembed: Setting JVM option: %s",(char *)optionStrings.item(idx));
             options[idx].optionString = (char *) optionStrings.item(idx);
+            options[idx].extraInfo = NULL;
         }
         vm_args.nOptions = optionStrings.length();
         vm_args.options = options;
@@ -115,9 +130,12 @@ public:
         vm_args.version = JNI_VERSION_1_6;
         /* load and initialize a Java VM, return a JNI interface pointer in env */
         JNIEnv *env;       /* receives pointer to native method interface */
-        JNI_CreateJavaVM(&javaVM, (void**)&env, &vm_args);
+        int createResult = JNI_CreateJavaVM(&javaVM, (void**)&env, &vm_args);
 
         delete [] options;
+        
+        if (createResult != 0)
+            throw MakeStringException(0, "javaembed: Unable to initialize JVM (%d)",createResult);
     }
     ~JavaGlobalState()
     {


### PR DESCRIPTION
1) The java.class.path parameter mistakenly receives an empty directory value if CLASSPATH isn't set in the environment. This manifests as a ':' prepended to the -Djava.class.path=xxx option passed to the JVM.

2) An exception should be thrown if the JVM cannot be initialized.

3) Add support for optional 'jvmlibpath' to environment.conf to explicitly support the -Djava.library.path=xxx option for the JVM.
