### PR TITLE
HPCC-12303 Fix incorrect return check for BoolHash getValue

### DIFF
--- a/esp/services/ws_dfu/ws_dfuXRefService.cpp
+++ b/esp/services/ws_dfu/ws_dfuXRefService.cpp
@@ -496,7 +496,10 @@ bool CWsDfuXRefEx::onDFUXRefList(IEspContext &context, IEspDFUXRefListRequest &r
             ForEachItemIn(i,primaryThorProcesses)
             {
                 const char *thorProcess = primaryThorProcesses.item(i);
-                if (uniqueProcesses.getValue(thorProcess))
+                if (!thorProcess || !*thorProcess)
+                    continue;
+                bool* found = uniqueProcesses.getValue(thorProcess);
+                if (found && *found)
                     continue;
                 uniqueProcesses.setValue(thorProcess, true);
                 addXRefNode(thorProcess, pXRefNodeTree);

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -309,7 +309,8 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
             getClusterGroupName(cluster, thorClusterGroupName);
             if (!thorClusterGroupName.length())
                 continue;
-            if (uniqueThorClusterGroupNames.getValue(thorClusterGroupName.str()))
+            bool* found = uniqueThorClusterGroupNames.getValue(thorClusterGroupName.str());
+            if (found && *found)
                 continue;
 
             uniqueThorClusterGroupNames.setValue(thorClusterGroupName.str(), true);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1068,7 +1068,10 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
         {
             SCMStringBuffer processName;
             thorInstances->str(processName);
-            if ((processName.length() < 1) || uniqueProcesses.getValue(processName.str()))
+            if (processName.length() < 1)
+                continue;
+            bool* found = uniqueProcesses.getValue(processName.str());
+            if (found && *found)
                 continue;
 
             uniqueProcesses.setValue(processName.str(), true);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -477,7 +477,8 @@ void CWsWorkunitsEx::refreshValidClusters()
     {
         SCMStringBuffer s;
         IStringVal &val = it->str(s);
-        if (!validClusters.getValue(val.str()))
+        bool* found = validClusters.getValue(val.str());
+        if (!found || !*found)
             validClusters.setValue(val.str(), true);
     }
 }
@@ -487,7 +488,8 @@ bool CWsWorkunitsEx::isValidCluster(const char *cluster)
     if (!cluster || !*cluster)
         return false;
     CriticalBlock block(crit);
-    if (validClusters.getValue(cluster))
+    bool* found = validClusters.getValue(cluster);
+    if (found && *found)
         return true;
     if (validateTargetClusterName(cluster))
     {
@@ -4127,13 +4129,16 @@ bool CWsWorkunitsEx::onWUGetZAPInfo(IEspContext &context, IEspWUGetZAPInfoReques
         }
 
         //Get Thor IP
-        BoolHash uniqueProcesses, uniqueThorIPs;
+        BoolHash uniqueProcesses;
         Owned<IStringIterator> thorInstances = cw->getProcesses("Thor");
         ForEach (*thorInstances)
         {
             SCMStringBuffer processName;
             thorInstances->str(processName);
-            if ((processName.length() < 1) || uniqueProcesses.getValue(processName.str()))
+            if (processName.length() < 1)
+                continue;
+            bool* found = uniqueProcesses.getValue(processName.str());
+            if (found && *found)
                 continue;
 
             uniqueProcesses.setValue(processName.str(), true);


### PR DESCRIPTION
Two groups of code changes are made in the ECLWatch ESP services:
1. Fix incorrect return check for BoolHash getValue().
2. In ws_machine service, replace the CIArrayOf<CStateHash> with
MapStringToMyClass<IStateHash>.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
