### PR TITLE
HPCC-10224 Fix CSocket::name returning non terminated strings

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -1020,23 +1020,23 @@ int CSocket::name(char *retname,size32_t namemax)
         namemax = 0;
     if (namemax)
         retname[0] = 0;
-    retname[0] = 0;
     if (state != ss_open) {
         THROWJSOCKEXCEPTION(JSOCKERR_not_opened);
     }
     DEFINE_SOCKADDR(u);
-    socklen_t ul = sizeof(u);       
+    socklen_t ul = sizeof(u);
     if (::getsockname(sock,&u.sa, &ul)<0) {
         THROWJSOCKEXCEPTION(ERRNO());
     }
     SocketEndpoint ep;
     getSockAddrEndpoint(u,ul,ep);
-    StringBuffer s;
-    ep.getIpText(s);
-    if (namemax>=1) {
+    if (namemax>=1)
+    {
+        StringBuffer s;
+        ep.getIpText(s);
         if (namemax-1<s.length())
             s.setLength(namemax-1);
-        memcpy(retname,s.str(),s.length());
+        memcpy(retname,s.str(),s.length()+1);
     }
     return ep.port;
 }


### PR DESCRIPTION
CSocket::name, which returns the local server address rather than the
peer address, doesn't seem to be used except a few places in ESP.

The function was memcopying strings without including the null terminator.

Also fixes a couple other issues, like attempting to write to a null
string.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
