### PR TITLE
HPCC-11692 Spurious "unregistered query" errors

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -2388,7 +2388,6 @@ void EclAgent::logException(std::exception & e)
 static unsigned __int64 crcLogicalFileTime(IDistributedFile * file, unsigned __int64 crc, const char * filename)
 {
     CDateTime dt;
-    StringBuffer dtstr;
     file->getModificationTime(dt);
     unsigned __int64 modifiedTime = dt.getSimple();
     PrintLog("getDatasetHash adding crc %"I64F"u for file %s", modifiedTime, filename);

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3688,7 +3688,6 @@ public:
     static unsigned __int64 crcLogicalFileTime(IDistributedFile * file, unsigned __int64 crc, const char * filename)
     {
         CDateTime dt;
-        StringBuffer dtstr;
         file->getModificationTime(dt);
         unsigned __int64 modifiedTime = dt.getSimple();
         return rtlHash64Data(sizeof(modifiedTime), &modifiedTime, crc);

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2094,7 +2094,7 @@ public:
 
     virtual hash64_t addHash64(hash64_t hashValue) const
     {
-        hashValue = rtlHash64Data(sizeof(fileTimeStamp), &fileTimeStamp, hashValue);
+        hashValue = fileTimeStamp.getHash(hashValue);
         if (fileCheckSum)
             hashValue = rtlHash64Data(sizeof(fileCheckSum), &fileCheckSum, hashValue);
         return hashValue;

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -901,9 +901,13 @@ public:
     static hash64_t getQueryHash(const char *id, const IQueryDll *dll, const IRoxiePackage &package, const IPropertyTree *stateInfo, IArrayOf<IResolvedFile> &files, bool isDynamic)
     {
         hash64_t hashValue = package.queryHash();
+        if (traceLevel > 8)
+            DBGLOG("getQueryHash: %s %"I64F"u from package", id, hashValue);
         if (dll)
         {
             hashValue = rtlHash64VStr(dll->queryDll()->queryName(), hashValue);
+            if (traceLevel > 8)
+                DBGLOG("getQueryHash: %s %"I64F"u from dll", id, hashValue);
             if (!allFilesDynamic && !isDynamic && !package.isCompulsory())
             {
                 IConstWorkUnit *wu = dll->queryWorkUnit();
@@ -934,6 +938,8 @@ public:
                                         if (indexFile)
                                         {
                                             hashValue = indexFile->addHash64(hashValue);
+                                            if (traceLevel > 8)
+                                                DBGLOG("getQueryHash: %s %"I64F"u from index %s", id, hashValue, indexName);
                                             files.append(*const_cast<IResolvedFile *>(indexFile));
                                         }
                                     }
@@ -946,6 +952,8 @@ public:
                                             if (dataFile)
                                             {
                                                 hashValue = dataFile->addHash64(hashValue);
+                                                if (traceLevel > 8)
+                                                    DBGLOG("getQueryHash: %s %"I64F"u from index %s", id, hashValue, fileName);
                                                 files.append(*const_cast<IResolvedFile *>(dataFile));
                                             }
                                         }
@@ -959,12 +967,18 @@ public:
         }
         if (id)
             hashValue = rtlHash64VStr(id, hashValue);
+        if (traceLevel > 8)
+            DBGLOG("getQueryHash: %s %"I64F"u from id", id, hashValue);
         if (stateInfo)
         {
             StringBuffer xml;
             toXML(stateInfo, xml);
             hashValue = rtlHash64Data(xml.length(), xml.str(), hashValue);
+            if (traceLevel > 8)
+                DBGLOG("getQueryHash: %s %"I64F"u from stateInfo", id, hashValue);
         }
+        if (traceLevel > 8)
+            DBGLOG("getQueryHash: %s %"I64F"u", id, hashValue);
         return hashValue;
     }
     

--- a/system/jlib/jtime.cpp
+++ b/system/jlib/jtime.cpp
@@ -174,6 +174,23 @@ void CDateTime::serialize(MemoryBuffer &dst) const
     dst.append(year).append(mon).append(utc_mday).append(utc_hour).append(utc_min).append(utc_sec).append(nanosec);
 }
 
+// See http://www.isthe.com/chongo/tech/comp/fnv/index.html and eclrtl.cpp
+
+#define FNV_64_PRIME I64C(0x100000001b3U)
+#define APPLY_FNV64(hval, next) { hval *= FNV_64_PRIME; hval ^= next; }
+
+hash64_t CDateTime::getHash(hash64_t hash) const
+{
+    APPLY_FNV64(hash, utc_sec);
+    APPLY_FNV64(hash, utc_min);
+    APPLY_FNV64(hash, utc_hour);
+    APPLY_FNV64(hash, utc_mday);
+    APPLY_FNV64(hash, utc_mon);
+    APPLY_FNV64(hash, utc_year);
+    APPLY_FNV64(hash, nanosec);
+    return hash;
+}
+
 void CDateTime::clear()
 {
     utc_sec = 0;

--- a/system/jlib/jtime.hpp
+++ b/system/jlib/jtime.hpp
@@ -71,6 +71,7 @@ public:
 
     void deserialize(MemoryBuffer & src);
     void serialize(MemoryBuffer & dst) const;
+    hash64_t getHash(hash64_t init) const;
 
     CDateTime & operator=(CDateTime const & other) { set(other); return *this; }
     void clear();


### PR DESCRIPTION
The queryHash is now derived from (among other things) the timestamps of the
files used by the query. Unfortunately the calculation of the hash included
the uninitialized filler byte in the CDateTiem structure.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
