### PR TITLE
HPCC-10374 - Fix sorted loader issue effecting global sort

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1848,7 +1848,9 @@ bool CHttpRequest::readContentToBuffer(MemoryBuffer& buffer, __int64& bytesNotRe
 
 bool CHttpRequest::readUploadFileName(CMimeMultiPart* mimemultipart, StringBuffer& fileName, MemoryBuffer& contentBuffer, __int64& bytesNotRead)
 {
-    if (contentBuffer.length())
+    //Make sure that contentBuffer contains all of the mime headers for a file. The readUploadFileName() retrieves
+    //the file name from those headers and moves a data pointer to the end of those headers.
+    if ((bytesNotRead < 1) || (contentBuffer.length() > 512))
         mimemultipart->readUploadFileName(contentBuffer, fileName);
 
     while((fileName.length() < 1) && (bytesNotRead > 0))

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1474,11 +1474,8 @@ protected:
             }
             else
             {
-                // 0 rows, no overflow and candidate for allMemRows
-                if ((rc_allDiskOrAllMem == diskMemMix) || // must supply allMemRows, only here if no spilling (see above)
-                    (NULL!=allMemRows && (rc_allMem == diskMemMix)) ||
-                    (NULL!=allMemRows && (rc_mixed == diskMemMix) && 0 == overflowCount) // if allMemRows given, only if no spilling
-                   )
+                // If 0 rows, no overflow, don't return stream, except for rc_allDisk which will never fill allMemRows
+                if (allMemRows && (0 == overflowCount) && (diskMemMix != rc_allDisk))
                     return NULL;
             }
         }


### PR DESCRIPTION
If global sort had spilt, but 0 rows left in memory when
finished, it would incorrectly return a NULL stream.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
