### PR TITLE
HPCC-11619 Show xmlns declarations in WSDL display

### DIFF
--- a/esp/xslt/xmlformatter.xsl
+++ b/esp/xslt/xmlformatter.xsl
@@ -137,6 +137,7 @@
     <div class="not-expd">
       <xsl:text>&lt;</xsl:text>
       <span class="start-tag"><xsl:value-of select="name(.)"/></span>
+      <xsl:call-template name="namespace-attr" />
       <xsl:apply-templates select="@*"/>
       <xsl:text>/&gt;</xsl:text>
     </div>
@@ -147,6 +148,7 @@
     <div class="not-expd">
       <xsl:text>&lt;</xsl:text>
       <span class="start-tag"><xsl:value-of select="name(.)"/></span>
+      <xsl:call-template name="namespace-attr" />
       <xsl:apply-templates select="@*"/>
       <xsl:text>&gt;</xsl:text>
 
@@ -247,9 +249,35 @@
       <span class="start-tag">
         <xsl:value-of select="$tagname"/>
       </span>
+      <xsl:call-template name="namespace-attr" />
       <xsl:apply-templates select="@*"/>
       <xsl:text>&gt;</xsl:text>
     </div>
+  </xsl:template>
+
+  <xsl:template name="namespace-attr">
+    <xsl:if test="count(namespace::node()) > count(../namespace::node())">
+      <xsl:variable name="namespaces-str">
+        <xsl:for-each select="../namespace::node()"><xsl:text>&lt;</xsl:text><xsl:value-of select="name()" /><xsl:text>&gt;</xsl:text></xsl:for-each>
+      </xsl:variable>
+      <xsl:for-each select="namespace::node()">
+        <xsl:variable name="n1" select="name()"/>
+        <xsl:variable name="v1" select="."/>
+        <xsl:if test="$v1 != 'http://www.w3.org/XML/1998/namespace'"> <!-- extra namespace added by browsers -->
+          <xsl:variable name="namespace-str"><xsl:text>&lt;</xsl:text><xsl:value-of select="name()" /><xsl:text>&gt;</xsl:text></xsl:variable>
+          <xsl:if test="not(contains($namespaces-str, $namespace-str))">
+            <xsl:choose>
+              <xsl:when test="$n1 != ''">
+                <xsl:text> xmlns:</xsl:text><xsl:value-of select="$n1" /><xsl:text>="</xsl:text><xsl:value-of select="$v1"/><xsl:text>"</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text> xmlns="</xsl:text><xsl:value-of select="$v1"/><xsl:text>"</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:if>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template name="expand-comment">


### PR DESCRIPTION
When displaying a WSDL inside WsECL links tab, the existing
stylesheet strips out the namespace declarations. That is
because the stylesheet handles the xmlns declarations as
normal xml attributes. The xmlns declarations are special
'attributes' which should be handled using namespace axes.
The code in this fix shows the xmlns declarations by
reading/filtering namespace axes. The code also filters out
a default xml namespace added by browsers.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
