### PR TITLE
HPCC-9415 Use epoll, add EPOLLRDHUP define for Centos5.x

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -17,3 +17,5 @@ environment=${ENV_XML_FILE}
 sourcedir=${CONFIG_SOURCE_PATH}
 blockname=${DIR_NAME}
 interface=*
+# enable epoll method for notification events (true/false)
+use_epoll=true


### PR DESCRIPTION
As far as I can tell EPOLLRDHUP is in the kernel just not in the epoll.h header for Centos 5.x so I added a check and define if needed.
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
