### PR TITLE
HPCC-12326 Fix 4 memory leaks in ESP libs

### DIFF
--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -533,8 +533,7 @@ void ReferencedFileList::ensureFile(const char *ln, unsigned flags, const char *
     else
     {
         const char *refln = file->getLogicalName();
-        //Cannot clear the ownership for the file because the setValue() does not take the ownership.
-        //See MappingStringToIInterface.
+        // NOTE: setValue links its parameter
         map.setValue(refln, file);
     }
 }
@@ -671,7 +670,8 @@ void ReferencedFileList::resolveSubFiles(StringArray &subfiles, bool checkLocalF
         {
             file->resolve(process.get(), srcCluster, user, remote, remotePrefix, checkLocalFirst, &childSubFiles, resolveForeign);
             const char *ln = file->getLogicalName();
-            map.setValue(ln, file.getClear());
+            // NOTE: setValue links its parameter
+            map.setValue(ln, file);
         }
     }
     if (childSubFiles.length())

--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -533,7 +533,9 @@ void ReferencedFileList::ensureFile(const char *ln, unsigned flags, const char *
     else
     {
         const char *refln = file->getLogicalName();
-        map.setValue(refln, file.getClear());
+        //Cannot clear the ownership for the file because the setValue() does not take the ownership.
+        //See MappingStringToIInterface.
+        map.setValue(refln, file);
     }
 }
 

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -10394,11 +10394,11 @@ const char *queryIdFromQuerySetWuid(const char *querySetName, const char *wuid, 
 
 extern WORKUNIT_API void gatherLibraryNames(StringArray &names, StringArray &unresolved, IWorkUnitFactory &workunitFactory, IConstWorkUnit &cw, IPropertyTree *queryset)
 {
-    IConstWULibraryIterator &wulibraries = cw.getLibraries();
-    ForEach(wulibraries)
+    Owned<IConstWULibraryIterator> wulibraries = &cw.getLibraries();
+    ForEach(*wulibraries)
     {
         SCMStringBuffer libname;
-        IConstWULibrary &wulibrary = wulibraries.query();
+        IConstWULibrary &wulibrary = wulibraries->query();
         wulibrary.getName(libname);
         if (names.contains(libname.str()) || unresolved.contains(libname.str()))
             continue;

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1695,11 +1695,11 @@ void CWsDfuEx::getFilePartsOnClusters(IEspContext &context, const char* clusterR
         Owned<IPartDescriptorIterator> pi = fdesc->getIterator();
         ForEach(*pi)
         {
-            IPartDescriptor *part = &pi->get();
-            unsigned partIndex = part->queryPartIndex();
-
+            IPartDescriptor& part = pi->query();
+            unsigned partIndex = part.queryPartIndex();
+                        
             StringBuffer partSizeStr;
-            IPropertyTree *partPropertyTree = part->getProperties();
+            IPropertyTree* partPropertyTree = &part.queryProperties();
             if (!partPropertyTree)
                 partSizeStr.set("<N/A>");
             else
@@ -1714,10 +1714,10 @@ void CWsDfuEx::getFilePartsOnClusters(IEspContext &context, const char* clusterR
                 if(size<mn) mn=size;
             }
 
-            for (unsigned int i=0; i<part->numCopies(); i++)
+            for (unsigned int i=0; i<part.numCopies(); i++)
             {
                 StringBuffer b;
-                part->queryNode(i)->endpoint().getUrlStr(b);
+                part.queryNode(i)->endpoint().getUrlStr(b);
 
                 Owned<IEspDFUPart> FilePart = createDFUPart("","");
                 FilePart->setId(partIndex+1);

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -391,17 +391,17 @@ bool deletePkgInfo(const char *name, const char *target, const char *process, bo
     StringBuffer lcName(name);
     name = lcName.toLowerCase().str();
 
-    IPropertyTree *mapEntry = NULL;
+    Owned<IPropertyTree> mapEntry;
     StringBuffer xpath;
     if (!globalScope)
     {
         xpath.appendf("PackageMap[@id='%s::%s'][@querySet='%s']", target, name, target);
-        mapEntry = pkgSetRegistry->getPropTree(xpath.str());
+        mapEntry.setown(pkgSetRegistry->getPropTree(xpath.str()));
     }
     if (!mapEntry)
     {
         xpath.clear().appendf("PackageMap[@id='%s'][@querySet='%s']", name, target);
-        mapEntry = pkgSetRegistry->getPropTree(xpath.str());
+        mapEntry.setown(pkgSetRegistry->getPropTree(xpath.str()));
         if (!mapEntry)
             throw MakeStringException(PKG_DELETE_NOT_FOUND, "Unable to delete %s - information not found", lcName.str());
     }


### PR DESCRIPTION
(1) memory leak inside the ReferencedFileList::
ensureFile() in workunit dll;
(2) memory leak inside the gatherLibraryNames() in
workunit dll;
(3) memory leak inside deletePkgInfo() in WsPackageProcess;
(4) memory leak inside CWsDfuEx::getFilePartsOnClusters().

Signed-off-by: wangkx kevin.wang@lexisnexis.com
