### PR TITLE
HPCC-10929 Set file's ContentType in WsDFU/DFUQuery response

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -2788,7 +2788,10 @@ void CWsDfuEx::getAPageOfSortedLogicalFile(IEspContext &context, IUserDescriptor
                         bKeyFile = true;
                     }
 
-                    File->setIsKeyFile(bKeyFile);
+                    if (version < 1.24)
+                        File->setIsKeyFile(bKeyFile);
+                    else if (kind && *kind)
+                        File->setContentType(kind);
                 }
 
                 StringBuffer buf;


### PR DESCRIPTION
The 'kind' attribute of a logical file should be returned as ContentType
inside the WsDFU/DFUQuery response if: (1) ESP WsDFU Client is 1.24 or
newer; and (2) the file has the 'kind' attribute.

The 'IsKeyFile' should not be set if the WsDFU Client is 1.24 or newer.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
