### PR TITLE
HPCC-10439 DOCS:VMWare Version

### DIFF
--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -137,7 +137,7 @@
 
         <listitem>
           <para>A virtualization software package:
-          VMware<superscript>®</superscript> Player or Server (version 4.0 or
+          VMware<superscript>®</superscript> Player or Server (version 5.0 or
           later) or Oracle VM VirtualBox (version 4.0 or later).</para>
         </listitem>
 


### PR DESCRIPTION
Fix HPCC-10439 DOCS:VMWare Version
Revise VM docs to reflect support for
VMWare player 5.0 or better.

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com

@JamesDeFabia
