### PR TITLE
HPCC-11788 Remove ECLWatch Tech Preview from legacy ECLWatch

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -296,10 +296,6 @@ public:
 
             IPropertyTree *folderQueryset = ensureNavFolder(data, "Queries", NULL, NULL, false, 3);
             ensureNavLink(*folderQueryset, "Browse", "/WsWorkunits/WUQuerySets", "Browse Published Queries");
-
-            IPropertyTree *folderTP = CEspBinding::ensureNavFolder(data, "Tech Preview", "Technical Preview");
-            IPropertyTree *eclWatchTP = CEspBinding::ensureNavLink(*folderTP, "ECL Watch", "/esp/files/stub.htm?Widget=HPCCPlatformWidget", "ECL Watch", NULL, NULL, 1);
-            eclWatchTP->setProp("@target", "_blank");
         }
     }
 


### PR DESCRIPTION
The menu item of the ECLWatch Tech Preview is removed from legacy
ECLWatch.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
