### PR TITLE
HPCC-12349 toJSON outputs extra characters for unicode strings

### DIFF
--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -512,7 +512,7 @@ void CommonJsonWriter::outputUtf8(unsigned len, const char *field, const char *f
     if ((flags & XWFopt) && (rtlTrimUtf8StrLen(len, field) == 0))
         return;
     checkDelimit();
-    appendJSONStringValue(out, checkItemName(fieldname), len, field, true);
+    appendJSONStringValue(out, checkItemName(fieldname), rtlUtf8Size(len, field), field, true);
 }
 
 void CommonJsonWriter::outputBeginArray(const char *fieldname)


### PR DESCRIPTION
JSON outputUnicode and outputUtf8 are handling byte count vs character count inconsistently when calling appendJSONStringValue.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
