### PR TITLE
HPCC-11084 Possible fix for regression created from 9892.

### DIFF
--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -2056,7 +2056,7 @@ void HqlLex::loadXML(const YYSTYPE & errpos, const char *name, const char * chil
         return;
     }
 
-    if (false && inmacro)
+    if (inmacro)
     {
         inmacro->loadXML(errpos, name);
         return;


### PR DESCRIPTION
Removed (FALSE)  short circuited IF statement for loading xml scope within
inmacro lexer.

Signed-off-by: jamienoss james.noss@lexisnexis.com
