### PR TITLE
HPCC-12416 Regression suite run is creating temporary ecl file that is not cleaned up

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -312,6 +312,11 @@ class Regression:
 
         except Exception as e:
             self.StopTimeoutThread()
+            suite.close()
+            raise(e)
+
+        except KeyboardInterrupt as e:
+            suite.close()
             raise(e)
 
 
@@ -391,8 +396,12 @@ class Regression:
 
         except Exception as e:
             self.StopTimeoutThread()
+            suite.close()
             raise(e)
 
+        except KeyboardInterrupt as e:
+            suite.close()
+            raise(e)
 
     def runSuiteQ(self, clusterName, eclfile):
         report = self.buildLogging(clusterName)
@@ -430,6 +439,11 @@ class Regression:
 
         except Exception as e:
             self.StopTimeoutThread()
+            eclfile.close()
+            raise(e)
+
+        except KeyboardInterrupt as e:
+            eclfile.close()
             raise(e)
 
     def runQuery(self, cluster, query, report, cnt=1, publish=False,  th = 0):

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -49,7 +49,7 @@ class Suite:
             pass
 
         # If there are some temprary files left, then remove them
-        for file in glob.glob(self.dir_ec+'/_tmp*.ecl'):
+        for file in glob.glob(self.dir_ec+'/_temp*.ecl'):
             os.unlink(file)
 
         self.buildSuite(args, isSetup, fileList)
@@ -163,3 +163,7 @@ class Suite:
     def close(self):
         for ecl in self.suite:
             ecl.close()
+
+        # If there are some temprary files left, then remove them
+        for file in glob.glob(self.dir_ec+'/_temp*.ecl'):
+            os.unlink(file)

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -48,9 +48,7 @@ class Suite:
             self.dynamicSources=checkClusters(self.dynamicSources,  "Dynamic source")
             pass
 
-        # If there are some temprary files left, then remove them
-        for file in glob.glob(self.dir_ec+'/_temp*.ecl'):
-            os.unlink(file)
+        self.cleanUp()
 
         self.buildSuite(args, isSetup, fileList)
 
@@ -160,10 +158,12 @@ class Suite:
     def getSuiteName(self):
         return self.name
 
+    def cleanUp(self):
+        # If there are some temporary files left, then remove them
+        for file in glob.glob(self.dir_ec+'/_temp*.ecl'):
+            os.unlink(file)
+
     def close(self):
         for ecl in self.suite:
             ecl.close()
-
-        # If there are some temprary files left, then remove them
-        for file in glob.glob(self.dir_ec+'/_temp*.ecl'):
-            os.unlink(file)
+        self.cleanUp()


### PR DESCRIPTION
Add code to close suite when Ctr-C (KeyboardInterrupt exception) raised
into runSuiteQ(), runSuite() and runSuiteP() methods

Add code to remove all remaining, temporary generated ECL file into suite
init() and close() methods

Signed-off-by: Attila Vamos attila.vamos@gmail.com
