### PR TITLE
HPCC-11025 - Fix various MP close socket issues

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -3074,8 +3074,8 @@ void IpAddress::setNetAddress(size32_t sz,const void *src)
     if (sz==sizeof(unsigned)) { // IPv4
         netaddr[0] = 0;
         netaddr[1] = 0;
-        netaddr[2]=0xffff0000;
         netaddr[3] = *(const unsigned *)src;
+        netaddr[2] = netaddr[3] ? 0xffff0000 : 0; // leave as null if Ipv4 address is null
     }
     else if (!IP4only&&(sz==sizeof(netaddr))) { // IPv6
         memcpy(&netaddr,src,sz);

--- a/system/mp/mpbase.hpp
+++ b/system/mp/mpbase.hpp
@@ -144,6 +144,7 @@ extern mp_decl void initMyNode(unsigned short port);
 
 interface IMP_Exception: extends IException
 {
+    virtual const SocketEndpoint &queryEndpoint() const = 0;
 };
 
 enum MessagePassingError

--- a/thorlcr/master/mawatchdog.cpp
+++ b/thorlcr/master/mawatchdog.cpp
@@ -196,7 +196,20 @@ void CMasterWatchdogBase::main()
         {
             HeartBeatPacketHeader hb;
             MemoryBuffer progressData;
-            unsigned sz = readPacket(hb, progressData);
+            unsigned sz;
+            try
+            {
+                sz = readPacket(hb, progressData);
+            }
+            catch (IMP_Exception *e)
+            {
+                if (MPERR_link_closed != e->errorCode())
+                    throw;
+                const SocketEndpoint &ep = e->queryEndpoint();
+                StringBuffer epStr;
+                ep.getUrlStr(epStr);
+                abortThor(MakeThorOperatorException(TE_AbortException, "Watchdog has lost connectivity with Thor slave: %s (Process terminated or node down?)", epStr.str()));
+            }
             if (stopped)
                 break;
             else if (sz)


### PR DESCRIPTION
Fix:
1) Spot non-MP clients connecting to the MP port early and ignore.
2) IpAddress::setNetAddress - set 'null' ip if null IPv4 provided.
3) Ignore InterCommunicator close sockets as exceptions unless
specifically listening to socket closed.
4) Ingore Communicator close socket exceptions unless part
internal to group communicator is based on.
5) Ensure close socket exception on Thor watchdog recycles Thor.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
