### PR TITLE
HPCC-10452 Add timeout handling to Regression Suite.

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -14,6 +14,7 @@ Result:
 |
 |       usage: regress [-h] [--version] [--config [CONFIG]]
 |                       [--loglevel [{info,debug}]] [--suiteDir [SUITEDIR]]
+|                       [--timeout [TIMEOUT]]
 |                       {list,run,query} ...
 | 
 |       HPCC Platform Regression suite
@@ -32,6 +33,8 @@ Result:
 |                                  Set the log level.
 |            --suiteDir [SUITEDIR], -s [SUITEDIR]
 |                               suiteDir to use. Default value is the current directory and it can handle relative path.
+|            --timeout [TIMEOUT], -t [TIMEOUT]
+|                               timeout for query execution.
 
 	
 Steps to run Regression Suite
@@ -265,5 +268,32 @@ To skip (similar to exclusion)
 
 To build and publish testcase (e.g.:for libraries)
 //publish
+
+To set individual timeout for test case
+//timeout <timeout value in sec>
+
+7. Configuration setting in regress.json file:
+----------------------------------------------
+
+        "ip": "127.0.0.1",                              - ECl server address
+        "username": "regress",                          - Regression Suite dedicated username and pasword
+        "password": "regress",
+        "roxie": "127.0.0.1:9876",                      - Roxie server addres (not used)
+        "server": "127.0.0.1:8010",                     - EclWatch service server address
+        "suiteDir": "",                                 - default suite directory location - ""-> current directory
+        "eclDir": "ecl",                                - ECL test cases directory source
+        "setupDir": "ecl/setup",                        - ECL setup source directory
+        "keyDir": "ecl/key",                            - XML key files directory to check testcases result
+        "archiveDir": "archives",                       - Archive directory path for testcases generated XML results
+        "resultDir": "results",                         - Current testcases generated XML results
+        "regressionDir": "~/HPCCSystems-regression",    - Regression suite work and log file directory (in user private space)
+        "logDir": "~/HPCCSystems-regression/log",       - Regression suite run log directory
+        "Clusters": [                                   - List of known clusters name
+            "hthor",
+            "thor",
+            "roxie"
+        ],
+        "timeout":"600",                                - Default test case timeout in sec. Can be override by command line parameter or //timeout tag in ECL file
+        "maxAttemptCount":"3"                           - Max retry count to reset timeout if a testcase in any early stage (compiled, blocked) of execution pipeline.
 
 **Important! Actually regression suite compares the test case result with xml files stored in testing/regression/ecl/key independently from the cluster.**

--- a/testing/regress/hpcc/common/config.py
+++ b/testing/regress/hpcc/common/config.py
@@ -60,7 +60,7 @@ class Config:
             rC = namedtuple("Regress", js.keys())
             return _dict(getattr(rC(**js), "Regress"))
         except IOError as e:
-            print(e)
+            raise(e)
 
     #implement writing out of a config.
     def writeConfig(self, file):

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -22,7 +22,7 @@ import logging
 from ...common.shell import Shell
 from ...util.ecl.file import ECLFile
 from ...common.error import Error
-
+from ...util.util import queryWuid
 
 class ECLcmd(Shell):
     def __init__(self):
@@ -48,7 +48,8 @@ class ECLcmd(Shell):
             if server:
                 args.append('--server=' + server)
             if not name:
-                name = eclfile.ecl
+                #name = eclfile.ecl
+                name = eclfile.getJobname()
             if username:
                 args.append("--username=" + username)
             if password:
@@ -71,6 +72,8 @@ class ECLcmd(Shell):
                     wuid = i.split()[1]
                 if "state:" in i:
                     state = i.split()[1]
+                if "aborted" in i:
+                    state = "aborted"
                 if cnt > 4:
                     result += i + "\n"
                 cnt += 1
@@ -89,9 +92,12 @@ class ECLcmd(Shell):
                 else:
                     test = False
                     eclfile.diff = 'Error'
-                
             else:
-                test = eclfile.testResults()
+                if queryWuid(eclfile.getJobname())['state'] == 'aborted':
+                    eclfile.diff = eclfile.ecl+'\n\t'+'Aborted ( reason: '+eclfile.getAbortReason()+' )'
+                    test = False
+                else:
+                    test = eclfile.testResults()
             report.addResult(eclfile)
             if not test:
                 return False

--- a/testing/regress/hpcc/util/expandcheck.py
+++ b/testing/regress/hpcc/util/expandcheck.py
@@ -24,7 +24,7 @@ class ExpandCheck:
 
     @staticmethod
     def dir_exists(path, require=False):
-        logging.debug("dir_exists(path: %s, require: %d", path, require)
+        logging.debug("dir_exists(path: %s, require: %s)", path, require)
         if '~' in path:
             path = os.path.expanduser(path)
         else:

--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -22,18 +22,23 @@
 import argparse
 import logging
 import os
+import platform
 import atexit
+import traceback
 
 from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
-from hpcc.util.util import checkPqParam
+from hpcc.util.util import checkPqParam,  getVersionNumbers
 
 if __name__ == "__main__":
+    ver = getVersionNumbers()
+    if (ver['main'] >= 2) and (ver['minor'] >= 7):
+        atexit.register(logging.shutdown)
     prog = "regress"
     description = 'HPCC Platform Regression suite'
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('--version', '-v', action='version',
-                        version='%(prog)s 0.0.2')
+                        version='%(prog)s 0.0.3')
     parser.add_argument('--config', help="Config file to use.",
                         nargs='?', default="regress.json")
     parser.add_argument('--loglevel', help="Set the log level.",
@@ -41,6 +46,8 @@ if __name__ == "__main__":
                         choices=['info', 'debug'])
     parser.add_argument('--suiteDir', '-s', help="suiteDir to use.",
                         nargs='?', default=".")
+    parser.add_argument('--timeout', '-t', help="timeout for query execution.",
+                        nargs='?', default="-1")
 
     subparsers = parser.add_subparsers(help='sub-command help')
     parser_list = subparsers.add_parser('list', help='list help')
@@ -51,7 +58,7 @@ if __name__ == "__main__":
     parser_run.add_argument('cluster', help="Run the cluster suite.",
                             nargs='?', type=str,  default='setup')
     parser_run.add_argument('--pq', help="Parallel query execution with threadNumber threads. ('-1' can be use to calculate usable thread count on a single node system)",
-                            type=checkPqParam,  default = 1,   metavar="threadNumber")
+                            type=checkPqParam,  default = 0,   metavar="threadNumber")
 
     parser_query = subparsers.add_parser('query', help='query help')
     parser_query.add_argument('query', help="Name of a single ECL query (mandatory).",
@@ -66,6 +73,10 @@ if __name__ == "__main__":
     suiteDir = ""
     if 'suiteDir' in args:
         suiteDir = args.suiteDir
+    timeout = -1
+    if 'timeout' in args:
+        timeout = args.timeout
+    regress = None
     try:
         if 'clusters' in args:
             Clusters = ['setup']
@@ -80,7 +91,7 @@ if __name__ == "__main__":
                 print "\nMissing ECL query file!\n"
                 parser_query.print_help()
                 exit()
-            regress = Regression(args.config, args.loglevel, suiteDir)
+            regress = Regression(args.config, args.loglevel, suiteDir,  timeout)
             ecl = os.path.join(regress.dir_ec, args.query)
             eclfile = ECLFile(ecl, regress.dir_a, regress.dir_ex,
                               regress.dir_r)
@@ -91,29 +102,19 @@ if __name__ == "__main__":
             else:
                 targetClusters.append(args.cluster)
             for cluster in targetClusters:
-                logging.warn("Target: %s" % cluster)
-                logging.warn("Queries: %s" % 1)
                 try:
                     if not eclfile.testSkip(cluster)['skip']:
                         if not eclfile.testExclusion(cluster):
-                            report = regress.buildLogging(args.query)
-                            if args.publish or eclfile.testPublish():
-                                regress.runQuery(cluster, eclfile, report, 1, True)
-                            else:
-                                regress.runQuery(cluster, eclfile, report)
-                            Regression.displayReport(report)
+                            regress.runSuiteQ(cluster, eclfile)
                         else:
-                            #print args.query+" excluded on "+cluster+" cluster."
                             logging.warn("%s. %s excluded on this cluster." % (1, args.query))
                     else:
-                        #print args.query+" skipped on "+cluster+" cluster."
                         logging.warn("%s. %s skipped on this cluster." % (1, args.query))
                 except IOError:
-                    #print "Query "+args.query+ " does not exist!"
                     logging.error("%s. Query %s does not exist!" % (1,  args.query))
                     exit()
         elif 'cluster' in args:
-            regress = Regression(args.config, args.loglevel, suiteDir,  args.pq)
+            regress = Regression(args.config, args.loglevel, suiteDir,  timeout,  args.pq)
             regress.bootstrap(args.cluster)
             if 'setup' in args.cluster:
                 regress.runSuite('setup', regress.setup)
@@ -124,5 +125,10 @@ if __name__ == "__main__":
                     regress.runSuite(args.cluster, regress.suites[args.cluster])
     except Exception as e:
         logging.critical(e)
+        logging.critical(traceback.format_exc())
+        print "Abend."
     except KeyboardInterrupt:
         logging.critical("Keyboard Interrupt Caught.")
+        regress.StopTimeoutThread()
+
+    exit()

--- a/testing/regress/regress.json
+++ b/testing/regress/regress.json
@@ -17,6 +17,8 @@
             "hthor",
             "thor",
             "roxie"
-        ]
+        ],
+        "timeout":"600",
+        "maxAttemptCount":"3"
     }
 }


### PR DESCRIPTION
Add timeout handling for both suite and individual query run to avoid system
hang-up when a test case fails.

There are 3 levels of timeout handling:
- timeout value set up in Regression Suite config file (e.g.: regress.json)
- timeout value in command line parameter (override config value, both valid
  for all test cases)
- timeout value with //timeout tag in individual ECL file (override config
  and CLI value for current test case)

If a test case (workunit) blocked in execution pipeline (long compile, blocked
by server, etc) and timeout occurred, then RS reset the timeout value.
To avoid endless loop there is a maxAttemptCount in regress.json file.

Add more exception handling and logs.

Improve debug logging.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
