### PR TITLE
HPCC-11353 Workflow tab needs explanation

### DIFF
--- a/esp/src/eclwatch/WUDetailsWidget.js
+++ b/esp/src/eclwatch/WUDetailsWidget.js
@@ -348,6 +348,8 @@ define([
             } else if (name === "WorkflowCount" && newValue) {
                 this.widget._Workflows.set("title", this.i18n.Workflows + " (" + newValue + ")");
                 this.setDisabled(this.widget._Workflows.id, false);
+            } else if (name === "WorkflowCount" && newValue === 0){
+                this.widget._Workflows.set("tooltip", this.i18n.WorkFlowTip);
             } else if (name === "variables") {
                 var tooltip = "";
                 for (var key in newValue) {

--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -514,6 +514,7 @@ define({root:
     Who: "Who",
     Width: "Width",
     Workflows: "Workflows",
+    WorkFlowTip: "No scheduled workunits to display",
     Workunit: "Workunit",
     Workunits: "Workunits",
     Wrap: "Wrap",


### PR DESCRIPTION
Add ability for users to see a tool tip if scheduled work unit is not set
therefore, disabling the tab.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
