### PR TITLE
HPCC-9882 Check and return exception message from removeEntry()

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1181,8 +1181,11 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                         superFileNames.append(filename);
                     }
                 }
-                if (!fdir.removeEntry(filename, userdesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT))
+                if (!fdir.removeEntry(filename, userdesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT, true))
+                {
+                    filesCannotBeDeleted.append(filename);//Add the file to the 'CannotBeDeleted' list for future use
                     returnStr.appendf("<Message><Value>Failed to delete %s</Value></Message>", filename);
+                }
                 else
                 {
                     PROGLOG("Deleted Logical File: %s by: %s\n",filename, username.str());

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1181,16 +1181,9 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                         superFileNames.append(filename);
                     }
                 }
-                if (!fdir.removeEntry(filename, userdesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT, true))
-                {
-                    filesCannotBeDeleted.append(filename);//Add the file to the 'CannotBeDeleted' list for future use
-                    returnStr.appendf("<Message><Value>Failed to delete %s</Value></Message>", filename);
-                }
-                else
-                {
-                    PROGLOG("Deleted Logical File: %s by: %s\n",filename, username.str());
-                    returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>", filename);
-                }
+                fdir.removeEntry(filename, userdesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT, true);
+                PROGLOG("Deleted Logical File: %s by: %s\n",filename, username.str());
+                returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>", filename);
             }
             catch(IException* e)
             {

--- a/esp/smc/SMCLib/LogicFileWrapper.cpp
+++ b/esp/smc/SMCLib/LogicFileWrapper.cpp
@@ -79,13 +79,9 @@ bool LogicFileWrapper::doDeleteFile(const char* logicalName,const char *cluster,
             }
         }
 
-        if (!fdir.removeEntry(cname.str(), udesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT, true))
-            returnStr.appendf("<Message><Value>Failed to delete %s</Value></Message>", cname.str());
-        else
-        {
-            returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>", cname.str());
-            DBGLOG("%s", returnStr.str());
-        }
+        fdir.removeEntry(cname.str(), udesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT, true);
+        returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>", cname.str());
+        DBGLOG("%s", returnStr.str());
         return true;
     }
     catch (IException *e)

--- a/esp/smc/SMCLib/LogicFileWrapper.cpp
+++ b/esp/smc/SMCLib/LogicFileWrapper.cpp
@@ -26,6 +26,8 @@
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
+#define REMOVE_FILE_SDS_CONNECT_TIMEOUT (1000*15)  // 15 seconds
+
 LogicFileWrapper::LogicFileWrapper()
 {
 
@@ -77,7 +79,7 @@ bool LogicFileWrapper::doDeleteFile(const char* logicalName,const char *cluster,
             }
         }
 
-        if (!fdir.removeEntry(cname.str(), udesc))
+        if (!fdir.removeEntry(cname.str(), udesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT, true))
             returnStr.appendf("<Message><Value>Failed to delete %s</Value></Message>", cname.str());
         else
         {


### PR DESCRIPTION
This fix is based on the fix in pull request 4968 which allows the
removeEntry() to send out exception message to caller. This fix sets
the throwException flag to true when WsDFU calls the removeEntry(). If
an exception is catched, the existing code will sent the exception
message to EclWatch to display.
