### PR TITLE
HPCC-11140 Memory corruption if keyindex returns zero

### DIFF
--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -594,6 +594,7 @@ public:
             {
                 keySize = ki->keySize();
                 keyedSize = ki->keyedSize();
+                assertex(keySize);
                 keyBuffer = (char *) malloc(keySize);
             }
             else
@@ -2543,6 +2544,8 @@ public:
         {
             IKeyIndex *ki = _keyset->queryPart(0);
             keySize = ki->keySize();
+            if (!keySize)
+                throw MakeStringException(0, "Invalid key size 0 in key %s", ki->queryFileName());
             keyedSize = ki->keyedSize();
             numkeys = _keyset->numParts();
         }
@@ -2566,6 +2569,7 @@ public:
         unsigned i;
         for (i = 0; i < numkeys; i++)
         {
+            assertex(keySize);
             if (!keyBuffer) keyBuffer = (char *) malloc(keySize);
             segs.setLow(0, keyBuffer);
             loop
@@ -2605,6 +2609,7 @@ public:
                         fixedValue = NULL;
                         break;
                     }
+                    assertex(sortFieldOffset);
                     void *fixedValue = malloc(sortFieldOffset);
                     memcpy(fixedValue, keyBuffer, sortFieldOffset);
                     fixedArray.append(fixedValue);
@@ -2627,6 +2632,7 @@ public:
                     }
 #endif
                     // Now advance segments 0 through sortFromSeg-1 to next legal value...
+                    assertex(keySize);
                     char *nextBuffer = (char *) malloc(keySize);
                     memcpy(nextBuffer, keyBuffer, keySize);
                     keyBuffer = nextBuffer;
@@ -2825,6 +2831,7 @@ public:
             mb.read(keyno);
             keyNoArray.append(keyno);
             keyCursor = keyset->queryPart(keyno)->getCursor(ctx);
+            assertex(keySize);
             keyBuffer = (char *) malloc(keySize);
             cursorArray.append(*keyCursor);
             keyCursor->deserializeCursorPos(mb, keyBuffer);


### PR DESCRIPTION
Should not be happening, but some invalid keys are causing Roxie to restart
after heap corruptions.

The same invalid keys may also report key size mismatch on key [merger]

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
