### PR TITLE
HPCC-10530 Query deleted mid-flight may never terminate (and may spam da...

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -459,6 +459,7 @@ extern void saveTopology();
 #define LOGGING_TRACELEVELSET   0x10
 #define LOGGING_CHECKINGHEAP    0x20
 #define LOGGING_FLAGSPRESENT    0x40
+#define LOGGING_WUID            0x80
 
 class LogItem : public CInterface
 {

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -3411,6 +3411,8 @@ private:
                     loggingFlags |= LOGGING_BLIND;
                 if (ctx->queryCheckingHeap())
                     loggingFlags |= LOGGING_CHECKINGHEAP;
+                if (ctx->queryWorkUnit())
+                    loggingFlags |= LOGGING_WUID;
                 if (debugContext)
                 {
                     loggingFlags |= LOGGING_DEBUGGERACTIVE;


### PR DESCRIPTION
...li)

If a roxie query is deleted while it is running, the slave will try to look up
the wu in dali (using an invalid WUID), and then restart the worker thread.
This is after the slave has responded to the retry request with an ROXIE_ALIVE
message, so the server's retries count is reset. This can cause the query to
continue indefinitely, with a failed Dali workunit lookup ever few seconds
(leading to huge Dali logs, huge Roxie logs, and leaked query threads in the
roxie server).

Clean up the passing of the wuid to ensure it is only interpreted as a wuid
when it really is a wuid.

Clean up the exception handling to ensure that errors get back to the server
whereever possible.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
