### PR TITLE
HPCC-11062 Set Archived to true in the response of searching archived WU

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2040,6 +2040,7 @@ void doWUQueryFromArchive(IEspContext &context, const char* sashaServerIP, unsig
 
                     Owned<IEspECLWorkunit> info= createECLWorkunit("","");
                     info->setWuid(wuid);
+                    info->setArchived(true);
                     if (notEmpty(wuidArray.item(1)))
                           info->setOwner(wuidArray.item(1));
                     if (notEmpty(wuidArray.item(2)))


### PR DESCRIPTION
Calling WUQuery + Type="archived workunits" returns a list of WUs. The
response "Archived" field for each WU should be set to 'true'.
