### PR TITLE
HPCC-10497 Invalid installed bundle can canse ecl-bundle to core

### DIFF
--- a/ecl/ecl-bundle/ecl-bundle.cpp
+++ b/ecl/ecl-bundle/ecl-bundle.cpp
@@ -723,7 +723,7 @@ private:
         assertex(version && *version);
         ForEachItemIn(idx, bundles)
         {
-            if (strieq(version, bundles.item(idx).queryVersion()))
+            if (bundles.item(idx).queryVersion() && strieq(version, bundles.item(idx).queryVersion()))
                 return idx;
         }
         return NotFound;


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
