### PR TITLE
HPCC-10301 Read enough data for mime header process when uploading files

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1848,7 +1848,9 @@ bool CHttpRequest::readContentToBuffer(MemoryBuffer& buffer, __int64& bytesNotRe
 
 bool CHttpRequest::readUploadFileName(CMimeMultiPart* mimemultipart, StringBuffer& fileName, MemoryBuffer& contentBuffer, __int64& bytesNotRead)
 {
-    if (contentBuffer.length())
+    //Make sure that contentBuffer contains all of the mime headers for a file. The readUploadFileName() retrieves
+    //the file name from those headers and moves a data pointer to the end of those headers.
+    if ((bytesNotRead < 1) || (contentBuffer.length() > 512))
         mimemultipart->readUploadFileName(contentBuffer, fileName);
 
     while((fileName.length() < 1) && (bytesNotRead > 0))


### PR DESCRIPTION
When uploading files, a data buffer is used to process the file data
(1k) block by block. After one file is read, a part of file data for the
next file is left inside the data buffer. If the data does not contain
all of the mime headers for the file, the file data cannot be treated
properly. This fix checks the data size in the data buffer. If the
data buffer has less than 512 bytes, then I append the next 1K block
to the data buffer before processing.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
