### PR TITLE
HPCC-10156 Add TpListTargetClusters method to WsTopology

### DIFF
--- a/esp/scm/ws_topology.ecm
+++ b/esp/scm/ws_topology.ecm
@@ -262,6 +262,22 @@ ESPStruct TpServices
     ESParray<ESPstruct TpSashaServer> TpSashaServers;
 };
 
+ESPStruct TpClusterNameType
+{
+    string Name;
+    string Type;
+    bool   IsDefault;
+};
+
+ESPrequest TpListTargetClustersRequest
+{
+};
+
+ESPresponse [exceptions_inline] TpListTargetClustersResponse
+{
+    ESParray<ESPstruct TpClusterNameType>   TargetClusters;
+};
+
 //  ===========================================================================
 ESPStruct TpTargetCluster
 {
@@ -583,6 +599,7 @@ ESPservice [noforms, version("1.19"), default_client_version("1.19"), exceptions
     ESPmethod [resp_xsl_default("/esp/xslt/tplog.xslt")] TpLogFile(TpLogFileRequest, TpLogFileResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/tplogdisplay.xslt")] TpLogFileDisplay(TpLogFileRequest, TpLogFileResponse);
     ESPmethod TpGetComponentFile(TpGetComponentFileRequest, TpGetComponentFileResponse);
+    ESPmethod TpListTargetClusters(TpListTargetClustersRequest, TpListTargetClustersResponse);
 
     ESPmethod SystemLog(SystemLogRequest, SystemLogResponse);
 };

--- a/esp/services/ws_topology/ws_topologyService.hpp
+++ b/esp/services/ws_topology/ws_topologyService.hpp
@@ -87,6 +87,8 @@ private:
     bool                                m_bDiskThresholdIsPercentage;
     bool                                m_bEncapsulatedSystem;
     bool                                m_enableSNMP;
+    StringAttr                          defaultTargetClusterName;
+    StringAttr                          defaultTargetClusterPrefix;
 
     void getThorXml(const char *cluster,StringBuffer& strBuff);
     void getThorLog(const char *cluster,MemoryBuffer& returnbuff);
@@ -116,6 +118,8 @@ public:
     virtual void init(IPropertyTree *cfg, const char *process, const char *service);
 
     bool onTpClusterQuery(IEspContext &context, IEspTpClusterQueryRequest &req, IEspTpClusterQueryResponse &resp);
+
+    bool onTpListTargetClusters(IEspContext &context, IEspTpListTargetClustersRequest &req, IEspTpListTargetClustersResponse &resp);
 
     bool onTpTargetClusterQuery(IEspContext &context, IEspTpTargetClusterQueryRequest &req, IEspTpTargetClusterQueryResponse &resp);
 


### PR DESCRIPTION
The existing TpTargetClusterQuery method returns too much information and
can be slow. A new method is requested which only returns cluster name,
type, and whether the cluster is a 'default' target (for jobs like syntax check, 
etc) or not. This fix implements the new method called TpListTargetClusters.

The default target cluster may be specified in esp.xml (see the other
subtask in the parent issue). If not, the isDefault will be set using
the following logic: Loop through all targets. If an hthor is found,
it will be the 'default'. If no hthor, the first thor cluster will be
the 'default'. If no hther and no thor, the first roxie cluster will
be the 'default'.
