### PR TITLE
HPCC-10413 - Reinstate non-sequential subfile orders

### DIFF
--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -1153,7 +1153,6 @@ static void checksuperfile(const char *lfn,bool fix=false)
         root->setPropInt("@numsubfiles",subnum);
     i = 0;
     byte fixstate = 0;
-    bool outOfSequence = false;
     loop {
         bool err = false;
         IPropertyTree *sub = root->queryPropTree(path.clear().appendf("SubFile[%d]",i+1).str());
@@ -1171,13 +1170,6 @@ static void checksuperfile(const char *lfn,bool fix=false)
                     fixed = true;
                     i--;
                 }
-            }
-            else if (pn != i+1) {
-                if (!outOfSequence)
-                    ERRLOG("SuperFile %s: corrupt, subfile file part @num values out of sequence, starting at part: %d", lname.get(), pn);
-                if (fix && (outOfSequence || doFix()))
-                    sub->setPropInt("@num", i+1);
-                outOfSequence = true;
             }
         }
         else


### PR DESCRIPTION
A regression was introduced way back in 3.10.0, which
meant that the orders of subfiles were ignored, meaning
AddSuperFile @ position, was effectively being ignored.
Worse than that, it also meant the internal representation
of order of subfiles differed from the DFS meta file order,
which consequently cause bugs like HPCC-10287.

This commit:
1) Reinstates ordered subfiles as defined by SubFile @num
2) Rollsback the previous 4.2 commit which asserted the SubFile's
must have sequential order
3) Rollsback the daliadmin checksuperfile addition for OOO
SubFile's
4) Removes spurious "subfile:" tracing added in HPCC-9218

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
