### PR TITLE
HPCC-11021 Check if parsing is being aborted before looping again.

### DIFF
--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -1488,6 +1488,8 @@ void HqlLex::doIsValid(YYSTYPE & returnToken)
 
 void HqlLex::checkNextLoop(const YYSTYPE & errpos, bool first, int startLine, int startCol)
 {
+    if (yyParser->aborting)
+        return;
     if (loopTimes++ > MAX_LOOP_TIMES)
     {
         reportError(errpos, ERR_TMPLT_LOOPEXCESSMAX,"The loop exceeded the limit: infinite loop is suspected");


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
