### PR TITLE
HPCC-11601 Add --exception-level option to ecl-run

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -106,6 +106,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 
 #define ECLOPT_CHECK_PACKAGEMAPS "--check-packagemaps"
 
+#define ECLOPT_EXCEPTION_LEVEL "--exception-level"
 #define ECLOPT_RESULT_LIMIT "--limit"
 #define ECLOPT_RESULT_LIMIT_INI "resultLimit"
 #define ECLOPT_RESULT_LIMIT_ENV "ECL_RESULT_LIMIT"

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -450,7 +450,7 @@ private:
 class EclCmdRun : public EclCmdWithEclTarget
 {
 public:
-    EclCmdRun() : optWaitTime((unsigned)-1), optNoRoot(false)
+    EclCmdRun() : optWaitTime((unsigned)-1), optNoRoot(false), optExceptionSeverity("info")
     {
         optObj.accept = eclObjWuid | eclObjArchive | eclObjSharedObject | eclObjWuid | eclObjQuery;
     }
@@ -475,6 +475,8 @@ public:
             if (iter.matchOption(optWaitTime, ECLOPT_WAIT))
                 continue;
             if (iter.matchFlag(optNoRoot, ECLOPT_NOROOT))
+                continue;
+            if (iter.matchOption(optExceptionSeverity, ECLOPT_EXCEPTION_LEVEL))
                 continue;
             if (EclCmdWithEclTarget::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
@@ -540,6 +542,7 @@ public:
         req->setWait((int)optWaitTime);
         if (optInput.length())
             req->setInput(optInput.get());
+        req->setExceptionSeverity(optExceptionSeverity); //throws exception if invalid value
 
         if (debugValues.length())
             req->setDebugValues(debugValues);
@@ -581,18 +584,21 @@ public:
             "   <ecl_file|->           ECL text file to publish\n"
             "   <so|dll|->             workunit dll or shared object to publish\n"
             " Options:\n"
-            "   -t, --target=<val>     target cluster to run job on\n"
-            "                          (defaults to cluster defined inside workunit)\n"
-            "   -n, --name=<val>       job name\n"
-            "   -in,--input=<file|xml> file or xml content to use as query input\n"
-            "   -X<name>=<value>       sets the stored input value (stored('name'))\n"
-            "   --wait=<ms>            time to wait for completion\n",
+            "   -t, --target=<val>        target cluster to run job on\n"
+            "                             (defaults to cluster defined inside workunit)\n"
+            "   -n, --name=<val>          job name\n"
+            "   -in,--input=<file|xml>    file or xml content to use as query input\n"
+            "   -X<name>=<value>          sets the stored input value (stored('name'))\n"
+            "   --wait=<ms>               time to wait for completion\n"
+            "   --exception-level=<level> minimum severity level for exceptions\n"
+            "                             values: 'info', 'warning', 'error'\n",
             stdout);
         EclCmdWithEclTarget::usage();
     }
 private:
     StringAttr optName;
     StringAttr optInput;
+    StringAttr optExceptionSeverity;
     IArrayOf<IEspNamedValue> variables;
     unsigned optWaitTime;
     bool optNoRoot;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -512,6 +512,13 @@ ESPresponse [exceptions_inline] WUResubmitResponse
     [min_ver("1.40")] ESParray<ESPstruct ResubmittedWU, WU> WUs;
 };
 
+ESPenum WUExceptionSeverity : string
+{
+    INFO("info"),
+    WARNING("warning"),
+    ERROR("error")
+};
+
 ESPrequest WURunRequest
 {
     string QuerySet;
@@ -524,6 +531,7 @@ ESPrequest WURunRequest
     bool NoRootTag(0);
     ESParray<ESPstruct NamedValue> DebugValues;
     ESParray<ESPstruct NamedValue> Variables;
+    ESPenum WUExceptionSeverity ExceptionSeverity("info");
 };
 
 ESPresponse [exceptions_inline] WURunResponse

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1009,6 +1009,21 @@ bool CWsWorkunitsEx::onWUSubmit(IEspContext &context, IEspWUSubmitRequest &req, 
     return true;
 }
 
+WUExceptionSeverity checkGetExceptionSeverity(CWUExceptionSeverity severity)
+{
+    switch (severity)
+    {
+        case CWUExceptionSeverity_INFO:
+            return ExceptionSeverityInformation;
+        case CWUExceptionSeverity_WARNING:
+            return ExceptionSeverityWarning;
+        case CWUExceptionSeverity_ERROR:
+            return ExceptionSeverityError;
+    }
+
+    throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT,"invalid exception severity");
+}
+
 bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWURunResponse &resp)
 {
     try
@@ -1020,6 +1035,8 @@ bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWU
         StringBuffer wuidStr = req.getWuid();
         const char* runWuid = wuidStr.trim().str();
         StringBuffer wuid;
+
+        WUExceptionSeverity severity = checkGetExceptionSeverity(req.getExceptionSeverity());
 
         if (runWuid && *runWuid)
         {
@@ -1062,7 +1079,7 @@ bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWU
                 unsigned flags = WorkUnitXML_SeverityTags;
                 if (req.getNoRootTag())
                     flags |= WorkUnitXML_NoRoot;
-                getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), result, flags);
+                getFullWorkUnitResultsXML(context.queryUserId(), context.queryPassword(), cw.get(), result, flags, severity);
                 resp.setResults(result.str());
                 break;
             }


### PR DESCRIPTION
Sets the minimum exception severity for reporting exceptions.

Possible values "info", "warning", "error".  "info" is default and will
return all exceptions.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
