### PR TITLE
HPCC-10978 Fix windows build breack by removing use of strncasecmp

### DIFF
--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -41,7 +41,7 @@ bool checkForeign(const char *lfn)
     if (*lfn=='~')
         lfn++;
     static size_t l = strlen("foreign");
-    if (strncasecmp("foreign", lfn, l)==0)
+    if (strnicmp("foreign", lfn, l)==0)
     {
         lfn+=l;
         while (isspace(*lfn))


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
