### PR TITLE
HPCC-10979 Fix custom tributton control handling of tab and spacebar

### DIFF
--- a/esp/files/req_array.js
+++ b/esp/files/req_array.js
@@ -216,13 +216,18 @@ function onBoolChange(checkbox) {
        hiddenCtrl.value = checkbox.checked ? "1" : "0";
 }
 
-function onFocusTriButton(btn) 
+function onTriButtonKeyPress(obj) 
 {
-    btn.blur();
+    if (event.keyCode == 32) //space
+    {
+	onClickTriButton(obj, 1);
+        return false;
+    }
+    return true;
 }
+
 function onClickTriButton(btn, clicks) 
 {
-    btn.blur();
     while (clicks--)
     {
         if (btn.value=='default')

--- a/esp/xslt/wsecl3_form.xsl
+++ b/esp/xslt/wsecl3_form.xsl
@@ -1182,7 +1182,7 @@ function switchInputForm()
             </xsl:variable>
             <!-- use tristate true/false/default -->
 
-            <xsl:text disable-output-escaping="yes"><![CDATA[<input class='tributton' type='text' readonly='1' size='6' onFocus='onFocusTriButton(this)' onClick='onClickTriButton(this, 1)' name=']]></xsl:text>
+            <xsl:text disable-output-escaping="yes"><![CDATA[<input class='tributton' type='text' readonly='1' size='6' onkeypress='onTriButtonKeyPress(this)' onClick='onClickTriButton(this, 1)' name=']]></xsl:text>
             <xsl:value-of select="$fieldId"/>
             <xsl:text disable-output-escaping="yes"><![CDATA[' id=']]></xsl:text>
             <xsl:value-of select="$fieldId"/>


### PR DESCRIPTION
Allow tributton to recieve focus, and move on to next tabindex when tab
key is pressed.  Rotate tributton state when spacebar is pressed.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
