### PR TITLE
HPCC-11635 389DirectoryServer LDAP cannot create HPCC OUs

### DIFF
--- a/initfiles/componentfiles/configxml/ldapserver.xsd
+++ b/initfiles/componentfiles/configxml/ldapserver.xsd
@@ -247,6 +247,7 @@
                         <xs:restriction base="xs:string">
                             <xs:enumeration value="ActiveDirectory"/>
                             <xs:enumeration value="OpenLDAP"/>
+                            <xs:enumeration value="389DirectoryServer"/>
                             <xs:enumeration value="Fedora389"/>
 			    <xs:enumeration value="iPlanet"/>
                         </xs:restriction>

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -154,6 +154,7 @@ class CLdapConfig : public CInterface, implements ILdapConfig
 {
 private:
     LdapServerType       m_serverType; 
+    StringAttr           m_cfgServerType;//LDAP Server type name (ActiveDirectory, Fedora389, etc)
 
     Owned<IPropertyTree> m_cfg;
 
@@ -196,19 +197,21 @@ public:
 
         //Check for LDAP Server type in config
         m_serverType = LDAPSERVER_UNKNOWN;
-        const char* serverType = cfg->queryProp(".//@serverType");
-        if (serverType && *serverType)
+        m_cfgServerType.set(cfg->queryProp(".//@serverType"));
+        if (m_cfgServerType.length())
         {
-            if (0 == stricmp(serverType, "ActiveDirectory"))
+            if (0 == stricmp(m_cfgServerType, "ActiveDirectory"))
                 m_serverType = ACTIVE_DIRECTORY;
-            else if (0 == stricmp(serverType, "OpenLDAP"))
+            else if (0 == stricmp(m_cfgServerType, "389DirectoryServer"))//uses iPlanet style ACI
                 m_serverType = OPEN_LDAP;
-            else if (0 == stricmp(serverType, "Fedora389"))
+            else if (0 == stricmp(m_cfgServerType, "OpenLDAP"))
                 m_serverType = OPEN_LDAP;
-            else if (0 == stricmp(serverType, "iPlanet"))
+            else if (0 == stricmp(m_cfgServerType, "Fedora389"))
+                m_serverType = OPEN_LDAP;
+            else if (0 == stricmp(m_cfgServerType, "iPlanet"))
                 m_serverType = IPLANET;
             else
-                throw MakeStringException(-1, "Unknown LDAP serverType '%s' specified",serverType);
+                throw MakeStringException(-1, "Unknown LDAP serverType '%s' specified",m_cfgServerType.get());
         }
         else
         {
@@ -395,6 +398,11 @@ public:
     virtual LdapServerType getServerType()
     {
         return m_serverType;
+    }
+
+    virtual const char * getCfgServerType() const
+    {
+        return m_cfgServerType.get();
     }
 
     virtual const char* getSdFieldName()

--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -79,6 +79,7 @@ interface ILdapConnectionPool : extends IInterface
 interface ILdapConfig : extends IInterface
 {
     virtual LdapServerType getServerType() = 0;
+    virtual const char * getCfgServerType() const = 0;
     virtual StringBuffer& getLdapHost(StringBuffer& hostbuf) = 0;
     virtual void markDown(const char* ldaphost) = 0;
     virtual int getLdapPort() = 0;

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -520,7 +520,12 @@ void CLdapSecManager::init(const char *serviceName, IPropertyTree* cfg)
     else if(ldap_client->getServerType() == IPLANET)
         pp = new CIPlanetAciProcessor(cfg);
     else if(ldap_client->getServerType() == OPEN_LDAP)
-        pp = new COpenLdapAciProcessor(cfg);
+    {
+        if (0 == stricmp(ldap_client->getLdapConfig()->getCfgServerType(), "389DirectoryServer"))//uses iPlanet style ACI
+            pp = new CIPlanetAciProcessor(cfg);
+        else
+            pp = new COpenLdapAciProcessor(cfg);
+    }
     else
         throwUnexpected();
 


### PR DESCRIPTION
Dali/ESP treat 389 Directory Server as an Open LDAP implementation, which
is the case except that OUs need to be added using the ACI syntax of iPlanet.
This fix adds a new "389DirectoryServer" option to the configuration, and
when selected, the permissions processor will use these iPlant style ACI
strings.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
