### PR TITLE
HPCC-10620 : Ensure logical file meta data is checked

### DIFF
--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -74,7 +74,7 @@ void CDiskReadMasterBase::init()
                 }
             }
         }
-        validateFile(file);
+        validateFile();
         void *ekey;
         size32_t ekeylen;
         helper->getEncryptKey(ekeylen,ekey);

--- a/thorlcr/activities/thdiskbase.ipp
+++ b/thorlcr/activities/thdiskbase.ipp
@@ -40,7 +40,7 @@ public:
     void init();
     void serializeSlaveData(MemoryBuffer &dst, unsigned slave);
     void done();
-    virtual void validateFile(IDistributedFile *file) { }
+    virtual void validateFile() { }
     void deserializeStats(unsigned node, MemoryBuffer &mb);
     void getXGMML(unsigned idx, IPropertyTree *edge);
 };


### PR DESCRIPTION
Regression in HPCC-8624, caused the logical file meta info the
query supplies to no longer to be checked against the published
DFS meta info. i.e. formatCRC, compression, grouping

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
