### PR TITLE
HPCC-11051 Sporadic empty lists

### DIFF
--- a/esp/src/eclwatch/ActivityWidget.js
+++ b/esp/src/eclwatch/ActivityWidget.js
@@ -257,7 +257,6 @@ define([
                 }
             }).placeAt(this.openButton.domNode, "after");
 
-            this.noDataMessage = this.i18n.loadingMessage;
             this.activity = ESPActivity.Get();
             var retVal = new declare([OnDemandGrid, Keyboard, Selection, ColumnResizer, DijitRegistry, ESPUtil.GridHelper])({
                 allowSelectAll: true,

--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -473,8 +473,6 @@ define([
                     Modified: { label: this.i18n.ModifiedUTCGMT, width: 155}
                 }
             }, this.id + "WorkunitsGrid");
-            this.workunitsGrid.noDataMessage = "<span class='dojoxGridNoData'>" + this.i18n.noDataMessage + "</span>";
-            this.workunitsGrid.loadingMessage = "<span class='dojoxGridNoData'>" + this.i18n.loadingMessage + "</span>";
 
             var context = this;
             on(document, "." + context.id + "LogicalNameClick:click", function (evt) {

--- a/esp/src/eclwatch/ESPDFUWorkunit.js
+++ b/esp/src/eclwatch/ESPDFUWorkunit.js
@@ -104,7 +104,7 @@ define([
         },
 
         _hasCompletedSetter: function(completed) {
-            var justCompleted = !this.hasCompleted && completed;
+            var justCompleted = lang.exists("hasCompleted", this) && !this.hasCompleted && completed;
             this.hasCompleted = completed;
             if (justCompleted) {
                 topic.publish("hpcc/dfu_wu_completed", this);

--- a/esp/src/eclwatch/ESPUtil.js
+++ b/esp/src/eclwatch/ESPUtil.js
@@ -15,12 +15,15 @@
 ############################################################################## */
 define([
     "dojo/_base/declare",
+    "dojo/_base/lang",
+    "dojo/i18n",
+    "dojo/i18n!./nls/hpcc",
     "dojo/_base/array",
     "dojo/Stateful",
     "dojo/json",
 
     "dijit/registry"
-], function (declare, arrayUtil, Stateful, json,
+], function (declare, lang, i18n, nlsHPCC, arrayUtil, Stateful, json,
     registry) {
 
     var SingletonData = declare([Stateful], {
@@ -62,7 +65,14 @@ define([
                 }
             }
             if (changed) {
-                this.set("changedCount", this.get("changedCount") + 1);
+                try {
+                    this.set("changedCount", this.get("changedCount") + 1);
+                } catch (e) {
+                    /*  changedCount can notify a dgrid instance that a row has changed.  
+                    *   There is an issue (TODO check issue number) with dgrid which can cause an exception to be thrown during the notify.
+                    *   By catching these exceptions here normal execution can continue.
+                    */
+                }
             }
         }
     });
@@ -139,6 +149,8 @@ define([
         GridHelper: declare(null, {
             allowTextSelection: true,
             pagedGridObserver: [],
+            noDataMessage: "<span class='dojoxGridNoData'>" + nlsHPCC.noDataMessage + "</span>",
+            loadingMessage: "<span class='dojoxGridNoData'>" + nlsHPCC.loadingMessage + "</span>",
 
             onSelectionChanged: function (callback) {
                 this.on("dgrid-select", function (event) {

--- a/esp/src/eclwatch/EventScheduleWorkunitWidget.js
+++ b/esp/src/eclwatch/EventScheduleWorkunitWidget.js
@@ -163,9 +163,7 @@ define([
                     EventName: { label: this.i18n.EventName, width: 90, sortable: true },
                     EventText: { label: this.i18n.EventText, sortable: true }
                 }
-            },
-            this.id + "EventGrid");
-            this.eventGrid.set("noDataMessage", "<span class='dojoxGridNoData'>" + this.i18n.NoScheduledEvents + "</span>");
+            }, this.id + "EventGrid");
 
             on(document, "." + context.id + "WuidClick:click", function (evt) {
                 if (context._onRowDblClick) {

--- a/esp/src/eclwatch/GetDFUWorkunitsWidget.js
+++ b/esp/src/eclwatch/GetDFUWorkunitsWidget.js
@@ -361,7 +361,6 @@ define([
                     PercentDone: { label: this.i18n.PctComplete, width: 90, sortable: false }
                 }
             }, this.id + "WorkunitsGrid");
-            this.workunitsGrid.noDataMessage = "<span class='dojoxGridNoData'>" + this.i18n.noDataMessage + "</span>";
 
             var context = this;
             on(document, "." + context.id + "IDClick:click", function (evt) {

--- a/esp/src/eclwatch/GridDetailsWidget.js
+++ b/esp/src/eclwatch/GridDetailsWidget.js
@@ -96,10 +96,6 @@ define([
 
         //  Implementation  ---
         initGrid: function() {
-            var context = this;
-            this.noDataMessage = this.i18n.noDataMessage;
-            this.loadingMessage = this.i18n.loadingMessage;
-
             var store = new Memory({
                 idProperty: this.idProperty,
                 data: []
@@ -107,6 +103,7 @@ define([
             this.store = Observable(store);
 
             this.grid = this.createGrid(this.id + "Grid");
+            var context = this;
             this.grid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onRowDblClick) {
                     var row = context.grid.row(evt).data;
@@ -119,12 +116,6 @@ define([
             this.grid.onContentChanged(function (object, removedFrom, insertedInto) {
                 context._refreshActionState();
             });
-            if (!this.grid.get("noDataMessage")) {
-                this.grid.set("noDataMessage", "<span class='dojoxGridNoData'>" + this.noDataMessage + "</span>");
-            }
-            if (!this.grid.get("loadingMessage")) {
-                this.grid.set("loadingMessage", "<span class='dojoxGridNoData'>" + this.loadingMessage + "</span>");
-            }
             this.grid.startup();
         },
 

--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -410,7 +410,6 @@ define([
                     return this.inherited(arguments, [FileSpray.CreateFileListStore()]);
                 }
             }, this.id + "LandingZonesGrid");
-            this.landingZonesGrid.set("noDataMessage", "<span class='dojoxGridNoData'>" + this.i18n.noDataMessage + "</span>");
 
             var context = this;
             this.landingZonesGrid.on(".dgrid-row:contextmenu", function (evt) {

--- a/esp/src/eclwatch/QuerySetQueryWidget.js
+++ b/esp/src/eclwatch/QuerySetQueryWidget.js
@@ -391,9 +391,7 @@ define([
                         }
                     }
                 }
-            },
-            this.id + "QuerySetGrid");
-            this.querySetGrid.set("noDataMessage", "<span class='dojoxGridNoData'>" + this.i18n.noDataMessage + "</span>");
+            }, this.id + "QuerySetGrid");
             on(document, "." + context.id + "WuidClick:click", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.querySetGrid.row(evt).data;

--- a/esp/src/eclwatch/SearchResultsWidget.js
+++ b/esp/src/eclwatch/SearchResultsWidget.js
@@ -81,8 +81,6 @@ define([
                 allowSelectAll: true,
                 deselectOnRefresh: false,
                 store: this.store,
-                loadingMessage: "<span class='dojoxGridNoData'>" + this.i18n.loadingMessage + "</span>",
-                noDataMessage: "<span class='dojoxGridNoData'>" + this.i18n.noDataMessage + "</span>",
                 columns: {
                     col1: selector({ width: 27, selectorType: 'checkbox' }),
                     Type: { label: this.i18n.What, width: 108, sortable: true },

--- a/esp/src/eclwatch/TimingPageWidget.js
+++ b/esp/src/eclwatch/TimingPageWidget.js
@@ -77,7 +77,7 @@ define([
 
                 this.timingTreeMap.init(lang.mixin(params, {
                     query: {
-                        graphsOnly: false,
+                        graphsOnly: false
                     }
                 }));
                 this.timingTreeMap.onClick = function (value) {

--- a/esp/src/eclwatch/UserQueryWidget.js
+++ b/esp/src/eclwatch/UserQueryWidget.js
@@ -236,7 +236,6 @@ define([
                     }
                 }
             }, this.id + "GroupsGrid");
-            this.groupsGrid.noDataMessage = "<span class='dojoxGridNoData'>" + this.i18n.noDataMessage + "</span>";
             var context = this;
             on(document, ".WuidClick:click", function (evt) {
                 if (context._onGroupsRowDblClick) {
@@ -334,7 +333,6 @@ define([
                     }
                 }
             }, this.id + "UsersGrid");
-            this.usersGrid.noDataMessage = "<span class='dojoxGridNoData'>" + this.i18n.noDataMessage + "</span>";
             var context = this;
             on(document, ".WuidClick:click", function (evt) {
                 if (context._onUsersRowDblClick) {

--- a/esp/src/eclwatch/WUQueryWidget.js
+++ b/esp/src/eclwatch/WUQueryWidget.js
@@ -400,7 +400,6 @@ define([
                     TotalThorTime: { label: this.i18n.TotalThorTime, width: 117 }
                 }
             }, this.id + "WorkunitsGrid");
-            this.workunitsGrid.noDataMessage = "<span class='dojoxGridNoData'>" + this.i18n.noDataMessage + "</span>";
 
             var context = this;
             on(document, "." + context.id + "WuidClick:click", function (evt) {


### PR DESCRIPTION
An occasional dgrid exception was causing several "issues" within new ECL Watch,
most obvious was empty lists, but could also have caused forms to be empty or not
refreshed etc.
Improved loading message for slower list loads.
Improved default store population.

Fixes HPCC-11051

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
