### PR TITLE
HPCC-9556 Support #ONWARNING and fix other issues

### DIFF
--- a/common/fileview2/fvtransform.cpp
+++ b/common/fileview2/fvtransform.cpp
@@ -241,8 +241,8 @@ void ViewFieldECLTransformer::transform(unsigned & lenTarget, char * & target, u
     actuals.append(*LINK(sourceExpr));
     appendArray(actuals, extraArgs);
 
-    ThrowingErrorReceiver errors;
-    OwnedHqlExpr call = createBoundFunction(&errors, function, actuals, NULL, true);
+    Owned<IErrorReceiver> errorReporter = createThrowingErrorReceiver();
+    OwnedHqlExpr call = createBoundFunction(errorReporter, function, actuals, NULL, true);
     OwnedHqlExpr castValue = ensureExprType(call, utf8Type);
     OwnedHqlExpr folded = quickFoldExpression(castValue, NULL, 0);
     IValue * foldedValue = folded->queryValue();
@@ -294,12 +294,12 @@ void ViewTransformerRegistry::addPlugins(const char * name)
     loadedPlugins.setown(new SafePluginMap(&pluginCtx, true));
     loadedPlugins->loadFromList(name);
 
-    ThrowingErrorReceiver errors;
-    dataServer.setown(createNewSourceFileEclRepository(&errors, name, ESFallowplugins, 0));
+    Owned<IErrorReceiver> errorReporter = createThrowingErrorReceiver();
+    dataServer.setown(createNewSourceFileEclRepository(errorReporter, name, ESFallowplugins, 0));
 
     HqlScopeArray scopes;
     HqlParseContext parseCtx(dataServer, NULL);
-    HqlLookupContext ctx(parseCtx, &errors);
+    HqlLookupContext ctx(parseCtx, errorReporter);
     getRootScopes(scopes, dataServer, ctx);
 
     ForEachItemIn(i, scopes)

--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -19,25 +19,107 @@
 #include "hqlerror.hpp"
 #include "hqlerrors.hpp"
 
-void MultiErrorReceiver::reportError(int errNo, const char* msg, const char * filename, int lineno, int column, int position)
+class HQL_API CECLError : public CInterfaceOf<IECLError>
+{
+public:
+    CECLError(ErrorSeverity _severity, int _no, const char* _msg, const char* _filename, int _lineno, int _column, int _position);
+
+    virtual int             errorCode() const { return no; }
+    virtual StringBuffer &  errorMessage(StringBuffer & ret) const { return ret.append(msg); }
+    virtual MessageAudience errorAudience() const { return MSGAUD_user; }
+    virtual const char* getFilename() const { return filename; }
+    virtual WarnErrorCategory getCategory() const { return WECunknown; }
+    virtual int getLine() const { return lineno; }
+    virtual int getColumn() const { return column; }
+    virtual int getPosition() const { return position; }
+    virtual StringBuffer& toString(StringBuffer&) const;
+    virtual ErrorSeverity getSeverity() const { return severity; }
+    virtual IECLError * cloneSetSeverity(ErrorSeverity _severity) const;
+
+protected:
+    ErrorSeverity severity;
+    int no;
+    StringAttr msg;
+    StringAttr filename;
+    int lineno;
+    int column;
+    int position;
+};
+
+CECLError::CECLError(ErrorSeverity _severity, int _no, const char* _msg, const char* _filename, int _lineno, int _column, int _position):
+  severity(_severity), msg(_msg), filename(_filename)
+{
+    no = _no;
+    lineno = _lineno;
+    column = _column;
+    position = _position;
+}
+
+
+StringBuffer& CECLError::toString(StringBuffer& buf) const
+{
+    buf.append(filename);
+
+    if(lineno && column)
+        buf.append('(').append(lineno).append(',').append(column).append(')');
+    buf.append(" : ");
+
+    buf.append(no).append(": ").append(msg);
+    return buf;
+}
+
+IECLError * CECLError::cloneSetSeverity(ErrorSeverity newSeverity) const
+{
+    return new CECLError(newSeverity,
+                         errorCode(), msg, filename,
+                         getLine(), getColumn(), getPosition());
+}
+
+extern HQL_API IECLError *createECLError(ErrorSeverity severity, int errNo, const char *msg, const char * filename, int lineno, int column, int pos)
+{
+    return new CECLError(severity,errNo,msg,filename,lineno,column,pos);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+void IErrorReceiver::reportError(int errNo, const char *msg, const char *filename, int lineno, int column, int position)
 {
     Owned<IECLError> err = createECLError(errNo,msg,filename,lineno,column,position);
     report(err);
 }
 
-void MultiErrorReceiver::reportWarning(int warnNo, const char* msg, const char * filename, int lineno, int column, int position)
+void IErrorReceiver::reportWarning(int warnNo, const char *msg, const char *filename, int lineno, int column, int position)
 {
-    Owned<IECLError> warn = createECLWarning(warnNo,msg,filename,lineno,column,position);
+    Owned<IECLError> warn = createECLError(SeverityWarning,warnNo,msg,filename,lineno,column,position);
     report(warn);
 }
 
-void MultiErrorReceiver::report(IECLError* error) 
+//---------------------------------------------------------------------------------------------------------------------
+
+void ErrorReceiverSink::report(IECLError* error)
 {
-    msgs.append(*LINK(error)); 
-    if (error->isError())
-        errs++;
-    else
+    switch (error->getSeverity())
+    {
+    case SeverityWarning:
         warns++;
+        break;
+    case SeverityError:
+    case SeverityFatal:
+        errs++;
+        break;
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+
+
+void MultiErrorReceiver::report(IECLError* error)
+{
+    ErrorReceiverSink::report(error);
+
+    msgs.append(*LINK(error));
+
     StringBuffer msg;
     DBGLOG("reportError(%d:%d) : %s", error->getLine(), error->getColumn(), error->errorMessage(msg).str());
 }
@@ -58,46 +140,10 @@ IECLError *MultiErrorReceiver::firstError()
     ForEachItemIn(i, msgs)
     {
         IECLError* error = item(i);
-        if (error->isError())
+        if (isError(error->getSeverity()))
             return error;
     }
     return NULL;
-}
-
-CECLError::CECLError(bool _isError, int _no, const char* _msg, const char* _filename, int _lineno, int _column, int _position):
-  msg(_msg), filename(_filename)
-{
-    iserror = _isError;
-    no = _no;
-    lineno = _lineno;
-    column = _column;
-    position = _position;
-}
-
-
-StringBuffer& CECLError::toString(StringBuffer& buf)
-{
-    buf.append(filename);
-    
-    if(lineno && column)
-        buf.append('(').append(lineno).append(',').append(column).append(')');
-    buf.append(" : ");
-
-    buf.append(no).append(": ").append(msg);
-    return buf;
-}
-
-extern HQL_API IECLError *createECLError(bool isError, int errNo, const char *msg, const char * filename, int lineno, int column, int pos)
-{
-    return new CECLError(isError,errNo,msg,filename,lineno,column,pos);
-}
-
-extern HQL_API IECLError * changeErrorType(bool isError, IECLError * error)
-{
-    StringBuffer msg;
-    return new CECLError(isError,
-                         error->errorCode(), error->errorMessage(msg).str(), error->getFilename(), 
-                         error->getLine(), error->getColumn(), error->getPosition());
 }
 
 extern HQL_API void reportErrors(IErrorReceiver & receiver, IECLErrorArray & errors)
@@ -108,43 +154,44 @@ extern HQL_API void reportErrors(IErrorReceiver & receiver, IECLErrorArray & err
 
 //---------------------------------------------------------------------------------------------------------------------
 
-class HQL_API FileErrorReceiver : public CInterface, implements IErrorReceiver
+class HQL_API FileErrorReceiver : public ErrorReceiverSink
 {
 public:
-    IMPLEMENT_IINTERFACE;
-
-    int errcount;
-    int warncount;
-    FILE *f;
-
     FileErrorReceiver(FILE *_f)
     {
-        errcount = 0;
-        warncount = 0;
         f = _f;
     }
 
-    virtual void reportError(int errNo, const char *msg, const char * filename, int _lineno, int _column, int _pos)
+    virtual void report(IECLError* error)
     {
-        errcount++;
-        if (!filename) filename = "";
-        fprintf(f, "%s(%d,%d): error C%04d: %s\n", filename, _lineno, _column, errNo, msg);
+        ErrorReceiverSink::report(error);
+
+        ErrorSeverity severity = error->getSeverity();
+        if (severity <= SeverityInfo)
+            return;
+
+        unsigned code = error->errorCode();
+        const char * filename = error->getFilename();
+        unsigned line = error->getLine();
+        unsigned column = error->getColumn();
+        unsigned position = error->getPosition();
+
+        StringBuffer msg;
+        error->errorMessage(msg);
+        if (isError(severity))
+        {
+            if (!filename) filename = "";
+            fprintf(f, "%s(%d,%d): error C%04d: %s\n", filename, line, column, code, msg.str());
+        }
+        else
+        {
+            if (!filename) filename = *unknownAtom;
+            fprintf(f, "%s(%d,%d): warning C%04d: %s\n", filename, line, column, code, msg.str());
+        }
     }
 
-    virtual void reportWarning(int warnNo, const char *msg, const char * filename, int _lineno, int _column, int _pos)
-    {
-        warncount++;
-        if (!filename) filename = *unknownAtom;
-        fprintf(f, "%s(%d,%d): warning C%04d: %s\n", filename, _lineno, _column, warnNo, msg);
-    }
-
-    virtual void report(IECLError* e)
-    {
-        expandReportError(this, e);
-    }
-
-    virtual size32_t errCount() { return errcount; };
-    virtual size32_t warnCount() { return warncount; };
+protected:
+    FILE *f;
 };
 
 extern HQL_API IErrorReceiver *createFileErrorReceiver(FILE *f)
@@ -154,18 +201,31 @@ extern HQL_API IErrorReceiver *createFileErrorReceiver(FILE *f)
 
 //---------------------------------------------------------------------------------------------------------------------
 
-void ThrowingErrorReceiver::reportError(int errNo, const char *msg, const char *filename, int lineno, int column, int pos)
+class HQL_API ThrowingErrorReceiver : public ErrorReceiverSink
 {
-    throw createECLError(errNo, msg, filename, lineno, column, pos);
-}
+    virtual void report(IECLError* error);
+};
 
 void ThrowingErrorReceiver::report(IECLError* error)
 {
-    expandReportError(this, error);
+    throw error;
 }
 
-void ThrowingErrorReceiver::reportWarning(int warnNo, const char *msg, const char *filename, int lineno, int column, int pos)
+IErrorReceiver * createThrowingErrorReceiver()
 {
+    return new ThrowingErrorReceiver;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+class HQL_API NullErrorReceiver : public ErrorReceiverSink
+{
+public:
+};
+
+IErrorReceiver * createNullErrorReceiver()
+{
+    return new NullErrorReceiver;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -189,69 +249,16 @@ void reportError(IErrorReceiver * errors, int errNo, const ECLlocation & loc, co
 }
 
 
-void expandReportError(IErrorReceiver * errors, IECLError* error)
-{
-    StringBuffer msg;
-    error->errorMessage(msg);
-    if (error->isError())
-        errors->reportError(error->errorCode(), msg.str(), error->getFilename(), error->getLine(), error->getColumn(), error->getPosition());
-    else
-        errors->reportWarning(error->errorCode(), msg.str(), error->getFilename(), error->getLine(), error->getColumn(), error->getPosition());
-}
-
-
-//---------------------------------------------------------------------------------------------------------------------
-
-class IndirectErrorReceiver : public CInterface, implements IErrorReceiver
-{
-public:
-    IndirectErrorReceiver(IErrorReceiver * _prev) : prev(_prev) {}
-    IMPLEMENT_IINTERFACE
-
-    virtual void reportError(int errNo, const char *msg, const char *filename, int lineno, int column, int pos)
-    {
-        prev->reportError(errNo, msg, filename, lineno, column, pos);
-    }
-    virtual void report(IECLError* err)
-    {
-        prev->report(err);
-    }
-    virtual void reportWarning(int warnNo, const char *msg, const char *filename, int lineno, int column, int pos)
-    {
-        prev->reportWarning(warnNo, msg, filename, lineno, column, pos);
-    }
-    virtual size32_t errCount()
-    {
-        return prev->errCount();
-    }
-    virtual size32_t warnCount()
-    {
-        return prev->warnCount();
-    }
-
-protected:
-    Linked<IErrorReceiver> prev;
-};
-
 class ErrorInserter : public IndirectErrorReceiver
 {
 public:
-    ErrorInserter(IErrorReceiver * _prev, IECLError * _error) : IndirectErrorReceiver(_prev), error(_error) {}
+    ErrorInserter(IErrorReceiver & _prev, IECLError * _error) : IndirectErrorReceiver(_prev), error(_error) {}
 
-    virtual void reportError(int errNo, const char *msg, const char *filename, int lineno, int column, int pos)
+    virtual void report(IECLError* error)
     {
-        flush();
-        IndirectErrorReceiver::reportError(errNo, msg, filename, lineno, column, pos);
-    }
-    virtual void report(IECLError* err)
-    {
-        flush();
-        IndirectErrorReceiver::report(err);
-    }
-    virtual void reportWarning(int warnNo, const char *msg, const char *filename, int lineno, int column, int pos)
-    {
-        flush();
-        IndirectErrorReceiver::reportWarning(warnNo, msg, filename, lineno, column, pos);
+        if (isError(error->getSeverity()))
+            flush();
+        IndirectErrorReceiver::report(error);
     }
 
 protected:
@@ -267,6 +274,51 @@ protected:
 protected:
     Linked<IECLError> error;
 };
+
+//---------------------------------------------------------------------------------------------------------------------
+
+class AbortingErrorReceiver : public IndirectErrorReceiver
+{
+public:
+    AbortingErrorReceiver(IErrorReceiver & _prev) : IndirectErrorReceiver(_prev) {}
+
+    virtual void report(IECLError* error)
+    {
+        Owned<IECLError> mappedError = prevErrorProcessor->mapError(error);
+        prevErrorProcessor->report(mappedError);
+        if (isError(mappedError->getSeverity()))
+            throw MakeStringExceptionDirect(HQLERR_ErrorAlreadyReported, "");
+    }
+};
+
+IErrorReceiver * createAbortingErrorReceiver(IErrorReceiver & prev)
+{
+    return new AbortingErrorReceiver(prev);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+class DedupingErrorReceiver : public IndirectErrorReceiver
+{
+public:
+    DedupingErrorReceiver(IErrorReceiver & _prev) : IndirectErrorReceiver(_prev) {}
+
+    virtual void report(IECLError* error)
+    {
+        if (errors.contains(*error))
+            return;
+        errors.append(*LINK(error));
+        IndirectErrorReceiver::report(error);
+    }
+
+private:
+    Array errors;
+};
+
+IErrorReceiver * createDedupingErrorReceiver(IErrorReceiver & prev)
+{
+    return new DedupingErrorReceiver(prev);
+}
 
 //---------------------------------------------------------------------------------------------------------------------
 
@@ -291,8 +343,8 @@ void checkEclVersionCompatible(Shared<IErrorReceiver> & errors, const char * ecl
             {
                 //This adds the warning if any other warnings occur.
                 VStringBuffer msg("Mismatch in subminor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
-                Owned<IECLError> warning = createECLWarning(HQLERR_VersionMismatch, msg.str(), NULL, 0, 0);
-                errors.setown(new ErrorInserter(errors, warning));
+                Owned<IECLError> warning = createECLError(SeverityWarning, HQLERR_VersionMismatch, msg.str(), NULL, 0, 0);
+                errors.setown(new ErrorInserter(*errors, warning));
             }
         }
     }

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -62,6 +62,7 @@
 #include "jprop.hpp"
 #include "jptree.hpp"
 #include "defvalue.hpp"
+#include "hqlerror.hpp"
 
 interface IXmlScope;
 interface IHqlScope;
@@ -804,28 +805,6 @@ enum ExprPropKind
 #else
     typedef unsigned short node_operator;
 #endif
-
-interface HQL_API IECLError: public IException
-{
-public:
-    virtual const char* getFilename() = 0;
-    virtual int getLine() = 0;
-    virtual int getColumn() = 0;
-    virtual int getPosition() = 0;
-    virtual StringBuffer& toString(StringBuffer&) = 0;
-    virtual bool isError() = 0;
-};
-
-interface HQL_API IErrorReceiver : public IInterface
-{
-    virtual void reportError(int errNo, const char *msg, const char *filename, int lineno, int column, int pos) = 0;
-    virtual void report(IECLError* err) = 0;
-    virtual void reportWarning(int warnNo, const char *msg, const char *filename, int lineno, int column, int pos) = 0;
-    virtual size32_t errCount() = 0;
-    virtual size32_t warnCount() = 0;
-};
-
-typedef IArrayOf<IECLError> IECLErrorArray;
 
 interface IHqlSimpleScope : public IInterface
 {
@@ -1816,7 +1795,6 @@ inline int boolToInt(bool x)                    { return x ? 1 : 0; }
 extern HQL_API IHqlExpression * createFunctionDefinition(IIdAtom * name, IHqlExpression * value, IHqlExpression * parms, IHqlExpression * defaults, IHqlExpression * attrs);
 extern HQL_API IHqlExpression * createFunctionDefinition(IIdAtom * name, HqlExprArray & args);
 extern HQL_API IHqlExpression * queryNonDelayedBaseAttribute(IHqlExpression * expr);
-extern HQL_API void gatherWarnings(IErrorReceiver * errs, IHqlExpression * expr);
 
 #define NO_AGGREGATE        \
          no_count:          \

--- a/ecl/hql/hqlfold.hpp
+++ b/ecl/hql/hqlfold.hpp
@@ -51,9 +51,10 @@ extern HQLFOLD_API IHqlExpression * foldConstantOperator(IHqlExpression * expr, 
 extern HQLFOLD_API IHqlExpression * quickFoldExpression(IHqlExpression * expr, ITemplateContext *context=NULL, unsigned options=0);
 extern HQLFOLD_API void quickFoldExpressions(HqlExprArray & target, const HqlExprArray & source, ITemplateContext *context, unsigned options);
 
-extern HQLFOLD_API IHqlExpression * foldHqlExpression(IHqlExpression * expr, ITemplateContext *context=NULL, unsigned options=0);
-extern HQLFOLD_API IHqlExpression * foldScopedHqlExpression(IHqlExpression * dataset, IHqlExpression * expr, unsigned options=0);
-extern HQLFOLD_API void foldHqlExpression(HqlExprArray & tgt, HqlExprArray & src, unsigned options=0);
+extern HQLFOLD_API IHqlExpression * foldHqlExpression(IHqlExpression * expr); // No errors reported.
+extern HQLFOLD_API IHqlExpression * foldHqlExpression(IErrorReceiver & errorProcessor, IHqlExpression * expr, ITemplateContext *context=NULL, unsigned options=0);
+extern HQLFOLD_API IHqlExpression * foldScopedHqlExpression(IErrorReceiver & errorProcessor, IHqlExpression * dataset, IHqlExpression * expr, unsigned options=0);
+extern HQLFOLD_API void foldHqlExpression(IErrorReceiver & errorProcessor, HqlExprArray & tgt, HqlExprArray & src, unsigned options=0);
 extern HQLFOLD_API IHqlExpression * lowerCaseHqlExpr(IHqlExpression * expr);
 extern HQLFOLD_API IHqlExpression * foldExprIfConstant(IHqlExpression * expr);
 

--- a/ecl/hql/hqlfold.ipp
+++ b/ecl/hql/hqlfold.ipp
@@ -67,7 +67,7 @@ class CExprFolderTransformer : public FOLD_PARENT, public NullFolderMixin
 {
     typedef FOLD_PARENT PARENT;
 public:
-    CExprFolderTransformer(ITemplateContext *templateContext, unsigned _options);
+    CExprFolderTransformer(IErrorReceiver & _errorProcessor, ITemplateContext *templateContext, unsigned _options);
 
     void setScope(IHqlExpression * expr)                { stopDatasetTransform(expr); }
 
@@ -112,6 +112,7 @@ private:
 
 protected:
     ITemplateContext *templateContext;
+    IErrorReceiver & errorProcessor;
     unsigned foldOptions;
     StringBuffer nodeText[2];
 };

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -577,10 +577,11 @@ public:
     void reportWarningVa(int errNo, const attribute& a, const char* format, va_list args);
     void reportWarning(int warnNo, const char *msg, int lineno, int column);
     void addResult(IHqlExpression *query, const attribute& errpos);
-    bool okToReportError(const ECLlocation & pos);
-// interface IErrorReceiver
+
+    // interface IErrorReceiver
     virtual void reportError(int errNo, const char *msg, const char *filename=NULL, int lineno=0, int column=0, int pos=0);
-    virtual void report(IECLError*);
+    virtual void report(IECLError * error);
+    virtual IECLError * mapError(IECLError * error);
     virtual void reportWarning(int warnNo, const char *msg, const char *filename=NULL, int lineno=0, int column=0, int pos=0);
     virtual size32_t errCount();
     virtual size32_t warnCount();
@@ -834,6 +835,7 @@ protected:
     bool legacyWhenSemantics;
     bool isQuery;
     bool parseConstantText;
+    bool expandingMacroPosition;
     unsigned m_maxErrorsAllowed;
 
     IECLErrorArray pendingWarnings;

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -1666,9 +1666,11 @@ failure
     ;
 
 warningAction
-    : TOK_IGNORE        {   $$.setExpr(createAttribute(ignoreAtom), $1); }
+    : TOK_LOG           {   $$.setExpr(createAttribute(logAtom), $1); }
+    | TOK_IGNORE        {   $$.setExpr(createAttribute(ignoreAtom), $1); }
     | TOK_WARNING       {   $$.setExpr(createAttribute(warningAtom), $1); }
     | TOK_ERROR         {   $$.setExpr(createAttribute(errorAtom), $1); }
+    | FAIL              {   $$.setExpr(createAttribute(failAtom), $1); }
     ;
 
 optPersistOpts
@@ -5187,7 +5189,7 @@ compareExpr
                             parser->normalizeExpression($4, type_dictionary, false);
                             OwnedHqlExpr dict = $4.getExpr();
                             OwnedHqlExpr row = createValue(no_rowvalue, makeNullType(), $1.getExpr());
-                            OwnedHqlExpr indict = createINDictExpr(parser->errorHandler, $4.pos, row, dict);
+                            OwnedHqlExpr indict = createINDictExpr(*parser->errorHandler, $4.pos, row, dict);
                             $$.setExpr(getInverse(indict));
                             $$.setPosition($3);
                         }
@@ -5198,7 +5200,7 @@ compareExpr
                             parser->normalizeExpression($4, type_dictionary, false);
                             OwnedHqlExpr dict = $4.getExpr();
                             OwnedHqlExpr row = $1.getExpr();
-                            OwnedHqlExpr indict = createINDictRow(parser->errorHandler, $4.pos, row, dict);
+                            OwnedHqlExpr indict = createINDictRow(*parser->errorHandler, $4.pos, row, dict);
                             $$.setExpr(getInverse(indict));
                             $$.setPosition($3);
                         }
@@ -5209,7 +5211,7 @@ compareExpr
                             parser->normalizeExpression($3, type_dictionary, false);
                             OwnedHqlExpr dict = $3.getExpr();
                             OwnedHqlExpr row = createValue(no_rowvalue, makeNullType(), $1.getExpr());
-                            $$.setExpr(createINDictExpr(parser->errorHandler, $3.pos, row, dict));
+                            $$.setExpr(createINDictExpr(*parser->errorHandler, $3.pos, row, dict));
                             $$.setPosition($2);
                         }
     | dataRow TOK_IN dictionary
@@ -5219,7 +5221,7 @@ compareExpr
                             parser->normalizeExpression($3, type_dictionary, false);
                             OwnedHqlExpr dict = $3.getExpr();
                             OwnedHqlExpr row = $1.getExpr();
-                            $$.setExpr(createINDictRow(parser->errorHandler, $3.pos, row, dict));
+                            $$.setExpr(createINDictRow(*parser->errorHandler, $3.pos, row, dict));
                             $$.setPosition($2);
                         }
     | dataSet EQ dataSet    
@@ -6941,7 +6943,7 @@ dataRow
                             $3.unwindCommaList(args);
                             OwnedHqlExpr dict = $1.getExpr();
                             OwnedHqlExpr row = createValue(no_rowvalue, makeNullType(), args);
-                            $$.setExpr(createSelectMapRow(parser->errorHandler, $3.pos, dict, row));
+                            $$.setExpr(createSelectMapRow(*parser->errorHandler, $3.pos, dict, row));
                         }
     | dataSet '[' NOBOUNDCHECK expression ']'
                         {   
@@ -7089,7 +7091,7 @@ simpleDataRow
     | ROW '(' inlineDatasetValue ',' recordDef ')'
                         {
                             OwnedHqlExpr row = createRow(no_temprow, $3.getExpr(), $5.getExpr());
-                            $$.setExpr(convertTempRowToCreateRow(parser->errorHandler, $3.pos, row));
+                            $$.setExpr(convertTempRowToCreateRow(*parser->errorHandler, $3.pos, row));
                             $$.setPosition($1);
                         }
     | ROW '(' startLeftSeqRow ',' recordDef ')' endSelectorSequence

--- a/ecl/hql/hqlir.cpp
+++ b/ecl/hql/hqlir.cpp
@@ -1341,7 +1341,7 @@ public:
                 appendStringAsCPP(line, msg.length(), msg.str(), false);
                 line.append("'");
                 line.append(",").append(warning->errorAudience());
-                line.append(",").append(warning->isError());
+                line.append(",").append((unsigned)warning->getSeverity());
                 line.append(")");
                 break;
             }

--- a/ecl/hql/hqlopt.hpp
+++ b/ecl/hql/hqlopt.hpp
@@ -34,7 +34,7 @@ enum
     HOOexpensive                = 0x0200,   // include potentially expensive optimizations
 };
 
-extern HQL_API IHqlExpression * optimizeHqlExpression(IHqlExpression * expr, unsigned options);
-extern HQL_API void optimizeHqlExpression(HqlExprArray & target, HqlExprArray & source, unsigned options);
+extern HQL_API IHqlExpression * optimizeHqlExpression(IErrorReceiver & errorProcessor, IHqlExpression * expr, unsigned options);
+extern HQL_API void optimizeHqlExpression(IErrorReceiver & errorProcessor, HqlExprArray & target, HqlExprArray & source, unsigned options);
 
 #endif

--- a/ecl/hql/hqlopt.ipp
+++ b/ecl/hql/hqlopt.ipp
@@ -41,7 +41,7 @@ class CTreeOptimizer : public NewHqlTransformer, public NullFolderMixin
 {
     friend class ExpandMonitor;
 public:
-    CTreeOptimizer(unsigned _options);
+    CTreeOptimizer(IErrorReceiver & _errorProcessor, unsigned _options);
 
 protected:
     virtual void analyseExpr(IHqlExpression * expr);
@@ -123,6 +123,7 @@ protected:
 
 protected:
     typedef NewHqlTransformer PARENT;
+    IErrorReceiver & errorProcessor;
     unsigned options;
     StringBuffer nodeText[2];
     HqlExprAttr noHoistAttr;

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -1747,7 +1747,7 @@ IValue *HqlLex::foldConstExpression(const YYSTYPE & errpos, IHqlExpression * exp
         try 
         {
             CTemplateContext context(this, yyParser->lookupCtx, xmlScope, startLine, startCol);
-            OwnedHqlExpr folded = foldHqlExpression(expr, &context, HFOthrowerror|HFOfoldimpure|HFOforcefold);
+            OwnedHqlExpr folded = foldHqlExpression(*yyParser, expr, &context, HFOthrowerror|HFOfoldimpure|HFOforcefold);
             if (folded)
             {
                 if (folded->queryValue())
@@ -1815,7 +1815,7 @@ void HqlLex::doApply(YYSTYPE & returnToken)
     if (actions)
     {
         CTemplateContext context(this, yyParser->lookupCtx, xmlScope,line,col);
-        OwnedHqlExpr folded = foldHqlExpression(actions, &context, HFOthrowerror|HFOfoldimpure|HFOforcefold);
+        OwnedHqlExpr folded = foldHqlExpression(*yyParser, actions, &context, HFOthrowerror|HFOfoldimpure|HFOforcefold);
     }
     else
         reportError(returnToken, ERR_EXPECTED_CONST, "Constant expression expected");

--- a/ecl/hql/hqlplugininfo.cpp
+++ b/ecl/hql/hqlplugininfo.cpp
@@ -15,12 +15,14 @@
     limitations under the License.
 ############################################################################## */
 
-#include "jfile.hpp" 
+#include "jfile.hpp"
+#include "jlog.hpp"
 #include "hqlerror.hpp"
 #include "hqlcollect.hpp"
 #include "hqlrepository.hpp"
 #include "hqlplugins.hpp"
 #include "hqlplugininfo.hpp"
+#include "hqlexpr.hpp"
 
 namespace repositoryCommon {
 

--- a/ecl/hql/hqlrepository.cpp
+++ b/ecl/hql/hqlrepository.cpp
@@ -85,26 +85,6 @@ extern HQL_API void importRootModulesToScope(IHqlScope * scope, HqlLookupContext
 
 //-------------------------------------------------------------------------------------------------------------------
 
-void lookupAllRootDefinitions(IHqlScope * scope, HqlLookupContext & ctx)
-{
-    HqlExprArray rootSymbols;
-    scope->getSymbols(rootSymbols);
-    ForEachItemIn(i, rootSymbols)
-    {
-        ::Release(scope->lookupSymbol(rootSymbols.item(i).queryId(), LSFsharedOK, ctx));
-    }
-}
-
-void lookupAllRootDefinitions(IEclRepository * repository)
-{
-    HqlParseContext parseCtx(repository, NULL);
-    ThrowingErrorReceiver errs;
-    HqlLookupContext ctx(parseCtx, &errs);
-    lookupAllRootDefinitions(repository->queryRootScope(), ctx);
-}
-
-//-------------------------------------------------------------------------------------------------------------------
-
 IHqlExpression * getResolveAttributeFullPath(const char * attrname, unsigned lookupFlags, HqlLookupContext & ctx)
 {
     Owned<IHqlScope> parentScope;

--- a/ecl/hql/hqlrepository.hpp
+++ b/ecl/hql/hqlrepository.hpp
@@ -37,10 +37,6 @@ extern HQL_API void getRootScopes(HqlScopeArray & rootScopes, IEclRepository * r
 extern HQL_API void getImplicitScopes(HqlScopeArray & implicitScopes, IEclRepository * repository, IHqlScope * scope, HqlLookupContext & ctx);
 extern HQL_API void importRootModulesToScope(IHqlScope * scope, HqlLookupContext & ctx);
 
-
-extern HQL_API void lookupAllRootDefinitions(IHqlScope * scope, HqlLookupContext & ctx);
-extern HQL_API void lookupAllRootDefinitions(IEclRepository * repository);
-
 extern HQL_API IHqlScope * getResolveDottedScope(const char * modname, unsigned lookupFlags, HqlLookupContext & ctx);
 extern HQL_API IHqlExpression * getResolveAttributeFullPath(const char * attrname, unsigned lookupFlags, HqlLookupContext & ctx);
 

--- a/ecl/hql/hqlutil.hpp
+++ b/ecl/hql/hqlutil.hpp
@@ -458,10 +458,10 @@ extern HQL_API bool isNullList(IHqlExpression * expr);
 
 extern HQL_API IHqlExpression *getDictionaryKeyRecord(IHqlExpression *record);
 extern HQL_API IHqlExpression *getDictionarySearchRecord(IHqlExpression *record);
-extern HQL_API IHqlExpression * createSelectMapRow(IErrorReceiver * errors, ECLlocation & location, IHqlExpression * dict, IHqlExpression *values);
-extern HQL_API IHqlExpression * createINDictExpr(IErrorReceiver * errors, ECLlocation & location, IHqlExpression *expr, IHqlExpression *dict);
-extern HQL_API IHqlExpression *createINDictRow(IErrorReceiver * errors, ECLlocation & location, IHqlExpression *row, IHqlExpression *dict);
-extern HQL_API IHqlExpression * convertTempRowToCreateRow(IErrorReceiver * errors, ECLlocation & location, IHqlExpression * expr);
+extern HQL_API IHqlExpression * createSelectMapRow(IErrorReceiver & errorProcessor, ECLlocation & location, IHqlExpression * dict, IHqlExpression *values);
+extern HQL_API IHqlExpression * createINDictExpr(IErrorReceiver & errorProcessor, ECLlocation & location, IHqlExpression *expr, IHqlExpression *dict);
+extern HQL_API IHqlExpression *createINDictRow(IErrorReceiver & errorProcessor, ECLlocation & location, IHqlExpression *row, IHqlExpression *dict);
+extern HQL_API IHqlExpression * convertTempRowToCreateRow(IErrorReceiver & errorProcessor, ECLlocation & location, IHqlExpression * expr);
 extern HQL_API IHqlExpression * convertTempTableToInlineTable(IErrorReceiver & errors, ECLlocation & location, IHqlExpression * expr);
 extern HQL_API void setPayloadAttribute(HqlExprArray &args);
 
@@ -505,81 +505,76 @@ protected:
     bool streamingAllowed;
 };
 
-extern HQL_API IAtom * getWarningAction(unsigned errorCode, const HqlExprArray & overrides, unsigned first);
-class HQL_API WarningProcessor
+/*
+ *
+ *This class is used for processing the onWarningMappings.
+ *
+ * Global onWarnings are simple, and are just added to a class instance
+ * local onWarnings are
+ * - applied in a stack-wise manner, so should be removed when no longer processing inside them
+ * - only apply until the next defined symbol - to prevent them having an effect too far down the tree
+ *
+ * For this reason SymbolBlocks and Blocks are used to ensure those rules are followed
+ *
+ */
+class HQL_API ErrorSeverityMapper : public IndirectErrorReceiver
 {
 public:
-    struct OnWarningState
+    struct ErrorSeverityMapperState
     {
         IHqlExpression * symbol;
-        unsigned firstOnWarning;
-        unsigned onWarningMax;
+        unsigned firstActiveMapping;
+        unsigned maxMappings;
     };
 
-    struct OnWarningStateSymbolBlock
+    struct SymbolScope
     {
-        inline OnWarningStateSymbolBlock(WarningProcessor & _processor, IHqlExpression * _expr) : processor(_processor) { processor.pushSymbol(state, _expr); }
-        inline ~OnWarningStateSymbolBlock() { processor.popSymbol(state); }
+        inline SymbolScope(ErrorSeverityMapper & _processor, IHqlExpression * _expr) : processor(_processor) { processor.pushSymbol(state, _expr); }
+        inline ~SymbolScope() { processor.popSymbol(state); }
 
     private:
-        WarningProcessor & processor;
-        OnWarningState state;
+        ErrorSeverityMapper & processor;
+        ErrorSeverityMapperState state;
     };
 
-    struct OnWarningStateBlock
+    struct Scope
     {
-        inline OnWarningStateBlock(WarningProcessor & _processor) : processor(_processor) { processor.saveState(state); }
-        inline ~OnWarningStateBlock() { processor.restoreState(state); }
+        inline Scope(ErrorSeverityMapper & _processor) : processor(_processor) { processor.saveState(state); }
+        inline ~Scope() { processor.restoreState(state); }
 
     private:
-        WarningProcessor & processor;
-        OnWarningState state;
+        ErrorSeverityMapper & processor;
+        ErrorSeverityMapperState state;
     };
 
 public:
-    WarningProcessor();
+    ErrorSeverityMapper(IErrorReceiver & errorProcessor);
 
-    void addGlobalOnWarning(unsigned code, IAtom * action);
-    void addGlobalOnWarning(IHqlExpression * setMetaExpr);
-    void addWarning(IECLError * warning);
-    inline void checkForGlobalOnWarning(IHqlExpression * expr)
-    {
-        if ((expr->getOperator() == no_setmeta) && (expr->queryChild(0)->queryName() == onWarningAtom))
-            addGlobalOnWarning(expr);
-    }
-    void processMetaAnnotation(IHqlExpression * expr);
-    void processWarningAnnotation(IHqlExpression * expr);
-    void pushSymbol(OnWarningState & saved, IHqlExpression * _symbol);
-    void popSymbol(const OnWarningState & saved) { restoreState(saved); }
-    void saveState(OnWarningState & saved);
+    virtual IECLError * mapError(IECLError * error);
+
+    bool addCommandLineMapping(const char * mapping);
+    void addOnWarning(unsigned code, IAtom * action);
+    void addOnWarning(IHqlExpression * setMetaExpr);
+    unsigned processMetaAnnotation(IHqlExpression * expr);
+    void pushSymbol(ErrorSeverityMapperState & saved, IHqlExpression * _symbol);
+    void popSymbol(const ErrorSeverityMapperState & saved) { restoreState(saved); }
+    void restoreLocalOnWarnings(unsigned prevMax);
+    void saveState(ErrorSeverityMapperState & saved) const;
     void setSymbol(IHqlExpression * _symbol);
-    void restoreState(const OnWarningState & saved);
-    void report(IErrorReceiver & errors);
-    void report(IErrorReceiver * errors, IErrorReceiver * warnings, IECLError * warning);   // process warning now.
+    void restoreState(const ErrorSeverityMapperState & saved);
 
-    inline void appendUnique(IECLErrorArray & list, IECLError * search)
-    {
-        if (!list.contains(*search))
-            list.append(*LINK(search));
-    }
-    inline unsigned numErrors() const { return allErrors.ordinality(); }
     inline IHqlExpression * queryActiveSymbol() { return activeSymbol; }
 
-
-protected:
-    void combineSandboxWarnings();
-    void applyGlobalOnWarning();
+private:
+    ErrorSeverityMapper(const ErrorSeverityMapper &); // prevent this being called
 
 protected:
     IHqlExpression * activeSymbol;
-    IECLErrorArray possibleWarnings;
-    IECLErrorArray warnings;
-    IECLErrorArray allErrors;
-    HqlExprArray globalOnWarnings;
-    HqlExprArray localOnWarnings;
-    unsigned firstLocalOnWarning;
+    HqlExprArray severityMappings;
+    unsigned firstActiveMapping;
 };
 
+extern HQL_API bool isGlobalOnWarning(IHqlExpression * expr);
 
 extern HQL_API IHqlExpression * queryDefaultMaxRecordLengthExpr();
 extern HQL_API IHqlExpression * getFixedSizeAttr(unsigned size);
@@ -730,5 +725,6 @@ protected:
 };
 
 extern HQL_API bool joinHasRightOnlyHardMatch(IHqlExpression * expr, bool allowSlidingMatch);
+extern HQL_API void gatherParseWarnings(IErrorReceiver * errs, IHqlExpression * expr);
 
 #endif

--- a/ecl/hql/hqlvalid.cpp
+++ b/ecl/hql/hqlvalid.cpp
@@ -129,7 +129,7 @@ IHqlExpression * checkCreateConcreteModule(IErrorReceiver * errors, IHqlExpressi
     return createDelayedScope(check.getClear());
 }
 
-void reportAbstractModule(IErrorReceiver * errors, IHqlExpression * expr, const ECLlocation & errpos)
+void reportAbstractModule(IErrorReceiver & errors, IHqlExpression * expr, const ECLlocation & errpos)
 {
     IHqlScope * scope = expr->queryScope();
     StringBuffer fieldText;
@@ -151,11 +151,11 @@ void reportAbstractModule(IErrorReceiver * errors, IHqlExpression * expr, const 
     }
 
     if (fieldText.length())
-        reportError(errors, ERR_ABSTRACT_MODULE, errpos, "Cannot use an abstract MODULE in this context (%s undefined)", fieldText.str());
+        reportError(&errors, ERR_ABSTRACT_MODULE, errpos, "Cannot use an abstract MODULE in this context (%s undefined)", fieldText.str());
     else if (expr->hasAttribute(interfaceAtom))
-        reportError(errors, ERR_ABSTRACT_MODULE, errpos, "Cannot use an abstract MODULE in this context (INTERFACE must be instantiated)");
+        reportError(&errors, ERR_ABSTRACT_MODULE, errpos, "Cannot use an abstract MODULE in this context (INTERFACE must be instantiated)");
     else
-        reportError(errors, ERR_ABSTRACT_MODULE, errpos, "Cannot use an abstract MODULE in this context");
+        reportError(&errors, ERR_ABSTRACT_MODULE, errpos, "Cannot use an abstract MODULE in this context");
 }
 
 IHqlExpression * checkCreateConcreteModule(IErrorReceiver * errors, IHqlExpression * expr, const IHqlExpression * locationExpr)

--- a/ecl/hql/hqlvalid.hpp
+++ b/ecl/hql/hqlvalid.hpp
@@ -20,7 +20,7 @@
 #include "hqlexpr.hpp"
 
 //Checking functions
-extern HQL_API void reportAbstractModule(IErrorReceiver * errors, IHqlExpression * expr, const ECLlocation & errpos);
+extern HQL_API void reportAbstractModule(IErrorReceiver & errorProcessor, IHqlExpression * expr, const ECLlocation & errpos);
 extern HQL_API IHqlExpression * checkCreateConcreteModule(IErrorReceiver * errors, IHqlExpression * expr, const ECLlocation & errpos);
 extern HQL_API IHqlExpression * checkCreateConcreteModule(IErrorReceiver * errors, IHqlExpression * expr, const IHqlExpression * locationExpr);
 extern HQL_API IHqlExpression * createLocationAttr(ISourcePath * filename, int lineno, int column, int position);

--- a/ecl/hql/hqlwuerr.hpp
+++ b/ecl/hql/hqlwuerr.hpp
@@ -26,9 +26,8 @@ public:
     WorkUnitErrorReceiver(IWorkUnit * _wu, const char * _component) { wu.set(_wu); component.set(_component); }
     IMPLEMENT_IINTERFACE;
 
-    virtual void reportError(int errNo, const char *msg, const char * filename, int lineno, int column, int pos);
+    virtual IECLError * mapError(IECLError * error);
     virtual void report(IECLError*);
-    virtual void reportWarning(int warnNo, const char *msg, const char * filename, int lineno, int column, int pos);
     virtual size32_t errCount();
     virtual size32_t warnCount();
 

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -271,8 +271,6 @@
 #define HQLERR_OnceCannotAccessStored           4618
 #define HQLERR_ThorCombineOnlyLocal             4619
 
-#define HQLERR_ErrorAlreadyReported             4799            // special case...
-
 //Internal errors....
 #define HQLERR_NoClearOnLocalDataset            4800
 #define HQLERR_NoCreateLocalDataset             4801

--- a/ecl/hqlcpp/hqlckey.cpp
+++ b/ecl/hqlcpp/hqlckey.cpp
@@ -710,7 +710,7 @@ void KeyedJoinInfo::buildTransformBody(BuildCtx & ctx, IHqlExpression * transfor
             newTransform.setown(expandDatasetReferences(newTransform, expandedKey));
     }
 
-    newTransform.setown(optimizeHqlExpression(newTransform, HOOfold|HOOcompoundproject));
+    newTransform.setown(optimizeHqlExpression(translator.queryErrorProcessor(), newTransform, HOOfold|HOOcompoundproject));
     newTransform.setown(foldHqlExpression(newTransform));
 
     BoundRow * selfCursor = translator.buildTransformCursors(ctx, newTransform, expr->queryChild(0), joinDataset, expr, joinSeq);

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -939,14 +939,14 @@ public:
 
     unsigned getOptimizeFlags() const;
     unsigned getSourceAggregateOptimizeFlags() const;
-    inline void addGlobalOnWarning(IHqlExpression * setMetaExpr) { warningProcessor.addGlobalOnWarning(setMetaExpr); }
+    void addGlobalOnWarning(IHqlExpression * setMetaExpr);
 
     ClusterType getTargetClusterType() const { return targetClusterType; }
     inline bool targetRoxie() const { return targetClusterType == RoxieCluster; }
     inline bool targetHThor() const { return targetClusterType == HThorCluster; }
     inline bool targetThor() const { return isThorCluster(targetClusterType); }
-    inline IErrorReceiver * queryErrors() { return errors; }
-    inline WarningProcessor & queryWarningProcessor() { return warningProcessor; }
+    inline IErrorReceiver & queryErrorProcessor() { return *errorProcessor; }
+    inline ErrorSeverityMapper & queryLocalOnWarningMapper() { return *localOnWarnings; }
 
     void pushMemberFunction(MemberFunction & func);
     void popMemberFunction();
@@ -1903,7 +1903,9 @@ protected:
     ExprExprMap         physicalIndexCache;
     unsigned            litno;
     StringAttr          soName;
-    IErrorReceiver *    errors;
+    Owned<ErrorSeverityMapper> globalOnWarnings;
+    Owned<ErrorSeverityMapper> localOnWarnings;
+    Linked<IErrorReceiver> errorProcessor;
     HqlCppOptions       options;
     HqlCppDerived       derived;
     bool                checkedEmbeddedCpp;
@@ -1956,7 +1958,6 @@ protected:
     HqlExprArray activityExprStack;             //only used for improving the error reporting
     PointerArray recordIndexCache;
     Owned<ITimeReporter> timeReporter;
-    WarningProcessor warningProcessor;
     CIArrayOf<SourceFieldUsage> trackedSources;
 };
 

--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -1680,7 +1680,7 @@ IHqlExpression * HqlCppTranslator::getResourcedChildGraph(BuildCtx & ctx, IHqlEx
     {
         unsigned time = msTick();
         traceExpression("BeforeOptimizeSub", resourced);
-        resourced.setown(optimizeHqlExpression(resourced, getOptimizeFlags()|HOOcompoundproject));
+        resourced.setown(optimizeHqlExpression(queryErrorProcessor(), resourced, getOptimizeFlags()|HOOcompoundproject));
         traceExpression("AfterOptimizeSub", resourced);
         updateTimer("workunit;optimize graph", msTick()-time);
     }

--- a/ecl/hqlcpp/hqlcpputil.cpp
+++ b/ecl/hqlcpp/hqlcpputil.cpp
@@ -278,7 +278,7 @@ IHqlExpression * addExpressionModifier(IHqlExpression * expr, typemod_t modifier
 
 
 
-static void expandFieldNames(StringBuffer & out, IHqlExpression * record, StringBuffer & prefix, const char * sep, IHqlExpression * formatFunc)
+static void expandFieldNames(IErrorReceiver & errorProcessor, StringBuffer & out, IHqlExpression * record, StringBuffer & prefix, const char * sep, IHqlExpression * formatFunc)
 {
     ForEachChild(i, record)
     {
@@ -286,10 +286,10 @@ static void expandFieldNames(StringBuffer & out, IHqlExpression * record, String
         switch (cur->getOperator())
         {
         case no_record:
-            expandFieldNames(out, cur, prefix, sep, formatFunc);
+            expandFieldNames(errorProcessor, out, cur, prefix, sep, formatFunc);
             break;
         case no_ifblock:
-            expandFieldNames(out, cur->queryChild(1), prefix, sep, formatFunc);
+            expandFieldNames(errorProcessor, out, cur->queryChild(1), prefix, sep, formatFunc);
             break;
         case no_field:
             {
@@ -300,7 +300,7 @@ static void expandFieldNames(StringBuffer & out, IHqlExpression * record, String
                     HqlExprArray args;
                     args.append(*createConstant(lowerName.str()));
                     OwnedHqlExpr bound = createBoundFunction(NULL, formatFunc, args, NULL, true);
-                    OwnedHqlExpr folded = foldHqlExpression(bound, NULL, HFOthrowerror|HFOfoldimpure|HFOforcefold);
+                    OwnedHqlExpr folded = foldHqlExpression(errorProcessor, bound, NULL, HFOthrowerror|HFOfoldimpure|HFOforcefold);
                     assertex(folded->queryValue());
                     lowerName.clear();
                     getStringValue(lowerName, folded);
@@ -313,7 +313,7 @@ static void expandFieldNames(StringBuffer & out, IHqlExpression * record, String
                     {
                         unsigned len = prefix.length();
                         prefix.append(lowerName).append(".");
-                        expandFieldNames(out, cur->queryRecord(), prefix, sep, formatFunc);
+                        expandFieldNames(errorProcessor, out, cur->queryRecord(), prefix, sep, formatFunc);
                         prefix.setLength(len);
                         break;
                     }
@@ -331,10 +331,10 @@ static void expandFieldNames(StringBuffer & out, IHqlExpression * record, String
     }
 }
 
-void expandFieldNames(StringBuffer & out, IHqlExpression * record, const char * sep, IHqlExpression * formatFunc)
+void expandFieldNames(IErrorReceiver & errorProcessor, StringBuffer & out, IHqlExpression * record, const char * sep, IHqlExpression * formatFunc)
 {
     StringBuffer prefix;
-    expandFieldNames(out, record, prefix, sep, formatFunc);
+    expandFieldNames(errorProcessor, out, record, prefix, sep, formatFunc);
 }
 
 

--- a/ecl/hqlcpp/hqlcpputil.hpp
+++ b/ecl/hqlcpp/hqlcpputil.hpp
@@ -43,7 +43,7 @@ extern ITypeInfo * makeRowReferenceType(const CHqlBoundExpr & bound);
 
 extern IHqlExpression * addMemberSelector(IHqlExpression * expr, IHqlExpression * selector);
 extern IHqlExpression * addExpressionModifier(IHqlExpression * expr, typemod_t modifier, IInterface * extra=NULL);
-extern void expandFieldNames(StringBuffer & out, IHqlExpression * record, const char * sep, IHqlExpression * formatFunc);
+extern void expandFieldNames(IErrorReceiver & errorProcessor, StringBuffer & out, IHqlExpression * record, const char * sep, IHqlExpression * formatFunc);
 extern IHqlExpression * ensurePositiveOrZeroInt64(IHqlExpression * expr);
 
 extern void getOutputLibraryName(SCMStringBuffer & libraryName, IConstWorkUnit * wu);

--- a/ecl/hqlcpp/hqliter.cpp
+++ b/ecl/hqlcpp/hqliter.cpp
@@ -147,7 +147,7 @@ void TransformSequenceBuilder::buildSequence(BuildCtx & ctx, BuildCtx * declarec
             }
             OwnedHqlExpr test = getInverse(cond);
             if (translator.queryOptions().foldFilter)
-                test.setown(foldScopedHqlExpression(expr->queryChild(0)->queryNormalizedSelector(), test));
+                test.setown(foldScopedHqlExpression(translator.queryErrorProcessor(), expr->queryChild(0)->queryNormalizedSelector(), test));
             if (translator.queryOptions().spotCSE)
                 test.setown(spotScalarCSE(test));
             translator.buildFilteredReturn(ctx, test, failedFilterValue);

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -1840,10 +1840,10 @@ IHqlExpression * ResourcerInfo::wrapRowOwn(IHqlExpression * expr)
 
 //---------------------------------------------------------------------------
 
-EclResourcer::EclResourcer(IErrorReceiver * _errors, IConstWorkUnit * _wu, ClusterType _targetClusterType, unsigned _clusterSize, const HqlCppOptions & _translatorOptions)
+EclResourcer::EclResourcer(IErrorReceiver & _errors, IConstWorkUnit * _wu, ClusterType _targetClusterType, unsigned _clusterSize, const HqlCppOptions & _translatorOptions)
 { 
     wu.set(_wu);
-    errors = _errors;
+    errors = &_errors;
     lockTransformMutex(); 
     targetClusterType = _targetClusterType; 
     clusterSize = _clusterSize ? _clusterSize : FIXED_CLUSTER_SIZE;
@@ -5188,7 +5188,7 @@ IHqlExpression * resourceThorGraph(HqlCppTranslator & translator, IHqlExpression
 {
     HqlExprArray transformed;
     {
-        EclResourcer resourcer(translator.queryErrors(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
+        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
         if (graphIdExpr)
             resourcer.setNewChildQuery(graphIdExpr, 0);
 
@@ -5206,7 +5206,7 @@ static IHqlExpression * doResourceGraph(HqlCppTranslator & translator, HqlExprCo
     HqlExprArray transformed;
     unsigned totalResults;
     {
-        EclResourcer resourcer(translator.queryErrors(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
+        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
         if (isChild)
             resourcer.setChildQuery(true);
         resourcer.setNewChildQuery(graphIdExpr, numResults);
@@ -5254,7 +5254,7 @@ IHqlExpression * resourceRemoteGraph(HqlCppTranslator & translator, IHqlExpressi
 {
     HqlExprArray transformed;
     {
-        EclResourcer resourcer(translator.queryErrors(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
+        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
 
         resourcer.resourceRemoteGraph(expr, transformed);
     }

--- a/ecl/hqlcpp/hqlresource.ipp
+++ b/ecl/hqlcpp/hqlresource.ipp
@@ -351,7 +351,7 @@ class EclResourcer
 {
     friend class SelectHoistTransformer;
 public:
-    EclResourcer(IErrorReceiver * _errors, IConstWorkUnit * _wu, ClusterType _targetClusterType, unsigned _clusterSize, const HqlCppOptions & _translatorOptions);
+    EclResourcer(IErrorReceiver & _errors, IConstWorkUnit * _wu, ClusterType _targetClusterType, unsigned _clusterSize, const HqlCppOptions & _translatorOptions);
     ~EclResourcer();
 
     void resourceGraph(IHqlExpression * expr, HqlExprArray & transformed);

--- a/ecl/hqlcpp/hqltcppc.cpp
+++ b/ecl/hqlcpp/hqltcppc.cpp
@@ -2340,7 +2340,7 @@ void CBitfieldInfo::setColumn(HqlCppTranslator & translator, BuildCtx & ctx, IRe
     if (bitOffset > 0)
         newValue.setown(createValue(no_lshift, LINK(storageType), newValue.getClear(), getSizetConstant(bitOffset)));
     if (newValue->isConstant())
-        newValue.setown(foldHqlExpression(newValue, 0, 0));
+        newValue.setown(foldHqlExpression(translator.queryErrorProcessor(), newValue));
     OwnedHqlExpr final = createValue(no_bor, LINK(storageType), oldValue, newValue.getClear());
 
     CHqlBoundTarget boundTarget;

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -1027,12 +1027,10 @@ class HqlScopeTagger : public ScopedDependentTransformer
 {
     typedef ScopedDependentTransformer Parent;
 public:
-    HqlScopeTagger(IErrorReceiver * _errors);
+    HqlScopeTagger(IErrorReceiver & _errors, ErrorSeverityMapper & _errorMapper);
 
     virtual IHqlExpression * createTransformed(IHqlExpression * expr);
     virtual ANewTransformInfo * createTransformInfo(IHqlExpression * expr);
-
-    void reportWarnings();
 
 protected:
     void checkActiveRow(IHqlExpression * expr);
@@ -1047,12 +1045,12 @@ protected:
     IHqlExpression * transformWithin(IHqlExpression * dataset, IHqlExpression * scope);
 
     bool isValidNormalizeSelector(IHqlExpression * expr);
-    void reportError(const char * msg, bool warning = false);
+    void reportError(const char * msg, ErrorSeverity severity);
     void reportSelectorError(IHqlExpression * selector, IHqlExpression * expr);
 
 protected:
-    IErrorReceiver * errors;
-    WarningProcessor collector;
+    IErrorReceiver & errors;
+    ErrorSeverityMapper & errorMapper;
 };
 
 //---------------------------------------------------------------------------
@@ -1202,7 +1200,7 @@ protected:
 
 protected:
     HqlCppTranslator & translator;
-    IErrorReceiver * errors;
+    IErrorReceiver * errorProcessor;
 
     HqlExprArray forwardReferences;
     HqlExprArray defines;

--- a/ecl/regress/issue9556.ecl
+++ b/ecl/regress/issue9556.ecl
@@ -1,0 +1,24 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+r1 := { unsigned id; };
+r2 := { dataset(r1) ds; };
+ds := DATASET('x', r2, thor);
+
+#onwarning (2131, ignore);
+x := NOFOLD(ds).ds;
+output(x);

--- a/ecl/regress/issue9556a.eclxml
+++ b/ecl/regress/issue9556a.eclxml
@@ -1,0 +1,10 @@
+<Archive legacyImport="0"
+         legacyWhen="0">
+ <Query attributePath="_local_directory_.temp"/>
+ <OnWarning value="1006=ignore"/>
+ <Module key="_local_directory_" name="_local_directory_">
+  <Attribute key="temp" name="temp" sourcePath="temp.ecl">
+   case(0,&apos;default&apos;);&#10;&#10;&#10;
+  </Attribute>
+ </Module>
+</Archive>

--- a/ecl/regress/issue9556b.eclxml
+++ b/ecl/regress/issue9556b.eclxml
@@ -1,0 +1,10 @@
+<Archive legacyImport="0"
+         legacyWhen="0">
+ <Query attributePath="_local_directory_.temp"/>
+ <OnWarning value="1006=log"/>
+ <Module key="_local_directory_" name="_local_directory_">
+  <Attribute key="temp" name="temp" sourcePath="temp.ecl">
+   case(0,&apos;default&apos;);&#10;&#10;&#10;
+  </Attribute>
+ </Module>
+</Archive>

--- a/ecl/regress/issue9556c.eclxml
+++ b/ecl/regress/issue9556c.eclxml
@@ -1,0 +1,10 @@
+<Archive legacyImport="0"
+         legacyWhen="0">
+ <Query attributePath="_local_directory_.temp"/>
+ <OnWarning value="1006=error"/>
+ <Module key="_local_directory_" name="_local_directory_">
+  <Attribute key="temp" name="temp" sourcePath="temp.ecl">
+   case(0,&apos;default&apos;);&#10;&#10;&#10;
+  </Attribute>
+ </Module>
+</Archive>

--- a/ecl/regress/issue9556d.eclxml
+++ b/ecl/regress/issue9556d.eclxml
@@ -1,0 +1,10 @@
+<Archive legacyImport="0"
+         legacyWhen="0">
+ <Query attributePath="_local_directory_.temp"/>
+ <OnWarning value="1006-"/>
+ <Module key="_local_directory_" name="_local_directory_">
+  <Attribute key="temp" name="temp" sourcePath="temp.ecl">
+   case(0,&apos;default&apos;);&#10;&#10;&#10;
+  </Attribute>
+ </Module>
+</Archive>

--- a/ecl/regress/issue9556e.eclxml
+++ b/ecl/regress/issue9556e.eclxml
@@ -1,0 +1,10 @@
+<Archive legacyImport="0"
+         legacyWhen="0">
+ <Query attributePath="_local_directory_.temp"/>
+ <OnWarning value="1006+"/>
+ <Module key="_local_directory_" name="_local_directory_">
+  <Attribute key="temp" name="temp" sourcePath="temp.ecl">
+   case(0,&apos;default&apos;);&#10;&#10;&#10;
+  </Attribute>
+ </Module>
+</Archive>

--- a/ecl/regress/issue9556f.eclxml
+++ b/ecl/regress/issue9556f.eclxml
@@ -1,0 +1,25 @@
+<Archive>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <OnWarning value="2131=ignore"/>
+ <Query>
+idRec := { unsigned id; };
+inRec := { unsigned id, dataset(idRec) ids; };
+d := DATASET('in', inRec, thor);
+output(SORT(d, id).ids);
+ </Query>
+</Archive>

--- a/ecl/regress/issue9556g.eclxml
+++ b/ecl/regress/issue9556g.eclxml
@@ -1,0 +1,25 @@
+<Archive>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <OnWarning value="2131=error"/>
+ <Query>
+idRec := { unsigned id; };
+inRec := { unsigned id, dataset(idRec) ids; };
+d := DATASET('in', inRec, thor);
+output(SORT(d, id).ids);
+ </Query>
+</Archive>

--- a/ecl/regress/issue9556h.eclxml
+++ b/ecl/regress/issue9556h.eclxml
@@ -1,0 +1,32 @@
+<Archive>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <Module name="common">
+  <Attribute name="v1" flags="65536">
+export v1 := 'Hello';
+  </Attribute>
+  <Attribute name="v2" flags="65536">
+export v2 := 'World';
+  </Attribute>
+ </Module>
+ <Query>
+
+import common;
+output(common.v1 + ' ' + common.v2 + '!');
+
+ </Query>
+</Archive>

--- a/ecl/regress/issue9556i.eclxml
+++ b/ecl/regress/issue9556i.eclxml
@@ -1,0 +1,27 @@
+<Archive>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <OnWarning value="2131=error"/>
+ <Query>
+//Command line maps it to an error, but #ONWARNING maps it to just log the information
+#ONWARNING(2131, LOG);
+idRec := { unsigned id; };
+inRec := { unsigned id, dataset(idRec) ids; };
+d := DATASET('in', inRec, thor);
+output(SORT(d, id).ids);
+ </Query>
+</Archive>

--- a/ecl/regress/issue9556j.eclxml
+++ b/ecl/regress/issue9556j.eclxml
@@ -1,0 +1,29 @@
+<Archive>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <OnWarning value="2131=error"/>
+ <Query>
+//Command line maps it to an error, but #ONWARNING maps it to information
+//but local onwarning maps it back to an error!
+#ONWARNING(2131, LOG);
+idRec := { unsigned id; };
+inRec := { unsigned id, dataset(idRec) ids; };
+d := DATASET('in', inRec, thor);
+ids := SORT(d, id).ids : onwarning(2131, error);
+output(ids);
+ </Query>
+</Archive>

--- a/ecl/regress/issue9556k.eclxml
+++ b/ecl/regress/issue9556k.eclxml
@@ -1,0 +1,28 @@
+<Archive>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <OnWarning value="2131=fail"/>
+ <Query>
+//Command line maps it to a fatal error, #ONWARNING and local onwarning try to map it back, but fail
+#ONWARNING(2131, LOG);
+idRec := { unsigned id; };
+inRec := { unsigned id, dataset(idRec) ids; };
+d := DATASET('in', inRec, thor);
+ids := SORT(d, id).ids : onwarning(2131, ignore);
+output(ids);
+ </Query>
+</Archive>

--- a/ecl/regress/issue9556l_err.eclxml
+++ b/ecl/regress/issue9556l_err.eclxml
@@ -1,0 +1,27 @@
+<Archive>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <OnWarning value="2131=unknown"/>
+ <Query>
+//Test unknown severity
+idRec := { unsigned id; };
+inRec := { unsigned id, dataset(idRec) ids; };
+d := DATASET('in', inRec, thor);
+ids := SORT(d, id).ids : onwarning(2131, ignore);
+output(ids);
+ </Query>
+</Archive>

--- a/ecl/regress/issue9556m_err.eclxml
+++ b/ecl/regress/issue9556m_err.eclxml
@@ -1,0 +1,27 @@
+<Archive>
+<!--
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+ <OnWarning value="unknown=ignore"/>
+ <Query>
+//Test unknown severity
+idRec := { unsigned id; };
+inRec := { unsigned id, dataset(idRec) ids; };
+d := DATASET('in', inRec, thor);
+ids := SORT(d, id).ids : onwarning(2131, ignore);
+output(ids);
+ </Query>
+</Archive>

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -51,6 +51,7 @@
 #include "ws_dfuService.hpp"
 
 #include "hqlerror.hpp"
+#include "hqlexpr.hpp"
 #include "eclrtl.hpp"
 
 #define     Action_Delete           "Delete"

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -28,6 +28,7 @@
 #include "wuwebview.hpp"
 #include "dllserver.hpp"
 #include "wujobq.hpp"
+#include "hqlexpr.hpp"
 
 #ifdef _USE_ZLIB
 #include "zcrypt.hpp"


### PR DESCRIPTION
This pull request
- Fixes #ONWARNING so it works throughout the warning processing
- Allows command line options -w<nnn>=severity to map warnings to different levels
- Adds command line warning options to archives
- Cleans up the way errors and warnings are processed, so they always go through a delegated chain of IErrorReceivers.

There is a small associated change in the ln repository
