### PR TITLE
HPCC-11154 Missing entries in default environment

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4380,9 +4380,9 @@ public:
         else if (roxie)
         {
             roxieProcess.set(roxie->queryProp("@name"));
-            clusterWidth = roxie->getPropInt("@numChannels", 1);
             platform = RoxieCluster;
             getRoxieProcessServers(roxie, roxieServers);
+            clusterWidth = roxieServers.length();
         }
         else 
         {

--- a/deployment/deploy/RoxieDeploymentEngine.cpp
+++ b/deployment/deploy/RoxieDeploymentEngine.cpp
@@ -38,8 +38,6 @@ CRoxieDeploymentEngine::CRoxieDeploymentEngine(IEnvDeploymentEngine& envDepEngin
 
 void CRoxieDeploymentEngine::checkInstance(IPropertyTree& node) const
 {
-    if (!m_process.getPropInt("@numChannels", 0))
-        throw MakeStringException(0, "Number of channels must be set for process %s", m_name.get());
     CDeploymentEngine::checkInstance(node);
 }
 

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -787,6 +787,7 @@
                 buildSet="roxie"
                 callbackRetries="3"
                 callbackTimeout="500"
+                channelsPerNode="1"
                 checkCompleted="true"
                 checkFileDate="true"
                 clusterWidth="1"
@@ -853,7 +854,6 @@
                 name="myroxie"
                 nodeCacheMem="100"
                 nodeCachePreload="false"
-                numChannels="1"
                 numDataCopies="1"
                 parallelAggregate="0"
                 perChannelFlowLimit="10"
@@ -989,6 +989,7 @@
                pluginsPath="${PLUGINS_PATH}"
                replicateAsync="false"
                replicateOutputs="false"
+               slavesPerNode="1"
                watchdogEnabled="true"
                watchdogProgressEnabled="true">
    <Debug/>


### PR DESCRIPTION
Makes it easier to change the settings manually (e.g. to set up a multinode
system) if they default values are already there to remind me what the names
are.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
