### PR TITLE
HPCC-10408 - DFS supers were always assuming mixed width

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -5129,7 +5129,7 @@ public:
                 }
             }
             unsigned np = file.numParts();
-            if (width)
+            if (0 == width)
                 width = np;
             else if (np!=width)
                 mixedwidth = true;


### PR DESCRIPTION
As a consequence it was manually setting the replicate node #
as a property for each part descriptor in the super.
It should make no net difference, but was unecessary and
inefficient.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
