### PR TITLE
HPCC-10819 - inline set sometimes incorrectly output in loop graph

### DIFF
--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -59,7 +59,7 @@ public:
         dataLinkStart();
         __uint64 numRows = helper->numRows();
         // local when generated from a child query (the range is per node, don't split)
-        bool isLocal = container.queryLocalData()||(container.queryOwnerId() && container.queryOwner().isLocalOnly());
+        bool isLocal = container.queryLocalData() || container.queryOwner().isLocalChild();
         if (!isLocal && ((helper->getFlags() & TTFdistributed) != 0))
         {
             __uint64 nodes = container.queryCodeContext()->getNodes();


### PR DESCRIPTION
If a loop graph had local only activities (no global coordination)
then the inline dataset was being output on all nodes, instead of
just node 1.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
