### PR TITLE
HPCC-12145 Jsocket printf causes invalid output from eclcc

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -2657,7 +2657,7 @@ IpAddress & queryHostIP()
     if (cachehostip.isNull()) {
         if (!cachehostip.ipset(GetCachedHostName())) {
             cachehostip.ipset(queryLocalIP());          
-            printf("hostname %s not resolved, using localhost\n",GetCachedHostName()); // don't use jlog in case recursive
+            // printf("hostname %s not resolved, using localhost\n",GetCachedHostName()); // don't use jlog in case recursive
         }
     }
     return cachehostip;


### PR DESCRIPTION
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
