### PR TITLE
HPCC-10313 Stop Ws_fs/WsWorkunits Schedule thread correctly

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -48,7 +48,7 @@ int Schedule::run()
 {
     try
     {
-        while(true)
+        while(!stopping)
         {
             {
                 Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
@@ -78,7 +78,7 @@ int Schedule::run()
                     itr->next();
                 }
             }
-            sleep(60);
+            semSchedule.wait(1000*60);
         }
     }
     catch(IException *e)
@@ -91,7 +91,6 @@ int Schedule::run()
     {
         ERRLOG("Unknown exception in WS_FS Schedule::run");
     }
-
     return 0;
 }
 

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -25,8 +25,21 @@
 
 class Schedule : public Thread
 {
+    bool stopping;
+    Semaphore semSchedule;
     IEspContainer* m_container;
 public:
+    Schedule()
+    {
+        stopping = false;
+    };
+    ~Schedule()
+    {
+        stopping = true;
+        semSchedule.signal();
+        join();
+    }
+
     virtual int run();
     virtual void setContainer(IEspContainer * container)
     {

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -2617,7 +2617,7 @@ int WUSchedule::run()
 {
     try
     {
-        while(true)
+        while(!stopping)
         {
             Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
             Owned<IConstWorkUnitIterator> itr = factory->getWorkUnitsByState(WUStateScheduled);
@@ -2652,7 +2652,7 @@ int WUSchedule::run()
                     }
                 }
             }
-            sleep(60);
+            semSchedule.wait(1000*60);
         }
     }
     catch(IException *e)

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -317,9 +317,22 @@ void xsltTransform(const char* xml, const char* sheet, IProperties *params, Stri
 
 class WUSchedule : public Thread
 {
+    bool stopping;
+    Semaphore semSchedule;
     IEspContainer* m_container;
 
 public:
+    WUSchedule()
+    {
+        stopping = false;
+    }
+    ~WUSchedule()
+    {
+        stopping = true;
+        semSchedule.signal();
+        join();
+    }
+
     virtual int run();
     virtual void setContainer(IEspContainer * container)
     {


### PR DESCRIPTION
In Debug mode, when EclWatch ESP stops, stacktrace shows by the
destructor of the thread. It is because the thread is still running
in an infinite lop. This fix adds a 'stopping' flag and a semaphore
into the thread. When the ESP stops, the flag is set to true and
the semaphore is signaled, which breaks the lop. No stacktrace
shows.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
