### PR TITLE
HPCC-10175 Remove Roxie test page option from HPCC Platform

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -101,7 +101,6 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
     Owned<IPropertyTree> proc_cfg = getProcessConfig(tree, procname);
     m_viewConfig = proc_cfg ? proc_cfg->getPropBool("@httpConfigAccess") : false;   
     m_formOptions = proc_cfg ? proc_cfg->getPropBool("@formOptionsAccess") : false;
-    m_roxieOption = proc_cfg ? proc_cfg->getPropBool("@roxieTestAccess") : false;
     m_includeSoapTest = true;
     m_configFile.set(tree ? tree->queryProp("@config") : "esp.xml");
     Owned<IPropertyTree> bnd_cfg = getBindingConfig(tree, bindname, procname);
@@ -1892,7 +1891,6 @@ int EspHttpBinding::onGetXForm(IEspContext &context, CHttpRequest* request, CHtt
 
         xform->setParameter("formOptionsAccess", m_formOptions?"1":"0");
         xform->setParameter("includeSoapTest", m_includeSoapTest?"1":"0");
-        xform->setParameter("includeRoxieTest", m_roxieOption?"1":"0");
 
         // set the prop noDefaultValue param
         IProperties* props = context.queryRequestParameters();

--- a/esp/bindings/http/platform/httpbinding.hpp
+++ b/esp/bindings/http/platform/httpbinding.hpp
@@ -148,7 +148,6 @@ protected:
     bool                    m_includeSoapTest;
     StringBuffer            m_challenge_realm;
     StringAttr              m_defaultSvcVersion;
-    bool                    m_roxieOption;
 
 public:
     EspHttpBinding(IPropertyTree* cfg, const char *bindname=NULL, const char *procname=NULL);


### PR DESCRIPTION
Does not require code review.
Should be merged after https://github.com/hpcc-systems/LN/pull/607

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
