### PR TITLE
HPCC-10646 Warning: case label value is less than minimum value for type

### DIFF
--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -150,7 +150,7 @@ void *Thread::_threadmain(void *v)
 }
 
 // JCSMORE - should have a setPriority(), unsupported under _WIN32
-void Thread::adjustPriority(char delta)
+void Thread::adjustPriority(int delta)
 {
     if (delta < -2)
         prioritydelta = -2;
@@ -229,7 +229,7 @@ bool Thread::isCurrentThread() const
 }
 
 // _nicelevel ranges from -20 to 19, the higher the nice level, the less cpu time the thread will get.
-void Thread::setNice(char _nicelevel)
+void Thread::setNice(int _nicelevel)
 {
     if (_nicelevel < -20 || _nicelevel > 19)
         throw MakeStringException(0, "nice level should be between -20 and 19");

--- a/system/jlib/jthread.hpp
+++ b/system/jlib/jthread.hpp
@@ -67,8 +67,8 @@ class jlib_decl Thread : public CInterface, public IThread
 private:
     ThreadId threadid;
     unsigned short stacksize; // in 4K blocks
-    char prioritydelta;
-    char nicelevel;
+    int prioritydelta;
+    int nicelevel;
 
     bool alive;
     unsigned tidlog;
@@ -103,9 +103,9 @@ public:
     Thread() { init(NULL); }
     ~Thread();
 
-    void adjustPriority(char delta);
+    void adjustPriority(int delta);
     bool isCurrentThread() const;
-    void setNice(char nicelevel);
+    void setNice(int nicelevel);
     void setStackSize(size32_t size);               // required stack size in bytes - called before start() (obviously)
     const char *getName() { const char *ret = ithreadname?ithreadname->get():NULL; return ret?ret:"unknown"; }
     bool isAlive() { return alive; }


### PR DESCRIPTION
Change Thread class char (implicit used as TinyInt) type datamembers to int.
Change related functions parameter from char to int.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
