### PR TITLE
HPCC-10264 After publishing using a remote dali, roxie requires remote d...

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -582,8 +582,8 @@ interface INamedGroupStore: implements IGroupResolver
     virtual void addUnique(IGroup *group,StringBuffer &lname,const char *dir=NULL) = 0;
     virtual void swapNode(const IpAddress &from, const IpAddress &to) = 0;
     virtual IGroup *lookup(const char *logicalgroupname, StringBuffer &dir, GroupType &groupType) = 0;
-    virtual unsigned setDefaultTimeout(unsigned timems) = 0;                                    // sets default timeout for SDS connections and locking                                                                                         // returns previous value
-
+    virtual unsigned setDefaultTimeout(unsigned timems) = 0;     // sets default timeout for SDS connections and locking
+    virtual unsigned setRemoteTimeout(unsigned timems) = 0;      // sets default timeout for remote SDS connections and locking
 };
 
 extern da_decl INamedGroupStore  &queryNamedGroupStore();

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -314,6 +314,7 @@ private:
             StringBuffer foreignGroup("foreign::");
             foreignGroup.append(cloneFrom).append("::").append(groupName);
             GroupType groupType;
+            queryNamedGroupStore().setRemoteTimeout(2000);
             Owned<IGroup> group = queryNamedGroupStore().lookup(foreignGroup, dir, groupType);
             ClusterPartDiskMapSpec dmSpec;
             dmSpec.fromProp(&elem);
@@ -422,7 +423,15 @@ public:
             return NULL;
         if (fdesc->queryProperties().hasProp("cloneFromGroup") && fdesc->queryProperties().hasProp("@cloneFromDir"))
         {
-            return recreateCloneSource(fdesc, _lfn);
+            try
+            {
+                return recreateCloneSource(fdesc, _lfn);
+            }
+            catch (IException *E)
+            {
+                E->Release();
+                return NULL;
+            }
         }
         else // Legacy mode - recently cloned files should have the extra info
         {


### PR DESCRIPTION
...ali

Roxie was looking up every group in remote dali, with a 5 minute timeout, and
no cachine of failures.

Add support for caching failures to the named group store code, and the
ability to set a shorter timeout.

Change Roxie to ignore remote dali information if not available.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
