### PR TITLE
HPCC-9293 Ensure spill names are consistent for each compile

### DIFF
--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -1887,6 +1887,7 @@ public:
     inline unsigned __int64 getUniqueId() { return ::getUniqueId(); } //{ return ++nextUid; }
     inline StringBuffer & getUniqueId(StringBuffer & target) { return appendUniqueId(target, getUniqueId()); }
     inline unsigned curGraphSequence() const { return activeGraph ? graphSeqNumber : 0; }
+    UniqueSequenceCounter & querySpillSequence() { return spillSequence; }
 
 public:
     void traceExpression(const char * title, IHqlExpression * expr, unsigned level=500);
@@ -1944,6 +1945,7 @@ protected:
     unsigned            nextFieldId;
     HqlExprArray        internalFunctions;
     HqlExprArray        internalFunctionExternals;
+    UniqueSequenceCounter spillSequence;
     
 #ifdef SPOT_POTENTIAL_COMMON_ACTIVITIES
     LocationArray       savedActivityLocations;

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -539,7 +539,7 @@ IHqlExpression * CResourceOptions::createSpillName(bool isGraphResult)
 
     StringBuffer s;
     s.append("~spill::");
-    getUniqueId(s);
+    appendUniqueId(s, spillSequence.next());
     return createConstant(s.str());
 }
 
@@ -1260,7 +1260,7 @@ IHqlExpression * ResourcerInfo::createSpillName()
         else if (useGlobalResult())
         {
             StringBuffer valueText;
-            getUniqueId(valueText.append("spill"));
+            appendUniqueId(valueText.append("spill"), options->spillSequence.next());
             spillName.setown(createConstant(valueText.str()));
         }
         else
@@ -1886,7 +1886,8 @@ IHqlExpression * ResourcerInfo::wrapRowOwn(IHqlExpression * expr)
 
 //---------------------------------------------------------------------------
 
-EclResourcer::EclResourcer(IErrorReceiver & _errors, IConstWorkUnit * _wu, ClusterType _targetClusterType, unsigned _clusterSize, const HqlCppOptions & _translatorOptions)
+EclResourcer::EclResourcer(IErrorReceiver & _errors, IConstWorkUnit * _wu, ClusterType _targetClusterType, unsigned _clusterSize, const HqlCppOptions & _translatorOptions, UniqueSequenceCounter & spillSequence)
+: options(spillSequence)
 { 
     wu.set(_wu);
     errors = &_errors;
@@ -5672,7 +5673,7 @@ IHqlExpression * resourceThorGraph(HqlCppTranslator & translator, IHqlExpression
 {
     HqlExprArray transformed;
     {
-        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
+        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions(), translator.querySpillSequence());
         if (graphIdExpr)
             resourcer.setNewChildQuery(graphIdExpr, 0);
 
@@ -5690,7 +5691,7 @@ static IHqlExpression * doResourceGraph(HqlCppTranslator & translator, HqlExprCo
     HqlExprArray transformed;
     unsigned totalResults;
     {
-        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
+        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions(), translator.querySpillSequence());
         if (isChild)
             resourcer.setChildQuery(true);
         resourcer.setNewChildQuery(graphIdExpr, numResults);
@@ -5738,7 +5739,7 @@ IHqlExpression * resourceRemoteGraph(HqlCppTranslator & translator, IHqlExpressi
 {
     HqlExprArray transformed;
     {
-        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions());
+        EclResourcer resourcer(translator.queryErrorProcessor(), translator.wu(), targetClusterType, clusterSize, translator.queryOptions(), translator.querySpillSequence());
 
         resourcer.resourceRemoteGraph(expr, transformed);
     }

--- a/ecl/hqlcpp/hqlresource.ipp
+++ b/ecl/hqlcpp/hqlresource.ipp
@@ -38,12 +38,47 @@ enum ResourceType {
 class CResourceOptions
 {
 public:
-    CResourceOptions() { memset(this, 0, sizeof(*this)); state.updateSequence = 0; }
+    CResourceOptions(UniqueSequenceCounter & _spillSequence)
+    : spillSequence(_spillSequence)
+    {
+        filteredSpillThreshold = 0;
+        minimizeSpillSize = 0;
+        allowThroughSpill = false;
+        allowThroughResult = false;
+        cloneFilteredIndex = false;
+        spillSharedConditionals = false;
+        shareDontExpand = false;
+        useGraphResults = false;
+        noConditionalLinks = false;
+        minimiseSpills = false;
+        hoistResourced = false;
+        isChildQuery = false;
+        groupedChildIterators = false;
+        allowSplitBetweenSubGraphs = false;
+        preventKeyedSplit = false;
+        preventSteppedSplit = false;
+        minimizeSkewBeforeSpill = false;
+        expandSingleConstRow = false;
+        createSpillAsDataset = false;
+        optimizeSharedInputs = false;
+        combineSiblings = false;
+        actionLinkInNewGraph = false;
+        convertCompoundToExecuteWhen = false;
+        useResultsForChildSpills = false;
+        alwaysUseGraphResults = false;
+        newBalancedSpotter = false;
+        graphIdExpr = NULL;
+        nextResult = 0;
+        clusterSize = 0;
+        targetClusterType = ThorLCRCluster;
+        state.updateSequence = 0;
+    }
 
     IHqlExpression * createSpillName(bool isGraphResult);
     void noteGraphsChanged() { state.updateSequence++; }
 
 public:
+    UniqueSequenceCounter & spillSequence;
     unsigned filteredSpillThreshold;
     unsigned minimizeSpillSize;
     bool     allowThroughSpill;
@@ -427,7 +462,7 @@ class EclResourcer
     friend class SelectHoistTransformer;
     friend class CSplitterInfo;
 public:
-    EclResourcer(IErrorReceiver & _errors, IConstWorkUnit * _wu, ClusterType _targetClusterType, unsigned _clusterSize, const HqlCppOptions & _translatorOptions);
+    EclResourcer(IErrorReceiver & _errors, IConstWorkUnit * _wu, ClusterType _targetClusterType, unsigned _clusterSize, const HqlCppOptions & _translatorOptions, UniqueSequenceCounter & _spillSequence);
     ~EclResourcer();
 
     void resourceGraph(IHqlExpression * expr, HqlExprArray & transformed);


### PR DESCRIPTION
It makes it easier to compare locally generated work units, and
the simpler names make the spills easier to read.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
