### PR TITLE
HPCC-10465 - Global merge bug if varrecs and late detection

### DIFF
--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -77,6 +77,7 @@ void CThorKeyArray::clear()
     totalfilesize = 0;
     filerecsize = 0;
     filerecnum = 0;
+    needFPosExpand = false;
 }
 
 void CThorKeyArray::setSampling(size32_t _maxsamplesize, unsigned _divisor)
@@ -108,6 +109,8 @@ void CThorKeyArray::add(const void *row)
     totalfilesize += recSz;
     if (filerecnum==0)
         filerecsize=recSz;
+    else if (filerecsize!=recSz)
+        needFPosExpand = true;
     filerecnum++;
 
     if (maxsamplesize)
@@ -146,7 +149,7 @@ void CThorKeyArray::add(const void *row)
     }
     if (filepos)
         filepos->append(totalfilesize);
-    else if (filerecsize!=recSz)
+    else if (needFPosExpand)
     {
         expandFPos();
         filepos->append(totalfilesize);

--- a/thorlcr/msort/tsorta.hpp
+++ b/thorlcr/msort/tsorta.hpp
@@ -76,6 +76,7 @@ class CThorKeyArray
     size32_t filerecsize;
     size32_t filerecnum;
     offset_t totalfilesize;
+    bool needFPosExpand;
 
     void split();
     offset_t findLessEqRowPos(const void * row);


### PR DESCRIPTION
Global merge builds up a local sample of the keys as it performs
the local merge, as it exceeds a threshold, the sample is divided
to keep the size down. If the keys are variable length but fixed
with up to the point when the 1st sample occurs, the file
positions the mechanism is tracking got out of sync.
Consequently, when merging from the spilt key stream, the seek
positions were wrong, which could result in deserialization
errors.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
