### PR TITLE
HPCC-11487 Search Results defaults to "loading..." message

### DIFF
--- a/esp/src/eclwatch/SearchResultsWidget.js
+++ b/esp/src/eclwatch/SearchResultsWidget.js
@@ -63,7 +63,7 @@ define([
             if (params.searchText) {
                 this.doSearch(params.searchText);
             }
-            this._refreshActionState();
+            this.refreshGrid();
         },
 
         getTitle: function () {
@@ -338,6 +338,7 @@ define([
             if (this.searchText) {
                 this.searchAll();
             }
+            this._refreshActionState();
         },
 
         refreshActionState: function (selection) {


### PR DESCRIPTION
It should default to "Zero Rows" message until a search is performed.

Fixes HPCC-11487

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
