### PR TITLE
HPCC-11656 Weird behaviour in search box

### DIFF
--- a/esp/src/eclwatch/templates/HPCCPlatformWidget.html
+++ b/esp/src/eclwatch/templates/HPCCPlatformWidget.html
@@ -5,7 +5,7 @@
             <div class="right">
                 <div class="seperator grey"></div>
                 <form id="search-form" onsubmit="return false;">
-                    <input id="${id}FindText" class="roundForm" data-dojo-props="placeHolder: '${i18n.PlaceholderFindText}'" data-dojo-type="dijit.form.TextBox" />
+                    <input id="${id}FindText" class="roundForm" data-dojo-props="placeHolder: '${i18n.PlaceholderFindText}', trim: true" data-dojo-type="dijit.form.TextBox" />
                     <button id="${id}Find" type="submit" data-dojo-props="iconClass:'iconFind', showLabel: false" data-dojo-attach-event="onClick:_onFind" data-dojo-type="dijit.form.Button">${i18n.Find}</button>
                 </form>
                 <div class="seperator grey"></div>


### PR DESCRIPTION
Search text is now trimmed by the entry field.
Delay Load Widget would fail if called twice in "quick" succession for the same
item.

Fixes HPCC-11656

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
