### PR TITLE
HPCC-11523 Fix roxie core on unloadable workunits

### DIFF
--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1282,12 +1282,12 @@ public:
     }
     virtual int getDebugValueInt(const char * propname, int defVal) const
     {
-        assertex(dll->queryWorkUnit());
+        assertex(dll && dll->queryWorkUnit());
         return dll->queryWorkUnit()->getDebugValueInt(propname, defVal);
     }
     virtual bool getDebugValueBool(const char * propname, bool defVal) const
     {
-        assertex(dll->queryWorkUnit());
+        assertex(dll && dll->queryWorkUnit());
         return dll->queryWorkUnit()->getDebugValueBool(propname, defVal);
     }
     bool getEnableFieldTranslation() const


### PR DESCRIPTION
Queries that are suspended because dll cannot be loaded may core if called

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
