### PR TITLE
HPCC-10529 Wrong formatted debug log cause exception in logging.

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -370,7 +370,7 @@ class Regression:
         self.loggermutex.acquire()
         self.exitmutexes[th].acquire()
 
-        logging.debug("runQuery(cluster:", cluster, ", query:", query, ", report:", report, ", cnt:", cnt, ", publish:", publish, ")")
+        logging.debug("runQuery(cluster: '%s', query: '%s', cnt: %d, publish: %s, thread id: %d" % ( cluster, query.ecl, cnt, publish,  th))
         logging.warn("%3d. Test: %s" % (cnt, query.ecl))
 
         self.loggermutex.release()

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -112,7 +112,7 @@ class ECLFile:
         # Standard string has a problem with unicode characters
         # use byte arrays and binary file open instead
         tag = b'//no' + target.encode()
-        logging.debug("testExclusion (ecl:'%s', target: '%s', tag:'%s'", self.ecl, target, tag)
+        logging.debug("testExclusion (ecl:'%s', target: '%s', tag:'%s')", self.ecl, target, tag)
         eclText = open(self.getEcl(), 'rb')
         retVal = False
         for line in eclText:
@@ -126,7 +126,7 @@ class ECLFile:
         # Standard string has a problem with unicode characters
         # use byte arrays and binary file open instead
         tag = b'//publish'
-        logging.debug("%3d. testPublish (ecl:'%s', tag:'%s'", self.taskId, self.ecl,  tag)
+        logging.debug("%3d. testPublish (ecl:'%s', tag:'%s')", self.taskId, self.ecl,  tag)
         eclText = open(self.getEcl(), 'rb')
         retVal = False
         for line in eclText:


### PR DESCRIPTION
Fix debug log message format.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
