### PR TITLE
HPCC-11452 Ensure control:queries does not split lines

### DIFF
--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1127,7 +1127,7 @@ public:
                 }
             }
         }
-        toXML(xref, reply, 1);
+        toXML(xref, reply, 1, XML_NewlinesOnly|XML_Format|XML_SortTags);
     }
     virtual void resetQueryTimings()
     {


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
