### PR TITLE
HPCC-11444 Fix signature of FlushingJsonBuffer::startDataset

### DIFF
--- a/common/thorhelper/roxiehelper.cpp
+++ b/common/thorhelper/roxiehelper.cpp
@@ -1102,7 +1102,7 @@ void FlushingJsonBuffer::encodeXML(const char *x, unsigned flags, unsigned len, 
     appendJSONStringValue(s, NULL, len, x, true);
 }
 
-void FlushingJsonBuffer::startDataset(const char *elementName, const char *resultName, unsigned sequence, bool _extend)
+void FlushingJsonBuffer::startDataset(const char *elementName, const char *resultName, unsigned sequence, bool _extend, const IProperties *xmlns)
 {
     CriticalBlock b(crit);
     extend = _extend;

--- a/common/thorhelper/roxiehelper.hpp
+++ b/common/thorhelper/roxiehelper.hpp
@@ -174,7 +174,7 @@ public:
     }
 
     void encodeXML(const char *x, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=false);
-    void startDataset(const char *elementName, const char *resultName, unsigned sequence, bool _extend = false);
+    void startDataset(const char *elementName, const char *resultName, unsigned sequence, bool _extend = false, const IProperties *xmlns=NULL);
     void startScalar(const char *resultName, unsigned sequence);
 };
 


### PR DESCRIPTION
Base rather than derived version was being called because the
signatures no longer matched.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
