### PR TITLE
HPCC-11231 Add FileScopeAccess control to access file scope permissions

### DIFF
--- a/esp/eclwatch/ws_XSLT/access_permissionresetinput.xslt
+++ b/esp/eclwatch/ws_XSLT/access_permissionresetinput.xslt
@@ -303,8 +303,8 @@
         <input type="hidden" name="rtitle" value="{rtitle}"/>
         <input type="hidden" name="prefix" value="{prefix}"/>
         <input type="hidden" name="BasednName" value="{BasednName}"/>
-        <input type="hidden" name="userarray" value=""/>
-        <input type="hidden" name="grouparray" value=""/>
+        <input type="hidden" id="userarray" name="userarray" value=""/>
+        <input type="hidden" id="grouparray" name="grouparray" value=""/>
 
         <h3>Permission Reset</h3>
         <div>

--- a/esp/services/ws_access/ws_accessService.hpp
+++ b/esp/services/ws_access/ws_accessService.hpp
@@ -53,6 +53,7 @@ public:
             ensureNavLink(*folder, "Users", "/ws_access/Users", "Users");
             ensureNavLink(*folder, "Groups", "/ws_access/Groups", "Groups");
             ensureNavLink(*folder, "Permissions", "/ws_access/Permissions", "Permissions");
+            ensureNavLink(*folder, "FileScopes", "/ws_access/Resources?rtype=file&rtitle=FileScope", "FileScopes");
         }
     }
 
@@ -67,6 +68,7 @@ class Cws_accessEx : public Cws_access
     SecResourceType str2type(const char* rtstr);
 
     void setBasedns(IEspContext &context);
+    const char* getBaseDN(IEspContext &context, const char* rtype, StringBuffer& baseDN);
     bool permissionAddInputOnResource(IEspContext &context, IEspPermissionAddRequest &req, IEspPermissionAddResponse &resp);
     bool permissionAddInputOnAccount(IEspContext &context, const char* accountName, IEspPermissionAddRequest &req, IEspPermissionAddResponse &resp);
     bool getNewFileScopePermissions(ISecManager* secmgr, IEspResourceAddRequest &req, StringBuffer& existingResource, StringArray& newResources);

--- a/initfiles/componentfiles/configxml/buildsetCC.xml.in
+++ b/initfiles/componentfiles/configxml/buildsetCC.xml.in
@@ -165,6 +165,10 @@
                           path="FileIOAccess"
                           resource="FileIOAccess"
                           service="ws_fileio"/>
+     <AuthenticateFeature description="Access to permissions for file scopes"
+                          path="FileScopeAccess"
+                          resource="FileScopeAccess"
+                          service="ws_access"/>
      <AuthenticateFeature description="Access to WS ECL service"
                           path="WsEclAccess"
                           resource="WsEclAccess"

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -167,6 +167,10 @@
                           path="FileIOAccess"
                           resource="FileIOAccess"
                           service="ws_fileio"/>
+     <AuthenticateFeature description="Access to permissions for file scopes"
+                          path="FileScopeAccess"
+                          resource="FileScopeAccess"
+                          service="ws_access"/>
      <AuthenticateFeature description="Access to WS ECL service"
                           path="WsEclAccess"
                           resource="WsEclAccess"
@@ -535,6 +539,11 @@
                          resource="FileIOAccess"
                          service="ws_fileio"/>
     <AuthenticateFeature authenticate="Yes"
+                         description="Access to permissions for file scopes"
+                         path="FileScopeAccess"
+                         resource="FileScopeAccess"
+                         service="ws_access"/>
+    <AuthenticateFeature authenticate="Yes"
                          description="Access to WS ECL service"
                          path="WsEclAccess"
                          resource="WsEclAccess"
@@ -695,6 +704,10 @@
                          path="FileIOAccess"
                          resource="FileIOAccess"
                          service="ws_fileio"/>
+    <AuthenticateFeature description="Access to permissions for file scopes"
+                         path="FileScopeAccess"
+                         resource="FileScopeAccess"
+                         service="ws_access"/>
     <AuthenticateFeature description="Access to WS ECL service"
                          path="WsEclAccess"
                          resource="WsEclAccess"


### PR DESCRIPTION
The FileScopeAccess is added to WsAccess which allows authenticated
user to control File Scope access.

Also add code to check permission before allowing a user to access Enable
/disable scope scan and Clear Permission Cache.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
