### PR TITLE
HPCC-11253 Do not lock superfiles in roxie

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -429,7 +429,7 @@ extern unsigned defaultKeyedJoinPreload;
 extern unsigned defaultPrefetchProjectPreload;
 extern bool defaultCheckingHeap;
 
-extern unsigned delayedSlaveQueryRelease;
+extern unsigned slaveQueryReleaseDelaySeconds;
 
 extern StringBuffer logDirectory;
 extern StringBuffer pluginDirectory;

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -429,6 +429,8 @@ extern unsigned defaultKeyedJoinPreload;
 extern unsigned defaultPrefetchProjectPreload;
 extern bool defaultCheckingHeap;
 
+extern unsigned delayedSlaveQueryRelease;
+
 extern StringBuffer logDirectory;
 extern StringBuffer pluginDirectory;
 extern StringBuffer pluginsList;

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -403,6 +403,19 @@ public:
         return buf.str();
     }
 
+    static const char *getSuperFilePath(StringBuffer &buf, const char *lfn)
+    {
+        CDfsLogicalFileName lfnParser;
+        lfnParser.set(lfn);
+        if (!lfnParser.isForeign())
+        {
+            lfnParser.makeFullnameQuery(buf, DXB_SuperFile, true);
+            return buf.str();
+        }
+        else
+            return NULL;
+    }
+
     virtual IPropertyTree *getPackageMap(const char *id)
     {
         Owned<IPropertyTree> ret = loadDaliTree("PackageMaps/PackageMap", id);
@@ -631,6 +644,16 @@ public:
     {
         StringBuffer xpath;
         return getSubscription(id, getPackageMapPath(xpath, id), notifier);
+    }
+
+    virtual IDaliPackageWatcher *getSuperFileSubscription(const char *lfn, ISDSSubscription *notifier)
+    {
+        StringBuffer xpathBuf;
+        const char *xpath = getSuperFilePath(xpathBuf, lfn);
+        if (xpath)
+            return getSubscription(lfn, xpath, notifier);
+        else
+            return NULL;
     }
 
     virtual bool connected() const

--- a/roxie/ccd/ccddali.hpp
+++ b/roxie/ccd/ccddali.hpp
@@ -49,6 +49,7 @@ interface IRoxieDaliHelper : extends IInterface
     virtual IDaliPackageWatcher *getPackageSetsSubscription(ISDSSubscription *notifier) = 0;
     virtual IPropertyTree *getPackageMap(const char *id) = 0;
     virtual IDaliPackageWatcher *getPackageMapSubscription(const char *id, ISDSSubscription *notifier) = 0;
+    virtual IDaliPackageWatcher *getSuperFileSubscription(const char *lfn, ISDSSubscription *notifier) = 0;
     virtual void releaseSubscription(IDaliPackageWatcher *subscription) = 0;
     virtual bool connect(unsigned timeout) = 0;
     virtual void disconnect() = 0;

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1681,11 +1681,14 @@ protected:
     {
         if (traceLevel > 2)
             DBGLOG("Superfile %s change detected", lfn.get());
-        CriticalBlock b(lock);
-        if (cached)
+
         {
-            cached->removeCache(this);
-            cached = NULL;
+            CriticalBlock b(lock);
+            if (cached)
+            {
+                cached->removeCache(this);
+                cached = NULL;
+            }
         }
         globalPackageSetManager->requestReload();
     }
@@ -1746,6 +1749,7 @@ public:
     }
     virtual void beforeDispose()
     {
+        notifier.clear();
         if (cached)
         {
             cached->removeCache(this);

--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -120,7 +120,7 @@ interface IResolvedFileCreator : extends IResolvedFile
 };
 
 extern IResolvedFileCreator *createResolvedFile(const char *lfn, const char *physical, bool isSuperFile);
-extern IResolvedFile *createResolvedFile(const char *lfn, const char *physical, IDistributedFile *dFile, IRoxieDaliHelper *daliHelper, bool cacheIt, bool writeAccess);
+extern IResolvedFile *createResolvedFile(const char *lfn, const char *physical, IDistributedFile *dFile, IRoxieDaliHelper *daliHelper, bool isDynamic, bool cacheIt, bool writeAccess);
 
 interface IRoxiePublishCallback
 {

--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -99,6 +99,7 @@ interface IResolvedFile : extends ISimpleSuperFileEnquiry
 
     virtual const CDateTime &queryTimeStamp() const = 0;
     virtual unsigned queryCheckSum() const = 0;
+    virtual hash64_t addHash64(hash64_t hashValue) const = 0;
 
     virtual const char *queryPhysicalName() const = 0; // Returns NULL unless in local file mode.
     virtual const char *queryFileName() const = 0;

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -129,6 +129,8 @@ unsigned defaultKeyedJoinPreload = 0;
 unsigned dafilesrvLookupTimeout = 10000;
 bool defaultCheckingHeap = false;
 
+unsigned delayedSlaveQueryRelease = 60;
+
 unsigned logQueueLen;
 unsigned logQueueDrop;
 bool useLogQueue;
@@ -719,6 +721,8 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         defaultKeyedJoinPreload = topology->getPropInt("@defaultKeyedJoinPreload", 0);
         defaultPrefetchProjectPreload = topology->getPropInt("@defaultPrefetchProjectPreload", 10);
         defaultCheckingHeap = topology->getPropInt("@checkingHeap", false);  // NOTE - not in configmgr - too dangerous!
+        delayedSlaveQueryRelease = topology->getPropInt("@delayedSlaveQueryRelease", false);
+
         diskReadBufferSize = topology->getPropInt("@diskReadBufferSize", 0x10000);
         fieldTranslationEnabled = topology->getPropBool("@fieldTranslationEnabled", false);
 

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -923,6 +923,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
 
         setDaliServixSocketCaching(true);  // enable daliservix caching
         loadPlugins();
+        createDelayedReleaser();
         globalPackageSetManager = createRoxiePackageSetManager(standAloneDll.getClear());
         globalPackageSetManager->load();
         unsigned snifferChannel = numChannels+2; // MORE - why +2 not +1 ??
@@ -1047,6 +1048,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
     stopPerformanceMonitor();
     ::Release(globalPackageSetManager);
     globalPackageSetManager = NULL;
+    stopDelayedReleaser();
     cleanupPlugins();
     closeMulticastSockets();
     releaseSlaveDynamicFileCache();

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -129,7 +129,7 @@ unsigned defaultKeyedJoinPreload = 0;
 unsigned dafilesrvLookupTimeout = 10000;
 bool defaultCheckingHeap = false;
 
-unsigned delayedSlaveQueryRelease = 60;
+unsigned slaveQueryReleaseDelaySeconds = 60;
 
 unsigned logQueueLen;
 unsigned logQueueDrop;
@@ -720,8 +720,9 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         defaultFullKeyedJoinPreload = topology->getPropInt("@defaultFullKeyedJoinPreload", 0);
         defaultKeyedJoinPreload = topology->getPropInt("@defaultKeyedJoinPreload", 0);
         defaultPrefetchProjectPreload = topology->getPropInt("@defaultPrefetchProjectPreload", 10);
-        defaultCheckingHeap = topology->getPropInt("@checkingHeap", false);  // NOTE - not in configmgr - too dangerous!
-        delayedSlaveQueryRelease = topology->getPropInt("@delayedSlaveQueryRelease", false);
+        defaultCheckingHeap = topology->getPropBool("@checkingHeap", false);  // NOTE - not in configmgr - too dangerous!
+
+        slaveQueryReleaseDelaySeconds = topology->getPropInt("@slaveQueryReleaseDelaySeconds", 60);
 
         diskReadBufferSize = topology->getPropInt("@diskReadBufferSize", 0x10000);
         fieldTranslationEnabled = topology->getPropBool("@fieldTranslationEnabled", false);

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -898,11 +898,57 @@ public:
             return NULL;
     }
 
-    static hash64_t getQueryHash(const char *id, const IQueryDll *dll, const IHpccPackage &package, const IPropertyTree *stateInfo)
+    static hash64_t getQueryHash(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo, IArrayOf<IResolvedFile> &files)
     {
         hash64_t hashValue = package.queryHash();
         if (dll)
+        {
             hashValue = rtlHash64VStr(dll->queryDll()->queryName(), hashValue);
+            if (!allFilesDynamic)
+            {
+                IConstWorkUnit *wu = dll->queryWorkUnit();
+                if (wu) // wu may be null in some unit test cases
+                {
+                    SCMStringBuffer bStr;
+                    if (getClusterType(wu->getDebugValue("targetClusterType", bStr).str(), RoxieCluster) == RoxieCluster)
+                    {
+                        Owned<IConstWUGraphIterator> graphs = &wu->getGraphs(GraphTypeActivities);
+                        ForEach(*graphs)
+                        {
+                            Owned<IPropertyTree> graphXgmml = graphs->query().getXGMMLTree(false);
+                            Owned<IPropertyTreeIterator> nodes = graphXgmml->getElements(".//node");
+                            ForEach(*nodes)
+                            {
+                                IPropertyTree &node = nodes->query();
+                                const char *fileName = queryNodeFileName(node);
+                                const char *indexName = queryNodeIndexName(node);
+                                // MORE - what about write? What about packages that resolve everything without dali?
+                                if (indexName && (!fileName || !streq(indexName, fileName)))
+                                {
+                                    bool isOpt = node.getPropBool("att[@name='_isIndexOpt']/@value") || pretendAllOpt;
+                                    const IResolvedFile *indexFile = package.lookupFileName(indexName, isOpt, true, true, wu);
+                                    if (indexFile)
+                                    {
+                                        hashValue = indexFile->addHash64(hashValue);
+                                        files.append(*const_cast<IResolvedFile *>(indexFile));
+                                    }
+                                }
+                                if (fileName)
+                                {
+                                    bool isOpt = node.getPropBool("att[@name='_isOpt']/@value") || pretendAllOpt;
+                                    const IResolvedFile *dataFile = package.lookupFileName(fileName, isOpt, true, true, wu);
+                                    if (dataFile)
+                                    {
+                                        hashValue = dataFile->addHash64(hashValue);
+                                        files.append(*const_cast<IResolvedFile *>(dataFile));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
         if (id)
             hashValue = rtlHash64VStr(id, hashValue);
         if (stateInfo)
@@ -1408,10 +1454,11 @@ static void checkWorkunitVersionConsistency(const IQueryDll *dll)
         throw MakeStringException(ROXIE_MISMATCH, "Workunit did not export createProcess function");
 }
 
-extern IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IHpccPackage &package, const IPropertyTree *stateInfo, bool isDynamic, bool forceRetry)
+extern IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo, bool isDynamic, bool forceRetry)
 {
     CriticalBlock b(CQueryFactory::queryCreateLock);
-    hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo);
+    IArrayOf<IResolvedFile> queryFiles; // Note - these should stay in scope long enough to ensure still cached when (if) query is loaded for real
+    hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo, queryFiles);
     IQueryFactory *cached = getQueryFactory(hashValue, 0);
     if (cached && !(cached->loadFailed() && (reloadRetriesFailed || forceRetry)))
     {
@@ -1674,10 +1721,11 @@ public:
     }
 };
 
-IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IHpccPackage &package, unsigned channel, const IPropertyTree *stateInfo, bool isDynamic, bool forceRetry)
+IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, unsigned channel, const IPropertyTree *stateInfo, bool isDynamic, bool forceRetry)
 {
     CriticalBlock b(CQueryFactory::queryCreateLock);
-    hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo);
+    IArrayOf<IResolvedFile> queryFiles; // Note - these should stay in scope long enough to ensure still cached when (if) query is loaded for real
+    hash64_t hashValue = CQueryFactory::getQueryHash(id, dll, package, stateInfo, queryFiles);
     IQueryFactory *cached = getQueryFactory(hashValue, channel);
     if (cached)
     {

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -246,8 +246,8 @@ extern const IQueryDll *createExeQueryDll(const char *exeName);
 extern const IQueryDll *createWuQueryDll(IConstWorkUnit *wu);
 
 extern IRecordLayoutTranslator *createRecordLayoutTranslator(const char *logicalName, IDefRecordMeta const * diskMeta, IDefRecordMeta const * activityMeta);
-extern IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IHpccPackage &package, const IPropertyTree *stateInfo, bool isDynamic, bool forceRetry);
-extern IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IHpccPackage &package, unsigned _channelNo, const IPropertyTree *stateInfo, bool isDynamic, bool forceRetry);
+extern IQueryFactory *createServerQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo, bool isDynamic, bool forceRetry);
+extern IQueryFactory *createSlaveQueryFactory(const char *id, const IQueryDll *dll, const IRoxiePackage &package, unsigned _channelNo, const IPropertyTree *stateInfo, bool isDynamic, bool forceRetry);
 extern IQueryFactory *getQueryFactory(hash64_t hashvalue, unsigned channel);
 extern IQueryFactory *createServerQueryFactoryFromWu(IConstWorkUnit *wu);
 extern IQueryFactory *createSlaveQueryFactoryFromWu(IConstWorkUnit *wu, unsigned channelNo);

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -74,7 +74,7 @@ SafePluginMap *plugins;
 
 const char *queryNodeFileName(const IPropertyTree &graphNode)
 {
-    if (graphNode.hasProp("att[@name='_fileName_dynamic']"))
+    if (graphNode.hasProp("att[@name='_file_dynamic']"))
         return NULL;
     else
         return graphNode.queryProp("att[@name='_fileName']/@value");
@@ -82,13 +82,13 @@ const char *queryNodeFileName(const IPropertyTree &graphNode)
 
 const char *queryNodeIndexName(const IPropertyTree &graphNode)
 {
-    if (graphNode.hasProp("att[@name='_indexFileName_dynamic']"))
+    if (graphNode.hasProp("att[@name='_indexFile_dynamic']"))
         return NULL;
     else
     {
         const char * id = graphNode.queryProp("att[@name='_indexFileName']/@value");
         if (!id)
-            id = graphNode.queryProp("att[@name='_fileName']/@value");
+            id = queryNodeFileName(graphNode);
         return id;
     }
 }

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -172,7 +172,22 @@ public:
         }
         queue.append(*new DelayedReleaseQueueItem(_goer, delaySeconds));
     }
-} delayedReleaser;
+};
+
+Owned<DelayedReleaserThread> delayedReleaser;
+
+void createDelayedReleaser()
+{
+    delayedReleaser.setown(new DelayedReleaserThread);
+}
+
+void stopDelayedReleaser()
+{
+    if (delayedReleaser)
+        delayedReleaser->stop();
+    delayedReleaser.clear();
+}
+
 
 //-------------------------------------------------------------------------
 
@@ -1237,7 +1252,7 @@ protected:
             queryHash = newHash;
         }
         if (slaveQueryReleaseDelaySeconds)
-            delayedReleaser.delayedRelease(oldSlaveManagers.getClear(), slaveQueryReleaseDelaySeconds);
+            delayedReleaser->delayedRelease(oldSlaveManagers.getClear(), slaveQueryReleaseDelaySeconds);
     }
 
     mutable CriticalSection updateCrit;  // protects updates of slaveManagers and serverManager

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -118,6 +118,7 @@ interface IRoxieQuerySetManagerSet : extends IInterface
 
 interface IRoxieQueryPackageManagerSet : extends IInterface
 {
+    virtual void requestReload() = 0;
     virtual void load() = 0;
     virtual void doControlMessage(IPropertyTree *xml, StringBuffer &reply, const IRoxieContextLogger &ctx) = 0;
     virtual IQueryFactory *getQuery(const char *id, StringBuffer *querySet, const IRoxieContextLogger &logctx) const = 0;
@@ -141,8 +142,5 @@ extern void mergeQueries(IPropertyTree *s1, IPropertyTree *s2);
 
 extern const char *queryNodeFileName(const IPropertyTree &graphNode);
 extern const char *queryNodeIndexName(const IPropertyTree &graphNode);
-
-extern IPropertyTreeIterator *getNodeSubFileNames(const IPropertyTree &graphNode);
-extern IPropertyTreeIterator *getNodeSubIndexNames(const IPropertyTree &graphNode);
 
 #endif

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -143,4 +143,7 @@ extern void mergeQueries(IPropertyTree *s1, IPropertyTree *s2);
 extern const char *queryNodeFileName(const IPropertyTree &graphNode);
 extern const char *queryNodeIndexName(const IPropertyTree &graphNode);
 
+extern void createDelayedReleaser();
+extern void stopDelayedReleaser();
+
 #endif


### PR DESCRIPTION
In place of locking superfiles, we subscribe to them so that if they change
any queries using them are automatically reloaded.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
