### PR TITLE
HPCC-10286 Add dependency for Ubuntu 13.10 (Saucy)

### DIFF
--- a/cmake_modules/dependencies/saucy.cmake
+++ b/cmake_modules/dependencies/saucy.cmake
@@ -1,0 +1,1 @@
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.53.0, libicu48, libxalanc111, libxerces-c3.1, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync")


### PR DESCRIPTION
Build requires libxalan-c-dev which includes libxalan-c111. libxalan-c-dev replaces previous libxalan110-dev
Install requires libxalan-c111

libboost-regex1.53.0 and libxerces-c3.1 are current Ubuntu 13.10 build system has.
