### PR TITLE
HPCC-11830 Fix bad group name lookup for multi instance ecalgent

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3053,7 +3053,7 @@ IGroup *EclAgent::getHThorGroup(StringBuffer &out)
     StringBuffer mygroupname("hthor__");
     agentTopology->getProp("@name",mygroupname);
     size32_t l = mygroupname.length();
-    unsigned ins = 0;
+    unsigned ins = 1;
     SocketEndpoint ep(0,queryMyNode()->endpoint());
     Owned<IGroup> mygrp = createIGroup(1,&ep);
     loop


### PR DESCRIPTION
For a cluster with multiple eclagent instances defined, eclagent
looks up the matching group name, comparing it's ip with the
pubilshed group ip's, to lookup it looks for groupnames that
match configuration name with extensions '_<n>'. The hthor
lookup code was incorrectly starting with a base of 1 vs 2 for
the 2nd instance.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
