### PR TITLE
HPCC-11311 Show exception when Queries Using file is run on LDAP system

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1261,6 +1261,10 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
 
 bool CWsWorkunitsEx::onWUListQueriesUsingFile(IEspContext &context, IEspWUListQueriesUsingFileRequest &req, IEspWUListQueriesUsingFileResponse &resp)
 {
+    ISecManager *secmgr = context.querySecManager();
+    if (secmgr && secmgr->querySecMgrType()==SMT_LDAP)
+        throw MakeStringException(ECLWATCH_INVALID_SEC_MANAGER, "List Queries using file not yet supported in LDAP enabled environments");
+
     const char *target = req.getTarget();
     const char *process = req.getProcess();
 


### PR DESCRIPTION
This is not yet supported, but displaying "no queries found" is misleading.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
