### PR TITLE
HPCC-10470 Roxie Graphs are not getting merged correctly

### DIFF
--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1075,10 +1075,10 @@ public:
                     if (thisGraphNameStr.length() && (stricmp(graphName, thisGraphNameStr.s.str()) != 0))
                         continue; // not interested in this one
                 }
-                reply.appendf("<Graph id='%s'><xgmml><graph>", thisGraphNameStr.s.str());
+                reply.appendf("<Graph id='%s'><xgmml>", thisGraphNameStr.s.str());
                 Owned<IPropertyTree> graphXgmml = graphs->query().getXGMMLTree(false);
                 getGraphStats(reply, *graphXgmml);
-                reply.append("</graph></xgmml></Graph>");
+                reply.append("</xgmml></Graph>");
             }
         }
     }


### PR DESCRIPTION
The xgmml being returned from control:querystats was not layed out as expected
(an extra graph layer). While this did not cause any problems displaying the
graphs, it prevented the merge code from operating correctly.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
