### PR TITLE
HPCC-11006 Download zipped WU XML if it is big

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -44,7 +44,14 @@
                 <xsl:otherwise>
                   <xsl:value-of select="$wuid"/>
                   &nbsp;
-                  <a href="/esp/iframe?esp_iframe_title=ECL Workunit XML - {$wuid}&amp;inner=/WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Type%3dXML" >XML</a>
+                  <xsl:choose>
+                    <xsl:when test="WUXMLSize &lt; 5000000">
+                      <a href="/esp/iframe?esp_iframe_title=ECL Workunit XML - {$wuid}&amp;inner=/WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Type%3dXML%26Option%3d1" >XML</a><xsl:value-of select="WUXMLSize"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <a href="/esp/iframe?esp_iframe_title=Download ECL Workunit XML - {$wuid}&amp;inner=/WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Type%3dXML%26Option%3d2" >Download XML</a>
+                    </xsl:otherwise>
+                  </xsl:choose>
                   &nbsp;
                   <a href="/esp/iframe?esp_iframe_title=ECL Playground - {$wuid}&amp;inner=/esp/files/stub.htm%3fWidget%3dECLPlaygroundWidget%26Wuid%3d{$wuid}%26Target%3d{Cluster}" >ECL Playground</a>
                 </xsl:otherwise>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -232,6 +232,7 @@ ESPStruct [nil_remove] ECLWorkunit
     [min_ver("1.29")] string ApplicationValuesDesc;
     [min_ver("1.29")] string WorkflowsDesc;
     [min_ver("1.31")] bool HasArchiveQuery(false);
+    [min_ver("1.49")] int64 WUXMLSize;
     [min_ver("1.38")] ESParray<ESPstruct ThorLogInfo> ThorLogList;
     [min_ver("1.47")] ESParray<string, URL> ResourceURLs;
 };
@@ -1450,7 +1451,7 @@ ESPresponse [exceptions_inline] WUCreateZAPInfoResponse
 };
 
 ESPservice [
-    version("1.48"), default_client_version("1.48"),
+    version("1.49"), default_client_version("1.49"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -899,6 +899,12 @@ void WsWuInfo::getInfo(IEspECLWorkunit &info, unsigned flags)
     info.setDescription(cw->getDebugValue("description", s).str());
     if (version > 1.21)
         info.setXmlParams(cw->getXmlParams(s).str());
+    if (version >= 1.49)
+    {
+        SCMStringBuffer xml;
+        exportWorkUnitToXML(cw, xml, true, false);
+        info.setWUXMLSize(xml.length());
+    }
 
     info.setResultLimit(cw->getResultLimit());
     info.setArchived(false);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2418,12 +2418,20 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
             else if (strieq(File_XML,req.getType()))
             {
                 winfo.getWorkunitXml(req.getPlainText(), mb);
-                resp.setThefile(mb);
-                const char* plainText = req.getPlainText();
-                if (plainText && (!stricmp(plainText, "yes")))
-                    resp.setThefile_mimetype(HTTP_TYPE_TEXT_PLAIN);
+                if (opt < 2)
+                {
+                    resp.setThefile(mb);
+                    const char* plainText = req.getPlainText();
+                    if (plainText && (!stricmp(plainText, "yes")))
+                        resp.setThefile_mimetype(HTTP_TYPE_TEXT_PLAIN);
+                    else
+                        resp.setThefile_mimetype(HTTP_TYPE_APPLICATION_XML);
+                }
                 else
-                    resp.setThefile_mimetype(HTTP_TYPE_APPLICATION_XML);
+                {
+                    VStringBuffer xmlName("%s.xml", wuid.get());
+                    openSaveFile(context, 2, xmlName.str(), HTTP_TYPE_APPLICATION_XML, mb, resp);
+                }
             }
         }
     }


### PR DESCRIPTION
In this fix, the size of WU XML is returned in WsWorkunits/WUInfo
response. WUInfo xslt page checks the size. If the size is greater
than 5MB, the page displays a Download XML link. When the link is
clicked, the WU XML is zipped and downloaded.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
