### PR TITLE
HPCC-11050 Download c++ file option doesn't work in new eclwatch

### DIFF
--- a/esp/src/eclwatch/LogsWidget.js
+++ b/esp/src/eclwatch/LogsWidget.js
@@ -83,6 +83,10 @@ define([
                     case "Workunit XML":
                         params = "/WUFile?Wuid=" + this.wu.Wuid + "&Type=XML";
                         break;
+                    case "cpp":
+                    case "hpp":
+                        params = "/WUFile?Wuid=" + this.wu.Wuid + "&Name=" + item.Orig.Name + "&IPAddress=" + item.Orig.IPAddress + "&Description=" + item.Orig.Description + "&Type=" + item.Orig.Type;
+                        break;
                 }
 
                 return ESPRequest.getBaseURL() + params + (option ? "&Option=" + option : "&Option=1");


### PR DESCRIPTION
Fixes HPCC-11050

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
