### PR TITLE
HPCC-12164 Cant bind HPCCAdmin to LDAP on 389DS

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -358,7 +358,12 @@ public:
             else if(m_serverType == ACTIVE_DIRECTORY)
                 m_sysuser_dn.append("cn=").append(m_sysuser_commonname.str()).append(",").append(m_sysuser_basedn.str());
             else if(m_serverType == OPEN_LDAP)
-                m_sysuser_dn.append("cn=").append(m_sysuser_commonname.str()).append(",").append(m_sysuser_basedn.str());
+            {
+                if (0==strcmp("Directory Manager",m_sysuser_commonname.str()))
+                    m_sysuser_dn.append("cn=").append(m_sysuser_commonname.str()).append(",").append(m_sysuser_basedn.str());
+                else
+                    m_sysuser_dn.append("uid=").append(m_sysuser_commonname.str()).append(",").append(m_sysuser_basedn.str()).append(",").append(m_basedn.str());
+            }
         }
 
         m_maxConnections = cfg->getPropInt(".//@maxConnections", DEFAULT_LDAP_POOL_SIZE);


### PR DESCRIPTION
Because we now LDAP bind an HPCC Admin account instead of the LDAP Admin
account, we need to rework the distinguished name string used for the bind.
This fix adds a check of whether or not we are binding as LDAP Admin, which
would be the initldap tool that creates the initial OUs and HPCC Admin account,
and uses the CN specifier if we are, otherwise specifies UID

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
