### PR TITLE
HPCC-10490 Show primary clusters for XRef

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4256,7 +4256,7 @@ class CEnvironmentClusterInfo: public CInterface, implements IConstWUClusterInfo
     SocketEndpointArray roxieServers;
     StringAttr thorQueue;
     StringArray thorProcesses;
-    StringArray primaryThorProcess;
+    StringArray primaryThorProcesses;
     StringAttr prefix;
     ClusterType platform;
     unsigned clusterWidth;
@@ -4277,12 +4277,12 @@ public:
                 const char* thorName = thor.queryProp("@name");
                 thorProcesses.append(thorName);
                 if (!isMultiThor)
-                    primaryThorProcess.append(thorName);
+                    primaryThorProcesses.append(thorName);
                 else
                 {
                     const char *nodeGroup = thor.queryProp("@nodeGroup");
                     if (!nodeGroup || strieq(nodeGroup, thorName))
-                        primaryThorProcess.append(thorName);
+                        primaryThorProcesses.append(thorName);
                 }
                 unsigned nodes = thor.getCount("ThorSlaveProcess");
                 if (!nodes)
@@ -4364,7 +4364,7 @@ public:
     }
     const StringArray & getPrimaryThorProcesses() const
     {
-        return primaryThorProcess;
+        return primaryThorProcesses;
     }
 
     const SocketEndpointArray & getRoxieServers() const

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -552,6 +552,7 @@ interface IConstWUClusterInfo : extends IInterface
     virtual IStringVal & getServerQueue(IStringVal & str) const = 0;
     virtual IStringVal & getRoxieProcess(IStringVal & str) const = 0;
     virtual const StringArray & getThorProcesses() const = 0;
+    virtual const StringArray & getPrimaryThorProcesses() const = 0;
     virtual const SocketEndpointArray & getRoxieServers() const = 0;
 };
 

--- a/esp/services/ws_dfu/ws_dfuXRefService.hpp
+++ b/esp/services/ws_dfu/ws_dfuXRefService.hpp
@@ -160,6 +160,7 @@ private:
 
 private:
     IXRefFilesNode* getFileNodeInterface(IXRefNode& XRefNode,const char* nodeType);
+    void addXRefNode(const char* name, IPropertyTree* pXRefNodeTree);
 public:
    IMPLEMENT_IINTERFACE;
 


### PR DESCRIPTION
In multi-thor setups, the XREF cluster list should show
the primary cluster only. This fix picks the primary
cluster only if its name matches the group name.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
