### PR TITLE
HPCc-11060 - Support multi-qualifiers on sds subscription nodes

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -609,10 +609,19 @@ private:
 
 /////////////////
 
+class CQualifiers : public CSimpleInterface, implements IInterface
+{
+    StringArray qualifiers;
+public:
+    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+    inline void add(const char *qualifier) { qualifiers.append(qualifier); }
+    inline unsigned count() const { return qualifiers.ordinality(); }
+    inline const char *item(unsigned i) const { return qualifiers.item(i); }
+};
 class CSubscriberContainer : public CSubscriberContainerBase
 {
     StringAttr xpath, fullXpath;
-    StringArray qualifierStack;
+    PointerIArrayOf<CQualifiers> qualifierStack;
     bool sub, sendValue;
     unsigned depth;
 public:
@@ -655,16 +664,22 @@ public:
                 if (!nextSep || startQ < nextSep)
                     break;
 
-                qualifierStack.append(""); // no qualifier for this segment.
+                qualifierStack.append(NULL); // no qualifier for this segment.
             }
 
-            const char *endQ = queryNextUnquoted(startQ, ']');
-            assertex(endQ);
-            strippedXpath.append(startQ-path, path);
+            Owned<CQualifiers> qualifiers = new CQualifiers;
+            do
+            {
+                const char *endQ = queryNextUnquoted(startQ+1, ']');
+                assertex(endQ);
+                strippedXpath.append(startQ-path, path);
 
-            StringAttr qualifier(startQ+1, endQ-startQ-1);
-            qualifierStack.append(qualifier);
-            path = endQ+1;
+                StringAttr qualifier(startQ+1, endQ-startQ-1);
+                qualifiers->add(qualifier);
+                path = endQ+1;
+            }
+            while (NULL != (startQ = queryNextUnquoted(path, '[')));
+            qualifierStack.append(qualifiers.getClear());
         }
         fullXpath.set(xpath);
         if (strippedXpath.length()) // some qualifications
@@ -686,36 +701,40 @@ public:
     {
         ForEachItemIn(q, qualifierStack)
         {
-            const char *qualifier = qualifierStack.item(q);
             if (stack.ordinality() <= q+1)
             {
                 // No more stack available (e.g. because deleted below this point)
                 return true;
             }
             PTree &item = stack.item(q+1); // stack +1, top is root unqualified.
-            if (qualifier && '\0' != *qualifier)
+            CQualifiers *qualifiers = qualifierStack.item(q);
+            if (qualifiers)
             {
-                const char *q = qualifier;
-                bool numeric = true;
-                loop
+                for (unsigned q2=0; q2<qualifiers->count(); q2++)
                 {
-                    if ('\0' == *q) break;
-                    else if (!isdigit(*q)) { numeric = false; break; }
-                    else q++;
-                }
-                if (numeric)
-                {
-                    unsigned qnum = atoi(qualifier);
-                    if (!item.queryParent())
+                    const char *qualifier = qualifiers->item(q2);
+                    const char *q = qualifier;
+                    bool numeric = true;
+                    loop
                     {
-                        if (qnum != 1)
+                        if ('\0' == *q) break;
+                        else if (!isdigit(*q)) { numeric = false; break; }
+                        else q++;
+                    }
+                    if (numeric)
+                    {
+                        unsigned qnum = atoi(qualifier);
+                        if (!item.queryParent())
+                        {
+                            if (qnum != 1)
+                                return false;
+                        }
+                        else if (((PTree *)item.queryParent())->findChild(&item) != qnum-1)
                             return false;
                     }
-                    else if (((PTree *)item.queryParent())->findChild(&item) != qnum-1)
+                    else if (!item.checkPattern(qualifier))
                         return false;
                 }
-                else if (!item.checkPattern(qualifier))
-                    return false;
             }
         }
         return true;

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -641,7 +641,6 @@ const char *queryNextUnquoted(const char *str, char c)
     bool quote = false;
     while (end != str)
     {
-        ++str;
         if ('"' == *str)
         {
             if (quote) quote = false;
@@ -649,6 +648,7 @@ const char *queryNextUnquoted(const char *str, char c)
         }
         else if (c == *str && !quote)
             break;
+        ++str;
     }
     return str==end?NULL:str;
 }
@@ -1878,6 +1878,8 @@ IPropertyTree *PTree::addPropTree(const char *xpath, IPropertyTree *val)
 
 bool PTree::removeTree(IPropertyTree *child)
 {
+    if (child == this)
+        throw MakeIPTException(-1, "Cannot remove self");
     if (children)
     {
         Owned<IPropertyTreeIterator> iter = children->getIterator(false);


### PR DESCRIPTION
e.g. support querySDS().subscribe("/a/b[@a1='v1][@a2='v2']");

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
