### PR TITLE
HPCC-2566 Allow attribute values to be specified on the command line

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -2141,7 +2141,7 @@ const char * const helpText[] = {
 #ifdef _WIN32
     "!   -brk <n>      Trigger a break point in eclcc after nth allocation",
 #endif
-    "    -Dname=value  Override the setting of a particular attribute",
+    "!   -Dname=value  Override the definition of a global attribute 'name'",
     "!   --deny=all    Disallow use of all named features not specifically allowed using --allow",
     "!   --deny=str    Disallow use of named feature",
     "    -help, --help Display this message",

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -299,6 +299,7 @@ protected:
     void processFile(EclCompileInstance & info);
     void processReference(EclCompileInstance & instance, const char * queryAttributePath);
     void processBatchFiles();
+    void processDefinitions(EclRepositoryArray & repositories);
     void reportCompileErrors(IErrorReceiver & errorProcessor, const char * processName);
     void setDebugOption(const char * name, bool value);
     void usage();
@@ -338,6 +339,7 @@ protected:
     StringArray inputFileNames;
     StringArray applicationOptions;
     StringArray debugOptions;
+    StringArray definitions;
     StringArray warningMappings;
     StringArray compileOptions;
     StringArray linkOptions;
@@ -1216,6 +1218,47 @@ void EclCC::processSingleQuery(EclCompileInstance & instance,
         updateWorkunitTimeStat(instance.wu, SSTcompilestage, "compile", StTimeElapsed, NULL, totalTimeNs);
 }
 
+void EclCC::processDefinitions(EclRepositoryArray & repositories)
+{
+    ForEachItemIn(iDef, definitions)
+    {
+        const char * definition = definitions.item(iDef);
+        StringAttr name;
+        StringBuffer value;
+        const char * eq = strchr(definition, '=');
+        if (eq)
+        {
+            name.set(definition, eq-definition);
+            value.append(eq+1);
+        }
+        else
+        {
+            name.set(definition);
+            value.append("true");
+        }
+        value.append(";");
+
+        StringAttr module;
+        const char * attr;
+        const char * dot = strrchr(name, '.');
+        if (dot)
+        {
+            module.set(name, dot-name);
+            attr = dot+1;
+        }
+        else
+        {
+            module.set("");
+            attr = name;
+        }
+
+        //Create a repository with just that attribute.
+        Owned<IFileContents> contents = createFileContentsFromText(value, NULL);
+        repositories.append(*createSingleDefinitionEclRepository(module, attr, contents));
+    }
+}
+
+
 void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML)
 {
     instance.srcArchive.setown(createPTreeFromXMLString(archiveXML, ipt_caseInsensitive));
@@ -1226,6 +1269,20 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
     {
         IPropertyTree &item = iter->query();
         instance.wu->setDebugValue(item.queryProp("@name"), item.queryProp("@value"), true);
+    }
+
+    //Mainly for testing...
+    Owned<IPropertyTreeIterator> iterDef = archiveTree->getElements("Definition");
+    ForEach(*iterDef)
+    {
+        IPropertyTree &item = iterDef->query();
+        const char * name = item.queryProp("@name");
+        const char * value = item.queryProp("@value");
+        StringBuffer definition;
+        definition.append(name);
+        if (value)
+            definition.append('=').append(value);
+        definitions.append(definition);
     }
 
     const char * queryText = archiveTree->queryProp("Query");
@@ -1260,6 +1317,8 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
         archiveCollection.setown(createArchiveEclCollection(archiveTree));
 
     EclRepositoryArray repositories;
+    //Items first in the list have priority -Dxxx=y overrides all
+    processDefinitions(repositories);
     repositories.append(*LINK(pluginsRepository));
     if (archiveTree->getPropBool("@useLocalSystemLibraries", false)) // Primarily for testing.
         repositories.append(*LINK(libraryRepository));
@@ -1297,6 +1356,7 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
     }
 
     repositories.append(*createRepository(archiveCollection));
+
     instance.dataServer.setown(createCompoundRepository(repositories));
 
     //Ensure classes are not linked by anything else
@@ -1363,6 +1423,8 @@ void EclCC::processFile(EclCompileInstance & instance)
             expandedSourceName.append(curFilename);
 
         EclRepositoryArray repositories;
+        //Items first in the list have priority -Dxxx=y overrides all
+        processDefinitions(repositories);
         repositories.append(*LINK(pluginsRepository));
         repositories.append(*LINK(libraryRepository));
         if (bundlesRepository)
@@ -1793,6 +1855,10 @@ bool EclCC::parseCommandLineOptions(int argc, const char* argv[])
             else
                 deniedPermissions.append(tempArg);
         }
+        else if (iter.matchFlag(tempArg, "-D"))
+        {
+            definitions.append(tempArg);
+        }
         else if (iter.matchFlag(optArchive, "-E"))
         {
         }
@@ -2075,6 +2141,7 @@ const char * const helpText[] = {
 #ifdef _WIN32
     "!   -brk <n>      Trigger a break point in eclcc after nth allocation",
 #endif
+    "    -Dname=value  Override the setting of a particular attribute",
     "!   --deny=all    Disallow use of all named features not specifically allowed using --allow",
     "!   --deny=str    Disallow use of named feature",
     "    -help, --help Display this message",

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -256,9 +256,9 @@ class EclccCompileThread : public CInterface, implements IPooledThread, implemen
         {
             //Allow eclcc-xx-<n> so that multiple values can be passed through for the same named debug symbol
             const char * start = option + (*option=='-' ? 1 : 6);
-            const char * dash = strchr(start, '-');     // position of second dash, if present
+            const char * dash = strrchr(start, '-');     // position of second dash, if present
             StringAttr optName;
-            if (dash)
+            if (dash && (dash != start))
                 optName.set(start, dash-start);
             else
                 optName.set(start);
@@ -278,14 +278,19 @@ class EclccCompileThread : public CInterface, implements IPooledThread, implemen
                 eclccCmd.appendf(" -I%s", value);
             else if (stricmp(optName, "libraryPath") == 0)
                 eclccCmd.appendf(" -L%s", value);
-            else if (stricmp(start, "-allow")==0 || stricmp(optName, "-allow")==0)
+            else if (stricmp(optName, "-allow")==0)
             {
                 if (isLocal)
                     throw MakeStringException(0, "eclcc-allow option can not be set per-workunit");  // for security reasons
-                eclccCmd.appendf(" -%s=%s", start, value);
+                eclccCmd.appendf(" -%s=%s", optName.get(), value);
+            }
+            else if (*optName == 'd')
+            {
+                //Short term work around for the problem that all debug names get lower-cased
+                eclccCmd.appendf(" -D%s=%s", optName.get()+1, value);
             }
             else
-                eclccCmd.appendf(" -%s=%s", start, value);
+                eclccCmd.appendf(" -%s=%s", optName.get(), value);
         }
         else if (strchr(option, '-'))
         {

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -410,6 +410,20 @@ public:
                     cmdLine.append('=').append(value);
             }
         }
+        if (cmd.definitions.length())
+        {
+            ForEachItemIn(i, cmd.definitions)
+            {
+                IEspNamedValue &item = cmd.definitions.item(i);
+                const char *name = item.getName();
+                const char *value = item.getValue();
+                cmdLine.append(" \"-D").append(name);
+                if (value)
+                    cmdLine.append('=').append(value);
+                cmdLine.append("\"");
+            }
+            cmd.definitions.kill();
+        }
         if ((int)cmd.optResultLimit > 0)
         {
             cmdLine.append(" -fapplyInstantEclTransformations=1");
@@ -555,6 +569,8 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     }
     if (matchVariableOption(iter, 'f', debugValues))
+        return EclCmdOptionMatch;
+    if (matchVariableOption(iter, 'D', definitions))
         return EclCmdOptionMatch;
     if (iter.matchPathFlag(optLibPath, ECLOPT_LIB_PATH_S))
         return EclCmdOptionMatch;

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -158,6 +158,7 @@ bool extractEclCmdOption(bool & option, IProperties * globals, const char * envN
 bool extractEclCmdOption(unsigned & option, IProperties * globals, const char * envName, const char * propertyName, unsigned defval);
 
 bool matchVariableOption(ArgvIterator &iter, const char prefix, IArrayOf<IEspNamedValue> &values);
+void addNamedValue(const char * name, const char * value, IArrayOf<IEspNamedValue> &values);
 
 enum eclObjParameterType
 {
@@ -256,6 +257,7 @@ public:
             "   --ecl-only             Send ecl text to hpcc without generating archive\n"
             "   --limit=<limit>        Sets the result limit for the query, defaults to 100\n"
             "   -f<option>[=value]     Set an ECL option (equivalent to #option)\n"
+            "   -Dname=value           Override the definition of a global attribute 'name'\n"
             " eclcc options:\n"
             "   -Ipath                 Add path to locations to search for ecl imports\n"
             "   -Lpath                 Add path to locations to search for system libraries\n"
@@ -272,6 +274,7 @@ public:
     StringAttr optAttributePath;
     StringAttr optSnapshot;
     IArrayOf<IEspNamedValue> debugValues;
+    IArrayOf<IEspNamedValue> definitions;
     unsigned optResultLimit;
     bool optNoArchive;
     bool optLegacy;

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -51,6 +51,21 @@ size32_t getMaxRequestEntityLength(EclCmdCommon &cmd)
     return config->getPropInt("Software[1]/EspProcess[1]/EspProtocol[@type='http_protocol'][1]/@maxRequestEntityLength");
 }
 
+void expandDefintionsAsDebugValues(const IArrayOf<IEspNamedValue> & definitions, IArrayOf<IEspNamedValue> & debugValues)
+{
+    ForEachItemIn(i, definitions)
+    {
+        IEspNamedValue &item = definitions.item(i);
+        const char *name = item.getName();
+        const char *value = item.getValue();
+
+        StringBuffer passThroughName;
+        passThroughName.append("eclcc-D").append(name).append("-").append(i);
+        addNamedValue(passThroughName, value, debugValues);
+    }
+
+}
+
 bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *cluster, const char *name, StringBuffer *wuid, StringBuffer *wucluster, bool noarchive, bool displayWuid=true, bool compress=true)
 {
     bool useCompression = false;
@@ -119,6 +134,7 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
         req->setQueryMainDefinition(cmd.optAttributePath);
     if (cmd.optSnapshot.length())
         req->setSnapshot(cmd.optSnapshot);
+    expandDefintionsAsDebugValues(cmd.definitions, cmd.debugValues);
     if (cmd.debugValues.length())
     {
         req->setDebugValues(cmd.debugValues);
@@ -591,6 +607,7 @@ public:
             req->setInput(optInput.get());
         req->setExceptionSeverity(optExceptionSeverity); //throws exception if invalid value
 
+        expandDefintionsAsDebugValues(definitions, debugValues);
         if (debugValues.length())
             req->setDebugValues(debugValues);
         if (variables.length())

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -713,6 +713,9 @@ importId
     | '$'               {
                             $$.setExpr(createAttribute(selfAtom), $1);
                         }
+    | '^'               {
+                            $$.setExpr(createAttribute(_root_Atom), $1);
+                        }
     | importId '.' UNKNOWN_ID
                         {
                             $$.setExpr(createAttribute(_dot_Atom, $1.getExpr(), createId($3.getId())), $1);

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -10067,10 +10067,18 @@ inline bool isDollarModule(IHqlExpression * expr)
     return expr->isAttribute() && (expr->queryName() == selfAtom);
 }
 
+inline bool isRootModule(IHqlExpression * expr)
+{
+    return expr->isAttribute() && (expr->queryName() == _root_Atom);
+}
+
 IHqlExpression * HqlGram::resolveImportModule(const attribute & errpos, IHqlExpression * expr)
 {
     if (isDollarModule(expr))
         return LINK(queryExpression(globalScope));
+    if (isRootModule(expr))
+        return LINK(queryExpression(lookupCtx.queryRepository()->queryRootScope()));
+
     IAtom * name = expr->queryName();
     if ((name != _dot_Atom) && (name != _container_Atom))
     {
@@ -10191,8 +10199,16 @@ void HqlGram::processImport(attribute & modulesAttr, IIdAtom * aliasName)
     {
         IHqlExpression & cur = modules.item(i);
         //IMPORT $; is a no-op.  Don't add the real name of the $ module into scope
-        if (!aliasName && isDollarModule(&cur))
-            continue;
+        if (!aliasName)
+        {
+            if (isDollarModule(&cur))
+                continue;
+            if (isRootModule(&cur))
+            {
+                reportError(ERR_BAD_IMPORT, modulesAttr, "An alias name must be provided when importing ^");
+                return;
+            }
+        }
 
         OwnedHqlExpr module = resolveImportModule(modulesAttr, &cur);
         if (module)

--- a/ecl/regress/doption.eclxml
+++ b/ecl/regress/doption.eclxml
@@ -1,0 +1,29 @@
+<Archive>
+    <Definition name="gch.val1" value="10"/>
+    <Definition name="val2" value="'hello'"/>
+    <Module name="gch">
+        <Attribute name="val1">
+            export val1 := 1234;
+        </Attribute>
+    </Module>
+    <Module name="blah.blah">
+        <Attribute name="val1">
+            export val1 := 3.1415;
+        </Attribute>
+    </Module>
+    <Module name="">
+        <Attribute name="val2">
+            export val2 := 5678;
+        </Attribute>
+    </Module>
+    <Query>
+
+        import gch;
+        import ^ as root;
+        import blah;
+        gch.val1;
+        root.val2;
+        blah.blah.val1;
+
+    </Query>
+</Archive>

--- a/ecl/regress/doption2.ecl
+++ b/ecl/regress/doption2.ecl
@@ -1,0 +1,3 @@
+import ^ as root;
+#IFDEFINED(gch.val1, 'undefined');
+#IFDEFINED(root.val2, 'unknown');

--- a/ecl/regress/doption2.ecl
+++ b/ecl/regress/doption2.ecl
@@ -1,3 +1,3 @@
 import ^ as root;
-#IFDEFINED(gch.val1, 'undefined');
+#IFDEFINED(root.gch.val1, 'undefined');
 #IFDEFINED(root.val2, 'unknown');

--- a/ecl/regress/doption3.eclxml
+++ b/ecl/regress/doption3.eclxml
@@ -1,0 +1,25 @@
+<Archive>
+    <Definition name="blah.blah.blah.blah" value="'blah'"/>
+    <Module name="definitions">
+        <Attribute name="val1">
+            export val1 := 'hi';
+        </Attribute>
+    </Module>
+    <Module name="">
+        <Attribute name="val2">
+            export val2 := 'defined';
+        </Attribute>
+    </Module>
+    <Query>
+
+        import definitions;
+        import ^ as root;
+        val1 := 'me';
+        #IFDEFINED(val1, 'undefined');
+        #IFDEFINED(definitions.val1, 'undefined');
+        #IFDEFINED(root.val2, 'undefined');
+        import blah;
+        blah.blah.blah.blah;
+
+    </Query>
+</Archive>


### PR DESCRIPTION
Also allow ^ as a synonym for the root scope.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
