### PR TITLE
HPCC-11598 Autogenerate 'OriginalTextFilesPath' stored variable for setup & some log generation fixup

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -1,4 +1,4 @@
-Overview of Regression Suite usage (v:0.0.21)
+Overview of Regression Suite usage (v:0.0.22)
 ==============================================
 
 To use Regression Suite change directory to HPCC-Platform/testing/regress subdirectory.
@@ -211,7 +211,7 @@ The result:
 |            -------------------------------------------------
 |
 
-
+To setup the proper environment for text search test cases there is a new component called setuptext.ecl. It uses data files from other location and the default location stored into the options.ecl. RS generates location from the run-time environment and passes it to the setup via stored variable called 'OriginalTextFilesPath'.
 
 4. To run Regression Suite on a selected cluster (e.g. Thor):
 -------------------------------------------------------------

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -28,10 +28,10 @@ import glob
 from hpcc.util import argparse
 from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
-from hpcc.util.util import checkPqParam,  getVersionNumbers,  checkXParam
+from hpcc.util.util import checkPqParam,  getVersionNumbers,  checkXParam,  convertPath
 from hpcc.common.error import Error
 
-prog_version = "0.0.21"
+prog_version = "0.0.22"
 
 # For coverage
 if ('coverage' in os.environ) and (os.environ['coverage'] == '1'):
@@ -114,6 +114,8 @@ class RegressMain:
 
     def setup(self):
         if self.args.target in self.regress.config.Clusters:
+            self.args.setupExtraX = []
+            self.args.setupExtraX.append('OriginalTextFilesPath='+self.regressionSuiteHpccMainDir)
             if  self.args.pq :
                 self.regress.runSuiteP(self.args.target, self.regress.Setup(self.args))
             else:
@@ -219,6 +221,7 @@ class RegressMain:
             regressionSuiteFullPath = os.path.realpath(regressionSuiteMainDir)
             self.args.config = str(os.path.join(regressionSuiteFullPath, self.args.config))
 
+            self.regressionSuiteHpccMainDir = convertPath(regressionSuiteFullPath)+"::download"
             self.regress = Regression(self.args)
             logging.debug("Suite version:%s",  versionStr)
             logging.debug("Suite full path:%s",  regressionSuiteFullPath)

--- a/testing/regress/ecl/setup/setupsearchindex.ecl
+++ b/testing/regress/ecl/setup/setupsearchindex.ecl
@@ -22,7 +22,10 @@ import $.Options;
 import Std.File;
 Files := $.Files(__PLATFORM__, false);
 
-rebuildSearchIndex := Options.OriginalTextFilesIp <> '' AND Options.OriginalTextFilesPath <> '';
+string OriginalTextFilesIp := Options.OriginalTextFilesIp : STORED('OriginalTextFilesIp');
+string OriginalTextFilesPath := Options.OriginalTextFilesPath : STORED('OriginalTextFilesPath');
+
+rebuildSearchIndex := OriginalTextFilesIp <> '' AND OriginalTextFilesPath <> '';
 
 IF(rebuildSearchIndex,
     SetupText.createSearchIndex(),

--- a/testing/regress/ecl/setup/setuptext.ecl
+++ b/testing/regress/ecl/setup/setuptext.ecl
@@ -24,9 +24,12 @@ import $;
 import $.Options;
 import $.TS;
 
+string OriginalTextFilesIp := Options.OriginalTextFilesIp : STORED('OriginalTextFilesIp');
+string OriginalTextFilesPath := Options.OriginalTextFilesPath : STORED('OriginalTextFilesPath');
+
 EXPORT SetupText := FUNCTION
 
-DirectoryPath := '~file::' + Options.OriginalTextFilesIp + '::' + Options.OriginalTextFilesPath + '::';          // path of the documents that are used to build the search index
+DirectoryPath := '~file::' + OriginalTextFilesIp + '::' + OriginalTextFilesPath + '::';          // path of the documents that are used to build the search index
 
 MaxDocumentLineLength := 50000;
 

--- a/testing/regress/hpcc/common/logger.py
+++ b/testing/regress/hpcc/common/logger.py
@@ -90,9 +90,9 @@ class Logger(object):
             if len(self.logBuffer):
                 stream = self.stream
                 for item in self.logBuffer:
-                        for line in self.logBuffer[item]:
-                            stream.write(line)
-                            stream.write(self.terminator)
+                    for line in self.logBuffer[item]:
+                        stream.write(line)
+                        stream.write(self.terminator)
                 self.logBuffer.clear()
                 self.taskIds = {}
                 self.isBuffer = False

--- a/testing/regress/hpcc/common/logger.py
+++ b/testing/regress/hpcc/common/logger.py
@@ -82,21 +82,20 @@ class Logger(object):
     class ProgressFileHandler(logging.FileHandler):
         terminator = '\n'
         isBuffer = False
-        logBuffer=[]
-        toSort = False
+        logBuffer=dict()
         taskId = 0
         taskIds = {}
 
         def close(self):
             if len(self.logBuffer):
-                if self.toSort:
-                    self.logBuffer.sort()
                 stream = self.stream
                 for item in self.logBuffer:
-                    stream.write(item)
-                    stream.write(self.terminator)
-                self.logBuffer = []
-                self.toSort = False
+                        for line in self.logBuffer[item]:
+                            stream.write(line)
+                            stream.write(self.terminator)
+                self.logBuffer.clear()
+                self.taskIds = {}
+                self.isBuffer = False
             self.flush()
             self.stream.close()
 
@@ -133,29 +132,23 @@ class Logger(object):
                 if record.levelname == 'CRITICAL':
                     msg += " [level: "+record.levelname+" ]"
                     msg = "{0:3d}".format(taskId) +". " + msg
-                if toSort:
-                    self.toSort = True
                 if isBuffer:
                     #toggle buffer switch
                     self.isBuffer = not self.isBuffer
                     isBuffer = False
                 if self.isBuffer or isBuffer:
                     if len(msg):
-                        msg = msg.replace(". Test:",". Case:")
-                        msg = msg[0:4]+'-'+record.asctime+'-'+msg[4:]
-                        self.logBuffer.append(msg)
+                        self.logBuffer.setdefault(taskId,  []).append(msg)
                 else:
                     if len(self.logBuffer):
-                        if self.toSort:
-                            self.logBuffer.sort()
                         for item in self.logBuffer:
-                            item = item[0:4] +item[23:]
-                            item = item.replace(". Case:",". Test:")
-                            item = item.replace(". Debug-", ".  ")
-                            stream.write(item)
-                            stream.write(self.terminator)
-                        self.logBuffer = []
-                        self.toSort = False
+                            for line in self.logBuffer[item]:
+                                line = line.replace(". Debug-", ".  ")
+                                stream.write(line)
+                                stream.write(self.terminator)
+                        self.logBuffer.clear()
+                        self.taskIds = {}
+                        self.isBuffer = False
                     if  len(msg):
                         stream.write(msg)
                         stream.write(self.terminator)
@@ -167,9 +160,15 @@ class Logger(object):
 
     def addHandler(self, fd, level='info'):
         root_logger = logging.getLogger()
-        channel = self.ProgressFileHandler(fd)
-        channel.setLevel(getattr(logging, level.upper()))
-        root_logger.addHandler(channel)
+        self.channel = self.ProgressFileHandler(fd)
+        self.channel.setLevel(getattr(logging, level.upper()))
+        root_logger.addHandler(self.channel)
+
+    def removeHandler(self):
+        root_logger = logging.getLogger()
+        root_logger.removeHandler(self.channel)
+        self.channel.flush()
+        self.channel.close()
 
     def enable_pretty_logging(self):
         root_logger = logging.getLogger()

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -26,7 +26,10 @@ from ..common.error import Error
 
 class Suite:
     def __init__(self, name, dir_ec, dir_a, dir_ex, dir_r, logDir, args, isSetup=False,  fileList = None):
-        self.name = name
+        if isSetup:
+            self.name = 'setup_'+name
+        else:
+            self.name = name
         self.suite = []
         self.dir_ec = dir_ec
         self.dir_a = dir_a
@@ -40,7 +43,7 @@ class Suite:
 
         if len(self.exclude):
             curTime = time.strftime("%y-%m-%d-%H-%M")
-            logName = name + "-exclusion." + curTime + ".log"
+            logName = self.name + "-exclusion." + curTime + ".log"
             self.logName = os.path.join(self.logDir, logName)
             self.log = open(self.logName, "w");
             for item in self.exclude:

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -88,6 +88,13 @@ class ECLFile:
             self.processKeyValPairs(optXs,  self.optXHash)
             pass
 
+        # Process setupExtraX parameters if any
+        if 'setupExtraX' in args:
+            args.setupExtraX[0]=self.removeQuote(args.setupExtraX[0])
+            optXs = ("-X"+args.setupExtraX[0].replace(',',  ',-X')).split(',')
+            self.processKeyValPairs(optXs,  self.optXHash)
+            pass
+
         self.mergeHashToStrArray(self.optXHash,  self.optX)
         pass
 

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -20,6 +20,7 @@
 import argparse
 import platform
 import logging
+import os
 
 from ..common.error import Error
 
@@ -63,6 +64,19 @@ def getVersionNumbers():
     if isPositiveIntNum(version[2]):
         verNum['patch'] = int(version[2])
     return(verNum);
+
+def convertPath(osPath):
+    hpccPath = ''
+    osPath = osPath.lstrip(os.sep)
+    # remove current dir
+    [osPath, sep,  curDir] = osPath.rpartition(os.sep)
+    osPath = osPath.replace(os.sep,  '::')
+    for i in range(0,  len(osPath)):
+        if osPath[i] >= 'A' and osPath[i] <= 'Z':
+            hpccPath = hpccPath +'^'
+        hpccPath = hpccPath +osPath[i]
+
+    return hpccPath
 
 import json
 import urllib2


### PR DESCRIPTION
Add code to generate 'OriginalTextFilesPath' and pass it along with
'OriginalTextFilesIp' CLI parameter to setup ECL programs via stored variables.

Add fix some log generation problems:
- large amount log entries sorting problem
- setup log file naming problem
- mix-up log entries among the clusters log files when the target is 'all'

Update README.rst

Signed-off-by: Attila Vamos attila.vamos@gmail.com
