### PR TITLE
HPCC-11027 Increase dali version to 3.11 and check it in WsDFU

### DIFF
--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -37,7 +37,7 @@ extern void closedownDFS();
 // base is saved in store whenever block exhausted, so replacement coven servers can restart 
 
 // server side versioning.
-#define ServerVersion    "3.10"
+#define ServerVersion    "3.11"
 #define MinClientVersion "1.5"
 
 

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -3332,8 +3332,8 @@ bool CWsDfuEx::doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc,
         return true;
     }
 
-    if (queryDaliServerVersion().compare("5.0") < 0)
-    {
+    if (queryDaliServerVersion().compare("3.11") < 0)
+    {//Dali server does not support Filtered File Query. Use legacy code.
         getAPageOfSortedLogicalFile(context, udesc, req, resp);
         return true;
     }


### PR DESCRIPTION
This fix increases the dali version to 3.11. Browse Logical Files
in WsDFU checks the dali version to decide whether dali supports
filtered file query or not.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
