### PR TITLE
HPCC-10374 - Fix sorted loader issue effecting global sort

### DIFF
--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1474,11 +1474,8 @@ protected:
             }
             else
             {
-                // 0 rows, no overflow and candidate for allMemRows
-                if ((rc_allDiskOrAllMem == diskMemMix) || // must supply allMemRows, only here if no spilling (see above)
-                    (NULL!=allMemRows && (rc_allMem == diskMemMix)) ||
-                    (NULL!=allMemRows && (rc_mixed == diskMemMix) && 0 == overflowCount) // if allMemRows given, only if no spilling
-                   )
+                // If 0 rows, no overflow, don't return stream, except for rc_allDisk which will never fill allMemRows
+                if (allMemRows && (0 == overflowCount) && (diskMemMix != rc_allDisk))
                     return NULL;
             }
         }


### PR DESCRIPTION
If global sort had spilt, but 0 rows left in memory when
finished, it would incorrectly return a NULL stream.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
