### PR TITLE
HPCC-11417 Eliminate epoll uninitialized warning

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -4231,9 +4231,9 @@ class CSocketEpollThread: public CSocketBaseThread
         struct epoll_event event;
         event.events = event_mask;
 
-        // write all bytes to remove uninitialed warnings
-        // event.data.fd = fd;
-        event.data.u64 = (uint64_t)fd;
+        // write all bytes to eliminate uninitialized warnings
+        memset(&event, 0, sizeof(event));
+        event.data.fd = fd;
 
 # ifdef EPOLLTRACE
         DBGLOG("EPOLL: op(%d) fd %d to epfd %d", op, fd, efd);

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -4230,7 +4230,11 @@ class CSocketEpollThread: public CSocketBaseThread
         int srtn;
         struct epoll_event event;
         event.events = event_mask;
-        event.data.fd = fd;
+
+        // write all bytes to remove uninitialed warnings
+        // event.data.fd = fd;
+        event.data.u64 = (uint64_t)fd;
+
 # ifdef EPOLLTRACE
         DBGLOG("EPOLL: op(%d) fd %d to epfd %d", op, fd, efd);
 # endif

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -4229,10 +4229,11 @@ class CSocketEpollThread: public CSocketBaseThread
     {
         int srtn;
         struct epoll_event event;
-        event.events = event_mask;
 
         // write all bytes to eliminate uninitialized warnings
         memset(&event, 0, sizeof(event));
+
+        event.events = event_mask;
         event.data.fd = fd;
 
 # ifdef EPOLLTRACE


### PR DESCRIPTION
Added to remove epoll uninitialized byte warning.
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
