### PR TITLE
HPCC-10181 Add Compile Time to WUQueryDetails response

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1283,6 +1283,7 @@ ESPresponse [exceptions_inline] WUQueryDetailsResponse
     [min_ver("1.46")] bool IsLibrary;
     [min_ver("1.46")] string Priority;
     [min_ver("1.46")] string WUSnapShot; //Label
+    [min_ver("1.46")] string CompileTime;
     [min_ver("1.46")] ESParray<string> LibrariesUsed;
     [min_ver("1.46")] int CountGraphs;
     [min_ver("1.46")] ESParray<string> GraphIds;

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1139,6 +1139,11 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
         resp.setIsLibrary(query->getPropBool("@isLibrary"));
         SCMStringBuffer s;
         resp.setWUSnapShot(cw->getSnapshot(s).str()); //Label
+        cw->getTimeStamp("Compiled", "EclCCServer", s);
+        if (!s.length())
+            cw->getTimeStamp("Compiled", "EclServer", s);
+        if (s.length())
+            resp.setCompileTime(s.str());
         StringArray libUsed, graphIds;
         Owned<IConstWULibraryIterator> libs = &cw->getLibraries();
         ForEach(*libs)


### PR DESCRIPTION
The compile time is read from TimeStamps/TimeStamp[@application=
"EclServer" or "EclCCServer"] inside ECL WU xml.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
