### PR TITLE
HPCC-10407 - Logical file does not open

### DIFF
--- a/esp/files/scripts/QuerySetLogicalFilesWidget.js
+++ b/esp/files/scripts/QuerySetLogicalFilesWidget.js
@@ -27,11 +27,12 @@ define([
     "dgrid/extensions/DijitRegistry",
 
     "hpcc/GridDetailsWidget",
+    "hpcc/LFDetailsWidget",
     "hpcc/WsWorkunits",
     "hpcc/ESPUtil"
 ], function (declare, arrayUtil, lang, on,
                 OnDemandGrid, Keyboard, Selection, selector, ColumnResizer, DijitRegistry,
-                GridDetailsWidget, WsWorkunits, ESPUtil) {
+                GridDetailsWidget, LFDetailsWidget, WsWorkunits, ESPUtil) {
     return declare("QuerySetLogicalFilesWidget", [GridDetailsWidget], {
 
         gridTitle: "Logical Files",
@@ -58,7 +59,7 @@ define([
                 store: this.store,
                 columns: {
                     col1: selector({ width: 27, selectorType: 'checkbox' }),
-                    Name: { label: "Logical Files", width: 108, sortable: false },
+                    Name: {label: "Logical Files", width: 180, sortable: false}
                 }
             }, domID);
 
@@ -69,6 +70,33 @@ define([
                 }
             });
             return retVal;
+        },
+
+        createDetail: function (id, row, params) {
+            return new LFDetailsWidget.fixCircularDependency({
+                id: id,
+                title: params.Name,
+                closable: true,
+                hpcc: {
+                    params: {
+                        Name: params.Name
+                    }
+                }
+            });
+        },
+
+        _onOpen: function(){
+            var selections = this.grid.getSelected();
+            var firstTab = null;
+            for (var i = selections.length - 1; i >= 0; --i) {
+                var tab = this.ensurePane(this.id + "_" + selections[i].Id, selections[i]);
+                if (i == 0) {
+                    firstTab = tab;
+                }
+            }
+            if (firstTab) {
+                this.selectChild(firstTab);
+            }
         },
 
         refreshGrid: function (args) {

--- a/esp/files/scripts/QuerySetQueryWidget.js
+++ b/esp/files/scripts/QuerySetQueryWidget.js
@@ -28,7 +28,7 @@ define([
     "dijit/MenuSeparator",
     "dijit/PopupMenuItem",
 
-    "dgrid/OnDemandGrid",
+    "dgrid/Grid",
     "dgrid/Keyboard",
     "dgrid/Selection",
     "dgrid/selector",
@@ -64,7 +64,7 @@ define([
     "dojox/layout/TableContainer"
 ], function (declare, lang, dom, domForm, iframe, arrayUtil, on,
                 registry, Menu, MenuItem, MenuSeparator, PopupMenuItem,
-                OnDemandGrid, Keyboard, Selection, selector, ColumnResizer, DijitRegistry, Pagination,
+                Grid, Keyboard, Selection, selector, ColumnResizer, DijitRegistry, Pagination,
                 _TabContainerWidget, ESPBase, ESPWorkunit, ESPLogicalFile, TargetSelectWidget, QuerySetDetailsWidget, WsWorkunits, ESPQuery, ESPUtil,
                 template) {
     return declare("QuerySetQueryWidget", [_TabContainerWidget], {
@@ -121,7 +121,6 @@ define([
             });
             this.initQuerySetGrid();
             this.selectChild(this.queriesTab, true);
-            this.refreshGrid();
         },
 
         initTab: function () {
@@ -252,10 +251,11 @@ define([
         initQuerySetGrid: function (params) {
             var context = this;
             var store = ESPQuery.CreateQueryStore();
-            this.querySetGrid = declare([OnDemandGrid, Keyboard, Selection, ColumnResizer, DijitRegistry, ESPUtil.GridHelper, Pagination,])({
+            this.querySetGrid = new declare([Grid, Pagination, Selection, ColumnResizer, Keyboard, DijitRegistry, ESPUtil.GridHelper])({
                 allowSelectAll: true,
                 deselectOnRefresh: false,
                 store: store,
+                query: this.getFilter(),
                 sort: [{ attribute: "Id" }],
                 rowsPerPage: 50,
                 pagingLinks: 1,


### PR DESCRIPTION
A logical file once inside of querysetquerywidget does not open a logical
file details page. There is also multiple calls being requested upon
WUListQueries.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
