### PR TITLE
HPCC-11693 Catch and handle OOM and failover when setting up HT

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1435,6 +1435,7 @@ protected:
             case ROXIEMM_MEMORY_POOL_EXHAUSTED:
             case ROXIEMM_MEMORY_LIMIT_EXCEEDED:
             case ROXIEMM_LARGE_MEMORY_EXHAUSTED:
+                e->Release();
                 return false;
             default:
                 throw;
@@ -1494,6 +1495,7 @@ protected:
                     case ROXIEMM_MEMORY_POOL_EXHAUSTED:
                     case ROXIEMM_MEMORY_LIMIT_EXCEEDED:
                     case ROXIEMM_LARGE_MEMORY_EXHAUSTED:
+                        e->Release();
                         break;
                     default:
                         throw;
@@ -1850,11 +1852,11 @@ public:
             {
                 msg.append("SmartJoin - ");
                 if (joinHelper)
-                    msg.append("Failed over to hash distributed standard join");
+                    msg.append("Failed over to standard join");
                 else if (needGlobal && doPerformLocalLookup())
                     msg.append("Failed over to hash distributed local lookup join");
                 else
-                    msg.append("Global all in memory lookup join");
+                    msg.append("All in memory lookup join");
             }
             else
                 msg.append("LookupJoin");

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -279,7 +279,6 @@ protected:
 
     void init(rowidx_t initialSize);
     const void *allocateRowTable(rowidx_t num);
-    const void *allocateNewRows(rowidx_t requiredRows);
     rowidx_t getNewSize(rowidx_t requiredRows);
     bool resizeRowTable(void **oldRows, memsize_t newCapacity, bool copy, roxiemem::IRowResizeCallback &callback, unsigned maxSpillCost);
     void serialize(IRowSerializerTarget &out);
@@ -294,7 +293,7 @@ public:
     void setup(IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=true);
     inline void setAllowNulls(bool b) { allowNulls = b; }
     inline void setDefaultMaxSpillCost(unsigned _defaultMaxSpillCost) { defaultMaxSpillCost = _defaultMaxSpillCost; }
-
+    inline unsigned queryDefaultMaxSpillCost() const { return defaultMaxSpillCost; }
     void clearRows();
     void kill();
 
@@ -412,6 +411,8 @@ public:
     void registerWriteCallback(IWritePosCallback &cb);
     void unregisterWriteCallback(IWritePosCallback &cb);
     inline void setAllowNulls(bool b) { CThorExpandingRowArray::setAllowNulls(b); }
+    inline void setDefaultMaxSpillCost(unsigned defaultMaxSpillCost) { CThorExpandingRowArray::setDefaultMaxSpillCost(defaultMaxSpillCost); }
+    inline unsigned queryDefaultMaxSpillCost() const { return CThorExpandingRowArray::queryDefaultMaxSpillCost(); }
     void kill();
     void clearRows();
     void compact();

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -257,6 +257,8 @@ class graph_decl CThorExpandingRowArray : public CSimpleInterface
         virtual void unlock() const {  }
     } dummyLock;
 
+    bool _ensure(rowidx_t requiredRows, unsigned maxSpillCost);
+    const void *_allocateRowTable(rowidx_t num, unsigned maxSpillCost);
 
 // for direct access by another CThorExpandingRowArray only
     inline void transferRowsCopy(const void **outRows, bool takeOwnership);
@@ -279,12 +281,12 @@ protected:
 
     void init(rowidx_t initialSize);
     const void *allocateRowTable(rowidx_t num);
+    const void *allocateRowTable(rowidx_t num, unsigned maxSpillCost);
     rowidx_t getNewSize(rowidx_t requiredRows);
     bool resizeRowTable(void **oldRows, memsize_t newCapacity, bool copy, roxiemem::IRowResizeCallback &callback, unsigned maxSpillCost);
     void serialize(IRowSerializerTarget &out);
     void doSort(rowidx_t n, void **const rows, ICompare &compare, unsigned maxCores);
     inline rowidx_t getRowsCapacity() const { return rows ? RoxieRowCapacity(rows) / sizeof(void *) : 0; }
-    bool _ensure(rowidx_t requiredRows, unsigned maxSpillCost);
 public:
     CThorExpandingRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=true, rowidx_t initialSize=InitialSortElements);
     ~CThorExpandingRowArray();

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -275,15 +275,17 @@ protected:
     StableSortFlag stableSort;
     rowidx_t maxRows;  // Number of rows that can fit in the allocated memory.
     rowidx_t numRows;  // High water mark of rows added
+    unsigned defaultMaxSpillCost;
 
-    void init(rowidx_t initialSize, StableSortFlag stableSort);
+    void init(rowidx_t initialSize);
     const void *allocateRowTable(rowidx_t num);
     const void *allocateNewRows(rowidx_t requiredRows);
     rowidx_t getNewSize(rowidx_t requiredRows);
-    bool resizeRowTable(void **oldRows, memsize_t newCapacity, bool copy, roxiemem::IRowResizeCallback &callback);
+    bool resizeRowTable(void **oldRows, memsize_t newCapacity, bool copy, roxiemem::IRowResizeCallback &callback, unsigned maxSpillCost);
     void serialize(IRowSerializerTarget &out);
     void doSort(rowidx_t n, void **const rows, ICompare &compare, unsigned maxCores);
     inline rowidx_t getRowsCapacity() const { return rows ? RoxieRowCapacity(rows) / sizeof(void *) : 0; }
+    bool _ensure(rowidx_t requiredRows, unsigned maxSpillCost);
 public:
     CThorExpandingRowArray(CActivityBase &activity, IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=true, rowidx_t initialSize=InitialSortElements);
     ~CThorExpandingRowArray();
@@ -291,6 +293,7 @@ public:
     // NB: throws error on OOM by default
     void setup(IRowInterfaces *rowIf, bool allowNulls=false, StableSortFlag stableSort=stableSort_none, bool throwOnOom=true);
     inline void setAllowNulls(bool b) { allowNulls = b; }
+    inline void setDefaultMaxSpillCost(unsigned _defaultMaxSpillCost) { defaultMaxSpillCost = _defaultMaxSpillCost; }
 
     void clearRows();
     void kill();
@@ -377,6 +380,7 @@ public:
     void deserialize(size32_t sz, const void *buf);
     void deserializeExpand(size32_t sz, const void *data);
     bool ensure(rowidx_t requiredRows);
+    bool ensure(rowidx_t requiredRows, unsigned maxSpillCost);
     void compact();
     virtual IThorArrayLock &queryLock() { return dummyLock; }
 


### PR DESCRIPTION
If it manages to avoid OOM on gather, but OOM's setting up sized
HT, then catch OOM exception coming back from roxiemem and let
it degrade to distributed local lookup join.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
