### PR TITLE
HPCC-11515 Under-caching of dynamic filename resolution

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -985,7 +985,7 @@ public:
     }
 
     Owned<IWUGraphProgress> graphProgress; // could make local to endGraph and pass to reset - might be cleaner
-    void endGraph(bool aborting)
+    virtual void endGraph(bool aborting)
     {
         if (graph)
         {
@@ -1828,6 +1828,7 @@ class CRoxieServerContext : public CSlaveContext, implements IRoxieServerContext
 
 protected:
     Owned<WorkflowMachine> workflow;
+    mutable MapStringToMyClass<IResolvedFile> fileCache;
     SafeSocket *client;
     bool isBlocked;
     bool isHttp;
@@ -2770,14 +2771,33 @@ public:
         }
     }
 
-    virtual const IResolvedFile *resolveLFN(const char *filename, bool isOpt)
+    virtual const IResolvedFile *resolveLFN(const char *fileName, bool isOpt)
     {
-        return factory->queryPackage().lookupFileName(filename, isOpt, false, true, workUnit);
+        CriticalBlock b(contextCrit);
+        StringBuffer expandedName;
+        expandLogicalFilename(expandedName, fileName, workUnit, false);
+        Linked<const IResolvedFile> ret = fileCache.getValue(expandedName);
+        if (!ret)
+        {
+            ret.setown(factory->queryPackage().lookupFileName(fileName, isOpt, false, false, workUnit));
+            if (ret)
+            {
+                IResolvedFile *add = const_cast<IResolvedFile *>(ret.get());
+                fileCache.setValue(expandedName, add);
+            }
+        }
+        return ret.getClear();
     }
 
     virtual IRoxieWriteHandler *createLFN(const char *filename, bool overwrite, bool extend, const StringArray &clusters)
     {
         return factory->queryPackage().createFileName(filename, overwrite, extend, clusters, workUnit);
+    }
+
+    virtual void endGraph(bool aborting)
+    {
+        fileCache.kill();
+        CSlaveContext::endGraph(aborting);
     }
 
     virtual void onFileCallback(const RoxiePacketHeader &header, const char *lfn, bool isOpt, bool isLocal)

--- a/version.cmake
+++ b/version.cmake
@@ -4,7 +4,7 @@
 set ( HPCC_PROJECT "community" )
 set ( HPCC_MAJOR 4 )
 set ( HPCC_MINOR 2 )
-set ( HPCC_POINT 7 )
-set ( HPCC_MATURITY "closedown" )
-set ( HPCC_SEQUENCE 1 )
+set ( HPCC_POINT 8 )
+set ( HPCC_MATURITY "rc" )
+set ( HPCC_SEQUENCE 0 )
 ###


### PR DESCRIPTION
Cache any dynamic file lookups until the end of the current graph.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
