### PR TITLE
HPCC-10242 Fix preflight not working for roxie server and thor master

### DIFF
--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -653,7 +653,7 @@ private:
     bool isLegacyFilter(const char* processType, const char* dependency);
     bool excludePartition(const char* partition) const;
     void appendProcessInstance(const char* name, const char* directory1, const char* directory2, StringArray& machineInstances, StringArray& directories);
-    void getProcesses(IConstEnvironment* constEnv, IPropertyTree* envRoot, const char* processName, const char* processType, const char* directory, CGetMachineInfoData& machineInfoData, BoolHash& uniqueProcesses, BoolHash* uniqueRoxieProcesses = NULL);
+    void getProcesses(IConstEnvironment* constEnv, IPropertyTree* envRoot, const char* processName, const char* processType, const char* directory, CGetMachineInfoData& machineInfoData, bool isThorOrRoxieProcess, BoolHash& uniqueProcesses, BoolHash* uniqueRoxieProcesses = NULL);
     void getThorProcesses(IConstEnvironment* constEnv,  IPropertyTree* cluster, const char* processName, const char* processType, const char* directory, CGetMachineInfoData& machineInfoData, BoolHash& uniqueProcesses);
     const char* getProcessTypeFromMachineType(const char* machineType);
     void readSettingsForTargetClusters(IEspContext& context, StringArray& targetClusters, CGetMachineInfoData& machineInfoData, IPropertyTree* targetClustersOut);


### PR DESCRIPTION
The problem is caused by the code which was added into getProcesses() by HPCC-8770. 
The getProcesses() is called for both ThorMasterProcess/RoxieServerProcess and other 
server processes. For other server processes, the code is used to pick up server information
from Environment/Software setting tree. For ThorMasterProcess and RoxieServerProcess, 
the code should be skipped. 
The problem is fixed by adding an input flag to getProcesses(). For ThorMasterProcess 
and RoxieServerProcess, the flag is set to true and that code will be skipped. 
