### PR TITLE
HPCC-11996 Read correct HTTP header for AcceptLanguage

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1028,7 +1028,8 @@ StringBuffer& CHttpMessage::getHeader(const char* headername, StringBuffer& head
         const char* colon = strchr(header, ':');
         if(colon == NULL)
             continue;
-        if(strncmp(headername, header, colon - header) == 0)
+        unsigned len = colon - header;
+        if((strlen(headername) == len) && (strncmp(headername, header, len) == 0))
         {
             headerval.append(colon + 2);
             break;


### PR DESCRIPTION
The existing ESP does not read correct HTTP header for
AcceptLanguage. It returns the 'Accept' header due to a
bug.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
