### PR TITLE
HPCC-10262 Base Store cached data could "leak" between instances

### DIFF
--- a/esp/files/scripts/ESPRequest.js
+++ b/esp/files/scripts/ESPRequest.js
@@ -248,8 +248,11 @@ define([
         Store: declare(null, {
             SortbyProperty: 'Sortby',
             DescendingProperty: 'Descending',
+            useSingletons: true,
 
             constructor: function (options) {
+                this.cachedArray = {};
+
                 if (!this.service) {
                     throw new Error("service:  Undefined - Missing service name (eg 'WsWorkunts').");
                 }
@@ -271,22 +274,26 @@ define([
                 return item[this.idProperty];
             },
 
+            getCachedArray: function (create) {
+                return this.useSingletons ? lang.getObject(this.service + "." + this.action, create, _StoreSingletons) : this.cachedArray;
+            },
+
             exists: function (id) {
-                var item = lang.getObject(this.service + "." + this.action, false, _StoreSingletons);
-                if (item) {
-                    return item[id] !== undefined;
+                var cachedArray = this.getCachedArray(false);
+                if (cachedArray) {
+                    return cachedArray[id] !== undefined;
                 }
                 return false;
             },
 
             get: function (id, item) {
                 if (!this.exists(id)) {
-                    var newItem = lang.getObject(this.service + "." + this.action, true, _StoreSingletons);
-                    newItem[id] = this.create(id, item);
-                    return newItem[id];
+                    var cachedArray = this.getCachedArray(true);
+                    cachedArray[id] = this.create(id, item);
+                    return cachedArray[id];
                 }
-                var item = lang.getObject(this.service + "." + this.action, false, _StoreSingletons);
-                return item[id];
+                var cachedArray = this.getCachedArray(false);
+                return cachedArray[id];
             },
 
             create: function (id, item) {

--- a/esp/files/scripts/ESPResult.js
+++ b/esp/files/scripts/ESPResult.js
@@ -40,16 +40,20 @@ define([
         action: "WUResult",
         responseQualifier: "WUResultResponse.Result",
         responseTotalQualifier: "WUResultResponse.Total",
-        idProperty: "rowNum",
+        idProperty: "__hpcc_id",
         startProperty: "Start",
         countProperty: "Count",
+        useSingletons: false,
         preRequest: function (request) {
             if (this.name && this.cluster) {
+                this.idPrefix = this.name + "_" + this.cluster;
                 request['LogicalName'] = this.name;
                 request['Cluster'] = this.cluster;
             } else if (this.name) {
+                this.idPrefix = this.name;
                 request['LogicalName'] = this.name;
             } else {
+                this.idPrefix = this.wuid + "_" + this.sequence;
                 request['Wuid'] = this.wuid;
                 request['Sequence'] = this.sequence;
             }
@@ -68,8 +72,10 @@ define([
                 this.XmlSchema = [];
             }
             var rows = this.getValues(domXml, "Row", ["Row"]);
+            var context = this;
             arrayUtil.forEach(rows, function(item, index) {
-                item.rowNum = request.Start + index + 1;
+                item.__hpcc_rowNum = request.Start + index + 1;
+                item.__hpcc_id = context.idPrefix + "_" + item.__hpcc_rowNum;
             });
             response.Result = rows;
         }
@@ -330,7 +336,7 @@ define([
                     cells: [
                         [
                             {
-                                label: "##", field: this.store.idProperty, width: 54, className: "resultGridCell", sortable: false
+                                label: "##", field: "__hpcc_rowNum", width: 54, className: "resultGridCell", sortable: false
                             }
                         ]
                     ]


### PR DESCRIPTION
Fetching two result sets at the same time can cause their results to get written to each other.

Fixes HPCC-10262

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
