### PR TITLE
HPCC-10611 DOCS:Mark RFS functions in Std library as deprecated

### DIFF
--- a/docs/ECLStandardLibraryReference/SLR-Mods/RfsAction.xml
+++ b/docs/ECLStandardLibraryReference/SLR-Mods/RfsAction.xml
@@ -39,7 +39,10 @@
 
   <para>The <emphasis role="bold">RfsAction </emphasis>function sends the
   <emphasis>query</emphasis> to the <emphasis>server</emphasis>. This is used
-  when there is no expected return value</para>
+  when there is no expected return value.</para>
+
+  <para>This function is now considered deprecated in favor of using the EMBED
+  mechanism. It will be removed in Version 6.0. </para>
 
   <para>Example:</para>
 

--- a/docs/ECLStandardLibraryReference/SLR-Mods/RfsQuery.xml
+++ b/docs/ECLStandardLibraryReference/SLR-Mods/RfsQuery.xml
@@ -49,6 +49,9 @@
   string that can be used in a DATASET declaration to read data from an RFS
   (Remote File Server) instance (e.g. rfsmysql) on another node.</para>
 
+  <para>This function is now considered deprecated in favor of using the EMBED
+  mechanism. It will be removed in Version 6.0. </para>
+
   <para>Example:</para>
 
   <programlisting format="linespecific">IMPORT Std;


### PR DESCRIPTION
Signed-off-by: JamesDeFabia James.Defabia@LexisNexis.com
