### PR TITLE
HPCC-10735 Support different query classes in the regression suite

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -112,17 +112,21 @@ Command:
 Result:
 
 |
-|       usage: ecl-test run [-h] [--target [target_cluster | all]] [--publish]
+|       usage: ecl-test run [-h] [--target [target_cluster | all]] [--publish] 
 |                           [--pq threadNumber]
+|                           [--runclass [class]] [--excludeclass [class]]
 |
 |       optional arguments:
-|        -h, --help               show this help message and exit
-|        --target [target_cluster | all], -t [target_cluster | all]
-|                                 target cluster for single query run. If target = 'all' then run query on all clusters. Default value is thor.
+|         -h, --help         show this help message and exit
+|         --target [target_cluster | all], -t [target_cluster | all]
+|                                     Target cluster for single query run. If target = 'all' then run query on all clusters. Default value is thor.
 |        --publish, -p            publish compiled query instead of run.
-|        --pq threadNumber        parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
+|        --pq threadNumber  Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
+|        --runclass class[,class,...], -r class[,class,...]
+|                                 run subclass(es) of the suite. Default value is 'all'
+|        --excludeclass class[,class,...], -e class[,class,...]
+|                                 exclude subclass(es) of the suite. Default value is 'none'
 |
-
 
 Parameters of Regression Suite query sub-command:
 -------------------------------------------------
@@ -478,6 +482,10 @@ The format of the output is the same as 'run', except there is a log, result and
 
     If //nokey is present then the following tag prevents the output being stored in the result log file.
 //nooutput
+
+    To define a class to be executed/excluded in run mode.
+//class=<class_name>
+
 
 7. Key file handling:
 ---------------------

--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -117,16 +117,16 @@ Result:
 |                           [--runclass [class]] [--excludeclass [class]]
 |
 |       optional arguments:
-|         -h, --help         show this help message and exit
-|         --target [target_cluster | all], -t [target_cluster | all]
-|                                     Target cluster for single query run. If target = 'all' then run query on all clusters. Default value is thor.
+|        -h, --help               show this help message and exit
+|        --target [target_cluster | all], -t [target_cluster | all]
+|                                 target cluster for single query run. If target = 'all' then run query on all clusters. Default value is thor.
 |        --publish, -p            publish compiled query instead of run.
-|        --pq threadNumber  Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
+|        --pq threadNumber        parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
 |        --runclass class[,class,...], -r class[,class,...]
 |                                 run subclass(es) of the suite. Default value is 'all'
 |        --excludeclass class[,class,...], -e class[,class,...]
 |                                 exclude subclass(es) of the suite. Default value is 'none'
-|
+
 
 Parameters of Regression Suite query sub-command:
 -------------------------------------------------

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -186,6 +186,10 @@ class RegressMain:
                                 action='store_true')
         parser_run.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
                                 type=checkPqParam,  default = 0,   metavar="threadNumber")
+        parser_run.add_argument('--runclass', '-r', help="run subclass(es) of the suite. Default value is 'all'",
+                                nargs=1,  default = ['all'],   metavar="class[,class,...]")
+        parser_run.add_argument('--excludeclass', '-e', help="exclude subclass(es) of the suite. Default value is 'none'",
+                                nargs=1,  default = ['none'],   metavar="class[,class,...]")
 
         parser_query = subparsers.add_parser('query', help='query help')
         parser_query.set_defaults(func='query')

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -149,12 +149,39 @@ class Regression:
         report = Report(name)
         curTime = time.strftime("%y-%m-%d-%H-%M-%S")
         logName = name + "." + curTime + ".log"
+        self.args.testId=curTime
         logHandler = os.path.join(self.logDir, logName)
+        self.args.testFile=logHandler
+        self.saveConfig()
         self.log.addHandler(logHandler, 'DEBUG')
         return (report, logHandler)
 
     def closeLogging(self):
         self.log.removeHandler()
+
+    def saveConfig(self):
+        confLogName = 'environment-'+self.args.testId + ".conf"
+        logFileName = os.path.join(self.logDir, confLogName)
+        try:
+            log = open(logFileName, "w");
+            log.write("Environment info\n")
+            log.write("Args:\n")
+            for arg in self.args.__dict__:
+                argStr = arg +'=\"'+str(self.args.__dict__[arg])+'\"'
+                log.write(argStr+"\n")
+
+            log.write("\nConfigs:\n")
+            for conf in self.config.__dict__:
+                if conf != '_dict__d':
+                    confStr = conf +'=\"'+str(self.config.__dict__[conf])+'\"'
+                    log.write(confStr+"\n")
+                else:
+                    for subConf in self.config.__dict__[conf]:
+                        confStr = subConf +'=\"'+str(self.config.__dict__[conf][subConf])+'\"'
+                        log.write(confStr+"\n")
+            log.close()
+        except IOError:
+            logging.error("Can't open %s file to write!" %(logFileName))
 
     @staticmethod
     def displayReport(report,  elapsTime=0):

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -264,6 +264,17 @@ class ECLFile:
         logging.debug("%3d. testNoOutput() returns with: %s",  self.taskId,  retVal)
         return retVal
 
+    def testInClass(self,  classDefined):
+        retVal=False
+        for c in classDefined:
+            tag = b'//class='+c.encode()
+            logging.debug("%3d. testInClass (ecl:'%s', tag:'%s')", self.taskId, self.ecl,  tag)
+            retVal = self.__checkTag(tag)
+            if retVal:
+                break
+        logging.debug("%3d. testInClass() returns with: %s",  self.taskId,  retVal)
+        return retVal
+
     def getTimeout(self):
         timeout = 0
         # Standard string has a problem with unicode characters


### PR DESCRIPTION
Add new run CLI parameters: --runclass and - --excludeclass
Add run/exl test class handler to ecl file
Add test class run/excl checking in suite building
Change content of excluded file log to refer why that file is excluded

Create environment log file (from args and config) for every
(setup/query/run) execution (to help tracing)

Update README.rst and built-in help.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
