### PR TITLE
HPCC-10704 Enhance Enable/Disable scope scan confirm dialog

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_resources.xslt
+++ b/esp/eclwatch/ws_XSLT/access_resources.xslt
@@ -198,14 +198,14 @@
               <xsl:if test="scopeScansStatus/isEnabled=0">
                 <td>
                   <form action="/ws_access/EnableScopeScans">
-                    <input id="EnableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Enable Scope Scans" onclick="return confirm('Are you sure you want to enable Scope Scans?')"/>
+                    <input id="EnableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Enable Scope Scans" onclick="return confirm('Are you sure you want to enable Scope Scans? Changes will revert to configuration settings on DALI reboot.')"/>
                   </form>
                 </td>
               </xsl:if>
               <xsl:if test="scopeScansStatus/isEnabled=1">
                 <td>
                   <form action="/ws_access/DisableScopeScans">
-                    <input id="DisableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Disable Scope Scans" onclick="return confirm('Are you sure you want to disable Scope Scans?')"/>
+                    <input id="DisableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Disable Scope Scans" onclick="return confirm('Are you sure you want to disable Scope Scans?  Changes will revert to configuration settings on DALI reboot.')"/>
                   </form>
                 </td>
               </xsl:if>


### PR DESCRIPTION
When clicking the Enable/Disable Scope Scans button, the confirmation
dialog should notify you that "Changes will revert to configuration
settings on DALI reboot."

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
