### PR TITLE
HPCC-12334 Fix core if -main is used with no filename

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1048,7 +1048,8 @@ void EclCC::processSingleQuery(EclCompileInstance & instance,
     const char * defaultErrorPathname = sourcePathname ? sourcePathname : queryAttributePath;
 
     //The following is only here to provide information about the source file being compiled when reporting leaks
-    setActiveSource(instance.inputFile->queryFilename());
+    if (instance.inputFile)
+        setActiveSource(instance.inputFile->queryFilename());
 
     {
         //Minimize the scope of the parse context to reduce lifetime of cached items.


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
