### PR TITLE
HPCC-11282 OSX build error - sem_timedwait not defined

### DIFF
--- a/system/jlib/jsem.hpp
+++ b/system/jlib/jsem.hpp
@@ -121,7 +121,10 @@ protected:
 
 #include <semaphore.h>
 
-//#define USE_OLD_SEMAPHORE_CODE
+#ifdef __APPLE__
+ // sem_timedwait is not available in OSX, so continue to use old code
+ #define USE_OLD_SEMAPHORE_CODE
+#endif
 
 class jlib_decl Semaphore
 {


### PR DESCRIPTION
Go back to old semaphore code on OSX

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
