### PR TITLE
HPCC-10515 Use POST to send ZAP Report request

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -749,18 +749,20 @@
                     }
                     function createZAPInfo(wuid, espIP, thorIP, ESPBuildVersion, problemDesciption, history, timingInfo)
                     {
-                        var href = "/WsWorkunits/WUCreateZAPInfo?WUID=" + wuid;
-                        href += "&ESPIPAddress=" + espIP;
+                        document.getElementById("ESPIPAddress").value=espIP;
                         if (thorIP != '')
-                            href += "&ThorIPAddress=" + thorIP;
-                        href += "&BuildVersion=" + ESPBuildVersion;
+                            document.getElementById("ESPIPAddress").value=thorIP;
+                        document.getElementById("BuildVersion").value=ESPBuildVersion;
                         if (problemDesciption != '')
-                            href += "&ProblemDescription=" + problemDesciption;
+                            document.getElementById("ProblemDescription").value=problemDesciption;
                         if (history != '')
-                            href += "&WhatChanged=" + history;
+                            document.getElementById("WhatChanged").value=history;
                         if (timingInfo != '')
-                            href += "&WhereSlow=" + timingInfo;
-                        document.location.href=href;
+                            document.getElementById("WhereSlow").value=timingInfo;
+
+                        document.forms['protect'].action = "/WsWorkunits/WUCreateZAPInfo";
+                        document.forms['protect'].encType="application/x-www-form-urlencoded";
+                        document.forms['protect'].submit();
                     }
                ]]></xsl:text>
           </script>

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -778,6 +778,12 @@
               <input type="hidden" name="DescriptionOrig" value="{Description}"/>
               <input type="hidden" name="ClusterOrig" value="{Cluster}"/>
               <input type="hidden" name="ProtectedOrig" value="{Protected}"/>
+              <input type="hidden" id="ESPIPAddress" name="ESPIPAddress" value=""/>
+              <input type="hidden" id="ThorIPAddress" name="ThorIPAddress" value=""/>
+              <input type="hidden" id="BuildVersion" name="BuildVersion" value=""/>
+              <input type="hidden" id="ProblemDescription" name="ProblemDescription" value=""/>
+              <input type="hidden" id="WhatChanged" name="WhatChanged" value=""/>
+              <input type="hidden" id="WhereSlow" name="WhereSlow" value=""/>
               <input type="button" name="Type" value="Save" class="sbutton" onclick="updateWorkunit('{$wuid}');">
                         <xsl:if test="number(AccessFlag) &lt; 7">
                           <xsl:attribute name="disabled">disabled</xsl:attribute>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1428,7 +1428,7 @@ ESPresponse [exceptions_inline] WUGetZAPInfoResponse
 
 ESPrequest [nil_remove] WUCreateZAPInfoRequest
 {
-    string WUID;
+    string Wuid;
     string ESPIPAddress;
     string ThorIPAddress;
     string BuildVersion;

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3954,16 +3954,16 @@ bool CWsWorkunitsEx::onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfo
         throw MakeStringException(ECLWATCH_CANNOT_COMPRESS_DATA,"The data cannot be compressed.");
 #else
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
-        Owned<IConstWorkUnit> cwu = factory->openWorkUnit(req.getWUID(), false);
+        Owned<IConstWorkUnit> cwu = factory->openWorkUnit(req.getWuid(), false);
         if(!cwu.get())
-            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT, "Cannot open workunit %s.", req.getWUID());
+            throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT, "Cannot open workunit %s.", req.getWuid());
 
         //Create output report file
         StringBuffer zipFile;
         StringBuffer userName;
         if (context.queryUser())
             userName.append(context.queryUser()->getName());
-        zipFile.append("ZAPReport_").append(req.getWUID()).append('_').append(userName.str()).append(".zip");
+        zipFile.append("ZAPReport_").append(req.getWuid()).append('_').append(userName.str()).append(".zip");
         SCMStringBuffer temp;
         StringBuffer sb;
         sb.append("Workunit:     ").append(cwu->getWuid(temp)).append("\r\n");
@@ -4013,7 +4013,7 @@ bool CWsWorkunitsEx::onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfo
 #endif
             StringBuffer fs;
             //add report file to ZIP
-            fs.append("ZAPReport_").append(req.getWUID()).append('_').append(userName.str()).append(".txt");
+            fs.append("ZAPReport_").append(req.getWuid()).append('_').append(userName.str()).append(".txt");
             zipper->addContentToZIP(sb.length(), (void*)sb.str(), (char*)fs.str(), false);
 
             //add ECL query/archive to zip
@@ -4024,7 +4024,7 @@ bool CWsWorkunitsEx::onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfo
                 query->getQueryText(temp);
                 if (temp.length())
                 {
-                    fs.clear().append("ZAPReport_").append(req.getWUID()).append('_').append(userName.str()).append(".");
+                    fs.clear().append("ZAPReport_").append(req.getWuid()).append('_').append(userName.str()).append(".");
                     fs.append(isArchiveQuery(temp.str()) ? "archive" : "ecl");
                     ecl.append(temp.str());
                     zipper->addContentToZIP(ecl.length(), (void*)ecl.str(), (char*)fs.str(), true);
@@ -4042,7 +4042,7 @@ bool CWsWorkunitsEx::onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfo
             //Add Workunit XML file
             MemoryBuffer wuXmlMB;
             winfo.getWorkunitXml(NULL, wuXmlMB);
-            fs.clear().append("ZAPReport_").append(req.getWUID()).append('_').append(userName.str()).append(".xml");
+            fs.clear().append("ZAPReport_").append(req.getWuid()).append('_').append(userName.str()).append(".xml");
             zipper->addContentToZIP(wuXmlMB.length(), (void*)wuXmlMB.toByteArray(), (char*)fs.str(), true);
 
             //Write out ZIP file


### PR DESCRIPTION
The existing code uses HTTP Get method to send ZAP Report request.
When a ZAP Report request contains a large size parameter, the
parameter will be trancated and a Bad request error shows. In this
fix, the HTTP POST method is used to send ZAP Report request.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
