### PR TITLE
H11570 Fix incorrect '@' display when WsDFU deleting superfile

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -133,6 +133,14 @@ ESPStruct DFUSpaceItem
     string SmallestSize;
 };
 
+ESPStruct DFUActionInfo
+{
+    string FileName;
+    string NodeGroup;
+    string ActionResult;
+    bool   Failed;
+};
+
 ESPrequest [nil_remove] DFUQueryRequest
 {
     string Prefix;
@@ -236,7 +244,8 @@ DFUArrayActionResponse
 {
     [min_ver("1.04")] string BackToPage;
     [min_ver("1.18")] string RedirectTo;
-    string DFUArrayActionResult;
+    string DFUArrayActionResult; //used by legacy eclwatch
+    [min_ver("1.27")] ESParray<ESPstruct DFUActionInfo> ActionResults;
 };
 
 ESPrequest 
@@ -641,7 +650,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.26"), default_client_version("1.26"),
+    version("1.27"), default_client_version("1.27"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1134,8 +1134,28 @@ bool CWsDfuEx::onAddtoSuperfile(IEspContext &context, IEspAddtoSuperfileRequest 
     return true;
 }
 
+void CWsDfuEx::setDeleteFileResults(const char* fileName, const char* nodeGroup, bool failed, const char* actionResult, StringBuffer& resultString,
+    IArrayOf<IEspDFUActionInfo>& actionResults)
+{
+    if (!fileName || !*fileName)
+        return;
+    Owned<IEspDFUActionInfo> resultObj = createDFUActionInfo("", "");
+    resultObj->setFileName(fileName);
+    resultObj->setFailed(failed);
+    if (nodeGroup && *nodeGroup)
+        resultObj->setNodeGroup(nodeGroup);
+    if (actionResult && *actionResult)
+    {
+        resultObj->setActionResult(actionResult);
+        resultString.appendf("<Message><Value>%s</Value></Message>", actionResult);
+    }
+    actionResults.append(*resultObj.getClear());
+    return;
+}
+
 bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &req, IEspDFUArrayActionResponse &resp)
 {
+    double version = context.getClientVersion();
     StringBuffer username;
     context.getUserID(username);
 
@@ -1149,17 +1169,29 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
     StringBuffer returnStr;
 
     StringArray superFileNames, filesCannotBeDeleted;
+    IArrayOf<IEspDFUActionInfo> actionResults;
     for(int j = 0; j < 2; j++) //j=0: delete superfiles first
     {
         for(unsigned i = 0; i < req.getLogicalFiles().length(); i++)
         {
-            const char* filename = req.getLogicalFiles().item(i);
-            if(!filename || !*filename)
+            const char* fileNameAndNodeGroup = req.getLogicalFiles().item(i);
+            if(!fileNameAndNodeGroup || !*fileNameAndNodeGroup)
                 continue;
 
+            const char* fileName = NULL;
+            const char* nodeGroup = NULL;
+            StringArray fileNameOrNodeGroup;
+            fileNameOrNodeGroup.appendListUniq(fileNameAndNodeGroup, "@");
+            fileName = fileNameOrNodeGroup.item(0);
+            if (fileNameOrNodeGroup.length() > 1)
+            {
+                nodeGroup = fileNameOrNodeGroup.item(1);
+                if (!*nodeGroup || strieq(nodeGroup, "null")) //null is used by new ECLWatch for a superfile
+                    nodeGroup = NULL;
+            }
             if (j>0)
             { // 2nd pass, now we want to skip superfiles and the files which cannot do the lookup.
-                if (superFileNames.contains(filename) || filesCannotBeDeleted.contains(filename))
+                if (superFileNames.contains(fileNameAndNodeGroup) || filesCannotBeDeleted.contains(fileNameAndNodeGroup))
                     continue;
             }
 
@@ -1167,11 +1199,17 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
             {
                 IDistributedFileDirectory &fdir = queryDistributedFileDirectory();
                 {
-                    Owned<IDistributedFile> df = fdir.lookup(filename, userdesc, true);
+                    Owned<IDistributedFile> df = fdir.lookup(fileNameAndNodeGroup, userdesc, true);
                     if(!df)
                     {
-                        returnStr.appendf("<Message><Value>Cannot delete %s: file not found</Value></Message>", filename);
-                        filesCannotBeDeleted.append(filename);
+                        StringBuffer message;
+                        if (!nodeGroup || !*nodeGroup)
+                            message.appendf("Cannot delete %s: file not found", fileName);
+                        else
+                            message.appendf("Cannot delete %s on %s: file not found", fileName, nodeGroup);
+                        setDeleteFileResults(fileName, nodeGroup, true, message, returnStr, actionResults);
+                        PROGLOG("Deleted Logical File: %s by: %s\n",fileNameAndNodeGroup, username.str());
+                        filesCannotBeDeleted.append(fileNameAndNodeGroup);
                         continue;
                     }
                     if (0==j) // skip non-super files on 1st pass
@@ -1179,33 +1217,49 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                         if(!df->querySuperFile())
                             continue;
 
-                        superFileNames.append(filename);
+                        superFileNames.append(fileNameAndNodeGroup);
                     }
                 }
-                fdir.removeEntry(filename, userdesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT, true);
-                PROGLOG("Deleted Logical File: %s by: %s\n",filename, username.str());
-                returnStr.appendf("<Message><Value>Deleted File %s</Value></Message>", filename);
+                fdir.removeEntry(fileNameAndNodeGroup, userdesc, NULL, REMOVE_FILE_SDS_CONNECT_TIMEOUT, true);
+                StringBuffer message;
+                if (!nodeGroup || !*nodeGroup)
+                    message.appendf("File %s deleted", fileName);
+                else
+                    message.appendf("File %s deleted on %s", fileName, nodeGroup);
+                setDeleteFileResults(fileName, nodeGroup, false, message, returnStr, actionResults);
             }
             catch(IException* e)
             {
-                filesCannotBeDeleted.append(filename);
+                filesCannotBeDeleted.append(fileNameAndNodeGroup);
 
                 StringBuffer emsg;
                 e->errorMessage(emsg);
                 if((e->errorCode() == DFSERR_CreateAccessDenied) && (req.getType() != NULL))
                     emsg.replaceString("Create ", "Delete ");
 
-                returnStr.appendf("<Message><Value>Cannot delete %s: %s</Value></Message>", filename, emsg.str());
+                StringBuffer message;
+                if (!nodeGroup || !*nodeGroup)
+                    message.appendf("Cannot delete %s: %s", fileName, emsg.str());
+                else
+                    message.appendf("Cannot delete %s on %s: %s", fileName, nodeGroup, emsg.str());
+                setDeleteFileResults(fileName, nodeGroup, true, message, returnStr, actionResults);
                 e->Release();
             }
             catch(...)
             {
-                returnStr.appendf("<Message><Value>Cannot delete %s: unknown exception.</Value></Message>", filename);
+                StringBuffer message;
+                if (!nodeGroup || !*nodeGroup)
+                    message.appendf("Cannot delete %s: unknown exception.", fileName);
+                else
+                    message.appendf("Cannot delete %s on %s: unknown exception.", fileName, nodeGroup);
+                setDeleteFileResults(fileName, nodeGroup, true, message, returnStr, actionResults);
             }
         }
     }
 
-    resp.setDFUArrayActionResult(returnStr.str());
+    if (version >= 1.27)
+        resp.setActionResults(actionResults);
+    resp.setDFUArrayActionResult(returnStr.str());//Used by legacy
     return true;
 }
 

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -134,6 +134,8 @@ private:
         const char* beforeSubFile, bool existingSuperfile, bool autocreatesuper, bool deleteFile, bool removeSuperfile =  true);
     void getFilePartsOnClusters(IEspContext &context, const char* clusterReq, StringArray& clusters, IDistributedFile* df, IEspDFUFileDetail& FileDetails,
         offset_t& mn, offset_t& mx, offset_t& sum, offset_t& count);
+    void setDeleteFileResults(const char* fileName, const char* nodeGroup, bool failed, const char* message, StringBuffer& resultString,
+        IArrayOf<IEspDFUActionInfo>& actionResults);
 private:
     bool         m_disableUppercaseTranslation;
     StringBuffer m_clusterName;


### PR DESCRIPTION
When a superfile is deleted, ESP should not return '@null' or '@' as
a part of the file name inside WsDFU/DFUArrayAction Response.

For new ECLWatch to identify which files are failed to be deleted and
which files are deleted, two result arrays (SuccessActions and
FailedActions) are added into the WsDFU/DFUArrayAction Response. (for
HPCC-11677).

Signed-off-by: wangkx kevin.wang@lexisnexis.com
