### PR TITLE
HPCC-12079 Start Activity Cache timeout from cache creation completion

### DIFF
--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -672,6 +672,7 @@ ActivityInfo* CWsSMCEx::createActivityInfo(IEspContext &context)
     Owned<ActivityInfo> activityInfo = new ActivityInfo();
     readTargetClusterInfo(context, clusters, serverStatusRoot, activityInfo);
     readRunningWUsAndQueuedWUs(context, envRoot, serverStatusRoot, dfuRecoveryRoot, activityInfo);
+    activityInfo->timeCached.setNow();
     return activityInfo.getClear();
 }
 

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -93,7 +93,7 @@ struct ActivityInfo : public CInterface, implements IInterface
 {
     IMPLEMENT_IINTERFACE;
 
-    ActivityInfo() { timeCached.setNow(); };
+    ActivityInfo() {};
     bool isCachedActivityInfoValid(unsigned timeOutSeconds);
 
     CDateTime timeCached;


### PR DESCRIPTION
The WsSMC.Activity method checks the cache timeout to decide
whether it can use the Activity information cache or not. The
existing code starts the cache timeout at the beginning of
creating the cache. If the cache creation takes a longer time
than the timeout value, the second Activity request may have
to re-build the cache as soon as the first Activity request
finishes the cache creation. This fix sets the starting time
of the timeout at the end of the cache creation.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
