### PR TITLE
HPCC-10799 FIX potential invalid C++ for EXISTS(a+b)

### DIFF
--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -730,7 +730,7 @@ void HqlCppTranslator::doBuildAssignAggregateLoop(BuildCtx & ctx, const CHqlBoun
                 if (multiPath)
                 {
                     BuildCtx condctx(ctx);
-                    buildFilter(condctx, optimized);
+                    condctx.addFilter(optimized);
                     assignBound(condctx, target, queryBoolExpr(true));
                 }
                 else


### PR DESCRIPTION
Prevent a translated expression from being re-translated

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
