### PR TITLE
HPCC-11237 Return correct GraphNum in WsWorkunits/WUGraphTiming

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -5533,7 +5533,7 @@ bool parseGraphTimerLabel(const char *label, StringAttr &graphName, unsigned & g
         }
     }
 
-    if (graphName && memicmp(graphName, "graph", 5))
+    if (graphName && !memicmp(graphName, "graph", 5))
         graphNum = atoi(graphName + 5);
 
     return true;


### PR DESCRIPTION
A bug is fixed for returning GraphNum in WsWorkunits/WUGraphTiming.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
