### PR TITLE
HPCC-12297 assert(hostname) error if SOAPCALL to invalid IP

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -210,6 +210,9 @@ public:
                 path.append("/");
             }
         }
+        IpAddress ipaddr(host);
+        if ( ipaddr.isNull())
+            throw MakeStringException(-1, "Invalid IP address %s", host.str());
     }
 };
 

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -791,7 +791,14 @@ size32_t CSocket::avail_read()
 
 int CSocket::pre_connect (bool block)
 {
-    assertex(hostname);
+    if (NULL == hostname || NULL == (*hostname))
+    {
+        StringBuffer err;
+        err.appendf("CSocket::pre_connect - Invalid/missing host IP address raised in : %s, line %d",__FILE__, __LINE__);
+        IJSOCK_Exception *e = new SocketException(JSOCKERR_bad_netaddr,err.str());
+        throw e;
+    }
+
     DEFINE_SOCKADDR(u);
     if (targetip.isNull()) {
         set_return_addr(hostport,hostname);


### PR DESCRIPTION
Currently CSocket::pre_connect asserts that the hostname is valid. This
pull request changes the assertex to a JSocket exception with a meaningful

Signed-off-by: William Whitehead <william.whitehead@lexisnexis.com
