### PR TITLE
HPCC-11789 DFU Workunits not showing owners

### DIFF
--- a/esp/src/eclwatch/GetDFUWorkunitsWidget.js
+++ b/esp/src/eclwatch/GetDFUWorkunitsWidget.js
@@ -341,7 +341,7 @@ define([
                             return "Unknown";
                         }
                     },
-                    Owner: { label: this.i18n.Owner, width: 90 },
+                    User: { label: this.i18n.Owner, width: 90 },
                     JobName: { label: this.i18n.JobName },
                     ClusterName: { label: this.i18n.Cluster, width: 126 },
                     StateMessage: { label: this.i18n.State, width: 72 },


### PR DESCRIPTION
Fixes HPCC-11789

Modify the grid call from Owners to Users (which is what the response is sending).

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
