### PR TITLE
HPCC-10134 - LogicalToPhysical file was not working

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -273,6 +273,7 @@ void CSlaveMessageHandler::main()
                     else
                         queryThorFileManager().getPhysicalName(job, logicalName, partNo, phys);
                     msg.append(phys);
+                    job.queryJobComm().reply(msg);
                     break;
                 }
                 case smt_getFileOffset:


### PR DESCRIPTION
A missing line in the master handling of getFilePart was causing
the slaves to never receive the reply.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
