### PR TITLE
HPCC-10153 Add PublishedBy/IsLibrary to WUListQueries response

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1065,6 +1065,11 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
             q->setPriority(getQueryPriorityName(query.getPropInt("@priority")));
         if (query.hasProp("@comment"))
             q->setComment(query.queryProp("@comment"));
+        if (version >= 1.46)
+        {
+            q->setPublishedBy(query.queryProp("@publishedBy"));
+            q->setIsLibrary(query.getPropBool("@isLibrary"));
+        }
 
         try
         {


### PR DESCRIPTION
Those two items should be added to WUListQueries response in order
to display them on ListQueries page.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
