### PR TITLE
HPCC-10287 - Catch out of order supers when removing a subfile

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -4180,8 +4180,23 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
                     e->Release();
                     return false;
                 }
-                if (!parent->querySubFileNamed(subfile))
+                CDistributedSuperFile *sf = dynamic_cast<CDistributedSuperFile *>(parent.get());
+                unsigned pos = findSubFileOrd(subfile);
+                if ((pos==NotFound) || (pos>=sf->subfiles.ordinality()))
+                    pos = sf->findSubFile(subfile);
+                if (pos==NotFound)
+                {
+                    // why isn't this an exception?
                     WARNLOG("addSubFile: File %s is not a subfile of %s", subfile.get(),parent->queryLogicalName());
+                }
+                else
+                {
+                    VStringBuffer path("SubFile[@name=\"%s\"]", subfile.get());
+                    IPropertyTree *sub = sf->root->queryPropTree(path.str());
+                    dbgassertex(sub);
+                    if ((pos+1) != sub->getPropInt("@num"))
+                        ThrowStringException(-1, "RemoveSubFile: SuperFile %s, subfile %s, part numbers are out of sequence. SubFile[@num=\"%d\"] is at position %d", sf->logicalName.get(), subfile.get(), sub->getPropInt("@num"), pos+1);
+                }
             }
             // Try to lock all files
             addFileLock(parent);
@@ -4405,8 +4420,8 @@ protected:
             return;
         try {
             // Find all reported indexes and bail on bad range (before we lock any file)
+            // JCSMORE this should check that @num are sequence in order with no gaps, add 'before' and remove resequence already
             Owned<IPropertyTreeIterator> subit = root->getElements("SubFile");
-            // Adding a sub 'before' another get the list out of order (but still valid)
             OwnedMalloc<unsigned> subFiles(n, true);
             ForEach (*subit)
             {

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -1149,6 +1149,7 @@ static void checksuperfile(const char *lfn,bool fix=false)
         root->setPropInt("@numsubfiles",subnum);
     i = 0;
     byte fixstate = 0;
+    bool outOfSequence = false;
     loop {
         bool err = false;
         IPropertyTree *sub = root->queryPropTree(path.clear().appendf("SubFile[%d]",i+1).str());
@@ -1166,6 +1167,13 @@ static void checksuperfile(const char *lfn,bool fix=false)
                     fixed = true;
                     i--;
                 }
+            }
+            else if (pn != i+1) {
+                if (!outOfSequence)
+                    ERRLOG("SuperFile %s: corrupt, subfile file part @num values out of sequence, starting at part: %d", lname.get(), pn);
+                if (fix && (outOfSequence || doFix()))
+                    sub->setPropInt("@num", i+1);
+                outOfSequence = true;
             }
         }
         else


### PR DESCRIPTION
Also allow daliadmin checksuperfile to check and fix these cases

Previously, a removeSubFile on a super file that had its
subfiles out of order, could cause the wrong subfile to be
removed.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
