### PR TITLE
HPCC-12297 Remove use of NULL for a non-pointer comparison

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -791,7 +791,7 @@ size32_t CSocket::avail_read()
 
 int CSocket::pre_connect (bool block)
 {
-    if (NULL == hostname || NULL == (*hostname))
+    if (NULL == hostname || '\0' == (*hostname))
     {
         StringBuffer err;
         err.appendf("CSocket::pre_connect - Invalid/missing host IP address raised in : %s, line %d",__FILE__, __LINE__);


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
