### PR TITLE
HPCC-10099 DOCS:JavaScript Embed

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -3280,8 +3280,11 @@ add1(10);
 
             <para><emphasis role="bold">RPM-based systems:</emphasis></para>
 
+            <para>JavaScript support not available for CentOS 5.x, only
+            available for CentOS 6.x</para>
+
             <para>On an RPM-based system (CentOS/Red Hat/SuSe) install
-            <emphasis role="bold">v8embed</emphasis></para>
+            <emphasis role="bold">v8embed.</emphasis></para>
 
             <para><emphasis role="bold">Debian-based
             systems:</emphasis></para>

--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -3280,8 +3280,8 @@ add1(10);
 
             <para><emphasis role="bold">RPM-based systems:</emphasis></para>
 
-            <para>JavaScript support not available for CentOS 5.x, only
-            available for CentOS 6.x</para>
+            <para>JavaScript support is available for CentOS 6.x or later (not
+            available for CentOS 5.x).</para>
 
             <para>On an RPM-based system (CentOS/Red Hat/SuSe) install
             <emphasis role="bold">v8embed.</emphasis></para>

--- a/docs/RDDERef/RDDE_Mods/Packages.xml
+++ b/docs/RDDERef/RDDE_Mods/Packages.xml
@@ -354,5 +354,12 @@
         </listitem>
       </itemizedlist>
     </sect2>
+    
   </sect1>
+  
+      
+        <xi:include href="../../RDDERef/RDDE_Mods/ManagePackage.xml"
+                        xpointer="element(/1)"
+                  xmlns:xi="http://www.w3.org/2001/XInclude" />
+                  
 </chapter>

--- a/docs/RDDERef/RDDE_Mods/Packages.xml
+++ b/docs/RDDERef/RDDE_Mods/Packages.xml
@@ -356,10 +356,5 @@
     </sect2>
     
   </sect1>
-  
-      
-        <xi:include href="../../RDDERef/RDDE_Mods/ManagePackage.xml"
-                        xpointer="element(/1)"
-                  xmlns:xi="http://www.w3.org/2001/XInclude" />
-                  
+                
 </chapter>


### PR DESCRIPTION
Fix HPCC-10099 DOCS:JavaScript Embed
Add documentation that JavaScript support
is not currently available for CentOS 5.x
javascript plugin is disabled on CentOS 5.x build

@JamesDeFabia 
