### PR TITLE
HPCC-11650 Fix issues, with conditional varying exections paths

### DIFF
--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -429,7 +429,7 @@ class graph_decl CGraphBase : public CInterface, implements IEclGraphResults, im
     mutable CriticalSection crit;
     CriticalSection evaluateCrit;
     CGraphElementTable containers;
-    CGraphElementArray sinks, connectedSinks;
+    CGraphElementArray sinks, activeSinks;
     bool sink, complete, global, localChild;
     mutable int localOnly;
     activity_id parentActivityId;
@@ -617,7 +617,7 @@ public:
     IThorActivityIterator *getConnectedIterator();
     IThorActivityIterator *getSinkIterator() const
     {
-        return new CGraphElementArrayIterator(connectedSinks);
+        return new CGraphElementArrayIterator(activeSinks);
     }
     IPropertyTree &queryXGMML() const { return *xgmml; }
     void addActivity(CGraphElementBase *element)
@@ -628,6 +628,10 @@ public:
             return;
         }
         containers.replace(*element);
+    }
+    void addActiveSink(CGraphElementBase &sink)
+    {
+        activeSinks.append(*LINK(&sink));
     }
     unsigned activityCount() const
     {


### PR DESCRIPTION
Conditional activities in subgraphs, that were re-executed
in particular if re-executed in master (e.g. in LOOP), where the
condition varied per execution could cause problems.
The code to detect the active sinks in a created subgraph,
unintentionally considered  activities that were not part
of the execution path, but had been in previous execution as
sinks.
This causes the master to call methods in the inactive activities,
e.g. onStart(). You may normally get away with it, but if the
onStart() relied on a value, created in a dependent subgraph that
had not been executed in this LOOP iteration, then it would fail.

This commit fixes the issue, by ensuring that only active sinks
are explicitly added to the 'activeSinks' list, each time the
subgraph is connected up.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
