### PR TITLE
HPCC-12077 Grid Hyperlink clicks do not get de-registered correctly

### DIFF
--- a/esp/src/eclwatch/ActivityWidget.js
+++ b/esp/src/eclwatch/ActivityWidget.js
@@ -290,12 +290,12 @@ define([
                             var img = row.getStateImage();
                             if (context.activity.isInstanceOfQueue(row)) {
                                 if (row.ClusterType === 3) {
-                                    return "<img src='" + img + "'/>&nbsp;<a href='#' class='" + context.id + "RowClick'>" + _name + "</a>";
+                                    return "<img src='" + img + "'/>&nbsp;<a href='#' class='dgrid-row-url'>" + _name + "</a>";
                                 } else {
                                     return "<img src='" + img + "'/>&nbsp;" + _name;
                                 }
                             }
-                            return "<img src='" + img + "'/>&nbsp;<a href='#' class='" + context.id + "RowClick'>" + row.Wuid + "</a>";
+                            return "<img src='" + img + "'/>&nbsp;<a href='#' class='dgrid-row-url'>" + row.Wuid + "</a>";
                         }
                     }),
                     GID: {
@@ -303,7 +303,7 @@ define([
                         formatter: function (_gid, row) {
                             if (context.activity.isInstanceOfWorkunit(row)) {
                                 if (row.GraphName) {
-                                    return "<a href='#' class='" + context.id + "GraphClick'>" + row.GraphName + "-" + row.GID + "</a>";
+                                    return "<a href='#' class='dgrid-row-url2'>" + row.GraphName + "-" + row.GID + "</a>";
                                 }
                             }
                             return "";
@@ -339,7 +339,7 @@ define([
                 }
             }, domID);
 
-            on(document, "." + this.id + "RowClick:click", function (evt) {
+            retVal.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = retVal.row(evt).data;
                     context._onRowDblClick(row, {
@@ -348,7 +348,7 @@ define([
                 }
             });
 
-            on(document, "." + this.id + "GraphClick:click", function (evt) {
+            retVal.on(".dgrid-row-url2:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = retVal.row(evt).data;
                     context._onRowDblClick(row, {

--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -433,7 +433,7 @@ define([
                             if (row.__hpcc_isDir) {
                                 return name;
                             }
-                            return (row.getStateImageHTML ? row.getStateImageHTML() + "&nbsp;" : "") + "<a href='#' rowIndex=" + row + " class='" + context.id + "LogicalNameClick'>" + name + "</a>";
+                            return (row.getStateImageHTML ? row.getStateImageHTML() + "&nbsp;" : "") + "<a href='#' class='dgrid-row-url'>" + name + "</a>";
                         },
                         renderExpando: function (level, hasChildren, expanded, object) {
                             var dir = this.grid.isRTL ? "right" : "left";
@@ -457,7 +457,7 @@ define([
             }, this.id + "WorkunitsGrid");
 
             var context = this;
-            on(document, "." + context.id + "LogicalNameClick:click", function (evt) {
+            this.workunitsGrid.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.workunitsGrid.row(evt).data;
                     context._onRowDblClick(item);

--- a/esp/src/eclwatch/EventScheduleWorkunitWidget.js
+++ b/esp/src/eclwatch/EventScheduleWorkunitWidget.js
@@ -140,7 +140,7 @@ define([
                     Wuid: {
                         label: this.i18n.Workunit, width: 180, sortable: true,
                         formatter: function (Wuid) {
-                            return "<a href='#' class='" + context.id + "WuidClick'>" + Wuid + "</a>";
+                            return "<a href='#' class='dgrid-row-url'>" + Wuid + "</a>";
                         }
                     },
                     Cluster: { label: this.i18n.Cluster, width: 100, sortable: true },
@@ -152,7 +152,7 @@ define([
                 }
             }, this.id + "EventGrid");
 
-            on(document, "." + context.id + "WuidClick:click", function (evt) {
+            this.eventGrid.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.eventGrid.row(evt).data;
                     context._onRowDblClick(item);

--- a/esp/src/eclwatch/GetDFUWorkunitsWidget.js
+++ b/esp/src/eclwatch/GetDFUWorkunitsWidget.js
@@ -330,7 +330,7 @@ define([
                         width: 180,
                         formatter: function (ID, idx) {
                             var wu = ESPDFUWorkunit.Get(ID);
-                            return "<img src='" + wu.getStateImage() + "'>&nbsp;<a href='#' rowIndex=" + idx + " class='" + context.id + "IDClick'>" + ID + "</a>";
+                            return "<img src='" + wu.getStateImage() + "'>&nbsp;<a href='#' class='dgrid-row-url'>" + ID + "</a>";
                         }
                     },
                     Command: {
@@ -352,7 +352,7 @@ define([
             }, this.id + "WorkunitsGrid");
 
             var context = this;
-            on(document, "." + context.id + "IDClick:click", function (evt) {
+            this.workunitsGrid.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.workunitsGrid.row(evt).data;
                     context._onRowDblClick(item.ID);

--- a/esp/src/eclwatch/GraphsWidget.js
+++ b/esp/src/eclwatch/GraphsWidget.js
@@ -123,7 +123,7 @@ define([
                     Name: {
                         label: this.i18n.Name, width: 72, sortable: true,
                         formatter: function (Name, row) {
-                            return "<a href='#' class='" + context.id + "GraphClick'>" + Name + "</a>";
+                            return "<a href='#' class='dgrid-row-url'>" + Name + "</a>";
                         }
                     },
                     Label: { label: this.i18n.Label, sortable: true },
@@ -146,7 +146,7 @@ define([
                 context.syncSelectionFrom(context.grid);
             });
 
-            on(document, "." + this.id + "GraphClick:click", function (evt) {
+            retVal.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = retVal.row(evt).data;
                     context._onRowDblClick(row);

--- a/esp/src/eclwatch/LogsWidget.js
+++ b/esp/src/eclwatch/LogsWidget.js
@@ -152,7 +152,7 @@ define([
                             width: 117,
                             formatter: function (Type, row) {
                                 if (context.canShowContent(Type)) {
-                                    return "<a href='#' rowIndex=" + row.id + " class='" + context.id + "HelperClick'>" + Type + "</a>";
+                                    return "<a href='#' class='dgrid-row-url'>" + Type + "</a>";
                                 }
                                 return Type;
                             }
@@ -166,7 +166,7 @@ define([
                         }
                     }
                 }, domID);
-                on(document, "." + this.id + "HelperClick:click", function (evt) {
+                retVal.on(".dgrid-row-url:click", function (evt) {
                     if (context._onRowDblClick) {
                         var row = context.grid.row(evt).data;
                         context._onRowDblClick(row);

--- a/esp/src/eclwatch/QuerySetErrorsWidget.js
+++ b/esp/src/eclwatch/QuerySetErrorsWidget.js
@@ -58,13 +58,6 @@ define([
                     State: { label: this.i18n.State, width: 108, sortable: false }
                 }
             }, domID);
-
-            on(document, "." + this.id + "WuidClick:click", function (evt) {
-                if (context._onRowDblClick) {
-                    var row = retVal.row(evt).data;
-                    context._onRowDblClick(row);
-                }
-            });
             return retVal;
         },
 

--- a/esp/src/eclwatch/QuerySetQueryWidget.js
+++ b/esp/src/eclwatch/QuerySetQueryWidget.js
@@ -341,7 +341,7 @@ define([
                     Id: {
                         label: this.i18n.ID,
                         formatter: function (Id, idx) {
-                            return "<a href='#' rowIndex=" + idx + " class='" + context.id + "IdClick'>" + Id + "</a>";
+                            return "<a href='#' class='dgrid-row-url'>" + Id + "</a>";
                         }
                     },
                     Name: {
@@ -357,7 +357,7 @@ define([
                         width: 180,
                         label: this.i18n.WUID,
                         formatter: function (Wuid, idx) {
-                            return "<a href='#' rowIndex=" + idx + " class='" + context.id + "WuidClick'>" + Wuid + "</a>";
+                            return "<a href='#' class='dgrid-row-url2'>" + Wuid + "</a>";
                         }
                     },
                     Dll: {
@@ -376,13 +376,13 @@ define([
                     }
                 }
             }, this.id + "QuerySetGrid");
-            on(document, "." + context.id + "IdClick:click", function (evt) {
+            this.querySetGrid.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.querySetGrid.row(evt).data;
                     context._onRowDblClick(item);
                 }
             });
-            on(document, "." + context.id + "WuidClick:click", function (evt) {
+            this.querySetGrid.on(".dgrid-row-url2:click", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.querySetGrid.row(evt).data;
                     context._onRowDblClick(item, true);

--- a/esp/src/eclwatch/ResourcesWidget.js
+++ b/esp/src/eclwatch/ResourcesWidget.js
@@ -87,13 +87,13 @@ define([
                     DisplayPath: {
                         label: this.i18n.Name, sortable: true,
                         formatter: function (url, row) {
-                            return "<a href='#' class='" + context.id + "URLClick'>" + url + "</a>";
+                            return "<a href='#' class='dgrid-row-url'>" + url + "</a>";
                         }
                     }
                 }
             }, domID);
 
-            on(document, "." + this.id + "URLClick:click", function (evt) {
+            retVal.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = retVal.row(evt).data;
                     context._onRowDblClick(row);

--- a/esp/src/eclwatch/ResultsWidget.js
+++ b/esp/src/eclwatch/ResultsWidget.js
@@ -97,13 +97,13 @@ define([
                     Name: {
                         label: this.i18n.Name, width: 180, sortable: true,
                         formatter: function (Name, idx) {
-                            return "<a href='#' rowIndex=" + idx + " class='" + context.id + "ResultClick'>" + Name + "</a>";
+                            return "<a href='#' class='dgrid-row-url'>" + Name + "</a>";
                         }
                     },
                     FileName: {
                         label: this.i18n.FileName, sortable: true,
                         formatter: function (FileName, idx) {
-                            return "<a href='#' rowIndex=" + idx + " class='" + context.id + "FileClick'>" + FileName + "</a>";
+                            return "<a href='#' class='dgrid-row-url2'>" + FileName + "</a>";
                         }
                     },
                     Value: {
@@ -116,7 +116,7 @@ define([
                         formatter: function (ResultViews, idx) {
                             var retVal = "";
                             arrayUtil.forEach(ResultViews, function (item, idx) {
-                                retVal += "<a href='#' viewName=" + encodeURIComponent(item) + " class='" + context.id + "ViewClick'>" + item + "</a>&nbsp;";
+                                retVal += "<a href='#' viewName=" + encodeURIComponent(item) + " class='dgrid-row-url3'>" + item + "</a>&nbsp;";
                             });
                             return retVal;
                         }
@@ -125,19 +125,19 @@ define([
             }, domID);
 
             var context = this;
-            on(document, "." + this.id + "ResultClick:click", function (evt) {
+            retVal.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = context.grid.row(evt).data;
                     context._onRowDblClick(row);
                 }
             });
-            on(document, "." + this.id + "FileClick:click", function (evt) {
+            retVal.on(".dgrid-row-url2:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = context.grid.row(evt).data;
                     context._onRowDblClickFile(row);
                 }
             });
-            on(document, "." + this.id + "ViewClick:click", function (evt) {
+            retVal.on(".dgrid-row-url3:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = context.grid.row(evt).data;
                     context._onRowDblClickView(row, evt.srcElement.getAttribute("viewName"));

--- a/esp/src/eclwatch/SearchResultsWidget.js
+++ b/esp/src/eclwatch/SearchResultsWidget.js
@@ -82,14 +82,14 @@ define([
                     Summary: {
                         label: this.i18n.Who, sortable: true,
                         formatter: function (summary, idx) {
-                            return "<a href='#' rowIndex=" + idx + " class='" + context.id + "SearchResultClick'>" + summary + "</a>";
+                            return "<a href='#' class='dgrid-row-url'>" + summary + "</a>";
                         }
                     }
                 }
             }, domID);
 
             var context = this;
-            on(document, "." + this.id + "SearchResultClick:click", function (evt) {
+            retVal.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = retVal.row(evt).data;
                     context._onRowDblClick(row);

--- a/esp/src/eclwatch/SourceFilesWidget.js
+++ b/esp/src/eclwatch/SourceFilesWidget.js
@@ -67,7 +67,7 @@ define([
                     Name: {
                         label: "Name", sortable: true,
                         formatter: function (Name, row) {
-                            return dojoConfig.getImageHTML(row.IsSuperFile ? "folder_table.png" : "file.png") + "&nbsp;<a href='#' rowIndex=" + row + " class='" + context.id + "SourceFileClick'>" + Name + "</a>";
+                            return dojoConfig.getImageHTML(row.IsSuperFile ? "folder_table.png" : "file.png") + "&nbsp;<a href='#' class='dgrid-row-url'>" + Name + "</a>";
                         }
                     },
                     Count: { label: "Usage", width: 72, sortable: true }
@@ -75,7 +75,7 @@ define([
             }, domID);
 
             var context = this;
-            on(document, "." + this.id + "SourceFileClick:click", function (evt) {
+            retVal.on("." + this.id + "dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var row = context.grid.row(evt).data;
                     context._onRowDblClick(row);

--- a/esp/src/eclwatch/TimingPageWidget.js
+++ b/esp/src/eclwatch/TimingPageWidget.js
@@ -104,7 +104,7 @@ define([
                             sortable: true,
                             formatter: function (Name, row) {
                                 if (row.GraphName) {
-                                    return "<a href='#' class='" + context.id + "GraphClick'>" + Name + "</a>";
+                                    return "<a href='#' class='dgrid-row-url'>" + Name + "</a>";
                                 }
                                 return Name;
                             }
@@ -117,7 +117,7 @@ define([
                     context.syncSelectionFrom(context.grid);
                 });
 
-                on(document, "." + this.id + "GraphClick:click", function (evt) {
+                retVal.on(".dgrid-row-url:click", function (evt) {
                     if (context._onRowDblClick) {
                         var row = retVal.row(evt).data;
                         context._onRowDblClick(row);

--- a/esp/src/eclwatch/UserQueryWidget.js
+++ b/esp/src/eclwatch/UserQueryWidget.js
@@ -394,12 +394,6 @@ define([
                 }
             }, this.id + "GroupsGrid");
             var context = this;
-            on(document, ".WuidClick:click", function (evt) {
-                if (context._onGroupsRowDblClick) {
-                    var item = context.groupsGrid.row(evt).data;
-                    context._onGroupsRowDblClick(item.name);
-                }
-            });
             this.groupsGrid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onGroupsRowDblClick) {
                     var item = context.groupsGrid.row(evt).data;
@@ -492,12 +486,6 @@ define([
                 }
             }, this.id + "UsersGrid");
             var context = this;
-            on(document, ".WuidClick:click", function (evt) {
-                if (context._onUsersRowDblClick) {
-                    var item = context.usersGrid.row(evt).data;
-                    context._onUsersRowDblClick(item.username,item.fullname,item.passwordexpiration);
-                }
-            });
             this.usersGrid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onUsersRowDblClick) {
                     var item = context.usersGrid.row(evt).data;
@@ -606,12 +594,6 @@ define([
                 }
             }, this.id + "PermissionsGrid");
             var context = this;
-            on(document, ".WuidClick:click", function (evt) {
-                if (context._onPermissionsRowDblClick) {
-                    var item = context.permissionsGrid.row(evt).data;
-                    context._onPermissionsRowDblClick(item.username, item.fullname, item.passwordexpiration);
-                }
-            });
             this.permissionsGrid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onPermissionsRowDblClick) {
                     var item = context.permissionsGrid.row(evt).data;

--- a/esp/src/eclwatch/WUQueryWidget.js
+++ b/esp/src/eclwatch/WUQueryWidget.js
@@ -377,7 +377,7 @@ define([
                         label: this.i18n.WUID, width: 180,
                         formatter: function (Wuid, idx) {
                             var wu = ESPWorkunit.Get(Wuid);
-                            return wu.getStateImageHTML() + "&nbsp;<a href='#' rowIndex=" + idx + " class='" + context.id + "WuidClick'>" + Wuid + "</a>";
+                            return wu.getStateImageHTML() + "&nbsp;<a href='#' class='dgrid-row-url'>" + Wuid + "</a>";
                         }
                     },
                     Owner: { label: this.i18n.Owner, width: 90 },
@@ -390,7 +390,7 @@ define([
             }, this.id + "WorkunitsGrid");
 
             var context = this;
-            on(document, "." + context.id + "WuidClick:click", function (evt) {
+            this.workunitsGrid.on(".dgrid-row-url:click", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.workunitsGrid.row(evt).data;
                     context._onRowDblClick(item.Wuid);


### PR DESCRIPTION
This causes the hyperlink event to fire more than once on subsequent visits,
which invariably will corrupt the embedded HTML.

Fixes HPCC-12077

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
