### PR TITLE
HPCC-12224 eclagent.log sometimes shows activity not related to workunit

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1687,9 +1687,9 @@ void WsWuInfo::getWorkunitEclAgentLog(const char* fileName, const char* agentPid
 
     StringBuffer pidstr;
     if (agentPid && *agentPid)
-        pidstr.appendf(" %s ", agentPid);
+        pidstr.appendf("%s ", agentPid);
     else
-        pidstr.appendf(" %5d ", cw->getAgentPID());
+        pidstr.appendf("%d ", cw->getAgentPID());
     char const * pidchars = pidstr.str();
     while(!eof)
     {
@@ -1708,8 +1708,24 @@ void WsWuInfo::getWorkunitEclAgentLog(const char* fileName, const char* agentPid
                 break;
         }
 
+        //Locate PID column index
+        int idxPID = 0;
+        const char * p = line.str();
+        for (int x = 0; *p && x < 3; x++)
+        {
+            p = strchr(p, ' ');
+            if (!p)
+                break;
+            do
+            {
+                p++;
+            } while (*p == ' ');
+            if (x == 2 && *p)
+                idxPID = p - line.str();
+        }
+
         //Retain all rows that match a unique program instance - by retaining all rows that match a pid
-        if(strstr(line.str(), pidchars))
+        if (idxPID && 0==strncmp(line.str() + idxPID, pidchars, strlen(pidchars)))
         {
             //Check if this is a new instance using line sequence number
             if (strncmp(line.str(), "00000000", 8) == 0)


### PR DESCRIPTION
The code that extracts a particular workunit's eclagent logfile from the master
logfile uses the process id as the key. However, it scans the entire line looking
for that PID, and when by chance that pid string appears elsewhere (ie as a thread
id) then it incorrectly includes that line in the logfile. This code change
locates the actual PID column in the logfile entry and compares it to the
search PID

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
