### PR TITLE
HPCC-11653 Only check query status on 1 roxie node for 4.2.6

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1046,7 +1046,7 @@ IPropertyTree* getQueriesOnCluster(const char *target, const char *queryset)
     try
     {
         Owned<ISocket> sock = ISocket::connect_timeout(eps.item(0), ROXIECONNECTIONTIMEOUT);
-        return sendRoxieControlAllNodes(sock, "<control:queries/>", true, ROXIECONTROLQUERYTIMEOUT);
+        return sendRoxieControlQuery(sock, "<control:queries/>", ROXIECONTROLQUERYTIMEOUT);
     }
     catch(IException* e)
     {


### PR DESCRIPTION
Without the optimizations added to 5.0 checking status is prohibitively
slow.

Can instead consider migrating the changes in pull request:

hpcc-systems#5658

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
