### PR TITLE
HPCC-11453 WsEcl shouldn't use ptr_noroot

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -1421,7 +1421,7 @@ void appendEclInputXsds(StringBuffer &content, IPropertyTree *xsd, BoolHash &add
 
 void CWsEclBinding::SOAPSectionToXsd(WsEclWuInfo &wsinfo, const char *parmXml, StringBuffer &schema, bool isRequest, IPropertyTree *xsdtree)
 {
-    Owned<IPropertyTree> tree = createPTreeFromXMLString(parmXml, ipt_none, (PTreeReaderOptions)(ptr_ignoreWhiteSpace|ptr_noRoot));
+    Owned<IPropertyTree> tree = createPTreeFromXMLString(parmXml);
 
     schema.appendf("<xsd:element name=\"%s%s\">", wsinfo.queryname.sget(), isRequest ? "Request" : "Response");
     schema.append("<xsd:complexType>");


### PR DESCRIPTION
Now that createPTreeFromXMLString supports ptr_noroot, it's become apparent that WsEcl shouldn't be setting it.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
