### PR TITLE
HPCC-11069 On some systems, eclcc gives SIGPIPE error in libjvm in debug...

### DIFF
--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -131,7 +131,7 @@ public:
 
         // These may be useful for debugging
 #ifdef _DEBUG
-        optionStrings.append("-Xcheck:jni");
+        // optionStrings.append("-Xcheck:jni");
         // optionStrings.append("-verbose:jni");
 #endif
 


### PR DESCRIPTION
... builds

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
