### PR TITLE
HPCC-10299 Support AppKey and ECL filters in WsWorkunits/WUQuery

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -1904,6 +1904,7 @@ mapEnums workunitSortFields[] =
    { WUSFpriority, "@priorityClass" },
    { WUSFprotected, "@protected" },
    { WUSFwuid, "@" },
+   { WUSFecl, "Query/Text" },
    { WUSFfileread, "FilesRead/File/@name" },
    { WUSFroxiecluster, "RoxieQueryInfo/@roxieClusterName" },
    { WUSFbatchloginid, "Application/Dispatcher/FTPUserID" },
@@ -2389,6 +2390,8 @@ public:
                     namefilterhi.set(fv);
                 else if (subfmt==WUSFwildwuid)
                     namefilter.set(fv);
+                else if (subfmt==WUSFapplication)
+                    query.append("[").append(fv).append("]");
                 else if (!fv || !*fv)
                     unknownAttributes.append(getEnumText(subfmt,workunitSortFields));
                 else {

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2390,7 +2390,7 @@ public:
                     namefilterhi.set(fv);
                 else if (subfmt==WUSFwildwuid)
                     namefilter.set(fv);
-                else if (subfmt==WUSFapplication)
+                else if (subfmt==WUSFcustom)
                     query.append("[").append(fv).append("]");
                 else if (!fv || !*fv)
                     unknownAttributes.append(getEnumText(subfmt,workunitSortFields));

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1101,6 +1101,8 @@ enum WUSortField
     WUSFbatchoutputfile = 19,
     WUSFtotalthortime = 20,
     WUSFwildwuid = 21,
+    WUSFecl = 22,
+    WUSFapplication = 23,
     WUSFterm = 0,
     WUSFreverse = 256,
     WUSFnocase = 512,

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1102,7 +1102,7 @@ enum WUSortField
     WUSFtotalthortime = 20,
     WUSFwildwuid = 21,
     WUSFecl = 22,
-    WUSFapplication = 23,
+    WUSFcustom = 23,
     WUSFterm = 0,
     WUSFreverse = 256,
     WUSFnocase = 512,

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1660,14 +1660,14 @@ bool addWUQueryFilterTime(WUSortField *filters, unsigned short &count, MemoryBuf
     return true;
 }
 
-bool addWUQueryFilterApplication(WUSortField *filters, unsigned short &count, MemoryBuffer &buff, const char *appname, const char *appkey, const char *appdata, WUSortField sortField)
+bool addWUQueryFilterApplication(WUSortField *filters, unsigned short &count, MemoryBuffer &buff, const char *appname, const char *appkey, const char *appdata)
 {
     if (isEmpty(appname) && isEmpty(appkey) && isEmpty(appdata)) //no application filter
         return false;
     VStringBuffer path("Application/%s/%s", appname && *appname ? appname : "*", appkey && *appkey ? appkey : "*");
     if(appdata && *appdata)
         path.append("=?~\"").append(appdata).append("\"");
-    filters[count++] = sortField;
+    filters[count++] = WUSFcustom;
     buff.append(path.str());
     return true;
 }
@@ -1764,7 +1764,7 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
 
     addWUQueryFilterTime(filters, filterCount, filterbuf, req.getStartDate(), WUSFwuid);
     addWUQueryFilterTime(filters, filterCount, filterbuf, req.getEndDate(), WUSFwuidhigh);
-    addWUQueryFilterApplication(filters, filterCount, filterbuf, req.getApplicationName(), req.getApplicationKey(), req.getApplicationData(), WUSFapplication);
+    addWUQueryFilterApplication(filters, filterCount, filterbuf, req.getApplicationName(), req.getApplicationKey(), req.getApplicationData());
 
     filters[filterCount] = WUSFterm;
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1660,6 +1660,18 @@ bool addWUQueryFilterTime(WUSortField *filters, unsigned short &count, MemoryBuf
     return true;
 }
 
+bool addWUQueryFilterApplication(WUSortField *filters, unsigned short &count, MemoryBuffer &buff, const char *appname, const char *appkey, const char *appdata, WUSortField sortField)
+{
+    if (isEmpty(appname) && isEmpty(appkey) && isEmpty(appdata)) //no application filter
+        return false;
+    VStringBuffer path("Application/%s/%s", appname && *appname ? appname : "*", appkey && *appkey ? appkey : "*");
+    if(appdata && *appdata)
+        path.append("=?~\"").append(appdata).append("\"");
+    filters[count++] = sortField;
+    buff.append(path.str());
+    return true;
+}
+
 void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQueryResponse & resp)
 {
     SecAccessFlags accessOwn;
@@ -1748,9 +1760,11 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
     addWUQueryFilter(filters, filterCount, filterbuf, req.getLogicalFile(), WUSFfileread);
     addWUQueryFilter(filters, filterCount, filterbuf, req.getOwner(), (WUSortField) (WUSFuser | WUSFnocase));
     addWUQueryFilter(filters, filterCount, filterbuf, req.getJobname(), (WUSortField) (WUSFjob | WUSFnocase));
+    addWUQueryFilter(filters, filterCount, filterbuf, req.getECL(), (WUSortField) (WUSFecl | WUSFwild));
 
     addWUQueryFilterTime(filters, filterCount, filterbuf, req.getStartDate(), WUSFwuid);
     addWUQueryFilterTime(filters, filterCount, filterbuf, req.getEndDate(), WUSFwuidhigh);
+    addWUQueryFilterApplication(filters, filterCount, filterbuf, req.getApplicationName(), req.getApplicationKey(), req.getApplicationData(), WUSFapplication);
 
     filters[filterCount] = WUSFterm;
 
@@ -2104,8 +2118,6 @@ bool CWsWorkunitsEx::onWUQuery(IEspContext &context, IEspWUQueryRequest & req, I
             doWUQueryFromArchive(context, sashaServerIp.get(), sashaServerPort, *archivedWuCache, awusCacheMinutes, req, resp);
         else if(notEmpty(wuid) && looksLikeAWuid(wuid))
             doWUQueryBySingleWuid(context, wuid, resp);
-        else if (notEmpty(req.getECL()) || notEmpty(req.getApplicationName()) || notEmpty(req.getApplicationKey()) || notEmpty(req.getApplicationData()))
-            doWUQueryByXPath(context, req, resp);
         else if (notEmpty(req.getLogicalFile()) && req.getLogicalFileSearchType() && strieq(req.getLogicalFileSearchType(), "Created"))
             doWUQueryByFile(context, req.getLogicalFile(), resp);
         else


### PR DESCRIPTION
In this fix, a user can use WsWorkunits/WUQuery to search ECL
Workunits which contain (wildcard match) specified AppKey/Data
or Query/Text attribute.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
