### PR TITLE
HPCC-10454 Extend ECL tool with query, status and abort commands.

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3930,6 +3930,11 @@ mapEnums states[] = {
    { WUStateSize, NULL }
 };
 
+const char * getWorkunitStateStr(WUState state)
+{
+    return states[state].str;
+}
+
 IConstWorkUnitIterator * CWorkUnitFactory::getWorkUnitsByState(WUState state)
 {
     StringBuffer path("*");

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1354,4 +1354,6 @@ extern WORKUNIT_API void descheduleWorkunit(char const * wuid);
 void WORKUNIT_API testWorkflow();
 #endif
 
+const char * getWorkunitStateStr(WUState state);
+
 #endif

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -760,6 +760,8 @@ public:
                 retVal = true;
                 continue;
             }
+            if (EclCmdCommon::matchCommandLineOption(iter, true) != EclCmdOptionMatch)
+                return false;
         }
         return retVal;
     }
@@ -885,6 +887,8 @@ public:
                 retVal = true;
                 continue;
             }
+            if (EclCmdCommon::matchCommandLineOption(iter, true) != EclCmdOptionMatch)
+                return false;
         }
         return retVal;
     }
@@ -961,6 +965,8 @@ public:
             {
                 continue;
             }
+            if (EclCmdCommon::matchCommandLineOption(iter, true) != EclCmdOptionMatch)
+                return false;
         }
         return retVal;
     }
@@ -1052,10 +1058,8 @@ public:
             {
                 continue;
             }
-            if (iter.matchFlag(optVerbose, ECLOPT_VERBOSE)||iter.matchFlag(optVerbose, ECLOPT_VERBOSE_S))
-            {
-                continue;
-            }
+            if (EclCmdCommon::matchCommandLineOption(iter, true) != EclCmdOptionMatch)
+                return false;
         }
         return retVal;
     }
@@ -1085,34 +1089,32 @@ public:
         Owned<IClientWUQueryResponse> resp = client->WUQuery(req);
         int res = resp->queryClientStatus();
 
-        //if (!resp->getCount_isNull())
-        {
-            IArrayOf<IConstECLWorkunit>& wus = resp->getWorkunits();
+        IArrayOf<IConstECLWorkunit>& wus = resp->getWorkunits();
 
-            if (wus.ordinality() == 1)
+        if (wus.ordinality() == 1)
+        {
+
+            if (optVerbose)
             {
+                fprintf(stdout, "ID: %-18s, job name: %s, state:", wus.item(0).getWuid(), wus.item(0).getJobname());
+            }
+
+            fprintf(stdout, "%s\n", getWorkunitStateStr((WUState) wus.item(0).getStateID()) );
+        }
+        else
+        {
+            ForEachItemIn(idx, wus)
+            {
+                if (idx == optListLimit)
+                    break;
 
                 if (optVerbose)
-                {
-                    fprintf(stdout, "ID: %-18s, job name: %s, state:", wus.item(0).getWuid(), wus.item(0).getJobname());
-                }
-
-                fprintf(stdout, "%s\n", getWorkunitStateStr((WUState) wus.item(0).getStateID()) );
-            }
-            else
-            {
-                ForEachItemIn(idx, wus)
-                {
-                    if (idx == optListLimit)
-                        break;
-
-                    if (optVerbose)
-                        fprintf(stdout, "ID: %s, job name: %s, state: %s\n", wus.item(idx).getWuid(), wus.item(idx).getJobname(), getWorkunitStateStr((WUState) wus.item(idx).getStateID()) );
-                    else
-                        fprintf(stdout, "%s,%s,%s\n", wus.item(idx).getWuid(), wus.item(idx).getJobname(), getWorkunitStateStr((WUState) wus.item(idx).getStateID()) );
-                }
+                    fprintf(stdout, "ID: %s, job name: %s, state: %s\n", wus.item(idx).getWuid(), wus.item(idx).getJobname(), getWorkunitStateStr((WUState) wus.item(idx).getStateID()) );
+                else
+                    fprintf(stdout, "%s,%s,%s\n", wus.item(idx).getWuid(), wus.item(idx).getJobname(), getWorkunitStateStr((WUState) wus.item(idx).getStateID()) );
             }
         }
+
         return 0;
     }
     virtual void usage()

--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -199,6 +199,10 @@ void EclCMDShell::usage()
            "   deactivate  deactivate the given query alias name\n"
            "   queries     show or manipulate queries and querysets\n"
            "   roxie       commands specific to roxie clusters\n"
+           "   abort       abort workunit(s) for WUID or job name\n"
+           "   status      show workunit(s) current status for WUID or job name\n"
+           "   getname     provide job name from WUID\n"
+           "   getwuid     provide WUID from job name\n"
            "\nRun 'ecl help <command>' for more information on a specific command\n\n"
     );
 }


### PR DESCRIPTION
Implement new ecl tool commands:
    - abort
    - getname
    - getwuid
    - status

Signed-off-by: Attila Vamos attila.vamos@gmail.com
