### PR TITLE
HPCC-11281 Fix OSX compile issues with file caching

### DIFF
--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -2470,9 +2470,15 @@ int CSysLogEventLogger::writeDataLog(size32_t datasize, byte const * data)
         data += written;
         datasize -= written;
     }
-#ifdef __linux__
+#ifndef _WIN32
+#ifdef F_FULLFSYNC
+    fcntl(dataLogFile, F_FULLFSYNC);
+#else
     fdatasync(dataLogFile);
+#endif
+#ifdef POSIX_FADV_DONTNEED
     posix_fadvise(dataLogFile, 0, 0, POSIX_FADV_DONTNEED);
+#endif
 #endif
     return fpos;
 }


### PR DESCRIPTION
Should fix OSX compile issues.
Or I could add to platform.h generic logic to determine if posix_fadvise() exists from XOPEN_SOURCE and/or POSIX_C_SOURCE values and use that macro.  Which is more preferable ?
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
