### PR TITLE
HPCC-11618 Roxie core when detaching from dali

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -726,10 +726,10 @@ public:
                 closeDllServer();
                 closeEnvironment();
                 clientShutdownWorkUnit();
+                disconnectRoxieQueues();
                 ::closedownClientProcess(); // dali client closedown
                 isConnected = false;
                 disconnectSem.signal();
-                disconnectRoxieQueues();
             }
         }
     }

--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -863,6 +863,7 @@ public:
         {
             DBGLOG("RoxieWorkUnitListener::disconnectQueue");
             queue->cancelAcceptConversation();
+            queue.clear();
         }
     }
 


### PR DESCRIPTION
If roxie detaches from dali while a Workunit listener thread is at certain
locations inside dodequeue, Roxie may core.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
