### PR TITLE
HPCC-10698 - Avoid deadlock if retrying lock on superfiles

### DIFF
--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -467,6 +467,7 @@ class DaliTests : public CppUnit::TestFixture
 // This test requires access to an external IP with dafilesrv running
 //        CPPUNIT_TEST(testDFSRename3);
         CPPUNIT_TEST(testDFSAddFailReAdd);
+        CPPUNIT_TEST(testDFSRetrySuperLock);
         CPPUNIT_TEST(testDFSHammer);
     CPPUNIT_TEST_SUITE_END();
 
@@ -1661,6 +1662,60 @@ public:
         ASSERT(NULL != sfile->querySubFileNamed("regress::addreadd::sub3") && "regress::addreadd::sub3, should be a subfile of super2");
         sfile.setown(dir.lookupSuperFile("regress::addreadd::super1", user));
         ASSERT(0 == sfile->numSubFiles() && "regress::addreadd::super1 should contain 0 subfiles");
+    }
+
+    void testDFSRetrySuperLock()
+    {
+        setupDFS("retrysuperlock");
+
+        Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user); // disabled, auto-commit
+
+        logctx.CTXLOG("Creating regress::retrysuperlock::super1 and regress::retrysuperlock::sub1");
+        Owned<IDistributedSuperFile> sfile = dir.createSuperFile("regress::retrysuperlock::super1", user, false, false, transaction);
+        sfile->addSubFile("regress::retrysuperlock::sub1", false, NULL, false, transaction);
+        sfile.clear();
+
+        class CShortLock : implements IThreaded
+        {
+            StringAttr fileName;
+            unsigned secDelay;
+            CThreaded threaded;
+        public:
+            CShortLock(const char *_fileName, unsigned _secDelay) : fileName(_fileName), secDelay(_secDelay), threaded("CShortLock", this) { }
+            ~CShortLock()
+            {
+                threaded.join();
+            }
+            virtual void main()
+            {
+                Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(fileName, NULL);
+
+                if (!file)
+                {
+                    PROGLOG("File %s not found", fileName.get());
+                    return;
+                }
+                PROGLOG("Locked file: %s, sleeping (before unlock) for %d secs", fileName.get(), secDelay);
+
+                MilliSleep(secDelay * 1000);
+
+                PROGLOG("Unlocking file: %s", fileName.get());
+            }
+            void start() { threaded.start(); }
+        };
+
+        /* Tests transaction failing, due to lock and retrying after having partial success */
+
+        CShortLock sL("regress::retrysuperlock::super1", 15);
+        sL.start();
+
+        sfile.setown(dir.lookupSuperFile("regress::retrysuperlock::super1", user));
+        if (sfile)
+        {
+            logctx.CTXLOG("Removing subfiles from regress::retrysuperlock::super1");
+            sfile->removeSubFile(NULL, false);
+            logctx.CTXLOG("SUCCEEDED");
+        }
     }
 
     void testDFSRename2()


### PR DESCRIPTION
The transaction retry mechanism, clears all tracked files,
including the superfiles that the transaction was based on.
If there's a timeout during lock, the (nasty)
locking mechanism frees the lock on the super only, but retains
the lock on the subs.
When the retry mechanism, retries, because it's lost track of
the previously looked up super, it looks it up again and now
has two sets of locks to the subfiles, which it will never be
able to get exclusive locks to.

This fix, ensures that the supers that started the transaction
mechanism are not cleared, so that the retry mechanism will
reuse the same instances.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
