### PR TITLE
HPCC-11717 LDAP login for system Admin fails on non-ActiveDirectory

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1076,6 +1076,8 @@ public:
                 {
                     user.setFullName(m_ldapconfig->getSysUserCommonName());
                     user.setAuthenticateStatus(AS_AUTHENTICATED);
+                    if (m_ldapconfig->getServerType() != ACTIVE_DIRECTORY)
+                        return true;
                     sysUser = true;
                 }
                 else


### PR DESCRIPTION
Do not try to query DN and other unnecessary LDAP information about an
authenticated non-ActiveDirectory LDAP system admin. Continue querying
this information if it is an HPCC system admin and if its an HPCC user
account (ou=users,ou=ecl).

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
