### PR TITLE
HPCC-11901 CSV auto discovery generates wrong field names if recordstructurepresent=false

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -682,7 +682,7 @@ void CCsvPartitioner::storeFieldName(const char * start, unsigned len)
     }
     else
     {
-        fieldName.append("field").append(fieldCount);
+        fieldName.set("field").append(fieldCount);
     }
 
     // Check discovered field name uniqueness


### PR DESCRIPTION
Fix record structure generation.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
