### PR TITLE
HPCC-11509 ESP cache of packagemap info leaking connections

### DIFF
--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -382,7 +382,8 @@ public:
 
     void load(const char *id)
     {
-        load(getPackageMapById(id, true));
+        Owned<IPropertyTree> xml = getPackageMapById(id, true);
+        load(xml);
     }
 
     virtual void gatherFileMappingForQuery(const char *queryname, IPropertyTree *fileInfo) const

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -931,7 +931,8 @@ bool CWsPackageProcessEx::onGetQueryFileMapping(IEspContext &context, IEspGetQue
     const char *pmid = req.getPMID();
     if (pmid && *pmid)
     {
-        ownedmap.setown(createPackageMapFromPtree(getPackageMapById(req.getGlobalScope() ? NULL : target, pmid, true), target, pmid));
+        Owned<IPropertyTree> pm = getPackageMapById(req.getGlobalScope() ? NULL : target, pmid, true);
+        ownedmap.setown(createPackageMapFromPtree(pm, target, pmid));
         if (!ownedmap)
             throw MakeStringException(PKG_LOAD_PACKAGEMAP_FAILED, "Error loading package map %s", req.getPMID());
         map = ownedmap;


### PR DESCRIPTION
A couple of uses of getPackageMapById leaked the resulting Dali connection and
thus left the packagemap locked.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
