### PR TITLE
HPCC-11860 Fix confusing formatting of hidl ProcInfo::out_method

### DIFF
--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -2098,34 +2098,40 @@ void ProcInfo::out_clarion_method()
 void ProcInfo::out_method(const char *classpfx, int omitvirt)
 {
     if (virt&&!omitvirt)
+    {
         if (callback) 
             outf("HRPCvirtualcallback ");
-        else {
+        else
             outf("virtual ");
-        }
-        if (rettype==NULL) 
-        {
-            outs("void");
-        }
+    }
+
+    if (rettype==NULL)
+        outs("void");
+    else
+        rettype->out_type();
+
+    if (classpfx)
+        outf(" %s::%s",classpfx,name);
+    else
+        outf(" %s",name);
+
+    out_parameter_list("");
+
+    if (constfunc)
+    {
+        if (isSCM)
+            outf(" const");
         else
-            rettype->out_type();
-        if (classpfx)
-            outf(" %s::%s",classpfx,name);
+            outf(" /* const (omitted by HIDL) */");
+    }
+
+    if ((virt==2)&&!omitvirt)
+    {
+        if (isSCM)
+            outf(" = 0");
         else
-            outf(" %s",name);
-        out_parameter_list("");
-        if (constfunc) {
-            if (isSCM)
-                outf(" const");
-            else
-                outf(" /* const (omitted by HIDL) */");
-        }
-        if ((virt==2)&&!omitvirt) {
-            if (isSCM)
-                outf(" = 0");
-            else
-                outf(" HRPCpure%s",callback?"callback":"");
-        }
+            outf(" HRPCpure%s", callback ? "callback" : "");
+    }
 }
 
 void ProcInfo::out_parameter_list(const char *pfx,int forclarion)


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
