### PR TITLE
HPCC-12033 Default target environment for regression suite should be configurable

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -92,13 +92,13 @@ Command:
 Result:
 
 |
-|       usage: ecl-test setup [-h] [--target [target_cluster | all]]
+|       usage: ecl-test setup [-h] [--target [target_cluster_list | all]]
 |                             [--pq threadNumber]
 |
 |       optional arguments:
 |        -h, --help               show this help message and exit
-|        --target [target_cluster | all], -t [target_cluster | all]
-|                                 target cluster for single query run. If target = 'all' then run query on all clusters. Default value is thor.
+|        --target [target_cluster_list | all], -t [target_cluster_list | all]
+|                                 run the setup on target cluster(s). If target = 'all' then run setup on all clusters. If not defined then default value(s) come from config (ecl-test.json by default).
 |        --pq threadNumber        parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
 |
 
@@ -112,14 +112,14 @@ Command:
 Result:
 
 |
-|       usage: ecl-test run [-h] [--target [target_cluster | all]] [--publish] 
+|       usage: ecl-test run [-h] [--target [target_cluster_list | all]] [--publish]
 |                           [--pq threadNumber]
 |                           [--runclass [class]] [--excludeclass [class]]
 |
 |       optional arguments:
 |        -h, --help               show this help message and exit
-|        --target [target_cluster | all], -t [target_cluster | all]
-|                                 target cluster for single query run. If target = 'all' then run query on all clusters. Default value is thor.
+|        --target [target_cluster_list | all], -t [target_cluster_list | all]
+|                                 run the cluster(s) suite. If target = 'all' then run suite on all clusters. If not defined then default value(s) come from config (ecl-test.json by default).
 |        --publish, -p            publish compiled query instead of run.
 |        --pq threadNumber        parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
 |        --runclass class[,class,...], -r class[,class,...]
@@ -138,7 +138,7 @@ Command:
 Result:
 
 |
-|       usage: ecl-test query [-h] [--target [target_cluster | all]] [--publish]
+|       usage: ecl-test query [-h] [--target [target_cluster_list | all]] [--publish]
 |                             [--pq threadNumber]
 |                             ECL_query [ECL_query ...]
 |
@@ -147,8 +147,8 @@ Result:
 |
 |       optional arguments:
 |        -h, --help               show this help message and exit
-|        --target [target_cluster | all], -t [target_cluster | all]
-|                                 target cluster for single query run. If target = 'all' then run query on all clusters. Default value is thor.
+|        --target [target_cluster_list | all], -t [target_cluster_list | all]
+|                                 target cluster(s) for query to run. If target = 'all' then run query on all clusters. If not defined then default value(s) come from config (ecl-test.json by default).
 |        --publish, -p            publish compiled query instead of run.
 |        --pq threadNumber        parallel query execution for multiple test cases specified in CLI with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )
 |
@@ -596,7 +596,21 @@ So if you have a new test case and it works well on all clusters (or some of the
         "timeout":"720",                                - Default test case timeout in sec. Can be override by command line parameter or //timeout tag in ECL file
         "maxAttemptCount":"3"                           - Max retry count to reset timeout if a testcase in any early stage (compiled, blocked) of execution pipeline.
 
-Optionally the config file can contain a section of default values for stored parameters like this:
+Optionally the config file can contain some sections of default values:
+
+If -t | --target command line parameter omitted then the regression test engine try to read default target(s) from the relevant array of these two. (If the array doesn't exists then the engine uses 'thor' target as default.)
+
+        "defaultSetupClusters": [
+            "hthor",
+            "thor3"
+        ]
+
+        "defaultTargetClusters": [
+            "thor",
+            "thor3"
+        ]
+
+For stored parameters:
 
     "Params":[
                 "querya.ecl:param1=value1,param2=value2",

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -28,7 +28,7 @@ import glob
 from hpcc.util import argparse
 from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
-from hpcc.util.util import checkPqParam, getVersionNumbers, checkXParam, convertPath, getRealIPAddress, parentPath
+from hpcc.util.util import checkPqParam, getVersionNumbers, checkXParam, convertPath, getRealIPAddress, parentPath, checkClusters
 from hpcc.common.error import Error
 
 # For coverage
@@ -170,15 +170,15 @@ class RegressMain:
 
         parser_setup = subparsers.add_parser('setup', help='setup help')
         parser_setup.set_defaults(func='setup')
-        parser_setup.add_argument('--target', '-t', help="Run the setup on target cluster. If target = 'all' then run setup on all clusters. Default value is thor.",
-                                nargs='?', type=str,  default='thor', metavar="target_cluster | all")
+        parser_setup.add_argument('--target', '-t', help="Run the setup on target cluster(s). If target = 'all' then run setup on all clusters. If not defined then default value(s) come from config (ecl-test.json by default).",
+                                nargs='?', type=str,  default='', metavar="target_cluster_list | all")
         parser_setup.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
                                 type=checkPqParam,  default = 0,   metavar="threadNumber")
 
         parser_run = subparsers.add_parser('run', help='run help')
         parser_run.set_defaults(func='run')
-        parser_run.add_argument('--target', '-t', help="Run the cluster suite. If target = 'all' then run suite on all clusters. Default value is thor.",
-                                nargs='?', type=str,  default='thor', metavar="target_cluster | all")
+        parser_run.add_argument('--target', '-t', help="Run the cluster(s) suite. If target = 'all' then run suite on all clusters. If not defined then default value(s) come from config (ecl-test.json by default).",
+                                nargs='?', type=str,  default='', metavar="target_cluster_list | all")
         parser_run.add_argument('--publish', '-p', help="Publish compiled query instead of run.",
                                 action='store_true')
         parser_run.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
@@ -192,8 +192,8 @@ class RegressMain:
         parser_query.set_defaults(func='query')
         parser_query.add_argument('query', help="One or more ECL file(s). It can contain wildcards. (mandatory).",
                                   nargs='+', metavar="ECL_query")
-        parser_query.add_argument('--target', '-t', help="Target cluster for query to run. If target = 'all' then run query on all clusters. Default value is thor.",
-                                nargs='?', default='thor', metavar="target_cluster | all")
+        parser_query.add_argument('--target', '-t', help="Target cluster(s) for query to run. If target = 'all' then run query on all clusters. If not defined then default value(s) come from config (ecl-test.json by default).",
+                                nargs='?', default='', metavar="target_cluster_list | all")
         parser_query.add_argument('--publish', '-p', help="Publish compiled query instead of run.",
                                 action='store_true')
         parser_query.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
@@ -224,11 +224,30 @@ class RegressMain:
 
             self.targetClusters = []
             if 'target' in self.args:
-                if 'all' == self.args.target:
+                if '' == self.args.target:
+                    # Target not specified, use default from config
+                    try:
+                        if self.args.func == 'setup':
+                            defaultTargets = self.regress.config.defaultSetupClusters
+                            targetSet='defaultSetupClusters'
+                        else:
+                            defaultTargets = self.regress.config.defaultTargetClusters
+                            targetSet='defaultTargetClusters'
+
+                        self.targetClusters = checkClusters(defaultTargets, targetSet)
+
+                    except AttributeError:
+                        # It seems there is no defaultSetupClusters|defaultTargetClusters array in the config file
+                        self.targetClusters.append('thor')
+                elif 'all' == self.args.target:
                     for cluster in self.regress.config.Clusters:
                         self.targetClusters.append(str(cluster))
                 else:
-                    if self.args.target in self.regress.config.Clusters:
+                    if ',' in self.args.target:
+                        # target is a list, process it
+                        targets = self.args.target.split(',')
+                        self.targetClusters = checkClusters(targets, 'target')
+                    elif self.args.target in self.regress.config.Clusters:
                         self.targetClusters.append(self.args.target)
                     else:
                         logging.error("%s. Unknown target cluster:'%s'!" % (1,  self.args.target))

--- a/testing/regress/ecl-test.json
+++ b/testing/regress/ecl-test.json
@@ -24,6 +24,12 @@
         ],
         "timeout":"720",
         "maxAttemptCount":"3",
+        "defaultSetupClusters": [
+            "thor"
+        ],
+        "defaultTargetClusters": [
+            "thor"
+        ],
         "Params":[
             "PassTest.ecl:bla='A value'"
         ]

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -158,3 +158,15 @@ def getRealIPAddress():
         pass
 
     return ipAddress
+
+def checkClusters(clusters,  targetSet):
+    targetClusters =[]
+    for cluster in clusters:
+        cluster = cluster.strip()
+        if cluster in gConfig.Clusters:
+            targetClusters.append(cluster)
+        else:
+            logging.error("%s. Unknown cluster:'%s' in %s:'%s'!" % (1,  cluster,  targetSet,  clusters))
+            raise Error("4000")
+
+    return  targetClusters


### PR DESCRIPTION
Add "defaultSetupClusters" and "defaultTargetClusters" arrays to ecl-test.json
config file

Implement code to process default cluster(s) from config if it is not specified
in command line

Implement code to process cluster list if provided with -t |--target command
line parameter

Update built-in help and README.rst

Signed-off-by: Attila.Vamos attila.vamos@gmail.com
