### PR TITLE
HPCC-11145 FireFox is unable to do "inline" downloads

### DIFF
--- a/esp/src/eclwatch/InfoGridWidget.js
+++ b/esp/src/eclwatch/InfoGridWidget.js
@@ -98,7 +98,7 @@ define([
             startup: function (args) {
                 this.inherited(arguments);
                 if (this.showToolbar) {
-                    if (has("ie") <= 9) {
+                    if (has("ie") <= 9 || has("ff")) {
                         this.widget.Download.set("disabled", true);
                     }
                 }


### PR DESCRIPTION
The same is true for ie <= 9

Fixes HPCC-11145

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
