### PR TITLE
HPCC-11467 Regression suite uses different options for ecl query and ecl run

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -31,7 +31,7 @@ from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
 from hpcc.common.error import Error
 
-prog_version = "0.0.19"
+prog_version = "0.0.20"
 
 # For coverage
 if ('coverage' in os.environ) and (os.environ['coverage'] == '1'):

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -129,7 +129,6 @@ class Regression:
 
         self.suites[cluster] = Suite(cluster, self.dir_ec, self.dir_a, self.dir_ex, self.dir_r, self.logDir,  False,  fileList)
         self.maxtasks = len(self.suites[cluster].getSuite())
-        os.chdir(self.regressionDir)
 
     def createDirectory(self, dir_n):
         if not os.path.isdir(dir_n):
@@ -144,7 +143,6 @@ class Regression:
         logging.debug("Setup Dir      : %s", self.setupDir)
         self.setupSuite = Suite(cluster, self.setupDir, self.dir_a, self.dir_ex, self.dir_r, self.logDir,  True)
         self.maxtasks = len(self.setupSuite.getSuite())
-        os.chdir(self.regressionDir)
         return self.setupSuite
 
     def buildLogging(self, name):


### PR DESCRIPTION
Fix implemented and tested

Signed-off-by: Attila Vamos attila.vamos@gmail.com
