### PR TITLE
HPCC-10517 Fix Package subfile nodes sometimes added to DALI as empty

### DIFF
--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -236,7 +236,10 @@ void addPackageMapInfo(StringArray &filesNotFound, IPropertyTree *pkgSetRegistry
                     IPropertyTree &subtree = sub_iter->query();
                     const char *subid = subtree.queryProp("@value");
                     if (subid && *subid == '~')
-                        subtree.setProp("@value", subid+1);
+                    {
+                        StringAttr value(subid+1);
+                        subtree.setProp("@value", value.get());
+                    }
                 }
             }
             mapTree->addPropTree("Package", LINK(&item));


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
