### PR TITLE
HPCC-10328 - Sasha CLI archive vs backup back to front

### DIFF
--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -1277,7 +1277,7 @@ bool processArchiverCommand(ISashaCommand *cmd)
                         if (cmd->getDFU())
                             doArchiveDfuWorkUnit(wuid,ret); 
                         else
-                            doArchiveWorkUnit(wufactory,wuid,ret,true,cmd->getAction()!=SCA_ARCHIVE,NULL);  
+                            doArchiveWorkUnit(wufactory,wuid,ret,true,cmd->getAction()==SCA_ARCHIVE,NULL);
                     }
                     else  if (cmd->getDFU()) 
                         doRestoreDfuWorkUnit(wuid,ret); 


### PR DESCRIPTION
The Sasha CLI was treating 'archive' to mean 'backup' and
vice versa. (backup leaves the workunits in Dali)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
