### PR TITLE
HPCC-10837 ws_workunits build break if USE_ZLIB=false

### DIFF
--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -277,7 +277,7 @@ bool CWsTopologyEx::onSystemLog(IEspContext &context,IEspSystemLogRequest  &req,
         else
         {
 #ifndef _USE_ZLIB
-            throw MakeStringException(ERRORID_ECLWATCH_TOPOLOGY+109,"The data cannot be compressed.");
+            throw MakeStringException(ECLWATCH_CANNOT_COMPRESS_DATA,"The data cannot be compressed.");
 #else
             StringBuffer ifname;
             unsigned threadID = (unsigned) (memsize_t) GetCurrentThreadId();

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3917,7 +3917,7 @@ bool CWsWorkunitsEx::onWUDeployWorkunit(IEspContext &context, IEspWUDeployWorkun
     }
     return true;
 }
-
+#ifdef _USE_ZLIB
 void CWsWorkunitsEx::addProcessLogfile(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, PointerArray &mbArr)
 {
     Owned<IPropertyTreeIterator> procs = cwu->getProcesses(process, NULL);
@@ -3967,7 +3967,7 @@ void CWsWorkunitsEx::addProcessLogfile(IZZIPor* zipper, Owned<IConstWorkUnit> &c
         }
     }
 }
-
+#endif
 
 bool CWsWorkunitsEx::onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfoRequest &req, IEspWUCreateZAPInfoResponse &resp)
 {

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -118,8 +118,9 @@ public:
     bool onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfoRequest &req, IEspWUCreateZAPInfoResponse &resp);
     bool onWUGetZAPInfo(IEspContext &context, IEspWUGetZAPInfoRequest &req, IEspWUGetZAPInfoResponse &resp);
 private:
+#ifdef _USE_ZLIB
     void addProcessLogfile(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, PointerArray &mbArr);
-
+#endif
     unsigned awusCacheMinutes;
     StringBuffer queryDirectory;
     StringAttr daliServers;


### PR DESCRIPTION
When -DUSE_ZLIB=false is specified in CMAKE command line, ws_workunits
build fails because of references to data types defined in zcrypt.hpp.
This fix wraps those references in #ifdef _USE_ZLIB to protect them

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
