### PR TITLE
HPCC-10184 Potential memory leak in uncompress routine

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -812,7 +812,8 @@ static void *uncompress(const void *src, size32_t &sz)
         assertex(sz);
         expander = createLZWExpander();
         src = ((const char *)src) + sizeof(size32_t);
-        void *uncompressedValue = malloc(sz); assertex(uncompressedValue);
+        uncompressedValue = malloc(sz);
+        assertex(uncompressedValue);
         expander->init(src);
         expander->expand(uncompressedValue);
         expander->Release();


### PR DESCRIPTION
In the event of an exception in the expander, the memory buffer being
expanded into is not freed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
