### PR TITLE
HPCC-12001 Improve performance for WsWorkunits.WUListQueries

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1250,7 +1250,9 @@ void CWsWorkunitsEx::checkAndSetClusterQueryState(IEspContext &context, const ch
         threadHandles.append(handle);
     }
 
-    //block for worker theads to finish, if necessary and then collect results
+    //block for worker threads to finish, if necessary and then collect results
+    //Not use joinAll() because multiple threads may call this method. Each call uses the pool to create
+    //its own threads of checking query state. Each call should only join the ones created by that call.
     ForEachItemIn(ii, threadHandles)
         clusterQueryStatePool->join(threadHandles.item(ii));
 }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -49,6 +49,7 @@
 #define ESP_WORKUNIT_DIR "workunits/"
 
 #define SDS_LOCK_TIMEOUT (5*60*1000) // 5 mins
+const unsigned CHECK_QUERY_STATUS_THREAD_POOL_SIZE = 40;
 
 class ExecuteExistingQueryInfo
 {
@@ -460,6 +461,13 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
 
     m_sched.start();
     filesInUse.subscribe();
+
+    //Start thread pool
+    xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/ClusterQueryStateThreadPoolSize", process, service);
+    CClusterQueryStateThreadFactory* threadFactory = new CClusterQueryStateThreadFactory();
+    clusterQueryStatePool.setown(createThreadPool("CheckAndSetClusterQueryState Thread Pool", threadFactory, NULL,
+            cfg->getPropInt(xpath.str(), CHECK_QUERY_STATUS_THREAD_POOL_SIZE)));
+    threadFactory->Release();
 }
 
 void CWsWorkunitsEx::refreshValidClusters()

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -49,7 +49,7 @@
 #define ESP_WORKUNIT_DIR "workunits/"
 
 #define SDS_LOCK_TIMEOUT (5*60*1000) // 5 mins
-const unsigned CHECK_QUERY_STATUS_THREAD_POOL_SIZE = 40;
+const unsigned CHECK_QUERY_STATUS_THREAD_POOL_SIZE = 25;
 
 class ExecuteExistingQueryInfo
 {
@@ -464,10 +464,9 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
 
     //Start thread pool
     xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/ClusterQueryStateThreadPoolSize", process, service);
-    CClusterQueryStateThreadFactory* threadFactory = new CClusterQueryStateThreadFactory();
+    Owned<CClusterQueryStateThreadFactory> threadFactory = new CClusterQueryStateThreadFactory();
     clusterQueryStatePool.setown(createThreadPool("CheckAndSetClusterQueryState Thread Pool", threadFactory, NULL,
             cfg->getPropInt(xpath.str(), CHECK_QUERY_STATUS_THREAD_POOL_SIZE)));
-    threadFactory->Release();
 }
 
 void CWsWorkunitsEx::refreshValidClusters()

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -346,7 +346,6 @@ class CClusterQueryStateThreadFactory : public CInterface, public IThreadFactory
         Owned<CClusterQueryStateParam> param;
     public:
         IMPLEMENT_IINTERFACE;
-        CClusterQueryStateThread() {}
 
         void init(void *_param)
         {

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -220,6 +220,9 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
             <xsl:if test="string(@viewTimeout) != ''">
                 <ViewTimeout><xsl:value-of select="@viewTimeout"/></ViewTimeout>
             </xsl:if>
+            <xsl:if test="string(@clusterQueryStateThreadPoolSize) != ''">
+                <ClusterQueryStateThreadPoolSize><xsl:value-of select="@clusterQueryStateThreadPoolSize"/></ClusterQueryStateThreadPoolSize>
+            </xsl:if>
             <xsl:if test="string(@AWUsCacheTimeout) != ''">
                 <AWUsCacheMinutes><xsl:value-of select="@AWUsCacheTimeout"/></AWUsCacheMinutes>
             </xsl:if>

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -76,6 +76,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="clusterQueryStateThreadPoolSize" type="xs:nonNegativeInteger" use="optional" default="25">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>Default thread pool size for checking query state on clusters</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="AWUsCacheTimeout" type="xs:nonNegativeInteger" use="optional" default="15">
                 <xs:annotation>
                     <xs:appinfo>


### PR DESCRIPTION
To get Query status on clusters, WsWorkunits.WUListQueries has to
send control:queries/ calls to each roxie cluster. This fix
creates a thread pool to send the calls in parallel.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
