### PR TITLE
HPCC-11938 Fix incorrect Number of Queries from WUListQueries

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1378,7 +1378,7 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
     }
 
     resp.setQuerysetQueries(queries);
-    resp.setNumberOfQueries(queries.length());
+    resp.setNumberOfQueries(numberOfQueries);
 
     return true;
 }


### PR DESCRIPTION
Existing WsWorkunits.WUListQueries returns incorrect Number of Queries.
The bug is fixed now.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
