### PR TITLE
HPCC-10345 Disable Banner Setup for non-admin if authentication is set

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -540,7 +540,7 @@
                         <tr>
                             <td align="left">
                                 <xsl:choose>
-                                    <xsl:when test="SuperUser">
+                                    <xsl:when test="SuperUser=1">
                                         <A href="javascript:void(0)" onclick="SetBanner();">
                                             <h3>Existing Activity on Servers:</h3>
                                         </A>
@@ -651,7 +651,7 @@
                     </xsl:for-each>
                     <xsl:apply-templates select="DFUJobs"/>
                 </form>
-                <xsl:if test="SuperUser">
+                <xsl:if test="SuperUser=1">
                     <span id="SetBannerFrame"   style="display:none; visibility:hidden">
                         <form id="SetBannerForm">
                             <table>


### PR DESCRIPTION
A flag 'SuperUser' is used to decide whether the web link of Banner Setup
should be displayed or not. (The flag is set to true if no authentication
is set or the esp service is used by an admin user.) The existing code
still shows the Setup link for non admin user due to a bug inside index.xslt
file. The bug is fixed by this fix.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
