### PR TITLE
HPCC-12000 CDfsLogicalFileName::set,removeForeign broken.

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -532,7 +532,7 @@ void CDfsLogicalFileName::set(const char *name, bool removeForeign)
     normalizeName(name, lfn, false);
     if (removeForeign)
     {
-        const char *_lfn = get(true);
+        StringAttr _lfn = get(true);
         lfn.clear();
         lfn.set(_lfn);
     }


### PR DESCRIPTION
Regression introduced by HPCC-11571.
Was causing set DFLN to become blank.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
