### PR TITLE
HPCC-10274 Add workunit xml file to Bug Report zip file

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3997,6 +3997,12 @@ bool CWsWorkunitsEx::onWUReportBug(IEspContext &context, IEspWUReportBugRequest 
             addProcess(zipper, cwu, winfo, "EclAgent", eclagentLogMB);
             addProcess(zipper, cwu, winfo, "Thor", thorLogMB);
 
+            //Add Workunit XML file
+            MemoryBuffer wuXmlMB;
+            winfo.getWorkunitXml(NULL, wuXmlMB);
+            fs.clear().append("bugReport_").append(req.getWUID()).append('_').append(userName.str()).append(".xml");
+            zipper->addContentToZIP(wuXmlMB.length(), (void*)wuXmlMB.toByteArray(), (char*)fs.str(), true);
+
             //Write out ZIP file
             zipper->zipToFile(zipFile.str());
         }


### PR DESCRIPTION
It would be helpful to include the workuntil xml as a file in the
zip file created when the user chooses the create bug report ECLWatch
option

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
