### PR TITLE
Compiling HPCC on ARM

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -3328,7 +3328,7 @@ public:
         selecthandler.setown(createSocketSelectHandler(NULL));
         threads.setown(createThreadPool("CRemoteFileServerPool",this,NULL,MAX_THREADS,60*1000,
 #ifdef __64BIT__
-            0,
+            0, // Unlimited stack size
 #else
             0x10000,
 #endif

--- a/common/thorhelper/thorcommon.cpp
+++ b/common/thorhelper/thorcommon.cpp
@@ -1314,7 +1314,7 @@ IExtRowStream *createRowStream(IFile *file, IRowInterfaces *rowIf, unsigned rwFl
     return createRowStreamEx(file, rowIf, 0, (offset_t)-1, (unsigned __int64)-1, rwFlags, eexp);
 }
 
-
+// Memory map sizes can be big, restrict to 64-bit platforms.
 void useMemoryMappedRead(bool on)
 {
 #if defined(_DEBUG) || defined(__64BIT__)

--- a/common/thorhelper/thorrparse.cpp
+++ b/common/thorhelper/thorrparse.cpp
@@ -1979,6 +1979,7 @@ void RegexNamedPattern::getTraceText(StringBuffer & s)
 RegexMatchAction RegexNamedPattern::match(RegexState & state)
 {
 #ifdef __64BIT__
+    // 64-bit systems have more space for stack
     RegexMatchState matched(def);
     return def->match(state, &end, matched);
 #else

--- a/dali/dafilesrv/dafilesrv.cpp
+++ b/dali/dafilesrv/dafilesrv.cpp
@@ -328,6 +328,7 @@ int main(int argc,char **argv)
     InitModuleObjects();
     EnableSEHtoExceptionMapping();
 #ifndef __64BIT__
+    // Restrict stack sizes on 32-bit systems
     Thread::setDefaultStackSize(0x10000);   // 64K stack (also set in windows DSP)
 #endif
     Owned<IFile> sentinelFile = createSentinelTarget();

--- a/dali/rfs/rfsmysql/rfsmysql.cpp
+++ b/dali/rfs/rfsmysql/rfsmysql.cpp
@@ -64,7 +64,8 @@ static int _memicmp (const void *s1, const void *s2, size_t len)
 }
 
 #endif
-#if defined(_M_X64) || defined ( __x86_64) || __WORDSIZE==64
+#if defined(_M_X64) || defined ( __x86_64) || \
+    defined(__aarch64__) || __WORDSIZE==64
 #define __64BIT__
 typedef unsigned long memsize_t;
 #else

--- a/dali/rfs/rfspostgres/rfspostgres.cpp
+++ b/dali/rfs/rfspostgres/rfspostgres.cpp
@@ -75,7 +75,8 @@ static char *_itoa(unsigned long n, char *str, int b)
 
 
 #endif
-#if defined(_M_X64) || defined ( __x86_64) || __WORDSIZE==64
+#if defined(_M_X64) || defined ( __x86_64) || \
+    defined(__aarch64__) || __WORDSIZE==64
 #define __64BIT__
 typedef unsigned long memsize_t;
 #else

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -263,6 +263,7 @@ int main(int argc, const char* argv[])
     sashaProgramName = argv[0];
 
 #ifndef __64BIT__
+    // Restrict stack sizes on 32-bit systems
     Thread::setDefaultStackSize(0x20000);
 #endif
     setDaliServixSocketCaching(true);

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -143,6 +143,7 @@ int main(int argc, char* argv[])
 
         EnableSEHtoExceptionMapping();
 #ifndef __64BIT__
+        // Restrict stack sizes on 32-bit systems
         Thread::setDefaultStackSize(0x20000);
 #endif
         setAllocHook(true);

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -773,7 +773,10 @@ IValue * foldExternalCall(IHqlExpression* expr, unsigned foldOptions, ITemplateC
 
     // Get the length and address of the stack
     unsigned len = fstack.getSp();
+// ARMFIX: All 5 __64BIT__ usages in this file could be replaced by one at the top
+// regarding the type of a few local variables via typedef
 #ifdef __64BIT__
+    // ARMFIX: This will have to change for ARM. See info below.
     while (len<6*REGSIZE) 
         len = fstack.pushPtr(NULL);         // ensure enough to fill 6 registers
 #endif

--- a/ecl/hql/hqlstack.cpp
+++ b/ecl/hql/hqlstack.cpp
@@ -24,6 +24,7 @@ FuncCallStack::FuncCallStack() {
     stackbuf = (char *)malloc(tos);
     numToFree = 0;
 #ifdef __64BIT__
+    // ARMFIX: See the header file for more comments
     numFpRegs = 0;
     for (unsigned i=0;i<MAXFPREGS;i++)
         fpRegs[i] = 0.0;

--- a/ecl/hql/hqlstack.hpp
+++ b/ecl/hql/hqlstack.hpp
@@ -47,6 +47,8 @@ private:
     char*      toFree[MAXARGS];
     int        numToFree;
 #ifdef __64BIT__
+    // ARMFIX: If this is related to VFP registers in procedure call
+    // than both ARM32 and ARM64 use it and we'll need to account for it
     double      fpRegs[MAXFPREGS];
     unsigned    numFpRegs;
 #endif

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -7082,6 +7082,7 @@ class Vs6CppNameMangler
 public:
     Vs6CppNameMangler()
     {
+// Assuming Windows on ARM64 will have the same mangling
 #ifdef __64BIT__
         pointerBaseCode.set("E");
 #endif

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1330,6 +1330,8 @@ void HqlCppInstance::flushResources(const char *filename, ICodegenContextCallbac
         StringBuffer ln;
         ln.append(path).append(SharedObjectPrefix).append(trailing).append(LibraryExtension);
 #ifdef __64BIT__
+        // ARMFIX: Map all the uses of this property and make sure
+        // they're not used to mean x86_64 (it shouldn't, though)
         bool target64bit = workunit->getDebugValueBool("target64bit", true);
 #else
         bool target64bit = workunit->getDebugValueBool("target64bit", false);

--- a/ecl/hqlcpp/hqlecl.cpp
+++ b/ecl/hqlcpp/hqlecl.cpp
@@ -514,6 +514,8 @@ bool HqlDllGenerator::doCompile(ICppCompiler * compiler)
             compiler->setOptimizeLevel(optimizeLevel);
     }
 #ifdef __64BIT__
+    // ARMFIX: Map all the uses of this property and make sure
+    // they're not used to mean x86_64 (it shouldn't, though)
     bool target64bit = wu->getDebugValueBool("target64bit", true);
 #else
     bool target64bit = wu->getDebugValueBool("target64bit", false);
@@ -678,8 +680,21 @@ void setWorkunitHash(IWorkUnit * wu, IHqlExpression * expr)
 #ifdef _WIN32
     cacheCRC++; // make sure CRC is different in windows/linux
 #endif
-#ifdef __64BIT__
-    cacheCRC += 2; // make sure CRC is different for different host platform (shouldn't really matter if cross-compiling working properly, but fairly harmless)
+// make sure CRC is different for different host platform
+// shouldn't really matter if cross-compiling working properly,
+// but fairly harmless.
+#ifdef _ARCH_X86_
+    cacheCRC += 1;
+#endif
+#ifdef _ARCH_X86_64_
+    cacheCRC += 2;
+#endif
+// In theory, ARM and x86 workunits should be totally different, but...
+#ifdef _ARCH_ARM32_
+    cacheCRC += 3;
+#endif
+#ifdef _ARCH_ARM64_
+    cacheCRC += 4;
 #endif
     IExtendedWUInterface *ewu = queryExtendedWU(wu);
     cacheCRC = ewu->calculateHash(cacheCRC);

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -458,6 +458,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
 #endif
 
 #ifndef __64BIT__
+    // Restrict stack sizes on 32-bit systems
     Thread::setDefaultStackSize(0x10000);   // NB under windows requires linker setting (/stack:)
 #endif
     srand( (unsigned)time( NULL ) );

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -4636,6 +4636,7 @@ protected:
 #ifdef __64BIT__
     enum { numBitmapThreads = 20, maxBitmapSize = (unsigned)(I64C(0xFFFFFFFFFF) / HEAP_ALIGNMENT_SIZE / UNSIGNED_BITS) };      // Test larger range - in case we ever reduce the granularity
 #else
+    // Restrict heap sizes on 32-bit systems
     enum { numBitmapThreads = 20, maxBitmapSize = (unsigned)(I64C(0xFFFFFFFF) / HEAP_ALIGNMENT_SIZE / UNSIGNED_BITS) };      // 4Gb
 #endif
     class BitmapAllocatorThread : public Thread

--- a/services/runagent/frunssh.cpp
+++ b/services/runagent/frunssh.cpp
@@ -51,6 +51,7 @@ int main( int argc, char *argv[] )
     InitModuleObjects();
 
 #ifndef __64BIT__
+    // Restrict stack sizes on 32-bit systems
     Thread::setDefaultStackSize(0x10000);   // NB under windows requires linker setting (/stack:)
 #endif
 

--- a/system/include/platform.h
+++ b/system/include/platform.h
@@ -20,8 +20,37 @@
 
 #define _TESTING // this should remain set for the near future
 
+// **** Architecture detection ****
+// Ref: http://sourceforge.net/p/predef/wiki/Architectures/
+// Following GNU, ARMCC, ICC and MSVS macros only
+
+// Identify all possible flags that mean ARM32, even when in Thumb mode
+// further separation could be tested via #ifdef __thumb__
+#if defined(__arm__) || defined(__thumb__) \
+ || defined(_M_ARM) || defined(_M_ARMT) \
+ || defined(__TARGET_ARCH_ARM) || defined(__TARGET_ARCH_THUMB)
+#define _ARCH_ARM32_
+#endif
+
+// ARM64 has only one which all compilers follow
+#ifdef __aarch64__
+#define _ARCH_ARM64_
+#endif
+
+// Identify all possible flags that mean x86_64
+#if defined(__amd64__) || defined(__x86_64__) \
+ || defined(_M_X64) || defined(_M_AMD64)
+ #define _ARCH_X86_64_
+#else
+ // Identify all possible flags that mean x86
+ #if defined(__i386__) || defined(_M_IX86)
+  #define _ARCH_X86_
+ #endif
+#endif
+
 // **** START OF X-PLATFORM SECTION ****
-#if defined(_M_X64) || defined ( __x86_64) || __WORDSIZE==64
+
+#if defined(_ARCH_X86_64_) || defined(_ARCH_ARM64_) || __WORDSIZE==64
 #define __64BIT__
 #endif
 

--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -289,6 +289,7 @@ static double cycleToNanoScale;
 
 void calibrate_timing()
 {
+#if defined(_ARCH_X86_) || defined(_ARCH_X86_64_)
     if (useRDTSC) {
         unsigned long eax;
         unsigned long ebx; 
@@ -310,6 +311,7 @@ void calibrate_timing()
         if ((edx&0x10)==0)
             useRDTSC = false;
     }
+#endif
     if (useRDTSC) {
         unsigned startu = usTick();
         cycle_t start = getTSC();

--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -68,6 +68,7 @@ static unsigned memArea[32];
 #endif
 #endif
 
+// FIXME: Make sure this is still relevant, and if not, delete
 #ifndef _WIN32
 #ifndef __64BIT__
 #define USE_OLD_PU

--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -32,7 +32,10 @@ cycle_t jlib_decl get_cycles_now();  // equivalent to getTSC when available
 double jlib_decl getCycleToNanoScale();
 void jlib_decl display_time(const char * title, cycle_t diff);
 
-#if defined(_WIN32) && ! defined (_AMD64_)
+// X86 / X86_64
+#if defined(_ARCH_X86_64_) || defined(_ARCH_X86_)
+
+#if defined(_WIN32) && defined (_ARCH_X86_)
 #pragma warning(push)
 #pragma warning(disable:4035)
 inline cycle_t getTSC() { __asm { __asm _emit 0x0f __asm _emit 0x31 } }
@@ -47,8 +50,15 @@ inline volatile __int64 getTSC()
 }
 #else
 #include <intrin.h>
-inline cycle_t getTSC() { return __rdtsc(); }   
-#endif
+inline cycle_t getTSC() { return __rdtsc(); }
+#endif // WIN32
+
+#else
+// ARMFIX: cycle-count is not always available in user mode
+// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0338g/Bihbeabc.html
+// http://neocontra.blogspot.co.uk/2013/05/user-mode-performance-counters-for.html
+inline cycle_t getTSC() { return 0; }
+#endif // X86
 
 struct HardwareInfo
 {

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -819,7 +819,7 @@ static void PrintExceptionReport( PEXCEPTION_POINTERS pExceptionInfo)
     PrintLog( "SS:ESP:%04X:%08X  EBP:%08X",
         pCtx->SegSs, pCtx->Esp, pCtx->Ebp );
 #else
-    // ARMFIX
+    // ARMFIX: Implement register bank dump for ARM.
     PrintLog("Register bank not implemented for your platform");
 #endif
     
@@ -831,7 +831,7 @@ static void PrintExceptionReport( PEXCEPTION_POINTERS pExceptionInfo)
 #elif defined(_ARCH_X86_)
     doPrintStackReport(pCtx->Eip, pCtx->Ebp,pCtx->Esp);
 #else
-    // ARMFIX
+    // ARMFIX: Implement stack dump for ARM.
     PrintLog("Stack report not implemented for your platform");
 #endif
     if (SEHtermOnSystemDLLs || SEHtermAlways) {
@@ -885,7 +885,7 @@ public:
 #elif defined(_ARCH_X86_)
         sprintf(s,"SEH Exception(%08X) at %04X:%08X\n",u,pExp->ContextRecord->SegCs,pExp->ContextRecord->Eip);
 #else
-        // ARMFIX
+        // ARMFIX: Implement exception dump for ARM.
         sprintf(s,"SEH Exception");
 #endif
 #endif
@@ -1052,7 +1052,7 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
         bp = nextbp;
     }
 #else
-    // ARMFIX
+    // ARMFIX: Implement signal dump for ARM.
     PROGLOG("================================================");
     PROGLOG("Signal:    %d %s",signum,strsignal(signum));
     PROGLOG("More information unavailable on your platform");

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -736,19 +736,19 @@ static void StackWalk( size_t pc, size_t bp )
 static void doPrintStackReport( size_t ip, size_t _bp, size_t sp )
 {
     if (_bp==0) {
-#ifdef _AMD64_
-        PrintLog("inline assembler is not supported in 64bit AMD compiler; StackReport incomplete bp tend to not be used");
-#else
+#ifdef _ARCH_X86_
         __asm { 
             mov eax,ebp
             mov _bp,eax
         }
+#else
+        PrintLog("inline assembler is only supported for x86_32; StackReport incomplete bp tend to not be used");
 #endif
     }
     
     for (unsigned i=0;i<8;i++) {
         StringBuffer s;
-#ifdef _AMD64_
+#ifdef __64BIT__
         s.appendf("Stack[%016X]:",sp);
 #else
         s.appendf("Stack[%08X]:",sp);
@@ -758,7 +758,7 @@ static void doPrintStackReport( size_t ip, size_t _bp, size_t sp )
                 break;
             size_t v = *(size_t *)sp;
             sp += sizeof(unsigned);
-#ifdef _AMD64_
+#ifdef __64BIT__
             s.appendf(" %016X",v);
 #else
             s.appendf(" %08X",v);
@@ -804,29 +804,35 @@ static void PrintExceptionReport( PEXCEPTION_POINTERS pExceptionInfo)
     
     PrintLog( "\nRegisters:" );
     
-#ifdef _AMD64_
+#ifdef _ARCH_X86_64_
     PrintLog("RAX:%016" I64F "X  RBX:%016" I64F "X  RCX:%016" I64F "X  RDX:%016" I64F "X  RSI:%016" I64F "X  RDI:%016" I64F "X",
         pCtx->Rax, pCtx->Rbx, pCtx->Rcx, pCtx->Rdx, pCtx->Rsi, pCtx->Rdi );
     
     PrintLog( "CS:RIP:%04X:%016" I64F "X", pCtx->SegCs, pCtx->Rip );
     PrintLog( "SS:PSP:%04X:%016" I64F "X  PBP:%016" I64F "X",
         pCtx->SegSs, pCtx->Rsp, pCtx->Rbp );
-#else
+#elif defined(_ARCH_X86_)
     PrintLog("EAX:%08X  EBX:%08X  ECX:%08X  EDX:%08X  ESI:%08X  EDI:%08X",
         pCtx->Eax, pCtx->Ebx, pCtx->Ecx, pCtx->Edx, pCtx->Esi, pCtx->Edi );
     
     PrintLog( "CS:EIP:%04X:%08X", pCtx->SegCs, pCtx->Eip );
     PrintLog( "SS:ESP:%04X:%08X  EBP:%08X",
         pCtx->SegSs, pCtx->Esp, pCtx->Ebp );
+#else
+    // ARMFIX
+    PrintLog("Register bank not implemented for your platform");
 #endif
     
     PrintLog( "DS:%04X  ES:%04X  FS:%04X  GS:%04X",
         pCtx->SegDs, pCtx->SegEs, pCtx->SegFs, pCtx->SegGs );
     PrintLog( "Flags:%08X", pCtx->EFlags );
-#ifdef _AMD64_
+#ifdef _ARCH_X86_64_
     doPrintStackReport(pCtx->Rip, pCtx->Rbp,pCtx->Rsp);
-#else
+#elif defined(_ARCH_X86_)
     doPrintStackReport(pCtx->Eip, pCtx->Ebp,pCtx->Esp);
+#else
+    // ARMFIX
+    PrintLog("Stack report not implemented for your platform");
 #endif
     if (SEHtermOnSystemDLLs || SEHtermAlways) {
         char *s = szFaultingModule;
@@ -874,10 +880,13 @@ public:
             pExp->ContextRecord->SegFs, pExp->ContextRecord->SegGs);
 #else
         char s[80];
-#ifdef _AMD64_
+#ifdef _ARCH_X86_64_
         sprintf(s,"SEH Exception(%08X) at %04X:%016" I64F "X\n",u,pExp->ContextRecord->SegCs,pExp->ContextRecord->Rip);
-#else
+#elif defined(_ARCH_X86_)
         sprintf(s,"SEH Exception(%08X) at %04X:%08X\n",u,pExp->ContextRecord->SegCs,pExp->ContextRecord->Eip);
+#else
+        // ARMFIX
+        sprintf(s,"SEH Exception");
 #endif
 #endif
         msg.set(s);
@@ -954,7 +963,8 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
     signal(SIGFPE, SIG_DFL);
 #endif
     StringBuffer s;
-#if __WORDSIZE == 64
+
+#ifdef _ARCH_X86_64_
 #define I64X "%016" I64F "X"
     ucontext_t *uc = (ucontext_t *)extra;
 #ifdef __APPLE__
@@ -985,8 +995,8 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
         (unsigned __int64) uc->uc_mcontext.gregs[REG_RCX], (unsigned __int64) uc->uc_mcontext.gregs[REG_RDX], 
         (unsigned __int64) uc->uc_mcontext.gregs[REG_RSI], (unsigned __int64) uc->uc_mcontext.gregs[REG_RDI] );
     PROGLOG( "CS:EIP:%04X:"I64X"", ((unsigned) uc->uc_mcontext.gregs[REG_CSGSFS])&0xffff, ip );
-    PROGLOG( "   ESP:"I64X"  EBP:"I64X"", sp, (unsigned __int64) uc->uc_mcontext.gregs[REG_RBP] );  
-#endif    
+    PROGLOG( "   ESP:"I64X"  EBP:"I64X"", sp, (unsigned __int64) uc->uc_mcontext.gregs[REG_RBP] );
+#endif
     
     for (unsigned i=0;i<8;i++) {
         StringBuffer s;
@@ -998,7 +1008,8 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
         }
         PROGLOG( "%s",s.str());
     }
-#elif defined (__linux__)
+
+#elif defined (__linux__) && defined (_ARCH_X86_)
     ucontext_t *uc = (ucontext_t *)extra;
     unsigned ip = uc->uc_mcontext.gregs[REG_EIP];
     unsigned sp = uc->uc_mcontext.gregs[REG_ESP];
@@ -1039,8 +1050,14 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
             break;
         PROGLOG("%2d  %08X  %08X",n+1,fip,(unsigned) bp);
         bp = nextbp;
-    }   
+    }
+#else
+    // ARMFIX
+    PROGLOG("================================================");
+    PROGLOG("Signal:    %d %s",signum,strsignal(signum));
+    PROGLOG("More information unavailable on your platform");
 #endif
+
 #ifdef _EXECINFO_H
     PrintStackReport();
 #endif  

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -70,6 +70,7 @@
 #ifdef __64BIT__
 #define DEFAULT_STREAM_BUFFER_SIZE 0x100000
 #else
+// Restrict buffer sizes on 32-bit systems
 #define DEFAULT_STREAM_BUFFER_SIZE 0x10000
 #endif
 

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -487,6 +487,7 @@ int main( int argc, char *argv[]  )
 
     EnableSEHtoExceptionMapping(); 
 #ifndef __64BIT__
+    // Restrict stack sizes on 32-bit systems
     Thread::setDefaultStackSize(0x10000);   // NB under windows requires linker setting (/stack:)
 #endif
     const char *thorname = NULL;

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -249,6 +249,7 @@ int main( int argc, char *argv[]  )
 
     dummyProc();
 #ifndef __64BIT__
+    // Restrict stack sizes on 32-bit systems
     Thread::setDefaultStackSize(0x10000);   // NB under windows requires linker setting (/stack:)
 #endif
 


### PR DESCRIPTION
These are the first steps to run HPCC on ARM targets. 

The first patch adds architecture selection, and attempts to make each architecture macro unique, so that testing for each one of them will assume all others are not defined.

The second, uses those macros to separate compilation of x86 code from ARM, so that the compilation actually succeeds on ARM (tested on a Chromebook). It will not run, obviously.

Further changes in the pre-processor will be needed to identify all ARM-specific behaviour (flagged by macro ARMFIX), so that progress can be made slowly towards supporting ARM targets.
