### PR TITLE
HPCC-12300 remote copy creates ambiguous xpath

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -1177,8 +1177,11 @@ void FileSprayer::calculateSprayPartition()
         // Store discovered CSV record structure into target logical file.
         StringBuffer recStru;
         partitioners.item(0).getRecordStructure(recStru);
-        IDistributedFile * target = distributedTarget.get();
-        target->setECL(recStru.str());
+        if (recStru.length() > 0)
+        {
+            IDistributedFile * target = distributedTarget.get();
+            target->setECL(recStru.str());
+        }
     }
 
 }
@@ -2941,8 +2944,16 @@ void FileSprayer::updateTargetProperties()
 
             // and simple (top level) elements
             Owned<IPropertyTreeIterator> iter = srcAttr->getElements("*");
-            ForEach(*iter) {
-                curProps.addPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
+            ForEach(*iter)
+            {
+                const char * _propName = iter->query().queryName();
+                LOG(MCevent, unknownJob, "queryName():'%s'", _propName);
+                if (stricmp(_propName,"ECL") == 0)
+                    // To prevent multiple "ECL" properties and
+                    // keep existing source record structure definition
+                    curProps.setPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
+                else
+                    curProps.addPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
             }
         }
     }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -1172,7 +1172,7 @@ void FileSprayer::calculateSprayPartition()
     ForEachItemIn(idx2, partitioners)
         partitioners.item(idx2).getResults(partition);
 
-    if (partitioners.ordinality() > 0)
+    if ((partitioners.ordinality() > 0) && !srcAttr->hasProp("ECL"))
     {
         // Store discovered CSV record structure into target logical file.
         StringBuffer recStru;
@@ -2944,15 +2944,8 @@ void FileSprayer::updateTargetProperties()
 
             // and simple (top level) elements
             Owned<IPropertyTreeIterator> iter = srcAttr->getElements("*");
-            ForEach(*iter)
-            {
-                const char * _propName = iter->query().queryName();
-                if (stricmp(_propName,"ECL") == 0)
-                    // To prevent multiple "ECL" properties and
-                    // keep existing source record structure definition
-                    curProps.setPropTree(_propName,createPTreeFromIPT(&iter->query()));
-                else
-                    curProps.addPropTree(_propName,createPTreeFromIPT(&iter->query()));
+            ForEach(*iter) {
+                curProps.addPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
             }
         }
     }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -1179,8 +1179,8 @@ void FileSprayer::calculateSprayPartition()
         partitioners.item(0).getRecordStructure(recStru);
         if (recStru.length() > 0)
         {
-            IDistributedFile * target = distributedTarget.get();
-            target->setECL(recStru.str());
+            if (distributedTarget)
+                distributedTarget->setECL(recStru.str());
         }
     }
 
@@ -2947,13 +2947,12 @@ void FileSprayer::updateTargetProperties()
             ForEach(*iter)
             {
                 const char * _propName = iter->query().queryName();
-                LOG(MCevent, unknownJob, "queryName():'%s'", _propName);
                 if (stricmp(_propName,"ECL") == 0)
                     // To prevent multiple "ECL" properties and
                     // keep existing source record structure definition
-                    curProps.setPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
+                    curProps.setPropTree(_propName,createPTreeFromIPT(&iter->query()));
                 else
-                    curProps.addPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
+                    curProps.addPropTree(_propName,createPTreeFromIPT(&iter->query()));
             }
         }
     }


### PR DESCRIPTION
Fix 'ECL' property duplication bug.

Add code to prevent empty 'ECL' property creation.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
