### PR TITLE
HPCC-10445 Python crashed at exit of Regression Suite in overnight build and  test

### DIFF
--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -29,7 +29,6 @@ from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam
 
 if __name__ == "__main__":
-    atexit.register(logging.shutdown)
     prog = "regress"
     description = 'HPCC Platform Regression suite'
     parser = argparse.ArgumentParser(prog=prog, description=description)


### PR DESCRIPTION
Remove forced logging.shutdown() function call at the end of Regression Suite.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
