### PR TITLE
HPCC-11221 - Tool tips not displaying on landing page

### DIFF
--- a/esp/src/eclwatch/HPCCPlatformWidget.js
+++ b/esp/src/eclwatch/HPCCPlatformWidget.js
@@ -178,9 +178,9 @@ define([
             });
 
             this.createStackControllerTooltip(this.id + "_ECL", this.i18n.ECL);
-            this.createStackControllerTooltip(this.id + "_Files", this.i18n.files);
-            this.createStackControllerTooltip(this.id + "_RoxieQueries", this.i18n.publishedQueries);
-            this.createStackControllerTooltip(this.id + "_OPS", this.i18n.operations);
+            this.createStackControllerTooltip(this.id + "_Files", this.i18n.Files);
+            this.createStackControllerTooltip(this.id + "_RoxieQueries", this.i18n.PublishedQueries);
+            this.createStackControllerTooltip(this.id + "_OPS", this.i18n.Operations);
             this.initTab();
         },
 


### PR DESCRIPTION
Due to translations tool tips are not displaying.
Fixes HPCC-11221

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
