### PR TITLE
HPCC-3022 - Allow buildindex not to require maxlength if >4k

### DIFF
--- a/system/jhtree/ctfile.hpp
+++ b/system/jhtree/ctfile.hpp
@@ -135,6 +135,8 @@ public:
     void write(IFileIOStream *, CRC32 *crc = NULL);
 
     unsigned int getMaxKeyLength();
+    void setMaxKeyLength(unsigned max) { hdr.length = max; }
+    void checkMaxKeyLength(unsigned max) { if (max>hdr.length) setMaxKeyLength(max); }
     bool isVariable();
     inline unsigned int getNodeKeyLength() 
     {
@@ -197,7 +199,7 @@ protected:
     size32_t expandedSize;
     Owned<IRandRowExpander> rowexp;  // expander for rand rowdiff   
 
-    static char *expandKeys(void *src,unsigned keylength,size32_t &retsize, bool rowcompression);
+    static char *expandKeys(void *src,size32_t &retsize, bool rowcompression);
     static IRandRowExpander *expandQuickKeys(void *src, bool needCopy);
 
     static void releaseMem(void *togo, size32_t size);
@@ -298,7 +300,7 @@ public:
 class jhtree_decl CWriteNode : public CWriteNodeBase
 {
 private:
-    char *lastKeyValue;
+    MemoryAttr lastKeyValue;
     unsigned __int64 lastSequence;
 
 public:
@@ -307,7 +309,7 @@ public:
 
     size32_t compressValue(const char *keyData, size32_t size, char *result);
     bool add(offset_t pos, const void *data, size32_t size, unsigned __int64 sequence);
-    const void *getLastKeyValue() const { return lastKeyValue; }
+    const void *getLastKeyValue() const { return lastKeyValue.get(); }
     unsigned __int64 getLastSequence() const { return lastSequence; }
 };
 

--- a/system/jhtree/keybuild.cpp
+++ b/system/jhtree/keybuild.cpp
@@ -75,7 +75,7 @@ public:
 class CKeyBuilderBase : public CInterface
 {
 protected:
-    unsigned keyValueSize;
+    unsigned rawSize;
     count_t records;
     unsigned levels;
     offset_t nextPos;
@@ -88,17 +88,18 @@ protected:
     unsigned __int64 sequence;
     CRC32StartHT crcStartPosTable;
     CRC32EndHT crcEndPosTable;
-    bool doCrc;
+    bool doCrc, legacyCompat;
 
 public:
     IMPLEMENT_IINTERFACE;
 
-    CKeyBuilderBase(IFileIOStream *_out, unsigned flags, unsigned rawSize, offset_t _fileSize, unsigned nodeSize, unsigned _keyedSize, unsigned __int64 _startSequence) : out(_out)
+    CKeyBuilderBase(IFileIOStream *_out, unsigned flags, unsigned _rawSize, offset_t _fileSize, unsigned nodeSize, unsigned _keyedSize, unsigned __int64 _startSequence, bool _legacyCompat)
+        : out(_out), legacyCompat(_legacyCompat)
     {
         doCrc = false;
         sequence = _startSequence;
         keyHdr.setown(new CKeyHdr());
-        keyValueSize = rawSize;
+        rawSize = _rawSize;
         keyedSize = _keyedSize != (unsigned) -1 ? _keyedSize : rawSize;
 
         fileSize = _fileSize;
@@ -113,7 +114,7 @@ public:
         KeyHdr *hdr = keyHdr->getHdrStruct();
         hdr->nodeSize = nodeSize;
         hdr->extsiz = 4096;
-        hdr->length = keyValueSize; 
+        hdr->length = 0; // fill in at end
         hdr->ktype = flags; 
         hdr->timeid = 0;
         hdr->clstyp = 1;  // IDX_CLOSE
@@ -148,7 +149,7 @@ public:
         KeyHdr *hdr = keyHdr->getHdrStruct();
         records = hdr->nument;
         nextPos = hdr->nodeSize; // leaving room for header
-        keyValueSize = keyHdr->getMaxKeyLength();
+        rawSize = keyHdr->getMaxKeyLength();
         keyedSize = keyHdr->getNodeKeyLength();
     }
 
@@ -200,12 +201,26 @@ protected:
         return 0;
     }
 
-    void writeFileHeader(bool fixHdr, CRC32 *crc)
+    void writeFileHeader(CRC32 *crc)
     {
         if (out)
         {
             out->flush();
             out->seek(0, IFSbegin);
+
+#define LEGACY_DEFAULT_MAXLENGTH 4096
+            /* For legacy compatibility, where no explicit maxlength was provided.
+             * 1) Check if < default and set header to default - maintaining legacy key build/read behaviour.
+             * 2) Issue warning if runtime max exceeded default - key will not be compatible with legacy system, without MAXLENGTHs being added.
+             */
+            if (legacyCompat && rawSize==LEGACY_DEFAULT_MAXLENGTH)
+            {
+                if (keyHdr->getMaxKeyLength() < LEGACY_DEFAULT_MAXLENGTH)
+                    keyHdr->setMaxKeyLength(LEGACY_DEFAULT_MAXLENGTH);
+                else
+                    WARNLOG("Key created with legacy compatibility set, but key+payload size exceeds legacy default of 4096. Max size is: %d", keyHdr->getMaxKeyLength());
+            }
+
             keyHdr->write(out, crc);
         }
     }
@@ -344,8 +359,8 @@ private:
 public:
     IMPLEMENT_IINTERFACE;
 
-    CKeyBuilder(IFileIOStream *_out, unsigned flags, unsigned rawSize, offset_t fileSize, unsigned nodeSize, unsigned keyedSize, unsigned __int64 startSequence) 
-        : CKeyBuilderBase(_out, flags, rawSize, fileSize, nodeSize, keyedSize, startSequence)
+    CKeyBuilder(IFileIOStream *_out, unsigned flags, unsigned rawSize, offset_t fileSize, unsigned nodeSize, unsigned keyedSize, unsigned __int64 startSequence, bool legacyCompat)
+        : CKeyBuilderBase(_out, flags, rawSize, fileSize, nodeSize, keyedSize, startSequence, legacyCompat)
     {
         doCrc = true;
         activeNode = NULL;
@@ -380,7 +395,7 @@ public:
             writeMetadata(metaXML.str(), metaXML.length());
         }
         CRC32 headerCrc;
-        writeFileHeader(false, &headerCrc);
+        writeFileHeader(&headerCrc);
 
         if (fileCrc)
         {
@@ -489,9 +504,9 @@ protected:
     }
 };
 
-extern jhtree_decl IKeyBuilder *createKeyBuilder(IFileIOStream *_out, unsigned flags, unsigned rawSize, offset_t fileSize, unsigned nodeSize, unsigned keyFieldSize, unsigned __int64 startSequence)
+extern jhtree_decl IKeyBuilder *createKeyBuilder(IFileIOStream *_out, unsigned flags, unsigned rawSize, offset_t fileSize, unsigned nodeSize, unsigned keyFieldSize, unsigned __int64 startSequence, bool legacyCompat)
 {
-    return new CKeyBuilder(_out, flags, rawSize, fileSize, nodeSize, keyFieldSize, startSequence);
+    return new CKeyBuilder(_out, flags, rawSize, fileSize, nodeSize, keyFieldSize, startSequence, legacyCompat);
 }
 
 
@@ -544,7 +559,7 @@ public:
                 leafInfo.append(OLINK(nodes.item(idx2)));
         }
         buildTree(leafInfo);
-        writeFileHeader(true, NULL);
+        writeFileHeader(NULL);
     }
 
 protected:

--- a/system/jhtree/keybuild.hpp
+++ b/system/jhtree/keybuild.hpp
@@ -101,7 +101,7 @@ interface IKeyBuilder : public IInterface
     virtual unsigned __int64 createBlob(size32_t size, const char * _ptr) = 0;
 };
 
-extern jhtree_decl IKeyBuilder *createKeyBuilder(IFileIOStream *_out, unsigned flags, unsigned rawSize, offset_t fileSize, unsigned nodeSize, unsigned keyFieldSize, unsigned __int64 startSequence);
+extern jhtree_decl IKeyBuilder *createKeyBuilder(IFileIOStream *_out, unsigned flags, unsigned rawSize, offset_t fileSize, unsigned nodeSize, unsigned keyFieldSize, unsigned __int64 startSequence, bool legacyCompat=false);
 
 interface IKeyDesprayer : public IInterface
 {

--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -199,7 +199,9 @@ public:
         buildUserMetadata(metadata);                
         buildLayoutMetadata(metadata);
         unsigned nodeSize = metadata ? metadata->getPropInt("_nodeSize", NODESIZE) : NODESIZE;
-        builder.setown(createKeyBuilder(out, flags, maxDiskRecordSize, fileSize, nodeSize, helper->getKeyedSize(), isTopLevel ? 0 : totalCount));
+
+        bool legacyCompat = getOptBool(THOROPT_KEYBUILD_LEGACYCOMPAT, true);
+        builder.setown(createKeyBuilder(out, flags, maxDiskRecordSize, fileSize, nodeSize, helper->getKeyedSize(), isTopLevel ? 0 : totalCount, legacyCompat));
     }
 
 

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -61,6 +61,7 @@
 #define THOROPT_JOINHELPER_THREADS    "joinHelperThreads"       // Number of threads to use in threaded variety of join helper
 #define THOROPT_LKJOIN_LOCALFAILOVER  "lkjoin_localfailover"    // Force SMART to failover to distributed local lookup join (for testing only)   (default = false)
 #define THOROPT_LKJOIN_HASHJOINFAILOVER "lkjoin_hashjoinfailover" // Force SMART to failover to hash join (for testing only)                     (default = false)
+#define THOROPT_KEYBUILD_LEGACYCOMPAT "kbuild_legacycompat"     // Try to keep built key header max size compatible with legacy systems          (default = true)
 
 #define INITIAL_SELFJOIN_MATCH_WARNING_LEVEL 20000  // max of row matches before selfjoin emits warning
 


### PR DESCRIPTION
For legacy backward compatibility reasons, we have forced the max
key size (key+payload) to default to the max record size, which
in legacy systems used to be 4K. This can been overridden
with ,MAXLENGTH on the record structure.
However, this imposes a unnecessary restriction in the current
system, which has no default max record length and therefore
doesn't need to use a 'max' in the key header at all.

Fix by removing the max length check in the key builder, but for
continued backward compatibility, track the largest key+payload
and store it in the header. If the max is < old default legacy(4k)
set header max to 4K.
This will mean any key built on a new system with this
compatibility option on, will create a compatible key for legacy
system as long as the key+payload <= 4k.
If it is higher, it will issue a warning. Legacy systems can still
use the key, but they will need to specify MAXLENGTH.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
