### PR TITLE
HPCC-10590 Ignore ~ in subfile name from package

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -374,6 +374,12 @@ protected:
             {
                 StringBuffer subFileName;
                 subFileInfo->getSubFileName(idx, subFileName);
+                assertex(subFilename.length());
+                if (subFileName.charAt(0)=='~')
+                {
+                    // implies that a package file had ~ in subfile names - shouldn;t really, but we allow it (and just strip the ~
+                    subFileName.remove(0,1);
+                }
                 Owned<const IResolvedFile> subFileInfo = lookupExpandedFileName(subFileName, cache, false, false);  // NOTE - overwriting a superfile does NOT require write access to subfiles
                 if (subFileInfo)
                 {


### PR DESCRIPTION
Can get xpath errors if the ~ is left in place.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
