### PR TITLE
HPCC-10835 Add suspended/activated as filters for WUListQueries

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1108,6 +1108,13 @@ enum WUSortField
     WUSFwild = 2048
 };
 
+enum WUQueryFilterBoolean
+{
+    WUQFSNo = 0,
+    WUQFSYes = 1,
+    WUQFSAll = 2
+};
+
 enum WUQuerySortField
 {
     WUQSFId = 1,
@@ -1123,6 +1130,8 @@ enum WUQuerySortField
     WUQSFpriority = 11,
     WUQSFpriorityHi = 12,
     WUQSFQuerySet = 13,
+    WUQSFActivited = 14,
+    WUQSFSuspendedByUser = 15,
     WUQSFterm = 0,
     WUQSFreverse = 256,
     WUQSFnocase = 512,

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1236,6 +1236,8 @@ ESPrequest [nil_remove] WUListQueriesRequest
     nonNegativeInteger WarnTimeLimitHigh;
     nonNegativeInteger PriorityLow;
     nonNegativeInteger PriorityHigh;
+    [min_ver("1.48")] bool Activated;
+    [min_ver("1.48")] bool SuspendedByUser;
 
     nonNegativeInteger PageSize(0);
     nonNegativeInteger PageStartFrom(0);
@@ -1445,7 +1447,7 @@ ESPresponse [exceptions_inline] WUCreateZAPInfoResponse
 };
 
 ESPservice [
-    version("1.47"), default_client_version("1.47"),
+    version("1.48"), default_client_version("1.48"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1027,6 +1027,10 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
         addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getPriorityLow(), (WUQuerySortField) (WUQSFpriority | WUQSFnumeric));
     if (!req.getPriorityHigh_isNull())
         addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getPriorityHigh(), (WUQuerySortField) (WUQSFpriorityHi | WUQSFnumeric));
+    if (!req.getActivated_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getActivated(), (WUQuerySortField) (WUQSFActivited | WUQSFnumeric));
+    if (!req.getSuspendedByUser_isNull())
+        addWUQSQueryFilterInt(filters, filterCount, filterBuf, req.getSuspendedByUser(), (WUQuerySortField) (WUQSFSuspendedByUser | WUQSFnumeric));
     filters[filterCount] = WUQSFterm;
 
     unsigned numberOfQueries = 0;


### PR DESCRIPTION
Those two filters are requested from New ECLWatch. In this fix,
the code is added to read those two filters from WsWorkunits
WUListQueriesRequest, pass them to getQuerySetQueriesSorted() in
workunit.cpp and process them as post filters.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
