### PR TITLE
HPCC-10625 Regression suite causes ESP warnings

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -46,15 +46,16 @@ class Regression:
             self.timeoutThread = threading.Timer(1.0,  self.timeoutHandler)
             self.timeoutThread.start()
 
-    def __init__(self, config="regress.json", level='info', suiteDir=None,  timeout=-1,  numOfThreads=1):
+    def __init__(self, config="regress.json", level='info', suiteDir=None,  timeout=0,  numOfThreads=1):
         self.config = Config(config).configObj
         setConfig(self.config)
         self.suites = {}
         self.log = Logger(level)
-        if timeout == '-1':
+        if timeout == '0':
             self.timeout = int(self.config.timeout);
         else:
             self.timeout = int(timeout)
+        logging.debug("Suite timeout: %d sec / testcase", self.timeout)
         if numOfThreads == 0:
             numOfThreads = 1;
         if not suiteDir:
@@ -316,8 +317,10 @@ class Regression:
                 query.setTaskId(cnt)
                 self.timeouts[th] = self.timeout
                 timeout = query.getTimeout()
-                if timeout != -1:
+                if timeout != 0:
                    self.timeouts[th] = timeout
+                else:
+                    self.timeouts[th] = self.timeout
 
                 thread.start_new_thread(self.runQuery, (cluster, query, report, cnt, suite.testPublish(query.ecl),  th))
                 time.sleep(0.1)
@@ -356,7 +359,9 @@ class Regression:
             self.timeouts[threadId] = self.timeout
             timeout = eclfile.getTimeout()
             if timeout != 0:
-               self.timeouts[threadId] = timeout
+                self.timeouts[threadId] = timeout
+            else:
+                self.timeouts[threadId] = self.timeout
             sysThreadId = thread.start_new_thread(self.runQuery, (cluster, eclfile, report, cnt, eclfile.testPublish(),  threadId))
             time.sleep(0.1)
             self.CheckTimeout(cnt, threadId,  eclfile)

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -161,7 +161,7 @@ class ECLFile:
             if tag in line:
                 timeoutParts = line.split()
                 if len(timeoutParts) == 2:
-                    if isPositiveIntNum(timeoutParts[1]):
+                    if (timeoutParts[1] == '-1') or isPositiveIntNum(timeoutParts[1]) :
                         timeout = int(timeoutParts[1])
                 break
         logging.debug("%3d. Timeout is :%d sec",  self.taskId,  timeout)

--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     description = 'HPCC Platform Regression suite'
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('--version', '-v', action='version',
-                        version='%(prog)s 0.0.6')
+                        version='%(prog)s 0.0.7')
     parser.add_argument('--config', help="config file to use. Default: regress.json",
                         nargs='?', default="regress.json")
     parser.add_argument('--loglevel', help="set the log level. Use debug for more detailed logfile.",
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     parser.add_argument('--suiteDir', '-s', help="suiteDir to use. Default value is the current directory and it can handle relative path.",
                         nargs='?', default=".")
     parser.add_argument('--timeout', '-t', help="timeout for query execution in sec. Use -1 to disable timeout. Default value defined in regress.json config file.",
-                        nargs='?', default="-1")
+                        nargs='?', default="0")
 
     subparsers = parser.add_subparsers(help='sub-command help')
     parser_list = subparsers.add_parser('list', help='list help')


### PR DESCRIPTION
Fix timeout handling problem in sequential test case execution.
Change original password to registered one in regress.json

Signed-off-by: Attila Vamos attila.vamos@gmail.com
