### PR TITLE
HPCC-11276 Search queries by WUID in WsWorkunits.WUListQueries

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1246,6 +1246,7 @@ ESPrequest [nil_remove] WUListQueriesRequest
     nonNegativeInteger PriorityHigh;
     [min_ver("1.48")] bool Activated;
     [min_ver("1.48")] bool SuspendedByUser;
+    [min_ver("1.50")] string WUID;
 
     nonNegativeInteger PageSize(0);
     nonNegativeInteger PageStartFrom(0);

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1156,6 +1156,7 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
     MemoryBuffer filterBuf;
     const char* clusterReq = req.getClusterName();
     addWUQSQueryFilter(filters, filterCount, filterBuf, req.getQuerySetName(), WUQSFQuerySet);
+    addWUQSQueryFilter(filters, filterCount, filterBuf, req.getWUID(), WUQSFwuid);
     if (!req.getMemoryLimitLow_isNull())
         addWUQSQueryFilterInt64(filters, filterCount, filterBuf, req.getMemoryLimitLow(), (WUQuerySortField) (WUQSFmemoryLimit | WUQSFnumeric));
     if (!req.getMemoryLimitHigh_isNull())


### PR DESCRIPTION
By this fix, WUID can be used for searching queries in WsWorkunits.
WUListQueries.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
