### PR TITLE
HPCC-11082 - Global LOOP with row condition must recheck finishing

### DIFF
--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -365,6 +365,7 @@ public:
                         eof = true;
                         return NULL;
                     }
+                    finishedLooping = false; // reset because global and execute may feed rows back to this node
                 }
                 else if (finishedLooping)
                 {


### PR DESCRIPTION
A global LOOP with a condition on thw rows, must recheck the
'finishedLooping' condition. Just because there are 0 rows to
process at the start of the loop, does not mean there will be 0
after the next execute in the global case.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
