### PR TITLE
HPCC-10820 Roxiemem calls checkabort too often

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -896,6 +896,20 @@ public:
         }
     }
 
+    virtual unsigned checkInterval() const
+    {
+        unsigned interval = MAX_ABORT_CHECK_INTERVAL;
+        if (timeLimit)
+        {
+            interval = timeLimit / 10;
+            if (interval < MIN_ABORT_CHECK_INTERVAL)
+                interval = MIN_ABORT_CHECK_INTERVAL;
+            if (interval > MAX_ABORT_CHECK_INTERVAL)
+                interval = MAX_ABORT_CHECK_INTERVAL;
+        }
+        return interval;
+    }
+
     virtual void notifyAbort(IException *E)
     {
         CriticalBlock b(abortLock);

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -38,7 +38,6 @@
 namespace roxiemem {
 
 #define NOTIFY_UNUSED_PAGES_ON_FREE     // avoid linux swapping 'freed' pages to disk
-#define TIMEOUT_CHECK_FREQUENCY_MILLISECONDS 10
 
 unsigned memTraceLevel = 1;
 memsize_t memTraceSizeLimit = 0;
@@ -2667,7 +2666,7 @@ public:
         if (timeLimit)
         {
             cyclesChecked = get_cycles_now();
-            cyclesCheckInterval = nanosec_to_cycle(1000000 * TIMEOUT_CHECK_FREQUENCY_MILLISECONDS); // Could perhaps ask timelimit object what a suitable frequency is..
+            cyclesCheckInterval = nanosec_to_cycle(1000000 * timeLimit->checkInterval());
         }
         else
         {

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -469,9 +469,13 @@ interface IRowManager : extends IInterface
 
 extern roxiemem_decl void setDataAlignmentSize(unsigned size);
 
+#define MIN_ABORT_CHECK_INTERVAL 10
+#define MAX_ABORT_CHECK_INTERVAL 5000
+
 interface ITimeLimiter 
 {
-    virtual void checkAbort() = 0 ;
+    virtual void checkAbort() = 0;
+    virtual unsigned checkInterval() const = 0;
 };
 
 interface IActivityMemoryUsageMap : public IInterface


### PR DESCRIPTION
Make check frequency dependent on timeout.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
