### PR TITLE
Hpcc 11309 for 4.2.6

### DIFF
--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -765,6 +765,7 @@ public:
             else
                 superfile->addSubFile(subfiles[i],false,NULL,false,transaction);
         }
+        superfile.clear();
         transaction->commit();
     }
 
@@ -812,15 +813,15 @@ public:
         // Do we have something to delete?
         if (toremove.ordinality()) {
             transaction->start();
+            if (removesuperfile && toremove.ordinality()!=superfile->numSubFiles())
+                removesuperfile = false;
             ForEachItemIn(i2,toremove)
                 superfile->removeSubFile(toremove.item(i2).text.get(),delsub,false,transaction);
-            transaction->commit();
-        }
-        // Delete superfile if empty
-        if (removesuperfile && (superfile->numSubFiles() == 0)) {
+            // Delete superfile if empty
+            if (removesuperfile)
+                queryDistributedFileDirectory().removeEntry(superfname, user, transaction);
             superfile.clear();
-            // MORE - add file deletion to transaction
-            queryDistributedFileDirectory().removeEntry(superfname,user);
+            transaction->commit();
         }
     }
 


### PR DESCRIPTION
Back porting 5.0 changes to 4.2.6, comprised of 1 cherry-picked commits:

1)
commit 53afb630c01e8d8e3cc38780e9ad40cc5872f800
Author: Jake Smith jake.smith@lexisnexis.com
Date:   Thu May 1 19:14:06 2014 +0100

```
HPCC-11309 - Ensure IDFUHelper cooperate with transactions

Ensure they release their locks before committing transaction.
Also move remove super file operation into transaction.

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>
```
