### PR TITLE
HPCC-10741 Regression suite is dependent on minimum python version, it should  check at start up.

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -2,6 +2,8 @@ Overview of Regression Suite usage
 ==================================
 To use Regression Suite change directory to HPCC-Platform/testing/regress subdirectory.
 
+Regression Suite requires Python environment version >=2.6.6 and < 3.x
+
 Parameters of Regression Suite:
 -------------------------------
 

--- a/testing/regress/hpcc/common/logger.py
+++ b/testing/regress/hpcc/common/logger.py
@@ -138,9 +138,10 @@ class Logger(object):
                 if isBuffer:
                     #toggle buffer switch
                     self.isBuffer = not self.isBuffer
+                    isBuffer = False
                 if self.isBuffer or isBuffer:
                     if len(msg):
-                        msg.replace(". Test:",". Case:")
+                        msg = msg.replace(". Test:",". Case:")
                         msg = msg[0:4]+'-'+record.asctime+'-'+msg[4:]
                         self.logBuffer.append(msg)
                 else:

--- a/testing/regress/hpcc/common/report.py
+++ b/testing/regress/hpcc/common/report.py
@@ -90,6 +90,8 @@ class Report:
             reportStr += " (%02d:%02d:%02d) \n" % (hours,  mins,  elapsTime % 60)
             reportStr += "-------------------------------------------------\n"
         logging.warn(reportStr)
+        self.report._pass = []
+        self.report._fail = []
 
     def getResult(self, eclfile):
         pass

--- a/testing/regress/hpcc/util/ecl/cc.py
+++ b/testing/regress/hpcc/util/ecl/cc.py
@@ -29,6 +29,7 @@ class ECLCC(Shell):
     def __init__(self):
         self.defaults = []
         self.cmd = self.which('eclcc')
+        self.makeArchiveError=''
 
     def __ECLCC(self):
         return self.command(self.cmd, *self.defaults)

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -54,6 +54,8 @@ class ECLFile:
         self.xml_r = baseXml
         self.xml_a = 'archive_' + baseXml
         self.jobname = self.basename
+        self.diff = ''
+        self.abortReason =''
 
     def getExpected(self):
         return os.path.join(self.dir_ex, self.xml_e)
@@ -189,10 +191,10 @@ class ECLFile:
                                              tofile=self.xml_r):
                 self.diff += line
         except Exception as e:
-            logging.critical( e, extra={'taskId':self.taskId})
-            logging.critical("%s",  traceback.format_exc().replace("\n","\n\t\t"),  extra={'taskId':self.taskId} )
-            logging.critical("EXP: %s",  self.getExpected(),  extra={'taskId':self.taskId})
-            logging.critical("REC: %s",  self.getResults(),  extra={'taskId':self.taskId})
+            logging.debug( e, extra={'taskId':self.taskId})
+            logging.debug("%s",  traceback.format_exc().replace("\n","\n\t\t"),  extra={'taskId':self.taskId} )
+            logging.debug("EXP: %s",  self.getExpected(),  extra={'taskId':self.taskId})
+            logging.debug("REC: %s",  self.getResults(),  extra={'taskId':self.taskId})
             return False
         finally:
             if not self.diff:

--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -31,15 +31,32 @@ from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
 
+prog_version = "0.0.10"
+
 if __name__ == "__main__":
-    ver = getVersionNumbers()
-    if (ver['main'] >= 2) and (ver['minor'] >= 7):
-        atexit.register(logging.shutdown)
-    prog = "regress"
+
+    prog = "regress v:"+prog_version
     description = 'HPCC Platform Regression suite'
+    pythonVer = getVersionNumbers()
+
+    if (pythonVer['main'] <= 2) and (pythonVer['minor'] <=6) and (pythonVer['patch'] <6):
+        print "\nError!"
+        print "Your system has Python version "+platform.python_version()
+        print "To run "+description+", you need version: 2.6.6 or higher, but less than 3.x!\n"
+        exit()
+
+    if pythonVer['main'] >= 3:
+        print "\nError!"
+        print "Your system has Python version "+platform.python_version()
+        print "Actually "+description+", supports version >= 2.6.6 and <= 2.7.x\n"
+        exit()
+
+    if (pythonVer['main'] >= 2) and (pythonVer['minor'] >= 7):
+        atexit.register(logging.shutdown)
+
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('--version', '-v', action='version',
-                        version='%(prog)s 0.0.10')
+                        version='%(prog)s')
     parser.add_argument('--config', help="config file to use. Default: regress.json",
                         nargs='?', default="regress.json")
     parser.add_argument('--loglevel', help="set the log level. Use debug for more detailed logfile.",


### PR DESCRIPTION
Add code to check version of the installed Python system.
Add Python version related note into README.rst
Add initialization to some local variables.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
