### PR TITLE
HPCC-11391 Queries that are suspended only on slaves are not reported

### DIFF
--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -1611,7 +1611,7 @@ readAnother:
                     }
                     else
                     {
-                        queryFactory.setown(globalPackageSetManager->getQuery(queryName, logctx));
+                        queryFactory.setown(globalPackageSetManager->getQuery(queryName, NULL, logctx));
                         if (isHTTP)
                             client->setHttpMode(queryName, isRequestArray, httpHelper.queryContentFormat());
                         if (queryFactory)

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1098,7 +1098,7 @@ public:
             }
         }
     }
-    virtual void getQueryInfo(StringBuffer &reply, bool full, const IRoxieContextLogger &logctx) const
+    virtual void getQueryInfo(StringBuffer &reply, bool full, IArrayOf<IQueryFactory> *slaveQueries, const IRoxieContextLogger &logctx) const
     {
         Owned<IPropertyTree> xref = createPTree("Query", 0);
         xref->setProp("@id", id);
@@ -1114,6 +1114,17 @@ public:
             {
                 IActivityFactory *f = *allActivities.mapToValue(&i.query());
                 f->getXrefInfo(*xref, logctx);
+            }
+        }
+        if (slaveQueries)
+        {
+            ForEachItemIn(idx, *slaveQueries)
+            {
+                if (slaveQueries->item(idx).suspended())
+                {
+                    xref->setPropBool("@suspended", true);
+                    xref->setPropBool("@slaveSuspended", true);
+                }
             }
         }
         toXML(xref, reply, 1);

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -122,7 +122,7 @@ interface IQueryFactory : extends IInterface
     virtual void getGraphNames(StringArray &ret) const = 0;
 
     virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
-    virtual void getQueryInfo(StringBuffer &result, bool full, const IRoxieContextLogger &logctx) const = 0;
+    virtual void getQueryInfo(StringBuffer &result, bool full, IArrayOf<IQueryFactory> *slaveQueries,const IRoxieContextLogger &logctx) const = 0;
 };
 
 class ActivityArray : public CInterface

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -842,14 +842,16 @@ public:
         }
     }
 
-    virtual void getAllQueryInfo(StringBuffer &reply, bool full, const IRoxieContextLogger &logctx) const
+    virtual void getAllQueryInfo(StringBuffer &reply, bool full, const IRoxieQuerySetManagerSet *slaves, const IRoxieContextLogger &logctx) const
     {
         HashIterator elems(queries);
         for (elems.first(); elems.isValid(); elems.next())
         {
             IMapping &cur = elems.query();
             IQueryFactory *query = queries.mapToValue(&cur);
-            query->getQueryInfo(reply, full, logctx);
+            IArrayOf<IQueryFactory> slaveQueries;
+            slaves->getQueries(query->queryQueryName(), slaveQueries, logctx);
+            query->getQueryInfo(reply, full, &slaveQueries, logctx);
         }
         HashIterator aliasIterator(aliases);
         for (aliasIterator.first(); aliasIterator.isValid(); aliasIterator.next())
@@ -953,6 +955,17 @@ public:
         for (unsigned channel = 0; channel < numChannels; channel++)
             if (managers[channel])
                 managers[channel]->load(querySets, packages, hash); // MORE - this means the hash depends on the number of channels. Is that desirable?
+    }
+
+    virtual void getQueries(const char *id, IArrayOf<IQueryFactory> &queries, const IRoxieContextLogger &logctx) const
+    {
+        for (unsigned channel = 0; channel < numChannels; channel++)
+            if (managers[channel])
+            {
+                IQueryFactory *query = managers[channel]->getQuery(id, logctx);
+                if (query)
+                    queries.append(*query);
+            }
     }
 
 private:
@@ -1064,6 +1077,12 @@ public:
         return serverManager.getLink();
     }
 
+    IRoxieQuerySetManagerSet* getRoxieSlaveManagers()
+    {
+        CriticalBlock b2(updateCrit);
+        return slaveManagers.getLink();
+    }
+
     void getInfo(StringBuffer &reply, const IRoxieContextLogger &logctx) const
     {
         reply.appendf(" <PackageSet id=\"%s\" querySet=\"%s\"/>\n", queryPackageId(), querySet.get());
@@ -1127,10 +1146,10 @@ public:
             }
         }
     }
-    void getAllQueryInfo(StringBuffer &reply, bool full,  const IRoxieContextLogger &logctx) const
+    void getAllQueryInfo(StringBuffer &reply, bool full, const IRoxieContextLogger &logctx) const
     {
         CriticalBlock b2(updateCrit);
-        serverManager->getAllQueryInfo(reply, full, logctx);
+        serverManager->getAllQueryInfo(reply, full, slaveManagers, logctx);
     }
 protected:
     void reloadQueryManagers(CRoxieSlaveQuerySetManagerSet *newSlaveManagers, IRoxieQuerySetManager *newServerManager, hash64_t newHash)
@@ -1328,7 +1347,7 @@ public:
         throw MakeStringException(ROXIE_LIBRARY_ERROR, "No library available for %s", libraryName);
     }
 
-    IQueryFactory *getQuery(const char *id, const IRoxieContextLogger &logctx) const
+    IQueryFactory *getQuery(const char *id, IArrayOf<IQueryFactory> *slaveQueries, const IRoxieContextLogger &logctx) const
     {
         ForEachItemIn(idx, allQueryPackages)
         {
@@ -1337,7 +1356,14 @@ public:
             {
                 IQueryFactory *query = sm->getQuery(id, logctx);
                 if (query)
+                {
+                    if (slaveQueries)
+                    {
+                        Owned<IRoxieQuerySetManagerSet> slaveManagers = allQueryPackages.item(idx).getRoxieSlaveManagers();
+                        slaveManagers->getQueries(id, *slaveQueries, logctx);
+                    }
                     return query;
+                }
             }
         }
         return NULL;
@@ -1365,8 +1391,9 @@ public:
     {
         ForEachItemIn(idx, allQueryPackages)
         {
-            Owned<IRoxieQuerySetManager> sm = allQueryPackages.item(idx).getRoxieServerManager();
-            sm->getAllQueryInfo(reply, full, logctx);
+            Owned<IRoxieQuerySetManager> serverManager = allQueryPackages.item(idx).getRoxieServerManager();
+            Owned<IRoxieQuerySetManagerSet> slaveManagers = allQueryPackages.item(idx).getRoxieSlaveManagers();
+            serverManager->getAllQueryInfo(reply, full, slaveManagers, logctx);
         }
     }
 
@@ -1549,10 +1576,10 @@ public:
         return allQueryPackages->lookupLibrary(libraryName, expectedInterfaceHash, logctx);
     }
 
-    virtual IQueryFactory *getQuery(const char *id, const IRoxieContextLogger &logctx) const
+    virtual IQueryFactory *getQuery(const char *id, IArrayOf<IQueryFactory> *slaveQueries, const IRoxieContextLogger &logctx) const
     {
         ReadLockBlock b(packageCrit);
-        return allQueryPackages->getQuery(id, logctx);
+        return allQueryPackages->getQuery(id, slaveQueries, logctx);
     }
 
     virtual int getActivePackageCount() const
@@ -1609,9 +1636,10 @@ private:
                 const char *id = ids->query().queryProp("@id");
                 if (id)
                 {
-                    Owned<IQueryFactory> query = getQuery(id, logctx);
+                    IArrayOf<IQueryFactory> slaveQueries;
+                    Owned<IQueryFactory> query = getQuery(id, &slaveQueries, logctx);
                     if (query)
-                        query->getQueryInfo(reply, full, logctx);
+                        query->getQueryInfo(reply, full, &slaveQueries, logctx);
                     else
                         reply.appendf(" <Query id=\"%s\" error=\"Query not found\"/>\n", id);
                 }
@@ -1830,7 +1858,7 @@ private:
                 if (!id)
                     throw MakeStringException(ROXIE_MISSING_PARAMS, "No query name specified");
 
-                Owned<IQueryFactory> q = getQuery(id, logctx);
+                Owned<IQueryFactory> q = getQuery(id, NULL, logctx);
                 if (q)
                 {
                     Owned<IPropertyTree> tempTree = q->cloneQueryXGMML();
@@ -1845,7 +1873,7 @@ private:
                 const char *id = control->queryProp("Query/@id");
                 if (!id)
                     badFormat();
-                Owned<IQueryFactory> f = getQuery(id, logctx);
+                Owned<IQueryFactory> f = getQuery(id, NULL, logctx);
                 if (f)
                 {
                     unsigned warnLimit = f->getWarnTimeLimit();
@@ -2049,7 +2077,7 @@ private:
                 const char *id = control->queryProp("Query/@id");
                 if (id)
                 {
-                    Owned<IQueryFactory> f = getQuery(id, logctx);
+                    Owned<IQueryFactory> f = getQuery(id, NULL, logctx); // MORE - slave too?
                     if (f)
                     {
                         Owned<const IPropertyTree> stats = f->getQueryStats(from, to);
@@ -2081,7 +2109,7 @@ private:
                 {
                     if (stricmp(action, "listGraphNames") == 0)
                     {
-                        Owned<IQueryFactory> query = getQuery(id, logctx);
+                        Owned<IQueryFactory> query = getQuery(id, NULL, logctx); // MORE - slave too?
                         if (query)
                         {
                             reply.appendf("<Query id='%s'>\n", id);
@@ -2219,7 +2247,7 @@ private:
                 if (!id.length())
                     badFormat();
                 {
-                    Owned<IQueryFactory> f = getQuery(id, logctx);
+                    Owned<IQueryFactory> f = getQuery(id, NULL, logctx); // MORE - slave too?
                     if (f)
                         id.clear().append(f->queryQueryName());  // use the spelling of the query stored with the query factory
                 }

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -92,6 +92,12 @@ interface IFileIOArray : extends IInterface
     virtual StringBuffer &getId(StringBuffer &) const = 0;
 };
 
+interface IRoxieQuerySetManagerSet : extends IInterface
+{
+    virtual void load(const IPropertyTree *querySets, const IRoxiePackageMap &packages, hash64_t &hash) = 0;
+    virtual void getQueries(const char *id, IArrayOf<IQueryFactory> &queries, const IRoxieContextLogger &logctx) const = 0;
+};
+
 interface IRoxieQuerySetManager : extends IInterface
 {
     virtual bool isActive() const = 0;
@@ -101,7 +107,7 @@ interface IRoxieQuerySetManager : extends IInterface
     virtual void resetQueryTimings(const char *queryName, const IRoxieContextLogger &logctx) = 0;
     virtual void resetAllQueryTimings() = 0;
     virtual void getActivityMetrics(StringBuffer &reply) const = 0;
-    virtual void getAllQueryInfo(StringBuffer &reply, bool full, const IRoxieContextLogger &logctx) const = 0;
+    virtual void getAllQueryInfo(StringBuffer &reply, bool full, const IRoxieQuerySetManagerSet *slaves, const IRoxieContextLogger &logctx) const = 0;
 };
 
 interface IRoxieDebugSessionManager : extends IInterface
@@ -111,16 +117,11 @@ interface IRoxieDebugSessionManager : extends IInterface
     virtual IDebuggerContext *lookupDebuggerContext(const char *id) = 0;
 };
 
-interface IRoxieQuerySetManagerSet : extends IInterface
-{
-    virtual void load(const IPropertyTree *querySets, const IRoxiePackageMap &packages, hash64_t &hash) = 0;
-};
-
 interface IRoxieQueryPackageManagerSet : extends IInterface
 {
     virtual void load() = 0;
     virtual void doControlMessage(IPropertyTree *xml, StringBuffer &reply, const IRoxieContextLogger &ctx) = 0;
-    virtual IQueryFactory *getQuery(const char *id, const IRoxieContextLogger &logctx) const = 0;
+    virtual IQueryFactory *getQuery(const char *id, IArrayOf<IQueryFactory> *slaves, const IRoxieContextLogger &logctx) const = 0;
     virtual IQueryFactory *lookupLibrary(const char *libraryName, unsigned expectedInterfaceHash, const IRoxieContextLogger &logctx) const = 0;
     virtual int getActivePackageCount() const = 0;
 };


### PR DESCRIPTION
Update control:queryinfo, control:queries etc to show queries that are
suspended on some slaves only.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
