### PR TITLE
HPCC-10992 Improve cli password and INI file support

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -169,26 +169,13 @@ static bool getPackageFolder(StringBuffer & path)
 
 static bool getHomeFolder(StringBuffer & homepath)
 {
-#ifdef _WIN32
-    const char *home = getenv("APPDATA");
-    if (!home)
+    if (!getHomeDir(homepath))
         return false;
-    // Not the 'official' way - which changes with every windows version
-    // but should work well enough for us (and avoids sorting out windows include mess)
-    homepath.append(home);
-    addPathSepChar(homepath).append(DIR_NAME);
-#else
-    const char *home = getenv("HOME");
-    if (!home)
-    {
-        struct passwd *pw = getpwuid(getuid());
-        home = pw->pw_dir;
-        if (!home)
-            return false;
-    }
-    homepath.append(home);
-    addPathSepChar(homepath).append(".").append(DIR_NAME);
+    addPathSepChar(homepath);
+#ifndef WIN32
+    homepath.append('.');
 #endif
+    homepath.append(DIR_NAME);
     return true;
 }
 

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -341,6 +341,15 @@ bool EclCmdCommon::finalizeOptions(IProperties *globals)
     extractEclCmdOption(optUsername, globals, ECLOPT_USERNAME_ENV, ECLOPT_USERNAME_INI, NULL, NULL);
     extractEclCmdOption(optPassword, globals, ECLOPT_PASSWORD_ENV, ECLOPT_PASSWORD_INI, NULL, NULL);
 
+    if (!optUsername.isEmpty() && optPassword.isEmpty())
+    {
+        VStringBuffer prompt("%s's password: ", optUsername.get());
+        StringBuffer pw;
+        passwordInput(prompt, pw);
+        if (pw.length())
+            optPassword.set(pw);
+    }
+
     if (!optVerbose)
     {
         Owned<ILogMsgFilter> filter = getCategoryLogMsgFilter(MSGAUD_user, MSGCLS_error);

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -38,26 +38,6 @@
 #include <pwd.h>
 #endif
 
-static bool getHomeDir(StringBuffer & homepath)
-{
-#ifdef _WIN32
-    const char *home = getenv("APPDATA");
-    // Not the 'official' way - which changes with every windows version
-    // but should work well enough for us (and avoids sorting out windows include mess)
-#else
-    const char *home = getenv("HOME");
-    if (!home)
-    {
-        struct passwd *pw = getpwuid(getuid());
-        home = pw->pw_dir;
-    }
-#endif
-    if (!home)
-        return false;
-    homepath.append(home);
-    return true;
-}
-
 int EclCMDShell::callExternal(ArgvIterator &iter)
 {
     const char *argv[100];

--- a/system/jlib/jmisc.cpp
+++ b/system/jlib/jmisc.cpp
@@ -27,8 +27,10 @@
 #include "jexcept.hpp"
 #include "jstring.hpp"
 #include "jdebug.hpp"
+
 #ifndef _WIN32
 #include <sys/wait.h>
+#include <pwd.h>
 #endif
 
 #ifdef LOGCLOCK
@@ -649,9 +651,6 @@ void close_program(HANDLE handle)
 
 #endif
 
-
-
-
 #ifndef _WIN32
 bool CopyFile(const char *file, const char *newfile, bool fail)
 {
@@ -936,4 +935,24 @@ StringBuffer & hexdump2string(byte const * in, size32_t inSize, StringBuffer & o
         out.appendf("x%u", seq);
     out.append(" ]");
     return out;
+}
+
+jlib_decl bool getHomeDir(StringBuffer & homepath)
+{
+#ifdef _WIN32
+    const char *home = getenv("APPDATA");
+    // Not the 'official' way - which changes with every windows version
+    // but should work well enough for us (and avoids sorting out windows include mess)
+#else
+    const char *home = getenv("HOME");
+    if (!home)
+    {
+        struct passwd *pw = getpwuid(getuid());
+        home = pw->pw_dir;
+    }
+#endif
+    if (!home)
+        return false;
+    homepath.append(home);
+    return true;
 }

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -87,6 +87,7 @@ jlib_decl char* readarg(char*& curptr);
 jlib_decl bool invoke_program(const char *command_line, DWORD &runcode, bool wait=true, const char *outfile=NULL, HANDLE *rethandle=NULL, bool throwException = false, bool newProcessGroup = false);
 jlib_decl bool wait_program(HANDLE handle,DWORD &runcode,bool block=true);
 jlib_decl bool interrupt_program(HANDLE handle, bool killChildren, int signum=0); // no signum means use default
+jlib_decl bool getHomeDir(StringBuffer & homepath);
 
 #ifndef _WIN32
 jlib_decl bool CopyFile(const char *file, const char *newfile, bool fail);


### PR DESCRIPTION
Prompt cli user for password if username is initially provided,
but password is not.

Look for INI file in users home directory.

Password can be set in INI file as eclPassword=xxxx.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
