### PR TITLE
Hpcc 11648 fix

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -1,4 +1,4 @@
-Overview of Regression Suite usage (v:0.0.22)
+Overview of Regression Suite usage (v:0.0.24)
 ==============================================
 
 To use Regression Suite change directory to HPCC-Platform/testing/regress subdirectory.
@@ -561,11 +561,15 @@ So if you have a new test case and it works well on all clusters (or some of the
 9. Configuration setting in ecl-test.json file:
 -------------------------------------------------------------
 
-        "ip": "127.0.0.1",                              - ECl server address
+        "IpAddress":{
+            "hthor":"127.0.0.1",
+            "thor":"127.0.0.1",
+            "roxie": "127.0.0.1"
+        },
+        "roxieTestSocket": ":9876",                      - Roxie test socket addres (not used)
+        "epsSocket": ":8010",                          - ECl server socket
         "username": "regress",                          - Regression Suite dedicated username and pasword
         "password": "regress",
-        "roxie": "127.0.0.1:9876",                      - Roxie server addres (not used)
-        "server": "127.0.0.1:8010",                     - EclWatch service server address
         "suiteDir": "",                                 - default suite directory location - ""-> current directory
         "eclDir": "ecl",                                - ECL test cases directory source
         "setupDir": "ecl/setup",                        - ECL setup source directory
@@ -579,7 +583,7 @@ So if you have a new test case and it works well on all clusters (or some of the
             "thor",
             "roxie"
         ],
-        "timeout":"600",                                - Default test case timeout in sec. Can be override by command line parameter or //timeout tag in ECL file
+        "timeout":"720",                                - Default test case timeout in sec. Can be override by command line parameter or //timeout tag in ECL file
         "maxAttemptCount":"3"                           - Max retry count to reset timeout if a testcase in any early stage (compiled, blocked) of execution pipeline.
 
 Optionally the config file can contain a section of default values for stored parameters like this:

--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -566,8 +566,8 @@ So if you have a new test case and it works well on all clusters (or some of the
             "thor":"127.0.0.1",
             "roxie": "127.0.0.1"
         },
-        "roxieTestSocket": ":9876",                      - Roxie test socket addres (not used)
-        "epsSocket": ":8010",                          - ECl server socket
+        "roxieTestSocket": ":9876",                     - Roxie test socket address (not used)
+        "espSocket": ":8010",                           - ESP service address
         "username": "regress",                          - Regression Suite dedicated username and pasword
         "password": "regress",
         "suiteDir": "",                                 - default suite directory location - ""-> current directory

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -28,10 +28,10 @@ import glob
 from hpcc.util import argparse
 from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
-from hpcc.util.util import checkPqParam,  getVersionNumbers,  checkXParam,  convertPath
+from hpcc.util.util import checkPqParam, getVersionNumbers, checkXParam, convertPath, getRealIPAddress
 from hpcc.common.error import Error
 
-prog_version = "0.0.23"
+prog_version = "0.0.24"
 
 # For coverage
 if ('coverage' in os.environ) and (os.environ['coverage'] == '1'):
@@ -86,6 +86,7 @@ class RegressMain:
         # Go through the cluster list
         for cluster in targetClusters:
             try:
+                self.regress.config.ip = self.regress.config.IpAddress[cluster]
                 if len(eclfiles) > 1:
                     #Execute multiple ECL files like RUN to generates summary results and diff report.
                     self.regress.bootstrap(cluster, self.args,  eclfiles)
@@ -116,6 +117,8 @@ class RegressMain:
         if self.args.target in self.regress.config.Clusters:
             self.args.setupExtraX = []
             self.args.setupExtraX.append('OriginalTextFilesPath='+self.regressionSuiteHpccMainDir)
+            self.args.setupExtraX.append('OriginalTextFilesIp='+getRealIPAddress())
+            self.regress.config.ip = self.regress.config.IpAddress[self.args.target]
             if  self.args.pq :
                 self.regress.runSuiteP(self.args.target, self.regress.Setup(self.args))
             else:
@@ -126,6 +129,7 @@ class RegressMain:
 
     def run(self):
         if self.args.target in self.regress.config.Clusters:
+            self.regress.config.ip = self.regress.config.IpAddress[self.args.target]
             self.regress.bootstrap(self.args.target, self.args)
             if  self.args.pq :
                 self.regress.runSuiteP(self.args.target, self.regress.suites[self.args.target])

--- a/testing/regress/ecl-test.json
+++ b/testing/regress/ecl-test.json
@@ -6,7 +6,7 @@
             "roxie": "127.0.0.1"
         },
         "roxieTestSocket": ":9876",
-        "epsSocket": ":8010",
+        "espSocket": ":8010",
         "username": "regress",
         "password": "regress",
         "suiteDir": "",

--- a/testing/regress/ecl-test.json
+++ b/testing/regress/ecl-test.json
@@ -1,10 +1,14 @@
 {
     "Regress":{
-        "ip": "127.0.0.1",
+        "IpAddress":{
+            "hthor": "127.0.0.1",
+            "thor" : "127.0.0.1",
+            "roxie": "127.0.0.1"
+        },
+        "roxieTestSocket": ":9876",
+        "epsSocket": ":8010",
         "username": "regress",
         "password": "regress",
-        "roxie": "127.0.0.1:9876",
-        "server": "127.0.0.1:8010",
         "suiteDir": "",
         "eclDir": "ecl",
         "setupDir": "ecl/setup",
@@ -18,7 +22,7 @@
             "thor",
             "roxie"
         ],
-        "timeout":"600",
+        "timeout":"720",
         "maxAttemptCount":"3",
         "Params":[
             "PassTest.ecl:bla='A value'"

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -427,7 +427,7 @@ class Regression:
                                   username=self.config.username,
                                   password=self.config.password)
             wuid = query.getWuid()
-            logging.debug("res: '%s', wuid:'%s'"  % ( res,  wuid),  extra={'taskId':cnt})
+            logging.debug("CMD result: '%s', wuid:'%s'"  % ( res,  wuid),  extra={'taskId':cnt})
             if wuid == 'Not found':
                 res = False
         else:
@@ -436,7 +436,7 @@ class Regression:
             wuid="N/A"
 
         if wuid and wuid.startswith("W"):
-            url = "http://" + self.config.server
+            url = "http://" + self.config.ip+self.config.epsSocket
             url += "/WsWorkunits/WUInfo?Wuid="
             url += wuid
         else:

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -436,7 +436,7 @@ class Regression:
             wuid="N/A"
 
         if wuid and wuid.startswith("W"):
-            url = "http://" + self.config.ip+self.config.epsSocket
+            url = "http://" + self.config.ip+self.config.espSocket
             url += "/WsWorkunits/WUInfo?Wuid="
             url += wuid
         else:

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -90,9 +90,10 @@ class ECLFile:
 
         # Process setupExtraX parameters if any
         if 'setupExtraX' in args:
-            args.setupExtraX[0]=self.removeQuote(args.setupExtraX[0])
-            optXs = ("-X"+args.setupExtraX[0].replace(',',  ',-X')).split(',')
-            self.processKeyValPairs(optXs,  self.optXHash)
+            for extraX in args.setupExtraX:
+                extraX=self.removeQuote(extraX)
+                optXs = ("-X"+extraX.replace(',',  ',-X')).split(',')
+                self.processKeyValPairs(optXs,  self.optXHash)
             pass
 
         self.mergeHashToStrArray(self.optXHash,  self.optX)

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -108,14 +108,16 @@ def queryWuid(jobname,  taskId):
     state = 'N/A'
     result = 'Fail'
     if len(res):
-        results = res.split(',')
-        for result in results:
-            result = result.strip()
-            [key, val] = result.split(':')
-            if key == 'ID':
-                wuid = val
-            if key == 'state':
-                state = val
+        resultItems = res.split(',')
+        if len(resultItems) == 3:
+            result = 'OK'
+            for resultItem in resultItems:
+                resultItem = resultItem.strip()
+                [key, val] = resultItem.split(':')
+                if key == 'ID':
+                    wuid = val
+                if key == 'state':
+                    state = val
     return {'wuid':wuid, 'state':state,  'result':result}
 
 def abortWorkunit(wuid):

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -23,6 +23,7 @@ import logging
 import os
 
 from ..common.error import Error
+from ..common.shell import Shell
 
 def isPositiveIntNum(string):
     for i in range(0,  len(string)):
@@ -91,50 +92,64 @@ def getConfig():
     return gConfig
 
 def queryWuid(jobname,  taskId):
-    server = gConfig.server
-    host = "http://"+server+"/WsWorkunits/WUQuery.json?Jobname="+jobname
-    wuid="Not found"
-    auth_handler = urllib2.HTTPBasicAuthHandler()
-    auth_handler.add_password(realm='ESP (Authentication: LDAP server process)',
-                              uri=server,
-                              user=gConfig.username,
-                              passwd=gConfig.password)
-#    opener = urllib2.build_opener(auth_handler,  urllib2.HTTPHandler(debuglevel=1))
-    opener = urllib2.build_opener(auth_handler)
-    opener.add_handler(auth_handler)
-    urllib2.install_opener(opener)
-
-    result = "OK"
-    try:
-        response_stream = urllib2.urlopen(host)
-        json_response = response_stream.read()
-        resp = json.loads(json_response)
-        if resp['WUQueryResponse']['NumWUs'] > 0:
-            wuid= resp['WUQueryResponse']['Workunits']['ECLWorkunit'][0]['Wuid']
-            state =resp['WUQueryResponse']['Workunits']['ECLWorkunit'][0]['State']
-        else:
-            state = jobname+' not found'
-            result = "NotFound"
-    except KeyError as ke:
-        state = "Key error:"+ke.str()
-        result = "KeyError"
-        logging.debug("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
-    except urllib2.HTTPError as ex:
-        state = "HTTP Error: "+ str(ex.reason)
-        result = "HTTPError"
-        logging.debug("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
-    except urllib2.URLError as ex:
-        state = "URL Error: "+ str(ex.reason)
-        result = "URLError"
-        logging.debug("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
-    except Exception as ex:
-        state = "Unable to query "+ str(ex.reason)
-        result = "Exception"
-        logging.debug("%3d. %s in queryWuid(%s)",  taskId,  state,  jobname)
+    shell = Shell()
+    cmd = shell.which('ecl')
+    defaults = []
+    args = []
+    args.append('status')
+    args.append('-v')
+    args.append('-n=' + jobname)
+    args.append('--server=' + gConfig.ip)
+    args.append('--username=' + gConfig.username)
+    args.append('--password=' + gConfig.password)
+    res = shell.command(cmd, *defaults)(*args)
+    logging.debug("%3d. queryWuid(%s, cmd :'%s') result is: '%s'",  taskId,  jobname, cmd,  res)
+    wuid = "Not found"
+    state = 'N/A'
+    result = 'Fail'
+    if len(res):
+        results = res.split(',')
+        for result in results:
+            result = result.strip()
+            [key, val] = result.split(':')
+            if key == 'ID':
+                wuid = val
+            if key == 'state':
+                state = val
     return {'wuid':wuid, 'state':state,  'result':result}
 
 def abortWorkunit(wuid):
-    host = "http://"+gConfig.server+"/WsWorkunits/WUAbort?Wuids="+wuid
-    response_stream = urllib2.urlopen(host)
-    json_response = response_stream.read()
-    #print(json_response)
+    shell = Shell()
+    cmd = shell.which('ecl')
+    defaults=[]
+    args = []
+    args.append('abort')
+    args.append('-wu=' + wuid)
+    args.append('--server=' + gConfig.ip)
+    args.append('--username=' + gConfig.username)
+    args.append('--password=' + gConfig.password)
+    state=shell.command(cmd, *defaults)(*args)
+    return state
+
+import subprocess
+
+def getRealIPAddress():
+    ipAddress = '127.0.0.1'
+    try:
+        result = subprocess.Popen("ifconfig",  shell=False,  bufsize=8192,  stdout=subprocess.PIPE).stdout.read()
+        ethernetFound=False
+        results = result.split('\n')
+        for line in results:
+            if 'Ethernet' in line:
+                ethernetFound=True
+
+            if ethernetFound and 'inet addr' in line:
+                items = line.split()
+                ipAddress = items[1].split(':')[1]
+                break;
+    except  OSError:
+        pass
+    finally:
+        pass
+
+    return ipAddress


### PR DESCRIPTION
HPCC-11648 ecl-test.json server section being ignored

Reorganise ecl-test.json to store individual IP address for each cluster

Fix cluster IP handling problem.

Change queryWuid() and abortWorkunit() functions to use extended ECl tool.

Implement local IP query function.

Add Regression Test Engine IP address to OriginalTextFilesIp stored variable
for Setup. (Without this the remotely executed setupsearchindex.ecl doesn't
find the external data file)

Update README.rst

Signed-off-by: Attila Vamos attila.vamos@gmail.com
