### PR TITLE
HPCC-12031 Always throw exceptions if cannot allocate enough memory

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -439,7 +439,7 @@ static void *suballoc_aligned(size32_t pages, bool returnNullWhenExhausted)
                         return NULL;
                     VStringBuffer msg("Memory pool exhausted: Request for large memory denied (%u..%u)", heapLargeBlocks, largeBlocksRequired);
                     DBGLOG("%s", msg.str());
-                    throw MakeStringException(ROXIEMM_LARGE_MEMORY_EXHAUSTED, "%s", msg.str());
+                    throw MakeStringExceptionDirect(ROXIEMM_LARGE_MEMORY_EXHAUSTED, msg.str());
                 }
 
                 heapLargeBlocks = largeBlocksRequired;
@@ -2055,7 +2055,7 @@ public:
     }
 
     void * doAllocate(memsize_t _size, unsigned allocatorId, unsigned maxSpillCost);
-    bool expandHeap(void * original, memsize_t copysize, memsize_t oldcapacity, memsize_t newsize, unsigned activityId, unsigned maxSpillCost, IRowResizeCallback & callback);
+    void expandHeap(void * original, memsize_t copysize, memsize_t oldcapacity, memsize_t newsize, unsigned activityId, unsigned maxSpillCost, IRowResizeCallback & callback);
 
 protected:
     HugeHeaplet * allocateHeaplet(memsize_t _size, unsigned allocatorId, unsigned maxSpillCost);
@@ -3002,7 +3002,7 @@ public:
         ptr = ret;
     }
 
-    virtual bool resizeRow(void * original, memsize_t copysize, memsize_t newsize, unsigned activityId, unsigned maxSpillCost, IRowResizeCallback & callback)
+    virtual void resizeRow(void * original, memsize_t copysize, memsize_t newsize, unsigned activityId, unsigned maxSpillCost, IRowResizeCallback & callback)
     {
         assertex(newsize);
         assertex(!HeapletBase::isShared(original));
@@ -3010,19 +3010,19 @@ public:
         if (newsize <= curCapacity)
         {
             //resizeRow never shrinks memory
-            return true;
+            return;
         }
         if (curCapacity > FixedSizeHeaplet::maxHeapSize())
-            return hugeHeap.expandHeap(original, copysize, curCapacity, newsize, activityId, maxSpillCost, callback);
+        {
+            hugeHeap.expandHeap(original, copysize, curCapacity, newsize, activityId, maxSpillCost, callback);
+            return;
+        }
 
         void *ret = allocate(newsize, activityId, maxSpillCost);
-        if (!ret)
-            return false;
         memcpy(ret, original, copysize);
         memsize_t newCapacity = HeapletBase::capacity(ret);
         callback.atomicUpdate(newCapacity, ret);
         HeapletBase::release(original);
-        return true;
     }
 
     virtual void *finalizeRow(void * original, memsize_t initialSize, memsize_t finalSize, unsigned activityId)
@@ -3131,7 +3131,7 @@ public:
         return new CRoxieVariableRowHeap(this, activityId, (RoxieHeapFlags)roxieHeapFlags);
     }
 
-    bool checkLimit(unsigned numRequested, unsigned maxSpillCost)
+    void checkLimit(unsigned numRequested, unsigned maxSpillCost)
     {
         unsigned totalPages;
         releaseEmptyPages(false);
@@ -3179,14 +3179,16 @@ public:
                     releaseEmptyPages(true);
                     if (numHeapPages == atomic_read(&totalHeapPages))
                     {
-                        if (maxSpillCost != SpillAllCost)
-                            return false;
-
                         VStringBuffer msg("Memory limit exceeded: current %u, requested %u, limit %u", pageCount, numRequested, pageLimit);
                         logctx.CTXLOG("%s", msg.str());
-                        reportMemoryUsage(false);
-                        PrintStackReport();
-                        throw MakeStringException(ROXIEMM_MEMORY_LIMIT_EXCEEDED, "%s", msg.str());
+
+                        //Avoid a stack trace if the allocation is optional
+                        if (maxSpillCost == SpillAllCost)
+                        {
+                            reportMemoryUsage(false);
+                            PrintStackReport();
+                        }
+                        throw MakeStringExceptionDirect(ROXIEMM_MEMORY_LIMIT_EXCEEDED, msg.str());
                     }
                 }
             }
@@ -3203,7 +3205,6 @@ public:
                 getPeakActivityUsage();
             peakPages = totalPages;
         }
-        return true;
     }
 
     virtual void reportPeakStatistics(IStatisticTarget & target, unsigned detail)
@@ -3495,8 +3496,7 @@ HugeHeaplet * CHugeHeap::allocateHeaplet(memsize_t _size, unsigned allocatorId, 
 
     loop
     {
-        if (!rowManager->checkLimit(numPages, maxSpillCost))
-            return NULL;
+        rowManager->checkLimit(numPages, maxSpillCost);
 
         //If the allocation fails, then try and free some memory by calling the callbacks
         void * memory = suballoc_aligned(numPages, true);
@@ -3505,26 +3505,13 @@ HugeHeaplet * CHugeHeap::allocateHeaplet(memsize_t _size, unsigned allocatorId, 
 
         rowManager->restoreLimit(numPages);
         if (!rowManager->releaseCallbackMemory(maxSpillCost, true))
-        {
-            if (maxSpillCost == SpillAllCost)
-                throwHeapExhausted(numPages);
-            return NULL;
-        }
+            throwHeapExhausted(numPages);
     }
 }
 
 void * CHugeHeap::doAllocate(memsize_t _size, unsigned allocatorId, unsigned maxSpillCost)
 {
     HugeHeaplet *head = allocateHeaplet(_size, allocatorId, maxSpillCost);
-    if (!head)
-    {
-        if (memTraceLevel >= 2)
-        {
-            logctx.CTXLOG("RoxieMemMgr: CChunkingRowManager::allocate(size %"I64F"u) failed to allocate a block - pageLimit=%u peakPages=%u rowMgr=%p",
-                (unsigned __int64) _size, rowManager->pageLimit, rowManager->peakPages, this);
-        }
-        return NULL;
-    }
 
     if (memTraceLevel >= 2 || (memTraceSizeLimit && _size >= memTraceSizeLimit))
     {
@@ -3539,7 +3526,7 @@ void * CHugeHeap::doAllocate(memsize_t _size, unsigned allocatorId, unsigned max
     return head->allocateHuge(_size);
 }
 
-bool CHugeHeap::expandHeap(void * original, memsize_t copysize, memsize_t oldcapacity, memsize_t newsize, unsigned activityId, unsigned maxSpillCost, IRowResizeCallback & callback)
+void CHugeHeap::expandHeap(void * original, memsize_t copysize, memsize_t oldcapacity, memsize_t newsize, unsigned activityId, unsigned maxSpillCost, IRowResizeCallback & callback)
 {
     unsigned newPages = PAGES(newsize + HugeHeaplet::dataOffset(), HEAP_ALIGNMENT_SIZE);
     unsigned oldPages = PAGES(oldcapacity + HugeHeaplet::dataOffset(), HEAP_ALIGNMENT_SIZE);
@@ -3551,8 +3538,7 @@ bool CHugeHeap::expandHeap(void * original, memsize_t copysize, memsize_t oldcap
         // NOTE: we request permission only for the difference between the old
         // and new sizes, even though we may temporarily hold both. This not only
         // simplifies the code considerably, it's probably desirable
-        if (!rowManager->checkLimit(numPages, maxSpillCost))
-            return false;
+        rowManager->checkLimit(numPages, maxSpillCost);
 
         bool release = false;
         void *realloced = subrealloc_aligned(oldbase, oldPages, newPages);
@@ -3628,18 +3614,14 @@ bool CHugeHeap::expandHeap(void * original, memsize_t copysize, memsize_t oldcap
                 }
             }
 
-            return true;
+            return;
         }
 
         //If the allocation fails, then try and free some memory by calling the callbacks
 
         rowManager->restoreLimit(numPages);
         if (!rowManager->releaseCallbackMemory(maxSpillCost, true))
-        {
-            if (maxSpillCost == SpillAllCost)
-                throwHeapExhausted(newPages, oldPages);
-            return false;
-        }
+            throwHeapExhausted(newPages, oldPages);
     }
 }
 
@@ -3677,19 +3659,14 @@ void * CChunkedHeap::inlineDoAllocate(unsigned allocatorId, unsigned maxSpillCos
 
     loop
     {
-        if (!rowManager->checkLimit(1, maxSpillCost))
-            return NULL;
+        rowManager->checkLimit(1, maxSpillCost);
 
         donorHeaplet = allocateHeaplet();
         if (donorHeaplet)
             break;
         rowManager->restoreLimit(1);
         if (!rowManager->releaseCallbackMemory(maxSpillCost, true))
-        {
-            if (maxSpillCost == SpillAllCost)
-                throwHeapExhausted(1);
-            return NULL;
-        }
+            throwHeapExhausted(1);
     }
 
     if (memTraceLevel >= 5 || (memTraceLevel >= 3 && chunkSize > 32000))
@@ -4253,7 +4230,15 @@ public:
 
     void costAllocate(unsigned allocCost)
     {
-        row.setown(rowManager->allocate(size, 0, allocCost));
+        try
+        {
+            row.setown(rowManager->allocate(size, 0, allocCost));
+        }
+        catch (IException * e)
+        {
+            row.clear();
+            e->Release();
+        }
     }
 
     inline bool hasRow() const { return row != NULL; }
@@ -4361,7 +4346,8 @@ protected:
         ASSERT(PackedFixedSizeHeaplet::dataOffset() >= sizeof(PackedFixedSizeHeaplet));
         ASSERT(HugeHeaplet::dataOffset() >= sizeof(HugeHeaplet));
 
-        initializeHeap(false, useLargeMemory ? largeMemory : smallMemory, 0, NULL);
+        memsize_t memory = (useLargeMemory ? largeMemory : smallMemory) * (unsigned __int64)0x100000U;
+        initializeHeap(false, (unsigned)(memory / HEAP_ALIGNMENT_SIZE), 0, NULL);
     }
 
     void testCleanup()
@@ -4884,7 +4870,7 @@ protected:
     void testExhaust()
     {
         Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
-        rm1->setMemoryLimit(20*1024*1024);
+        rm1->setMemoryLimit(20*HEAP_ALIGNMENT_SIZE);
         try
         {
             unsigned i = 0;
@@ -4895,8 +4881,7 @@ protected:
         }
         catch (IException *E)
         {
-            StringBuffer s;
-            ASSERT(strcmp(E->errorMessage(s).str(), "memory limit exceeded")==0);
+            ASSERT(E->errorCode() == ROXIEMM_MEMORY_LIMIT_EXCEEDED);
             E->Release();
         }
         ASSERT(rm1->numPagesAfterCleanup(true)==20);

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -430,7 +430,7 @@ interface IRowManager : extends IInterface
     virtual void *allocate(memsize_t _size, unsigned activityId, unsigned maxSpillCost) = 0;
     virtual const char *cloneVString(const char *str) = 0;
     virtual const char *cloneVString(size32_t len, const char *str) = 0;
-    virtual bool resizeRow(void * original, memsize_t copysize, memsize_t newsize, unsigned activityId, unsigned maxSpillCost, IRowResizeCallback & callback) = 0;
+    virtual void resizeRow(void * original, memsize_t copysize, memsize_t newsize, unsigned activityId, unsigned maxSpillCost, IRowResizeCallback & callback) = 0;
     virtual void resizeRow(memsize_t & capacity, void * & original, memsize_t copysize, memsize_t newsize, unsigned activityId) = 0;
     virtual void *finalizeRow(void *final, memsize_t originalSize, memsize_t finalSize, unsigned activityId) = 0;
     virtual unsigned allocated() = 0;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
