### PR TITLE
HPCC-10440 - Ensure padded part copies have matching timestamps

### DIFF
--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -508,6 +508,7 @@ public:
                         if (p == partOffset)
                             p += job.querySlaves();
                         IPartDescriptor *partDesc = fileDesc.queryPart(p);
+                        CDateTime createTime, modifiedTime;
                         unsigned c=0;
                         for (; c<partDesc->numCopies(); c++)
                         {
@@ -520,6 +521,15 @@ public:
                                 ensureDirectoryForFile(path.str());
                                 OwnedIFile iFile = createIFile(path.str());
                                 OwnedIFileIO iFileIO = iFile->open(IFOcreate);
+                                iFileIO.clear();
+                                // ensure copies have matching datestamps, as they would do normally (backupnode expects it)
+                                if (partDesc->numCopies() > 1)
+                                {
+                                    if (0 == c)
+                                        iFile->getTime(&createTime, &modifiedTime, NULL);
+                                    else
+                                        iFile->setTime(&createTime, &modifiedTime, NULL);
+                                }
                             }
                             catch (IException *e)
                             {


### PR DESCRIPTION
When targeting a larger cluster with CLUSTER(<largercluster>)
Empty parts are created for the extra width. Those parts must
have matching timestamps, otherwise backupnode thinks they
mismatch and tried to copy them.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
