### PR TITLE
HPCC-9018 Packagemap-validate support for checking multiple queries

### DIFF
--- a/common/workunit/package.h
+++ b/common/workunit/package.h
@@ -49,7 +49,7 @@ interface IHpccPackageMap : extends IInterface
     virtual const IHpccPackage *matchPackage(const char *name) const = 0;
     virtual const char *queryPackageId() const = 0;
     virtual bool isActive() const = 0;
-    virtual bool validate(const char *queryid, StringArray &warn, StringArray &err, StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles) const = 0;
+    virtual bool validate(StringArray &queriesToVerify, StringArray &warn, StringArray &err, StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles) const = 0;
     virtual void gatherFileMappingForQuery(const char *queryname, IPropertyTree *fileInfo) const = 0;
 };
 

--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -456,6 +456,11 @@ public:
                 Owned<IPropertyTree> queryEntry = qs->getPropTree(xpath);
                 if (queryEntry)
                     tempQuerySet->addPropTree("Query", queryEntry.getClear());
+                else
+                {
+                    VStringBuffer msg("Query %s not found in %s queryset", queriesToCheck.item(i), querySet.sget());
+                    err.append(msg);
+                }
             }
             queries.setown(tempQuerySet->getElements("Query"));
         }

--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -415,7 +415,7 @@ public:
         }
     }
 
-    virtual bool validate(const char *queryToCheck, StringArray &warn, StringArray &err, 
+    virtual bool validate(StringArray &queriesToCheck, StringArray &warn, StringArray &err, 
         StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles) const
     {
         bool isValid = true;
@@ -446,10 +446,21 @@ public:
                     referencedPackages.setValue(baseId, true);
             }
         }
-        StringBuffer xpath("Query");
-        if (queryToCheck && *queryToCheck)
-            xpath.appendf("[@id='%s']", queryToCheck);
-        Owned<IPropertyTreeIterator> queries = qs->getElements(xpath);
+        Owned<IPropertyTree> tempQuerySet=createPTree();
+        Owned<IPropertyTreeIterator> queries;
+        if (queriesToCheck.length())
+        {
+            ForEachItemIn(i, queriesToCheck)
+            {
+                VStringBuffer xpath("Query[@id='%s']", queriesToCheck.item(i));
+                Owned<IPropertyTree> queryEntry = qs->getPropTree(xpath);
+                if (queryEntry)
+                    tempQuerySet->addPropTree("Query", queryEntry.getClear());
+            }
+            queries.setown(tempQuerySet->getElements("Query"));
+        }
+        else
+            queries.setown(qs->getElements("Query"));
         if (!queries->first())
         {
             warn.append("No Queries found");

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -683,11 +683,6 @@ public:
             StringAttr queryIds;
             if (iter.matchOption(queryIds, ECLOPT_QUERYID))
             {
-                optQueryIds.append(queryIds.get());
-                continue;
-            }
-            if (iter.matchOption(queryIds, ECLOPT_QUERYIDS))
-            {
                 optQueryIds.appendList(queryIds.get(), ",");
                 continue;
             }
@@ -820,8 +815,9 @@ public:
                     "   --active                    Validate the active packagemap\n"
                     "   --check-dfs                 Verify that subfiles exist in DFS\n"
                     "   -pm, --pmid                 Identifier of packagemap to validate\n"
-                    "   --queryid                   Query to verify against packagemap, parameter can be used more than once\n"
-                    "   --queryids                  Comma separated list of queries to verify against packagemap\n"
+                    "   --queryid                   Query to verify against packagemap, multiple queries can be\n"
+                    "                               specified using a comma separated list, or by using --queryid\n"
+                    "                               more than once. Default is all queries in the target queryset\n"
                     "   --global-scope              The specified packagemap can be shared across multiple targets\n",
                     stdout);
 

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -678,10 +678,19 @@ public:
                 continue;
             if (iter.matchOption(optPMID, ECLOPT_PMID) || iter.matchOption(optPMID, ECLOPT_PMID_S))
                 continue;
-            if (iter.matchOption(optQueryId, ECLOPT_QUERYID))
-                continue;
             if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
                 continue;
+            StringAttr queryIds;
+            if (iter.matchOption(queryIds, ECLOPT_QUERYID))
+            {
+                optQueryIds.append(queryIds.get());
+                continue;
+            }
+            if (iter.matchOption(queryIds, ECLOPT_QUERYIDS))
+            {
+                optQueryIds.appendList(queryIds.get(), ",");
+                continue;
+            }
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }
@@ -733,7 +742,7 @@ public:
         request->setActive(optValidateActive);
         request->setPMID(optPMID);
         request->setTarget(optTarget);
-        request->setQueryIdToVerify(optQueryId);
+        request->setQueriesToVerify(optQueryIds);
         request->setCheckDFS(optCheckDFS);
         request->setGlobalScope(optGlobalScope);
 
@@ -811,16 +820,18 @@ public:
                     "   --active                    Validate the active packagemap\n"
                     "   --check-dfs                 Verify that subfiles exist in DFS\n"
                     "   -pm, --pmid                 Identifier of packagemap to validate\n"
+                    "   --queryid                   Query to verify against packagemap, parameter can be used more than once\n"
+                    "   --queryids                  Comma separated list of queries to verify against packagemap\n"
                     "   --global-scope              The specified packagemap can be shared across multiple targets\n",
                     stdout);
 
         EclCmdCommon::usage();
     }
 private:
+    StringArray optQueryIds;
     StringAttr optFileName;
     StringAttr optTarget;
     StringAttr optPMID;
-    StringAttr optQueryId;
     bool optValidateActive;
     bool optCheckDFS;
     bool optGlobalScope;

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -127,8 +127,6 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_PMID "--pmid"
 #define ECLOPT_PMID_S "-pm"
 #define ECLOPT_QUERYID "--queryid"
-#define ECLOPT_QUERYIDS "--queryids"
-
 
 #define ECLOPT_DALIIP "--daliip"
 #define ECLOPT_PROCESS "--process"

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -127,6 +127,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_PMID "--pmid"
 #define ECLOPT_PMID_S "-pm"
 #define ECLOPT_QUERYID "--queryid"
+#define ECLOPT_QUERYIDS "--queryids"
 
 
 #define ECLOPT_DALIIP "--daliip"

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -157,6 +157,7 @@ ESPrequest ValidatePackageRequest
     bool Active;
     string PMID;
     string QueryIdToVerify;
+    ESParray<string> QueriesToVerify;
     bool CheckDFS;
     bool GlobalScope(0);
 };

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -795,7 +795,17 @@ bool CWsPackageProcessEx::onValidatePackage(IEspContext &context, IEspValidatePa
     if (!map)
         throw MakeStringException(PKG_LOAD_PACKAGEMAP_FAILED, "Error loading package map %s", id);
 
-    map->validate(req.getQueryIdToVerify(), warnings, errors, unmatchedQueries, unusedPackages, unmatchedFiles);
+    StringArray queriesToVerify;
+    const char *queryid = req.getQueryIdToVerify();
+    if (queryid && *queryid)
+        queriesToVerify.append(queryid);
+    ForEachItemIn(i, req.getQueriesToVerify())
+    {
+        queryid = req.getQueriesToVerify().item(i);
+        if (queryid && *queryid)
+            queriesToVerify.appendUniq(queryid);
+    }
+    map->validate(queriesToVerify, warnings, errors, unmatchedQueries, unusedPackages, unmatchedFiles);
 
     resp.setPMID(map->queryPackageId());
     resp.setWarnings(warnings);

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -502,9 +502,9 @@ public:
     {
         return BASE::isActive();
     }
-    virtual bool validate(const char *queryid, StringArray &wrn, StringArray &err, StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles) const
+    virtual bool validate(StringArray &queryids, StringArray &wrn, StringArray &err, StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles) const
     {
-        return BASE::validate(queryid, wrn, err, unmatchedQueries, unusedPackages, unmatchedFiles);
+        return BASE::validate(queryids, wrn, err, unmatchedQueries, unusedPackages, unmatchedFiles);
     }
     virtual void gatherFileMappingForQuery(const char *queryname, IPropertyTree *fileInfo) const
     {


### PR DESCRIPTION
Add support for validating a package against a list of specific queries.  If no queries are specified
the entire target queryset is used.

Multiple queries can be specified by using the --queryid command line option multiple times, or by
using --queryids followed by a comma delimited list of queryids.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
