### PR TITLE
HPCC-9322 Allow active name to be used with ecl-unpublish

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1427,7 +1427,7 @@ bool CWsWorkunitsEx::onWUQuerysetQueryAction(IEspContext &context, IEspWUQuerySe
                     break;
                 case CQuerySetQueryActionTypes_Delete:
                     removeNamedQuery(queryset, id);
-                    query = NULL;
+                    query.clear();
                     break;
                 case CQuerySetQueryActionTypes_RemoveAllAliases:
                     removeAliasesFromNamedQuery(queryset, id);


### PR DESCRIPTION
Fix build break in previous commit

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
