### PR TITLE
HPCC-10683 Fix WU connection leak in WsWorkunits & a warning in ESP log

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -640,7 +640,7 @@ public:
     virtual unsigned __int64 getHash() const;
     virtual IStringIterator *getLogs(const char *type, const char *component) const;
     virtual IStringIterator *getProcesses(const char *type) const;
-    virtual IPropertyTreeIterator& getProcesses(const char *type, const char *instance) const;
+    virtual IPropertyTreeIterator* getProcesses(const char *type, const char *instance) const;
 
     virtual bool getWuDate(unsigned & year, unsigned & month, unsigned& day);
     virtual IStringVal & getSnapshot(IStringVal & str) const;
@@ -1103,7 +1103,7 @@ public:
             { return c->getLogs(type, instance); }
     virtual IStringIterator *getProcesses(const char *type) const
             { return c->getProcesses(type); }
-    virtual IPropertyTreeIterator& getProcesses(const char *type, const char *instance) const
+    virtual IPropertyTreeIterator* getProcesses(const char *type, const char *instance) const
             { return c->getProcesses(type, instance); }
 
     virtual void clearExceptions()
@@ -5232,7 +5232,7 @@ IStringIterator *CLocalWorkUnit::getLogs(const char *type, const char *instance)
         return new CStringPTreeAttrIterator(p->getElements(xpath.str()), "@log");
 }
 
-IPropertyTreeIterator& CLocalWorkUnit::getProcesses(const char *type, const char *instance) const
+IPropertyTreeIterator* CLocalWorkUnit::getProcesses(const char *type, const char *instance) const
 {
     VStringBuffer xpath("Process/%s/", type);
     if (instance)
@@ -5240,7 +5240,7 @@ IPropertyTreeIterator& CLocalWorkUnit::getProcesses(const char *type, const char
     else
         xpath.append("*");
     CriticalBlock block(crit);
-    return * p->getElements(xpath.str());
+    return p->getElements(xpath.str());
 }
 
 IStringIterator *CLocalWorkUnit::getProcesses(const char *type) const

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -925,7 +925,7 @@ interface IConstWorkUnit : extends IInterface
     virtual unsigned __int64 getHash() const = 0;
     virtual IStringIterator *getLogs(const char *type, const char *instance=NULL) const = 0;
     virtual IStringIterator *getProcesses(const char *type) const = 0;
-    virtual IPropertyTreeIterator& getProcesses(const char *type, const char *instance) const = 0;
+    virtual IPropertyTreeIterator* getProcesses(const char *type, const char *instance) const = 0;
 };
 
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3898,15 +3898,16 @@ bool CWsWorkunitsEx::onWUDeployWorkunit(IEspContext &context, IEspWUDeployWorkun
 
 void CWsWorkunitsEx::addProcessLogfile(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, PointerArray &mbArr)
 {
-    IPropertyTreeIterator& proc = cwu->getProcesses(process, NULL);
-    ForEach (proc)
+    Owned<IPropertyTreeIterator> procs = cwu->getProcesses(process, NULL);
+    ForEach (*procs)
     {
         StringBuffer logSpec;
-        proc.query().getProp("@log",logSpec);
+        IPropertyTree& proc = procs->query();
+        proc.getProp("@log",logSpec);
         if (!logSpec.length())
             continue;
         StringBuffer pid;
-        pid.appendf("%d",proc.query().getPropInt("@pid"));
+        pid.appendf("%d",proc.getPropInt("@pid"));
         MemoryBuffer * pMB = NULL;
         try
         {


### PR DESCRIPTION
When a new job is submitted, WsWorkunit creates connections to
dali to get information about the WU. Due to a bug, one of the
connections is not released. The same problem also occurs when
a ZAP Report is created. The bug is fixed here.

The WsWorkunits::WUUpdate method is used when a user wants to
modify a wu. The last step of the method is to retrieve/send
back the updated information about the WU. The information
includes possible thor log files for the WU. The WUUpdate method
is also called when a new job is submitted. A Warning line "
WARNING: Cannot find TargetClusterInfo for workunit ..." is
written to esp log when the method trys to retrieve thor log
information. This is because the WU is just created and no
cluster has been specified for the WU yet. This fix skips the
warning code if no cluster has been specified for a WU.
