### PR TITLE
HPCC-11497 Fix spurious notify on parent changes

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -682,7 +682,7 @@ public:
     bool querySub() const { return sub; }
     bool querySendValue() const { return sendValue; }
     unsigned queryDepth() const { return depth; }
-    bool qualify(CPTStack &stack)
+    bool qualify(CPTStack &stack, bool below)
     {
         ForEachItemIn(q, qualifierStack)
         {
@@ -690,7 +690,7 @@ public:
             if (stack.ordinality() <= q+1)
             {
                 // No more stack available (e.g. because deleted below this point)
-                return true;
+                return below; // NB: return true if below=true (meaning head of subscriber path)
             }
             PTree &item = stack.item(q+1); // stack +1, top is root unqualified.
             if (qualifier && '\0' != *qualifier)
@@ -778,7 +778,7 @@ public:
         ForEachItemIn(s, *list)
         {
             CSubscriberContainer &subscriber = list->item(s);
-            if (subscriber.qualify(stack))
+            if (subscriber.qualify(stack, false))
             {
                 if (!results) results = new CSubscriberContainerList(xpath);
                 subscriber.Link();
@@ -8071,7 +8071,7 @@ public:
                     CSubscriberContainer &subscriber = subs.item(s);
                     if (!subscriber.isUnsubscribed())
                     {
-                        if (subscriber.qualify(stack))
+                        if (subscriber.qualify(stack, true))
                             SDSManager->handleNotify(subscriber, state, stack);
                         else
                             pruned.append(*LINK(&subscriber));
@@ -8088,7 +8088,7 @@ public:
                         CSubscriberContainer &subscriber = subs.item(s);
                         if (!subscriber.isUnsubscribed())
                         {
-                            if (subscriber.qualify(stack))
+                            if (subscriber.qualify(stack, true))
                                 SDSManager->handleNotify(subscriber, state, stack);
                             else
                                 pruned.append(*LINK(&subscriber));
@@ -8140,7 +8140,7 @@ public:
                     CSubscriberContainer &subscriber = subs.item(s);
                     if (!subscriber.isUnsubscribed())
                     {
-                        if (subscriber.qualify(stack))
+                        if (subscriber.qualify(stack, false))
                         {
                             if (subscriber.querySendValue())
                             {

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -682,7 +682,7 @@ public:
     bool querySub() const { return sub; }
     bool querySendValue() const { return sendValue; }
     unsigned queryDepth() const { return depth; }
-    bool qualify(CPTStack &stack, bool below)
+    bool qualify(CPTStack &stack, bool matchIfPartial)
     {
         ForEachItemIn(q, qualifierStack)
         {
@@ -690,7 +690,7 @@ public:
             if (stack.ordinality() <= q+1)
             {
                 // No more stack available (e.g. because deleted below this point)
-                return below; // NB: return true if below=true (meaning head of subscriber path)
+                return matchIfPartial; // NB: return true if matchIfPartial=true (meaning head of subscriber path matched commit stack)
             }
             PTree &item = stack.item(q+1); // stack +1, top is root unqualified.
             if (qualifier && '\0' != *qualifier)


### PR DESCRIPTION
If a parent path of a subscriber was commited to, the subscribers
were spuriously notified.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
