### PR TITLE
HPCC-12311 Remove extra calls to Dali for JobQueues

### DIFF
--- a/common/workunit/wujobq.hpp
+++ b/common/workunit/wujobq.hpp
@@ -72,6 +72,10 @@ interface IJobQueueConst: extends IInterface
     virtual bool getLastDequeuedInfo(StringAttr &wuid, CDateTime &enqueuedt, int &priority)=0;
     virtual void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state, StringBuffer& stateDetails)=0;
     virtual void getState(StringBuffer& state, StringBuffer& stateDetails)=0;
+    virtual bool paused()=0;    // true if paused
+    virtual bool paused(StringBuffer& info)=0;    // true if paused
+    virtual bool stopped()=0;   // true if stopped
+    virtual bool stopped(StringBuffer& info)=0;   // true if stopped
 };
 
 interface IJobQueue: extends IJobQueueConst
@@ -114,12 +118,8 @@ interface IJobQueue: extends IJobQueueConst
 // control:
     virtual void pause()=0;     // marks queue as paused - and subsequent dequeues block until resumed
     virtual void pause(const char *info)=0;     // marks queue as paused - and subsequent dequeues block until resumed
-    virtual bool paused()=0;    // true if paused
-    virtual bool paused(StringBuffer& info)=0;    // true if paused
     virtual void stop()=0;      // sets stopped flags - all current and subsequent dequeues return NULL
     virtual void stop(const char *info)=0;      // sets stopped flags - all current and subsequent dequeues return NULL
-    virtual bool stopped()=0;   // true if stopped
-    virtual bool stopped(StringBuffer& info)=0;   // true if stopped
     virtual void resume()=0;    // removes paused or stopped flag
     virtual void resume(const char *info)=0;    // removes paused or stopped flag
 

--- a/common/workunit/wujobq.hpp
+++ b/common/workunit/wujobq.hpp
@@ -71,9 +71,7 @@ interface IJobQueueConst: extends IInterface
     virtual unsigned copyItems(CJobQueueContents &dest)=0;  // takes a snapshot copy of the entire queue (returns number copied)
     virtual bool getLastDequeuedInfo(StringAttr &wuid, CDateTime &enqueuedt, int &priority)=0;
     virtual void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state, StringBuffer& stateDetails)=0;
-
     virtual void getState(StringBuffer& state, StringBuffer& stateDetails)=0;
-    virtual void getWUIDs(StringArray& ids)=0;
 };
 
 interface IJobQueue: extends IJobQueueConst
@@ -142,7 +140,6 @@ interface IJobQueue: extends IJobQueueConst
 interface IJQSnapshot : extends IInterface
 {
     virtual IJobQueueConst *getJobQueue(const char *name)=0;
-    virtual bool isJQSnapshotValid(unsigned timeOutSeconds)=0;
 };
 
 extern WORKUNIT_API IJQSnapshot *createJQSnapshot();

--- a/common/workunit/wujobq.hpp
+++ b/common/workunit/wujobq.hpp
@@ -59,7 +59,24 @@ interface IDynamicPriority
     virtual int get()=0;
 };
 
-interface IJobQueue: extends IInterface
+interface IJobQueueConst: extends IInterface
+{
+    virtual unsigned ordinality()=0;            // number of items on queue
+    virtual unsigned waiting()=0;               // number currently waiting on dequeue
+    virtual IJobQueueItem *getItem(unsigned idx)=0;
+    virtual IJobQueueItem *getHead()=0;
+    virtual IJobQueueItem *getTail()=0;
+    virtual IJobQueueItem *find(const char *wuid)=0;
+    virtual unsigned findRank(const char *wuid)=0;
+    virtual unsigned copyItems(CJobQueueContents &dest)=0;  // takes a snapshot copy of the entire queue (returns number copied)
+    virtual bool getLastDequeuedInfo(StringAttr &wuid, CDateTime &enqueuedt, int &priority)=0;
+    virtual void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state, StringBuffer& stateDetails)=0;
+
+    virtual void getState(StringBuffer& state, StringBuffer& stateDetails)=0;
+    virtual void getWUIDs(StringArray& ids)=0;
+};
+
+interface IJobQueue: extends IJobQueueConst
 {
 
 // enqueuing
@@ -79,20 +96,6 @@ interface IJobQueue: extends IInterface
     virtual void getStats(unsigned &connected,unsigned &waiting, unsigned &enqueued)=0; // this not quick as validates clients still running
     virtual bool waitStatsChange(unsigned timeout)=0;
     virtual void cancelWaitStatsChange()=0;
-
-
-//enquiry
-    virtual unsigned ordinality()=0;            // number of items on queue
-    virtual unsigned waiting()=0;               // number currently waiting on dequeue
-    virtual IJobQueueItem *getItem(unsigned idx)=0;
-    virtual IJobQueueItem *getHead()=0;
-    virtual IJobQueueItem *getTail()=0;
-    virtual IJobQueueItem *find(const char *wuid)=0;
-    virtual unsigned findRank(const char *wuid)=0;
-    virtual unsigned copyItems(CJobQueueContents &dest)=0;  // takes a snapshot copy of the entire queue (returns number copied)
-    virtual bool getLastDequeuedInfo(StringAttr &wuid, CDateTime &enqueuedt, int &priority)=0;
-    virtual void copyItemsAndState(CJobQueueContents& contents, StringBuffer& state, StringBuffer& stateDetails)=0;
-
 
 //manipulation
     virtual IJobQueueItem *take(const char *wuid)=0; // finds and removes
@@ -136,6 +139,13 @@ interface IJobQueue: extends IInterface
 
 };
 
+interface IJQSnapshot : extends IInterface
+{
+    virtual IJobQueueConst *getJobQueue(const char *name)=0;
+    virtual bool isJQSnapshotValid(unsigned timeOutSeconds)=0;
+};
+
+extern WORKUNIT_API IJQSnapshot *createJQSnapshot();
 
 extern WORKUNIT_API IJobQueueItem *createJobQueueItem(const char *wuid);
 extern WORKUNIT_API IJobQueueItem *deserializeJobQueueItem(MemoryBuffer &mb); 

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -250,8 +250,7 @@ void CActivityInfo::createActivityInfo()
     }
     catch(IException* e)
     {
-        StringBuffer eMsg;
-        ERRLOG("CActivityInfo::createActivityInfo: %s", e->errorMessage(eMsg).str());
+        EXCLOG(e, "CActivityInfo::createActivityInfo");
         e->Release();
     }
 

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -27,7 +27,6 @@
 
 #include "dalienv.hpp"
 #include "WUWrapper.hpp"
-#include "wujobq.hpp"
 #include "dfuwu.hpp"
 #include "exception_util.hpp"
 
@@ -143,19 +142,6 @@ void CWsSMCEx::init(IPropertyTree *cfg, const char *process, const char *service
     activityInfoCacheSeconds = cfg->getPropInt(xpath.str(), DEFAULTACTIVITYINFOCACHETIMEOUTSECOND);
 }
 
-static void countProgress(IPropertyTree *t,unsigned &done,unsigned &total)
-{
-    total = 0;
-    done = 0;
-    Owned<IPropertyTreeIterator> it = t->getElements("DFT/progress");
-    ForEach(*it) {
-        IPropertyTree &e=it->query();
-        if (e.getPropInt("@done",0))
-            done++;
-        total++;
-    }
-}
-
 struct CActiveWorkunitWrapper: public CActiveWorkunit
 {
     CActiveWorkunitWrapper(IEspContext &context, const char* wuid,const char* location = NULL,unsigned index=0): CActiveWorkunit("","")
@@ -187,7 +173,7 @@ struct CActiveWorkunitWrapper: public CActiveWorkunit
         setStateID(wu->getState());
         if (wu->getState() == WUStateBlocked)
         {
-        	wu->getStateEx(stateEx);
+            wu->getStateEx(stateEx);
             if (notCheckVersion || (version > 1.00))
                 setExtra(stateEx.str());
         }
@@ -240,36 +226,639 @@ struct CActiveWorkunitWrapper: public CActiveWorkunit
     }
 };
 
-bool CWsSMCEx::onIndex(IEspContext &context, IEspSMCIndexRequest &req, IEspSMCIndexResponse &resp)
+bool CActivityInfo::isCachedActivityInfoValid(unsigned timeOutSeconds)
 {
-    resp.setRedirectUrl("/");
-    return true;
+    CDateTime timeNow;
+    timeNow.setNow();
+    return timeNow.getSimple() <= timeCached.getSimple() + timeOutSeconds;;
 }
 
-static int stringcmp(const char **a, const char **b)
+void CActivityInfo::createActivityInfo()
 {
-    return strcmp(*a, *b);
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IConstEnvironment> env = factory->openEnvironment();
+    if (!env)
+        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO,"Failed to get environment information.");
+
+    CConstWUClusterInfoArray clusters;
+    Owned<IPropertyTree> envRoot= &env->getPTree();
+    getEnvironmentClusterInfo(envRoot, clusters);
+
+    jobQueueSnapshot.setown(createJQSnapshot());
+
+    Owned<IRemoteConnection> connStatusServers = querySDS().connect("/Status/Servers",myProcessSession(),RTM_LOCK_READ,30000);
+    if (!connStatusServers)
+        throw MakeStringException(ECLWATCH_CANNOT_GET_STATUS_INFO, "Failed to get status server information.");
+
+    serverStatusRoot = connStatusServers->queryRoot();
+
+    readTargetClusterInfo(clusters);
+    readActiveWUsAndQueuedWUs(envRoot);
+
+    timeCached.setNow();
 }
 
-bool isInWuList(IArrayOf<IEspActiveWorkunit>& aws, const char* wuid)
+void CActivityInfo::readTargetClusterInfo(CConstWUClusterInfoArray& clusters)
 {
-    bool bFound = false;
-    if (wuid && *wuid && (aws.length() > 0))
+    ForEachItemIn(c, clusters)
     {
-        ForEachItemIn(k, aws)
+        IConstWUClusterInfo &cluster = clusters.item(c);
+        Owned<CWsSMCTargetCluster> targetCluster = new CWsSMCTargetCluster();
+        readTargetClusterInfo(cluster, targetCluster);
+        if (cluster.getPlatform() == ThorLCRCluster)
+            thorTargetClusters.append(*targetCluster.getClear());
+        else if (cluster.getPlatform() == RoxieCluster)
+            roxieTargetClusters.append(*targetCluster.getClear());
+        else
+            hthorTargetClusters.append(*targetCluster.getClear());
+    }
+}
+
+void CActivityInfo::readTargetClusterInfo(IConstWUClusterInfo& cluster, CWsSMCTargetCluster* targetCluster)
+{
+    SCMStringBuffer clusterName;
+    cluster.getName(clusterName);
+    targetCluster->clusterName.set(clusterName.str());
+    targetCluster->clusterType = cluster.getPlatform();
+    targetCluster->clusterSize = cluster.getSize();
+    cluster.getServerQueue(targetCluster->serverQueue.queueName);
+    cluster.getAgentQueue(targetCluster->agentQueue.queueName);
+
+    StringBuffer statusServerName;
+    CWsSMCQueue* jobQueue = NULL;
+    if (targetCluster->clusterType == ThorLCRCluster)
+    {
+        statusServerName.set(getStatusServerTypeName(WsSMCSSTThorLCRCluster));
+        jobQueue = &targetCluster->clusterQueue;
+        cluster.getThorQueue(jobQueue->queueName);
+    }
+    else if (targetCluster->clusterType == RoxieCluster)
+    {
+        statusServerName.set(getStatusServerTypeName(WsSMCSSTRoxieCluster));
+        jobQueue = &targetCluster->agentQueue;
+    }
+    else
+    {
+        statusServerName.set(getStatusServerTypeName(WsSMCSSTHThorCluster));
+        jobQueue = &targetCluster->agentQueue;
+    }
+
+    targetCluster->statusServerName.set(statusServerName.str());
+    targetCluster->queueName.set(jobQueue->queueName.str());
+
+    if (!jobQueueSnapshot)
+        WARNLOG("CActivityInfo::readTargetClusterInfo: jobQueueSnapshot not found.");
+    else
+    {
+        Owned<IJobQueueConst> queue = jobQueueSnapshot->getJobQueue(jobQueue->queueName.str());
+        if (!queue)
+            WARNLOG("CActivityInfo::readTargetClusterInfo: failed to get info for Job queue %s", jobQueue->queueName.str());
+        else
         {
-            IEspActiveWorkunit& wu = aws.item(k);
-            const char* wuid0 = wu.getWuid();
-            const char* server0 = wu.getServer();
-            if (wuid0 && !strcmp(wuid0, wuid) && (!server0 || strcmp(server0, "ECLagent")))
+            queue->getState(jobQueue->queueState, jobQueue->queueStateDetails);
+            if (jobQueue->queueState.length())
+                targetCluster->queueStatus.set(jobQueue->queueState.str());
+        }
+    }
+
+    if (serverStatusRoot)
+    {
+        jobQueue->foundQueueInStatusServer = findQueueInStatusServer(statusServerName.str(), targetCluster->queueName.get());
+        if (!jobQueue->foundQueueInStatusServer)
+            targetCluster->clusterStatusDetails.appendf("Cluster %s not attached; ", clusterName.str());
+    }
+
+    return;
+}
+
+const char *CActivityInfo::getStatusServerTypeName(WsSMCStatusServerType type)
+{
+    return (type < WsSMCSSTterm) ? WsSMCStatusServerTypeNames[type] : NULL;
+}
+
+bool CActivityInfo::findQueueInStatusServer(const char* serverName, const char* queueName)
+{
+    bool foundQueue = false;
+    VStringBuffer path("Server[@name=\"%s\"]", serverName);
+    Owned<IPropertyTreeIterator> it(serverStatusRoot->getElements(path.str()));
+    ForEach(*it)
+    {
+        IPropertyTree& serverStatusNode = it->query();
+        const char* queue = serverStatusNode.queryProp("@queue");
+        if (!queue || !*queue)
+            continue;
+
+        StringArray qlist;
+        qlist.appendListUniq(queue, ",");
+        ForEachItemIn(q, qlist)
+        {
+            if (strieq(qlist.item(q), queueName))
             {
-                bFound = true;
+                foundQueue = true;
                 break;
+            }
+        }
+        if (foundQueue)
+            break;
+    }
+    return foundQueue;
+}
+
+void CActivityInfo::readActiveWUsAndQueuedWUs(IPropertyTree* envRoot)
+{
+    readRunningWUsOnStatusServer(WsSMCSSTThorLCRCluster);
+    readWUsInTargetClusterJobQueues(thorTargetClusters);
+    readRunningWUsOnStatusServer(WsSMCSSTRoxieCluster);
+    readWUsInTargetClusterJobQueues(roxieTargetClusters);
+    readRunningWUsOnStatusServer(WsSMCSSTHThorCluster);
+    readWUsInTargetClusterJobQueues(hthorTargetClusters);
+
+    readRunningWUsOnStatusServer(WsSMCSSTECLagent);
+    readRunningWUsAndJobQueueforOtherStatusServers();
+    //TODO: add queued WUs for ECLCCServer/ECLServer here. Right now, they are under target clusters.
+
+    getDFUServersAndWUs(envRoot);
+    getDFURecoveryJobs();
+}
+
+void CActivityInfo::readRunningWUsOnStatusServer(WsSMCStatusServerType statusServerType)
+{
+    const char* serverName = getStatusServerTypeName(statusServerType);
+    if (!serverName || !*serverName)
+        return;
+    bool isECLAgent = (statusServerType == WsSMCSSTECLagent);
+    VStringBuffer path("Server[@name=\"%s\"]", serverName);
+    Owned<IPropertyTreeIterator> itrStatusServer(serverStatusRoot->getElements(path.str()));
+    ForEach(*itrStatusServer)
+    {
+        IPropertyTree& serverStatusNode = itrStatusServer->query();
+
+        StringBuffer serverInstance;
+        if ((statusServerType == WsSMCSSTThorLCRCluster) || (statusServerType == WsSMCSSTRoxieCluster))
+            serverStatusNode.getProp("@cluster", serverInstance);
+        else
+            serverInstance.appendf("%s on %s", serverName, serverStatusNode.queryProp("@node"));
+
+        Owned<IPropertyTreeIterator> wuids(serverStatusNode.getElements("WorkUnit"));
+        ForEach(*wuids)
+        {
+            const char* wuid=wuids->query().queryProp(NULL);
+            if (!wuid || !*wuid || isDuplicatedECLWUID(wuid))
+                continue;
+
+            CWsSMCTargetCluster* targetCluster;
+            if (statusServerType == WsSMCSSTRoxieCluster)
+                targetCluster = findWUClusterInfo(wuid, isECLAgent, roxieTargetClusters, thorTargetClusters, hthorTargetClusters);
+            else if (statusServerType == WsSMCSSTHThorCluster)
+                targetCluster = findWUClusterInfo(wuid, isECLAgent, hthorTargetClusters, thorTargetClusters, roxieTargetClusters);
+            else
+                targetCluster = findWUClusterInfo(wuid, isECLAgent, thorTargetClusters, roxieTargetClusters, hthorTargetClusters);
+            if (!targetCluster)
+                continue;
+
+            const char* targetClusterName = targetCluster->clusterName.get();
+            CWsSMCQueue* jobQueue;
+            if (statusServerType == WsSMCSSTThorLCRCluster)
+                jobQueue = &targetCluster->clusterQueue;
+            else
+                jobQueue = &targetCluster->agentQueue;
+
+            Owned<IEspActiveWorkunit> wu;
+            if (!isECLAgent)
+            {
+                const char *cluster = serverStatusNode.queryProp("Cluster");
+                StringBuffer queueName;
+                if (cluster) // backward compat check.
+                    getClusterThorQueueName(queueName, cluster);
+                else
+                    queueName.append(targetCluster->queueName.get());
+
+                createActiveWorkUnit(wu, wuid, !strieq(targetClusterName, serverInstance.str()) ? serverInstance.str() : NULL, 0, serverName,
+                    queueName, serverInstance.str(), targetClusterName, false);
+
+                if (wu->getStateID() == WUStateRunning) //'aborting' may be another possible status
+                {
+                    int sgDuration = serverStatusNode.getPropInt("@sg_duration", -1);
+                    int subgraph = serverStatusNode.getPropInt("@subgraph", -1);
+                    if (subgraph > -1 && sgDuration > -1)
+                    {
+                        const char* graph = serverStatusNode.queryProp("@graph");
+                        VStringBuffer durationStr("%d min", sgDuration);
+                        VStringBuffer subgraphStr("%d", subgraph);
+
+                        wu->setGraphName(graph);
+                        wu->setDuration(durationStr.str());
+                        wu->setGID(subgraphStr.str());
+                    }
+
+                    if (serverStatusNode.getPropInt("@memoryBlocked ", 0) != 0)
+                        wu->setMemoryBlocked(1);
+                }
+            }
+            else
+            {
+                createActiveWorkUnit(wu, wuid, serverInstance.str(), 0, serverName, serverName, serverInstance.str(), targetClusterName, false);
+
+                if (targetCluster->clusterType == ThorLCRCluster)
+                    wu->setClusterType(CLUSTER_TYPE_THOR);
+                else if (targetCluster->clusterType == RoxieCluster)
+                    wu->setClusterType(CLUSTER_TYPE_ROXIE);
+                else
+                    wu->setClusterType(CLUSTER_TYPE_HTHOR);
+                wu->setClusterQueueName(targetCluster->queueName.get());
+
+                if (wu->getStateID() != WUStateRunning)
+                {
+                    const char *extra = wu->getExtra();
+                    if (wu->getStateID() != WUStateBlocked || !extra || !*extra)  // Blocked on persist treated as running here
+                    {
+                        aws.append(*wu.getLink());
+                        jobQueue->countQueuedJobs++;
+                        continue;
+                    }
+                }
+
+                //Should this be set only if wu->getStateID() == WUStateRunning?
+                if (serverStatusNode.getPropInt("@memoryBlocked ", 0) != 0)
+                    wu->setMemoryBlocked(1);
+            }
+
+            aws.append(*wu.getLink());
+            jobQueue->countRunningJobs++;
+        }
+    }
+}
+
+bool CActivityInfo::isDuplicatedECLWUID(const char* wuid)
+{
+    bool* idFound = uniqueECLWUIDs.getValue(wuid);
+    if (!idFound || !*idFound)
+        uniqueECLWUIDs.setValue(wuid, true);
+    return idFound;
+}
+
+CWsSMCTargetCluster* CActivityInfo::findWUClusterInfo(const char* wuid, bool isOnECLAgent, CIArrayOf<CWsSMCTargetCluster>& targetClusters,
+    CIArrayOf<CWsSMCTargetCluster>& targetClusters1, CIArrayOf<CWsSMCTargetCluster>& targetClusters2)
+{
+    StringAttr clusterName;
+    try
+    {
+        Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
+        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid, false);
+        if (!cw)
+            return NULL;
+        clusterName.set(cw->queryClusterName());
+        if (!clusterName.length())
+            return NULL;
+    }
+    catch (IException *e)
+    {//Exception may be thrown when the openWorkUnit() is called inside the CWUWrapper
+        StringBuffer msg;
+        WARNLOG("Failed to open workunit %s: %s", wuid, e->errorMessage(msg).str());
+        e->Release();
+        return NULL;
+    }
+
+    const char* cluster = clusterName.str();
+    CWsSMCTargetCluster* targetCluster = findTargetCluster(cluster, targetClusters);
+    if (targetCluster || !isOnECLAgent)
+        return targetCluster;
+
+    targetCluster = findTargetCluster(cluster, targetClusters1);
+    if (targetCluster)
+        return targetCluster;
+
+    return findTargetCluster(cluster, targetClusters2);
+}
+
+
+CWsSMCTargetCluster* CActivityInfo::findTargetCluster(const char* clusterName, CIArrayOf<CWsSMCTargetCluster>& targetClusters)
+{
+    ForEachItemIn(i, targetClusters)
+    {
+        CWsSMCTargetCluster& targetCluster = targetClusters.item(i);
+        if (strieq(targetCluster.clusterName.get(), clusterName))
+            return &targetCluster;
+    }
+    return NULL;
+}
+
+void CActivityInfo::createActiveWorkUnit(Owned<IEspActiveWorkunit>& ownedWU, const char* wuid, const char* location,
+    unsigned index, const char* serverName, const char* queueName, const char* instanceName, const char* targetClusterName, bool useContext)
+{
+    try
+    {
+        if (useContext)
+            ownedWU.setown(new CActiveWorkunitWrapper(context, wuid, location, index));
+        else
+            ownedWU.setown(new CActiveWorkunitWrapper(wuid, location, index));
+    }
+    catch (IException *e)
+    {   //if the wu cannot be opened for some reason, the openWorkUnit() inside the CActiveWorkunitWrapper() may throw an exception.
+        //We do not want the exception stops this process of retrieving/showing all active WUs. And that WU should still be displayed
+        //with the exception.
+        StringBuffer msg;
+        ownedWU.setown(new CActiveWorkunitWrapper(wuid, "", "", e->errorMessage(msg).str(), "normal"));
+        ownedWU->setStateID(WUStateUnknown);
+        e->Release();
+    }
+
+    ownedWU->setServer(serverName);
+    ownedWU->setQueueName(queueName);
+    if (instanceName && *instanceName)
+        ownedWU->setInstance(instanceName); // JCSMORE In thor case at least, if queued it is unknown which instance it will run on..
+    if (targetClusterName && *targetClusterName)
+        ownedWU->setTargetClusterName(targetClusterName);
+}
+
+void CActivityInfo::readWUsInTargetClusterJobQueues(CIArrayOf<CWsSMCTargetCluster>& targetClusters)
+{
+    ForEachItemIn(i, targetClusters)
+    {
+        CWsSMCTargetCluster& targetCluster = targetClusters.item(i);
+        if (targetCluster.clusterType == ThorLCRCluster)
+            readWUsInTargetClusterJobQueue(targetCluster, targetCluster.clusterQueue, targetCluster.clusterName.get());
+        if (targetCluster.agentQueue.queueName.length())
+            readWUsInTargetClusterJobQueue(targetCluster, targetCluster.agentQueue, targetCluster.agentQueue.queueName.str());
+        if (targetCluster.serverQueue.queueName.length()) //TODO: queued WUs for ECLCCServer/ECLServer should not be here.
+            readWUsInTargetClusterJobQueue(targetCluster, targetCluster.serverQueue, targetCluster.serverQueue.queueName.str());
+    }
+}
+
+void CActivityInfo::readWUsInTargetClusterJobQueue(CWsSMCTargetCluster& targetCluster, CWsSMCQueue& jobQueue, const char* queueName)
+{
+    StringArray wuidList;
+    readWUIDsInJobQueue(jobQueue.queueName.str(), wuidList);
+
+    ForEachItemIn(i, wuidList)
+    {
+        const char* wuid = wuidList.item(i);
+        if (!wuid || !*wuid || isDuplicatedECLWUID(wuid))
+            continue;
+
+        Owned<IEspActiveWorkunit> wu;
+        createActiveWorkUnit(wu, wuid, jobQueue.queueName.str(), ++jobQueue.countQueuedJobs, targetCluster.statusServerName.str(),
+            queueName, NULL, targetCluster.clusterName.get(), false);
+        aws.append(*wu.getLink());
+    }
+}
+
+void CActivityInfo::readWUIDsInJobQueue(const char* queueName, StringArray& wuidList)
+{
+    if (!queueName || !*queueName)
+    {
+        WARNLOG("CActivityInfo::readWUIDsInJobQueue: job queue not specified.");
+        return;
+    }
+    if (!jobQueueSnapshot)
+    {
+        WARNLOG("CActivityInfo::readWUIDsInJobQueue: jobQueueSnapshot not found.");
+        return;
+    }
+
+    Owned<IJobQueueConst> jobQueue = jobQueueSnapshot->getJobQueue(queueName);
+    if (!jobQueue)
+        WARNLOG("CActivityInfo::readWUsInJobQueue: failed to get info for job queue %s.", queueName);
+    else
+        jobQueue->getWUIDs(wuidList);
+}
+
+void CActivityInfo::readRunningWUsAndJobQueueforOtherStatusServers()
+{
+    BoolHash uniqueServers;
+    Owned<IPropertyTreeIterator> it(serverStatusRoot->getElements("Server"));
+    ForEach(*it)
+    {
+        IPropertyTree& serverNode = it->query();
+        const char* serverName = serverNode.queryProp("@name");
+        const char* node = serverNode.queryProp("@node");
+        const char* queueName = serverNode.queryProp("@queue");
+        unsigned port = serverNode.getPropInt("@mpport", 0);
+        if (!serverName || !*serverName || !node || !*node || strieq(serverName, STATUS_SERVER_DFUSERVER)
+            || strieq(serverName, getStatusServerTypeName(WsSMCSSTThorLCRCluster)) || strieq(serverName, getStatusServerTypeName(WsSMCSSTRoxieCluster))
+            || strieq(serverName, getStatusServerTypeName(WsSMCSSTHThorCluster)) || strieq(serverName, getStatusServerTypeName(WsSMCSSTECLagent)))
+            continue; //target clusters, ECLAgent, DFUServer already handled separately
+
+        VStringBuffer instanceName("%s_on_%s:%d", serverName, node, port); //where to get a better instance name?
+        Owned<IPropertyTreeIterator> wuids(serverNode.getElements("WorkUnit"));
+        ForEach(*wuids)
+        {
+            const char* wuid=wuids->query().queryProp(NULL);
+            if (!wuid || !*wuid || isDuplicatedECLWUID(wuid))
+                continue;
+
+            Owned<IEspActiveWorkunit> wu;
+            createActiveWorkUnit(wu, wuid, NULL, 0, serverName, queueName, instanceName.str(), NULL, false);
+            aws.append(*wu.getLink());
+        }
+
+        bool* found = uniqueServers.getValue(instanceName);
+        if (!found || !*found)
+        {
+            uniqueServers.setValue(instanceName, true);
+            getServerJobQueue(queueName, instanceName, serverName, node, port);
+        }
+    }
+
+    return;
+}
+
+void CActivityInfo::getDFUServersAndWUs(IPropertyTree* envRoot)
+{
+    if (!envRoot)
+        return;
+
+    VStringBuffer path("Software/%s", eqDfu);
+    Owned<IPropertyTreeIterator> services = envRoot->getElements(path);
+    ForEach(*services)
+    {
+        IPropertyTree &serviceTree = services->query();
+        const char *qname = serviceTree.queryProp("@queue");
+        if (!qname || !*qname)
+            continue;
+
+        StringArray queues;
+        queues.appendListUniq(qname, ",");
+        const char *serverName = serviceTree.queryProp("@name");
+        ForEachItemIn(q, queues)
+        {
+            StringArray wuidList;
+            const char *queueName = queues.item(q);
+            readDFUWUDetails(queueName, serverName, wuidList, readDFUWUIDs(queueName, wuidList));
+            getServerJobQueue(queueName, serverName, STATUS_SERVER_DFUSERVER, NULL, 0);
+        }
+    }
+}
+
+unsigned CActivityInfo::readDFUWUIDs(const char* queueName, StringArray& wuidList)
+{
+    unsigned runningWUCount = 0;
+    VStringBuffer path("Server[@name=\"DFUserver\"]/Queue[@name=\"%s\"]",queueName);
+    Owned<IPropertyTreeIterator> iter = serverStatusRoot->getElements(path.str());
+    ForEach(*iter)
+    {
+        Owned<IPropertyTreeIterator> iterj = iter->query().getElements("Job");
+        ForEach(*iterj)
+        {
+            const char *wuid = iterj->query().queryProp("@wuid");
+            if (wuid && *wuid && (*wuid!='!')) // filter escapes -- see queuedJobs() in dfuwu.cpp
+            {
+                wuidList.append(wuid);
+                runningWUCount++;
             }
         }
     }
 
-    return bFound;
+    readWUIDsInJobQueue(queueName, wuidList);
+    return runningWUCount;
+}
+
+void CActivityInfo::readDFUWUDetails(const char* queueName, const char* serverName, StringArray& wuidList, unsigned runningWUCount)
+{
+    Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
+    ForEachItemIn(i, wuidList)
+    {
+        StringBuffer jname, uname, state, error;
+        const char *wuid = wuidList.item(i);
+        if (i<runningWUCount)
+            state.set("running");
+        else
+            state.set("queued");
+
+        try
+        {
+            Owned<IConstDFUWorkUnit> dfuwu = factory->openWorkUnit(wuid, false);
+            dfuwu->getUser(uname);
+            dfuwu->getJobName(jname);
+        }
+        catch (IException *e)
+        {
+            e->errorMessage(error);
+            state.appendf(" (%s)", error.str());
+            e->Release();
+        }
+
+        Owned<IEspActiveWorkunit> wu(new CActiveWorkunitWrapper(wuid, uname.str(), jname.str(), state.str(), "normal"));
+        wu->setServer(STATUS_SERVER_DFUSERVER);
+        wu->setInstance(serverName);
+        wu->setQueueName(queueName);
+        aws.append(*wu.getLink());
+    }
+}
+
+void CActivityInfo::getDFURecoveryJobs()
+{
+    Owned<IRemoteConnection> connDFURecovery = querySDS().connect("DFU/RECOVERY",myProcessSession(), RTM_LOCK_READ, 30000);
+    if (!connDFURecovery)
+        return;
+
+    Owned<IPropertyTreeIterator> it(connDFURecovery->queryRoot()->getElements("job"));
+    ForEach(*it)
+    {
+        IPropertyTree &jb=it->query();
+        if (!jb.getPropBool("Running",false))
+            continue;
+
+        unsigned done = 0, total = 0;
+        Owned<IPropertyTreeIterator> it = jb.getElements("DFT/progress");
+        ForEach(*it)
+        {
+            IPropertyTree &p=it->query();
+            if (p.getPropInt("@done",0))
+                done++;
+            total++;
+        }
+
+        StringBuffer cmd;
+        cmd.append(jb.queryProp("@command")).append(" ").append(jb.queryProp("@command_parameters"));
+
+        Owned<IEspDFUJob> job = new CDFUJob("","");
+        job->setTimeStarted(jb.queryProp("@time_started"));
+        job->setDone(done);
+        job->setTotal(total);
+        job->setCommand(cmd.str());
+        DFURecoveryJobs.append(*job.getLink());
+    }
+}
+
+void CActivityInfo::getServerJobQueue(const char* queueName, const char* serverName,
+    const char* serverType, const char* networkAddress, unsigned port)
+{
+    if (!queueName || !*queueName || !serverName || !*serverName || !serverType || !*serverType)
+        return;
+
+    Owned<IEspServerJobQueue> jobQueue = createServerJobQueue("", "");
+    jobQueue->setQueueName(queueName);
+    jobQueue->setServerName(serverName);
+    jobQueue->setServerType(serverType);
+    if (networkAddress && *networkAddress)
+    {
+        jobQueue->setNetworkAddress(networkAddress);
+        jobQueue->setPort(port);
+    }
+
+    readServerJobQueueStatus(jobQueue);
+
+    serverJobQueues.append(*jobQueue.getClear());
+}
+
+void CActivityInfo::readServerJobQueueStatus(IEspServerJobQueue* jobQueue)
+{
+    if (!jobQueueSnapshot)
+    {
+        WARNLOG("CActivityInfo::readServerJobQueueStatus: jobQueueSnapshot not found.");
+        return;
+    }
+
+    StringBuffer queueStateDetails;
+    bool jobQueueFound = false, hasRunning = false,  hasPaused =  false;
+
+    StringArray qlist;
+    qlist.appendListUniq(jobQueue->getQueueName(), ",");
+    ForEachItemIn(i, qlist)
+    {
+        const char* qname = qlist.item(i);
+        Owned<IJobQueueConst> queue = jobQueueSnapshot->getJobQueue(qname);
+        if (!queue)
+            continue;
+
+        jobQueueFound = true;
+
+        StringBuffer status, details;
+        queue->getState(status, details);
+        if (!status || !*status)
+            continue;
+
+        if (strieq(status.str(), "paused"))
+            hasPaused =  true;
+        else if (!strieq(status.str(), "stopped"))
+            hasRunning =  true;
+
+        if (details && *details)
+            queueStateDetails.appendf("%s: queue %s; %s;", qname, status.str(), details.str());
+        else
+            queueStateDetails.appendf("%s: queue %s;", qname, status.str());
+    }
+
+    if (hasRunning)
+        jobQueue->setQueueStatus("running");
+    else if (hasPaused)
+        jobQueue->setQueueStatus("paused");
+    else
+    {
+        jobQueue->setQueueStatus("stopped");
+        if (!jobQueueFound)
+            queueStateDetails.setf("%s not found in Status Server list", jobQueue->getQueueName());
+        else if (!queueStateDetails.length())
+            queueStateDetails.setf("No status set in Status Server list for %s", jobQueue->getQueueName());
+    }
+    jobQueue->setStatusDetails(queueStateDetails.str());
+}
+
+bool CWsSMCEx::onIndex(IEspContext &context, IEspSMCIndexRequest &req, IEspSMCIndexResponse &resp)
+{
+    resp.setRedirectUrl("/");
+    return true;
 }
 
 void CWsSMCEx::readBannerAndChatRequest(IEspContext& context, IEspActivityRequest &req, IEspActivityResponse& resp)
@@ -341,91 +930,6 @@ void CWsSMCEx::setBannerAndChatData(double version, IEspActivityResponse& resp)
         resp.setBannerScroll(m_BannerScroll.str());
 }
 
-void CWsSMCEx::createActiveWorkUnit(Owned<IEspActiveWorkunit>& ownedWU, IEspContext &context, const char* wuid, const char* location,
-    unsigned index, const char* serverName, const char* queueName, const char* instanceName, const char* targetClusterName, bool useContext)
-{
-    try
-    {
-        if (useContext)
-            ownedWU.setown(new CActiveWorkunitWrapper(context, wuid, location, index));
-        else
-            ownedWU.setown(new CActiveWorkunitWrapper(wuid, location, index));
-    }
-    catch (IException *e)
-    {   //if the wu cannot be opened for some reason, the openWorkUnit() inside the CActiveWorkunitWrapper() may throw an exception.
-        //We do not want the exception stops this process of retrieving/showing all active WUs. And that WU should still be displayed
-        //with the exception.
-        StringBuffer msg;
-        ownedWU.setown(new CActiveWorkunitWrapper(wuid, "", "", e->errorMessage(msg).str(), "normal"));
-        ownedWU->setStateID(WUStateUnknown);
-        e->Release();
-    }
-
-    ownedWU->setServer(serverName);
-    ownedWU->setQueueName(queueName);
-    if (instanceName && *instanceName)
-        ownedWU->setInstance(instanceName); // JCSMORE In thor case at least, if queued it is unknown which instance it will run on..
-    if (targetClusterName && *targetClusterName)
-        ownedWU->setTargetClusterName(targetClusterName);
-}
-
-void CWsSMCEx::readWUsAndStateFromJobQueue(IEspContext& context, CWsSMCTargetCluster& targetCluster,
-     CWsSMCQueue& jobQueue, const char* queueName, BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws)
-{
-    CJobQueueContents contents;
-    Owned<IJobQueue> queue = createJobQueue(jobQueue.queueName.str());
-    queue->copyItemsAndState(contents, jobQueue.queueState, jobQueue.queueStateDetails);
-    Owned<IJobQueueIterator> iter = contents.getIterator();
-    jobQueue.countQueuedJobs=0;
-    ForEach(*iter)
-    {
-        const char* wuid = iter->query().queryWUID();
-        if (!wuid || !*wuid || uniqueWUIDs.getValue(wuid))
-            continue;
-
-        uniqueWUIDs.setValue(wuid, true);
-
-        const char* queue = NULL;
-        if (queueName && *queueName)
-            queue = queueName;
-        else
-            queue = targetCluster.clusterName.get();
-
-        Owned<IEspActiveWorkunit> wu;
-        createActiveWorkUnit(wu, context, wuid, jobQueue.queueName.str(), ++jobQueue.countQueuedJobs, targetCluster.statusServerName.str(),
-            queue, NULL, targetCluster.clusterName.get(), false);
-        aws.append(*wu.getLink());
-    }
-}
-
-bool CWsSMCEx::findQueueInStatusServer(IEspContext& context, IPropertyTree* serverStatusRoot, const char* serverName, const char* queueName)
-{
-    bool foundServer = false;
-    VStringBuffer path("Server[@name=\"%s\"]", serverName);
-    Owned<IPropertyTreeIterator> it(serverStatusRoot->getElements(path.str()));
-    ForEach(*it)
-    {
-        IPropertyTree& serverStatusNode = it->query();
-        const char* queue = serverStatusNode.queryProp("@queue");
-        if (!queue || !*queue)
-            continue;
-
-        StringArray qlist;
-        qlist.appendListUniq(queue, ",");
-        ForEachItemIn(q, qlist)
-        {
-            if (strieq(qlist.item(q), queueName))
-            {
-                foundServer = true;
-                break;
-            }
-        }
-        if (foundServer)
-            break;
-    }
-    return foundServer;
-}
-
 void CWsSMCEx::sortTargetClusters(IArrayOf<IEspTargetCluster>& clusters, const char* sortBy, bool descending)
 {
     if (!sortBy || !*sortBy || strieq(sortBy, "name"))
@@ -494,191 +998,6 @@ void CWsSMCEx::setClusterStatus(IEspContext& context, const CWsSMCTargetCluster&
         returnCluster->setStatusDetails(queueStatusDetails.str());
 }
 
-void CWsSMCEx::getWUsNotOnTargetCluster(IEspContext &context, IPropertyTree* serverStatusRoot, IArrayOf<IEspServerJobQueue>& serverJobQueues,
-     IArrayOf<IEspActiveWorkunit>& aws)
-{
-    BoolHash uniqueServers;
-    Owned<IPropertyTreeIterator> it(serverStatusRoot->getElements("Server"));
-    ForEach(*it)
-    {
-        IPropertyTree& serverNode = it->query();
-        const char* serverName = serverNode.queryProp("@name");
-        const char* instance = serverNode.queryProp("@node");
-        const char* queueName = serverNode.queryProp("@queue");
-        unsigned port = serverNode.getPropInt("@mpport", 0);
-        if (!serverName || !*serverName || !instance || !*instance || strieq(serverName, STATUS_SERVER_DFUSERVER) ||//DFUServer already handled separately
-            strieq(serverName, "ThorMaster") || strieq(serverName, "RoxieServer") || strieq(serverName, "HThorServer"))//target clusters already handled separately
-            continue;
-
-        VStringBuffer instanceName("%s_on_%s:%d", serverName, instance, port);
-        Owned<IPropertyTreeIterator> wuids(serverNode.getElements("WorkUnit"));
-        ForEach(*wuids)
-        {
-            const char* wuid=wuids->query().queryProp(NULL);
-            if (!wuid || !*wuid)
-                continue;
-
-            if (isInWuList(aws, wuid))
-                continue;
-
-            Owned<IEspActiveWorkunit> wu;
-            createActiveWorkUnit(wu, context, wuid, NULL, 0, serverName, queueName, instanceName.str(), NULL, false);
-            aws.append(*wu.getLink());
-        }
-        if (!uniqueServers.getValue(instanceName))
-        {
-            uniqueServers.setValue(instanceName, true);
-            addServerJobQueue(serverJobQueues, queueName, instanceName, serverName, instance, port);
-        }
-    }
-
-    return;
-}
-
-void CWsSMCEx::readDFUWUs(IEspContext &context, const char* queueName, const char* serverName, IArrayOf<IEspActiveWorkunit>& aws)
-{
-    StringAttrArray wulist;
-    unsigned running = queuedJobs(queueName, wulist);
-    Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
-    ForEachItemIn(i, wulist)
-    {
-        StringBuffer jname, uname, state, error;
-        const char *wuid = wulist.item(i).text.get();
-        if (i<running)
-            state.set("running");
-        else
-            state.set("queued");
-
-        try
-        {
-            Owned<IConstDFUWorkUnit> dfuwu = factory->openWorkUnit(wuid, false);
-            dfuwu->getUser(uname);
-            dfuwu->getJobName(jname);
-        }
-        catch (IException *e)
-        {
-            e->errorMessage(error);
-            state.appendf(" (%s)", error.str());
-            e->Release();
-        }
-
-        Owned<IEspActiveWorkunit> wu(new CActiveWorkunitWrapper(wuid, uname.str(), jname.str(), state.str(), "normal"));
-        wu->setServer(STATUS_SERVER_DFUSERVER);
-        wu->setInstance(serverName);
-        wu->setQueueName(queueName);
-        aws.append(*wu.getLink());
-    }
-}
-
-void CWsSMCEx::getDFUServersAndWUs(IEspContext &context, IPropertyTree* envRoot, IArrayOf<IEspServerJobQueue>& serverJobQueues, IArrayOf<IEspActiveWorkunit>& aws)
-{
-    if (!envRoot)
-        return;
-
-    VStringBuffer path("Software/%s", eqDfu);
-    Owned<IPropertyTreeIterator> services = envRoot->getElements(path);
-    ForEach(*services)
-    {
-        IPropertyTree &serviceTree = services->query();
-        const char *qname = serviceTree.queryProp("@queue");
-        const char *serverName = serviceTree.queryProp("@name");
-        if (!qname || !*qname)
-            continue;
-
-        StringArray queues;
-        queues.appendListUniq(qname, ",");
-        ForEachItemIn(q, queues)
-        {
-            const char *queueName = queues.item(q);
-            readDFUWUs(context, queueName, serverName, aws);
-            addServerJobQueue(serverJobQueues, queueName, serverName, STATUS_SERVER_DFUSERVER, NULL, 0);
-        }
-    }
-}
-
-void CWsSMCEx::getDFURecoveryJobs(IEspContext &context, const IPropertyTree* dfuRecoveryRoot, IArrayOf<IEspDFUJob>& jobs)
-{
-    if (!dfuRecoveryRoot)
-        return;
-
-    Owned<IPropertyTreeIterator> it(dfuRecoveryRoot->getElements("job"));
-    ForEach(*it)
-    {
-        IPropertyTree &e=it->query();
-        if (!e.getPropBool("Running",false))
-            continue;
-
-        StringBuffer cmd;
-        unsigned done, total;
-        countProgress(&e,done,total);
-        cmd.append(e.queryProp("@command")).append(" ").append(e.queryProp("@command_parameters"));
-
-        Owned<IEspDFUJob> job = new CDFUJob("","");
-        job->setTimeStarted(e.queryProp("@time_started"));
-        job->setDone(done);
-        job->setTotal(total);
-        job->setCommand(cmd.str());
-        jobs.append(*job.getLink());
-    }
-}
-
-bool ActivityInfo::isCachedActivityInfoValid(unsigned timeOutSeconds)
-{
-    CDateTime timeNow;
-    timeNow.setNow();
-    return timeNow.getSimple() <= timeCached.getSimple() + timeOutSeconds;;
-}
-
-void CWsSMCEx::clearActivityInfoCache()
-{
-    CriticalBlock b(getActivityCrit);
-    activityInfoCache.clear();
-}
-
-ActivityInfo* CWsSMCEx::getActivityInfo(IEspContext &context)
-{
-    CriticalBlock b(getActivityCrit);
-
-    if (activityInfoCache && activityInfoCache->isCachedActivityInfoValid(activityInfoCacheSeconds))
-        return activityInfoCache.getLink();
-
-    DBGLOG("CWsSMCEx::getActivityInfo - rebuild cached information");
-    {
-        EspTimeSection timer("createActivityInfo");
-        activityInfoCache.setown(createActivityInfo(context));
-    }
-
-    return activityInfoCache.getLink();
-}
-
-ActivityInfo* CWsSMCEx::createActivityInfo(IEspContext &context)
-{
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-    Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO,"Failed to get environment information.");
-
-    CConstWUClusterInfoArray clusters;
-    Owned<IPropertyTree> envRoot= &env->getPTree();
-    getEnvironmentClusterInfo(envRoot, clusters);
-
-    Owned<IRemoteConnection> connStatusServers = querySDS().connect("/Status/Servers",myProcessSession(),RTM_LOCK_READ,30000);
-    IPropertyTree* serverStatusRoot = connStatusServers->queryRoot();
-    if (!serverStatusRoot)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_STATUS_INFO, "Failed to get status server information.");
-
-    IPropertyTree* dfuRecoveryRoot = NULL;
-    Owned<IRemoteConnection> connDFURecovery = querySDS().connect("DFU/RECOVERY",myProcessSession(), RTM_LOCK_READ, 30000);
-    if (connDFURecovery)
-    	dfuRecoveryRoot = connDFURecovery->queryRoot();
-
-    Owned<ActivityInfo> activityInfo = new ActivityInfo();
-    readTargetClusterInfo(context, clusters, serverStatusRoot, activityInfo);
-    readRunningWUsAndQueuedWUs(context, envRoot, serverStatusRoot, dfuRecoveryRoot, activityInfo);
-    activityInfo->timeCached.setNow();
-    return activityInfo.getClear();
-}
-
 // This method reads job information from both /Status/Servers and IJobQueue.
 //
 // Each server component (a thor cluster, a dfuserver, or an eclagent) is one 'Server' branch under
@@ -723,7 +1042,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
         if (version >= 1.06)
             setBannerAndChatData(version, resp);
 
-        Owned<ActivityInfo> activityInfo = getActivityInfo(context);
+        Owned<CActivityInfo> activityInfo = getActivityInfo(context);
         setActivityResponse(context, activityInfo, req, resp);
     }
     catch(IException* e)
@@ -734,266 +1053,27 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
     return true;
 }
 
-const char *CWsSMCEx::getStatusServerTypeName(WsSMCStatusServerType type)
+void CWsSMCEx::clearActivityInfoCache()
 {
-    return (type < WsSMCSSTterm) ? WsSMCStatusServerTypeNames[type] : NULL;
+    CriticalBlock b(getActivityCrit);
+    activityInfoCache.clear();
 }
 
-void CWsSMCEx::readTargetClusterInfo(IEspContext &context, CConstWUClusterInfoArray& clusters, IPropertyTree* serverStatusRoot,
-    ActivityInfo* activityInfo)
+CActivityInfo* CWsSMCEx::getActivityInfo(IEspContext &context)
 {
-    ForEachItemIn(c, clusters)
+    CriticalBlock b(getActivityCrit);
+
+    if (activityInfoCache && activityInfoCache->isCachedActivityInfoValid(activityInfoCacheSeconds))
+        return activityInfoCache.getLink();
+
+    DBGLOG("CWsSMCEx::getActivityInfo - rebuild cached information");
     {
-        IConstWUClusterInfo &cluster = clusters.item(c);
-        Owned<CWsSMCTargetCluster> targetCluster = new CWsSMCTargetCluster();
-        readTargetClusterInfo(context, cluster, serverStatusRoot, targetCluster);
-        if (cluster.getPlatform() == ThorLCRCluster)
-            activityInfo->thorTargetClusters.append(*targetCluster.getClear());
-        else if (cluster.getPlatform() == RoxieCluster)
-            activityInfo->roxieTargetClusters.append(*targetCluster.getClear());
-        else
-            activityInfo->hthorTargetClusters.append(*targetCluster.getClear());
-    }
-}
-
-void CWsSMCEx::readTargetClusterInfo(IEspContext& context, IConstWUClusterInfo& cluster, IPropertyTree* serverStatusRoot, CWsSMCTargetCluster* targetCluster)
-{
-    SCMStringBuffer clusterName;
-    cluster.getName(clusterName);
-    targetCluster->clusterName.set(clusterName.str());
-    targetCluster->clusterType = cluster.getPlatform();
-    targetCluster->clusterSize = cluster.getSize();
-    cluster.getServerQueue(targetCluster->serverQueue.queueName);
-    cluster.getAgentQueue(targetCluster->agentQueue.queueName);
-
-    StringBuffer statusServerName;
-    CWsSMCQueue* jobQueue = NULL;
-    if (targetCluster->clusterType == ThorLCRCluster)
-    {
-        statusServerName.set(getStatusServerTypeName(WsSMCSSTThorLCRCluster));
-        jobQueue = &targetCluster->clusterQueue;
-        cluster.getThorQueue(jobQueue->queueName);
-    }
-    else if (targetCluster->clusterType == RoxieCluster)
-    {
-        statusServerName.set(getStatusServerTypeName(WsSMCSSTRoxieCluster));
-        jobQueue = &targetCluster->agentQueue;
-    }
-    else
-    {
-        statusServerName.set(getStatusServerTypeName(WsSMCSSTHThorCluster));
-        jobQueue = &targetCluster->agentQueue;
+        EspTimeSection timer("createActivityInfo");
+        activityInfoCache.setown(new CActivityInfo(context));
+        activityInfoCache->createActivityInfo();
     }
 
-    targetCluster->statusServerName.set(statusServerName.str());
-    targetCluster->queueName.set(jobQueue->queueName.str());
-
-    if (serverStatusRoot)
-    {
-        jobQueue->foundQueueInStatusServer = findQueueInStatusServer(context, serverStatusRoot, statusServerName.str(), targetCluster->queueName.get());
-        if (!jobQueue->foundQueueInStatusServer)
-            targetCluster->clusterStatusDetails.appendf("Cluster %s not attached; ", clusterName.str());
-    }
-
-    return;
-}
-
-void CWsSMCEx::readRunningWUsAndQueuedWUs(IEspContext &context, IPropertyTree* envRoot, IPropertyTree* serverStatusRoot,
-    IPropertyTree* dfuRecoveryRoot, ActivityInfo* activityInfo)
-{
-    BoolHash uniqueWUIDs;
-    readRunningWUsOnStatusServer(context, serverStatusRoot, WsSMCSSTThorLCRCluster, activityInfo->thorTargetClusters, activityInfo->roxieTargetClusters, activityInfo->hthorTargetClusters, uniqueWUIDs, activityInfo->aws);
-    readWUsAndStateFromJobQueue(context, activityInfo->thorTargetClusters, uniqueWUIDs, activityInfo->aws);
-    readRunningWUsOnStatusServer(context, serverStatusRoot, WsSMCSSTRoxieCluster, activityInfo->roxieTargetClusters, activityInfo->thorTargetClusters, activityInfo->hthorTargetClusters, uniqueWUIDs, activityInfo->aws);
-    readWUsAndStateFromJobQueue(context, activityInfo->roxieTargetClusters, uniqueWUIDs, activityInfo->aws);
-    readRunningWUsOnStatusServer(context, serverStatusRoot, WsSMCSSTHThorCluster, activityInfo->hthorTargetClusters, activityInfo->thorTargetClusters, activityInfo->roxieTargetClusters, uniqueWUIDs, activityInfo->aws);
-    readWUsAndStateFromJobQueue(context, activityInfo->hthorTargetClusters, uniqueWUIDs, activityInfo->aws);
-
-    readRunningWUsOnStatusServer(context, serverStatusRoot, WsSMCSSTECLagent, activityInfo->thorTargetClusters, activityInfo->roxieTargetClusters, activityInfo->hthorTargetClusters, uniqueWUIDs, activityInfo->aws);
-
-    getWUsNotOnTargetCluster(context, serverStatusRoot, activityInfo->serverJobQueues, activityInfo->aws);
-    getDFUServersAndWUs(context, envRoot, activityInfo->serverJobQueues, activityInfo->aws);
-    getDFURecoveryJobs(context, dfuRecoveryRoot, activityInfo->DFURecoveryJobs);
-}
-
-void CWsSMCEx::readRunningWUsOnStatusServer(IEspContext& context, IPropertyTree* serverStatusRoot, WsSMCStatusServerType statusServerType,
-        CIArrayOf<CWsSMCTargetCluster>& targetClusters, CIArrayOf<CWsSMCTargetCluster>& targetClusters1, CIArrayOf<CWsSMCTargetCluster>& targetClusters2,
-        BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws)
-{
-    const char* serverName = getStatusServerTypeName(statusServerType);
-    if (!serverName || !*serverName)
-        return;
-    bool isECLAgent = (statusServerType == WsSMCSSTECLagent);
-    VStringBuffer path("Server[@name=\"%s\"]", serverName);
-    Owned<IPropertyTreeIterator> itrStatusServer(serverStatusRoot->getElements(path.str()));
-    ForEach(*itrStatusServer)
-    {
-        IPropertyTree& serverStatusNode = itrStatusServer->query();
-
-        StringBuffer instance;
-        if ((statusServerType == WsSMCSSTThorLCRCluster) || (statusServerType == WsSMCSSTRoxieCluster))
-            serverStatusNode.getProp("@cluster", instance);
-        else
-            instance.appendf("%s on %s", serverName, serverStatusNode.queryProp("@node"));
-
-        const char* graph = NULL;
-        int sgDuration = -1;
-        int subgraph = -1;
-        StringBuffer durationStr, subgraphStr;
-        if (!isECLAgent)
-        {
-            sgDuration = serverStatusNode.getPropInt("@sg_duration", -1);
-            subgraph = serverStatusNode.getPropInt("@subgraph", -1);
-            graph = serverStatusNode.queryProp("@graph");
-            durationStr.appendf("%d min", sgDuration);
-            subgraphStr.appendf("%d", subgraph);
-        }
-
-        Owned<IPropertyTreeIterator> wuids(serverStatusNode.getElements("WorkUnit"));
-        ForEach(*wuids)
-        {
-            const char* wuid=wuids->query().queryProp(NULL);
-            if (!wuid || !*wuid || (isECLAgent && uniqueWUIDs.getValue(wuid)))
-                continue;
-
-            CWsSMCTargetCluster* targetCluster = findWUClusterInfo(context, wuid, isECLAgent, targetClusters, targetClusters1, targetClusters2);
-            if (!targetCluster)
-                continue;
-
-            const char* targetClusterName = targetCluster->clusterName.get();
-            CWsSMCQueue* jobQueue;
-            if (statusServerType == WsSMCSSTThorLCRCluster)
-                jobQueue = &targetCluster->clusterQueue;
-            else
-                jobQueue = &targetCluster->agentQueue;
-
-            Owned<IEspActiveWorkunit> wu;
-            if (!isECLAgent)
-            {
-                uniqueWUIDs.setValue(wuid, true);
-
-                const char *cluster = serverStatusNode.queryProp("Cluster");
-                StringBuffer queueName;
-                if (cluster) // backward compat check.
-                    getClusterThorQueueName(queueName, cluster);
-                else
-                    queueName.append(targetCluster->queueName.get());
-
-                createActiveWorkUnit(wu, context, wuid, !strieq(targetClusterName, instance.str()) ? instance.str() : NULL, 0, serverName,
-                    queueName, instance.str(), targetClusterName, false);
-
-                if (wu->getStateID() == WUStateRunning) //'aborting' may be another possible status
-                {
-                    if (subgraph > -1 && sgDuration > -1)
-                    {
-                        wu->setGraphName(graph);
-                        wu->setDuration(durationStr.str());
-                        wu->setGID(subgraphStr.str());
-                    }
-
-                    if (serverStatusNode.getPropInt("@memoryBlocked ", 0) != 0)
-                        wu->setMemoryBlocked(1);
-                }
-            }
-            else
-            {
-                createActiveWorkUnit(wu, context, wuid, instance.str(), 0, serverName, serverName, instance.str(), targetClusterName, false);
-
-                if (targetCluster->clusterType == ThorLCRCluster)
-                    wu->setClusterType(CLUSTER_TYPE_THOR);
-                else if (targetCluster->clusterType == RoxieCluster)
-                    wu->setClusterType(CLUSTER_TYPE_ROXIE);
-                else
-                    wu->setClusterType(CLUSTER_TYPE_HTHOR);
-                wu->setClusterQueueName(targetCluster->queueName.get());
-
-                if (wu->getStateID() != WUStateRunning)
-                {
-                    const char *extra = wu->getExtra();
-                    if (wu->getStateID() != WUStateBlocked || !extra || !*extra)  // Blocked on persist treated as running here
-                    {
-                        aws.append(*wu.getLink());
-                        jobQueue->countQueuedJobs++;
-                        continue;
-                    }
-                }
-
-                if (serverStatusNode.getPropInt("@memoryBlocked ", 0) != 0)
-                    wu->setMemoryBlocked(1);
-            }
-
-            aws.append(*wu.getLink());
-            jobQueue->countRunningJobs++;
-        }
-    }
-}
-
-void CWsSMCEx::readWUsAndStateFromJobQueue(IEspContext& context, CIArrayOf<CWsSMCTargetCluster>& targetClusters, BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws)
-{
-    ForEachItemIn(i, targetClusters)
-        readWUsAndStateFromJobQueue(context, targetClusters.item(i), uniqueWUIDs, aws);
-}
-
-void CWsSMCEx::readWUsAndStateFromJobQueue(IEspContext& context, CWsSMCTargetCluster& targetCluster, BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws)
-{
-    if (targetCluster.clusterType == ThorLCRCluster)
-    {
-        readWUsAndStateFromJobQueue(context, targetCluster, targetCluster.clusterQueue, NULL, uniqueWUIDs, aws);
-        targetCluster.queueStatus.set(targetCluster.clusterQueue.queueState);
-    }
-    if (targetCluster.agentQueue.queueName.length())
-    {
-        readWUsAndStateFromJobQueue(context, targetCluster, targetCluster.agentQueue, targetCluster.agentQueue.queueName.str(), uniqueWUIDs, aws);
-        if (targetCluster.clusterType != ThorLCRCluster)
-            targetCluster.queueStatus.set(targetCluster.agentQueue.queueState);
-    }
-    if (targetCluster.serverQueue.queueName.length())
-        readWUsAndStateFromJobQueue(context, targetCluster, targetCluster.serverQueue, targetCluster.serverQueue.queueName.str(), uniqueWUIDs, aws);
-}
-
-CWsSMCTargetCluster* CWsSMCEx::findTargetCluster(const char* clusterName, CIArrayOf<CWsSMCTargetCluster>& targetClusters)
-{
-    ForEachItemIn(i, targetClusters)
-    {
-        CWsSMCTargetCluster& targetCluster = targetClusters.item(i);
-        if (strieq(targetCluster.clusterName.get(), clusterName))
-            return &targetCluster;
-    }
-    return NULL;
-}
-
-CWsSMCTargetCluster* CWsSMCEx::findWUClusterInfo(IEspContext& context, const char* wuid, bool isOnECLAgent, CIArrayOf<CWsSMCTargetCluster>& targetClusters,
-    CIArrayOf<CWsSMCTargetCluster>& targetClusters1, CIArrayOf<CWsSMCTargetCluster>& targetClusters2)
-{
-    StringAttr clusterName;
-    try
-    {
-        Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
-        Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid, false);
-        if (!cw)
-            return NULL;
-        clusterName.set(cw->queryClusterName());
-        if (!clusterName.length())
-            return NULL;
-    }
-    catch (IException *e)
-    {//Exception may be thrown when the openWorkUnit() is called inside the CWUWrapper
-        StringBuffer msg;
-        WARNLOG("Failed to open workunit %s: %s", wuid, e->errorMessage(msg).str());
-        e->Release();
-        return NULL;
-    }
-
-    const char* cluster = clusterName.str();
-    CWsSMCTargetCluster* targetCluster = findTargetCluster(cluster, targetClusters);
-    if (targetCluster || !isOnECLAgent)
-        return targetCluster;
-
-    targetCluster = findTargetCluster(cluster, targetClusters1);
-    if (targetCluster)
-        return targetCluster;
-
-    return findTargetCluster(cluster, targetClusters2);
+    return activityInfoCache.getLink();
 }
 
 void CWsSMCEx::addWUsToResponse(IEspContext &context, const IArrayOf<IEspActiveWorkunit>& aws, IEspActivityResponse& resp)
@@ -1042,7 +1122,7 @@ void CWsSMCEx::addWUsToResponse(IEspContext &context, const IArrayOf<IEspActiveW
     return;
 }
 
-void CWsSMCEx::setActivityResponse(IEspContext &context, ActivityInfo* activityInfo, IEspActivityRequest &req, IEspActivityResponse& resp)
+void CWsSMCEx::setActivityResponse(IEspContext &context, CActivityInfo* activityInfo, IEspActivityRequest &req, IEspActivityResponse& resp)
 {
     double version = context.getClientVersion();
     const char* sortBy = req.getSortBy();
@@ -1053,9 +1133,9 @@ void CWsSMCEx::setActivityResponse(IEspContext &context, ActivityInfo* activityI
         IArrayOf<IEspTargetCluster> hthorClusters;
         IArrayOf<IEspTargetCluster> roxieClusters;
 
-        setESPTargetClusters(context, activityInfo->thorTargetClusters, thorClusters);
-        setESPTargetClusters(context, activityInfo->roxieTargetClusters, roxieClusters);
-        setESPTargetClusters(context, activityInfo->hthorTargetClusters, hthorClusters);
+        setESPTargetClusters(context, activityInfo->queryThorTargetClusters(), thorClusters);
+        setESPTargetClusters(context, activityInfo->queryRoxieTargetClusters(), roxieClusters);
+        setESPTargetClusters(context, activityInfo->queryHThorTargetClusters(), hthorClusters);
 
         sortTargetClusters(thorClusters, sortBy, descending);
         sortTargetClusters(roxieClusters, sortBy, descending);
@@ -1069,14 +1149,15 @@ void CWsSMCEx::setActivityResponse(IEspContext &context, ActivityInfo* activityI
         resp.setThorClusterList(thorClusters);
         resp.setRoxieClusterList(roxieClusters);
         resp.setHThorClusterList(hthorClusters);
-        resp.setServerJobQueues(activityInfo->serverJobQueues);
+        resp.setServerJobQueues(activityInfo->queryServerJobQueues());
     }
     else
     {//for backward compatible
         IArrayOf<IEspThorCluster> thorClusters;
-        ForEachItemIn(i, activityInfo->thorTargetClusters)
+        CIArrayOf<CWsSMCTargetCluster>& thorTargetClusters = activityInfo->queryThorTargetClusters();
+        ForEachItemIn(i, thorTargetClusters)
         {
-            CWsSMCTargetCluster& targetCluster = activityInfo->thorTargetClusters.item(i);
+            CWsSMCTargetCluster& targetCluster = thorTargetClusters.item(i);
             Owned<IEspThorCluster> respThorCluster = new CThorCluster("", "");
             respThorCluster->setClusterName(targetCluster.clusterName.get());
             respThorCluster->setQueueStatus(targetCluster.queueStatus.get());
@@ -1091,9 +1172,10 @@ void CWsSMCEx::setActivityResponse(IEspContext &context, ActivityInfo* activityI
         if (version > 1.06)
         {
             IArrayOf<IEspRoxieCluster> roxieClusters;
-            ForEachItemIn(i, activityInfo->roxieTargetClusters)
+            CIArrayOf<CWsSMCTargetCluster>& roxieTargetClusters = activityInfo->queryRoxieTargetClusters();
+            ForEachItemIn(i, roxieTargetClusters)
             {
-                CWsSMCTargetCluster& targetCluster = activityInfo->roxieTargetClusters.item(i);
+                CWsSMCTargetCluster& targetCluster = roxieTargetClusters.item(i);
                 Owned<IEspRoxieCluster> respRoxieCluster = new CRoxieCluster("", "");
                 respRoxieCluster->setClusterName(targetCluster.clusterName.get());
                 respRoxieCluster->setQueueStatus(targetCluster.queueStatus.get());
@@ -1112,9 +1194,10 @@ void CWsSMCEx::setActivityResponse(IEspContext &context, ActivityInfo* activityI
         if (version > 1.11)
         {
             IArrayOf<IEspHThorCluster> hThorClusters;
-            ForEachItemIn(i, activityInfo->hthorTargetClusters)
+            CIArrayOf<CWsSMCTargetCluster>& hthorTargetClusters = activityInfo->queryHThorTargetClusters();
+            ForEachItemIn(i, hthorTargetClusters)
             {
-                CWsSMCTargetCluster& targetCluster = activityInfo->hthorTargetClusters.item(i);
+                CWsSMCTargetCluster& targetCluster = hthorTargetClusters.item(i);
                 Owned<IEspHThorCluster> respHThorCluster = new CHThorCluster("", "");
                 respHThorCluster->setClusterName(targetCluster.clusterName.get());
                 respHThorCluster->setQueueStatus(targetCluster.queueStatus.get());
@@ -1129,10 +1212,10 @@ void CWsSMCEx::setActivityResponse(IEspContext &context, ActivityInfo* activityI
                 resp.setAccessRight("Access_Full");
         }
         if (version > 1.03)
-            resp.setServerJobQueues(activityInfo->serverJobQueues);
+            resp.setServerJobQueues(activityInfo->queryServerJobQueues());
     }
-    resp.setDFUJobs(activityInfo->DFURecoveryJobs);
-    addWUsToResponse(context, activityInfo->aws, resp);
+    resp.setDFUJobs(activityInfo->queryDFURecoveryJobs());
+    addWUsToResponse(context, activityInfo->queryActiveWUs(), resp);
     return;
 }
 
@@ -1144,75 +1227,6 @@ void CWsSMCEx::setESPTargetClusters(IEspContext& context, const CIArrayOf<CWsSMC
         setESPTargetCluster(context, targetClusters.item(i), respTargetCluster);
         respTargetClusters.append(*respTargetCluster.getClear());
     }
-}
-
-void CWsSMCEx::addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName,
-    const char* serverType, const char* networkAddress, unsigned port)
-{
-    if (!queueName || !*queueName || !serverName || !*serverName || !serverType || !*serverType)
-        return;
-
-    StringBuffer queueState;
-    StringBuffer queueStateDetails;
-    Owned<IJobQueue> queue = createJobQueue(queueName);
-    if (queue->stopped(queueStateDetails))
-        queueState.set("stopped");
-    else if (queue->paused(queueStateDetails))
-        queueState.set("paused");
-    else
-        queueState.set("running");
-    addServerJobQueue(jobQueues, queueName, serverName, serverType, networkAddress, port, queueState.str(), queueStateDetails.str());
-}
-
-void CWsSMCEx::addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName,
-    const char* serverType, const char* networkAddress, unsigned port, const char* queueState, const char* queueStateDetails)
-{
-    if (!queueName || !*queueName || !serverName || !*serverName || !serverType || !*serverType)
-        return;
-
-    if (!queueState || !*queueState)
-        queueState = "running";
-
-    Owned<IEspServerJobQueue> jobQueue = createServerJobQueue("", "");
-    jobQueue->setQueueName(queueName);
-    jobQueue->setServerName(serverName);
-    jobQueue->setServerType(serverType);
-    if (networkAddress && *networkAddress)
-    {
-        jobQueue->setNetworkAddress(networkAddress);
-        jobQueue->setPort(port);
-    }
-    setServerJobQueueStatus(jobQueue, queueState, queueStateDetails);
-
-    jobQueues.append(*jobQueue.getClear());
-}
-
-void CWsSMCEx::setServerJobQueueStatus(double version, IEspServerJobQueue* jobQueue, const char* status, const char* details)
-{
-    if (!status || !*status)
-        return;
-
-    jobQueue->setQueueStatus(status);
-    if (version >= 1.17)
-    	setServerJobQueueStatusDetails(jobQueue, status, details);
-}
-
-void CWsSMCEx::setServerJobQueueStatus(IEspServerJobQueue* jobQueue, const char* status, const char* details)
-{
-    if (!status || !*status)
-        return;
-    jobQueue->setQueueStatus(status);
-    setServerJobQueueStatusDetails(jobQueue, status, details);
-}
-
-void CWsSMCEx::setServerJobQueueStatusDetails(IEspServerJobQueue* jobQueue, const char* status, const char* details)
-{
-    StringBuffer queueState;
-    if (details && *details)
-        queueState.appendf("queue %s; %s;", status, details);
-    else
-        queueState.appendf("queue %s;", status);
-    jobQueue->setStatusDetails(queueState.str());
 }
 
 void CWsSMCEx::addCapabilities(IPropertyTree* pFeatureNode, const char* access, 
@@ -2034,29 +2048,29 @@ void CWsSMCEx::getStatusServerInfo(IEspContext &context, const char *serverType,
     if (!serverType || !*serverType)
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Server type not specified.");
 
-    Owned<ActivityInfo> activityInfo = getActivityInfo(context);
+    Owned<CActivityInfo> activityInfo = getActivityInfo(context);
     if (!activityInfo)
         throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get Activity Info cache.");
 
     if (strieq(serverType,STATUS_SERVER_THOR))
     {
-        setTargetClusterInfo(context, serverType, server, activityInfo->thorTargetClusters, activityInfo->aws, statusServerInfo);
+        setTargetClusterInfo(context, serverType, server, activityInfo->queryThorTargetClusters(), activityInfo->queryActiveWUs(), statusServerInfo);
     }
     else if (strieq(serverType,STATUS_SERVER_ROXIE))
     {
-        setTargetClusterInfo(context, serverType, server, activityInfo->roxieTargetClusters, activityInfo->aws, statusServerInfo);
+        setTargetClusterInfo(context, serverType, server, activityInfo->queryRoxieTargetClusters(), activityInfo->queryActiveWUs(), statusServerInfo);
     }
     else if (strieq(serverType,STATUS_SERVER_HTHOR))
     {
-        setTargetClusterInfo(context, serverType, server, activityInfo->hthorTargetClusters, activityInfo->aws, statusServerInfo);
+        setTargetClusterInfo(context, serverType, server, activityInfo->queryHThorTargetClusters(), activityInfo->queryActiveWUs(), statusServerInfo);
     }
     else if (strieq(serverType,STATUS_SERVER_DFUSERVER))
     {
-        setServerQueueInfo(context, serverType, server, activityInfo->serverJobQueues, activityInfo->aws, statusServerInfo);
+        setServerQueueInfo(context, serverType, server, activityInfo->queryServerJobQueues(), activityInfo->queryActiveWUs(), statusServerInfo);
     }
     else
     {
-        setServerQueueInfo(context, serverType, networkAddress, port, activityInfo->serverJobQueues, activityInfo->aws, statusServerInfo);
+        setServerQueueInfo(context, serverType, networkAddress, port, activityInfo->queryServerJobQueues(), activityInfo->queryActiveWUs(), statusServerInfo);
     }
 }
 
@@ -2217,3 +2231,4 @@ void CWsSMCEx::setActiveWUs(IEspContext &context, IEspActiveWorkunit& wu, IEspAc
         e->Release();
     }
 }
+

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -87,6 +87,7 @@ public:
     CWsSMCQueue clusterQueue;
     CWsSMCQueue agentQueue;
     CWsSMCQueue serverQueue;
+    StringArray queuedWUIDs;
 
     CWsSMCTargetCluster(){};
     virtual ~CWsSMCTargetCluster(){};
@@ -108,22 +109,20 @@ class CActivityInfo : public CInterface, implements IInterface
     IArrayOf<IEspServerJobQueue> serverJobQueues;
     IArrayOf<IEspDFUJob> DFURecoveryJobs;
 
-    IPropertyTree* serverStatusRoot;
-
-    void readTargetClusterInfo(CConstWUClusterInfoArray& clusters);
-    void readTargetClusterInfo(IConstWUClusterInfo& cluster, CWsSMCTargetCluster* targetCluster);
-    bool findQueueInStatusServer(const char* serverName, const char* queueName);
+    void readTargetClusterInfo(CConstWUClusterInfoArray& clusters, IPropertyTree* serverStatusRoot);
+    void readTargetClusterInfo(IConstWUClusterInfo& cluster, IPropertyTree* serverStatusRoot, CWsSMCTargetCluster* targetCluster);
+    bool findQueueInStatusServer(IPropertyTree* serverStatusRoot, const char* serverName, const char* queueName);
     const char *getStatusServerTypeName(WsSMCStatusServerType type);
-    void readActiveWUsAndQueuedWUs(IPropertyTree* envRoot);
-    void readRunningWUsOnStatusServer(WsSMCStatusServerType statusServerType);
+    bool readJobQueue(const char* queueName, StringArray& wuids, StringBuffer& state, StringBuffer& stateDetails);
+    void readActiveWUsAndQueuedWUs(IPropertyTree* envRoot, IPropertyTree* serverStatusRoot);
+    void readRunningWUsOnStatusServer(IPropertyTree* serverStatusRoot, WsSMCStatusServerType statusServerType);
     void readWUsInTargetClusterJobQueues(CIArrayOf<CWsSMCTargetCluster>& targetClusters);
     void readWUsInTargetClusterJobQueue(CWsSMCTargetCluster& targetCluster, CWsSMCQueue& jobQueue, const char* queueName);
-    void readWUIDsInJobQueue(const char* queueName, StringArray& wuidList);
-    void readRunningWUsAndJobQueueforOtherStatusServers();
+    void readRunningWUsAndJobQueueforOtherStatusServers(IPropertyTree* serverStatusRoot);
     void createActiveWorkUnit(Owned<IEspActiveWorkunit>& ownedWU, const char* wuid, const char* location,
         unsigned index, const char* serverName, const char* queueName, const char* instanceName, const char* targetClusterName, bool useContext);
-    void getDFUServersAndWUs(IPropertyTree* envRoot);
-    unsigned readDFUWUIDs(const char* queueName, StringArray& wuidList);
+    void getDFUServersAndWUs(IPropertyTree* envRoot, IPropertyTree* serverStatusRoot);
+    unsigned readDFUWUIDs(IPropertyTree* serverStatusRoot, const char* queueName, StringArray& wuidList);
     void readDFUWUDetails(const char* queueName, const char* serverName, StringArray& wuidList, unsigned runningWUCount);
     void getDFURecoveryJobs();
     void getServerJobQueue(const char* queueName, const char* serverName, const char* serverType, const char* networkAddress, unsigned port);

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -95,7 +95,6 @@ public:
 
 class CActivityInfo : public CInterface, implements IInterface
 {
-    IEspContext& context;
     CDateTime timeCached;
     BoolHash uniqueECLWUIDs;
 
@@ -114,12 +113,12 @@ class CActivityInfo : public CInterface, implements IInterface
     bool findQueueInStatusServer(IPropertyTree* serverStatusRoot, const char* serverName, const char* queueName);
     const char *getStatusServerTypeName(WsSMCStatusServerType type);
     bool readJobQueue(const char* queueName, StringArray& wuids, StringBuffer& state, StringBuffer& stateDetails);
-    void readActiveWUsAndQueuedWUs(IPropertyTree* envRoot, IPropertyTree* serverStatusRoot);
-    void readRunningWUsOnStatusServer(IPropertyTree* serverStatusRoot, WsSMCStatusServerType statusServerType);
-    void readWUsInTargetClusterJobQueues(CIArrayOf<CWsSMCTargetCluster>& targetClusters);
-    void readWUsInTargetClusterJobQueue(CWsSMCTargetCluster& targetCluster, CWsSMCQueue& jobQueue, const char* queueName);
-    void readRunningWUsAndJobQueueforOtherStatusServers(IPropertyTree* serverStatusRoot);
-    void createActiveWorkUnit(Owned<IEspActiveWorkunit>& ownedWU, const char* wuid, const char* location,
+    void readActiveWUsAndQueuedWUs(IEspContext& context, IPropertyTree* envRoot, IPropertyTree* serverStatusRoot);
+    void readRunningWUsOnStatusServer(IEspContext& context, IPropertyTree* serverStatusRoot, WsSMCStatusServerType statusServerType);
+    void readWUsInTargetClusterJobQueues(IEspContext& context, CIArrayOf<CWsSMCTargetCluster>& targetClusters);
+    void readWUsInTargetClusterJobQueue(IEspContext& context, CWsSMCTargetCluster& targetCluster, CWsSMCQueue& jobQueue, const char* queueName);
+    void readRunningWUsAndJobQueueforOtherStatusServers(IEspContext& context, IPropertyTree* serverStatusRoot);
+    void createActiveWorkUnit(IEspContext& context, Owned<IEspActiveWorkunit>& ownedWU, const char* wuid, const char* location,
         unsigned index, const char* serverName, const char* queueName, const char* instanceName, const char* targetClusterName, bool useContext);
     void getDFUServersAndWUs(IPropertyTree* envRoot, IPropertyTree* serverStatusRoot);
     unsigned readDFUWUIDs(IPropertyTree* serverStatusRoot, const char* queueName, StringArray& wuidList);
@@ -130,16 +129,16 @@ class CActivityInfo : public CInterface, implements IInterface
     CWsSMCTargetCluster* findWUClusterInfo(const char* wuid, bool isOnECLAgent, CIArrayOf<CWsSMCTargetCluster>& targetClusters,
         CIArrayOf<CWsSMCTargetCluster>& targetClusters1, CIArrayOf<CWsSMCTargetCluster>& targetClusters2);
     CWsSMCTargetCluster* findTargetCluster(const char* clusterName, CIArrayOf<CWsSMCTargetCluster>& targetClusters);
-    bool isDuplicatedECLWUID(const char* wuid);
+    bool checkSetUniqueECLWUID(const char* wuid);
 
 public:
     IMPLEMENT_IINTERFACE;
 
-    CActivityInfo(IEspContext& _context): context(_context) {};
+    CActivityInfo() {};
     virtual ~CActivityInfo() { jobQueueSnapshot.clear(); };
 
     bool isCachedActivityInfoValid(unsigned timeOutSeconds);
-    void createActivityInfo();
+    void createActivityInfo(IEspContext& context);
 
     inline CIArrayOf<CWsSMCTargetCluster>& queryThorTargetClusters() { return thorTargetClusters; };
     inline CIArrayOf<CWsSMCTargetCluster>& queryRoxieTargetClusters() { return roxieTargetClusters; };

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -19,6 +19,7 @@
 #define _ESPWIZ_WsSMC_HPP__
 
 #include "ws_smc_esp.ipp"
+#include "wujobq.hpp"
 #include "TpWrapper.hpp"
 #include "WUXMLInfo.hpp"
 
@@ -65,6 +66,8 @@ public:
     CWsSMCQueue(bool foundQueue = false): countRunningJobs(0), countQueuedJobs(0), statusType(RunningNormal)
     {
         foundQueueInStatusServer = foundQueue;
+        countRunningJobs = 0;
+        countQueuedJobs = 0;
     }
     virtual ~CWsSMCQueue(){};
 };
@@ -89,14 +92,13 @@ public:
     virtual ~CWsSMCTargetCluster(){};
 };
 
-struct ActivityInfo : public CInterface, implements IInterface
+class CActivityInfo : public CInterface, implements IInterface
 {
-    IMPLEMENT_IINTERFACE;
-
-    ActivityInfo() {};
-    bool isCachedActivityInfoValid(unsigned timeOutSeconds);
-
+    IEspContext& context;
     CDateTime timeCached;
+    BoolHash uniqueECLWUIDs;
+
+    Owned<IJQSnapshot> jobQueueSnapshot;
 
     CIArrayOf<CWsSMCTargetCluster> thorTargetClusters;
     CIArrayOf<CWsSMCTargetCluster> roxieTargetClusters;
@@ -105,6 +107,48 @@ struct ActivityInfo : public CInterface, implements IInterface
     IArrayOf<IEspActiveWorkunit> aws;
     IArrayOf<IEspServerJobQueue> serverJobQueues;
     IArrayOf<IEspDFUJob> DFURecoveryJobs;
+
+    IPropertyTree* serverStatusRoot;
+
+    void readTargetClusterInfo(CConstWUClusterInfoArray& clusters);
+    void readTargetClusterInfo(IConstWUClusterInfo& cluster, CWsSMCTargetCluster* targetCluster);
+    bool findQueueInStatusServer(const char* serverName, const char* queueName);
+    const char *getStatusServerTypeName(WsSMCStatusServerType type);
+    void readActiveWUsAndQueuedWUs(IPropertyTree* envRoot);
+    void readRunningWUsOnStatusServer(WsSMCStatusServerType statusServerType);
+    void readWUsInTargetClusterJobQueues(CIArrayOf<CWsSMCTargetCluster>& targetClusters);
+    void readWUsInTargetClusterJobQueue(CWsSMCTargetCluster& targetCluster, CWsSMCQueue& jobQueue, const char* queueName);
+    void readWUIDsInJobQueue(const char* queueName, StringArray& wuidList);
+    void readRunningWUsAndJobQueueforOtherStatusServers();
+    void createActiveWorkUnit(Owned<IEspActiveWorkunit>& ownedWU, const char* wuid, const char* location,
+        unsigned index, const char* serverName, const char* queueName, const char* instanceName, const char* targetClusterName, bool useContext);
+    void getDFUServersAndWUs(IPropertyTree* envRoot);
+    unsigned readDFUWUIDs(const char* queueName, StringArray& wuidList);
+    void readDFUWUDetails(const char* queueName, const char* serverName, StringArray& wuidList, unsigned runningWUCount);
+    void getDFURecoveryJobs();
+    void getServerJobQueue(const char* queueName, const char* serverName, const char* serverType, const char* networkAddress, unsigned port);
+    void readServerJobQueueStatus(IEspServerJobQueue* jobQueue);
+    CWsSMCTargetCluster* findWUClusterInfo(const char* wuid, bool isOnECLAgent, CIArrayOf<CWsSMCTargetCluster>& targetClusters,
+        CIArrayOf<CWsSMCTargetCluster>& targetClusters1, CIArrayOf<CWsSMCTargetCluster>& targetClusters2);
+    CWsSMCTargetCluster* findTargetCluster(const char* clusterName, CIArrayOf<CWsSMCTargetCluster>& targetClusters);
+    bool isDuplicatedECLWUID(const char* wuid);
+
+public:
+    IMPLEMENT_IINTERFACE;
+
+    CActivityInfo(IEspContext& _context): context(_context) {};
+    virtual ~CActivityInfo() { jobQueueSnapshot.clear(); };
+
+    bool isCachedActivityInfoValid(unsigned timeOutSeconds);
+    void createActivityInfo();
+
+    inline CIArrayOf<CWsSMCTargetCluster>& queryThorTargetClusters() { return thorTargetClusters; };
+    inline CIArrayOf<CWsSMCTargetCluster>& queryRoxieTargetClusters() { return roxieTargetClusters; };
+    inline CIArrayOf<CWsSMCTargetCluster>& queryHThorTargetClusters() { return hthorTargetClusters; };
+
+    inline IArrayOf<IEspActiveWorkunit>& queryActiveWUs() { return aws; };
+    inline IArrayOf<IEspServerJobQueue>& queryServerJobQueues() { return serverJobQueues; };
+    inline IArrayOf<IEspDFUJob>& queryDFURecoveryJobs() { return DFURecoveryJobs; };
 };
 
 class CWsSMCEx : public CWsSMC
@@ -112,7 +156,7 @@ class CWsSMCEx : public CWsSMC
     long m_counter;
     CTpWrapper m_ClusterStatus;
     CriticalSection getActivityCrit;
-    Owned<ActivityInfo> activityInfoCache;
+    Owned<CActivityInfo> activityInfoCache;
     unsigned activityInfoCacheSeconds;
 
     StringBuffer m_ChatURL;
@@ -151,59 +195,30 @@ public:
     virtual bool onRoxieControlCmd(IEspContext &context, IEspRoxieControlCmdRequest &req, IEspRoxieControlCmdResponse &resp);
     virtual bool onGetStatusServerInfo(IEspContext &context, IEspGetStatusServerInfoRequest &req, IEspGetStatusServerInfoResponse &resp);
 private:
-    void addCapabilities( IPropertyTree* pFeatureNode, const char* access, 
-                                 IArrayOf<IEspCapability>& capabilities);
+    void addCapabilities( IPropertyTree* pFeatureNode, const char* access, IArrayOf<IEspCapability>& capabilities);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName,
-        const char* serverType, const char* networkAddress, unsigned port);
+        const char* serverType, const char* networkAddress, unsigned port, IJQSnapshot* jobQueueSnapshot);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName,
         const char* serverType, const char* networkAddress, unsigned port, const char* queueState, const char* queueStateDetails);
     void readBannerAndChatRequest(IEspContext& context, IEspActivityRequest &req, IEspActivityResponse& resp);
     void setBannerAndChatData(double version, IEspActivityResponse& resp);
     void getServersAndWUs(IEspContext &context, IEspActivityRequest &req, IPropertyTree* envRoot, CConstWUClusterInfoArray& clusters,
-        ActivityInfo* activityInfo);
+        CActivityInfo* activityInfo);
 
     void sortTargetClusters(IArrayOf<IEspTargetCluster>& clusters, const char* sortBy, bool descending);
-    void createActiveWorkUnit(Owned<IEspActiveWorkunit>& ownedWU, IEspContext &context, const char* wuid, const char* location,
-        unsigned index, const char* serverName, const char* queueName, const char* instanceName, const char* targetClusterName, bool useContext);
-    void readDFUWUs(IEspContext &context, const char* queueName, const char* serverName, IArrayOf<IEspActiveWorkunit>& aws);
-    void readRunningWUsOnECLAgent(IEspContext& context, IPropertyTreeIterator* itStatusECLagent, CConstWUClusterInfoArray& clusters,
-         CWsSMCTargetCluster& targetCluster, BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws);
-    void readWUsAndStateFromJobQueue(IEspContext& context, CWsSMCTargetCluster& targetCluster, CWsSMCQueue& queue, const char* listQueue, BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws);
     void addToTargetClusterList(IArrayOf<IEspTargetCluster>& clusters, IEspTargetCluster* cluster, const char* sortBy, bool descending);
-    bool findQueueInStatusServer(IEspContext& context, IPropertyTree* serverStatusRoot, const char* serverName, const char* queueName);
     void getClusterQueueStatus(const CWsSMCTargetCluster& targetCluster, ClusterStatusType& queueStatusType, StringBuffer& queueStatusDetails);
     void setClusterStatus(IEspContext& context, const CWsSMCTargetCluster& targetCluster, IEspTargetCluster* returnCluster);
     void getTargetClusterAndWUs(IEspContext& context, CConstWUClusterInfoArray& clusters, IConstWUClusterInfo& cluster,
-         IPropertyTree* serverStatusRoot, IPropertyTreeIterator* itStatusECLagent, IEspTargetCluster* returnCluster, IArrayOf<IEspActiveWorkunit>& aws);
-    void getWUsNotOnTargetCluster(IEspContext &context, IPropertyTree* serverStatusRoot, IArrayOf<IEspServerJobQueue>& serverJobQueues, IArrayOf<IEspActiveWorkunit>& aws);
-    void getDFUServersAndWUs(IEspContext &context, IPropertyTree* envRoot, IArrayOf<IEspServerJobQueue>& serverJobQueues, IArrayOf<IEspActiveWorkunit>& aws);
-    void getDFURecoveryJobs(IEspContext &context, const IPropertyTree* dfuRecoveryRoot, IArrayOf<IEspDFUJob>& jobs);
+        IPropertyTree* serverStatusRoot, IPropertyTreeIterator* itStatusECLagent, IEspTargetCluster* returnCluster, IArrayOf<IEspActiveWorkunit>& aws);
     const char* createQueueActionInfo(IEspContext &context, const char* action, IEspSMCQueueRequest &req, StringBuffer& info);
-    void setServerJobQueueStatus(double version, IEspServerJobQueue* jobQueue, const char* status, const char* details);
-    void setServerJobQueueStatus(IEspServerJobQueue* jobQueue, const char* status, const char* details);
-    void setServerJobQueueStatusDetails(IEspServerJobQueue* jobQueue, const char* status, const char* details);
     void setJobPriority(IEspContext &context, IWorkUnitFactory* factory, const char* wuid, const char* queue, WUPriorityClass& priority);
 
-    void readTargetClusterInfo(IEspContext &context, CConstWUClusterInfoArray& clusters, IPropertyTree* serverStatusRoot,
-        ActivityInfo* activityInfo);
-    void readTargetClusterInfo(IEspContext& context, IConstWUClusterInfo& cluster, IPropertyTree* serverStatusRoot, CWsSMCTargetCluster* targetCluster);
-    void readRunningWUsAndQueuedWUs(IEspContext &context, IPropertyTree* envRoot, IPropertyTree* serverStatusRoot,
-        IPropertyTree* dfuRecoveryRoot, ActivityInfo* activityInfo);
-    CWsSMCTargetCluster* findWUClusterInfo(IEspContext& context, const char* wuid, bool isOnECLAgent,
-            CIArrayOf<CWsSMCTargetCluster>& targetClusters, CIArrayOf<CWsSMCTargetCluster>& targetClusters1, CIArrayOf<CWsSMCTargetCluster>& targetClusters2);
-    CWsSMCTargetCluster* findTargetCluster(const char* clusterName, CIArrayOf<CWsSMCTargetCluster>& targetClusters);
-    void readRunningWUsOnStatusServer(IEspContext& context, IPropertyTree* serverStatusRoot, WsSMCStatusServerType statusServerType,
-            CIArrayOf<CWsSMCTargetCluster>& targetClusters, CIArrayOf<CWsSMCTargetCluster>& targetClusters1, CIArrayOf<CWsSMCTargetCluster>& targetClusters2,
-            BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws);
-    void readWUsAndStateFromJobQueue(IEspContext& context, CWsSMCTargetCluster& targetCluster, BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws);
-    void readWUsAndStateFromJobQueue(IEspContext& context, CIArrayOf<CWsSMCTargetCluster>& targetClusters, BoolHash& uniqueWUIDs, IArrayOf<IEspActiveWorkunit>& aws);
     void setESPTargetClusters(IEspContext& context, const CIArrayOf<CWsSMCTargetCluster>& targetClusters, IArrayOf<IEspTargetCluster>& respTargetClusters);
-    ActivityInfo* createActivityInfo(IEspContext &context);
     void clearActivityInfoCache();
-    ActivityInfo* getActivityInfo(IEspContext &context);
-    void setActivityResponse(IEspContext &context, ActivityInfo* activityInfo, IEspActivityRequest &req, IEspActivityResponse& resp);
+    CActivityInfo* getActivityInfo(IEspContext &context);
+    void setActivityResponse(IEspContext &context, CActivityInfo* activityInfo, IEspActivityRequest &req, IEspActivityResponse& resp);
     void addWUsToResponse(IEspContext &context, const IArrayOf<IEspActiveWorkunit>& aws, IEspActivityResponse& resp);
-    const char *getStatusServerTypeName(WsSMCStatusServerType type);
 
     void getStatusServerInfo(IEspContext &context, const char *serverType, const char *serverName, const char *networkAddress, unsigned port, IEspStatusServerInfo& statusServerInfo);
     void setTargetClusterInfo(IEspContext &context, const char *serverType, const char *serverName, const CIArrayOf<CWsSMCTargetCluster>& targetClusters,
@@ -282,4 +297,3 @@ public:
 };
 
 #endif //_ESPWIZ_WsSMC_HPP__
-


### PR DESCRIPTION
The existing WsSMC.Activity code retrieves JobQueue info
using the functions inside wujobq and dfuwu. The
createJobQueue() and copyItemsAndState() are used for an
ECL job queue. The queuedJobs() is used for a DFL job queue.
Each of those functions creates at least one connection to
Dali. Since an HPCC systrem contains multiple job queues, a
lot of the connections are created for one onActivity call.
In this fix, only one connection is used to Dali which gets
the /JobQueues tree and the tree has the JobQueue info for
all of the job queues.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
