### PR TITLE
HPCC-xxxx - Regression introduced by hpcc-9577, possible crash

### DIFF
--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -853,7 +853,7 @@ public:
     unsigned querySlaves() const { return slaveGroup->ordinality(); }
     ICommunicator &queryJobComm() const { return *jobComm; }
     IGroup &queryJobGroup() const { return *jobGroup; }
-    bool queryTimeActivities() const { return timeActivities; }
+    inline bool queryTimeActivities() const { return timeActivities; }
     unsigned queryMaxDefaultActivityCores() const { return maxActivityCores; }
     IGroup &querySlaveGroup() const { return *slaveGroup; }
     const rank_t &queryMyRank() const { return myrank; }
@@ -900,7 +900,7 @@ protected:
     Linked<IHThorArg> baseHelper;
     mptag_t mpTag; // to be used by any direct inter master<->slave communication
     bool abortSoon;
-    const bool &timeActivities; // purely for access efficiency
+    bool timeActivities; // purely for access efficiency
     size32_t parentExtractSz;
     const byte *parentExtract;
     bool receiving, cancelledReceive, reInit;


### PR DESCRIPTION
Use of a method that used to return a referene to a boolean
to return non-reference causes invalid memory access.
The reference used to be stored as a reference member in a class.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
