### PR TITLE
HPCC-10278 Create bug report feature not handling multiple logfiles

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3896,7 +3896,7 @@ bool CWsWorkunitsEx::onWUDeployWorkunit(IEspContext &context, IEspWUDeployWorkun
     return true;
 }
 
-void CWsWorkunitsEx::addProcess(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, MemoryBuffer &mb)
+void CWsWorkunitsEx::addProcessLogfile(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, PointerArray &mbArr)
 {
     IPropertyTreeIterator& proc = cwu->getProcesses(process, NULL);
     ForEach (proc)
@@ -3907,15 +3907,34 @@ void CWsWorkunitsEx::addProcess(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsW
             continue;
         StringBuffer pid;
         pid.appendf("%d",proc.query().getPropInt("@pid"));
-        mb.clear();
-        if (0 == stricmp(process, "EclAgent"))
-            winfo.getWorkunitEclAgentLog(logName.str(), pid.str(), mb);
-        else if (0 == stricmp(process, "Thor"))
-            winfo.getWorkunitThorLog(logName.str(), mb);
-        else
-            return;
+        MemoryBuffer * pMB = new MemoryBuffer;
+        try
+        {
+            if (0 == stricmp(process, "EclAgent"))
+                winfo.getWorkunitEclAgentLog(logName.str(), pid.str(), *pMB);
+            else if (0 == stricmp(process, "Thor"))
+                winfo.getWorkunitThorLog(logName.str(), *pMB);
+            else
+            {
+                delete pMB;
+                return;
+            }
+            mbArr.append(pMB);
+        }
+        catch(IException *e)
+        {
+            StringBuffer s;
+            e->errorMessage(s);
+            if (s.length())
+            {
+                pMB->append(s.str());
+                mbArr.append(pMB);
+            }
+            e->Release();
+        }
 
-        zipper->addContentToZIP(mb.length(), mb.bufferBase(), (char*)logName.str(), true);
+        if (pMB && pMB->length())
+            zipper->addContentToZIP(pMB->length(), pMB->bufferBase(), (char*)logName.str(), true);
     }
 }
 
@@ -3992,13 +4011,19 @@ bool CWsWorkunitsEx::onWUReportBug(IEspContext &context, IEspWUReportBugRequest 
 
             //Add logfiles to ZIP
             WsWuInfo winfo(context, cwu);
-            MemoryBuffer eclagentLogMB;
-            MemoryBuffer thorLogMB;
-            addProcess(zipper, cwu, winfo, "EclAgent", eclagentLogMB);
-            addProcess(zipper, cwu, winfo, "Thor", thorLogMB);
+            PointerArray eclAgentLogs;//array of dynamically allocated MemoryBuffers
+            PointerArray thorLogs;
+
+            addProcessLogfile(zipper, cwu, winfo, "EclAgent", eclAgentLogs);
+            addProcessLogfile(zipper, cwu, winfo, "Thor", thorLogs);
 
             //Write out ZIP file
             zipper->zipToFile(zipFile.str());
+
+            for (aindex_t x=0; x<eclAgentLogs.length(); x++)
+                delete (MemoryBuffer*)eclAgentLogs.item(x);
+            for (aindex_t x=0; x<thorLogs.length(); x++)
+                delete (MemoryBuffer*)thorLogs.item(x);
         }
 
         //Download ZIP file to user

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -118,7 +118,7 @@ public:
     bool onWUReportBug(IEspContext &context, IEspWUReportBugRequest &req, IEspWUReportBugResponse &resp);
     bool onWUGetBugReportInfo(IEspContext &context, IEspWUGetBugReportInfoRequest &req, IEspWUGetBugReportInfoResponse &resp);
 private:
-    void addProcess(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, MemoryBuffer &mb);
+    void CWsWorkunitsEx::addProcessLogfile(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, PointerArray &mbArr);
 
     unsigned awusCacheMinutes;
     StringBuffer queryDirectory;


### PR DESCRIPTION
Currently ws_workunits uses a single MemoryBuffer in the call to add
logfiles to the bug report. But if there are multiple logfiles, the
buffer gets cleared leaving only the last one. This code change dynamically
allocates MemoryBuffers as needed (one for each logfile) and saves them
in a pointerArray, and frees them up once the ZIP file has been created

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
