### PR TITLE
HPCC-10905 addScope tool cleanup

### DIFF
--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -1236,14 +1236,18 @@ bool CLdapSecManager::createUserScopes()
 {
     Owned<ISecUserIterator> it = getAllUsers();
     it->first();
+    bool rc = true;
     while(it->isValid())
     {
         ISecUser &user = it->get();
         if (!m_ldap_client->createUserScope(user))
+        {
             PROGLOG("Error creating scope for user '%s'", user.getName());
+            rc = false;
+        }
         it->next();
     }
-    return true;
+    return rc;
 }
 
 

--- a/tools/addScopes/addScopes.cpp
+++ b/tools/addScopes/addScopes.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
     if(argc != 2)
     {
         printf("usage: addScopes daliconf.xml\n");
-        printf("\n\n\tCreates user-specific LDAP private file scopes 'hpccinternal::<user>'\n\tand grants users access to their scope. The configuration file\n\tdaliconf.xml is the dali configuration file, typically\n\tfound in /var/lib/HPCCSystems/mydali");
+        printf("\n\tCreates all user-specific LDAP private file scopes 'hpccinternal::<user>'\n\tand grants users access to their scope. The configuration file\n\tdaliconf.xml is the dali configuration file, typically\n\tfound in /var/lib/HPCCSystems/mydali\n\n");
         return -1;
     }
 
@@ -54,10 +54,7 @@ int main(int argc, char* argv[])
             return -1;
         }
         bool ok = secmgr->createUserScopes();
-        if(ok)
-            printf("User scopes added\n");
-        else
-            printf("Some scopes not added\n");
+        printf(ok ? "User scopes added\n" : "Some scopes not added\n");
 #endif
     }
     catch(IException* e)


### PR DESCRIPTION
This change fixes the messy format of usage message, and ensures a warning
message is displayed if one or more scopes could not be added

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
