### PR TITLE
HPCC-10989 Prevent "global" graph layout

### DIFF
--- a/esp/files/scripts/GraphPageWidget.js
+++ b/esp/files/scripts/GraphPageWidget.js
@@ -467,7 +467,7 @@ define([
         },
 
         loadGraphFromXGMML: function (xgmml) {
-            this.global.loadXGMML(xgmml, false);
+            this.global.loadXGMML(xgmml, false, true);
             this.refreshMain();
             this.refreshOverview();
             this.loadSubgraphs();

--- a/esp/files/scripts/GraphWidget.js
+++ b/esp/files/scripts/GraphWidget.js
@@ -132,7 +132,7 @@ require([
                 }
             },
 
-            loadXGMML: function (xgmml, merge) {
+            loadXGMML: function (xgmml, merge, skipLayout) {
                 this.registerEvents();
                 if (this._plugin && this.xgmml != xgmml) {
                     this.setMessage("Loading Data...");
@@ -140,8 +140,12 @@ require([
                         this._plugin.mergeXGMML(xgmml);
                     else
                         this._plugin.loadXGMML(xgmml);
-                    this.setMessage("Performing Layout...");
-                    this._plugin.startLayout("dot");
+                    if (skipLayout) {
+                        this.setMessage("");
+                    } else {
+                        this.setMessage("Performing Layout...");
+                        this._plugin.startLayout("dot");
+                    }
                     this.xgmml = xgmml;
                 }
             },


### PR DESCRIPTION
The global layout will block the main layout and is not needed.

Fixes HPCC-10989

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
