### PR TITLE
HPCC-11033 Load WU timer info in one call for WU Details

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -558,7 +558,7 @@ class CLocalWorkUnit : public CInterface, implements IConstWorkUnit , implements
     mutable bool activitiesCached;
     mutable bool webServicesInfoCached;
     mutable bool roxieQueryInfoCached;
-    mutable bool timerCached;
+    mutable bool timersCached;
     mutable IArrayOf<IWUActivity> activities;
     mutable IArrayOf<IWUPlugin> plugins;
     mutable IArrayOf<IWULibrary> libraries;
@@ -3006,7 +3006,7 @@ void CLocalWorkUnit::init()
     activitiesCached = false;
     webServicesInfoCached = false;
     roxieQueryInfoCached = false;
-    timerCached = false;
+    timersCached = false;
     dirty = false;
     abortDirty = true;
     abortState = false;
@@ -5520,7 +5520,7 @@ public:
 void CLocalWorkUnit::loadTimers() const
 {
     CriticalBlock block(crit);
-    if (timerCached)
+    if (timersCached)
         return;
 
     assertex(timers.length() == 0);
@@ -5530,7 +5530,7 @@ void CLocalWorkUnit::loadTimers() const
         IPropertyTree *rp = &r->query();
         timers.append(*new CLocalWUTimer(rp->queryProp("@name"), rp->getPropInt("@count"), rp->getPropInt("@duration")));
     }
-    timerCached = true;
+    timersCached = true;
 }
 
 StringBuffer &formatGraphTimerLabel(StringBuffer &str, const char *graphName, unsigned subGraphNum, unsigned __int64 subId)

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -228,6 +228,24 @@ interface IConstWUGraphIterator : extends IScmIterator
     virtual IConstWUGraph & query() = 0;
 };
 
+interface IConstWUTimer : extends IInterface
+{
+    virtual IStringVal & getName(IStringVal & ret) const = 0;
+    virtual unsigned getCount() const = 0;
+    virtual unsigned getDuration() const = 0;
+};
+
+interface IWUTimer : extends IConstWUTimer
+{
+    virtual void setName(const char * str) = 0;
+    virtual void setCount(unsigned c) = 0;
+    virtual void setDuration(unsigned d) = 0;
+};
+
+interface IConstWUTimerIterator : extends IScmIterator
+{
+    virtual IConstWUTimer & query() = 0;
+};
 
 //! IWUResult
 enum
@@ -899,6 +917,7 @@ interface IConstWorkUnit : extends IInterface
     virtual IConstWUWebServicesInfo * getWebServicesInfo() const = 0;
     virtual IConstWURoxieQueryInfo * getRoxieQueryInfo() const = 0;
     virtual IStringIterator & getTimers() const = 0;
+    virtual IConstWUTimerIterator & getTimerIterator() const = 0;
     virtual IConstWUTimeStampIterator & getTimeStamps() const = 0;
     virtual IConstWUStatisticIterator & getStatistics() const = 0;
     virtual IConstWUStatistic * getStatistic(const char * name) const = 0;

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1197,29 +1197,29 @@ IDistributedFile* WsWuInfo::getLogicalFileData(IEspContext& context, const char*
     context.getUserID(username);
     Owned<IUserDescriptor> userdesc(createUserDescriptor());
     userdesc->set(username.str(), context.queryPassword());
-    IDistributedFile* df = queryDistributedFileDirectory().lookup(logicalName, userdesc);
+    Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalName, userdesc);
     if (!df)
         return NULL;
 
     bool blocked;
     if (df->isCompressed(&blocked) && !blocked)
-        return df;
+        return df.getClear();
 
     IPropertyTree& properties = df->queryAttributes();
     const char * format = properties.queryProp("@format");
     if (format && (stricmp(format,"csv")==0 || memicmp(format, "utf", 3) == 0))
     {
         showFileContent = true;
-        return df;
+        return df.getClear();
     }
     const char * recordEcl = properties.queryProp("ECL");
     if (!recordEcl)
-        return df;
+        return df.getClear();
 
     MultiErrorReceiver errs;
     Owned<IHqlExpression> ret = ::parseQuery(recordEcl, &errs);
     showFileContent = errs.errCount() == 0;
-    return df;
+    return df.getClear();
 }
 
 void WsWuInfo::getEclSchemaChildFields(IArrayOf<IEspECLSchemaItem>& schemas, IHqlExpression * expr, bool isConditional)

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -336,6 +336,41 @@ void WsWuInfo::getVariables(IEspECLWorkunit &info, unsigned flags)
     }
 }
 
+void WsWuInfo::addTimerToList(SCMStringBuffer& name, unsigned count, unsigned duration, unsigned& totalThorTimerCount,
+    StringBuffer& totalThorTimeValue, IArrayOf<IEspECLTimer>& timers)
+{
+    StringBuffer fd;
+    formatDuration(fd, duration);
+
+    if (strieq(name.str(), TOTALTHORTIME))
+    {
+        totalThorTimeValue = fd;
+        totalThorTimerCount = count;
+        return;
+    }
+
+    Owned<IEspECLTimer> t= createECLTimer("","");
+    name.s.replace('_', ' ');
+    t->setName(name.str());
+    t->setValue(fd.str());
+    t->setCount(count);
+
+    if (version > 1.19)
+    {
+        StringAttr graphName;
+        unsigned graphNum, subGraphNum, subId;
+        if (parseGraphTimerLabel(name.str(), graphName, graphNum, subGraphNum, subId))
+        {
+            if (graphName.length() > 0)
+                t->setGraphName(graphName);
+            if (subId > 0)
+                t->setSubGraphId((int)subId);
+        }
+    }
+
+    timers.append(*t.getLink());
+}
+
 void WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
 {
     if (!(flags & WUINFO_IncludeTimers))
@@ -345,106 +380,33 @@ void WsWuInfo::getTimers(IEspECLWorkunit &info, unsigned flags)
         StringBuffer totalThorTimeValue;
         unsigned totalThorTimerCount = 0; //Do we need this?
 
-        //This should be switched to using getStatistics() once backward compatibility is no longer required. (5.0?)
-        //The code inside the #if 0 is equivalent.
         IArrayOf<IEspECLTimer> timers;
-#if 0
         Owned<IConstWUStatisticIterator> it = &cw->getStatistics();
-        ForEach(*it)
+        if (it->first())
         {
-            IConstWUStatistic & cur = it->query();
-            //Only interested in timings...
-            if (cur.getKind() != SMEASURE_TIME_NS)
-                continue;
-
-            SCMStringBuffer name;
-            cur.getDescription(name);
-            name.s.replace('_', ' ');
-
-            unsigned __int64 count = cur.getCount();
-            unsigned __int64 duration = nanoToMilli(cur.getValue());
-            StringBuffer fd;
-            formatDuration(fd, duration);
-
-            if (strieq(name.str(), TOTALTHORTIME))
+            ForEach(*it)
             {
-                totalThorTimeValue = fd;
-                totalThorTimerCount = count;
-                continue;
+                IConstWUStatistic & cur = it->query();
+                //Only interested in timings...
+                if (cur.getKind() != SMEASURE_TIME_NS)
+                    continue;
+
+                SCMStringBuffer name;
+                cur.getDescription(name);
+                addTimerToList(name, cur.getCount(), nanoToMilli(cur.getValue()), totalThorTimerCount, totalThorTimeValue, timers);
             }
-
-            Owned<IEspECLTimer> t= createECLTimer("","");
-            t->setName(name.str());
-            t->setValue(fd.str());
-            t->setCount(count);
-
-            if (version > 1.19)
-            {
-                StringAttr graphName;
-                unsigned graphNum;
-                unsigned subGraphNum;
-                unsigned subId;
-                if (parseGraphTimerLabel(name.str(), graphName, graphNum, subGraphNum, subId))
-                {
-                    if (graphName.length() > 0)
-                    {
-                        t->setGraphName(graphName);
-                    }
-                    if (subId > 0)
-                    {
-                        t->setSubGraphId((int)subId);
-                    }
-                }
-            }
-
-            timers.append(*t.getLink());
         }
-#else
-        Owned<IStringIterator> it = &cw->getTimers();
-        ForEach(*it)
-        {
-            SCMStringBuffer name;
-            it->str(name);
-            unsigned count = cw->getTimerCount(name.str());
-            unsigned duration = cw->getTimerDuration(name.str());
-            StringBuffer fd;
-            formatDuration(fd, duration);
-            name.s.replace('_', ' ');
-
-            if (strieq(name.str(), TOTALTHORTIME))
+        else
+        {//backward compatibility for WU without Statistics
+            Owned<IConstWUTimerIterator> it = &cw->getTimerIterator();
+            ForEach(*it)
             {
-                totalThorTimeValue = fd;
-                totalThorTimerCount = count;
-                continue;
+                IConstWUTimer& timer = it->query();
+                SCMStringBuffer name;
+                timer.getName(name);
+                addTimerToList(name, timer.getCount(), timer.getDuration(), totalThorTimerCount, totalThorTimeValue, timers);
             }
-
-            Owned<IEspECLTimer> t= createECLTimer("","");
-            t->setName(name.str());
-            t->setValue(fd.str());
-            t->setCount(count);
-
-            if (version > 1.19)
-            {
-                StringAttr graphName;
-                unsigned graphNum;
-                unsigned subGraphNum;
-                unsigned subId;
-                if (parseGraphTimerLabel(name.str(), graphName, graphNum, subGraphNum, subId))
-                {
-                    if (graphName.length() > 0)
-                    {
-                        t->setGraphName(graphName);
-                    }
-                    if (subId > 0)
-                    {
-                        t->setSubGraphId((int)subId);
-                    }
-                }
-            }
-
-            timers.append(*t.getLink());
         }
-#endif
 
         if (totalThorTimeValue.length() > 0)
         {
@@ -1229,35 +1191,35 @@ void WsWuInfo::getWorkflow(IEspECLWorkunit &info, unsigned flags)
         info.setEventSchedule(1); //Can reschedule
 }
 
-bool shouldFileContentBeShown(IEspContext &context, const char * logicalName)
+IDistributedFile* WsWuInfo::getLogicalFileData(IEspContext& context, const char* logicalName, bool& showFileContent)
 {
     StringBuffer username;
     context.getUserID(username);
-
     Owned<IUserDescriptor> userdesc(createUserDescriptor());
     userdesc->set(username.str(), context.queryPassword());
-
-    Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalName, userdesc);
+    IDistributedFile* df = queryDistributedFileDirectory().lookup(logicalName, userdesc);
     if (!df)
-        return false;
+        return NULL;
 
     bool blocked;
     if (df->isCompressed(&blocked) && !blocked)
-        return false;
+        return df;
 
-    IPropertyTree & properties = df->queryAttributes();
+    IPropertyTree& properties = df->queryAttributes();
     const char * format = properties.queryProp("@format");
     if (format && (stricmp(format,"csv")==0 || memicmp(format, "utf", 3) == 0))
     {
-        return true;
+        showFileContent = true;
+        return df;
     }
     const char * recordEcl = properties.queryProp("ECL");
     if (!recordEcl)
-        return false;
+        return df;
 
     MultiErrorReceiver errs;
     Owned<IHqlExpression> ret = ::parseQuery(recordEcl, &errs);
-    return errs.errCount() == 0;
+    showFileContent = errs.errCount() == 0;
+    return df;
 }
 
 void WsWuInfo::getEclSchemaChildFields(IArrayOf<IEspECLSchemaItem>& schemas, IHqlExpression * expr, bool isConditional)
@@ -1354,6 +1316,11 @@ void WsWuInfo::getResult(IConstWUResult &r, IArrayOf<IEspECLResult>& results, un
     SCMStringBuffer filename;
     r.getResultLogicalName(filename);
 
+    bool showFileContent = false;
+    Owned<IDistributedFile> df = NULL;
+    if (filename.length())
+        df.setown(getLogicalFileData(context, filename.str(), showFileContent));
+
     StringBuffer value, link;
     if (r.getResultStatus() == ResultStatusUndefined)
         value.set("[undefined]");
@@ -1412,23 +1379,8 @@ void WsWuInfo::getResult(IConstWUResult &r, IArrayOf<IEspECLResult>& results, un
     else
     {
         value.append('[').append(r.getResultTotalRowCount()).append(" rows]");
-        if(r.getResultSequence()>=0)
-        {
-            if(filename.length())
-            {
-                StringBuffer username;
-                context.getUserID(username);
-
-                Owned<IUserDescriptor> userdesc(createUserDescriptor());
-                userdesc->set(username.str(), context.queryPassword());
-
-                Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(filename.str(), userdesc);
-                if(df && df->queryAttributes().hasProp("ECL"))
-                    link.append(r.getResultSequence());
-            }
-            else
-                link.append(r.getResultSequence());
-        }
+        if((r.getResultSequence()>=0) && (!filename.length() || (df && df->queryAttributes().hasProp("ECL"))))
+            link.append(r.getResultSequence());
     }
 
     Owned<IEspECLResult> result= createECLResult("","");
@@ -1451,7 +1403,7 @@ void WsWuInfo::getResult(IConstWUResult &r, IArrayOf<IEspECLResult>& results, un
     }
 
     if (filename.length())
-        result->setShowFileContent(shouldFileContentBeShown(context, filename.str()));
+        result->setShowFileContent(showFileContent);
 
     result->setName(name.str());
     result->setLink(link.str());

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -181,6 +181,8 @@ public:
     void getWorkunitCpp(const char* cppname, const char* description, const char* ipAddress, MemoryBuffer& buf, bool forDownload);
     void getEventScheduleFlag(IEspECLWorkunit &info);
     unsigned getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IEspECLWorkunit &info);
+    IDistributedFile* getLogicalFileData(IEspContext& context, const char* logicalName, bool& showFileContent);
+    void addTimerToList(SCMStringBuffer& name, unsigned count, unsigned duration, unsigned& totalThorTimerCount, StringBuffer& totalThorTimeValue, IArrayOf<IEspECLTimer>& timers);
 
 public:
     IEspContext &context;


### PR DESCRIPTION
The existing ECL WU Details page takes a long time to load when a
WU has many timer items or helper files. The load time is improved
by this fix. 1. WUinfo code will use WU Statistics data about timers
if the Statistics data is available. 2. If the Statistics data is
not avaliable, an new interface IConstWUTimerIterator is implemented
to get the timer data in one call. For an ECL WU with 4635 timer
items, the time to read timer data is decreased from >100 seconds to
<0.1 second. 3. This fix also reduces the time of reading helper
file data by combining 2 file lookup calls into one call.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
