### PR TITLE
HPCC-11440 State hash should be comparable across clusters

### DIFF
--- a/common/workunit/package.cpp
+++ b/common/workunit/package.cpp
@@ -41,7 +41,7 @@ CPackageNode::CPackageNode(IPropertyTree *p)
     else
         node.setown(createPTree("HpccPackages"));
     StringBuffer xml;
-    toXML(node, xml);
+    toXML(node, xml, 0, XML_SortTags);
     hash = rtlHash64Data(xml.length(), xml.str(), 9994410);
 }
 

--- a/roxie/ccd/ccdstate.hpp
+++ b/roxie/ccd/ccdstate.hpp
@@ -60,6 +60,8 @@ interface IRoxiePackage : public IHpccPackage
     virtual IRoxieWriteHandler *createFileName(const char *fileName, bool overwrite, bool extend, const StringArray &clusters, IConstWorkUnit *wu) const = 0;
     // Lookup information in package about what in-memory indexes should be built for file
     virtual IPropertyTreeIterator *getInMemoryIndexInfo(const IPropertyTree &graphNode) const = 0;
+    // Set the hash to be used for this package
+    virtual void setHash(hash64_t newhash)  = 0;
 };
 
 interface IResolvedFileCache


### PR DESCRIPTION
In order to be able to compare hashes across clusters (which are liable to
have differences in topology files), exclude the topology hash from the
package hash and instead return it separately.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
