### PR TITLE
HPCC-10784 Keyed limits on stepped indexreads can be miscalculated

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -3490,7 +3490,7 @@ public:
                 resent = false;
                 {
                     TransformCallbackAssociation associate(callback, tlk); // want to destroy this before we advance to next key...
-                    while (!aborted && rawSeek ? tlk->lookupSkip(rawSeek, steppingOffset, steppingLength) : tlk->lookup(true))
+                    while (!aborted && (rawSeek ? tlk->lookupSkip(rawSeek, steppingOffset, steppingLength) : tlk->lookup(true)))
                     {
                         rawSeek = NULL;  // only want to do the seek first time we look for a particular seek value
                         keyprocessed++;
@@ -3520,6 +3520,7 @@ public:
                             if (diff < 0)
                             {
                                 rawSeek = steppingRow;
+                                keyProcessed--;
                                 break;
                             }
                         }

--- a/tools/dumpkey/dumpkey.cpp
+++ b/tools/dumpkey/dumpkey.cpp
@@ -69,6 +69,7 @@ void doOption(const char *opt)
 
 int main(int argc, const char **argv)
 {
+    InitModuleObjects();
 #ifdef _WIN32
     _setmode( _fileno( stdout ), _O_BINARY );
     _setmode( _fileno( stdin ), _O_BINARY );


### PR DESCRIPTION
Overcounting in stepped mode as some seeks don't result in a hit.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
