### PR TITLE
HPCC-12347 Refresh graph only merged new data into control

### DIFF
--- a/esp/src/eclwatch/GraphPageWidget.js
+++ b/esp/src/eclwatch/GraphPageWidget.js
@@ -416,9 +416,9 @@ define([
 
         refreshData: function () {
             if (lang.exists("params.Wuid", this)) {
-                this.refreshGraphFromWU(this.wu, this.graphName);
+                this.loadGraphFromWu(this.wu, this.graphName, true);
             } else if (lang.exists("params.QueryId", this)) {
-                this.refreshGraphFromQuery(this.targetQuery, this.queryId, this.graphName);
+                this.loadGraphFromQuery(this.targetQuery, this.queryId, this.graphName);
             }
         },
 
@@ -477,7 +477,7 @@ define([
             this.loadEdges();
         },
 
-        loadGraphFromWu: function (wu, graphName) {
+        loadGraphFromWu: function (wu, graphName, refresh) {
             var deferred = new Deferred();
             this.overview.setMessage(this.i18n.FetchingData);
             this.main.setMessage(this.i18n.FetchingData);
@@ -489,7 +489,7 @@ define([
                 context.local.setMessage("");
                 context.loadGraphFromXGMML(xgmml, svg);
                 deferred.resolve();
-            });
+            }, refresh);
             return deferred.promise;
         },
 

--- a/esp/src/eclwatch/GraphTreeWidget.js
+++ b/esp/src/eclwatch/GraphTreeWidget.js
@@ -421,9 +421,9 @@ define([
 
         refreshData: function () {
             if (lang.exists("params.Wuid", this)) {
-                this.refreshGraphFromWU(this.wu, this.graphName);
+                this.loadGraphFromWu(this.wu, this.graphName, true);
             } else if (lang.exists("params.QueryId", this)) {
-                this.refreshGraphFromQuery(this.targetQuery, this.queryId, this.graphName);
+                this.loadGraphFromQuery(this.targetQuery, this.queryId, this.graphName);
             }
         },
 
@@ -465,7 +465,7 @@ define([
             this.loadEdges();
         },
 
-        loadGraphFromWu: function (wu, graphName) {
+        loadGraphFromWu: function (wu, graphName, refresh) {
             var deferred = new Deferred();
             this.main.setMessage(this.i18n.FetchingData);
             var context = this;
@@ -473,7 +473,7 @@ define([
                 context.main.setMessage("");
                 context.loadGraphFromXGMML(xgmml, svg);
                 deferred.resolve();
-            });
+            }, refresh);
             return deferred.promise;
         },
 


### PR DESCRIPTION
Refresh graph should re-fetch the data and do a clean load.

Fixes HPCC-12347

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
