### PR TITLE
HPCC-11304 Field translation options not working correctly

### DIFF
--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -105,6 +105,7 @@ protected:
     virtual bool getEnableFieldTranslation() const
     {
         const char *val = queryEnv("control:enableFieldTranslation");
+        if (!val) val = queryEnv("enableFieldTranslation"); // Backward compatibility
         if (val)
             return strToBool(val);
         else

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -856,7 +856,7 @@ public:
         memoryLimit = defaultMemoryLimit;
         timeLimit = defaultTimeLimit[priority];
         warnTimeLimit = 0;
-        enableFieldTranslation = fieldTranslationEnabled;
+        enableFieldTranslation = package.getEnableFieldTranslation();
 
     }
 
@@ -928,7 +928,7 @@ public:
             timeLimit = (unsigned) wu->getDebugValueInt("timeLimit", defaultTimeLimit[priority]);
             warnTimeLimit = (unsigned) wu->getDebugValueInt("warnTimeLimit", 0);
             SCMStringBuffer bStr;
-            enableFieldTranslation = strToBool(wu->getDebugValue("layoutTranslationEnabled", bStr).str());
+            enableFieldTranslation = wu->getDebugValueBool("layoutTranslationEnabled", enableFieldTranslation);
 
             // MORE - does package override stateInfo, or vice versa?
 


### PR DESCRIPTION
There are several mechanisms for controlling whether field translation should
be allowed.
1. In the workunit, using #option (layoutTranslationEnabled,1)
2. In the package file, using control:enableFieldTranslation=”1”
3. In the RoxieTopology.xml file, using fieldTranslationEnabled=”1”

The global setting can be overridden temporarily (until the next time “service
hpcc-init start” is executed) using testsocket

In theory, the workunit setting should (if present) override the package file,
which should in turn (if present) override the global setting. If none are
present, field translation is disabled.

However, the workunit setting was always used, defaulting to false if not
present.

Also make the control: optional in the package file for back-compatibility

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
