### PR TITLE
HPCC-10315 add unicode version of fn_hyphen_match

### DIFF
--- a/plugins/proxies/lib_saltlib.ecllib
+++ b/plugins/proxies/lib_saltlib.ecllib
@@ -15,10 +15,12 @@
     limitations under the License.
 ############################################################################## */
 
-/* Proxy service header for (EE-only) saltlib plugin version SALTLIB 1.0.03 */
+/* Proxy service header for (EE-only) saltlib plugin version SALTLIB 1.0.04 */
 
 export SaltLib := SERVICE
   boolean UnicodeLocaleWithinEditN(const unicode left, const unicode right, unsigned4 distance,  const varstring localename) : c, pure,entrypoint='ulUnicodeLocaleWithinEditN', hole;
+  unsigned4 UnicodeLocaleHyphenMatch(const unicode left, const unicode right, unsigned4 minlen,  const varstring localename) : c, pure,entrypoint='ulUnicodeLocaleHyphenMatch', hole;
+  unsigned4 UnicodeHyphenMatch(const unicode left, const unicode right, unsigned4 minlen) : c, pure,entrypoint='ulUnicodeHyphenMatch', hole;
   integer4 UnicodeLocaleMatchBagofwords(const unicode left, const unicode right, const varstring localename, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords', hole;
   unicode UnicodeLocaleGetRangeOfWords(const unicode text, unsigned4 s_index, unsigned4 e_index, const varstring localename) : c,pure,entrypoint='ulUnicodeLocaleGetRangeOfWords';
   integer4 StringMatchBagofwords(const string left, const string right, unsigned4 mode, unsigned4 score_mode, unsigned fn, unsigned fn_arg1, unsigned fn_arg2) : c, pure,entrypoint='ulStringMatchBagofwords', hole;


### PR DESCRIPTION
Implement UnicodeHyphenMatch() and UnicodeLocaleHaphenMatch() based on
the implementation of SALTxx.fn_hyphen_match()

Signed-off-by: Edin Muharemagic edin.muharemagic@lexisnexis.com
