### PR TITLE
HPCC-10806 DOCS:Package Ref name

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -2868,15 +2868,11 @@ OUTPUT(ValidWords)
 
       <para><emphasis role="bold">Centos/Red Hat/SuSe</emphasis></para>
 
-      <programlisting>sudo rpm -e hpccsystems-platform-xxxx-<emphasis>n.n.nnnn</emphasis> </programlisting>
-
-      <para>(where <emphasis>n.n.nnnn</emphasis> is the build number)</para>
+      <programlisting>sudo rpm -e hpccsystems-platform </programlisting>
 
       <para><emphasis role="bold">Ubuntu/Debian </emphasis></para>
 
-      <programlisting>sudo dpkg -r hpccsystems-platform-xxxx-<emphasis>n.n.nnnn</emphasis> </programlisting>
-
-      <para>(where <emphasis>n.n.nnnn</emphasis> is the build number)</para>
+      <programlisting>sudo dpkg -r hpccsystems-platform</programlisting>
     </sect1>
 
     <sect1 id="Helper-Applications">


### PR DESCRIPTION
Fix HPCC-10806 DOCS:Package Ref name
Fix the name of the installation package
specified in the Installing and Running
documentation from more specific to more generic
and less specific.

@JamesDeFabia please review

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com
