### PR TITLE
HPCC-11399 Fix request with JSON nulls being treated as empty not null

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -6460,7 +6460,9 @@ public:
     void readValueNotify(const char *name, bool skipAttributes)
     {
         StringBuffer value;
-        readValue(value);
+        if (readValue(value)==elementTypeNull)
+            return;
+
         if ('@'==*name)
         {
             if (!skipAttributes)


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
