### PR TITLE
HPCC-10664 - Hold locks to subfiles, release super

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6462,6 +6462,18 @@ bool CDistributedFilePart::getModifiedTime(bool allowphysical,bool forcephysical
     return false;
 }
 
+unsigned getSuperFileSubs(IDistributedSuperFile *super, IArrayOf<IDistributedFile> &subFiles, bool superSub)
+{
+    unsigned numSubs = super->numSubFiles(superSub);
+    for (unsigned s=0; s<numSubs; s++)
+    {
+        IDistributedFile &subFile = super->querySubFile(s, superSub);
+        subFiles.append(*LINK(&subFile));
+    }
+    return numSubs;
+}
+
+
 // --------------------------------------------------------
 
 class CNamedGroupIterator: public CInterface, implements INamedGroupIterator

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -330,6 +330,7 @@ interface IDistributedSuperFile: extends IDistributedFile
                                 // returns file for part (not linked) NULL if not found
 };
 
+extern da_decl unsigned getSuperFileSubs(IDistributedSuperFile *super, IArrayOf<IDistributedFile> &subFiles, bool superSub=false);
 
 interface ISimpleSuperFileEnquiry: extends IInterface // lightweight local
 {

--- a/thorlcr/activities/diskread/thdiskread.cpp
+++ b/thorlcr/activities/diskread/thdiskread.cpp
@@ -30,7 +30,7 @@ class CDiskReadMasterVF : public CDiskReadMasterBase
 {
 public:
     CDiskReadMasterVF(CMasterGraphElement *info) : CDiskReadMasterBase(info) { }
-    virtual void validateFile()
+    virtual void validateFile(IDistributedFile *file)
     {
         IHThorDiskReadBaseArg *helper = (IHThorDiskReadBaseArg *)queryHelper();
         bool codeGenGrouped = 0 != (TDXgrouped & helper->getFlags());
@@ -77,6 +77,7 @@ public:
     }
     virtual void done()
     {
+        CDiskReadMasterVF::done();
         IHThorDiskReadBaseArg *helper = (IHThorDiskReadBaseArg *)queryHelper();
         if (0 != (helper->getFlags() & TDXtemporary) && !container.queryJob().queryUseCheckpoints())
             container.queryTempHandler()->deregisterFile(fileName, fileDesc->queryProperties().getPropBool("@pausefile"));
@@ -165,7 +166,8 @@ public:
         {
             if (!helper->hasSegmentMonitors() && !helper->hasFilter() && !(helper->getFlags() & TDXtemporary))
             {
-                if (file.get() && canMatch)
+                IDistributedFile *file = queryReadFile(0);
+                if (file && canMatch)
                 {
                     if (0 != (TDRunfilteredcount & helper->getFlags()) && file->queryAttributes().hasProp("@recordCount"))
                     {

--- a/thorlcr/activities/diskwrite/thdiskwrite.cpp
+++ b/thorlcr/activities/diskwrite/thdiskwrite.cpp
@@ -57,7 +57,7 @@ class CsvWriteActivityMaster : public CWriteMasterBase
 {
 public:
     CsvWriteActivityMaster(CMasterGraphElement *info) : CWriteMasterBase(info) {}
-    void done()
+    virtual void done()
     {
         IPropertyTree &props = fileDesc->queryProperties();
         props.setProp("@format", "utf8n");

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -58,6 +58,7 @@ public:
     }
     virtual void init()
     {
+        CMasterActivity::init();
         OwnedRoxieString fname(helper->getFileName());
         dlfn.set(fname);
         isLocal = 0 != (TIWlocal & helper->getFlags());
@@ -267,6 +268,7 @@ public:
             if (!dlfn.isExternal())
                 queryThorFileManager().publish(container.queryJob(), fname, false, *fileDesc);
         }
+        CMasterActivity::done();
     }
     virtual void slaveDone(size32_t slaveIdx, MemoryBuffer &mb)
     {

--- a/thorlcr/activities/join/thjoin.cpp
+++ b/thorlcr/activities/join/thjoin.cpp
@@ -100,10 +100,7 @@ public:
         container.queryJob().freeMPTag(barrierMpTag);
         delete climitedcmp;
     }
-    void init()
-    {
-    }
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         if (!islocal)
         {
@@ -111,7 +108,7 @@ public:
             serializeMPtag(dst, barrierMpTag);
         }
     }
-    void preStart(size32_t parentExtractSz, const byte *parentExtract)
+    virtual void preStart(size32_t parentExtractSz, const byte *parentExtract)
     {
         CMasterActivity::preStart(parentExtractSz, parentExtract);
         ActPrintLog("preStart");
@@ -127,7 +124,7 @@ public:
             }
         }
     }
-    void process()
+    virtual void process()
     {
         ActPrintLog("process");
         CMasterActivity::process();
@@ -299,7 +296,7 @@ public:
         }
         ActPrintLog("process exit");
     }
-    void deserializeStats(unsigned node, MemoryBuffer &mb)
+    virtual void deserializeStats(unsigned node, MemoryBuffer &mb)
     {
         CMasterActivity::deserializeStats(node, mb);
         rowcount_t lhsProgressCount, rhsProgressCount;
@@ -311,7 +308,7 @@ public:
             rhsProgress->set(node, rhsProgressCount);
         }
     }
-    void getXGMML(unsigned idx, IPropertyTree *edge)
+    virtual void getXGMML(unsigned idx, IPropertyTree *edge)
     {
         CMasterActivity::getXGMML(idx, edge);
 

--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -27,7 +27,6 @@ class CKeyedJoinMaster : public CMasterActivity
 {
     IHThorKeyedJoinArg *helper;
     Owned<CSlavePartMapping> dataFileMapping;
-    Owned<IDistributedFile> indexFile, dataFile;
     MemoryBuffer offsetMapMb, initMb;
     bool localKey;
     unsigned numTags;
@@ -68,8 +67,10 @@ public:
     }
     virtual void init()
     {
+        CMasterActivity::init();
         OwnedRoxieString indexFileName(helper->getIndexFileName());
-        indexFile.setown(queryThorFileManager().lookup(container.queryJob(), indexFileName, false, 0 != (helper->getJoinFlags() & JFindexoptional), true));
+        Owned<IDistributedFile> dataFile;
+        Owned<IDistributedFile> indexFile = queryThorFileManager().lookup(container.queryJob(), indexFileName, false, 0 != (helper->getJoinFlags() & JFindexoptional), true);
 
         unsigned keyReadWidth = (unsigned)container.queryJob().getWorkUnitValueInt("KJKRR", 0);
         if (!keyReadWidth || keyReadWidth>container.queryJob().querySlaves())
@@ -229,7 +230,6 @@ public:
                             Owned<IGroup> grp = container.queryJob().querySlaveGroup().subset((unsigned)0, dataReadWidth);
                             dataFileMapping.setown(getFileSlaveMaps(dataFile->queryLogicalName(), *dataFileDesc, container.queryJob().queryUserDescriptor(), *grp, false, false, NULL));
                             dataFileMapping->serializeFileOffsetMap(offsetMapMb.clear());
-                            queryThorFileManager().noteFileRead(container.queryJob(), dataFile);
                         }
                         else
                             indexFile.clear();
@@ -240,25 +240,27 @@ public:
                 indexFile.clear();
         }
         if (indexFile)
-            queryThorFileManager().noteFileRead(container.queryJob(), indexFile);
+        {
+            addReadFile(indexFile);
+            if (dataFile)
+                addReadFile(dataFile);
+        }
         else
             initMb.append((unsigned)0);
     }
     virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         dst.append(initMb);
-        if (indexFile && helper->diskAccessRequired())
+        IDistributedFile *dataFile = queryReadFile(1); // 0 == indexFile, 1 == dataFile
+        if (dataFile)
         {
-            if (dataFile)
-            {
-                dataFileMapping->serializeMap(slave, dst);
-                dst.append(offsetMapMb);
-            }
-            else
-            {
-                CSlavePartMapping::serializeNullMap(dst);
-                CSlavePartMapping::serializeNullOffsetMap(dst);
-            }
+            dataFileMapping->serializeMap(slave, dst);
+            dst.append(offsetMapMb);
+        }
+        else
+        {
+            CSlavePartMapping::serializeNullMap(dst);
+            CSlavePartMapping::serializeNullOffsetMap(dst);
         }
     }
     virtual void deserializeStats(unsigned node, MemoryBuffer &mb)
@@ -283,20 +285,6 @@ public:
             attr.append(progressLabels.item(p));
             edge->setPropInt64(attr.str(), progress.queryTotal());
         }
-    }
-    virtual void kill()
-    {
-        CMasterActivity::kill();
-        indexFile.clear();
-        dataFile.clear();
-    }
-    virtual void done()
-    {
-        CMasterActivity::done();
-        if (indexFile)
-            indexFile->setAccessed();
-        if (dataFile)
-            dataFile->setAccessed();
     }
 };
 

--- a/thorlcr/activities/keypatch/thkeypatch.cpp
+++ b/thorlcr/activities/keypatch/thkeypatch.cpp
@@ -42,6 +42,7 @@ public:
     }
     virtual void init()
     {
+        CMasterActivity::init();
         helper = (IHThorKeyPatchArg *)queryHelper();
 
         OwnedRoxieString originalName(helper->getOriginalName());
@@ -54,8 +55,8 @@ public:
         if (originalIndexFile->querySuperFile() || patchFile->querySuperFile())
             throw MakeActivityException(this, 0, "Patching super files not supported");
         
-        queryThorFileManager().noteFileRead(container.queryJob(), originalIndexFile);
-        queryThorFileManager().noteFileRead(container.queryJob(), patchFile);
+        addReadFile(originalIndexFile);
+        addReadFile(patchFile);
 
         width = originalIndexFile->numParts();
 
@@ -164,8 +165,7 @@ public:
 
         container.queryTempHandler()->registerFile(outputName, container.queryOwner().queryGraphId(), 0, false, WUFileStandard, &clusters);
         queryThorFileManager().publish(container.queryJob(), outputName, false, *newIndexDesc);
-        originalIndexFile->setAccessed();
-        patchFile->setAccessed();
+        CMasterActivity::done();
     }
     void preStart(size32_t parentExtractSz, const byte *parentExtract)
     {

--- a/thorlcr/activities/merge/thmerge.cpp
+++ b/thorlcr/activities/merge/thmerge.cpp
@@ -44,15 +44,16 @@ public:
     GlobalMergeActivityMaster(CMasterGraphElement *info) : CMasterActivity(info)
     {
     }
-    void init()
+    virtual void init()
     {
+        CMasterActivity::init();
         replyTag = createReplyTag();
     }
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         dst.append(replyTag);
     }
-    void process()
+    virtual void process()
     {
         ActPrintLog("GlobalMergeActivityMaster::process");
         CMasterActivity::process();     
@@ -118,8 +119,7 @@ public:
         delete [] intertags;
         ActPrintLog("GlobalMergeActivityMaster::process exit");
     }
-
-    void abort()
+    virtual void abort()
     {
         CMasterActivity::abort();
         cancelReceiveMsg(RANK_ALL, replyTag);
@@ -134,5 +134,3 @@ CActivityBase *createMergeActivityMaster(CMasterGraphElement *container)
     else
         return new GlobalMergeActivityMaster(container);
 }
-
-

--- a/thorlcr/activities/msort/thmsort.cpp
+++ b/thorlcr/activities/msort/thmsort.cpp
@@ -39,6 +39,7 @@ public:
 
     virtual void init()
     {
+        CMasterActivity::init();
         IHThorSortArg *helper = (IHThorSortArg *)queryHelper();
         IHThorAlgorithm *algo = static_cast<IHThorAlgorithm *>(helper->selectInterface(TAIalgorithm_1));
         OwnedRoxieString algoname = algo->getAlgorithm();
@@ -56,8 +57,8 @@ class CMSortActivityMaster : public CMasterActivity
     IThorSorterMaster *imaster;
     mptag_t mpTagRPC, barrierMpTag;
     Owned<IBarrier> barrier;
-    Owned<IDistributedFile> coSortFile;
-    
+    StringBuffer cosortfilenames;
+
 public:
     CMSortActivityMaster(CMasterGraphElement *info)
       : CMasterActivity(info)
@@ -66,7 +67,6 @@ public:
         barrierMpTag = container.queryJob().allocateMPTag();
         barrier.setown(container.queryJob().createBarrier(barrierMpTag));
     }
-
     ~CMSortActivityMaster()
     {
         container.queryJob().freeMPTag(mpTagRPC);
@@ -76,6 +76,7 @@ public:
 protected:
     virtual void init()
     {
+        CMasterActivity::init();
         IHThorSortArg *helper = (IHThorSortArg *)queryHelper();
         IHThorAlgorithm *algo = static_cast<IHThorAlgorithm *>(helper->selectInterface(TAIalgorithm_1));
         OwnedRoxieString algoname(algo->getAlgorithm());
@@ -84,6 +85,23 @@ protected:
         {
             Owned<IException> e = MakeActivityException(this, 0, "Ignoring, unsupported sort order algorithm '%s'", algoname.get());
             reportExceptionToWorkunit(container.queryJob().queryWorkUnit(), e);
+        }
+        OwnedRoxieString cosortlogname(helper->getSortedFilename());
+        if (cosortlogname&&*cosortlogname)
+        {
+            Owned<IDistributedFile> coSortFile = queryThorFileManager().lookup(container.queryJob(), cosortlogname);
+            addReadFile(coSortFile);
+            Owned<IFileDescriptor> fileDesc = coSortFile->getFileDescriptor();
+            unsigned o;
+            for (o=0; o<fileDesc->numParts(); o++)
+            {
+                Owned<IPartDescriptor> partDesc = fileDesc->getPart(o);
+                if (cosortfilenames.length())
+                    cosortfilenames.append("|");
+
+                // JCSMORE - picking the primary here, means no automatic use of backup copy, could use RMF's possibly.
+                getPartFilename(*partDesc, 0, cosortfilenames);
+            }
         }
     }
     virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
@@ -136,24 +154,6 @@ protected:
             if (!skewThreshold)
                 skewThreshold = container.queryJob().getWorkUnitValueInt("defaultSkewThreshold", 0);
         }
-        StringBuffer cosortfilenames;
-        OwnedRoxieString cosortlogname(helper->getSortedFilename());
-        if (cosortlogname&&*cosortlogname)
-        {
-            coSortFile.setown(queryThorFileManager().lookup(container.queryJob(), cosortlogname));
-            Owned<IFileDescriptor> fileDesc = coSortFile->getFileDescriptor();
-            queryThorFileManager().noteFileRead(container.queryJob(), coSortFile);
-            unsigned o;
-            for (o=0; o<fileDesc->numParts(); o++)
-            {
-                Owned<IPartDescriptor> partDesc = fileDesc->getPart(o);
-                if (cosortfilenames.length())
-                    cosortfilenames.append("|");
-
-                // JCSMORE - picking the primary here, means no automatic use of backup copy, could use RMF's possibly.
-                getPartFilename(*partDesc, 0, cosortfilenames);
-            }
-        }
 
         Owned<IRowInterfaces> rowif = createRowInterfaces(container.queryInput(0)->queryHelper()->queryOutputMeta(),queryActivityId(),queryCodeContext());
         Owned<IRowInterfaces> auxrowif = createRowInterfaces(helper->querySortedRecordSize(),queryActivityId(),queryCodeContext());
@@ -190,14 +190,6 @@ protected:
         }
         ::Release(imaster);
         ActPrintLog("process exit");
-    }
-    virtual void done()
-    {
-        ActPrintLog("done");
-        CMasterActivity::done();
-        if (coSortFile)
-            coSortFile->setAccessed();
-        ActPrintLog("done exit");
     }
 };
 

--- a/thorlcr/activities/pipewrite/thpipewrite.cpp
+++ b/thorlcr/activities/pipewrite/thpipewrite.cpp
@@ -34,6 +34,7 @@ public:
     }
     virtual void done()
     {
+        CMasterActivity::done();
         IHThorPipeWriteArg *helper = (IHThorPipeWriteArg *)queryHelper();
         Owned<IWUResult> r;
         Owned<IWorkUnit> wu = &container.queryJob().queryWorkUnit().lock();

--- a/thorlcr/activities/result/thresult.cpp
+++ b/thorlcr/activities/result/thresult.cpp
@@ -34,6 +34,7 @@ public:
     CResultActivityMaster(CMasterGraphElement *info) : CMasterActivity(info) { }
     virtual void init()
     {
+        CMasterActivity::init();
         replyTag = createReplyTag();
     }
     virtual void abort()

--- a/thorlcr/activities/spill/thspill.cpp
+++ b/thorlcr/activities/spill/thspill.cpp
@@ -32,8 +32,9 @@ public:
     {
         recordsProcessed = 0;
     }
-    void init()
+    virtual void init()
     {
+        CMasterActivity::init();
         IHThorSpillArg *helper = (IHThorSpillArg *)queryHelper();
         IArrayOf<IGroup> groups;
         OwnedRoxieString fname(helper->getFileName());
@@ -64,15 +65,16 @@ public:
             queryThorFileManager().publish(container.queryJob(), fname, true, *fileDesc);
         }
     }
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         IHThorSpillArg *helper = (IHThorSpillArg *)queryHelper();
         IPartDescriptor *partDesc = fileDesc->queryPart(slave);
         partDesc->serialize(dst);
         dst.append(helper->getTempUsageCount());
     }
-    void done()
+    virtual void done()
     {
+        CMasterActivity::done();
         if (!container.queryOwner().queryOwner() || container.queryOwner().isGlobal()) // I am in a child query
         {
             IHThorSpillArg *helper = (IHThorSpillArg *)queryHelper();
@@ -81,7 +83,7 @@ public:
             queryThorFileManager().publish(container.queryJob(), fname, true, *fileDesc);
         }
     }
-    void slaveDone(size32_t slaveIdx, MemoryBuffer &mb)
+    virtual void slaveDone(size32_t slaveIdx, MemoryBuffer &mb)
     {
         if (mb.length()) // if 0 implies aborted out from this slave.
         {

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -37,10 +37,11 @@ CDiskReadMasterBase::CDiskReadMasterBase(CMasterGraphElement *info) : CMasterAct
 
 void CDiskReadMasterBase::init()
 {
+    CMasterActivity::init();
     IHThorDiskReadBaseArg *helper = (IHThorDiskReadBaseArg *) queryHelper();
     fileName.setown(helper->getFileName());
-    file.setown(queryThorFileManager().lookup(container.queryJob(), fileName, 0 != ((TDXtemporary|TDXjobtemp) & helper->getFlags()), 0 != (TDRoptional & helper->getFlags()), true));
 
+    Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), fileName, 0 != ((TDXtemporary|TDXjobtemp) & helper->getFlags()), 0 != (TDRoptional & helper->getFlags()), true);
     if (file)
     {
         if (file->numParts() > 1)
@@ -50,15 +51,14 @@ void CDiskReadMasterBase::init()
         reInit = 0 != (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename));
         if (container.queryLocal() || helper->canMatchAny()) // if local, assume may match
         {
+            bool temp = 0 != (TDXtemporary & helper->getFlags());
             bool local;
-            if (0 == (TDXtemporary & helper->getFlags())) // don't add temp files
-            {
-                queryThorFileManager().noteFileRead(container.queryJob(), file);
-                local = container.queryLocal();
-            }
-            else
+            if (temp)
                 local = false;
+            else
+                local = container.queryLocal();
             mapping.setown(getFileSlaveMaps(file->queryLogicalName(), *fileDesc, container.queryJob().queryUserDescriptor(), container.queryJob().querySlaveGroup(), local, false, hash, file->querySuperFile()));
+            addReadFile(file, temp);
         }
         if (0 != (helper->getFlags() & TDRfilenamecallback)) // only get/serialize if using virtual file name fields
         {
@@ -74,7 +74,7 @@ void CDiskReadMasterBase::init()
                 }
             }
         }
-        validateFile();
+        validateFile(file);
         void *ekey;
         size32_t ekeylen;
         helper->getEncryptKey(ekeylen,ekey);
@@ -108,17 +108,6 @@ void CDiskReadMasterBase::serializeSlaveData(MemoryBuffer &dst, unsigned slave)
         mapping->serializeMap(slave, dst);
     else
         CSlavePartMapping::serializeNullMap(dst);
-}
-
-void CDiskReadMasterBase::done()
-{
-    IHThorDiskReadBaseArg *helper = (IHThorDiskReadBaseArg *) queryHelper();
-    fileDesc.clear();
-    if (!abortSoon) // in case query has relinquished control of file usage to another query (e.g. perists)
-    {
-        if (file)
-            file->setAccessed();
-    }
 }
 
 void CDiskReadMasterBase::deserializeStats(unsigned node, MemoryBuffer &mb)
@@ -309,6 +298,7 @@ void CWriteMasterBase::serializeSlaveData(MemoryBuffer &dst, unsigned slave)
 
 void CWriteMasterBase::done()
 {
+    CMasterActivity::done();
     publish();
     if (TAKdiskwrite == container.getKind() && (0 != (diskHelperBase->getFlags() & TDXtemporary)) && container.queryOwner().queryOwner()) // I am in a child query
     {

--- a/thorlcr/activities/thdiskbase.ipp
+++ b/thorlcr/activities/thdiskbase.ipp
@@ -33,14 +33,12 @@ protected:
     IHash *hash;
     Owned<ProgressInfo> inputProgress;
     OwnedRoxieString fileName;
-    Owned<IDistributedFile> file;
 
 public:
     CDiskReadMasterBase(CMasterGraphElement *info);
-    void init();
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave);
-    void done();
-    virtual void validateFile() { }
+    virtual void init();
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave);
+    virtual void validateFile(IDistributedFile *file) { }
     void deserializeStats(unsigned node, MemoryBuffer &mb);
     void getXGMML(unsigned idx, IPropertyTree *edge);
 };

--- a/thorlcr/activities/topn/thtopn.cpp
+++ b/thorlcr/activities/topn/thtopn.cpp
@@ -34,8 +34,10 @@ public:
     {
         if (sD) delete [] sD;
     }
-    void init()
+    virtual void init()
     {
+        CMasterActivity::init();
+
         // prepare topology.
 
         unsigned rootNodes = container.queryJob().querySlaves();
@@ -94,7 +96,7 @@ public:
             nextLevel->kill();
         }
     }
-    void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
+    virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         serializeMPtag(dst, mpTag);
         dst.append(sD[slave].length());

--- a/thorlcr/activities/wuidwrite/thwuidwrite.cpp
+++ b/thorlcr/activities/wuidwrite/thwuidwrite.cpp
@@ -49,8 +49,9 @@ public:
         workunitWriteLimit = 0;
         mpTag = container.queryJob().allocateMPTag(); // used by local too
     }
-    void init()
+    virtual void init()
     {
+        CMasterActivity::init();
         workunitWriteLimit = getOptInt(THOROPT_OUTPUTLIMIT, DEFAULT_WUIDWRITE_LIMIT);
         if (workunitWriteLimit>DALI_RESULT_OUTPUTMAX)
             throw MakeActivityException(this, 0, "Dali result outputs are restricted to a maximum of %d MB, the default limit is %d MB. A huge dali result usually indicates the ECL needs altering.", DALI_RESULT_OUTPUTMAX, DEFAULT_WUIDWRITE_LIMIT);
@@ -153,7 +154,7 @@ public:
         resultName.set(helper->queryName());
         resultSeq = helper->getSequence();
     }
-    void init()
+    virtual void init()
     {
         CWorkUnitWriteGlobalMasterBase::init();
         if (appendOutput)

--- a/thorlcr/activities/xmlwrite/thxmlwrite.cpp
+++ b/thorlcr/activities/xmlwrite/thxmlwrite.cpp
@@ -33,10 +33,10 @@ public:
     {
         helper = (IHThorXmlWriteArg *)queryHelper();
     }
-    void init()
+    virtual void init()
     {
-        assertex(!(helper->getFlags() & TDWextend));
         CWriteMasterBase::init();
+        assertex(!(helper->getFlags() & TDWextend));
 
         IPropertyTree &props = fileDesc->queryProperties();
         StringBuffer rowTag;

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -237,12 +237,15 @@ class graphmaster_decl CMasterActivity : public CActivityBase, implements IThrea
     bool asyncStart;
     MemoryBuffer *data;
     CriticalSection progressCrit;
+    IArrayOf<IDistributedFile> readFiles;
 
 protected:
     ProgressInfoArray progressInfo;
     CTimingInfo timingInfo;
     IBitSet *notedWarnings;
 
+    void addReadFile(IDistributedFile *file, bool temp=false);
+    IDistributedFile *queryReadFile(unsigned f);
     virtual void process() { }
 public:
     IMPLEMENT_IINTERFACE;
@@ -253,7 +256,7 @@ public:
     virtual void deserializeStats(unsigned node, MemoryBuffer &mb);
     virtual void getXGMML(unsigned idx, IPropertyTree *edge);
     virtual void getXGMML(IWUGraphProgress *progress, IPropertyTree *node);
-    virtual void init() { }
+    virtual void init();
     virtual void handleSlaveMessage(CMessageBuffer &msg) { }
     virtual void reset();
     virtual MemoryBuffer &queryInitializationData(unsigned slave) const;
@@ -263,8 +266,11 @@ public:
     virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave) { }
     virtual void slaveDone(size32_t slaveIdx, MemoryBuffer &mb) { }
 
+    virtual void preStart(size32_t parentExtractSz, const byte *parentExtract);
     virtual void startProcess(bool async=true);
     virtual bool wait(unsigned timeout);
+    virtual void done();
+    virtual void kill();
 
 // IExceptionHandler
     virtual bool fireException(IException *e);


### PR DESCRIPTION
Ensure that any activity that lookups a file, holds the locks to
the subfiles and releases the lock to the super. This allows
other jobs/components to manipulate the super, once the job has
established which files it needs.
Hold list of distributed files used by activity in base class
and convert any supers to list of subs just before query starts.

This commit also contains some tyding up:
- making virtual declarations more consistent
- common up the setAccessed calls
- remove a few redundant method definitions

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
