### PR TITLE
HPCC-10888 Fix Potential buffer overruns

### DIFF
--- a/system/security/securesocket/securesocket.cpp
+++ b/system/security/securesocket/securesocket.cpp
@@ -868,10 +868,7 @@ public:
             throw MakeStringException(-1, "ctx can't be created");
         }
 
-        char passwdbuf[128];
-        strcpy(passwdbuf, passphrase);
-
-        SSL_CTX_set_default_passwd_cb_userdata(m_ctx, passwdbuf);
+        SSL_CTX_set_default_passwd_cb_userdata(m_ctx, (void*)passphrase);
         SSL_CTX_set_default_passwd_cb(m_ctx, pem_passwd_cb);
 
         if(SSL_CTX_use_certificate_file(m_ctx, certfile, SSL_FILETYPE_PEM) <= 0)
@@ -920,10 +917,7 @@ public:
         {
             StringBuffer passbuf;
             decrypt(passbuf, passphrase);
-            char passwdbuf[128];
-            strcpy(passwdbuf, passbuf.str());
-
-            SSL_CTX_set_default_passwd_cb_userdata(m_ctx, passwdbuf);
+            SSL_CTX_set_default_passwd_cb_userdata(m_ctx, (void*)passbuf.str());
             SSL_CTX_set_default_passwd_cb(m_ctx, pem_passwd_cb);
         }
 


### PR DESCRIPTION
Remove unnecessary strcpy to unneeded buffer by using the string as it
is provided (and casting it to required void \* )

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
