### PR TITLE
HPCC-10624 Fix incorrect warning when SKIP used in a ROLLUP

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4709,7 +4709,7 @@ IHqlExpression * CExprFolderTransformer::doFoldTransformed(IHqlExpression * unfo
                                 ok = false;
                                 break;
                             }
-                            IHqlExpression * match = getExtractSelect(cur, field);
+                            IHqlExpression * match = getExtractSelect(cur, field, false);
                             if (!match)
                             {
                                 ok = false;
@@ -4752,7 +4752,7 @@ IHqlExpression * CExprFolderTransformer::doFoldTransformed(IHqlExpression * unfo
 #if 1
                     if (!expr->isDataset() && !expr->isDatarow())
                     {
-                        OwnedHqlExpr  match = getExtractSelect(left->queryChild(0), expr->queryChild(1));
+                        OwnedHqlExpr  match = getExtractSelect(left->queryChild(0), expr->queryChild(1), false);
                         if (match && match->isConstant())
                             return match.getClear();
                     }
@@ -4762,7 +4762,7 @@ IHqlExpression * CExprFolderTransformer::doFoldTransformed(IHqlExpression * unfo
                     //Should enable once I've had time to investigate
                     if (!expr->isDataset())// && !expr->isDatarow())
                     {
-                        OwnedHqlExpr  match = getExtractSelect(left->queryChild(0), expr->queryChild(1));
+                        OwnedHqlExpr  match = getExtractSelect(left->queryChild(0), expr->queryChild(1), false);
                         if (match)// && match->isConstant())
                             return match.getClear();
                     }

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -2383,7 +2383,7 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
                 {
                 case no_createrow:
                     {
-                        OwnedHqlExpr match = getExtractSelect(child->queryChild(0), transformed->queryChild(1));
+                        OwnedHqlExpr match = getExtractSelect(child->queryChild(0), transformed->queryChild(1), false);
                         if (match)
                         {
                             IHqlExpression * cur = match;
@@ -2418,7 +2418,7 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
                         if (values->numChildren() == 1) 
                         {
                             IHqlExpression * transform = values->queryChild(0);
-                            OwnedHqlExpr match = getExtractSelect(transform, transformed->queryChild(1));
+                            OwnedHqlExpr match = getExtractSelect(transform, transformed->queryChild(1), false);
                             if (match)
                             {
                                 IHqlExpression * cur = match;
@@ -2463,7 +2463,7 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
                         if (values->numChildren() == 1) 
                         {
                             IHqlExpression * transform = values->queryChild(0);
-                            OwnedHqlExpr match = getExtractSelect(transform, extracted->queryChild(1));
+                            OwnedHqlExpr match = getExtractSelect(transform, extracted->queryChild(1), false);
                             if (match)
                             {
                                 IHqlExpression * cur = match;

--- a/ecl/hql/hqlpmap.hpp
+++ b/ecl/hql/hqlpmap.hpp
@@ -181,9 +181,9 @@ extern HQL_API bool transformReturnsSide(IHqlExpression * expr, node_operator si
 
 extern HQL_API bool sortDistributionMatches(IHqlExpression * dataset, bool isLocal);
 
-extern HQL_API IHqlExpression * getExtractSelect(IHqlExpression * transform, IHqlExpression * field);
+extern HQL_API IHqlExpression * getExtractSelect(IHqlExpression * transform, IHqlExpression * field, bool okToSkipRow);
 //Find the assignment that corresponds to select (with selector "selector") and return the assigned value
-extern HQL_API IHqlExpression * getExtractSelect(IHqlExpression * transform, IHqlExpression * selector, IHqlExpression * select);
+extern HQL_API IHqlExpression * getExtractSelect(IHqlExpression * transform, IHqlExpression * selector, IHqlExpression * select, bool okToSkipRow);
 extern HQL_API IHqlExpression * getParentDatasetSelector(IHqlExpression * ds);
 //return all selects from the expression that refer to a particular selector
 extern HQL_API void gatherSelects(HqlExprCopyArray & selectors, IHqlExpression * expr, IHqlExpression * selector);

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -4679,7 +4679,7 @@ public:
             node_operator childOp = child->getOperator();
             if (childOp == no_createrow)
             {
-                OwnedHqlExpr match = getExtractSelect(child->queryChild(0), transformed->queryChild(1));
+                OwnedHqlExpr match = getExtractSelect(child->queryChild(0), transformed->queryChild(1), false);
                 if (match)
                 {
                     IHqlExpression * cur = queryUncastExpr(match);

--- a/ecl/hql/hqlvalid.cpp
+++ b/ecl/hql/hqlvalid.cpp
@@ -200,7 +200,7 @@ IHqlExpression * queryAmbiguousRollupCondition(IHqlExpression * expr, bool stric
     ForEachItemIn(i, selects)
     {
         IHqlExpression * select = &selects.item(i);
-        OwnedHqlExpr value = getExtractSelect(transform, selector, select);
+        OwnedHqlExpr value = getExtractSelect(transform, selector, select, true);
         if (!value)
             return select;
 
@@ -236,7 +236,7 @@ IHqlExpression * queryAmbiguousRollupCondition(IHqlExpression * expr, const HqlE
     ForEachItemIn(i, selects)
     {
         IHqlExpression * select = &selects.item(i);
-        OwnedHqlExpr value = getExtractSelect(transform, selector, select);
+        OwnedHqlExpr value = getExtractSelect(transform, selector, select, true);
         if (!value)
             return select;
 
@@ -268,7 +268,7 @@ void filterAmbiguousRollupCondition(HqlExprArray & ambiguousSelects, HqlExprArra
     ForEachItemInRev(i, selects)
     {
         IHqlExpression * select = &selects.item(i);
-        OwnedHqlExpr value = getExtractSelect(transform, selector, select);
+        OwnedHqlExpr value = getExtractSelect(transform, selector, select, true);
         if (value)
         {
             if (value->getOperator() == no_constant)

--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -1686,7 +1686,7 @@ IHqlExpression * HqlCppTranslator::getResourcedChildGraph(BuildCtx & ctx, IHqlEx
     }
 
     traceExpression("BeforeResourcing Child", resourced);
-    cycle_t time = msTick();
+    unsigned time = msTick();
     HqlExprCopyArray activeRows;
     gatherActiveCursors(ctx, activeRows);
     if (graphKind == no_loop)

--- a/ecl/hqlcpp/hqlcset.cpp
+++ b/ecl/hqlcpp/hqlcset.cpp
@@ -863,7 +863,7 @@ BoundRow * InlineLinkedDictionaryCursor::buildSelectMap(BuildCtx & ctx, IHqlExpr
     if (optimizedLookupFunc.length())
     {
         args.add(*LINK(dictionary), 0);
-        args.append(*getExtractSelect(searchExpr->queryChild(0), queryFirstField(searchRecord)));
+        args.append(*getExtractSelect(searchExpr->queryChild(0), queryFirstField(searchRecord), false));
         args.append(*::createRow(no_null, LINK(record))); // the default record
         lookupFunction = createIdAtom(optimizedLookupFunc);
     }
@@ -927,7 +927,7 @@ void InlineLinkedDictionaryCursor::buildInDataset(BuildCtx & ctx, IHqlExpression
     if (optimizedLookupFunc.length())
     {
         args.add(*LINK(dictionary), 0);
-        args.append(*getExtractSelect(searchExpr->queryChild(0), queryFirstField(searchRecord)));
+        args.append(*getExtractSelect(searchExpr->queryChild(0), queryFirstField(searchRecord), false));
         lookupFunction = createIdAtom(optimizedLookupFunc);
     }
     else

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -9190,7 +9190,7 @@ IHqlExpression * HqlCppTranslator::getResourcedGraph(IHqlExpression * expr, IHql
 
     traceExpression("BeforeResourcing", resourced);
 
-    cycle_t time = msTick();
+    unsigned time = msTick();
     if (outputLibraryId)
     {
         unsigned numResults = outputLibrary->numResultsUsed();


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
