### PR TITLE
HPCC-10754 Regression suite should have option to have per-target key files

### DIFF
--- a/testing/regress/hpcc/common/report.py
+++ b/testing/regress/hpcc/common/report.py
@@ -119,10 +119,17 @@ class Report:
     def __addEclFile(self, eclfile):
         result = {}
         result['File'] = eclfile.ecl
-        if eclfile.diff:
+        if eclfile.wuid == 'Not found':
+            result['Result'] = 'Fail'
+            result['Diff'] = ''
+            self.report._fail.append(_dict(result))
+        elif eclfile.diff:
             if eclfile.testNoKey():
                 result['Result'] = 'Pass'
-                result['Diff'] = eclfile.diff
+                if eclfile.testNoOutput():
+                    result['Diff'] = ''
+                else:
+                    result['Diff'] = eclfile.diff
                 self.report._pass.append(_dict(result))
             else:
                 result['Result'] = 'Fail'

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -58,7 +58,7 @@ class Suite:
             if file.endswith(".ecl"):
                 ecl = os.path.join(self.dir_ec, file)
                 eclfile = ECLFile(ecl, self.dir_a, self.dir_ex,
-                                  self.dir_r)
+                                  self.dir_r,  self.name)
                 result = eclfile.testSkip(self.name)
                 if not result['skip']:
                     if not eclfile.testExclusion(self.name):

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -106,9 +106,16 @@ class ECLcmd(Shell):
                 if queryWuid(eclfile.getJobname(), eclfile.getTaskId())['state'] == 'aborted':
                     eclfile.diff = eclfile.ecl+'\n\t'+'Aborted ( reason: '+eclfile.getAbortReason()+' )'
                     test = False
+                elif eclfile.getIgnoreResult():
+                    logging.debug("%3d. Ignore result (ecl:'%s')", eclfile.getTaskId(),  eclfile.getBaseEcl())
+                    test = True
                 elif eclfile.testNoKey():
                     # keyfile comparaison disabled with //nokey tag
-                    eclfile.diff = 'Output of '+eclfile.ecl +' test is:\n\t'+ data
+                    if eclfile.testNoOutput():
+                        #output generation disabled with //nooutput tag
+                        eclfile.diff = '-'
+                    else:
+                        eclfile.diff = 'Output of '+eclfile.ecl +' test is:\n\t'+ data
                     test = True
                 else:
                     test = eclfile.testResults()

--- a/testing/regress/hpcc/util/expandcheck.py
+++ b/testing/regress/hpcc/util/expandcheck.py
@@ -38,7 +38,8 @@ class ExpandCheck:
                 except:
                     raise IOError("REQUIRED DIRECTORY NOT FOUND. " + path)
             else:
-                logging.info( "DIRECTORY NOT FOUND. " + path)
+                logging.debug( "DIRECTORY NOT FOUND. " + path)
+                path = None
 
         return(path)
 

--- a/testing/regress/regress
+++ b/testing/regress/regress
@@ -31,7 +31,7 @@ from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
 
-prog_version = "0.0.11"
+prog_version = "0.0.12"
 
 if __name__ == "__main__":
 
@@ -66,6 +66,10 @@ if __name__ == "__main__":
                         nargs='?', default=".")
     parser.add_argument('--timeout', '-t', help="timeout for query execution in sec. Use -1 to disable timeout. Default value defined in regress.json config file.",
                         nargs='?', default="0")
+    parser.add_argument('--keyDir', '-k', help="key file directory to compare test output. Default value defined in regress.json config file.",
+                        nargs='?', default="ecl/key")
+    parser.add_argument('--ignoreResult', '-i', help="completely ignore the result.",
+                        action='store_true')
 
     subparsers = parser.add_subparsers(help='sub-command help')
     parser_list = subparsers.add_parser('list', help='list help')
@@ -88,12 +92,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    suiteDir = ""
-    if 'suiteDir' in args:
-        suiteDir = args.suiteDir
-    timeout = -1
-    if 'timeout' in args:
-        timeout = args.timeout
     # Resolve Regression Suite starting path for regress.json config file
     # It is necessary when Regression Suite doesn't started from its home directory
     regressionSuiteMainDir = os.path.dirname(__file__)
@@ -103,7 +101,7 @@ if __name__ == "__main__":
     try:
         if 'clusters' in args:
             Clusters = ['setup']
-            regress = Regression(args.config, args.loglevel, suiteDir)
+            regress = Regression(args)
             for cluster in regress.config.Clusters:
                 Clusters.append(str(cluster))
             print "Avaliable Clusters: "
@@ -114,10 +112,10 @@ if __name__ == "__main__":
                 print "\nMissing ECL query file!\n"
                 parser_query.print_help()
                 exit()
-            regress = Regression(args.config, args.loglevel, suiteDir,  timeout)
+            regress = Regression(args)
             eclfiles=[]   # List for ECL filenames to be executed
             if  ('*' in args.query) or ('?' in args.query):
-                # There is any wildcard in ECL file name, resolve it
+                # If there is any wildcard in ECL file name, resolve it
                 eclwild = os.path.join(regress.dir_ec, args.query)
                 eclfiles = glob.glob(eclwild)
 
@@ -140,7 +138,7 @@ if __name__ == "__main__":
                 try:
                     # Execute ECL files one by one on the cluster
                     for ecl in eclfiles:
-                        eclfile = ECLFile(ecl, regress.dir_a, regress.dir_ex, regress.dir_r)
+                        eclfile = ECLFile(ecl, regress.dir_a, regress.dir_ex, regress.dir_r, cluster)
                         # Check if this query is not skip on this cluster and not part of setup
                         if (not eclfile.testSkip(cluster)['skip']) and (not eclfile.testSkip('setup')['skip'] ):
                             if not eclfile.testExclusion(cluster):
@@ -154,7 +152,7 @@ if __name__ == "__main__":
                     exit()
             print("End.")
         elif 'cluster' in args:
-            regress = Regression(args.config, args.loglevel, suiteDir,  timeout,  args.pq)
+            regress = Regression(args)
             regress.bootstrap(args.cluster)
             if 'setup' in args.cluster:
                 regress.runSuite('setup', regress.Setup())


### PR DESCRIPTION
Add new global command line parameter --ignoreResult |-i to completely ignore
the result in both query and run mode.

Add new global command line parameter --keyDir [KEYDIR] |-k [KEYDIR] to use
alternative keyfile directory to compare test output in both query and run
mode.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
