### PR TITLE
HPCC-11384 Fix Activity Structure issues for WsSMC

### DIFF
--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1100,7 +1100,8 @@ void CWsSMCEx::getWUsNotOnTargetCluster(IEspContext &context, IPropertyTree* ser
         const char* instance = serverNode.queryProp("@node");
         const char* queueName = serverNode.queryProp("@queue");
         unsigned port = serverNode.getPropInt("@mpport", 0);
-        if (!serverName || !*serverName || !instance || !*instance || strieq(serverName, "DFUserver"))//DFUServer already handled separately
+        if (!serverName || !*serverName || !instance || !*instance || strieq(serverName, "DFUserver") ||//DFUServer already handled separately
+            strieq(serverName, "ThorMaster") || strieq(serverName, "RoxieServer") || strieq(serverName, "HThorServer"))//target clusters already handled separately
             continue;
 
         VStringBuffer instanceName("%s_on_%s:%d", serverName, instance, port);


### PR DESCRIPTION
The Activity information for target clusters is returned inside the
TargetCluster structure. Existing code also returns a ServerJobQueue
structure which contains incorrect information for the target
cluster. In this fix, the code is added to not return the
ServerJobQueue for target clusters.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
