### PR TITLE
HPCC-11485 Return same file data in WsDFU/DFUQuery & DFUFileView

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -81,7 +81,7 @@ private:
     void setFileNameFilter(const char* fname, const char* prefix, StringBuffer &buff);
     void setDFUQueryFilters(IEspDFUQueryRequest& req, StringBuffer& filterBuf);
     void setDFUQuerySortOrder(IEspDFUQueryRequest& req, StringBuffer& sortBy, bool& descending, DFUQResultField* sortOrder);
-    bool addToLogicalFileList(IPropertyTree& file, double version, IArrayOf<IEspDFULogicalFile>& logicalFiles);
+    bool addToLogicalFileList(IPropertyTree& file, const char* nodeGroup, double version, IArrayOf<IEspDFULogicalFile>& logicalFiles);
     void setDFUQueryResponse(IEspContext &context, unsigned totalFiles, StringBuffer& sortBy, bool descending, unsigned pageStart,
         unsigned pageSize, IEspDFUQueryRequest & req, IEspDFUQueryResponse & resp);
     void getLogicalFileAndDirectory(IEspContext &context, IUserDescriptor* udesc, const char *dirname, IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& numFiles, int& numDirs);


### PR DESCRIPTION
For each logical file, both WsDFU requests should return the same
data. In this fix, both WsDFU methods call the same function to read
logical file information. The function is enhanced to handle both
WsDFU requests.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
