### PR TITLE
HPCC-12425 Display 'Total Cluster Time' in ECLWatch UI

### DIFF
--- a/esp/eclwatch/ws_XSLT/workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/workunits.xslt
@@ -23,7 +23,6 @@
    <xsl:variable name="cluster" select="/WUQueryResponse/Cluster"/>
    <xsl:variable name="roxiecluster" select="/WUQueryResponse/RoxieCluster"/>
    <xsl:variable name="state" select="/WUQueryResponse/State"/>
-   <xsl:variable name="totalThorTime" select="/WUQueryResponse/TotalThorTime"/>
    <xsl:variable name="pagesize" select="/WUQueryResponse/PageSize"/>
    <xsl:variable name="pagestartfrom" select="/WUQueryResponse/PageStartFrom"/>
    <xsl:variable name="start" select="/WUQueryResponse/StartDate"/>
@@ -326,18 +325,18 @@
                                </xsl:otherwise>
                            </xsl:choose>
                 <xsl:choose>
-                  <xsl:when test="$sortby='ThorTime' and $descending &lt; 1">
-                    <th style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('ThorTime', 1)">
-                      Total Thor Time<img src="/esp/files_/img/upsimple.png" width="10" height="10"></img>
+                  <xsl:when test="$sortby='ClusterTime' and $descending &lt; 1">
+                    <th style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('ClusterTime', 1)">
+                      Total Cluster Time<img src="/esp/files_/img/upsimple.png" width="10" height="10"></img>
                     </th>
                   </xsl:when>
-                  <xsl:when test="$sortby='ThorTime'">
-                    <th style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('ThorTime', 0)">
-                      Total Thor Time<img src="/esp/files_/img/downsimple.png" width="10" height="10"></img>
+                  <xsl:when test="$sortby='ClusterTime'">
+                    <th style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('ClusterTime', 0)">
+                      Total Cluster Time<img src="/esp/files_/img/downsimple.png" width="10" height="10"></img>
                     </th>
                   </xsl:when>
                   <xsl:otherwise>
-                    <th style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('ThorTime', 0)">Total Thor Time</th>
+                    <th style="cursor:pointer" onmouseover="bgColor='#FFFFFF'" onmouseout="bgColor='#CCCCCC'" onclick="headerClicked('ClusterTime', 0)">Total Cluster Time</th>
                   </xsl:otherwise>
                 </xsl:choose>
                            </xsl:otherwise>
@@ -720,53 +719,7 @@
          </td>
         <xsl:if test="not(string-length($archived))">
         <td>
-          <xsl:choose>
-            <xsl:when test="string-length(TotalThorTime) and not(string-length($totalThorTime)) and not(string-length($archived))">
-              <xsl:choose>
-                <xsl:when test="string-length($filters)">
-                  <xsl:choose>
-                    <xsl:when test="string-length($sortby) and $descending &lt; 1">
-                      <a href="javascript:go('/WsWorkunits/WUQuery?{$filters}&amp;TotalThorTime={TotalThorTime}&amp;Sortby={$sortby}')">
-                        <xsl:value-of select="TotalThorTime"/>
-                      </a>
-                    </xsl:when>
-                    <xsl:when test="string-length($sortby)">
-                      <a href="javascript:go('/WsWorkunits/WUQuery?{$filters}&amp;TotalThorTime={TotalThorTime}&amp;Sortby={$sortby}&amp;Descending=1')">
-                        <xsl:value-of select="TotalThorTime"/>
-                      </a>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <a href="javascript:go('/WsWorkunits/WUQuery?{$filters}&amp;TotalThorTime={TotalThorTime}')">
-                        <xsl:value-of select="TotalThorTime"/>
-                      </a>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:choose>
-                    <xsl:when test="string-length($sortby) and $descending &lt; 1">
-                      <a href="javascript:go('/WsWorkunits/WUQuery?TotalThorTime={TotalThorTime}&amp;Sortby={$sortby}')">
-                        <xsl:value-of select="TotalThorTime"/>
-                      </a>
-                    </xsl:when>
-                    <xsl:when test="string-length($sortby)">
-                      <a href="javascript:go('/WsWorkunits/WUQuery?TotalThorTime={TotalThorTime}&amp;Sortby={$sortby}&amp;Descending=1')">
-                        <xsl:value-of select="TotalThorTime"/>
-                      </a>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <a href="javascript:go('/WsWorkunits/WUQuery?TotalThorTime={TotalThorTime}')">
-                        <xsl:value-of select="TotalThorTime"/>
-                      </a>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </xsl:otherwise>
-              </xsl:choose>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="TotalThorTime"/>
-            </xsl:otherwise>
-          </xsl:choose>
+         <xsl:value-of select="TotalClusterTime"/>
         </td>
         </xsl:if>
       </tr>

--- a/esp/src/eclwatch/ESPWorkunit.js
+++ b/esp/src/eclwatch/ESPWorkunit.js
@@ -45,8 +45,8 @@ define([
 
         _watched: [],
         preRequest: function (request) {
-            if (request.Sortby && request.Sortby === "TotalThorTime") {
-                request.Sortby = "ThorTime";
+            if (request.Sortby && request.Sortby === "TotalClusterTime") {
+                request.Sortby = "ClusterTime";
             }
         },
         create: function (id) {

--- a/esp/src/eclwatch/WUQueryWidget.js
+++ b/esp/src/eclwatch/WUQueryWidget.js
@@ -395,7 +395,7 @@ define([
                     Cluster: { label: this.i18n.Cluster, width: 90 },
                     RoxieCluster: { label: this.i18n.RoxieCluster, width: 99 },
                     State: { label: this.i18n.State, width: 90 },
-                    TotalThorTime: { label: this.i18n.TotalThorTime, width: 117 }
+                    TotalClusterTime: { label: this.i18n.TotalClusterTime, width: 117 }
                 }
             }, this.id + "WorkunitsGrid");
 

--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -506,7 +506,7 @@ define({root:
     Top: "Top",
     ToSizes: "To Sizes",
     TotalSize: "Total Size",
-    TotalThorTime: "Total Thor Time",
+    TotalClusterTime: "Total Cluster Time",
     TransitionGuide: "Transition Guide",
     Tree: "Tree",
     Type: "Type",

--- a/esp/src/eclwatch/templates/WUDetailsWidget.html
+++ b/esp/src/eclwatch/templates/WUDetailsWidget.html
@@ -84,8 +84,8 @@
                                 <div id="${id}Cluster"></div>
                             </li>
                             <li>
-                                <label class="Prompt" for="${id}TotalThorTime">${i18n.TotalThorTime}:</label>
-                                <div id="${id}TotalThorTime"></div>
+                                <label class="Prompt" for="${id}TotalClusterTime">${i18n.TotalClusterTime}:</label>
+                                <div id="${id}TotalClusterTime"></div>
                             </li>
                         </ul>
                     </form>


### PR DESCRIPTION
The existing ECLWatch displays the 'Total Thor Time' inside
both ECL Workunits page and ECL WU Details page. The 'total
cluster time' has been added for hthor and roxie. The timing
information, as well as the 'total thor time', should be
displayed under new name 'total cluster time' in both pages.

This fix includes both legacy ECLWatch and new ECLWatch. The
related code in legacy ECLWatch is also cleaned.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
