### PR TITLE
HPCC-10526 add regress to Platform and Clienttools distribution packages

### DIFF
--- a/clienttools/install/post_install.sh
+++ b/clienttools/install/post_install.sh
@@ -46,7 +46,9 @@ IS_UNINSTALL=0
 CUR_DIR=$(pwd)
 [ "$SRC_DIR" != "." ] && cd $SRC_DIR 
 SRC_DIR=$(pwd)
-CT_BIN=$(echo $SRC_DIR | sed -n "s/^\(.*clienttools\)\(.*\)/\1/p")/bin
+CT_HOME=$(echo $SRC_DIR | sed -n "s/^\(.*clienttools\)\(.*\)/\1/p")
+CT_BIN=${CT_HOME}/bin
+ECL_TEST_DIR=${CT_HOME}/testing/regress
 cd $CUR_DIR
 
 
@@ -63,15 +65,23 @@ then
        [ -e ${CT_BIN}/${file} ] && \
            ln -sf ${CT_BIN}/${file}  ${TARGET_DIR}/${file}  
     done
+    [ -e ${ECL_TEST_DIR}/ecl-test ] && \
+           ln -sf ${ECL_TEST_DIR}/ecl-test  ${TARGET_DIR}/ecl-test  
+    
 
 else
     # Remove symbolic link
     for file in ${files_to_link[@]}
     do
        [ ! -e ${TARGET_DIR}/${file} ] && continue
-       ls -l ${TARGET_DIR}/${file} | egrep -q "${CT_BIN}/${file}$" 
+       ls -l ${TARGET_DIR}/${file} | egrep -q "${CT_BIN}/${file}$"
        [ $? -eq 0 ] && rm -rf ${TARGET_DIR}/${file}
     done
+    if [ -e ${TARGET_DIR}/ecl-test ]
+    then
+       ls -l ${TARGET_DIR}/ecl-test | egrep -q "${ECL_TEST_DIR}/ecl-test"
+       [ $? -eq 0 ] && rm -rf ${TARGET_DIR}/ecl-test
+    fi
 fi
 
 exit 0

--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -77,7 +77,7 @@ for D in ${PATH//:/ } ; do
     fi
 done
 if [ -n "${NEW_PATH}" ]; then
-    NEW_PATH="${NEW_PATH}:${PATH_PREFIX}/sbin:${PATH_PREFIX}/etc/init.d"
+    NEW_PATH="${NEW_PATH}:${PATH_PREFIX}/sbin:${PATH_PREFIX}/etc/init.d:${PATH_PREFIX}/testing/regress"
 fi
 
 if [[ $platform == 'linux' ]]; then

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -14,3 +14,7 @@
 #    limitations under the License.
 ################################################################################
 HPCC_ADD_SUBDIRECTORY (unittests)
+install( DIRECTORY regress DESTINATION "./testing" COMPONENT Runtime
+         USE_SOURCE_PERMISSIONS
+         PATTERN regress/ecl EXCLUDE )
+


### PR DESCRIPTION
add regress  to <INSTALL_DIRIRECTORY>/testing/ exclude ecl directory which has test cases.
