### PR TITLE
HPCC-11679 Catch exception in connection destructors

### DIFF
--- a/dali/base/dacsds.ipp
+++ b/dali/base/dacsds.ipp
@@ -87,7 +87,16 @@ public:
         if (connected)
         {
             bool deleteRoot = false;
-            manager.commit(*this, &deleteRoot);
+            try
+            {
+                manager.commit(*this, &deleteRoot);
+            }
+            catch (IException *e)
+            {
+                VStringBuffer errMsg("beforeDispose commit connectionid=%"I64F"x, xpath=%s", connectionId, xpath.get());
+                EXCLOG(e, errMsg.str());
+                e->Release();
+            }
         }
         root.clear();
     }


### PR DESCRIPTION
Avoid problems with exceptions being generated during clearup,
that causes problems if clearing up to handle an original exception.
Catch exception in connection beforeDispose and generate a log entry
only.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
