### PR TITLE
HPCC-8686 - Allow global join merge stream to spill

### DIFF
--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -101,7 +101,7 @@ void getResources(IHqlExpression * expr, CResources & resources, const CResource
         }
         else
         {
-            resources.setHeavyweight().set(RESslavememory, MEM_Const_Minimal+SORT_BUFFER_TOTAL+JOINR_SMART_BUFFER_SIZE);
+            resources.setHeavyweight().set(RESslavememory, MEM_Const_Minimal+SORT_BUFFER_TOTAL+JOIN_SMART_BUFFER_SIZE);
             if (!isLocal)
             {
 #ifndef SORT_USING_MP

--- a/testing/regress/ecl/joinpartition.ecl
+++ b/testing/regress/ecl/joinpartition.ecl
@@ -1,0 +1,54 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+IMPORT std.system.thorlib;
+
+UNSIGNED numrecs := 2000000 : STORED('numrecs');
+
+rec := RECORD
+ UNSIGNED8 key;
+END;
+
+seed := DATASET([{0}], rec);
+
+rec addNodeNum(rec L, UNSIGNED4 c) := transform
+ SELF.key := c-1;
+ SELF := L;
+END;
+
+one_per_node := DISTRIBUTE(NORMALIZE(seed, thorlib.nodes(), addNodeNum(LEFT, COUNTER)), (UNSIGNED4) key);
+
+rec generatePseudoRandom(rec L, UNSIGNED4 c) := TRANSFORM
+ SELF.key := (L.key * numrecs) + c;
+END;
+
+bigstream := NORMALIZE(one_per_node, numrecs, generatePseudoRandom(LEFT, COUNTER));
+
+smlstream := SAMPLE(bigstream, 100);
+
+joinPartitionL := JOIN(bigstream, smlstream, LEFT.key=RIGHT.key, PARTITION LEFT); // default
+joinPartitionR := JOIN(smlstream, bigstream, LEFT.key=RIGHT.key, PARTITION RIGHT);
+
+rec checksort(rec l, rec r) := TRANSFORM
+ SELF.key := IF(l.key <= r.key, r.key, ERROR('ERROR - records not in sequence'));
+ SELF := r;
+END;
+
+checksortedL := NOFOLD(ITERATE(joinPartitionL, checksort(LEFT, RIGHT), LOCAL));
+checksortedR := NOFOLD(ITERATE(joinPartitionR, checksort(LEFT, RIGHT), LOCAL));
+IF(COUNT(checksortedL) = COUNT(smlstream), OUTPUT('Join partition left succeeded'), FAIL('ERROR- count did not match expected'));
+IF(COUNT(checksortedR) = COUNT(smlstream), OUTPUT('Join partition right succeeded'), FAIL('ERROR- count did not match expected'));

--- a/testing/regress/ecl/key/joinpartition.xml
+++ b/testing/regress/ecl/key/joinpartition.xml
@@ -1,0 +1,6 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>Join partition left succeeded</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>Join partition right succeeded</Result_2></Row>
+</Dataset>

--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -234,14 +234,13 @@ public:
         Linked<IRowInterfaces> primaryRowIf, secondaryRowIf;
 
         StringAttr primaryInputStr, secondaryInputStr;
-        bool &secondaryInputStopped = rightInputStopped;
-        bool &primaryInputStopped = leftInputStopped;
+        bool *secondaryInputStopped, *primaryInputStopped;
         if (rightpartition)
         {
             primaryInput.set(inputs.item(1));
             secondaryInput.set(inputs.item(0));
-            secondaryInputStopped = leftInputStopped;
-            primaryInputStopped = rightInputStopped;
+            secondaryInputStopped = &leftInputStopped;
+            primaryInputStopped = &rightInputStopped;
             primaryInputStr.set("R");
             secondaryInputStr.set("L");
         }
@@ -249,6 +248,8 @@ public:
         {
             primaryInput.set(inputs.item(0));
             secondaryInput.set(inputs.item(1));
+            secondaryInputStopped = &rightInputStopped;
+            primaryInputStopped = &leftInputStopped;
             primaryInputStr.set("L");
             secondaryInputStr.set("R");
         }
@@ -258,11 +259,11 @@ public:
                                                     false, RCUNBOUND, this, false, &container.queryJob().queryIDiskUsage()));
         ActPrintLog("JOIN: Starting %s then %s", secondaryInputStr.get(), primaryInputStr.get());
         startInput(secondaryInput);
-        secondaryInputStopped = false;
+        *secondaryInputStopped = false;
         try
         {
             startInput(primaryInput);
-            primaryInputStopped = false;
+            *primaryInputStopped = false;
         }
         catch (IException *e)
         {

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -624,13 +624,13 @@ class COverflowableBuffer : public CSimpleInterface, implements IRowWriterMultiR
     IRowInterfaces *rowIf;
     Owned<IThorRowCollector> collector;
     Owned<IRowWriter> writer;
-    bool eoi, grouped, shared;
+    bool eoi, shared;
 
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    COverflowableBuffer(CActivityBase &_activity, IRowInterfaces *_rowIf, bool _grouped, bool _shared, unsigned spillPriority)
-        : activity(_activity), rowIf(_rowIf), grouped(_grouped), shared(_shared)
+    COverflowableBuffer(CActivityBase &_activity, IRowInterfaces *_rowIf, bool grouped, bool _shared, unsigned spillPriority)
+        : activity(_activity), rowIf(_rowIf), shared(_shared)
     {
         collector.setown(createThorRowCollector(activity, rowIf, NULL, stableSort_none, rc_mixed, spillPriority, grouped));
         writer.setown(collector->getWriter());

--- a/thorlcr/thorutil/thbufdef.hpp
+++ b/thorlcr/thorutil/thbufdef.hpp
@@ -32,7 +32,7 @@
 #define INDEXWRITE_SMART_BUFFER_SIZE            (0x100000*12)           // 12MB
 #define COUNTPROJECT_SMART_BUFFER_SIZE          (0x100000*12)           // 12MB
 #define ENTH_SMART_BUFFER_SIZE                  (0x100000*12)           // 12MB
-#define JOINR_SMART_BUFFER_SIZE                 (0x100000*12)           // 12MB
+#define JOIN_SMART_BUFFER_SIZE                 (0x100000*12)            // 12MB
 #define LOOKUPJOINL_SMART_BUFFER_SIZE           (0x100000*12)           // 12MB
 #define CATCH_BUFFER_SIZE                       (0x100000*12)           // 12MB
 #define SKIPLIMIT_BUFFER_SIZE                   (0x100000*12)           // 12MB

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -449,7 +449,7 @@ public:
 
     //A thread calling the following functions must own the lock, or guarantee no other thread will access
     void sort(ICompare & compare, unsigned maxcores);
-    rowidx_t save(IFile &file, bool useCompression);
+    rowidx_t save(IFile &file, bool useCompression, const char *tracingPrefix);
     const void **getBlock(rowidx_t readRows);
     inline void noteSpilled(rowidx_t spilledRows)
     {


### PR DESCRIPTION
Global join used to merge partitioned side to disk, change to
merge to memory and conditional spill on demand.
Also refactor global join code to remove duplicated code shared
between rightPartition/leftPartition implementations.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
