### PR TITLE
HPCC-11816 Fix regression introduced by HPCC-11571

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -393,7 +393,7 @@ void CDfsLogicalFileName::normalizeName(const char *name, StringAttr &res, bool 
                     throw MakeStringException(-1, "Unexpected character '%c' in logical name '%s' detected", *s, name);
             }
         }
-        c = *s++;
+        c = *++s;
     }
     bool isext = memicmp(name,EXTERNAL_SCOPE "::",sizeof(EXTERNAL_SCOPE "::")-1)==0;
     if (!isext && !allowWild && wilddetected)


### PR DESCRIPTION
logical filenames with cluster postfix's, e.g. file@cluster
were being incorrectly passed by CDfsLogicalFileName

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
