### PR TITLE
HPCC-12037 virtual(logicalfilename) missing implicit scope

### DIFF
--- a/thorlcr/activities/thdiskbase.cpp
+++ b/thorlcr/activities/thdiskbase.cpp
@@ -39,9 +39,12 @@ void CDiskReadMasterBase::init()
 {
     CMasterActivity::init();
     IHThorDiskReadBaseArg *helper = (IHThorDiskReadBaseArg *) queryHelper();
-    fileName.setown(helper->getFileName());
+    OwnedRoxieString helperFileName = helper->getFileName();
+    StringBuffer expandedFileName;
+    queryThorFileManager().addScope(container.queryJob(), helperFileName, expandedFileName);
+    fileName.set(expandedFileName);
 
-    Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), fileName, 0 != ((TDXtemporary|TDXjobtemp) & helper->getFlags()), 0 != (TDRoptional & helper->getFlags()), true);
+    Owned<IDistributedFile> file = queryThorFileManager().lookup(container.queryJob(), helperFileName, 0 != ((TDXtemporary|TDXjobtemp) & helper->getFlags()), 0 != (TDRoptional & helper->getFlags()), true);
     if (file)
     {
         if (file->numParts() > 1)

--- a/thorlcr/activities/thdiskbase.ipp
+++ b/thorlcr/activities/thdiskbase.ipp
@@ -32,7 +32,7 @@ protected:
     Owned<CSlavePartMapping> mapping;
     IHash *hash;
     Owned<ProgressInfo> inputProgress;
-    OwnedRoxieString fileName;
+    StringAttr fileName;
 
 public:
     CDiskReadMasterBase(CMasterGraphElement *info);

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -348,8 +348,6 @@ void CDiskWriteSlaveActivityBase::open()
             rwFlags |= rw_crc;
         out.setown(createRowWriter(stream, ::queryRowInterfaces(input), rwFlags));
     }
-    CDfsLogicalFileName dlfn;
-    dlfn.set(logicalFilename);
     if (extend || (external && !query))
         stream->seek(0,IFSend);
     ActPrintLog("Created output stream for %s", fName.get());


### PR DESCRIPTION
For a relative logical filename (i.e. without ~ prefix), the
implicit workunit scope was not being prepended to the front of
the logical filename in a virtual(logicalfilename) field output.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
