### PR TITLE
HPCC-11101 Fail publishing queries with foreign files in old eclwatch

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -650,14 +650,16 @@
 
                 var exceptionHtml = "Workunit successfully published.";
                 var headerText = "Workunit Published";
-                var i = o.responseText.indexOf('<h3>Exception');
+                var hasException = 0;
+                var i = o.responseText.indexOf('<Exception>');
                 if (i > -1) {
+                    hasException = 1;
                     headerText = "Error Publishing Workunit";
-                    var j = o.responseText.indexOf('<table');
+                    var j = o.responseText.indexOf('<Message>');
                     if (j > -1) {
-                        var k = o.responseText.indexOf('</table>');
+                        var k = o.responseText.indexOf('</Message>');
                         if (k > -1) {
-                            exceptionHtml = o.responseText.substring(j, k+8);
+                            exceptionHtml = o.responseText.substring(j+9, k);
                         }
                     }
                 } else {
@@ -690,7 +692,7 @@
                 }
                 var publishDialog =
                      new YAHOO.widget.SimpleDialog("publishDialog",
-                      { width: "300px",
+                      { width: hasException ? null : "300px",
                         fixedcenter: true,
                         visible: false,
                         draggable: false,

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1108,7 +1108,7 @@ ESPrequest [nil_remove] WUPublishWorkunitRequest
     string Comment;
     bool DontCopyFiles(false);
     string SourceProcess;
-    bool AllowForeignFiles(true);
+    bool AllowForeignFiles(false);
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse


### PR DESCRIPTION
Change ESDL default for publish to be allowForeign==false.  Matching
default cli and now old eclwatch behavior.

Also fix old eclwatch display of exceptions when publish fails.

Another issue is being worked on for new eclwatch.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
