### PR TITLE
HPCC-10481 - Dynamic group leaves groupType uninitialized

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6288,7 +6288,10 @@ public:
             }
             free(buf);
             if (epa.ordinality())
+            {
+                groupType = grp_unknown;
                 return createIGroup(epa);
+            }
         }
         StringBuffer range;
         StringBuffer parent;


### PR DESCRIPTION
A DFS lookup of a dynamic group, e.g. a ip set, left the
referene groupType uninitialized. Consequently it could caused
out of range array lookups into the default replication paths.
This happened when the replication directory of the
ClusterPartDiskMapSpec of a ClusterInfo instance was setup
which was introduced by the previous commit of this issue.

Default groupType to grp_unknown if lookup group based on
ip's.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
