### PR TITLE
HPCC-9892 Remove dummy LOADXML

### DIFF
--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -1096,7 +1096,7 @@ class HqlLex
         void setXmlSymbol(const YYSTYPE & errpos, const char *name, const char *value, bool append);
         IIterator *getSubScopes(const YYSTYPE & errpos, const char *name, bool doAll);
         IXmlScope *queryTopXmlScope();
-        IXmlScope *ensureTopXmlScope(const YYSTYPE & errpos);
+        IXmlScope *ensureTopXmlScope();
 
         IHqlExpression *lookupSymbol(IIdAtom * name, const attribute& errpos);
         void reportError(const YYSTYPE & returnToken, int errNo, const char *format, ...) __attribute__((format(printf, 4, 5)));

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -1057,7 +1057,7 @@ void HqlLex::doExport(YYSTYPE & returnToken, bool toXml)
     StringBuffer buf;
     toXML(data, buf, 0);
     if (toXml)
-        ensureTopXmlScope(returnToken)->loadXML(buf.str(), exportname->getAtomNamePtr());
+        ensureTopXmlScope()->loadXML(buf.str(), exportname->getAtomNamePtr());
     else
         setXmlSymbol(returnToken, exportname->getAtomNamePtr(), buf.str(), false);
     data->Release();
@@ -1219,7 +1219,7 @@ void HqlLex::doLoop(YYSTYPE & returnToken)
     }
 
     ::Release(forLoop);
-    forLoop = new CDummyScopeIterator(ensureTopXmlScope(returnToken));
+    forLoop = new CDummyScopeIterator(ensureTopXmlScope());
     forFilter.clear();
     forBody.setown(createFileContentsFromText(forBodyText, sourcePath));
     loopTimes = 0;
@@ -1408,9 +1408,7 @@ void resetLexerUniqueNames() { gUniqueId = 0; }
 
 void HqlLex::declareUniqueName(const char *name, const char * pattern)
 {
-    IXmlScope *top = queryTopXmlScope();
-    if (!top)
-        top = xmlScope = createXMLScope();
+    IXmlScope *top = ensureTopXmlScope();
 
     StringBuffer value;
     if (!top->getValue(name,value))
@@ -1980,7 +1978,6 @@ void HqlLex::reportWarning(WarnErrorCategory category, const YYSTYPE & returnTok
 }
 
 //====================================== XML DB =============================================
-
 IXmlScope *HqlLex::queryTopXmlScope()
 {
     IXmlScope *top = NULL;
@@ -1996,17 +1993,11 @@ IXmlScope *HqlLex::queryTopXmlScope()
     return top;
 }
 
-IXmlScope *HqlLex::ensureTopXmlScope(const YYSTYPE & errpos)
+IXmlScope *HqlLex::ensureTopXmlScope()
 {
     IXmlScope *top = queryTopXmlScope();
     if (!top)
-    {
-    	reportError(errpos, ERR_XML_NOSCOPE, "No XML scope active");
-
-    	// recovery: create a default XML scope
-    	top = xmlScope = ::loadXML("<xml></xml>");
-    }
-
+    	top = xmlScope = createXMLScope();
     return top;
 }
 
@@ -2015,14 +2006,25 @@ StringBuffer &HqlLex::lookupXmlSymbol(const YYSTYPE & errpos, const char *name, 
     if (*name==0)
         name=NULL;
 
-    IXmlScope *top = ensureTopXmlScope(errpos);
-    top->getValue(name, ret);
+    IXmlScope *top = ensureTopXmlScope();
+    bool idFound = top->getValue(name, ret);
+    if (idFound)
+    	return ret;
+
+    HqlLex * lexer = parentLex;
+    while (lexer && !idFound)
+    {
+    	if (lexer->xmlScope)
+            idFound = lexer->xmlScope->getValue(name, ret);
+    	lexer = lexer->parentLex;
+    }
+
     return ret;
 }
 
 void HqlLex::setXmlSymbol(const YYSTYPE & errpos, const char *name, const char *value, bool append)
 {
-    IXmlScope *top = ensureTopXmlScope(errpos);
+    IXmlScope *top = ensureTopXmlScope();
     bool ok;
     if (append)
         ok = top->appendValue(name, value);
@@ -2039,7 +2041,7 @@ void HqlLex::setXmlSymbol(const YYSTYPE & errpos, const char *name, const char *
 
 void HqlLex::declareXmlSymbol(const YYSTYPE & errpos, const char *name)
 {
-    IXmlScope *top = ensureTopXmlScope(errpos);
+    IXmlScope *top = ensureTopXmlScope();
     if (!top->declareValue(name))
     {
         StringBuffer msg("Symbol has already been declared: ");
@@ -2050,7 +2052,7 @@ void HqlLex::declareXmlSymbol(const YYSTYPE & errpos, const char *name)
 
 IIterator *HqlLex::getSubScopes(const YYSTYPE & errpos, const char *name, bool doAll)
 {
-    IXmlScope *top = ensureTopXmlScope(errpos);
+    IXmlScope *top = ensureTopXmlScope();
     return top->getScopes(name, doAll);
 }
 
@@ -2094,7 +2096,7 @@ void HqlLex::loadXML(const YYSTYPE & errpos, const char *name, const char * chil
         }
 
         // recovery: create a default XML scope
-        xmlScope = ::loadXML("<xml></xml>");
+        xmlScope = createXMLScope();
     }
 }
 


### PR DESCRIPTION
This is a stage1 fix. It allows for dummy LOADXMLs to be removed
and have macro parameters declared before an internal (to macro def) LOADXML
to still exist.

This alters none of the ill behaviours relating to %IDs% and LOADXMLs.

Signed-off-by: jamienoss james.noss@lexisnexis.com
