### PR TITLE
HPCC-10142 Support queryLogicalFilename on hthor

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -7791,7 +7791,6 @@ void CHThorDiskReadBaseActivity::resolve()
 {
     OwnedRoxieString fileName(helper.getFileName());
     mangleHelperFileName(mangledHelperFileName, fileName, agent.queryWuid(), helper.getFlags());
-    logicalFileName.set(mangledHelperFileName.str());
     if (helper.getFlags() & (TDXtemporary | TDXjobtemp))
     {
         StringBuffer mangledFilename;
@@ -7803,6 +7802,7 @@ void CHThorDiskReadBaseActivity::resolve()
     else
     {
         ldFile.setown(agent.resolveLFN(mangledHelperFileName.str(), "Read", 0 != (helper.getFlags() & TDRoptional)));
+        logicalFileName.set(mangledHelperFileName.str());
         if (ldFile)
         {
             Owned<IFileDescriptor> fdesc;

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -2161,6 +2161,9 @@ protected:
     unsigned __int64 localOffset;
     unsigned __int64 offsetOfPart;
     StringBuffer mangledHelperFileName;
+    StringAttr logicalFileName;
+    StringArray subfileLogicalFilenames;
+    Owned<ISuperFileDescriptor> superfile;
 
     void close();
     virtual void open();
@@ -2196,7 +2199,7 @@ public:
 //interface IFilePositionProvider
     virtual unsigned __int64 getFilePosition(const void * row);
     virtual unsigned __int64 getLocalFilePosition(const void * row);
-    virtual const char * queryLogicalFilename(const void * row) { return "MORE!"; }
+    virtual const char * queryLogicalFilename(const void * row) { return logicalFileName.get(); }
 };
 
 class CHThorBinaryDiskReadBase : public CHThorDiskReadBaseActivity, implements IIndexReadContext


### PR DESCRIPTION
Build superfile name structure to enable mapping of subfiles into supers

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
