### PR TITLE
HPCC-11610 Control:reload may leave state hash incorrect

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1625,6 +1625,7 @@ private:
                             {
                                 if (traceLevel)
                                     DBGLOG("Package map %s, active %s already loaded", packageMapId, isActive ? "true" : "false");
+                                stateHash = rtlHash64Data(sizeof(stateHash), &stateHash, oldPackageManager->getHash());
                                 allQueryPackages.append(*oldPackageManager.getClear());
                             }
                             else


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
