### PR TITLE
HPCC-10608 Fix compressed file symbol not showing in ECLWatch

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -655,7 +655,7 @@
           <img id="mn{position()}" class="menu1" src="/esp/files/img/menu1.png" onclick="{$popup}"></img>
       </td>
             <td>
-              <xsl:if test="isZipfile=1">
+              <xsl:if test="IsCompressed=1">
                 <img border="0" src="/esp/files/img/zip.gif" title="Compressed" width="16" height="16"/>
               </xsl:if>
             </td>

--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -229,7 +229,7 @@
                     <tr><th>Job Name:</th><td><xsl:value-of select="JobName"/></td></tr>
                 </xsl:if>
                 <tr><th>Size:</th><td><xsl:value-of select="Filesize"/>
-                    <xsl:if test="number(ZipFile)">
+                    <xsl:if test="IsCompressed=1">
                         (This is a compressed file.)
                     </xsl:if>
                 </td></tr>


### PR DESCRIPTION
In cpp code of WsDFU, both isZipfile and ZipFile have been
renamed to 'IsCompressed'. But, the old names are still
in the existing XSLT files. This fix renames them to
'IsCompressed'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
