### PR TITLE
HPCC-11148 Fix WsEcl JSONTest formatting of int64 values

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -2141,9 +2141,10 @@ int CWsEclBinding::getJsonTestForm(IEspContext &context, CHttpRequest* request, 
     Owned<IXslTransform> xform = xslp->createXslTransform();
     xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/wsecl3_jsontest.xsl").str());
 
+    StringBuffer encodedMsg;
     StringBuffer srcxml;
     srcxml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><srcxml><jsonreq><![CDATA[");
-    srcxml.append(jsonmsg.str());
+    srcxml.append(encodeJSON(encodedMsg, jsonmsg.str())); //encode the whole thing for javascript embedding
     srcxml.append("]]></jsonreq></srcxml>");
     xform->setXmlSource(srcxml.str(), srcxml.length());
 


### PR DESCRIPTION
Also fix escaping of json embedded in javascript.  The current request
is embedded in javascript for processing but the whole message needed to
be escaped to properly handle special characters.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
