### PR TITLE
HPCC-11814 File writes failing in roxie

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -486,7 +486,7 @@ protected:
                     }
                 }
             }
-            if (!result && resolveLocal)
+            if (!result && (resolveLocal || alwaysCreate))
             {
                 StringBuffer useName;
                 bool wasDFS = false;


### PR DESCRIPTION
All attempts to write files in Roxie failing with "Cannot write file" error.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
