### PR TITLE
HPCC-10405 Change WU State column for better display

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -830,13 +830,13 @@
                             <col width="250" class="cluster"/>
                         </colgroup>
                         <colgroup>
-                            <col width="200" class="cluster"/>
+                            <col width="300" class="cluster"/>
                         </colgroup>
                         <colgroup>
                             <col width="150" class="cluster"/>
                         </colgroup>
                         <colgroup>
-                            <col width="500" class="cluster"/>
+                            <col width="400" class="cluster"/>
                         </colgroup>
                         <xsl:if test="(position()=1 and $showTitle='1')">
                             <tr>

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -173,7 +173,7 @@ struct CActiveWorkunitWrapper: public CActiveWorkunit
         else if(index)
             stateStr.appendf("queued(%d) [%s]", index, state.str());
         else if(location && *location)
-            stateStr.appendf("%s [on %s]", state.str(), location);
+            stateStr.appendf("%s [%s]", state.str(), location);
         else
             stateStr.set(state.str());
         setStateID(wu->getState());


### PR DESCRIPTION
On legacy EclWatch Activity page, the WU State column
is changed for better display: 1. change width from 200
to 300; 2. remove an extra word 'on' from the display.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
