### PR TITLE
HPCC-10733 Set value for logical file attribute 'ActualSize'

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -80,7 +80,7 @@ ESPStruct DFUFileDetail
     string Dir;
     string PathMask;
     string Filesize;
-    string ActualSize;
+    [depr_ver("1.23")] string ActualSize;
     string RecordSize;
     string RecordCount;
     string Wuid;
@@ -631,7 +631,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.22"), default_client_version("1.22"),
+    version("1.23"), default_client_version("1.23"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -501,13 +501,13 @@ public:
                 fileName.clear().append(resolved->queryPhysicalName());
             resolved.clear();
         }
+        else
+            throw MakeStringException(ROXIE_FILE_ERROR, "Cannot write %s", fileName.str());
+        // filename by now is a local filename
         Owned<IRoxieDaliHelper> daliHelper = connectToDali();
-        bool disconnected = !daliHelper->connected();
-        // MORE - not sure this is really the right test. If there SHOULD be a dali but is's unavailable, we should fail.
-        Owned<ILocalOrDistributedFile> ldFile = createLocalOrDistributedFile(fileName, NULL, disconnected, !disconnected, true);
+        Owned<ILocalOrDistributedFile> ldFile = createLocalOrDistributedFile(fileName, NULL, true, false, true);
         if (!ldFile)
             throw MakeStringException(ROXIE_FILE_ERROR, "Cannot write %s", fileName.str());
-
         return createRoxieWriteHandler(daliHelper, ldFile.getClear(), clusters);
     }
 


### PR DESCRIPTION
The 'ActualSize' is one of logical file attributes which was added
10 years ago. But, its value is never set. It is set by this fix: if the 
file has @compressedSize, set the @compressedSize to be the
'ActualSize'. If not, set @size to be the 'ActualSize'.
