### PR TITLE
HPCC-10930 Better support in regression suite for targeting specific queries

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -1,5 +1,6 @@
-Overview of Regression Suite usage
-==================================
+Overview of Regression Suite usage (v:0.0.14)
+==============================================
+
 To use Regression Suite change directory to HPCC-Platform/testing/regress subdirectory.
 
 Regression Suite requires Python environment version >=2.6.6 and < 3.x
@@ -92,17 +93,20 @@ Command:
 Result:
 
 |
-|       usage: ecl-test query [-h] [--publish] [ECL query] [target cluster | all]
+|       usage: ecl-test query [-h] [--cluster [target_cluster | all]] [--publish]
+|                  [--pq threadNumber]
+|                  ECL query [ECL query ...]
 |
 |       positional arguments:
-|         ECL query             Name of a single ECL query. It can contain wildcards. (mandatory).
-|         target cluster | all  Cluster for single query run. If cluster = 'all' then run single query on all clusters. Default value is thor.
+|         ECL query                   Name of one or more ECL file(s). It can contain wildcards. (mandatory).
 |
 |       optional arguments:
-|         -h, --help            show this help message and exit
-|         --publish             Publish compiled query instead of run.
-
-
+|         -h, --help                    Show this help message and exit
+|         --cluster [target_cluster | all], -c [target_cluster | all]
+|                                            Cluster for single query run. If cluster = 'all' then run query on all clusters. Default value is thor.
+|         --publish, -p               Publish compiled query instead of run.
+|         --pq threadNumber    Parallel query execution for multiple test cases specified in CLI with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumer = numberOfLocalCore * 2 )
+|
 
 Steps to run Regression Suite
 =============================
@@ -304,14 +308,12 @@ If --pq option used (in this case with 16 threads) then then the content of the 
 The logfile generated into the HPCCSystems-regression/log subfolder of the user personal folder and sorted by the test case number.
 
 
-5. To run Regression Suite with selected test case on a selected cluster (e.g. Thor): 
--------------------------------------------------------------------------------------
-
-(In this use case the default cluster is: thor)
+5. To run Regression Suite with selected test case on a selected cluster (e.g. Thor) or all:
+--------------------------------------------------------------------------------------------------------------------------
 
 Command:
 
-        ./ecl-test query [-h] [--publish] test_name [target cluster | all]
+        ./ecl-test query test_name [test_name...] [-h] [--cluster cluster|all] [--pq threadNumber|-1]
 
 Positional arguments:
         test_name               Name of a single ECL query. It can contain wildcards. (mandatory).
@@ -319,10 +321,96 @@ Positional arguments:
                                 If cluster = 'all' then run ECL query on all clusters.
 Optional arguments:
         -h, --help            Show help message and exit
+        --cluster [target_cluster | all]
+                                   Cluster for single query run. If cluster = 'all' then run query on all clusters. Default value is thor.
         --publish             Publish compiled query instead of run.
+        --pq threadNumber    Parallel query execution for multiple test cases specified in CLI with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumer = numberOfLocalCore * 2 )
 
 
-The format of result is same as above:
+
+The format of result is same as above, but there is log, result and diff for all cluster:
+
+|         [Action] Suite: hthor
+|         [Action] Queries: 9
+|         [Action]
+|         [Action]   1. Test: aggsq1.ecl
+|         [Action]   2. Test: aggsq1a.ecl
+|         [Action]   3. Test: aggsq1seq.ecl
+|         [Pass]   1. Pass W20140313-171024 (2 sec)
+|         [Pass]   1. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171024
+|         [Action]   4. Test: aggsq2.ecl
+|         [Action]   5. Test: aggsq2seq.ecl
+|         [Failure]   2. Fail W20140313-171025 (2 sec)
+|         [Failure]   2. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171025
+|         [Action]   6. Test: aggsq3.ecl
+|         [Pass]   3. Pass W20140313-171026 (2 sec)
+|         [Pass]   3. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171026
+|         [Action]   7. Test: aggsq3seq.ecl
+|         [Pass]   4. Pass W20140313-171027 (2 sec)
+|         [Pass]   4. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171027
+|         [Action]   8. Test: aggsq4.ecl
+|         [Pass]   5. Pass W20140313-171028 (2 sec)
+|         [Pass]   5. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171028
+|         [Action]   9. Test: aggsq4seq.ecl
+|         [Pass]   6. Pass W20140313-171029 (2 sec)
+|         [Pass]   6. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171029
+|         [Pass]   7. Pass W20140313-171029-1 (3 sec)
+|         [Pass]   7. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171029-1
+|         [Pass]   8. Pass W20140313-171030 (2 sec)
+|         [Pass]   8. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171030
+|         [Pass]   9. Pass W20140313-171031 (2 sec)
+|         [Pass]   9. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171031
+|         [Action]
+|         [Action]
+|             Results
+|             `-------------------------------------------------`
+|             Passing: 8
+|             Failure: 1
+|             `-------------------------------------------------`
+|             KEY FILE NOT FOUND. /home/ati/MyPython/RegressionSuite/ecl/key/aggsq1a.xml
+|             `-------------------------------------------------`
+|             Log: /home/ati/HPCCSystems-regression/log/hthor.14-03-13-17-10-24.log
+|             `-------------------------------------------------`
+|             Elapsed time: 10 sec  (00:00:10)
+|             `-------------------------------------------------`
+|
+|         [Action] Suite: thor
+|         [Action] Queries: 2
+|         [Action]
+|         [Action]   1. Test: aggsq2.ecl
+|         [Action]   2. Test: aggsq2seq.ecl
+|         [Pass]   1. Pass W20140313-171035 (3 sec)
+|         [Pass]   1. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171035
+|         [Pass]   2. Pass W20140313-171036 (4 sec)
+|         [Pass]   2. URL http://127.0.0.1:8010/WsWorkunits/WUInfo?Wuid=W20140313-171036
+|         [Action]
+|         [Action]
+|             Results
+|             `-------------------------------------------------`
+|             Passing: 2
+|             Failure: 0
+|             `-------------------------------------------------`
+|             Log: /home/ati/HPCCSystems-regression/log/thor.14-03-13-17-10-35.log
+|             `-------------------------------------------------`
+|             Elapsed time: 7 sec  (00:00:07)
+|             `-------------------------------------------------`
+|
+|         [Action] Suite: roxie
+|         [Action] Queries: 0
+|         [Action]
+|         [Action]
+|         [Action]
+|             Results
+|             `-------------------------------------------------`
+|             Passing: 0
+|             Failure: 0
+|             `-------------------------------------------------`
+|             Log: /home/ati/HPCCSystems-regression/log/roxie.14-03-13-17-10-42.log
+|             `-------------------------------------------------`
+|             Elapsed time: 2 sec  (00:00:02)
+|             `-------------------------------------------------`
+|
+|         End.
 
 6. Tags used in testcases:
 --------------------------

--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -328,7 +328,7 @@ Optional arguments:
 
 
 
-The format of result is same as above, but there is log, result and diff for all cluster:
+The format of the output is the same as 'run', except there is a log, result and diff per cluster targeted:
 
 |         [Action] Suite: hthor
 |         [Action] Queries: 9

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -30,6 +30,7 @@ import glob
 from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
+from hpcc.common.error import Error
 
 prog_version = "0.0.14"
 
@@ -121,7 +122,7 @@ if __name__ == "__main__":
             eclfiles=[]   # List for ECL filenames to be executed
             for ecl in args.query:
                 if not ('.ecl' in ecl):
-                    args.cluster = ecl
+                    logging.error("%s. Not an ECL file:'%s'!" % (1,  ecl))
                 elif  ('*' in ecl) or ('?' in ecl):
                     # If there is any wildcard in ECL file name, resolve it
                     eclwild = os.path.join(regress.dir_ec, ecl)
@@ -148,19 +149,18 @@ if __name__ == "__main__":
                     targetClusters.append(args.cluster)
                 else:
                     logging.error("%s. Unknown cluster:'%s'!" % (1,  args.cluster))
-                    print "Abend."
-                    exit()
+                    raise Error("4000")
             # Go through the cluster list
             for cluster in targetClusters:
                 try:
                     if len(eclfiles) > 1:
-                        #Execute multiple ECl files like RUN to generates summary results and diff report.
+                        #Execute multiple ECL files like RUN to generates summary results and diff report.
                         regress.bootstrap(cluster, eclfiles)
                         if  'pq' in args:
                             regress.runSuiteP(cluster, regress.suites[cluster])
                         else:
                             regress.runSuite(cluster, regress.suites[cluster])
-                    else:
+                    elif len(eclfiles) == 1:
                         # Execute one ECL file on the cluster
                         for ecl in eclfiles:
                             eclfile = ECLFile(ecl, regress.dir_a, regress.dir_ex, regress.dir_r, cluster)
@@ -172,6 +172,9 @@ if __name__ == "__main__":
                                     logging.warn("%s. %s excluded on %s cluster." % (1,  eclfile.getBaseEcl(), cluster))
                             else:
                                 logging.warn("%s. %s skipped on %s cluster." % (1, eclfile.getBaseEcl(), cluster))
+                    else:
+                        logging.error("%s. No ECL file match for cluster:'%s'!" % (1,  args.cluster))
+                        raise Error("4001")
                 except IOError:
                     logging.error("%s. Query %s does not exist!" % (1,  eclfile.getBaseEcl()))
                     exit()
@@ -186,12 +189,15 @@ if __name__ == "__main__":
                 else:
                     regress.runSuite(args.cluster, regress.suites[args.cluster])
             print("End.")
+    except Error as e:
+        logging.critical(e)
+        exit(e.getErrorCode());
     except Exception as e:
         logging.critical(e)
         logging.critical(traceback.format_exc())
-        print "Abend."
     except KeyboardInterrupt:
         logging.critical("Keyboard Interrupt Caught.")
+    finally:
         regress.StopTimeoutThread()
 
     exit()

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -31,7 +31,7 @@ from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
 
-prog_version = "0.0.13"
+prog_version = "0.0.14"
 
 if __name__ == "__main__":
 
@@ -84,12 +84,14 @@ if __name__ == "__main__":
                             type=checkPqParam,  default = 0,   metavar="threadNumber")
 
     parser_query = subparsers.add_parser('query', help='query help')
-    parser_query.add_argument('query', help="Name of a single ECL query. It can contain wildcards. (mandatory).",
-                              nargs='?', metavar="ECL query")
-    parser_query.add_argument('cluster', help="Cluster for single query run. If cluster = 'all' then run single query on all clusters. Default value is thor.",
+    parser_query.add_argument('query', help="One or more ECL file(s). It can contain wildcards. (mandatory).",
+                              nargs='+', metavar="ECL query")
+    parser_query.add_argument('--cluster', '-c', help="Cluster for query to run. If cluster = 'all' then run query on all clusters. Default value is thor.",
                             nargs='?', default='thor', metavar="target_cluster | all")
-    parser_query.add_argument('--publish', help="Publish compiled query instead of run.",
+    parser_query.add_argument('--publish', '-p', help="Publish compiled query instead of run.",
                             action='store_true')
+    parser_query.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumer = numberOfLocalCore * 2 )",
+                            type=checkPqParam,  default = 0,   metavar="threadNumber")
 
     args = parser.parse_args()
 
@@ -98,11 +100,14 @@ if __name__ == "__main__":
     regressionSuiteMainDir = os.path.dirname(__file__)
     regressionSuiteFullPath = os.path.realpath(regressionSuiteMainDir)
     args.config = str(os.path.join(regressionSuiteFullPath, args.config))
-    regress = None
+
+    regress = Regression(args)
+    logging.debug("Suite version:%s",  versionStr)
+    logging.debug("Suite full path:%s",  regressionSuiteFullPath)
+
     try:
         if 'clusters' in args:
             Clusters = ['setup']
-            regress = Regression(args)
             for cluster in regress.config.Clusters:
                 Clusters.append(str(cluster))
             print "Avaliable Clusters: "
@@ -113,47 +118,65 @@ if __name__ == "__main__":
                 print "\nMissing ECL query file!\n"
                 parser_query.print_help()
                 exit()
-            regress = Regression(args)
             eclfiles=[]   # List for ECL filenames to be executed
-            if  ('*' in args.query) or ('?' in args.query):
-                # If there is any wildcard in ECL file name, resolve it
-                eclwild = os.path.join(regress.dir_ec, args.query)
-                eclfiles = glob.glob(eclwild)
+            for ecl in args.query:
+                if not ('.ecl' in ecl):
+                    args.cluster = ecl
+                elif  ('*' in ecl) or ('?' in ecl):
+                    # If there is any wildcard in ECL file name, resolve it
+                    eclwild = os.path.join(regress.dir_ec, ecl)
+                    eclfiles.extend( glob.glob(eclwild))
+                else:
+                    # We have simple ECL file in parameter list, put it on the eclfile list
+                    eclPath = os.path.join(regress.dir_ec, ecl)
+                    eclfiles.append(eclPath)
+
+            if len(eclfiles) > 1:
+                # Remove duplicates
+                tempList = list(set(eclfiles))
+                eclfiles = tempList
 
                 # Sort ECL filenames to ensure correct execution order
                 eclfiles.sort()
 
-            else:
-                # We have only one ECL file in parameter list, put it on the eclfile list
-                ecl = os.path.join(regress.dir_ec, args.query)
-                eclfiles.append(ecl)
-
             targetClusters = []
-            if 'all' in args.cluster:
+            if 'all' == args.cluster:
                 for cluster in regress.config.Clusters:
                     targetClusters.append(str(cluster))
             else:
-                targetClusters.append(args.cluster)
+                if args.cluster in regress.config.Clusters:
+                    targetClusters.append(args.cluster)
+                else:
+                    logging.error("%s. Unknown cluster:'%s'!" % (1,  args.cluster))
+                    print "Abend."
+                    exit()
             # Go through the cluster list
             for cluster in targetClusters:
                 try:
-                    # Execute ECL files one by one on the cluster
-                    for ecl in eclfiles:
-                        eclfile = ECLFile(ecl, regress.dir_a, regress.dir_ex, regress.dir_r, cluster)
-                        # Check if this query is not skip on this cluster and not part of setup
-                        if (not eclfile.testSkip(cluster)['skip']) and (not eclfile.testSkip('setup')['skip'] ):
-                            if not eclfile.testExclusion(cluster):
-                                regress.runSuiteQ(cluster, eclfile)
-                            else:
-                                logging.warn("%s. %s excluded on %s cluster." % (1,  eclfile.getBaseEcl(), cluster))
+                    if len(eclfiles) > 1:
+                        #Execute multiple ECl files like RUN to generates summary results and diff report.
+                        regress.bootstrap(cluster, eclfiles)
+                        if  'pq' in args:
+                            regress.runSuiteP(cluster, regress.suites[cluster])
                         else:
-                            logging.warn("%s. %s skipped on %s cluster." % (1, eclfile.getBaseEcl(), cluster))
+                            regress.runSuite(cluster, regress.suites[cluster])
+                    else:
+                        # Execute one ECL file on the cluster
+                        for ecl in eclfiles:
+                            eclfile = ECLFile(ecl, regress.dir_a, regress.dir_ex, regress.dir_r, cluster)
+                            # Check if this query is not skip on this cluster and not part of setup
+                            if (not eclfile.testSkip(cluster)['skip']) and (not eclfile.testSkip('setup')['skip'] ):
+                                if not eclfile.testExclusion(cluster):
+                                    regress.runSuiteQ(cluster, eclfile)
+                                else:
+                                    logging.warn("%s. %s excluded on %s cluster." % (1,  eclfile.getBaseEcl(), cluster))
+                            else:
+                                logging.warn("%s. %s skipped on %s cluster." % (1, eclfile.getBaseEcl(), cluster))
                 except IOError:
                     logging.error("%s. Query %s does not exist!" % (1,  eclfile.getBaseEcl()))
                     exit()
             print("End.")
         elif 'cluster' in args:
-            regress = Regression(args)
             regress.bootstrap(args.cluster)
             if 'setup' in args.cluster:
                 regress.runSuite('setup', regress.Setup())

--- a/testing/regress/hpcc/common/error.py
+++ b/testing/regress/hpcc/common/error.py
@@ -23,9 +23,11 @@ ERROR = {
     "1002": "Command timed out.",
     "2000": "Value must be of Type Suite or ECLFile.",
     "2001": "ECL Directory does not exist.",
-    "2002": "suiteDir not set. Set in regress.json or use --suiteDir",
+    "2002": "suiteDir not set. Set in ecl-test.json or use --suiteDir",
     "3000": "Return is null",
-    "3001": "Return diff does not match."
+    "3001": "Return diff does not match.",
+    "4000": "Unknown cluster!",
+    "4001": "No ECl file!"
 }
 
 
@@ -39,3 +41,6 @@ class Error(Exception):
             return "Error (%s): %s \n %s\n" % (self.code,
                                                ERROR[self.code], self.err)
         return "Error (%s): %s " % (self.code, ERROR[self.code])
+        
+    def getErrorCode(self):
+        return self.code

--- a/testing/regress/hpcc/common/report.py
+++ b/testing/regress/hpcc/common/report.py
@@ -72,12 +72,13 @@ class Report:
                 reportStr += "-------------------------------------------------\n"
         if self.report._fail:
             for result in self.report._fail:
-                try:
-                    reportStr += result.Diff.replace('\\n',  '\n').replace('"',  '')
-                except Exception as ex:
-                    logging.debug("Exception:'%s'",  str(ex))
-                    reportStr += repr(result.Diff).replace('\\n',  '\n').replace('"',  '')
-                reportStr += "\n"
+                if len(result.Diff) > 0:
+                    try:
+                        reportStr += result.Diff.replace('\\n',  '\n').replace('"',  '')
+                    except Exception as ex:
+                        logging.debug("Exception:'%s'",  str(ex))
+                        reportStr += repr(result.Diff).replace('\\n',  '\n').replace('"',  '')
+                    reportStr += "\n"
             reportStr += "-------------------------------------------------\n"
         if log:
             reportStr += "Log: %s\n" % str(log)
@@ -121,7 +122,10 @@ class Report:
         result['File'] = eclfile.ecl
         if eclfile.wuid == 'Not found':
             result['Result'] = 'Fail'
-            result['Diff'] = ''
+            if len(eclfile.diff) > 0:
+                result['Diff'] = eclfile.diff
+            else:
+                result['Diff'] = ''
             self.report._fail.append(_dict(result))
         elif eclfile.diff:
             if eclfile.testNoKey():

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -121,14 +121,14 @@ class Regression:
     def setLogLevel(self, level):
         self.log.setLevel(level)
 
-    def bootstrap(self, cluster):
+    def bootstrap(self, cluster,  fileList=None):
         self.createDirectory(self.regressionDir)
         self.createDirectory(self.dir_a)
         self.createDirectory(self.dir_r)
         self.createDirectory(self.logDir)
 
         if cluster in self.config.Clusters:
-            self.createSuite(cluster)
+            self.createSuite(cluster,  fileList)
             self.maxtasks = len(self.suites[cluster].getSuite())
         os.chdir(self.regressionDir)
 
@@ -137,9 +137,9 @@ class Regression:
         if not os.path.isdir(dir_n):
             os.makedirs(dir_n)
 
-    def createSuite(self, cluster):
+    def createSuite(self, cluster,  fileList):
         self.suites[cluster] = Suite(cluster, self.dir_ec,
-                                     self.dir_a, self.dir_ex, self.dir_r, self.logDir)
+                                     self.dir_a, self.dir_ex, self.dir_r, self.logDir,  fileList)
 
     def Setup(self):
         self.setupDir = ExpandCheck.dir_exists(os.path.join(self.suiteDir, self.config.setupDir), True)
@@ -160,7 +160,6 @@ class Regression:
         report[0].display(report[1],  elapsTime)
 
     def runSuiteP(self, name, suite):
-        print "runSuiteP"
         report = self.buildLogging(name)
         if name == "setup":
             cluster = 'hthor'
@@ -312,7 +311,6 @@ class Regression:
         time.sleep(2)
 
     def runSuite(self, name, suite):
-        print "runSuite"
         report = self.buildLogging(name)
         if name == "setup":
             cluster = 'hthor'
@@ -353,7 +351,6 @@ class Regression:
 
 
     def runSuiteQ(self, clusterName, eclfile):
-        #print "runSuiteQ"
         report = self.buildLogging(clusterName)
         logging.debug("runSuiteQ( clusterName:'%s', eclfile:'%s')",  clusterName,  eclfile.ecl,  extra={'taskId':0})
 

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -25,7 +25,7 @@ from ..util.ecl.file import ECLFile
 from ..common.error import Error
 
 class Suite:
-    def __init__(self, name, dir_ec, dir_a, dir_ex, dir_r, logDir):
+    def __init__(self, name, dir_ec, dir_a, dir_ex, dir_r, logDir,  fileList = None):
         self.name = name
         self.suite = []
         self.dir_ec = dir_ec
@@ -36,7 +36,7 @@ class Suite:
         self.exclude = []
         self.publish = []
 
-        self.buildSuite()
+        self.buildSuite(fileList)
 
         if len(self.exclude):
             curTime = time.strftime("%y-%m-%d-%H-%M")
@@ -49,11 +49,15 @@ class Suite:
             
 
 
-    def buildSuite(self):
-        if not os.path.isdir(self.dir_ec):
-            raise Error("2001", err="Not Found: %s" % self.dir_ec)
-        allfiles = os.listdir(self.dir_ec)
-        allfiles.sort()
+    def buildSuite(self,  fileList):
+        if fileList == None:
+            if not os.path.isdir(self.dir_ec):
+                raise Error("2001", err="Not Found: %s" % self.dir_ec)
+            allfiles = os.listdir(self.dir_ec)
+            allfiles.sort()
+        else:
+                allfiles = fileList
+
         for file in allfiles:
             if file.endswith(".ecl"):
                 ecl = os.path.join(self.dir_ec, file)

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -93,7 +93,12 @@ class ECLcmd(Shell):
             return err + "\n"
         finally:
             if wuid ==  'N/A':
-                wuid = queryWuid(eclfile.getJobname(), eclfile.getTaskId())['wuid']
+                res = queryWuid(eclfile.getJobname(), eclfile.getTaskId())
+                logging.debug("%3d. queryWuid() -> 'result':'%s', 'wuid':'%s', 'state':'%s'", eclfile.getTaskId(),  res['result'],  res['wuid'],  res['state'])
+                wuid = res['wuid']
+                if res['result'] != "OK":
+                    eclfile.diff=eclfile.getBaseEcl()+'\n\t'+res['state']+'\n'
+                    logging.error("%3d. %s in queryWuid(%s)",  eclfile.getTaskId(),  res['state'],  eclfile.getJobname())
 
             eclfile.addResults(data, wuid)
             if cmd == 'publish':

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -71,6 +71,7 @@ def queryWuid(jobname,  taskId):
     opener.add_handler(auth_handler)
     urllib2.install_opener(opener)
 
+    result = "OK"
     try:
         response_stream = urllib2.urlopen(host)
         json_response = response_stream.read()
@@ -80,19 +81,24 @@ def queryWuid(jobname,  taskId):
             state =resp['WUQueryResponse']['Workunits']['ECLWorkunit'][0]['State']
         else:
             state = jobname+' not found'
+            result = "NotFound"
     except KeyError as ke:
         state = "Key error:"+ke.str()
+        result = "KeyError"
         logging.debug("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
     except urllib2.HTTPError as ex:
         state = "HTTP Error: "+ str(ex.reason)
+        result = "HTTPError"
         logging.debug("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
     except urllib2.URLError as ex:
         state = "URL Error: "+ str(ex.reason)
-        logging.error("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
+        result = "URLError"
+        logging.debug("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
     except Exception as ex:
         state = "Unable to query "+ str(ex.reason)
+        result = "Exception"
         logging.debug("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
-    return {'wuid':wuid, 'state':state}
+    return {'wuid':wuid, 'state':state,  'result':result}
 
 def abortWorkunit(wuid):
     host = "http://"+gConfig.server+"/WsWorkunits/WUAbort?Wuids="+wuid


### PR DESCRIPTION
Implement
    - a handler to query a list of ECL files (with wildcards) in command line
    - a handler to execute multiple query like run a suite to generate
      final result and diff report
    - handler to use parallel execution for multiple ECL query files

Update README.rst and built-in help text.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
