### PR TITLE
HPCC-11412 Excessive log file size in Roxie

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -1261,7 +1261,8 @@ public:
             {
                 if (state==STATEstarted || state==STATEstarting)
                 {
-                    CTXLOG("STATE: activity %d reset without stop", activityId);
+                    if (traceStartStop || traceLevel > 2)
+                        CTXLOG("STATE: activity %d reset without stop", activityId);
                     stop(false);
                 }
                 if (ctx->queryTimeActivities())


### PR DESCRIPTION
As a temporary workaround, until we can find and fix the reason, allow the
tracing of activity reset without stop to be suppressed via traceLevel.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
