### PR TITLE
HPCC-11280 Fix trivial clang warning about nested comments

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1386,7 +1386,7 @@ protected:
         else
         {
             /* NB: It is likely that there will be unflushed rows in the rhsNodeRows arrays after we are done here.
-            /* These will need flushing when all is done and clearNonLocalRows will need recalling to process rest
+             * These will need flushing when all is done and clearNonLocalRows will need recalling to process rest
              */
             ForEachItemIn(a, rhsNodeRows)
             {


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
