### PR TITLE
HPCC-12428 Java package support is broken

### DIFF
--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -1297,13 +1297,16 @@ public:
         {
             prevtext.clear();
             // Name should be in the form class.method:signature
-            const char *funcname = strchr(text, '.');
+            const char *funcname = strrchr(text, '.');
             if (!funcname)
                 throw MakeStringException(MSGAUD_user, 0, "javaembed: Invalid import name %s - Expected classname.methodname:signature", text.str());
             const char *signature = strchr(funcname, ':');
             if (!signature)
                 throw MakeStringException(MSGAUD_user, 0, "javaembed: Invalid import name %s - Expected classname.methodname:signature", text.str());
             StringBuffer classname(funcname-text, text);
+            // While it's probably preferred for people to use . as the separator in nested classes (to match java import statement),
+            // we accept / too (to match what you would see in the jar)
+            classname.replace('/', '.');
             funcname++;  // skip the '.'
             StringBuffer methodname(signature-funcname, funcname);
             signature++; // skip the ':'


### PR DESCRIPTION
Java classloader requires . not / to separate packages, but we could not parse
a classname containing a .

Fix both ways - accept / as the package separator, and parse classnames that
contain ., so that either will be accepted.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
