### PR TITLE
HPCC-10227 - Use key cache in indexread/count

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -1893,7 +1893,7 @@ public:
                 StringBuffer filename;
                 rfn.getPath(filename);
                 Owned<IDelayedFile> lfile = queryThor().queryFileCache().lookup(*this, filePart);
-                partKeySet->addIndex(createKeyIndex(filename.str(), crc, *(lfile.get()), false, false));
+                partKeySet->addIndex(createKeyIndex(filename.str(), crc, *lfile, false, false));
             }
             while (ip<numIndexParts);
 


### PR DESCRIPTION
Particularly critical when performing index counts in child
queries. Without cachine the parts are continually reopened at
a rapid rate which can cause network issues.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
