### PR TITLE
HPCC-10561 Fix issues highlighted by coverity scan

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -693,6 +693,7 @@ public:
         xmlStoredDatasetReadFlags = ptr_none;
         if (_debuggerActive)
         {
+            assertex(header);
             CSlaveDebugContext *slaveDebugContext = new CSlaveDebugContext(this, logctx, *header);
             slaveDebugContext->init(_packet);
             debugContext.setown(slaveDebugContext);


### PR DESCRIPTION
Add assert to ensure that invalid parameter combinations do not
crash. I don't believe this could ever happen, but this shuts up
coverity (and is good practice).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
