### PR TITLE
HPCC-11622 Add QueryID/Name as WsWorkunits/WUListQueries filters

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1259,6 +1259,8 @@ ESPrequest [nil_remove] WUListQueriesRequest
     [min_ver("1.48")] bool Activated;
     [min_ver("1.48")] bool SuspendedByUser;
     [min_ver("1.50")] string WUID;
+    [min_ver("1.51")] string QueryID;
+    [min_ver("1.51")] string QueryName;
 
     nonNegativeInteger PageSize(0);
     nonNegativeInteger PageStartFrom(0);
@@ -1555,7 +1557,7 @@ ESPresponse [exceptions_inline] WUCheckFeaturesResponse
 };
 
 ESPservice [
-    version("1.50"), default_client_version("1.50"),
+    version("1.51"), default_client_version("1.51"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1233,6 +1233,8 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
     MemoryBuffer filterBuf;
     const char* clusterReq = req.getClusterName();
     addWUQSQueryFilter(filters, filterCount, filterBuf, req.getQuerySetName(), WUQSFQuerySet);
+    addWUQSQueryFilter(filters, filterCount, filterBuf, req.getQueryID(), (WUQuerySortField) (WUQSFId | WUQSFwild));
+    addWUQSQueryFilter(filters, filterCount, filterBuf, req.getQueryName(), (WUQuerySortField) (WUQSFname | WUQSFwild));
     addWUQSQueryFilter(filters, filterCount, filterBuf, req.getWUID(), WUQSFwuid);
     if (!req.getMemoryLimitLow_isNull())
         addWUQSQueryFilterInt64(filters, filterCount, filterBuf, req.getMemoryLimitLow(), (WUQuerySortField) (WUQSFmemoryLimit | WUQSFnumeric));


### PR DESCRIPTION
Add wildcards search for QueryID and QueryName to the WUListQueries.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
