### PR TITLE
HPCC-11060 - Support multi-qualifiers on sds subscription nodes

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -667,16 +667,17 @@ public:
             }
 
             Owned<CQualifiers> qualifiers = new CQualifiers;
-			strippedXpath.append(startQ-path, path);
-			loop
-			{
-				const char *endQ = queryNextUnquoted(startQ+1, ']');
-				assertex(endQ);
+            strippedXpath.append(startQ-path, path);
+            loop
+            {
+                const char *endQ = queryNextUnquoted(startQ+1, ']');
+                if (!endQ)
+                    throw MakeSDSException(SDSExcpt_SubscriptionParseError, "Missing closing brace: %s", xpath.get());
                 StringAttr qualifier(startQ+1, endQ-startQ-1);
                 qualifiers->add(qualifier);
                 path = endQ+1;
                 if ('[' != *path)
-                	break;
+                    break;
                 startQ = path;
             }
             qualifierStack.append(qualifiers.getClear());

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -609,11 +609,10 @@ private:
 
 /////////////////
 
-class CQualifiers : public CSimpleInterface, implements IInterface
+class CQualifiers : public CInterfaceOf<IInterface>
 {
     StringArray qualifiers;
 public:
-    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
     inline void add(const char *qualifier) { qualifiers.append(qualifier); }
     inline unsigned count() const { return qualifiers.ordinality(); }
     inline const char *item(unsigned i) const { return qualifiers.item(i); }
@@ -668,17 +667,18 @@ public:
             }
 
             Owned<CQualifiers> qualifiers = new CQualifiers;
-            do
-            {
-                const char *endQ = queryNextUnquoted(startQ+1, ']');
-                assertex(endQ);
-                strippedXpath.append(startQ-path, path);
-
+			strippedXpath.append(startQ-path, path);
+			loop
+			{
+				const char *endQ = queryNextUnquoted(startQ+1, ']');
+				assertex(endQ);
                 StringAttr qualifier(startQ+1, endQ-startQ-1);
                 qualifiers->add(qualifier);
                 path = endQ+1;
+                if ('[' != *path)
+                	break;
+                startQ = path;
             }
-            while (NULL != (startQ = queryNextUnquoted(path, '[')));
             qualifierStack.append(qualifiers.getClear());
         }
         fullXpath.set(xpath);

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -609,10 +609,19 @@ private:
 
 /////////////////
 
+class CQualifiers : public CSimpleInterface, implements IInterface
+{
+    StringArray qualifiers;
+public:
+    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+    inline void add(const char *qualifier) { qualifiers.append(qualifier); }
+    inline unsigned count() const { return qualifiers.ordinality(); }
+    inline const char *item(unsigned i) const { return qualifiers.item(i); }
+};
 class CSubscriberContainer : public CSubscriberContainerBase
 {
     StringAttr xpath, fullXpath;
-    StringArray qualifierStack;
+    PointerIArrayOf<CQualifiers> qualifierStack;
     bool sub, sendValue;
     unsigned depth;
 public:
@@ -655,16 +664,22 @@ public:
                 if (!nextSep || startQ < nextSep)
                     break;
 
-                qualifierStack.append(""); // no qualifier for this segment.
+                qualifierStack.append(NULL); // no qualifier for this segment.
             }
 
-            const char *endQ = queryNextUnquoted(startQ, ']');
-            assertex(endQ);
-            strippedXpath.append(startQ-path, path);
+            Owned<CQualifiers> qualifiers = new CQualifiers;
+            do
+            {
+                const char *endQ = queryNextUnquoted(startQ+1, ']');
+                assertex(endQ);
+                strippedXpath.append(startQ-path, path);
 
-            StringAttr qualifier(startQ+1, endQ-startQ-1);
-            qualifierStack.append(qualifier);
-            path = endQ+1;
+                StringAttr qualifier(startQ+1, endQ-startQ-1);
+                qualifiers->add(qualifier);
+                path = endQ+1;
+            }
+            while (NULL != (startQ = queryNextUnquoted(path, '[')));
+            qualifierStack.append(qualifiers.getClear());
         }
         fullXpath.set(xpath);
         if (strippedXpath.length()) // some qualifications
@@ -686,36 +701,40 @@ public:
     {
         ForEachItemIn(q, qualifierStack)
         {
-            const char *qualifier = qualifierStack.item(q);
             if (stack.ordinality() <= q+1)
             {
                 // No more stack available (e.g. because deleted below this point)
                 return true;
             }
             PTree &item = stack.item(q+1); // stack +1, top is root unqualified.
-            if (qualifier && '\0' != *qualifier)
+            CQualifiers *qualifiers = qualifierStack.item(q);
+            if (qualifiers)
             {
-                const char *q = qualifier;
-                bool numeric = true;
-                loop
+                for (unsigned q2=0; q2<qualifiers->count(); q2++)
                 {
-                    if ('\0' == *q) break;
-                    else if (!isdigit(*q)) { numeric = false; break; }
-                    else q++;
-                }
-                if (numeric)
-                {
-                    unsigned qnum = atoi(qualifier);
-                    if (!item.queryParent())
+                    const char *qualifier = qualifiers->item(q2);
+                    const char *q = qualifier;
+                    bool numeric = true;
+                    loop
                     {
-                        if (qnum != 1)
+                        if ('\0' == *q) break;
+                        else if (!isdigit(*q)) { numeric = false; break; }
+                        else q++;
+                    }
+                    if (numeric)
+                    {
+                        unsigned qnum = atoi(qualifier);
+                        if (!item.queryParent())
+                        {
+                            if (qnum != 1)
+                                return false;
+                        }
+                        else if (((PTree *)item.queryParent())->findChild(&item) != qnum-1)
                             return false;
                     }
-                    else if (((PTree *)item.queryParent())->findChild(&item) != qnum-1)
+                    else if (!item.checkPattern(qualifier))
                         return false;
                 }
-                else if (!item.checkPattern(qualifier))
-                    return false;
             }
         }
         return true;

--- a/dali/base/dasds.hpp
+++ b/dali/base/dasds.hpp
@@ -196,6 +196,7 @@ enum SDSExceptionCodes
     SDSExcpt_ClientCacheDirty,
     SDSExcpt_InvalidSessionId,
     SDSExcpt_LockHeld,
+    SDSExcpt_SubscriptionParseError
 };
 
 interface ISDSException : extends IException { };

--- a/dali/base/dasds.ipp
+++ b/dali/base/dasds.ipp
@@ -448,6 +448,8 @@ public:
                 return out.append("Dirty client cache members used");
             case SDSExcpt_LockHeld:
                 return out.append("Lock held");
+            case SDSExcpt_SubscriptionParseError:
+                return out.append("Subscription parse error");
             default:
                 return out.append("INTERNAL ERROR");
         }

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -637,49 +637,45 @@ const char *splitXPath(const char *xpath, StringBuffer &headPath)
 
 const char *queryNextUnquoted(const char *str, char c)
 {
-    const char *end = str+strlen(str);
-    bool quote = false;
-    while (end != str)
-    {
-        if ('"' == *str)
-        {
-            if (quote) quote = false;
-            else quote = true;
-        }
-        else if (c == *str && !quote)
-            break;
-        ++str;
-    }
-    return str==end?NULL:str;
+	bool quote = false;
+	loop
+	{
+		char next = *str;
+		if (next == '\0')
+			return NULL;
+		if ('"' == next)
+			quote = !quote;
+		else if (c == next && !quote)
+			return str;
+		++str;
+	}
 }
 
 const char *queryHead(const char *xpath, StringBuffer &head)
 {
     if (!xpath) return NULL;
-    StringBuffer path;
     const char *start = xpath;
-    const char *end = xpath+strlen(xpath);
     bool quote = false;
     bool braced = false;
-    while (end != xpath)
+    loop
     {
+		if (*xpath == '\0')
+			return NULL;
         ++xpath;
-        if (*xpath == '"')
-        {
-            if (quote) quote = false;
-            else quote = true;
-        }
-        else if (*xpath == ']' && !quote)
+		char next = *xpath;
+		if ('"' == next)
+			quote = !quote;
+        else if (next == ']' && !quote)
         {
             assertex(braced);
             braced = false;
         }
-        else if (*xpath == '[' && !quote)
+        else if (next == '[' && !quote)
         {
             assertex(!braced);
             braced = true;
         }
-        else if (*xpath == '/' && !quote && !braced)
+        else if (next == '/' && !quote && !braced)
         {
             if ('/' == *start) // so leading '//'
                 return start;
@@ -691,8 +687,6 @@ const char *queryHead(const char *xpath, StringBuffer &head)
             break;
         }
     }
-    if (xpath == end)
-        return NULL;
     head.append(xpath-start, start);
     return xpath+1;
 }

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -641,7 +641,6 @@ const char *queryNextUnquoted(const char *str, char c)
     bool quote = false;
     while (end != str)
     {
-        ++str;
         if ('"' == *str)
         {
             if (quote) quote = false;
@@ -649,6 +648,7 @@ const char *queryNextUnquoted(const char *str, char c)
         }
         else if (c == *str && !quote)
             break;
+        ++str;
     }
     return str==end?NULL:str;
 }
@@ -1878,6 +1878,8 @@ IPropertyTree *PTree::addPropTree(const char *xpath, IPropertyTree *val)
 
 bool PTree::removeTree(IPropertyTree *child)
 {
+    if (child == this)
+        throw MakeIPTException(-1, "Cannot remove self");
     if (children)
     {
         Owned<IPropertyTreeIterator> iter = children->getIterator(false);

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -637,18 +637,18 @@ const char *splitXPath(const char *xpath, StringBuffer &headPath)
 
 const char *queryNextUnquoted(const char *str, char c)
 {
-	bool quote = false;
-	loop
-	{
-		char next = *str;
-		if (next == '\0')
-			return NULL;
-		if ('"' == next)
-			quote = !quote;
-		else if (c == next && !quote)
-			return str;
-		++str;
-	}
+    bool quote = false;
+    loop
+    {
+        char next = *str;
+        if (next == '\0')
+            return NULL;
+        if ('"' == next)
+            quote = !quote;
+        else if (c == next && !quote)
+            return str;
+        ++str;
+    }
 }
 
 const char *queryHead(const char *xpath, StringBuffer &head)
@@ -659,12 +659,12 @@ const char *queryHead(const char *xpath, StringBuffer &head)
     bool braced = false;
     loop
     {
-		if (*xpath == '\0')
-			return NULL;
+        if (*xpath == '\0')
+            return NULL;
         ++xpath;
-		char next = *xpath;
-		if ('"' == next)
-			quote = !quote;
+        char next = *xpath;
+        if ('"' == next)
+            quote = !quote;
         else if (next == ']' && !quote)
         {
             assertex(braced);


### PR DESCRIPTION
e.g. support querySDS().subscribe("/a/b[@a1='v1][@a2='v2']");

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
