### PR TITLE
HPCC-10514 - Spurious boolean, causing premature timeouts

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -4438,7 +4438,7 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
         }
         bool prepare()
         {
-            parent.setown(transaction->lookupSuperFile(parentlname,true));
+            parent.setown(transaction->lookupSuperFile(parentlname));
             if (!parent)
                 throw MakeStringException(-1,"removeSubFile: SuperFile %s cannot be found",parentlname.get());
             if (!subfile.isEmpty())
@@ -4530,7 +4530,7 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
         }
         bool prepare()
         {
-            parent.setown(transaction->lookupSuperFile(parentlname,true));
+            parent.setown(transaction->lookupSuperFile(parentlname));
             if (!parent)
                 throw MakeStringException(-1,"removeOwnedSubFiles: SuperFile %s cannot be found", parentlname.get());
             // Try to lock all files


### PR DESCRIPTION
Super file lookups in a couple of the transaction types could
timeout.
An ancient change that removed a boolean, left in a boolean
in a lookupSuperFile call, which was being interpretted as the
timeout of 1ms.
Most of the time it would still get away with it, as the window
was small enough in Dali that 1ms on a the unambiguous superfile
path, meant it succeeded within 1ms.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
