### PR TITLE
HPCC-10442 Fix rendering of embeded view resources when using libxslt

### DIFF
--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -395,15 +395,17 @@ bool WuWebView::getEspInclude(const char *includename, MemoryBuffer &includebuf,
 
 bool WuWebView::getInclude(const char *includename, MemoryBuffer &includebuf, bool &pathOnly)
 {
-    int len=strlen(includename);
-    if (len<8)
-        return false;
     //eliminate "file://"
-    if (strncmp(includename, "file://", 7)==0)
-        includename+=7;
-    //eliminate extra '/' for windows absolute paths
-    if (len>9 && includename[2]==':')
-        includename++;
+    if (strncmp(includename, "file:", 5)==0)
+        includename+=5;
+    if (*includename=='/')
+    {
+        while (includename[1]=='/')
+            includename++;
+        //eliminate extra '/' for windows absolute paths
+        if (includename[1] && includename[2]==':')
+            includename++;
+    }
     if (mapEspDirectories && !strnicmp(includename, "/esp/", 5))
         return getEspInclude(includename+5, includebuf, pathOnly);
 

--- a/esp/bindings/bindutil.cpp
+++ b/esp/bindings/bindutil.cpp
@@ -643,43 +643,11 @@ StringBuffer &Utils::url_encode(const char* url, StringBuffer& encoded_url)
     return encoded_url;
 }
 
-static char translateHex(char hex) {
-    if(hex >= 'A')
-        return (hex & 0xdf) - 'A' + 10;
-    else
-        return hex - '0';
-}
-
 int Utils::url_decode(const char* url, StringBuffer& result)
 {
-    if(!url || !*url)
-        return 0;
-
-    const char *finger = url;
-    while (*finger)
-    {
-        char c = *finger++;
-        if (c == '+')
-            c = ' ';
-        else if (c == '%')
-        {
-            if(*finger != '\0')
-            {
-                c = translateHex(*finger);
-                finger++;
-            }
-            if(*finger != '\0')
-            {
-                c = (char)(c*16 + translateHex(*finger));
-                finger++;
-            }
-        }
-        result.append(c);
-    }
-
+    appendDecodedURL(result, url);
     return 0;
 }
-
 
 void Utils::SplitURL(const char* url, StringBuffer& protocol,StringBuffer& UserName,StringBuffer& Password,StringBuffer& host, StringBuffer& port, StringBuffer& path)
 {

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -1273,6 +1273,41 @@ void appendURL(StringBuffer *dest, const char *src, size32_t len, char lower)
   }
 }
 
+inline char translateHex(char hex)
+{
+    if(hex >= 'A')
+        return (hex & 0xdf) - 'A' + 10;
+    else
+        return hex - '0';
+}
+
+inline char translateHex(char h1, char h2)
+{
+    return (translateHex(h1) * 16 + translateHex(h2));
+}
+
+StringBuffer &appendDecodedURL(StringBuffer &s, const char *url)
+{
+    if(!url)
+        return s;
+
+    while (*url)
+    {
+        char c = *url++;
+        if (c == '+')
+            c = ' ';
+        else if (c == '%')
+        {
+            if (isxdigit(url[0]) && isxdigit(url[1]))
+            {
+                c = translateHex(url[0], url[1]);
+                url+=2;
+            }
+        }
+        s.append(c);
+    }
+    return s;
+}
 
 static StringBuffer & appendStringExpandControl(StringBuffer &out, unsigned len, const char * src, bool addBreak, bool isCpp, bool isUtf8)
 {

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -354,6 +354,7 @@ interface IEntityHelper
 };
 
 void jlib_decl appendURL(StringBuffer *dest, const char *src, size32_t len = -1, char lower=FALSE);
+extern jlib_decl StringBuffer &appendDecodedURL(StringBuffer &out, const char *url);
 extern jlib_decl StringBuffer & appendStringAsCPP(StringBuffer &out, unsigned len, const char * src, bool addBreak);
 extern jlib_decl StringBuffer & appendStringAsQuotedCPP(StringBuffer &out, unsigned len, const char * src, bool addBreak);
 extern jlib_decl StringBuffer & appendDataAsHex(StringBuffer &out, unsigned len, const void * data);

--- a/system/xmllib/libxslt_processor.cpp
+++ b/system/xmllib/libxslt_processor.cpp
@@ -760,7 +760,15 @@ xmlDocPtr libXsltIncludeHandler(const xmlChar * URI, xmlDictPtr dict, int option
 {
     bool mbContainsPath=false;
     MemoryBuffer mb;
-    if (!handler->getInclude((const char *)URI, mb, mbContainsPath))
+    StringBuffer decodedURI;
+    appendDecodedURL(decodedURI, (const char *)URI);
+    if (strchr(decodedURI.str(), '%')) //libxstl seems to double encode
+    {
+        StringBuffer s;
+        appendDecodedURL(s, decodedURI.str());
+        decodedURI.swapWith(s);
+    }
+    if (!handler->getInclude(decodedURI, mb, mbContainsPath))
         return originalLibXsltIncludeHandler(URI, dict, options, NULL, type);
     if (mbContainsPath)
         return originalLibXsltIncludeHandler((const xmlChar *)mb.append((char)0).toByteArray(), dict, options, NULL, type);


### PR DESCRIPTION
This is not a regression.  It may only affect resources with certain
type of original path... i.e. directories with spaces in the names.

Libxslt was double url encoding the path before passing it to the
registered include handler callback.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
