### PR TITLE
HPCC-12361 - Assert error (hashtable not empty) from new statistics

### DIFF
--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -956,6 +956,7 @@ typedef StructArrayOf<Statistic> StatsArray;
 class CollectionHashTable : public SuperHashTableOf<CStatisticCollection, StatsScopeId>
 {
 public:
+    ~CollectionHashTable() { releaseAll(); }
     virtual void     onAdd(void *et);
     virtual void     onRemove(void *et);
     virtual unsigned getHashFromElement(const void *et) const;


### PR DESCRIPTION
Missing a releaseAll(), it seems.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
