### PR TITLE
HPCC-11157 Allow install-cluster run concurrently

### DIFF
--- a/initfiles/sbin/CMakeLists.txt
+++ b/initfiles/sbin/CMakeLists.txt
@@ -41,6 +41,7 @@ FOREACH( oFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/alter_confs.sh
     ${CMAKE_CURRENT_SOURCE_DIR}/cluster_script.py
     ${CMAKE_CURRENT_SOURCE_DIR}/deploy-java-files.exp
+    ${CMAKE_CURRENT_SOURCE_DIR}/install-hpcc.exp
 )
     install ( PROGRAMS ${oFILES} DESTINATION sbin COMPONENT Runtime )
 ENDFOREACH ( oFILES )

--- a/initfiles/sbin/cluster_script.py
+++ b/initfiles/sbin/cluster_script.py
@@ -283,6 +283,12 @@ class ScriptExecution(object):
             self.usage()
             exit(0)
 
+        if not os.path.isfile(self.script_file):
+            print("\nFile " + self.script_file + " does not exist.\n")
+            exit(0)
+
+
+
 
     def log_input_parameters(self):
         self.logger.info("Current parameters:")

--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -22,51 +22,70 @@
 # Flow:
 #
 # 1. SSH Keys Generated.
-# 2. Script copied to node.
-# 3. Install package copied to node.
-# 4. SSH Keys copied to node.
-# 5. Run CheckInstall to determine if  package is installed.
-# 6. Install/Upgrade if needed.
-# 7. Run CheckKeys to determine if sshkeys are installed.
-# 8. Install keys if different then installed or no keys installed.
-# 9. Return.
+# 2. Run install-hpcc.sh through cluster-script.py to perform HPCC install and 
+#        configuration on remote hosts
+# 3. Return.
 #
 
 ###<REPLACE>###
 
-source  ${INSTALL_DIR}/etc/init.d/lock.sh
-source  ${INSTALL_DIR}/etc/init.d/pid.sh
 source  ${INSTALL_DIR}/etc/init.d/hpcc_common
 source  ${INSTALL_DIR}/etc/init.d/init-functions
 source  ${INSTALL_DIR}/etc/init.d/export-path
 
-REMOTE_INSTALL="/tmp/remote_install"
-NEW="${REMOTE_INSTALL}/new_keys"
-CMDPREFIX="sudo"
+export REMOTE_INSTALL="/tmp/remote_install"
+export NEW="${REMOTE_INSTALL}/new_keys"
+export CMDPREFIX="sudo"
 
 print_usage(){
-    echo "usage: install-cluster.sh [-h|--help] [-k|--newkey] <Platform Package>"
+    echo ""
+    echo "usage: install-cluster.sh [-h|--help] [-k|--newkey] [-n|--concurrent <number>] <Platform Package>"
+    echo "   -k:  generate a new ssh key pair."
+    echo "   -n:  how many concurrent execution allowd. The default is 5"
+    echo "   <Platform Package>: HPCCSystems package file."
+    echo ""
     exit 1
 }
 
-getUser(){
-    read -p "Input admin username:" USER;
-    echo;
-    if [ "${USER}" == "root" ]; then
-        CMDPREFIX=""
-    fi
-}
+getUserAndPasswd(){
 
-getPW(){
-    stty -echo;
-    read -p "Input admin password:" PASS;
-    stty echo;
-    echo;
-}
+    trial=0
+    max_trial=3
+    while [ 1 ]
+    do
+       echo ""
+       read -p "Please enter admin username: " ADMIN_USER;
+       echo ""
+       echo "Please enter ssh/scp user password. If this is no password required (assume"
+       echo "the user has ssh private key: <user home>/.ssh/id_rsa) just press 'Enter':"
+       read -s PASS
+       echo ""
 
+       echo "You entered user $ADMIN_USER and a password ($(echo $PASS | sed 's/./\./g'))."
+       read -p  "Are these correct? [Y|n] " answer
+       if [ "$answer" = "Y" ] || [ "$answer" = "y" ]
+       then
+          break
+       fi
 
-getIPS(){
-    IPS=`${INSTALL_DIR}/sbin/configgen -env ${CONFIG_DIR}/${ENV_XML_FILE} -machines | awk -F, '{print $1}'  | sort | uniq`
+       trial=$(expr $trial \+ 1)
+       if [ $trial -eq $max_trial ]
+       then
+          echo ""
+          echo "Exceeded maximum attempts. Giving up."
+          echo ""
+          exit 1
+       fi
+    done
+
+  if [ "$file_transfer_user" == "root" ]
+  then
+     CMDPREFIX=""
+  fi
+
+  export ADMIN_USER
+  export PASS
+
 }
 
 
@@ -92,7 +111,10 @@ createPayload(){
     cp -r ${CONFIG_DIR}/${ENV_XML_FILE} ${REMOTE_INSTALL}
     cp -r ${CONFIG_DIR}/${ENV_CONF_FILE} ${REMOTE_INSTALL}
     cp -r ${INSTALL_DIR}/sbin/remote-install-engine.sh ${REMOTE_INSTALL}
+
+    echo "tar -zcvf /tmp/remote_install.tgz ${REMOTE_INSTALL}/*"
     tar -zcvf /tmp/remote_install.tgz ${REMOTE_INSTALL}/*
+    ls -l /tmp/remote_install.tgz 
     rm -rf ${REMOTE_INSTALL}
 }
 
@@ -100,89 +122,30 @@ removePayload(){
     rm /tmp/remote_install.tgz
 }
 
-copyPayload(){
-    expect -c "set timeout -1;
-        spawn scp /tmp/remote_install.tgz $USER@$1:~;
-        expect {
-            *?assword:* {
-                    send \"$PASS\r\";
-            } yes/no)? {
-                    send \"yes\r\";
-                    set timeout -1;
-            } timeout {
-                    exit;
-            } eof {
-                    exit;
-            }
-        }
-        interact;";
-}
+if [ "${USER}" != "root" ]; then
+   echo ""
+   echo "The script must run as root or sudo."
+   echo ""
+   exit 1
+fi
 
-expandPayload(){
-    expect -c "set timeout -1;
-        spawn ssh $USER@$1 \"cd /; tar -zxf ~/remote_install.tgz\";
-        expect {
-            *?assword:* {
-                    send \"$PASS\r\";
-            } yes/no)? {
-                    send \"yes\r\";
-                    set timeout -1;
-            } timeout {
-                    exit;
-            } eof {
-                    exit;
-            }
-        }
-        interact;";
-}
-
-runPayload(){
-    basepkg=`basename ${PKG}`
-    expect -c "set timeout 3;
-        spawn ssh $USER@$1;
-        expect {
-            *?assword:* {
-                    send \"$PASS\r\";
-            } yes/no)? {
-                    send \"yes\r\";
-                    set timeout -1;
-            } timeout {
-                    exit;
-            } eof {
-                    exit;
-            } "${USER}@" { 
-                  # Allow non-password connection go through without changing following code.
-                  # This is will be replaced when HPCC-11156 is fixed.
-                  send \"hostname\r\" 
-            }
-        }
-        expect "${USER}@" {
-            send \"${CMDPREFIX} ${REMOTE_INSTALL}/remote-install-engine.sh ${REMOTE_INSTALL}/${basepkg}\r\";
-            expect *?assword* {
-                send \"${PASS}\r\";
-            }
-        }
-        expect "${USER}@" {
-            send \"exit\r\";
-        }
-        interact;"
-}
-
-
-
-getUser
-getPW
-getIPS
 
 NEW_KEY=0
+OPTIONS="-l DEBUG -e ${CONFIG_DIR}/${ENV_CONF_FILE} -s ${SECTION:-DEFAULT}"
 
-TEMP=`/usr/bin/getopt -o kh --long help,newkey -n 'install-cluster' -- "$@"`
+TEMP=`/usr/bin/getopt -o n:s:kh --long help,newkey,concurrent: -n 'install-cluster' -- "$@"`
 if [ $? != 0 ] ; then echo "Failure to parse commandline." >&2 ; exit 1 ; fi
 eval set -- "$TEMP"
 while true ; do
     case "$1" in
         -k|--newkey) NEW_KEY=1
             shift ;;
+        -n|--concurrent) 
+            if [ -n "$2" ] && [[ $2 =~ ^[0-9]+$ ]]
+            then
+               [ $2 -gt 0 ] && OPTOINS="${OPTIONS:+"$OPTIONS "}-n $2"
+            fi
+            shift 2 ;;
         -h|--help) print_usage
                    shift ;;
         --) shift ; break ;;
@@ -191,6 +154,12 @@ while true ; do
 done
 for arg do arg=$arg; done
 PKG=${arg}
+[ -z "$PKG" ] && print_usage
+
+export PKG
+
+getUserAndPasswd
+
 
 pkgtype=`echo "${PKG}" | grep -i rpm`
 if [ -z $pkgtype ]; then
@@ -202,19 +171,22 @@ fi
 if [ ${NEW_KEY} -eq 1 ]; then
     generateKey
 fi
+export NEW_KEY
 
 createPayload;
 
-for IP in $IPS; do
-    if ping -c 1 -w 5 -n $IP > /dev/null 2>&1; then
-        echo "$IP: Host is alive."
-        copyPayload $IP;
-        expandPayload $IP;
-        runPayload $IP;
-        echo "$IP: Done.";
-    else
-        echo "$IP: Cannot Ping host? (Host Alive?)"
-    fi
-done
+expected_python_version=2.6
+is_python_installed ${expected_python_version}
+
+if [ $? -eq 0 ]
+then
+   chksum=$(md5sum ${INSTALL_DIR}/sbin/install-hpcc.exp | cut -d' ' -f1)
+   eval ${INSTALL_DIR}/sbin/cluster_script.py -f ${INSTALL_DIR}/sbin/install-hpcc.exp -c $chksum $OPTIONS
+else
+   echo ""
+   echo "Cannot detect python version ${expected_python_version}+. Will run on the cluster hosts sequentially."
+   echo ""
+   run_cluster ${INSTALL_DIR}/sbin/install-hpcc.exp 0
+fi
 
 removePayload;

--- a/initfiles/sbin/install-hpcc.exp
+++ b/initfiles/sbin/install-hpcc.exp
@@ -1,0 +1,218 @@
+#!/usr/bin/env expect 
+################################################################################
+#    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+################################################################################
+#
+# Usage: install-hpcc.exp
+#
+# This script is used as a remote engine for a cluster installation.
+#
+# Flow:
+#
+# 1. Copay HPCC package and script to node.
+# 2. call remote-install-engine.sh to install and configure HPCC.
+#
+
+
+
+proc print_usage {} {
+    puts ""
+    puts "Usage: [lindex [split $::argv0 '/' ] end]  <host ip>"
+    puts ""
+    exit 1
+}
+
+
+proc testWithPing {} {
+   global ip
+   spawn ping -c1 -W 5 ${ip}
+   expect eof {
+      catch wait result
+      if { [lindex $result 3] != 0 } {
+         echo "${ip}: Cannot Ping host? (Host Alive?)"
+         exit 1
+      }
+   }
+   sleep 1
+   puts "${ip}: Host is alive."
+}
+
+proc checkSSHConnection {} {
+   global ip user password prompt
+
+   set timeout 60
+   spawn ssh ${user}@${ip} 
+   expect {
+      *?assword:* {
+         send "${password}\r";
+         exp_continue
+      } "*?ermission denied*" {
+         puts "The user or password is wrong"
+         exit 1
+      } yes/no)? {
+         send "yes\r";
+         exp_continue
+      } timeout {
+         exit 1;
+      } eof {
+         exit 1;
+      }  -re "${prompt}" { 
+         puts "Connection is OK"
+         send "exit\r"
+      }
+   }
+   expect -re .*
+   interact;
+}
+
+proc copyPayload {} {
+   global ip user password prompt
+   
+   set timeout 300
+   spawn scp /tmp/remote_install.tgz ${user}@${ip}:~;
+   expect {
+      *?assword:* {
+         send "${password}\r";
+         exp_continue
+      } "*?ermission denied*" {
+         puts "The user or password is wrong"
+         exit 1
+      } yes/no)? {
+         send "yes\r";
+         exp_continue
+      } timeout {
+         exit 1;
+      } eof {
+         catch wait result
+         if { [lindex $result 3] != 0 } {
+            exit [lindex $result 3]
+         }
+      }
+   }
+   sleep 1
+}
+
+proc expandPayload {} {
+   global ip user password prompt
+
+   set timeout 180
+   spawn ssh ${user}@${ip} "cd /; tar -zxf ~/remote_install.tgz"
+   expect {
+      *?assword:* {
+         send "${password}\r"
+         exp_continue
+      } "*?ermission denied*" {
+         puts "The user or password is wrong"
+         exit 1
+      } yes/no)? {
+         send "yes\r";
+         exp_continue
+      } timeout {
+         exit 1;
+      } eof {
+         catch wait result
+         if { [lindex $result 3] != 0 } {
+            exit [lindex $result 3]
+         }
+      } 
+   }
+   sleep 1
+}
+
+proc runPayload {} {
+   global ip user password prompt pkg cmd_prefix remote_install
+
+   set basepkg  [file tail  ${pkg}]
+   set timeout 60
+   spawn ssh ${user}@${ip}
+   expect {
+      *?assword:* {
+         send "${password}\r"
+         exp_continue
+      } "*?ermission denied*" {
+         puts "The user or password is wrong"
+         exit 1
+      } yes/no)? {
+         send "yes\r"
+         exp_continue
+      } timeout {
+         exit 1;
+      } eof {
+         exit 1;
+      } -re "${prompt}" {}
+   }
+   send "${cmd_prefix} ${remote_install}/remote-install-engine.sh ${remote_install}/${basepkg}\r"
+   expect {
+      *?assword:* {
+         send "${password}\r"
+         exp_continue
+      } "*?ermission denied*" {
+         puts "The user or password is wrong"
+         exit 1
+      } timeout {
+         exit 1;
+      } eof {
+         exit 1;
+      }  -re "${prompt}" {}
+   }
+
+   expect  -re .*
+   send "echo \$?\r"
+   expect   -re "(\r\n| )(\[0-9]*)\r\n" {
+      if { [string compare $expect_out(2,string) "0" ] == 0 } {
+         puts "${ip}: Done."
+      } else {
+         puts "${ip}: Cannot Ping host? (Host Alive?)"
+         exit 1
+      }
+   }
+   send "exit\r"
+   interact
+}
+
+
+####################################################################
+#                                                                  #
+# Main                                                             #
+#                                                                  #
+####################################################################
+set ip  [lindex $argv 0]
+if { [string length $ip ] == 0 } {
+   puts "Missing hostname or ip"
+   print_usage
+   exit 1
+}
+
+# Check required environment variables
+if { [catch {
+        set user            $::env(ADMIN_USER)
+        set password        $::env(PASS)
+        set cmd_prefix      $::env(CMDPREFIX)
+        set remote_install  $::env(REMOTE_INSTALL)
+        set pkg             $::env(PKG)
+     } error] } {
+
+   puts stderr "Missing environment variable.\n$error"
+   exit 1
+}
+
+
+set prompt  "(${user}@|\\r\\n\\$ |\\r\\n# )"
+
+testWithPing
+checkSSHConnection
+copyPayload
+expandPayload
+runPayload


### PR DESCRIPTION
1. Original install-cluster.sh is divided to two files:
   1.1.  install-cluster.sh:
        1.1.1.  top level script.
        1.1.2.  get admin user passwords.
        1.1.3.   create package for remote install
        1.1.4 .  excute install-hpcc.exp through cluster_script.py if python 2.6+ detected.
                   It allows mulitple instances run simultanously. If no suitable python
                   installed install-hpcc.exp will execute sequentially for each ip.
   
   1.2.  install-hpcc.exp
        1.2.1. run on each host to install and configure HPCC.
        1.2.2.  check connection logic is added. If it fails no furhter action will be
                  applied on the host.
        1.2.3. Add handling ssh/scp connection without password which is normal in cloud
                 environment.
2. The original script only install if hpcc user doesn't exists on the host. The fix
   lefts the restriction to allow installation always go through. If HPCC exists and the
   image version is newer it will update it.
3. Log file is at /var/log/HPCCSystesm/cluster/XX_install-hpcc_yyyymmdd_HHMMSS.log
   For concurrent exection XX is "cc". If run sequentially it is "se".
