### PR TITLE
HPCC-11459 Add flag to toXML to allow newlines only formatting

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -5240,7 +5240,7 @@ static void _toXML(const IPropertyTree *tree, IIOStream &out, unsigned indent, b
             {
                 if (first)
                 {
-                    if (flags & XML_Format) inlinebody = false;
+                    if (flags & XML_Format|XML_NewlinesOnly) inlinebody = false;
                     first = false;
                     writeCharToStream(out, ' ');
                 }
@@ -5288,7 +5288,7 @@ static void _toXML(const IPropertyTree *tree, IIOStream &out, unsigned indent, b
     bool empty;
     if (isBinary)
     {
-        if (flags & XML_Format) inlinebody = false;
+        if (flags & XML_Format|XML_NewlinesOnly) inlinebody = false;
         writeStringToStream(out, " xsi:type=\"SOAP-ENC:base64\"");
         empty = (!tree->getPropBin(NULL, thislevelbin))||(thislevelbin.length()==0);
     }
@@ -5305,11 +5305,11 @@ static void _toXML(const IPropertyTree *tree, IIOStream &out, unsigned indent, b
     }
     if (sub->first())
     {
-        if (flags & XML_Format) inlinebody = false;
+        if (flags & XML_Format|XML_NewlinesOnly) inlinebody = false;
     }
     else if (empty && !(flags & XML_Sanitize))
     {
-        if (flags & XML_Format)
+        if (flags & XML_Format|XML_NewlinesOnly)
             writeStringToStream(out, "/>\n");
         else
             writeStringToStream(out, "/>");
@@ -5364,7 +5364,8 @@ static void _toXML(const IPropertyTree *tree, IIOStream &out, unsigned indent, b
             else
                 JBASE64_Encode(thislevelbin.toByteArray(), thislevelbin.length(), out);
         }
-        else {
+        else
+        {
             if (flags & XML_NoEncode)
             {
                 writeStringToStream(out, thislevel);
@@ -5385,7 +5386,7 @@ static void _toXML(const IPropertyTree *tree, IIOStream &out, unsigned indent, b
                     encodeXML(s, out, ENCODE_WHITESPACE, (unsigned)-1, true);
                 }
             }
-            
+
             if (!inlinebody)
                 writeStringToStream(out, "\n");
         }
@@ -5395,7 +5396,7 @@ static void _toXML(const IPropertyTree *tree, IIOStream &out, unsigned indent, b
 
     writeStringToStream(out, "</");
     writeStringToStream(out, name);
-    if (flags & XML_Format)
+    if (flags & XML_Format|XML_NewlinesOnly)
         writeStringToStream(out, ">\n");
     else
         writeCharToStream(out, '>');

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -213,6 +213,7 @@ jlib_decl IPropertyTree *createPTreeFromJSONString(unsigned len, const char *jso
 #define XML_SanitizeAttributeValues 0x10
 #define XML_SingleQuoteAttributeValues 0x20
 #define XML_NoBinaryEncode64 0x40
+#define XML_NewlinesOnly 0x80
 
 jlib_decl StringBuffer &toXML(const IPropertyTree *tree, StringBuffer &ret, unsigned indent = 0, byte flags=XML_Format);
 jlib_decl void toXML(const IPropertyTree *tree, IIOStream &out, unsigned indent = 0, byte flags=XML_Format);


### PR DESCRIPTION
Signed-off-by: Jake Smith jake.smith@lexisnexis.com
