### PR TITLE
HPCC-10454 Fix build break in windows - missing _API specifier

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1354,6 +1354,6 @@ extern WORKUNIT_API void descheduleWorkunit(char const * wuid);
 void WORKUNIT_API testWorkflow();
 #endif
 
-const char * getWorkunitStateStr(WUState state);
+extern WORKUNIT_API const char * getWorkunitStateStr(WUState state);
 
 #endif


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
