### PR TITLE
HPCC-2205 RoxiePipe logging to /c$/roxiepipe

### DIFF
--- a/roxie/roxiepipe/roxiepipe.cpp
+++ b/roxie/roxiepipe/roxiepipe.cpp
@@ -580,9 +580,16 @@ int main(int argc, char *argv[])
         }
     }
 
+    StringBuffer logDir;
+    if (!logFile.length())
+    {
+        if (!getConfigurationDirectory(NULL,"log","roxiepipe","roxiepipe",logDir))
+            logDir.append(".");
+    }
+
     //Build logfile from component properties settings
     Owned<IComponentLogFileCreator> lf;
-    lf.setown(createComponentLogFileCreator(".", "roxiepipe"));
+    lf.setown(createComponentLogFileCreator(logDir.str(), "roxiepipe"));
     if (logFile.length())
         lf->setCompleteFilespec(logFile.str());
     lf->setCreateAliasFile(false);


### PR DESCRIPTION
Currently roxiepipe defaults to placing logfiles in the current directory,
making it difficult for OPs to locate them. This code change queries the
system log directory, and puts the (rolling) logfiles there

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
