### PR TITLE
HPCC-10113 - Dedup RHS if keep and no atmost/abortlimit

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -665,6 +665,7 @@ public:
         rightHash = NULL;
         compareLeftRight = NULL;
         keepLimit = 0;
+        dedup = false;
         switch (joinKind)
         {
             case join_all:
@@ -694,8 +695,13 @@ public:
 
                 fuzzyMatch = 0 != (JFmatchrequired & flags);
                 bool maySkip = 0 != (flags & JFtransformMaySkip);
-                dedup = compareRight && !maySkip && !fuzzyMatch && !returnMany;
-
+                if (compareRight && !maySkip && !fuzzyMatch)
+                {
+                    if (returnMany)
+                        dedup = (1==keepLimit) && (0 == atMost) && (0==abortLimit);
+                    else
+                        dedup = true;
+                }
                 // code gen should spot invalid constants on KEEP with LOOKUP (without MANY)
                 break;
             }


### PR DESCRIPTION
Can still dedup RHS with KEEP(1) as long as there is no ATMOST
or LIMIT

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
