### PR TITLE
HPCC-10126 htpasswd Authentication Modify Users Issue

### DIFF
--- a/esp/services/ws_access/ws_accessService.hpp
+++ b/esp/services/ws_access/ws_accessService.hpp
@@ -78,6 +78,7 @@ class Cws_accessEx : public Cws_access
     void getBaseDNsForAddingPermssionToAccount(CLdapSecManager* secmgr, const char* prefix, const char* accountName, 
         int accountType, StringArray& basednNames);
     int enableDisableScopeScans(IEspContext &context, bool doEnable, StringBuffer &retMsg);
+    CLdapSecManager* queryLDAPSecurityManager(IEspContext &context);
 
 public:
     IMPLEMENT_IINTERFACE;

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -442,6 +442,7 @@ public:
     virtual int queryDefaultPermission(ISecUser& user);
     virtual bool clearPermissionsCache(ISecUser &user);
     virtual bool authenticateUser(ISecUser & user, bool &superUser);
+    virtual secManagerType querySecMgrType() { return SMT_LDAP; }
 };
 
 #endif

--- a/system/security/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/htpasswdSecurity/htpasswdSecurity.cpp
@@ -37,6 +37,11 @@ public:
 		userMap.kill();
 	}
 
+	secManagerType querySecMgrType()
+	{
+		return SMT_HTPasswd;
+	}
+
 	IAuthMap * createAuthMap(IPropertyTree * authconfig)
 	{
 		CAuthMap* authmap = new CAuthMap(this);

--- a/system/security/shared/defaultsecuritymanager.hpp
+++ b/system/security/shared/defaultsecuritymanager.hpp
@@ -82,6 +82,7 @@ public:
     virtual bool createUserScopes() { return false; }
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) { return 0; }
     virtual int queryDefaultPermission(ISecUser& user) { return SecAccess_Full; }
+    virtual secManagerType querySecMgrType() { return SMT_Default; }
 };
 
 class CLocalSecurityManager : public CDefaultSecurityManager
@@ -93,6 +94,7 @@ public:
     IAuthMap * createAuthMap(IPropertyTree * authconfig);
 protected:
     virtual bool IsPasswordValid(ISecUser& sec_user);
+    virtual secManagerType querySecMgrType() { return SMT_Local; }
 };
 
 

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -257,6 +257,14 @@ interface IAuthMap : extends IInterface
     virtual ISecResourceList * getResourceList(const char * path) = 0;
 };
 
+enum secManagerType
+{
+    SMT_New,
+    SMT_Default,
+    SMT_Local,
+    SMT_LDAP,
+    SMT_HTPasswd
+};
 interface ISecManager : extends IInterface
 {
     virtual ISecUser * createUser(const char * user_name) = 0;
@@ -300,6 +308,7 @@ interface ISecManager : extends IInterface
     virtual int queryDefaultPermission(ISecUser& user) = 0;
     virtual bool clearPermissionsCache(ISecUser & user) = 0;
     virtual bool authenticateUser(ISecUser & user, bool &superUser) = 0;
+    virtual secManagerType querySecMgrType() = 0;
 };
 
 interface IExtSecurityManager


### PR DESCRIPTION
When HTPASSWD authentication is enabled, LDAP specific features such as
permissions, grouping,etc are not supported. This pull request adds a new
error message "LDAP Security manager is required for this feature. Please
 enable LDAP in the system configuration" that is now displayed any time
these features are selected

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
