### PR TITLE
HPCC-10888 Fix Potential buffer overruns

### DIFF
--- a/system/security/securesocket/securesocket.cpp
+++ b/system/security/securesocket/securesocket.cpp
@@ -827,6 +827,7 @@ private:
     bool m_verify;
     bool m_address_match;
     Owned<CStringSet> m_peers;
+    StringBuffer password;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -867,11 +868,8 @@ public:
         {
             throw MakeStringException(-1, "ctx can't be created");
         }
-
-        char passwdbuf[128];
-        strcpy(passwdbuf, passphrase);
-
-        SSL_CTX_set_default_passwd_cb_userdata(m_ctx, passwdbuf);
+        password.append(passphrase);
+        SSL_CTX_set_default_passwd_cb_userdata(m_ctx, (void*)password.str());
         SSL_CTX_set_default_passwd_cb(m_ctx, pem_passwd_cb);
 
         if(SSL_CTX_use_certificate_file(m_ctx, certfile, SSL_FILETYPE_PEM) <= 0)
@@ -918,12 +916,8 @@ public:
         const char* passphrase = config->queryProp("passphrase");
         if(passphrase && *passphrase)
         {
-            StringBuffer passbuf;
-            decrypt(passbuf, passphrase);
-            char passwdbuf[128];
-            strcpy(passwdbuf, passbuf.str());
-
-            SSL_CTX_set_default_passwd_cb_userdata(m_ctx, passwdbuf);
+            decrypt(password, passphrase);
+            SSL_CTX_set_default_passwd_cb_userdata(m_ctx, (void*)password.str());
             SSL_CTX_set_default_passwd_cb(m_ctx, pem_passwd_cb);
         }
 

--- a/system/security/securesocket/securesocket.cpp
+++ b/system/security/securesocket/securesocket.cpp
@@ -827,7 +827,7 @@ private:
     bool m_verify;
     bool m_address_match;
     Owned<CStringSet> m_peers;
-    StringBuffer password;
+    StringAttr password;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -868,8 +868,8 @@ public:
         {
             throw MakeStringException(-1, "ctx can't be created");
         }
-        password.append(passphrase);
-        SSL_CTX_set_default_passwd_cb_userdata(m_ctx, (void*)password.str());
+        password.set(passphrase);
+        SSL_CTX_set_default_passwd_cb_userdata(m_ctx, (void*)password.sget());
         SSL_CTX_set_default_passwd_cb(m_ctx, pem_passwd_cb);
 
         if(SSL_CTX_use_certificate_file(m_ctx, certfile, SSL_FILETYPE_PEM) <= 0)
@@ -916,8 +916,10 @@ public:
         const char* passphrase = config->queryProp("passphrase");
         if(passphrase && *passphrase)
         {
-            decrypt(password, passphrase);
-            SSL_CTX_set_default_passwd_cb_userdata(m_ctx, (void*)password.str());
+            StringBuffer pwd;
+            decrypt(pwd, passphrase);
+            password.set(pwd);
+            SSL_CTX_set_default_passwd_cb_userdata(m_ctx, (void*)password.sget());
             SSL_CTX_set_default_passwd_cb(m_ctx, pem_passwd_cb);
         }
 


### PR DESCRIPTION
Previous code was copying password to a local buffer which went out of scope
when returning from the constructor. This change copyies the password to
a StringBuffer member where it will persist the lifetime of the object

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
