### PR TITLE
HPCC-12083 Remove ROXIEMM_LARGE_MEMORY_EXHAUSTED from newly merged code

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1436,7 +1436,6 @@ protected:
             {
             case ROXIEMM_MEMORY_POOL_EXHAUSTED:
             case ROXIEMM_MEMORY_LIMIT_EXCEEDED:
-            case ROXIEMM_LARGE_MEMORY_EXHAUSTED:
                 e->Release();
                 return false;
             default:
@@ -1496,7 +1495,6 @@ protected:
                     {
                     case ROXIEMM_MEMORY_POOL_EXHAUSTED:
                     case ROXIEMM_MEMORY_LIMIT_EXCEEDED:
-                    case ROXIEMM_LARGE_MEMORY_EXHAUSTED:
                         e->Release();
                         break;
                     default:


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
