### PR TITLE
HPCC-11782 Regression test engine ignores server address when publishing queries.

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -1,4 +1,4 @@
-Overview of Regression Suite usage (v:0.0.27)
+Overview of Regression Suite usage (v:0.0.28)
 ==============================================
 
 To use Regression Suite change directory to HPCC-Platform/testing/regress subdirectory.

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -31,7 +31,7 @@ from hpcc.util.ecl.file import ECLFile
 from hpcc.util.util import checkPqParam, getVersionNumbers, checkXParam, convertPath, getRealIPAddress
 from hpcc.common.error import Error
 
-prog_version = "0.0.27"
+prog_version = "0.0.28"
 
 # For coverage
 if ('coverage' in os.environ) and (os.environ['coverage'] == '1'):

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -40,6 +40,10 @@ class ECLcmd(Shell):
         args.append('--target=' + cluster)
         args.append('--cluster=' + cluster)
 
+        server = kwargs.pop('server', False)
+        if server:
+            args.append('--server=' + server)
+
         username = kwargs.pop('username', False)
         if username:
                 args.append("--username=" + username)
@@ -62,9 +66,6 @@ class ECLcmd(Shell):
         else:
             args.append('--exception-level=warning')
             args.append('--noroot')
-            server = kwargs.pop('server', False)
-            if server:
-                args.append('--server=' + server)
 
             name = kwargs.pop('name', False)
             if not name:

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -166,7 +166,7 @@ class ECLFile:
 
     def getWuid(self):
         return self.wuid
-        
+
     def setWuid(self,  wuid):
         self.wuid = wuid
 


### PR DESCRIPTION
Add fix for command execution

Fix whitespace error in file.py

Update version numbers.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
