### PR TITLE
HPCC-12036 Warn if floating point indices used when perhaps a range was ...

### DIFF
--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -73,7 +73,7 @@
 #define WRN_RECORDMANYFIELDS        1049
 #define WRN_RESERVED_FUTURE         1050 /* Identifier likely to be reserved in future versions */
 #define WRN_SILLY_EXISTS            1051
-
+#define WRN_INT_OR_RANGE_EXPECTED   1052 /* Integer or integer range (i.e. 2..3) expected when real detected */
 //#define ECL_WARN_END          1100
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -5460,6 +5460,9 @@ rangeOrIndices
 
 rangeExpr
     : expression        {
+                            IHqlExpression * expr = $1.queryExpr();
+                            if (expr->isConstant() && !expr->queryType()->isInteger())
+                                parser->reportWarning(CategoryMistake, WRN_INT_OR_RANGE_EXPECTED, $1.pos, "Floating point index used. Was an index range intended instead?");
                             parser->normalizeExpression($1, type_int, false);
                             parser->checkPositive($1);
                             $$.setExpr($1.getExpr());
@@ -6973,9 +6976,12 @@ globalValueAttribute
 
 dataRow
     : dataSet '[' expression ']'
-                        {   
+                        {
+                            IHqlExpression * expr = $3.queryExpr();
+                            if (expr->isConstant() && !expr->queryType()->isInteger())
+                                parser->reportWarning(CategoryMistake, WRN_INT_OR_RANGE_EXPECTED, $3.pos, "Floating point index used. Was an index range intended instead?");
                             parser->normalizeExpression($3, type_int, false);
-                            $$.setExpr(createRow(no_selectnth, $1.getExpr(), $3.getExpr()));    
+                            $$.setExpr(createRow(no_selectnth, $1.getExpr(), $3.getExpr()));
                         }
     | dictionary '[' expressionList ']'
                         {

--- a/ecl/regress/issue12036.ecl
+++ b/ecl/regress/issue12036.ecl
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+#onwarning ('mistake', error);
+
+s := [2,3,5,7];
+s[2..4];
+s[2.4];
+
+'abcde'[2..4];
+'abcde'[2.4];
+
+ds := dataset([{2},{3},{5},{7}], {integer a});
+ds[2..4];
+ds[2.4];


### PR DESCRIPTION
...intended

I'm not %100 on the actual warning message.
Also, I wondered if I should consolidate into a single routine, either as a static within hqlgram.y or as a method of HqlGram. didn't choose the later as couldn't come up with a suitable name due to how specific it should be and lack of reuse. Nor the first as I believe we wish to avoid these.

Signed-off-by: jamienoss james.noss@lexisnexis.com
