### PR TITLE
HPCC-11794 Avoid multiple control:queries calls for same queryset

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -178,6 +178,7 @@ public:
     unsigned getGraphIdsByQueryId(const char *target, const char *queryId, StringArray& graphIds);
     bool getQueryFiles(const char* query, const char* target, StringArray& logicalFiles, IArrayOf<IEspQuerySuperFile> *superFiles);
     void getGraphsByQueryId(const char *target, const char *queryId, const char *graphName, const char *subGraphId, IArrayOf<IEspECLGraphEx>& ECLGraphs);
+    void checkAndSetClusterQueryState(IEspContext &context, const char* cluster, const char* querySetId, IArrayOf<IEspQuerySetQuery>& queries);
 
     bool onWUQuery(IEspContext &context, IEspWUQueryRequest &req, IEspWUQueryResponse &resp);
     bool onWUPublishWorkunit(IEspContext &context, IEspWUPublishWorkunitRequest & req, IEspWUPublishWorkunitResponse & resp);


### PR DESCRIPTION
To get query status, the existing code does control:queries call
for each query. It takes a long time for WUListQueries. This
fix collects unique QuerySetIDs for all of the queries and calls
the control:queries for each unique QuerySetID. Then, set query
status for the queries which belong to the QuerySet.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
