### PR TITLE
HPCC-11627 Requesting per-query logging can cause roxie cores

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -873,6 +873,7 @@ public:
     virtual void CTXLOGl(LogItem *logItem) const
     {
         // NOTE - we don't actually print anything to logfile here - was already printed on slave
+        CriticalBlock b(crit);
         log.append(*logItem);
         flush(false, false);
     }


### PR DESCRIPTION
Appending logging information from slaves to the context was not threadsafe.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
