### PR TITLE
HPCC-10794 - Sasha search fails to find some workunits

### DIFF
--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -73,6 +73,8 @@ static void mkDateCompare(bool dfu,const char *dt,StringBuffer &out,char fill)
             else
                 out.append(fill);
         out.append('-');
+        if (dt[i]) // skip '-'
+            i++;
         while (dt[i]||(out.length()<16))
             if (dt[i])
                 out.append(dt[i++]);


### PR DESCRIPTION
If a workunit search has a pattern which includes a time, Sasha
incorrectly normalizes the date/time format of the workunit,
introducing a spurious '-' and in so doing, fails to find the
workunits being searched for.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
