### PR TITLE
HPCC-9847 ECLCC crash due to dynamic record type within a MODULE

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -2924,6 +2924,8 @@ IHqlExpression * ensureExprType(IHqlExpression * expr, ITypeInfo * type, node_op
         {
             if (!expr->queryRecord())
                 return LINK(expr);      // something seriously wrong - will get picked up elsewhere...
+            if(!queryOriginalRecord(type))
+                 throwUnexpectedX("Cast to DATASET with no record TYPE specified");   //  cf. HPCC-9847
             OwnedHqlExpr transform = createRecordMappingTransform(no_newtransform, queryOriginalRecord(type), expr->queryNormalizedSelector());
             if (transform)
                 return createDatasetF(no_newusertable, LINK(expr), LINK(queryOriginalRecord(type)), LINK(transform), NULL);

--- a/ecl/regress/issue9847.ecl
+++ b/ecl/regress/issue9847.ecl
@@ -1,0 +1,13 @@
+testMod(dataset ds) := MODULE
+  tmpRecord := record
+    dataset(recordof(ds)) child_ds1 := [];
+  end;
+  export tmpDataset := dataset([{ds}], tmpRecord);
+END;
+
+r := record
+  string20 s20;
+end;
+d := dataset([{'aaa'}], r);
+blarg := testMod(d);
+blarg.tmpDataset;


### PR DESCRIPTION
The fix here is only temporary, to prevent the crash. Really the grammar/syntax
should be changed to force (possibly implicitly) dynamic record types as VIRTUAL
types when passed as a function argument.

p.s. I'm not sure if the ECL code should be added to the regression suite since it is incorrect.

Signed-off-by: jamienoss james.noss@lexisnexis.com
