### PR TITLE
HPCC-10155 Prevent DFU Spray to output 100,000's of "CSV splitRecordSize(65536) at end of file" for hours.

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -44,7 +44,7 @@
   NB: It assumes records cannot be split between parts!
 */
 
-#define MAX_NUMBER_OF_BUFFER_OVERRUN 100
+const static unsigned maxNumberOfBufferOverrun = 100;
 const offset_t noSizeLimit = I64C(0x7fffffffffffffff);
 
 CPartitioner::CPartitioner()
@@ -267,8 +267,6 @@ void CInputBasePartitioner::findSplitPoint(offset_t splitOffset, PartitionCursor
         bool processFullBuffer =  (nextInputOffset + blockSize) < splitOffset;
 
         unsigned size = getSplitRecordSize(buffer+bufferOffset, numInBuffer-bufferOffset, processFullBuffer);
-        if( numOfBufferOverrun == 0 )
-            numOfProcessedBytes = 0;
 
         if (size==0)
             throwError1(DFTERR_PartitioningZeroSizedRowLink,((offset_t)(buffer+bufferOffset)));
@@ -317,8 +315,7 @@ CInputBasePartitioner::CInputBasePartitioner(unsigned _headerSize, unsigned expe
     else
         openfilecache->Link();
 
-    numOfBufferOverrun = 0;
-    numOfProcessedBytes = 0;
+    clearBufferOverrun();
 }
 
 IFileIOCache *CInputBasePartitioner::openfilecache = NULL;
@@ -695,7 +692,7 @@ size32_t CCsvPartitioner::getSplitRecordSize(const byte * start, unsigned maxToR
                }
                else
                {
-                   numOfBufferOverrun = 0;
+                   clearBufferOverrun();
                    return (size32_t)(cur + matchLen - start);
                }
             }
@@ -767,7 +764,7 @@ size32_t CCsvPartitioner::getSplitRecordSize(const byte * start, unsigned maxToR
 
     numOfProcessedBytes += (unsigned)(end - start);
 
-    if (++numOfBufferOverrun > MAX_NUMBER_OF_BUFFER_OVERRUN)
+    if (++numOfBufferOverrun > maxNumberOfBufferOverrun)
         throwError1(DFTERR_EndOfCsvRecordNotFound, numOfProcessedBytes);
 
     return end - start;
@@ -1002,7 +999,7 @@ size32_t CUtfPartitioner::getSplitRecordSize(const byte * start, unsigned maxToR
                }
                else
                {
-                   numOfBufferOverrun = 0;
+                   clearBufferOverrun();
                    return (size32_t)(cur + matchLen - start);
                }
             }
@@ -1074,7 +1071,7 @@ size32_t CUtfPartitioner::getSplitRecordSize(const byte * start, unsigned maxToR
 
     numOfProcessedBytes += (unsigned)(end - start);
 
-    if (++numOfBufferOverrun > MAX_NUMBER_OF_BUFFER_OVERRUN)
+    if (++numOfBufferOverrun > maxNumberOfBufferOverrun)
         throwError1(DFTERR_EndOfUtfRecordNotFound, numOfProcessedBytes);
 
     return end - start;

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -764,6 +764,8 @@ size32_t CCsvPartitioner::getSplitRecordSize(const byte * start, unsigned maxToR
 
     numOfProcessedBytes += (unsigned)(end - start);
 
+    LOG(MCdebugProgress, unknownJob, "CSV splitRecordSize(%d) at end of file", (unsigned) (end - start));
+
     if (++numOfBufferOverrun > maxNumberOfBufferOverrun)
         throwError1(DFTERR_EndOfCsvRecordNotFound, numOfProcessedBytes);
 
@@ -1070,6 +1072,8 @@ size32_t CUtfPartitioner::getSplitRecordSize(const byte * start, unsigned maxToR
         throwError(DFTERR_EndOfRecordNotFound);
 
     numOfProcessedBytes += (unsigned)(end - start);
+
+    LOG(MCdebugProgress, unknownJob, "UTF splitRecordSize(%d) at end of file", (unsigned) (end - start));
 
     if (++numOfBufferOverrun > maxNumberOfBufferOverrun)
         throwError1(DFTERR_EndOfUtfRecordNotFound, numOfProcessedBytes);

--- a/dali/ft/daftformat.ipp
+++ b/dali/ft/daftformat.ipp
@@ -154,7 +154,7 @@ protected:
         return (byte *)((bufattr.length()!=bufferSize)?bufattr.allocate(bufferSize):bufattr.bufferBase()); 
     }
     virtual void killBuffer()  { bufattr.clear(); }
-    virtual void clearBufferOverrun(void) { numOfBufferOverrun = 0; numOfProcessedBytes = 0;}
+    virtual void clearBufferOverrun() { numOfBufferOverrun = 0; numOfProcessedBytes = 0; }
 protected: 
     Owned<IFileIOStream>   inStream;
     MemoryAttr             bufattr;

--- a/dali/ft/daftformat.ipp
+++ b/dali/ft/daftformat.ipp
@@ -154,6 +154,7 @@ protected:
         return (byte *)((bufattr.length()!=bufferSize)?bufattr.allocate(bufferSize):bufattr.bufferBase()); 
     }
     virtual void killBuffer()  { bufattr.clear(); }
+    virtual void clearBufferOverrun(void) { numOfBufferOverrun = 0; numOfProcessedBytes = 0;}
 protected: 
     Owned<IFileIOStream>   inStream;
     MemoryAttr             bufattr;
@@ -166,7 +167,7 @@ protected:
     bool                   doInputCRC;
     static IFileIOCache    *openfilecache;
     static CriticalSection openfilecachesect;
-    
+
     unsigned               numOfBufferOverrun;
     unsigned               numOfProcessedBytes;
 };

--- a/dali/ft/daftformat.ipp
+++ b/dali/ft/daftformat.ipp
@@ -166,6 +166,9 @@ protected:
     bool                   doInputCRC;
     static IFileIOCache    *openfilecache;
     static CriticalSection openfilecachesect;
+    
+    unsigned               numOfBufferOverrun;
+    unsigned               numOfProcessedBytes;
 };
 
 

--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -72,6 +72,8 @@
 #define DFTERR_CannotFindLastXmlRecord          8099
 #define DFTERR_CouldNotOpenCompressedFile       8100
 #define DFTERR_EndOfXmlRecordNotFound           8101
+#define DFTERR_EndOfCsvRecordNotFound           8102
+#define DFTERR_EndOfUtfRecordNotFound           8103
 
 //Internal errors
 #define DFTERR_UnknownFormatType                8190
@@ -132,6 +134,8 @@
 #define DFTERR_CannotFindFirstXmlRecord_Text    "Could not find the start of the first record"
 #define DFTERR_CouldNotOpenCompressedFile_Text  "Could not open file %s as compressed file"
 #define DFTERR_EndOfXmlRecordNotFound_Text      "End of XML record not found (need to increase maxRecordSize?)! At offset:%"I64F"d, record size (>%d bytes) is larger than expected maxRecordSize (%d bytes)."
+#define DFTERR_EndOfCsvRecordNotFound_Text      "End of CSV record not found (wrong record terminator defined or need to increase maxRecordSize?)! CSV splitRecordSize() processed %d bytes without find terminator!"
+#define DFTERR_EndOfUtfRecordNotFound_Text      "End of UTF record not found (wrong record terminator defined or need to increase maxRecordSize?)! UTF splitRecordSize() processed %d bytes without find terminator!"
 
 #define DFTERR_UnknownFormatType_Text           "INTERNAL: Save unknown format type"
 #define DFTERR_OutputOffsetMismatch_Text        "INTERNAL: Output offset does not match expected (%"I64F"d expected %"I64F"d) at %s of block %d"

--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -134,8 +134,8 @@
 #define DFTERR_CannotFindFirstXmlRecord_Text    "Could not find the start of the first record"
 #define DFTERR_CouldNotOpenCompressedFile_Text  "Could not open file %s as compressed file"
 #define DFTERR_EndOfXmlRecordNotFound_Text      "End of XML record not found (need to increase maxRecordSize?)! At offset:%"I64F"d, record size (>%d bytes) is larger than expected maxRecordSize (%d bytes)."
-#define DFTERR_EndOfCsvRecordNotFound_Text      "End of CSV record not found (wrong record terminator defined or need to increase maxRecordSize?)! CSV splitRecordSize() processed %d bytes without find terminator!"
-#define DFTERR_EndOfUtfRecordNotFound_Text      "End of UTF record not found (wrong record terminator defined or need to increase maxRecordSize?)! UTF splitRecordSize() processed %d bytes without find terminator!"
+#define DFTERR_EndOfCsvRecordNotFound_Text      "End of CSV record not found (wrong record terminator defined or need to increase maxRecordSize?) after processing %d bytes!"
+#define DFTERR_EndOfUtfRecordNotFound_Text      "End of UTF record not found (wrong record terminator defined or need to increase maxRecordSize?) after processing %d bytes!"
 
 #define DFTERR_UnknownFormatType_Text           "INTERNAL: Save unknown format type"
 #define DFTERR_OutputOffsetMismatch_Text        "INTERNAL: Output offset does not match expected (%"I64F"d expected %"I64F"d) at %s of block %d"


### PR DESCRIPTION
This change implement buffer overruns monitoring. Every time when
getSplitRecordSize() reach at the end of the current buffer (and it is not
forced by processFullBuffer parameter) it counts the event and cumulate the
processed bytes. When the number of events exceeds the
MAX_NUMBER_OF_BUFFER_OVERRUN value it generates an exception to break this
possible wrong process.

This changes impacts both CCsvPartionier and CUtfPartitioner.

(This prevention is already implemented into corresponding QuickPartitioners)

Signed-off-by: Attila Vamos attila.vamos@gmail.com
