### PR TITLE
HPCC-10528 New threaded concat code can lock up

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -12173,9 +12173,8 @@ class CRoxieThreadedConcatReader : public CInterface, implements IRecordPullerCa
 public:
     IMPLEMENT_IINTERFACE;
     CRoxieThreadedConcatReader(InterruptableSemaphore &_ready, bool _grouped)
-    : puller(false), grouped(_grouped), ready(_ready), eof(false)
+    : puller(false), grouped(_grouped), atEog(true), ready(_ready), eof(false)
     {
-
     }
 
     void start(unsigned parentExtractSize, const byte *parentExtract, bool paused, IRoxieSlaveContext *ctx)
@@ -12202,6 +12201,7 @@ public:
             ReleaseRoxieRow(buffer.item(idx));
         buffer.clear();
         eof = false;
+        atEog = true;
     }
 
     void setInput(IRoxieInput *_in)
@@ -12230,8 +12230,7 @@ public:
 
     virtual void processDone()
     {
-        eof = true;
-        ready.signal();
+        processRow(NULL);
     }
 
     virtual bool fireException(IException *e)
@@ -12244,20 +12243,29 @@ public:
 
     bool peek(const void * &row, bool &anyActive)
     {
-        if (buffer.ordinality())
-        {
-            space.signal();
-            row = buffer.dequeue();
-            return true;
-        }
         if (!eof)
+        {
+            if (buffer.ordinality())
+            {
+                space.signal();
+                row = buffer.dequeue();
+                if (row==NULL)
+                {
+                    if (atEog)
+                    {
+                        eof = true;
+                        return false;
+                    }
+                    else
+                        atEog = true;
+                }
+                else if (grouped)
+                    atEog = false;
+                return true;
+            }
             anyActive = true;
+        }
         return false;
-    }
-
-    inline bool atEof() const
-    {
-        return eof;
     }
 
 protected:
@@ -12265,6 +12273,7 @@ protected:
     InterruptableSemaphore space;
     InterruptableSemaphore &ready;
     SafeQueueOf<const void, true> buffer;
+    bool atEog;
     bool eof;
     bool grouped;
 };
@@ -12366,7 +12375,11 @@ public:
         loop
         {
             if (readyPending && !inGroup)
-                readyPending--;
+            {
+                if (readyPending > 1)
+                    ready.signal(readyPending-1);
+                readyPending = 0;
+            }
             else
                 ready.wait();
             bool anyActive = false;


### PR DESCRIPTION
Improper handling of readyPending (the optimization to just use them up rather
than signalling all at once is not valid, as they would only get used up when
!inGroup).

Also a potential race condition in the eof handling in peek.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
