### PR TITLE
HPCC-11668 Add custom password end date.

### DIFF
--- a/esp/src/eclwatch/HPCCPlatformWidget.js
+++ b/esp/src/eclwatch/HPCCPlatformWidget.js
@@ -190,7 +190,7 @@ define([
                                 case -2:
                                     break;
                                 default:
-                                    if (response.MyAccountResponse.passwordDaysRemaining <= 10) {
+                                    if (response.MyAccountResponse.passwordDaysRemaining <= response.MyAccountResponse.passwordExpirationWarningDays) {
                                         if (confirm(context.i18n.PasswordExpirePrefix + response.MyAccountResponse.passwordDaysRemaining + context.i18n.PasswordExpirePostfix)) {
                                             context._onUserID();
                                         }


### PR DESCRIPTION
An enhancement was added where the admin can set a custom date from when to start warning the user if they would like to change their password. Tapping into that to determine when to notify user in ECL Watch.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
