### PR TITLE
HPCC-10130 - Set accessedTime for all files

### DIFF
--- a/thorlcr/activities/fetch/thfetch.cpp
+++ b/thorlcr/activities/fetch/thfetch.cpp
@@ -93,6 +93,12 @@ public:
         if (!container.queryLocalOrGrouped())
             dst.append((int)mpTag);
     }
+    virtual void done()
+    {
+        CMasterActivity::done();
+        if (fetchFile)
+            fetchFile->setAccessed();
+    }
 };
 
 class CCsvFetchActivityMaster : public CFetchActivityMaster

--- a/thorlcr/activities/hashdistrib/thhashdistrib.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistrib.cpp
@@ -165,11 +165,16 @@ public:
 
         queryThorFileManager().noteFileRead(container.queryJob(), file);
     }
-
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         HashDistributeMasterBase::serializeSlaveData(dst, slave); // have to chain for standard activity data..
         dst.append(tlkMb);
+    }
+    virtual void done()
+    {
+        HashDistributeMasterBase::done();
+        if (file)
+            file->setAccessed();
     }
 };
 

--- a/thorlcr/activities/indexread/thindexread.cpp
+++ b/thorlcr/activities/indexread/thindexread.cpp
@@ -192,7 +192,7 @@ public:
         inputProgress.setown(new ProgressInfo);
         reInit = 0 != (indexBaseHelper->getFlags() & (TIRvarfilename|TIRdynamicfilename));
     }
-    void init()
+    virtual void init()
     {
         nofilter = false;
         OwnedRoxieString indexName(indexBaseHelper->getFileName());
@@ -227,7 +227,7 @@ public:
             }
         }
     }
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         OwnedRoxieString indexName(indexBaseHelper->getFileName());
         dst.append(indexName);
@@ -254,7 +254,7 @@ public:
         if (partNumbers.ordinality())
             fileDesc->serializeParts(dst, partNumbers);
     }
-    void deserializeStats(unsigned node, MemoryBuffer &mb)
+    virtual void deserializeStats(unsigned node, MemoryBuffer &mb)
     {
         CMasterActivity::deserializeStats(node, mb);
         rowcount_t progress;
@@ -267,7 +267,7 @@ public:
             progressInfoArr.item(p).set(node, st);
         }
     }
-    void getXGMML(unsigned idx, IPropertyTree *edge)
+    virtual void getXGMML(unsigned idx, IPropertyTree *edge)
     {
         CMasterActivity::getXGMML(idx, edge);
         StringBuffer label;
@@ -287,10 +287,16 @@ public:
         CMasterActivity::abort();
         cancelReceiveMsg(RANK_ALL, mpTag);
     }
-    void kill()
+    virtual void kill()
     {
         CMasterActivity::kill();
         index.clear();
+    }
+    virtual void done()
+    {
+        CMasterActivity::done();
+        if (index)
+            index->setAccessed();
     }
 };
 
@@ -324,7 +330,7 @@ public:
     {
         helper = (IHThorIndexReadArg *)queryHelper();
     }
-    void init()
+    virtual void init()
     {
         CIndexReadBase::init();
         if (!container.queryLocalOrGrouped())
@@ -333,7 +339,7 @@ public:
                 limit = (rowcount_t)helper->getKeyedLimit();
         }
     }
-    void process()
+    virtual void process()
     {
         if (limit != RCMAX)
             processKeyedLimit();

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -41,10 +41,7 @@ public:
         width = 0;
         copyTlk = globals->getPropBool("@diffCopyTlk", true); // because tlk can have meta data and diff/patch does not support
     }
-    ~CKeyDiffMaster()
-    {
-    }
-    void init()
+    virtual void init()
     {
         helper = (IHThorKeyDiffArg *)queryHelper();
         OwnedRoxieString origName(helper->getOriginalName());
@@ -78,7 +75,7 @@ public:
         patchDesc.setown(queryThorFileManager().create(container.queryJob(), outputName, clusters, groups, 0 != (KDPoverwrite & helper->getFlags()), 0, !local, width));
         patchDesc->queryProperties().setProp("@kind", "keydiff");
     }
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         if (slave < width) // if false - due to mismatch width fitting - fill in with a blank entry
         {
@@ -107,7 +104,7 @@ public:
         else
             dst.append(false); // no part
     }
-    void slaveDone(size32_t slaveIdx, MemoryBuffer &mb)
+    virtual void slaveDone(size32_t slaveIdx, MemoryBuffer &mb)
     {
         if (mb.length()) // if 0 implies aborted out from this slave.
         {
@@ -149,7 +146,7 @@ public:
             }
         }
     }
-    void done()
+    virtual void done()
     {
         StringBuffer scopedName;
         OwnedRoxieString outputName(helper->getOutputName());
@@ -199,8 +196,10 @@ public:
         index->setProp("@name", originalIndexFile->queryLogicalName());
         if (originalIndexFile->getFileCheckSum(checkSum))
             index->setPropInt64("@checkSum", checkSum);
+        originalIndexFile->setAccessed();
+        newIndexFile->setAccessed();
     }
-    void preStart(size32_t parentExtractSz, const byte *parentExtract)
+    virtual void preStart(size32_t parentExtractSz, const byte *parentExtract)
     {
         CMasterActivity::preStart(parentExtractSz, parentExtract);
         IHThorKeyDiffArg *helper = (IHThorKeyDiffArg *) queryHelper();
@@ -213,7 +212,7 @@ public:
                 throw MakeActivityException(this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
         }
     }
-    void kill()
+    virtual void kill()
     {
         CMasterActivity::kill();
         originalIndexFile.clear();

--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -66,7 +66,7 @@ public:
             if (TAG_NULL != tags[i])
                 container.queryJob().freeMPTag(tags[i]);
     }
-    void init()
+    virtual void init()
     {
         OwnedRoxieString indexFileName(helper->getIndexFileName());
         indexFile.setown(queryThorFileManager().lookup(container.queryJob(), indexFileName, false, 0 != (helper->getJoinFlags() & JFindexoptional), true));
@@ -244,7 +244,7 @@ public:
         else
             initMb.append((unsigned)0);
     }
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         dst.append(initMb);
         if (indexFile && helper->diskAccessRequired())
@@ -261,7 +261,7 @@ public:
             }
         }
     }
-    void deserializeStats(unsigned node, MemoryBuffer &mb)
+    virtual void deserializeStats(unsigned node, MemoryBuffer &mb)
     {
         CMasterActivity::deserializeStats(node, mb);
         ForEachItemIn(p, progressLabels)
@@ -271,7 +271,7 @@ public:
             progressInfoArr.item(p).set(node, st);
         }
     }
-    void getXGMML(unsigned idx, IPropertyTree *edge)
+    virtual void getXGMML(unsigned idx, IPropertyTree *edge)
     {
         CMasterActivity::getXGMML(idx, edge);
         assertex(0 == idx);
@@ -284,11 +284,19 @@ public:
             edge->setPropInt64(attr.str(), progress.queryTotal());
         }
     }
-    void kill()
+    virtual void kill()
     {
         CMasterActivity::kill();
         indexFile.clear();
         dataFile.clear();
+    }
+    virtual void done()
+    {
+        CMasterActivity::done();
+        if (indexFile)
+            indexFile->setAccessed();
+        if (dataFile)
+            dataFile->setAccessed();
     }
 };
 

--- a/thorlcr/activities/msort/thmsort.cpp
+++ b/thorlcr/activities/msort/thmsort.cpp
@@ -138,8 +138,8 @@ protected:
         }
         StringBuffer cosortfilenames;
         OwnedRoxieString cosortlogname(helper->getSortedFilename());
-        if (cosortlogname&&*cosortlogname) {
-
+        if (cosortlogname&&*cosortlogname)
+        {
             coSortFile.setown(queryThorFileManager().lookup(container.queryJob(), cosortlogname));
             Owned<IFileDescriptor> fileDesc = coSortFile->getFileDescriptor();
             queryThorFileManager().noteFileRead(container.queryJob(), coSortFile);
@@ -157,9 +157,11 @@ protected:
 
         Owned<IRowInterfaces> rowif = createRowInterfaces(container.queryInput(0)->queryHelper()->queryOutputMeta(),queryActivityId(),queryCodeContext());
         Owned<IRowInterfaces> auxrowif = createRowInterfaces(helper->querySortedRecordSize(),queryActivityId(),queryCodeContext());
-        try {   
+        try
+        {
             imaster->SortSetup(rowif,helper->queryCompare(),helper->querySerialize(),cosortfilenames.length()!=0,true,cosortfilenames.toCharArray(),auxrowif);
-            if (barrier->wait(false)) { // local sort complete
+            if (barrier->wait(false)) // local sort complete
+            {
                 size32_t maxdeviance = getOptUInt(THOROPT_SORT_MAX_DEVIANCE, 10*1024*1024);
                 try
                 {
@@ -193,6 +195,8 @@ protected:
     {
         ActPrintLog("done");
         CMasterActivity::done();
+        if (coSortFile)
+            coSortFile->setAccessed();
         ActPrintLog("done exit");
     }
 };

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -114,8 +114,11 @@ void CDiskReadMasterBase::done()
 {
     IHThorDiskReadBaseArg *helper = (IHThorDiskReadBaseArg *) queryHelper();
     fileDesc.clear();
-    if (!abortSoon) // in case query has relinquished control of file usage to another query (e.g. perists) 
-        queryThorFileManager().updateAccessTime(container.queryJob(), fileName);
+    if (!abortSoon) // in case query has relinquished control of file usage to another query (e.g. perists)
+    {
+        if (file)
+            file->setAccessed();
+    }
 }
 
 void CDiskReadMasterBase::deserializeStats(unsigned node, MemoryBuffer &mb)

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1115,7 +1115,7 @@ public:
     virtual unsigned __int64 getDatasetHash(const char * name, unsigned __int64 hash)
     {
         unsigned checkSum = 0;
-        Owned<IDistributedFile> iDfsFile = queryThorFileManager().lookup(job, name, false, true);
+        Owned<IDistributedFile> iDfsFile = queryThorFileManager().lookup(job, name, false, true, false); // NB: do not update accessed
         if (iDfsFile.get())
         {
             if (iDfsFile->getFileCheckSum(checkSum))

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -254,7 +254,7 @@ public:
         LOG(daliAuditLogCat,"%s",outs.str());
     }
 
-    IDistributedFile *lookup(CJobBase &job, const char *logicalName, bool temporary=false, bool optional=false, bool reportOptional=false)
+    IDistributedFile *lookup(CJobBase &job, const char *logicalName, bool temporary=false, bool optional=false, bool reportOptional=false, bool updateAccessed=true)
     {
         StringBuffer scopedName;
         bool paused = false;
@@ -299,6 +299,8 @@ public:
             }
             return NULL;
         }
+        if (updateAccessed)
+            file->setAccessed();
         return LINK(file);
     }
 
@@ -599,16 +601,6 @@ public:
         Owned<IDistributedFilePart> part = file->getPart(partno);
         return part->queryAttributes().getPropInt64("@offset");;
     }
-
-    void updateAccessTime(CJobBase &job, const char *logicalName)
-    {
-        StringBuffer scoped;
-        addScope(job, logicalName, scoped);
-        Owned<IDistributedFile> f = queryDistributedFileDirectory().lookup(scoped.str(), job.queryUserDescriptor());
-        if (f)
-            f->setAccessed();
-    }
-
     virtual bool scanLogicalFiles(CJobBase &job, const char *_pattern, StringArray &results)
     {
         if (strcspn(_pattern, "*?") == strlen(_pattern))

--- a/thorlcr/mfilemanager/thmfilemanager.hpp
+++ b/thorlcr/mfilemanager/thmfilemanager.hpp
@@ -45,7 +45,7 @@ interface IDistributedFile;
 interface IThorFileManager : extends IInterface
 {
     virtual void noteFileRead(CJobBase &job, IDistributedFile *file, bool extended=false) = 0;
-    virtual IDistributedFile *lookup(CJobBase &job, const char *logicalName, bool temporary=false, bool optional=false, bool reportOptional=false) = 0;
+    virtual IDistributedFile *lookup(CJobBase &job, const char *logicalName, bool temporary=false, bool optional=false, bool reportOptional=false, bool updateAccessed=true) = 0;
     virtual IFileDescriptor *create(CJobBase &job, const char *logicalName, StringArray &groupNames, IArrayOf<IGroup> &groups, bool overwriteok, unsigned helperFlags=0, bool nonLocalIndex=false, unsigned restrictedWidth=0) = 0;
     virtual void publish(CJobBase &job, const char *logicalName, bool mangle, IFileDescriptor &file, Owned<IDistributedFile> *publishedFile=NULL, unsigned partOffset=0, bool createMissingParts=true) = 0;
     virtual void clearCacheEntry(const char *name) = 0;
@@ -54,7 +54,6 @@ interface IThorFileManager : extends IInterface
     virtual StringBuffer &getPhysicalName(CJobBase &job, const char *logicalName, unsigned partno, StringBuffer &res) = 0;
     virtual StringBuffer &getPublishPhysicalName(CJobBase &job, const char *logicalName, unsigned partno, StringBuffer &res) = 0;
     virtual unsigned __int64 getFileOffset(CJobBase &job, const char *logicalName, unsigned partno) = 0;
-    virtual void updateAccessTime(CJobBase &job, const char *logicalName) = 0;
     virtual bool scanLogicalFiles(CJobBase &job, const char *_pattern, StringArray &results) = 0;
 };
 


### PR DESCRIPTION
Previously only persist updated accessedTime
Update setAccessedTime mechanism so that it established a separate short term lock to attributes, for update if the file being called is not locked - to enable setAccessed to be called on files open for read, without deadlocking the system if other clients also have file open for read.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
