### PR TITLE
HPCC-11691 Roxie can core on control:unlockdali

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -721,6 +721,7 @@ public:
             CriticalBlock b(daliConnectionCrit);
             if (isConnected)
             {
+                isConnected = false;
                 delete serverStatus;
                 serverStatus = NULL;
                 closeDllServer();
@@ -728,7 +729,6 @@ public:
                 clientShutdownWorkUnit();
                 disconnectRoxieQueues();
                 ::closedownClientProcess(); // dali client closedown
-                isConnected = false;
                 disconnectSem.signal();
             }
         }


### PR DESCRIPTION
If there is a wu queue active, Roxie may core on a control:unlockDali call, as
the queue is cleared asynchronously.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
