### PR TITLE
HPCC-10693 - Allow CSV,HEADING read in child query.

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -843,6 +843,8 @@ bool isGlobalActivity(CGraphElementBase &container)
         {
             Owned<IHThorCsvReadArg> helper = (IHThorCsvReadArg *)container.helperFactory();
             // if header lines, then [may] need to co-ordinate across slaves
+            if (container.queryOwner().queryOwner() && (!container.queryOwner().isGlobal())) // I am in a child query
+                return false;
             return helper->queryCsvParameters()->queryHeaderLen() > 0;
         }
 // dependent on child acts?


### PR DESCRIPTION
Normally a CSV with HEADING is marked global, meaning slaves
inter-communicate. However, if in child query, child reads all
parts and it is local.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
