### PR TITLE
HPCC-11261 - fileservice superfile actions can lockup on retry

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1156,6 +1156,25 @@ FILESERVICES_API void FILESERVICES_CALL fsAddSuperFile(IGlobalCodeContext *gctx,
 }
 
 
+class CImplicitSuperTransaction
+{
+    IDistributedFileTransaction *transaction;
+public:
+    CImplicitSuperTransaction(IDistributedFileTransaction *_transaction)
+    {
+        if (!_transaction->active()) // then created implicitly
+        {
+            transaction = _transaction;
+            transaction->start();
+        }
+    }
+    ~CImplicitSuperTransaction()
+    {
+        if (transaction)
+            transaction->commit();
+    }
+};
+
 FILESERVICES_API void FILESERVICES_CALL fslAddSuperFile(ICodeContext *ctx, const char *lsuperfn,const char *_lfn,unsigned atpos,bool addcontents, bool strict)
 {
     Owned<IDistributedSuperFile> file;
@@ -1185,7 +1204,11 @@ FILESERVICES_API void FILESERVICES_CALL fslAddSuperFile(ICodeContext *ctx, const
     StringBuffer other;
     if (atpos>1)
         other.append("#").append(atpos);
-    file->addSubFile(lfn.str(),atpos>0,(atpos>1)?other.str():NULL,addcontents,transaction);
+    {
+        CImplicitSuperTransaction implicitTransaction(transaction);
+        file->addSubFile(lfn.str(),atpos>0,(atpos>1)?other.str():NULL,addcontents,transaction);
+        file.clear();
+    }
     StringBuffer s("AddSuperFile ('");
     s.append(lsfn).append("', '");
     s.append(lfn).append('\'');
@@ -1217,7 +1240,11 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveSuperFile(ICodeContext *ctx, co
     lookupSuperFile(ctx, lsuperfn, file, true, lsfn, false, true);
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
     assertex(transaction);
-    file->removeSubFile(_lfn?lfn.str():NULL,del,remcontents,transaction);
+    {
+        CImplicitSuperTransaction implicitTransaction(transaction);
+        file->removeSubFile(_lfn?lfn.str():NULL,del,remcontents,transaction);
+        file.clear();
+    }
     StringBuffer s;
     if (_lfn)
         s.append("RemoveSuperFile ('");
@@ -1261,7 +1288,11 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveOwnedSubFiles(ICodeContext *ctx
     lookupSuperFile(ctx, lsuperfn, file, true, lsfn, false, true);
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
     assertex(transaction);
-    file->removeOwnedSubFiles(del,transaction);
+    {
+        CImplicitSuperTransaction implicitTransaction(transaction);
+        file->removeOwnedSubFiles(del,transaction);
+        file.clear();
+    }
     VStringBuffer s("RemoveOwnedSubFiles ('%s'", lsfn.str());
     if (del)
         s.append(", del");
@@ -1295,7 +1326,12 @@ FILESERVICES_API void FILESERVICES_CALL fslSwapSuperFile(ICodeContext *ctx, cons
 
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
     assertex(transaction);
-    file1->swapSuperFile(file2,transaction);
+    {
+        CImplicitSuperTransaction implicitTransaction(transaction);
+        file1->swapSuperFile(file2,transaction);
+        file1.clear();
+        file2.clear();
+    }
     StringBuffer s("SwapSuperFile ('");
     s.append(lsfn1).append("', '");
     s.append(lsfn2).append("') '");

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1167,6 +1167,8 @@ public:
             transaction = _transaction;
             transaction->start();
         }
+        else
+            transaction = NULL;
     }
     ~CImplicitSuperTransaction()
     {

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1207,7 +1207,7 @@ FILESERVICES_API void FILESERVICES_CALL fslAddSuperFile(ICodeContext *ctx, const
     {
         CImplicitSuperTransaction implicitTransaction(transaction);
         file->addSubFile(lfn.str(),atpos>0,(atpos>1)?other.str():NULL,addcontents,transaction);
-        file.clear();
+        file.clear(); // Must clear file before implicit transaction executed in destructor
     }
     StringBuffer s("AddSuperFile ('");
     s.append(lsfn).append("', '");
@@ -1243,7 +1243,7 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveSuperFile(ICodeContext *ctx, co
     {
         CImplicitSuperTransaction implicitTransaction(transaction);
         file->removeSubFile(_lfn?lfn.str():NULL,del,remcontents,transaction);
-        file.clear();
+        file.clear(); // Must clear file before implicit transaction executed in destructor
     }
     StringBuffer s;
     if (_lfn)
@@ -1291,7 +1291,7 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveOwnedSubFiles(ICodeContext *ctx
     {
         CImplicitSuperTransaction implicitTransaction(transaction);
         file->removeOwnedSubFiles(del,transaction);
-        file.clear();
+        file.clear(); // Must clear file before implicit transaction executed in destructor
     }
     VStringBuffer s("RemoveOwnedSubFiles ('%s'", lsfn.str());
     if (del)
@@ -1329,6 +1329,7 @@ FILESERVICES_API void FILESERVICES_CALL fslSwapSuperFile(ICodeContext *ctx, cons
     {
         CImplicitSuperTransaction implicitTransaction(transaction);
         file1->swapSuperFile(file2,transaction);
+        // Must clear files before implicit transaction executed in destructor
         file1.clear();
         file2.clear();
     }


### PR DESCRIPTION
Back porting 5.0 changes to 4.2.6, comprised of 3 cherry-picked commits:

1) [ NB: This was opened as separate issue to fix regression introduced by HPCC-11261 ]
commit 4cc6ced8aa10ffbac47e15ef6edf1988fdec2311
Author: Jake Smith jake.smith@lexisnexis.com
Date:   Wed Apr 30 16:37:00 2014 +0100

```
HPCC-11288 - regression if inside transaction

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>
```

2) commit ce5aea2f2c687947c18d2b8e3b6bc79ce64b537a
Author: Jake Smith jake.smith@lexisnexis.com
Date:   Tue Apr 29 11:54:09 2014 +0100

```
HPCC-11261 - add some comments

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>
```

3) commit c461b36d501fc3d06bc4f7ac17570e88b251910a
Author: Jake Smith jake.smith@lexisnexis.com
Date:   Tue Apr 29 11:27:55 2014 +0100

```
HPCC-11261 - fileservice superfile actions can lockup on retry

superfile actions that block due to other locks, clear their
cached files on pause/retry. However, the superfiles from
fileservices were still being held behind the transactions back.
On retry the transaction restablishes the file locks, but is
now in contention with the superfiles held in the caller.

Change so that transaction is started/committed (if required)
after the file is release in the caller

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>
```
