### PR TITLE
HPCC-10579 Improve many lookup join implementation in roxie

### DIFF
--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -11870,8 +11870,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityJoinOrDenormalize(BuildCtx & c
         //Lookup join doesn't need the left sort (unless it is reused elsewhere), or the right sort unless it is deduping.
         if (canReuseLeftCompare || !isLookupJoin)
             generateSortCompare(instance->nestedctx, instance->classctx, no_left, lhsDsRef, joinInfo.queryLeftSort(), true, noSortAttr, false, isLightweight, isLocalSort);
-        if (!(isLookupJoin && isManyLookup && !couldBeKeepOne && !targetThor()))            // many lookup doesn't need to dedup the rhs
-            generateSortCompare(instance->nestedctx, instance->classctx, no_right, rhsDsRef, joinInfo.queryRightSort(), isLocalSort, noSortAttr, canReuseLeftCompare, isLightweight, isLocalSort);
+        generateSortCompare(instance->nestedctx, instance->classctx, no_right, rhsDsRef, joinInfo.queryRightSort(), isLocalSort, noSortAttr, canReuseLeftCompare, isLightweight, isLocalSort);
 
         bool isGlobal = !isLocalJoin && !instance->isChildActivity();
         generateSerializeKey(instance->nestedctx, no_left, lhsDsRef, joinInfo.queryLeftSort(), isGlobal, false, false);

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -484,7 +484,7 @@ protected:
         case TAKsmartjoin:
         case TAKsmartdenormalize:
         case TAKsmartdenormalizegroup:
-            return createRoxieServerLookupJoinActivityFactory(id, subgraphId, *this, helperFactory, kind);
+            return createRoxieServerLookupJoinActivityFactory(id, subgraphId, *this, helperFactory, kind, node);
         case TAKmerge:
             return createRoxieServerMergeActivityFactory(id, subgraphId, *this, helperFactory, kind);
         case TAKnormalize:

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -379,7 +379,7 @@ extern IRoxieServerActivityFactory *createRoxieServerGroupActivityFactory(unsign
 extern IRoxieServerActivityFactory *createRoxieServerFirstNActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerSelectNActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerSelfJoinActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
-extern IRoxieServerActivityFactory *createRoxieServerLookupJoinActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
+extern IRoxieServerActivityFactory *createRoxieServerLookupJoinActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind, IPropertyTree &_graphNode);
 extern IRoxieServerActivityFactory *createRoxieServerAllJoinActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerTopNActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);
 extern IRoxieServerActivityFactory *createRoxieServerLimitActivityFactory(unsigned _id, unsigned _subgraphId, IQueryFactory &_queryFactory, HelperFactory *_helperFactory, ThorActivityKind _kind);

--- a/testing/ecl/key/manylookup.xml
+++ b/testing/ecl/key/manylookup.xml
@@ -1,0 +1,38 @@
+<Dataset name='Result 1'>
+ <Row><key>1</key></Row>
+ <Row><key>1</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>3</key></Row>
+ <Row><key>3</key></Row>
+ <Row><key>4</key></Row>
+ <Row><key>4</key></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><key>1</key></Row>
+ <Row><key>1</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>3</key></Row>
+ <Row><key>3</key></Row>
+ <Row><key>4</key></Row>
+ <Row><key>4</key></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><key>1</key></Row>
+ <Row><key>2</key></Row>
+ <Row><key>3</key></Row>
+ <Row><key>4</key></Row>
+</Dataset>

--- a/testing/ecl/manylookup.ecl
+++ b/testing/ecl/manylookup.ecl
@@ -1,0 +1,17 @@
+rec := RECORD
+ unsigned key;
+END;
+
+lhs := dataset([{1},{2},{3},{4},{5}], rec);
+rhs := dataset([
+  {1},{2},{2},{2},{2},{3},{4},
+  {1},{2},{2},{2},{2},{3},{4}
+  ], rec);
+
+j1 := JOIN(lhs, rhs, LEFT.key=RIGHT.key, TRANSFORM(rec, SELF:=LEFT), MANY LOOKUP);
+j2 := JOIN(lhs, rhs, LEFT.key=RIGHT.key, TRANSFORM(rec, SELF:=LEFT), MANY LOOKUP, HINT(usefewtable));
+j3 := JOIN(lhs, rhs, LEFT.key=RIGHT.key, TRANSFORM(rec, SELF:=LEFT), LOOKUP);
+
+output(NOFOLD(j1));
+output(NOFOLD(j2));
+output(NOFOLD(j3));


### PR DESCRIPTION
Similar concept to the thor improvements in HPCC-9244, which can dramatically
improve performance on pathogenic cases that have many dups on RHS.

Should not slow down other cases (though may increase memory usage a little).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
