### PR TITLE
HPCC-11897 Spaces in filenames should be allowed

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -334,26 +334,24 @@ void CDfsLogicalFileName::expand(IUserDescriptor *user)
 
 inline void normalizeScope(const char *name, const char *scope, unsigned len, StringBuffer &res, bool strict)
 {
-    bool scopeStarted=false;
-    bool scopeEnded=false;
-    const char *s2=scope;
+    while (len && isspace(scope[len-1]))
+    {
+        if (strict)
+            throw MakeStringException(-1, "Scope contains trailing spaces in file name '%s'", name);
+        len--;
+    }
+    while (len && isspace(scope[0]))
+    {
+        if (strict)
+            throw MakeStringException(-1, "Scope contains leading spaces in file name '%s'", name);
+        len--;
+        scope++;
+    }
+    if (!len)
+        throw MakeStringException(-1, "Scope is blank in file name '%s'", name);
     while (len--)
     {
-        if (isspace(*s2))
-        {
-            if (strict)
-               throw MakeStringException(-1, "Scope contains spaces in file name '%s'", name);
-            if (scopeStarted) // ignore leading spaces if !strict
-                scopeEnded = true;
-        }
-        else
-        {
-            if (scopeEnded)
-               throw MakeStringException(-1, "Scope contains spaces in file name '%s'", name);
-            scopeStarted = true;
-            res.append(*s2);
-        }
-        ++s2;
+        res.append(*scope++);
     }
 }
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -895,6 +895,7 @@ StringBuffer &CDfsLogicalFileName::makeFullnameQuery(StringBuffer &query, DfsXml
 StringBuffer &CDfsLogicalFileName::makeXPathLName(StringBuffer &lfnNodeName) const
 {
     const char *s=get(true);    // skip foreign
+    // Ensure only chars that are accepted by jptree in an xpath element are used
     bool first=true;
     loop
     {
@@ -919,7 +920,11 @@ StringBuffer &CDfsLogicalFileName::makeXPathLName(StringBuffer &lfnNodeName) con
                     c = toupper(*s);
                     // fall through
                 default:
-                    lfnNodeName.append(c);
+                    if (isalnum(c))
+                        lfnNodeName.append(c);
+                    else
+                        lfnNodeName.append('_').append((unsigned) (unsigned char) c);
+                    break;
                 }
                 ++s;
             }

--- a/testing/regress/ecl/multilfn.ecl
+++ b/testing/regress/ecl/multilfn.ecl
@@ -20,6 +20,7 @@ import Std.File AS FileServices;
 import std.str;
 
 #option('slaveDaliClient', true);
+#option('allFilenamesDynamic', true);
 
 rec := RECORD, MAXLENGTH(256)
   STRING    album;

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -2274,13 +2274,14 @@ public:
                                ". :: scope1 :: file",
                                ":: scope1 :: file",
                                "~ scope1 :: scope2 :: file  ",
+                               ". :: scope1 :: file nine",
+                               ". :: scope1 :: file ten  ",
                                ". :: scope1 :: file",
                                NULL                                             // terminator
                              };
         const char *invalidLfns[] = {
-                               ". :: scope1 :: file nine",
-                               ". :: scope1 :: file ten",
                                ". :: sc~ope1::file",
+                               ". ::  ::file",
                                "~~scope1::file",
                                "~sc~ope1::file2",
                                ".:: scope1::file*",


### PR DESCRIPTION
While it might have been better not to allow them from the start (arguable),
it does not seem like a good idea to make it impossible to read files in 5.0
that were legally created with earlier versions...

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
