### PR TITLE
HPCC-11061 - Ensure Dali group created if missing

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -8619,7 +8619,7 @@ class CInitGroups
             messages.append(msg).newline();
             matchExisting = matchOldEnv = false;
         }
-        if (!matchExisting && !matchOldEnv)
+        if (!existingClusterGroup || (!matchExisting && !matchOldEnv))
         {
             VStringBuffer msg("New cluster layout for cluster %s", gname.str());
             WARNLOG("%s", msg.str());


### PR DESCRIPTION
If the loaded environment Cluster matches the existing one,
Dali didn't bother to create the Group (it assumed it must have
been created before). If however, something changes the
Environment behind it's back, it will mean the Group will never
be created. This fix ensures it is, if missing.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
