### PR TITLE
HPCC-11801 ERROR: Query suspended: Different version of file already loaded

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -150,6 +150,7 @@ public:
             }
             if (nextTimeout != INFINITE)
                 nextTimeout = nextTimeout * 1000;
+            clearKeyStoreCache(false);   // Allows us to fully release files we no longer need because of unloaded queries
         }
         if (traceLevel)
             DBGLOG("DelayedReleaserThread %p exiting", this);


### PR DESCRIPTION
Need to clear the keystore cache after the delayed release has happened -
clearing it before will have no effect, as it only clears entries that are not
in use.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
