### PR TITLE
HPCC-11747 InfoGrid stops monitoring WU after completion

### DIFF
--- a/esp/src/eclwatch/ESPWorkunit.js
+++ b/esp/src/eclwatch/ESPWorkunit.js
@@ -308,6 +308,8 @@ define([
                         Source: "ESPWorkunit.resubmit",
                         Exceptions: [{ Source: context.Wuid, Message: context.i18n.Resubmitted }]
                     });
+                    context.hasCompleted = false;
+                    context.startMonitor(true);
                 }
                 return response;
             });
@@ -321,6 +323,8 @@ define([
                         Source: "ESPWorkunit.recover",
                         Exceptions: [{ Source: context.Wuid, Message: context.i18n.Restarted }]
                     });
+                    context.hasCompleted = false;
+                    context.startMonitor(true);
                 }
                 return response;
             });
@@ -429,6 +433,13 @@ define([
                         lang.mixin(response.WUInfoResponse.Workunit.Results, {
                             ResultViews: response.WUInfoResponse.ResultViews
                         });
+                    }
+                    if (args.onGetWUExceptions && !lang.exists("WUInfoResponse.Workunit.Exceptions.ECLException", response)) {
+                        lang.mixin(response.WUInfoResponse.Workunit, {
+                            Exceptions: {
+                                ECLException: []
+                            }
+                        })
                     }
                     context.updateData(response.WUInfoResponse.Workunit);
 

--- a/esp/src/eclwatch/InfoGridWidget.js
+++ b/esp/src/eclwatch/InfoGridWidget.js
@@ -310,6 +310,11 @@ define([
                             }
                         });
                     });
+                    this.wu.watch(function (name, oldValue, newValue) {
+                        if (name === "Exceptions") {
+                            context.loadExceptions(newValue.ECLException);
+                        }
+                    });
                 }
             },
 


### PR DESCRIPTION
Added extra logic to handle the secnario where a WU completed with Exceptions
and was subsequently restarted and completed with no exceptions.

Fixes HPCC-11747

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
