### PR TITLE
HPCC-12349 JSON outputUnicode outputs extra characters

### DIFF
--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -512,7 +512,7 @@ void CommonJsonWriter::outputUtf8(unsigned len, const char *field, const char *f
     if ((flags & XWFopt) && (rtlTrimUtf8StrLen(len, field) == 0))
         return;
     checkDelimit();
-    appendJSONStringValue(out, checkItemName(fieldname), len, field, true);
+    appendJSONStringValue(out, checkItemName(fieldname), rtlUtf8Size(len, field), field, true);
 }
 
 void CommonJsonWriter::outputBeginArray(const char *fieldname)

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -1482,7 +1482,7 @@ int utf8CharLen(const unsigned char *ch, unsigned maxsize)
         return 1;
 
     unsigned char len = utf8CharLen(*ch);
-    if (maxsize!=(unsigned)-1 && len>maxsize)
+    if (len>maxsize)
         return 0;
     for (unsigned pos = 1; pos < len; pos++)
         if ((ch[pos] < 128) || (ch[pos] >= 192))

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -371,7 +371,7 @@ extern jlib_decl const char *encodeXML(const char *x, IIOStream &out, unsigned f
 extern jlib_decl void decodeXML(ISimpleReadStream &in, StringBuffer &out, unsigned len=(unsigned)-1);
 
 extern jlib_decl int utf8CharLen(unsigned char ch);
-extern jlib_decl int utf8CharLen(const unsigned char *ch);
+extern jlib_decl int utf8CharLen(const unsigned char *ch, unsigned maxsize = (unsigned)-1);
 
 inline const char *encodeUtf8XML(const char *x, StringBuffer &ret, unsigned flags=false, unsigned len=(unsigned)-1)
 {


### PR DESCRIPTION
JSON outputUnicode and outputUtf8 are handling byte count vs character count inconsistently when calling appendJSONStringValue.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
