### PR TITLE
HPCC-8191: WsEcl support for building REST URLs (HTTP-GET)

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -736,7 +736,9 @@ void appendRESTParameter(StringBuffer &out, const StringArray &path, const char 
     unsigned len = out.length();
     if (len && out.charAt(len-1)!='?')
         out.append('&');
-    out.append(s).append('=').append(value);
+    out.append(s).append('=');
+    if (value && *value)
+        appendURL(&out, value);
 }
 
 static void buildRestURL(StringArray& parentTypes, StringArray &path, IXmlType* type, StringBuffer& out, const char* tag, unsigned flags, unsigned depth=0)
@@ -2735,16 +2737,16 @@ int CWsEclBinding::getRestURL(IEspContext *ctx, CHttpRequest *request, CHttpResp
         {
             StringArray parentTypes;
             StringArray path;
-            StringBuffer url;
-            url.set("/WsEcl/proxy/query/").append(wsinfo.qsetname).append('/').append(wsinfo.queryname).append('?');
-            buildRestURL(parentTypes, path, type, url, NULL, 0);
+
+            StringBuffer urlParams("?");
+            buildRestURL(parentTypes, path, type, urlParams, NULL, 0);
 
             StringBuffer xml;
             appendXMLOpenTag(xml, "resturl");
             appendXMLTag(xml, "version", "3");
             appendXMLTag(xml, "target", wsinfo.qsetname);
             appendXMLTag(xml, "query", wsinfo.queryname);
-            appendXMLTag(xml, "url", url);
+            appendXMLTag(xml, "urlParams", urlParams);
             appendXMLCloseTag(xml, "resturl");
 
             Owned<IXslProcessor> xslp = getXslProcessor();

--- a/esp/services/ws_ecl/ws_ecl_service.hpp
+++ b/esp/services/ws_ecl/ws_ecl_service.hpp
@@ -139,6 +139,7 @@ public:
     void getDynNavData(IEspContext &context, IProperties *params, IPropertyTree & data);
     void addQueryNavLink(IPropertyTree &data, IPropertyTree *query, const char *setname, const char *qname=NULL);
     void getQueryNames(IPropertyTree* settree, const char *id, const char *qname, StringArray& qnames);
+    int getRestURL(IEspContext *context, CHttpRequest *request, CHttpResponse *response, WsEclWuInfo &wsinfo, IProperties *parms);
 
     virtual const char* getRootPage() {return "files/esp_app_tree.html";}
 

--- a/esp/xslt/CMakeLists.txt
+++ b/esp/xslt/CMakeLists.txt
@@ -35,6 +35,7 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_form.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_boxform.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_links.xslt
+    ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_url.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_tabview.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_xmltest.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/wsecl3_jsontest.xsl

--- a/esp/xslt/wsecl3_form.xsl
+++ b/esp/xslt/wsecl3_form.xsl
@@ -135,7 +135,7 @@
         <xsl:with-param name="types" select="$enum-types"/>
     </xsl:call-template>
 <xsl:text disable-output-escaping="yes"><![CDATA[
-
+m
 function setESPFormAction()  // reqType: 0: regular form, 1: soap, 2: form param passing, 3: roxiexml
 {
     var form = document.forms['esp_form'];
@@ -149,12 +149,10 @@ function setESPFormAction()  // reqType: 0: regular form, 1: soap, 2: form param
             actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes" select="concat('/WsEcl/forms/soap/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
         else if (actval.value=="esp_json")
             actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes"  select="concat('/WsEcl/forms/json/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
-        else if (actval.value=="roxie_soap")
-            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes"  select="concat('/WsEcl/forms/roxiesoap/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
-        else if (actval.value=="roxie_xml")
-            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes"  select="concat('/WsEcl/forms/roxiexml/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
         else if (actval.value=="run_xslt")
             actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes"  select="concat('/WsEcl/xslt/query/', $queryPath, '/', $methodName)"/><xsl:text disable-output-escaping="yes"><![CDATA[";
+        else if (actval.value=="proxy_xml")
+            actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes"  select="concat('/WsEcl/proxy/query/', $queryPath, '/', $methodName, '/xml?view=xml&amp;display')"/><xsl:text disable-output-escaping="yes"><![CDATA[";
         else if (actval.value=="xml")
             actionpath = "]]></xsl:text><xsl:value-of disable-output-escaping="yes"  select="concat('/WsEcl/submit/query/', $queryPath, '/', $methodName, '/xml?view=xml&amp;display')"/><xsl:text disable-output-escaping="yes"><![CDATA[";
         else if (actval.value=="json")
@@ -170,8 +168,12 @@ function setESPFormAction()  // reqType: 0: regular form, 1: soap, 2: form param
          form.action = document.getElementById('dest_url').value;
     else
         form.action = actionpath;
-
-    //alert("Form action = " + form.action);
+    var methodval = document.getElementById('method_type').value;
+    form.method = methodval;
+    if (methodval == "GET")
+        form.target = "_blank";
+    else
+        form.target = "_self";
 
     // firefox now save input values (version 1.5)
     saveInputValues(form);
@@ -306,17 +308,22 @@ function switchInputForm()
 
                 <tr class='commands'>
                   <td align='left'>
-                    <select id="submit_type" name="submit_type_">
+                    <select id="submit_type">
                         <xsl:for-each select="/FormInfo/CustomViews/Result">
                             <option><xsl:attribute name="value"><xsl:value-of select="."/></xsl:attribute><xsl:value-of select="."/></option>
                         </xsl:for-each>
                         <option value="run_xslt">Output Tables</option>
+                        <option value="proxy_xml">Output XML (Proxy mode)</option>
                         <option value="xml">Output XML</option>
                         <option value="json">Output JSON</option>
                         <option value="esp_soap">SOAP Test</option>
                         <option value="esp_json">JSON Test</option>
                     </select>&nbsp;
-                   <input type='submit' value='Submit' name='S1'/>
+                    <select id="method_type">
+                         <option value="POST">FORM POST</option>
+                        <option value="GET">REST URL</option>
+                    </select>&nbsp;
+                   <input type='submit' value='Submit'/>
 
           &nbsp;<input type='button' value='Clear All' onclick='onClearAll()'  title='Reset the form, and remove all arrays you added'/>
            </td>

--- a/esp/xslt/wsecl3_form.xsl
+++ b/esp/xslt/wsecl3_form.xsl
@@ -135,7 +135,7 @@
         <xsl:with-param name="types" select="$enum-types"/>
     </xsl:call-template>
 <xsl:text disable-output-escaping="yes"><![CDATA[
-m
+
 function setESPFormAction()  // reqType: 0: regular form, 1: soap, 2: form param passing, 3: roxiexml
 {
     var form = document.forms['esp_form'];

--- a/esp/xslt/wsecl3_links.xslt
+++ b/esp/xslt/wsecl3_links.xslt
@@ -27,6 +27,9 @@
                     <a  target="_blank" href="/WsEcl/forms/ecl/query/{$pathval}/{$queryname}">Form</a>
                 </li>
                 <li>
+                    Sample REST URL:&nbsp;&nbsp;<a  target="_blank" href="/WsEcl/example/url/query/{$pathval}/{$queryname}">link</a>
+                </li>
+                <li>
                     Sample Request:&nbsp;&nbsp;<a href="/WsEcl/example/request/query/{$pathval}/{$queryname}?display">display</a>&nbsp;&nbsp;<a  target="_blank" href="/WsEcl/example/request/query/{$pathval}/{$queryname}">link</a>
                 </li>
                 <li>

--- a/esp/xslt/wsecl3_url.xslt
+++ b/esp/xslt/wsecl3_url.xslt
@@ -10,43 +10,53 @@
     <xsl:output method="html" indent="yes"/>
     <xsl:variable name="target" select="/resturl/target"/>
     <xsl:variable name="queryname" select="/resturl/query"/>
-    <xsl:variable name="url" select="/resturl/url"/>
+    <xsl:variable name="urlParams" select="/resturl/urlParams"/>
     <xsl:template match="/">
         <xsl:apply-templates select="resturl"/>
     </xsl:template>
     <xsl:template match="resturl">
         <head>
-            <title>WsECL Query Sample Rest URL</title>
+            <title>WsECL Query Sample Rest URLs</title>
             <link rel="shortcut icon" href="/esp/files/img/affinity_favicon_1.ico" />
             <script>
-                function doUpdateURL()
+                function doUpdateURL(content_type)
                 {
-                    var updateURL = document.getElementById('updateURL');
-                    var hrefURL = document.getElementById('hrefURL');
+                    var updateURL = document.getElementById('updateURL' + content_type);
+                    var hrefURL = document.getElementById('hrefURL' + content_type);
                     hrefURL.innerHTML = updateURL.value;
                     hrefURL.setAttribute('href', updateURL.value);
                 }
             </script>
         </head>
         <br/>
-        <h1>WsECL REST URL</h1>
+        <h1>WsECL REST URLs</h1>
         <br/>
         <h2><xsl:value-of select="$target"/>&nbsp;/&nbsp;<xsl:value-of select="$queryname"/></h2><br/>
         <br/>
-        Add parameter values to the following URL to execute the <xsl:value-of select="$queryname"/> query on <xsl:value-of select="$target"/>.
+        Add parameter values to the following URLs to execute the <xsl:value-of select="$queryname"/> query on <xsl:value-of select="$target"/>.
         <br/>
         <br/>
+        XML REST URL Link:<br/>
         <br/>
-        REST URL Link:<br/>
-        <br/>
-        <a id="hrefURL" target="_blank" href="{$url}"><xsl:value-of select="$url"/></a>
-        <br/>
+        <a id="hrefURLXML" target="_blank" href="/WsEcl/submit/query/{$target}/{$queryname}/xml{$urlParams}">/WsEcl/submit/query/<xsl:value-of select="$target"/>/<xsl:value-of select="$queryname"/>/xml<xsl:value-of select="$urlParams"/></a>
         <br/>
         <br/>
         <form>
             Edit Link: <br/>
-            <input type="text" id="updateURL" name="updateURL" value="{$url}" size="150"/><br/>
-            <input type="button" name="Update" onClick="doUpdateURL()" value="Update"/>
+            <input type="text" id="updateURLXML" name="updateURLXML" value="/WsEcl/submit/query/{$target}/{$queryname}/xml{$urlParams}" size="150"/><br/>
+            <input type="button" onClick="doUpdateURL('XML')" value="Update"/>
+        </form>
+        <br/>
+        <br/>
+        JSON REST URL Link:<br/>
+        <br/>
+        <a id="hrefURLJSON" target="_blank" href="/WsEcl/submit/query/{$target}/{$queryname}/json{$urlParams}">/WsEcl/submit/query/<xsl:value-of select="$target"/>/<xsl:value-of select="$queryname"/>/json<xsl:value-of select="$urlParams"/></a>
+        <br/>
+        <br/>
+        <form>
+            Edit Link: <br/>
+            <input type="text" id="updateURLJSON" value="/WsEcl/submit/query/{$target}/{$queryname}/json{$urlParams}" size="150"/><br/>
+            <input type="button" onClick="doUpdateURL('JSON')" value="Update"/>
         </form>
     </xsl:template>
 </xsl:stylesheet>

--- a/esp/xslt/wsecl3_url.xslt
+++ b/esp/xslt/wsecl3_url.xslt
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+## HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.  All rights reserved.
+-->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY nbsp "&#160;">
+]>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="html" indent="yes"/>
+    <xsl:variable name="target" select="/resturl/target"/>
+    <xsl:variable name="queryname" select="/resturl/query"/>
+    <xsl:variable name="url" select="/resturl/url"/>
+    <xsl:template match="/">
+        <xsl:apply-templates select="resturl"/>
+    </xsl:template>
+    <xsl:template match="resturl">
+        <head>
+            <title>WsECL Query Sample Rest URL</title>
+            <link rel="shortcut icon" href="/esp/files/img/affinity_favicon_1.ico" />
+            <script>
+                function doUpdateURL()
+                {
+                    var updateURL = document.getElementById('updateURL');
+                    var hrefURL = document.getElementById('hrefURL');
+                    hrefURL.innerHTML = updateURL.value;
+                    hrefURL.setAttribute('href', updateURL.value);
+                }
+            </script>
+        </head>
+        <br/>
+        <h1>WsECL REST URL</h1>
+        <br/>
+        <h2><xsl:value-of select="$target"/>&nbsp;/&nbsp;<xsl:value-of select="$queryname"/></h2><br/>
+        <br/>
+        Add parameter values to the following URL to execute the <xsl:value-of select="$queryname"/> query on <xsl:value-of select="$target"/>.
+        <br/>
+        <br/>
+        <br/>
+        REST URL Link:<br/>
+        <br/>
+        <a id="hrefURL" target="_blank" href="{$url}"><xsl:value-of select="$url"/></a>
+        <br/>
+        <br/>
+        <br/>
+        <form>
+            Edit Link: <br/>
+            <input type="text" id="updateURL" name="updateURL" value="{$url}" size="150"/><br/>
+            <input type="button" name="Update" onClick="doUpdateURL()" value="Update"/>
+        </form>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Add a link to the Links tag to get an example (unpopulated) REST URL.

Also add support to the generated form to make calls using HTTP-GET
which can be used to build specific REST URLs with the provided
parameters filled in.

Signed-off-by: Anthony Fishbeck Anthony.Fishbeck@lexisnexis.com
