### PR TITLE
HPCC-11668 ECLWatch needs to support configurable password expiry num da...

### DIFF
--- a/esp/scm/ws_account.ecm
+++ b/esp/scm/ws_account.ecm
@@ -38,6 +38,7 @@ ESPresponse [exceptions_inline] MyAccountResponse
     string lastName;
     string passwordExpiration;
     int    passwordDaysRemaining;
+    [min_ver("1.01")] int passwordExpirationWarningDays;
 };
 
 
@@ -66,7 +67,7 @@ ESPresponse [exceptions_inline] VerifyUserResponse
 	int retcode;
 };
 
-ESPservice [exceptions_inline("./smc_xslt/exceptions.xslt")] ws_account
+ESPservice [version("1.01"), default_client_version("1.01"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_account
 {
     ESPmethod [client_xslt("/esp/xslt/account_myaccount.xslt")] MyAccount(MyAccountRequest, MyAccountResponse);
     ESPmethod [client_xslt("/esp/xslt/account_input.xslt")] UpdateUserInput(UpdateUserInputRequest, UpdateUserInputResponse);

--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -168,6 +168,10 @@ bool Cws_accountEx::onMyAccount(IEspContext &context, IEspMyAccountRequest &req,
             resp.setFirstName(user->getFirstName());
             resp.setLastName(user->getLastName());
             resp.setUsername(user->getName());
+
+            double version = context.getClientVersion();
+            if (version >= 1.01)
+                resp.setPasswordExpirationWarningDays(context.querySecManager()->getPasswordExpirationWarningDays());
         }
     }
     catch(IException* e)


### PR DESCRIPTION
...ys

This update adds the system configuration ESP "passwordExpirationWarningDays"
to the ESP MyAccountResponse. The client can use this value to determine
whether or not to display the "Your Password will expire in xx days.."
prompt

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
