### PR TITLE
HPCC-10764 Regression suite run stalls on some query failues, e.g. codegen  issues

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -397,14 +397,19 @@ class Regression:
                                   username=self.config.username,
                                   password=self.config.password)
             wuid = query.getWuid()
+            logging.debug("res: '%s', wuid:'%s'"  % ( res,  wuid))
         else:
             res = False
             report[0].addResult(query)
+            wuid="N/A"
 
-        if wuid:
+        if wuid and wuid.startswith("W"):
             url = "http://" + self.config.server
             url += "/WsWorkunits/WUInfo?Wuid="
             url += wuid
+        else:
+            url = "N/A"
+            res = False
 
         self.loggermutex.acquire()
         elapsTime = time.time()-startTime
@@ -412,7 +417,7 @@ class Regression:
             logging.info("%3d. Pass %s (%d sec)" % (cnt, wuid,  elapsTime))
             logging.info("%3d. URL %s" % (cnt,url))
         else:
-            if not wuid:
+            if not wuid or not wuid.startswith("W"):
                 logging.error("%3d. Fail No WUID (%d sec)" % (cnt,  elapsTime))
             else:
                 logging.error("%3d. Fail %s (%d sec)" % (cnt, wuid,  elapsTime))

--- a/testing/regress/hpcc/util/ecl/cc.py
+++ b/testing/regress/hpcc/util/ecl/cc.py
@@ -37,6 +37,7 @@ class ECLCC(Shell):
         try:
             return self.__ECLCC()('-E', file)
         except Error as err:
+            logging.debug("getArchive exception:'%s'",  repr(err))
             self.makeArchiveError = str(err)
             return repr(err)
 

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -61,7 +61,7 @@ class ECLcmd(Shell):
             args.append("--name=" + name)
             args.append(eclfile.getArchive())
         data = ""
-        wuid = ""
+        wuid = "N/A"
         state = ""
         try:
             #print "runCmd:", args
@@ -73,6 +73,7 @@ class ECLcmd(Shell):
             cnt = 0
             for i in ret:
                 if "wuid:" in i:
+                    logging.debug("------ runCmd:" + repr(i) + "------")
                     wuid = i.split()[1]
                 if "state:" in i:
                     state = i.split()[1]
@@ -89,6 +90,9 @@ class ECLcmd(Shell):
             logging.error("------" + err + "------")
             return err + "\n"
         finally:
+            if wuid ==  'N/A':
+                wuid = queryWuid(eclfile.getJobname(), eclfile.getTaskId())['wuid']
+
             eclfile.addResults(data, wuid)
             if cmd == 'publish':
                 if state == 'compiled':

--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     description = 'HPCC Platform Regression suite'
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('--version', '-v', action='version',
-                        version='%(prog)s 0.0.9')
+                        version='%(prog)s 0.0.10')
     parser.add_argument('--config', help="config file to use. Default: regress.json",
                         nargs='?', default="regress.json")
     parser.add_argument('--loglevel', help="set the log level. Use debug for more detailed logfile.",


### PR DESCRIPTION
Add checking to avoid run stall on some query failures code gen issues.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
