### PR TITLE
HPCC-10032 Add schema generator support for xpath('')

### DIFF
--- a/common/deftype/deftype.hpp
+++ b/common/deftype/deftype.hpp
@@ -365,8 +365,9 @@ public:
     virtual void addField(const char * name, ITypeInfo & type) = 0;
     virtual void addSetField(const char * name, const char * itemname, ITypeInfo & type) = 0;
     virtual void beginIfBlock() = 0;
-    virtual bool beginDataset(const char * name, const char * childname) = 0;
-    virtual void beginRecord(const char * name) = 0;
+    virtual bool beginDataset(const char * name, const char * childname, bool hasMixedContent, unsigned *updateMixed) = 0;
+    virtual void beginRecord(const char * name, bool hasMixedContent, unsigned *updateMixed) = 0;
+    virtual void updateMixedRecord(unsigned updateToken, bool hasMixedContent) = 0;
     virtual void endIfBlock() = 0;
     virtual void endDataset(const char * name, const char * childname) = 0;
     virtual void endRecord(const char * name) = 0;
@@ -381,8 +382,9 @@ public:
     virtual void addField(const char * name, ITypeInfo & type);
     virtual void addSetField(const char * name, const char * itemname, ITypeInfo & type);
     virtual void beginIfBlock()                                     { optionalNesting++; }
-    virtual bool beginDataset(const char * name, const char * childname);
-    virtual void beginRecord(const char * name);
+    virtual bool beginDataset(const char * name, const char * childname, bool hasMixedContent, unsigned *updateMixed);
+    virtual void beginRecord(const char * name, bool hasMixedContent, unsigned *updateMixed);
+    virtual void updateMixedRecord(unsigned updateToken, bool hasMixedContent);
     virtual void endIfBlock()                                       { optionalNesting--; }
     virtual void endDataset(const char * name, const char * childname);
     virtual void endRecord(const char * name);
@@ -392,7 +394,7 @@ public:
     void getXml(IStringVal & results);
 
 private:
-    void addSchemaPrefix();
+    void addSchemaPrefix(bool hasMixedContent=false);
     void addSchemaSuffix();
     void clear();
     void getXmlTypeName(StringBuffer & xmlType, ITypeInfo & type);

--- a/common/fileview2/fvdatasource.hpp
+++ b/common/fileview2/fvdatasource.hpp
@@ -52,6 +52,8 @@ interface IFvDataSourceMetaData : extends IInterface
     virtual const char *queryXmlTag() const = 0;
     virtual const IntArray &queryAttrList() const = 0;
     virtual const IntArray &queryAttrList(unsigned column) const = 0;
+    virtual bool mixedContent(unsigned column) const = 0;
+    virtual bool mixedContent() const = 0;
 };
 
 IFvDataSourceMetaData * deserializeDataSourceMeta(MemoryBuffer & in);

--- a/common/fileview2/fvrelate.cpp
+++ b/common/fileview2/fvrelate.cpp
@@ -720,7 +720,7 @@ void ViewERdiagramVisitor::beginIfBlock()
     activeFieldCount++;
 }
 
-bool ViewERdiagramVisitor::beginDataset(const char * name, const char * childname)
+bool ViewERdiagramVisitor::beginDataset(const char * name, const char * childname, bool mixed, unsigned *updateMixed)
 {
     noteNextField();
     builder.noteField(activeFieldId.str(), name, "dataset");
@@ -731,7 +731,7 @@ bool ViewERdiagramVisitor::beginDataset(const char * name, const char * childnam
     return false;       // don't expand contents
 }
 
-void ViewERdiagramVisitor::beginRecord(const char * name)
+void ViewERdiagramVisitor::beginRecord(const char * name, bool mixedContent, unsigned *updateMixed)
 {
     noteNextField();
     builder.noteField(activeFieldId.str(), name, "record");

--- a/common/fileview2/fvrelate.ipp
+++ b/common/fileview2/fvrelate.ipp
@@ -340,8 +340,9 @@ public:
     virtual void addField(const char * name, ITypeInfo & type);
     virtual void addSetField(const char * name, const char * itemname, ITypeInfo & type);
     virtual void beginIfBlock();
-    virtual bool beginDataset(const char * name, const char * childname);
-    virtual void beginRecord(const char * name);
+    virtual bool beginDataset(const char * name, const char * childname, bool mixedContent, unsigned *updateMixed);
+    virtual void beginRecord(const char * name, bool mixedContent, unsigned *updateMixed);
+    virtual void updateMixedRecord(unsigned updateMixed, bool mixed){}
     virtual void endIfBlock();
     virtual void endDataset(const char * name, const char * childname);
     virtual void endRecord(const char * name);

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -589,7 +589,7 @@ ITypeInfo * containsSingleSimpleFieldBlankXPath(IResultSetMetaData * meta)
 
 void fvSplitXPath(const char *xpath, StringBuffer &s, const char *&name, const char **childname=NULL)
 {
-    if (!xpath || !*xpath)
+    if (!xpath)
         return;
     const char * slash = strchr(xpath, '/');
     if (!slash)
@@ -628,7 +628,7 @@ void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) c
         case FVFFbeginrecord:
             if (useXPath)
                 fvSplitXPath(meta->queryXPath(idx), xname, name);
-            builder.beginRecord(name);
+            builder.beginRecord(name, meta->mixedContent(idx), NULL);
             break;
         case FVFFendrecord:
             if (useXPath)
@@ -643,9 +643,10 @@ void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) c
                 ITypeInfo * singleFieldType = (useXPath && name && *name && childname && *childname) ? containsSingleSimpleFieldBlankXPath(column.childMeta.get()) : NULL;
                 if (!singleFieldType || !builder.addSingleFieldDataset(name, childname, *singleFieldType))
                 {
-                    if (builder.beginDataset(name, childname))
+                    const CResultSetMetaData *childMeta = static_cast<const CResultSetMetaData *>(column.childMeta.get());
+                    if (builder.beginDataset(name, childname, childMeta->meta->mixedContent(), NULL))
                     {
-                        static_cast<const CResultSetMetaData *>(column.childMeta.get())->getXmlSchema(builder, useXPath);
+                        childMeta->getXmlSchema(builder, useXPath);
                     }
                     builder.endDataset(name, childname);
                 }

--- a/common/fileview2/fvsource.ipp
+++ b/common/fileview2/fvsource.ipp
@@ -87,6 +87,7 @@ public:
     IntArray nestedAttributes;
     OwnedITypeInfo type;
     byte           flags;
+    bool hasMixedContent;
 };
 
 class DataSourceMetaData : public CInterface, implements IFvDataSourceMetaData, public IRecordSizeEx
@@ -111,6 +112,8 @@ public:
     virtual const char *queryXmlTag() const;
     virtual const IntArray &queryAttrList() const;
     virtual const IntArray &queryAttrList(unsigned column) const;
+    virtual bool mixedContent(unsigned column) const;
+    virtual bool mixedContent() const;
 
 
     virtual IFvDataSourceMetaData * queryChildMeta(unsigned column) const;
@@ -139,8 +142,8 @@ public:
 
 protected:
     void addSimpleField(const char * name, const char * xpath, ITypeInfo * type);
-    void gatherFields(IHqlExpression * expr, bool isConditional);
-    void gatherChildFields(IHqlExpression * expr, bool isConditional);
+    void gatherFields(IHqlExpression * expr, bool isConditional, bool *pMixedContent);
+    void gatherChildFields(IHqlExpression * expr, bool isConditional, bool *pMixedContent);
     void gatherAttributes();
     void gatherNestedAttributes(DataSourceMetaItem &rec, aindex_t &idx);
     void init();
@@ -155,6 +158,7 @@ protected:
     unsigned numVirtualFields;
     bool isStoredFixedWidth;
     bool randomIsOk;
+    bool hasMixedContent;
     byte numFieldsToIgnore;
     StringAttr tagname;
 };

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -2603,7 +2603,7 @@ int CWsEclBinding::getWsEclDefinition(CHttpRequest* request, CHttpResponse* resp
 
             Owned<IPropertyTree> xsds_tree;
             if (xsds.length())
-                xsds_tree.setown(createPTreeFromXMLString(xsds.str()));
+                xsds_tree.setown(createPTreeFromXMLString(xsds.str(), ipt_ordered));
             if (xsds_tree)
             {
                 StringBuffer xpath;


### PR DESCRIPTION
Add support for xpath('') to schema generation code in both hqlutil.cpp
and fileview2.

For child sets, datasets, and rows, xpath('') needs to generate
schemas where children of the field become direct children of the
current record. For simple types the parent complexType needs to
be marked as containing mixed content.  When xpath('') is nested
across multiple child levels, both mixed content and child elements
need to move up to the nearest parent with out xpath('').

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
