### PR TITLE
HPCC-11410 DOCS:Clarify User Security module

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
@@ -1003,11 +1003,7 @@
     features are listed as <emphasis role="bold">Resources</emphasis> when
     setting permissions using ECL Watch.</para>
 
-    <para>There are many ECL Watch feature permissions, not all of them are
-    shown in detail here. The permissions shown and described here are the
-    more common and relevant permissions. There are additional permissions
-    which are typically not relevant to the vast majority of system
-    users.</para>
+    <para>ECL Watch feature permission settings that are not listed are not relevant and should not be used.</para>
 
     <para>The following sections show the level of access required to be able
     to use ECL Watch features:</para>


### PR DESCRIPTION
Fix HPCC-11410 DOCS:Clarify User Security module
Clarify a section in the Clarify User Security xml module
used by the Installing and Running HPCC document. 

@JamesDeFabia please review
