### PR TITLE
HPCC-10481 - Default replicate dir causing problems

### DIFF
--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -383,6 +383,10 @@ struct CClusterInfo: public CInterface, implements IClusterInfo
                     {
                         mspec.setDefaultBaseDir(defaultDir);   // MORE - should possibly set up the rest of the mspec info from the group info here
                     }
+                    if (mspec.defaultCopies>1 && mspec.defaultReplicateDir.isEmpty())
+                    {
+                        mspec.setDefaultReplicateDir(queryBaseDirectory(groupType, 1));
+                    }
                     return; // ok
                 }
                 name.clear();


### PR DESCRIPTION
Set the default replicate directory based on type in clusterinfo.
Was causing problems if not, when other components of different
type than the group type, e.g. processing a thor group file on
eclagent. It would then get local (e.g. eclagent) default dir
and construct the wrong file path.

The symptom seen was that when eclagent deleted files, it failed
to delete replicate parts.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
