### PR TITLE
HPCC-10657 Fix WsSMC crash when failed in setting WU priority

### DIFF
--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1889,8 +1889,14 @@ bool CWsSMCEx::onSetJobPriority(IEspContext &context, IEspSMCPriorityRequest &re
 {
     try
     {
+        const char* wuid = req.getWuid();
+        if (!wuid || !*wuid)
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "Workunit ID not specified.");
+
         Owned<IWorkUnitFactory> factory = getSecWorkUnitFactory(*context.querySecManager(), *context.queryUser());
-        Owned<IWorkUnit> lw = factory->updateWorkUnit(req.getWuid());
+        Owned<IWorkUnit> lw = factory->updateWorkUnit(wuid);
+        if (!lw)
+            throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT, "Cannot update Workunit %s", wuid);
 
         if(stricmp(req.getPriority(),"high")==0)
             lw->setPriority(PriorityClassHigh);


### PR DESCRIPTION
When an invalid WU ID is used to change WU priority, ESP crashed
inside WsSMC. This is because an invalid point to WU was returned
for the invalid WU ID and WsSMC did not validate the point. In
this fix, the validation code is added to the WsSMC.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
