### PR TITLE
HPCC-11441 Fold IF() at parse time to avoid binding issues later

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -5644,8 +5644,7 @@ primexpr1
                         {
                             parser->normalizeExpression($5);
                             parser->normalizeExpression($7);
-                            ITypeInfo * type = parser->checkPromoteIfType($5, $7);
-                            $$.setExpr(createValue(no_if, type, $3.getExpr(), $5.getExpr(), $7.getExpr()), $1);
+                            $$.setExpr(parser->processIfProduction($3, $5, &$7), $1);
                         }
     | IFF '(' booleanExpr ',' expression ',' expression ')'
                         {

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -8759,19 +8759,18 @@ IHqlExpression * HqlGram::processIfProduction(attribute & condAttr, attribute & 
             right.setown(createNullExpr(left));
     }
 
-    //MORE: Not sure about this!
-    if (parsingTemplateAttribute && cond->isConstant())
-    {
-        OwnedHqlExpr folded = quickFoldExpression(cond);
-        if (folded->queryValue())
-            return folded->queryValue()->getBoolValue() ? left.getClear() : right.getClear();
-    }
-
     if (left->queryRecord() && falseAttr)
         right.setown(checkEnsureRecordsMatch(left, right, *falseAttr, false));
 
     if (isGrouped(left) != isGrouped(right))
         reportError(ERR_GROUPING_MISMATCH, trueAttr, "Branches of the condition have different grouping");
+
+    if (cond->isConstant())
+    {
+        OwnedHqlExpr folded = quickFoldExpression(cond);
+        if (folded->queryValue())
+            return folded->queryValue()->getBoolValue() ? left.getClear() : right.getClear();
+    }
 
     return ::createIf(cond.getClear(), left.getClear(), right.getClear());
 }

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -1479,8 +1479,13 @@ IHqlExpression * createIf(IHqlExpression * cond, IHqlExpression * left, IHqlExpr
     if (left->isDatarow() || right->isDatarow())
         return createRow(no_if, cond, createComma(left, right));
 
-    ITypeInfo * type = ::getPromotedECLType(left->queryType(), right->queryType());
-    return createValue(no_if, type, cond, left, right);
+    ITypeInfo * leftType = left->queryType();
+    ITypeInfo * rightType = right->queryType();
+    Owned<ITypeInfo> type = ::getPromotedECLType(leftType, rightType);
+    if (isStringType(type) && (leftType->getStringLen() != rightType->getStringLen()))
+        type.setown(getStretchedType(UNKNOWN_LENGTH, type));
+
+    return createValue(no_if, type.getClear(), cond, left, right);
 }
 
 extern HQL_API unsigned numRealChildren(IHqlExpression * expr)


### PR DESCRIPTION
- Note this also speeds parsing up since the expression trees are smaller

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
