### PR TITLE
HPCC-9684 - Issue better error message when writing to foreign

### DIFF
--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -323,6 +323,8 @@ public:
         {
             if (!dlfn.setValidate(scopedName.str()))
                 throw MakeStringException(99, "Cannot publish %s, invalid logical name", scopedName.str());
+            if (dlfn.isForeign())
+                throw MakeStringException(99, "Cannot publish to a foreign Dali: %s", scopedName.str());
             efile.setown(queryDistributedFileDirectory().lookup(dlfn, job.queryUserDescriptor(), true));
             if (efile)
             {


### PR DESCRIPTION
Various changes/refactoring meant, it was already better
in fact, before this commit, it complained about not being
able to remove a foreign.

This change makes it explicit that you can't write to a foreign

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
