### PR TITLE
HPCC-11838 Don't hoist expressions from within SIZEOF()

### DIFF
--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -330,6 +330,9 @@ public:
     void markHoistPoints(IHqlExpression * expr)
     {
         node_operator op = expr->getOperator();
+        if (op == no_sizeof)
+            return;
+
         if (expr->isDataset() || (expr->isDatarow() && (op != no_select)))
         {
             if (!translator.canAssignInline(&ctx, expr))

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -7934,6 +7934,7 @@ void AutoScopeMigrateTransformer::doAnalyseExpr(IHqlExpression * expr)
     case no_allnodes:
     case no_keyedlimit:
     case no_nothor:
+    case no_sizeof:
         return;
     case no_sequential:
         return;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
