### PR TITLE
HPCC-10380 Refactor Matchbagofwords

### DIFF
--- a/plugins/proxies/lib_saltlib.ecllib
+++ b/plugins/proxies/lib_saltlib.ecllib
@@ -24,5 +24,8 @@ export SaltLib := SERVICE
   integer4 UnicodeLocaleMatchBagofwords(const unicode left, const unicode right, const varstring localename, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords', hole;
   unicode UnicodeLocaleGetRangeOfWords(const unicode text, unsigned4 s_index, unsigned4 e_index, const varstring localename) : c,pure,entrypoint='ulUnicodeLocaleGetRangeOfWords';
   integer4 StringMatchBagofwords(const string left, const string right, unsigned4 mode, unsigned4 score_mode, unsigned fn, unsigned fn_arg1, unsigned fn_arg2) : c, pure,entrypoint='ulStringMatchBagofwords', hole;
+  integer4 UnicodeMatchBagofwords2(const unicode left, const unicode right, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords2', hole;
+  integer4 UnicodeLocaleMatchBagofwords2(const unicode left, const unicode right, const varstring localename, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords2', hole;
+  integer4 StringMatchBagofwords2(const string left, const string right, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulStringMatchBagofwords2', hole;
 END;
 


### PR DESCRIPTION
- Refactor matchBagofwords() to make it easier to add new modes of operation
  in the future
- Use new code structure to implement StringMatchBagofwords2(),
  UnicodeMatchBagofwords2() and UnicodeLocaleMAthcBagofwords2()
- Preserve the existing interfaces StringMatchBagofwords() and
  UnicodeLocaleMAthcBagofwords() for compatibility

Signed-off-by: Edin Muharemagic edin.muharemagic@lexisnexis.com
