### PR TITLE
HPCC-9310 Results as spills

### DIFF
--- a/thorlcr/activities/catch/thcatchslave.cpp
+++ b/thorlcr/activities/catch/thcatchslave.cpp
@@ -167,7 +167,7 @@ class CSkipCatchSlaveActivity : public CCatchSlaveActivityBase
         try
         {
             gathered = true;
-            Owned<IRowWriterMultiReader> overflowBuf = createOverflowableBuffer(*this, queryRowInterfaces(input), true);
+            Owned<IRowWriterMultiReader> overflowBuf = createOverflowableBuffer(*this, ::queryRowInterfaces(input), true);
             running = true;
             while (running)
             {
@@ -238,7 +238,7 @@ public:
                 }
             }
             catch (IException *_e) { e.setown(_e); }
-            catch (...) { throw MakeActivityException(this, 0, "Unknown exception caught"); }
+            catch (...) { throw MakeActivityException(*this, 0, "Unknown exception caught"); }
             if (e.get())
             {
                 eos = true;

--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -73,7 +73,7 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
                 if (minRequired == maxRowSize)
                 {
                     OwnedRoxieString fileName(activity.helper->getFileName());
-                    throw MakeActivityException(&activity, 0, "File %s contained a line of length greater than %d bytes.", fileName.get(), minRequired);
+                    throw MakeActivityException(activity, 0, "File %s contained a line of length greater than %d bytes.", fileName.get(), minRequired);
                 }
                 if (minRequired >= maxRowSize/2)
                     minRequired = maxRowSize;
@@ -106,7 +106,7 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
             {
                 iFileIO.setown(createCompressedFileReader(iFile, activity.eexp));
                 if (!iFileIO)
-                    throw MakeActivityException(&activity, 0, "Failed to open block compressed file '%s'", filename.get());
+                    throw MakeActivityException(activity, 0, "Failed to open block compressed file '%s'", filename.get());
                 checkFileCrc = false;
             }
             else
@@ -337,7 +337,7 @@ public:
                 {
                     unsigned lnum;
                     if (!superFDesc->mapSubPart(pnum, subFile, lnum))
-                        throw MakeActivityException(this, 0, "mapSubPart failed, file=%s, partnum=%d", logicalFilename.get(), pnum);
+                        throw MakeActivityException(*this, 0, "mapSubPart failed, file=%s, partnum=%d", logicalFilename.get(), pnum);
                     pnum = lnum;
                 }
                 if (pnum > localLastPart[subFile]) // don't think they can really be out of order

--- a/thorlcr/activities/diskread/thdiskread.cpp
+++ b/thorlcr/activities/diskread/thdiskread.cpp
@@ -37,7 +37,7 @@ public:
         bool isGrouped = fileDesc->isGrouped();
         if (isGrouped != codeGenGrouped)
         {
-            Owned<IException> e = MakeActivityWarning(&container, TE_GroupMismatch, "DFS and code generated group info. differs: DFS(%s), CodeGen(%s), using DFS info", isGrouped?"grouped":"ungrouped", codeGenGrouped?"grouped":"ungrouped");
+            Owned<IException> e = MakeActivityWarning(container, TE_GroupMismatch, "DFS and code generated group info. differs: DFS(%s), CodeGen(%s), using DFS info", isGrouped?"grouped":"ungrouped", codeGenGrouped?"grouped":"ungrouped");
             container.queryJob().fireException(e);
         }
         IOutputMetaData *recordSize = helper->queryDiskRecordSize()->querySerializedDiskMeta();
@@ -57,7 +57,7 @@ public:
                 if (isGrouped) rSz++;
                 if (rSz >= MIN_ROWCOMPRESS_RECSIZE)
                 {
-                    Owned<IException> e = MakeActivityWarning(&container, TE_CompressionMismatch, "Ignoring compression attribute on file '%s', which is not published as compressed in DFS", fileName.get());
+                    Owned<IException> e = MakeActivityWarning(container, TE_CompressionMismatch, "Ignoring compression attribute on file '%s', which is not published as compressed in DFS", fileName.get());
                     container.queryJob().fireException(e);
                 }
             }

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -214,14 +214,14 @@ void CDiskRecordPartHandler::open()
             if (!blockCompressed)
                 throw MakeStringException(-1,"Unsupported compressed file format: %s", filename.get());
             else 
-                throw MakeActivityException(&activity, 0, "Failed to open block compressed file '%s'", filename.get());
+                throw MakeActivityException(activity, 0, "Failed to open block compressed file '%s'", filename.get());
         }
     }
     else
         in.setown(createRowStream(iFile, activity.queryDiskRowInterfaces(), rwFlags));
     if (!in)
-        throw MakeActivityException(&activity, 0, "Failed to open file '%s'", filename.get());
-    ActPrintLog(&activity, "%s[part=%d]: %s (%s)", kindStr, which, activity.isFixedDiskWidth ? "fixed" : "variable", filename.get());
+        throw MakeActivityException(activity, 0, "Failed to open file '%s'", filename.get());
+    ActPrintLog(activity, "%s[part=%d]: %s (%s)", kindStr, which, activity.isFixedDiskWidth ? "fixed" : "variable", filename.get());
     if (activity.isFixedDiskWidth) 
     {
         if (!compressed || blockCompressed)
@@ -231,7 +231,7 @@ void CDiskRecordPartHandler::open()
             {
                 offset_t lsize = partDesc->queryProperties().getPropInt64("@size");
                 if (0 != lsize % fixedSize)
-                    throw MakeActivityException(&activity, TE_BadFileLength, "Fixed length file %s [DFS size=%"I64F"d] is not a multiple of fixed record size : %d", filename.get(), lsize, fixedSize);
+                    throw MakeActivityException(activity, TE_BadFileLength, "Fixed length file %s [DFS size=%"I64F"d] is not a multiple of fixed record size : %d", filename.get(), lsize, fixedSize);
             }
         }
     }
@@ -316,7 +316,7 @@ public:
                     StringBuffer s;
                     e->errorMessage(s);
                     s.append(" - handling file: ").append(filename.get());
-                    IException *e2 = MakeActivityException(&activity, e, "%s", s.str());
+                    IException *e2 = MakeActivityException(activity, e, "%s", s.str());
                     e->Release();
                     throw e2;
                 }
@@ -412,7 +412,7 @@ public:
             needTransform = helper->needTransform();
             if (unsorted)
             {
-                Owned<IException> e = MakeActivityWarning(this, 0, "Diskread - ignoring 'unsorted' because marked 'grouped'");
+                Owned<IException> e = MakeActivityWarning(*this, 0, "Diskread - ignoring 'unsorted' because marked 'grouped'");
                 fireException(e);
                 unsorted = false;
             }
@@ -672,7 +672,7 @@ public:
                 StringBuffer s;
                 e->errorMessage(s);
                 s.append(" - handling file: ").append(filename.get());
-                IException *e2 = MakeActivityException(&activity, e, "%s", s.str());
+                IException *e2 = MakeActivityException(activity, e, "%s", s.str());
                 e->Release();
                 eoi = true;
                 throw e2;

--- a/thorlcr/activities/fetch/thfetch.cpp
+++ b/thorlcr/activities/fetch/thfetch.cpp
@@ -67,12 +67,12 @@ public:
                 free(ekey);
                 if (!encrypted)
                 {
-                    Owned<IException> e = MakeActivityWarning(&container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", helper->getFileName());
+                    Owned<IException> e = MakeActivityWarning(container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", helper->getFileName());
                     container.queryJob().fireException(e);
                 }
             }
             else if (encrypted)
-                throw MakeActivityException(this, 0, "File '%s' was published as encrypted but no encryption key provided", fname.get());
+                throw MakeActivityException(*this, 0, "File '%s' was published as encrypted but no encryption key provided", fname.get());
             mapping.setown(getFileSlaveMaps(fetchFile->queryLogicalName(), *fileDesc, container.queryJob().queryUserDescriptor(), container.queryJob().querySlaveGroup(), container.queryLocalOrGrouped(), false, NULL, fetchFile->querySuperFile()));
             mapping->serializeFileOffsetMap(offsetMapMb);
             addReadFile(fetchFile);

--- a/thorlcr/activities/fetch/thfetchslave.cpp
+++ b/thorlcr/activities/fetch/thfetchslave.cpp
@@ -140,7 +140,7 @@ public:
         for (c=0; c<offsetCount; c++)
         {
             FPosTableEntry &e = offsetTable[c];
-            ActPrintLog(&owner, "Table[%d] : base=%"I64F"d, top=%"I64F"d, slave=%d", c, e.base, e.top, e.index);
+            ActPrintLog(owner, "Table[%d] : base=%"I64F"d, top=%"I64F"d, slave=%d", c, e.base, e.top, e.index);
         }
         files = parts.ordinality();
         if (files)
@@ -174,7 +174,7 @@ public:
     {
         fposHash = new CFPosHandler(*iFetchHandler, offsetCount, offsetTable);
         keyIn.set(_keyIn);
-        distributor = createHashDistributor(&owner, owner.queryContainer().queryJob().queryJobComm(), tag, false, this);
+        distributor = createHashDistributor(&owner, owner.queryJob().queryJobComm(), tag, false, this);
         keyOutStream.setown(distributor->connect(keyRowIf, keyIn, fposHash, NULL));
     }
     virtual IRowStream *queryOutput() { return this; }
@@ -570,7 +570,7 @@ public:
             if (thisLineLength < minRequired || avail < minRequired)
                 break;
             if (minRequired == maxRowSize)
-                throw MakeActivityException(this, 0, "CSV fetch line of length greater than %d bytes.", minRequired);
+                throw MakeActivityException(*this, 0, "CSV fetch line of length greater than %d bytes.", minRequired);
             if (minRequired >= maxRowSize/2)
                 minRequired = maxRowSize;
             else
@@ -647,7 +647,7 @@ public:
             if (!parser->next())
             {
                 StringBuffer tmpStr;
-                throw MakeActivityException(this, 0, "%s", fetchStream->getPartName(filePartIndex, tmpStr).str());
+                throw MakeActivityException(*this, 0, "%s", fetchStream->getPartName(filePartIndex, tmpStr).str());
             }
         }
         size32_t retSz = ((IHThorXmlFetchArg *)fetchBaseHelper)->transform(rowBuilder, lastMatch->get(), keyRow, fpos);

--- a/thorlcr/activities/funnel/thfunnel.cpp
+++ b/thorlcr/activities/funnel/thfunnel.cpp
@@ -63,7 +63,7 @@ public:
             for (s=0; s<slaves; s++)
             {
                 if (!container.queryJob().queryJobComm().send(msg, ((rank_t) s+1), (mptag_t) replyTags.item(s), LONGTIMEOUT))
-                    throw MakeActivityException(this, 0, "Failed to give result to slave");
+                    throw MakeActivityException(*this, 0, "Failed to give result to slave");
             }
             if (readSome) // got some, have told slaves to ignore rest, so finish
                 break;

--- a/thorlcr/activities/funnel/thfunnelslave.cpp
+++ b/thorlcr/activities/funnel/thfunnelslave.cpp
@@ -118,7 +118,7 @@ class CParallelFunnel : public CSimpleInterface, implements IRowStream
                 funnel.fireException(e);
                 e->Release();
             }
-            ActPrintLog(&funnel.activity.queryContainer(), "%s: Read %"I64F"d records", idStr.get(), readThisInput);
+            ActPrintLog(funnel.activity, "%s: Read %"I64F"d records", idStr.get(), readThisInput);
         }
     };
 
@@ -597,7 +597,7 @@ public:
             if (err) {
                 eog = true;
                 rows.kill();
-                throw MakeActivityException(this, -1, "mismatched input row count for Combine");
+                throw MakeActivityException(*this, -1, "mismatched input row count for Combine");
             }
             if (eog) 
                 break;

--- a/thorlcr/activities/hashdistrib/thhashdistrib.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistrib.cpp
@@ -130,19 +130,19 @@ public:
         queryThorFileManager().addScope(container.queryJob(), indexFileName, scoped);
         Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), indexFileName);
         if (!file)
-            throw MakeActivityException(this, 0, "KeyedDistribute: Failed to find key: %s", scoped.str());
+            throw MakeActivityException(*this, 0, "KeyedDistribute: Failed to find key: %s", scoped.str());
         if (0 == file->numParts())
-            throw MakeActivityException(this, 0, "KeyedDistribute: Can't distribute based on an empty key: %s", scoped.str());
+            throw MakeActivityException(*this, 0, "KeyedDistribute: Can't distribute based on an empty key: %s", scoped.str());
 
         checkFormatCrc(this, file, helper->getFormatCrc(), true);
         Owned<IFileDescriptor> fileDesc = file->getFileDescriptor();
         Owned<IPartDescriptor> tlkDesc = fileDesc->getPart(fileDesc->numParts()-1);
         if (!tlkDesc->queryProperties().hasProp("@kind") || 0 != stricmp("topLevelKey", tlkDesc->queryProperties().queryProp("@kind")))
-            throw MakeActivityException(this, 0, "Cannot distribute using a non-distributed key: '%s'", scoped.str());
+            throw MakeActivityException(*this, 0, "Cannot distribute using a non-distributed key: '%s'", scoped.str());
         unsigned location;
         OwnedIFile iFile;
         StringBuffer filePath;
-        if (!getBestFilePart(this, *tlkDesc, iFile, location, filePath))
+        if (!getBestFilePart(*this, *tlkDesc, iFile, location, filePath))
             throw MakeThorException(TE_FileNotFound, "Top level key part does not exist, for key: %s", file->queryLogicalName());
         OwnedIFileIO iFileIO = iFile->open(IFOread);
         assertex(iFileIO);
@@ -226,7 +226,7 @@ public:
                 for (i=0;i<n;i++) {
                     double r = ((double)sizes[i]-(double)avg)/(double)avg;
                     if ((r>=maxskew)||(-r>maxskew)) {
-                        throw MakeActivityException(this, TE_DistributeFailedSkewExceeded, "DISTRIBUTE maximum skew exceeded (node %d has %"I64F"d, average is %"I64F"d)",i+1,sizes[i],avg);
+                        throw MakeActivityException(*this, TE_DistributeFailedSkewExceeded, "DISTRIBUTE maximum skew exceeded (node %d has %"I64F"d, average is %"I64F"d)",i+1,sizes[i],avg);
                     }               
                 }
             }

--- a/thorlcr/activities/indexread/thindexread.cpp
+++ b/thorlcr/activities/indexread/thindexread.cpp
@@ -114,14 +114,14 @@ protected:
                     if (rowCrc || fileCrc)
                     {
                         checkTLKConsistency = false;
-                        Owned<IException> e = MakeActivityWarning(&container, 0, "Cannot validate that tlks in superfile %s match, some crc attributes are missing", super->queryLogicalName());
+                        Owned<IException> e = MakeActivityWarning(container, 0, "Cannot validate that tlks in superfile %s match, some crc attributes are missing", super->queryLogicalName());
                         container.queryJob().fireException(e);
                     }       
                 }
                 if (rowCrc && fileCrc)
                 {
                     checkTLKConsistency = false;
-                    Owned<IException> e = MakeActivityWarning(&container, 0, "Cannot validate that tlks in superfile %s match, due to mixed crc types.", super->queryLogicalName());
+                    Owned<IException> e = MakeActivityWarning(container, 0, "Cannot validate that tlks in superfile %s match, due to mixed crc types.", super->queryLogicalName());
                     container.queryJob().fireException(e);
                 }
                 if (checkTLKConsistency)
@@ -132,7 +132,7 @@ protected:
                         first = false;
                     }
                     else if (tlkCrc != _tlkCrc)
-                        throw MakeActivityException(this, 0, "Sorted output on super files comprising of non coparitioned sub keys is not supported (TLK's do not match)");
+                        throw MakeActivityException(*this, 0, "Sorted output on super files comprising of non coparitioned sub keys is not supported (TLK's do not match)");
                 }
             }
             if (!nofilter)
@@ -175,7 +175,7 @@ protected:
             superSubIndex++;
             f = &iter->query();
             if (width != f->numParts()-1)
-                throw MakeActivityException(this, 0, "Super key %s, with mixture of sub key width are not supported.", f->queryLogicalName());
+                throw MakeActivityException(*this, 0, "Super key %s, with mixture of sub key width are not supported.", f->queryLogicalName());
         }
     }
 
@@ -204,7 +204,7 @@ public:
             bool localKey = index->queryAttributes().getPropBool("@local");
 
             if (container.queryLocalData() && !localKey)
-                throw MakeActivityException(this, 0, "Index Read cannot be LOCAL unless supplied index is local");
+                throw MakeActivityException(*this, 0, "Index Read cannot be LOCAL unless supplied index is local");
 
             nofilter = 0 != (TIRnofilter & indexBaseHelper->getFlags());
             if (index->queryAttributes().getPropBool("@local"))

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -65,7 +65,7 @@ public:
         IOutputMetaData * diskSize = helper->queryDiskRecordSize();
         unsigned minSize = diskSize->getMinRecordSize();
         if (minSize > KEYBUILD_MAXLENGTH)
-            throw MakeActivityException(this, 0, "Index minimum record length (%d) exceeds %d internal limit", minSize, KEYBUILD_MAXLENGTH);
+            throw MakeActivityException(*this, 0, "Index minimum record length (%d) exceeds %d internal limit", minSize, KEYBUILD_MAXLENGTH);
         unsigned maxSize;
         if (diskSize->isVariableSize())
         {
@@ -77,7 +77,7 @@ public:
         else
             maxSize = diskSize->getFixedSize();
         if (maxSize > KEYBUILD_MAXLENGTH)
-            throw MakeActivityException(this, 0, "Index maximum record length (%d) exceeds %d internal limit. Maximum size = %d, try adjusting index MAXLENGTH", maxSize, KEYBUILD_MAXLENGTH, minSize);
+            throw MakeActivityException(*this, 0, "Index maximum record length (%d) exceeds %d internal limit. Maximum size = %d, try adjusting index MAXLENGTH", maxSize, KEYBUILD_MAXLENGTH, minSize);
 
         singlePartKey = 0 != (helper->getFlags() & TIWsmall) || dlfn.isExternal();
         clusters.kill();
@@ -105,22 +105,22 @@ public:
         {
             restrictedWidth = helper->getWidth();
             if (restrictedWidth > container.queryJob().querySlaves())
-                throw MakeActivityException(this, 0, "Unsupported, can't refactor to width(%d) larger than host cluster(%d)", restrictedWidth, container.queryJob().querySlaves());
+                throw MakeActivityException(*this, 0, "Unsupported, can't refactor to width(%d) larger than host cluster(%d)", restrictedWidth, container.queryJob().querySlaves());
             else if (restrictedWidth < container.queryJob().querySlaves())
             {
                 if (!isLocal)
-                    throw MakeActivityException(this, 0, "Unsupported, refactoring to few parts only supported for local indexes.");
+                    throw MakeActivityException(*this, 0, "Unsupported, refactoring to few parts only supported for local indexes.");
                 assertex(!singlePartKey);
                 unsigned gwidth = groups.item(0).ordinality();
                 if (0 != container.queryJob().querySlaves() % gwidth)
-                    throw MakeActivityException(this, 0, "Unsupported, refactored target size (%d) must be factor of thor cluster width (%d)", groups.item(0).ordinality(), container.queryJob().querySlaves());
+                    throw MakeActivityException(*this, 0, "Unsupported, refactored target size (%d) must be factor of thor cluster width (%d)", groups.item(0).ordinality(), container.queryJob().querySlaves());
                 if (0 == restrictedWidth)
                     restrictedWidth = gwidth;
                 ForEachItemIn(g, groups)
                 {
                     IGroup &group = groups.item(g);
                     if (gwidth != groups.item(g).ordinality())
-                        throw MakeActivityException(this, 0, "Unsupported, cannot output multiple refactored widths, targeting cluster '%s' and '%s'", clusters.item(0), clusters.item(g));
+                        throw MakeActivityException(*this, 0, "Unsupported, cannot output multiple refactored widths, targeting cluster '%s' and '%s'", clusters.item(0), clusters.item(g));
                     if (gwidth != restrictedWidth)
                         groups.replace(*group.subset((unsigned)0, restrictedWidth), g);
                 }
@@ -144,7 +144,7 @@ public:
             if (!f) f = _f;
             Owned<IDistributedFilePart> existingTlk = f->getPart(f->numParts()-1);
             if (!existingTlk->queryAttributes().hasProp("@kind") || 0 != stricmp("topLevelKey", existingTlk->queryAttributes().queryProp("@kind")))
-                throw MakeActivityException(this, 0, "Cannot build new key '%s' based on non-distributed key '%s'", fname.get(), diName.get());
+                throw MakeActivityException(*this, 0, "Cannot build new key '%s' based on non-distributed key '%s'", fname.get(), diName.get());
             IPartDescriptor *tlkDesc = fileDesc->queryPart(fileDesc->numParts()-1);
             IPropertyTree &props = tlkDesc->queryProperties();
             if (existingTlk->queryAttributes().hasProp("@size"))
@@ -333,7 +333,7 @@ public:
             if (file)
             {
                 if (0 == (TIWoverwrite & helper->getFlags()))
-                    throw MakeActivityException(this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
+                    throw MakeActivityException(*this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
                 checkSuperFileOwnership(*file);
             }
         }

--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -191,7 +191,7 @@ public:
         StringBuffer partFname;
         getPartFilename(partDesc, 0, partFname);
         bool compress=false;
-        OwnedIFileIO iFileIO = createMultipleWrite(this, partDesc, 0, compress, false, NULL, this, false, true, &abortSoon);
+        OwnedIFileIO iFileIO = createMultipleWrite(*this, partDesc, 0, compress, false, NULL, this, false, true, &abortSoon);
         Owned<IFileIOStream> out = createBufferedIOStream(iFileIO);
         ActPrintLog("INDEXWRITE: created fixed output stream %s", partFname.str());
         unsigned flags = COL_PREFIX;
@@ -224,12 +224,12 @@ public:
             if(*nameBuff == '_' && strcmp(name, "_nodeSize") != 0)
             {
                 OwnedRoxieString fname(helper->getFileName());
-                throw MakeActivityException(this, 0, "Invalid name %s in user metadata for index %s (names beginning with underscore are reserved)", name.str(), fname.get());
+                throw MakeActivityException(*this, 0, "Invalid name %s in user metadata for index %s (names beginning with underscore are reserved)", name.str(), fname.get());
             }
             if(!validateXMLTag(name.str()))
             {
                 OwnedRoxieString fname(helper->getFileName());
-                throw MakeActivityException(this, 0, "Invalid name %s in user metadata for index %s (not legal XML element name)", name.str(), fname.get());
+                throw MakeActivityException(*this, 0, "Invalid name %s in user metadata for index %s (not legal XML element name)", name.str(), fname.get());
             }
             if(!metadata) metadata.setown(createPTree("metadata"));
             metadata->setProp(name.str(), value.str());
@@ -276,7 +276,7 @@ public:
         catch (CATCHALL)
         {
             abortSoon = true;
-            e.setown(MakeActivityException(this, 0, "INDEXWRITE: Error closing file: %s - unknown exception", partFname.str()));
+            e.setown(MakeActivityException(*this, 0, "INDEXWRITE: Error closing file: %s - unknown exception", partFname.str()));
         }
         try 
         { 
@@ -568,7 +568,7 @@ public:
                             copyFile(dstIFile, existingTlkIFile);
                         }
                         else
-                            doReplicate(this, *tlkDesc, NULL);
+                            doReplicate(*this, *tlkDesc, NULL);
                     }
                 }
             }
@@ -660,7 +660,7 @@ public:
         }
         if (reportOverflow && totalCount == I64C(0x100000000))
         {
-            Owned<IThorException> e = MakeActivityWarning(this, TE_MoxieIndarOverflow, "Moxie indar sequence number has overflowed");
+            Owned<IThorException> e = MakeActivityWarning(*this, TE_MoxieIndarOverflow, "Moxie indar sequence number has overflowed");
             fireException(e);
             reportOverflow = false;
         }
@@ -670,7 +670,7 @@ public:
         if (singlePartKey && !fewcapwarned && totalCount>(FEWWARNCAP*0x100000))
         {
             fewcapwarned = true;
-            Owned<IThorException> e = MakeActivityWarning(this, TE_BuildIndexFewExcess, "BUILDINDEX: building single part key because marked as 'FEW' but row count in excess of %dM", FEWWARNCAP);
+            Owned<IThorException> e = MakeActivityWarning(*this, TE_BuildIndexFewExcess, "BUILDINDEX: building single part key because marked as 'FEW' but row count in excess of %dM", FEWWARNCAP);
             fireException(e);
         }
     }

--- a/thorlcr/activities/join/thjoin.cpp
+++ b/thorlcr/activities/join/thjoin.cpp
@@ -163,7 +163,7 @@ public:
                 if (!container.queryLocalOrGrouped() && container.getKind() == TAKselfjoin)
                 {
                     if (betweenjoin) {
-                        throw MakeActivityException(this, -1, "SELF BETWEEN JOIN not supported"); // Gavin shouldn't generate
+                        throw MakeActivityException(*this, -1, "SELF BETWEEN JOIN not supported"); // Gavin shouldn't generate
                     }
                     Owned<IRowInterfaces> rowif = createRowInterfaces(container.queryInput(0)->queryHelper()->queryOutputMeta(),queryActivityId(),queryCodeContext());
                     ICompare *cmpleft = helper->queryCompareLeft();
@@ -184,7 +184,7 @@ public:
                             if (TE_SkewError == e->errorCode())
                             {
                                 StringBuffer s;
-                                Owned<IThorException> e2 = MakeActivityException(this, TE_JoinFailedSkewExceeded, "SELFJOIN failed. %s", e->errorMessage(s).str());
+                                Owned<IThorException> e2 = MakeActivityException(*this, TE_JoinFailedSkewExceeded, "SELFJOIN failed. %s", e->errorMessage(s).str());
                                 e->Release();
                                 fireException(e2);
                             }
@@ -212,7 +212,7 @@ public:
                             if (TE_SkewError == e->errorCode())
                             {
                                 StringBuffer s;
-                                Owned<IThorException> e2 = MakeActivityException(this, TE_JoinFailedSkewExceeded, "JOIN failed, skewed %s. %s", rightpartition?"RHS":"LHS", e->errorMessage(s).str());
+                                Owned<IThorException> e2 = MakeActivityException(*this, TE_JoinFailedSkewExceeded, "JOIN failed, skewed %s. %s", rightpartition?"RHS":"LHS", e->errorMessage(s).str());
                                 e->Release();
                                 fireException(e2);
                             }
@@ -239,7 +239,7 @@ public:
                                     {
                                         VStringBuffer s("JOIN failed, %s skewed, based on distribution of %s partition points. ", rightpartition?"LHS":"RHS", rightpartition?"RHS":"LHS");
                                         e->errorMessage(s);
-                                        Owned<IThorException> e2 = MakeActivityException(this, TE_JoinFailedSkewExceeded, "%s", s.str());
+                                        Owned<IThorException> e2 = MakeActivityException(*this, TE_JoinFailedSkewExceeded, "%s", s.str());
                                         e->Release();
                                         fireException(e2);
                                     }
@@ -271,7 +271,7 @@ public:
                             {
                                 VStringBuffer s("JOIN failed. %s skewed, based on distribution of presorted %s partition points. ", rightpartition?"LHS":"RHS", rightpartition?"RHS":"LHS");
                                 e->errorMessage(s);
-                                Owned<IThorException> e2 = MakeActivityException(this, TE_JoinFailedSkewExceeded, "%s", s.str());
+                                Owned<IThorException> e2 = MakeActivityException(*this, TE_JoinFailedSkewExceeded, "%s", s.str());
                                 e->Release();
                                 fireException(e2);
                             }
@@ -289,7 +289,7 @@ public:
             {
                 if (e->errorCode()!=MPERR_link_closed) 
                     throw;
-                ActPrintLogEx(&queryContainer(), thorlog_null, MCwarning, "WARNING: MPERR_link_closed in SortDone");
+                ActPrintLogEx(*this, thorlog_null, MCwarning, "WARNING: MPERR_link_closed in SortDone");
                 e->Release();
             }
             ::Release(imaster);
@@ -338,13 +338,13 @@ public:
             if (count >= selfJoinWarnLevel)
             {
                 selfJoinWarnLevel *= 2;
-                Owned<IException> e = MakeActivityWarning(this, -1, "SELFJOIN: Warning %d preliminary matches, join will take some time", count);
+                Owned<IException> e = MakeActivityWarning(*this, -1, "SELFJOIN: Warning %d preliminary matches, join will take some time", count);
                 CMasterActivity::fireException(e);
                 lastMsgTime = msTick();
             }
             else if (msTick() > lastMsgTime + MSGTIME)
             {
-                Owned<IException> e = MakeActivityWarning(this, -1, "SELFJOIN: Warning %d preliminary matches, join will take some time", count);
+                Owned<IException> e = MakeActivityWarning(*this, -1, "SELFJOIN: Warning %d preliminary matches, join will take some time", count);
                 CMasterActivity::fireException(e);
                 lastMsgTime = msTick();
             }

--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -301,11 +301,11 @@ public:
             if (!doglobaljoin())
             {
                 Sleep(1000); // let original error through
-                throw MakeActivityException(this, TE_BarrierAborted, "JOIN: Barrier Aborted");
+                throw MakeActivityException(*this, TE_BarrierAborted, "JOIN: Barrier Aborted");
             }
         }
         if (!leftStream.get()||!rightStream.get())
-            throw MakeActivityException(this, TE_FailedToStartJoinStreams, "Failed to start join streams");
+            throw MakeActivityException(*this, TE_FailedToStartJoinStreams, "Failed to start join streams");
         joinhelper->init(leftStream, rightStream, ::queryRowAllocator(inputs.item(0)),::queryRowAllocator(inputs.item(1)),::queryRowMetaData(inputs.item(0)), &abortSoon);
     }
     void stopLeftInput()
@@ -470,8 +470,8 @@ public:
             primaryCollate = collate;
             primaryCollateUpper = collateupper;
         }
-        primaryRowIf.set(queryRowInterfaces(primaryInput));
-        secondaryRowIf.set(queryRowInterfaces(secondaryInput));
+        primaryRowIf.set(::queryRowInterfaces(primaryInput));
+        secondaryRowIf.set(::queryRowInterfaces(secondaryInput));
 
         OwnedConstThorRow partitionRow;
         rowcount_t totalrows;

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -50,9 +50,9 @@ public:
         originalIndexFile.setown(queryThorFileManager().lookup(container.queryJob(), origName));
         newIndexFile.setown(queryThorFileManager().lookup(container.queryJob(), updatedName));
         if (originalIndexFile->numParts() != newIndexFile->numParts())
-            throw MakeActivityException(this, TE_KeyDiffIndexSizeMismatch, "Index %s and %s differ in width", origName.get(), updatedName.get());
+            throw MakeActivityException(*this, TE_KeyDiffIndexSizeMismatch, "Index %s and %s differ in width", origName.get(), updatedName.get());
         if (originalIndexFile->querySuperFile() || newIndexFile->querySuperFile())
-            throw MakeActivityException(this, 0, "Diffing super files not supported");  
+            throw MakeActivityException(*this, 0, "Diffing super files not supported");
 
         width = originalIndexFile->numParts();
 
@@ -65,7 +65,7 @@ public:
         if (!local)
             width--; // 1 part == No n distributed / Monolithic key
         if (width > container.queryJob().querySlaves())
-            throw MakeActivityException(this, 0, "Unsupported: keydiff(%s, %s) - Cannot diff a key that's wider(%d) than the target cluster size(%d)", originalIndexFile->queryLogicalName(), newIndexFile->queryLogicalName(), width, container.queryJob().querySlaves());
+            throw MakeActivityException(*this, 0, "Unsupported: keydiff(%s, %s) - Cannot diff a key that's wider(%d) than the target cluster size(%d)", originalIndexFile->queryLogicalName(), newIndexFile->queryLogicalName(), width, container.queryJob().querySlaves());
 
         IArrayOf<IGroup> groups;
         OwnedRoxieString outputName(helper->getOutputName());
@@ -209,7 +209,7 @@ public:
             OwnedRoxieString outputName(helper->getOutputName());
             Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), outputName, false, true);
             if (file)
-                throw MakeActivityException(this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
+                throw MakeActivityException(*this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
         }
     }
     virtual void kill()

--- a/thorlcr/activities/keydiff/thkeydiffslave.cpp
+++ b/thorlcr/activities/keydiff/thkeydiffslave.cpp
@@ -79,8 +79,8 @@ public:
         StringBuffer originalFilePart, updatedFilePart;
         OwnedRoxieString origName(helper->getOriginalName());
         OwnedRoxieString updatedName(helper->getUpdatedName());
-        locateFilePartPath(this, origName, *originalIndexPart, originalFilePart);
-        locateFilePartPath(this, updatedName, *updatedIndexPart, updatedFilePart);
+        locateFilePartPath(*this, origName, *originalIndexPart, originalFilePart);
+        locateFilePartPath(*this, updatedName, *updatedIndexPart, updatedFilePart);
         StringBuffer patchFilePath;
         getPartFilename(*patchPart, 0, patchFilePath);
         if (globals->getPropBool("@replicateAsync", true))
@@ -96,8 +96,8 @@ public:
             if (!copyTlk)
             {
                 StringBuffer tmp;
-                locateFilePartPath(this, tmp.clear().append(origName).append(" [TLK]").str(), *originalIndexTlkPart, originalFilePart.clear());
-                locateFilePartPath(this, tmp.clear().append(updatedName).append(" [TLK]").str(), *updatedIndexTlkPart, updatedFilePart.clear());
+                locateFilePartPath(*this, tmp.clear().append(origName).append(" [TLK]").str(), *originalIndexTlkPart, originalFilePart.clear());
+                locateFilePartPath(*this, tmp.clear().append(updatedName).append(" [TLK]").str(), *updatedIndexTlkPart, updatedFilePart.clear());
                 getPartFilename(*patchTlkPart, 0, tmp.clear());
                 tlkDiffGenerator.setown(createKeyDiffGenerator(originalFilePart.str(), updatedFilePart.str(), tmp.str(), 0, true, COMPRESS_METHOD_LZMA));
             }
@@ -123,18 +123,18 @@ public:
             try
             {
                 if (patchPart->numCopies() > 1)
-                    doReplicate(this, *patchPart);
+                    doReplicate(*this, *patchPart);
                 if (tlk && copyTlk)
                 {
                     StringBuffer patchFilePathTlk, updatedFilePartTlk, tmp;
                     getPartFilename(*patchTlkPart, 0, patchFilePathTlk);
                     OwnedRoxieString updatedName(helper->getUpdatedName());
-                    locateFilePartPath(this, tmp.append(updatedName).append(" [TLK]").str(), *updatedIndexTlkPart, updatedFilePartTlk);
+                    locateFilePartPath(*this, tmp.append(updatedName).append(" [TLK]").str(), *updatedIndexTlkPart, updatedFilePartTlk);
                     OwnedIFile dstIFileTlk = createIFile(patchFilePathTlk.str());
                     OwnedIFile updatedIFileTlk = createIFile(updatedFilePartTlk.str());
                     copyFile(dstIFileTlk, updatedIFileTlk);
                     if (patchTlkPart->numCopies() > 1)
-                        doReplicate(this, *patchTlkPart);
+                        doReplicate(*this, *patchTlkPart);
                 }
             }
             catch (IException *e)

--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -95,7 +95,7 @@ public:
             localKey = indexFile->queryAttributes().getPropBool("@local");
 
             if (container.queryLocalData() && !localKey)
-                throw MakeActivityException(this, 0, "Keyed Join cannot be LOCAL unless supplied index is local");
+                throw MakeActivityException(*this, 0, "Keyed Join cannot be LOCAL unless supplied index is local");
 
             checkFormatCrc(this, indexFile, helper->getIndexFormatCrc(), true);
             Owned<IFileDescriptor> indexFileDesc = indexFile->getFileDescriptor();
@@ -126,9 +126,9 @@ public:
                     else
                     {
                         if (hasTlk != keyHasTlk)
-                            throw MakeActivityException(this, 0, "Local/Single part keys cannot be mixed with distributed(tlk) keys in keyedjoin");
+                            throw MakeActivityException(*this, 0, "Local/Single part keys cannot be mixed with distributed(tlk) keys in keyedjoin");
                         if (keyHasTlk && superIndexWidth != f.numParts()-1)
-                            throw MakeActivityException(this, 0, "Super sub keys of different width cannot be mixed with distributed(tlk) keys in keyedjoin");
+                            throw MakeActivityException(*this, 0, "Super sub keys of different width cannot be mixed with distributed(tlk) keys in keyedjoin");
                     }
                 }
                 if (keyHasTlk)
@@ -183,7 +183,7 @@ public:
                         StringBuffer filePath;
                         Owned<IFileDescriptor> fileDesc = f->getFileDescriptor();
                         Owned<IPartDescriptor> tlkDesc = fileDesc->getPart(fileDesc->numParts()-1);
-                        if (!getBestFilePart(this, *tlkDesc, iFile, location, filePath))
+                        if (!getBestFilePart(*this, *tlkDesc, iFile, location, filePath))
                             throw MakeThorException(TE_FileNotFound, "Top level key part does not exist, for key: %s", f->queryLogicalName());
                         OwnedIFileIO iFileIO = iFile->open(IFOread);
                         assertex(iFileIO);
@@ -206,7 +206,7 @@ public:
                         if (dataFile)
                         {
                             if (superIndex)
-                                throw MakeActivityException(this, 0, "Superkeys and full keyed joins are not supported");
+                                throw MakeActivityException(*this, 0, "Superkeys and full keyed joins are not supported");
                             Owned<IFileDescriptor> dataFileDesc = getConfiguredFileDescriptor(*dataFile);
                             void *ekey;
                             size32_t ekeylen;
@@ -218,12 +218,12 @@ public:
                                 free(ekey);
                                 if (!encrypted)
                                 {
-                                    Owned<IException> e = MakeActivityWarning(&container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", helper->getFileName());
+                                    Owned<IException> e = MakeActivityWarning(container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", helper->getFileName());
                                     container.queryJob().fireException(e);
                                 }
                             }
                             else if (encrypted)
-                                throw MakeActivityException(this, 0, "File '%s' was published as encrypted but no encryption key provided", fetchFilename.get());
+                                throw MakeActivityException(*this, 0, "File '%s' was published as encrypted but no encryption key provided", fetchFilename.get());
                             unsigned dataReadWidth = (unsigned)container.queryJob().getWorkUnitValueInt("KJDRR", 0);
                             if (!dataReadWidth || dataReadWidth>container.queryJob().querySlaves())
                                 dataReadWidth = container.queryJob().querySlaves();

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -752,7 +752,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                                 assertex(0 == prevVal);
                                 // I will not get anymore from 'sender', tell sender I've processed all and there will be no more results.
                                 if (!comm.send(msg, sender, resultMpTag, LONGTIMEOUT))
-                                    throw MakeActivityException(&owner, 0, "CKeyedFetchRequestProcessor {3} - comm send failed");
+                                    throw MakeActivityException(owner, 0, "CKeyedFetchRequestProcessor {3} - comm send failed");
                                 if (0 == --endRequestsCount)
                                     break;
                                 continue;
@@ -859,7 +859,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                                     replyRows.serialize(replyMb);
                                     replyRows.kill();
                                     if (!comm.send(replyMb, sender, resultMpTag, LONGTIMEOUT))
-                                        throw MakeActivityException(&owner, 0, "CKeyedFetchRequestProcessor {1} - comm send failed");
+                                        throw MakeActivityException(owner, 0, "CKeyedFetchRequestProcessor {1} - comm send failed");
                                     replyMb.rewrite(sizeof(retCount));
                                 }
                             }
@@ -870,7 +870,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                                 replyRows.serialize(replyMb);
                                 replyRows.kill();
                                 if (!comm.send(replyMb, sender, resultMpTag, LONGTIMEOUT))
-                                    throw MakeActivityException(&owner, 0, "CKeyedFetchRequestProcessor {2} - comm send failed");
+                                    throw MakeActivityException(owner, 0, "CKeyedFetchRequestProcessor {2} - comm send failed");
                                 replyMb.rewrite(sizeof(retCount));
                             }
                         }
@@ -1019,7 +1019,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
             {
                 CMessageBuffer msg;
                 if (!owner.container.queryJob().queryJobComm().send(msg, n+1, requestMpTag, LONGTIMEOUT))
-                    throw MakeActivityException(&owner, 0, "CKeyedFetchHandler::stop - comm send failed");
+                    throw MakeActivityException(owner, 0, "CKeyedFetchHandler::stop - comm send failed");
             }
         }
         void decPendingReplies(unsigned c=1)
@@ -1097,7 +1097,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                             total -= requests;
                             { CriticalUnblock ub(crit);
                                 if (!owner.container.queryJob().queryJobComm().send(msg, n+1, requestMpTag, LONGTIMEOUT))
-                                    throw MakeActivityException(&owner, 0, "CKeyedFetchHandler - comm send failed");
+                                    throw MakeActivityException(owner, 0, "CKeyedFetchHandler - comm send failed");
                             }
                             if (0 == total)
                                 break;
@@ -1265,7 +1265,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
             }
             catch (IException *e)
             {
-                ::ActPrintLog(&owner, e);
+                ::ActPrintLog(owner, e);
                 throw;
             }
             return NULL;
@@ -1315,7 +1315,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                                     memcpy(joinFieldsPtr, &fJoinFieldsRow, sizeof(const void *));
                                 }
 #ifdef TRACE_JOINGROUPS
-                                ::ActPrintLog(&owner, "CJoinGroup [result] %x from %d", currentJG, __LINE__);
+                                ::ActPrintLog(owner, "CJoinGroup [result] %x from %d", currentJG, __LINE__);
 #endif
                                 noteStats(partManager->querySeeks(), partManager->queryScans());
                                 size32_t lorsz = owner.keyLookupAllocator->queryOutputMeta()->getRecordSize(lookupRow.getSelf());
@@ -1402,7 +1402,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                                 memcpy(joinFieldsPtr, &fJoinFieldsRow, sizeof(const void *));
                             }
 #ifdef TRACE_JOINGROUPS
-                            ::ActPrintLog(&owner, "CJoinGroup [end marker returned] %x from %d", currentJG, __LINE__);
+                            ::ActPrintLog(owner, "CJoinGroup [end marker returned] %x from %d", currentJG, __LINE__);
 #endif
                             noteStats(partManager->querySeeks(), partManager->queryScans());
                             currentJG = NULL;
@@ -1449,7 +1449,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
             }
             catch (IException *e)
             {
-                ::ActPrintLog(&owner, e);
+                ::ActPrintLog(owner, e);
                 throw;
             }
             noteStats(partManager->querySeeks(), partManager->queryScans());
@@ -1758,7 +1758,7 @@ public:
         {
             inputHelper->queryOutputMeta()->toXML((byte *) jg->queryLeft(), xmlwrite);
         }
-        throw MakeActivityException(this, 0, "More than %d match candidates in keyed join for row %s", abortLimit, xmlwrite.str());
+        throw MakeActivityException(*this, 0, "More than %d match candidates in keyed join for row %s", abortLimit, xmlwrite.str());
     }
     bool checkAbortLimit(CJoinGroup *jg)
     {

--- a/thorlcr/activities/keypatch/thkeypatch.cpp
+++ b/thorlcr/activities/keypatch/thkeypatch.cpp
@@ -51,9 +51,9 @@ public:
         patchFile.setown(queryThorFileManager().lookup(container.queryJob(), patchName));
         
         if (originalIndexFile->numParts() != patchFile->numParts())
-            throw MakeActivityException(this, TE_KeyPatchIndexSizeMismatch, "Index %s and patch %s differ in width", originalName.get(), patchName.get());
+            throw MakeActivityException(*this, TE_KeyPatchIndexSizeMismatch, "Index %s and patch %s differ in width", originalName.get(), patchName.get());
         if (originalIndexFile->querySuperFile() || patchFile->querySuperFile())
-            throw MakeActivityException(this, 0, "Patching super files not supported");
+            throw MakeActivityException(*this, 0, "Patching super files not supported");
         
         addReadFile(originalIndexFile);
         addReadFile(patchFile);
@@ -70,7 +70,7 @@ public:
         if (!local && width > 1)
             width--; // 1 part == No n distributed / Monolithic key
         if (width > container.queryJob().querySlaves())
-            throw MakeActivityException(this, 0, "Unsupported: keypatch(%s, %s) - Cannot patch a key that's wider(%d) than the target cluster size(%d)", originalIndexFile->queryLogicalName(), patchFile->queryLogicalName(), width, container.queryJob().querySlaves());
+            throw MakeActivityException(*this, 0, "Unsupported: keypatch(%s, %s) - Cannot patch a key that's wider(%d) than the target cluster size(%d)", originalIndexFile->queryLogicalName(), patchFile->queryLogicalName(), width, container.queryJob().querySlaves());
 
         IArrayOf<IGroup> groups;
         OwnedRoxieString outputName(helper->getOutputName());
@@ -177,7 +177,7 @@ public:
             OwnedRoxieString outputName(helper->getOutputName());
             Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), outputName, false, true);
             if (file)
-                throw MakeActivityException(this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
+                throw MakeActivityException(*this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
         }
     }
 };

--- a/thorlcr/activities/keypatch/thkeypatchslave.cpp
+++ b/thorlcr/activities/keypatch/thkeypatchslave.cpp
@@ -79,8 +79,8 @@ public:
         StringBuffer originalFilePart, patchFilePart;
         OwnedRoxieString originalName(helper->getOriginalName());
         OwnedRoxieString patchName(helper->getPatchName());
-        locateFilePartPath(this, originalName, *originalIndexPart, originalFilePart);
-        locateFilePartPath(this, patchName, *patchPart, patchFilePart);
+        locateFilePartPath(*this, originalName, *originalIndexPart, originalFilePart);
+        locateFilePartPath(*this, patchName, *patchPart, patchFilePart);
 
         StringBuffer newIndexFilePath;
         getPartFilename(*newIndexPart, 0, newIndexFilePath);
@@ -97,8 +97,8 @@ public:
             if (!copyTlk)
             {
                 StringBuffer tmp;
-                locateFilePartPath(this, tmp.clear().append(originalName).append(" [TLK]").str(), *originalIndexTlkPart, originalFilePart);
-                locateFilePartPath(this, tmp.clear().append(patchName).append(" [TLK]").str(), *patchTlkPart, patchFilePart);
+                locateFilePartPath(*this, tmp.clear().append(originalName).append(" [TLK]").str(), *originalIndexTlkPart, originalFilePart);
+                locateFilePartPath(*this, tmp.clear().append(patchName).append(" [TLK]").str(), *patchTlkPart, patchFilePart);
                 getPartFilename(*newIndexTlkPart, 0, tmp.clear());
                 tlkPatchApplicator.setown(createKeyDiffApplicator(patchFilePart.str(), originalFilePart.str(), tmp.str(), NULL, true, true));
             }
@@ -120,18 +120,18 @@ public:
             try
             {
                 if (newIndexPart->numCopies() > 1)
-                    doReplicate(this, *newIndexPart);
+                    doReplicate(*this, *newIndexPart);
                 if (tlk && copyTlk)
                 {
                     StringBuffer newFilePathTlk, patchFilePathTlk, tmp;
                     getPartFilename(*newIndexTlkPart, 0, newFilePathTlk);
                     OwnedRoxieString patchName(helper->getPatchName());
-                    locateFilePartPath(this, tmp.append(patchName).append(" [TLK]").str(), *patchTlkPart, patchFilePathTlk);
+                    locateFilePartPath(*this, tmp.append(patchName).append(" [TLK]").str(), *patchTlkPart, patchFilePathTlk);
                     OwnedIFile newIFileTlk = createIFile(newFilePathTlk.str());
                     OwnedIFile patchIFileTlk = createIFile(patchFilePathTlk.str());
                     copyFile(newIFileTlk, patchIFileTlk);
                     if (newIndexTlkPart->numCopies() > 1)
-                        doReplicate(this, *newIndexTlkPart);
+                        doReplicate(*this, *newIndexTlkPart);
                 }
             }
             catch (IException *e)

--- a/thorlcr/activities/limit/thlimitslave.cpp
+++ b/thorlcr/activities/limit/thlimitslave.cpp
@@ -211,7 +211,7 @@ class CSkipLimitSlaveActivity : public CLimitSlaveActivityBase
 
             // We used to warn if excessive buffering. I think there should be callback to signal,
             // Alternatively, could do via IDiskUsage whish smart buffer used to take...
-            //throw MakeActivityException(this, 0, "SkipLimit(%"ACTPF"d) exceeded activity buffering limit", container.queryId());
+            //throw MakeActivityException(*this, 0, "SkipLimit(%"ACTPF"d) exceeded activity buffering limit", container.queryId());
         }
         buf->flush();
         stopInput(count);

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -196,7 +196,7 @@ class CBroadcaster : public CSimpleInterface
         }
         void wait()
         {
-            ActPrintLog(&broadcaster.activity, "CSend::wait(), messages to send: %d", broadcastQueue.ordinality());
+            ActPrintLog(broadcaster.activity, "CSend::wait(), messages to send: %d", broadcastQueue.ordinality());
             addBlock(NULL);
             threaded.join();
         }
@@ -220,7 +220,7 @@ class CBroadcaster : public CSimpleInterface
                 abort(false);
                 broadcaster.cancel(e);
             }
-            ActPrintLog(&broadcaster.activity, "Sender stopped");
+            ActPrintLog(broadcaster.activity, "Sender stopped");
         }
     } sender;
 
@@ -284,7 +284,7 @@ class CBroadcaster : public CSimpleInterface
                 if (0 == sendRecv) // send
                 {
 #ifdef _TRACEBROADCAST
-                    ActPrintLog(&activity, "Broadcast node %d Sending to node %d, origin %d, size %d, code=%d", myNode, t, origin, sendLen, (unsigned)sendItem->queryCode());
+                    ActPrintLog(activity, "Broadcast node %d Sending to node %d, origin %d, size %d, code=%d", myNode, t, origin, sendLen, (unsigned)sendItem->queryCode());
 #endif
                     CMessageBuffer &msg = sendItem->queryMsg();
                     msg.setReplyTag(rt); // simulate sendRecv
@@ -293,7 +293,7 @@ class CBroadcaster : public CSimpleInterface
                 else // recv reply
                 {
 #ifdef _TRACEBROADCAST
-                    ActPrintLog(&activity, "Broadcast node %d Sent to node %d, origin %d, size %d, code=%d - received ack", myNode, t, origin, sendLen, (unsigned)sendItem->queryCode());
+                    ActPrintLog(activity, "Broadcast node %d Sent to node %d, origin %d, size %d, code=%d - received ack", myNode, t, origin, sendLen, (unsigned)sendItem->queryCode());
 #endif
                     if (!activity.receiveMsg(replyMsg, t, rt))
                         break;
@@ -319,7 +319,7 @@ class CBroadcaster : public CSimpleInterface
             CMessageBuffer ackMsg;
             Owned<CSendItem> sendItem = new CSendItem(msg);
 #ifdef _TRACEBROADCAST
-            ActPrintLog(&activity, "Broadcast node %d received from node %d, origin node %d, size %d, code=%d", myNode, (unsigned)sendRank, sendItem->queryOrigin(), sendItem->length(), (unsigned)sendItem->queryCode());
+            ActPrintLog(activity, "Broadcast node %d received from node %d, origin node %d, size %d, code=%d", myNode, (unsigned)sendRank, sendItem->queryOrigin(), sendItem->length(), (unsigned)sendItem->queryCode());
 #endif
             comm.send(ackMsg, sendRank, replyTag); // send ack
             sender.addBlock(sendItem.getLink());
@@ -332,7 +332,7 @@ class CBroadcaster : public CSimpleInterface
                     if (slaveStop(sendItem->queryOrigin()-1) || allDone)
                     {
                         recvInterface->bCastReceive(NULL); // signal last
-                        ActPrintLog(&activity, "recvLoop, received last slaveStop");
+                        ActPrintLog(activity, "recvLoop, received last slaveStop");
                         // NB: this slave has nothing more to receive.
                         // However the sender will still be re-broadcasting some packets, including these stop packets
                         return;
@@ -1207,7 +1207,7 @@ public:
             rows.flush();
             rhsRows += rows.numCommitted();
             if (rhsRows > RIMAX)
-                throw MakeActivityException(this, 0, "Too many RHS rows: %"RCPF"d", rhsRows);
+                throw MakeActivityException(*this, 0, "Too many RHS rows: %"RCPF"d", rhsRows);
         }
         return (rowidx_t)rhsRows;
     }
@@ -1419,7 +1419,7 @@ protected:
         {
             rowcount_t res = size/3*4; // make HT 1/3 bigger than # rows
             if ((res < size) || (res > RIMAX)) // check for overflow, or result bigger than rowidx_t size
-                throw MakeActivityException(this, 0, "Too many rows on RHS for hash table: %"RCPF"d", res);
+                throw MakeActivityException(*this, 0, "Too many rows on RHS for hash table: %"RCPF"d", res);
             size = (rowidx_t)res;
         }
         rhsTableLen = size;
@@ -1531,7 +1531,7 @@ protected:
 
                 // NB: lhs ordering and grouping lost from here on..
                 if (grouped)
-                    throw MakeActivityException(this, 0, "Degraded to distributed lookup join, LHS order cannot be preserved");
+                    throw MakeActivityException(*this, 0, "Degraded to distributed lookup join, LHS order cannot be preserved");
 
                 // If HT sized already and now spilt, too big clear and size when local size known
                 clearHT();
@@ -1643,7 +1643,7 @@ protected:
 
                 // NB: lhs ordering and grouping lost from here on.. (will have been caught earlier if global)
                 if (grouped)
-                    throw MakeActivityException(this, 0, "Degraded to standard join, LHS order cannot be preserved");
+                    throw MakeActivityException(*this, 0, "Degraded to standard join, LHS order cannot be preserved");
 
                 rowLoader.setown(createThorRowLoader(*this, queryRowInterfaces(leftITDL), helper->isLeftAlreadyLocallySorted() ? NULL : compareLeft));
                 left.setown(rowLoader->load(left, abortSoon, false));
@@ -1745,7 +1745,7 @@ public:
                         CommonXmlWriter xmlwrite(0);
                         if (outputMeta && outputMeta->hasXML())
                             outputMeta->toXML((const byte *) leftRow.get(), xmlwrite);
-                        throw MakeActivityException(this, 0, "More than %d match candidates in join for row %s", abortLimit, xmlwrite.str());
+                        throw MakeActivityException(*this, 0, "More than %d match candidates in join for row %s", abortLimit, xmlwrite.str());
                     }
                     catch (IException *_e)
                     {
@@ -2230,7 +2230,7 @@ protected:
             {
                 rhsTotalCount = rightMeta.totalRowsMax;
                 if (rhsTotalCount > RIMAX)
-                    throw MakeActivityException(this, 0, "Too many rows on RHS for ALL join: %"RCPF"d", rhsTotalCount);
+                    throw MakeActivityException(*this, 0, "Too many rows on RHS for ALL join: %"RCPF"d", rhsTotalCount);
                 rhs.ensure((rowidx_t)rhsTotalCount);
             }
             while (!abortSoon)

--- a/thorlcr/activities/loop/thloop.cpp
+++ b/thorlcr/activities/loop/thloop.cpp
@@ -82,7 +82,7 @@ protected:
             container.queryJob().queryJobComm().send(msg, n+1, mpTag, LONGTIMEOUT);
 
         if (!ok)
-            throw MakeActivityException(this, 0, "Executed LOOP with empty input and output %u times", emptyIterations);
+            throw MakeActivityException(*this, 0, "Executed LOOP with empty input and output %u times", emptyIterations);
 
         return final;
     }
@@ -186,7 +186,7 @@ class CLoopActivityMaster : public CLoopActivityMasterBase
             bool overLimit = slaveEmptyIterations > maxEmptyLoopIterations;
             emptyIterations->set(sender-1, overLimit);
             if (emptyIterations->scan(0, 0) >= nodes) // all empty
-                throw MakeActivityException(this, 0, "Executed LOOP with empty input and output > %d maxEmptyLoopIterations times on all nodes", maxEmptyLoopIterations);
+                throw MakeActivityException(*this, 0, "Executed LOOP with empty input and output > %d maxEmptyLoopIterations times on all nodes", maxEmptyLoopIterations);
         }
     }
 public:
@@ -227,7 +227,7 @@ public:
                 IThorBoundLoopGraph *boundGraph = queryContainer().queryLoopGraph();
                 unsigned condLoopCounter = (flags & IHThorLoopArg::LFcounter) ? loopCounter : 0;
                 unsigned loopAgain = (flags & IHThorLoopArg::LFnewloopagain) ? helper->loopAgainResult() : 0;
-                ownedResults.setown(queryGraph().createThorGraphResults(3)); // will not be cleared until next sync
+                ownedResults.setown(queryJob().createThorGraphResults(queryGraphId())); // will not be cleared until next sync
                 // ensures remote results are available, via owning activity (i.e. this loop act)
                 // so that when the master/slave result parts are fetched, it will retreive from the act, not the (already cleaed) graph localresults
                 ownedResults->setOwner(container.queryId());
@@ -277,7 +277,7 @@ public:
         if (!global)
             return;
         IHThorGraphLoopArg *helper = (IHThorGraphLoopArg *) queryHelper();
-        Owned<IThorGraphResults> results = queryGraph().createThorGraphResults(1);
+        Owned<IThorGraphResults> results = queryJob().createThorGraphResults(queryGraphId());
         if (helper->getFlags() & IHThorGraphLoopArg::GLFcounter)
             queryContainer().queryLoopGraph()->prepareCounterResult(*this, results, 1, 0);
         loopGraph->setResults(results);
@@ -294,7 +294,7 @@ public:
             return;
         unsigned maxIterations = helper->numIterations();
         if ((int)maxIterations < 0) maxIterations = 0;
-        Owned<IThorGraphResults> loopResults = queryGraph().createThorGraphResults(maxIterations);
+        Owned<IThorGraphResults> loopResults = queryJob().createThorGraphResults(queryGraphId());
         IThorResult *result = loopResults->createResult(*this, 0, this, true);
 
         helper->createParentExtract(extractBuilder);

--- a/thorlcr/activities/msort/thgroupsortslave.cpp
+++ b/thorlcr/activities/msort/thgroupsortslave.cpp
@@ -60,7 +60,7 @@ public:
         dataLinkStart();
         input = inputs.item(0);
         unsigned spillPriority = container.queryGrouped() ? SPILL_PRIORITY_GROUPSORT : SPILL_PRIORITY_LARGESORT;
-        iLoader.setown(createThorRowLoader(*this, queryRowInterfaces(input), iCompare, unstable ? stableSort_none : stableSort_earlyAlloc, rc_mixed, spillPriority));
+        iLoader.setown(createThorRowLoader(*this, ::queryRowInterfaces(input), iCompare, unstable ? stableSort_none : stableSort_earlyAlloc, rc_mixed, spillPriority));
         startInput(input);
         eoi = false;
         if (container.queryGrouped())
@@ -156,7 +156,7 @@ public:
         if (ret && prev && icompare->docompare(prev, ret) > 0)
         {
             // MORE - better to give mismatching rows than indexes?
-            throw MakeActivityException(this, TE_NotSorted, "detected incorrectly sorted rows (row %"RCPF"d,  %"RCPF"d))", getDataLinkCount(), getDataLinkCount()+1);
+            throw MakeActivityException(*this, TE_NotSorted, "detected incorrectly sorted rows (row %"RCPF"d,  %"RCPF"d))", getDataLinkCount(), getDataLinkCount()+1);
         }
         prev.set(ret);
         if (ret)
@@ -175,7 +175,7 @@ public:
         if (ret && prev && stepCompare->docompare(prev, ret, numFields) > 0)
         {
             // MORE - better to give mismatching rows than indexes?
-            throw MakeActivityException(this, TE_NotSorted, "detected incorrectly sorted rows (row %"RCPF"d,  %"RCPF"d))", getDataLinkCount(), getDataLinkCount()+1);
+            throw MakeActivityException(*this, TE_NotSorted, "detected incorrectly sorted rows (row %"RCPF"d,  %"RCPF"d))", getDataLinkCount(), getDataLinkCount()+1);
         }
         prev.set(ret);
         if (ret)

--- a/thorlcr/activities/msort/thmsort.cpp
+++ b/thorlcr/activities/msort/thmsort.cpp
@@ -46,7 +46,7 @@ public:
         unsigned flags = algo->getAlgorithmFlags();
         if (algoname && (0 != stricmp(algoname, "quicksort")))
         {
-            Owned<IException> e = MakeActivityException(this, 0, "Ignoring, unsupported sort order algorithm '%s'", algoname.get());
+            Owned<IException> e = MakeActivityException(*this, 0, "Ignoring, unsupported sort order algorithm '%s'", algoname.get());
             reportExceptionToWorkunit(container.queryJob().queryWorkUnit(), e);
         }
     }
@@ -83,7 +83,7 @@ protected:
         unsigned flags = algo->getAlgorithmFlags();
         if (algoname && (0 != stricmp(algoname, "quicksort")))
         {
-            Owned<IException> e = MakeActivityException(this, 0, "Ignoring, unsupported sort order algorithm '%s'", algoname.get());
+            Owned<IException> e = MakeActivityException(*this, 0, "Ignoring, unsupported sort order algorithm '%s'", algoname.get());
             reportExceptionToWorkunit(container.queryJob().queryWorkUnit(), e);
         }
         OwnedRoxieString cosortlogname(helper->getSortedFilename());
@@ -172,7 +172,7 @@ protected:
                     if (TE_SkewError == e->errorCode())
                     {
                         StringBuffer s;
-                        Owned<IThorException> e2 = MakeActivityException(this, TE_SortFailedSkewExceeded, "SORT failed. %s", e->errorMessage(s).str());
+                        Owned<IThorException> e2 = MakeActivityException(*this, TE_SortFailedSkewExceeded, "SORT failed. %s", e->errorMessage(s).str());
                         e->Release();
                         fireException(e2);
                     }

--- a/thorlcr/activities/msort/thmsortslave.cpp
+++ b/thorlcr/activities/msort/thmsortslave.cpp
@@ -98,14 +98,14 @@ public:
             }
             catch (CATCHALL)
             {
-                Owned<IException> e = MakeActivityException(this, 0, "Unknown exception starting sort input");
+                Owned<IException> e = MakeActivityException(*this, 0, "Unknown exception starting sort input");
                 fireException(e);
                 barrier->cancel();
                 throw;
             }
             dataLinkStart();
             
-            Linked<IRowInterfaces> rowif = queryRowInterfaces(input);
+            Linked<IRowInterfaces> rowif = ::queryRowInterfaces(input);
             Owned<IRowInterfaces> auxrowif = createRowInterfaces(helper->querySortedRecordSize(),queryActivityId(),queryCodeContext());
             sorter->Gather(
                 rowif,
@@ -122,7 +122,7 @@ public:
             input = NULL;
             if (abortSoon)
             {
-                ActPrintLogEx(&queryContainer(), thorlog_null, MCwarning, "MSortSlaveActivity::start aborting");
+                ActPrintLogEx(*this, thorlog_null, MCwarning, "MSortSlaveActivity::start aborting");
                 barrier->cancel();
                 return;
             }
@@ -135,7 +135,7 @@ public:
         }
         catch (CATCHALL)
         {
-            Owned<IException> e = MakeActivityException(this, 0, "Unknown exception gathering sort input");
+            Owned<IException> e = MakeActivityException(*this, 0, "Unknown exception gathering sort input");
             fireException(e);
             barrier->cancel();
             throw;
@@ -202,7 +202,7 @@ public:
 
 CActivityBase *createMSortSlave(CGraphElementBase *container)
 {
-    ActPrintLog(container, "MSortSlaveActivity::createMSortSlave");
+    ActPrintLog(*container, "MSortSlaveActivity::createMSortSlave");
     return new MSortSlaveActivity(container);
 }
 

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -268,7 +268,7 @@ public:
 
 #define CATCH_MEMORY_EXCEPTIONS \
 catch (IException *e) {     \
-  IException *ne = MakeActivityException(&activity, e); \
+  IException *ne = MakeActivityException(activity, e); \
   ::Release(e); \
   throw ne; \
 }
@@ -1197,7 +1197,7 @@ retry:
                         return NULL;
                     }
                     if (curgroup.ordinality() > INITIAL_SELFJOIN_MATCH_WARNING_LEVEL) {
-                        Owned<IThorException> e = MakeActivityWarning(&activity, TE_SelfJoinMatchWarning, "Exceeded initial match limit");
+                        Owned<IThorException> e = MakeActivityWarning(activity, TE_SelfJoinMatchWarning, "Exceeded initial match limit");
                         e->setAction(tea_warning);
                         e->queryData().append((unsigned)curgroup.ordinality());
                         activity.fireException(e);
@@ -1671,7 +1671,7 @@ class CMultiCoreJoinHelper: public CMultiCoreJoinHelperBase
         {
             stopped = false;
             // JCSMORE - could have a spilling variety instead here..
-            rowStream.setown(createSmartInMemoryBuffer(&parent->activity, parent->rowIf, SMALL_SMART_BUFFER_SIZE));
+            rowStream.setown(createSmartInMemoryBuffer(parent->activity, parent->rowIf, SMALL_SMART_BUFFER_SIZE));
         }
         int run()
         {
@@ -1917,8 +1917,8 @@ public:
         unsigned limit = activity.queryContainer().queryXGMML().getPropInt("hint[@name=\"limit\"]/@value", numworkers*1000);
         unsigned readGranularity = activity.queryContainer().queryXGMML().getPropInt("hint[@name=\"readgranularity\"]/@value", DEFAULT_WR_READ_GRANULARITY);
         unsigned writeGranularity = activity.queryContainer().queryXGMML().getPropInt("hint[@name=\"writegranularity\"]/@value", DEFAULT_WR_WRITE_GRANULARITY);
-        ActPrintLog(&activity, "CMultiCoreUnorderedJoinHelper: limit=%d, readGranularity=%d, writeGranularity=%d", limit, readGranularity, writeGranularity);
-        multiWriter.setown(createSharedWriteBuffer(&activity, rowIf, limit, readGranularity, writeGranularity));
+        ActPrintLog(activity, "CMultiCoreUnorderedJoinHelper: limit=%d, readGranularity=%d, writeGranularity=%d", limit, readGranularity, writeGranularity);
+        multiWriter.setown(createSharedWriteBuffer(activity, rowIf, limit, readGranularity, writeGranularity));
         workers = new cWorker *[numthreads];
         for (unsigned i=0;i<numthreads;i++) 
             workers[i] = new cWorker(this);
@@ -2014,7 +2014,7 @@ IJoinHelper *createJoinHelper(CActivityBase &activity, IHThorJoinArg *helper, IR
     if (!parallelmatch||helper->getKeepLimit()||((helper->getJoinFlags()&JFslidingmatch)!=0)) // currently don't support betweenjoin or keep and multicore
         return jhelper;
     unsigned numthreads = activity.getOptInt(THOROPT_JOINHELPER_THREADS, getAffinityCpus());
-    ActPrintLog(&activity, "Join helper using %d threads", numthreads);
+    ActPrintLog(activity, "Join helper using %d threads", numthreads);
     if (unsortedoutput)
         return new CMultiCoreUnorderedJoinHelper(activity, numthreads, false, jhelper, helper, rowIf);
     return new CMultiCoreJoinHelper(activity, numthreads, false, jhelper, helper, rowIf);
@@ -2033,7 +2033,7 @@ IJoinHelper *createSelfJoinHelper(CActivityBase &activity, IHThorJoinArg *helper
     if (!parallelmatch||helper->getKeepLimit()||((helper->getJoinFlags()&JFslidingmatch)!=0)) // currently don't support betweenjoin or keep and multicore
         return jhelper;
     unsigned numthreads = activity.getOptInt(THOROPT_JOINHELPER_THREADS, getAffinityCpus());
-    ActPrintLog(&activity, "Self join helper using %d threads", numthreads);
+    ActPrintLog(activity, "Self join helper using %d threads", numthreads);
     if (unsortedoutput)
         return new CMultiCoreUnorderedJoinHelper(activity, numthreads, true, jhelper, helper, rowIf);
     return new CMultiCoreJoinHelper(activity, numthreads, true, jhelper, helper, rowIf);

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -333,13 +333,13 @@ public:
                     {
                         StringBuffer tempname;
                         GetTempName(tempname,"nsplit",true); // use alt temp dir
-                        smartBuf.setown(createSharedSmartDiskBuffer(this, tempname.str(), outputs.ordinality(), queryRowInterfaces(input), &container.queryJob().queryIDiskUsage()));
+                        smartBuf.setown(createSharedSmartDiskBuffer(*this, tempname.str(), outputs.ordinality(), ::queryRowInterfaces(input), &container.queryJob().queryIDiskUsage()));
                         ActPrintLog("Using temp spill file: %s", tempname.str());
                     }
                     else
                     {
                         ActPrintLog("Spill is 'balanced'");
-                        smartBuf.setown(createSharedSmartMemBuffer(this, outputs.ordinality(), queryRowInterfaces(input), NSPLITTER_SPILL_BUFFER_SIZE));
+                        smartBuf.setown(createSharedSmartMemBuffer(*this, outputs.ordinality(), ::queryRowInterfaces(input), NSPLITTER_SPILL_BUFFER_SIZE));
                     }
                     // mark any unconnected outputs of smartBuf as already stopped.
                     ForEachItemIn(o, outputs)

--- a/thorlcr/activities/piperead/thprslave.cpp
+++ b/thorlcr/activities/piperead/thprslave.cpp
@@ -59,7 +59,7 @@ protected:
                     toread=max_len-sizeRead;
                 size32_t numRead = stream->read(toread, target+sizeRead);
                 if (numRead==(size32_t)-1) {
-                    ::ActPrintLog(parent, "read aborted");
+                    ::ActPrintLog(*parent, "read aborted");
                     numRead = 0;
                     sizeRead = 0;
                 }
@@ -79,7 +79,7 @@ protected:
         pipeCommand.setown(cmd);
         ActPrintLog("open: %s", cmd);
         if (!pipe->run(pipeTrace, cmd, globals->queryProp("@externalProgDir"), true, true, true, 0x10000)) // 64K error buffer
-            throw MakeActivityException(this, TE_FailedToCreateProcess, "Failed to create process in %s for : %s", globals->queryProp("@externalProgDir"), cmd);
+            throw MakeActivityException(*this, TE_FailedToCreateProcess, "Failed to create process in %s for : %s", globals->queryProp("@externalProgDir"), cmd);
         pipeFinished = false;
         registerSelfDestructChildProcess(pipe->getProcessHandle());
         pipeStream->setStream(pipe->getOutputStream());
@@ -115,7 +115,7 @@ protected:
                         e->Release();
                     }
                 }
-                throw MakeActivityException(this, TE_PipeReturnedFailure, "Process returned %d:%s - PIPE(%s)", retcode, stdError.str(), pipeCommand.get());
+                throw MakeActivityException(*this, TE_PipeReturnedFailure, "Process returned %d:%s - PIPE(%s)", retcode, stdError.str(), pipeCommand.get());
             }
         }
     }
@@ -464,7 +464,7 @@ public:
         if (wrexc)
             throw wrexc.getClear();
         if (retcode!=0 && !(flags & TPFnofail))
-            throw MakeActivityException(this, TE_PipeReturnedFailure, "Process returned %d", retcode);
+            throw MakeActivityException(*this, TE_PipeReturnedFailure, "Process returned %d", retcode);
     }
     virtual void kill()
     {
@@ -544,7 +544,7 @@ int PipeWriterThread::run()
     }
     catch (IException *e)
     {
-        ActPrintLog(&activity,e,"PipeWriterThread.3");
+        ActPrintLog(activity,e,"PipeWriterThread.3");
         if (exc.get())
             e->Release();
         else

--- a/thorlcr/activities/pipewrite/thpwslave.cpp
+++ b/thorlcr/activities/pipewrite/thpwslave.cpp
@@ -78,7 +78,7 @@ public:
     {
         pipeCommand.setown(cmd);
         if(!pipe->run("PIPEWRITE", cmd, globals->queryProp("@externalProgDir"), true, false, true, 0x10000 )) // 64K error buffer
-            throw MakeActivityException(this, TE_FailedToCreateProcess, "PIPEWRITE: Failed to create process in %s for : %s", globals->queryProp("@externalProgDir"), cmd);
+            throw MakeActivityException(*this, TE_FailedToCreateProcess, "PIPEWRITE: Failed to create process in %s for : %s", globals->queryProp("@externalProgDir"), cmd);
         pipeOpen = true;
         registerSelfDestructChildProcess(pipe->getProcessHandle());
         writeTransformer->writeHeader(pipe);
@@ -112,7 +112,7 @@ public:
                     e->Release();
                 }
             }
-            throw MakeActivityException(this, TE_PipeReturnedFailure, "Process returned %d:%s - PIPE(%s)", retcode, stdError.str(), pipeCommand.get());    
+            throw MakeActivityException(*this, TE_PipeReturnedFailure, "Process returned %d:%s - PIPE(%s)", retcode, stdError.str(), pipeCommand.get());
         }
     }
     void process()

--- a/thorlcr/activities/selectnth/thselectnthslave.cpp
+++ b/thorlcr/activities/selectnth/thselectnthslave.cpp
@@ -114,7 +114,7 @@ public:
             meta.appendf("META(totalRowsMin=%"I64F"d,totalRowsMax=%"I64F"d,rowsOutput=%"RCPF"d,spilled=%"I64F"d,byteTotal=%"I64F"d)",
                 info.totalRowsMin,info.totalRowsMax,info.rowsOutput,info.spilled,info.byteTotal);
 #if 0                 
-            Owned<IThorException> e = MakeActivityWarning(this, -1, "%s", meta.str());
+            Owned<IThorException> e = MakeActivityWarning(*this, -1, "%s", meta.str());
             fireException(e);
 #else
             ActPrintLog("%s",meta.str());

--- a/thorlcr/activities/thactivityutil.ipp
+++ b/thorlcr/activities/thactivityutil.ipp
@@ -71,7 +71,7 @@ IRowStream *createSequentialPartHandler(CPartHandler *partHandler, IArrayOf<IPar
 void initMetaInfo(ThorDataLinkMetaInfo &info);
 class CThorDataLink : implements IThorDataLink
 {
-    CActivityBase *owner;
+    CActivityBase &owner;
     rowcount_t count, icount;
     unsigned outputId;
     unsigned limit;
@@ -135,7 +135,7 @@ protected:
 
 
 public:
-    CThorDataLink(CActivityBase *_owner) : owner(_owner)
+    CThorDataLink(CActivityBase *_owner) : owner(*_owner)
     {
         icount = count = 0;
     }
@@ -155,7 +155,7 @@ public:
         mb.append(count);
     }
 
-    unsigned __int64 queryTotalCycles() const { return ((CSlaveActivity *)owner)->queryTotalCycles(); }
+    unsigned __int64 queryTotalCycles() const { return ((CSlaveActivity &)owner).queryTotalCycles(); }
 
     inline rowcount_t getDataLinkGlobalCount()
     {
@@ -166,7 +166,7 @@ public:
         return icount; 
     } 
 
-    CActivityBase *queryFromActivity() { return owner; }
+    CActivityBase *queryFromActivity() { return &owner; }
 
     void initMetaInfo(ThorDataLinkMetaInfo &info); // for derived children to call from getMetaInfo
     static void calcMetaInfoSize(ThorDataLinkMetaInfo &info,IThorDataLink *input); // for derived children to call from getMetaInfo
@@ -201,12 +201,12 @@ IThorDataLink *createDataLinkSmartBuffer(CActivityBase *activity,IThorDataLink *
 
 bool isSmartBufferSpillNeeded(CActivityBase *act);
 
-StringBuffer &locateFilePartPath(CActivityBase *activity, const char *logicalFilename, IPartDescriptor &partDesc, StringBuffer &filePath);
-void doReplicate(CActivityBase *activity, IPartDescriptor &partDesc, ICopyFileProgress *iProgress=NULL);
+StringBuffer &locateFilePartPath(CActivityBase &activity, const char *logicalFilename, IPartDescriptor &partDesc, StringBuffer &filePath);
+void doReplicate(CActivityBase &activity, IPartDescriptor &partDesc, ICopyFileProgress *iProgress=NULL);
 void cancelReplicates(CActivityBase *activity, IPartDescriptor &partDesc);
 
 interface IPartDescriptor;
-IFileIO *createMultipleWrite(CActivityBase *activity, IPartDescriptor &partDesc, unsigned recordSize, bool &compress, bool extend, ICompressor *ecomp, ICopyFileProgress *iProgress, bool direct, bool renameToPrimary, bool *aborted, StringBuffer *_locationName=NULL);
+IFileIO *createMultipleWrite(CActivityBase &activity, IPartDescriptor &partDesc, unsigned recordSize, bool &compress, bool extend, ICompressor *ecomp, ICopyFileProgress *iProgress, bool direct, bool renameToPrimary, bool *aborted, StringBuffer *_locationName=NULL);
 
 
 #endif

--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -85,12 +85,12 @@ void CDiskReadMasterBase::init()
             free(ekey);
             if (!encrypted)
             {
-                Owned<IException> e = MakeActivityWarning(&container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", fileName.get());
+                Owned<IException> e = MakeActivityWarning(container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", fileName.get());
                 container.queryJob().fireException(e);
             }
         }
         else if (encrypted)
-            throw MakeActivityException(this, 0, "File '%s' was published as encrypted but no encryption key provided", fileName.get());
+            throw MakeActivityException(*this, 0, "File '%s' was published as encrypted but no encryption key provided", fileName.get());
     }
 }
 
@@ -203,7 +203,7 @@ void CWriteMasterBase::preStart(size32_t parentExtractSz, const byte *parentExtr
             if (file)
             {
                 if (0 == ((TDWextend+TDWoverwrite) & diskHelperBase->getFlags()))
-                    throw MakeActivityException(this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
+                    throw MakeActivityException(*this, TE_OverwriteNotSpecified, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", file->queryLogicalName());
                 checkSuperFileOwnership(*file);
             }
         }

--- a/thorlcr/activities/when/thwhenslave.cpp
+++ b/thorlcr/activities/when/thwhenslave.cpp
@@ -29,21 +29,21 @@ protected:
     const byte *savedParentExtract;
     bool global;
     Owned<IBarrier> barrier;
-    CSlaveActivity *activity;
+    CSlaveActivity &activity;
 
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CDependencyExecutorSlaveActivity(CSlaveActivity *_activity) : activity(_activity)
+    CDependencyExecutorSlaveActivity(CSlaveActivity *_activity) : activity(*_activity)
     {
-        global = !activity->queryContainer().queryOwner().queryOwner() || activity->queryContainer().queryOwner().isGlobal();
+        global = !activity.queryContainer().queryOwner().queryOwner() || activity.queryContainer().queryOwner().isGlobal();
     }
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
     {
         if (global)
         {
-            mptag_t barrierTag = activity->queryContainer().queryJob().deserializeMPTag(data);
-            barrier.setown(activity->queryContainer().queryJob().createBarrier(barrierTag));
+            mptag_t barrierTag = activity.queryJob().deserializeMPTag(data);
+            barrier.setown(activity.queryJob().createBarrier(barrierTag));
         }
     }
     void preStart(size32_t parentExtractSz, const byte *parentExtract)
@@ -61,7 +61,7 @@ public:
         else
         {
             ActPrintLog(activity, "Executing dependencies");
-            activity->queryContainer().executeDependencies(savedParentExtractSz, savedParentExtract, controlId, true);
+            activity.queryContainer().executeDependencies(savedParentExtractSz, savedParentExtract, controlId, true);
         }
         return true;
     }

--- a/thorlcr/activities/wuidwrite/thwuidwrite.cpp
+++ b/thorlcr/activities/wuidwrite/thwuidwrite.cpp
@@ -55,7 +55,7 @@ public:
         CMasterActivity::init();
         workunitWriteLimit = activityMaxSize ? activityMaxSize : getOptInt(THOROPT_OUTPUTLIMIT, DEFAULT_WUIDWRITE_LIMIT);
         if (workunitWriteLimit>DALI_RESULT_OUTPUTMAX)
-            throw MakeActivityException(this, 0, "Configured max result size, %d MB, exceeds absolute max limit of %d MB. A huge Dali result usually indicates the ECL needs altering.", workunitWriteLimit, DALI_RESULT_OUTPUTMAX);
+            throw MakeActivityException(*this, 0, "Configured max result size, %d MB, exceeds absolute max limit of %d MB. A huge Dali result usually indicates the ECL needs altering.", workunitWriteLimit, DALI_RESULT_OUTPUTMAX);
         assertex(workunitWriteLimit<=0x1000); // 32bit limit because MemoryBuffer/CMessageBuffers involved etc.
         workunitWriteLimit *= 0x100000;
     }

--- a/thorlcr/activities/xmlparse/thxmlparseslave.cpp
+++ b/thorlcr/activities/xmlparse/thxmlparseslave.cpp
@@ -145,7 +145,7 @@ public:
             s.append("INTERNAL ERROR ").append(e->errorCode()).append(": ");
             e->errorMessage(s);
             e->Release();
-            throw MakeActivityException(this, 0, "%s", s.str());
+            throw MakeActivityException(*this, 0, "%s", s.str());
         }
         catch (IException *e)
         {
@@ -154,7 +154,7 @@ public:
             s.append(") INTERNAL ERROR ").append(e->errorCode()).append(": ");
             e->errorMessage(s);
             e->Release();
-            throw MakeActivityException(this, 0, "%s", s.str());
+            throw MakeActivityException(*this, 0, "%s", s.str());
         }
         eogNext = false;
         anyThisGroup = false;

--- a/thorlcr/activities/xmlread/thxmlreadslave.cpp
+++ b/thorlcr/activities/xmlread/thxmlreadslave.cpp
@@ -69,7 +69,7 @@ class CXmlReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
             {
                 iFileIO.setown(createCompressedFileReader(iFile, activity.eexp));
                 if (!iFileIO)
-                    throw MakeActivityException(&activity, 0, "Failed to open block compressed file '%s'", filename.get());
+                    throw MakeActivityException(activity, 0, "Failed to open block compressed file '%s'", filename.get());
                 checkFileCrc = false;
             }
             else
@@ -129,7 +129,7 @@ class CXmlReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
                 if (PTreeRead_syntax != e->errorCode())
                     throw;
                 Owned<IException> _e = e;
-                offset_t localFPos = makeLocalFposOffset(activity.queryContainer().queryJob().queryMyRank()-1, e->queryOffset());
+                offset_t localFPos = makeLocalFposOffset(activity.queryJob().queryMyRank()-1, e->queryOffset());
                 StringBuffer context;
                 context.append("Logical filename = ").append(activity.logicalFilename).newline();
                 context.append("Local fileposition = ");
@@ -145,7 +145,7 @@ class CXmlReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
                 StringBuffer s("XMLRead actId(");
                 s.append(activity.queryContainer().queryId()).append(") out of memory.").newline();
                 s.append("INTERNAL ERROR ").append(e->errorCode());
-                Owned<IException> e2 = MakeActivityException(&activity, e, "%s", s.str());
+                Owned<IException> e2 = MakeActivityException(activity, e, "%s", s.str());
                 e->Release();
                 throw e2.getClear();
             }
@@ -154,7 +154,7 @@ class CXmlReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
                 StringBuffer s("XMLRead actId(");
                 s.append(activity.queryContainer().queryId());
                 s.append(") INTERNAL ERROR ").append(e->errorCode());
-                Owned<IException> e2 = MakeActivityException(&activity, e, "%s", s.str());
+                Owned<IException> e2 = MakeActivityException(activity, e, "%s", s.str());
                 e->Release();
                 throw e2.getClear();
             }

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -188,6 +188,10 @@ public:
         Owned<IRowStream> stream = getRowStream();
         return stream->nextRow();
     }
+    virtual rowcount_t getResultCount()
+    {
+        return rowStreamCount;
+    }
 };
 
 /////

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -121,6 +121,7 @@ interface IThorResult : extends IInterface
     virtual void serialize(MemoryBuffer &mb) = 0;
     virtual void getLinkedResult(unsigned & count, byte * * & ret) = 0;
     virtual const void * getLinkedRowResult() = 0;
+    virtual rowcount_t getResultCount() = 0;
 };
 
 class CActivityBase;
@@ -1089,6 +1090,7 @@ protected:
         virtual void getLinkedResult(unsigned & count, byte * * & ret) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
         virtual void getDictionaryResult(unsigned & count, byte * * & ret) { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
         virtual const void * getLinkedRowResult() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
+        virtual rowcount_t getResultCount() { throw MakeStringException(0, "Graph Result %d accessed before it is created", id); }
     };
     IArrayOf<IThorResult> results;
     CriticalSection cs;
@@ -1155,6 +1157,7 @@ public:
 
     virtual void setOwner(activity_id _ownerId) { ownerId = _ownerId; }
     virtual activity_id queryOwnerId() const { return ownerId; }
+    virtual unsigned getResultCount() const { return results.ordinality(); }
 };
 
 extern graph_decl IThorResult *createResult(ILWActivity &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -316,8 +316,9 @@ void CSlaveMessageHandler::main()
                     msg.read(resultId);
                     mptag_t replyTag = job.deserializeMPTag(msg);
                     Owned<IThorResult> result = job.getOwnedResult(gid, ownerId, resultId);
+                    rowcount_t rowCount = result->getResultCount();
                     Owned<IRowStream> resultStream = result->getRowStream();
-                    sendInChunks(job.queryJobComm(), sender, replyTag, resultStream, result->queryRowInterfaces());
+                    sendInChunks(job.queryJobComm(), sender, replyTag, rowCount, resultStream, result->queryRowInterfaces());
                     break;
                 }
             }
@@ -2046,6 +2047,11 @@ public:
     {
         ensure();
         return result->getLinkedRowResult();
+    }
+    virtual rowcount_t getResultCount()
+    {
+        ensure();
+        return result->getResultCount();
     }
 };
 

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -78,7 +78,6 @@ public:
     virtual void done();
     virtual void reset();
     virtual void abort(IException *e);
-    IThorResult *createResult(CActivityBase &activity, unsigned id, IThorGraphResults *results, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
     IThorResult *createResult(CActivityBase &activity, unsigned id, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
     IThorResult *createGraphLoopResult(CActivityBase &activity, IRowInterfaces *rowIf, bool distributed, unsigned spillPriority=SPILL_PRIORITY_RESULT);
 
@@ -171,6 +170,7 @@ public:
     virtual StringBuffer &getWorkUnitValue(const char *prop, StringBuffer &str) const;
     virtual bool getWorkUnitValueBool(const char *prop, bool defVal) const;
     virtual IBarrier *createBarrier(mptag_t tag);
+    virtual IThorGraphResults *createThorGraphResults(graph_id gid);
 
 // IExceptionHandler
     virtual bool fireException(IException *e);

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1130,6 +1130,11 @@ IGraphTempHandler *CJobSlave::createTempHandler(bool errorOnMissing)
     return new CSlaveGraphTempHandler(*this, errorOnMissing);
 }
 
+IThorGraphResults *CJobSlave::createThorGraphResults(graph_id gid)
+{
+    return new CThorSlaveGraphResults(*this, gid);
+}
+
 IThorResult *CJobSlave::getGlobalResult(ILWActivity &activity, graph_id gid, IRowInterfaces *rowIf, activity_id ownerId, unsigned id)
 {
     mptag_t replyTag = createReplyTag();

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -163,6 +163,7 @@ public:
         return new CSlaveGraph(*this);
     }
     virtual IBarrier *createBarrier(mptag_t tag);
+    virtual IThorGraphResults *createThorGraphResults(graph_id gid);
     IThorResult *getGlobalResult(ILWActivity &activity, graph_id gid, IRowInterfaces *rowIf, activity_id ownerId, unsigned id);
 
 // IExceptionHandler

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -105,7 +105,6 @@ public:
     void initWithActData(MemoryBuffer &in, MemoryBuffer &out);
     void getDone(MemoryBuffer &doneInfoMb);
     void serializeDone(MemoryBuffer &mb);
-    IThorResult *getGlobalResult(CActivityBase &activity, IRowInterfaces *rowIf, activity_id ownerId, unsigned id);
 
     virtual void executeSubGraph(size32_t parentExtractSz, const byte *parentExtract);
     virtual bool serializeStats(MemoryBuffer &mb);
@@ -115,7 +114,6 @@ public:
     virtual void abort(IException *e);
     virtual void done();
     virtual void end();
-    virtual IThorGraphResults *createThorGraphResults(unsigned num);
 
 // IExceptionHandler
     virtual bool fireException(IException *e)
@@ -165,6 +163,7 @@ public:
         return new CSlaveGraph(*this);
     }
     virtual IBarrier *createBarrier(mptag_t tag);
+    IThorResult *getGlobalResult(ILWActivity &activity, graph_id gid, IRowInterfaces *rowIf, activity_id ownerId, unsigned id);
 
 // IExceptionHandler
     virtual bool fireException(IException *e)
@@ -195,7 +194,7 @@ public:
 };
 
 interface IPartDescriptor;
-extern graphslave_decl bool ensurePrimary(CActivityBase *activity, IPartDescriptor &partDesc, OwnedIFile & ifile, unsigned &location, StringBuffer &path);
+extern graphslave_decl bool ensurePrimary(CActivityBase &activity, IPartDescriptor &partDesc, OwnedIFile & ifile, unsigned &location, StringBuffer &path);
 extern graphslave_decl IReplicatedFile *createEnsurePrimaryPartFile(CActivityBase &activity, const char *logicalFilename, IPartDescriptor *partDesc);
 extern graphslave_decl IThorFileCache *createFileCache(unsigned limit);
 

--- a/thorlcr/master/thactivitymaster.cpp
+++ b/thorlcr/master/thactivitymaster.cpp
@@ -388,7 +388,7 @@ public:
                 ret = createWhenActivityMaster(this);
                 break;
             default:
-                throw MakeActivityException(this, TE_UnsupportedActivityKind, "Unsupported activity kind: %s", activityKindStr(kind));
+                throw MakeActivityException(*this, TE_UnsupportedActivityKind, "Unsupported activity kind: %s", activityKindStr(kind));
         }
         return ret;
     }
@@ -638,12 +638,12 @@ void checkFormatCrc(CActivityBase *activity, IDistributedFile *file, unsigned he
             if (super) fileStr.append("Superfile: ").append(file->queryLogicalName()).append(", subfile: ");
             else fileStr.append("File: ");
             fileStr.append(f->queryLogicalName());
-            Owned<IThorException> e = MakeActivityException(activity, TE_FormatCrcMismatch, "%s: Layout does not match published layout. %s", kindStr.str(), fileStr.str());
+            Owned<IThorException> e = MakeActivityException(*activity, TE_FormatCrcMismatch, "%s: Layout does not match published layout. %s", kindStr.str(), fileStr.str());
             if (index && !f->queryAttributes().hasProp("_record_layout")) // Cannot verify if _true_ crc mismatch if soft layout missing anymore
                 LOG(MCwarning, thorJob, e);
             else
             {
-                if (!activity->queryContainer().queryJob().getWorkUnitValueInt("skipFileFormatCrcCheck", 0))
+                if (!activity->queryJob().getWorkUnitValueInt("skipFileFormatCrcCheck", 0))
                     throw LINK(e);
                 e->setAction(tea_warning);
                 activity->fireException(e);

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -174,7 +174,7 @@ public:
     }
     StringBuffer &mangleLFN(CJobBase &job, const char *lfn, StringBuffer &out)
     {
-        out.append(lfn).append("__").append(job.queryCodeContext().getWuid());
+        out.append(lfn).append("__").append(job.queryWuid());
         return out;
     }
     StringBuffer &addScope(CJobBase &job, const char *logicalname, StringBuffer &ret, bool temporary=false, bool paused=false)

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -105,7 +105,7 @@ class CWriteIntercept : public CSimpleInterface
                     StringBuffer err;
                     err.append("Cannot create ").append(idxFile->queryFilename());
                     LOG(MCerror, thorJob, "%s", err.str());
-                    throw MakeActivityException(&activity, -1, "%s", err.str());
+                    throw MakeActivityException(activity, -1, "%s", err.str());
                 }
                 idxFileStream.setown(createBufferedIOStream(idxFileIO,0x100000));
                 offset_t s = 0;
@@ -190,7 +190,7 @@ public:
         Owned<IExtRowWriter> output = createRowWriter(dataFile, rowIf);
 
         bool overflowed = false;
-        ActPrintLog(&activity, "Local Overflow Merge start");
+        ActPrintLog(activity, "Local Overflow Merge start");
         unsigned ret=0;
         loop
         {
@@ -233,7 +233,7 @@ public:
         }
         if (overflowed)
             WARNLOG("Overflowed by %"I64F"d", overflowsize);
-        ActPrintLog(&activity, "Local Overflow Merge done: overflow file '%s', size = %"I64F"d", dataFile->queryFilename(), dataFile->size());
+        ActPrintLog(activity, "Local Overflow Merge done: overflow file '%s', size = %"I64F"d", dataFile->queryFilename(), dataFile->size());
         return end;
     }
     IRowStream *getStream(offset_t startOffset, rowcount_t max)
@@ -321,24 +321,24 @@ class CMiniSort
         //compression TBD
         CMessageBuffer mbin;
 #ifdef  _FULL_TRACE
-        ActPrintLog(&activity, "MiniSort sendToPrimaryNode waiting");
+        ActPrintLog(activity, "MiniSort sendToPrimaryNode waiting");
 #endif
         clusterComm.recv(mbin,1,mpTag);
 #ifdef  _FULL_TRACE
-        ActPrintLog(&activity, "MiniSort sendToPrimaryNode continue %u bytes",mbin.length());
+        ActPrintLog(activity, "MiniSort sendToPrimaryNode continue %u bytes",mbin.length());
 #endif
         if (mbin.length()==0) {
-            ActPrintLog(&activity, "aborting sendToPrimaryNode");
+            ActPrintLog(activity, "aborting sendToPrimaryNode");
             // TBD?
             return;
         }
         byte fn;
         mbin.read(fn);
         if (fn!=255)
-            throw MakeActivityException(&activity, -1, "MiniSort sendToPrimaryNode: Protocol error(1) %d",(int)fn);
+            throw MakeActivityException(activity, -1, "MiniSort sendToPrimaryNode: Protocol error(1) %d",(int)fn);
         mb.init(mbin.getSender(),mpTag,mbin.getReplyTag());
 #ifdef  _FULL_TRACE
-        ActPrintLog(&activity, "MiniSort sendToPrimaryNode %u bytes",mb.length());
+        ActPrintLog(activity, "MiniSort sendToPrimaryNode %u bytes",mb.length());
 #endif
         clusterComm.reply(mb);
     }
@@ -350,48 +350,48 @@ class CMiniSort
         do {
             done = rowArray.serializeBlock(mbout.clear(),from,to-from,blksize,false);
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort serialized %u rows, %u bytes",done,mbout.length());
+            ActPrintLog(activity, "MiniSort serialized %u rows, %u bytes",done,mbout.length());
 #endif
             from += done;
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort sendToSecondaryNode(%d) send %u",(int)node,mbout.length());
+            ActPrintLog(activity, "MiniSort sendToSecondaryNode(%d) send %u",(int)node,mbout.length());
 #endif
             clusterComm.sendRecv(mbout,node,mpTag);
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort sendToSecondaryNode(%d) got %u",(int)node,mbout.length());
+            ActPrintLog(activity, "MiniSort sendToSecondaryNode(%d) got %u",(int)node,mbout.length());
 #endif
             byte fn;
             mbout.read(fn);
             if (fn!=254)
-                throw MakeActivityException(&activity, -1, "MiniSort sendToPrimaryNode: Protocol error(2) %d",(int)fn);
+                throw MakeActivityException(activity, -1, "MiniSort sendToPrimaryNode: Protocol error(2) %d",(int)fn);
         } while (done!=0);
     }
     void appendFromPrimaryNode(IRowWriter &writer)
     {
 #ifdef  _FULL_TRACE
-        ActPrintLog(&activity, "MiniSort appending from primary node");
+        ActPrintLog(activity, "MiniSort appending from primary node");
 #endif
         CMessageBuffer mbin;
         loop
         {
             mbin.clear();
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort appendFromPrimaryNode waiting");
+            ActPrintLog(activity, "MiniSort appendFromPrimaryNode waiting");
 #endif
             clusterComm.recv(mbin,1,mpTag);
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort appendFromPrimaryNode continue %u bytes",mbin.length());
+            ActPrintLog(activity, "MiniSort appendFromPrimaryNode continue %u bytes",mbin.length());
 #endif
             CMessageBuffer mbout;
             mbout.init(mbin.getSender(),mpTag,mbin.getReplyTag());
             byte fn=254;
             mbout.append(fn);
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort appendFromPrimaryNode reply %u bytes",mbout.length());
+            ActPrintLog(activity, "MiniSort appendFromPrimaryNode reply %u bytes",mbout.length());
 #endif
             clusterComm.reply(mbout);
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort got from primary node %d",mbin.length());
+            ActPrintLog(activity, "MiniSort got from primary node %d",mbin.length());
 #endif
             if (mbin.length()==0)
                 break;
@@ -401,7 +401,7 @@ class CMiniSort
     void appendFromSecondaryNode(IRowWriter &writer, rank_t node, Semaphore &sem)
     {
 #ifdef  _FULL_TRACE
-        ActPrintLog(&activity, "MiniSort appending from node %d",(int)node);
+        ActPrintLog(activity, "MiniSort appending from node %d",(int)node);
 #endif
         CMessageBuffer mbin;
         bool first = true;
@@ -412,7 +412,7 @@ class CMiniSort
             mbin.append(fn);
             clusterComm.sendRecv(mbin,node,mpTag);
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort got %u from node %d",mbin.length(),(int)node);
+            ActPrintLog(activity, "MiniSort got %u from node %d",mbin.length(),(int)node);
 #endif
             if (first)
             {
@@ -458,7 +458,7 @@ public:
             {
                 unsigned done = serialize(*spillableStream, mb.clear(), blksize);
 #ifdef  _FULL_TRACE
-                ActPrintLog(&activity, "MiniSort serialized %u rows, %u bytes",done,mb.length());
+                ActPrintLog(activity, "MiniSort serialized %u rows, %u bytes",done,mb.length());
 #endif
                 sendToPrimaryNode(mb);
                 if (!done)
@@ -519,13 +519,13 @@ public:
             collector->transferRowsOut(globalRows); // will sort in process
 
 #ifdef  _FULL_TRACE
-            ActPrintLog(&activity, "MiniSort got %d rows %"I64F"d bytes", globalRows.ordinality(),(unsigned __int64)(globalRows.getMemUsage()));
+            ActPrintLog(activity, "MiniSort got %d rows %"I64F"d bytes", globalRows.ordinality(),(unsigned __int64)(globalRows.getMemUsage()));
 #endif
             UnsignedArray points;
             globalRows.partition(iCompare, numNodes, points);
 #ifdef  _FULL_TRACE
             for (unsigned pi=0;pi<points.ordinality();pi++)
-                ActPrintLog(&activity, "points[%d] = %u",pi, points.item(pi));
+                ActPrintLog(activity, "points[%d] = %u",pi, points.item(pi));
 #endif
             class casyncfor2: public CAsyncFor
             {
@@ -560,7 +560,7 @@ public:
 class CThorSorter : public CSimpleInterface, implements IThorSorter, implements ISortSlaveBase, implements ISortSlaveMP,
     private IThreaded
 {
-    CActivityBase *activity;
+    CActivityBase &activity;
     SocketEndpoint myendpoint;
     IDiskUsage *iDiskUsage;
     Linked<ICommunicator> clusterComm;
@@ -735,9 +735,9 @@ class CThorSorter : public CSimpleInterface, implements IThorSorter, implements 
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    CThorSorter(CActivityBase *_activity, SocketEndpoint &ep, IDiskUsage *_iDiskUsage, ICommunicator *_clusterComm, mptag_t _mpTagRPC)
+    CThorSorter(CActivityBase &_activity, SocketEndpoint &ep, IDiskUsage *_iDiskUsage, ICommunicator *_clusterComm, mptag_t _mpTagRPC)
         : activity(_activity), myendpoint(ep), iDiskUsage(_iDiskUsage), clusterComm(_clusterComm), mpTagRPC(_mpTagRPC),
-          rowArray(*_activity, _activity), threaded("CThorSorter", this)
+          rowArray(_activity, &_activity), threaded("CThorSorter", this)
     {
         numnodes = 0;
         partno = 0;
@@ -795,7 +795,7 @@ public:
     }
     virtual rowcount_t GetMinMax(size32_t &keybufsize,void *&keybuf,size32_t &avrecsize)
     {
-        CThorExpandingRowArray ret(*activity, rowif, true);
+        CThorExpandingRowArray ret(activity, rowif, true);
         avrecsize = 0;
         if (rowArray.ordinality()>0) {
             const void *kp = rowArray.get(0);
@@ -861,9 +861,9 @@ public:
     {
         // finds the keys within the ranges specified
         // uses empty keys (0 size) if none found
-        CThorExpandingRowArray low(*activity, rowif, true);
-        CThorExpandingRowArray high(*activity, rowif, true);
-        CThorExpandingRowArray mid(*activity, rowif, true);
+        CThorExpandingRowArray low(activity, rowif, true);
+        CThorExpandingRowArray high(activity, rowif, true);
+        CThorExpandingRowArray mid(activity, rowif, true);
         low.deserializeExpand(lbufsize, lkeybuf);
         high.deserializeExpand(hbufsize, hkeybuf);
         unsigned n=low.ordinality();
@@ -913,13 +913,13 @@ public:
     }
     virtual void MultiBinChop(size32_t keybufsize, const byte * keybuf, unsigned num, rowcount_t * pos, byte cmpfn, bool useaux)
     {
-        CThorExpandingRowArray keys(*activity, useaux?auxrowif:rowif, true);
+        CThorExpandingRowArray keys(activity, useaux?auxrowif:rowif, true);
         keys.deserialize(keybufsize, keybuf);
         doBinChop(keys, pos, num, cmpfn);
     }
     virtual void MultiBinChopStart(size32_t keybufsize, const byte * keybuf, byte cmpfn)
     {
-        CThorExpandingRowArray keys(*activity, rowif, true);
+        CThorExpandingRowArray keys(activity, rowif, true);
         keys.deserializeExpand(keybufsize, keybuf);
         assertex(multibinchoppos==NULL); // check for reentrancy
         multibinchopnum = keys.ordinality();
@@ -948,7 +948,7 @@ public:
         for (i=0;i<mapsize;i++)
             ActPrintLog(activity, "%"RCPF"d ",overflowmap[i]);
 #endif
-        CThorExpandingRowArray keys(*activity, useaux?auxrowif:rowif, true);
+        CThorExpandingRowArray keys(activity, useaux?auxrowif:rowif, true);
         keys.deserialize(keybufsize, keybuf);
         for (i=0;i<mapsize-1;i++)
             AdjustOverflow(overflowmap[i], keys.query(i), cmpfn);
@@ -1026,7 +1026,7 @@ public:
     {
         // actually doesn't get Nth row but numsplits samples distributed evenly through the rows
         assertex(numsplits);
-        CThorExpandingRowArray ret(*activity, rowif, true);
+        CThorExpandingRowArray ret(activity, rowif, true);
         unsigned numrows = rowArray.ordinality();
         if (numrows) {
             for (unsigned i=0;i<numsplits;i++) {
@@ -1045,7 +1045,7 @@ public:
     virtual void StartMiniSort(rowcount_t globalTotal)
     {
         // JCSMORE partno and numnodes should be implicit
-        CMiniSort miniSort(*activity, *rowif, *clusterComm, partno, numnodes, mpTagRPC);
+        CMiniSort miniSort(activity, *rowif, *clusterComm, partno, numnodes, mpTagRPC);
 
         Owned<IRowStream> sortedStream;
         try
@@ -1198,7 +1198,7 @@ public:
         icollate = _icollate?_icollate:_icompare;
         icollateupper = _icollateupper?_icollateupper:icollate;
 
-        Owned<IThorRowLoader> sortedloader = createThorRowLoader(*activity, rowif, nosort?NULL:icompare, isstable ? stableSort_earlyAlloc : stableSort_none, rc_allDiskOrAllMem, SPILL_PRIORITY_SELFJOIN);
+        Owned<IThorRowLoader> sortedloader = createThorRowLoader(activity, rowif, nosort?NULL:icompare, isstable ? stableSort_earlyAlloc : stableSort_none, rc_allDiskOrAllMem, SPILL_PRIORITY_SELFJOIN);
         Owned<IRowStream> overflowstream;
         memsize_t inMemUsage = 0;
         try
@@ -1224,7 +1224,7 @@ public:
             {
                 assertex(!intercept);
                 overflowinterval=sortedloader->overflowScale();
-                intercept.setown(new CWriteIntercept(*activity, rowif, overflowinterval));
+                intercept.setown(new CWriteIntercept(activity, rowif, overflowinterval));
                 grandtotalsize = intercept->write(overflowstream);
                 intercept->transferRows(rowArray); // get sample rows
             }
@@ -1264,6 +1264,6 @@ public:
 
 IThorSorter *CreateThorSorter(CActivityBase *activity, SocketEndpoint &ep,IDiskUsage *iDiskUsage,ICommunicator *clusterComm, mptag_t _mpTagRPC)
 {
-    return new CThorSorter(activity, ep, iDiskUsage, clusterComm, _mpTagRPC);
+    return new CThorSorter(*activity, ep, iDiskUsage, clusterComm, _mpTagRPC);
 }
 

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -112,7 +112,7 @@ void ProcessSlaveActivity::main()
         }
         else
         {
-            e = MakeActivityException(this, _e);
+            e = MakeActivityException(*this, _e);
             if (QUERYINTERFACE(_e, ISEH_Exception))
             {
                 IThorException *e2 = MakeThorFatal(e, TE_SEH, "FATAL: (SEH)");
@@ -132,12 +132,12 @@ void ProcessSlaveActivity::main()
         else
             m.append("standard library exception (std::exception ").append(es.what()).append(")");
         m.appendf(" in %"ACTPF"d",container.queryId());
-        ActPrintLogEx(&queryContainer(), thorlog_null, MCerror, "%s", m.str());
+        ActPrintLogEx(*this, thorlog_null, MCerror, "%s", m.str());
         exception.setown(MakeThorFatal(NULL, TE_UnknownException, "%s", m.str()));
     }
     catch (CATCHALL)
     {
-        ActPrintLogEx(&queryContainer(), thorlog_null, MCerror, "Unknown exception thrown in process()");
+        ActPrintLogEx(*this, thorlog_null, MCerror, "Unknown exception thrown in process()");
         exception.setown(MakeThorFatal(NULL, TE_UnknownException, "FATAL: Unknown exception thrown by ProcessThread"));
     }
     try { endProcess(); }

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -425,10 +425,11 @@ public:
                             msg.read(resultId);
                             mptag_t replyTag = job->deserializeMPTag(msg);
                             Owned<IThorResult> result = job->getOwnedResult(gid, ownerId, resultId);
+                            rowcount_t rowCount = result->getResultCount();
                             Owned<IRowStream> resultStream = result->getRowStream();
                             msg.setReplyTag(replyTag);
                             msg.clear();
-                            sendInChunks(job->queryJobComm(), 0, replyTag, resultStream, result->queryRowInterfaces());
+                            sendInChunks(job->queryJobComm(), 0, replyTag, rowCount, resultStream, result->queryRowInterfaces());
                             doReply = false;
                         }
                         break;

--- a/thorlcr/thorcodectx/thcodectx.cpp
+++ b/thorlcr/thorcodectx/thcodectx.cpp
@@ -125,6 +125,8 @@ const char * CThorCodeContextBase::cloneVString(size32_t len, const char * str) 
 
 IEclGraphResults *CThorCodeContextBase::resolveLocalQuery(__int64 gid)
 {
+    if (0 == gid)
+        return job.queryGlobalResults();
     IEclGraphResults *graph = job.getGraph((graph_id)gid);
     graph->Release(); // resolveLocalQuery doesn't own, can't otherwise will be circular ref.
     return graph;

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -51,13 +51,13 @@ interface ISmartRowBuffer: extends IRowStream
 };
 
 class CActivityBase;
-extern graph_decl ISmartRowBuffer * createSmartBuffer(CActivityBase *activity, const char * tempname, 
+extern graph_decl ISmartRowBuffer * createSmartBuffer(ILWActivity &activity, const char * tempname,
                                                       size32_t buffsize, 
                                                       IRowInterfaces *rowif
                                                       ); 
 
 
-extern graph_decl ISmartRowBuffer * createSmartInMemoryBuffer(CActivityBase *activity,
+extern graph_decl ISmartRowBuffer * createSmartInMemoryBuffer(ILWActivity &activity,
                                                       IRowInterfaces *rowIf,
                                                       size32_t buffsize);
 
@@ -69,9 +69,9 @@ interface ISharedSmartBuffer : extends IRowWriter
     virtual void reset() = 0;
 };
 
-extern graph_decl ISharedSmartBuffer *createSharedSmartMemBuffer(CActivityBase *activity, unsigned outputs, IRowInterfaces *rowif, unsigned buffSize=((unsigned)-1));
+extern graph_decl ISharedSmartBuffer *createSharedSmartMemBuffer(ILWActivity &activity, unsigned outputs, IRowInterfaces *rowif, unsigned buffSize=((unsigned)-1));
 interface IDiskUsage;
-extern graph_decl ISharedSmartBuffer *createSharedSmartDiskBuffer(CActivityBase *activity, const char *tempname, unsigned outputs, IRowInterfaces *rowif, IDiskUsage *iDiskUsage=NULL);
+extern graph_decl ISharedSmartBuffer *createSharedSmartDiskBuffer(ILWActivity &ctivity, const char *tempname, unsigned outputs, IRowInterfaces *rowif, IDiskUsage *iDiskUsage=NULL);
 
 
 interface IRowWriterMultiReader : extends IRowWriter
@@ -79,7 +79,7 @@ interface IRowWriterMultiReader : extends IRowWriter
     virtual IRowStream *getReader() = 0;
 };
 
-extern graph_decl IRowWriterMultiReader *createOverflowableBuffer(CActivityBase &activity, IRowInterfaces *rowif, bool grouped, bool shared=false, unsigned spillPriority=SPILL_PRIORITY_OVERFLOWABLE_BUFFER);
+extern graph_decl IRowWriterMultiReader *createOverflowableBuffer(ILWActivity &activity, IRowInterfaces *rowif, bool grouped, bool shared=false, unsigned spillPriority=SPILL_PRIORITY_OVERFLOWABLE_BUFFER);
 // NB first write all then read (not interleaved!)
 
 // Multiple writers, one reader
@@ -91,7 +91,7 @@ interface IRowMultiWriterReader : extends IRowStream
 
 #define DEFAULT_WR_READ_GRANULARITY 10000 // Amount reader extracts when empty to avoid contention with writer
 #define DEFAULT_WR_WRITE_GRANULARITY 1000 // Amount writers buffer up before committing to output
-extern graph_decl IRowMultiWriterReader *createSharedWriteBuffer(CActivityBase *activity, IRowInterfaces *rowif, unsigned limit, unsigned readGranularity=DEFAULT_WR_READ_GRANULARITY, unsigned writeGranularity=DEFAULT_WR_WRITE_GRANULARITY);
+extern graph_decl IRowMultiWriterReader *createSharedWriteBuffer(ILWActivity &activity, IRowInterfaces *rowif, unsigned limit, unsigned readGranularity=DEFAULT_WR_READ_GRANULARITY, unsigned writeGranularity=DEFAULT_WR_WRITE_GRANULARITY);
 
 
 #endif

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -262,7 +262,7 @@ class graph_decl CThorExpandingRowArray : public CSimpleInterface
     inline void transferRowsCopy(const void **outRows, bool takeOwnership);
 
 protected:
-    CActivityBase &activity;
+    ILWActivity &activity;
     IRowInterfaces *rowIf;
     IEngineRowAllocator *allocator;
     IOutputRowSerializer *serializer;
@@ -285,9 +285,9 @@ protected:
     void doSort(rowidx_t n, void **const rows, ICompare &compare, unsigned maxCores);
     inline rowidx_t getRowsCapacity() const { return rows ? RoxieRowCapacity(rows) / sizeof(void *) : 0; }
 public:
-    CThorExpandingRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=true, rowidx_t initialSize=InitialSortElements);
+    CThorExpandingRowArray(ILWActivity &activity, IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=true, rowidx_t initialSize=InitialSortElements);
     ~CThorExpandingRowArray();
-    CActivityBase &queryActivity() { return activity; }
+    ILWActivity &queryActivity() { return activity; }
     // NB: throws error on OOM by default
     void setup(IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=true);
     inline void setAllowNulls(bool b) { allowNulls = b; }
@@ -398,7 +398,7 @@ class graph_decl CThorSpillableRowArray : private CThorExpandingRowArray, implem
     ICopyArrayOf<IWritePosCallback> writeCallbacks;
 public:
 
-    CThorSpillableRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, rowidx_t initialSize=InitialSortElements, size32_t commitDelta=CommitStep);
+    CThorSpillableRowArray(ILWActivity &activity, IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, rowidx_t initialSize=InitialSortElements, size32_t commitDelta=CommitStep);
     ~CThorSpillableRowArray();
     // NB: default throwOnOom to false
     void setup(IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=false)
@@ -526,10 +526,10 @@ interface IThorRowCollector : extends IThorRowCollectorCommon
     virtual IRowStream *getStream(bool shared=false, CThorExpandingRowArray *allMemRows=NULL) = 0;
 };
 
-extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT);
-extern graph_decl IThorRowLoader *createThorRowLoader(CActivityBase &activity, ICompare *iCompare=NULL, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT);
-extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT, bool preserveGrouping=false);
-extern graph_decl IThorRowCollector *createThorRowCollector(CActivityBase &activity, ICompare *iCompare=NULL, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT, bool preserveGrouping=false);
+extern graph_decl IThorRowLoader *createThorRowLoader(ILWActivity &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT);
+extern graph_decl IThorRowLoader *createThorRowLoader(ILWActivity &activity, ICompare *iCompare=NULL, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT);
+extern graph_decl IThorRowCollector *createThorRowCollector(ILWActivity &activity, IRowInterfaces *rowIf, ICompare *iCompare=NULL, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT, bool preserveGrouping=false);
+extern graph_decl IThorRowCollector *createThorRowCollector(ILWActivity &activity, ICompare *iCompare=NULL, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=SPILL_PRIORITY_DEFAULT, bool preserveGrouping=false);
 
 
 

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -448,7 +448,7 @@ extern graph_decl IRowServer *createRowServer(CActivityBase *activity, IRowStrea
 extern graph_decl IRowStream *createUngroupStream(IRowStream *input);
 
 interface IRowInterfaces;
-extern graph_decl void sendInChunks(ICommunicator &comm, rank_t dst, mptag_t mpTag, IRowStream *input, IRowInterfaces *rowIf);
+extern graph_decl void sendInChunks(ICommunicator &comm, rank_t dst, mptag_t mpTag, rowcount_t rowCount, IRowStream *input, IRowInterfaces *rowIf);
 
 extern graph_decl void logDiskSpace();
 

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -310,48 +310,48 @@ interface IThorException : extends IException
     virtual void setSeverity(WUExceptionSeverity severity) = 0;
 };
 
-class CGraphElementBase;
+interface ILWActivity;
 class CActivityBase;
 class CGraphBase;
 interface IRemoteConnection;
 enum ActLogEnum { thorlog_null=0,thorlog_ecl=1,thorlog_all=2 };
 
-extern graph_decl StringBuffer &ActPrintLogArgsPrep(StringBuffer &res, const CGraphElementBase *container, const ActLogEnum flags, const char *format, va_list args);
-extern graph_decl void ActPrintLogEx(const CGraphElementBase *container, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, ...) __attribute__((format(printf, 4, 5)));
-extern graph_decl void ActPrintLogArgs(const CGraphElementBase *container, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, va_list args);
-extern graph_decl void ActPrintLogArgs(const CGraphElementBase *container, IException *e, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, va_list args);
-extern graph_decl void ActPrintLog(const CActivityBase *activity, const char *format, ...) __attribute__((format(printf, 2, 3)));
-extern graph_decl void ActPrintLog(const CActivityBase *activity, IException *e, const char *format, ...) __attribute__((format(printf, 3, 4)));
-extern graph_decl void ActPrintLog(const CActivityBase *activity, IException *e);
+extern graph_decl StringBuffer &ActPrintLogArgsPrep(StringBuffer &res, ILWActivity &activity, const ActLogEnum flags, const char *format, va_list args);
+extern graph_decl void ActPrintLogEx(ILWActivity &activity, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, ...) __attribute__((format(printf, 4, 5)));
+extern graph_decl void ActPrintLogArgs(ILWActivity &activity, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, va_list args);
+extern graph_decl void ActPrintLogArgs(ILWActivity &activity, IException *e, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, va_list args);
+extern graph_decl void ActPrintLog(ILWActivity &activity, const char *format, ...) __attribute__((format(printf, 2, 3)));
+extern graph_decl void ActPrintLog(ILWActivity &activity, IException *e);
 
-inline void ActPrintLog(const CGraphElementBase *container, const char *format, ...) __attribute__((format(printf, 2, 3)));
-inline void ActPrintLog(const CGraphElementBase *container, const char *format, ...)
+inline void ActPrintLog(ILWActivity &activity, const char *format, ...) __attribute__((format(printf, 2, 3)));
+inline void ActPrintLog(ILWActivity &activity, const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    ActPrintLogArgs(container, thorlog_ecl, MCdebugProgress, format, args);
+    ActPrintLogArgs(activity, thorlog_ecl, MCdebugProgress, format, args);
     va_end(args);
 }
-inline void ActPrintLogEx(const CGraphElementBase *container, IException *e, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, ...) __attribute__((format(printf, 5, 6)));
-inline void ActPrintLogEx(const CGraphElementBase *container, IException *e, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, ...)
+inline void ActPrintLogEx(ILWActivity &activity, IException *e, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, ...) __attribute__((format(printf, 5, 6)));
+inline void ActPrintLogEx(ILWActivity &activity, IException *e, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    ActPrintLogArgs(container, e, flags, logCat, format, args);
+    ActPrintLogArgs(activity, e, flags, logCat, format, args);
     va_end(args);
 }
-inline void ActPrintLog(const CGraphElementBase *container, IException *e, const char *format, ...) __attribute__((format(printf, 3, 4)));
-inline void ActPrintLog(const CGraphElementBase *container, IException *e, const char *format, ...)
+inline void ActPrintLog(ILWActivity &activity, IException *e, const char *format, ...) __attribute__((format(printf, 3, 4)));
+inline void ActPrintLog(ILWActivity &activity, IException *e, const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    ActPrintLogArgs(container, e, thorlog_null, MCexception(e, MSGCLS_error), format, args);
+    ActPrintLogArgs(activity, e, thorlog_null, MCexception(e, MSGCLS_error), format, args);
     va_end(args);
 }
-inline void ActPrintLog(const CGraphElementBase *container, IException *e)
+inline void ActPrintLog(ILWActivity &activity, IException *e)
 {
-    ActPrintLogEx(container, e, thorlog_null, MCexception(e, MSGCLS_error), "%s", "");
+    ActPrintLogEx(activity, e, thorlog_null, MCexception(e, MSGCLS_error), "%s", "");
 }
+
 extern graph_decl void GraphPrintLogArgsPrep(StringBuffer &res, CGraphBase *graph, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, va_list args);
 extern graph_decl void GraphPrintLogArgs(CGraphBase *graph, IException *e, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, va_list args);
 extern graph_decl void GraphPrintLogArgs(CGraphBase *graph, const ActLogEnum flags, const LogMsgCategory &logCat, const char *format, va_list args);
@@ -381,16 +381,11 @@ inline void GraphPrintLog(CGraphBase *graph, const char *format, ...)
     GraphPrintLogArgs(graph, thorlog_null, MCdebugProgress, format, args);
     va_end(args);
 }
-extern graph_decl IThorException *MakeActivityException(CActivityBase *activity, int code, const char *_format, ...) __attribute__((format(printf, 3, 4)));
-extern graph_decl IThorException *MakeActivityException(CActivityBase *activity, IException *e, const char *xtra, ...) __attribute__((format(printf, 3, 4)));
-extern graph_decl IThorException *MakeActivityException(CActivityBase *activity, IException *e);
-extern graph_decl IThorException *MakeActivityWarning(CActivityBase *activity, int code, const char *_format, ...) __attribute__((format(printf, 3, 4)));
-extern graph_decl IThorException *MakeActivityWarning(CActivityBase *activity, IException *e, const char *format, ...) __attribute__((format(printf, 3, 4)));
-extern graph_decl IThorException *MakeActivityException(CGraphElementBase *activity, int code, const char *_format, ...) __attribute__((format(printf, 3, 4)));
-extern graph_decl IThorException *MakeActivityException(CGraphElementBase *activity, IException *e, const char *xtra, ...) __attribute__((format(printf, 3, 4)));
-extern graph_decl IThorException *MakeActivityException(CGraphElementBase *activity, IException *e);
-extern graph_decl IThorException *MakeActivityWarning(CGraphElementBase *activity, int code, const char *_format, ...) __attribute__((format(printf, 3, 4)));
-extern graph_decl IThorException *MakeActivityWarning(CGraphElementBase *activity, IException *e, const char *format, ...) __attribute__((format(printf, 3, 4)));
+extern graph_decl IThorException *MakeActivityException(ILWActivity &activity, int code, const char *_format, ...) __attribute__((format(printf, 3, 4)));
+extern graph_decl IThorException *MakeActivityException(ILWActivity &activity, IException *e, const char *xtra, ...) __attribute__((format(printf, 3, 4)));
+extern graph_decl IThorException *MakeActivityException(ILWActivity &activity, IException *e);
+extern graph_decl IThorException *MakeActivityWarning(ILWActivity &activity, int code, const char *_format, ...) __attribute__((format(printf, 3, 4)));
+extern graph_decl IThorException *MakeActivityWarning(ILWActivity &activity, IException *e, const char *format, ...) __attribute__((format(printf, 3, 4)));
 extern graph_decl IThorException *MakeGraphException(CGraphBase *graph, int code, const char *format, ...);
 extern graph_decl IThorException *MakeThorException(int code, const char *format, ...) __attribute__((format(printf, 2, 3)));
 extern graph_decl IThorException *MakeThorException(IException *e);
@@ -398,7 +393,7 @@ extern graph_decl IThorException *MakeThorAudienceException(LogMsgAudience audie
 extern graph_decl IThorException *MakeThorOperatorException(int code, const char *format, ...) __attribute__((format(printf, 2, 3)));
 extern graph_decl IThorException *MakeThorFatal(IException *e, int code, const char *format, ...) __attribute__((format(printf, 3, 4)));
 extern graph_decl IThorException *ThorWrapException(IException *e, const char *msg, ...) __attribute__((format(printf, 2, 3)));
-extern graph_decl void setExceptionActivityInfo(CGraphElementBase &container, IThorException *e);
+extern graph_decl void setExceptionActivityInfo(ILWActivity &container, IThorException *e);
 
 extern graph_decl void GetTempName(StringBuffer &name, const char *prefix=NULL,bool altdisk=false);
 extern graph_decl void SetTempDir(const char *name, const char *tempPrefix, bool clear);
@@ -436,7 +431,7 @@ void graph_decl serializeThorException(IException *e, MemoryBuffer &out);
 
 class CActivityBase;
 interface IPartDescriptor;
-extern graph_decl bool getBestFilePart(CActivityBase *activity, IPartDescriptor &partDesc, OwnedIFile & ifile, unsigned &location, StringBuffer &path, IExceptionHandler *eHandler = NULL);
+extern graph_decl bool getBestFilePart(CActivityBase &activity, IPartDescriptor &partDesc, OwnedIFile & ifile, unsigned &location, StringBuffer &path, IExceptionHandler *eHandler = NULL);
 extern graph_decl StringBuffer &getFilePartLocations(IPartDescriptor &partDesc, StringBuffer &locations);
 extern graph_decl StringBuffer &getPartFilename(IPartDescriptor &partDesc, unsigned copy, StringBuffer &filePath, bool localMount=false);
 


### PR DESCRIPTION
Inactive at the moment until codegen options changed.
This commits adds support for graph results used as spills.
The advantage is that that results are to memory and only spilled
on demand as memory pressure requires and it addressed an issue
where distribution as not maintained if a child query required
a 'result' that was a spill.

Broken into 3 commits to separate the noise from the real changes:
1)
There are quite a few auxiliary changes needed to utility classes to
avoid circular references. So that CThorGraphResult objects
can continue to reference a representation of the activity and
their utility objects, without link counting the original
activity and therefore the graphs those activities belong to.

2) Fix an issue serializing dictionary that are now stored as results between slaves and master.

3) Implement the job results container for spills

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
