### PR TITLE
HPCC-9521 Refactor CDfsLogicalFileName to make it purely representationa...

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -431,7 +431,7 @@ interface IDistributedFileDirectory: extends IInterface
                                         unsigned timeout=INFINITE
                                     ) = 0;  // links, returns NULL if not found
 
-    virtual IDistributedFile *lookup(   const CDfsLogicalFileName &logicalname,
+    virtual IDistributedFile *lookup(   CDfsLogicalFileName &logicalname,
                                         IUserDescriptor *user,
                                         bool writeaccess=false,
                                         bool hold = false,
@@ -652,7 +652,7 @@ extern da_decl StringBuffer &getClusterSpareGroupName(IPropertyTree &cluster, St
 
 extern da_decl IDistributedFileTransaction *createDistributedFileTransaction(IUserDescriptor *user);
 
-extern da_decl const char *normalizeLFN(const char *s, StringBuffer &normalized, IUserDescriptor *user);
+extern da_decl const char *normalizeLFN(const char *s, StringBuffer &normalized);
 
 extern da_decl IDFAttributesIterator *createSubFileFilter(IDFAttributesIterator *_iter,IUserDescriptor* _user, bool includesub, unsigned timems=INFINITE); // takes ownership of iter
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -33,6 +33,7 @@
 #include "dadfs.hpp"
 #include "dasds.hpp"
 #include "daclient.hpp"
+#include <vector>
 
 #ifdef _DEBUG
 //#define TEST_DEADLOCK_RELEASE
@@ -90,48 +91,99 @@ inline bool validFNameChar(char c)
  * This helper class is used for temporary inline super-files
  * only.
  */
+
 class CMultiDLFN
 {
-    unsigned count;
-    CDfsLogicalFileName *dlfns;
-
+    std::vector<CDfsLogicalFileName> dlfns;
+    bool expanded;
+    StringBuffer prefix;
 public:
-    CMultiDLFN(const char *prefix,const StringArray &lfns)
+    CMultiDLFN(const char *_prefix,const StringArray &lfns)
     {
         unsigned c = lfns.ordinality();
-        count = 0;
-        dlfns = new CDfsLogicalFileName[c];
-        StringBuffer lfn(prefix);
-        size32_t l = lfn.length();
-        for (unsigned i=0;i<c;i++) {
+        StringBuffer lfn(_prefix);
+        size32_t len = lfn.length();
+        expanded = true;
+        for (unsigned i=0;i<c;i++) {    //Populate CDfsLogicalFileName array with each logical filespec
             const char * s = lfns.item(i);
             skipSp(s);
             if (*s=='~')
-                s++;
+                s++;//scope provided, create CDfsLogicalFileName as-is
             else {
-                lfn.setLength(l);
+                lfn.setLength(len);//scope not specified, append it before creating CDfsLogicalFileName
                 lfn.append(s);
                 s = lfn.str();
             }
-            dlfns[count++].set(s);
+            CDfsLogicalFileName lfn;
+            lfn.set(s);
+            dlfns.push_back(lfn);
+            if (expanded && (strchr(s,'*') || strchr(s,'?')))
+                expanded = false;
         }
+        prefix.append(_prefix);
     }
 
     CMultiDLFN(CMultiDLFN &other)
     {
-        count = other.ordinality();
-        dlfns = new CDfsLogicalFileName[count];
-        ForEachItemIn(i,other) {
-            dlfns[i].set(other.item(i));
-        }
+        expanded = other.expanded;
+        prefix = other.prefix;
+        ForEachItemIn(i,other)
+            dlfns.push_back(other.item(i));
     }
 
-    ~CMultiDLFN()
+    void expand(IUserDescriptor *_udesc)
     {
-        delete [] dlfns;
+        if (expanded)
+            return;
+        StringArray lfnExpanded;
+        StringBuffer tmp;
+        const char * s = prefix.str();
+        const char *start = strchr(s,'{');
+        for (unsigned idx=0; idx < dlfns.size(); idx++)
+        {
+            const char *suffix = dlfns.at(idx).get();
+            if (strchr(suffix,'*') || strchr(suffix,'?'))
+            {
+                tmp.clear();
+                if (*suffix=='~')
+                    tmp.append((strcmp(suffix+1,"*")==0) ? "?*" : suffix+1);
+                else
+                    tmp.append(suffix);
+                tmp.clip().toLowerCase();
+                Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),_udesc,false,true,NULL);
+                prefix.setLength(start-s);
+                ForEach(*iter)
+                {
+                    IPropertyTree &attr = iter->query();
+                    if (!&attr)
+                        continue;
+                    const char *name = attr.queryProp("@name");
+                    if (!name||!*name)
+                        continue;
+                    if (memicmp(name,prefix.str(),prefix.length())==0) // optimize
+                        lfnExpanded.append(name+prefix.length());
+                    else
+                    {
+                        tmp.clear().append('~').append(name); // need leading ~ otherwise will get two prefixes
+                        lfnExpanded.append(tmp.str());
+                    }
+                }
+            }
+            else
+                lfnExpanded.append(suffix);
+        }
+
+        dlfns.clear();
+        ForEachItemIn(i3,lfnExpanded)
+        {
+            CDfsLogicalFileName item;
+            item.set(lfnExpanded.item(i3));
+            dlfns.push_back(item);
+        }
+        expanded = true;
     }
 
-    static CMultiDLFN *create(const char *_mlfn, IUserDescriptor *_udesc)
+    static CMultiDLFN *create(const char *_mlfn)
     {
         StringBuffer mlfn(_mlfn);
         mlfn.trim();
@@ -145,7 +197,7 @@ public:
         const char *start = strchr(s,'{');
         if (!start)
             return NULL;
-        mlfn.setLength(start-s);
+        mlfn.setLength(start-s);//isolate prefix (anything before leading {
         StringArray lfns;
         lfns.appendList(start+1, ",");
         bool anywilds = false;
@@ -156,50 +208,8 @@ public:
                 break;
             }
         }
-        if (anywilds) {
-            StringArray lfnout;
-            StringBuffer tmp;
-            ForEachItemIn(i2,lfns) {
-                const char *suffix = lfns.item(i2);
-                if (strchr(suffix,'*')||strchr(suffix,'?')) {
-                    tmp.clear();
-                    if (*suffix=='~')
-                        tmp.append((strcmp(suffix+1,"*")==0)?"?*":suffix+1);
-                    else
-                        tmp.append(mlfn).append(suffix);
-                    tmp.clip().toLowerCase();
-                    Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),_udesc,false,true,NULL);
-                    mlfn.setLength(start-s);
-                    ForEach(*iter) {
-                        IPropertyTree &attr = iter->query();
-                        if (!&attr)
-                            continue;
-                        const char *name = attr.queryProp("@name");
-                        if (!name||!*name)
-                            continue;
-                        if (memicmp(name,mlfn.str(),mlfn.length())==0) // optimize
-                            lfnout.append(name+mlfn.length());
-                        else {
-                            tmp.clear().append('~').append(name); // need leading ~ otherwise will get two prefixes
-                            lfnout.append(tmp.str());
-                        }
-                    }
-                }
-                else
-                    lfnout.append(suffix);
-            }
-            lfns.kill();
-            ForEachItemIn(i3,lfnout) {
-                lfns.append(lfnout.item(i3));
-            }
-            // if wildcards, create object even if 0 matches,
-            // if 0 matches, the logical file will look like an empty temp. super "{}"
-            return new CMultiDLFN(mlfn.str(),lfns);
-        }
-        if (lfns.ordinality()==0)
-            return NULL;
-        CMultiDLFN *ret =  new CMultiDLFN(mlfn.str(),lfns);
-        if (ret->ordinality())
+        CMultiDLFN *ret =  new CMultiDLFN(mlfn.str(), lfns);
+        if (ret->ordinality() || anywilds)
             return ret;
         delete ret;
         return NULL;
@@ -207,16 +217,12 @@ public:
 
     const CDfsLogicalFileName &item(unsigned idx)
     {
-        assertex(idx<count);
-        return dlfns[idx];
+        assertex(idx < dlfns.size());
+        return dlfns.at(idx);
     }
 
-    unsigned ordinality()
-    {
-        return count;
-    }
-
-
+    inline unsigned ordinality() const { return dlfns.size(); }
+    inline bool isExpanded()     const { return expanded; }
 };
 
 
@@ -224,7 +230,6 @@ CDfsLogicalFileName::CDfsLogicalFileName()
 {
     allowospath = false;
     multi = NULL;
-    udesc = NULL;
     clear();
 }
 
@@ -250,6 +255,12 @@ bool CDfsLogicalFileName::isSet() const
     return s&&*s;
 }
 
+CDfsLogicalFileName & CDfsLogicalFileName::operator = (CDfsLogicalFileName const &from)
+{
+    set(from);
+    return *this;
+}
+
 void CDfsLogicalFileName::set(const CDfsLogicalFileName &other)
 {
     lfn.set(other.lfn);
@@ -268,52 +279,60 @@ bool CDfsLogicalFileName::isForeign() const
 {
     if (localpos!=0)
         return true;
-    if (multi) {
-        ForEachItemIn(i1,*multi) {
+    if (multi)
+    {
+        if (!multi->isExpanded())
+            throw MakeStringException(-1, "Must call CDfsLogicalFileName::expand() before calling CDfsLogicalFileName::isForeign(), wildcards are specified");
+        ForEachItemIn(i1,*multi)
             if (multi->item(i1).isForeign())        // if any are say all are
                 return true;
-        }
     }
     return false;
 }
 
-void CDfsLogicalFileName::set(const char *name)
+bool CDfsLogicalFileName::isExpanded() const
 {
-    clear();
-    StringBuffer str;
-    if (!name)
-        return;
-    skipSp(name);
-    try {
-        multi = CMultiDLFN::create(name,udesc);
-    }
-    catch (IException *e) {
-        StringBuffer err;
-        e->errorMessage(err);
-        WARNLOG("CDfsLogicalFileName::set %s",err.str());
-        e->Release();
-    }
-    if (multi) {
-        StringBuffer full;
-        full.append('{');
-        ForEachItemIn(i1,*multi) {
-            if (i1)
-                full.append(',');
-            const CDfsLogicalFileName &item = multi->item(i1);
-            full.append(item.get());
-            if (item.isExternal())
-                external = external || item.isExternal();
+    if (multi)
+        return multi->isExpanded();
+    return true;
+}
+
+void CDfsLogicalFileName::expand(IUserDescriptor *user)
+{
+    if (multi && !multi->isExpanded())
+    {
+        try
+        {
+            multi->expand(user);//expand wildcard specifications
+            StringBuffer full("{");
+            ForEachItemIn(i1,*multi)
+            {
+                if (i1)
+                    full.append(',');
+                const CDfsLogicalFileName &item = multi->item(i1);
+                StringAttr norm;
+                normalizeName(item.get(), norm);
+                full.append(norm);
+                if (item.isExternal())
+                    external = external || item.isExternal();
+            }
+            full.append('}');
+            lfn.set(full);
         }
-        full.append('}');
-        lfn.set(full);
-        return;
+        catch (IException *e)
+        {
+            StringBuffer err;
+            e->errorMessage(err);
+            ERRLOG("CDfsLogicalFileName::expand %s",err.str());
+            e->Release();
+            throw;
+        }
     }
-    if (allowospath&&(isAbsolutePath(name)||(stdIoHandle(name)>=0)||(strstr(name,"::")==NULL))) {
-        RemoteFilename rfn;
-        rfn.setRemotePath(name);
-        setExternal(rfn);
-        return;
-    }
+}
+
+void CDfsLogicalFileName::normalizeName(const char * name, StringAttr &res)
+{
+    StringBuffer str;
     StringBuffer nametmp;
     const char *s = name;
     const char *ct = NULL;
@@ -335,6 +354,12 @@ void CDfsLogicalFileName::set(const char *name)
         }
         s++;
     }
+    if (wilddetected)
+    {
+        res.set(name);
+        return;
+    }
+
     bool isext = memicmp(name,EXTERNAL_SCOPE "::",sizeof(EXTERNAL_SCOPE "::")-1)==0;
     if (!isext&&wilddetected)
         throw MakeStringException(-1,"Wildcards not allowed in filename (%s)",name);
@@ -377,7 +402,7 @@ void CDfsLogicalFileName::set(const char *name)
                             str.append("::");
                             tailpos = str.length();
                             str.append(s+2);
-                            lfn.set(str);
+                            res.set(str);
                             return;
                         }
 
@@ -421,10 +446,49 @@ void CDfsLogicalFileName::set(const char *name)
     }
     skipSp(s);
     str.append(s).clip().toLowerCase();
-    lfn.set(str);
+    res.set(str);
 }
 
 
+void CDfsLogicalFileName::set(const char *name)
+{
+    clear();
+    StringBuffer str;
+    if (!name)
+        return;
+    skipSp(name);
+    try {
+        multi = CMultiDLFN::create(name);
+    }
+    catch (IException *e) {
+        StringBuffer err;
+        e->errorMessage(err);
+        WARNLOG("CDfsLogicalFileName::set %s",err.str());
+        e->Release();
+    }
+    if (multi) {
+        StringBuffer full;
+        full.append('{');
+        ForEachItemIn(i1,*multi) {
+            if (i1)
+                full.append(',');
+            const CDfsLogicalFileName &item = multi->item(i1);
+            full.append(item.get());
+            if (item.isExternal())
+                external = external || item.isExternal();
+        }
+        full.append('}');
+        lfn.set(full);
+        return;
+    }
+    if (allowospath&&(isAbsolutePath(name)||(stdIoHandle(name)>=0)||(strstr(name,"::")==NULL))) {
+        RemoteFilename rfn;
+        rfn.setRemotePath(name);
+        setExternal(rfn);
+        return;
+    }
+    normalizeName(name, lfn);
+}
 bool CDfsLogicalFileName::setValidate(const char *lfn,bool removeforeign)
 {
     // NB will allows multi
@@ -2752,7 +2816,6 @@ public:
 
     bool init(const char *fname,IUserDescriptor *user,bool onlylocal,bool onlydfs, bool write)
     {
-        lfn.setUserDescriptor(user);
         fileExists = false;
         if (!onlydfs)
             lfn.allowOsPath(true);

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -59,11 +59,12 @@ class da_decl CDfsLogicalFileName
     CMultiDLFN *multi;   // for temp superfile
     bool external;
     bool allowospath;
-    IUserDescriptor *udesc;
+
 public:
     CDfsLogicalFileName();
     ~CDfsLogicalFileName();
 
+    CDfsLogicalFileName & operator = (CDfsLogicalFileName const &from);
     void set(const char *lfn);
     void set(const CDfsLogicalFileName &lfn);
     bool setValidate(const char *lfn,bool removeforeign=false); // checks for invalid chars
@@ -71,7 +72,6 @@ public:
     bool setFromMask(const char *partmask,const char *rootdir=NULL);
     void clear();
     bool isSet() const;
-    void setUserDescriptor(IUserDescriptor *_udesc) { udesc = _udesc; }
     /*
      * Foreign files are distributed files whose meta data is stored on a foreign
      * Dali Server, so their names are resolved externally.
@@ -133,6 +133,9 @@ public:
     const void resolveWild();  // only for multi
     IPropertyTree *createSuperTree() const;
     void allowOsPath(bool allow=true) { allowospath = allow; } // allow local OS path to be specified
+    bool isExpanded() const;
+    void expand(IUserDescriptor *user);
+    void normalizeName(const char * name, StringAttr &res);
 };
 
 // abstract class, define getCmdText to return tracing text of commands

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1554,14 +1554,16 @@ bool FindInStringArray(StringArray& clusters, const char *cluster)
     return bFound;
 }
 
-static void getFilePermission(const CDfsLogicalFileName &dlfn, ISecUser* user, IUserDescriptor* udesc, ISecManager* secmgr, int& permission)
+static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser* user, IUserDescriptor* udesc, ISecManager* secmgr, int& permission)
 {
     if (dlfn.isMulti())
     {
+        if (!dlfn.isExpanded())
+            dlfn.expand(udesc);
         unsigned i = dlfn.multiOrdinality();
         while (i--)
         {
-            getFilePermission(dlfn.multiItem(i), user, udesc, secmgr, permission);
+            getFilePermission((CDfsLogicalFileName &)dlfn.multiItem(i), user, udesc, secmgr, permission);
         }
     }
     else

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -181,7 +181,6 @@ CWriteMasterBase::CWriteMasterBase(CMasterGraphElement *info) : CMasterActivity(
     replicateProgress.setown(new ProgressInfo);
     diskHelperBase = (IHThorDiskWriteArg *)queryHelper();
     targetOffset = 0;
-    dlfn.setUserDescriptor(container.queryJob().queryUserDescriptor());
 }
 
 void CWriteMasterBase::deserializeStats(unsigned node, MemoryBuffer &mb)

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -222,7 +222,7 @@ public:
             }
             tmp.append(logicalname).clip();
         }
-        normalizeLFN(tmp.str(), ret, job.queryUserDescriptor());
+        normalizeLFN(tmp.str(), ret);
         return ret;
     }
 


### PR DESCRIPTION
...l of a logical file, avoid it resolving/looking up

Currently CDfsLogicalFileName resolves any wildcards in logical file names
when it is instantiated. This is unnecessary since in most cases they dont
need to be. This pull request delays the expansion until it is actually
needed, by adding a new "isWild" and "expand" method to the interface.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
