### PR TITLE
HPCC-10423 Fix regression xpath('') shouldn't output xml tag

### DIFF
--- a/common/fileview2/fvsource.cpp
+++ b/common/fileview2/fvsource.cpp
@@ -43,7 +43,7 @@ inline void appendNextXpathName(StringBuffer &s, const char *&xpath)
 
 void splitXmlTagNamesFromXPath(const char *xpath, StringAttr &inner, StringAttr *outer=NULL)
 {
-    if (!xpath || !*xpath)
+    if (!xpath)
         return;
 
     StringBuffer s1;


### PR DESCRIPTION
This regression was introduced in 4.2.  

xpath('') is used to store mixed content when a tag with both attributes
and content are needed.

&lt;tag att='mixed'>content&lt;/tag>

This regression caused the content to be inside an extra tag.

&lt;tag att='mixed'>&lt;name>content&lt;/name>&lt;/tag>

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
