### PR TITLE
HPCC-11457 Regression Suite generates wrong name for the published query

### DIFF
--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -50,6 +50,13 @@ class ECLcmd(Shell):
 
         if cmd == 'publish':
             args.append(eclfile.getArchive())
+
+            name = kwargs.pop('name', False)
+            if not name:
+                name = eclfile.getBaseEclName()
+
+            args.append("--name=" + name)
+
         else:
             args.append('--noroot')
             server = kwargs.pop('server', False)

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -126,6 +126,9 @@ class ECLFile:
     def getBaseEcl(self):
         return self.ecl
 
+    def getBaseEclName(self):
+        return self.basename
+
     def getWuid(self):
         return self.wuid
 


### PR DESCRIPTION
Fix for generate a proper archive file name.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
