### PR TITLE
HPCC-10164 Don't substitute constants into ATMOST join conditions

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4016,9 +4016,7 @@ public:
         case no_attr_expr:
             {
                 IAtom * name = expr->queryName();
-                if (name == atmostAtom)
-                    return LINK(expr);
-                else if (name == _selectors_Atom)
+                if (name == _selectors_Atom)
                 {
                     HqlExprArray args;
                     ForEachChild(i, expr)
@@ -5120,12 +5118,18 @@ IHqlExpression * CExprFolderTransformer::percolateConstants(IHqlExpression * exp
                         updated.setown(removeProperty(updated, atmostAtom));
                     else
                     {
-                        HqlExprArray args;
-                        unwindChildren(args, updated);
-                        args.replace(*LINK(oldCond), 2);
-                        removeProperty(args, atmostAtom);
-                        args.append(*LINK(atmost));
-                        updated.setown(updated->clone(args));
+                        //KEYED joins support ATMOST and RIGHT.xxx = value
+                        if (!isKeyedJoin(updated) && joinHasRightOnlyHardMatch(updated, false))
+                        {
+                            HqlExprArray args;
+                            unwindChildren(args, updated);
+                            args.replace(*LINK(oldCond), 2);
+                            removeProperty(args, atmostAtom);
+                            args.append(*LINK(atmost));
+                            updated.setown(updated->clone(args));
+                        }
+                        else
+                            updated.setown(appendOwnedOperand(updated, createAttribute(_conditionFolded_Atom)));
                     }
                 }
                 //otherwise this might convert to an all join, accept variants that are supported by all joins

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -7735,7 +7735,7 @@ void HqlGram::checkJoinFlags(const attribute &err, IHqlExpression * join)
         if (keep && !isMany)
             reportError(ERR_BADKIND_LOOKUPJOIN, err, "%s joins do not support KEEP", joinText);
         if (join->hasAttribute(atmostAtom) && !isMany)
-            reportError(ERR_BADKIND_LOOKUPJOIN, err, "%s joins do not support ATMOST", joinText);
+            reportError(ERR_BADKIND_LOOKUPJOIN, err, "Non-Many %s joins do not support ATMOST", joinText);
         if (rowLimit && !isMany)
             reportError(ERR_BADKIND_LOOKUPJOIN, err, "%s joins do not support LIMIT (they can only match 1 entry)", joinText);
         if (isKey(join->queryChild(1)))

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -701,6 +701,7 @@ public:
 
     inline bool hasRequiredEqualities() const { return leftReq.ordinality() != 0; }
     inline bool hasOptionalEqualities() const { return leftOpt.ordinality() != 0; }
+    inline bool hasHardRightNonEquality() const { return hasRightNonEquality; }
     inline const HqlExprArray & queryLeftReq() { return leftReq; }
     inline const HqlExprArray & queryRightReq() { return rightReq; }
     inline const HqlExprArray & queryLeftOpt() { return leftOpt; }
@@ -716,6 +717,7 @@ public:
     OwnedHqlExpr extraMatch;
     HqlExprArray slidingMatches;
     bool conditionAllEqualities;
+    bool hasRightNonEquality;
 protected:
     HqlExprArray leftReq;
     HqlExprArray leftOpt;
@@ -724,5 +726,7 @@ protected:
     HqlExprArray rightOpt;
     HqlExprArray rightSorts;
 };
+
+extern HQL_API bool joinHasRightOnlyHardMatch(IHqlExpression * expr, bool allowSlidingMatch);
 
 #endif

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -11539,7 +11539,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityJoinOrDenormalize(BuildCtx & c
     JoinSortInfo joinInfo;
     joinInfo.findJoinSortOrders(expr, slidingAllowed);
 
-    if (atmostAttr && !joinInfo.conditionAllEqualities)
+    if (atmostAttr && joinInfo.hasHardRightNonEquality())
     {
         if (isAllJoin)
             allowAllToLookupConvert = false;

--- a/ecl/regress/issue10164.ecl
+++ b/ecl/regress/issue10164.ecl
@@ -1,0 +1,23 @@
+namesRecord :=
+            RECORD
+string20        surname;
+string10        forename;
+integer2        age := 25;
+            END;
+
+xRecord :=
+            RECORD
+string20        surname;
+string10        forename;
+            END;
+
+namesTable := index(namesRecord,'i');
+
+
+x := DATASET(['Smith','Blogs'], { string20 surname, });
+
+p := PROJECT(NOFOLD(x), transform(xRecord, SELF.forename := 'John'; SELF := LEFT));
+
+j := JOIN(p, namesTable, LEFT.surname = RIGHT.surname AND LEFT.forename = RIGHT.forename, ATMOST(100), LOOKUP, MANY);
+
+output(j,,'out.d00',overwrite);


### PR DESCRIPTION
This should be improved later (see HPCC-10166), but this fixes the compile
errors.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
