### PR TITLE
HPCC-10271 Simplify selection between CCsvPartitoner and CCsvQuickPartioner.

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -2012,7 +2012,7 @@ IFormatPartitioner * createFormatPartitioner(const SocketEndpoint & ep, const Fi
         case FFTblocked:
             return new CSimpleBlockedPartitioner(sameFormats);
         case FFTcsv:
-            if (srcFormat.quote && *srcFormat.quote)
+            if (srcFormat.hasQuote())
                 return new CCsvPartitioner(srcFormat);
             else
                 return new CCsvQuickPartitioner(srcFormat, sameFormats);

--- a/dali/ft/daftformat.ipp
+++ b/dali/ft/daftformat.ipp
@@ -266,12 +266,6 @@ public:
         : CCsvPartitioner(_format) 
     { 
         noTranslation = _noTranslation;
-        const char * quote = _format.quote.get();  
-        if (quote && (*quote == '\0')) { 
-            isquoted = false;
-        }       
-        else // default is quoted
-            isquoted = true;
     }
 
 protected:
@@ -280,7 +274,6 @@ protected:
 
 protected:
     bool                        noTranslation;
-    bool                        isquoted;
 };
 
 //---------------------------------------------------------------------------

--- a/dali/ft/filecopy.hpp
+++ b/dali/ft/filecopy.hpp
@@ -56,6 +56,7 @@ public:
     void serializeExtra(MemoryBuffer & out, unsigned version) const;
     void set(FileFormatType _type, unsigned _recordSize = 0) { type = _type, recordSize = _recordSize; }
     void set(const FileFormat & src);
+    bool hasQuote() const                           { return (quote == NULL) || (*quote != '\0'); }
 
 public:
     FileFormatType      type;


### PR DESCRIPTION
Add code to check the source file is quoted or not at the partitioner creation
stage. If it is quoted then use CCsvPartitioner() else use
CCsvQuickPartitioner.

Remove unnecessary code from CCsvQuickPartitioner constructor and
CCsvPartitioner::findSplitPoint() method.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
