### PR TITLE
HPCC-12427 GetESPServiceBaseURL(type) matches on name

### DIFF
--- a/esp/src/eclwatch/WsTopology.js
+++ b/esp/src/eclwatch/WsTopology.js
@@ -38,7 +38,7 @@ define([
                     arrayUtil.forEach(response.TpServiceQueryResponse.ServiceList.TpEspServers.TpEspServer, function (item, idx) {
                         if (lang.exists("TpBindings.TpBinding", item)) {
                             arrayUtil.forEach(item.TpBindings.TpBinding, function (binding, idx) {
-                                if (binding.Name === type) {
+                                if (binding.Service === type) {
                                     retVal = ESPRequest.getURL({
                                         port: binding.Port,
                                         pathname: ""


### PR DESCRIPTION
It should match on Service type.

Fixes HPCC-12427

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
