### PR TITLE
HPCC-11132 Add tooltips for log icons and config file icons

### DIFF
--- a/esp/eclwatch/ws_XSLT/machines.xslt
+++ b/esp/eclwatch/ws_XSLT/machines.xslt
@@ -390,7 +390,7 @@
                         <xsl:value-of select="OS"/>
                         <xsl:text>);</xsl:text>
                     </xsl:attribute>
-                    <img border="0" src="/esp/files_/img/base.gif" alt="View log file..." width="19" height="16"/>
+                    <img border="0" src="/esp/files_/img/base.gif" alt="View log file..." title="View log file..." width="19" height="16"/>
                 </a>            
                 <xsl:value-of select="Name"/>
             </td>

--- a/esp/eclwatch/ws_XSLT/services.xslt
+++ b/esp/eclwatch/ws_XSLT/services.xslt
@@ -548,7 +548,8 @@
                                                         <xsl:value-of select="OS"/>
                                                         <xsl:text>);</xsl:text>
                                                     </xsl:attribute>
-                                                    <img border="0" src="&filePathEntity;/img/base.gif" alt="View log file" width="19" height="16"/>
+                                                    <img border="0" src="&filePathEntity;/img/base.gif" alt="View log file"
+                                                        title="View log file" width="19" height="16"/>
                                                 </a>
                                             </xsl:if>
                                         </td>
@@ -571,7 +572,8 @@
                               <xsl:text>%26OsType%3d</xsl:text>
                               <xsl:value-of select="OS"/>
                             </xsl:variable>
-                          <img onclick="getConfigXML('{$href0}')" border="0" src="/esp/files_/img/config.png" alt="View deployed configuration file" width="14" height="14"/>
+                          <img onclick="getConfigXML('{$href0}')" border="0" src="/esp/files_/img/config.png" alt="View deployed configuration file"
+                            title="View deployed configuration file" width="14" height="14"/>
                         </xsl:when>
                                                 <xsl:otherwise>
                                                     <img border="0" src="/esp/files_/img/blank.png" width="14" height="14"/>
@@ -720,7 +722,8 @@
                               <xsl:text>%26OsType%3d</xsl:text>
                               <xsl:value-of select="OS"/>
                             </xsl:attribute>
-                            <img border="0" src="/esp/files_/img/config.png" alt="View deployed configuration file" width="14" height="14"/>
+                            <img border="0" src="/esp/files_/img/config.png" alt="View deployed configuration file"
+                              title="View deployed configuration file" width="14" height="14"/>
                           </a>
                         </td>
                       </tr>

--- a/esp/eclwatch/ws_XSLT/targetclusters.xslt
+++ b/esp/eclwatch/ws_XSLT/targetclusters.xslt
@@ -302,7 +302,7 @@
         </td>
         <td align="left" width="20">
           <a href="javascript:showDetails('{$type}', '{$name}');">
-            <img id="view_details_{$name}" border="0" src="&filePathEntity;/img/keyfile.png" align="middle"/>
+            <img id="view_details_{$name}" border="0" src="&filePathEntity;/img/keyfile.png" alt="View details" title="View details" align="middle"/>
           </a>
         </td>
         <!--xsl:if test="type='RoxieCluster'">
@@ -477,7 +477,8 @@
                   <xsl:text disable-output-escaping="yes">&amp;inner=/WsTopology/TpGetComponentFile%3fFileType%3dcfg%26CompType%3d</xsl:text>
                   <xsl:value-of select="concat($type2, 'Cluster%26CompName%3d', Name, '%26Directory%3d', $absolutePath, '%26OsType%3d', OS)"/>
                 </xsl:variable>
-                <img onclick="getConfigXML('{$href0}')" border="0" src="&filePathEntity;/img/config.png" alt="View configuration file..." width="14" height="14"/>
+                <img onclick="getConfigXML('{$href0}')" border="0" src="&filePathEntity;/img/config.png" alt="View configuration file..." 
+                  title="View configuration file..." width="14" height="14"/>
                 <xsl:value-of select="Directory"/>
               </td>
             </tr>
@@ -700,7 +701,7 @@
                               <xsl:value-of select="OS"/>
                               <xsl:text disable-output-escaping="yes">);</xsl:text>
                             </xsl:attribute>
-                            <img border="0" src="&filePathEntity;/img/base.gif" alt="View log file" width="19" height="16"/>
+                            <img border="0" src="&filePathEntity;/img/base.gif" alt="View log file" title="View log file" width="19" height="16"/>
                           </a>
                         </xsl:if>
                       </td>
@@ -723,7 +724,8 @@
                               <xsl:text disable-output-escaping="yes">%26OsType%3d</xsl:text>
                               <xsl:value-of select="OS"/>
                             </xsl:variable>
-                            <img onclick="getConfigXML('{$href0}')" border="0" src="/esp/files_/img/config.png" alt="View deployed configuration file" width="14" height="14"/>
+                            <img onclick="getConfigXML('{$href0}')" border="0" src="/esp/files_/img/config.png" alt="View deployed configuration file"
+                              title="View configuration file..." width="14" height="14"/>
                           </xsl:when>
                           <xsl:otherwise>
                             <img border="0" src="/esp/files_/img/blank.png" width="14" height="14"/>
@@ -817,7 +819,8 @@
                               <xsl:text disable-output-escaping="yes">%26OsType%3d</xsl:text>
                               <xsl:value-of select="OS"/>
                             </xsl:attribute>
-                            <img border="0" src="/esp/files_/img/config.png" alt="View deployed configuration file" width="14" height="14"/>
+                            <img border="0" src="/esp/files_/img/config.png" alt="View deployed configuration file"
+                              title="View configuration file..." width="14" height="14"/>
                           </a>
                           <xsl:value-of select="Directory"/>
                         </td>

--- a/esp/eclwatch/ws_XSLT/topology.xslt
+++ b/esp/eclwatch/ws_XSLT/topology.xslt
@@ -187,7 +187,8 @@
           <xsl:text disable-output-escaping="yes">&amp;inner=/WsTopology/TpGetComponentFile%3fFileType%3dcfg%26CompType%3d</xsl:text>
           <xsl:value-of select="concat($type2, 'Cluster%26CompName%3d', Name, '%26Directory%3d', $absolutePath, '%26OsType%3d', OS)"/>
         </xsl:variable>
-        <img onclick="getConfigXML('{$href0}')" border="0" src="/esp/files_/img/config.png" alt="View configuration file..." width="14" height="14"/>
+        <img onclick="getConfigXML('{$href0}')" border="0" src="/esp/files_/img/config.png" alt="View configuration file..."
+          title="View configuration file..." width="14" height="14"/>
       </td>
       <td>
         <a  href="/WsTopology/TpMachineQuery?Type={$type3}MACHINES&amp;Cluster={Name}&amp;Path={Path}&amp;Directory={Directory}&amp;LogDirectory={$logPath}">


### PR DESCRIPTION
Based on the request, on System Servers page, Cluster Processes
page, and Target clusters page, I add tooltips to the icons of
logs and configuration files. Right now, those pages display
inside new ECLWatch.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
