### PR TITLE
HPCC-11070 Roxie returning incorrect value for thorlib.node()

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3653,7 +3653,7 @@ public:
     virtual void deleteFile(const char * logicalName) { throwUnexpected(); }
 
     virtual unsigned getNodes() { return numChannels; }
-    virtual unsigned getNodeNum() { return 1; }
+    virtual unsigned getNodeNum() { return 0; }
     virtual char *getFilePart(const char *logicalPart, bool create=false) { UNIMPLEMENTED; }
     virtual unsigned __int64 getFileOffset(const char *logicalPart) { throwUnexpected(); }
 


### PR DESCRIPTION
Roxie returns 1 for thorlib.node() but hthor returns 0, and thor returns
0-based values.

For consistency with hthor and a 1-way thor, Roxie should be returning 0.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
