### PR TITLE
HPCC-10449 Unicode literals in embedded Python using wrong codepage

### DIFF
--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -331,7 +331,8 @@ public:
                 PyErr_Clear();
                 StringBuffer wrapped;
                 wrapPythonText(wrapped, text);
-                code.setown(Py_CompileString(wrapped, "<embed>", Py_file_input));
+                PyCompilerFlags flags = { PyCF_SOURCE_IS_UTF8 };
+                code.setown(Py_CompileStringFlags(wrapped, "<embed>", Py_file_input, &flags));
             }
             checkPythonError();
             if (code)


### PR DESCRIPTION
Need to tell Python that the source is utf8.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
