### PR TITLE
HPCC-10691 Increase libxslt template stack depth

### DIFF
--- a/system/xmllib/libxslt_processor.cpp
+++ b/system/xmllib/libxslt_processor.cpp
@@ -698,7 +698,7 @@ CLibXslProcessor::CLibXslProcessor()
     xmlSubstituteEntitiesDefault(1);
     xmlThrDefSaveNoEmptyTags(1);
     xmlLoadExtDtdDefaultValue = 1;
-
+    xsltMaxDepth = 20000;
     xsltSetLoaderFunc(NULL);
     originalLibXsltIncludeHandler = xsltDocDefaultLoader;
     xsltSetLoaderFunc(globalLibXsltIncludeHandler);


### PR DESCRIPTION
This only affects distributions that use libxslt rather than xalan-c
for xslt processing.

This somewhat arbitrary check to prevent infinite recursion is set
too low by default for the highly recursive way the tabular result xslt
is currently written.

Increasing the limit should have no effect on stylesheets that do not
currently hit the limit.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
