### PR TITLE
HPCC-10269 Always CUtfQuickPartitioner() created for UTF8 encoded CSV files.

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -2043,7 +2043,7 @@ IFormatPartitioner * createFormatPartitioner(const SocketEndpoint & ep, const Fi
                 return new CXmlQuickPartitioner(srcFormat, sameFormats);
             else
             {
-                if (srcFormat.quote && *srcFormat.quote)
+                if (srcFormat.hasQuote())
                     return new CUtfPartitioner(srcFormat);
                 else
                     return new CUtfQuickPartitioner(srcFormat, sameFormats);

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -2042,7 +2042,12 @@ IFormatPartitioner * createFormatPartitioner(const SocketEndpoint & ep, const Fi
             if (srcFormat.rowTag)
                 return new CXmlQuickPartitioner(srcFormat, sameFormats);
             else
-                return new CUtfQuickPartitioner(srcFormat, sameFormats);
+            {
+                if (srcFormat.quote && *srcFormat.quote)
+                    return new CUtfPartitioner(srcFormat);
+                else
+                    return new CUtfQuickPartitioner(srcFormat, sameFormats);
+            }
         }
     }
     if (!calcOutput)

--- a/dali/ft/daftformat.ipp
+++ b/dali/ft/daftformat.ipp
@@ -297,7 +297,7 @@ protected:
     virtual size32_t getTransformRecordSize(const byte * record, unsigned maxToRead);
     virtual size32_t getSplitRecordSize(const byte * record, unsigned maxToRead, bool processFullBuffer)
     {
-        return getSplitRecordSize(record,maxToRead,processFullBuffer,false);
+        return getSplitRecordSize(record,maxToRead,processFullBuffer,true);
     }
     
 private:


### PR DESCRIPTION
Check the source file is quoted or not. If it is then use CUtfPartitioner()
else use CUtfQuickPartitioner.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
