### PR TITLE
HPCC-10259 Add ability to browse Workunit resources

### DIFF
--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -283,6 +283,7 @@ public:
     IPropertyTree *ensureManifest();
 
     virtual void getResultViewNames(StringArray &names);
+    virtual void getResourceURLs(StringArray &urls, const char *prefix);
     virtual void renderResults(const char *viewName, const char *xml, StringBuffer &html);
     virtual void renderResults(const char *viewName, StringBuffer &html);
     virtual void renderSingleResult(const char *viewName, const char *resultname, StringBuffer &html);
@@ -451,6 +452,25 @@ bool WuWebView::getResourceByPath(const char *path, MemoryBuffer &mb)
     if (!res)
         return false;
     return getResource(res, mb);
+}
+
+void WuWebView::getResourceURLs(StringArray &urls, const char *prefix)
+{
+    SCMStringBuffer wuid;
+    cw->getWuid(wuid);
+    StringBuffer url(prefix);
+    urls.append(url.append("manifest/").append(wuid.str()));
+
+    Owned<IPropertyTreeIterator> iter = ensureManifest()->getElements("Resource");
+    ForEach(*iter)
+    {
+        IPropertyTree &res = iter->query();
+        url.set(prefix).append("res/").append(wuid.str());
+        if (res.hasProp("@ResourcePath"))
+            urls.append(url.append(res.queryProp("@ResourcePath")));
+        else if (res.hasProp("@filename"))
+            urls.append(url.append('/').append(res.queryProp("@filename")));
+    }
 }
 
 void WuWebView::getResultViewNames(StringArray &names)

--- a/common/wuwebview/wuwebview.hpp
+++ b/common/wuwebview/wuwebview.hpp
@@ -42,6 +42,7 @@
 interface IWuWebView : extends IInterface
 {
     virtual void getResultViewNames(StringArray &names)=0;
+    virtual void getResourceURLs(StringArray &urls, const char *prefix)=0;
     virtual void renderResults(const char *viewName, const char *xml, StringBuffer &html)=0;
     virtual void renderResults(const char *viewName, StringBuffer &html)=0;
     virtual void renderSingleResult(const char *viewName, const char *resultname, StringBuffer &html)=0;

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -705,6 +705,22 @@
       </xsl:if>
 
       <xsl:if test="number(Archived) &lt; 1">
+        <xsl:if test="count(ResourceURLs/URL)">
+          <p>
+            <div class="wugroup">
+              <div class="WuGroupHdrLeft">
+                <A href="javascript:void(0)" onclick="toggleElement('Resources');" id="explinkResources" class="wusectionexpand">
+                  Resources: (<xsl:value-of select="count(ResourceURLs/URL)"/>)
+                </A>
+              </div>
+            </div>
+            <div id="Resources" class="wusectioncontent">
+              <table id="ResourceTable" class="wusectiontable">
+                <xsl:apply-templates select="ResourceURLs"/>
+              </table>
+            </div>
+          </p>
+        </xsl:if>
         <xsl:if test="count(Helpers/ECLHelpFile)">
           <p>
             <div class="wugroup">
@@ -1225,6 +1241,17 @@
         </xsl:if>
       </td>
     </tr>
+  </xsl:template>
+  <xsl:template match="ResourceURLs">
+    <xsl:for-each select="URL">
+    <tr>
+      <td>
+        <a href="{text()}" >
+          <xsl:value-of select="."/>
+        </a>
+      </td>
+    </tr>
+    </xsl:for-each>
   </xsl:template>
   <xsl:template match="ECLHelpFile">
     <tr>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -233,7 +233,7 @@ ESPStruct [nil_remove] ECLWorkunit
     [min_ver("1.29")] string WorkflowsDesc;
     [min_ver("1.31")] bool HasArchiveQuery(false);
     [min_ver("1.38")] ESParray<ESPstruct ThorLogInfo> ThorLogList;
-
+    [min_ver("1.47")] ESParray<string, URL> ResourceURLs;
 };
 
 ESPStruct [nil_remove] WUECLAttribute
@@ -592,6 +592,7 @@ ESPrequest WUInfoRequest
     [min_ver("1.16")] bool IncludeApplicationValues(true);
     [min_ver("1.16")] bool IncludeWorkflows(true);
     [min_ver("1.39")] bool IncludeXmlSchemas(false);
+    [min_ver("1.47")] bool IncludeResourceURLs(true);
     [min_ver("1.16")] bool SuppressResultSchemas(false);
     [min_ver("1.25")] string ThorSlaveIP;
 };
@@ -1443,7 +1444,7 @@ ESPresponse [exceptions_inline] WUCreateZAPInfoResponse
 };
 
 ESPservice [
-    version("1.46"), default_client_version("1.46"),
+    version("1.47"), default_client_version("1.47"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1630,15 +1630,20 @@ void WsWuInfo::getSubFiles(IPropertyTreeIterator* f, IEspECLSourceFile* eclSuper
     return;
 }
 
-bool WsWuInfo::getResultViews(StringArray &viewnames, unsigned flags)
+bool WsWuInfo::getResourceInfo(StringArray &viewnames, StringArray &urls, unsigned flags)
 {
-    if (!(flags & WUINFO_IncludeResultsViewNames))
+    if (!(flags & (WUINFO_IncludeResultsViewNames | WUINFO_IncludeResourceURLs)))
         return true;
     try
     {
         Owned<IWuWebView> wv = createWuWebView(*cw, NULL, NULL, false);
         if (wv)
-            wv->getResultViewNames(viewnames);
+        {
+            if (flags & WUINFO_IncludeResultsViewNames)
+                wv->getResultViewNames(viewnames);
+            if (flags & WUINFO_IncludeResourceURLs)
+                wv->getResourceURLs(urls, NULL);
+        }
         return true;
     }
     catch(IException* e)

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -117,6 +117,7 @@ private:
 #define WUINFO_IncludeSourceFiles       0x0400
 #define WUINFO_IncludeResultsViewNames  0x0800
 #define WUINFO_IncludeXmlSchema         0x1000
+#define WUINFO_IncludeResourceURLs      0x2000
 #define WUINFO_All                      0xFFFF
 
 class WsWuInfo
@@ -140,7 +141,7 @@ public:
             throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.", wuid_);
     }
 
-    bool getResultViews(StringArray &resultViews, unsigned flags);
+    bool getResourceInfo(StringArray &viewnames, StringArray &urls, unsigned flags);
 
     void getCommon(IEspECLWorkunit &info, unsigned flags);
     void getInfo(IEspECLWorkunit &info, unsigned flags);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1762,15 +1762,20 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
                     flags|=WUINFO_IncludeEclSchemas;
                 if (req.getIncludeXmlSchemas())
                     flags|=WUINFO_IncludeXmlSchema;
+                if (req.getIncludeResultsViewNames())
+                    flags|=WUINFO_IncludeResultsViewNames;
+                if (req.getIncludeResourceURLs())
+                    flags|=WUINFO_IncludeResourceURLs;
 
                 WsWuInfo winfo(context, wuid.str());
                 winfo.getInfo(resp.updateWorkunit(), flags);
 
-                if (req.getIncludeResultsViewNames())
+                if (req.getIncludeResultsViewNames()||req.getIncludeResourceURLs())
                 {
-                    StringArray views;
-                    winfo.getResultViews(views, WUINFO_IncludeResultsViewNames);
+                    StringArray views, urls;
+                    winfo.getResourceInfo(views, urls, flags);
                     resp.setResultViews(views);
+                    resp.updateWorkunit().setResourceURLs(urls);
                 }
             }
             catch (IException *e)


### PR DESCRIPTION
WsWorkunits::WuInfo now supports an IncludeResourceURLs option
(defaulting to true) which will display a list of the relative urls
for accessing a workunit's embedded resources directly.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
