### PR TITLE
HPCC-12295 Packagemap validate should ignore ~~ on file names

### DIFF
--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -52,7 +52,8 @@ bool checkForeign(const char *lfn)
 }
 const char *skipForeign(const char *name, StringBuffer *ip)
 {
-    if (*name=='~')
+    unsigned maxTildas = 2;
+    while (maxTildas-- && *name=='~')
         name++;
     const char *d1 = strstr(name, "::");
      if (d1)


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
