### PR TITLE
HPCC-11187 ecl-queries-list should show wuid and snapshot info

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -9488,7 +9488,7 @@ static void clearAliases(IPropertyTree * queryRegistry, const char * id)
     }
 }
 
-IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll, bool library, const char *userid)
+IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, const char * wuid, const char * dll, bool library, const char *userid, const char *snapshot)
 {
     StringBuffer lcName(name);
     lcName.toLowerCase();
@@ -9520,6 +9520,8 @@ IPropertyTree * addNamedQuery(IPropertyTree * queryRegistry, const char * name, 
         newEntry->setPropBool("@isLibrary", true);
     if (userid && *userid)
         newEntry->setProp("@publishedBy", userid);
+    if (snapshot && *snapshot)
+        newEntry->setProp("@snapshot", snapshot);
     return queryRegistry->addPropTree("Query", newEntry);
 }
 
@@ -9791,6 +9793,9 @@ void addQueryToQuerySet(IWorkUnit *workunit, const char *querySetName, const cha
     SCMStringBuffer targetClusterType;
     workunit->getDebugValue("targetclustertype", targetClusterType);
 
+    SCMStringBuffer snapshot;
+    workunit->getSnapshot(snapshot);
+
     if (currentTargetClusterType.length() < 1) 
     {
         queryRegistry->setProp("@targetclustertype", targetClusterType.str());
@@ -9803,7 +9808,7 @@ void addQueryToQuerySet(IWorkUnit *workunit, const char *querySetName, const cha
         }
     }
 
-    IPropertyTree *newEntry = addNamedQuery(queryRegistry, cleanQueryName, wuid.str(), dllName.str(), isLibrary(workunit), userid);
+    IPropertyTree *newEntry = addNamedQuery(queryRegistry, cleanQueryName, wuid.str(), dllName.str(), isLibrary(workunit), userid, snapshot.str());
     newQueryId.append(newEntry->queryProp("@id"));
     workunit->setIsQueryService(true); //will check querysets before delete
     workunit->commit();

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -192,38 +192,50 @@ public:
         line.append(suspendedOnCluster ? 'X' : ' ');
         line.append(query.getSuspended() ? 'S' : ' ');
         line.append(isActive ? 'A' : ' ');
-        line.append(' ').append(queryid);
-        if (!query.getTimeLimit_isNull())
-        {
-            if (line.length() < 34)
-                line.appendN(34 - line.length(), ' ');
-            line.append(' ').append(query.getTimeLimit());
-        }
-        if (!query.getWarnTimeLimit_isNull())
-        {
-            if (line.length() < 41)
-                line.appendN(41 - line.length(), ' ');
-            line.append(' ').append(query.getWarnTimeLimit());
-        }
-        if (query.getPriority())
-        {
-            if (line.length() < 48)
-                line.appendN(48 - line.length(), ' ');
-            line.append(' ').append(query.getPriority());
-        }
-        if (query.getMemoryLimit())
-        {
-            if (line.length() < 53)
-                line.appendN(53 - line.length(), ' ');
-            line.append(' ').append(query.getMemoryLimit());
-        }
+        line.append("  ").append(queryid);
+        if (line.length() < 34)
+            line.appendN(34 - line.length(), ' ');
+        line.append(' ').append(query.getWuid());
         if (query.getComment())
         {
-            if (line.length() < 64)
-                line.appendN(64 - line.length(), ' ');
+            if (line.length() < 51)
+                line.appendN(51 - line.length(), ' ');
             line.append(' ').append(query.getComment());
         }
         fputs(line.append('\n').str(), stdout);
+        StringBuffer metaTags;
+        if (!query.getTimeLimit_isNull())
+            metaTags.append("timeLimit=").append(query.getTimeLimit());
+        if (!query.getWarnTimeLimit_isNull())
+        {
+            if (metaTags.length())
+                metaTags.append(", ");
+            metaTags.append("warnTimeLimit=").append(query.getWarnTimeLimit());
+        }
+        if (query.getPriority())
+        {
+            if (metaTags.length())
+                metaTags.append(", ");
+            metaTags.append("priority=").append(query.getPriority());
+        }
+        if (query.getMemoryLimit())
+        {
+            if (metaTags.length())
+                metaTags.append(", ");
+            metaTags.append("memLimit=").append(query.getMemoryLimit());
+        }
+        if (query.getSnapshot())
+        {
+            if (metaTags.length())
+                metaTags.append(", ");
+            metaTags.append("snapshot=").append(query.getSnapshot());
+        }
+        if (metaTags.length())
+        {
+            fputs("          [", stdout);
+            fputs(metaTags.str(), stdout);
+            fputs("]\n\n", stdout);
+        }
     }
 
     void outputQueryset(IConstWUQuerySetDetail &qs)
@@ -232,9 +244,8 @@ public:
         if (qs.getQuerySetName())
             fprintf(stdout, "\nTarget: %s\n", qs.getQuerySetName());
         fputs("\n", stdout);
-        fputs("                                   Time   Warn        Memory\n", stdout);
-        fputs("Flags Query Id                     Limit  Limit  Pri  Limit      Comment\n", stdout);
-        fputs("----- ---------------------------- ------ ------ ---- ---------- ------------\n", stdout);
+        fputs("Flags Query Id                     WUID             Comment\n", stdout);
+        fputs("----- ---------------------------- ---------------- ------------\n", stdout);
 
         IArrayOf<IConstQuerySetQuery> &queries = qs.getQueries();
         ForEachItemIn(id, queries)

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1189,6 +1189,7 @@ ESPStruct [nil_remove] QuerySetQuery
     [min_ver("1.46")] bool IsLibrary;
     [min_ver("1.46")] bool Activated;
     [min_ver("1.46")] string PublishedBy;
+    [min_ver("1.48")] string snapshot;
 };
 
 ESPStruct QuerySetAlias
@@ -1474,7 +1475,7 @@ ESPresponse [exceptions_inline] WUCreateZAPInfoResponse
 };
 
 ESPservice [
-    version("1.47"), default_client_version("1.47"),
+    version("1.48"), default_client_version("1.48"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -816,6 +816,8 @@ void gatherQuerySetQueryDetails(IEspContext &context, IPropertyTree *query, IEsp
         queryInfo->setPriority(getQueryPriorityName(query->getPropInt("@priority")));
     if (query->hasProp("@comment"))
         queryInfo->setComment(query->queryProp("@comment"));
+    if (query->hasProp("@snapshot"))
+        queryInfo->setSnapshot(query->queryProp("@snapshot"));
     double version = context.getClientVersion();
     if (version >= 1.46)
     {


### PR DESCRIPTION
Add wuid and snapshot info to the output of ecl-queries-list.

Reformat output to be more readable and extensible.

For performance reasons snapshot will only show up for queries published
after the build containing this change in installed.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
