### PR TITLE
HPCC-12053 Make relative filename handling consistent.

### DIFF
--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -71,10 +71,7 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase, public CThorDat
                 if (thisLineLength < minRequired || avail < minRequired)
                     break;
                 if (minRequired == maxRowSize)
-                {
-                    OwnedRoxieString fileName(activity.helper->getFileName());
-                    throw MakeActivityException(&activity, 0, "File %s contained a line of length greater than %d bytes.", fileName.get(), minRequired);
-                }
+                    throw MakeActivityException(&activity, 0, "File %s contained a line of length greater than %d bytes.", activity.logicalFilename.get(), minRequired);
                 if (minRequired >= maxRowSize/2)
                     minRequired = maxRowSize;
                 else

--- a/thorlcr/activities/fetch/thfetch.cpp
+++ b/thorlcr/activities/fetch/thfetch.cpp
@@ -67,12 +67,12 @@ public:
                 free(ekey);
                 if (!encrypted)
                 {
-                    Owned<IException> e = MakeActivityWarning(&container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", helper->getFileName());
+                    Owned<IException> e = MakeActivityWarning(&container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", fetchFile->queryLogicalName());
                     container.queryJob().fireException(e);
                 }
             }
             else if (encrypted)
-                throw MakeActivityException(this, 0, "File '%s' was published as encrypted but no encryption key provided", fname.get());
+                throw MakeActivityException(this, 0, "File '%s' was published as encrypted but no encryption key provided", fetchFile->queryLogicalName());
             mapping.setown(getFileSlaveMaps(fetchFile->queryLogicalName(), *fileDesc, container.queryJob().queryUserDescriptor(), container.queryJob().querySlaveGroup(), container.queryLocalOrGrouped(), false, NULL, fetchFile->querySuperFile()));
             mapping->serializeFileOffsetMap(offsetMapMb);
             addReadFile(fetchFile);

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -44,7 +44,7 @@ static IKeyManager *getKeyManager(IKeyIndex *keyIndex, IHThorIndexReadBaseArg *h
     return klManager.getClear();
 }
 
-static IKeyIndex *openKeyPart(CActivityBase *activity, const char *logicalFilename, IPartDescriptor &partDesc)
+static IKeyIndex *openKeyPart(CActivityBase *activity, IPartDescriptor &partDesc)
 {
     RemoteFilename rfn;
     partDesc.getFilename(0, rfn);
@@ -244,7 +244,7 @@ void CIndexPartHandlerHelper::setPart(IPartDescriptor *_partDesc, unsigned partN
 {
     reset();
     partDesc.set(_partDesc);
-    keyIndex.setown(openKeyPart(&activity, activity.logicalFilename.get(), *partDesc));
+    keyIndex.setown(openKeyPart(&activity, *partDesc));
     recSize = keyIndex->keySize(); 
     klManager.setown(getKeyManager(keyIndex, activity.helper, activity.fixedDiskRecordSize));
     activity.setManager(klManager);
@@ -336,7 +336,7 @@ class CIndexReadSlaveActivity : public CIndexReadSlaveBase, public CThorDataLink
                 Owned<IKeyIndexSet> keyIndexSet = createKeyIndexSet();
                 ForEachItemIn(p, activity.partDescs)
                 {
-                    keyIndex.setown(openKeyPart(&activity, activity.logicalFilename.get(), activity.partDescs.item(p)));
+                    keyIndex.setown(openKeyPart(&activity, activity.partDescs.item(p)));
                     keyIndexSet->addIndex(keyIndex.getClear());
                 }
                 klManager.setown(createKeyMerger(keyIndexSet, activity.fixedDiskRecordSize, activity.seekGEOffset, NULL));
@@ -344,7 +344,7 @@ class CIndexReadSlaveActivity : public CIndexReadSlaveBase, public CThorDataLink
             }
             else
             {
-                keyIndex.setown(openKeyPart(&activity, activity.logicalFilename.get(), activity.partDescs.item(0)));
+                keyIndex.setown(openKeyPart(&activity, activity.partDescs.item(0)));
                 klManager.setown(createKeyManager(keyIndex, activity.fixedDiskRecordSize, NULL));
             }
             activity.helper->createSegmentMonitors(klManager);
@@ -361,7 +361,7 @@ class CIndexReadSlaveActivity : public CIndexReadSlaveBase, public CThorDataLink
             {
                 activity.callback.clearManager();
                 klManager->releaseSegmentMonitors();
-                Owned<IKeyIndex> keyIndex = openKeyPart(&activity, activity.logicalFilename.get(), activity.partDescs.item(p));
+                Owned<IKeyIndex> keyIndex = openKeyPart(&activity, activity.partDescs.item(p));
                 klManager.setown(getKeyManager(keyIndex, activity.helper, activity.fixedDiskRecordSize));
                 activity.setManager(klManager);
                 count += klManager->checkCount(keyedLimit-count); // part max, is total limit [keyedLimit] minus total so far [count]
@@ -395,7 +395,7 @@ class CIndexReadSlaveActivity : public CIndexReadSlaveBase, public CThorDataLink
                 {
                     activity.callback.clearManager();
                     klManager->releaseSegmentMonitors();
-                    Owned<IKeyIndex> keyIndex = openKeyPart(&activity, activity.logicalFilename.get(), activity.partDescs.item(currentPart));
+                    Owned<IKeyIndex> keyIndex = openKeyPart(&activity, activity.partDescs.item(currentPart));
                     klManager.setown(getKeyManager(keyIndex, activity.helper, activity.fixedDiskRecordSize));
                     activity.setManager(klManager);
                 }
@@ -820,7 +820,7 @@ public:
             ForEachItemIn(p, partDescs)
             {
                 IPartDescriptor &partDesc = partDescs.item(p);
-                Owned<IKeyIndex> keyIndex = openKeyPart(this, logicalFilename.get(), partDesc);
+                Owned<IKeyIndex> keyIndex = openKeyPart(this, partDesc);
                 Owned<IKeyManager> klManager = getKeyManager(keyIndex, helper, fixedDiskRecordSize);
                 setManager(klManager);
                 while (klManager->lookup(true))
@@ -933,7 +933,7 @@ public:
             ForEachItemIn(p, partDescs)
             {
                 IPartDescriptor &partDesc = partDescs.item(p);
-                Owned<IKeyIndex> keyIndex = openKeyPart(this, logicalFilename.get(), partDesc);
+                Owned<IKeyIndex> keyIndex = openKeyPart(this, partDesc);
                 Owned<IKeyManager> klManager = getKeyManager(keyIndex, helper, fixedDiskRecordSize);
                 setManager(klManager);
                 if (helper->hasFilter())

--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -222,15 +222,9 @@ public:
             StringBuffer name(nameLen, nameBuff);
             StringBuffer value(valueLen, valueBuff);
             if(*nameBuff == '_' && strcmp(name, "_nodeSize") != 0)
-            {
-                OwnedRoxieString fname(helper->getFileName());
-                throw MakeActivityException(this, 0, "Invalid name %s in user metadata for index %s (names beginning with underscore are reserved)", name.str(), fname.get());
-            }
+                throw MakeActivityException(this, 0, "Invalid name %s in user metadata for index %s (names beginning with underscore are reserved)", name.str(), logicalFilename.get());
             if(!validateXMLTag(name.str()))
-            {
-                OwnedRoxieString fname(helper->getFileName());
-                throw MakeActivityException(this, 0, "Invalid name %s in user metadata for index %s (not legal XML element name)", name.str(), fname.get());
-            }
+                throw MakeActivityException(this, 0, "Invalid name %s in user metadata for index %s (not legal XML element name)", name.str(), logicalFilename.get());
             if(!metadata) metadata.setown(createPTree("metadata"));
             metadata->setProp(name.str(), value.str());
         }

--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -218,12 +218,12 @@ public:
                                 free(ekey);
                                 if (!encrypted)
                                 {
-                                    Owned<IException> e = MakeActivityWarning(&container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", helper->getFileName());
+                                    Owned<IException> e = MakeActivityWarning(&container, TE_EncryptionMismatch, "Ignoring encryption key provided as file '%s' was not published as encrypted", dataFile->queryLogicalName());
                                     container.queryJob().fireException(e);
                                 }
                             }
                             else if (encrypted)
-                                throw MakeActivityException(this, 0, "File '%s' was published as encrypted but no encryption key provided", fetchFilename.get());
+                                throw MakeActivityException(this, 0, "File '%s' was published as encrypted but no encryption key provided", dataFile->queryLogicalName());
                             unsigned dataReadWidth = (unsigned)container.queryJob().getWorkUnitValueInt("KJDRR", 0);
                             if (!dataReadWidth || dataReadWidth>container.queryJob().querySlaves())
                                 dataReadWidth = container.queryJob().querySlaves();

--- a/thorlcr/activities/thdiskbase.ipp
+++ b/thorlcr/activities/thdiskbase.ipp
@@ -49,7 +49,7 @@ class CWriteMasterBase : public CMasterActivity
     Owned<ProgressInfo> replicateProgress;
     __int64 recordsProcessed;
     bool published;
-    OwnedRoxieString filename;
+    StringAttr fileName;
     CDfsLogicalFileName dlfn;
 protected:
     StringArray clusters;

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -420,6 +420,7 @@ void CDiskWriteSlaveActivityBase::init(MemoryBuffer &data, MemoryBuffer &slaveDa
 {
     diskHelperBase = static_cast <IHThorDiskWriteArg *> (queryHelper());
 
+    StringAttr logicalFilename;
     data.read(logicalFilename);
     dlfn.set(logicalFilename);
     if (diskHelperBase->getFlags() & TDXtemporary)

--- a/thorlcr/activities/thdiskbaseslave.ipp
+++ b/thorlcr/activities/thdiskbaseslave.ipp
@@ -104,7 +104,7 @@ protected:
     Owned<IExtRowWriter> out;
     Owned<IFileIOStream> outraw;
     Owned<IPartDescriptor> partDesc;
-    StringAttr logicalFilename, fName;
+    StringAttr fName;
     CRC32 fileCRC;
     bool compress, grouped, calcFileCrc, rfsQueryParallel;
     offset_t uncompressedBytesWritten;

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -743,10 +743,8 @@ public:
     {
         if (!temp || job.queryUseCheckpoints())
         {
-            StringBuffer scopedName;
-            queryThorFileManager().addScope(job, name, scopedName, temp || fileKind==WUFileJobOwned);
             Owned<IWorkUnit> wu = &job.queryWorkUnit().lock();
-            wu->addFile(scopedName.str(), clusters, usageCount, fileKind, job.queryGraphName());
+            wu->addFile(name, clusters, usageCount, fileKind, job.queryGraphName());
         }
         else
             CGraphTempHandler::registerFile(name, graphId, usageCount, temp, fileKind, clusters);
@@ -755,10 +753,8 @@ public:
     {
         if (kept || job.queryUseCheckpoints())
         {
-            StringBuffer scopedName;
-            queryThorFileManager().addScope(job, name, scopedName, kept, kept);
             Owned<IWorkUnit> wu = &job.queryWorkUnit().lock();
-            wu->releaseFile(scopedName.str());
+            wu->releaseFile(name);
         }
         else
             CGraphTempHandler::deregisterFile(name);

--- a/thorlcr/mfilemanager/thmfilemanager.hpp
+++ b/thorlcr/mfilemanager/thmfilemanager.hpp
@@ -47,7 +47,7 @@ interface IThorFileManager : extends IInterface
     virtual void noteFileRead(CJobBase &job, IDistributedFile *file, bool extended=false) = 0;
     virtual IDistributedFile *lookup(CJobBase &job, const char *logicalName, bool temporary=false, bool optional=false, bool reportOptional=false, bool updateAccessed=true) = 0;
     virtual IFileDescriptor *create(CJobBase &job, const char *logicalName, StringArray &groupNames, IArrayOf<IGroup> &groups, bool overwriteok, unsigned helperFlags=0, bool nonLocalIndex=false, unsigned restrictedWidth=0) = 0;
-    virtual void publish(CJobBase &job, const char *logicalName, bool mangle, IFileDescriptor &file, Owned<IDistributedFile> *publishedFile=NULL, unsigned partOffset=0, bool createMissingParts=true) = 0;
+    virtual void publish(CJobBase &job, const char *logicalName, IFileDescriptor &file, Owned<IDistributedFile> *publishedFile=NULL, unsigned partOffset=0, bool createMissingParts=true) = 0;
     virtual void clearCacheEntry(const char *name) = 0;
     virtual StringBuffer &mangleLFN(CJobBase &job, const char *lfn, StringBuffer &out) = 0;
     virtual StringBuffer &addScope(CJobBase &job, const char *logicalname, StringBuffer &ret, bool temporary=false, bool paused=false) = 0;


### PR DESCRIPTION
Fixes regression introduced by HPCC-12037

Uncovered some inconsistencies in how names in meta info were
published when dealing with relative logical names.
One interestnig difference, exposed that UPDATE on relative
logical names wasn't working, causing in effect the UPDATE to be
ignore.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
