### PR TITLE
HPCC-11474 Support publishing larger ECL archives

### DIFF
--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -52,7 +52,7 @@ include_directories (
          ./../../common/dllserver
          ./../../common/fileview2
          ./../../common/workunit
-         ./../../esp/clients
+         ./../../esp/bindings/http/client
          ./../../common/environment
          ./../../esp/bindings/SOAP/xpp
          ./../../system/include

--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -52,7 +52,6 @@ include_directories (
          ./../../common/dllserver
          ./../../common/fileview2
          ./../../common/workunit
-         ./../../esp/bindings/http/client
          ./../../common/environment
          ./../../esp/bindings/SOAP/xpp
          ./../../system/include

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -566,6 +566,8 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     if (iter.matchOption(optSnapshot, ECLOPT_SNAPSHOT) || iter.matchOption(optSnapshot, ECLOPT_SNAPSHOT_S))
         return EclCmdOptionMatch;
+    if (iter.matchFlag(optNoCompression, ECLOPT_NO_COMPRESSION))
+        return EclCmdOptionMatch;
     if (iter.matchFlag(optNoArchive, ECLOPT_ECL_ONLY))
         return EclCmdOptionMatch;
     if (iter.matchFlag(optLegacy, ECLOPT_LEGACY) || iter.matchFlag(optLegacy, ECLOPT_LEGACY_DASH))

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -566,8 +566,6 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     if (iter.matchOption(optSnapshot, ECLOPT_SNAPSHOT) || iter.matchOption(optSnapshot, ECLOPT_SNAPSHOT_S))
         return EclCmdOptionMatch;
-    if (iter.matchFlag(optNoCompression, ECLOPT_NO_COMPRESSION))
-        return EclCmdOptionMatch;
     if (iter.matchFlag(optNoArchive, ECLOPT_ECL_ONLY))
         return EclCmdOptionMatch;
     if (iter.matchFlag(optLegacy, ECLOPT_LEGACY) || iter.matchFlag(optLegacy, ECLOPT_LEGACY_DASH))

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -92,7 +92,6 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_SNAPSHOT "--snapshot"
 #define ECLOPT_SNAPSHOT_S "-sn"
 #define ECLOPT_ECL_ONLY "--ecl-only"
-#define ECLOPT_NO_COMPRESSION "--no-compress"
 
 #define ECLOPT_WAIT "--wait"
 #define ECLOPT_WAIT_INI "waitTimeout"
@@ -240,7 +239,7 @@ public:
 class EclCmdWithEclTarget : public EclCmdCommon
 {
 public:
-    EclCmdWithEclTarget() : optLegacy(false), optNoCompression(false), optNoArchive(false), optResultLimit((unsigned)-1)
+    EclCmdWithEclTarget() : optLegacy(false), optNoArchive(false), optResultLimit((unsigned)-1)
     {
     }
     virtual eclCmdOptionMatchIndicator matchCommandLineOption(ArgvIterator &iter, bool finalAttempt=false);
@@ -251,7 +250,6 @@ public:
         EclCmdCommon::usage();
         fprintf(stdout,
             "   --main=<definition>    Definition to use from legacy ECL repository\n"
-            "   --no-compress          Don't compress payload when deploying (server < 5.0)"
             "   --snapshot,-sn=<label> Snapshot label to use from legacy ECL repository\n"
             "   --ecl-only             Send ecl text to hpcc without generating archive\n"
             "   --limit=<limit>        Sets the result limit for the query, defaults to 100\n"
@@ -274,7 +272,6 @@ public:
     IArrayOf<IEspNamedValue> debugValues;
     unsigned optResultLimit;
     bool optNoArchive;
-    bool optNoCompression;
     bool optLegacy;
 };
 

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -30,17 +30,11 @@
 bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *cluster, const char *name, StringBuffer *wuid, StringBuffer *wucluster, bool noarchive, bool displayWuid=true, bool compress=true)
 {
     bool useCompression = false;
-    int maxBufferSize = 0;
     try
     {
         Owned<IClientWUCheckFeaturesRequest> req = client->createWUCheckFeaturesRequest();
         Owned<IClientWUCheckFeaturesResponse> resp = client->WUCheckFeatures(req);
         useCompression = resp->getDeployment().getUseCompression();
-        int maxEntity = resp->getMaxRequestEntityLength();
-        if (maxEntity > 1000)
-        {
-            maxBufferSize = ((maxEntity - 999) / 4) * 3; //account for soap, other parameters, and base64 encoding (n / 4 * 3)
-        }
     }
     catch(IException *E) //most likely an older ESP
     {
@@ -87,12 +81,6 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
         default:
             fprintf(stderr, "Cannot deploy %s\n", cmd.optObj.queryTypeName());
             return false;
-    }
-
-    if (maxBufferSize && cmd.optObj.mb.length() > maxBufferSize)
-    {
-        fprintf(stderr, "\nError %s is larger than maxRequestEntityLength configured for ESP allows\n", objType.str()); //objType already notes if its compressed
-        return false;
     }
 
     if (name && *name)

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1821,7 +1821,7 @@ int CHttpRequest::processHeaders(IMultiException *me)
     if (getEspLogRequests() || getEspLogLevel()>LogNormal)
         logMessage(LOGHEADERS, "HTTP request headers received:\n");
 
-    if(m_content_length > 0 && m_MaxRequestEntityLength > 0 && m_content_length > m_MaxRequestEntityLength && (!isUpload()))
+    if(m_content_length > 0 && m_MaxRequestEntityLength > 0 && m_content_length > m_MaxRequestEntityLength && (!isUpload(false)))
         throw createEspHttpException(HTTP_STATUS_BAD_REQUEST_CODE, "The request length was too long.", HTTP_STATUS_BAD_REQUEST);
 
     return 0;

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -233,10 +233,13 @@ public:
         return false;
     }
 
-    virtual bool isUpload()
+    virtual bool isUpload(bool checkMimeType=true)
     {
-        if(m_queryparams && m_queryparams->hasProp("upload_") && !Utils::strncasecmp(m_content_type.get(), "multipart", strlen("multipart")))
-            return true;
+        if(m_queryparams && m_queryparams->hasProp("upload_"))
+        {
+            if (!checkMimeType || !Utils::strncasecmp(m_content_type.get(), "multipart", strlen("multipart")))
+                return true;
+        }
         return false;
     }
 };

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1504,7 +1504,7 @@ ESPresponse [exceptions_inline] WUCheckFeaturesResponse
     int BuildVersionMajor;
     int BuildVersionMinor;
     int BuildVersionPoint;
-    int maxRequestEntityLength;
+    unsigned maxRequestEntityLength;
     ESPStruct DeploymentFeatures Deployment;
 };
 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1490,6 +1490,24 @@ ESPresponse [exceptions_inline] WUCreateZAPInfoResponse
     [http_content("application/octet-stream")] binary thefile;
 };
 
+ESPrequest [nil_remove] WUCheckFeaturesRequest
+{
+};
+
+ESPStruct DeploymentFeatures
+{
+    bool UseCompression;
+};
+
+ESPresponse [exceptions_inline] WUCheckFeaturesResponse
+{
+    int BuildVersionMajor;
+    int BuildVersionMinor;
+    int BuildVersionPoint;
+    int maxRequestEntityLength;
+    ESPStruct DeploymentFeatures Deployment;
+};
+
 ESPservice [
     version("1.50"), default_client_version("1.50"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
@@ -1563,6 +1581,7 @@ ESPservice [
     ESPmethod [resp_xsl_default("/esp/xslt/QueriesUsingFile.xslt")] WUListQueriesUsingFile(WUListQueriesUsingFileRequest, WUListQueriesUsingFileResponse);
     ESPmethod WUCreateZAPInfo(WUCreateZAPInfoRequest, WUCreateZAPInfoResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/WUZAPInfoForm.xslt")] WUGetZAPInfo(WUGetZAPInfoRequest, WUGetZAPInfoResponse);
+    ESPmethod WUCheckFeatures(WUCheckFeaturesRequest, WUCheckFeaturesResponse);
 };
 
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -19,6 +19,7 @@
 #include "ws_fs.hpp"
 
 #include "jlib.hpp"
+#include "jflz.hpp"
 #include "daclient.hpp"
 #include "dalienv.hpp"
 #include "dadfs.hpp"
@@ -3535,6 +3536,19 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
     return onGetNotFound(context, request, response, service);
 }
 
+bool isDeploymentTypeCompressed(const char *type)
+{
+    if (type && *type)
+        return (0==strncmp(type, "compressed_", strlen("compressed_")));
+    return false;
+}
+
+const char *skipCompressedTypeQualifier(const char *type)
+{
+    if (isDeploymentTypeCompressed(type))
+        type += strlen("compressed_");
+    return type;
+}
 
 void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEspWUDeployWorkunitResponse & resp)
 {
@@ -3553,7 +3567,15 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
 
     if (req.getObject().length())
     {
-        StringBuffer text(req.getObject().length(), req.getObject().toByteArray());
+        MemoryBuffer mb;
+        const MemoryBuffer *uncompressed = &req.getObject();
+        if (isDeploymentTypeCompressed(req.getObjType()))
+        {
+            fastLZDecompressToBuffer(mb, req.getObject().bufferBase());
+            uncompressed = &mb;
+        }
+
+        StringBuffer text(uncompressed->length(), uncompressed->toByteArray());
         wu.setQueryText(text.str());
     }
     if (req.getQueryMainDefinition())
@@ -3676,8 +3698,16 @@ void CWsWorkunitsEx::deploySharedObject(IEspContext &context, IEspWUDeployWorkun
     if (isEmpty(cluster))
        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Cluster name required when deploying a shared object.");
 
+    const MemoryBuffer *uncompressed = &req.getObject();
+    MemoryBuffer mb;
+    if (isDeploymentTypeCompressed(req.getObjType()))
+    {
+        fastLZDecompressToBuffer(mb, req.getObject().bufferBase());
+        uncompressed = &mb;
+    }
+
     StringBuffer wuid;
-    deploySharedObject(context, wuid, req.getFileName(), cluster, req.getName(), req.getObject(), dir, xml);
+    deploySharedObject(context, wuid, req.getFileName(), cluster, req.getName(), *uncompressed, dir, xml);
 
     WsWuInfo winfo(context, wuid.str());
     winfo.getCommon(resp.updateWorkunit(), WUINFO_All);
@@ -3687,8 +3717,7 @@ void CWsWorkunitsEx::deploySharedObject(IEspContext &context, IEspWUDeployWorkun
 
 bool CWsWorkunitsEx::onWUDeployWorkunit(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEspWUDeployWorkunitResponse & resp)
 {
-    const char *type = req.getObjType();
-
+    const char *type = skipCompressedTypeQualifier(req.getObjType());
     try
     {
         if (!context.validateFeatureAccess(OWN_WU_ACCESS, SecAccess_Write, false))
@@ -3696,12 +3725,14 @@ bool CWsWorkunitsEx::onWUDeployWorkunit(IEspContext &context, IEspWUDeployWorkun
 
         if (notEmpty(req.getCluster()) && !isValidCluster(req.getCluster()))
             throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid cluster name: %s", req.getCluster());
+        if (!type || !*type)
+            throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT, "WUDeployWorkunit unspecified object type.");
         if (strieq(type, "archive")|| strieq(type, "ecl_text"))
             deployEclOrArchive(context, req, resp);
         else if (strieq(type, "shared_object"))
             deploySharedObject(context, req, resp, queryDirectory.str());
         else
-            throw MakeStringException(ECLWATCH_INVALID_INPUT, "WUDeployWorkunit '%s' unkown object type.", type);
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "WUDeployWorkunit '%s' unknown object type.", type);
     }
     catch(IException* e)
     {

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -403,6 +403,7 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
         sashaServerPort = cfg->getPropInt(xpath.str(), DEFAULT_SASHA_PORT);
     }
 
+    maxRequestEntityLength = cfg->getPropInt("Software[1]/EspProcess[1]/EspProtocol[@type='http_protocol'][1]/@maxRequestEntityLength");
     directories.set(cfg->queryPropTree("Software/Directories"));
 
     const char *name = cfg->queryProp("Software/EspProcess/@name");
@@ -4029,5 +4030,15 @@ bool CWsWorkunitsEx::onWUGetZAPInfo(IEspContext &context, IEspWUGetZAPInfoReques
     {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
+    return true;
+}
+
+bool CWsWorkunitsEx::onWUCheckFeatures(IEspContext &context, IEspWUCheckFeaturesRequest &req, IEspWUCheckFeaturesResponse &resp)
+{
+    resp.setBuildVersionMajor(BUILD_VERSION_MAJOR);
+    resp.setBuildVersionMinor(BUILD_VERSION_MINOR);
+    resp.setBuildVersionPoint(BUILD_VERSION_POINT);
+    resp.setMaxRequestEntityLength(maxRequestEntityLength);
+    resp.updateDeployment().setUseCompression(true);
     return true;
 }

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -166,7 +166,7 @@ class CWsWorkunitsEx : public CWsWorkunits
 public:
     IMPLEMENT_IINTERFACE;
 
-    CWsWorkunitsEx(){port=8010;}
+    CWsWorkunitsEx() : maxRequestEntityLength(0) {port=8010;}
 
     virtual ~CWsWorkunitsEx()
     {
@@ -257,6 +257,8 @@ public:
     bool isQuerySuspended(const char* query, IConstWUClusterInfo *clusterInfo, unsigned wait, StringBuffer& errorMessage);
     bool onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfoRequest &req, IEspWUCreateZAPInfoResponse &resp);
     bool onWUGetZAPInfo(IEspContext &context, IEspWUGetZAPInfoRequest &req, IEspWUGetZAPInfoResponse &resp);
+    bool onWUCheckFeatures(IEspContext &context, IEspWUCheckFeaturesRequest &req, IEspWUCheckFeaturesResponse &resp);
+
 private:
 #ifdef _USE_ZLIB
     void addProcessLogfile(IZZIPor* zipper, Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, PointerArray &mbArr);
@@ -273,6 +275,7 @@ private:
     WUSchedule m_sched;
     unsigned short port;
     Owned<IPropertyTree> directories;
+    int maxRequestEntityLength;
 public:
     QueryFilesInUse filesInUse;
 };


### PR DESCRIPTION
Check ESP configuration for maxRequestEntityLength.  Try compressing
archive if larger than limit.  If still too big give sensible error
message.

User can also increase configured maxRequestEntityLength limit.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
