### PR TITLE
HPCC-11213 Allow roxie queries with ambiguous elements

### DIFF
--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -410,6 +410,13 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="allowAmbiguousRequests" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:appinfo>
+          <tooltip>If enabled, requests will not fail if they contain more than one element of the same name for an item that shouldn't repeat</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="callbackRetries" type="xs:nonNegativeInteger" use="optional" default="3">
       <xs:annotation>
         <xs:appinfo>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -768,6 +768,7 @@
              program="${EXEC_PATH}/ftslave"/>
   </FTSlaveProcess>
   <RoxieCluster allFilesDynamic="true"
+                allowAmbiguousRequests="false"
                 blindLogging="false"
                 blobCacheMem="0"
                 build="${projname}_${version}-${stagever}"

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -327,6 +327,7 @@ extern IPropertyTree* topology;
 extern StringArray allQuerySetNames;
 
 extern bool allFilesDynamic;
+extern bool allowAmbiguousRequests;
 extern bool crcResources;
 extern bool logFullQueries;
 extern bool blindLogging;

--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -1359,12 +1359,18 @@ private:
         else
             throw MakeStringException(ROXIE_DATA_ERROR, "Malformed request");
     }
+    inline byte getQueryPTFlags()
+    {
+        if (allowAmbiguousRequests)
+            return ipt_caseInsensitive | ipt_allowAmbiguousXpath;
+        return ipt_caseInsensitive;
+    }
     void parseQueryPTFromString(Owned<IPropertyTree> &queryPT, HttpHelper &httpHelper, const char *text, PTreeReaderOptions options)
     {
         if (strieq(httpHelper.queryContentType(), "application/json"))
-            queryPT.setown(createPTreeFromJSONString(text, ipt_caseInsensitive, options));
+            queryPT.setown(createPTreeFromJSONString(text, getQueryPTFlags(), options));
         else
-            queryPT.setown(createPTreeFromXMLString(text, ipt_caseInsensitive, options));
+            queryPT.setown(createPTreeFromXMLString(text, getQueryPTFlags(), options));
     }
     void doMain(const char *runQuery)
     {
@@ -1648,7 +1654,7 @@ readAnother:
                                 }
                                 else
                                 {
-                                    IPropertyTree *fixedreq = createPTree(queryName, ipt_caseInsensitive);
+                                    IPropertyTree *fixedreq = createPTree(queryName, getQueryPTFlags());
                                     Owned<IPropertyTreeIterator> iter = queryXml->getElements("*");
                                     ForEach(*iter)
                                     {

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -93,6 +93,7 @@ IPropertyTree* ccdChannels;
 StringArray allQuerySetNames;
 
 bool allFilesDynamic;
+bool allowAmbiguousRequests;
 bool crcResources;
 bool useRemoteResources;
 bool checkFileDate;
@@ -650,6 +651,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         minIbytiDelay = topology->getPropInt("@minIbytiDelay", 2);
         initIbytiDelay = topology->getPropInt("@initIbytiDelay", 50);
         allFilesDynamic = topology->getPropBool("@allFilesDynamic", false);
+        allowAmbiguousRequests = topology->getPropBool("@allowAmbiguousRequests", false);
         crcResources = topology->getPropBool("@crcResources", false);
         ignoreOrphans = topology->getPropBool("@ignoreOrphans", true);
         chunkingHeap = topology->getPropBool("@chunkingHeap", true);

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -1716,7 +1716,7 @@ IPropertyTree *PTree::queryPropTree(const char *xpath) const
     if (iter->first())
     {
         element = &iter->query();
-        if (iter->next())
+        if (iter->next() && !IptFlagTst(flags, ipt_allowAmbiguousXpath))
             AMBIGUOUS_PATH("getProp",xpath);
     }
     return element;

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -169,7 +169,7 @@ interface IPTreeNodeCreator : extends IInterface
 };
 
 // NB ipt_ext5 - used by SDS
-enum ipt_flags { ipt_none=0x00, ipt_caseInsensitive=0x01, ipt_binary=0x02, ipt_ordered=0x04, ipt_ext1=0x08, ipt_ext2=16, ipt_ext3=32, ipt_ext4=64, ipt_ext5=128 };
+enum ipt_flags { ipt_none=0x00, ipt_caseInsensitive=0x01, ipt_binary=0x02, ipt_ordered=0x04, ipt_allowAmbiguousXpath=0x08, ipt_ext2=16, ipt_ext3=32, ipt_ext4=64, ipt_ext5=128 };
 jlib_decl IPTreeMaker *createPTreeMaker(byte flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
 jlib_decl IPTreeMaker *createRootLessPTreeMaker(byte flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
 jlib_decl IPTreeReader *createXMLStreamReader(ISimpleReadStream &stream, IPTreeNotifyEvent &iEvent, PTreeReaderOptions xmlReaderOptions=ptr_ignoreWhiteSpace, size32_t bufSize=0);


### PR DESCRIPTION
Some existing applications migrating to OSS relied on this
undesirable behavior.

Add optional PTree support for not throwing and exception when querying
properties with ambiguous xpaths.  Make it optional by requiring the
flag ipt_allowAmbiguousXpath when creating the PTree.

Add optional roxie support for queries with ambiguous elements.  Make
it configurable using the config option allowAmbiguousRequests.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
