### PR TITLE
HPCC-10483 Incorrect Edit Distance Return

### DIFF
--- a/ecllibrary/teststd/uni/TestEditDistance.ecl
+++ b/ecllibrary/teststd/uni/TestEditDistance.ecl
@@ -38,6 +38,9 @@ EXPORT TestEditDistance := MODULE
     EXPORT Test23 := ASSERT(Uni.EditDistance(alpha,manyDigits+U'12345') = 255, CONST);
     EXPORT Test24 := ASSERT(Uni.EditDistance(alpha,manyDigits+U'123456') = 255, CONST);
     EXPORT Test25 := ASSERT(Uni.EditDistance(U'123456789',U'987654321') = 8, CONST);
+    EXPORT Test26 := ASSERT(Uni.EditDistance(U'AVILÉS',U'AVILES') = 1, CONST);
+    EXPORT Test27 := ASSERT(Uni.EditDistance(U'MOMBRU',U'MOMBRÚ') = 1, CONST);
+    EXPORT Test28 := ASSERT(Uni.EditDistance(U'ALVAREZ',U'ÁLVAREZ') = 1, CONST);
   END;
 
 END;

--- a/plugins/unicodelib/unicodelib.cpp
+++ b/plugins/unicodelib/unicodelib.cpp
@@ -290,8 +290,8 @@ private:
     void doCreateCEList(RuleBasedCollator& rbc) {
         UErrorCode status = U_ZERO_ERROR;
         CollationElementIterator*  ceIterator = rbc.createCollationElementIterator( ustring_ );
-        if (!capacity_) {
-            capacity_ = ustring_.length();
+        if (!capacity_ || capacity_ <= ustring_.length()) {
+            capacity_ = 2*ustring_.length(); // cover the case where the number of CEs exceeds the unicode string length
         }
         ces_ = new uint32_t[capacity_]; 
         uint32_t ce = 0; 


### PR DESCRIPTION
- CEList constructor does not handle the case where the number of
  collation elements exceeds the length of unicode string

Signed-off-by: Edin Muharemagic edin.muharemagic@lexisnexis.com
