### PR TITLE
HPCC-10911 DOCS:start up logging

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -871,8 +871,9 @@
                       <entry>There are log files for each component in
                       directories below <emphasis
                       role="bold">/var/log/HPCCSystems</emphasis> (default
-                      location). If any component fails to start, these logs
-                      can help in troubleshooting.</entry>
+                      location) including an hpcc-init log for the start up
+                      process. If any component fails to start, these logs can
+                      help in troubleshooting.</entry>
                     </row>
                   </tbody>
                 </tgroup>


### PR DESCRIPTION
Fix HPCC-10911 DOCS:start up logging
Document the new hpcc-init log which
logs start up init activity

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com

@JamesDeFabia  please review
