### PR TITLE
HPCC-10127 Configmgr - Location section missing in esp.xml

### DIFF
--- a/initfiles/componentfiles/configxml/@temp/esp_service.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service.xsl
@@ -239,6 +239,9 @@ xmlns:seisint="http://seisint.com"  xmlns:set="http://exslt.org/sets" exclude-re
             <xsl:when test="$authMethod='htpasswd'">
               <Authenticate method="htpasswd">
                 <xsl:attribute name="htpasswdFile"> <xsl:value-of select="$bindingNode/../Authentication/@htpasswdFile"/> </xsl:attribute>
+                <xsl:for-each select="$bindingNode/Authenticate[@path='/']">
+                    <Location path="/" resource="{@resource}" required="{@access}" description="{@description}"/>
+                </xsl:for-each>
               </Authenticate>
             </xsl:when>
         </xsl:choose>


### PR DESCRIPTION
- Location section is missing in configuration file esp.xml when
  binding to ws_ecl service and using htpasswd.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
