### PR TITLE
HPCC-10247 This should convert field names from the source unicode encoding  (e.g., could be utf16)

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -901,8 +901,12 @@ void CUtfPartitioner::storeFieldName(const char * start, unsigned len)
 
     // Check the field name
     StringBuffer fieldName;
-    fieldName.append(start, 0, len);
-    fieldName.trim();
+    MemoryBuffer temp;
+    if( convertUtf(temp, UtfReader::Utf8, len, start, utfFormat))
+    {
+        fieldName.append(temp.length(), temp.toByteArray());
+        fieldName.trim();
+    }
 
     if (isRecordStructurePresent && (0 < fieldName.length() ))
     {

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -902,7 +902,7 @@ void CUtfPartitioner::storeFieldName(const char * start, unsigned len)
     // Check the field name
     StringBuffer fieldName;
     MemoryBuffer temp;
-    if( convertUtf(temp, UtfReader::Utf8, len, start, utfFormat))
+    if (convertUtf(temp, UtfReader::Utf8, len, start, utfFormat))
     {
         fieldName.append(temp.length(), temp.toByteArray());
         fieldName.trim();


### PR DESCRIPTION
Add conversion for fieldnames defined in the first row.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
