### PR TITLE
HPCC-11472 Choropleth does not display in ECL Playground

### DIFF
--- a/esp/src/eclwatch/viz/DojoD3Choropleth.js
+++ b/esp/src/eclwatch/viz/DojoD3Choropleth.js
@@ -39,6 +39,11 @@ define([
 
         resize: function (args) {
             //  No resize (yet - its too slow)
+            this.calcGeom();
+            d3.select(this.target.domDivID).select("svg")
+                .attr("width", this.target.width)
+                .attr("height", this.target.height)
+            ;
         },
 
         renderTo: function (_target) {


### PR DESCRIPTION
Only worked in IE because it fails to clip the SVG element.

Fixes HPCC-11472

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
