### PR TITLE
HPCC-11997 ECLWatch should not auto-refresh archived WU pages

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1277,7 +1277,6 @@ bool CFileSprayEx::getArchivedWUInfo(IEspContext &context, IEspGetDFUWorkunit &r
         }
 
         getInfoFromSasha(context, sashaAddress.str(), wuid, &resp.updateResult());
-        resp.setAutoRefresh(WUDETAILS_REFRESH_MINS);
         return true;
     }
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1466,7 +1466,6 @@ void getArchivedWUInfo(IEspContext &context, const char* sashaServerIP, unsigned
         getSashaNode(ep);
     if (getWsWuInfoFromSasha(context, ep, wuid, &resp.updateWorkunit()))
     {
-        resp.setAutoRefresh(WUDETAILS_REFRESH_MINS);
         resp.setCanCompile(false);
         return;
     }


### PR DESCRIPTION
This fix removes the code for specifying auto-refresh values in
both WsWorkunits.WUInfo response and FileSpray.GetDFUWorkunit
response for archived WU. Without the value, both ECL WU page and
DFU WU page will not do auto-refresh in legacy ECLWatch.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
