### PR TITLE
HPCC-10451 UnicodeWithinEditN and UnicodeGetRangeOfWords

### DIFF
--- a/plugins/proxies/lib_saltlib.ecllib
+++ b/plugins/proxies/lib_saltlib.ecllib
@@ -15,16 +15,16 @@
     limitations under the License.
 ############################################################################## */
 
-/* Proxy service header for (EE-only) saltlib plugin version SALTLIB 1.0.04 */
+/* Proxy service header for (EE-only) saltlib plugin version SALTLIB 1.0.05 */
 
 export SaltLib := SERVICE : plugin('saltlib')
   boolean UnicodeLocaleWithinEditN(const unicode left, const unicode right, unsigned4 distance,  const varstring localename) : c, pure,entrypoint='ulUnicodeLocaleWithinEditN', hole;
+  boolean UnicodeWithinEditN(const unicode left, const unicode right, unsigned4 distance) : c, pure,entrypoint='ulUnicodeWithinEditN', hole;
   unsigned4 UnicodeLocaleHyphenMatch(const unicode left, const unicode right, unsigned4 minlen,  const varstring localename) : c, pure,entrypoint='ulUnicodeLocaleHyphenMatch', hole;
   unsigned4 UnicodeHyphenMatch(const unicode left, const unicode right, unsigned4 minlen) : c, pure,entrypoint='ulUnicodeHyphenMatch', hole;
-  integer4 UnicodeLocaleMatchBagofwords(const unicode left, const unicode right, const varstring localename, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords', hole;
   unicode UnicodeLocaleGetRangeOfWords(const unicode text, unsigned4 s_index, unsigned4 e_index, const varstring localename) : c,pure,entrypoint='ulUnicodeLocaleGetRangeOfWords';
-  integer4 StringMatchBagofwords(const string left, const string right, unsigned4 mode, unsigned4 score_mode, unsigned fn, unsigned fn_arg1, unsigned fn_arg2) : c, pure,entrypoint='ulStringMatchBagofwords', hole;
-  integer4 UnicodeMatchBagofwords2(const unicode left, const unicode right, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords2', hole;
+  unicode UnicodeGetRangeOfWords(const unicode text, unsigned4 s_index, unsigned4 e_index) : c,pure,entrypoint='ulUnicodeGetRangeOfWords';
+  integer4 UnicodeMatchBagofwords2(const unicode left, const unicode right, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeMatchBagofwords2', hole;
   integer4 UnicodeLocaleMatchBagofwords2(const unicode left, const unicode right, const varstring localename, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulUnicodeLocaleMatchBagofwords2', hole;
   integer4 StringMatchBagofwords2(const string left, const string right, unsigned4 mode, unsigned4 score_mode) : c, pure,entrypoint='ulStringMatchBagofwords2', hole;
 END;


### PR DESCRIPTION
- Add declarations for UnicodeWithinEditN and UnicodeGetRangeOfWords
- Remove declarations for deprecated functions UnicodeLocaleMatchBagofwords
  and StringMatchBagofwords

Signed-off-by: Edin Muharemagic edin.muharemagic@lexisnexis.com
