### PR TITLE
HPCC-11053 - Fix regression if keyedjoin fetch file is missing

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -251,16 +251,20 @@ public:
     virtual void serializeSlaveData(MemoryBuffer &dst, unsigned slave)
     {
         dst.append(initMb);
-        IDistributedFile *dataFile = queryReadFile(1); // 0 == indexFile, 1 == dataFile
-        if (dataFile)
+        IDistributedFile *indexFile = queryReadFile(0); // 0 == indexFile, 1 == dataFile
+        if (indexFile && helper->diskAccessRequired())
         {
-            dataFileMapping->serializeMap(slave, dst);
-            dst.append(offsetMapMb);
-        }
-        else
-        {
-            CSlavePartMapping::serializeNullMap(dst);
-            CSlavePartMapping::serializeNullOffsetMap(dst);
+            IDistributedFile *dataFile = queryReadFile(1);
+            if (dataFile)
+            {
+                dataFileMapping->serializeMap(slave, dst);
+                dst.append(offsetMapMb);
+            }
+            else
+            {
+                CSlavePartMapping::serializeNullMap(dst);
+                CSlavePartMapping::serializeNullOffsetMap(dst);
+            }
         }
     }
     virtual void deserializeStats(unsigned node, MemoryBuffer &mb)


### PR DESCRIPTION
If using ,OPT on the dataset of an index, there was a
serialization error. Regression introduced by HPCC-10664

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
