### PR TITLE
HPCC-10267 DOCS:Rm ConfigMgr

### DIFF
--- a/docs/UsingConfigManager/CMakeLists.txt
+++ b/docs/UsingConfigManager/CMakeLists.txt
@@ -13,6 +13,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ################################################################################
-
-DOCBOOK_TO_PDF( ${FO_XSL} UsingConfigManager.xml "UsingConfigManager")
-
+# commented out per issue # HPCC-10267
+#
+#
+#DOCBOOK_TO_PDF( ${FO_XSL} UsingConfigManager.xml "UsingConfigManager")
+#
+#
+########################################################################


### PR DESCRIPTION
Fix HPCC-10267 DOCS:Rm ConfigMgr
Remove Using Config Manager from the
automated doc builds. TEMPORARILY.

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com
