### PR TITLE
HPCC-10753 Regression suite should default pickBestEngine=false for all queries

### DIFF
--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -37,6 +37,8 @@ class ECLcmd(Shell):
         args.append(cmd)
         args.append('-v')
         args.append('--cluster=' + cluster)
+        args.append('-fpickBestEngine=false')
+        args.append('--target=' + cluster)
 
         username = kwargs.pop('username', False)
         if username:

--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -31,7 +31,7 @@ from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
 
-prog_version = "0.0.10"
+prog_version = "0.0.11"
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Add this parameter to all queries

Signed-off-by: Attila Vamos attila.vamos@gmail.com
