### PR TITLE
HPCC-12339 Change user's filter for logical file name to lower case

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -3056,6 +3056,7 @@ void CWsDfuEx::setFileNameFilter(const char* fname, const char* prefix, StringBu
         }
         fileNameFilter.append("*");
     }
+    fileNameFilter.toLowerCase();
     filterBuf.append(DFUQFTspecial).append(DFUQFilterSeparator).append(DFUQSFFileNameWithPrefix).append(DFUQFilterSeparator).append(fileNameFilter.str()).append(DFUQFilterSeparator);
 }
 


### PR DESCRIPTION
In WsDFU.DFUQuery, a user may type in a logical file name or a
prefix as a filter. Upper case value inside the filter should be
changed to lower case before using as the filter for the DFUQuery.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
