### PR TITLE
HPCC-11748 Fix WsDFU.DFUQuery not return compressed file size

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -84,6 +84,9 @@ ESPStruct DFUFileDetail
 {
     string Name;
     string Filename;
+    [min_ver("1.28")] string Prefix;
+    [min_ver("1.28")] string NodeGroup;
+    [min_ver("1.28")] int NumParts;
     string Description;
     string Dir;
     string PathMask;
@@ -119,6 +122,7 @@ ESPStruct DFUFileDetail
     [min_ver("1.21")] string ContentType;
     [min_ver("1.22")] int64 CompressedFileSize;
     [min_ver("1.22")] bool IsCompressed(false);
+    [min_ver("1.28")] bool BrowseData(true);
 };
 
 ESPStruct DFUSpaceItem
@@ -650,7 +654,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUSearchDataRespons
 
 //  ===========================================================================
 ESPservice [
-    version("1.27"), default_client_version("1.27"),
+    version("1.28"), default_client_version("1.28"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {


### PR DESCRIPTION
The existing WsDFU.DFUQuery does not return compressed size. That
is caused by reading a wrong property tree of a logical file. It
is fixed now. The code of WsDFU.DFUFile is changed to return
prefix, nodegroup, and NumParts, which are the same as
WsDFU.DFUQuery.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
