### PR TITLE
HPCC-9254 Reduce get_cycle_now overhead

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -5209,6 +5209,7 @@ class CRoxieServerInlineTableActivity : public CRoxieServerActivity
     IHThorInlineTableArg &helper;
     __uint64 curRow;
     __uint64 numRows;
+    __uint64 timerInterval;
 
 public:
     CRoxieServerInlineTableActivity(const IRoxieServerActivityFactory *_factory, IProbeManager *_probeManager)
@@ -5223,12 +5224,16 @@ public:
         curRow = 0;
         CRoxieServerActivity::start(parentExtractSize, parentExtract, paused);
         numRows = helper.numRows();
+        timerInterval = numRows / 1000ULL;
+        if (timerInterval < 2)
+            timerInterval = 2;
     }
 
     virtual bool needsAllocator() const { return true; }
     virtual const void *nextInGroup()
     {
-        ActivityTimer t(totalCycles, timeActivities, ctx->queryDebugContext());
+        if ( (curRow == numRows-1) || (curRow % timerInterval) == 0)
+            ActivityTimer t(totalCycles, timeActivities, ctx->queryDebugContext());
         // Filtering empty rows, returns the next valid row
         while (curRow < numRows)
         {


### PR DESCRIPTION
This is for discussion.  The change below greatly reduces calls to time each row, but still preserves start to end and some intermediate timing.  For Thor there are many more places like this to change so perhaps a different approach is required.  But for Roxie, this change reveals about a 15% speed up with a Release build on the example ecl source.
Also note, adding timeActivities="false" to the environment is an existing option (but without activity timings)
We could also slide the timerInterval scale from 1/10 to 1/100 to 1/1000, etc. as time progresses.
What are your thoughts @ghalliday, @richardkchapman, @jakesmith ?
