### PR TITLE
HPCC-12220 SuperHashTable kill not resetting tablecount

### DIFF
--- a/system/jlib/jsuperhash.cpp
+++ b/system/jlib/jsuperhash.cpp
@@ -457,6 +457,7 @@ void SuperHashTable::releaseAll(void)
         if (et)
             onRemove(et);
     }
+    tablecount = 0;
 }
 
 void SuperHashTable::kill(void)


### PR DESCRIPTION
releaseAll() was not resetting tablecount, as a consequence
the HT size would spuriously continue to grow + increase the
cost of releaseAll's time to walk the HT to clear elements

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
