### PR TITLE
HPCC-10798 Fix publishing query not adding cluster to local files

### DIFF
--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -343,8 +343,6 @@ void ReferencedFile::cloneInfo(IDFUhelper *helper, IUserDescriptor *user, const 
         return;
     if (!(flags & (RefFileRemote | RefFileForeign | RefFileNotOnCluster)))
         return;
-    if (!daliip.length())
-        return;
     if (fileSrcCluster.length())
         srcCluster = fileSrcCluster;
 


### PR DESCRIPTION
A regression in 4.2.2.  Remove overzealous parameter check added by
HPCC-10610 to ReferencedFile::cloneInfo.  If the file was not
associated with a remote dali, the destination cluster was no
longer added.

Signed-off-by: Tony anthony.fishbeck@lexisnexis.com
