### PR TITLE
HPCC-11122 Alt tag causes missing image to display "Active"

### DIFF
--- a/esp/src/eclwatch/templates/QuerySetDetailsWidget.html
+++ b/esp/src/eclwatch/templates/QuerySetDetailsWidget.html
@@ -14,7 +14,7 @@
                     <h2>
                         <img id="${id}SuspendImg" src="" alt=""/>&nbsp;
                         <img id="${id}SuspendCluster" src="" alt=""/>&nbsp;
-                        <img id="${id}ActiveImg" src="" alt="${i18n.Active}"/>&nbsp;
+                        <img id="${id}ActiveImg" src="" alt=""/>&nbsp;
                         <span id="${id}QueryId" class="bold">${i18n.QueryDetailsfor}</span>
                     </h2>
                     <form id="${id}SummaryForm">


### PR DESCRIPTION
Remove alt tag on ActiveImg so that alt tag text does not show if query is not active.

Signed-off by Miguel Vazquez miguel.vazquez@lexisnexis.com
