### PR TITLE
HPCC-11773 Regression test engine crash when ECL throws connection

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -1,4 +1,4 @@
-Overview of Regression Suite usage (v:0.0.26)
+Overview of Regression Suite usage (v:0.0.27)
 ==============================================
 
 To use Regression Suite change directory to HPCC-Platform/testing/regress subdirectory.

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -31,7 +31,7 @@ from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam, getVersionNumbers, checkXParam, convertPath, getRealIPAddress
 from hpcc.common.error import Error
 
-prog_version = "0.0.26"
+prog_version = "0.0.27"
 
 # For coverage
 if ('coverage' in os.environ) and (os.environ['coverage'] == '1'):

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -415,17 +415,25 @@ class Regression:
         wuid = None
         if ECLCC().makeArchive(query):
             eclCmd = ECLcmd()
+            try:
+                if publish:
+                    res = eclCmd.runCmd("publish", cluster, query, report[0],
+                                      server=self.config.ip,
+                                      username=self.config.username,
+                                      password=self.config.password)
+                else:
+                    res = eclCmd.runCmd("run", cluster, query, report[0],
+                                      server=self.config.ip,
+                                      username=self.config.username,
+                                      password=self.config.password)
+            except Error as e:
+                res = False
+                wuid = 'Not found'
+                query.setWuid(wuid)
+                query.diff = query.getBaseEcl()+"\n\t"+str(e)
+                report[0].addResult(query)
+                pass
 
-            if publish:
-                res = eclCmd.runCmd("publish", cluster, query, report[0],
-                                  server=self.config.ip,
-                                  username=self.config.username,
-                                  password=self.config.password)
-            else:
-                res = eclCmd.runCmd("run", cluster, query, report[0],
-                                  server=self.config.ip,
-                                  username=self.config.username,
-                                  password=self.config.password)
             wuid = query.getWuid()
             logging.debug("CMD result: '%s', wuid:'%s'"  % ( res,  wuid),  extra={'taskId':cnt})
             if wuid == 'Not found':

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -166,6 +166,9 @@ class ECLFile:
 
     def getWuid(self):
         return self.wuid
+        
+    def setWuid(self,  wuid):
+        self.wuid = wuid
 
     def addResults(self, results, wuid):
         filename = self.getResults()


### PR DESCRIPTION
Implement connection error handling.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
