### PR TITLE
HPCC-10316 correct package name for libxalan

### DIFF
--- a/cmake_modules/dependencies/saucy.cmake
+++ b/cmake_modules/dependencies/saucy.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.53.0, libicu48, libxalanc111, libxerces-c3.1, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.53.0, libicu48, libxalan-c111, libxerces-c3.1, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync")


### PR DESCRIPTION
Add '-' to libxalan package name. It should "libxalan-c111" instead of "libxalanc111"
