### PR TITLE
HPCC-10742 - Ensure in-progress partial output is removed

### DIFF
--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -675,7 +675,11 @@ public:
     ~CWriteHandler()
     {
         primaryio.clear(); // should close
-        if (aborted && *aborted) return;
+        if (aborted && *aborted)
+        {
+            primary->remove(); // i.e. never completed, so remove partial (temp) primary
+            return;
+        }
         if (renameToPrimary)
         {
             OwnedIFile tmpIFile;


### PR DESCRIPTION
If a write output is aborted, the partial file was not being
deleted.
NB: If the process died on the other hand, the CFIPScope did
ensure the partial file was deleted.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
