### PR TITLE
HPCC-11861 Copying query .so files can result in truncated .so files

### DIFF
--- a/common/dllserver/dllserver.cpp
+++ b/common/dllserver/dllserver.cpp
@@ -498,7 +498,7 @@ void DllServer::copyFileLocally(RemoteFilename & targetName, RemoteFilename & so
 
     OwnedIFile source = createIFile(sourceName);
     OwnedIFile target = createIFile(targetName);
-    copyFile(target, source);
+    source->copyTo(target, 0, NULL, true);
 }
 
 IIterator * DllServer::createDllIterator()

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -784,7 +784,21 @@ public:
             StringBuffer localName(queryDirectory);
             localName.append(name);
             if (checkFileExists(localName.str()))
-                return createDllEntry(localName.str(), false, NULL);
+            {
+                try
+                {
+                    return createDllEntry(localName.str(), false, NULL);
+                }
+                catch (ICorruptDllException *E)
+                {
+                    remove(localName.str());
+                    E->Release();
+                }
+                catch (...)
+                {
+                    throw;
+                }
+            }
         }
         CriticalBlock b(crit);
         Owned<IRoxieDaliHelper> daliHelper = connectToDali();

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -286,5 +286,9 @@ extern jlib_decl bool safe_ecvt(size_t len, char * buffer, double value, int num
 extern jlib_decl bool safe_fcvt(size_t len, char * buffer, double value, int numPlaces, int * decimal, int * sign);
 extern jlib_decl StringBuffer &getTempFilePath(StringBuffer & target, const char * component, IPropertyTree * pTree);
 
+interface jlib_thrown_decl ICorruptDllException: extends IException
+{
+};
+
 #endif
 


### PR DESCRIPTION
Use a temporary file. Also, if trying to load a corrupted dll, retry the copy
(fixing issue HPCC-11558).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
