### PR TITLE
HPCC-11214 Improved Page Refresh, Back and Next

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -311,7 +311,6 @@ define([
                 }
             });
             this.initWorkunitsGrid();
-            this.selectChild(this.workunitsTab, true);
 
             this.filter.on("clear", function (evt) {
                 context.refreshGrid();

--- a/esp/src/eclwatch/DFUWUDetailsWidget.js
+++ b/esp/src/eclwatch/DFUWUDetailsWidget.js
@@ -133,7 +133,6 @@ define([
                 });
                 this.wu.refresh();
             }
-            this.selectChild(this.summaryWidget, true);
         },
 
         initTab: function () {

--- a/esp/src/eclwatch/DelayLoadWidget.js
+++ b/esp/src/eclwatch/DelayLoadWidget.js
@@ -50,9 +50,8 @@ define([
 
         ensureWidget: function () {
             var deferred = new Deferred();
-            var childWidgetID = this.id + "-DL";
             if (this.__hpcc_resolved) {
-                deferred.resolve(this.widget[childWidgetID]);
+                deferred.resolve(this.widget[this.childWidgetID]);
             } else {
                 this.__hpcc_resolved = true;
                 this.startLoading();
@@ -62,7 +61,7 @@ define([
                         widget = widget.fixCircularDependency;
                     }
                     var widgetInstance = new widget(lang.mixin({
-                        id: context.id + "-DL",
+                        id: context.childWidgetID,
                         style: {
                             margin: "0px",
                             padding: "0px",
@@ -92,11 +91,30 @@ define([
         init: function (params) {
             if (this.__hpcc_initalized)
                 return;
+
+            this.childWidgetID = this.id + "-DL";
             this.__hpcc_initalized = true;
 
+            var context = this;
             this.ensureWidget().then(function (widget) {
                 widget.init(params);
+                if (context.__hpcc_hash) {
+                    context.doRestoreFromHash(context.__hpcc_hash);
+                    context.__hpcc_hash = null;
+                }
             });
+        },
+        restoreFromHash: function (hash) {
+            if (this.widget && this.widget[this.childWidgetID]) {
+                this.doRestoreFromHash(hash);
+            } else {
+                this.__hpcc_hash = hash;
+            }
+        },    
+        doRestoreFromHash: function (hash) {
+            if (this.widget[this.childWidgetID].restoreFromHash) {
+                this.widget[this.childWidgetID].restoreFromHash(hash);
+            }
         }
     });
 });

--- a/esp/src/eclwatch/EventScheduleWorkunitWidget.js
+++ b/esp/src/eclwatch/EventScheduleWorkunitWidget.js
@@ -94,7 +94,6 @@ define([
                 Target: params.Cluster
             });
             this.initEventGrid();
-            this.selectChild(this.eventTab, true);
 
             this.filter.on("clear", function (evt) {
                 context.refreshGrid();

--- a/esp/src/eclwatch/GetDFUWorkunitsWidget.js
+++ b/esp/src/eclwatch/GetDFUWorkunitsWidget.js
@@ -196,7 +196,6 @@ define([
                 DFUState: true,
                 includeBlank: true
             });
-            this.selectChild(this.workunitsTab, true);
 
             var context = this;
             this.filter.on("clear", function (evt) {

--- a/esp/src/eclwatch/LFDetailsWidget.js
+++ b/esp/src/eclwatch/LFDetailsWidget.js
@@ -179,7 +179,6 @@ define([
                 });
                 this.logicalFile.refresh();
             }
-            this.selectChild(this.summaryWidget, true);
             this.copyTargetSelect.init({
                 Groups: true
             });

--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -326,7 +326,6 @@ define([
                 return;
 
             this.initLandingZonesGrid();
-            this.selectChild(this.landingZonesTab, true);
             this.sprayFixedDestinationSelect.init({
                 Groups: true
             });

--- a/esp/src/eclwatch/QuerySetDetailsWidget.js
+++ b/esp/src/eclwatch/QuerySetDetailsWidget.js
@@ -130,8 +130,6 @@ define([
                 context.updateInput(name, oldValue, newValue);
             });
             this.query.refresh();
-
-            this.selectChild(this.summaryTab, true);
         },
 
         initTab: function () {

--- a/esp/src/eclwatch/QuerySetQueryWidget.js
+++ b/esp/src/eclwatch/QuerySetQueryWidget.js
@@ -125,7 +125,6 @@ define([
                 Target: params.Cluster
             });
             this.initQuerySetGrid();
-            this.selectChild(this.queriesTab, true);
 
             var context = this;
             this.filter.on("clear", function (evt) {

--- a/esp/src/eclwatch/QueryTestWidget.js
+++ b/esp/src/eclwatch/QueryTestWidget.js
@@ -78,8 +78,6 @@ define([
                 return;
 
             this.query = ESPQuery.Get(params.QuerySet, params.QueryId);
-
-            this.selectChild(this.soapTab, true);
         },
 
         setContent: function (target, type, postfix) {

--- a/esp/src/eclwatch/SFDetailsWidget.js
+++ b/esp/src/eclwatch/SFDetailsWidget.js
@@ -145,7 +145,6 @@ define([
                 });
                 this.logicalFile.refresh();
             }
-            this.selectChild(this.summaryWidget, true);
             this.subfilesGrid.startup();
         },
 

--- a/esp/src/eclwatch/WUDetailsWidget.js
+++ b/esp/src/eclwatch/WUDetailsWidget.js
@@ -251,7 +251,6 @@ define([
                 this.wu.refresh();
             }
             this.infoGridWidget.init(params);
-            this.selectChild(this.summaryWidget, true);
         },
 
         initTab: function () {

--- a/esp/src/eclwatch/WUQueryWidget.js
+++ b/esp/src/eclwatch/WUQueryWidget.js
@@ -239,7 +239,6 @@ define([
             });
 
             this.initWorkunitsGrid();
-            this.selectChild(this.workunitsTab, true);
 
             var context = this;
             this.filter.on("clear", function (evt) {

--- a/esp/src/eclwatch/stub.js
+++ b/esp/src/eclwatch/stub.js
@@ -80,6 +80,9 @@ define([
                     widget.placeAt(dojo.body(), "last");
                     widget.startup();
                     widget.init(params);
+                    if (widget.restoreFromHash) {
+                        widget.restoreFromHash(dojoConfig.urlInfo.hash);
+                    }
                 }
 
                 document.title = widget.getTitle ? widget.getTitle() : params.Widget;


### PR DESCRIPTION
Refresh current page now re-selects tabs as far as possible.
Forward and Back buttons now working better.  Previously back would need to be
pressed twice when navigating over the "default" tab for an inner page.

Fixes HPCC-11214

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
