### PR TITLE
HPCC-11795 Paging request was using wrong field for WUListQueries

### DIFF
--- a/esp/src/eclwatch/ESPQuery.js
+++ b/esp/src/eclwatch/ESPQuery.js
@@ -44,7 +44,7 @@ define([
         responseTotalQualifier: "WUListQueriesResponse.NumberOfQueries",
         idProperty: "__hpcc_id",
         startProperty: "PageStartFrom",
-        countProperty: "NumberOfQueries",
+        countProperty: "PageSize",
 
         _watched: [],
 


### PR DESCRIPTION
Fixes HPCC-11795

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
