### PR TITLE
HPCC-10358 Rename WUGetBugInfo to WUGetZAPInfo, etc

### DIFF
--- a/esp/eclwatch/ws_XSLT/CMakeLists.txt
+++ b/esp/eclwatch/ws_XSLT/CMakeLists.txt
@@ -133,7 +133,7 @@ FOREACH ( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/dropzonefile.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/hpccresourcelist.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/dropzonefilelist.xslt
-    ${CMAKE_CURRENT_SOURCE_DIR}/WUBugReportForm.xslt
+    ${CMAKE_CURRENT_SOURCE_DIR}/WUZAPInfoForm.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/WUCopyLogicalFiles.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/WUDeployWorkunit.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/access_accountpermissions.xslt

--- a/esp/eclwatch/ws_XSLT/WUZAPInfoForm.xslt
+++ b/esp/eclwatch/ws_XSLT/WUZAPInfoForm.xslt
@@ -18,7 +18,7 @@
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="html"/>
-    <xsl:template match="/WUGetBugReportInfoResponse">
+    <xsl:template match="/WUGetZAPInfoResponse">
         <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
             <head>
                 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
@@ -66,7 +66,7 @@
                                 var desc = document.getElementById("ProblemDescription").value;
                                 var history = document.getElementById("WhatChanged").value;
                                 var timing = document.getElementById("WhereSlow").value;
-                                opener.createBugReport(wuid, espIP, thorIP, buildVersion, desc, history, timing);
+                                opener.createZAPInfo(wuid, espIP, thorIP, buildVersion, desc, history, timing);
                             }
                             window.close();
                         }
@@ -86,7 +86,7 @@
                 </script>
             </head>
             <body class="yui-skin-sam" onload="nof5();onLoad()">
-                <h3 style="text-align: center;">Report</h3>
+                <h3 style="text-align: center;">Zipped Analysis Package</h3>
                 <p/>
                 <form action="" method="POST">
                     <input type="hidden" id="WUID" name="WUID" value="{WUID}"/>

--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -738,18 +738,18 @@
 </soap:Envelope>
         */
 
-                    function popupBugReportForm()
+                    function popupZAPInfoForm()
                     {
-                        mywindow = window.open ("/WsWorkunits/WUGetBugReportInfo?WUID="+wid,
+                        mywindow = window.open ("/WsWorkunits/WUGetZAPInfo?WUID="+wid,
                             "mywindow", "location=0,status=1,scrollbars=1,resizable=1,width=800,height=760");
                         if (mywindow.opener == null)
                             mywindow.opener = window;
                         mywindow.focus();
                         return false;
                     }
-                    function createBugReport(wuid, espIP, thorIP, ESPBuildVersion, problemDesciption, history, timingInfo)
+                    function createZAPInfo(wuid, espIP, thorIP, ESPBuildVersion, problemDesciption, history, timingInfo)
                     {
-                        var href = "/WsWorkunits/WUReportBug?WUID=" + wuid;
+                        var href = "/WsWorkunits/WUCreateZAPInfo?WUID=" + wuid;
                         href += "&ESPIPAddress=" + espIP;
                         if (thorIP != '')
                             href += "&ThorIPAddress=" + thorIP;

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -788,7 +788,7 @@
                           <xsl:attribute name="disabled">disabled</xsl:attribute>
                         </xsl:if>
                       </input>
-              <input type="button" name="ZAPReport" style="width: 120px" value="Z.A.P. Report" class="sbutton" onclick="return popupBugReportForm()"/>
+              <input type="button" name="ZAPReport" style="width: 120px" value="Z.A.P. Report" class="sbutton" onclick="return popupZAPInfoForm()"/>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
In WsWorkunits service, the method WUGetBugReportInfo has been renamed
to WUGetZAPInfo. And the method WUReportBug has been renamed to
WUCreateZAPInfo. In this fix, similar changes are made in XSLT files,
as well as CMAKEList.txt, to match the method name changes.
