### PR TITLE
HPCC-11778 EclWatch should use NodeGroup instead of ClusterName

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -631,7 +631,9 @@ define([
                         title: params.Name,
                         closable: true,
                         delayWidget: "SFDetailsWidget",
-                        _hpccParams: params
+                        _hpccParams: {
+                            Name: params.Name
+                        }
                     });
                 } else {
                     retVal = new DelayLoadWidget({

--- a/esp/src/eclwatch/ESPLogicalFile.js
+++ b/esp/src/eclwatch/ESPLogicalFile.js
@@ -41,6 +41,7 @@ define([
             var idParts = id.split("--");
             _logicalFiles[id] = new LogicalFile({
                 Cluster: idParts[0] ? idParts[0] : "",
+                NodeGroup: idParts[0] ? idParts[0] : "",
                 Name: idParts[1]
             });
         }

--- a/esp/src/eclwatch/ESPResult.js
+++ b/esp/src/eclwatch/ESPResult.js
@@ -87,10 +87,10 @@ define([
                     sequence: this.Sequence,
                     isComplete: this.isComplete()
                 });
-            } else if (lang.exists("Name", this) && lang.exists("ClusterName", this)) {
+            } else if (lang.exists("Name", this) && lang.exists("NodeGroup", this)) {
                 this.store = new Store({
                     wuid: this.Wuid,
-                    cluster: this.ClusterName,
+                    cluster: this.NodeGroup,
                     name: this.Name,
                     isComplete: true
                 });
@@ -355,9 +355,9 @@ define([
                 if (this.Wuid && lang.exists("Sequence", this)) {
                     request['Wuid'] = this.Wuid;
                     request['Sequence'] = this.Sequence;
-                } else if (this.Name && this.ClusterName) {
+                } else if (this.Name && this.NodeGroup) {
                     request['LogicalName'] = this.Name;
-                    request['Cluster'] = this.ClusterName;
+                    request['Cluster'] = this.NodeGroup;
                 } else if (this.Name) {
                     request['LogicalName'] = this.Name;
                 }

--- a/esp/src/eclwatch/LFDetailsWidget.js
+++ b/esp/src/eclwatch/LFDetailsWidget.js
@@ -197,7 +197,7 @@ define([
                 if (currSel.id == this.summaryWidget.id) {
                 } else if (currSel.id == this.contentWidget.id) {
                     this.contentWidget.init({
-                        ClusterName: this.logicalFile.NodeGroup,
+                        NodeGroup: this.logicalFile.NodeGroup,
                         LogicalName: this.logicalFile.Name
                     });
                 } else if (currSel.id == this.sourceWidget.id) {

--- a/esp/src/eclwatch/ResultWidget.js
+++ b/esp/src/eclwatch/ResultWidget.js
@@ -137,7 +137,7 @@ define([
                     }
                 });
             } else if (params.LogicalName) {
-                var logicalFile = ESPLogicalFile.Get(params.ClusterName, params.LogicalName);
+                var logicalFile = ESPLogicalFile.Get(params.NodeGroup, params.LogicalName);
                 var context = this;
                 logicalFile.getInfo({
                     onAfterSend: function (response) {
@@ -145,7 +145,7 @@ define([
                     }
                 });
             } else if (params.result && params.result.Name) {
-                var logicalFile = ESPLogicalFile.Get(params.result.ClusterName, params.result.Name);
+                var logicalFile = ESPLogicalFile.Get(params.result.NodeGroup, params.result.Name);
                 var context = this;
                 logicalFile.getInfo({
                     onAfterSend: function (response) {

--- a/esp/src/eclwatch/SFDetailsWidget.js
+++ b/esp/src/eclwatch/SFDetailsWidget.js
@@ -33,6 +33,7 @@ define([
     "dijit/layout/TabContainer",
     "dijit/layout/ContentPane",
     "dijit/Toolbar",
+    "dijit/ToolbarSeparator",
     "dijit/TooltipDialog",
     "dijit/form/Form",
     "dijit/form/SimpleTextarea",
@@ -52,7 +53,7 @@ define([
 
     "dijit/TooltipDialog"
 ], function (exports, declare, lang, i18n, nlsHPCC, arrayUtil, dom, domAttr, domClass, domForm, query, Memory, Observable, all,
-                BorderContainer, TabContainer, ContentPane, Toolbar, TooltipDialog, Form, SimpleTextarea, TextBox, Button, DropDownButton, TitlePane, registry,
+                BorderContainer, TabContainer, ContentPane, Toolbar, ToolbarSeparator, TooltipDialog, Form, SimpleTextarea, TextBox, Button, DropDownButton, TitlePane, registry,
                 selector,
                 _TabContainerWidget,
                 ESPUtil, ESPLogicalFile,
@@ -131,7 +132,7 @@ define([
 
             var context = this;
             if (params.Name) {
-                this.logicalFile = ESPLogicalFile.Get(params.ClusterName, params.Name);
+                this.logicalFile = ESPLogicalFile.Get("", params.Name);
                 var data = this.logicalFile.getData();
                 for (var key in data) {
                     this.updateInput(key, null, data[key]);
@@ -196,7 +197,6 @@ define([
                     Name: { label: this.i18n.LogicalName },
                     Owner: { label: this.i18n.Owner, width: 72 },
                     Description: { label: this.i18n.Description, width: 153 },
-                    ClusterName: { label: this.i18n.Cluster, width: 108 },
                     RecordCount: { label: this.i18n.Records, width: 72, sortable: false },
                     Totalsize: { label: this.i18n.Size, width: 72, sortable: false },
                     Parts: { label: this.i18n.Parts, width: 45, sortable: false },

--- a/esp/src/eclwatch/SearchResultsWidget.js
+++ b/esp/src/eclwatch/SearchResultsWidget.js
@@ -46,6 +46,7 @@ define([
 
         gridTitle: nlsHPCC.title_SearchResults,
         idProperty: "id",
+        _rowID: 0,
 
         doSearch: function (searchText) {
             lang.mixin(this.params, {
@@ -134,32 +135,32 @@ define([
                         }
                     });
                     break;
+                case "SuperFile":
+                    return new DelayLoadWidget({
+                        id: id,
+                        title: row.Summary,
+                        closable: true,
+                        delayWidget: "SFDetailsWidget",
+                        hpcc: {
+                            params: {
+                                Name: row._name
+                            }
+                        }
+                    });
+                    break;
                 case "LogicalFile":
-                    if (row.isSuperfile) {
-                        return new DelayLoadWidget({
-                            id: id,
-                            title: row.Summary,
-                            closable: true,
-                            delayWidget: "SFDetailsWidget",
-                            hpcc: {
-                                params: {
-                                    Name: row._name
-                                }
+                    return new DelayLoadWidget({
+                        id: id,
+                        title: row.Summary,
+                        closable: true,
+                        delayWidget: "LFDetailsWidget",
+                        hpcc: {
+                            params: {
+                                NodeGroup: row._nodeGroup,
+                                Name: row._name
                             }
-                        });
-                    } else {
-                        return new DelayLoadWidget({
-                            id: id,
-                            title: row.Summary,
-                            closable: true,
-                            delayWidget: "LFDetailsWidget",
-                            hpcc: {
-                                params: {
-                                    Name: row._name
-                                }
-                            }
-                        });
-                    }
+                        }
+                    });
                     break;
                 default:
                     break;
@@ -174,7 +175,7 @@ define([
                 var context = this;
                 arrayUtil.forEach(workunits, function (item, idx) {
                     context.store.add({
-                        id: "WsWorkunitsWUQuery" + idPrefix + idx,
+                        id: "WsWorkunitsWUQuery" + idPrefix + ++context._rowID,
                         Type: "ECL Workunit",
                         Reason: prefix,
                         Summary: item.Wuid,
@@ -194,7 +195,7 @@ define([
                 var context = this;
                 arrayUtil.forEach(workunits, function (item, idx) {
                     context.store.add({
-                        id: "FileSprayGetDFUWorkunits" + idPrefix + idx,
+                        id: "FileSprayGetDFUWorkunits" + idPrefix + ++context._rowID,
                         Type: "DFU Workunit",
                         Reason: prefix,
                         Summary: item.ID,
@@ -230,14 +231,26 @@ define([
                 var idPrefix = prefix.split(" ").join("_");
                 var context = this;
                 arrayUtil.forEach(items, function (item, idx) {
-                    context.store.add({
-                        id: "WsDfuDFUQuery" + idPrefix + idx,
-                        Type: "Logical File",
-                        Reason: prefix,
-                        Summary: item.Name,
-                        _type: "LogicalFile",
-                        _name: item.Name
-                    });
+                    if (item.isSuperfile) {
+                        context.store.add({
+                            id: "WsDfuDFUQuery" + idPrefix + ++context._rowID,
+                            Type: "Super File",
+                            Reason: prefix,
+                            Summary: item.Name,
+                            _type: "SuperFile",
+                            _name: item.Name
+                        });
+                    } else {
+                        context.store.add({
+                            id: "WsDfuDFUQuery" + idPrefix + ++context._rowID,
+                            Type: "Logical File",
+                            Reason: prefix,
+                            Summary: item.Name + " (" + item.NodeGroup + ")",
+                            _type: "LogicalFile",
+                            _nodeGroup: item.NodeGroup,
+                            _name: item.Name
+                        });
+                    }
                 });
                 return items.length;
             }

--- a/esp/src/eclwatch/SourceFilesWidget.js
+++ b/esp/src/eclwatch/SourceFilesWidget.js
@@ -97,7 +97,9 @@ define([
                     delayWidget: "SFDetailsWidget",
                     hpcc: {
                         type: "SFDetailsWidget",
-                        params: row
+                        params: {
+                            Name: row.Name
+                        }
                     }
                 });
             } else {
@@ -109,6 +111,7 @@ define([
                     hpcc: {
                         type: "LFDetailsWidget",
                         params: {
+                            NodeGroup: row.FileCluster,
                             Name: row.Name
                         }
                     }

--- a/esp/src/eclwatch/templates/DFUQueryWidget.html
+++ b/esp/src/eclwatch/templates/DFUQueryWidget.html
@@ -152,7 +152,7 @@
                         <input id="${id}Name" title="${i18n.Name}:" name="LogicalName" colspan="2" style="width:100%;" data-dojo-props="trim: true, placeHolder:'${i18n.somefile}'" data-dojo-type="dijit.form.TextBox" />
                         <input id="${id}Description" title="${i18n.Description}:" name="Description" colspan="2" style="width:100%;" data-dojo-props="trim: true, placeHolder:'${i18n.SomeDescription}'" data-dojo-type="dijit.form.TextBox" />
                         <input id="${id}Owner" title="${i18n.Owner}:" name="Owner" colspan="2" data-dojo-props="trim: true, placeHolder:'${i18n.JSmith}'" data-dojo-type="dijit.form.TextBox" />
-                        <input id="${id}ClusterTargetSelect" title="${i18n.Cluster}:" name="ClusterName" colspan="2" style="display: inline-block; vertical-align: middle" data-dojo-type="TargetSelectWidget" />
+                        <input id="${id}ClusterTargetSelect" title="${i18n.Cluster}:" name="NodeGroup" colspan="2" style="display: inline-block; vertical-align: middle" data-dojo-type="TargetSelectWidget" />
                         <input id="${id}FromSize" title="${i18n.FromSizes}:" name="FileSizeFrom" colspan="2" data-dojo-props="trim: true, placeHolder:'4096'" data-dojo-type="dijit.form.TextBox" />
                         <input id="${id}ToSize" title="${i18n.ToSizes}:" name="FileSizeTo" colspan="2" data-dojo-props="trim: true, placeHolder:'16777216'" data-dojo-type="dijit.form.TextBox" />
                         <select id="${id}FileType" title="${i18n.FileType}:" name="FileType" colspan="2" data-dojo-type="dijit.form.Select">

--- a/esp/src/eclwatch/templates/LFDetailsWidget.html
+++ b/esp/src/eclwatch/templates/LFDetailsWidget.html
@@ -78,7 +78,7 @@
                                 <div id="${id}Owner"></div>
                             </li>
                             <li>
-                                <label for="${id}ClusterName">${i18n.ClusterName}: </label>
+                                <label for="${id}NodeGroup">${i18n.ClusterName}: </label>
                                 <div id="${id}NodeGroup"></div>
                             </li>
                             <li>

--- a/esp/src/eclwatch/templates/SFDetailsWidget.html
+++ b/esp/src/eclwatch/templates/SFDetailsWidget.html
@@ -7,6 +7,8 @@
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     <div id="${id}Save" data-dojo-attach-event="onClick:_onSave" data-dojo-type="dijit.form.Button">${i18n.Save}</div>
                     <div id="${id}Delete" data-dojo-attach-event="onClick:_onDelete" data-dojo-type="dijit.form.Button">${i18n.Delete}</div>
+                    <span data-dojo-type="dijit.ToolbarSeparator"></span>
+                    <div id="${id}NewPage" class="right" data-dojo-attach-event="onClick:_onNewPage" data-dojo-props="iconClass:'iconNewPage', showLabel:false" data-dojo-type="dijit.form.Button">${i18n.OpenInNewPage}</div>
                 </div>
                 <div data-dojo-props="region: 'center'" data-dojo-type="dijit.layout.ContentPane">
                     <h2>


### PR DESCRIPTION
For WsDFU related calls, switch to NodeGroup from ClusterName.
Search Results would not open Super Files correctly
SuperFile contents list should not show Cluster
Add "Open in new window" to SuperFile details

Fixes HPCC-11778

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
