### PR TITLE
HPCC-10047 Rename MakeStringException etc

### DIFF
--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -821,7 +821,7 @@ processedProgress:
             StringBuffer localFilename;
             localTempFilename.getPath(localFilename);
             if (!recursiveCreateDirectoryForFile(localFilename))
-                throw MakeOsException(GetLastError(), "Failed to create directory for file: %s", localFilename.str());
+                throw makeOsExceptionV(GetLastError(), "Failed to create directory for file: %s", localFilename.str());
 
             OwnedIFile outFile = createIFile(localFilename.str());
             // if we want spray to not fill page cache use IFEnocache

--- a/deployment/deploy/DeploymentEngine.cpp
+++ b/deployment/deploy/DeploymentEngine.cpp
@@ -1459,7 +1459,7 @@ void CDeploymentEngine::copyInstallFiles(const char* instanceName, int instanceI
     {
         int nThreads = m_threadPool->runningCount();
         if (nThreads > 0)
-            throw MakeOsException(-1, "Unfinished threads detected!");
+            throw makeOsException(-1, "Unfinished threads detected!");
     }
 
     bool bCompare = m_compare;//save
@@ -1618,7 +1618,7 @@ void CDeploymentEngine::copyInstallFiles(const char* instanceName, int instanceI
     {
         m_compare = bCompare;
         m_threadPool->joinAll();
-        throw MakeErrnoException("Error deploying %s", m_name.get());
+        throw makeErrnoExceptionV("Error deploying %s", m_name.get());
     }
 }
 
@@ -2174,7 +2174,7 @@ int CDeploymentEngine::determineInstallFiles(IPropertyTree& processNode, CInstal
     }
     catch (...)
     {
-        throw MakeErrnoException("Error creating file list for process %s", m_name.get());
+        throw makeErrnoExceptionV("Error creating file list for process %s", m_name.get());
     }
 
     m_pCallback->printStatus(STATUS_NORMAL, NULL, NULL, NULL, NULL);

--- a/deployment/deploy/configgenengine.cpp
+++ b/deployment/deploy/configgenengine.cpp
@@ -330,7 +330,7 @@ int CConfigGenEngine::determineInstallFiles(IPropertyTree& processNode, CInstall
     }
     catch (...)
     {
-        throw MakeErrnoException("Error creating file list for process %s", m_name.get());
+        throw makeErrnoExceptionV("Error creating file list for process %s", m_name.get());
     }
 
     m_pCallback->printStatus(STATUS_NORMAL, NULL, NULL, NULL, NULL);

--- a/esp/bindings/SOAP/Platform/soaptype.cpp
+++ b/esp/bindings/SOAP/Platform/soaptype.cpp
@@ -1358,7 +1358,7 @@ void CClientWsTest::async_TestQuery(IClientTestRequest *request, IClientWsTestEv
     } while (0 != status && (errno == EINTR));
     if (status) {
         Release();
-        throw MakeOsException(errno);
+        throw makeOsException(errno);
     }
 #endif
 }

--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -675,7 +675,7 @@ public:
             {
                 int nThreads = m_threadPool->runningCount();
                 if (nThreads > 0)
-                    throw MakeOsException(-1, "Unfinished threads detected!");
+                    throw makeOsException(-1, "Unfinished threads detected!");
             }
 
             Owned<IPropertyTreeIterator> iter = pComputers->getElements(XML_TAG_COMPUTER);
@@ -776,7 +776,7 @@ public:
             if (m_threadPool)
                 m_threadPool->joinAll();
 
-            throw MakeErrnoException("Unknown Exception during cloud operation %s", getFnString(m_eA));
+            throw makeErrnoExceptionV("Unknown Exception during cloud operation %s", getFnString(m_eA));
         }
 
         return false;

--- a/roxie/roxiepipe/roxiepipe.cpp
+++ b/roxie/roxiepipe/roxiepipe.cpp
@@ -125,7 +125,7 @@ public:
 
         if (bytesRead < 0)
         {
-            throw MakeOsException(errno,"readInput");
+            throw makeOsException(errno, "readInput");
         }
 
         if (inputLen > 0)
@@ -160,7 +160,7 @@ public:
                 int bw = write(1, finger, len);
                 if (bw < 0)
                 {
-                    throw MakeOsException(errno,"writeOutput");
+                    throw makeOsException(errno, "writeOutput");
                 }
                 PROGLOG("Wrote %d bytes to stdout (tried to write %d)", bw, len);
                 len -= bw;

--- a/system/jlib/jaio.cpp
+++ b/system/jlib/jaio.cpp
@@ -152,7 +152,7 @@ void AsyncBlockReader::enqueue(AsyncRequest *req)
         rd = (int)(insize-offset);
     if (aioread64(infile, req->buffer, rd, offset, FILE_BEGIN, &req->result)==-1) 
     {
-        throw MakeOSException("async failed ");
+        throw makeOSException("async failed ");
     }
     offset+=rd;
 }

--- a/system/jlib/jbuff.cpp
+++ b/system/jlib/jbuff.cpp
@@ -606,7 +606,7 @@ MemoryBuffer &MemoryBuffer::appendFile(const char *fileName)
     int r;
     while ((r = _read(h, buf, 1024)) != 0)
     {
-        if (-1==r) throw MakeErrnoException("MemoryBuffer::appendFile");
+        if (-1==r) throw makeErrnoException("MemoryBuffer::appendFile");
         append(r, buf); 
     }
     _close(h);

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -193,7 +193,7 @@ static void doSetCompilerPath(const char * path, const char * includes, const ch
 #endif
         if (verbose)
             PrintLog("SetCompilerPath - no compiler found");
-        throw MakeOsException(GetLastError(), "setCompilerPath could not locate compiler %s", fname.str());
+        throw makeOsExceptionV(GetLastError(), "setCompilerPath could not locate compiler %s", fname.str());
     }
 
     if(tmpdir && *tmpdir)

--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -860,7 +860,7 @@ unsigned getAffinityCpus()
     }
     else // fall back to legacy num system cpus
     {
-        Owned<IException> e = MakeOsException(GetLastError(), "Failed to get affinity");
+        Owned<IException> e = makeOsException(GetLastError(), "Failed to get affinity");
         EXCLOG(e, NULL);
         unsigned cpuSpeed;
         getCpuInfo(numCpus, cpuSpeed);

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -72,49 +72,49 @@ protected:
 };  
 
 
-IException *MakeStringExceptionVA(int code, const char *format, va_list args)
+IException *makeStringExceptionVA(int code, const char *format, va_list args)
 {
     StringBuffer eStr;
     eStr.limited_valist_appendf(1024, format, args);
     return new StringException(code, eStr.str());
 }
 
-IException *MakeStringException(int code,const char *format, ...)
+IException *makeStringExceptionV(int code,const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    IException *ret = MakeStringExceptionVA(code, format, args);
+    IException *ret = makeStringExceptionVA(code, format, args);
     va_end(args);
     return ret;
 }
 
-IException jlib_decl *MakeStringExceptionDirect(int code,const char *why)
+IException jlib_decl *makeStringException(int code,const char *why)
 {
     return new StringException(code,why);
 }
 
-IException *MakeStringExceptionVA(MessageAudience aud, int code, const char *format, va_list args)
+IException *makeStringExceptionVA(MessageAudience aud, int code, const char *format, va_list args)
 {
     StringBuffer eStr;
     eStr.limited_valist_appendf(1024, format, args);
     return new StringException(code, eStr.str(), aud);
 }
 
-IException *MakeStringException(MessageAudience aud, int code, const char *format, ...)
+IException *makeStringExceptionV(MessageAudience aud, int code, const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    IException *ret = MakeStringExceptionVA(aud, code, format, args);
+    IException *ret = makeStringExceptionVA(aud, code, format, args);
     va_end(args);
     return ret;
 }
 
-IException jlib_decl *MakeStringExceptionDirect(MessageAudience aud,int code,const char *why)
+IException jlib_decl *makeStringException(MessageAudience aud,int code,const char *why)
 {
     return new StringException(code,why,aud);
 }
 
-void jlib_decl ThrowStringException(int code,const char *format, ...)
+void jlib_decl throwStringExceptionV(int code,const char *format, ...)
 {
     va_list args;
     va_start(args, format);
@@ -146,12 +146,17 @@ protected:
 };  
 
 
-IOSException *MakeOsException(int code)
+IOSException *makeOsException(int code)
 {
     return new OsException(code);
 }
 
-IOSException *MakeOsException(int code, const char *msg, ...)
+IOSException *makeOsException(int code, const char *msg)
+{
+    return new OsException(code, msg);
+}
+
+IOSException *makeOsExceptionV(int code, const char *msg, ...)
 {
     StringBuffer eStr;
     va_list args;
@@ -188,12 +193,17 @@ protected:
 };  
 
 
-IErrnoException *MakeErrnoException(int errn)
+IErrnoException *makeErrnoException(int errn, const char *msg)
 {
-    return new ErrnoException(errn);
+    return new ErrnoException(errn, msg);
 }
 
-IErrnoException *MakeErrnoException(int errn, const char *msg, ...)
+IErrnoException *makeErrnoException(const char *msg)
+{
+    return new ErrnoException(-1, msg);
+}
+
+IErrnoException *makeErrnoExceptionV(int errn, const char *msg, ...)
 {
     StringBuffer eStr;
     va_list args;
@@ -203,7 +213,7 @@ IErrnoException *MakeErrnoException(int errn, const char *msg, ...)
     return new ErrnoException(errn, eStr.str());
 }
 
-IErrnoException *MakeErrnoException(const char *msg, ...)
+IErrnoException *makeErrnoExceptionV(const char *msg, ...)
 {
     StringBuffer eStr;
     va_list args;
@@ -213,12 +223,12 @@ IErrnoException *MakeErrnoException(const char *msg, ...)
     return new ErrnoException(-1, eStr.str());
 }
 
-IErrnoException *MakeErrnoException(MessageAudience aud, int errn)
+IErrnoException *makeErrnoException(MessageAudience aud, int errn, const char *msg)
 {
-    return new ErrnoException(errn, "", aud);
+    return new ErrnoException(errn, msg, aud);
 }
 
-IErrnoException *MakeErrnoException(MessageAudience aud, int errn, const char *msg, ...)
+IErrnoException *makeErrnoExceptionV(MessageAudience aud, int errn, const char *msg, ...)
 {
     StringBuffer eStr;
     va_list args;
@@ -228,7 +238,7 @@ IErrnoException *MakeErrnoException(MessageAudience aud, int errn, const char *m
     return new ErrnoException(errn, eStr.str(), aud);
 }
 
-IErrnoException *MakeErrnoException(MessageAudience aud, const char *msg, ...)
+IErrnoException *makeErrnoExceptionV(MessageAudience aud, const char *msg, ...)
 {
     StringBuffer eStr;
     va_list args;

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -118,7 +118,7 @@ void jlib_decl throwStringExceptionV(int code,const char *format, ...)
 {
     va_list args;
     va_start(args, format);
-    IException *ret = MakeStringExceptionVA(code, format, args);
+    IException *ret = makeStringExceptionVA(code, format, args);
     va_end(args);
     throw ret;
 }
@@ -248,7 +248,7 @@ IErrnoException *makeErrnoExceptionV(MessageAudience aud, const char *msg, ...)
     return new ErrnoException(-1, eStr.str(), aud);
 }
 
-const char* SerializeMessageAudience(MessageAudience ma)
+const char* serializeMessageAudience(MessageAudience ma)
 {
     const char* ret;
     switch(ma)
@@ -267,7 +267,7 @@ const char* SerializeMessageAudience(MessageAudience ma)
     return ret;
 }
 
-MessageAudience DeserializeMessageAudience(const char* text)
+MessageAudience deserializeMessageAudience(const char* text)
 {
     MessageAudience ma = MSGAUD_unknown;
     if (text && *text)
@@ -344,7 +344,7 @@ public:
                 StringBuffer msg;
                 msg.appendf("[%s] ",source);
                 e.errorMessage(msg);
-                array_.append(*MakeStringException(e.errorAudience(), e.errorCode(), "%s", msg.str()));
+                array_.append(*makeStringExceptionV(e.errorAudience(), e.errorCode(), "%s", msg.str()));
             }
             else
                 array_.append(*LINK(&e));
@@ -378,7 +378,7 @@ public:
             buffer.appendf("<Code>%d</Code>", exception.errorCode());
             
             if (indent) buffer.append("\n\t\t");
-            buffer.appendf("<Audience>%s</Audience>", SerializeMessageAudience( exception.errorAudience() ));
+            buffer.appendf("<Audience>%s</Audience>", serializeMessageAudience( exception.errorAudience() ));
             
             if (simplified)
             {
@@ -412,7 +412,7 @@ public:
             xml = wrapper.appendf("<Exceptions>%s</Exceptions>", xml).str();
         Owned<IPropertyTree> pTree = createPTreeFromXMLString(xml);
         if (!pTree)
-            throw MakeStringException(-1, "Failed to deserialize IMultiException!");
+            throw makeStringException(-1, "Failed to deserialize IMultiException!");
         Owned<IPropertyTreeIterator> i = pTree->getElements("Exception");
         
         if (pTree->hasProp("Source"))
@@ -431,10 +431,10 @@ public:
         {
             IPropertyTree* pNode = &i->query();
             IException* pException = 
-                MakeStringExceptionDirect(
-                DeserializeMessageAudience(pNode->queryProp("Audience")), 
-                pNode->getPropInt("Code", -1), 
-                pNode->queryProp("Message"));
+                makeStringException(
+                   deserializeMessageAudience(pNode->queryProp("Audience")),
+                   pNode->getPropInt("Code", -1),
+                   pNode->queryProp("Message"));
             array_.append(*pException);
         }
     }   
@@ -471,7 +471,7 @@ private:
     mutable Mutex        m_mutex;
 };
 
-IMultiException *MakeMultiException(const char* source/*=NULL*/)
+IMultiException *makeMultiException(const char* source/*=NULL*/)
 {
     return new CMultiException(source);
 }
@@ -497,9 +497,9 @@ void userBreakpoint()
 #endif
 }
 
-void RaiseAssertException(const char *assertion, const char *file, unsigned line)
+void raiseAssertException(const char *assertion, const char *file, unsigned line)
 {
-    PrintStackReport();
+    printStackReport();
     StringBuffer s;
     s.append("assert(");
     s.append(assertion);
@@ -525,12 +525,12 @@ void RaiseAssertException(const char *assertion, const char *file, unsigned line
 #endif
 #endif
 
-    throw MakeStringExceptionDirect(3000, s.toCharArray()); // 3000: internal error
+    throw makeStringException(3000, s.toCharArray()); // 3000: internal error
 }
 
-void RaiseAssertCore(const char *assertion, const char *file, unsigned line)
+void raiseAssertCore(const char *assertion, const char *file, unsigned line)
 {
-    PrintStackReport();
+    printStackReport();
     StringBuffer s;
     s.append("assert(");
     s.append(assertion);
@@ -1162,7 +1162,7 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
 #endif
 
 #ifdef _EXECINFO_H
-    PrintStackReport();
+    printStackReport();
 #endif  
     StringBuffer threadlist;
     PROGLOG( "ThreadList:\n%s",getThreadList(threadlist).str());
@@ -1221,7 +1221,7 @@ void jlib_decl *setSEHtoExceptionHandler(IExceptionHandler *handler)
     return ret;
 }
 
-void jlib_decl EnableSEHtoExceptionMapping()
+void jlib_decl enableSEHtoExceptionMapping()
 {
 #ifdef NOSEH
     return;
@@ -1246,7 +1246,7 @@ void jlib_decl EnableSEHtoExceptionMapping()
 }
 
 
-void  jlib_decl DisableSEHtoExceptionMapping()
+void  jlib_decl disableSEHtoExceptionMapping()
 {
 #ifdef NOSEH
     return;
@@ -1311,7 +1311,7 @@ IException * deserializeException(MemoryBuffer & in)
     StringAttr text;
     in.read(code);
     in.read(text);
-    return MakeStringException(code, "%s", text.get());
+    return makeStringExceptionV(code, "%s", text.get());
 }
 
 void jlib_decl serializeException(IException * e, MemoryBuffer & out)
@@ -1328,7 +1328,7 @@ void jlib_decl serializeException(IException * e, MemoryBuffer & out)
 }
 
 
-void PrintStackReport()
+void printStackReport()
 {
 #ifdef _WIN32
     unsigned onstack=1234;

--- a/system/jlib/jexcept.hpp
+++ b/system/jlib/jexcept.hpp
@@ -24,8 +24,8 @@
 #include "jlib.hpp"
 #include "errno.h"
 
-jlib_decl const char* SerializeMessageAudience(MessageAudience ma);
-jlib_decl MessageAudience DeserializeMessageAudience(const char* text);
+jlib_decl const char* serializeMessageAudience(MessageAudience ma);
+jlib_decl MessageAudience deserializeMessageAudience(const char* text);
 
 //the following interface to be thrown when a user command explicitly calls for a failure
 
@@ -59,7 +59,7 @@ interface jlib_thrown_decl IMultiException : extends IException
     virtual MessageAudience errorAudience() const = 0;
 };
 
-IMultiException jlib_decl *MakeMultiException(const char* source = NULL);
+IMultiException jlib_decl *makeMultiException(const char* source = NULL);
 
 interface IExceptionHandler
 {
@@ -76,6 +76,7 @@ void jlib_decl throwStringExceptionV(int code, const char *format, ...) __attrib
 
 // Macros for legacy names of above functions
 
+#define MakeMultiException makeMultiException
 #define MakeStringException makeStringExceptionV
 #define MakeStringExceptionVA makeStringExceptionVA
 #define MakeStringExceptionDirect makeStringException
@@ -111,31 +112,36 @@ interface jlib_thrown_decl IOutOfMemException: extends IException
 };
 
 
-void  jlib_decl EnableSEHtoExceptionMapping(); // return value can be used to disable
-void  jlib_decl DisableSEHtoExceptionMapping();         
+void  jlib_decl enableSEHtoExceptionMapping();
+void  jlib_decl disableSEHtoExceptionMapping();
 // NB only enables for current thread or threads started after call
 // requires /EHa option to be set in VC++ options (after /GX)
+// Macros for legacy names of above functions
+#define EnableSEHtoExceptionMapping enableSEHtoExceptionMapping
+#define DisableSEHtoExceptionMapping disableSEHtoExceptionMapping
 
 void jlib_decl *setSEHtoExceptionHandler(IExceptionHandler *handler); // sets handler and return old value
 
 
-void  jlib_decl setTerminateOnSEHInSystemDLLs(bool set=true);
+void jlib_decl setTerminateOnSEHInSystemDLLs(bool set=true);
 void jlib_decl setTerminateOnSEH(bool set=true);
 
 
-#define makeUnexpectedException()  MakeStringException(9999, "Internal Error at %s(%d)", __FILE__, __LINE__)
-#define throwUnexpected()          throw MakeStringException(9999, "Internal Error at %s(%d)", __FILE__, __LINE__)
-#define throwUnexpectedX(x)        throw MakeStringException(9999, "Internal Error '" x "' at %s(%d)", __FILE__, __LINE__)
+#define makeUnexpectedException()  makeStringExceptionV(9999, "Internal Error at %s(%d)", __FILE__, __LINE__)
+#define throwUnexpected()          throw makeStringExceptionV(9999, "Internal Error at %s(%d)", __FILE__, __LINE__)
+#define throwUnexpectedX(x)        throw makeStringExceptionV(9999, "Internal Error '" x "' at %s(%d)", __FILE__, __LINE__)
 #define assertThrow(x)             assertex(x)
 
-#define UNIMPLEMENTED throw MakeStringException(-1, "UNIMPLEMENTED feature at %s(%d)", __FILE__, __LINE__)
-#define UNIMPLEMENTED_X(reason) throw MakeStringException(-1, "UNIMPLEMENTED '" reason "' at %s(%d)", __FILE__, __LINE__)
-#define UNIMPLEMENTED_XY(a,b) throw MakeStringException(-1, "UNIMPLEMENTED " a " %s at %s(%d)", b, __FILE__, __LINE__)
+#define UNIMPLEMENTED throw makeStringExceptionV(-1, "UNIMPLEMENTED feature at %s(%d)", __FILE__, __LINE__)
+#define UNIMPLEMENTED_X(reason) throw makeStringExceptionV(-1, "UNIMPLEMENTED '" reason "' at %s(%d)", __FILE__, __LINE__)
+#define UNIMPLEMENTED_XY(a,b) throw makeStringExceptionV(-1, "UNIMPLEMENTED " a " %s at %s(%d)", b, __FILE__, __LINE__)
 
 IException jlib_decl * deserializeException(MemoryBuffer & in); 
 void jlib_decl serializeException(IException * e, MemoryBuffer & out); 
 
-void  jlib_decl PrintStackReport();
+void  jlib_decl printStackReport();
+// Macro for legacy name of above function
+#define PrintStackReport printStackReport
 
 #ifdef _DEBUG
 #define RELEASE_CATCH_ALL       int*********
@@ -145,11 +151,11 @@ void  jlib_decl PrintStackReport();
 
 //These are used in several places to wrap error reporting, to keep error numbers+text together.  E.g.,
 //#define XYZfail 99    #define XXZfail_Text "Failed"     throwError(XYZfail)
-#define throwError(x)                           ThrowStringException(x, (x ## _Text))
-#define throwError1(x,a)                        ThrowStringException(x, (x ## _Text), a)
-#define throwError2(x,a,b)                      ThrowStringException(x, (x ## _Text), a, b)
-#define throwError3(x,a,b,c)                    ThrowStringException(x, (x ## _Text), a, b, c)
-#define throwError4(x,a,b,c,d)                  ThrowStringException(x, (x ## _Text), a, b, c, d)
+#define throwError(x)                           throwStringExceptionV(x, (x ## _Text))
+#define throwError1(x,a)                        throwStringExceptionV(x, (x ## _Text), a)
+#define throwError2(x,a,b)                      throwStringExceptionV(x, (x ## _Text), a, b)
+#define throwError3(x,a,b,c)                    throwStringExceptionV(x, (x ## _Text), a, b, c)
+#define throwError4(x,a,b,c,d)                  throwStringExceptionV(x, (x ## _Text), a, b, c, d)
 
 #endif
 

--- a/system/jlib/jexcept.hpp
+++ b/system/jlib/jexcept.hpp
@@ -66,27 +66,36 @@ interface IExceptionHandler
    virtual bool fireException(IException *e) = 0;
 };
 
-IException jlib_decl *MakeStringException(int code,const char *why, ...) __attribute__((format(printf, 2, 3)));
-IException jlib_decl *MakeStringExceptionVA(int code,const char *why, va_list args);
-IException jlib_decl *MakeStringExceptionDirect(int code,const char *why);
-IException jlib_decl *MakeStringException(MessageAudience aud,int code,const char *why, ...) __attribute__((format(printf, 3, 4)));
-IException jlib_decl *MakeStringExceptionVA(MessageAudience aud,int code,const char *why, va_list args);
-IException jlib_decl *MakeStringExceptionDirect(MessageAudience aud,int code,const char *why);
-void jlib_decl ThrowStringException(int code,const char *format, ...) __attribute__((format(printf, 2, 3), noreturn));
+IException jlib_decl *makeStringExceptionV(int code, const char *why, ...) __attribute__((format(printf, 2, 3)));
+IException jlib_decl *makeStringExceptionVA(int code, const char *why, va_list args);
+IException jlib_decl *makeStringException(int code, const char *why);
+IException jlib_decl *makeStringExceptionV(MessageAudience aud, int code, const char *why, ...) __attribute__((format(printf, 3, 4)));
+IException jlib_decl *makeStringExceptionVA(MessageAudience aud, int code, const char *why, va_list args);
+IException jlib_decl *makeStringException(MessageAudience aud, int code, const char *why);
+void jlib_decl throwStringExceptionV(int code, const char *format, ...) __attribute__((format(printf, 2, 3), noreturn));
+
+// Macros for legacy names of above functions
+
+#define MakeStringException makeStringExceptionV
+#define MakeStringExceptionVA makeStringExceptionVA
+#define MakeStringExceptionDirect makeStringException
+#define ThrowStringException throwStringExceptionV
 
 interface jlib_thrown_decl IOSException: extends IException{};
-IOSException jlib_decl *MakeOsException(int code);
-IOSException jlib_decl *MakeOsException(int code, const char *msg, ...) __attribute__((format(printf, 2, 3)));
+IOSException jlib_decl *makeOsException(int code);
+IOSException jlib_decl *makeOsException(int code, const char *msg);
+IOSException jlib_decl *makeOsExceptionV(int code, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 
 #define DISK_FULL_EXCEPTION_CODE ENOSPC
 
 interface jlib_thrown_decl IErrnoException: extends IException{};
-IErrnoException jlib_decl *MakeErrnoException(int errn=-1);
-IErrnoException jlib_decl *MakeErrnoException(int errn, const char *why, ...) __attribute__((format(printf, 2, 3)));
-IErrnoException jlib_decl *MakeErrnoException(const char *why, ...) __attribute__((format(printf, 1, 2)));
-IErrnoException jlib_decl *MakeErrnoException(MessageAudience aud,int errn=-1);
-IErrnoException jlib_decl *MakeErrnoException(MessageAudience aud,int errn, const char *why, ...) __attribute__((format(printf, 3, 4)));
-IErrnoException jlib_decl *MakeErrnoException(MessageAudience aud,const char *why, ...) __attribute__((format(printf, 2, 3)));
+IErrnoException jlib_decl *makeErrnoException(int errn, const char *why);
+IErrnoException jlib_decl *makeErrnoException(const char *why);
+IErrnoException jlib_decl *makeErrnoExceptionV(int errn, const char *why, ...) __attribute__((format(printf, 2, 3)));
+IErrnoException jlib_decl *makeErrnoExceptionV(const char *why, ...) __attribute__((format(printf, 1, 2)));
+IErrnoException jlib_decl *makeErrnoException(MessageAudience aud, int errn, const char *why);
+IErrnoException jlib_decl *makeErrnoExceptionV(MessageAudience aud, int errn, const char *why, ...) __attribute__((format(printf, 3, 4)));
+IErrnoException jlib_decl *makeErrnoExceptionV(MessageAudience aud, const char *why, ...) __attribute__((format(printf, 2, 3)));
 
 void jlib_decl pexception(const char *msg,IException *e); // like perror except for exceptions
 jlib_decl StringBuffer & formatSystemError(StringBuffer & out, unsigned errcode);

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -287,7 +287,7 @@ bool WindowsCreateDirectory(const char * path)
         if ((retry++==10)||  // some or all of the following can occur when the domain controller gets busy
                              // retrying improves chance of success
             ((err!=ERROR_NETNAME_DELETED)&&(err!=ERROR_DEV_NOT_EXIST)&&(err!=ERROR_GEN_FAILURE)&&(err!=ERROR_NETWORK_BUSY)&&(err!=ERROR_BAD_NET_NAME))) 
-            throw MakeOsException(err,"WindowsCreateDirectory %s", path);
+            throw makeOsExceptionV(err,"WindowsCreateDirectory %s", path);
         //PROGLOG("Retrying(%d) WindowsCreateDirectory %s, err=%d",retry,filename,err);
         Sleep(retry*100); 
     }
@@ -602,7 +602,7 @@ HANDLE CFile::openHandle(IFOmode mode, IFSHmode sharemode, bool async, int stdh)
     {   
         DWORD err = GetLastError();
         if ((IFOread!=mode) || ((err!=ERROR_FILE_NOT_FOUND) && (err!=ERROR_PATH_NOT_FOUND)))
-            throw MakeOsException(err,"CFile::open %s (%x, %x)", filename.get(), mode, share);
+            throw makeOsExceptionV(err,"CFile::open %s (%x, %x)", filename.get(), mode, share);
         return NULLFILE;
     }
 #else
@@ -634,7 +634,7 @@ HANDLE CFile::openHandle(IFOmode mode, IFSHmode sharemode, bool async, int stdh)
     if (handle == -1)
     {
         if ((IFOread!=mode) || (errno != ENOENT))
-            throw MakeErrnoException(errno, "CFile::open %s", filename.get());
+            throw makeErrnoExceptionV(errno, "CFile::open %s", filename.get());
         return NULLFILE;
     }
     // check not a directory (compatible with windows)
@@ -644,12 +644,12 @@ HANDLE CFile::openHandle(IFOmode mode, IFSHmode sharemode, bool async, int stdh)
         int err = errno;
         close(handle);
         handle = NULLFILE;
-        throw MakeErrnoException(err, "CFile::open fstat %s", filename.get());
+        throw makeErrnoExceptionV(err, "CFile::open fstat %s", filename.get());
     }
     if (S_ISDIR(info.st_mode)) {
         close(handle);
         handle = NULLFILE;
-        throw MakeErrnoException(EISDIR, "CFile::open %s", filename.get());
+        throw makeErrnoExceptionV(EISDIR, "CFile::open %s", filename.get());
     }
 
 #ifdef CFILEIOTRACE
@@ -701,7 +701,7 @@ bool CFile::remove()
         if ((retry++==10)||  // some or all of the following can occur when the domain controller gets busy
                              // retrying improves chance of success
             ((err!=ERROR_NETNAME_DELETED)&&(err!=ERROR_DEV_NOT_EXIST)&&(err!=ERROR_GEN_FAILURE)&&(err!=ERROR_NETWORK_BUSY)&&(err!=ERROR_BAD_NET_NAME))) 
-            throw MakeOsException(err,"CFile::remove %s", filename.get());
+            throw makeOsExceptionV(err, "CFile::remove %s", filename.get());
         //PROGLOG("Retrying(%d) DeleteFile %s, err=%d",retry,filename,err);
         Sleep(retry*100); 
     }
@@ -716,7 +716,7 @@ bool CFile::remove()
             return true;
     }
     if (ENOENT!=errno)
-        throw MakeErrnoException("CFile::remove %s", filename.get());
+        throw makeErrnoExceptionV("CFile::remove %s", filename.get());
     return false;
 #endif
 }
@@ -741,7 +741,7 @@ void CFile::rename(const char *newname)
             dst = rfn.getLocalPath(path.clear()).str();
     }
     if (-1 == ::rename(filename, dst)) 
-        throw MakeErrnoException("CFile::rename(%s, %s)", filename.get(),dst);
+        throw makeErrnoExceptionV("CFile::rename(%s, %s)", filename.get(),dst);
     filename.set(path);
 }
 
@@ -765,13 +765,13 @@ void CFile::move(const char *newname)
         if ((retry++==10)||  // some or all of the following can occur when the domain controller gets busy
                              // retrying improves chance of success
             ((err!=ERROR_NETNAME_DELETED)&&(err!=ERROR_DEV_NOT_EXIST)&&(err!=ERROR_GEN_FAILURE)&&(err!=ERROR_NETWORK_BUSY)&&(err!=ERROR_BAD_NET_NAME))) 
-            throw MakeOsException(err,"CFile::move(%s, %s)", filename.get(), newname);
+            throw makeOsExceptionV(err, "CFile::move(%s, %s)", filename.get(), newname);
         Sleep(retry*100); 
     }
 #else
     int ret=::rename(filename.get(),newname);
     if (ret==-1)
-        throw MakeErrnoException("CFile::move(%s, %s)", filename.get(), newname);
+        throw makeErrnoExceptionV("CFile::move(%s, %s)", filename.get(), newname);
 #endif
     filename.set(newname);
 }
@@ -888,7 +888,7 @@ void CFile::copySection(const RemoteFilename &dest, offset_t toOfs, offset_t fro
         StringBuffer s;
         s.append("copyFile target=").append(target->queryFilename()).append(" source=").append(queryFilename()).append("; read/write failure").append(": ");
         e->errorMessage(s);
-        IException *e2 = MakeOsException(e->errorCode(), "%s", s.str());
+        IException *e2 = makeOsExceptionV(e->errorCode(), "%s", s.str());
         e->Release();
         throw e2;
     }
@@ -908,12 +908,12 @@ void CFile::setReadOnly(bool ro)
     {
         DWORD err = GetLastError();
         if ( (err!=ERROR_FILE_NOT_FOUND) && (err!=ERROR_PATH_NOT_FOUND) )
-            throw MakeOsException(err, "CFile::setReadOnly %s", filename.get());
+            throw makeOsExceptionV(err, "CFile::setReadOnly %s", filename.get());
     }
 #else
     struct stat info;
     if (stat(filename, &info) != 0)
-        throw MakeErrnoException("CFile::setReadOnly() %s", filename.get());
+        throw makeErrnoExceptionV("CFile::setReadOnly() %s", filename.get());
     // not sure correct but consistant with isReadOnly
     if (ro)
         info.st_mode &= ~(S_IWUSR|S_IWGRP|S_IWOTH);
@@ -955,13 +955,13 @@ bool CFile::setCompression(bool set)
 #ifdef _WIN32
     DWORD attr=::GetFileAttributes(filename.get());
     if(attr==-1)
-        throw MakeOsException(::GetLastError(), "CFile::setCompression %s", filename.get());
+        throw makeOsExceptionV(::GetLastError(), "CFile::setCompression %s", filename.get());
     if (((attr & FILE_ATTRIBUTE_COMPRESSED) != 0) == set)
         return true;
 
     HANDLE handle=::CreateFile(filename.get(),GENERIC_READ|GENERIC_WRITE,0,NULL,OPEN_EXISTING,FILE_FLAG_BACKUP_SEMANTICS,NULL);
     if(handle==INVALID_HANDLE_VALUE)
-        throw MakeOsException(::GetLastError(), "CFile::setCompression %s", filename.get());
+        throw makeOsExceptionV(::GetLastError(), "CFile::setCompression %s", filename.get());
 
     USHORT compression=set ? COMPRESSION_FORMAT_DEFAULT : COMPRESSION_FORMAT_NONE;
     DWORD bytes;
@@ -972,7 +972,7 @@ bool CFile::setCompression(bool set)
     }
     DWORD err=::GetLastError();
     ::CloseHandle(handle);
-    throw MakeOsException(err, "CFile::setCompression %s", filename.get());
+    throw makeOsExceptionV(err, "CFile::setCompression %s", filename.get());
 #else
     return false;
 #endif
@@ -985,7 +985,7 @@ offset_t CFile::compressedSize()
     if(lo==INVALID_FILE_SIZE && (err=::GetLastError())!=NO_ERROR)
     {
         if ( (err!=ERROR_FILE_NOT_FOUND) && (err!=ERROR_PATH_NOT_FOUND) )
-            throw MakeOsException(err,"CFile::compressedSize %s", filename.get());
+            throw makeOsExceptionV(err,"CFile::compressedSize %s", filename.get());
         return -1;
     }
     return makeint64(hi,lo);
@@ -1011,15 +1011,17 @@ public:
         locked = false;
 #ifdef _WIN32
         handle=::CreateFile(file->queryFilename(),GENERIC_READ,FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE,NULL,OPEN_EXISTING,FILE_FLAG_BACKUP_SEMANTICS,NULL);
-        if(handle==INVALID_HANDLE_VALUE) {
+        if(handle==INVALID_HANDLE_VALUE)
+        {
             handle = NULLFILE;
-            throw MakeOsException(GetLastError(),"CDiscretionaryFileLock::openhandle %s", file->queryFilename());
+            throw makeOsExceptionV(GetLastError(), "CDiscretionaryFileLock::openhandle %s", file->queryFilename());
         }
 #else
         handle = _lopen(file->queryFilename(), O_RDONLY, 0);
-        if (handle == -1) {
+        if (handle == -1)
+        {
             handle = NULLFILE;
-            throw MakeErrnoException(errno, "CDiscretionaryFileLock::openhandle %s",file->queryFilename());
+            throw makeErrnoExceptionV(errno, "CDiscretionaryFileLock::openhandle %s", file->queryFilename());
         }
 #endif
     }
@@ -1033,7 +1035,7 @@ public:
         if (cfileio)
             handle = cfileio->queryHandle();
         if (handle==NULLFILE)
-            throw MakeStringException(-1,"CDiscretionaryFileLock - invalid parameter"); 
+            throw makeStringException(-1, "CDiscretionaryFileLock - invalid parameter");
     }
     ~CDiscretionaryFileLock()
     {
@@ -1078,7 +1080,7 @@ public:
             
             DWORD err = ::GetLastError();
             if (err!=ERROR_LOCK_VIOLATION) 
-                throw MakeOsException(err, "CDiscretionaryFileLock::lock");
+                throw makeOsException(err, "CDiscretionaryFileLock::lock");
 #else
             if (setShareLock(handle,exclusive?IFSHnone:IFSHread))
                 break;
@@ -1107,7 +1109,7 @@ public:
             OVERLAPPED overlapped;
             memset(&overlapped,0,sizeof(overlapped));
             if (!UnlockFileEx(handle,0,1,0,&overlapped)) 
-                throw MakeOsException(::GetLastError(), "CDiscretionaryFileLock::unlockhandle");
+                throw makeOsException(::GetLastError(), "CDiscretionaryFileLock::unlockhandle");
 #else
             setShareLock(handle,IFSHfull);
 #endif
@@ -1671,7 +1673,7 @@ public:
             DWORD err = GetLastError();
             if (err==ERROR_BROKEN_PIPE)  // windows returns this at end of pipe
                 return 0;
-            throw MakeOsException(GetLastError(),"CSequentialFileIO::read"); 
+            throw makeOsException(GetLastError(),"CSequentialFileIO::read");
         }
         size32_t ret = (size32_t)numRead;
 #else
@@ -1688,20 +1690,21 @@ public:
         size32_t ret;
 #ifdef _WIN32
         DWORD numWritten;
-        if (!WriteFile(file,data,len,&numWritten,NULL))
-            throw MakeOsException(GetLastError(),"CSequentialFileIO::write");
+        if (!WriteFile(file, data, len, &numWritten, NULL))
+            throw makeOsException(GetLastError(), "CSequentialFileIO::write");
         if (numWritten != len)
-            throw MakeOsException(DISK_FULL_EXCEPTION_CODE,"CSequentialFileIO::write");
-        ret = (size32_t)numWritten;
+            throw makeOsException(DISK_FULL_EXCEPTION_CODE, "CSequentialFileIO::write");
+        ret = (size32_t) numWritten;
 #else
         ret = ::write(file,data,len);
-        if (ret==(size32_t)-1) {
+        if (ret==(size32_t)-1)
+        {
             PrintStackReport();
             ERRLOG("errno(%d): %"I64F"d %u",errno,pos,len);
-            throw MakeErrnoException(errno,"CFileIO::write");
+            throw makeErrnoException(errno, "CFileIO::write");
         }
         if (ret<len)
-            throw MakeOsException(DISK_FULL_EXCEPTION_CODE,"CSequentialFileIO::write");
+            throw makeOsException(DISK_FULL_EXCEPTION_CODE, "CSequentialFileIO::write");
 #endif
         pos += ret;
         return ret;
@@ -1800,7 +1803,7 @@ void CFileIO::close()
     if (file != NULLFILE)
     {
         if (!CloseHandle(file))
-            throw MakeOsException(GetLastError(),"CFileIO::close");
+            throw makeOsException(GetLastError(),"CFileIO::close");
     }
     file = NULLFILE;
 }
@@ -1808,7 +1811,7 @@ void CFileIO::close()
 void CFileIO::flush()
 {
     if (!FlushFileBuffers(file))
-        throw MakeOsException(GetLastError(),"CFileIO::flush");
+        throw makeOsException(GetLastError(),"CFileIO::flush");
 }
 
 offset_t CFileIO::size()
@@ -1818,7 +1821,7 @@ offset_t CFileIO::size()
     if (pos.LowPart==-1) {
         DWORD err = GetLastError();
         if (err!=0)     
-            throw MakeOsException(err,"CFileIO::size");
+            throw makeOsException(err,"CFileIO::size");
     }
     return pos.QuadPart;
 }
@@ -1831,7 +1834,7 @@ size32_t CFileIO::read(offset_t pos, size32_t len, void * data)
     DWORD numRead;
     setPos(pos);
     if (ReadFile(file,data,len,&numRead,NULL) == 0)
-        throw MakeOsException(GetLastError(),"CFileIO::read");
+        throw makeOsException(GetLastError(),"CFileIO::read");
     return (size32_t)numRead;
 }
 
@@ -1849,9 +1852,9 @@ size32_t CFileIO::write(offset_t pos, size32_t len, const void * data)
     DWORD numWritten;
     setPos(pos);
     if (!WriteFile(file,data,len,&numWritten,NULL))
-        throw MakeOsException(GetLastError(),"CFileIO::write");
+        throw makeOsException(GetLastError(),"CFileIO::write");
     if (numWritten != len)
-        throw MakeOsException(DISK_FULL_EXCEPTION_CODE,"CFileIO::write");
+        throw makeOsException(DISK_FULL_EXCEPTION_CODE,"CFileIO::write");
     return (size32_t)numWritten;
 }
 
@@ -1861,7 +1864,7 @@ void CFileIO::setSize(offset_t pos)
     CriticalBlock procedure(cs);
     setPos(pos);
     if (!SetEndOfFile(file))
-        throw MakeOsException(GetLastError(), "CFileIO::setSize");
+        throw makeOsException(GetLastError(), "CFileIO::setSize");
 }
 
 #else
@@ -1923,7 +1926,7 @@ void CFileIO::close()
 #endif
         }
         if (::close(file) < 0)
-            throw MakeErrnoException(errno,"CFileIO::close");
+            throw makeErrnoException(errno, "CFileIO::close");
         file=NULLFILE;
     }
 }
@@ -1936,7 +1939,7 @@ void CFileIO::flush()
 #else
     if (fdatasync(file) != 0)
 #endif
-        throw MakeOsException(DISK_FULL_EXCEPTION_CODE,"CFileIO::flush");
+        throw makeOsException(DISK_FULL_EXCEPTION_CODE, "CFileIO::flush");
 #ifdef POSIX_FADV_DONTNEED
     if (extraFlags & IFEnocache)
         posix_fadvise(file, 0, 0, POSIX_FADV_DONTNEED);
@@ -1991,11 +1994,10 @@ static void sync_file_region(int fd, offset_t offset, offset_t nbytes)
 size32_t CFileIO::write(offset_t pos, size32_t len, const void * data)
 {
     size32_t ret = pwrite(file,data,len,pos);
-    if (ret==(size32_t)-1) {
-        throw MakeErrnoException(errno,"CFileIO::write");
-    }
+    if (ret==(size32_t)-1)
+        throw makeErrnoException(errno, "CFileIO::write");
     if (ret<len)
-        throw MakeOsException(DISK_FULL_EXCEPTION_CODE,"CFileIO::write");
+        throw makeOsException(DISK_FULL_EXCEPTION_CODE, "CFileIO::write");
     if ( (extraFlags & IFEnocache) && (ret > 0) )
     {
         if (atomic_add_and_read(&bytesWritten, ret) >= PGCFLUSH_BLKSIZE)
@@ -2015,7 +2017,7 @@ size32_t CFileIO::write(offset_t pos, size32_t len, const void * data)
 void CFileIO::setSize(offset_t pos)
 {
     if (0 != ftruncate(file, pos))
-        throw MakeErrnoException(errno, "CFileIO::setSize");
+        throw makeErrnoException(errno, "CFileIO::setSize");
 }
 #endif
 
@@ -2128,7 +2130,7 @@ public:
                         CriticalBlock block(parent->cs);
                         parent->results.zap(*this,true); // don't delete as array does not own
                         parent = NULL;
-                        throw MakeOsException(err,"CFileAsyncResult::getResult");
+                        throw makeOsException(err,"CFileAsyncResult::getResult");
                     }
                     value = 0;
                 }
@@ -2141,7 +2143,7 @@ public:
         }
         ret = value;
         if (value<wrsize)
-            throw MakeOsException(DISK_FULL_EXCEPTION_CODE,"CFileAsyncResult::getResult");
+            throw makeOsException(DISK_FULL_EXCEPTION_CODE,"CFileAsyncResult::getResult");
         return true;
     }
 };
@@ -2161,7 +2163,7 @@ void CFileAsyncIO::close()
     if (file != NULLFILE)
     {
         if (!CloseHandle(file))
-            throw MakeOsException(GetLastError(),"CFileAsyncIO::close");
+            throw makeOsException(GetLastError(),"CFileAsyncIO::close");
     }
     file = NULLFILE;
 }
@@ -2173,7 +2175,7 @@ offset_t CFileAsyncIO::size()
     if (pos.LowPart==-1) {
         DWORD err = GetLastError();
         if (err!=0)     
-            throw MakeOsException(GetLastError(),"CFileAsyncIO::size");
+            throw makeOsException(GetLastError(),"CFileAsyncIO::size");
     }
     return pos.QuadPart;
 }
@@ -2200,7 +2202,7 @@ void CFileAsyncIO::setSize(offset_t size)
     tempPos.QuadPart = size; 
     tempPos.LowPart = SetFilePointer(file, tempPos.LowPart, &tempPos.HighPart, FILE_BEGIN);
     if (!SetEndOfFile(file))
-        throw MakeOsException(GetLastError(), "CFileIO::setSize");
+        throw makeOsException(GetLastError(), "CFileIO::setSize");
 }
 
 
@@ -2219,7 +2221,7 @@ IFileAsyncResult *CFileAsyncIO::readAsync(offset_t pos, size32_t len, void * dat
             results.append(*res);
         }
         else
-            throw MakeOsException(GetLastError(),"CFileIO::readAsync");
+            throw makeOsException(GetLastError(),"CFileIO::readAsync");
     }   
     else {
         res->value = val; // won't need to wait
@@ -2234,7 +2236,7 @@ IFileAsyncResult *CFileAsyncIO::writeAsync(offset_t pos, size32_t len, const voi
     if (WriteFile(file,data,len,&val,&res->overlapped) == 0) {
         int err = GetLastError();
         if (err != ERROR_IO_PENDING)
-            throw MakeOsException(GetLastError(),"CFileIO::writeAsync");
+            throw makeOsException(GetLastError(),"CFileIO::writeAsync");
         CriticalBlock block(cs);
         res->parent = this;
         results.append(*res);
@@ -2287,10 +2289,10 @@ public:
                 if (aio_errno != EINPROGRESS)
                 {
                     if (aio_errno)
-                        throw MakeErrnoException(aio_errno,"CFileAsyncResult::getResult");
+                        throw makeErrnoException(aio_errno, "CFileAsyncResult::getResult");
                     value = aio_return(&cb);
                     if (value<wrsize)
-                        throw MakeOsException(DISK_FULL_EXCEPTION_CODE,"CFileAsyncResult::getResult");
+                        throw makeOsException(DISK_FULL_EXCEPTION_CODE, "CFileAsyncResult::getResult");
                     break;
                 }
                 if (!wait)
@@ -2330,7 +2332,7 @@ void CFileAsyncIO::close()
     {
         aio_cancel(file,NULL);
         if (_lclose(file) < 0)
-            throw MakeErrnoException(errno, "CFileAsyncIO::close");
+            throw makeErrnoException(errno, "CFileAsyncIO::close");
     }
     file=NULLFILE;
 }
@@ -2350,7 +2352,7 @@ size32_t CFileAsyncIO::read(offset_t pos, size32_t len, void * data)
     _llseek(file,pos,SEEK_SET);
     size32_t ret = _lread(file,data,len);
     if (ret==(size32_t)-1)
-        throw MakeErrnoException(errno,"CFileAsyncIO::read");
+        throw makeErrnoException(errno, "CFileAsyncIO::read");
     return ret;
 
 }
@@ -2361,7 +2363,7 @@ size32_t CFileAsyncIO::write(offset_t pos, size32_t len, const void * data)
     _llseek(file,pos,SEEK_SET);
     size32_t ret = _lwrite(file,data,len);
     if (ret==(size32_t)-1)
-        throw MakeErrnoException(errno,"CFileAsyncIO::write");
+        throw makeErrnoException(errno, "CFileAsyncIO::write");
     return ret;
 }
 
@@ -2369,7 +2371,7 @@ void CFileAsyncIO::setSize(offset_t pos)
 {
     CriticalBlock procedure(cs);
     if ((file != NULLFILE)&&(0 != ftruncate(file, pos)))
-        throw MakeErrnoException(errno, "CFileIO::setSize");
+        throw makeErrnoException(errno, "CFileIO::setSize");
 }
 
 IFileAsyncResult *CFileAsyncIO::readAsync(offset_t pos, size32_t len, void * data)
@@ -2385,7 +2387,7 @@ IFileAsyncResult *CFileAsyncIO::readAsync(offset_t pos, size32_t len, void * dat
 
     int retval = aio_read(&(res->cb));
     if (retval==-1)
-        throw MakeErrnoException(errno,"CFileAsyncIO::readAsync");
+        throw makeErrnoException(errno, "CFileAsyncIO::readAsync");
     return res;
 }
 
@@ -2404,7 +2406,7 @@ IFileAsyncResult *CFileAsyncIO::writeAsync(offset_t pos, size32_t len, const voi
 
     int retval = aio_write(&(res->cb));
     if (retval==-1)
-        throw MakeErrnoException(errno,"CFileAsyncIO::writeAsync");
+        throw makeErrnoException(errno, "CFileAsyncIO::writeAsync");
     return res;
 }
 
@@ -5057,7 +5059,7 @@ StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out, bool mustE
         {
             OwnedIFile iFile = createIFile(relpath);
             if (!iFile->exists())
-                throw MakeStringException(-1, "makeAbsolutePath: could not resolve absolute path for %s", relpath);
+                throw makeStringExceptionV(-1, "makeAbsolutePath: could not resolve absolute path for %s", relpath);
         }
         return out.append(relpath); // if remote then already should be absolute
     }
@@ -5068,12 +5070,12 @@ StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out, bool mustE
         relpath = ".";
     DWORD res = GetFullPathName(relpath, sizeof(rPath), rPath, &filepart);
     if (0 == res)
-        throw MakeOsException(GetLastError(), "makeAbsolutePath: could not resolve absolute path for %s", relpath);
+        throw makeOsExceptionV(GetLastError(), "makeAbsolutePath: could not resolve absolute path for %s", relpath);
     else if (mustExist)
     {
         OwnedIFile iFile = createIFile(rPath);
         if (!iFile->exists())
-            throw MakeStringException(-1, "makeAbsolutePath: could not resolve absolute path for %s", rPath);
+            throw makeStringExceptionV(-1, "makeAbsolutePath: could not resolve absolute path for %s", rPath);
     }
     out.append(rPath);
 #else
@@ -5081,7 +5083,7 @@ StringBuffer &makeAbsolutePath(const char *relpath,StringBuffer &out, bool mustE
     if (mustExist)
     {
         if (!realpath(relpath, rPath))
-            throw MakeErrnoException(errno, "makeAbsolutePath: could not resolve absolute path for %s", relpath);
+            throw makeErrnoExceptionV(errno, "makeAbsolutePath: could not resolve absolute path for %s", relpath);
         out.append(rPath);
     }
     else
@@ -6236,14 +6238,14 @@ public:
             hmap = CreateFileMapping(hfile,NULL,writeaccess?PAGE_READWRITE:PAGE_READONLY,0, 0, NULL);
             if (!hmap) {
                 DWORD err = GetLastError();
-                throw MakeOsException(err,"CMemoryMappedFile::reinit");
+                throw makeOsException(err,"CMemoryMappedFile::reinit");
             }
         }
         li.QuadPart = realofs; 
         ptr = (byte *) MapViewOfFile(hmap, writeaccess?(FILE_MAP_READ|FILE_MAP_WRITE):FILE_MAP_READ, li.HighPart, li.LowPart, mapsz);
         if (!ptr) {
             DWORD err = GetLastError();
-            throw MakeOsException(err,"CMemoryMappedFile::reinit");
+            throw makeOsException(err,"CMemoryMappedFile::reinit");
         }
 #elif defined (_linux__)
         ptr = (byte *) mmap(NULL, mapsz, writeaccess?(PROT_READ|PROT_WRITE):PROT_READ, MAP_SHARED|MAP_NORESERVE, hfile, realofs);
@@ -6321,7 +6323,7 @@ size32_t SendFile(ISocket *target, IFileIO *fileio,offset_t start,size32_t len)
                     return (size32_t)sent;
                 int err = errno;
                 if ((err!=EINVAL)&&(err!=ENOSYS))
-                    throw MakeOsException(err,"sendfile");
+                    throw makeOsException(err, "sendfile");
 #else
                 UNIMPLEMENTED;
 #endif
@@ -6611,7 +6613,7 @@ extern jlib_decl void removeSentinelFile(IFile * sentinelFile)
                 StringBuffer s;
                 EXCLOG(E, s.appendf("Failed to remove sentinel file %s", sentinelFile->queryFilename()).str());
                 E->Release();
-                throw MakeOsException(errno, "removeSentinelFile - file cannot be removed.");
+                throw makeOsException(errno, "removeSentinelFile - file cannot be removed.");
             }
         }
     }
@@ -6632,7 +6634,7 @@ extern jlib_decl void writeSentinelFile(IFile * sentinelFile)
             StringBuffer s;
             EXCLOG(E, s.appendf("Failed to create sentinel file %s for rerun from script", sentinelFile->queryFilename()).str());
             E->Release();
-            throw MakeOsException(errno, "writeSentinelFile - file not created.");
+            throw makeOsException(errno, "writeSentinelFile - file not created.");
         }
     }
 }

--- a/system/jlib/jiface.hpp
+++ b/system/jlib/jiface.hpp
@@ -26,27 +26,27 @@
 #include "jscm.hpp"
 #include "jatomic.hpp"
 
-void jlib_decl RaiseAssertException(const char *assertion, const char *file, unsigned line);
-void jlib_decl RaiseAssertCore(const char *assertion, const char *file, unsigned line);
+void jlib_decl raiseAssertException(const char *assertion, const char *file, unsigned line);
+void jlib_decl raiseAssertCore(const char *assertion, const char *file, unsigned line);
 
 #undef assert
 #undef assertex
 
 #ifdef _PREFAST_
  #pragma warning (disable : 6244)   // generates too much noise at the moment
- #define assertex(p) ((p) ? ((void) 0) : (( (void) RaiseAssertException(#p, __FILE__, __LINE__), __analysis_assume(p))))
- #define assert(p) ((p) ? ((void) 0) : (( (void) RaiseAssertCore(#p, __FILE__, __LINE__), __analysis_assume(p))))
+ #define assertex(p) ((p) ? ((void) 0) : (( (void) raiseAssertException(#p, __FILE__, __LINE__), __analysis_assume(p))))
+ #define assert(p) ((p) ? ((void) 0) : (( (void) raiseAssertCore(#p, __FILE__, __LINE__), __analysis_assume(p))))
 #elif defined(_DEBUG)||defined(_TESTING)
- #define assertex(p) ((p) ? ((void) 0) : (( (void) RaiseAssertException(#p, __FILE__, __LINE__))))
- #define assert(p) ((p) ? ((void) 0) : (( (void) RaiseAssertCore(#p, __FILE__, __LINE__))))
+ #define assertex(p) ((p) ? ((void) 0) : (( (void) raiseAssertException(#p, __FILE__, __LINE__))))
+ #define assert(p) ((p) ? ((void) 0) : (( (void) raiseAssertCore(#p, __FILE__, __LINE__))))
 #else
  #define assertex(p)
  #define assert(p)
 #endif
 
 #if defined(_DEBUG)||defined(_TESTING)
-#define verifyex(p) ((p) ? ((void) 0) : (( (void) RaiseAssertException(#p, __FILE__, __LINE__))))
-#define verify(p) ((p) ? ((void) 0) : (( (void) RaiseAssertCore(#p, __FILE__, __LINE__))))
+#define verifyex(p) ((p) ? ((void) 0) : (( (void) raiseAssertException(#p, __FILE__, __LINE__))))
+#define verify(p) ((p) ? ((void) 0) : (( (void) raiseAssertCore(#p, __FILE__, __LINE__))))
 #else
 #define verifyex(p) ((void) (p))
 #define verify(p) ((void) (p))

--- a/system/jlib/jio.cpp
+++ b/system/jlib/jio.cpp
@@ -55,7 +55,7 @@ extern jlib_decl offset_t checked_lseeki64( int handle, offset_t offset, int ori
 {
     offset_t ret=_lseeki64(handle,offset,origin);
     if (ret==(offset_t)-1) 
-        throw MakeErrnoException("checked_lseeki64");
+        throw makeErrnoException("checked_lseeki64");
     return ret;
 }
 
@@ -89,7 +89,7 @@ extern jlib_decl size32_t checked_read(int file, void *buffer, size32_t len)
                     readNow = 0;
                     break;
                 }
-                throw MakeErrnoException(errno, "checked_read");
+                throw makeErrnoException(errno, "checked_read");
             }
         }
         else if (!readNow)
@@ -128,7 +128,7 @@ extern jlib_decl size32_t checked_pread(int file, void *buffer, size32_t len, of
         if (err == ERROR_INVALID_PARAMETER) // Win98 etc
             atomicsupported = false;
         else
-            throw MakeOsException(GetLastError(), "checked_pread");
+            throw makeOsException(GetLastError(), "checked_pread");
     }
     {
         CriticalBlock blk(atomicsection);
@@ -163,7 +163,7 @@ extern jlib_decl size32_t checked_pread(int file, void *buffer, size32_t len, of
                     readNow = 0;
                     break;
                 }
-                throw MakeErrnoException(errno,"checked_pread");
+                throw makeErrnoException(errno, "checked_pread");
             }
         }
         else if (!readNow)
@@ -184,7 +184,7 @@ extern jlib_decl size32_t checked_write( int handle, const void *buffer, size32_
     int ret=_write(handle,buffer,count);
     if ((size32_t)ret != count)
     {
-        throw MakeErrnoException((ret==-1)?errno:DISK_FULL_EXCEPTION_CODE, "checked_write");
+        throw makeErrnoException((ret==-1)?errno:DISK_FULL_EXCEPTION_CODE, "checked_write");
     }
     return (size32_t)ret;
 }

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -2334,7 +2334,7 @@ bool CSysLogEventLogger::win32Report(unsigned eventtype, unsigned category, unsi
                 if (res>0) 
                     copyFile(path,src);
                 else
-                    throw MakeOsException(GetLastError());
+                    throw makeOsException(GetLastError());
             }
         }
         catch (IException *e)

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -260,7 +260,7 @@ public:
         case EINPROGRESS:           return str.append("EINPROGRESS - operation now in progress ");
 #endif
         }
-        IException *ose = MakeOsException(err);
+        IException *ose = makeOsException(err);
         ose->errorMessage(str);
         ose->Release();
         return str;
@@ -2960,7 +2960,7 @@ StringBuffer & IpAddress::getIpText(StringBuffer & out) const
     char tmp[INET6_ADDRSTRLEN];
     const char *res = _inet_ntop(AF_INET6, &netaddr, tmp, sizeof(tmp));
     if (!res) 
-        throw MakeOsException(errno);
+        throw makeOsException(errno);
     return out.append(res);
 }
 

--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -354,7 +354,7 @@ void Thread::startRelease()
     if (!hThread || !threadid)
     {
         Release();
-        throw MakeOsException(GetLastError());
+        throw makeOsException(GetLastError());
     }
 #else
     int status;
@@ -397,7 +397,7 @@ void Thread::startRelease()
         StringBuffer s;
         getThreadList(s);
         ERRLOG("Running threads:\n %s",s.str());
-        throw MakeOsException(status);
+        throw makeOsException(status);
     }
     unsigned retryCount = 10;
     loop
@@ -1384,7 +1384,7 @@ public:
                 return 0;
             default:
                 aborted = true;
-                IException *e = MakeOsException(err, "Pipe: ReadFile failed (size %d)", sz);
+                IException *e = makeOsExceptionV(err, "Pipe: ReadFile failed (size %d)", sz);
                 PrintExceptionLog(e, NULL);
                 throw e;
             }
@@ -1411,7 +1411,7 @@ public:
                 return 0;
             default:
                 aborted = true;
-                IException *e = MakeOsException(err, "Pipe: ReadError failed (size %d)", sz);
+                IException *e = makeOsExceptionV(err, "Pipe: ReadError failed (size %d)", sz);
                 PrintExceptionLog(e, NULL);
                 throw e;
             }
@@ -1430,7 +1430,7 @@ public:
             if ((err==ERROR_HANDLE_EOF)||aborted)
                 sizeWritten = 0;
             else {
-                IException *e = MakeOsException(err, "Pipe: WriteFile failed (size %d)", sz);
+                IException *e = makeOsExceptionV(err, "Pipe: WriteFile failed (size %d)", sz);
                 PrintExceptionLog(e, NULL);
                 throw e;
             }
@@ -1845,14 +1845,15 @@ public:
         int errpipe[2];
         if (hasinput)
             if (::pipe(inpipe)==-1)
-                throw MakeOsException(errno);
+                throw makeOsException(errno);
         if (hasoutput)
             if (::pipe(outpipe)==-1)
-                throw MakeOsException(errno);
+                throw makeOsException(errno);
         if (haserror)
             if (::pipe(errpipe)==-1)
-                throw MakeOsException(errno);
-        loop {
+                throw makeOsException(errno);
+        loop
+        {
             pipeProcess = (HANDLE)fork();
             if (pipeProcess!=(HANDLE)-1) 
                 break;
@@ -1998,7 +1999,7 @@ public:
                 break;
             if (errno!=EINTR) {
                 aborted = true;
-                throw MakeErrnoException(errno,"Pipe: read failed (size %d)", sz);
+                throw makeErrnoExceptionV(errno,"Pipe: read failed (size %d)", sz);
             }
         }
         return aborted?((size32_t)-1):((size32_t)sizeRead);
@@ -2029,7 +2030,7 @@ public:
             if (aborted) 
                 break;
             if (errno!=EINTR) {
-                throw MakeErrnoException(errno,"Pipe: write failed (size %d)", sz);
+                throw makeErrnoExceptionV(errno, "Pipe: write failed (size %d)", sz);
             }
         }
         return aborted?((size32_t)-1):((size32_t)sizeWritten);
@@ -2056,7 +2057,7 @@ public:
                 break;
             if (errno!=EINTR) {
                 aborted = true;
-                throw MakeErrnoException(errno,"Pipe: readError failed (size %d)", sz);
+                throw makeErrnoExceptionV(errno, "Pipe: readError failed (size %d)", sz);
             }
         }
         return aborted?((size32_t)-1):((size32_t)sizeRead);

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -1970,7 +1970,7 @@ public:
     void impersonate()
     {
         if (!ImpersonateLoggedOnUser(usertoken))
-            throw MakeOsException(GetLastError());
+            throw makeOsException(GetLastError());
     }
 
     void revert()
@@ -2332,7 +2332,7 @@ StringBuffer jlib_decl passwordInput(const char* prompt, StringBuffer& passwd)
     if (term!=stdin)
         fclose(term);
     if (err)
-        throw MakeOsException(err);
+        throw makeOsException(err);
 #endif
     return passwd;
 }
@@ -2626,7 +2626,7 @@ int parseCommandLine(const char * cmdline, MemoryBuffer &mb, const char** &argvo
                     }
                     if (c) {
                         if (argc==256) 
-                            throw MakeStringException(-1,"parseCommandLine: too many arguments");
+                            throw makeStringException(-1, "parseCommandLine: too many arguments");
                         arg[argc] = 0;
                     }
                 }

--- a/system/jlib/jvmem.cpp
+++ b/system/jlib/jvmem.cpp
@@ -90,7 +90,7 @@ public:
         lseek(hfile,savedPos,SEEK_SET);
         if (length<ofs+maxsize) {
             if (0 != ftruncate(hfile,ofs+maxsize))
-                throw MakeErrnoException(errno, "CVMSectionAllocator truncate");
+                throw makeErrnoException(errno, "CVMSectionAllocator truncate");
         }
         base = (byte *)mmap(NULL, maxsize, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_NORESERVE, hfile, _ofs);
 
@@ -243,7 +243,7 @@ public:
 #ifdef WIN32
         hfile = CreateFile(filename, GENERIC_READ|GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_FLAG_RANDOM_ACCESS, 0);
         if (hfile == INVALID_HANDLE_VALUE) 
-            throw MakeOsException(GetLastError(), "CVMAllocator(CreateFile) %s", filename);
+            throw makeOsExceptionV(GetLastError(), "CVMAllocator(CreateFile) %s", filename);
         LARGE_INTEGER li;
         li.QuadPart = nsections*SECTIONSIZE; 
 //      li.LowPart = SetFilePointer(hfile, li.LowPart, &li.HighPart, FILE_BEGIN);
@@ -252,7 +252,7 @@ public:
 #else
         hfile = _lopen(filename.get(), O_RDWR | O_CREAT | O_TRUNC, 0);
         if (hfile == -1)
-            throw MakeOsException(GetLastError(), "CMmapLargeMemoryAllocator(CreateFile) %s", filename.get());
+            throw makeOsExceptionV(GetLastError(), "CMmapLargeMemoryAllocator(CreateFile) %s", filename.get());
         unlink(filename);   // delete now (linux won't really delete until handle released)
 #endif
         for (unsigned i=nsections;i;)

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -367,7 +367,7 @@ CGraphElementBase::CGraphElementBase(CGraphBase &_owner, IPropertyTree &_xgmml) 
     xgmml->getProp("@id", helperName);
     helperFactory = (EclHelperFactory) queryJob().queryDllEntry().getEntry(helperName.str());
     if (!helperFactory)
-        throw MakeOsException(GetLastError(), "Failed to load helper factory method: %s (dll handle = %p)", helperName.str(), queryJob().queryDllEntry().getInstance());
+        throw makeOsExceptionV(GetLastError(), "Failed to load helper factory method: %s (dll handle = %p)", helperName.str(), queryJob().queryDllEntry().getInstance());
     alreadyUpdated = false;
     whichBranch = (unsigned)-1;
     whichBranchBitSet.setown(createBitSet());

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -322,7 +322,7 @@ int main( int argc, char *argv[]  )
             int err = _chdir(thorPath.str());
             if (err)
             {
-                IException *e = MakeErrnoException(-1, "Failed to change dir to '%s'",thorPath.str());
+                IException *e = makeErrnoExceptionV(-1, "Failed to change dir to '%s'", thorPath.str());
                 FLLOG(MCexception(e), thorJob, e);
                 throw e;
             }

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -724,7 +724,7 @@ const LogMsgJobInfo thorJob(UnknownJob, UnknownUser); // may be improved later
 void ensureDirectoryForFile(const char *fName)
 {
     if (!recursiveCreateDirectoryForFile(fName))
-        throw MakeOsException(GetLastError(), "Failed to create directory for file: %s", fName);
+        throw makeOsExceptionV(GetLastError(), "Failed to create directory for file: %s", fName);
 }
 
 // Not recommended to be used from slaves as tend to be one or more trying at same time.

--- a/tools/backupnode/backupnode.cpp
+++ b/tools/backupnode/backupnode.cpp
@@ -125,12 +125,12 @@ static bool CopySingleFile(IFile *srcfile,IFile *dstfile, bool compress, bool su
                 {
                     DWORD read;
                     if (!::ReadFile(hSource, buf, BUFSIZE, &read, NULL))
-                        throw MakeOsException(GetLastError(), "Failed to read file %s", source);
+                        throw makeOsExceptionV(GetLastError(), "Failed to read file %s", source);
                     if (read)
                     {
                         DWORD wrote;
                         if (!::WriteFile(hTarget, buf, read, &wrote, NULL))
-                            throw MakeOsException(GetLastError(), "Failed to write file %s", target);
+                            throw makeOsExceptionV(GetLastError(), "Failed to write file %s", target);
                         assertex(wrote==read);
                     }
                     else

--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -6330,7 +6330,7 @@ void EspServInfo::write_esp_client()
         outs("\t} while (0 != status && (errno == EINTR));\n");
         outs("\tif (status) {\n");
         outs("\t\tRelease();\n");
-        outs("\t\tthrow MakeOsException(errno);\n");
+        outs("\t\tthrow makeOsException(errno);\n");
         outs("\t}\n");
 
         outs("#endif\n");


### PR DESCRIPTION
Full rename on lesser-used functions, leave macro in place for the more
commonly-used ones. At least lets us move over at SOME point in the future.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
