### PR TITLE
HPCC-11858 Add a #option to only report the filename tail from assert

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1731,6 +1731,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.optimizeMax,"optimizeMax",false),
         DebugOption(options.useResultsForChildSpills,"useResultsForChildSpills",false),
         DebugOption(options.alwaysUseGraphResults,"alwaysUseGraphResults",false),
+        DebugOption(options.reportAssertFilenameTail,"reportAssertFilenameTail",false),        
     };
 
     //get options values from workunit

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -733,6 +733,7 @@ struct HqlCppOptions
     bool                optimizeMax;
     bool                useResultsForChildSpills;
     bool                alwaysUseGraphResults;
+    bool                reportAssertFilenameTail;
 };
 
 //Any information gathered while processing the query should be moved into here, rather than cluttering up the translator class

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -8790,7 +8790,12 @@ void HqlCppTranslator::doBuildStmtAssert(BuildCtx & ctx, IHqlExpression * expr)
         location.extractLocationAttr(locationAttr);
 
     if (location.sourcePath)
-        args.append(*createConstant(location.sourcePath->str()));
+    {
+        const char * filename = location.sourcePath->str();
+        if (options.reportAssertFilenameTail)
+            filename = pathTail(filename);
+        args.append(*createConstant(filename));
+    }
     else
         args.append(*getNullStringPointer(true));
 

--- a/testing/regress/ecl/assert.ecl
+++ b/testing/regress/ecl/assert.ecl
@@ -1,4 +1,3 @@
-#line(1)
 /*##############################################################################
 
     HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
@@ -15,6 +14,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
+
+#option ('reportAssertFilenameTail', true);
 
 val1 := 1;
 val2 := 1;

--- a/testing/regress/ecl/key/assert.xml
+++ b/testing/regress/ecl/key/assert.xml
@@ -1,19 +1,19 @@
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>26</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = 2]</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>27</Line><Source>user</Source><Message>Abc2</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>28</Line><Source>user</Source><Message>Assert (1 = 2) failed [1 = val4]</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>29</Line><Source>user</Source><Message>Abc3</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>36</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = 2]</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>37</Line><Source>user</Source><Message>Abc5</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>38</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = val4]</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>39</Line><Source>user</Source><Message>Abc6</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>34</Line><Source>user</Source><Message>Assert (2 = 1) failed [val1 = 1]</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>35</Line><Source>user</Source><Message>Abc4</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>46</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = 2]</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>47</Line><Source>user</Source><Message>Abc8</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>48</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = val4]</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>49</Line><Source>user</Source><Message>Abc9</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>44</Line><Source>user</Source><Message>Assert (2 = 1) failed [val1 = 1]</Message></Exception>
-<Exception><Code>100000</Code><Filename>/home/gavin/dev/hpcc/testing/regress/ecl/assert.ecl</Filename><Line>45</Line><Source>user</Source><Message>Abc7</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>27</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = 2]</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>28</Line><Source>user</Source><Message>Abc2</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>29</Line><Source>user</Source><Message>Assert (1 = 2) failed [1 = val4]</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>30</Line><Source>user</Source><Message>Abc3</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>37</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = 2]</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>38</Line><Source>user</Source><Message>Abc5</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>39</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = val4]</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>40</Line><Source>user</Source><Message>Abc6</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>35</Line><Source>user</Source><Message>Assert (2 = 1) failed [val1 = 1]</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>36</Line><Source>user</Source><Message>Abc4</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>47</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = 2]</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>48</Line><Source>user</Source><Message>Abc8</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>49</Line><Source>user</Source><Message>Assert (1 = 2) failed [val1 = val4]</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>50</Line><Source>user</Source><Message>Abc9</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>45</Line><Source>user</Source><Message>Assert (2 = 1) failed [val1 = 1]</Message></Exception>
+<Exception><Code>100000</Code><Filename>assert.ecl</Filename><Line>46</Line><Source>user</Source><Message>Abc7</Message></Exception>
 <Dataset name='Result 1'>
  <Row><val1>1</val1></Row>
  <Row><val1>2</val1></Row>


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
