### PR TITLE
HPCC-12053 Index writes were broken by last change.

### DIFF
--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -62,8 +62,7 @@ public:
         CMasterActivity::init();
         OwnedRoxieString helperFileName = helper->getFileName();
         StringBuffer expandedFileName;
-        bool mangle = 0 != (helper->getFlags() & (TDXtemporary|TDXjobtemp));
-        queryThorFileManager().addScope(container.queryJob(), helperFileName, expandedFileName, mangle);
+        queryThorFileManager().addScope(container.queryJob(), helperFileName, expandedFileName, false);
         fileName.set(expandedFileName);
         dlfn.set(fileName);
         isLocal = 0 != (TIWlocal & helper->getFlags());

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -46,16 +46,15 @@ public:
     {
         CMasterActivity::init();
         helper = (IHThorKeyDiffArg *)queryHelper();
-        bool mangle = 0 != (helper->getFlags() & (TDXtemporary|TDXjobtemp));
         OwnedRoxieString originalHelperName(helper->getOriginalName());
         OwnedRoxieString updatedHelperName(helper->getUpdatedName());
         OwnedRoxieString outputHelperName(helper->getOutputName());
         StringBuffer expandedFileName;
-        queryThorFileManager().addScope(container.queryJob(), originalHelperName, expandedFileName, mangle);
+        queryThorFileManager().addScope(container.queryJob(), originalHelperName, expandedFileName, false);
         originalName.set(expandedFileName);
-        queryThorFileManager().addScope(container.queryJob(), updatedHelperName, expandedFileName.clear(), mangle);
+        queryThorFileManager().addScope(container.queryJob(), updatedHelperName, expandedFileName.clear(), false);
         updatedName.set(expandedFileName);
-        queryThorFileManager().addScope(container.queryJob(), outputHelperName, expandedFileName.clear(), mangle);
+        queryThorFileManager().addScope(container.queryJob(), outputHelperName, expandedFileName.clear(), false);
         outputName.set(expandedFileName);
 
         originalIndexFile.setown(queryThorFileManager().lookup(container.queryJob(), originalHelperName));

--- a/thorlcr/activities/keypatch/thkeypatch.cpp
+++ b/thorlcr/activities/keypatch/thkeypatch.cpp
@@ -45,16 +45,15 @@ public:
     {
         CMasterActivity::init();
         helper = (IHThorKeyPatchArg *)queryHelper();
-        bool mangle = 0 != (helper->getFlags() & (TDXtemporary|TDXjobtemp));
         OwnedRoxieString originalHelperName(helper->getOriginalName());
         OwnedRoxieString patchHelperName(helper->getPatchName());
         OwnedRoxieString outputHelperName(helper->getOutputName());
         StringBuffer expandedFileName;
-        queryThorFileManager().addScope(container.queryJob(), originalHelperName, expandedFileName, mangle);
+        queryThorFileManager().addScope(container.queryJob(), originalHelperName, expandedFileName, false);
         originalName.set(expandedFileName);
-        queryThorFileManager().addScope(container.queryJob(), patchHelperName, expandedFileName.clear(), mangle);
+        queryThorFileManager().addScope(container.queryJob(), patchHelperName, expandedFileName.clear(), false);
         patchName.set(expandedFileName);
-        queryThorFileManager().addScope(container.queryJob(), outputHelperName, expandedFileName.clear(), mangle);
+        queryThorFileManager().addScope(container.queryJob(), outputHelperName, expandedFileName.clear(), false);
         outputName.set(expandedFileName);
 
         originalIndexFile.setown(queryThorFileManager().lookup(container.queryJob(), originalHelperName));


### PR DESCRIPTION
Index (+ keydiff/keypatch) writes were incorrectly testing for
TDX\* flags, as a consequence they were incorrectly mangling the
output filenames with temporary scopes, which could not be found
on lookup

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
