### PR TITLE
HPCC-10733 Depreciate WsDfu/DFUInfo attribute ActualSize

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -61,7 +61,7 @@ ESPStruct DFUPart
 {
     int Id;
     int Copy;
-    string ActualSize;
+    [depr_ver("1.23")] string ActualSize;
     string Ip;
     string Partsize;
 };
@@ -80,7 +80,7 @@ ESPStruct DFUFileDetail
     string Dir;
     string PathMask;
     string Filesize;
-    string ActualSize;
+    [depr_ver("1.23")] string ActualSize;
     string RecordSize;
     string RecordCount;
     string Wuid;
@@ -631,7 +631,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.22"), default_client_version("1.22"),
+    version("1.23"), default_client_version("1.23"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {


### PR DESCRIPTION
This attribute is never used. I increase WsDfu version to
1.23 and set the depr_ver("1.23") for the ActualSize.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
