### PR TITLE
HPCC-10744 Treat debug option values as compile time constants

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -1637,7 +1637,6 @@ bool checkConstant(node_operator op)
     case no_xmlencode:
     case no_sortpartition:
     case no_clustersize:
-    case no_debug_option_value:
         return false;
     }
     return true;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
