### PR TITLE
HPCC-11229 - Fix testLocalCluster dfu check

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -387,7 +387,9 @@ class CDFUengine: public CInterface, implements IDFUengine
         Owned<IPropertyTreeIterator> clusters;
         clusters.setown(root->getElements("ThorCluster"));
         ForEach(*clusters) {
-            if (strcmp(clusters->query().queryProp("@name"),groupname)==0)
+            StringBuffer thorClusterGroupName;
+            getClusterGroupName(clusters->query(), thorClusterGroupName);
+            if (strcmp(thorClusterGroupName.str(),groupname)==0)
                 return true;
         }
         clusters.setown(root->getElements("RoxieCluster"));


### PR DESCRIPTION
Ensure nodeGroup is checked against target groupname, by using
existing helper method getClusterGroupName

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
