### PR TITLE
HPCC-10536 Remove hardcoded references to c:\ and /c$

### DIFF
--- a/common/dllserver/dllserver.cpp
+++ b/common/dllserver/dllserver.cpp
@@ -28,9 +28,9 @@
 #include "thorplugin.hpp"
 
 #ifdef _WIN32
-#define DEFAULT_SERVER_ROOTDIR          "c:\\dllserver"
+#define DEFAULT_SERVER_ROOTDIR          "c:\\HPCCSystems\\hpcc-data\\temp\\dllserver"
 #else
-#define DEFAULT_SERVER_ROOTDIR          "/c$/dllserver"
+#define DEFAULT_SERVER_ROOTDIR          "/var/lib/HPCCSystems/dllserver/temp"
 #endif
 
 static Owned<IConstDomainInfo> hostDomain;

--- a/common/remote/rmtspawn.cpp
+++ b/common/remote/rmtspawn.cpp
@@ -392,12 +392,11 @@ void CRemoteSlave::run(int argc, char * argv[])
     CRemoteParentInfo info;
 
     bool paramsok = info.processCommandLine(argc, argv, logFile);
-    if (logFile.length()==0) { // not expected!
+    if (logFile.length()==0) { // not expected! Caller queries logfile location via getConfigurationDirectory
 #ifdef _WIN32
-        //logFile.append("c:\\");   // don't write to root on windows!
+        logFile.append("c:\\HPCCSystems\\logs\\ftslave");
 #else
-        if (checkDirExists("/c$"))
-            logFile.append("/c$/");
+        logFile.append("/var/log/HPCCSystems/ftslave");
 #endif
     }
     if (logFile.length())


### PR DESCRIPTION
There are a couple places (dlslerver.cpp and rmtspawn.cpp) where a default
filespec is used when querying the environment for temp and log directories
fail. Although this is unlikely, these default locations need to be updated
to use the HPCCSystems standard locations

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
