### PR TITLE
HPCC-11348 ecltest setup missing some options

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -1,4 +1,4 @@
-Overview of Regression Suite usage (v:0.0.15)
+Overview of Regression Suite usage (v:0.0.16)
 ==============================================
 
 To use Regression Suite change directory to HPCC-Platform/testing/regress subdirectory.
@@ -72,13 +72,14 @@ Command:
 Result:
 
 |
-|       usage: usage: ecl-test setup [-h] [--target [TARGET]]
+|       usage: usage: ecl-test setup [-h] [--target [TARGET]] [--pq threadNumber]
 |
 |       optional arguments:
 |         -h, --help            show this help message and exit
 |         --target [TARGET], -t [TARGET]
 |                               Run the setup on target cluster. Default value is
 |                               thor.
+|         --pq threadNumber  Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
 |
 
 Parameters of Regression Suite run sub-command:
@@ -97,7 +98,7 @@ Result:
 |         -h, --help         show this help message and exit
 |         --target [TARGET], -t [TARGET]
 |                            Run the cluster suite. Default value is thor.
-|         --pq threadNumber  Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumer = numberOfLocalCore * 2)
+|         --pq threadNumber  Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
 |
 
 
@@ -123,7 +124,7 @@ Result:
 |         --target [target_cluster | all], -t [target_cluster | all]
 |                                     Target cluster for single query run. If target = 'all' then run query on all clusters. Default value is thor.
 |         --publish, -p               Publish compiled query instead of run.
-|         --pq threadNumber           Parallel query execution for multiple test cases specified in CLI with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumer = numberOfLocalCore * 2 )
+|         --pq threadNumber           Parallel query execution for multiple test cases specified in CLI with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )
 |
 
 Steps to run Regression Suite
@@ -488,6 +489,41 @@ Then the RS executes alljoin.ecl on all target clusters and
     on hthor the output compared with hthor/alljoin.xml
     on thor and roxie the output compared with key/alljoin.xml
 
+For Setup keyfile handling same as Run/Query except the target specific keyfile stored platform directory under setup:
+
+ecl
+   |---hthor
+   |     alljoin.xml
+   |---key
+   |     alljoin.xml
+   |     setup.xml
+   |     setup_fetch.xml
+   |     setup_sq.xml
+   |     setup_xml.xml
+   |---setup
+   |      |
+   |      ---hthor
+   |      |       setup.xml
+   |      setup.ecl
+   |      setup_fetch.ecl
+   |      setup_sq.ecl
+   |      setup_xml.ecl
+   alljoin.ecl|
+
+If we execute setup on target hthor:
+
+     ./regress  setup -t hthor
+
+Then the RS executes all ecl files from setup directory and 
+    - the result of setup.ecl compared with ecl/setup/hthor/setup.xml
+    - all other test cases results compared with corresponding file in ecl/key directory.
+
+If we execute setup on any other target:
+
+     ./regress  setup -t thor|roxie
+
+Then the RS executes all ecl files from setup directory and 
+    - the test cases results compared with corresponding file in ecl/key directory.
 
 8. Key file generation:
 -----------------------
@@ -534,8 +570,3 @@ If your HPCC System is configured to use LDAP authentication you should change v
 
 Alternatively, ensure that your test system has a user "regress" with password "regress" and appropriate rights to be able to run the suite.
 
-
-Misc.
------
-
-**Important! Actually regression suite compares the test case result with xml files stored in testing/regression/ecl/key independently from the cluster.**

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -32,7 +32,11 @@ from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
 from hpcc.common.error import Error
 
-prog_version = "0.0.15"
+prog_version = "0.0.16"
+
+# For coverage
+if ('coverage' in os.environ) and (os.environ['coverage'] == '1'):
+    os.umask(0)
 
 class RegressMain:
 
@@ -111,8 +115,10 @@ class RegressMain:
 
     def setup(self):
         if self.args.target in self.regress.config.Clusters:
-            self.regress.bootstrap(self.args.target)
-            self.regress.runSuite(self.args.target, self.regress.Setup())
+            if  self.args.pq :
+                self.regress.runSuiteP(self.args.target, self.regress.Setup(self.args.target))
+            else:
+                self.regress.runSuite(self.args.target, self.regress.Setup(self.args.target))
         else:
             logging.error("%s. Unknown target cluster:'%s'!" % (1,  self.args.target))
             raise Error("4000")
@@ -177,12 +183,14 @@ class RegressMain:
         parser_setup.set_defaults(func='setup')
         parser_setup.add_argument('--target', '-t', help="Run the setup on target cluster. Default value is thor.",
                                 nargs='?', type=str,  default='thor')
+        parser_setup.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
+                                type=checkPqParam,  default = 0,   metavar="threadNumber")
 
         parser_run = subparsers.add_parser('run', help='run help')
         parser_run.set_defaults(func='run')
         parser_run.add_argument('--target', '-t', help="Run the cluster suite. Default value is thor.",
                                 nargs='?', type=str,  default='thor')
-        parser_run.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumer = numberOfLocalCore * 2 )",
+        parser_run.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
                                 type=checkPqParam,  default = 0,   metavar="threadNumber")
 
         parser_query = subparsers.add_parser('query', help='query help')
@@ -193,7 +201,7 @@ class RegressMain:
                                 nargs='?', default='thor', metavar="target_cluster | all")
         parser_query.add_argument('--publish', '-p', help="Publish compiled query instead of run.",
                                 action='store_true')
-        parser_query.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumer = numberOfLocalCore * 2 )",
+        parser_query.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
                                 type=checkPqParam,  default = 0,   metavar="threadNumber")
 
         self.args = parser.parse_args()

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -127,25 +127,25 @@ class Regression:
         self.createDirectory(self.dir_r)
         self.createDirectory(self.logDir)
 
-        if cluster in self.config.Clusters:
-            self.createSuite(cluster,  fileList)
-            self.maxtasks = len(self.suites[cluster].getSuite())
+        self.suites[cluster] = Suite(cluster, self.dir_ec, self.dir_a, self.dir_ex, self.dir_r, self.logDir,  False,  fileList)
+        self.maxtasks = len(self.suites[cluster].getSuite())
         os.chdir(self.regressionDir)
-
 
     def createDirectory(self, dir_n):
         if not os.path.isdir(dir_n):
             os.makedirs(dir_n)
 
-    def createSuite(self, cluster,  fileList):
-        self.suites[cluster] = Suite(cluster, self.dir_ec,
-                                     self.dir_a, self.dir_ex, self.dir_r, self.logDir,  fileList)
-
-    def Setup(self):
+    def Setup(self,  cluster):
+        self.createDirectory(self.regressionDir)
+        self.createDirectory(self.dir_a)
+        self.createDirectory(self.dir_r)
+        self.createDirectory(self.logDir)
         self.setupDir = ExpandCheck.dir_exists(os.path.join(self.suiteDir, self.config.setupDir), True)
         logging.debug("Setup Dir      : %s", self.setupDir)
-        return Suite('setup', self.setupDir, self.dir_a, self.dir_ex,
-                     self.dir_r, self.logDir)
+        self.setupSuite = Suite(cluster, self.setupDir, self.dir_a, self.dir_ex, self.dir_r, self.logDir,  True)
+        self.maxtasks = len(self.setupSuite.getSuite())
+        os.chdir(self.regressionDir)
+        return self.setupSuite
 
     def buildLogging(self, name):
         report = Report(name)


### PR DESCRIPTION
Add platform specific Setup result handling.
  It search the Setup related keyfile under ecl/setup/<platform>/
  directory first. If unsuccessful then it tries in ecl/key/.

Add parallel execution capability for Setup.

Update README.rst with these changes.

Add small changes to make coverage generation easier in Overnight Build
and Test System

Signed-off-by: Attila Vamos attila.vamos@gmail.com
