### PR TITLE
HPCC-10585 Incorrect log message in CDistributedFile

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -3623,7 +3623,7 @@ public:
                 reliter.setown(iter);
             }
             catch (IException *e) {
-                EXCLOG(e,"CDistributedFileDirectory::rename");
+                EXCLOG(e,"CDistributedFile::rename");
                 e->Release();
             }
             detachLogical();


### PR DESCRIPTION
rename method in dadfs.cpp logs incorrect class name
EXCLOG(e,"CDistributedFileDirectory::rename");

This fix corrects that to
EXCLOG(e,"CDistributedFile::rename");

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
