### PR TITLE
HPCC-11379 Remove uninitialised variable warnings (never actually a problem)

### DIFF
--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -1330,7 +1330,8 @@ public:
     {
         CriticalBlock b(crit);
         sharedResult.clear();
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
         {
             cnv2Latin1(length, contentMb.toByteArray()+offset, sharedResult);
@@ -1350,7 +1351,8 @@ public:
     {
         CriticalBlock b(crit);
         sharedResult.clear();
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
         {
             cnv2Latin1(length, contentMb.toByteArray()+offset, sharedResult);
@@ -1370,7 +1372,8 @@ public:
     {
         CriticalBlock b(crit);
         sharedResult.clear();
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
         {
             cnv2Latin1(length, contentMb.toByteArray()+offset, sharedResult);
@@ -1391,7 +1394,8 @@ public:
     {
         CriticalBlock b(crit);
         sharedResult.clear();
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
         {
             cnv2Latin1(length, contentMb.toByteArray()+offset, sharedResult);
@@ -1415,7 +1419,8 @@ public:
     }
     virtual bool readBool(const char * path, bool _default)
     {
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
             throw MakeStringException(0, "Attempting to extract xml content text as boolean");
 
@@ -1431,7 +1436,8 @@ public:
     }
     virtual __int64 readInt(const char * path, __int64 _default)
     {
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
             throw MakeStringException(0, "Attempting to extract xml content text as integer");
 
@@ -1446,7 +1452,8 @@ public:
     {
         CriticalBlock b(crit);
         sharedResult.clear();
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
         {
             cnv2Latin1(length, contentMb.toByteArray()+offset, sharedResult);
@@ -1468,7 +1475,8 @@ public:
     {
         CriticalBlock b(crit);
         sharedResult.clear();
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
         {
             cnv2Latin1(length, contentMb.toByteArray()+offset, sharedResult);
@@ -1489,7 +1497,8 @@ public:
     virtual void readStringX(size32_t & len, char * & text, const char * path, size32_t _lenDefault, const char * _default)
     {
         MemoryBuffer result;
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
         {
             if (length)
@@ -1511,7 +1520,8 @@ public:
     }
     virtual void readUnicodeX(size32_t & len, UChar * & text, const char * path, size32_t _lenDefault, const UChar * _default)
     {
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         if (contentRequest(path, offset, length))
         {
             rtlCodepageToUnicodeX(len, text, length, contentMb.toByteArray()+offset, "utf-8");
@@ -1528,7 +1538,8 @@ public:
     }
     virtual void readUtf8X(size32_t & len, char * & text, const char * path, size32_t _lenDefault, const char * _default)
     {
-        size32_t offset, length;
+        size32_t offset = 0;
+        size32_t length = 0;
         size32_t size;
         if (contentRequest(path, offset, length))
         {


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
