### PR TITLE
HPCC-9547 packagemap-validate warning when library redefines query files

### DIFF
--- a/common/workunit/package.h
+++ b/common/workunit/package.h
@@ -34,10 +34,13 @@ interface IHpccPackage : extends IInterface
 {
     virtual ISimpleSuperFileEnquiry *resolveSuperFile(const char *superFileName) const = 0;
     virtual bool hasSuperFile(const char *superFileName) const = 0;
+    virtual const char *locateSuperFile(const char *superFileName) const = 0;
+
     virtual const char *queryEnv(const char *varname) const = 0;
     virtual bool getEnableFieldTranslation() const = 0;
     virtual const IPropertyTree *queryTree() const = 0;
     virtual hash64_t queryHash() const = 0;
+    virtual const char *queryId() const = 0;
 };
 
 interface IHpccPackageMap : extends IInterface

--- a/common/workunit/referencedfilelist.hpp
+++ b/common/workunit/referencedfilelist.hpp
@@ -42,6 +42,7 @@ interface IReferencedFile : extends IInterface
     virtual const char *getLogicalName() const =0;
     virtual unsigned getFlags() const =0;
     virtual const SocketEndpoint &getForeignIP(SocketEndpoint &ep) const =0;
+    virtual const char *queryPackageId() const =0;
 };
 
 interface IReferencedFileIterator : extends IIteratorOf<IReferencedFile> { };

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1267,6 +1267,7 @@ extern WORKUNIT_API void deleteQuerySetQuery(const char *querySetName, const cha
 extern WORKUNIT_API const char *queryIdFromQuerySetWuid(const char *querySetName, const char *wuid, IStringVal &id);
 extern WORKUNIT_API void removeQuerySetAliasesFromNamedQuery(const char *querySetName, const char * id);
 extern WORKUNIT_API void setQueryCommentForNamedQuery(const char *querySetName, const char *id, const char *comment);
+extern WORKUNIT_API void gatherLibraryNames(StringArray &names, StringArray &unresolved, IWorkUnitFactory &workunitFactory, IConstWorkUnit &cw, IPropertyTree *queryset);
 
 extern WORKUNIT_API void associateLocalFile(IWUQuery * query, WUFileType type, const char * name, const char * description, unsigned crc);
 

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -453,6 +453,10 @@ public:
     {
         return CPackageNode::queryHash();
     }
+    virtual const char *queryId() const
+    {
+        return CPackageNode::queryId();
+    }
 };
 
 typedef CResolvedPackage<CRoxiePackageNode> CRoxiePackage;


### PR DESCRIPTION
In Packagemaps if a query and a library redefine the same file
ecl-packagemap-validate should give a warning.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
