### PR TITLE
HPCC-10372 - DeleteSuperFile possible crash

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -7033,7 +7033,11 @@ public:
         addFileLock(super);
         // Adds actions to transactions before this one and gets executed only on commit
         if (delSub)
+        {
+            transaction->descend();
             super->removeSubFile(NULL, true, false, transaction);
+            transaction->ascend();
+        }
     }
     virtual ~CRemoveSuperFileAction() {}
     bool prepare()


### PR DESCRIPTION
A regression introduced after 3.10.8, when DeleteSuperFile was
added to the transaction system, was causing DeletesuperFile
with delete-sub-files=true to crash sometimes.

The nested removeSubFile call was causing the parent action
(DeleteSuperFile) to be exected, which free the superfile,
leaving the super object in removeSubFile in a duff state.

Fix by using descend() / ascend() transaction calls to indicate
nested and delay both action until called in parent action.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
