### PR TITLE
HPCC-10310 ESP cores and restarts when invalid credentials are presented

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1243,7 +1243,7 @@ public:
             }
             if(rc != LDAP_SUCCESS)
             {
-                if (strstr(ldap_errstring, " data "))//if extended error strings are available (they are not in windows clients)
+                if (ldap_errstring && *ldap_errstring && strstr(ldap_errstring, " data "))//if extended error strings are available (they are not in windows clients)
                 {
 #ifdef _DEBUG
                     DBGLOG("LDAPBIND ERR: RC=%d, - '%s'", rc, ldap_errstring);


### PR DESCRIPTION
Running Fedora, calling ldap_get_option(LDAP_OPT_ERROR_STRING) after submitting
invalid credentials results in a NULL string which is getting passed to strstr
resulting in a core in ESP. This change first checks if there is a valid string
before calling strstr

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
