### PR TITLE
HPCC-10849 Disable through spills for roxie - they only cause problems

### DIFF
--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -1854,7 +1854,7 @@ EclResourcer::EclResourcer(IErrorReceiver * _errors, IConstWorkUnit * _wu, Clust
     options.isChildQuery = false;
     options.targetClusterType = targetClusterType;
     options.filteredSpillThreshold = _translatorOptions.filteredReadSpillThreshold;
-    options.allowThroughSpill = _translatorOptions.allowThroughSpill;
+    options.allowThroughSpill = (targetClusterType != RoxieCluster) && (targetClusterType != ThorLCRCluster) && _translatorOptions.allowThroughSpill;
     options.allowThroughResult = (targetClusterType != RoxieCluster) && (targetClusterType != ThorLCRCluster);
     options.cloneFilteredIndex = (targetClusterType != RoxieCluster);
     options.spillSharedConditionals = (targetClusterType == RoxieCluster);


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
