### PR TITLE
HPCC-12116 Do not allocate memory for 0 size in rtlMalloc

### DIFF
--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -66,9 +66,11 @@ MODULE_EXIT()
 // Miscellaneous string functions...
 ECLRTL_API void * rtlMalloc(size32_t size)
 {
-    void * retVal = malloc(size);
+    if (!size)
+        return NULL;
 
-    if( size && !retVal)
+    void * retVal = malloc(size);
+    if (!retVal)
     {
         PrintStackReport();
         rtlThrowOutOfMemory(0, "Memory allocation error!");


### PR DESCRIPTION
malloc(0) is undefined, but we would prefer NULL.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
