### PR TITLE
HPCC-11063 Upgrade sasha WUiterate() to return NumWUs to WsWorkunits

### DIFF
--- a/dali/sasha/sacmd.hpp
+++ b/dali/sasha/sacmd.hpp
@@ -15,7 +15,8 @@ enum SashaCommandAction
     SCA_COALESCE_SUSPEND,
     SCA_COALESCE_RESUME,
     SCA_WORKUNIT_SERVICES_GET,
-    SCA_LISTDT
+    SCA_LISTDT,
+    SCA_LIST_WITH_MATCHING_COUNT
 };
 
 
@@ -65,7 +66,8 @@ interface ISashaCommand: extends IInterface
     virtual bool send(INode *node,unsigned timeout=0) = 0;
     virtual bool accept(unsigned timeout) = 0;
     virtual void cancelaccept() = 0;
-    virtual bool reply() = 0;
+    virtual bool reply(bool clearBuf) = 0;
+    virtual bool IDSWithMatchingNumberReply() = 0;
 
     virtual bool getDFU() = 0;
     virtual void setDFU(bool val) = 0;
@@ -89,6 +91,8 @@ interface ISashaCommand: extends IInterface
     virtual void addDT(CDateTime &dt) = 0;
     virtual void getDT(CDateTime &dt,unsigned i) = 0;   // returned by SCA_LISTDT
 
+    virtual int getNumberOfIdsMatching() = 0;
+    virtual void setNumberOfIdsMatching(int val) = 0;
 };
 
 #define WUS_STATUS_OK           ((byte)0)

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -44,7 +44,7 @@
 
 extern void LDStest();
 
-#define SASHAVERSION "1.4"
+#define SASHAVERSION "1.5"
 
 #define DEFAULT_PERF_REPORT_DELAY (60*5)
 
@@ -179,8 +179,10 @@ public:
             WARNLOG("Command %d not handled",cmd->getAction());
         if (cmd->getAction()==SCA_WORKUNIT_SERVICES_GET)
             cmd->WUSreply();
+        else if (cmd->getAction()==SCA_LIST_WITH_MATCHING_COUNT)
+            cmd->IDSWithMatchingNumberReply();
         else
-            cmd->reply();
+            cmd->reply(true);
     }
     bool stop() 
     { 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -346,6 +346,7 @@ ESPrequest [nil_remove] WUQueryRequest
     string After;
     string Before;
     int Count;
+    [min_ver("1.50")] bool CountArchivedWUsMatching(false);
     [min_ver("1.03")] int64 PageSize(0);
     [min_ver("1.03")] int64 PageStartFrom(0);
     [min_ver("1.03")] int64 PageEndAt;
@@ -1451,7 +1452,7 @@ ESPresponse [exceptions_inline] WUCreateZAPInfoResponse
 };
 
 ESPservice [
-    version("1.49"), default_client_version("1.49"),
+    version("1.50"), default_client_version("1.50"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -2206,12 +2206,12 @@ ArchivedWuCacheElement* ArchivedWuCache::lookup(IEspContext &context, const char
     return NULL;
 }
 
-void ArchivedWuCache::add(const char* filter, const char* sashaUpdatedWhen, bool hasNextPage, IArrayOf<IEspECLWorkunit>& wus)
+void ArchivedWuCache::add(const char* filter, const char* sashaUpdatedWhen, bool hasNextPage, int numWUsMatching, unsigned numWUsReturned, IArrayOf<IEspECLWorkunit>& wus)
 {
     CriticalBlock block(crit);
 
     //Save new data
-    Owned<ArchivedWuCacheElement> e=new ArchivedWuCacheElement(filter, sashaUpdatedWhen, hasNextPage, /*data.str(),*/ wus);
+    Owned<ArchivedWuCacheElement> e=new ArchivedWuCacheElement(filter, sashaUpdatedWhen, hasNextPage, numWUsMatching, numWUsReturned, /*data.str(),*/ wus);
     if (cacheSize > 0)
     {
         if (cache.size() >= cacheSize)

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -258,11 +258,19 @@ struct DataCache: public CInterface, implements IInterface
     size32_t cacheSize;
 };
 
+interface IArchivedWUsReader : extends IInterface
+{
+    virtual void getArchivedWUs(unsigned startFrom, unsigned maxNumWUs, IArrayOf<IEspECLWorkunit>& results) = 0;
+    virtual bool getHasMoreWU() = 0;
+    virtual int getNumberOfWUsMatching() = 0;
+    virtual unsigned getNumberOfWUsReturned() = 0;
+};
+
 struct ArchivedWuCacheElement: public CInterface, implements IInterface
 {
     IMPLEMENT_IINTERFACE;
-    ArchivedWuCacheElement(const char* filter, const char* sashaUpdatedWhen, bool hasNextPage, /*const char* data,*/ IArrayOf<IEspECLWorkunit>& wus):m_filter(filter),
-        m_sashaUpdatedWhen(sashaUpdatedWhen), m_hasNextPage(hasNextPage)/*, m_data(data)*/
+    ArchivedWuCacheElement(const char* filter, const char* sashaUpdatedWhen, bool hasNextPage, int _numWUsMatching, unsigned _numWUsReturned,/*const char* data,*/ IArrayOf<IEspECLWorkunit>& wus):m_filter(filter),
+        m_sashaUpdatedWhen(sashaUpdatedWhen), m_hasNextPage(hasNextPage), numWUsMatching(_numWUsMatching), numWUsReturned(_numWUsReturned)/*, m_data(data)*/
     {
         m_timeCached.setNow();
         if (wus.length() > 0)
@@ -280,6 +288,8 @@ struct ArchivedWuCacheElement: public CInterface, implements IInterface
     std::string m_filter;
     std::string m_sashaUpdatedWhen;
     bool m_hasNextPage;
+    int numWUsMatching; //-1: not set
+    unsigned numWUsReturned;
 
     CDateTime m_timeCached;
     IArrayOf<IEspECLWorkunit> m_results;
@@ -292,7 +302,7 @@ struct ArchivedWuCache: public CInterface, implements IInterface
     ArchivedWuCache(size32_t _cacheSize=0): cacheSize(_cacheSize){}
     ArchivedWuCacheElement* lookup(IEspContext &context, const char* filter, const char* sashaUpdatedWhen, unsigned timeOutMin);
 
-    void add(const char* filter, const char* sashaUpdatedWhen, bool hasNextPage, IArrayOf<IEspECLWorkunit>& wus);
+    void add(const char* filter, const char* sashaUpdatedWhen, bool hasNextPage, int numWUsMatching, unsigned numWUsReturned, IArrayOf<IEspECLWorkunit>& wus);
 
     std::list<Linked<ArchivedWuCacheElement> > cache;
     CriticalSection crit;


### PR DESCRIPTION
1. Add a new sasha command action: SCA_LIST_WITH_MATCHING_COUNT. In
   this action, a flag 'NumberOfIdsMatching' is allowed to send to sasha
   WUiterate(). If the flag is set to true (default to false), the
   WUiterate() will count the number of workunits which match a group of
   search filters and return the number to the caller. 2. Revise
   WsWorkunits doWUQueryFromArchive() to send the sasha command with
   the flag (if a user requests) and return the number to the user. 3.
   Refactor the doWUQueryFromArchive() to be better encapsulated.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
