### PR TITLE
HPCC-11328 Add SortBy Activated to WsWorkunits.WUListQueries

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1188,6 +1188,8 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
             sortOrder[0] = WUQSFwuid;
         else if (strieq(sortBy, "DLL"))
             sortOrder[0] = WUQSFdll;
+        else if (strieq(sortBy, "Activated"))
+            sortOrder[0] = WUQSFActivited;
         else if (strieq(sortBy, "MemoryLimit"))
             sortOrder[0] = (WUQuerySortField) (WUQSFmemoryLimit | WUQSFnumeric);
         else if (strieq(sortBy, "TimeLimit"))


### PR DESCRIPTION
In WsWorkunits.WUListQueries response, return queries sorted by
'Activated'.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
