### PR TITLE
HPCC-10692 Allow options to be specified when running the regression suite

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -1,4 +1,4 @@
-Overview of Regression Suite usage (v:0.0.16)
+Overview of Regression Suite usage (v:0.0.21)
 ==============================================
 
 To use Regression Suite change directory to HPCC-Platform/testing/regress subdirectory.
@@ -19,6 +19,8 @@ Result:
 |                       [--loglevel [{info,debug}]] [--suiteDir [SUITEDIR]]
 |                       [--timeout [TIMEOUT]] [--keyDir [KEYDIR]]
 |                       [--ignoreResult]
+|                       [-X name1=value1[,name2=value2...]]
+|                       [-f optionA=valueA[,optionB=valueB...]]
 |                       {list,setup,run,query} ...
 | 
 |       HPCC Platform Regression suite
@@ -42,6 +44,24 @@ Result:
 |            --keyDir [KEYDIR], -k [KEYDIR]
 |                                  key file directory to compare test output. Default value defined in regress.json config file.
 |            --ignoreResult, -i    completely ignore the result.
+|            -X name1=value1[,name2=value2...]
+|                                  sets the stored input value (stored('name')).
+|            -f optionA=valueA[,optionB=valueB...]
+|                                  set an ECL option (equivalent to #option).
+
+Important!
+    There is a bug in Python argparse library whichis impacts the quoted parameters. So either in -X or -f or both contains a value with space(s) inside then the whole argument should be put in double quote!
+
+    Example: We should pass these names values pairs to set stored input values:
+                param1 = 1
+                param2 = A string
+                param2 = Other string
+
+    The proper ecl-test command is:
+            ./ecl-test -X"param1=1,param2=A string,param3=Other String" ...
+
+    Same format should use for -f option(s) and values. This problem doesn't impact parameters are stored in ecl-test.json config file. (See 9.)
+
 
 Parameters of Regression Suite list sub-command:
 ------------------------------------------------

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -31,7 +31,7 @@ from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam,  getVersionNumbers
 from hpcc.common.error import Error
 
-prog_version = "0.0.20"
+prog_version = "0.0.21"
 
 # For coverage
 if ('coverage' in os.environ) and (os.environ['coverage'] == '1'):
@@ -170,6 +170,10 @@ class RegressMain:
                             nargs='?', default="ecl/key")
         parser.add_argument('--ignoreResult', '-i', help="completely ignore the result.",
                             action='store_true')
+        parser.add_argument('-X', help="sets the stored input value (stored('name')).",
+                            nargs=1, type=checkXParam,  default='None',  metavar="name1=value1[,name2=value2...]")
+        parser.add_argument('-f', help="set an ECL option (equivalent to #option).",
+                            nargs=1, type=checkXParam,  default='None',  metavar="optionA=valueA[,optionB=valueB...]")
 
         subparsers = parser.add_subparsers(help='sub-command help')
 

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -48,6 +48,8 @@ class ECLcmd(Shell):
         if password:
             args.append("--password=" + password)
 
+        args = args + eclfile.getFParameters()
+
         if cmd == 'publish':
             args.append(eclfile.getArchive())
 


### PR DESCRIPTION
Add '-f...' parameter and handling code.

Overcome the python argparse library 'space in argument' handling problem.

Update '-X...' code to fix above problem

Update README.rst

Signed-off-by: Attila Vamos attila.vamos@gmail.com
