### PR TITLE
HPCC-11881 Roxie assert reading file::ip::x::y::z

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1444,9 +1444,16 @@ public:
             IPartDescriptor &part = *fdesc.queryPart(i);
             IPropertyTree &partProps = part.queryProperties();
             offset_t size = partProps.getPropInt64("@size", (unsigned __int64) -1);
-            assertex(size != (unsigned __int64) -1);
             map[i].base = i ? map[i-1].top : 0;
-            map[i].top = map[i].base + size;
+            if (size==(unsigned __int64) -1)
+            {
+                if (i==numParts-1)
+                    map[i].top = (unsigned __int64) -1;
+                else
+                    throw MakeStringException(ROXIE_DATA_ERROR, "CFilePartMap: file sizes not known for file %s", fileName.get());
+            }
+            else
+                map[i].top = map[i].base + size;
         }
         if (totalSize == (offset_t)-1)
             totalSize = map[numParts-1].top;

--- a/testing/regress/ecl/setup/setuptext.ecl
+++ b/testing/regress/ecl/setup/setuptext.ecl
@@ -452,7 +452,7 @@ boolean isNewDocumentFunction(string s) := false;
 
 convertTextFileToInversion(TS.sourceType sourceId, string filename, isNewDocumentFunction isNewDocument) := FUNCTION
 
-inFile := dataset(filename, { string line{maxlength(MaxDocumentLineLength)}, unsigned8 filepos{virtual(fileposition)} }, csv(SEPARATOR(''),quote([]),maxlength(MaxDocumentLineLength+8+4)));
+inFile := dataset(filename, { string line{maxlength(MaxDocumentLineLength)}, unsigned8 filepos{virtual(fileposition)} }, csv(SEPARATOR(''),quote([]),maxlength(MaxDocumentLineLength+8+4)), DYNAMIC);
 
     inputDocumentRecord createInputRecord(inFile l) := TRANSFORM
         self.source := sourceId;


### PR DESCRIPTION
We can live without the size for the last part in a multipart file. Safer than
trying to fix the IFileDescriptor to give us the size, and probably more
efficient too.

Also fix the setuptext test so that it can run (and reveal this issue).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
