### PR TITLE
HPCC-10775 Set job priority for multiple jobs

### DIFF
--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -205,13 +205,20 @@ ESPresponse [exceptions_inline] SMCJobResponse
 {
 };
 
+ESPStruct SMCJob
+{
+    string Wuid;
+    string QueueName;
+};
+
 ESPrequest SMCPriorityRequest
 {
-    int ClusterType;
-    string Cluster;
+    [dspr_ver("1.18")] int ClusterType;
+    [dspr_ver("1.18")] string Cluster;
     string QueueName;
     string Wuid;
     string Priority;
+    [min_ver("1.18")] ESParray<ESPstruct SMCJob> SMCJobs;
 };
 
 
@@ -321,7 +328,7 @@ RoxieControlCmdResponse
     ESParray<ESPstruct RoxieControlEndpointInfo, Endpoint> Endpoints;
 };
 
-ESPservice [noforms, version("1.17"), default_client_version("1.17"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [noforms, version("1.18"), default_client_version("1.18"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -213,8 +213,8 @@ ESPStruct SMCJob
 
 ESPrequest SMCPriorityRequest
 {
-    [dspr_ver("1.18")] int ClusterType;
-    [dspr_ver("1.18")] string Cluster;
+    [depr_ver("1.18")] int ClusterType;
+    [depr_ver("1.18")] string Cluster;
     string QueueName;
     string Wuid;
     string Priority;

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -88,6 +88,7 @@ class CWsSMCEx : public CWsSMC
     StringBuffer m_PortalURL;
     int m_BannerAction;
     bool m_EnableChatURL;
+    CriticalSection crit;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -150,6 +151,7 @@ private:
     void getDFURecoveryJobs(IEspContext &context, IArrayOf<IEspDFUJob>& jobs);
     const char* createQueueActionInfo(IEspContext &context, const char* action, IEspSMCQueueRequest &req, StringBuffer& info);
     void setServerJobQueueStatus(double version, IEspServerJobQueue* jobQueue, const char* status, const char* details);
+    void setJobPriority(IWorkUnitFactory* factory, const char* wuid, const char* queue, WUPriorityClass& priority);
 };
 
 


### PR DESCRIPTION
The existing code sets one job priority per ESP call. In the new
ECLWatch UI, multiple jobs may be selected to change job priority.
Multiple ESP calls have to be sent at the same time. After a few
successful calls, ESP stops to respond new calls. That is because
multiple threads try to access the same job queue at the same time.
One thread locks the job queue before previous thread updates the
priority and releases the lock. This fix moves the code of lock()
and updatePriority() into a critical section. A thread cannot
access the code before another thread leaves the code.

In this fix, I also add the code to support batch function which
allows to set job priority for multiple jobs in one ESP call.

This fix also depreciates two variables from SetJobPriority
request since they are not used.
