### PR TITLE
HPCC-11335 Allow cross-site WsEcl calls

### DIFF
--- a/esp/src/eclwatch/WsEcl.js
+++ b/esp/src/eclwatch/WsEcl.js
@@ -47,10 +47,19 @@ define([
         Call: function (target, method, query) {
             var deferred = new Deferred();
             var context = this;
-            xhr.get("/WsEcl/submit/query/" + target + "/" + method + "/json", {
-                query: query,
-                handleAs: "json"
-            }).then(function (response) {
+            var request = null;
+            if (dojoConfig.urlInfo.baseHost) {
+                request = script.get(dojoConfig.urlInfo.baseHost + "/WsEcl/submit/query/" + target + "/" + method + "/json", {
+                    query: query,
+                    jsonp: "jsonp"
+                });
+            } else {
+                request = xhr.get("/WsEcl/submit/query/" + target + "/" + method + "/json", {
+                    query: query,
+                    handleAs: "json"
+                });
+            }
+            request.then(function (response) {
                 var results = response[method + "Response"] && response[method + "Response"].Results ? response[method + "Response"].Results : {};
                 results = context._flattenResults(results);
                 deferred.resolve(results);

--- a/esp/src/eclwatch/dojoConfig.js
+++ b/esp/src/eclwatch/dojoConfig.js
@@ -12,6 +12,7 @@ var dojoConfig = (function () {
             pathname: location.pathname,
             hash: hashNodes.length >= 2 ? hashNodes[1] : "",
             params: searchNodes.length >= 2 ? searchNodes[1] : "",
+            baseHost: baseHost,
             basePath: baseHost + "/esp/files",
             resourcePath: baseHost + "/esp/files/eclwatch",
             scriptsPath: baseHost + "/esp/files/eclwatch",


### PR DESCRIPTION
Similar to the way WsEcl.Submit resolves the crosssite calls via topology,
resource calls can override crosssite target via "debugConfig"

Fixes HPCC-11335

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
