### PR TITLE
HPCC-10268 Add a log file for hpcc-init

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -44,39 +44,41 @@
 
 ###<REPLACE>###
 
+
+
 function print_usage {
-    echo >&2 "Usage: $0 [-c component] {start|stop|restart|status|setup}
+    echo "Usage: $0 [-c component] {start|stop|restart|status|setup}
        $0 [--componentlist] Display node component name list.
        $0 [--typelist] Display node component type list.
        $0 [-h] [--help] Display help"
-    echo >&2
+    echo
     print_components
     exit 0
 }
 
 function print_components {
     if [ ! -z ${compList} ];then
-        echo >&2 "Components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}:"
+        echo  "Components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}:"
         IFS=$'\n'
-        echo >&2 "${compList[*]}"
+        echo  "${compList[*]}"
         unset IFS
     else
-        echo >&2 "No components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}."
+        echo  "No components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}."
     fi
-    echo >&2
+    echo
     exit 0
 }
 
 function print_types {
     if [ ! -z ${compList} ];then
-        echo >&2 "Components types on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}:"
+        echo  "Components types on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}:"
         IFS=$'\n'
-        echo >&2 "${compTypeList[*]}"
+        echo  "${compTypeList[*]}"
         unset IFS
     else
-        echo >&2 "No components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}."
+        echo  "No components on this node as defined by ${CONFIG_DIR}/${ENV_XML_FILE}."
     fi
-    echo >&2
+    echo
     exit 0
 }
 
@@ -87,6 +89,17 @@ source  ${INSTALL_DIR}/etc/init.d/pid.sh
 source  ${INSTALL_DIR}/etc/init.d/hpcc_common
 source  ${INSTALL_DIR}/etc/init.d/init-functions
 source  ${INSTALL_DIR}/etc/init.d/export-path
+
+# Only root user can write following HPCC_INIT_LOG
+is_root
+
+HPCC_INIT_LOG=${LOG_DIR}/hpcc-init.log
+
+export PS4='+${BASH_SOURCE[1]} ${LINENO}: '
+[ -e ${HPCC_INIT_LOG}  ] && rm -rf ${HPCC_INIT_LOG}
+touch $HPCC_INIT_LOG
+exec 2> ${HPCC_INIT_LOG}
+set -x
 
 ## Debug variable allowing verbose debug output
 ##
@@ -99,12 +112,14 @@ DAFILESRV=${DAFILESRV:-0}
 set_environmentvars
 envfile=$configs/$environment
 
+# Know HPCC user after set_environmentvars
+chown ${user}:${user} $HPCC_INIT_LOG
+
 #Sourcing the hpcc environment
 configgen_path=${path}/sbin
 bin_path=${path}/bin
 source ${configgen_path}/hpcc_setenv
 
-is_root
 which_service
 get_commondirs
 

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -567,6 +567,7 @@ stop_component() {
                             return 3 
                         fi
                     fi
+                    sleep 1
                 done
             fi
             sleep 1


### PR DESCRIPTION
Turn on line execution trace with 'set -x' and redirect to the log file /var/log/HPCCSystems/hpcc-init.log. 
Add 'sleep 1' in stop process loop which reduces unnecessary iterations.
Change help message from STDERR to STDOUT.
