### PR TITLE
HPCC-11898 Roxie should support superfiles with >1 file

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1828,11 +1828,24 @@ public:
         {
             if (subFiles.length())
             {
-                assertex(subFiles.length()==1);
+                if (subFiles.length()!=1)
+                    throw MakeStringException(0, "Roxie does not support FETCH or KEYED JOIN to superkey with multiple parts");
                 fileMap.setown(createFilePartMap(lfn, *subFiles.item(0)));
             }
         }
         return fileMap.getLink();
+    }
+    virtual unsigned getNumParts() const
+    {
+        CriticalBlock b(lock);
+        unsigned numParts = 0;
+        ForEachItemIn(idx, subFiles)
+        {
+            unsigned thisNumParts = subFiles.item(idx)->numParts();
+            if (thisNumParts > numParts)
+                numParts = thisNumParts;
+        }
+        return numParts;
     }
     virtual void serializeFDesc(MemoryBuffer &mb, IFileDescriptor *fdesc, unsigned channel, bool isLocal) const
     {
@@ -1910,10 +1923,10 @@ public:
     {
         Owned<CFileIOArray> f = new CFileIOArray();
         f->addFile(NULL, 0);
-        if (subFiles.length())
+        ForEachItemIn(idx, subFiles)
         {
-            IFileDescriptor *fdesc = subFiles.item(0);
-            IFileDescriptor *remoteFDesc = remoteSubFiles.item(0);
+            IFileDescriptor *fdesc = subFiles.item(idx);
+            IFileDescriptor *remoteFDesc = remoteSubFiles.item(idx);
             if (fdesc)
             {
                 unsigned numParts = fdesc->numParts();
@@ -1926,7 +1939,7 @@ public:
                             IPartDescriptor *pdesc = fdesc->queryPart(i-1);
                             assertex(pdesc);
                             IPartDescriptor *remotePDesc = queryMatchingRemotePart(pdesc, remoteFDesc, i-1);
-                            Owned<ILazyFileIO> file = createPhysicalFile(subNames.item(0), pdesc, remotePDesc, ROXIE_FILE, numParts, cached != NULL, channel);
+                            Owned<ILazyFileIO> file = createPhysicalFile(subNames.item(idx), pdesc, remotePDesc, ROXIE_FILE, numParts, cached != NULL, channel);
                             IPropertyTree &partProps = pdesc->queryProperties();
                             f->addFile(file.getClear(), partProps.getPropInt64("@offset"));
                         }

--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -94,6 +94,7 @@ interface IResolvedFile : extends ISimpleSuperFileEnquiry
     virtual IFileIOArray *getIFileIOArray(bool isOpt, unsigned channel) const = 0;
     virtual IKeyArray *getKeyArray(IDefRecordMeta *activityMeta, TranslatorArray *translators, bool isOpt, unsigned channel, bool allowFieldTranslation) const = 0;
     virtual IFilePartMap *getFileMap() const = 0;
+    virtual unsigned getNumParts() const = 0;
     virtual IInMemoryIndexManager *getIndexManager(bool isOpt, unsigned channel, IFileIOArray *files, IRecordSize *recs, bool preload, int numKeys) const = 0;
     virtual offset_t getFileSize() const = 0;
 


### PR DESCRIPTION
Roxie gives an assert error on trying to read superfiles with >1 subfile. This
should be changed so that FETCH and KEYED JOIN throw a more meaningful error,
and other disk reads just work (since there is no technical reason they
can't)...

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
