### PR TITLE
HPCC-12092 DOCS: Error in Systems Admin. header

### DIFF
--- a/docs/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
+++ b/docs/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
@@ -780,7 +780,7 @@
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
     <sect1>
-      <title>Envrionment.conf</title>
+      <title>Environment.conf</title>
 
       <para>Another component of HPCC system configuration is the
       environment.conf file. Environment.conf contains some global definitions


### PR DESCRIPTION
FIX HPCC-12092 DOCS: Error in Systems Admin. header
Spelling error

Signed-off-by: g-pan greg.panagiotatos@lexisnexis.com
@JamesDeFabia please review
