### PR TITLE
HPCC-10511 Code using dmetaphone or saltlib may get undefined symbols

### DIFF
--- a/plugins/proxies/lib_metaphone.ecllib
+++ b/plugins/proxies/lib_metaphone.ecllib
@@ -17,7 +17,7 @@
 
 /* Proxy plugin definition for (EE-only) dmetaphone library version DMETAPHONE 1.1.05 */
 
-export MetaphoneLib := SERVICE
+export MetaphoneLib := SERVICE : plugin('metaphonelib')
   string DMetaphone1(const string src) : c,pure,entrypoint='mpDMetaphone1';
   string DMetaphone2(const string src) : c,pure,entrypoint='mpDMetaphone2';
   string DMetaphoneBoth(const string src) : c,pure,entrypoint='mpDMetaphoneBoth';

--- a/plugins/proxies/lib_saltlib.ecllib
+++ b/plugins/proxies/lib_saltlib.ecllib
@@ -17,7 +17,7 @@
 
 /* Proxy service header for (EE-only) saltlib plugin version SALTLIB 1.0.04 */
 
-export SaltLib := SERVICE
+export SaltLib := SERVICE : plugin('saltlib')
   boolean UnicodeLocaleWithinEditN(const unicode left, const unicode right, unsigned4 distance,  const varstring localename) : c, pure,entrypoint='ulUnicodeLocaleWithinEditN', hole;
   unsigned4 UnicodeLocaleHyphenMatch(const unicode left, const unicode right, unsigned4 minlen,  const varstring localename) : c, pure,entrypoint='ulUnicodeLocaleHyphenMatch', hole;
   unsigned4 UnicodeHyphenMatch(const unicode left, const unicode right, unsigned4 minlen) : c, pure,entrypoint='ulUnicodeHyphenMatch', hole;
@@ -25,4 +25,3 @@ export SaltLib := SERVICE
   unicode UnicodeLocaleGetRangeOfWords(const unicode text, unsigned4 s_index, unsigned4 e_index, const varstring localename) : c,pure,entrypoint='ulUnicodeLocaleGetRangeOfWords';
   integer4 StringMatchBagofwords(const string left, const string right, unsigned4 mode, unsigned4 score_mode, unsigned fn, unsigned fn_arg1, unsigned fn_arg2) : c, pure,entrypoint='ulStringMatchBagofwords', hole;
 END;
-


### PR DESCRIPTION
In 4.0.4, the ‘plugin proxy’ files would only have been shipped as part of the
clienttools package. As part of the refactoring of the clienttools build, they
appear to be getting included in the regular install too, meaning it’s
indeterminate whether the ‘real’ or the ‘proxy’ definition of dmetaphone and
saltlib gets picked up. If you get the proxy version, you get a link error.

Split the 'header' from the plugin solves the problem.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
