### PR TITLE
HPCC-11932 Roxie attach causing Roxie cluster to load empty package

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -251,6 +251,7 @@ private:
     static void writeCache(const char *foundLoc, const char *newLoc, IPropertyTree *val)
     {
         CriticalBlock b(cacheCrit);
+        loadCache();
         cache->removeProp(foundLoc);
         if (val)
             cache->addPropTree(newLoc, LINK(val));
@@ -692,12 +693,11 @@ public:
                     serverStatus = new CSDSServerStatus("RoxieServer");
                     serverStatus->queryProperties()->setProp("@cluster", roxieName.str());
                     serverStatus->commitProperties();
-                    initCache();
+                    isConnected = true; // Make sure this is set before the onReconnect calls, so that they refresh with info from Dali rather than from cache
                     ForEachItemIn(idx, watchers)
                     {
                         watchers.item(idx).onReconnect();
                     }
-                    isConnected = true;
                 }
                 catch(IException *e)
                 {


### PR DESCRIPTION
The onReconnect calls are supposed to reload from new information in dali, but
becuase of the isConnected being set AFTER the onReconnects, and the iniCache
happening before, the onReconnect was liable to reload from the empty cache
information.

The cache should not be cleared on reconnects (only needed on the initial
connect, and that can be handled more cleanly by calling loadCache in
writeCache). The isConnected needs to be set earlier - it was moved recently,
I believe just because it seemed like a good idea... Added a comment to
explain why it needs to be where it is.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
