### PR TITLE
HPCC-10688 EclWatch misreporting partially suspended queries

### DIFF
--- a/esp/eclwatch/ws_XSLT/WUQueryDetails.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQueryDetails.xslt
@@ -148,7 +148,7 @@
             <body class="yui-skin-sam">
                 <xsl:variable name="suspendedOnClusters">
                     <xsl:for-each select="Clusters/ClusterQueryState[State='Suspended']">
-                        <xsl:if test="position() > 1"><xsl:text>, </xsl:text></xsl:if><xsl:value-of select="Cluster"/>
+                        <xsl:if test="position() > 1"><xsl:text>, </xsl:text></xsl:if><xsl:value-of select="Cluster"/><xsl:if test="MixedNodeStates=1"><xsl:text>(some nodes)</xsl:text></xsl:if>
                     </xsl:for-each>
                 </xsl:variable>
                 <h3>Query Details for <xsl:value-of select="QueryId"/></h3>

--- a/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQuerysetQueries.xslt
@@ -444,12 +444,16 @@
                   <xsl:for-each select="Clusters/ClusterQueryState[State='Suspended']">
                       <xsl:choose>
                           <xsl:when test="position() = 1">
-                              <xsl:text>On Cluster(s): </xsl:text><xsl:value-of select="Cluster"/>
+                              <xsl:text>On Cluster(s): </xsl:text>
                           </xsl:when>
                           <xsl:otherwise>
-                              <xsl:text>, </xsl:text><xsl:value-of select="Cluster"/>
+                              <xsl:text>, </xsl:text>
                           </xsl:otherwise>
                       </xsl:choose>
+                      <xsl:value-of select="Cluster"/>
+                      <xsl:if test="MixedNodeStates=1">
+                        <xsl:text>(some nodes)</xsl:text>
+                      </xsl:if>
                   </xsl:for-each>
               </xsl:otherwise>
           </xsl:choose>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1168,6 +1168,7 @@ ESPStruct ClusterQueryState
     string Cluster;
     string State;
     [min_ver("1.46")] string Errors;
+    [min_ver("1.47")] bool MixedNodeStates;
 };
 
 ESPStruct [nil_remove] QuerySetQuery
@@ -1443,7 +1444,7 @@ ESPresponse [exceptions_inline] WUCreateZAPInfoResponse
 };
 
 ESPservice [
-    version("1.46"), default_client_version("1.46"),
+    version("1.47"), default_client_version("1.47"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);


### PR DESCRIPTION
Queries that are suspended on some roxie nodes but not others where not
always reported as suspended.  Make EclWatch use of control:queries check
all nodes.

Also if some nodes are suspended and others are not, indicate that
fact on EclWatch so that users are more aware that results and apparent
availability can be affected.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
