### PR TITLE
HPCC-8961 Add ulimits for enabling huge page support

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -381,6 +381,8 @@ createRuntime() {
     ulimit -c unlimited
     # for rtprio in Roxie
     ulimit -Hr 4
+    # to enable, must also increase vm.nr_hugepages and/or vm.nr_overcommit_hugepages
+    ulimit -l unlimited
 }
 
 start_dafilesrv() {

--- a/initfiles/sbin/add_conf_settings.sh.in
+++ b/initfiles/sbin/add_conf_settings.sh.in
@@ -42,5 +42,7 @@ ${USER_NAME}    soft    nproc     4096
 ${USER_NAME}    hard    nproc     8192
 ${USER_NAME}    soft    rtprio    0
 ${USER_NAME}    hard    rtprio    4
+${USER_NAME}    soft    memlock   unlimited
+${USER_NAME}    hard    memlock   unlimited
 %EOF
 


### PR DESCRIPTION
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com

Two init script changes required for using huge pages which should be ok for all distributions

In addition, memory needs to be reserved for huge pages, which can be done on most
distributions by editing sysctl.conf:

# add a small dedicated region (128*2M = 256MB)
vm.nr_hugepages = 128

# add room for huge page region to grow to max (4096 *2M = 8GB for example)
vm.nr_overcommit_hugepages = 4096

NOTE: huge page mem regions are not swappable and cannot be overcommitted
