### PR TITLE
HPCC-11136 - Fix problems writing to external files

### DIFF
--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -318,6 +318,8 @@ extern da_decl bool setReplicateDir(const char *name,StringBuffer &out, bool isr
 
 extern da_decl IFileDescriptor *createFileDescriptor();
 extern da_decl IFileDescriptor *createFileDescriptor(IPropertyTree *attr);      // ownership of attr tree is taken
+extern da_decl IFileDescriptor *createExternalFileDescriptor(const char *logicalname);
+extern da_decl IFileDescriptor *getExternalFileDescriptor(const char *logicalname, CDateTime *modTime=NULL);
 extern da_decl ISuperFileDescriptor *createSuperFileDescriptor(IPropertyTree *attr);        // ownership of attr tree is taken
 extern da_decl IFileDescriptor *deserializeFileDescriptor(MemoryBuffer &mb);
 extern da_decl IFileDescriptor *deserializeFileDescriptorTree(IPropertyTree *tree, INamedGroupStore *resolver=NULL, unsigned flags=0);  // flags IFDSF_*

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -2891,12 +2891,22 @@ public:
         }
         if (!onlylocal)
         {
-            dfile.setown(queryDistributedFileDirectory().lookup(lfn,user,write));
-            if (dfile.get())
+            if (lfn.isExternal())
             {
+                Owned<IFileDescriptor> fDesc = createExternalFileDescriptor(lfn.get());
+                dfile.setown(queryDistributedFileDirectory().createNew(fDesc, true));
+                Owned<IFile> file = getPartFile(0,0);
+                if (file.get())
+                    fileExists = file->exists();
                 if (write && lfn.isExternal()&&(dfile->numParts()==1))   // if it is writing to an external file then don't return distributed
                     dfile.clear();
                 return true;
+            }
+            else
+            {
+                dfile.setown(queryDistributedFileDirectory().lookup(lfn,user,write));
+                if (dfile.get())
+                    return true;
             }
             // MORE - should we create the IDistributedFile here ready for publishing (and/or to make sure it's locked while we write)?
             StringBuffer physicalPath;

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -427,7 +427,7 @@ void CHThorDiskWriteActivity::resolve()
                 else
                     throw MakeStringException(99, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", lfn.str());
             }
-            else if (f->exists() || agent.queryResolveFilesLocally())
+            else
             {
                 // special/local/external file
                 if (f->numParts()!=1)
@@ -675,7 +675,8 @@ void CHThorDiskWriteActivity::publish()
         logicalName.allowOsPath(true);
     if (!logicalName.setValidate(lfn.str()))
         throw MakeStringException(99, "Cannot publish %s, invalid logical name", lfn.str());
-    if (!logicalName.isExternal()) { // no need to publish externals
+    if (!logicalName.isExternal()) // no need to publish externals
+    {
         Owned<IDistributedFile> file = queryDistributedFileDirectory().createNew(desc);
         if(file->getModificationTime(modifiedTime))
             file->setAccessedTime(modifiedTime);

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -309,13 +309,13 @@ void CWriteMasterBase::done()
 
 void CWriteMasterBase::slaveDone(size32_t slaveIdx, MemoryBuffer &mb)
 {
-    if (dlfn.isExternal())
-        return;
     if (mb.length()) // if 0 implies aborted out from this slave.
     {
         rowcount_t slaveProcessed;
         mb.read(slaveProcessed);
         recordsProcessed += slaveProcessed;
+        if (dlfn.isExternal())
+            return;
 
         offset_t size, physicalSize;
         mb.read(size);

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -399,8 +399,8 @@ public:
             }
         }
         Owned<IFileDescriptor> desc;
-        if (efile.get() && !temporary && dlfn.isExternal())
-            desc.setown(efile->getFileDescriptor());
+        if (!temporary && dlfn.isExternal())
+            desc.setown(createExternalFileDescriptor(dlfn.get()));
         else
         {
             desc.setown(createFileDescriptor());


### PR DESCRIPTION
Problems:
1) DFS lookup was unconditionally creating a IDistributedFile for
externals
2) Thor by accident rather than by design relied on previous
lookup of the external, to create the distributed file as a
side-effect. And then due to the false-positive lookup, required
OVERWRITE despite the file being missing.
3) HThor always wrote to the wrong place (treated it a standard
scope name) and ignored overwrite.
4) Roxie failed in DFS detach() - fix detach() so it can handle
externals.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
