### PR TITLE
HPCC-12415 Excessive tracing from cassandra plugin

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -11601,7 +11601,7 @@ void HqlCppTranslator::buildScriptFunctionDefinition(BuildCtx &funcctx, IHqlExpr
     OwnedHqlExpr pluginPtr = createQuoted("Owned<IEmbedContext> __plugin", makeBoolType());  // Not really bool - at some point ECL may support without this aliasing...
     buildAssignToTemp(funcctx, pluginPtr, getPlugin);
     StringBuffer createParam;
-    createParam.append("Owned<IEmbedFunctionContext> __ctx = __plugin->createFunctionContext(");
+    createParam.append("Owned<IEmbedFunctionContext> __ctx = __plugin->createFunctionContextEx(ctx,");
     createParam.append(isImport ? "EFimport" : "EFembed");
     if (returnType->getTypeCode()==type_void)
         createParam.append("|EFnoreturn");

--- a/plugins/Rembed/Rembed.cpp
+++ b/plugins/Rembed/Rembed.cpp
@@ -1082,6 +1082,10 @@ class REmbedContext: public CInterfaceOf<IEmbedContext>
 public:
     virtual IEmbedFunctionContext *createFunctionContext(unsigned flags, const char *options)
     {
+        return createFunctionContextEx(NULL, flags, options);
+    }
+    virtual IEmbedFunctionContext *createFunctionContextEx(ICodeContext * ctx, unsigned flags, const char *options)
+    {
         return new REmbedFunctionContext(*queryGlobalState()->R, options);
     }
 };

--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -2309,6 +2309,10 @@ class JavaEmbedContext : public CInterfaceOf<IEmbedContext>
 public:
     virtual IEmbedFunctionContext *createFunctionContext(unsigned flags, const char *options)
     {
+        return createFunctionContextEx(NULL, flags, options);
+    }
+    virtual IEmbedFunctionContext *createFunctionContextEx(ICodeContext * ctx, unsigned flags, const char *options)
+    {
         assertex(flags & EFimport);
         return new JavaEmbedImportContext(queryContext(), options);
     }

--- a/plugins/mysql/mysqlembed.cpp
+++ b/plugins/mysql/mysqlembed.cpp
@@ -1153,6 +1153,10 @@ class MySQLEmbedContext : public CInterfaceOf<IEmbedContext>
 public:
     virtual IEmbedFunctionContext *createFunctionContext(unsigned flags, const char *options)
     {
+        return createFunctionContextEx(NULL, flags, options);
+    }
+    virtual IEmbedFunctionContext *createFunctionContextEx(ICodeContext * ctx, unsigned flags, const char *options)
+    {
         if (flags & EFimport)
             UNSUPPORTED("IMPORT");
         else

--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -1449,6 +1449,10 @@ class Python27EmbedContext : public CInterfaceOf<IEmbedContext>
 public:
     virtual IEmbedFunctionContext *createFunctionContext(unsigned flags, const char *options)
     {
+        return createFunctionContextEx(NULL, flags, options);
+    }
+    virtual IEmbedFunctionContext *createFunctionContextEx(ICodeContext * ctx, unsigned flags, const char *options)
+    {
         if (!threadContext)
         {
             if (!globalState.isInitialized())

--- a/plugins/sqlite3/sqlite3.cpp
+++ b/plugins/sqlite3/sqlite3.cpp
@@ -582,6 +582,10 @@ class SqLite3EmbedContext : public CInterfaceOf<IEmbedContext>
 public:
     virtual IEmbedFunctionContext *createFunctionContext(unsigned flags, const char *options)
     {
+        return createFunctionContextEx(NULL, flags, options);
+    }
+    virtual IEmbedFunctionContext *createFunctionContextEx(ICodeContext * ctx, unsigned flags, const char *options)
+    {
         if (flags & EFimport)
             UNSUPPORTED("IMPORT");
         else

--- a/plugins/v8embed/v8embed.cpp
+++ b/plugins/v8embed/v8embed.cpp
@@ -933,6 +933,10 @@ public:
     }
     virtual IEmbedFunctionContext *createFunctionContext(unsigned flags, const char *options)
     {
+        return createFunctionContextEx(NULL, flags, options);
+    }
+    virtual IEmbedFunctionContext *createFunctionContextEx(ICodeContext * ctx, unsigned flags, const char *options)
+    {
         if (flags & EFimport)
             UNSUPPORTED("IMPORT");
         if (!theFunctionContext)

--- a/rtl/eclrtl/eclrtl.hpp
+++ b/rtl/eclrtl/eclrtl.hpp
@@ -819,9 +819,11 @@ interface IEmbedFunctionContext : extends IInterface
 
 enum EmbedFlags { EFembed = 1, EFimport = 2, EFnoreturn = 4, EFnoparams = 8 }; // For createFunctionContext flags
 
+interface ICodeContext;
 interface IEmbedContext : extends IInterface
 {
-    virtual IEmbedFunctionContext *createFunctionContext(unsigned flags, const char *options) = 0;
+    virtual IEmbedFunctionContext *createFunctionContext(unsigned flags, const char *options) = 0; // legacy
+    virtual IEmbedFunctionContext *createFunctionContextEx(ICodeContext * ctx, unsigned flags, const char *options) = 0;
     // MORE - add syntax checked here!
 };
 


### PR DESCRIPTION
Added the ability to control the logging level within plugins, and to capture
logging from those plugins via the standard capture mechanisms.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
