### PR TITLE
HPCC-10366 Add parallel query support to regression suite

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -98,8 +98,15 @@ The result:
 -------------------------------------------------------------
 Command:
 
-        ./regress run thor
+        ./regress run cluster [-h] [--pq threadNumber]
 
+Positional arguments:
+  cluster            Run the cluster suite (default: setup).
+
+Optional arguments:
+  -h, --help         show help message and exit
+  --pq threadNumber  Parallel query execution with threadNumber threads.
+                    ('-1' can be use to calculate usable thread count on a single node system)
 
 The result is a list of test cases and their result. 
 
@@ -107,33 +114,124 @@ The first and last couple of lines look like this:
 
 |
 |        [Action] Suite: thor
-|        [Action] Queries: 253
-|        [Action] 
-|        [Action] 1. Test: groupglobal3b.ecl
-|        [Pass] Pass W20131029-165658
-|        [Pass] URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131029-165658
-|        [Action] 2. Test: realround.ecl
-|        [Pass] Pass W20131029-165701
-|        [Pass] URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131029-165701
-|        [Action] 3. Test: patmin.ecl
+|        [Action] Queries: 257
+|        [Action]
+|        [Action]   1. Test: agglist.ecl
+|        [Pass]   1. Pass W20131119-173524 (2 sec)
+|        [Pass]   1. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-173524
+|        [Action]   2. Test: aggregate.ecl
+|        [Pass]   2. Pass W20131119-173527 (1 sec)
+|        [Pass]   2. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-173527
+|        [Action]   3. Test: aggsq1.ecl
+
 |        .
 |        .
 |        .
-|        [Action] 252. Test: ds_map.ecl
-|        [Pass] Pass W20131029-171831
-|        [Pass] URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131029-171831
-|        [Action] 253. Test: lookupjoin.ecl
-|        [Pass] Pass W20131029-171833
-|        [Pass] URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131029-171833
+|        [Action] 256. Test: xmlout2.ecl
+|        [Pass] Pass W20131119-182536 (1 sec)
+|        [Pass] URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-182536
+|        [Action] 257. Test: xmlparse.ecl
+|        [Pass] Pass W20131119-182537 (1 sec)
+|        [Pass] URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-182537
 |        
 |         Results
 |         `-------------------------------------------------`
-|         Passing: 253
+|         Passing: 257
 |         Failure: 0
 |         `-------------------------------------------------`
-|         Log: /var/log/HPCCSystems/regression/thor.13-10-29-16-56.log
+|         Log: /home/ati/HPCCSystems-regression/log/thor.13-11-19-17-52-27.log
+|         `-------------------------------------------------`
+|         Elapsed time: 1992 sec  (00:33:12)
 |         `-------------------------------------------------`
 |
+
+If --pq option used (in this case with 16 threads) then then the content of the console log will be different like this:
+
+|
+|        [Action] Suite: thor
+|        [Action] Queries: 257
+|        [Action]
+|        [Action]   1. Test: agglist.ecl
+|        [Action]   2. Test: aggregate.ecl
+|        [Action]   3. Test: aggsq1.ecl
+|        [Action]   4. Test: aggsq1seq.ecl
+|        [Action]   5. Test: aggsq2.ecl
+|        [Action]   6. Test: aggsq2seq.ecl
+|        [Action]   7. Test: aggsq4.ecl
+|        [Action]   8. Test: aggsq4seq.ecl
+|        [Action]   9. Test: alljoin.ecl
+|        [Action]  10. Test: apply3.ecl
+|        [Action]  11. Test: atmost2.ecl
+|        [Action]  12. Test: bcd1.ecl
+|        [Action]  13. Test: bcd2.ecl
+|        [Action]  14. Test: bcd4.ecl
+|        [Action]  15. Test: betweenjoin.ecl
+|        [Action]  16. Test: bigrecs.ecl
+|        [Pass]   2. Pass W20131119-150514 (4 sec)
+|        [Pass]   2. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-150514
+|        [Pass]   1. Pass W20131119-150513 (4 sec)
+|        [Pass]   1. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-150513
+|        [Action]  17. Test: bloom2.ecl
+|        [Action]  18. Test: bug8688.ecl
+|        [Pass]   3. Pass W20131119-150514-5 (5 sec)
+|        [Pass]   3. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-150514-5
+|        [Action]  19. Test: builtin.ecl
+|        [Pass]  12. Pass W20131119-150517 (5 sec)
+|        [Pass]  12. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-150517
+|        [Action]  20. Test: casts.ecl
+|        [Pass]  14. Pass W20131119-150517-2 (6 sec)
+|        [Pass]  14. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-150517-2
+|        [Action]  21. Test: catchexpr.ecl
+|        .
+|        .
+|        .
+|        [Action] 257. Test: xmlparse.ecl
+|        [Pass] 240. Pass W20131119-160614 (9 sec)
+|        [Pass] 240. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160614
+|        [Pass] 241. Pass W20131119-160614-3 (10 sec)
+|        [Pass] 241. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160614-3
+|        [Pass] 254. Pass W20131119-160622-1 (2 sec)
+|        [Pass] 254. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160622-1
+|        [Pass] 191. Pass W20131119-160058-2 (327 sec)
+|        [Pass] 191. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160058-2
+|        [Pass] 245. Pass W20131119-160617-3 (9 sec)
+|        [Pass] 245. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160617-3
+|        [Pass] 248. Pass W20131119-160619-4 (7 sec)
+|        [Pass] 248. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160619-4
+|        [Pass] 249. Pass W20131119-160619-3 (9 sec)
+|        [Pass] 249. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160619-3
+|        [Pass] 250. Pass W20131119-160620 (10 sec)
+|        [Pass] 250. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160620
+|        [Pass] 252. Pass W20131119-160620-3 (10 sec)
+|        [Pass] 252. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160620-3
+|        [Pass] 253. Pass W20131119-160622 (8 sec)
+|        [Pass] 253. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160622
+|        [Pass] 255. Pass W20131119-160623 (8 sec)
+|        [Pass] 255. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160623
+|        [Pass] 256. Pass W20131119-160623-1 (9 sec)
+|        [Pass] 256. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160623-1
+|        [Pass] 257. Pass W20131119-160624 (9 sec)
+|        [Pass] 257. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160624
+|        [Pass] 213. Pass W20131119-160138-4 (305 sec)
+|        [Pass] 213. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-160138-4
+|        [Pass] 127. Pass W20131119-155918 (462 sec)
+|        [Pass] 127. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-155918
+|        [Pass] 100. Pass W20131119-155713 (600 sec)
+|        [Pass] 100. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20131119-155713
+|        [Action]
+|        [Action]
+|         Results
+|         `-------------------------------------------------`
+|         Passing: 257
+|         Failure: 0
+|         `-------------------------------------------------`
+|         Log: /home/ati/HPCCSystems-regression/log/thor.13-11-19-15-55-32.log
+|         `-------------------------------------------------`
+|         Elapsed time: 701 sec  (00:11:41)
+|         `-------------------------------------------------`
+|
+
+The logfile generated into the HPCCSystems-regression/log subfolder of the user personal folder and sorted by the test case number.
 
 
 5. To run Regression Suite with selected test case on a selected cluster (e.g. Thor): 
@@ -143,7 +241,15 @@ The first and last couple of lines look like this:
 
 Command:
 
-        ./regress query test_name [cluster]
+        ./regress query [-h] [--publish] test_name [target cluster | all]
+
+Positional arguments:
+        test_name               Name of a single ECL query (mandatory).
+        target cluster | all    Cluster for single query run (default: thor).
+                                If cluster = 'all' then run ECL query on all clusters.
+Optional arguments:
+        -h, --help            Show help message and exit
+        --publish             Publish compiled query instead of run.
 
 
 The format of result is same as above:

--- a/testing/regress/hpcc/common/report.py
+++ b/testing/regress/hpcc/common/report.py
@@ -47,7 +47,7 @@ class Report:
         self.report = _dict(report)
         self.name = name
 
-    def display(self, log=None):
+    def display(self, log=None,  elapsTime = 0):
         reportStr = "\n"
         reportStr += "Results\n"
         reportStr += "-------------------------------------------------\n"
@@ -61,6 +61,13 @@ class Report:
             reportStr += "-------------------------------------------------\n"
         if log:
             reportStr += "Log: %s\n" % str(log)
+            reportStr += "-------------------------------------------------\n"
+        if elapsTime:
+            reportStr += "Elapsed time: %d sec " % (elapsTime)
+            hours = elapsTime / 3600
+            elapsTime = elapsTime % 3600
+            mins = elapsTime / 60
+            reportStr += " (%02d:%02d:%02d) \n" % (hours,  mins,  elapsTime % 60)
             reportStr += "-------------------------------------------------\n"
         logging.warn(reportStr)
 

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -34,7 +34,7 @@ from ..util.expandcheck import ExpandCheck
 
 
 class Regression:
-    def __init__(self, config="regress.json", level='info', suiteDir=None):
+    def __init__(self, config="regress.json", level='info', suiteDir=None,  numOfThreads=1):
         self.config = Config(config).configObj
         self.suites = {}
         self.log = Logger(level)
@@ -63,14 +63,15 @@ class Regression:
         logging.debug("Archive Dir    : %s", self.dir_a)
 
         self.loggermutex = thread.allocate_lock()
-        self.numOfCpus = 1
+        if numOfThreads == -1:
+            self.numOfCpus = 1
+            if 'linux' in sys.platform :
+                command = 'grep cores /proc/cpuinfo | sort -u'
+                cpuInfo = os.popen(command).read()
+                self.numOfCpus = int(cpuInfo.split()[3])
+            numOfThreads = self.numOfCpus  * 2
 
-        if 'linux' in sys.platform :
-            command = 'grep cores /proc/cpuinfo | sort -u'
-            cpuInfo = os.popen(command).read()
-            self.numOfCpus = int(cpuInfo.split()[3])
-
-        self.maxthreads = self.numOfCpus * 2
+        self.maxthreads = numOfThreads
         self.maxtasks = 0
         self.exitmutexes = [thread.allocate_lock() for i in range(self.maxthreads)]
 

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -21,6 +21,7 @@ import logging
 import os
 import sys
 import time
+import thread
 
 from ..common.config import Config
 from ..common.error import Error
@@ -61,6 +62,18 @@ class Regression:
         logging.debug("Setup Dir      : %s", self.setupDir)
         logging.debug("Archive Dir    : %s", self.dir_a)
 
+        self.loggermutex = thread.allocate_lock()
+        self.numOfCpus = 1
+
+        if 'linux' in sys.platform :
+            command = 'grep cores /proc/cpuinfo | sort -u'
+            cpuInfo = os.popen(command).read()
+            self.numOfCpus = int(cpuInfo.split()[3])
+
+        self.maxthreads = self.numOfCpus * 2
+        self.maxtasks = 0
+        self.exitmutexes = [thread.allocate_lock() for i in range(self.maxthreads)]
+
     def setLogLevel(self, level):
         self.log.setLevel(level)
 
@@ -72,7 +85,9 @@ class Regression:
         self.setup = self.Setup()
         if cluster in self.config.Clusters:
             self.createSuite(cluster)
+            self.maxtasks = len(self.suites[cluster].getSuite())
         os.chdir(self.regressionDir)
+
 
     def createDirectory(self, dir_n):
         if not os.path.isdir(dir_n):
@@ -88,15 +103,44 @@ class Regression:
 
     def buildLogging(self, name):
         report = Report(name)
-        curTime = time.strftime("%y-%m-%d-%H-%M")
+        curTime = time.strftime("%y-%m-%d-%H-%M-%S")
         logName = name + "." + curTime + ".log"
         log = os.path.join(self.logDir, logName)
         self.log.addHandler(log, 'DEBUG')
         return (report, log)
 
     @staticmethod
-    def displayReport(report):
-        report[0].display(report[1])
+    def displayReport(report,  elapsTime=0):
+        report[0].display(report[1],  elapsTime)
+
+    def runSuiteP(self, name, suite):
+        report = self.buildLogging(name)
+        if name == "setup":
+            cluster = 'hthor'
+        else:
+            cluster = name
+
+        logging.warn("Suite: %s ",  name)
+        logging.warn("Queries: %s" % repr(len(suite.getSuite())))
+        logging.warn('%s','' , extra={'filebuffer':True,  'filesort':True})
+        cnt = 0
+        suite.setStarTime(time.time())
+        suiteItems = suite.getSuite()
+        while cnt in range(self.maxtasks):
+            query = suiteItems[cnt]
+            for th in range(self.maxthreads):
+                if not self.exitmutexes[th].locked():
+                    cnt += 1
+                    thread.start_new_thread(self.runQuery, (cluster, query, report, cnt, suite.testPublish(query.ecl),  th))
+                    break
+            time.sleep(0.1)
+
+        for mutex in self.exitmutexes:
+            while mutex.locked(): pass
+
+        logging.warn('%s','' , extra={'filebuffer':True,  'filesort':True})
+        suite.setEndTime(time.time())
+        Regression.displayReport(report, suite.getelapsTime())
 
     def runSuite(self, name, suite):
         report = self.buildLogging(name)
@@ -107,23 +151,32 @@ class Regression:
 
         logging.warn("Suite: %s" % name)
         logging.warn("Queries: %s" % repr(len(suite.getSuite())))
+        suite.setStarTime(time.time())
         cnt = 1
         for query in suite.getSuite():
             self.runQuery(cluster, query, report, cnt, suite.testPublish(query.ecl))
             cnt += 1
-        Regression.displayReport(report)
+        suite.setEndTime(time.time())
+        Regression.displayReport(report, suite.getelapsTime())
 
-    def runQuery(self, cluster, query, report, cnt=1, publish=False):
+    def runQuery(self, cluster, query, report, cnt=1, publish=False,  th = 0):
+        startTime = time.time()
+        self.exitmutexes[th].acquire()
+        self.loggermutex.acquire()
         logging.debug("runQuery(cluster:", cluster, ", query:", query, ", report:", report, ", cnt:", cnt, ", publish:", publish, ")")
-        logging.warn("%s. Test: %s" % (repr(cnt), query.ecl))
+        logging.warn("%3d. Test: %s" % (cnt, query.ecl))
         ECLCC().makeArchive(query)
+        eclCmd = ECLcmd()
+        self.loggermutex.release()
+        res = 0
+
         if publish:
-            res = ECLcmd().runCmd("publish", cluster, query, report[0],
+            res = eclCmd.runCmd("publish", cluster, query, report[0],
                               server=self.config.ip,
                               username=self.config.username,
                               password=self.config.password)
         else:
-            res = ECLcmd().runCmd("run", cluster, query, report[0],
+            res = eclCmd.runCmd("run", cluster, query, report[0],
                               server=self.config.ip,
                               username=self.config.username,
                               password=self.config.password)
@@ -133,12 +186,17 @@ class Regression:
             url += "/WsWorkunits/WUInfo?Wuid="
             url += wuid
 
+        self.loggermutex.acquire()
+        elapsTime = time.time()-startTime
         if res:
-            logging.info("Pass %s" % wuid)
-            logging.info("URL %s" % url)
+            logging.info("%3d. Pass %s (%d sec)" % (cnt, wuid,  elapsTime))
+            logging.info("%3d. URL %s" % (cnt,url))
         else:
             if not wuid:
-                logging.error("Fail No WUID")
+                logging.error("%3d. Fail No WUID (%d sec)" % (cnt,  elapsTime))
             else:
-                logging.error("Fail %s" % wuid)
-                logging.error("URL %s" % url)
+                logging.error("%3d. Fail %s (%d sec)" % (cnt, wuid,  elapsTime))
+                logging.error("%3d. URL %s" %  (cnt,url))
+        self.loggermutex.release()
+        query.setElapsTime(elapsTime)
+        self.exitmutexes[th].release()

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -75,6 +75,15 @@ class Suite:
         if ecl in self.publish:
             return True
         return False
-        
+
     def getSuite(self):
         return self.suite
+
+    def setStarTime(self,  time):
+        self.startTime = time
+
+    def setEndTime(self,  time):
+        self.endTime=time
+
+    def getelapsTime(self):
+        return self.endTime-self.startTime

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -34,6 +34,7 @@ class ECLFile:
     dir_a = None
     diff = ''
     wuid = None
+    elapsTime = 0
 
     def __init__(self, ecl, dir_a, dir_ex, dir_r):
         self.dir_ec = os.path.dirname(ecl)
@@ -112,7 +113,7 @@ class ECLFile:
         return False
 
     def testPublish(self):
-        # Standard strign has a problem with unicode characters
+        # Standard string has a problem with unicode characters
         # use byte arrays and binary file open instead
         tag = b'//publish'
         logging.debug("testPublish (ecl:", self.ecl,", tag: ", tag, ")")
@@ -129,8 +130,10 @@ class ECLFile:
             logging.debug("EXP: " + self.getExpected())
             logging.debug("REC: " + self.getResults())
             if not os.path.isfile(self.getExpected()):
+                self.diff += "KEY FILE NOT FOUND. " + self.getExpected()
                 raise IOError("KEY FILE NOT FOUND. " + self.getExpected())
             if not os.path.isfile(self.getResults()):
+                self.diff += "RESULT FILE NOT FOUND. " + self.getResults()
                 raise IOError("RESULT FILE NOT FOUND. " + self.getResults())
             expected = open(self.getExpected(), 'r').readlines()
             recieved = open(self.getResults(), 'r').readlines()
@@ -146,3 +149,6 @@ class ECLFile:
         if not self.diff:
             return True
         return False
+
+    def setElapsTime(self,  time):
+        self.elapsTime = time

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -17,28 +17,20 @@
 ############################################################################ */
 '''
 
-import os
-import logging
+import argparse
 
-class ExpandCheck:
+def isPositiveIntNum(string):
+    for i in range(0,  len(string)):
+        if (string[i] < '0') or (string[i] > '9'):
+            return False
+    return True
 
-    @staticmethod
-    def dir_exists(path, require=False):
-        logging.debug("dir_exists(path: %s, require: %d", path, require)
-        if '~' in path:
-            path = os.path.expanduser(path)
-        else:
-            path = os.path.abspath(path)
-        logging.debug("path: %s", path)
-        if not os.path.exists(path):
-            if require:
-                logging.debug("Path: %s not found and it is required!" ,path)
-                try:
-                    os.mkdir(path)
-                except:
-                    raise IOError("REQUIRED DIRECTORY NOT FOUND. " + path)
-            else:
-                logging.info( "DIRECTORY NOT FOUND. " + path)
+def checkPqParam(string):
+    param = str(string)
+    if isPositiveIntNum(string) or (string == '-1'):
+        value = int(string)
+    else:
+        msg = "Wrong value of threadNumber parameter: '"+string+"' !"
+        raise argparse.ArgumentTypeError(msg)
 
-        return(path)
-
+    return value

--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -26,6 +26,7 @@ import atexit
 
 from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
+from hpcc.util.util import checkPqParam
 
 if __name__ == "__main__":
     atexit.register(logging.shutdown)
@@ -41,15 +42,18 @@ if __name__ == "__main__":
                         choices=['info', 'debug'])
     parser.add_argument('--suiteDir', '-s', help="suiteDir to use.",
                         nargs='?', default=".")
+
     subparsers = parser.add_subparsers(help='sub-command help')
     parser_list = subparsers.add_parser('list', help='list help')
     parser_list.add_argument('clusters', help="Print clusters from config.",
                              action='store_true')
+
     parser_run = subparsers.add_parser('run', help='run help')
     parser_run.add_argument('cluster', help="Run the cluster suite.",
-                            nargs='?', default='setup')
-    parser_run.add_argument('--pq', help="Parallel query.",
-                            action='store_true')
+                            nargs='?', type=str,  default='setup')
+    parser_run.add_argument('--pq', help="Parallel query execution with threadNumber threads. ('-1' can be use to calculate usable thread count on a single node system)",
+                            type=checkPqParam,  default = 1,   metavar="threadNumber")
+
     parser_query = subparsers.add_parser('query', help='query help')
     parser_query.add_argument('query', help="Name of a single ECL query (mandatory).",
                               nargs='?', metavar="ECL query")
@@ -57,13 +61,13 @@ if __name__ == "__main__":
                             nargs='?', default='thor', metavar="target cluster | all")
     parser_query.add_argument('--publish', help="Publish compiled query instead of run.",
                             action='store_true')
+
     args = parser.parse_args()
 
     suiteDir = ""
     if 'suiteDir' in args:
         suiteDir = args.suiteDir
     try:
-        regress = Regression(args.config, args.loglevel, suiteDir)
         if 'clusters' in args:
             Clusters = ['setup']
             for cluster in regress.config.Clusters:
@@ -76,6 +80,7 @@ if __name__ == "__main__":
                 print "\nMissing ECL query file!\n"
                 parser_query.print_help()
                 exit()
+            regress = Regression(args.config, args.loglevel, suiteDir)
             ecl = os.path.join(regress.dir_ec, args.query)
             eclfile = ECLFile(ecl, regress.dir_a, regress.dir_ex,
                               regress.dir_r)
@@ -108,6 +113,7 @@ if __name__ == "__main__":
                     logging.error("%s. Query %s does not exist!" % (1,  args.query))
                     exit()
         elif 'cluster' in args:
+            regress = Regression(args.config, args.loglevel, suiteDir,  args.pq)
             regress.bootstrap(args.cluster)
             if 'setup' in args.cluster:
                 regress.runSuite('setup', regress.setup)

--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -22,16 +22,18 @@
 import argparse
 import logging
 import os
+import atexit
 
 from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
 
 if __name__ == "__main__":
+    atexit.register(logging.shutdown)
     prog = "regress"
     description = 'HPCC Platform Regression suite'
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('--version', '-v', action='version',
-                        version='%(prog)s 0.0.1')
+                        version='%(prog)s 0.0.2')
     parser.add_argument('--config', help="Config file to use.",
                         nargs='?', default="regress.json")
     parser.add_argument('--loglevel', help="Set the log level.",
@@ -46,13 +48,15 @@ if __name__ == "__main__":
     parser_run = subparsers.add_parser('run', help='run help')
     parser_run.add_argument('cluster', help="Run the cluster suite.",
                             nargs='?', default='setup')
+    parser_run.add_argument('--pq', help="Parallel query.",
+                            action='store_true')
     parser_query = subparsers.add_parser('query', help='query help')
-    parser_query.add_argument('query', help="Run a single ECL query.",
+    parser_query.add_argument('query', help="Name of a single ECL query (mandatory).",
                               nargs='?', metavar="ECL query")
-    parser_query.add_argument('cluster', help="Cluster for single query run.",
-                            nargs='?', default='thor', metavar="target cluster")
-    parser_query.add_argument('publish', help="Publish compiled query instead of run.",
-                            nargs='?', default='False')
+    parser_query.add_argument('cluster', help="Cluster for single query run. If cluster = 'all' then run single query on all clusters.",
+                            nargs='?', default='thor', metavar="target cluster | all")
+    parser_query.add_argument('--publish', help="Publish compiled query instead of run.",
+                            action='store_true')
     args = parser.parse_args()
 
     suiteDir = ""
@@ -75,24 +79,43 @@ if __name__ == "__main__":
             ecl = os.path.join(regress.dir_ec, args.query)
             eclfile = ECLFile(ecl, regress.dir_a, regress.dir_ex,
                               regress.dir_r)
-            if not eclfile.testSkip(args.cluster)['skip']:
-                if not eclfile.testExclusion(args.cluster):
-                    report = regress.buildLogging(args.query)
-                    if (args.publish == 'publish') or eclfile.testPublish():
-                        regress.runQuery(args.cluster, eclfile, report, 1, True)
-                    else:
-                        regress.runQuery(args.cluster, eclfile, report)
-                    Regression.displayReport(report)
-                else:
-                    print args.query+" excluded on "+args.cluster+" cluster."
+            targetClusters = []
+            if 'all' in args.cluster:
+                for cluster in regress.config.Clusters:
+                    targetClusters.append(str(cluster))
             else:
-                print args.query+" skipped on "+args.cluster+" cluster."
+                targetClusters.append(args.cluster)
+            for cluster in targetClusters:
+                logging.warn("Target: %s" % cluster)
+                logging.warn("Queries: %s" % 1)
+                try:
+                    if not eclfile.testSkip(cluster)['skip']:
+                        if not eclfile.testExclusion(cluster):
+                            report = regress.buildLogging(args.query)
+                            if args.publish or eclfile.testPublish():
+                                regress.runQuery(cluster, eclfile, report, 1, True)
+                            else:
+                                regress.runQuery(cluster, eclfile, report)
+                            Regression.displayReport(report)
+                        else:
+                            #print args.query+" excluded on "+cluster+" cluster."
+                            logging.warn("%s. %s excluded on this cluster." % (1, args.query))
+                    else:
+                        #print args.query+" skipped on "+cluster+" cluster."
+                        logging.warn("%s. %s skipped on this cluster." % (1, args.query))
+                except IOError:
+                    #print "Query "+args.query+ " does not exist!"
+                    logging.error("%s. Query %s does not exist!" % (1,  args.query))
+                    exit()
         elif 'cluster' in args:
             regress.bootstrap(args.cluster)
             if 'setup' in args.cluster:
                 regress.runSuite('setup', regress.setup)
             else:
-                regress.runSuite(args.cluster, regress.suites[args.cluster])
+                if  args.pq :
+                    regress.runSuiteP(args.cluster, regress.suites[args.cluster])
+                else:
+                    regress.runSuite(args.cluster, regress.suites[args.cluster])
     except Exception as e:
         logging.critical(e)
     except KeyboardInterrupt:


### PR DESCRIPTION
Part - 1:

Add parallel query support with --pq parameter for run mode. It uses threads
to accelerate test cases execution.

Sort result log when --pq used and test cases don't finished in same sequence
as they started.

Add 'all' parameter to query mode to run ECL program on all target clusters.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
