### PR TITLE
HPCC-12111 Use a different sub directory for each slave instance

### DIFF
--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -353,10 +353,10 @@ int main( int argc, char *argv[]  )
                 globals->setProp("@thorTempDirectory", tempDirStr.str());
             else
                 tempDirStr.append(globals->queryProp("@thorTempDirectory"));
+            addPathSepChar(tempDirStr).append(getMachinePortBase());
+
             logDiskSpace(); // Log before temp space is cleared
-            StringBuffer tempPrefix("thtmp");
-            tempPrefix.append(getMachinePortBase()).append("_");
-            SetTempDir(tempDirStr.str(), tempPrefix.str(), true);
+            SetTempDir(tempDirStr.str(), "thtmp", true);
 
             useMemoryMappedRead(globals->getPropBool("@useMemoryMappedRead"));
 


### PR DESCRIPTION
Use a sub directory based on port number under the configured
main temp directory, to keep temp files separate from different
slaves separately. This is mainly so that on restart, a slave
can clear out it's own temps easily.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
