### PR TITLE
HPCC-11783 Return NodeGroup in WUInfo ECLResult

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -699,6 +699,7 @@ public:
     virtual unsigned getWuidVersion() const;
     virtual void getBuildVersion(IStringVal & buildVersion, IStringVal & eclVersion) const;
     virtual IPropertyTree * getDiskUsageStats();
+    virtual IPropertyTree * getFile(const char *fileName) const;
     virtual IPropertyTreeIterator & getFileIterator() const;
     virtual bool archiveWorkUnit(const char *base,bool del,bool ignoredllerrors,bool deleteOwned);
     virtual void packWorkUnit(bool pack=true);
@@ -1291,6 +1292,8 @@ public:
             { c->addDiskUsageStats(avgNodeUsage, minNode, minNodeUsage, maxNode, maxNodeUsage, graphId); }
     virtual IPropertyTree * getDiskUsageStats()
             { return c->getDiskUsageStats(); }
+    virtual IPropertyTree * getFile(const char *fileName) const
+            { return c->getFile(fileName); }
     virtual IPropertyTreeIterator & getFileIterator() const
             { return c->getFileIterator(); }
     virtual IPropertyTreeIterator & getFilesReadIterator() const
@@ -6563,6 +6566,14 @@ IPropertyTreeIterator & CLocalWorkUnit::getFilesReadIterator() const
 {
     CriticalBlock block(crit);
     return * p->getElements("FilesRead/File");
+}
+
+IPropertyTree* CLocalWorkUnit::getFile(const char *fileName) const
+{
+    StringBuffer path("Files/File[@name=\"");
+    path.append(fileName).append("\"]");
+    CriticalBlock block(crit);
+    return p->getPropTree(path.str());
 }
 
 //=================================================================================================

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4884,6 +4884,35 @@ unsigned getEnvironmentHThorClusterNames(StringArray &eclAgentNames, StringArray
     return eclAgentNames.ordinality();
 }
 
+StringBuffer& getEnvironmentClusterNodeGroup(const char* cluster, StringBuffer& nodeGroup)
+{
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IConstEnvironment> env = factory->openEnvironment();
+    if (!env)
+        return nodeGroup;
+
+    VStringBuffer path("Software/ThorCluster[@name=\"%s\"]", cluster);
+    Owned<IPropertyTree> root = &env->getPTree();
+    IPropertyTree *node = root->queryPropTree(path.str());
+    if (!node)
+    {
+        path.setf("Software/RoxieCluster[@name=\"%s\"]", cluster);
+        node = root->queryPropTree(path.str());
+    }
+    if (node)
+    {
+        const char *groupName = node->queryProp("@nodeGroup");
+        if (!groupName||!*groupName)
+            groupName = cluster;
+        nodeGroup.set(groupName);
+    }
+    else //HThor
+    {
+        nodeGroup.set("hthor__").append(cluster);
+    }
+    return nodeGroup;
+}
+
 
 IStringVal& CLocalWorkUnit::getScope(IStringVal &str) const 
 {

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -944,6 +944,7 @@ interface IConstWorkUnit : extends IInterface
     virtual bool isBilled() const = 0;
     virtual bool getWuDate(unsigned & year, unsigned & month, unsigned & day) = 0;
     virtual IPropertyTree * getDiskUsageStats() = 0;
+    virtual IPropertyTree * getFile(const char *fileName) const = 0;
     virtual IPropertyTreeIterator & getFileIterator() const = 0;
     virtual bool getCloneable() const = 0;
     virtual IUserDescriptor * queryUserDescriptor() const = 0;

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1264,6 +1264,7 @@ extern WORKUNIT_API void clientShutdownWorkUnit();
 extern WORKUNIT_API IExtendedWUInterface * queryExtendedWU(IWorkUnit * wu);
 extern WORKUNIT_API unsigned getEnvironmentThorClusterNames(StringArray &thorNames, StringArray &groupNames, StringArray &targetNames, StringArray &queueNames);
 extern WORKUNIT_API unsigned getEnvironmentHThorClusterNames(StringArray &eclAgentNames, StringArray &groupNames, StringArray &targetNames);
+extern WORKUNIT_API StringBuffer& getEnvironmentClusterNodeGroup(const char* cluster, StringBuffer& nodeGroup);
 extern WORKUNIT_API StringBuffer &formatGraphTimerLabel(StringBuffer &str, const char *graphName, unsigned subGraphNum=0, unsigned __int64 subId=0);
 extern WORKUNIT_API StringBuffer &formatGraphTimerScope(StringBuffer &str, const char *graphName, unsigned subGraphNum, unsigned __int64 subId);
 extern WORKUNIT_API bool parseGraphTimerLabel(const char *label, StringAttr &graphName, unsigned & graphNum, unsigned &subGraphNum, unsigned &subId);

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -46,6 +46,7 @@ ESPStruct [nil_remove] ECLResult
     string Value;
     string Link;
     string FileName;
+    [min_ver("1.52")] string NodeGroup;
     bool   IsSupplied;
     bool   ShowFileContent(true);
     int64  Total;
@@ -1562,7 +1563,7 @@ ESPresponse [exceptions_inline] WUCheckFeaturesResponse
 };
 
 ESPservice [
-    version("1.51"), default_client_version("1.51"),
+    version("1.52"), default_client_version("1.52"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1326,25 +1326,14 @@ bool WsWuInfo::getResultEclSchemas(IConstWUResult &r, IArrayOf<IEspECLSchemaItem
 StringBuffer& WsWuInfo::getResultNodeGroup(const char* fileName, StringBuffer& nodeGroup)
 {
     if (!fileName || !*fileName)
-        return nodeGroup;
-    Owned<IPropertyTree> f = cw->getFile(fileName);
-    if (!f)
-        return nodeGroup;
-    const char* cluster = f->queryProp("@cluster");
-    if (!cluster || !*cluster)
-        return nodeGroup;
+        throw MakeStringException(ECLWATCH_INVALID_INPUT,"Result file not specified");
 
-    StringArray envClusters, envGroups, envTargets, envQueues;
-    getEnvironmentThorClusterNames(envClusters, envGroups, envTargets, envQueues);
-    getEnvironmentHThorClusterNames(envClusters, envGroups, envTargets);
-    ForEachItemIn(i, envClusters)
+    Owned<IPropertyTree> f = cw->getFile(fileName);
+    if (f)
     {
-        const char *clusterName = envClusters.item(i);
-        if (clusterName && strieq(clusterName, cluster))
-        {
-            nodeGroup.set(envGroups.item(i));
-            break;
-        }
+        const char* cluster = f->queryProp("@cluster");
+        if (cluster && *cluster)
+            getEnvironmentClusterNodeGroup(cluster, nodeGroup);
     }
     return nodeGroup;
 }

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -171,6 +171,7 @@ public:
     void getEclSchemaFields(IArrayOf<IEspECLSchemaItem>& schemas, IHqlExpression * expr, bool isConditional);
     bool getResultEclSchemas(IConstWUResult &r, IArrayOf<IEspECLSchemaItem>& schemas);
     void getResult(IConstWUResult &r, IArrayOf<IEspECLResult>& results, unsigned flags);
+    StringBuffer& getResultNodeGroup(const char* fileName, StringBuffer& nodeGroup);
 
     void getWorkunitEclAgentLog(const char* eclAgentInstance, const char* agentPid, MemoryBuffer& buf);
     void getWorkunitThorLog(const char *processName, MemoryBuffer& buf);


### PR DESCRIPTION
The WsWorkunits/WUInfo is updated to return 'NodeGroup'
inside the ECLResult when the result has a 'logicalName'.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
