### PR TITLE
HPCC-10920 Return ClusterName in WsDFU.DFUInfo response

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -357,7 +357,7 @@
     </xsl:template>
 
     <xsl:template match="DFUPart">
-        <xsl:if test="Copy=1"> <!-- Copy > 1: replicate copy -->
+        <xsl:if test="Copy=1"> <!-- Copy=1: display primary copy only -->
             <tr>
                 <td><xsl:value-of select="Id"/></td>
                 <td><xsl:value-of select="Ip"/></td>

--- a/esp/eclwatch/ws_XSLT/dfu_file.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_file.xslt
@@ -315,7 +315,7 @@
                     <col span="3" class="number"/>
                 </colgroup>
                 <tr class="grey"><th>Number</th><th>IP</th><th>Size</th><xsl:if test="string-length($actualSize)"><th>Actual Size</th></xsl:if></tr>
-                <xsl:apply-templates select="DFUFileParts/DFUPart">
+                <xsl:apply-templates select="DFUFilePartsOnClusters/DFUFilePartsOnCluster/DFUFileParts/DFUPart">
                     <xsl:sort select="Id" data-type="number"/>
                     <xsl:sort select="Copy" data-type="number"/>
                 </xsl:apply-templates>
@@ -357,13 +357,13 @@
     </xsl:template>
 
     <xsl:template match="DFUPart">
-    <xsl:if test="Copy mod  2 > 0">
+        <xsl:if test="Copy=1"> <!-- Copy > 1: replicate copy -->
             <tr>
-        <td><xsl:value-of select="Id"/></td>
-        <td><xsl:value-of select="Ip"/></td>
-        <td class="number"><xsl:value-of select="Partsize"/></td>
-        <xsl:if test="string-length($actualSize)"><td class="number"><xsl:value-of select="ActualSize"/></td></xsl:if>
-        </tr>
+                <td><xsl:value-of select="Id"/></td>
+                <td><xsl:value-of select="Ip"/></td>
+                <td class="number"><xsl:value-of select="Partsize"/></td>
+                <xsl:if test="string-length($actualSize)"><td class="number"><xsl:value-of select="ActualSize"/></td></xsl:if>
+            </tr>
         </xsl:if>
     </xsl:template>
 

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -73,6 +73,12 @@ ESPStruct DFUFileStat
     string MaxSkew;
 };
 
+ESPStruct DFUFilePartsOnCluster
+{
+    string Cluster;
+    ESParray<ESPstruct DFUPart> DFUFileParts;
+};
+
 ESPStruct DFUFileDetail
 {
     string Name;
@@ -86,7 +92,7 @@ ESPStruct DFUFileDetail
     string RecordCount;
     string Wuid;
     string Owner;
-    string Cluster;
+    [depr_ver("1.25")] string Cluster;
     string JobName;
     string Persistent;
     string Format;
@@ -100,7 +106,8 @@ ESPStruct DFUFileDetail
     string Ecl;
     [depr_ver("1.22")] bool ZipFile(false);
     ESPstruct DFUFileStat Stat;
-    ESParray<ESPstruct DFUPart> DFUFileParts;
+    [depr_ver("1.25")] ESParray<ESPstruct DFUPart> DFUFileParts;
+    [min_ver("1.25")] ESParray<ESPstruct DFUFilePartsOnCluster> DFUFilePartsOnClusters;
     bool isSuperfile(false);
     bool ShowFileContent(true);
     ESParray<string> subfiles;
@@ -631,7 +638,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.24"), default_client_version("1.24"),
+    version("1.25"), default_client_version("1.25"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -132,6 +132,8 @@ private:
     void parseStringArray(const char *input, StringArray& strarray);
     int superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
         const char* beforeSubFile, bool existingSuperfile, bool autocreatesuper, bool deleteFile, bool removeSuperfile =  true);
+    void getFilePartsOnClusters(IEspContext &context, const char* clusterReq, StringArray& clusters, IDistributedFile* df, IEspDFUFileDetail& FileDetails,
+        offset_t& mn, offset_t& mx, offset_t& sum, offset_t& count);
 private:
     bool         m_disableUppercaseTranslation;
     StringBuffer m_clusterName;


### PR DESCRIPTION
If a logical file is associated with only one cluster, the cluster
name is returned in WsDFU.DFUInfo response. If a logical file is
associated with multiple clusters, the cluster names are returned
inside a comma separated string in the response.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
