### PR TITLE
HPCC-11698 WARNING: Remote file connect Too many open files

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -574,6 +574,16 @@ class CRoxieFileCache : public CInterface, implements ICopyFileProgress, impleme
 
     RoxieFileStatus fileUpToDate(IFile *f, offset_t size, const CDateTime &modified, unsigned crc, bool isCompressed)
     {
+        // Ensure that SockFile does not keep these sockets open (or we will run out)
+        class AutoDisconnector
+        {
+        public:
+            AutoDisconnector(IFile *_f) : f(_f) {}
+            ~AutoDisconnector() { disconnectRemoteFile(f); }
+        private:
+            IFile *f;
+        } autoDisconnector(f);
+
         cacheFileConnect(f, dafilesrvLookupTimeout);  // set timeout to 10 seconds
         if (f->exists())
         {


### PR DESCRIPTION
Roxie was leaving sockets open for remote files that it has checked the
existance of but not actually opened. These were not covered by the code that
limits the number of remote files in use (since Roxie did not consider them to
be in use...)

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
