### PR TITLE
HPCC-11398 Spray file using NodeGroup and change related display

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -11741,34 +11741,34 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
     class CFileAttrIterator: public CInterface, implements IPropertyTreeIterator
     {
         Owned<IPropertyTree> cur;
-        StringArray fileClusterGroups;
+        StringArray fileNodeGroups;
 
-        void setFileCluster(IPropertyTree *attr, const char* group, StringArray& clusterFilter)
+        void setFileNodeGroup(IPropertyTree *attr, const char* group, StringArray& nodeGroupFilter)
         {
             if (!group || !*group)
                 return;
 
             //The group may contain multiple clusters and some of them may match with the clusterFilter.
-            if (clusterFilter.length() == 1)
-                attr->setProp(getDFUQResultFieldName(DFUQRFcluster), clusterFilter.item(0));//Filter has been handled on server side.
+            if (nodeGroupFilter.length() == 1)
+                attr->setProp(getDFUQResultFieldName(DFUQRFnodegroup), nodeGroupFilter.item(0));//Filter has been handled on server side.
             else
             {
-                StringArray clusters;
-                clusters.appendListUniq(group, ",");
-                ForEachItemIn(i,clusters)
+                StringArray groups;
+                groups.appendListUniq(group, ",");
+                ForEachItemIn(i,groups)
                 {
                     //Add a cluster if no cluster filter or the cluster matchs with cluster filter
-                    const char* cluster = clusters.item(i);
-                    if (cluster && *cluster && ((!clusterFilter.length()) || (clusterFilter.find(cluster) != NotFound)))
-                        fileClusterGroups.append(cluster);
+                    const char* node = groups.item(i);
+                    if (node && *node && ((!nodeGroupFilter.length()) || (nodeGroupFilter.find(node) != NotFound)))
+                        fileNodeGroups.append(node);
                 }
-                if (fileClusterGroups.length())
+                if (fileNodeGroups.length())
                 {
                     //if this file exists on multiple clusters, set one of the clusters as the "@DFUSFcluster" prop for
-                    //this attr, leaving the rest inside the fileClusterGroups array. Those clusters will be used by the
+                    //this attr, leaving the rest inside the fileNodeGroups array. Those clusters will be used by the
                     //duplicateFileAttrOnOtherClusterGroup() to duplicate this file attr on other clusters.
-                    attr->setProp(getDFUQResultFieldName(DFUQRFcluster), fileClusterGroups.item(fileClusterGroups.length() -1));
-                    fileClusterGroups.pop();
+                    attr->setProp(getDFUQResultFieldName(DFUQRFnodegroup), fileNodeGroups.item(fileNodeGroups.length() -1));
+                    fileNodeGroups.pop();
                 }
             }
         }
@@ -11791,7 +11791,7 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
             return;
         }
 
-        IPropertyTree *deserializeFileAttr(MemoryBuffer &mb, StringArray& clusterFilter)
+        IPropertyTree *deserializeFileAttr(MemoryBuffer &mb, StringArray& nodeGroupFilter)
         {
             IPropertyTree *attr = getEmptyAttr();
             StringAttr val;
@@ -11823,22 +11823,22 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
                 mb.read(at);
                 mb.read(val);
                 attr->setProp(at.get(),val.get());
-                if (strieq(at.get(), getDFUQResultFieldName(DFUQRFgroup)))
-                    setFileCluster(attr, val.get(), clusterFilter);
+                if (strieq(at.get(), getDFUQResultFieldName(DFUQRFnodegroups)))
+                    setFileNodeGroup(attr, val.get(), nodeGroupFilter);
             }
             attr->setPropInt64(getDFUQResultFieldName(DFUQRFsize), attr->getPropInt64(getDFUQResultFieldName(DFUQRForigsize), -1));//Sort the files with empty size to front
             setRecordCount(attr);
             return attr;
         }
 
-        IPropertyTree *duplicateFileAttrOnOtherClusterGroup(IPropertyTree *previousAttr)
+        IPropertyTree *duplicateFileAttrOnOtherNodeGroup(IPropertyTree *previousAttr)
         {
             IPropertyTree *attr = getEmptyAttr();
             Owned<IAttributeIterator> ai = previousAttr->getAttributes();
             ForEach(*ai)
                 attr->setProp(ai->queryName(),ai->queryValue());
-            attr->setProp(getDFUQResultFieldName(DFUQRFcluster), fileClusterGroups.item(fileClusterGroups.length()-1));
-            fileClusterGroups.pop();
+            attr->setProp(getDFUQResultFieldName(DFUQRFnodegroup), fileNodeGroups.item(fileNodeGroups.length()-1));
+            fileNodeGroups.pop();
             return attr;
         }
 
@@ -11846,7 +11846,7 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
         IMPLEMENT_IINTERFACE;
         MemoryBuffer mb;
         unsigned numfiles;
-        StringArray clusterFilter;
+        StringArray nodeGroupFilter;
 
         bool first()
         {
@@ -11858,9 +11858,9 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
 
         bool next()
         {
-            if (fileClusterGroups.length())
+            if (fileNodeGroups.length())
             {
-                IPropertyTree *attr = duplicateFileAttrOnOtherClusterGroup(cur);
+                IPropertyTree *attr = duplicateFileAttrOnOtherNodeGroup(cur);
                 cur.clear();
                 cur.setown(attr);
                 return true;
@@ -11868,7 +11868,7 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
             cur.clear();
             if (mb.getPos()>=mb.length())
                 return false;
-            cur.setown(deserializeFileAttr(mb, clusterFilter));
+            cur.setown(deserializeFileAttr(mb, nodeGroupFilter));
             return true;
         }
 
@@ -11892,8 +11892,8 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
             {
                 int fmt = localFilters[i];
                 int subfmt = (fmt&0xff);
-                if ((subfmt==DFUQRFcluster) && fv && *fv)
-                    clusterFilter.appendListUniq(fv, ",");
+                if ((subfmt==DFUQRFnodegroup) && fv && *fv)
+                    nodeGroupFilter.appendListUniq(fv, ",");
                 //Add more if needed
                 fv = fv + strlen(fv)+1;
             }

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -11757,16 +11757,16 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
                 groups.appendListUniq(group, ",");
                 ForEachItemIn(i,groups)
                 {
-                    //Add a cluster if no cluster filter or the cluster matchs with cluster filter
+                    //Add a group if no group filter or the group matches with group filter
                     const char* node = groups.item(i);
                     if (node && *node && ((!nodeGroupFilter.length()) || (nodeGroupFilter.find(node) != NotFound)))
                         fileNodeGroups.append(node);
                 }
                 if (fileNodeGroups.length())
                 {
-                    //if this file exists on multiple clusters, set one of the clusters as the "@DFUSFcluster" prop for
-                    //this attr, leaving the rest inside the fileNodeGroups array. Those clusters will be used by the
-                    //duplicateFileAttrOnOtherClusterGroup() to duplicate this file attr on other clusters.
+                    //if this file exists on multiple groups, set one of the groups as the "@DFUSFnodegroup" prop for
+                    //this attr, leaving the rest inside the fileNodeGroups array. Those groups will be used by the
+                    //duplicateFileAttrOnOtherNodeGroup() to duplicate this file attr on other groups.
                     attr->setProp(getDFUQResultFieldName(DFUQRFnodegroup), fileNodeGroups.item(fileNodeGroups.length() -1));
                     fileNodeGroups.pop();
                 }

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -240,7 +240,7 @@ enum DFUQResultField
 {
     DFUQRFname = 0,
     DFUQRFdescription = 1,
-    DFUQRFgroup = 2,
+    DFUQRFnodegroups = 2,
     DFUQRFkind = 3,
     DFUQRFtimemodified = 4,
     DFUQRFjob = 5,
@@ -251,7 +251,7 @@ enum DFUQResultField
     DFUQRFsize = 10,
     DFUQRForigsize = 11,
     DFUQRFworkunit = 12,
-    DFUQRFcluster = 13,
+    DFUQRFnodegroup = 13,
     DFUQRFnumsubfiles = 14,
     DFUQRFaccessed = 15,
     DFUQRFnumparts = 16,

--- a/esp/eclwatch/ws_XSLT/dfu.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu.xslt
@@ -20,7 +20,7 @@
     <xsl:output method="html"/>
     <xsl:variable name="owner" select="/DFUQueryResponse/Owner"/>
     <xsl:variable name="cluster" select="/DFUQueryResponse/Prefix"/>
-    <xsl:variable name="clustername" select="/DFUQueryResponse/ClusterName"/>
+    <xsl:variable name="nodegroup" select="/DFUQueryResponse/NodeGroup"/>
     
     <xsl:variable name="logicalname" select="/DFUQueryResponse/LogicalName"/>
     <xsl:variable name="descriptionfilter" select="/DFUQueryResponse/Description"/>
@@ -64,7 +64,7 @@
           <script language="JavaScript1.2" id="menuhandlers">
                     var owner = '<xsl:value-of select="$owner"/>';;
                     var cluster = '<xsl:value-of select="$cluster"/>';;
-                    var clusterName = '<xsl:value-of select="$clustername"/>';;
+                    var nodeGroup = '<xsl:value-of select="$nodegroup"/>';;
                     var logicalName = '<xsl:value-of select="$logicalname"/>';;
                     var descriptionFilter = '<xsl:value-of select="$descriptionfilter"/>';;
                     var startDate = '<xsl:value-of select="$startdate"/>';;
@@ -312,11 +312,11 @@
                                     }
                                     if (type != 3)
                                     {
-                                        if (clusterName)
+                                        if (nodeGroup)
                                         {
                                             if (numParam > 0)
                                                 url += '&';
-                                            url += 'ClusterName=' + clusterName;
+                                            url += 'NodeGroup=' + nodeGroup;
                                             numParam++;
                                         }
                                     }
@@ -324,7 +324,7 @@
                                     {
                                         if (numParam > 0)
                                             url += '&';
-                                        url += 'ClusterName=' + value;
+                                        url += 'NodeGroup=' + value;
                                         numParam++;
                                     }
                                     document.location.href=url;
@@ -570,14 +570,14 @@
                        </xsl:otherwise>
                    </xsl:choose>
                    <xsl:choose>
-                       <xsl:when test="$sortby='Cluster' and $descending &lt; 1">
-                          <th align="center" style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('Cluster', 1)">Cluster<img src="/esp/files/img/upsimple.png" width="10" height="10"></img></th>
+                       <xsl:when test="$sortby='NodeGroup' and $descending &lt; 1">
+                          <th align="center" style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('NodeGroup', 1)">NodeGroup<img src="/esp/files/img/upsimple.png" width="10" height="10"></img></th>
                        </xsl:when>
-                       <xsl:when test="$sortby='Cluster'">
-                          <th align="center" style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('Cluster', 0)">Cluster<img src="/esp/files/img/downsimple.png" width="10" height="10"></img></th>
+                       <xsl:when test="$sortby='NodeGroup'">
+                          <th align="center" style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('NodeGroup', 0)">NodeGroup<img src="/esp/files/img/downsimple.png" width="10" height="10"></img></th>
                        </xsl:when>
                        <xsl:otherwise>
-                          <th align="center" style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('Cluster', 0)">Cluster</th>
+                          <th align="center" style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('NodeGroup', 0)">NodeGroup</th>
                        </xsl:otherwise>
                    </xsl:choose>
                    <xsl:choose>
@@ -647,15 +647,15 @@
             <xsl:variable name="info_query">
                 <xsl:value-of select="Name"/>
                 <xsl:choose>
-                    <xsl:when test="string-length(ClusterName)">&amp;Cluster=<xsl:value-of select="ClusterName"/></xsl:when>
+                    <xsl:when test="string-length(NodeGroup)">&amp;NodeGroup=<xsl:value-of select="NodeGroup"/></xsl:when>
                 </xsl:choose>
             </xsl:variable>
       <td>
         <xsl:if test="FromRoxieCluster=1">
-          <input type="hidden" id="{Name}@{ClusterName}"/>
+          <input type="hidden" id="{Name}@{NodeGroup}"/>
         </xsl:if>
-        <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{ClusterName}" onclick="return clicked(this, event)"/>
-          <xsl:variable name="popup">return DFUFilePopup('<xsl:value-of select="$info_query"/>', '<xsl:value-of select="Name"/>', '<xsl:value-of select="ClusterName"/>', '<xsl:value-of select="Replicate"/>', '<xsl:value-of select="FromRoxieCluster"/>', '<xsl:value-of select="BrowseData"/>', '<xsl:value-of select="position()"/>')</xsl:variable>
+        <input type="checkbox" name="LogicalFiles_i{position()}" value="{Name}@{NodeGroup}" onclick="return clicked(this, event)"/>
+          <xsl:variable name="popup">return DFUFilePopup('<xsl:value-of select="$info_query"/>', '<xsl:value-of select="Name"/>', '<xsl:value-of select="NodeGroup"/>', '<xsl:value-of select="Replicate"/>', '<xsl:value-of select="FromRoxieCluster"/>', '<xsl:value-of select="BrowseData"/>', '<xsl:value-of select="position()"/>')</xsl:variable>
           <xsl:variable name="oncontextmenu">
             <xsl:value-of select="$popup"/>
           </xsl:variable>
@@ -731,13 +731,13 @@
             </td>
             <td>
                 <xsl:choose>
-                    <xsl:when test="string-length(ClusterName) and not(string-length($clustername))">
-                        <a href="javascript:doQuery(3, '{ClusterName}')">
-                            <xsl:value-of select="ClusterName"/>
+                    <xsl:when test="string-length(NodeGroup) and not(string-length($nodegroup))">
+                        <a href="javascript:doQuery(3, '{NodeGroup}')">
+                            <xsl:value-of select="NodeGroup"/>
                         </a>
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:value-of select="ClusterName"/>
+                        <xsl:value-of select="NodeGroup"/>
                     </xsl:otherwise>
                 </xsl:choose>
             </td>

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -33,7 +33,8 @@ ESPStruct SpaceItem
 ESPStruct DFULogicalFile
 {
     string Prefix;      
-    string ClusterName; 
+    [depr_ver("1.26")] string ClusterName;
+    [min_ver("1.26")] string NodeGroup;
     string Directory;
     string Description;
     string Parts;
@@ -135,7 +136,8 @@ ESPStruct DFUSpaceItem
 ESPrequest [nil_remove] DFUQueryRequest
 {
     string Prefix;
-    string ClusterName;
+    [depr_ver("1.26")] string ClusterName;
+    [min_ver("1.26")] string NodeGroup;
     string LogicalName;
     string Description;
     string Owner;
@@ -166,7 +168,8 @@ DFUQueryResponse
     ESParray<ESPstruct DFULogicalFile> DFULogicalFiles;
 
     string Prefix;
-    string ClusterName;
+    [depr_ver("1.26")] string ClusterName;
+    [min_ver("1.26")] string NodeGroup;
     string LogicalName;
     string Description;
     string Owner;
@@ -638,7 +641,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.25"), default_client_version("1.25"),
+    version("1.26"), default_client_version("1.26"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -100,7 +100,7 @@ private:
     __int64 findPositionByRecords(const __int64 records, bool decsend, IArrayOf<IEspDFULogicalFile>& LogicalFiles);
     __int64 findPositionByName(const char *name, bool descend, IArrayOf<IEspDFULogicalFile>& LogicalFiles);
     __int64 findPositionByOwner(const char *owner, bool descend, IArrayOf<IEspDFULogicalFile>& LogicalFiles);
-    __int64 findPositionByCluster(const char *Cluster, bool descend, IArrayOf<IEspDFULogicalFile>& LogicalFiles);
+    __int64 findPositionByNodeGroup(double version, const char *nodeGroup, bool descend, IArrayOf<IEspDFULogicalFile>& LogicalFiles);
     __int64 findPositionByDate(const char *datetime, bool descend, IArrayOf<IEspDFULogicalFile>& LogicalFiles);
     __int64 findPositionByDescription(const char *description, bool descend, IArrayOf<IEspDFULogicalFile>& LogicalFiles);
     bool checkDescription(const char *description, const char *descriptionFilter);

--- a/esp/services/ws_fs/CMakeLists.txt
+++ b/esp/services/ws_fs/CMakeLists.txt
@@ -58,6 +58,7 @@ include_directories (
          ./../../smc/SMCLib 
          ./../../bindings/SOAP/xpp 
          ./../../../common/remote 
+         ./../../../common/workunit
     )
 
 ADD_DEFINITIONS( -D_USRDLL )
@@ -70,6 +71,7 @@ target_link_libraries ( ws_fs
          esphttp 
          dalibase 
          environment 
+         workunit
          SMCLib 
          dfuwu 
     )

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -26,6 +26,7 @@
 #include "daclient.hpp"
 #include "wshelpers.hpp"
 #include "dfuwu.hpp"
+#include "workunit.hpp"
 #include "ws_fsService.hpp"
 #ifdef _WIN32
 #include "windows.h"
@@ -616,18 +617,7 @@ void getNodeGroupFromLFN(const char* lfn, StringBuffer& nodeGroup, const char* u
     StringBuffer clusterName;
     LogicFileWrapper lfw;
     lfw.FindClusterName(lfn, clusterName, udesc);
-
-    Owned<IPropertyTreeIterator> it = conn->queryRoot()->getElements("Software/ThorCluster");
-    ForEach(*it)
-    {
-        IPropertyTree& cluster = it->query();
-        const char* name = cluster.queryProp("@name");
-        if (name && strieq(name, clusterName.str()))
-        {
-            getClusterGroupName(cluster, nodeGroup);
-            break;
-        }
-    }
+    getClusterThorGroupName(nodeGroup, clusterName.str());
 }
 
 StringBuffer& constructFileMask(const char* filename, StringBuffer& filemask)

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -617,8 +617,7 @@ StringBuffer& getNodeGroupFromLFN(StringBuffer& nodeGroup, const char* lfn, cons
     StringBuffer clusterName;
     LogicFileWrapper lfw;
     lfw.FindClusterName(lfn, clusterName, udesc);
-    getClusterThorGroupName(nodeGroup, clusterName.str());
-    return nodeGroup;
+    return getClusterThorGroupName(nodeGroup, clusterName.str());
 }
 
 StringBuffer& constructFileMask(const char* filename, StringBuffer& filemask)

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -601,11 +601,11 @@ void setRoxieClusterPartDiskMapping(const char *clusterName, const char *default
     wuOptions->setReplicate(replicate);
 }
 
-void getNodeGroupFromLFN(const char* lfn, StringBuffer& nodeGroup, const char* username, const char* passwd)
+StringBuffer& getNodeGroupFromLFN(StringBuffer& nodeGroup, const char* lfn, const char* username, const char* passwd)
 {
     Owned<IRemoteConnection> conn = querySDS().connect("Environment", myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
     if (!conn)
-        return;
+        return nodeGroup;
 
     Owned<IUserDescriptor> udesc;
     if(username != NULL && *username != '\0')
@@ -618,6 +618,7 @@ void getNodeGroupFromLFN(const char* lfn, StringBuffer& nodeGroup, const char* u
     LogicFileWrapper lfw;
     lfw.FindClusterName(lfn, clusterName, udesc);
     getClusterThorGroupName(nodeGroup, clusterName.str());
+    return nodeGroup;
 }
 
 StringBuffer& constructFileMask(const char* filename, StringBuffer& filemask)
@@ -2344,7 +2345,7 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
         const char* destNodeGroupReq = req.getDestGroup();
         if(!destNodeGroupReq || !*destNodeGroupReq)
         {
-            getNodeGroupFromLFN(srcname, destNodeGroup, context.queryUserId(), context.queryPassword());
+            getNodeGroupFromLFN(destNodeGroup, srcname, context.queryUserId(), context.queryPassword());
             DBGLOG("Destination node group not specified, using source node group %s", destNodeGroup.str());
         }
         else


### PR DESCRIPTION
Read and display node group as spray target to thor cluster;
Rename related variables/methods from 'cluster' to 'NodeGroup';
Rename the variable 'DFUQRFcluster' to 'DFUQRFnodegroup' and rename
the variable 'DFUQRFgroup' to 'DFUQRFnodegroups';
Rename the 'Cluster' column to 'NodeGroup' on Browse Logical File
page.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
