### PR TITLE
 HPCC-10943 Progress bar hard to see in new ECL Watch

### DIFF
--- a/esp/src/eclwatch/css/hpcc.css
+++ b/esp/src/eclwatch/css/hpcc.css
@@ -135,6 +135,10 @@ hr.dashedLine {
     overflow: hidden;
 }
 
+.claro .dojoxUploaderFileListProgressBar{
+    background:rgb(0, 108, 204);
+}
+
 .claro #stubStackController{
     height: 32px;
     margin-top: 6px;


### PR DESCRIPTION
Override claro style for progress bar  background color to give user easier view of the progress completed.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
