### PR TITLE
HPCC-10595 Don't display ecl-packagemap-validate success on warnings

### DIFF
--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -779,6 +779,7 @@ public:
         StringArray &unusedFiles = resp->getFiles().getUnmatched();
         if (unusedFiles.ordinality()>0)
         {
+            validateMessages = true;
             fputs("\n   Files without matching package definitions:\n", stderr);
             ForEachItemIn(i, unusedFiles)
                 fprintf(stderr, "      %s\n", unusedFiles.item(i));
@@ -787,6 +788,7 @@ public:
         StringArray &notInDFS = resp->getFiles().getNotInDFS();
         if (notInDFS.ordinality()>0)
         {
+            validateMessages = true;
             fputs("\n   Packagemap SubFiles not found in DFS:\n", stderr);
             ForEachItemIn(i, notInDFS)
                 fprintf(stderr, "      %s\n", notInDFS.item(i));


### PR DESCRIPTION
Other warnings prevent the output of "validation successful" but warnings
about files that are unmapped or not in dfs currently don't prevent that
message.  Make all warnings behave consistently in this regard.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
