### PR TITLE
HPCC-11901 CSV auto discovery generates wrong field names if recordstructurepresent=false

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -613,7 +613,7 @@ void CCsvPartitioner::storeFieldName(const char * start, unsigned len)
     }
     else
     {
-        recordStructure.append("field");
+        recordStructure.set("field");
         recordStructure.append(fieldCount);
     }
     recordStructure.append(";\n");


### PR DESCRIPTION
Fix record structure generation.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
