### PR TITLE
HPCC-11046 Include IFF in contents of ECLLanguageReference

### DIFF
--- a/docs/ECLLanguageReference/ECLR-includer.xml
+++ b/docs/ECLLanguageReference/ECLR-includer.xml
@@ -599,6 +599,10 @@
                 xpointer="element(/1)"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
+   <xi:include href="ECLLanguageReference/ECLR_mods/BltInFunc-IFF.xml"
+                xpointer="element(/1)"
+                xmlns:xi="http://www.w3.org/2001/XInclude" />
+
     <xi:include href="ECLLanguageReference/ECLR_mods/BltInFunc-IMPORT.xml"
                 xpointer="element(/1)"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLLanguageReference/ECLR_mods/BltInFunc-IF.xml
+++ b/docs/ECLLanguageReference/ECLR_mods/BltInFunc-IF.xml
@@ -4,18 +4,10 @@
 <sect1 id="IF">
   <title>IF<indexterm>
       <primary>IF</primary>
-    </indexterm><indexterm>
-      <primary>IFF</primary>
     </indexterm></title>
 
   <para><emphasis role="bold">IF<indexterm>
       <primary>IF function</primary>
-    </indexterm>(</emphasis><emphasis>expression, trueresult
-  </emphasis><emphasis role="bold">[</emphasis><emphasis>, falseresult
-  </emphasis><emphasis role="bold">])</emphasis></para>
-
-  <para><emphasis role="bold">IFF<indexterm>
-      <primary>IFF function</primary>
     </indexterm>(</emphasis><emphasis>expression, trueresult
   </emphasis><emphasis role="bold">[</emphasis><emphasis>, falseresult
   </emphasis><emphasis role="bold">])</emphasis></para>
@@ -60,7 +52,7 @@
 
   <para>The <emphasis role="bold">IF</emphasis> function evaluates the
   <emphasis>expression</emphasis> (which must be a conditional expression with
-  a Boolean result) and returns either the <emphasis>truersult </emphasis>or
+  a Boolean result) and returns either the <emphasis>trueresult </emphasis>or
   <emphasis>falseresult</emphasis> based on the evaluation of the
   <emphasis>expression</emphasis>. Both the <emphasis>trueresult</emphasis>
   and <emphasis>falseresult</emphasis> must be the same type (i.e. both
@@ -70,10 +62,6 @@
   relies on the size of the two being the same, then a type cast to the
   required size may be required (typically to cast an empty string to the
   proper size so subsequent string indexing will not fail).</para>
-
-  <para>The <emphasis role="bold">IFF</emphasis> function performs the same
-  functionality as IF, but ensures that an <emphasis>expression</emphasis>
-  containing complex boolean logic is evaluated exactly as it appears.</para>
 
   <para>Example:</para>
 
@@ -95,7 +83,7 @@ MyAddress := IF(person.gender = 'M',
   // STRING182 ensures a proper-length string return
 </programlisting>
 
-  <para>See Also: <link linkend="MAP">MAP</link>, <link
-  linkend="EVALUATE">EVALUATE</link>, <link linkend="CASE">CASE</link>, <link
-  linkend="CHOOSE">CHOOSE</link>, <link linkend="SET">SET</link></para>
+  <para>See Also: <link linkend="IFF">IFF</link>, <link linkend="MAP">MAP</link>,
+  <link linkend="EVALUATE">EVALUATE</link>, <link linkend="CASE">CASE</link>,
+  <link linkend="CHOOSE">CHOOSE</link>, <link linkend="SET">SET</link></para>
 </sect1>

--- a/docs/ECLLanguageReference/ECLR_mods/BltInFunc-IFF.xml
+++ b/docs/ECLLanguageReference/ECLR_mods/BltInFunc-IFF.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<sect1 id="IFF">
+  <title>IFF<indexterm>
+      <primary>IFF</primary>
+    </indexterm></title>
+
+  <para><emphasis role="bold">IFF<indexterm>
+      <primary>IFF function</primary>
+    </indexterm>(</emphasis><emphasis>expression, trueresult
+  </emphasis><emphasis role="bold">[</emphasis><emphasis>, falseresult
+  </emphasis><emphasis role="bold">])</emphasis></para>
+
+  <para><informaltable colsep="1" frame="all" rowsep="1">
+      <tgroup cols="2">
+        <colspec colwidth="80.50pt" />
+
+        <colspec />
+
+        <tbody>
+          <row>
+            <entry><emphasis>expression</emphasis></entry>
+
+            <entry>A conditional expression.</entry>
+          </row>
+
+          <row>
+            <entry><emphasis>trueresult</emphasis></entry>
+
+            <entry>The result to return when the expression is true. This may
+            be any expression or action.</entry>
+          </row>
+
+          <row>
+            <entry><emphasis>falseresult</emphasis></entry>
+
+            <entry>The result to return when the expression is false. This may
+            be any expression or action. This may be omitted only if the
+            result is an action.</entry>
+          </row>
+
+          <row>
+            <entry>Return:</entry>
+
+            <entry>IF returns a single value, set, recordset, or
+            action.</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </informaltable></para>
+
+   <para>The <emphasis role="bold">IFF</emphasis> function performs the same
+  functionality as IF, but ensures that an <emphasis>expression</emphasis>
+  containing complex boolean logic is evaluated exactly as it appears.</para>
+
+  <para>See Also: <link linkend="IF">IF</link>, <link linkend="MAP">MAP</link>,
+  <link linkend="EVALUATE">EVALUATE</link>, <link linkend="CASE">CASE</link>,
+  <link linkend="CHOOSE">CHOOSE</link>, <link linkend="SET">SET</link></para>
+</sect1>


### PR DESCRIPTION
Separate out IFF from the description of IF in the language reference manual.

Signed-off-by: jamienoss james.noss@lexisnexis.com
