### PR TITLE
HPCC-11475 Improve error message deploying large archives to old ESP

### DIFF
--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -54,6 +54,7 @@ include_directories (
          ./../../common/workunit
          ./../../common/environment
          ./../../esp/bindings/SOAP/xpp
+         ./../../esp/bindings/http/client
          ./../../system/include
          ./../../esp/bindings
          ./../../ecl/hql

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -21,11 +21,35 @@
 #include "jargv.hpp"
 #include "jflz.hpp"
 #include "build-config.h"
+#include "httpclient.hpp"
 
 #include "workunit.hpp"
 #include "ws_workunits.hpp"
 #include "eclcmd_common.hpp"
 #include "eclcmd_core.hpp"
+
+size32_t getMaxRequestEntityLength(EclCmdCommon &cmd)
+{
+    if(cmd.optServer.isEmpty())
+        throw MakeStringException(-1, "Server IP not specified");
+
+    EclCmdURL url("?config_", cmd.optServer, cmd.optPort, cmd.optSSL);
+    Owned<IHttpClientContext> httpCtx = getHttpClientContext();
+
+    StringBuffer request; //empty
+    StringBuffer response;
+    StringBuffer status;
+    Owned<IHttpClient> httpclient = httpCtx->createHttpClient(NULL, url);
+    if (cmd.optUsername.length())
+        httpclient->setUserID(cmd.optUsername);
+    if (cmd.optPassword.length())
+         httpclient->setPassword(cmd.optPassword);
+     if (0 > httpclient->sendRequest("GET", NULL, request, response, status) || !response.length() || strncmp("200", status, 3))
+         throw MakeStringException(-1, "Error checking ESP configuration: %s:%s %s", cmd.optServer.sget(), cmd.optPort.sget(), status.str());
+
+    Owned<IPropertyTree> config = createPTreeFromXMLString(response);
+    return config->getPropInt("Software[1]/EspProcess[1]/EspProtocol[@type='http_protocol'][1]/@maxRequestEntityLength");
+}
 
 bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *cluster, const char *name, StringBuffer *wuid, StringBuffer *wucluster, bool noarchive, bool displayWuid=true, bool compress=true)
 {
@@ -101,7 +125,30 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
         cmd.debugValues.kill();
     }
 
-    Owned<IClientWUDeployWorkunitResponse> resp = client->WUDeployWorkunit(req);
+    Owned<IClientWUDeployWorkunitResponse> resp;
+    try
+    {
+         resp.setown(client->WUDeployWorkunit(req));
+    }
+    catch (IException *E)
+    {
+        //ESP doesn't want to process requests that are too large, and so disconnects before reading
+        //  this causes issues capturing the error returned... check if that may have been the issue
+        if (useCompression) //newer build, not a maxRequestEntityLength issue
+            throw;
+        size32_t maxEntity = getMaxRequestEntityLength(cmd); //only do the work to grab max buffersize if we've failed
+        if (maxEntity > 1000)
+        {
+            size32_t maxBufferSize = ((maxEntity - 999) / 4) * 3; //account for soap, other parameters, and base64 encoding (n / 4 * 3)
+            if (maxBufferSize && cmd.optObj.mb.length() > maxBufferSize)
+            {
+                fprintf(stderr, "\nError: %s is larger than maxRequestEntityLength configured for ESP allows.\n", objType.str());
+                E->Release();
+                return false;
+            }
+        }
+        throw;
+    }
     if (resp->getExceptions().ordinality())
         outputMultiExceptions(resp->getExceptions());
     const char *w = resp->getWorkunit().getWuid();


### PR DESCRIPTION
ESP aborts requests that are too large making it difficult to capture
the error returned.  If a deployment to an old ESP fails, check the
size limit to see if that was the likely problem.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
