### PR TITLE
HPCC-11625 Submitting Roxie Query in ECL Playground fails

### DIFF
--- a/esp/src/eclwatch/ESPQuery.js
+++ b/esp/src/eclwatch/ESPQuery.js
@@ -129,7 +129,9 @@ define([
                 var domXml = parser.parse(xml);
                 var query = {};
                 arrayUtil.forEach(domXml.firstChild.childNodes, function (item, idx) {
-                    query[item.tagName] = item.textContent;
+                    if (item.tagName) {
+                        query[item.tagName] = item.textContent;
+                    }
                 });
                 var context = this;
                 WsEcl.Submit(this.QuerySetId, this.Id, query).then(function (response) {

--- a/esp/src/eclwatch/ResultWidget.js
+++ b/esp/src/eclwatch/ResultWidget.js
@@ -183,6 +183,7 @@ define([
                         }
                     });
                     tableContainer.placeAt(origTableContainer.domNode, "replace");
+                    origTableContainer.destroyRecursive();
                     context.widget.Filter.on("clear", function (evt) {
                         context.refresh();
                     });

--- a/esp/src/eclwatch/WsEcl.js
+++ b/esp/src/eclwatch/WsEcl.js
@@ -90,6 +90,9 @@ define([
                 }).then(function (response) {
                     var results = response[method + "Response"] && response[method + "Response"].Results ? response[method + "Response"].Results : {};
                     results = context._flattenResults(results);
+                    if (lang.exists("Exceptions.Exception", response)) {
+                        results.Exception = response.Exceptions.Exception;
+                    };
                     deferred.resolve(results);
                 });
             });

--- a/esp/src/eclwatch/_TabContainerWidget.js
+++ b/esp/src/eclwatch/_TabContainerWidget.js
@@ -123,6 +123,9 @@ define([
 
         go: function (path, replace, noHash) {
             //console.log(this.id + ".go(" + path + ", " + replace + ", " + noHash + ")");
+            if (!path)
+                return;
+
             if (noHash) {
                 var d = 0;
             } else {


### PR DESCRIPTION
Added support for general exception.
Ignore \r\n within XML parse.
Result can not be opened, closed and reopened

Fixes HPCC-11625

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
