### PR TITLE
HPCC-10859 Change regress script and update README

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -37,15 +37,10 @@ Result:
 |            --suiteDir [SUITEDIR], -s [SUITEDIR]
 |                                  suiteDir to use. Default value is the current directory and it can handle relative path.
 |            --timeout [TIMEOUT], -t [TIMEOUT]
-<<<<<<< HEAD
-|                                  timeout for query execution in sec. Use -1 to disable timeout. Default value defined in regress.json config file (see: 7.)
+|                                  timeout for query execution in sec. Use -1 to disable timeout. Default value defined in ecl-test.json config file (see: 9.)
 |            --keyDir [KEYDIR], -k [KEYDIR]
 |                                  key file directory to compare test output. Default value defined in regress.json config file.
 |            --ignoreResult, -i    completely ignore the result.
-=======
-|                                  timeout for query execution in sec. Use -1 to disable timeout. Default value defined in ecl-test.json config file (see: 7.)
-
->>>>>>> HPCC-10859 Change regress script and update README
 
 Parameters of Regression Suite list sub-command:
 ------------------------------------------------

--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -9,12 +9,12 @@ Parameters of Regression Suite:
 
 Command:
  
-    ./regress <-h|--help>
+    ./ecl-test <-h|--help>
 
 Result:
 
 |
-|       usage: regress [-h] [--version] [--config [CONFIG]]
+|       usage: ecl-test [-h] [--version] [--config [CONFIG]]
 |                       [--loglevel [{info,debug}]] [--suiteDir [SUITEDIR]]
 |                       [--timeout [TIMEOUT]] [--keyDir [KEYDIR]]
 |                       [--ignoreResult]
@@ -31,31 +31,36 @@ Result:
 |       optional arguments:
 |            -h, --help            show this help message and exit
 |            --version, -v         show program's version number and exit
-|            --config [CONFIG]     config file to use. Default: regress.json.
+|            --config [CONFIG]     config file to use. Default: ecl-test.json.
 |            --loglevel [{info,debug}]
 |                                  set the log level. Use debug for more detailed logfile.
 |            --suiteDir [SUITEDIR], -s [SUITEDIR]
 |                                  suiteDir to use. Default value is the current directory and it can handle relative path.
 |            --timeout [TIMEOUT], -t [TIMEOUT]
+<<<<<<< HEAD
 |                                  timeout for query execution in sec. Use -1 to disable timeout. Default value defined in regress.json config file (see: 7.)
 |            --keyDir [KEYDIR], -k [KEYDIR]
 |                                  key file directory to compare test output. Default value defined in regress.json config file.
 |            --ignoreResult, -i    completely ignore the result.
+=======
+|                                  timeout for query execution in sec. Use -1 to disable timeout. Default value defined in ecl-test.json config file (see: 7.)
+
+>>>>>>> HPCC-10859 Change regress script and update README
 
 Parameters of Regression Suite list sub-command:
 ------------------------------------------------
 
 Command:
 
-    ./regress list <-h|--help>
+    ./ecl-test list <-h|--help>
 
 Result:
 
 |
-|       usage: regress list [-h]
+|       usage: ecl-test list [-h]
 |
 |       positional arguments:
-|         clusters    Print clusters from config (regress.json by default).
+|         clusters    Print clusters from config (ecl-test.json by default).
 |
 |       optional arguments:
 |         -h, --help  show this help message and exit
@@ -66,12 +71,12 @@ Parameters of Regression Suite run sub-command:
 
 Command:
 
-    ./regress run <-h|--help>
+    ./ecl-test run <-h|--help>
 
 Result:
 
 |
-|       usage: regress run [-h] [--pq threadNumber] [cluster]
+|       usage: ecl-test run [-h] [--pq threadNumber] [cluster]
 |
 |       positional arguments:
 |         cluster            Run the cluster suite. Default value is setup.
@@ -87,12 +92,12 @@ Parameters of Regression Suite query sub-command:
 
 Command:
 
-    ./regress query <-h|--help>
+    ./ecl-test query <-h|--help>
 
 Result:
 
 |
-|       usage: regress query [-h] [--publish] [ECL query] [target cluster | all]
+|       usage: ecl-test query [-h] [--publish] [ECL query] [target cluster | all]
 |
 |       positional arguments:
 |         ECL query             Name of a single ECL query. It can contain wildcards. (mandatory).
@@ -114,7 +119,7 @@ Steps to run Regression Suite
 ----------------------------------
 Command:
 
-    ./regress list
+    ./ecl-test list
 
 The result looks like this:
 
@@ -131,11 +136,11 @@ The result looks like this:
 
 Command:
 
-        ./regress run
+        ./ecl-test run
 
 or
 
-        ./regress run setup
+        ./ecl-test run setup
 
 The result:
 
@@ -168,7 +173,7 @@ The result:
 -------------------------------------------------------------
 Command:
 
-        ./regress run cluster [-h] [--pq threadNumber]
+        ./ecl-test run cluster [-h] [--pq threadNumber]
 
 Positional arguments:
   cluster            Run the cluster suite (default: setup).
@@ -311,7 +316,7 @@ The logfile generated into the HPCCSystems-regression/log subfolder of the user 
 
 Command:
 
-        ./regress query [-h] [--publish] test_name [target cluster | all]
+        ./ecl-test query [-h] [--publish] test_name [target cluster | all]
 
 Positional arguments:
         test_name               Name of a single ECL query. It can contain wildcards. (mandatory).
@@ -386,14 +391,13 @@ The regression suite stores every test case output into ~/HPCCSystems-regression
 
 So if you have a new test case and it works well on all clusters (or some of them and excluded from all others by //no<cluster> tag inside it See: 6. ) then you can get key file in 2 steps:
 
-1. Run test case with ./regress [suitedir] query <testcase.ecl> <cluster> .
+1. Run test case with ./ecl-test [suitedir] query <testcase.ecl> <cluster> .
 
 2. Copy the output (testcase.xml) file from ~/HPCCSystems-regression/result to the relevant key file directory.
 
 (To check everything is fine, repeat the step 1 and the query should now pass. )
 
-
-9. Configuration setting in regress.json file:
+9. Configuration setting in ecl-test.json file:
 -------------------------------------------------------------
 
         "ip": "127.0.0.1",                              - ECl server address
@@ -421,7 +425,7 @@ So if you have a new test case and it works well on all clusters (or some of the
 10. Authentication:
 -------------------
 
-If your HPCC System is configured to use LDAP authentication you should change value of "username" and "password" fields in regress.json file to yours.
+If your HPCC System is configured to use LDAP authentication you should change value of "username" and "password" fields in ecl-test.json file to yours.
 
 Alternatively, ensure that your test system has a user "regress" with password "regress" and appropriate rights to be able to run the suite.
 

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -67,7 +67,7 @@ if __name__ == "__main__":
                         nargs='?', default=".")
     parser.add_argument('--timeout', '-t', help="timeout for query execution in sec. Use -1 to disable timeout. Default value defined in ecl-test.json config file.",
                         nargs='?', default="0")
-    parser.add_argument('--keyDir', '-k', help="key file directory to compare test output. Default value defined in regress.json config file.",
+    parser.add_argument('--keyDir', '-k', help="key file directory to compare test output. Default value defined in ecl-test.json config file.",
                         nargs='?', default="ecl/key")
     parser.add_argument('--ignoreResult', '-i', help="completely ignore the result.",
                         action='store_true')
@@ -93,8 +93,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-
-    # Resolve Regression Suite starting path for regress.json config file
+    # Resolve Regression Suite starting path for ecl-test.json config file
     # It is necessary when Regression Suite doesn't started from its home directory
     regressionSuiteMainDir = os.path.dirname(__file__)
     regressionSuiteFullPath = os.path.realpath(regressionSuiteMainDir)

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -31,11 +31,12 @@ from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
 
-prog_version = "0.0.12"
+prog_version = "0.0.13"
 
 if __name__ == "__main__":
 
-    prog = "regress v:"+prog_version
+    prog = "ecl-test"
+    versionStr = prog+" v:"+prog_version
     description = 'HPCC Platform Regression suite'
     pythonVer = getVersionNumbers()
 
@@ -56,15 +57,15 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('--version', '-v', action='version',
-                        version='%(prog)s')
-    parser.add_argument('--config', help="config file to use. Default: regress.json",
-                        nargs='?', default="regress.json")
+                        version=versionStr)
+    parser.add_argument('--config', help="config file to use. Default: ecl-test.json",
+                        nargs='?', default="ecl-test.json")
     parser.add_argument('--loglevel', help="set the log level. Use debug for more detailed logfile.",
                         nargs='?', default="info",
                         choices=['info', 'debug'])
     parser.add_argument('--suiteDir', '-s', help="suiteDir to use. Default value is the current directory and it can handle relative path.",
                         nargs='?', default=".")
-    parser.add_argument('--timeout', '-t', help="timeout for query execution in sec. Use -1 to disable timeout. Default value defined in regress.json config file.",
+    parser.add_argument('--timeout', '-t', help="timeout for query execution in sec. Use -1 to disable timeout. Default value defined in ecl-test.json config file.",
                         nargs='?', default="0")
     parser.add_argument('--keyDir', '-k', help="key file directory to compare test output. Default value defined in regress.json config file.",
                         nargs='?', default="ecl/key")
@@ -73,7 +74,7 @@ if __name__ == "__main__":
 
     subparsers = parser.add_subparsers(help='sub-command help')
     parser_list = subparsers.add_parser('list', help='list help')
-    parser_list.add_argument('clusters', help="Print clusters from config (regress.json by default).",
+    parser_list.add_argument('clusters', help="Print clusters from config (ecl-test.json by default).",
                              action='store_true')
 
     parser_run = subparsers.add_parser('run', help='run help')
@@ -91,6 +92,7 @@ if __name__ == "__main__":
                             action='store_true')
 
     args = parser.parse_args()
+
 
     # Resolve Regression Suite starting path for regress.json config file
     # It is necessary when Regression Suite doesn't started from its home directory

--- a/testing/regress/ecl-test.json
+++ b/testing/regress/ecl-test.json
@@ -12,7 +12,7 @@
         "archiveDir": "archives",
         "resultDir": "results",
         "regressionDir": "~/HPCCSystems-regression",
-        "logDir": "~/HPCCSystems-regression/log",    
+        "logDir": "~/HPCCSystems-regression/log",
         "Clusters": [
             "hthor",
             "thor",

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -75,7 +75,6 @@ class Regression:
         self.suiteDir = ExpandCheck.dir_exists(self.suiteDir, True)
         self.regressionDir = ExpandCheck.dir_exists(self.config.regressionDir, True)
         self.logDir = ExpandCheck.dir_exists(self.config.logDir, True)
-        self.setupDir = ExpandCheck.dir_exists(os.path.join(self.suiteDir, self.config.setupDir), True)
         self.dir_ec = ExpandCheck.dir_exists(os.path.join(self.suiteDir, self.config.eclDir), True)
         self.dir_ex = ExpandCheck.dir_exists(os.path.join(self.suiteDir, self.keyDir), True)
         self.dir_a = os.path.join(self.regressionDir, self.config.archiveDir)
@@ -86,7 +85,7 @@ class Regression:
         logging.debug("Log Dir        : %s", self.logDir)
         logging.debug("ECL Dir        : %s", self.dir_ec)
         logging.debug("Key Dir        : %s", self.dir_ex)
-        logging.debug("Setup Dir      : %s", self.setupDir)
+        #logging.debug("Setup Dir      : %s", self.setupDir)
         logging.debug("Archive Dir    : %s", self.dir_a)
 
 
@@ -144,6 +143,8 @@ class Regression:
                                      self.dir_a, self.dir_ex, self.dir_r, self.logDir)
 
     def Setup(self):
+        self.setupDir = ExpandCheck.dir_exists(os.path.join(self.suiteDir, self.config.setupDir), True)
+        logging.debug("Setup Dir      : %s", self.setupDir)
         return Suite('setup', self.setupDir, self.dir_a, self.dir_ex,
                      self.dir_r, self.logDir)
 

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -85,7 +85,6 @@ class Regression:
         logging.debug("Log Dir        : %s", self.logDir)
         logging.debug("ECL Dir        : %s", self.dir_ec)
         logging.debug("Key Dir        : %s", self.dir_ex)
-        #logging.debug("Setup Dir      : %s", self.setupDir)
         logging.debug("Archive Dir    : %s", self.dir_a)
 
 


### PR DESCRIPTION
Rename regress to ecl-test
Update built-in help texts and README.rst
Fix setup dir related problem, based on the package doesn't contain any
test/setup code.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
