### PR TITLE
HPCC-11477 Activities are being reset excessively

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -1235,7 +1235,8 @@ public:
             CriticalBlock cb(statecrit);
             if (state != STATEstopped)
             {
-                state=STATEstopped;
+                if (state != STATEreset)
+                    state=STATEstopped;
 #ifdef TRACE_STARTSTOP
                 if (traceStartStop)
                 {


### PR DESCRIPTION
An activity with two outputs (typically a splitter) can be reset on one arm,
then (because of the stopSink issue where resets occur without stops), can be
stopped then reset on the other. The stop() causes the state no longer to be
reset, so the reset of the upstream activity tree is repeated.

When splitters are inputs to other splitters this can result in an exponential
explosion of calls to reset.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
