### PR TITLE
HPCC-11384 Fix Activity Structure issues for WsSMC

### DIFF
--- a/common/deftype/deftype.hpp
+++ b/common/deftype/deftype.hpp
@@ -362,7 +362,7 @@ typedef IArrayOf<ITypeInfo> TypeInfoArray;
 interface ISchemaBuilder
 {
 public:
-    virtual void addField(const char * name, ITypeInfo & type) = 0;
+    virtual void addField(const char * name, ITypeInfo & type, bool keyed) = 0;
     virtual void addSetField(const char * name, const char * itemname, ITypeInfo & type) = 0;
     virtual void beginIfBlock() = 0;
     virtual bool beginDataset(const char * name, const char * childname, bool hasMixedContent, unsigned *updateMixed) = 0;
@@ -379,7 +379,7 @@ class DEFTYPE_API XmlSchemaBuilder : public ISchemaBuilder
 public:
     XmlSchemaBuilder(bool _addHeader) { optionalNesting = 0; addHeader = _addHeader; }
 
-    virtual void addField(const char * name, ITypeInfo & type);
+    virtual void addField(const char * name, ITypeInfo & type, bool keyed);
     virtual void addSetField(const char * name, const char * itemname, ITypeInfo & type);
     virtual void beginIfBlock()                                     { optionalNesting++; }
     virtual bool beginDataset(const char * name, const char * childname, bool hasMixedContent, unsigned *updateMixed);
@@ -398,7 +398,7 @@ private:
     void addSchemaSuffix();
     void clear();
     void getXmlTypeName(StringBuffer & xmlType, ITypeInfo & type);
-    void appendField(StringBuffer &xml, const char * name, ITypeInfo & type);
+    void appendField(StringBuffer &xml, const char * name, ITypeInfo & type, bool keyed);
 
 protected:
     StringBuffer xml;

--- a/common/fileview2/fvrelate.cpp
+++ b/common/fileview2/fvrelate.cpp
@@ -699,7 +699,7 @@ void ViewERdiagramVisitor::visit(ViewRelation * relation)
 }
 
 
-void ViewERdiagramVisitor::addField(const char * name, ITypeInfo & type)
+void ViewERdiagramVisitor::addField(const char * name, ITypeInfo & type, bool keyed)
 {
     StringBuffer eclTypeName;
     noteNextField();
@@ -712,7 +712,7 @@ void ViewERdiagramVisitor::addField(const char * name, ITypeInfo & type)
 
 void ViewERdiagramVisitor::addSetField(const char * name, const char * itemname, ITypeInfo & type)
 {
-    addField(name, type);
+    addField(name, type, false);
 }
 
 void ViewERdiagramVisitor::beginIfBlock()

--- a/common/fileview2/fvrelate.ipp
+++ b/common/fileview2/fvrelate.ipp
@@ -337,7 +337,7 @@ public:
     virtual void visit(ViewRelation * relation);
 
 // ISchemaBuilder
-    virtual void addField(const char * name, ITypeInfo & type);
+    virtual void addField(const char * name, ITypeInfo & type, bool keyed);
     virtual void addSetField(const char * name, const char * itemname, ITypeInfo & type);
     virtual void beginIfBlock();
     virtual bool beginDataset(const char * name, const char * childname, bool mixedContent, unsigned *updateMixed);

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -613,6 +613,7 @@ void fvSplitXPath(const char *xpath, StringBuffer &s, const char *&name, const c
 void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) const
 {
     StringBuffer xname;
+    unsigned keyedCount = getNumKeyedColumns();
     ForEachItemIn(idx, columns)
     {
         CResultSetColumnInfo & column = columns.item(idx);
@@ -669,7 +670,7 @@ void CResultSetMetaData::getXmlSchema(ISchemaBuilder & builder, bool useXPath) c
                 {
                     if (useXPath)
                         fvSplitXPath(meta->queryXPath(idx), xname, name);
-                    builder.addField(name, type);
+                    builder.addField(name, type, idx < keyedCount);
                 }
                 break;
             }

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -7691,7 +7691,7 @@ void EclXmlSchemaBuilder::build(IHqlExpression * record, bool &hasMixedContent) 
                 default:
                     extractName(name.clear(), NULL, NULL, cur, NULL);
                     if (name.length())
-                        builder.addField(name, *type);
+                        builder.addField(name, *type, false);
                     else
                         hasMixedContent = true;
                     break;

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -5221,7 +5221,7 @@ void HqlCppTranslator::buildSetResultInfo(BuildCtx & ctx, IHqlExpression * origi
                 StringBuffer xml;
                 {
                     XmlSchemaBuilder xmlbuilder(false);
-                    xmlbuilder.addField(fieldName, *schemaType);
+                    xmlbuilder.addField(fieldName, *schemaType, false);
                     xmlbuilder.getXml(xml);
                 }
                 addSchemaResource(sequence, resultName.str(), xml.length()+1, xml.str());

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1100,7 +1100,8 @@ void CWsSMCEx::getWUsNotOnTargetCluster(IEspContext &context, IPropertyTree* ser
         const char* instance = serverNode.queryProp("@node");
         const char* queueName = serverNode.queryProp("@queue");
         unsigned port = serverNode.getPropInt("@mpport", 0);
-        if (!serverName || !*serverName || !instance || !*instance || strieq(serverName, "DFUserver"))//DFUServer already handled separately
+        if (!serverName || !*serverName || !instance || !*instance || strieq(serverName, "DFUserver") ||//DFUServer already handled separately
+            strieq(serverName, "ThorMaster") || strieq(serverName, "RoxieServer") || strieq(serverName, "HThorServer"))//target clusters already handled separately
             continue;
 
         VStringBuffer instanceName("%s_on_%s:%d", serverName, instance, port);


### PR DESCRIPTION
The Activity information for target clusters is returned inside the
TargetCluster structure. Existing code also returns a ServerJobQueue
structure which contains incorrect information for the target
cluster. In this fix, the code is added to not return the
ServerJobQueue for target clusters.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
