### PR TITLE
HPCC-12206 Avoid function call if no child expression

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -3951,7 +3951,8 @@ void CHqlExpression::setInitialHash(unsigned typeHash)
 {
     hashcode = op+typeHash;
     unsigned kids = operands.ordinality();
-    hashcode = hashc((const unsigned char *)operands.getArray(), kids * sizeof(IHqlExpression *), hashcode);
+    if (kids)
+        hashcode = hashc((const unsigned char *)operands.getArray(), kids * sizeof(IHqlExpression *), hashcode);
 }
 
 void CHqlExpression::sethash()


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
