### PR TITLE
HPCC-11992 Regression Test Engine crashed in Overnight Build

### DIFF
--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -59,8 +59,11 @@ class ECLFile:
         self.jobname = self.basename
         self.diff = ''
         self.abortReason =''
+
         #If there is a --publish CL parameter then force publish this ECL file
-        self.forcePublish=args.publish
+        self.forcePublish=False
+        if 'publish' in args:
+            self.forcePublish=args.publish
 
         self.optX =[]
         self.optXHash={}


### PR DESCRIPTION
Implement fix.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
