### PR TITLE
HPCC-11349 DOCS:DTD Errors

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/ssl-esp.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/ssl-esp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <sect1 id="ssl4esp">
   <title><emphasis role="bold">Configuring ESP Server to use HTTPS
   (SSL)</emphasis></title>

--- a/docs/RDDERef/RDDE_Mods/Packages.xml
+++ b/docs/RDDERef/RDDE_Mods/Packages.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <chapter>
   <title><emphasis role="bold">Packages and Packagemaps</emphasis></title>
 


### PR DESCRIPTION
Fix HPCC-11349 DOCS:DTD Errors
Fix for couple DTD errors reported 
on remote build machine. 
dtd needs to declare as docbook 4.5
