### PR TITLE
HPCC-10462 - Fix problem retrying add/remove ops in transactions

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1445,6 +1445,7 @@ public:
     }
     void retryActions()
     {
+        clearFiles(); // clear all previously tracked pending file changes, e.g. renames, super file additions/removals
         while (prepared) // unlock for retry
             actions.item(--prepared).retry();
     }


### PR DESCRIPTION
If a transaction fails (due to other locks), it will unlock the
files it has gained preparing the transaction thus far, pause
and try again.
HPCC-9218 tracked which pending operations were to occur, so
that multiple transactional ops would correctly detect if a sub
file had already been removed or added. This introduced this
regression, because when a transaction retries, these tracked
files need to cleared.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
