### PR TITLE
HPCC-11375 Query Test Page is initially blank

### DIFF
--- a/esp/src/eclwatch/QueryTestWidget.js
+++ b/esp/src/eclwatch/QueryTestWidget.js
@@ -78,6 +78,7 @@ define([
                 return;
 
             this.query = ESPQuery.Get(params.QuerySetId, params.Id);
+            this.initTab();
         },
 
         setContent: function (target, type, postfix) {


### PR DESCRIPTION
The first time the query test page is opened, the SOAP tab is blank.

Fixes HPCC-11375

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
