### PR TITLE
HPCC-10846 Allow #option ('saveCppTempFiles') to preserve C++ files.

### DIFF
--- a/ecl/hqlcpp/hqlecl.cpp
+++ b/ecl/hqlcpp/hqlecl.cpp
@@ -434,6 +434,9 @@ bool HqlDllGenerator::generateCode(HqlQueryContext & query)
             return false;
         }
 
+        if (wu->getDebugValueBool("saveEclTempFiles", false) || wu->getDebugValueBool("saveCppTempFiles", false))
+            setSaveGeneratedFiles(true);
+
         doExpand(translator);
         if (wu->getDebugValueBool("addTimingToWorkunit", true))
         {

--- a/ecl/regress/issue10846.ecl
+++ b/ecl/regress/issue10846.ecl
@@ -1,0 +1,19 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#option ('saveCppTempFiles', true);
+output('Hello');


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
