### PR TITLE
HPCC-11358 Sort WUs by Total Thor Time for both 5.0 WUs and 4.x WUs

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -1926,7 +1926,7 @@ mapEnums workunitSortFields[] =
    { WUSFbatchmachine, "Application/Dispatcher/Machine" },
    { WUSFbatchinputfile, "Application/Dispatcher/InputFileName" },
    { WUSFbatchoutputfile, "Application/Dispatcher/OutputFileName" },
-   { WUSFtotalthortime, "Timings/Timing[@name='Total thor time']/@duration" },
+   { WUSFtotalthortime, "Statistics/Statistic[@desc='Total thor time']/@value|Timings/Timing[@name='Total thor time']/@duration" },//Use Statistics first. If not found, use Timings
    { WUSFterm, NULL }
 };
 


### PR DESCRIPTION
The Total Thor Time of 5.0 WUs is stored under Statistics/Statistic
[@desc='Total thor time']/@value. For 4.x WUs, it is under Timings/
Timing[@name='Total thor time']/@duration. To sort the WUs, this
fix creates a multivalue sort key for the Total Thor Time. The
multivalued sort key is preparsed by the new code in this fix.
Now, WUQuery can sort WUs by Total Thor Time for both 5.x WUs and
4.x WUs.
