### PR TITLE
HPCC-11331 Show Enable Scope Scan ONLY on FileScope permission page

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_resources.xslt
+++ b/esp/eclwatch/ws_XSLT/access_resources.xslt
@@ -186,20 +186,22 @@
                 </form>
             </td>
 
-            <xsl:if test="scopeScansStatus/retcode=0">
-              <xsl:if test="scopeScansStatus/isEnabled=0">
-                <td>
-                  <form action="/ws_access/EnableScopeScans">
-                    <input id="EnableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Enable Scope Scans" onclick="return confirm('Are you sure you want to enable Scope Scans? Changes will revert to configuration settings on DALI reboot.')"/>
-                  </form>
-                </td>
-              </xsl:if>
-              <xsl:if test="scopeScansStatus/isEnabled=1">
-                <td>
-                  <form action="/ws_access/DisableScopeScans">
-                    <input id="DisableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Disable Scope Scans" onclick="return confirm('Are you sure you want to disable Scope Scans?  Changes will revert to configuration settings on DALI reboot.')"/>
-                  </form>
-                </td>
+            <xsl:if test="rtype='file' and rtitle='FileScope'">
+              <xsl:if test="scopeScansStatus/retcode=0">
+                <xsl:if test="scopeScansStatus/isEnabled=0">
+                  <td>
+                    <form action="/ws_access/EnableScopeScans">
+                      <input id="EnableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Enable Scope Scans" onclick="return confirm('Are you sure you want to enable Scope Scans? Changes will revert to configuration settings on DALI reboot.')"/>
+                    </form>
+                  </td>
+                </xsl:if>
+                <xsl:if test="scopeScansStatus/isEnabled=1">
+                  <td>
+                    <form action="/ws_access/DisableScopeScans">
+                      <input id="DisableScopeScansBtn" class="sbutton" type="submit"  name="action" value="Disable Scope Scans" onclick="return confirm('Are you sure you want to disable Scope Scans?  Changes will revert to configuration settings on DALI reboot.')"/>
+                    </form>
+                  </td>
+                </xsl:if>
               </xsl:if>
             </xsl:if>
 


### PR DESCRIPTION
The existing ECLWatch, the Enable Scope Scan buttons show on several
permission pages. It should show only on FileScope permission page.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
