### PR TITLE
HPCC-11918 Allow hpcc-run.sh and hpcc-push.sh run as hpcc user

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -113,6 +113,8 @@ set_environmentvars
 envfile=$configs/$environment
 
 # Know HPCC user after set_environmentvars
+log_dir_owner=$(ls -ld $LOG_DIR | awk '{print $3}')
+[ "log_dir_owner" != "${user}" ] && chown ${user}:${user} $LOG_DIR
 chown ${user}:${user} $HPCC_INIT_LOG
 
 #Sourcing the hpcc environment

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -960,3 +960,24 @@ run_cluster() {
    echo ""
 }
 
+##
+## Usage: cluster_tools_init 
+##    Initialization for cluster tools
+##
+cluster_tools_init() {
+
+   set_environmentvars
+
+   _cmd_prefix=
+   [ "$(id -u)" != "0" ] && _cmd_prefix=sudo
+
+   # Check and set log directory
+   CLUSTER_LOG_DIR=${LOG_DIR}/cluster
+   [ ! -d $LOG_DIR ]  && ${_cmd_prefix} /etc/init.d/hpcc-init status > /dev/null 2>&1
+
+   [ ! -d $CLUSTER_LOG_DIR ] && mkdir -p $CLUSTER_LOG_DIR
+   # workaround inconsistency of stat command
+   cluster_log_dir_owner=$(ls -ld $CLUSTER_LOG_DIR | awk '{print $3}')
+   [ "$cluster_log_dir_owner" != "${user}" ] && ${_cmd_prefix} chown ${user}:${user} $CLUSTER_LOG_DIR
+   
+}

--- a/initfiles/sbin/deploy-java-files.sh.in
+++ b/initfiles/sbin/deploy-java-files.sh.in
@@ -380,6 +380,8 @@ setUser() {
 # MAIN
 #
 ######################################################################
+cluster_tools_init
+
 source=
 target=
 update_classpath=0
@@ -459,7 +461,6 @@ fi
 
 [ -n "$source" ] && setUser
 
-set_environmentvars
 HPCC_CONFIG=${CONFIG_DIR}/${ENV_CONF_FILE}
 
 

--- a/initfiles/sbin/hpcc-push.sh.in
+++ b/initfiles/sbin/hpcc-push.sh.in
@@ -76,14 +76,15 @@ chmod +x ${SCRIPT_FILE}
 # MAIN
 #
 ############################################
-if [ "${USER}" != "root" ]; then
+cluster_tools_init
+
+if [ "${USER}" != "root" ] && [ "${USER}" != "${user}" ]; then
    echo ""
-   echo "The script must run as root or sudo."
+   echo "The script must run as root, $user or sudo."
    echo ""
    exit 1
 fi
 
-set_environmentvars
 
 source=
 target=

--- a/initfiles/sbin/hpcc-run.sh.in
+++ b/initfiles/sbin/hpcc-run.sh.in
@@ -244,15 +244,15 @@ end() {
 # MAIN
 #
 ############################################
-if [ "${USER}" != "root" ]; then
+cluster_tools_init
+
+if [ "${USER}" != "root" ] && [ "${USER}" != "${user}" ]; then
    echo ""
-   echo "The script must run as root or sudo."
+   echo "The script must run as root, $user or sudo."
    echo ""
    exit 1
 fi
 
-
-set_environmentvars
 envfile=$configs/$environment
 configfile=${CONFIG_DIR}/${ENV_CONF_FILE}
 

--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -122,6 +122,14 @@ removePayload(){
     rm /tmp/remote_install.tgz
 }
 
+
+######################################################################
+#
+# MAIN
+#
+######################################################################
+cluster_tools_init
+
 if [ "${USER}" != "root" ]; then
    echo ""
    echo "The script must run as root or sudo."


### PR DESCRIPTION
1) Modify hpcc-init.in to make HPCC log directory owned by HPCC user
2) Create cluster_tools_init function to create <HPCC log dir>/cluster and owned by HPCC user
3) Invoke cluster_tools_init at beginning of main routine of cluster tools:
   hpcc-install.sh, hpcc-run.sh, hpcc-push.sh and deploy-java-files.sh
4) Allow HPCC user to run hpcc-run.sh and hpcc-push.sh
