### PR TITLE
HPCC-11792 Add missing rtitle and rtype to PermissionAction

### DIFF
--- a/esp/src/eclwatch/ws_access.js
+++ b/esp/src/eclwatch/ws_access.js
@@ -185,6 +185,8 @@ define([
                 account_name: this.groupname ? this.groupname : this.username,
                 account_type: this.groupname ? 1 : 0,
                 basedn: row.__hpcc_parent.basedn,
+                rtitle: row.__hpcc_parent.rtitle,
+                rtype: row.__hpcc_parent.rtype,
                 rname: row.name,
                 action: "update"
             };


### PR DESCRIPTION
FileScope requires them (while the other permission seem not to).

Fixes HPCC-11792

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
