### PR TITLE
HPCC-10865 Activity Page Throws an Exception

### DIFF
--- a/esp/files/scripts/ActivityWidget.js
+++ b/esp/files/scripts/ActivityWidget.js
@@ -324,7 +324,7 @@ define([
                             }
                             if (row.Duration) {
                                 return state + " (" + row.Duration + ")";
-                            } else if (row.Instance && state.indexOf(row.Instance) === -1) {
+                            } else if (row.Instance && !(state.indexOf && state.indexOf(row.Instance) !== -1)) {
                                 return state + " [" + row.Instance + "]";
                             }
                             return state;


### PR DESCRIPTION
If State is numeric there is an invalid call to indexOf.

Fixes HPCC-10865

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
