### PR TITLE
HPCC-9990 Add an option to convert SORTED/DISTRIBUTED to ASSERT forms

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1544,6 +1544,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.defaultExpiry, "defaultExpiry", DEFAULT_EXPIRY_PERIOD),
 
         DebugOption(options.checkAsserts,"checkAsserts", true),
+        DebugOption(options.assertSortedDistributed,"assertSortedDistributed", false),
         DebugOption(options.optimizeLoopInvariant,"optimizeLoopInvariant", false),      // doesn't fully work yet! and has little effect, and messes up the alias dependencies
         DebugOption(options.defaultImplicitKeyedJoinLimit, "defaultImplicitKeyedJoinLimit", 10000),
         DebugOption(options.defaultImplicitIndexReadLimit, "defaultImplicitIndexReadLimit", 0),

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -577,6 +577,7 @@ struct HqlCppOptions
     bool                optimizeResourcedProjects;
     byte                notifyOptimizedProjects;
     bool                checkAsserts;
+    bool                assertSortedDistributed;
     bool                optimizeLoopInvariant;
     bool                warnOnImplicitJoinLimit;
     bool                warnOnImplicitReadLimit;

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -10526,6 +10526,7 @@ HqlTreeNormalizer::HqlTreeNormalizer(HqlCppTranslator & _translator) : NewHqlTra
     seenForceLocal = false;
     seenLocalUpload = false;
     const HqlCppOptions & translatorOptions = translator.queryOptions();
+    options.assertSortedDistributed = translatorOptions.assertSortedDistributed;
     options.removeAsserts = !translatorOptions.checkAsserts;
     options.commonUniqueNameAttributes = translatorOptions.commonUniqueNameAttributes;
     options.sortIndexPayload = translatorOptions.sortIndexPayload;
@@ -11381,7 +11382,7 @@ IHqlExpression * HqlTreeNormalizer::transformIfAssert(node_operator newOp, IHqlE
     unsigned max = expr->numChildren();
     HqlExprArray children;
     bool same = transformChildren(expr, children);
-    if (expr->hasAttribute(assertAtom) && !options.removeAsserts)
+    if ((expr->hasAttribute(assertAtom) || (options.assertSortedDistributed && (newOp != no_assertgrouped))) && !options.removeAsserts)
     {
         OwnedHqlExpr ret = createDataset(newOp, children);
         return expr->cloneAllAnnotations(ret);

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -1209,6 +1209,7 @@ protected:
     HqlExprArray defines;
     struct
     {
+        bool assertSortedDistributed;
         bool removeAsserts;
         bool commonUniqueNameAttributes;
         bool sortIndexPayload;


### PR DESCRIPTION
# option('assertSortedDistributed', TRUE);

will create assertions for both SORTED and DISTRIBUTED i.e. as if the following
was used.

SORTED(ds, ..., ASSERT)
DISTRIBUTED(ds, ..., ASSERT)

Signed-off-by: jamienoss james.noss@lexisnexis.com
