### PR TITLE
HPCC-11667 Advanced menu falls behind nav bar

### DIFF
--- a/esp/src/eclwatch/css/hpcc.css
+++ b/esp/src/eclwatch/css/hpcc.css
@@ -229,6 +229,20 @@ hr.dashedLine {
     cursor: pointer;
 }
 
+
+@media (max-width: 959px){
+    .claro .hpccTitlebar {
+        height:100px;
+    }
+    .searchUserMoreComponents{
+        width:100%;
+        margin-top:10px;
+    }
+    .seperator:first-child{
+        display:none;
+    }
+}
+
 #search-form{
     padding:0;
     margin:0;
@@ -620,6 +634,10 @@ hr.dashedLine {
 
 .hpccApp {
     height: 100%;
+}
+
+.searchUserMoreComponents{
+    float:right;
 }
 
 .navBarLoggedin{

--- a/esp/src/eclwatch/templates/HPCCPlatformWidget.html
+++ b/esp/src/eclwatch/templates/HPCCPlatformWidget.html
@@ -2,7 +2,7 @@
     <div id="${id}BorderContainer" class="hpccMainpage" data-dojo-props="gutters:false, liveSplitters:false" data-dojo-type="dijit.layout.BorderContainer">
         <div id="${id}Titlebar" class="hpccTitlebar" data-dojo-props="region: 'top'" data-dojo-type="dijit.layout.ContentPane">
             <div id="${id}StackController" class="left glow" data-dojo-props="containerId:'${id}TabContainer'" data-dojo-type="dijit.layout.StackController"></div>
-            <div class="right">
+            <div class="searchUserMoreComponents">
                 <div class="seperator grey"></div>
                 <form id="search-form" onsubmit="return false;">
                     <input id="${id}FindText" class="roundForm" data-dojo-props="placeHolder: '${i18n.PlaceholderFindText}', trim: true" data-dojo-type="dijit.form.TextBox" />


### PR DESCRIPTION
The advanced menu and search bar falls behind the navigation bar.
Utilize @media query to make items visible if under 960px resolution
which is 1024x768 screen resolution or if the browser window is scaled.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
