### PR TITLE
HPCC-11257  make 'hpcc-init stop' return 0 instead 3

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -538,7 +538,7 @@ stop_component() {
           removePid ${PIDPATH}
           unlock ${LOCKPATH}
        fi
-       return ${RCSTOP}
+       return 0
     fi
     
     stopcmd="${START_STOP_DAEMON} -K -p ${PIDPATH} >> tmp.txt 2>&1"
@@ -579,7 +579,7 @@ stop_component() {
         removePid ${PIDPATH}
         unlock ${LOCKPATH}
         log_success_msg  
-        RCSTOP=3
+        RCSTOP=0
     fi
     return ${RCSTOP}
 }


### PR DESCRIPTION
Set return code to 0 instead of 3 in following scenarios:
1) the process is already stopped.
2) the process is stopped after start-stop-daemon -K call and before
   or during the first check_status call.
