### PR TITLE
HPCC-12343 Missing content of diff result when a test case output doesn't  match to key file

### DIFF
--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -362,7 +362,8 @@ class ECLFile:
                                              recieved,
                                              fromfile=self.xml_e,
                                              tofile=self.xml_r):
-                self.diff += line
+                self.diff += str(line)
+            logging.debug("%3d. self.diff: '" + self.diff +"'",  self.taskId )
         except Exception as e:
             logging.debug( e, extra={'taskId':self.taskId})
             logging.debug("%s",  traceback.format_exc().replace("\n","\n\t\t"),  extra={'taskId':self.taskId} )


### PR DESCRIPTION
Fix Unicode string handling problem occured in Python 2.6.6. difflib.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
