### PR TITLE
HPCC-11785 Fix Thor Usage/Queue display in legacy ECLWatch

### DIFF
--- a/esp/files/jobqueue.js
+++ b/esp/files/jobqueue.js
@@ -168,7 +168,7 @@ var usageArray=null;
 var busagAarray = null;
 var nbusageArray = null;
 var totalWorkunits=0;
-
+var itemWidth=0.4;
 function displayQLegend()
 {
     var count = 3;
@@ -179,7 +179,6 @@ function displayQLegend()
     var svgdoc=svg.getSVGDocument();
     var g1=svgdoc.createElementNS("http://www.w3.org/2000/svg", "g");
     g1.setAttribute("transform","translate(20,20) scale(25,20)");
-    g1.setAttribute("id","top");
 
     var g=svgdoc.createElementNS("http://www.w3.org/2000/svg", "g");
     g.setAttribute("stroke-width","0.01");
@@ -187,7 +186,6 @@ function displayQLegend()
     g.setAttribute("font-size","0.5");
     g.setAttribute("stroke-width","0.01");
     g.setAttribute("alignment-baseline","middle");
-    g.setAttribute("id","toplines");
 
     for(var i=0;i<count;i++)
     {
@@ -235,7 +233,6 @@ function displayQBegin(queues, connected, count)
     g.setAttribute("font-size","0.5");
     g.setAttribute("stroke-width","0.01");
     g.setAttribute("alignment-baseline","middle");
-    g.setAttribute("id","toplines");
 
      var lines = queues + connected + 1;
     for(var i=0;i<lines;i++)
@@ -250,7 +247,7 @@ function displayQBegin(queues, connected, count)
         var line=svgdoc.createElementNS("http://www.w3.org/2000/svg", "line");
         line.setAttribute("x1",0);
         line.setAttribute("y1",i);
-        line.setAttribute("x2",count*0.3+0.3);
+        line.setAttribute("x2",count*itemWidth+0.3);
         line.setAttribute("y2",i);
         if(i==0 || i==(lines-1))
         {
@@ -286,12 +283,11 @@ function displayQueue(count,dt,running,queued,waiting,connected,idle,wuid1, wuid
 
     var g=svgdoc.createElementNS("http://www.w3.org/2000/svg", "g");
     g.setAttribute("stroke","black");
-    g.setAttribute("font-size","0.5");
+    g.setAttribute("font-size","0.4");
     g.setAttribute("stroke-width","0.02");
     g.setAttribute("alignment-baseline","middle");
-    g.setAttribute("id","toplines");
-
-    var xpos = 0.3*count - 0.1;
+ 
+    var xpos = itemWidth*count - 0.1;
     var ybase = max_queues + 2;
     var ypos = ybase+0.2;
 
@@ -300,7 +296,6 @@ function displayQueue(count,dt,running,queued,waiting,connected,idle,wuid1, wuid
         var gskew = svgdoc.createElementNS("http://www.w3.org/2000/svg", "g");
         var trans = "translate(" + xpos + "," + ypos + ") rotate(-90)";
         gskew.setAttribute("transform", trans);
-        gskew.setAttribute("font-size","0.35");
         var text3=svgdoc.createElementNS("http://www.w3.org/2000/svg", "text");
         text3.setAttribute("x",0);
         text3.setAttribute("y",0);
@@ -324,66 +319,44 @@ function displayQueue(count,dt,running,queued,waiting,connected,idle,wuid1, wuid
 
     if (running > 0)
     {
-        if (!isFF)
-        {
-            var s='<g stroke-width="1" onmouseout="hide_popup()" onclick="open_workunit(\''+wuid1+'\')"'+
-              ' onmouseover="show_q_popup(window.evt.screenX,window.evt.screenY,\''+wuid1+'\',\''+dt+'\')" stroke="blue">';
-            s+='<line x1="'+xpos+'" y1="'+ybase+'" x2="'+xpos+'" y2="'+(ybase - 1)+'" stroke-width="0.15" />'
-            s+='</g>';
-            g.appendChild(svg.getWindow().parseXML(s,svgdoc));
-        }
-        else
-        {
-            var g1=svgdoc.createElementNS("http://www.w3.org/2000/svg", "g");
-            g1.setAttribute("stroke","blue");
-            g1.setAttribute("stroke-width",1);
+        var g1=svgdoc.createElementNS("http://www.w3.org/2000/svg", "g");
+        g1.setAttribute("stroke","blue");
+        g1.setAttribute("stroke-width",1);
 
-            g1.addEventListener("mouseover",function(evt) { show_q_popup1(evt,wuid1,dt); }, false);
-            g1.addEventListener("mouseout",function(evt) { hide_popup(); }, false);
-            g1.addEventListener("click",function(evt) { open_workunit(wuid1); }, false);
-            
-            var line2=svgdoc.createElementNS("http://www.w3.org/2000/svg", "line");
-            line2.setAttribute("x1",+xpos);
-            line2.setAttribute("y1",ybase);
-            line2.setAttribute("x2",xpos);
-            line2.setAttribute("y2",ybase - 1);
-            line2.setAttribute("stroke-width",0.15);
-            g1.appendChild(line2);
-            
-            g.appendChild(g1);
-        }
+        g1.addEventListener("mouseover",function(evt) { show_q_popup1(evt,wuid1,dt); }, false);
+        g1.addEventListener("mouseout",function(evt) { hide_popup(); }, false);
+        g1.addEventListener("click",function(evt) { open_workunit(wuid1); }, false);
+
+        var line2=svgdoc.createElementNS("http://www.w3.org/2000/svg", "line");
+        line2.setAttribute("x1",+xpos);
+        line2.setAttribute("y1",ybase);
+        line2.setAttribute("x2",xpos);
+        line2.setAttribute("y2",ybase - 1);
+        line2.setAttribute("stroke-width",0.15);
+        g1.appendChild(line2);
+
+        g.appendChild(g1);
     }
 
     if (running > 1)
     {
-        if (!isFF)
-        {
-            var s='<g stroke-width="1" onmouseout="hide_popup()" onclick="open_workunit(\''+wuid2+'\')"'+
-              ' onmouseover="show_q_popup(window.evt.screenX,window.evt.screenY,\''+wuid2+'\',\''+dt+'\')" stroke="blue">';
-            s+='<line x1="'+xpos+'" y1="'+(ybase - 1)+'" x2="'+xpos+'" y2="'+(ybase - 2)+'" stroke-width="0.15" />'
-            s+='</g>';
-            g.appendChild(svg.getWindow().parseXML(s,svgdoc));
-        }
-        else
-        {
-            var g1=svgdoc.createElementNS("http://www.w3.org/2000/svg", "g");
-            g1.setAttribute("stroke","blue");
-            g1.setAttribute("stroke-width",1);
+        var g1=svgdoc.createElementNS("http://www.w3.org/2000/svg", "g");
+        g1.setAttribute("stroke","blue");
+        g1.setAttribute("stroke-width",1);
 
-            g1.addEventListener("mouseover",function(evt) { show_q_popup1(evt,wuid2,dt); }, false);
-            g1.addEventListener("mouseout",function(evt) { hide_popup(); }, false);
-            g1.addEventListener("click",function(evt) { open_workunit(wuid2); }, false);
-            
-            var line2=svgdoc.createElementNS("http://www.w3.org/2000/svg", "line");
-            line2.setAttribute("x1",+xpos);
-            line2.setAttribute("y1",ybase - 1);
-            line2.setAttribute("x2",xpos);
-            line2.setAttribute("y2",ybase - 2);
-            line2.setAttribute("stroke-width",0.15);
-            g1.appendChild(line2);
-            
-            g.appendChild(g1);
-        }
+        g1.addEventListener("mouseover",function(evt) { show_q_popup1(evt,wuid2,dt); }, false);
+        g1.addEventListener("mouseout",function(evt) { hide_popup(); }, false);
+        g1.addEventListener("click",function(evt) { open_workunit(wuid2); }, false);
+
+        var line2=svgdoc.createElementNS("http://www.w3.org/2000/svg", "line");
+        line2.setAttribute("x1",+xpos);
+        line2.setAttribute("y1",ybase - 1);
+        line2.setAttribute("x2",xpos);
+        line2.setAttribute("y2",ybase - 2);
+        line2.setAttribute("stroke-width",0.15);
+        g1.appendChild(line2);
+
+        g.appendChild(g1);
     }
 
     if (queued > 0)

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -392,6 +392,8 @@ void AddToClusterJobXLS(JobUsageArray& jobsummary, CDateTime &adjStart, CDateTim
 
         float xx1= (y==y1 ? x1 : 0.0F);
         float xx2= (y==y2 ? x2 : 86400.0F);
+        if (xx2<=xx1)
+            continue;
         jobUsage.m_usage += (xx2-xx1)/864.0F;
 
         float bhours = ((busEnd < xx2)? busEnd : xx2) - ((busStart > xx1) ? busStart : xx1);
@@ -802,6 +804,9 @@ bool getClusterJobSummaryXLS(double version, StringBuffer &xml, const char* clus
     for (int i = first; i <= last; i++)
     {
         Owned<CJobUsage> jobUsage =  new CJobUsage();
+        jobUsage->m_busage = 0.0;
+        jobUsage->m_nbusage = 0.0;
+        jobUsage->m_usage = 0.0;
         usageDT.getDateString(jobUsage->m_date);
         jobUsages.append(*jobUsage.getClear());
         usageDT.adjustTime(60*24);
@@ -814,7 +819,6 @@ bool getClusterJobSummaryXLS(double version, StringBuffer &xml, const char* clus
             continue;
 
         Owned<IEspECLJob> job = createEclJobFromAuditLine(version, jobs.item(idx).text.get());
-
         CDateTime adjStart;
         adjStart.setString(job->getStartedDate(),NULL,true);
         adjStart.adjustTime(delayTime);
@@ -931,6 +935,10 @@ void streamJobListResponse(IEspContext &context, const char *cluster, const char
         toTime.getString(tostr, false);
     }
 
+    response->setContentType(HTTP_TYPE_TEXT_HTML_UTF8);
+    response->setStatus(HTTP_STATUS_OK);
+    response->startSend();
+
     StringBuffer sb;
     sb.append("<script language=\"javascript\">parent.displayLegend(");
     appendQuoted(sb, fromstr.str(), true);
@@ -1036,7 +1044,7 @@ void streamJobListResponse(IEspContext &context, const char *cluster, const char
     sb.clear().append("<script language=\"javascript\">\r\n");
     sb.append("parent.displaySasha();\r\nparent.displayEnd(");
     appendQuoted(sb, xls, true).append(")</script>\r\n");
-    response->sendChunk(sb.str());
+    response->sendFinalChunk(sb.str());
 }
 
 bool checkSameStrings(const char* s1, const char* s2)
@@ -1264,8 +1272,6 @@ void appendQueueInfoFromAuditLine(IArrayOf<IEspThorQueue>& items, const char* li
 
     if (checkNewThorQueueItem(tq, showAll, items))
         items.append(*tq.getClear());
-
-    DBGLOG("Queue log: [%s]", line);
 }
 
 
@@ -1313,6 +1319,10 @@ void streamJobQueueListResponse(IEspContext &context, const char *cluster, const
             appendQueueInfoFromAuditLine(items, lines.item(idx).text.get(), longestQueue, maxConnected, maxDisplay, 2);
         countLines++;
     }
+
+    response->setContentType(HTTP_TYPE_TEXT_HTML_UTF8);
+    response->setStatus(HTTP_STATUS_OK);
+    response->startSend();
 
     if (items.length() < 1)
     {
@@ -1364,14 +1374,14 @@ void streamJobQueueListResponse(IEspContext &context, const char *cluster, const
     sb.append("parent.displayQEnd(\'<table><tr><td>");
     sb.append("Total Records in the Time Period: ").append(items.length());
     sb.append(" (<a href=\"/WsWorkunits/WUClusterJobQueueLOG?").append(xls);
-    sb.append("\">txt</a>...<a href=\"/WsWorkunits/WUClusterJobQueueXLS?").append(xls).append("\">xls</a>).");
+    sb.append("\">job_queue_log</a>...<a href=\"/WsWorkunits/WUClusterJobQueueXLS?").append(xls).append("\">job_queue.html</a>).");
     sb.append("</td></tr><tr><td>");
     if (count > maxDisplay)
         sb.append("Displayed: First ").append(maxDisplay).append(". ");
     sb.append("Max. Queue Length: ").append(longestQueue).append(".");
     sb.append("</td></tr></table>\')</script>\r\n");
 
-    response->sendChunk(sb.str());
+    response->sendFinalChunk(sb.str());
 }
 
 int CWsWorkunitsSoapBindingEx::onGet(CHttpRequest* request, CHttpResponse* response)
@@ -1419,6 +1429,9 @@ int CWsWorkunitsSoapBindingEx::onGet(CHttpRequest* request, CHttpResponse* respo
          }
          if(!strnicmp(path.str(), "/WsWorkunits/JobList", 20))
          {
+            if (ctx->getClientVersion()<=0)
+                ctx->setClientVersion(1.51);
+
             const char *cluster = params->queryProp("Cluster");
             const char *startDate = params->queryProp("StartDate");
             const char *endDate = params->queryProp("EndDate");
@@ -1513,7 +1526,8 @@ bool CWsWorkunitsEx::onWUClusterJobQueueXLS(IEspContext &context, IEspWUClusterJ
         MemoryBuffer mb;
         mb.setBuffer(xls.length(), (void*)xls.str());
         resp.setResult(mb);
-        resp.setResult_mimetype("application/vnd.ms-excel");
+        resp.setResult_mimetype(HTTP_TYPE_TEXT_HTML);
+        context.addCustomerHeader("Content-disposition", "attachment;filename=job_queue.html");
     }
     catch(IException* e)
     {
@@ -1599,7 +1613,8 @@ bool CWsWorkunitsEx::onWUClusterJobXLS(IEspContext &context, IEspWUClusterJobXLS
         MemoryBuffer mb;
         mb.setBuffer(xls.length(), (void*)xls.str());
         resp.setResult(mb);
-        resp.setResult_mimetype("application/vnd.ms-excel");
+        resp.setResult_mimetype(HTTP_TYPE_TEXT_HTML);
+        context.addCustomerHeader("Content-disposition", "attachment;filename=cluster_jobs.html");
     }
     catch(IException* e)
     {
@@ -1630,7 +1645,7 @@ bool CWsWorkunitsEx::onWUClusterJobSummaryXLS(IEspContext &context, IEspWUCluste
         MemoryBuffer mb;
         mb.setBuffer(xls.length(), (void*)xls.str());
         resp.setResult(mb);
-        resp.setResult_mimetype("application/vnd.ms-excel");
+        resp.setResult_mimetype(HTTP_TYPE_TEXT_HTML);
     }
     catch(IException* e)
     {

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -2516,8 +2516,6 @@ void WsWuJobQueueAuditInfo::getAuditLineInfo(const char* line, unsigned& longest
 
     if (checkNewThorQueueItem(tq, showAll, items))
         items.append(*tq.getClear());
-
-    DBGLOG("Queue log: [%s]", line);
 }
 
 bool WsWuJobQueueAuditInfo::checkSameStrings(const char* s1, const char* s2)


### PR DESCRIPTION
1. Add HTTP headers into JobList/JobQueue response. FireFox
   browser does not process existing Thor JobQueue response due
   to missing HTTP headers. 2. Set default client version before
   process JobList/JobQueue request. The requests are processed
   by CWsWorkunitsSoapBindingEx::onGet(). Since ECLWatch does
   not send ESP client version, the version has to be set to
   default client version inside the onGet(). If not, ESP
   response does not have enough data items to show JobList/
   JobQueue. 3. Fix job statistics display. For Chrome, the
   display is incorrect due to incorrect font. 4. Fix job queue
   not displayed on FireFox by removing extra code and changing
   the font of Date display from 0.35 to 0.4. 5. Rename web
   links both JobList page and JobQueue page for better meanings.
   For example, the 'xls' on the JobList page is renamed as
   'cluster_jobs.html' since the link is used to download an
   html file containing the job list. 6. Code clean.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
