### PR TITLE
HPCC-12302 Regression Test Engine doesn't use platform specific result file when run setup.

### DIFF
--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -91,7 +91,7 @@ class Suite:
             if file.endswith(".ecl"):
                 ecl = os.path.join(self.dir_ec, file)
                 eclfile = ECLFile(ecl, self.dir_a, self.dir_ex,
-                                  self.dir_r,  self.name, args)
+                                  self.dir_r,  self.args.target,  args)
                 if isSetup:
                     skipResult = eclfile.testSkip('setup')
                 else:


### PR DESCRIPTION
Fix expected result path generation bug.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
