### PR TITLE
HPCC-10801 Don't generate through spills for roxie or thor

### DIFF
--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -1872,7 +1872,7 @@ EclResourcer::EclResourcer(IErrorReceiver * _errors, IConstWorkUnit * _wu, Clust
     options.isChildQuery = false;
     options.targetClusterType = targetClusterType;
     options.filteredSpillThreshold = _translatorOptions.filteredReadSpillThreshold;
-    options.allowThroughSpill = _translatorOptions.allowThroughSpill;
+    options.allowThroughSpill = (targetClusterType != RoxieCluster) && (targetClusterType != ThorLCRCluster) && _translatorOptions.allowThroughSpill;
     options.allowThroughResult = (targetClusterType != RoxieCluster) && (targetClusterType != ThorLCRCluster);
     options.cloneFilteredIndex = (targetClusterType != RoxieCluster);
     options.spillSharedConditionals = (targetClusterType == RoxieCluster);


### PR DESCRIPTION
Note they are generally never created for thor anyway if the option to
project spill files is enabled.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
