### PR TITLE
HPCC-10749 Search WU/Query with non-existence of property/attr

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2322,11 +2322,7 @@ public:
                 : xPath(_xPath), sortOrder(_sortOrder), nameFilterLo(_nameFilterLo), nameFilterHi(_nameFilterHi)
             {
                 ForEachItemIn(x, _unknownAttributes)
-                {
-                    const char* attr = _unknownAttributes.item(x);
-                    if (attr && *attr)
-                        unknownAttributes.append(attr);
-                }
+                    unknownAttributes.append(_unknownAttributes.item(x));
             }
             virtual IRemoteConnection* getElements(IArrayOf<IPropertyTree> &elements)
             {
@@ -2464,7 +2460,7 @@ public:
             StringAttr querySet;
             StringAttr xPath;
             StringAttr sortOrder;
-            PostFilters& postFilters;
+            PostFilters postFilters;
             StringArray unknownAttributes;
 
             void populateQueryTree(IPropertyTree* queryRegistry, const char* querySetId, IPropertyTree* querySetTree, const char *xPath, IPropertyTree* queryTree)
@@ -2530,14 +2526,12 @@ public:
             IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
             CQuerySetQueriesPager(const char* _querySet, const char* _xPath, const char *_sortOrder, PostFilters& _postFilters, StringArray& _unknownAttributes)
-                : querySet(_querySet), xPath(_xPath), sortOrder(_sortOrder), postFilters(_postFilters), unknownAttributes(_unknownAttributes)
+                : querySet(_querySet), xPath(_xPath), sortOrder(_sortOrder)
             {
+                postFilters.activatedFilter = _postFilters.activatedFilter;
+                postFilters.suspendedByUserFilter = _postFilters.suspendedByUserFilter;
                 ForEachItemIn(x, _unknownAttributes)
-                {
-                    const char* attr = _unknownAttributes.item(x);
-                    if (attr && *attr)
-                        unknownAttributes.append(attr);
-                }
+                    unknownAttributes.append(_unknownAttributes.item(x));
             }
             virtual IRemoteConnection* getElements(IArrayOf<IPropertyTree> &elements)
             {

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2313,14 +2313,20 @@ public:
             StringAttr sortOrder;
             StringAttr nameFilterLo;
             StringAttr nameFilterHi;
-            StringArray& unknownAttributes;
+            StringArray unknownAttributes;
 
         public:
             IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
             CWorkUnitsPager(const char* _xPath, const char *_sortOrder, const char* _nameFilterLo, const char* _nameFilterHi, StringArray& _unknownAttributes)
-                : xPath(_xPath), sortOrder(_sortOrder), nameFilterLo(_nameFilterLo), nameFilterHi(_nameFilterHi), unknownAttributes(_unknownAttributes)
+                : xPath(_xPath), sortOrder(_sortOrder), nameFilterLo(_nameFilterLo), nameFilterHi(_nameFilterHi)
             {
+                ForEachItemIn(x, _unknownAttributes)
+                {
+                    const char* attr = _unknownAttributes.item(x);
+                    if (attr && *attr)
+                        unknownAttributes.append(attr);
+                }
             }
             virtual IRemoteConnection* getElements(IArrayOf<IPropertyTree> &elements)
             {
@@ -2459,7 +2465,7 @@ public:
             StringAttr xPath;
             StringAttr sortOrder;
             PostFilters& postFilters;
-            StringArray& unknownAttributes;
+            StringArray unknownAttributes;
 
             void populateQueryTree(IPropertyTree* queryRegistry, const char* querySetId, IPropertyTree* querySetTree, const char *xPath, IPropertyTree* queryTree)
             {
@@ -2526,6 +2532,12 @@ public:
             CQuerySetQueriesPager(const char* _querySet, const char* _xPath, const char *_sortOrder, PostFilters& _postFilters, StringArray& _unknownAttributes)
                 : querySet(_querySet), xPath(_xPath), sortOrder(_sortOrder), postFilters(_postFilters), unknownAttributes(_unknownAttributes)
             {
+                ForEachItemIn(x, _unknownAttributes)
+                {
+                    const char* attr = _unknownAttributes.item(x);
+                    if (attr && *attr)
+                        unknownAttributes.append(attr);
+                }
             }
             virtual IRemoteConnection* getElements(IArrayOf<IPropertyTree> &elements)
             {

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2313,12 +2313,13 @@ public:
             StringAttr sortOrder;
             StringAttr nameFilterLo;
             StringAttr nameFilterHi;
+            StringArray& unknownAttributes;
 
         public:
             IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-            CWorkUnitsPager(const char* _xPath, const char *_sortOrder, const char* _nameFilterLo, const char* _nameFilterHi)
-                : xPath(_xPath), sortOrder(_sortOrder), nameFilterLo(_nameFilterLo), nameFilterHi(_nameFilterHi)
+            CWorkUnitsPager(const char* _xPath, const char *_sortOrder, const char* _nameFilterLo, const char* _nameFilterHi, StringArray& _unknownAttributes)
+                : xPath(_xPath), sortOrder(_sortOrder), nameFilterLo(_nameFilterLo), nameFilterHi(_nameFilterHi), unknownAttributes(_unknownAttributes)
             {
             }
             virtual IRemoteConnection* getElements(IArrayOf<IPropertyTree> &elements)
@@ -2329,7 +2330,7 @@ public:
                 Owned<IPropertyTreeIterator> iter = conn->getElements(xPath);
                 if (!iter)
                     return NULL;
-                sortElements(iter, sortOrder.get(), nameFilterLo.get(), nameFilterHi.get(), elements);
+                sortElements(iter, sortOrder.get(), nameFilterLo.get(), nameFilterHi.get(), unknownAttributes, elements);
                 return conn.getClear();
             }
         };
@@ -2374,6 +2375,7 @@ public:
         StringAttr namefilter("*");
         StringAttr namefilterlo;
         StringAttr namefilterhi;
+        StringArray unknownAttributes;
         if (filters) {
             const char *fv = (const char *)filterbuf;
             for (unsigned i=0;filters[i]!=WUSFterm;i++) {
@@ -2385,6 +2387,8 @@ public:
                     namefilterhi.set(fv);
                 else if (subfmt==WUSFwildwuid)
                     namefilter.set(fv);
+                else if (!fv || !*fv)
+                    unknownAttributes.append(getEnumText(subfmt,workunitSortFields));
                 else {
                     query.append('[').append(getEnumText(subfmt,workunitSortFields)).append('=');
                     if (fmt&WUSFnocase)
@@ -2412,7 +2416,7 @@ public:
             }
         }
         IArrayOf<IPropertyTree> results;
-        Owned<IElementsPager> elementsPager = new CWorkUnitsPager(query.str(), so.length()?so.str():NULL, namefilterlo.get(), namefilterhi.get());
+        Owned<IElementsPager> elementsPager = new CWorkUnitsPager(query.str(), so.length()?so.str():NULL, namefilterlo.get(), namefilterhi.get(), unknownAttributes);
         Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,secmgr?sc:NULL,queryowner,cachehint,results,total);
         return new CConstWUArrayIterator(conn, results, secmgr, secuser);
     }
@@ -2455,6 +2459,7 @@ public:
             StringAttr xPath;
             StringAttr sortOrder;
             PostFilters& postFilters;
+            StringArray& unknownAttributes;
 
             void populateQueryTree(IPropertyTree* queryRegistry, const char* querySetId, IPropertyTree* querySetTree, const char *xPath, IPropertyTree* queryTree)
             {
@@ -2518,8 +2523,8 @@ public:
         public:
             IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-            CQuerySetQueriesPager(const char* _querySet, const char* _xPath, const char *_sortOrder, PostFilters& _postFilters)
-                : querySet(_querySet), xPath(_xPath), sortOrder(_sortOrder), postFilters(_postFilters)
+            CQuerySetQueriesPager(const char* _querySet, const char* _xPath, const char *_sortOrder, PostFilters& _postFilters, StringArray& _unknownAttributes)
+                : querySet(_querySet), xPath(_xPath), sortOrder(_sortOrder), postFilters(_postFilters), unknownAttributes(_unknownAttributes)
             {
             }
             virtual IRemoteConnection* getElements(IArrayOf<IPropertyTree> &elements)
@@ -2533,13 +2538,14 @@ public:
                 Owned<IPropertyTreeIterator> iter = elementTree->getElements("*");
                 if (!iter)
                     return NULL;
-                sortElements(iter, sortOrder.get(), NULL, NULL, elements);
+                sortElements(iter, sortOrder.get(), NULL, NULL, unknownAttributes, elements);
                 return conn.getClear();
             }
         };
         StringAttr querySet;
         StringBuffer xPath;
         StringBuffer so;
+        StringArray unknownAttributes;
         if (filters)
         {
             const char *fv = (const char *)filterbuf;
@@ -2556,6 +2562,8 @@ public:
                     postFilters.activatedFilter = (WUQueryFilterBoolean) atoi(fv);
                 else if (subfmt==WUQSFSuspendedByUser)
                     postFilters.suspendedByUserFilter = (WUQueryFilterBoolean) atoi(fv);
+                else if (!fv || !*fv)
+                    unknownAttributes.append(getEnumText(subfmt,querySortFields));
                 else {
                     xPath.append('[').append(getEnumText(subfmt,querySortFields)).append('=');
                     if (fmt&WUQSFnocase)
@@ -2584,7 +2592,7 @@ public:
             }
         }
         IArrayOf<IPropertyTree> results;
-        Owned<IElementsPager> elementsPager = new CQuerySetQueriesPager(querySet.get(), xPath.str(), so.length()?so.str():NULL, postFilters);
+        Owned<IElementsPager> elementsPager = new CQuerySetQueriesPager(querySet.get(), xPath.str(), so.length()?so.str():NULL, postFilters, unknownAttributes);
         Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,"",cachehint,results,total);
         return new CConstQuerySetQueryIterator(results);
     }

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -1581,8 +1581,7 @@ inline void filteredAdd(IArrayOf<IPropertyTree> &results,const char *namefilterl
         if (namefilterhi&&(strcmp(namefilterhi,n)<0))
             return;
     }
-    ForEachItemIn(i, unknownAttributes)
-    {
+    ForEachItemIn(i, unknownAttributes) {
         const char *attribute = unknownAttributes.item(i);
         if (!attribute || !*attribute)
             continue;
@@ -1729,17 +1728,8 @@ IRemoteConnection *getSortedElements( const char *basexpath,
     Owned<IPropertyTreeIterator> iter = conn->getElements(xpath);
     if (!iter)
         return NULL;
-    if (namefilterlo&&!*namefilterlo)
-        namefilterlo = NULL;
-    if (namefilterhi&&!*namefilterhi)
-        namefilterhi = NULL;
-    StringBuffer nbuf;
-    cSort sort;
-    if (sortorder&&*sortorder)
-        sort.dosort(*iter,sortorder,namefilterlo,namefilterhi,unknownAttributes,results);
-    else
-        ForEach(*iter)
-            filteredAdd(results,namefilterlo,namefilterhi,unknownAttributes,&iter->query());
+
+    sortElements(iter, sortorder, namefilterlo,namefilterhi,unknownAttributes, results);
     return conn.getClear();
 }
 
@@ -1911,9 +1901,11 @@ void sortElements(IPropertyTreeIterator* elementsIter,
         nameFilterLo = NULL;
     if (nameFilterHi&&!*nameFilterHi)
         nameFilterHi = NULL;
-    cSort sort;
     if (sortOrder && *sortOrder)
+    {
+        cSort sort;
         sort.dosort(*elementsIter,sortOrder,nameFilterLo,nameFilterHi,unknownAttributes, sortedElements);
+    }
     else
         ForEach(*elementsIter)
             filteredAdd(sortedElements,nameFilterLo,nameFilterHi,unknownAttributes, &elementsIter->query());

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -263,6 +263,7 @@ IRemoteConnection *getSortedElements( const char *basexpath,
                                      const char *sortorder, 
                                      const char *namefilterlo, // if non null filter less than this value
                                      const char *namefilterhi, // if non null filter greater than this value
+                                     StringArray& unknownAttributes,
                                      IArrayOf<IPropertyTree> &results);
 interface ISortedElementsTreeFilter : extends IInterface
 {
@@ -276,6 +277,7 @@ extern da_decl void sortElements( IPropertyTreeIterator* elementsIter,
                                      const char *sortorder, 
                                      const char *namefilterlo, // if non null filter less than this value
                                      const char *namefilterhi, // if non null filter greater than this value
+                                     StringArray& unknownAttributes, //the attribute not exist or empty
                                      IArrayOf<IPropertyTree> &sortedElements);
 
 extern da_decl IRemoteConnection *getElementsPaged(IElementsPager *elementsPager,


### PR DESCRIPTION
Using the existing code, WUQuery?State=unknown does not return "unknown"
WUs. The "unknown" WUs are WUs which do not have the @state or @state =
"". We do not suport any xpath syntax that allow you to test for the non
-existence of a property or attribute. In this fix, the code is added to
filter ECL WUs (and DFU WU, Query) with non-existence of a property or
attribute.
