### PR TITLE
HPCC-10239 Windows Build break in WsDeploy

### DIFF
--- a/deployment/deployutils/confighelper.hpp
+++ b/deployment/deployutils/confighelper.hpp
@@ -1,6 +1,6 @@
 #include "deployutils.hpp"
 
-class CConfigHelper
+class DEPLOYUTILS_API CConfigHelper
 {
 public:
 


### PR DESCRIPTION
DeployUtils file confighelper.cpp class "CConfigHelper" is called from
WsDeploy, but it is not exported from the dll. This fix adds the
DEPLOYUTILS_API define to the class definition so it gets exported

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
