### PR TITLE
HPCC-11932 Roxie attach causing Roxie cluster to load empty package

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -251,7 +251,8 @@ private:
     static void writeCache(const char *foundLoc, const char *newLoc, IPropertyTree *val)
     {
         CriticalBlock b(cacheCrit);
-        loadCache();
+        if (!cache)
+            initCache();
         cache->removeProp(foundLoc);
         if (val)
             cache->addPropTree(newLoc, LINK(val));


### PR DESCRIPTION
Better for writeCache to clear the cache if it does not exist - otherwise
cache file will never remove unwanted entries.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
