### PR TITLE
HPCC-11080 DOCS:Value Types link broken

### DIFF
--- a/docs/ECLLanguageReference/ECLR-includer.xml
+++ b/docs/ECLLanguageReference/ECLR-includer.xml
@@ -138,7 +138,7 @@
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
   </chapter>
 
-  <chapter id="Value_Types">
+  <chapter id="Value_Types_Chapter">
     <title><emphasis role="bold">Value Types</emphasis></title>
 
     <para>Value types<indexterm>

--- a/docs/ECLLanguageReference/ECLR_mods/Templ-GETDATATYPE.xml
+++ b/docs/ECLLanguageReference/ECLR_mods/Templ-GETDATATYPE.xml
@@ -42,5 +42,6 @@
   res; // Output: res = 'data9'
 </programlisting>
 
-  <para>See Also: <link linkend="Value_Types">Value Types</link></para>
+  <para>See Also: <link linkend="Value_Types_Chapter">Value
+  Types</link></para>
 </sect1>

--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
@@ -1582,7 +1582,7 @@
       </listitem>
 
       <listitem>
-        <para>Administrative utilities (such as TreeView)</para>
+        <para>Administrative utilities </para>
       </listitem>
     </itemizedlist>
 


### PR DESCRIPTION
Fix EPE-102 HPCC-11080 DOCS:Value Types link broken
Fix for the Value_Types link in the ECL Lang. Ref.
Issue itself was not a problem and did not manifest until
combining with other documents to produce the compiled help.
Each ID=attribute needs to be unique.

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com

@JamesDeFabia please review
