### PR TITLE
HPCC-11284 Assert failure on certain (unusual) file names in Roxie queri...

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -344,6 +344,35 @@ private:
         return dstfdesc.getClear();
     }
 
+    static StringBuffer &normalizeName(const char *name, StringBuffer &ret)
+    {
+        // Ensure only chars that are accepted by jptree in an xpath element are used
+        loop
+        {
+            char c = *name++;
+            if (!c)
+                break;
+            switch (c)
+            {
+            case '.':
+                ret.append(".."); // Double . as we use it to escape illegal chars
+                break;
+            case ':':
+            case '_':
+            case '-':
+                ret.append(c);
+                break;
+            default:
+                if (isalnum(c))
+                    ret.append(c); // Note - we COULD make the cache case-insensitive and we would be right to 99.9% if the time. But there is a weird syntax using H to force uppercase filenames...
+                else
+                    ret.append('.').append((unsigned) (unsigned char) c);
+                break;
+            }
+        }
+        return ret;
+    }
+
 public:
 
     IMPLEMENT_IINTERFACE;
@@ -488,8 +517,7 @@ public:
     virtual IFileDescriptor *resolveCachedLFN(const char *logicalName)
     {
         StringBuffer xpath("Files/");
-        StringBuffer lcname;
-        xpath.append(lcname.append(logicalName).toLowerCase());
+        normalizeName(logicalName, xpath);
         Owned<IPropertyTree> pt = readCache(xpath.str());
         if (pt)
         {
@@ -717,8 +745,7 @@ protected:
         if (fd)
             pt.setown(fd->getFileTree());
         StringBuffer xpath("Files/");
-        StringBuffer lcname;
-        xpath.append(lcname.append(logicalName).toLowerCase());
+        normalizeName(logicalName, xpath);
         writeCache(xpath.str(), xpath.str(), pt);
     }
 };

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -401,7 +401,7 @@ protected:
                 {
                     if (subFileName.charAt(0)=='~')
                     {
-                        // implies that a package file had ~ in subfile names - shouldn;t really, but we allow it (and just strip the ~
+                        // implies that a package file had ~ in subfile names - shouldn't really, but we allow it (and just strip the ~)
                         subFileName.remove(0,1);
                     }
                     if (traceLevel > 9)


### PR DESCRIPTION
...es

File names that might be accepted by dali but which contain characters that
are not accepted in an xpath will cause asserts in Roxie's local cache of dali
information

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
