### PR TITLE
HPCC-11456 Word Cloud Build Error

### DIFF
--- a/esp/src/eclwatch/QuerySetSuperFilesWidget.js
+++ b/esp/src/eclwatch/QuerySetSuperFilesWidget.js
@@ -67,7 +67,7 @@ define([
                 columns: {
                     col1: selector({
                         width: 27,
-                        selectorType: 'checkbox',
+                        selectorType: 'checkbox'
                     }),
                     __hpcc_display: tree({
                         label: this.i18n.SuperFiles,

--- a/esp/src/eclwatch/dojoConfig.js
+++ b/esp/src/eclwatch/dojoConfig.js
@@ -39,7 +39,8 @@ var dojoConfig = (function () {
         },
         packages: [{
             name: "d3",
-            location: urlInfo.basePath + "/d3"
+            location: urlInfo.basePath + "/d3",
+            main:"d3"
         }, {
             name: "topojson",
             location: urlInfo.basePath + "/topojson"

--- a/esp/src/eclwatch/package.js
+++ b/esp/src/eclwatch/package.js
@@ -4,6 +4,8 @@ var profile = (function(){
             "hpcc/eclwatch.profile": true,
             "hpcc/eclwatch.json": true,
             "hpcc/dojoConfig": true,
+            "hpcc/viz/DojoD3WordCloud": true,
+            "hpcc/viz/d3-cloud/d3.layout.cloud": true,
             "hpcc/viz/map/us.json": true,
             "hpcc/viz/map/us_counties.json": true
         };


### PR DESCRIPTION
Specify d3 entry point for third party sources.
Mark word cloud sources as "Copy Only".
Remove trailing "," in QuerySetSuperFilesWidget.js

Fixes HPCC-11456

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
