### PR TITLE
HPCC-9722 DOCS:Non-Windows Client Tools

### DIFF
--- a/docs/HPCCClientTools/CT_Mods/CT_Overview.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Overview.xml
@@ -90,8 +90,9 @@
         <title>Actions</title>
 
         <para>In step-by-step sections, there will be explicit actions to
-        perform. These are all shown with a bullet to differentiate action
-        steps from explanatory text, as shown here:</para>
+        perform. These are all shown with a bullet or a numbered step to
+        differentiate action steps from explanatory text, as shown
+        here:</para>
 
         <para><itemizedlist>
             <listitem>
@@ -107,48 +108,52 @@
       </sect3>
     </sect2>
 
-    <sect2 id="Installation">
-      <title><emphasis>Installation</emphasis></title>
+    <sect2 id="Installation" role="brk">
+      <title>Installation</title>
 
       <para>The installation program installs all client tools, including the
-      ECL IDE, ECLPlus, DFUPlus, and RoxieConfig. The installation program
-      provides the option to select which tools to install.</para>
+      ECL IDE, ECLPlus, DFUPlus, and the ECL Command line tools.</para>
 
-      <itemizedlist mark="bullet">
+      <orderedlist>
         <listitem>
-          <para>From the CD, your Build Server, or your download:</para>
+          <para>From the HPCC Systems download page, <ulink
+          url="http://hpccsystems.com/download/free-community-edition/client-tools">http://hpccsystems.com/download/free-community-edition/client-tools</ulink></para>
+
+          <para>Download the appropriate Client Tools for your Operating
+          System. (available for CentOS, Ubuntu, Mac OSX, or Windows)</para>
         </listitem>
 
         <listitem>
-          <para>Run <emphasis role="bold">setup.msi </emphasis>, then follow
-          the prompts</para>
+          <para>Install the client tools software to your machine.</para>
+
+          <para><emphasis role="bold">Windows: </emphasis></para>
+
+          <para>Run the executable file, for example:
+          hpccsystems-clienttools_community-4.X.X-XWindows-i386.exe on your
+          machine. Follow the prompts to complete the installation.</para>
+
+          <para><emphasis role="bold">RPM-Based Systems (CentOS/RedHat):
+          </emphasis></para>
+
+          <para>An RPM installation package is provided. Install RPM with the
+          -Uvh switch, the U or upgrade will perform an upgrade if a previous
+          version is already installed. <programlisting>sudo rpm -Uvh &lt;rpm file name&gt;</programlisting></para>
+
+          <para><emphasis role="bold">Debian-Based Systems
+          (Ubuntu):</emphasis></para>
+
+          <para>For Ubuntu installations a Debian package is provided. To
+          install the package, use:</para>
+
+          <programlisting>sudo dpkg -i &lt;deb filename&gt;</programlisting>
+
+          <para><emphasis role="bold">Mac OSX:</emphasis></para>
+
+          <para>Run the installation file, for example:
+          hpccsystems-clienttools_community-4.X.X-XDarwin-x86_64.dmg. Follow
+          the prompts to complete the installation.</para>
         </listitem>
-      </itemizedlist>
-
-      <para><emphasis>System Requirements</emphasis></para>
-
-      <para>The recommended system configuration is:</para>
-
-      <para>A Pentium III processor (or higher) and at least 128 megabytes
-      (MB) of RAM.</para>
-
-      <para>Microsoft Windows 2000, Windows XP, Windows Server 2003, Windows
-      Vista, Windows 7, or higher.</para>
-
-      <para>A full installation requires less than 16 MB of disk space.<!-- --></para>
-
-      <para>The optional Tutorial Data File is 100 MB.</para>
-
-      <para>In addition, you will need Internet Explorer 8 and have Active
-      Scripting support enabled (Javascript). If browser security is set to
-      High, you should add the ECLWatch IP (or DNS name) as a Trusted
-      Site.</para>
-
-      <para>Adobe Reader 5 (or higher) is required to view the documentation
-      PDF files.</para>
-
-      <para>GVC Viewer is used to display graphs in ECL Watch, RoxieConfig GUI
-      and ECL IDE. It is installed automatically.</para>
+      </orderedlist>
     </sect2>
   </sect1>
 </chapter>

--- a/docs/HPCCClientTools/CT_Mods/CT_Overview_withoutIDE.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Overview_withoutIDE.xml
@@ -76,8 +76,9 @@
         <title>Actions</title>
 
         <para>In step-by-step sections, there will be explicit actions to
-        perform. These are all shown with a bullet to differentiate action
-        steps from explanatory text, as shown here:</para>
+        perform. These are all shown with a bullet or a numbered step to
+        differentiate action steps from explanatory text, as shown
+        here:</para>
 
         <para><itemizedlist>
             <listitem>
@@ -93,48 +94,52 @@
       </sect3>
     </sect2>
 
-    <sect2 id="Installation">
-      <title><emphasis>Installation</emphasis></title>
+    <sect2 id="Installation" role="brk">
+      <title>Installation</title>
 
       <para>The installation program installs all client tools, including the
-      ECLPlus, DFUPlus, and RoxieConfig. The installation program provides the
-      option to select which tools to install.</para>
+      ECLPlus, DFUPlus, and the ECL Command line tools.</para>
 
-      <itemizedlist mark="bullet">
+      <orderedlist>
         <listitem>
-          <para>From the CD, your Build Server, or your download:</para>
+          <para>From the HPCC Systems download page, <ulink
+          url="http://hpccsystems.com/download/free-community-edition/client-tools">http://hpccsystems.com/download/free-community-edition/client-tools</ulink></para>
+
+          <para>Download the appropriate Client Tools for your Operating
+          System. (available for CentOS, Ubuntu, Mac OSX, or Windows)</para>
         </listitem>
 
         <listitem>
-          <para>Run <emphasis role="bold">setup.msi </emphasis>, then follow
-          the prompts</para>
+          <para>Install the client tools software to your machine.</para>
+
+          <para><emphasis role="bold">Windows: </emphasis></para>
+
+          <para>Run the executable file, for example:
+          hpccsystems-clienttools_community-4.X.X-XWindows-i386.exe on your
+          machine. Follow the prompts to complete the installation.</para>
+
+          <para><emphasis role="bold">RPM-Based Systems (CentOS/RedHat):
+          </emphasis></para>
+
+          <para>An RPM installation package is provided. Install RPM with the
+          -Uvh switch, the U or upgrade will perform an upgrade if a previous
+          version is already installed. <programlisting>sudo rpm -Uvh &lt;rpm file name&gt;</programlisting></para>
+
+          <para><emphasis role="bold">Debian-Based Systems
+          (Ubuntu):</emphasis></para>
+
+          <para>For Ubuntu installations a Debian package is provided. To
+          install the package, use:</para>
+
+          <programlisting>sudo dpkg -i &lt;deb filename&gt;</programlisting>
+
+          <para><emphasis role="bold">Mac OSX:</emphasis></para>
+
+          <para>Run the installation file, for example:
+          hpccsystems-clienttools_community-4.X.X-XDarwin-x86_64.dmg. Follow
+          the prompts to complete the installation.</para>
         </listitem>
-      </itemizedlist>
-
-      <para><emphasis>System Requirements</emphasis></para>
-
-      <para>The recommended system configuration is:</para>
-
-      <para>A Pentium III processor (or higher) and at least 128 megabytes
-      (MB) of RAM.</para>
-
-      <para>Microsoft Windows 2000, Windows XP, Windows Server 2003, Windows
-      Vista, Windows 7, or higher.</para>
-
-      <para>A full installation requires less than 16 MB of disk space.<!-- --></para>
-
-      <para>The optional Tutorial Data File is 100 MB.</para>
-
-      <para>In addition, you will need Internet Explorer 8 and have Active
-      Scripting support enabled (Javascript). If browser security is set to
-      High, you should add the ECLWatch IP (or DNS name) as a Trusted
-      Site.</para>
-
-      <para>Adobe Reader 5 (or higher) is required to view the documentation
-      PDF files.</para>
-
-      <para>GVC Viewer is used to display graphs in ECL Watch, and RoxieConfig
-      GUI. It is installed automatically.</para>
+      </orderedlist>
     </sect2>
   </sect1>
 </chapter>


### PR DESCRIPTION
Fix HPCC-9722 DOCS:Non-Windows Client Tools
Fixed the Client Tools doc to provide installation
instructions for Debian, CentOS, Mac as well as Windows OS

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com

@JamesDeFabia
