### PR TITLE
HPCC-12435 Remove leading '~' character from logical file name provided by queryLogicalFilename() on hthor

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -7826,7 +7826,11 @@ void CHThorDiskReadBaseActivity::resolve()
     else
     {
         ldFile.setown(agent.resolveLFN(mangledHelperFileName.str(), "Read", 0 != (helper.getFlags() & TDRoptional)));
-        logicalFileName.set(mangledHelperFileName.str());
+        if ( mangledHelperFileName.charAt(0) == '~')
+            logicalFileName.set(mangledHelperFileName.str()+1);
+        else
+            logicalFileName.set(mangledHelperFileName.str());
+
         if (ldFile)
         {
             Owned<IFileDescriptor> fdesc;


### PR DESCRIPTION
Add fix.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
