### PR TITLE
HPCC-10952 Add AuthenticateFeature 'FileUploadAccess' to env setting

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -159,6 +159,10 @@
                           path="FileDkcAccess"
                           resource="FileDkcAccess"
                           service="ws_fs"/>
+     <AuthenticateFeature description="Access to file upload"
+                          path="FileUploadAccess"
+                          resource="FileUploadAccess"
+                          service="ws_fs"/>
      <AuthenticateFeature description="Access to files in dropzone"
                           path="FileIOAccess"
                           resource="FileIOAccess"
@@ -521,6 +525,11 @@
                          resource="FileDkcAccess"
                          service="ws_fs"/>
     <AuthenticateFeature authenticate="Yes"
+                         description="Access to file upload"
+                         path="FileUploadAccess"
+                         resource="FileUploadAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature authenticate="Yes"
                          description="Access to files in dropzone"
                          path="FileIOAccess"
                          resource="FileIOAccess"
@@ -677,6 +686,10 @@
     <AuthenticateFeature description="Access to dkcing of key files"
                          path="FileDkcAccess"
                          resource="FileDkcAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature description="Access to file upload"
+                         path="FileUploadAccess"
+                         resource="FileUploadAccess"
                          service="ws_fs"/>
     <AuthenticateFeature description="Access to files in dropzone"
                          path="FileIOAccess"


### PR DESCRIPTION
The 'FileUploadAccess' permission is missing from the "Esp Features
for SMC". In this fix, the AuthenticateFeature 'FileUploadAccess' is
added to environment.xml. When ECLwatch is started, CLdapSecManager::
createFeatureMap() reads the 'FileUploadAccess' from esp.xml and adds
the permission into LDAP server.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
