### PR TITLE
Hpcc-11405 Enable upgrading HPCC Platform with install-cluster.sh

### DIFF
--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -150,6 +150,10 @@ runPayload(){
                     exit;
             } eof {
                     exit;
+            } "${USER}@" { 
+                  # Allow non-password connection go through without changing following code.
+                  # This is will be replaced when HPCC-11156 is fixed.
+                  send \"hostname\r\" 
             }
         }
         expect "${USER}@" {
@@ -204,21 +208,10 @@ createPayload;
 for IP in $IPS; do
     if ping -c 1 -w 5 -n $IP > /dev/null 2>&1; then
         echo "$IP: Host is alive."
-        if [ ${NEW_KEY} -ne 1 ]; then
-            CAN_SSH="`ssh -i /home/hpcc/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no hpcc@$IP exit > /dev/null 2>&1; echo $?`"
-        else
-            CAN_SSH=255
-        fi
-        if [ "$CAN_SSH" -eq 255 ]; then
-            echo "$IP: Cannot SSH to host with key..";
-            echo "$IP: Connecting with password.";
-            copyPayload $IP;
-            expandPayload $IP;
-            runPayload $IP;
-            echo "$IP: Done.";
-        else
-            echo "$IP: Has SSH Key, No install actions done.";
-        fi
+        copyPayload $IP;
+        expandPayload $IP;
+        runPayload $IP;
+        echo "$IP: Done.";
     else
         echo "$IP: Cannot Ping host? (Host Alive?)"
     fi

--- a/initfiles/sbin/remote-install-engine.sh.in
+++ b/initfiles/sbin/remote-install-engine.sh.in
@@ -75,6 +75,7 @@ pkgCmd(){
             echo "Bad option type."
             exit 1
         fi
+        [ $WITH_PLUGINS -eq 1 ] && PKGCMD="$PKGCMD --nodeps"
     else
         echo "BAD Package type."
         exit 1
@@ -194,7 +195,12 @@ if [ -z $pkgtype ]; then
     OSPKG="deb"
 else
     OSPKG="rpm"
+    WITH_PLUGINS=0
+    basename $PKG | grep -i with-plugins
+    [ $? -eq 0 ] && WITH_PLUGINS=1
 fi
+
+
 
 installPkg
 checkUser "hpcc"


### PR DESCRIPTION
Allow upgrading existing HPCC Platform. Add "--nodeps" options for rpm for installing platform with plugins. Also add support for non-password ssh connection.
