### PR TITLE
HPCC-10656 Roxie in standalone mode should not be xml encoding output strings

### DIFF
--- a/common/thorhelper/roxiehelper.cpp
+++ b/common/thorhelper/roxiehelper.cpp
@@ -743,7 +743,7 @@ void CSafeSocket::sendException(const char *source, unsigned code, const char *m
         response.startDataset("Exception", NULL, (unsigned) -1);
         response.appendf("<Source>%s</Source><Code>%d</Code>", source, code);
         response.append("<Message>");
-        response.encodeXML(message);
+        response.encodeString(message, strlen(message));
         response.append("</Message>");
     }
     catch(IException *EE)
@@ -873,11 +873,16 @@ void FlushingStringBuffer::appendf(const char *format, ...)
     append(t.length(), t.str());
 }
 
-void FlushingStringBuffer::encodeXML(const char *x, unsigned flags, unsigned len, bool utf8)
+void FlushingStringBuffer::encodeString(const char *x, unsigned len, bool utf8)
 {
-    StringBuffer t;
-    ::encodeXML(x, t, flags, len, utf8);
-    append(t.length(), t.str());
+    if (mlFmt==MarkupFmt_XML)
+    {
+        StringBuffer t;
+        ::encodeXML(x, t, 0, len, utf8);
+        append(t.length(), t.str());
+    }
+    else
+        append(len, x);
 }
 
 void FlushingStringBuffer::addPayload(StringBuffer &s, unsigned int reserve)
@@ -1096,7 +1101,7 @@ void FlushingStringBuffer::incrementRowCount()
     rowCount++;
 }
 
-void FlushingJsonBuffer::encodeXML(const char *x, unsigned flags, unsigned len, bool utf8)
+void FlushingJsonBuffer::encodeString(const char *x, unsigned len, bool utf8)
 {
     CriticalBlock b(crit);
     appendJSONStringValue(s, NULL, len, x, true);

--- a/common/thorhelper/roxiehelper.hpp
+++ b/common/thorhelper/roxiehelper.hpp
@@ -155,7 +155,7 @@ public:
     virtual void append(const char *data);
     virtual void append(unsigned len, const char *data);
     virtual void appendf(const char *format, ...) __attribute__((format(printf, 2, 3)));
-    virtual void encodeXML(const char *x, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=false);
+    virtual void encodeString(const char *x, unsigned len, bool utf8=false);
     virtual void flushXML(StringBuffer &current, bool isClosing);
     virtual void flush(bool closing) ;
     virtual void addPayload(StringBuffer &s, unsigned int reserve=0);
@@ -173,7 +173,7 @@ public:
     {
     }
 
-    void encodeXML(const char *x, unsigned flags=0, unsigned len=(unsigned)-1, bool utf8=false);
+    void encodeString(const char *x, unsigned len, bool utf8=false);
     void startDataset(const char *elementName, const char *resultName, unsigned sequence, bool _extend = false, const IProperties *xmlns=NULL);
     void startScalar(const char *resultName, unsigned sequence);
 };

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3437,7 +3437,7 @@ public:
                 }
                 else
                 {
-                    r->encodeXML(str, 0, len);
+                    r->encodeString(str, len);
                 }
             }
         }
@@ -3488,7 +3488,7 @@ public:
                     rtlDataAttr buff;
                     unsigned bufflen = 0;
                     rtlUnicodeToCodepageX(bufflen, buff.refstr(), len, str, "utf-8");
-                    r->encodeXML(buff.getstr(), 0, bufflen, true); // output as UTF-8
+                    r->encodeString(buff.getstr(), bufflen, true); // output as UTF-8
                 }
             }
         }


### PR DESCRIPTION
When -xml (or -json) is not specified, Roxie should not encode string outputs.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
