### PR TITLE
HPCC-11002 Fix Regression in 5.0 dataset with xpath('Name')

### DIFF
--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -260,12 +260,15 @@ void CommonXmlWriter::outputEndDataset(const char *dsname)
 
 void CommonXmlWriter::outputBeginNested(const char *fieldname, bool nestChildren, bool doIndent)
 {
+    if (!fieldname || !*fieldname)
+        return;
+
     const char * sep = strchr(fieldname, '/');
     if (sep)
     {
         StringAttr leading(fieldname, sep-fieldname);
-        outputBeginNested(leading, nestChildren);
-        outputBeginNested(sep+1, nestChildren);
+        outputBeginNested(leading, nestChildren, doIndent);
+        outputBeginNested(sep+1, nestChildren, doIndent);
         return;
     }
 
@@ -287,12 +290,15 @@ void CommonXmlWriter::outputBeginNested(const char *fieldname, bool nestChildren
 
 void CommonXmlWriter::outputEndNested(const char *fieldname, bool doIndent)
 {
+    if (!fieldname || !*fieldname)
+        return;
+
     const char * sep = strchr(fieldname, '/');
     if (sep)
     {
         StringAttr leading(fieldname, sep-fieldname);
-        outputEndNested(sep+1);
-        outputEndNested(leading);
+        outputEndNested(sep+1, doIndent);
+        outputEndNested(leading, doIndent);
         return;
     }
 


### PR DESCRIPTION
Fix that any xpath that resulted in a xml nesting tag with a blank name would
have created an unnamed tag of the form &lt;>&lt;/>.

Also fix recursive calls to outputBeginNested() were not passing along current value for doIndent.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
