### PR TITLE
HPCC-10279 esdl_srv_engine should return HTTP exceptions

### DIFF
--- a/esp/bindings/bindutil.cpp
+++ b/esp/bindings/bindutil.cpp
@@ -851,3 +851,28 @@ const char *mimeTypeFromFileExt(const char *ext)
        return "application/octet-stream";
     return "application/octet-stream";
 }
+
+class CEspHttpException: public CInterface, public IEspHttpException
+{
+public:
+    IMPLEMENT_IINTERFACE;
+
+    CEspHttpException(int code, const char *_msg, const char* _httpstatus) : errcode(code), msg(_msg), httpstatus(_httpstatus){ };
+    int errorCode() const { return (errcode); };
+    StringBuffer &  errorMessage(StringBuffer &str) const
+    {
+        return str.append("CEspHttpException: (").append(msg).append(")");
+    };
+    MessageAudience errorAudience() const { return (MSGAUD_user); };
+    virtual const char* getHttpStatus() {return httpstatus.get(); }
+
+private:
+    int errcode;
+    StringAttr msg;
+    StringAttr httpstatus;
+};
+
+IEspHttpException* createEspHttpException(int code, const char *_msg, const char* _httpstatus)
+{
+    return new CEspHttpException(code, _msg, _httpstatus);
+}

--- a/esp/bindings/bindutil.hpp
+++ b/esp/bindings/bindutil.hpp
@@ -100,5 +100,12 @@ protected:
   cycle_t         start_time;
 };
 
+interface IEspHttpException : extends IException
+{
+    virtual const char* getHttpStatus() = 0;
+};
+
+BINDUTIL_EXPORT IEspHttpException* createEspHttpException(int code, const char *_msg, const char* _httpstatus);
+
 
 #endif

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -30,13 +30,6 @@
 #include "http/platform/httptransport.ipp"
 #include "bindutil.hpp"
 
-
-
-IEspHttpException* createEspHttpException(int code, const char *_msg, const char* _httpstatus)
-{
-    return new CEspHttpException(code, _msg, _httpstatus);
-}
-
 bool httpContentFromFile(const char *filepath, StringBuffer &mimetype, MemoryBuffer &fileContents, bool &checkModifiedTime, StringBuffer &lastModified, StringBuffer &etag)
 {
     StringBuffer strfile(filepath);

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -40,33 +40,6 @@
 
 #define MAX_HTTP_HEADER_LEN 4094
 
-interface IEspHttpException : extends IException
-{
-    virtual const char* getHttpStatus() = 0;
-};
-
-class CEspHttpException: public CInterface, public IEspHttpException
-{
-public:
-    IMPLEMENT_IINTERFACE;
-
-    CEspHttpException(int code, const char *_msg, const char* _httpstatus) : errcode(code), msg(_msg), httpstatus(_httpstatus){ };
-    int errorCode() const { return (errcode); };
-    StringBuffer &  errorMessage(StringBuffer &str) const
-    {
-        return str.append("CEspHttpException: (").append(msg).append(")");
-    };
-    MessageAudience errorAudience() const { return (MSGAUD_user); };
-    virtual const char* getHttpStatus() {return httpstatus.get(); }
-
-private:
-    int errcode;
-    StringAttr msg;
-    StringAttr httpstatus;
-};
-
-IEspHttpException* createEspHttpException(int code, const char *_msg, const char* _httpstatus);
-
 enum MessageLogFlag
 {
     LOGALL = 0,


### PR DESCRIPTION
This fixes export issues that had broken the windows LN build, but exporting
HTTP Exceptions from the esphttp library.  Another pull request will revert
esdl service to using HTTP exceptions.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
