### PR TITLE
HPCC-11430 Prevent stack fault when parameter not substituted

### DIFF
--- a/ecl/hql/hqlmeta.cpp
+++ b/ecl/hql/hqlmeta.cpp
@@ -2826,6 +2826,7 @@ void calculateDatasetMeta(CHqlMetaInfo & meta, IHqlExpression * expr)
             meta.setUnknownGrouping();
         break;
     case no_externalcall:
+    case no_external:
         if (isGrouped(expr))
             meta.setUnknownGrouping();
         //No support for grouping?

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -6549,6 +6549,8 @@ ABoundActivity * HqlCppTranslator::buildActivity(BuildCtx & ctx, IHqlExpression 
             case no_executewhen:
                 result = doBuildActivityExecuteWhen(ctx, expr, isRoot);
                 break;
+            case no_param:
+                throwUnexpectedX("Create Parameter as an activity");
             case no_thor:
                 UNIMPLEMENTED;
                 break;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
