### PR TITLE
HPCC-11902 Allow targets shown in WsEcl to be restricted through config

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -317,6 +317,10 @@ bool CWsEclService::init(const char * name, const char * type, IPropertyTree * c
     else
         workunitTimeout = WAIT_FOREVER;
 
+    Owned<IPropertyTreeIterator> cfgTargets = serviceTree->getElements("Targets/Target");
+    ForEach(*cfgTargets)
+        targets.append(cfgTargets->query().queryProp(NULL));
+
     IPropertyTree *vips = serviceTree->queryPropTree(xpath.str());
     Owned<IStringIterator> roxieTargets = getTargetClusters("RoxieCluster", NULL);
     ForEach(*roxieTargets)
@@ -403,12 +407,15 @@ void CWsEclBinding::getRootNavigationFolders(IEspContext &context, IPropertyTree
     data.addProp("@action", "NavMenuEvent");
     data.addProp("@appName", "WsECL 3.0");
 
-    Owned<IStringIterator> targets = getTargetClusters(NULL, NULL);
+    Owned<IStringIterator> envTargets = getTargetClusters(NULL, NULL);
 
     SCMStringBuffer target;
-    ForEach(*targets)
+    ForEach(*envTargets)
     {
-        VStringBuffer parms("queryset=%s", targets->str(target).str());
+        envTargets->str(target);
+        if (wsecl->targets.length() && !wsecl->targets.contains(target.str()))
+            continue;
+        VStringBuffer parms("queryset=%s", target.str());
         ensureNavDynFolder(data, target.str(), target.str(), parms.str(), NULL);
     }
 }

--- a/esp/services/ws_ecl/ws_ecl_service.hpp
+++ b/esp/services/ws_ecl/ws_ecl_service.hpp
@@ -92,6 +92,7 @@ class CWsEclService : public CInterface,
 {
 public:
     MapStringToMyClass<ISmartSocketFactory> connMap;
+    StringArray targets;
     StringAttr auth_method;
     StringAttr portal_URL;
     unsigned roxieTimeout;

--- a/initfiles/componentfiles/configxml/@temp/esp_service.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service.xsl
@@ -942,6 +942,11 @@ xmlns:seisint="http://seisint.com"  xmlns:set="http://exslt.org/sets" exclude-re
                         </xsl:if>
                     </xsl:for-each>
                 </VIPS>
+                <Targets>
+                    <xsl:for-each select="Target">
+                        <Target><xsl:value-of select="@name"/></Target>
+                    </xsl:for-each>
+                </Targets>
             </xsl:when>
         </xsl:choose>
     </xsl:template>

--- a/initfiles/componentfiles/configxml/esp_service_wsecl2.xsd
+++ b/initfiles/componentfiles/configxml/esp_service_wsecl2.xsd
@@ -55,6 +55,18 @@
                 </xs:complexType>
               </xs:element>
             </xs:sequence>
+            <xs:sequence>
+              <xs:element name="Target" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <title>Targets</title>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="name" type="topologyClusterType" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
             <xs:attribute name="build" type="buildType" use="required">
                 <xs:annotation>
                     <xs:appinfo>

--- a/initfiles/componentfiles/configxml/esp_service_wsecl2.xsd
+++ b/initfiles/componentfiles/configxml/esp_service_wsecl2.xsd
@@ -59,11 +59,17 @@
               <xs:element name="Target" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                   <xs:appinfo>
-                    <title>Targets</title>
+                    <title>Restrict To Target(s)</title>
                   </xs:appinfo>
                 </xs:annotation>
                 <xs:complexType>
-                  <xs:attribute name="name" type="topologyClusterType" use="required"/>
+                  <xs:attribute name="name" type="topologyClusterType" use="required">
+	                <xs:annotation>
+	                  <xs:appinfo>
+	                    <tooltip>WsEcl will only display specified targets, if none specified WsEcl will display all targets.</tooltip>
+	                  </xs:appinfo>
+	                </xs:annotation>
+                  </xs:attribute>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>


### PR DESCRIPTION
This will allow individual WsEcl instances to be set up for individual,
or small sets of target clusters in environments with many targets
available.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
