### PR TITLE
HPCC-11999 Set url param for downloading WU Archive ECLXML

### DIFF
--- a/esp/src/eclwatch/LogsWidget.js
+++ b/esp/src/eclwatch/LogsWidget.js
@@ -82,8 +82,11 @@ define([
                         break;
                     case "cpp":
                     case "hpp":
-                    case "xml":
                         params = "/WUFile?Wuid=" + this.wu.Wuid + "&Name=" + item.Orig.Name + "&IPAddress=" + item.Orig.IPAddress + "&Description=" + item.Orig.Description + "&Type=" + item.Orig.Type;
+                        break;
+                    case "xml":
+                        if (option !== undefined)
+                            params = "/WUFile?Wuid=" + this.wu.Wuid + "&Name=" + item.Orig.Name + "&IPAddress=" + item.Orig.IPAddress + "&Description=" + item.Orig.Description + "&Type=" + item.Orig.Type;
                         break;
                 }
 

--- a/esp/src/eclwatch/LogsWidget.js
+++ b/esp/src/eclwatch/LogsWidget.js
@@ -82,6 +82,7 @@ define([
                         break;
                     case "cpp":
                     case "hpp":
+                    case "xml":
                         params = "/WUFile?Wuid=" + this.wu.Wuid + "&Name=" + item.Orig.Name + "&IPAddress=" + item.Orig.IPAddress + "&Description=" + item.Orig.Description + "&Type=" + item.Orig.Type;
                         break;
                 }


### PR DESCRIPTION
For WU Archive ECLXML file, the file type is 'xml'. The
logsWidget should set the url param for file dowmload using
the file type. The existing code does not set the url param.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
