### PR TITLE
HPCC-12450 Return start/stop clock time for graph

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -73,6 +73,8 @@ ESPStruct [nil_remove] ECLGraph
     [min_ver("1.09")] bool Complete;
     [min_ver("1.14")] bool Failed;
     int64 RunningId;
+    [min_ver("1.53")]string WhenStarted;
+    [min_ver("1.53")]string WhenFinished;
 };
 //  ===========================================================================
 ESPStruct [nil_remove] ECLGraphEx

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -767,6 +767,17 @@ void WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
                 g->setRunningId(id);
             }
 
+            if (version >= 1.53)
+            {
+                SCMStringBuffer s;
+                Owned<IConstWUStatistic> whenGraphStarted = cw->getStatistic(NULL, name.str(), StWhenGraphStarted);
+                Owned<IConstWUStatistic> whenGraphFinished = cw->getStatistic(NULL, name.str(), StWhenGraphFinished);
+                if (whenGraphStarted)
+                    g->setWhenStarted(whenGraphStarted->getFormattedValue(s).str());
+                if (whenGraphFinished)
+                    g->setWhenFinished(whenGraphFinished->getFormattedValue(s).str());
+            }
+
             Owned<IConstWUGraphProgress> progress = cw->getGraphProgress(name.str());
             if (progress)
             {


### PR DESCRIPTION
In this fix, the start/stop clock time for each ECL graph
are read from workunit statistics interface (kind=
'WhenGraphStarted' and kind='WhenGraphFinished') and
returned by WsWorkunits.WUinfo response.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
