### PR TITLE
HPCC-10287 - Add check for inadequencies of transaction impl.

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -4205,15 +4205,17 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
                 if (pos==NotFound)
                 {
                     // why isn't this an exception?
-                    WARNLOG("addSubFile: File %s is not a subfile of %s", subfile.get(),parent->queryLogicalName());
+                    WARNLOG("removeSubFile: File %s is not a subfile of %s", subfile.get(),parent->queryLogicalName());
                 }
                 else
                 {
                     VStringBuffer path("SubFile[@name=\"%s\"]", subfile.get());
                     IPropertyTree *sub = sf->root->queryPropTree(path.str());
-                    dbgassertex(sub);
-                    if ((pos+1) != sub->getPropInt("@num"))
-                        ThrowStringException(-1, "RemoveSubFile: SuperFile %s, subfile %s, part numbers are out of sequence. SubFile[@num=\"%d\"] is at position %d", sf->logicalName.get(), subfile.get(), sub->getPropInt("@num"), pos+1);
+                    if (sub) // if within trasaction, the subfile may not be in the commited structure yet
+                    {
+                        if ((pos+1) != sub->getPropInt("@num"))
+                            ThrowStringException(-1, "removeSubFile: SuperFile %s, subfile %s, part numbers are out of sequence. SubFile[@num=\"%d\"] is at position %d", sf->logicalName.get(), subfile.get(), sub->getPropInt("@num"), pos+1);
+                    }
                 }
             }
             // Try to lock all files


### PR DESCRIPTION
Avoid assert/crash if subfile being checked isn't actually in
the commited superfile structure, e.g. because it has just been
added in the transaction

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
