### PR TITLE
HPCC-10678 Include Package Map in new ECLWatch

### DIFF
--- a/esp/files/scripts/HPCCPlatformRoxieWidget.js
+++ b/esp/files/scripts/HPCCPlatformRoxieWidget.js
@@ -23,7 +23,7 @@ define([
 
     "hpcc/_TabContainerWidget",
     "hpcc/QuerySetQueryWidget",
-    //"hpcc/PackageMapQueryWidget",
+    "hpcc/PackageMapQueryWidget",
 
     "dojo/text!../templates/HPCCPlatformRoxieWidget.html",
 
@@ -33,7 +33,7 @@ define([
 
 ], function (declare, lang, i18n, nlsHPCC,
                 registry,
-                _TabContainerWidget, QuerySetQueryWidget, /*PackageMapQueryWidget,*/
+                _TabContainerWidget, QuerySetQueryWidget, PackageMapQueryWidget,
                 template) {
     return declare("HPCCPlatformRoxieWidget", [_TabContainerWidget], {
         templateString: template,

--- a/esp/files/scripts/PackageMapQueryWidget.js
+++ b/esp/files/scripts/PackageMapQueryWidget.js
@@ -96,7 +96,7 @@ define([
             var context = this;
             this.tabContainer.watch("selectedChildWidget", function (name, oval, nval) {
                 if ((nval.id != context.id + "Packages") && (!nval.initalized)) {
-                    nval.init(nval.params);
+                    nval.init(nval.params, context.targets);
                 }
                 context.selectedTab = nval;
             });
@@ -105,7 +105,6 @@ define([
         startup: function (args) {
             this.inherited(arguments);
             this.refreshActionState();
-            this.getSelections();
         },
 
         resize: function (args) {
@@ -378,8 +377,6 @@ define([
                 if (target.Processes != undefined)
                     this.addProcessSelections(this.processSelect, this.processesToList, target.Processes.Item);
             }
-            if (this.validateTab != null)
-                this.validateTab.initSelections(this.targets);
         },
 
         init: function (params) {
@@ -397,6 +394,7 @@ define([
             this.tabContainer.addChild(this.validateTab, 1);
 
             this.tabContainer.selectChild(this.packagesTab);
+            this.getSelections();
         },
 
         initPackagesGrid: function() {

--- a/esp/files/scripts/PackageMapValidateWidget.js
+++ b/esp/files/scripts/PackageMapValidateWidget.js
@@ -79,14 +79,12 @@ define([
             this.inherited(arguments);
         },
 
-        init: function (params) {
+        init: function (params, targets) {
             if (this.initalized)
                 return;
             this.initalized = true;
             this.validateResult.set('style', 'visibility:hidden');
-            if (params.targets == undefined)
-                return;
-            this.initSelection(params.targets);
+            this.initSelections(targets);
         },
 
         initSelections: function (targets) {

--- a/esp/files/templates/HPCCPlatformRoxieWidget.html
+++ b/esp/files/templates/HPCCPlatformRoxieWidget.html
@@ -6,8 +6,8 @@
         <div id="${id}TabContainer" data-dojo-props="region: 'center', tabPosition: 'top'" style="width: 100%; height: 100%" data-dojo-type="dijit.layout.StackContainer">
             <div id="${id}_Queries" title="${i18n.Queries}" data-dojo-type="QuerySetQueryWidget">
             </div>
-            <!--div id="${id}_PackageMaps" title="${i18n.PackageMaps}" data-dojo-type="PackageMapQueryWidget">
-            </div-->
+            <div id="${id}_PackageMaps" title="${i18n.PackageMaps}" data-dojo-type="PackageMapQueryWidget">
+            </div>
         </div>
     </div>
 </div>

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -335,10 +335,10 @@ void listPkgInfo(double version, const char *target, const char *process, IPrope
 void listPkgInfo(double version, const char *target, const char *process, IArrayOf<IConstPackageListMapData>* results)
 {
     Owned<IPropertyTree> pkgSetRegistry = getPkgSetRegistry((process && *process) ? process : "*", true);
-    if (!pkgSetRegistry)
-        throw MakeStringException(PKG_DALI_LOOKUP_ERROR, "Unable to retrieve package information from dali for process %s", (process && *process) ? process : "*");
-
-    listPkgInfo(version, target, process, pkgSetRegistry, results);
+    if (pkgSetRegistry) //will be NULL if no package map
+    {
+        listPkgInfo(version, target, process, pkgSetRegistry, results);
+    }
 }
 
 void getPkgInfo(const char *target, const char *process, StringBuffer &info)


### PR DESCRIPTION
In this fix, Package Map UI is enabled in new ECLWatch with minor code
changes. The existing code calls the getSelections() to retrieve target
cluster settings as soon as PackageMapQueryWidget is loaded. That does
not work for new ECLWatch. The new code calls the getSelections() after
the widget is initialized for display. Similar change is also made for
PackageMapValidateWidget.
