### PR TITLE
HPCC-12127 Use 64-bit integer for HTTP Content-Length header

### DIFF
--- a/esp/bindings/SOAP/Platform/soapbind.cpp
+++ b/esp/bindings/SOAP/Platform/soapbind.cpp
@@ -147,7 +147,7 @@ int CHttpSoapBinding::onSoapRequest(CHttpRequest* request, CHttpResponse* respon
     //response->setContentType(soapFault->get_content_type());
     response->setContentType(HTTP_TYPE_TEXT_XML_UTF8);
     response->setContent(soapFault->get_text());
-    DBGLOG("Sending SOAP Fault(%u): %s", response->getContentLength(), response->queryContent());
+    DBGLOG("Sending SOAP Fault(%"I64F"d): %s", response->getContentLength(), response->queryContent());
     {
         EspTimeSection sendtime("send fault [CHttpSoapBinding::onSoapRequest]");
         response->send();
@@ -226,7 +226,7 @@ int CHttpSoapBinding::HandleSoapRequest(CHttpRequest* request, CHttpResponse* re
     response->setContentType(soapresponse->get_content_type());
     response->setContent(soapresponse->get_text());
     
-    DBGLOG("Sending SOAP Response(%u)", response->getContentLength());
+    DBGLOG("Sending SOAP Response(%"I64F"d)", response->getContentLength());
     {
         EspTimeSection sendtime("send response [CHttpSoapBinding::HandleSoapRequest]");
         response->send();

--- a/esp/bindings/bindutil.cpp
+++ b/esp/bindings/bindutil.cpp
@@ -259,6 +259,39 @@ int Utils::getLine(int total_len, int cur_pos, const char* buf, int& oneline_len
     return cur_pos;
 }
 
+__int64 Utils::getLine(__int64 total_len, __int64 cur_pos, const char* buf, int& oneline_len)
+{
+    oneline_len = 0;
+    if(cur_pos >= total_len)
+    {
+        return total_len;
+    }
+
+    while(cur_pos < total_len && buf[cur_pos] != '\r' && buf[cur_pos] != '\n')
+    {
+        oneline_len++;
+        cur_pos++;
+    }
+
+    if(cur_pos == total_len)
+        return total_len;
+
+    if(buf[cur_pos] == '\r')
+    {
+        cur_pos++;
+    }
+
+    if(cur_pos == total_len)
+        return total_len;
+
+    if(buf[cur_pos] == '\n')
+    {
+        cur_pos++;
+    }
+
+    return cur_pos;
+}
+
 int Utils::strncasecmp(const char* s1, const char* s2, register size32_t n) 
 {
     bool s1isnull = (s1 == NULL);

--- a/esp/bindings/bindutil.hpp
+++ b/esp/bindings/bindutil.hpp
@@ -34,6 +34,7 @@ public:
     static char* getWord(char* oneline, char* & oneword, const char* separators, bool tws=false);
     static void parseNVPair(const char* nv, StringBuffer& name, StringBuffer& value);
     static int getLine(int total_len, int cur_len, const char* buf, int & oneline_len);
+    static __int64 getLine(__int64 total_len, __int64 cur_len, const char* buf, int & oneline_len);
     static int strncasecmp(const char* s1, const char* s2, register size32_t n);
     static int strcasecmp(const char* s1, const char* s2);
     static const char *stristr(const char *haystack, const char *needle);

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -487,10 +487,10 @@ int CEspHttpServer::processRequest()
     catch (...)
     {
         StringBuffer content_type;
-        unsigned len = m_request->getContentLength();
+        __int64 len = m_request->getContentLength();
         DBGLOG("Unknown Exception - processing request");
-        DBGLOG("METHOD: %s, PATH: %s, TYPE: %s, CONTENT-LENGTH: %d", m_request->queryMethod(), m_request->queryPath(), m_request->getContentType(content_type).str(), len);
-        if (len)
+        DBGLOG("METHOD: %s, PATH: %s, TYPE: %s, CONTENT-LENGTH: %"I64F"d", m_request->queryMethod(), m_request->queryPath(), m_request->getContentType(content_type).str(), len);
+        if (len > 0)
             m_request->logMessage(LOGCONTENT, "HTTP request content received:\n");
         return 0;
     }
@@ -637,7 +637,7 @@ inline void make_env_var(StringArray &env, StringBuffer &var, const char *name, 
     env.append(var.clear().append(name).append('=').append(value).str());
 }
 
-inline void make_env_var(StringArray &env, StringBuffer &var, const char *name, int value)
+inline void make_env_var(StringArray &env, StringBuffer &var, const char *name, __int64 value)
 {
     env.append(var.clear().append(name).append('=').append(value).str());
 }

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -54,8 +54,7 @@ protected:
     Owned<IBufferedSocket> m_bufferedsocket;
 
     StringAttr   m_content_type;
-    int          m_content_length;
-    __int64      m_content_length64;
+    __int64      m_content_length;
     StringBuffer m_content;
     StringBuffer m_header;
     OwnedIFileIOStream m_content_stream;
@@ -107,7 +106,7 @@ public:
     virtual int close();
 
     virtual bool supportClientXslt();
-    unsigned getContentLength(){return m_content_length;}
+    __int64 getContentLength(){return m_content_length;}
     const char *queryContent(){return m_content.str();}
     const char *queryHeader() { return m_header.str(); }
     void logSOAPMessage(const char* message, const char* prefix = NULL);
@@ -166,7 +165,7 @@ public:
         if (type==NULL || *type==0)
             return (m_content_type.length()==0);
 
-        return ( (m_content_length > 0 || m_content_length64 > 0 || Utils::strncasecmp(HTTP_TYPE_FORM_ENCODED,type,sizeof(HTTP_TYPE_FORM_ENCODED)-1)==0)
+        return ( (m_content_length > 0 || Utils::strncasecmp(HTTP_TYPE_FORM_ENCODED,type,sizeof(HTTP_TYPE_FORM_ENCODED)-1)==0)
             && Utils::strncasecmp(m_content_type.get(), type, strlen(type)) == 0);
     }
 

--- a/esp/bindings/http/platform/mime.cpp
+++ b/esp/bindings/http/platform/mime.cpp
@@ -250,7 +250,7 @@ void CMimeMultiPart::serialize(StringBuffer& contenttype, StringBuffer & buffer)
     }
 }
 
-void CMimeMultiPart::unserialize(const char* contenttype, int text_length, const char* text)
+void CMimeMultiPart::unserialize(const char* contenttype, __int64 text_length, const char* text)
 {
     char* typebuf = new char[strlen(contenttype) + 1];
     strcpy(typebuf, contenttype);
@@ -315,8 +315,8 @@ void CMimeMultiPart::unserialize(const char* contenttype, int text_length, const
     delete [] typebuf;
 
     int oneline_len = 0;
-    int cur_pos = 0;
-    int next_pos = Utils::getLine(text_length, 0, text, oneline_len);
+    __int64 cur_pos = 0;
+    __int64 next_pos = Utils::getLine(text_length, cur_pos, text, oneline_len);
     const char* curline = text;
     int boundarylen = m_boundary.length();
 
@@ -399,7 +399,7 @@ void CMimeMultiPart::unserialize(const char* contenttype, int text_length, const
 
         // Read in the content of one mime part
         cur_pos = next_pos;
-        int bb = cur_pos;
+        __int64 bb = cur_pos;
         next_pos = Utils::getLine(text_length, next_pos, text, oneline_len);
         const char* curline = text + cur_pos;
         while(next_pos < text_length && !(oneline_len >= 2 && !Utils::strncasecmp(m_boundary.get(), curline + 2, boundarylen)))
@@ -410,7 +410,7 @@ void CMimeMultiPart::unserialize(const char* contenttype, int text_length, const
         }
 
         // Get rid of CR/LF at the end of the content
-        int be = cur_pos - 1;
+        __int64 be = cur_pos - 1;
         if(be >0 && (text[be] == '\r' || text[be] == '\n'))
             be--;
 

--- a/esp/bindings/http/platform/mime.hpp
+++ b/esp/bindings/http/platform/mime.hpp
@@ -80,7 +80,7 @@ public:
     void readUploadFileName(MemoryBuffer& fileContent, StringBuffer& fileName);
 
     void serialize(StringBuffer& contenttype, StringBuffer & buffer);
-    void unserialize(const char* contenttype, int text_length, const char* text);
+    void unserialize(const char* contenttype, __int64 text_length, const char* text);
 };
 
 #endif

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -418,7 +418,7 @@ public:
         m_traceValues.append(str.str());
     }
 
-    virtual void addTraceSummaryValue(const char *name, int value)
+    virtual void addTraceSummaryValue(const char *name, __int64 value)
     {
         StringBuffer str;
         if (name && *name)

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -145,7 +145,7 @@ interface IEspContext : extends IInterface
     virtual void addCustomerHeader(const char* name, const char* val) = 0;
 
     virtual void addTraceSummaryValue(const char *name, const char *value)=0;
-    virtual void addTraceSummaryValue(const char *name, int value)=0;
+    virtual void addTraceSummaryValue(const char *name, __int64 value)=0;
     virtual void addTraceSummaryTimeStamp(const char *name)=0;
     virtual void flushTraceSummary()=0;
 


### PR DESCRIPTION
In the existing ESP code, two member variables are used to store
and set HTTP Content-Length header: m_content_length64 (int64)
and m_content_length (int). When an HTTP message content is very
large, m_content_length may have an incorrect value. ESP fails
to download a >4G file due to the incorrect value. This fix
changes the m_content_length to be int64 and replaces the
m_content_length64 with the m_content_length.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
