### PR TITLE
HPCC-11000 Update numFilesToProcess when removing a file from todo

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1066,6 +1066,7 @@ public:
             if (file == &todo.item(idx))
             {
                 todo.remove(idx);
+                atomic_dec(&numFilesToProcess);    // must decrement counter for SNMP accuracy
             }
         }
     }


### PR DESCRIPTION
The numFilesToProcess is a file counter used in roxie metrics.
