### PR TITLE
HPCC-11588 Better timeout for Roxie's initial dali connect

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -117,7 +117,7 @@ extern unsigned myNodeIndex;
 #define DEBUGREQUEST_TIMEOUT 5000
 #endif
 
-#define ROXIE_DALI_CONNECT_TIMEOUT 5000
+#define ROXIE_DALI_CONNECT_TIMEOUT 30000
 
 class RemoteActivityId
 {

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1671,7 +1671,10 @@ public:
     CRoxiePackageSetManager(const IQueryDll *_standAloneDll) :
         autoReloadThread(*this), standAloneDll(_standAloneDll)
     {
-        daliHelper.setown(connectToDali(ROXIE_DALI_CONNECT_TIMEOUT));
+        if (topology && topology->getPropBool("@lockDali", false))
+            daliHelper.setown(connectToDali());
+        else
+            daliHelper.setown(connectToDali(ROXIE_DALI_CONNECT_TIMEOUT));
         atomic_set(&autoPending, 0);
         autoReloadThread.start();
         pSetsNotifier.setown(daliHelper->getPackageSetsSubscription(this));


### PR DESCRIPTION
When first connecting to Dali, Roxie should wait longer (if lockDali not set),
or not at all (if it is). This helps avoid duplicated work at startup.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
