### PR TITLE
HPCC-11175 Fix issues with cache of files in use info

### DIFF
--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -242,6 +242,7 @@ void ReferencedFile::processLocalFileInfo(IDistributedFile *df, const char *dstC
     }
     else
     {
+        flags |= RefSubFile;
         if (!dstCluster || !*dstCluster)
             return;
         if (df->findCluster(dstCluster)==NotFound)

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4554,7 +4554,7 @@ extern WORKUNIT_API IStringIterator *getTargetClusters(const char *processType, 
     {
         StringBuffer xpath;
         xpath.appendf("%s", processType ? processType : "*");
-        if (processName)
+        if (processName && *processName)
             xpath.appendf("[@process=\"%s\"]", processName);
         Owned<IPropertyTreeIterator> targets = conn->queryRoot()->getElements("Software/Topology/Cluster");
         ForEach(*targets)

--- a/esp/eclwatch/ws_XSLT/CMakeLists.txt
+++ b/esp/eclwatch/ws_XSLT/CMakeLists.txt
@@ -77,6 +77,7 @@ FOREACH ( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/queryfiledetails.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/queryfilelist.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/queryfilelistdone.xslt
+    ${CMAKE_CURRENT_SOURCE_DIR}/QueriesUsingFile.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/result.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/result_lib.xslt
     ${CMAKE_CURRENT_SOURCE_DIR}/result_lib1.xslt

--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -142,7 +142,7 @@
                 ]);
             }
 
-            if (roxiecluster != 0) {
+            if (roxiecluster != 0 || cluster=="") {
                 oMenu.addItems([
                     { text: "Used By", onclick: { fn: queriesUsingDFUFile } }
                 ]);

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -1475,6 +1475,17 @@ int CWsWorkunitsSoapBindingEx::onGet(CHttpRequest* request, CHttpResponse* respo
             streamJobQueueListResponse(*ctx, cluster, startDate, endDate, response, xls.str());
             return 0;
         }
+        else if(!strnicmp(path.str(), "/WsWorkunits/filesInUse", 28))
+        {
+            StringBuffer xml;
+            wswService->filesInUse.toStr(xml);
+
+            response->setContent(xml);
+            response->setContentType("text/xml");
+            response->setStatus(HTTP_STATUS_OK);
+            response->send();
+            return 0;
+        }
     }
     catch(IException* e)
     {

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -328,16 +328,18 @@ void QueryFilesInUse::loadTarget(IPropertyTree *t, const char *target, unsigned 
             if (aborting)
                 return;
             IReferencedFile &rf = files->query();
-            if (!(rf.getFlags() & RefSubFile))
-                continue;
+            //if (!(rf.getFlags() & RefSubFile))
+            //    continue;
             const char *lfn = rf.getLogicalName();
             if (!lfn || !*lfn)
                 continue;
 
-            if (!queryTree->hasProp(xpath.setf("SubFile[@lfn='%s']", lfn)))
+            if (!queryTree->hasProp(xpath.setf("File[@lfn='%s']", lfn)))
             {
-                IPropertyTree *fileTree = queryTree->addPropTree("SubFile", createPTree("SubFile"));
+                IPropertyTree *fileTree = queryTree->addPropTree("File", createPTree("File"));
                 fileTree->setProp("@lfn", lfn);
+                if (rf.getFlags() & RefFileSuper)
+                    fileTree->setPropBool("@super", true);
                 const char *fpkgid = rf.queryPackageId();
                 if (fpkgid && *fpkgid)
                     fileTree->setProp("@pkgid", fpkgid);
@@ -368,7 +370,7 @@ IPropertyTreeIterator *QueryFilesInUse::findQueriesUsingFile(const char *target,
     if (!targetTree)
         return NULL;
 
-    VStringBuffer xpath("Query[SubFile/@lfn='%s']", lfn);
+    VStringBuffer xpath("Query[File/@lfn='%s']", lfn);
     return targetTree->getElements(xpath);
 }
 
@@ -1295,7 +1297,7 @@ bool CWsWorkunitsEx::onWUListQueriesUsingFile(IEspContext &context, IEspWUListQu
             Owned<IEspQueryUsingFile> q = createQueryUsingFile();
             q->setId(query.queryProp("@id"));
 
-            VStringBuffer xpath("SubFile[@lfn='%s']/@pkgid", lfn.str());
+            VStringBuffer xpath("File[@lfn='%s']/@pkgid", lfn.str());
             if (query.hasProp(xpath))
                 q->setPackage(query.queryProp(xpath));
             respQueries.append(*q.getClear());

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -114,6 +114,12 @@ public:
         CriticalBlock b(crit);
     }
     IPropertyTreeIterator *findQueriesUsingFile(const char *target, const char *lfn);
+    StringBuffer &toStr(StringBuffer &s)
+    {
+        CriticalBlock b(crit);
+        return toXML(tree, s);
+    }
+
 };
 
 class QueryFilesInUseUpdateThread : public Thread
@@ -246,6 +252,7 @@ private:
     WUSchedule m_sched;
     unsigned short port;
     Owned<IPropertyTree> directories;
+public:
     QueryFilesInUse filesInUse;
 };
 
@@ -254,6 +261,7 @@ class CWsWorkunitsSoapBindingEx : public CWsWorkunitsSoapBinding
 public:
     CWsWorkunitsSoapBindingEx(IPropertyTree *cfg, const char *name, const char *process, http_soap_log_level llevel) : CWsWorkunitsSoapBinding(cfg, name, process, llevel)
     {
+        wswService = NULL;
         VStringBuffer xpath("Software/EspProcess[@name=\"%s\"]/EspBinding[@name=\"%s\"]/BatchWatch", process, name);
         batchWatchFeaturesOnly = cfg->getPropBool(xpath.str(), false);
     }
@@ -281,15 +289,15 @@ public:
 
     virtual void addService(const char * name, const char * host, unsigned short port, IEspService & service)
     {
-        CWsWorkunitsEx* srv = dynamic_cast<CWsWorkunitsEx*>(&service);
-        if (srv)
-            srv->setPort(port);
+        wswService = dynamic_cast<CWsWorkunitsEx*>(&service);
+        if (wswService)
+            wswService->setPort(port);
         CWsWorkunitsSoapBinding::addService(name, host, port, service);
     }
 
-
 private:
     bool batchWatchFeaturesOnly;
+    CWsWorkunitsEx *wswService;
 };
 
 #endif


### PR DESCRIPTION
Set flag for local files that are not in a package or dfs superfile, so
they won't be ignored as in use by query.  Also fix issue with
getTargetClusters not returning any entries when processName="", so
calling WUListQueriesUsingFile with no cluster or process will look
on all roxies.

Also fix install of QueriesUsingFiles.xslt.

Also add a backdoor way of viewing the entire files in use cache, to
make debugging easier.  To see cache, go to
http://ip:port/WsWorkunits/filesinuse

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
