### PR TITLE
HPCC-11169 Add ResourceURLCount to WUQueryDetails response

### DIFF
--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -284,6 +284,7 @@ public:
 
     virtual void getResultViewNames(StringArray &names);
     virtual void getResourceURLs(StringArray &urls, const char *prefix);
+    virtual unsigned getResourceURLCount();
     virtual void renderResults(const char *viewName, const char *xml, StringBuffer &html);
     virtual void renderResults(const char *viewName, StringBuffer &html);
     virtual void renderSingleResult(const char *viewName, const char *resultname, StringBuffer &html);
@@ -456,6 +457,19 @@ bool WuWebView::getResourceByPath(const char *path, MemoryBuffer &mb)
     if (!res)
         return false;
     return getResource(res, mb);
+}
+
+unsigned WuWebView::getResourceURLCount()
+{
+    unsigned urlCount = 1;
+    Owned<IPropertyTreeIterator> iter = ensureManifest()->getElements("Resource");
+    ForEach(*iter)
+    {
+        IPropertyTree &res = iter->query();
+        if (res.hasProp("@ResourcePath") || res.hasProp("@filename"))
+            urlCount++;
+    }
+    return urlCount;
 }
 
 void WuWebView::getResourceURLs(StringArray &urls, const char *prefix)

--- a/common/wuwebview/wuwebview.hpp
+++ b/common/wuwebview/wuwebview.hpp
@@ -43,6 +43,7 @@ interface IWuWebView : extends IInterface
 {
     virtual void getResultViewNames(StringArray &names)=0;
     virtual void getResourceURLs(StringArray &urls, const char *prefix)=0;
+    virtual unsigned getResourceURLCount() = 0;
     virtual void renderResults(const char *viewName, const char *xml, StringBuffer &html)=0;
     virtual void renderResults(const char *viewName, StringBuffer &html)=0;
     virtual void renderSingleResult(const char *viewName, const char *resultname, StringBuffer &html)=0;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1295,6 +1295,7 @@ ESPresponse [exceptions_inline] WUQueryDetailsResponse
     [min_ver("1.46")] ESParray<string> LibrariesUsed;
     [min_ver("1.46")] int CountGraphs;
     [min_ver("1.46")] ESParray<string> GraphIds;
+    [min_ver("1.50")] int ResourceURLCount;
 };
 
 ESPrequest WUMultiQuerySetDetailsRequest

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1657,6 +1657,24 @@ bool WsWuInfo::getResourceInfo(StringArray &viewnames, StringArray &urls, unsign
     return false;
 }
 
+unsigned WsWuInfo::getResourceURLCount()
+{
+    try
+    {
+        Owned<IWuWebView> wv = createWuWebView(*cw, NULL, NULL, false);
+        if (wv)
+            return wv->getResourceURLCount();
+    }
+    catch(IException* e)
+    {
+        StringBuffer eMsg;
+        ERRLOG("%s", e->errorMessage(eMsg).str());
+        e->Release();
+    }
+
+    return 0;
+}
+
 void appendIOStreamContent(MemoryBuffer &mb, IFileIOStream *ios, bool forDownload)
 {
     StringBuffer line;

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -143,6 +143,7 @@ public:
     }
 
     bool getResourceInfo(StringArray &viewnames, StringArray &urls, unsigned flags);
+    unsigned getResourceURLCount();
 
     void getCommon(IEspECLWorkunit &info, unsigned flags);
     void getInfo(IEspECLWorkunit &info, unsigned flags);

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1207,8 +1207,7 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
     {
         StringArray views, urls;
         WsWuInfo winfo(context, wuid);
-        winfo.getResourceInfo(views, urls, WUINFO_IncludeResourceURLs);
-        resp.setResourceURLCount(urls.length());
+        resp.setResourceURLCount(winfo.getResourceURLCount());
     }
 
     return true;

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1205,7 +1205,6 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
     }
     if (version >= 1.50)
     {
-        StringArray views, urls;
         WsWuInfo winfo(context, wuid);
         resp.setResourceURLCount(winfo.getResourceURLCount());
     }

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1203,6 +1203,14 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
             resp.setClusters(clusterStates);
         }
     }
+    if (version >= 1.50)
+    {
+        StringArray views, urls;
+        WsWuInfo winfo(context, wuid);
+        winfo.getResourceInfo(views, urls, WUINFO_IncludeResourceURLs);
+        resp.setResourceURLCount(urls.length());
+    }
+
     return true;
 }
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1473,7 +1473,7 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
                 if (req.getIncludeResultsViewNames()||req.getIncludeResourceURLs()||(version >= 1.50))
                 {
                     StringArray views, urls;
-                    winfo.getResourceInfo(views, urls, flags);
+                    winfo.getResourceInfo(views, urls, WUINFO_IncludeResourceURLs);
                     IEspECLWorkunit& eclWU = resp.updateWorkunit();
                     if (req.getIncludeResultsViewNames())
                         resp.setResultViews(views);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1473,7 +1473,7 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
                 if (req.getIncludeResultsViewNames()||req.getIncludeResourceURLs()||(version >= 1.50))
                 {
                     StringArray views, urls;
-                    winfo.getResourceInfo(views, urls, WUINFO_IncludeResourceURLs);
+                    winfo.getResourceInfo(views, urls, WUINFO_IncludeResultsViewNames|WUINFO_IncludeResourceURLs);
                     IEspECLWorkunit& eclWU = resp.updateWorkunit();
                     if (req.getIncludeResultsViewNames())
                         resp.setResultViews(views);


### PR DESCRIPTION
The ResourceURLCount is added to WUQueryDetails response. Also fix
'the ResourceURLCount should not set to 0 when IncludeResourceURLs
is set to false'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
