### PR TITLE
HPCC-10015 Add WUID wildcard search for WUQuery

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2332,8 +2332,9 @@ public:
             }
         };
         Owned<ISortedElementsTreeFilter> sc = new CScopeChecker(secmgr,secuser);
-        StringBuffer query("*");
+        StringBuffer query;
         StringBuffer so;
+        StringAttr namefilter("*");
         StringAttr namefilterlo;
         StringAttr namefilterhi;
         if (filters) {
@@ -2345,6 +2346,8 @@ public:
                     namefilterlo.set(fv);
                 else if (subfmt==WUSFwuidhigh) 
                     namefilterhi.set(fv);
+                else if (subfmt==WUSFwildwuid)
+                    namefilter.set(fv);
                 else {
                     query.append('[').append(getEnumText(subfmt,workunitSortFields)).append('=');
                     if (fmt&WUSFnocase)
@@ -2356,6 +2359,7 @@ public:
                 fv = fv + strlen(fv)+1;
             }
         }
+        query.insert(0, namefilter.get());
         if (sortorder) {
             for (unsigned i=0;sortorder[i]!=WUSFterm;i++) {
                 if (so.length())

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1078,6 +1078,7 @@ enum WUSortField
     WUSFbatchinputfile = 18,
     WUSFbatchoutputfile = 19,
     WUSFtotalthortime = 20,
+    WUSFwildwuid = 21,
     WUSFterm = 0,
     WUSFreverse = 256,
     WUSFnocase = 512,

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2029,6 +2029,7 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
             bDoubleCheckState = true;
     }
 
+    addWUQueryFilter(filters, filterCount, filterbuf, req.getWuid(), WUSFwildwuid);
     addWUQueryFilter(filters, filterCount, filterbuf, req.getCluster(), WUSFcluster);
     if(version > 1.07)
         addWUQueryFilter(filters, filterCount, filterbuf, req.getRoxieCluster(), WUSFroxiecluster);
@@ -2385,13 +2386,8 @@ bool CWsWorkunitsEx::onWUQuery(IEspContext &context, IEspWUQueryRequest & req, I
 
         if (req.getType() && strieq(req.getType(), "archived workunits"))
             doWUQueryFromArchive(context, *archivedWuCache, awusCacheMinutes, req, resp);
-        else if(notEmpty(wuid))
-        {
-            if (!looksLikeAWuid(wuid))
-                throw MakeStringException(ECLWATCH_INVALID_INPUT, "Invalid Workunit ID: %s", wuid);
-
+        else if(notEmpty(wuid) && looksLikeAWuid(wuid))
             doWUQueryBySingleWuid(context, wuid, resp);
-        }
         else if (notEmpty(req.getECL()) || notEmpty(req.getApplicationName()) || notEmpty(req.getApplicationKey()) || notEmpty(req.getApplicationData()))
             doWUQueryByXPath(context, req, resp);
         else if (notEmpty(req.getLogicalFile()) && req.getLogicalFileSearchType() && strieq(req.getLogicalFileSearchType(), "Created"))


### PR DESCRIPTION
This fix implements WUID wildcard search for WUQuery. A user
may input W20130918\* as a search request and WUQuery returns
a list of WUs that were created on that day.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
