### PR TITLE
HPCC-10266 Disable banner usage from users

### DIFF
--- a/esp/files/scripts/ws_access.js
+++ b/esp/files/scripts/ws_access.js
@@ -1,0 +1,26 @@
+/*##############################################################################
+#    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+############################################################################## */
+define([
+    "hpcc/ESPRequest"
+], function (
+    ESPRequest) {
+    return {
+        UserEdit: function (params) {
+            return ESPRequest.send("ws_access", "UserEdit", params);
+        }
+    };
+});
+


### PR DESCRIPTION
Enable set banner messages to only administrators.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
