### PR TITLE
HPCC-11332 Recategorize joinmulti test as a stress test

### DIFF
--- a/testing/ecl/joinmulti.ecl
+++ b/testing/ecl/joinmulti.ecl
@@ -1,3 +1,4 @@
+//class=stress
 unsigned numgroups := 10000;
 unsigned largeGroupSize := 500;
 unsigned largeGroupFreq := 30;


### PR DESCRIPTION
As it takes ~6 minutes to run

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
