### PR TITLE
HPCC-10323 ESP incorrectly checks for errors querying file perms

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -880,8 +880,9 @@ public:
         int ret=-1;
         if (mb.remaining()>=sizeof(ret)) {
             mb.read(ret);
-            int e = 0;
-            if (mb.remaining()>=sizeof(e)) {
+            if (mb.remaining()>=sizeof(int)) {
+                int e = 0;
+                mb.read(e);
                 if (err)
                     *err = e;
                 else if (e) 


### PR DESCRIPTION
In dasess.cpp, CClientSessionManager::getPermissionsLDAP never reads
the error code from the message buffer into the local 'e' variable. This
code fix reads the error code, ensuring either the caller will receive
the error or an exception will be thrown if the caller does not want it

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
