### PR TITLE
HPCC-9906 Support DATASET(n, transform, LOCAL)

### DIFF
--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -305,6 +305,7 @@
 #define ERR_DSPARM_MISSINGFIELD     2261 /* Dataset has no field as required or mapped */
 #define ERR_DSPARM_MAPNOTUSED       2262 /* A map is not used */
 #define ERR_DSPARAM_TYPEMISMATCH    2263 /* Mapping fields type mismatch */
+#define ERR_DSPARAM_INVALIDOPTCOMB  2264 /* Dataset options DISTRIBUTED, LOCAL, and NOLOCAL cannot be used in combination */
 
 /* pattern/regex */
 #define ERR_TOKEN_IN_TOKEN          2280 /* token used inside a token definition */

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -2995,6 +2995,7 @@ datasetFlag
                             $$.setExpr(createExprAttribute(distributedAtom));
                             $$.setPosition($1);
                         }
+    | localAttribute
     ;
 
 optIndexFlags
@@ -8559,7 +8560,13 @@ simpleDataSet
                             IHqlExpression * counter = $7.getExpr();
                             if (counter)
                                 counter = createAttribute(_countProject_Atom, counter);
-                            $$.setExpr(createDataset(no_dataset_from_transform, $3.getExpr(), createComma($6.getExpr(), counter, $8.getExpr())));
+                            OwnedHqlExpr options = $8.getExpr();
+                            if (options)
+                            {
+                                if (options->numChildren() > 0)
+                                    parser->reportError(ERR_DSPARAM_INVALIDOPTCOMB, $8, "The DATASET options DISTRIBUTED, LOCAL, and NOLOCAL are not permutable.");
+                            }
+                            $$.setExpr(createDataset(no_dataset_from_transform, $3.getExpr(), createComma($6.getExpr(), counter, options.getClear())));
                             $$.setPosition($1);
                         }
     | ENTH '(' dataSet ',' expression optCommonAttrs ')'

--- a/testing/ecl/issue9906.ecl
+++ b/testing/ecl/issue9906.ecl
@@ -1,0 +1,8 @@
+IMPORT STD;
+
+ds1 := DATASET(2, TRANSFORM({UNSIGNED line}, SELF.line := COUNTER) , LOCAL);
+
+summary := TABLE(ds1, { COUNT(GROUP) }, LOCAL);
+COUNT(NOFOLD(summary)) = CLUSTERSIZE;
+COUNT(ds1) = 2 * CLUSTERSIZE;
+SUM(ds1, line) = 3 * CLUSTERSIZE;

--- a/testing/ecl/key/issue9906.xml
+++ b/testing/ecl/key/issue9906.xml
@@ -1,0 +1,11 @@
+<Result>
+<Dataset name='Result 1'>
+ <Row><Result_1>true</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>true</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>true</Result_3></Row>
+</Dataset>
+</Result>

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -59,7 +59,7 @@ public:
         dataLinkStart();
         __uint64 numRows = helper->numRows();
         // local when generated from a child query (the range is per node, don't split)
-        bool isLocal = container.queryOwnerId() && container.queryOwner().isLocalOnly();
+        bool isLocal = container.queryLocalData()||(container.queryOwnerId() && container.queryOwner().isLocalOnly());
         if (!isLocal && ((helper->getFlags() & TTFdistributed) != 0))
         {
             __uint64 nodes = container.queryCodeContext()->getNodes();


### PR DESCRIPTION
Added localAttribute options, 'LOCAL' and 'NOLOCAL', to allow datasets to be created with n rows on each node and n rows on a single node respectively.

Signed-off-by: JamieNoss james.noss@lexisnexis.com
