### PR TITLE
HPCC-10361 Prevent assignments that can SKIP from being lost

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -14610,6 +14610,29 @@ bool isPureActivityIgnoringSkip(IHqlExpression * expr)
     return true;
 }
 
+bool assignsContainSkip(IHqlExpression * expr)
+{
+    switch (expr->getOperator())
+    {
+    case no_newtransform:
+    case no_transform:
+    case no_assignall:
+        {
+            ForEachChild(i, expr)
+            {
+                if (assignsContainSkip(expr->queryChild(i)))
+                    return true;
+            }
+            return false;
+        }
+    case no_assign:
+        return containsSkip(expr->queryChild(1));
+    case no_alias_scope:
+        return assignsContainSkip(expr->queryChild(0));
+    default:
+        return false;
+    }
+}
 
 extern HQL_API bool isKnownTransform(IHqlExpression * transform)
 {

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1392,6 +1392,8 @@ extern HQL_API void queryRemoveRows(HqlExprCopyArray & tables, IHqlExpression * 
 
 extern HQL_API bool isPureActivity(IHqlExpression * expr);
 extern HQL_API bool isPureActivityIgnoringSkip(IHqlExpression * expr);
+extern HQL_API bool assignsContainSkip(IHqlExpression * expr);
+
 extern HQL_API bool isPureInlineDataset(IHqlExpression * expr);
 extern HQL_API bool transformHasSkipAttr(IHqlExpression * transform);
 extern HQL_API IHqlExpression * queryNewColumnProvider(IHqlExpression * expr);          // what is the transform/newtransform/record?

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -3053,6 +3053,10 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
                     if (!isPureActivityIgnoringSkip(child) || hasUnknownTransform(child))
                         break;
 
+                    IHqlExpression * childTransform = queryNewColumnProvider(child);
+                    if (assignsContainSkip(childTransform))
+                        break;
+
                     IHqlExpression * childCountProject = child->queryAttribute(_countProject_Atom);
                     //Don't merge two count projects - unless we go through and replace counter instances.
                     if (transformedCountProject && childCountProject)


### PR DESCRIPTION
Assignments that contained skips could be lost from a transform if it was merged
with a subsequent transform, and that transform didn't use the field the assignment
targetted.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
