### PR TITLE
HPCC-10183 ECL Record Layout metadata is not reported for XML files in h...

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -935,6 +935,9 @@ void CHThorXmlWriteActivity::setFormat(IFileDescriptor * desc)
     desc->queryProperties().setProp("@format","utf8n");
     desc->queryProperties().setProp("@rowTag",rowTag.str());
     desc->queryProperties().setProp("@kind", "xml");
+    const char *recordECL = helper.queryRecordECL();
+    if (recordECL && *recordECL)
+        desc->queryProperties().setProp("ECL", recordECL);
 }
 
 //=====================================================================================================


### PR DESCRIPTION
...thor

HThor is currently not writing the ECL record layout for XML files. This
fix checks to see if that information is available and if so, writes it
along with the other file properties

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
