### PR TITLE
HPCC-10784 Keyed limits on stepped indexreads can be miscalculated

### DIFF
--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -3098,7 +3098,7 @@ protected:
     virtual void createSegmentMonitors() = 0;
     virtual void setPartNo(bool filechanged)
     {
-        if (!lastPartNo.partNo)
+        if (!lastPartNo.partNo)  // Check for ,LOCAL indexes
         {
             assertex(filechanged);
             Owned<IKeyIndexSet> allKeys = createKeyIndexSet();
@@ -3184,7 +3184,7 @@ protected:
         unsigned __int64 result = 0;
         unsigned inputsDone = 0;
         bool ret = true;
-        unsigned saveStepping = steppingOffset;
+        unsigned saveStepping = steppingOffset;  // Avoid using a stepping keymerger for the checkCount - they don't support it (and would be inefficient)
         steppingOffset = 0;
         while (!aborted && inputsDone < inputCount)
         {

--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -2791,13 +2791,11 @@ public:
             unsigned key = mergeheap[i];
             keyBuffer = buffers[key];
             keyCursor = cursors[key];
-            ret += CKeyLevelManager::checkCount(max);
-            if (max)
-            {
-                if (ret > max)
-                    return ret;
-                max -= ret;
-            }
+            unsigned __int64 thisKeyCount = CKeyLevelManager::checkCount(max);
+            ret += thisKeyCount;
+            if (thisKeyCount > max)
+                return ret;
+            max -= thisKeyCount;
         }
         return ret;
     }


### PR DESCRIPTION
Fix regression in prior attempt to fix this (,LOCAL indexes broken).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
