### PR TITLE
HPCC-12107 Segmentation fault when supplying an incorrect Wuid to DATASET(WORKUNIT(...

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2197,15 +2197,13 @@ public:
     {
         StringBuffer wuidStr(wuid);
         wuidStr.trim();
-        if ('w' == wuidStr.charAt(0))
-        {
+        if (wuidStr.length() && ('w' == wuidStr.charAt(0)))
             wuidStr.setCharAt(0, 'W');
-        }
 
         if (!wuidStr.length() || ('W' != wuidStr.charAt(0)))
         {
             if (workUnitTraceLevel > 1)
-                PrintLog("openWorkUnit %s invalid WUID", (!wuidStr.length() ? "(null)":wuidStr.str()) );
+                PrintLog("openWorkUnit %s invalid WUID", nullText(wuidStr.str()));
 
             return NULL;
         }

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2197,8 +2197,18 @@ public:
     {
         StringBuffer wuidStr(wuid);
         wuidStr.trim();
-        if (!wuidStr.length())
+        if ('w' == wuidStr.charAt(0))
+        {
+            wuidStr.setCharAt(0, 'W');
+        }
+
+        if (!wuidStr.length() || ('W' != wuidStr.charAt(0)))
+        {
+            if (workUnitTraceLevel > 1)
+                PrintLog("openWorkUnit %s wrong WUID", (!wuidStr.length() ? "(null)":wuidStr.str()) );
+
             return NULL;
+        }
 
         if (workUnitTraceLevel > 1)
             PrintLog("openWorkUnit %s", wuidStr.str());
@@ -2216,7 +2226,10 @@ public:
                     return NULL;
                 }
             }
-            return wu;
+            if (wu)
+                return wu;
+            else
+                return NULL;
         }
         else
         {

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2205,7 +2205,7 @@ public:
         if (!wuidStr.length() || ('W' != wuidStr.charAt(0)))
         {
             if (workUnitTraceLevel > 1)
-                PrintLog("openWorkUnit %s wrong WUID", (!wuidStr.length() ? "(null)":wuidStr.str()) );
+                PrintLog("openWorkUnit %s invalid WUID", (!wuidStr.length() ? "(null)":wuidStr.str()) );
 
             return NULL;
         }
@@ -2226,10 +2226,7 @@ public:
                     return NULL;
                 }
             }
-            if (wu)
-                return wu;
-            else
-                return NULL;
+            return wu;
         }
         else
         {

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -742,7 +742,6 @@ IConstWUResult *EclAgent::getExternalResult(const char * wuid, const char *name,
     else
     {
         fail(0, "Missing or invalid workunit name in getExternalResult()");
-        return NULL;
     }
 }
 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -731,10 +731,19 @@ IConstWUResult *EclAgent::getResultForGet(const char *name, unsigned sequence)
 
 IConstWUResult *EclAgent::getExternalResult(const char * wuid, const char *name, unsigned sequence)
 {
+    LOG(MCsetresult, unknownJob, "EclAgent::getExternalResult(wuid:'%s',name='%s',sequence:%d)", nullText(wuid), nullText(name), sequence);
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
     Owned<IConstWorkUnit> externalWU = factory->openWorkUnit(wuid, false);
-    externalWU->remoteCheckAccess(queryUserDescriptor(), false);
-    return getWorkUnitResult(externalWU, name, sequence);
+    if (externalWU)
+    {
+        externalWU->remoteCheckAccess(queryUserDescriptor(), false);
+        return getWorkUnitResult(externalWU, name, sequence);
+    }
+    else
+    {
+        fail(0, "Missing or wrong workunit name in getExternalResult()");
+        return NULL;
+    }
 }
 
 void EclAgent::outputFormattedResult(const char * name, unsigned sequence, bool close)

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -741,7 +741,7 @@ IConstWUResult *EclAgent::getExternalResult(const char * wuid, const char *name,
     }
     else
     {
-        fail(0, "Missing or wrong workunit name in getExternalResult()");
+        fail(0, "Missing or invalid workunit name in getExternalResult()");
         return NULL;
     }
 }


### PR DESCRIPTION
Add code to check and convert 'w' to 'W' into secOpenWorkUnit()
Add code to check first character of the WUID into same function

Add code to check the return value of factory->openWorkUnit() to avoid
SEGFAULT caused by zero pointer.

Signed-off-by: Attila.Vamos attila.vamos@gmail.com
