### PR TITLE
HPCC-11753 Backmerge of control:queries speedup broke formatting

### DIFF
--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -625,7 +625,7 @@ public:
         afor.For(activeChildren.ordinality()+(isMaster ? 0 : 1), 10);
         activeChildren.kill();
         if (mergedReply)
-            toXML(mergedReply, reply);
+            toXML(mergedReply, reply, 0, (mergeType == CascadeMergeQueries) ? XML_Embed|XML_LineBreak|XML_SortTags : XML_Format);
         if (logctx.queryTraceLevel() > 5)
             logctx.CTXLOG("doControlQuery (%d) finished: %.80s", isMaster, queryText);
     }


### PR DESCRIPTION
Make sure we don't use multiple lines in control:queries return.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
