### PR TITLE
HPCC-10968 configutils build break

### DIFF
--- a/deployment/configutils/CMakeLists.txt
+++ b/deployment/configutils/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/common/environment
          ${HPCC_SOURCE_DIR}/dali/base
          ${HPCC_SOURCE_DIR}/deployment/deploy
-         ${CMAKE_BINARY_DIR}/oss
+         ${CMAKE_BINARY_DIR}
     )
 
 ADD_DEFINITIONS ( -D_USRDLL -DCONFIGUTILS_EXPORTS )


### PR DESCRIPTION
```
- build-config.h include path fix
```

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
