### PR TITLE
HPCC-10698 - Avoid deadlock if retrying lock on superfiles

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -844,10 +844,9 @@ interface IDistributedFileTransactionExt : extends IDistributedFileTransaction
     virtual void ascend()=0;   // ascend back from the deep, one step at a time
     virtual void autoCommit()=0; // if transaction not active, commit straight away
     virtual void addAction(CDFAction *action)=0;
-    virtual void addFile(IDistributedFile *file)=0;
-    virtual void ensureFile(IDistributedFile *file)=0;
+    virtual void addFile(IDistributedFile *file, bool keep)=0;
     virtual void clearFile(IDistributedFile *file)=0;
-    virtual void clearFiles()=0;
+    virtual void clearFiles(bool all)=0;
     virtual void noteAddSubFile(IDistributedSuperFile *super, const char *superName, IDistributedFile *sub) = 0;
     virtual void noteRemoveSubFile(IDistributedSuperFile *super, IDistributedFile *sub) = 0;
     virtual void clearSubFiles(IDistributedSuperFile *super) = 0;
@@ -1225,7 +1224,7 @@ public:
 
 class CDistributedFileTransaction: public CInterface, implements IDistributedFileTransactionExt
 {
-    class CTransactionFile : public CSimpleInterface
+    class CTransactionFile : public CInterface
     {
         class HTMapping : public CInterface
         {
@@ -1264,8 +1263,9 @@ class CDistributedFileTransaction: public CInterface, implements IDistributedFil
         OwningStringSuperHashTableOf<HTMapping> subFilesByName;
         StringAttr name;
         Linked<IDistributedFile> file;
+        bool keep;
     public:
-        CTransactionFile(CDistributedFileTransaction &_owner, const char *_name, IDistributedFile *_file) : owner(_owner), name(_name), file(_file)
+        CTransactionFile(CDistributedFileTransaction &_owner, const char *_name, IDistributedFile *_file, bool _keep) : owner(_owner), name(_name), file(_file), keep(_keep)
         {
         }
         const char *queryName() const { return name; }
@@ -1320,6 +1320,7 @@ class CDistributedFileTransaction: public CInterface, implements IDistributedFil
         }
         const void *queryFindParam() const { return &file; }
         const char *queryFindString() const { return name; }
+        bool queryKeep() const { return keep; }
     };
     CIArrayOf<CDFAction> actions;
     OwningSimpleHashTableOf<CTransactionFile, IDistributedFile *> trackedFiles;
@@ -1337,19 +1338,13 @@ class CDistributedFileTransaction: public CInterface, implements IDistributedFil
 
 
     void validateAddSubFile(IDistributedSuperFile *super, IDistributedFile *sub, const char *subName);
-    CTransactionFile *queryCreate(const char *name, IDistributedFile *file, bool recreate=false)
+    CTransactionFile *queryCreate(const char *name, IDistributedFile *file, bool keep)
     {
-        Owned<CTransactionFile> trackedFile;
-        if (!recreate)
-            trackedFile.set(trackedFiles.find(file));
-        if (!trackedFile)
-        {
-            StringBuffer tmp;
-            name = normalizeLFN(name, tmp);
-            trackedFile.setown(new CTransactionFile(*this, tmp.str(), file));
-            trackedFiles.replace(*trackedFile.getLink());
-            trackedFilesByName.replace(*trackedFile.getLink());
-        }
+        StringBuffer tmp;
+        name = normalizeLFN(name, tmp);
+        Owned<CTransactionFile> trackedFile = new CTransactionFile(*this, tmp.str(), file, keep);
+        trackedFiles.replace(*trackedFile.getLink());
+        trackedFilesByName.replace(*trackedFile.getLink());
         return trackedFile;
     }
     CTransactionFile *lookupTrackedFile(IDistributedFile *file)
@@ -1372,14 +1367,9 @@ public:
             rollback();
         assert(depth == 0);
     }
-    void ensureFile(IDistributedFile *file)
+    void addFile(IDistributedFile *file, bool keep)
     {
-        if (!trackedFiles.find(file))
-            addFile(file);
-    }
-    void addFile(IDistributedFile *file)
-    {
-        CTransactionFile *trackedFile = queryCreate(file->queryLogicalName(), file, false);
+        CTransactionFile *trackedFile = queryCreate(file->queryLogicalName(), file, keep);
         // Also add subfiles to cache
         IDistributedSuperFile *sfile = file->querySuperFile();
         if (sfile)
@@ -1389,13 +1379,13 @@ public:
             {
                 IDistributedFile *f = &iter->query();
                 trackedFile->noteAddSubFile(f);
-                addFile(f);
+                addFile(f, keep);
             }
         }
     }
     void noteAddSubFile(IDistributedSuperFile *super, const char *superName, IDistributedFile *sub)
     {
-        CTransactionFile *trackedSuper = queryCreate(superName, super);
+        CTransactionFile *trackedSuper = queryCreate(superName, super, false);
         trackedSuper->noteAddSubFile(sub);
     }
     void noteRemoveSubFile(IDistributedSuperFile *super, IDistributedFile *sub)
@@ -1417,7 +1407,7 @@ public:
         {
             trackedFiles.removeExact(trackedFile);
             trackedFilesByName.removeExact(trackedFile);
-            trackedFile = queryCreate(newName, file);
+            trackedFile = queryCreate(newName, file, false);
         }
     }
     void addAction(CDFAction *action)
@@ -1429,7 +1419,7 @@ public:
     {
         if (isactive)
             throw MakeStringException(-1,"Transaction already started");
-        clearFiles();
+        clearFiles(true);
         actions.kill();
         isactive = true;
         prepared = 0;
@@ -1450,7 +1440,11 @@ public:
     }
     void retryActions()
     {
-        clearFiles(); // clear all previously tracked pending file changes, e.g. renames, super file additions/removals
+        /* clear all previously tracked pending file changes, e.g. renames, super file additions/removals
+         * but keep any files added marked 'keep' that mechanism depends on
+         */
+        clearFiles(false);
+
         while (prepared) // unlock for retry
             actions.item(--prepared).retry();
     }
@@ -1499,7 +1493,7 @@ public:
     {
         // =============== COMMIT and CLEANUP
         commitActions();
-        clearFiles();
+        clearFiles(true);
         isactive = false;
         actions.kill();
         deleteFiles();
@@ -1525,7 +1519,7 @@ public:
             }
         }
         actions.kill(); // should be empty
-        clearFiles(); // release locks
+        clearFiles(true); // release locks
         if (!isactive)
             return;
         isactive = false;
@@ -1580,7 +1574,7 @@ public:
         {
             ret = queryDistributedFileDirectory().lookup(name, udesc, false, false, this, timeout);
             if (ret)
-                queryCreate(name, ret, true);
+                addFile(ret, false);
             return ret;
         }
     }
@@ -1594,7 +1588,7 @@ public:
         {
             IDistributedSuperFile *ret = queryDistributedFileDirectory().lookupSuperFile(name,udesc,this,timeout);
             if (ret)
-                addFile(ret);
+                addFile(ret, false);
             return ret;
         }
     }
@@ -1613,15 +1607,31 @@ public:
         return isactive;
     }
 
-    void clearFiles()
+    void clearFiles(bool all)
     {
+        SuperHashIteratorOf<CTransactionFile> iter(trackedFilesByName);
+        CIArrayOf<CTransactionFile> toKeep;
+        if (!all)
+        {
+            ForEach(iter)
+            {
+                CTransactionFile &file = iter.query();
+                if (file.queryKeep())
+                    toKeep.append(*LINK(&file));
+            }
+        }
         trackedFiles.kill();
         trackedFilesByName.kill();
+        ForEachItemIn(k, toKeep)
+        {
+            CTransactionFile &file = toKeep.item(k);
+            trackedFiles.replace(*LINK(&file));
+            trackedFilesByName.replace(*LINK(&file));
+        }
     }
     void clearFile(IDistributedFile *file)
     {
         CTransactionFile *trackedFile = lookupTrackedFile(file);
-        IDistributedSuperFile *sfile = file->querySuperFile();
         if (trackedFile)
         {
             Owned<IDistributedFileIterator> iter = trackedFile->getSubFiles();
@@ -5872,7 +5882,7 @@ public:
         }
         else
             localtrans.setown(new CDistributedFileTransaction(udesc));
-        localtrans->ensureFile(this);
+        localtrans->addFile(this, true);
 
         if (addcontents)
         {
@@ -5921,7 +5931,7 @@ public:
             localtrans.setown(new CDistributedFileTransaction(udesc));
 
         // Make sure this file is in cache (reuse below)
-        localtrans->ensureFile(this);
+        localtrans->addFile(this, true);
 
         // If recurring, traverse super-file subs (if super)
         if (remcontents)
@@ -5978,7 +5988,7 @@ public:
             localtrans.setown(new CDistributedFileTransaction(udesc));
 
         // Make sure this file is in cache (reuse below)
-        localtrans->addFile(this);
+        localtrans->addFile(this, true);
 
         cRemoveOwnedSubFilesAction *action = new cRemoveOwnedSubFilesAction(localtrans, queryLogicalName(), remsub);
         localtrans->addAction(action); // takes ownership
@@ -6007,7 +6017,7 @@ public:
         else
             localtrans.setown(new CDistributedFileTransaction(udesc));
         // Make sure this file is in cache
-        localtrans->ensureFile(this);
+        localtrans->addFile(this, true);
 
         cSwapFileAction *action = new cSwapFileAction(queryLogicalName(),_file->queryLogicalName());
         localtrans->addAction(action); // takes ownership
@@ -7450,7 +7460,7 @@ public:
                 root->setPropInt("@interleaved",interleaved?2:0); // this is ill placed
                 super.setown(new CDistributedSuperFile(parent, root, logicalname, user));
                 created = true;
-                transaction->addFile(super);
+                transaction->addFile(super, false);
             }
             addFileLock(super);
         }
@@ -7522,8 +7532,7 @@ class CRemoveSuperFileAction: public CDFAction
         virtual IUserDescriptor *queryUser() { return transaction->queryUser(); }
         virtual void descend() { transaction->descend(); }
         virtual void ascend() { transaction->ascend(); }
-        virtual void addFile(IDistributedFile *file) { transaction->addFile(file); }
-        virtual void ensureFile(IDistributedFile *file) { transaction->ensureFile(file); }
+        virtual void addFile(IDistributedFile *file, bool keep) { transaction->addFile(file, keep); }
         virtual void clearFile(IDistributedFile *file) { transaction->clearFile(file); }
         virtual void noteAddSubFile(IDistributedSuperFile *super, const char *superName, IDistributedFile *sub)
         {

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -467,6 +467,7 @@ class DaliTests : public CppUnit::TestFixture
 // This test requires access to an external IP with dafilesrv running
 //        CPPUNIT_TEST(testDFSRename3);
         CPPUNIT_TEST(testDFSAddFailReAdd);
+        CPPUNIT_TEST(testDFSRetrySuperLock);
         CPPUNIT_TEST(testDFSHammer);
     CPPUNIT_TEST_SUITE_END();
 
@@ -1661,6 +1662,60 @@ public:
         ASSERT(NULL != sfile->querySubFileNamed("regress::addreadd::sub3") && "regress::addreadd::sub3, should be a subfile of super2");
         sfile.setown(dir.lookupSuperFile("regress::addreadd::super1", user));
         ASSERT(0 == sfile->numSubFiles() && "regress::addreadd::super1 should contain 0 subfiles");
+    }
+
+    void testDFSRetrySuperLock()
+    {
+        setupDFS("retrysuperlock");
+
+        Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(user); // disabled, auto-commit
+
+        logctx.CTXLOG("Creating regress::retrysuperlock::super1 and regress::retrysuperlock::sub1");
+        Owned<IDistributedSuperFile> sfile = dir.createSuperFile("regress::retrysuperlock::super1", user, false, false, transaction);
+        sfile->addSubFile("regress::retrysuperlock::sub1", false, NULL, false, transaction);
+        sfile.clear();
+
+        class CShortLock : implements IThreaded
+        {
+            StringAttr fileName;
+            unsigned secDelay;
+            CThreaded threaded;
+        public:
+            CShortLock(const char *_fileName, unsigned _secDelay) : fileName(_fileName), secDelay(_secDelay), threaded("CShortLock", this) { }
+            ~CShortLock()
+            {
+                threaded.join();
+            }
+            virtual void main()
+            {
+                Owned<IDistributedFile> file=queryDistributedFileDirectory().lookup(fileName, NULL);
+
+                if (!file)
+                {
+                    PROGLOG("File %s not found", fileName.get());
+                    return;
+                }
+                PROGLOG("Locked file: %s, sleeping (before unlock) for %d secs", fileName.get(), secDelay);
+
+                MilliSleep(secDelay * 1000);
+
+                PROGLOG("Unlocking file: %s", fileName.get());
+            }
+            void start() { threaded.start(); }
+        };
+
+        /* Tests transaction failing, due to lock and retrying after having partial success */
+
+        CShortLock sL("regress::retrysuperlock::super1", 15);
+        sL.start();
+
+        sfile.setown(dir.lookupSuperFile("regress::retrysuperlock::super1", user));
+        if (sfile)
+        {
+            logctx.CTXLOG("Removing subfiles from regress::retrysuperlock::super1");
+            sfile->removeSubFile(NULL, false);
+            logctx.CTXLOG("SUCCEEDED");
+        }
     }
 
     void testDFSRename2()


### PR DESCRIPTION
The transaction retry mechanism, clears all tracked files,
including the superfiles that the transaction was based on.
If there's a timeout during lock, the (nasty)
locking mechanism frees the lock on the super only, but retains
the lock on the subs.
When the retry mechanism, retries, because it's lost track of
the previously looked up super, it looks it up again and now
has two sets of locks to the subfiles, which it will never be
able to get exclusive locks to.

This fix, ensures that the supers that started the transaction
mechanism are not cleared, so that the retry mechanism will
reuse the same instances.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
