### PR TITLE
HPCC-10801 Update error message to provide hint of workaround

### DIFF
--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -305,6 +305,7 @@
 #define HQLERR_ReadSpillBeforeWrite             4835
 #define HQLERR_DependencyWithinGraph            4836
 #define HQLERR_UnknownCompoundAssign            4837
+#define HQLERR_ReadSpillBeforeWriteFix          4838
 //#define HQLERR_Max                            4999
 
 //---- Text for all errors (make it easy to internationalise) ---------------------------
@@ -575,6 +576,7 @@
 #define HQLERR_ReadSpillBeforeWrite_Text        "INTERNAL: Attempt to read spill file %s before it is written"
 #define HQLERR_DependencyWithinGraph_Text       "INTERNAL: Dependency within a graph incorrectly generated for hThor (%u)"
 #define HQLERR_UnknownCompoundAssign_Text       "INTERNAL: Unrecognised compound assign %s"
+#define HQLERR_ReadSpillBeforeWriteFix_Text     "INTERNAL: Attempt to read spill file %s before it is written.  Try adding #option ('allowThroughSpill', false); to the query."
 
 #define WARNINGAT(e, x)                 reportWarning(e, x, x##_Text)
 #define WARNINGAT1(e, x, a)             reportWarning(e, x, x##_Text, a)

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -1961,7 +1961,10 @@ ABoundActivity * SourceBuilder::buildActivity(BuildCtx & ctx, IHqlExpression * e
         {
             StringBuffer spillName;
             getExprECL(nameExpr, spillName);
-            throwError1(HQLERR_ReadSpillBeforeWrite, spillName.str());
+            if (translator.queryOptions().allowThroughSpill)
+                throwError1(HQLERR_ReadSpillBeforeWriteFix, spillName.str());
+            else
+                throwError1(HQLERR_ReadSpillBeforeWrite, spillName.str());
         }
         translator.addFilenameConstructorParameter(*instance, "getFileName", nameExpr);
     }
@@ -2629,7 +2632,10 @@ void DiskReadBuilderBase::buildMembers(IHqlExpression * expr)
     {
         StringBuffer spillName;
         getExprECL(tableExpr->queryChild(0), spillName);
-        throwError1(HQLERR_ReadSpillBeforeWrite, spillName.str());
+        if (translator.queryOptions().allowThroughSpill)
+            throwError1(HQLERR_ReadSpillBeforeWriteFix, spillName.str());
+        else
+            throwError1(HQLERR_ReadSpillBeforeWrite, spillName.str());
     }
 
 


### PR DESCRIPTION
The issue is fixed in 5.0 by always disabling this option.  To minimize
potential changes, the error message is updated in this point release.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
