### PR TITLE
HPCC-11452 Ensure control:queries does not split lines

### DIFF
--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -627,7 +627,7 @@ public:
         afor.For(activeChildren.ordinality()+(isMaster ? 0 : 1), 10);
         activeChildren.kill();
         if (mergedReply)
-            toXML(mergedReply, reply);
+            toXML(mergedReply, reply, 0, (mergeType == CascadeMergeQueries) ? XML_Format | XML_NewlinesOnly : XML_Format);
         if (logctx.queryTraceLevel() > 5)
             logctx.CTXLOG("doControlQuery (%d) finished: %.80s", isMaster, queryText);
     }


### PR DESCRIPTION
Additional fixes needed for 5.0

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
