### PR TITLE
HPCC-10513 Fix missing persist dependencies for stored filenames

### DIFF
--- a/ecl/regress/issue10513.ecl
+++ b/ecl/regress/issue10513.ecl
@@ -1,0 +1,24 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+string prefix := '' : stored('prefix');
+
+in := dataset(prefix + 'file.in', { string x }, thor, opt);
+
+p := in : persist('p');
+
+output(p);


### PR DESCRIPTION
Possibly a regression caused by the fixes to the persist dependency
processing.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
