### PR TITLE
HPCC-10686 - Need to check subfile after lock retry

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -4473,8 +4473,11 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
                     {
                         sf->loadSubFiles(transaction, SDS_TRANSACTION_RETRY);
                         // potentially subfile _was_ a subfile, but isn't anymore, after dirty update
-                        if (!transaction->isSubFile(parent, subfile, true))
-                            WARNLOG("addSubFile: File %s is not a subfile of %s", subfile.get(), parent->queryLogicalName());
+                        if (!subfile.isEmpty())
+                        {
+                            if (!transaction->isSubFile(parent, subfile, true))
+                                WARNLOG("addSubFile: File %s is not a subfile of %s", subfile.get(), parent->queryLogicalName());
+                        }
                     }
                 }
                 if (sub)


### PR DESCRIPTION
Need to check if subfile provided in RemoveSubFile when
rechcking if sub is member of super after dirty lock.
subfile is empty in case of ClearSuperFile(calling RemoveSubFile)

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
