### PR TITLE
HPCC-9017 Add new open flags and copy logic to purge pgcache periodicall...

### DIFF
--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -92,7 +92,7 @@ size32_t CTransformer::read(size32_t maxLength, void * buffer)
 bool CTransformer::setPartition(RemoteFilename & remoteInputName, offset_t _startOffset, offset_t _length, bool compressedInput, const char *decryptKey)
 {
     CTransformerBase::setPartition(remoteInputName, _startOffset, _length);
-    input.setown(inputFile->open(IFOread));
+    input.setown(inputFile->open(IFOreadFlsh));
     if (compressedInput) {                          
         Owned<IExpander> expander;
         if (decryptKey&&*decryptKey) {
@@ -819,7 +819,7 @@ processedProgress:
                 throw MakeOsException(GetLastError(), "Failed to create directory for file: %s", localFilename.str());
 
             OwnedIFile outFile = createIFile(localFilename.str());
-            OwnedIFileIO outio = outFile->openShared(IFOcreate,IFSHnone);
+            OwnedIFileIO outio = outFile->openShared(IFOcreateFlsh,IFSHnone);
             if (!outio)
                 throwError1(DFTERR_CouldNotCreateOutput, localFilename.str());
             if (compressOutput) {

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -36,10 +36,13 @@ interface IMemoryMappedFile;
 class MemoryBuffer;
 class Semaphore;
 
-enum IFOmode { IFOcreate, IFOread, IFOwrite, IFOreadwrite, IFOcreaterw };    // modes for open
+enum IFOmode { IFOcreate=0x0,      IFOread=0x1,      IFOwrite=0x2,      IFOreadwrite=0x3,      IFOcreaterw=0x4,
+               IFOcreateFlsh=0x80, IFOreadFlsh=0x81, IFOwriteFlsh=0x82, IFOreadwriteFlsh=0x83, IFOcreaterwFlsh=0x84 };    // modes for open
 enum IFSHmode { IFSHnone, IFSHread=0x8, IFSHfull=0x10};   // sharing modes
 enum IFSmode { IFScurrent = FILE_CURRENT, IFSend = FILE_END, IFSbegin = FILE_BEGIN };    // seek mode
 enum CFPmode { CFPcontinue, CFPcancel, CFPstop };    // modes for ICopyFileProgress::onProgress return
+
+enum flushMethod { FLUSH_ASYNC = 0, FLUSH_WAIT, WRITE_WAIT, DONT_NEED };    // page cache flush methods
 
 class CDateTime;
 

--- a/system/jlib/jfile.ipp
+++ b/system/jlib/jfile.ipp
@@ -28,7 +28,6 @@
 #include <dirent.h>
 #endif
 
-
 class jlib_decl CFile : public CInterface, implements IFile
 {
     HANDLE openHandle(IFOmode mode, IFSHmode share, bool async, int stdh=-1);
@@ -86,8 +85,12 @@ public:
         GetHostIp(resfrom);
         copyTo(dest,0x100000,NULL,usetmp);
     }
-    
+
+    virtual void flush_fbuffers(flushMethod flshmeth, offset_t offset, size32_t len);
+    bool flush_pgcache;
+
 protected:
+    HANDLE fd;
     StringAttr filename;
     unsigned flags;
 };
@@ -97,6 +100,7 @@ class jlib_decl CFileIO : public CInterface, implements IFileIO
 {
 public:
     CFileIO(HANDLE,IFSHmode _sharemode);
+    CFileIO(HANDLE,IFSHmode _sharemode, bool flush_pgcache, bool syncdata);
     ~CFileIO();
     IMPLEMENT_IINTERFACE
 
@@ -119,6 +123,8 @@ protected:
     HANDLE              file;
     bool                throwOnError;
     IFSHmode            sharemode;
+    bool                flush_pgcache;
+    bool                syncdata;
 private:
     void setPos(offset_t pos);
 


### PR DESCRIPTION
HPCC-9017

New *Flsh open flags and doCopyFile() code to flush page cache to prevent it from growing excessively.
If *Flsh flags are used then can still disable with conf file setting pgcache_flush=false

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
