### PR TITLE
HPCC-10594 : Block access to foreign dali from logicalfilelist

### DIFF
--- a/common/thorhelper/enginecontext.hpp
+++ b/common/thorhelper/enginecontext.hpp
@@ -24,6 +24,7 @@
 interface IEngineContext
 {
     virtual DALI_UID getGlobalUniqueIds(unsigned num, SocketEndpoint *_foreignNode) = 0;
+    virtual bool allowDaliAccess() const = 0;
 };
 
 #endif // ENGINECONTEXT_HPP

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1554,6 +1554,13 @@ FILESERVICES_API void FILESERVICES_CALL fsRemoteDirectory(size32_t & __lenResult
 
 FILESERVICES_API void FILESERVICES_CALL fsLogicalFileList(ICodeContext *ctx, size32_t & __lenResult,void * & __result, const char *mask, bool includenormal, bool includesuper, bool unknownszero, const char *foreigndali)
 {
+    IEngineContext *engineCtx = ctx->queryEngineContext();
+    if (engineCtx && !engineCtx->allowDaliAccess())
+    {
+        Owned<IException> e = MakeStringException(-1, "FileServices.LogicalFileList cannot access Dali in this context - this normally means it is being called from a thor slave");
+        EXCLOG(e, NULL);
+        throw e.getClear();
+    }
     MemoryBuffer mb;
     if (!mask||!*mask)
         mask ="*";

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1020,6 +1020,11 @@ public:
             foreignNode.set(globals->queryProp("@DALISERVERS"));
         return ::getGlobalUniqueIds(num, &foreignNode);
     }
+    virtual bool allowDaliAccess() const
+    {
+        // NB. includes access to foreign Dalis.
+        return globals->getPropBool("Debug/@slaveDaliClient");
+    }
 };
 
 class CSlaveGraphTempHandler : public CGraphTempHandler


### PR DESCRIPTION
Fileservice calls can bypass the local Dali (and therefore the
check from slaves) and go directly to a foreign Dali.
This is highly undesirable, for the same reason it was blocked
by default from the local environment's Dali. It causes a flood
of requests that can usually be recoded more efficiently by
ensuring the request is called once or outside slaves.

LogicalFileList was the only call that in FileServices that
directly called a DFS call that sent a message directly.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
