### PR TITLE
HPCC-11561 Allow DEDUP and ROLLUP to include (child) rows as expressions

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -11278,13 +11278,7 @@ dedupFlags
     ;
 
 dedupFlag
-    : LEFT              {
-                            $$.setExpr(createAttribute(leftAtom));
-                        }
-    | RIGHT             {
-                            $$.setExpr(createAttribute(rightAtom));
-                        }
-    | KEEP expression   {
+    : KEEP expression   {
                             parser->normalizeExpression($2, type_int, false);
                             $$.setExpr(createExprAttribute(keepAtom, $2.getExpr()));
                         }
@@ -11305,6 +11299,16 @@ dedupFlag
                         }
     | MANY              {   $$.setExpr(createAttribute(manyAtom)); }
     | HASH              {   $$.setExpr(createAttribute(hashAtom)); }
+    | dataRow
+                        {
+                            //Backward compatibility... special case use of LEFT and RIGHT as modifiers.
+                            OwnedHqlExpr row = $1.getExpr();
+                            if (row->getOperator() == no_left)
+                                row.setown(createAttribute(leftAtom));
+                            else if (row->getOperator() == no_right)
+                                row.setown(createAttribute(rightAtom));
+                            $$.setExpr(row.getClear(), $1);
+                        }
     ;
 
 rollupExtra
@@ -11332,6 +11336,7 @@ rollupFlag
                             parser->normalizeExpression($2);
                             $$.setExpr(createAttribute(exceptAtom, $2.getExpr())); 
                         }
+    | dataRow
     ;
 
 conditions

--- a/ecl/regress/dedup10.ecl
+++ b/ecl/regress/dedup10.ecl
@@ -17,6 +17,10 @@
 
 //Normalize a denormalised dataset...
 
+childId := RECORD
+    unsigned a;
+    unsigned b;
+END;
 householdRecord := RECORD
 unsigned4 house_id;
 string20  address1;
@@ -26,6 +30,7 @@ string10 s_SequenceKey ;
 unsigned2 scoreRank;
 unsigned2 elementsMatched;
 data10    m_l90key;
+childId     child;
     END;
 
 
@@ -40,3 +45,19 @@ queue1 := join(householdDataset, householdDataset, left.zip = right.zip, z(left,
 BestHits:= Dedup(Queue1, whole record, except house_id,except zip);
 
 output(besthits);
+
+BestHits2 := Dedup(Queue1, ROW(Queue1));
+
+output(besthits2);
+
+householdRecord t(houseHoldRecord l, houseHoldRecord r) := TRANSFORM
+    SELF.score := l.score + r.score;
+    SELF := l;
+END; 
+BestHits3 := ROLLUP(Queue1, t(LEFT, RIGHT), ROW(Queue1));
+
+output(besthits3);
+
+BestHits4 := Dedup(Queue1, zip, child);
+
+output(besthits4);


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
