### PR TITLE
HPCC-12445 Libraries used shows incorrect value

### DIFF
--- a/esp/src/eclwatch/LibrariesUsedWidget.js
+++ b/esp/src/eclwatch/LibrariesUsedWidget.js
@@ -1,0 +1,71 @@
+/*##############################################################################
+#    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+############################################################################## */
+define([
+    "dojo/_base/declare",
+    "dojo/_base/lang",
+    "dojo/i18n",
+    "dojo/i18n!./nls/hpcc",
+    "dojo/_base/array",
+
+    "hpcc/GridDetailsWidget",
+    "hpcc/ESPQuery",
+    "hpcc/ESPUtil"
+], function (declare, lang, i18n, nlsHPCC, arrayUtil,
+                GridDetailsWidget, ESPQuery, ESPUtil) {
+    return declare("LibrariesUsedWidget", [GridDetailsWidget], {
+        i18n: nlsHPCC,
+
+        gridTitle: nlsHPCC.title_LibrariesUsed,
+        idProperty: "Name",
+
+        init: function (params) {
+            if (this.inherited(arguments))
+                return;
+
+            this.query = ESPQuery.Get(params.QuerySetId, params.Id);
+
+            this.refreshGrid();
+        },
+
+        createGrid: function (domID) {
+            var context = this;
+            var retVal = new declare([ESPUtil.Grid(false, true)])({
+                store: this.store,
+                columns: {
+                    Name: {label: this.i18n.LibrariesUsed}
+                }
+            }, domID);
+            return retVal;
+        },
+
+        refreshGrid: function (args) {
+            var context = this;
+            this.query.refresh().then(function (response) {
+                var librariesUsed = [];
+                if (lang.exists("LibrariesUsed.Item", context.query)) {
+                    arrayUtil.forEach(context.query.LibrariesUsed.Item, function (item, idx) {
+                        var file = {
+                            Name: item
+                        }
+                        librariesUsed.push(file);
+                    });
+                }
+                context.store.setData(librariesUsed);
+                context.grid.refresh();
+            });
+        }
+    });
+});

--- a/esp/src/eclwatch/QuerySetDetailsWidget.js
+++ b/esp/src/eclwatch/QuerySetDetailsWidget.js
@@ -84,6 +84,7 @@ define([
             this.graphsTab = registry.byId(this.id + "_Graphs");
             this.logicalFilesTab = registry.byId(this.id + "_QuerySetLogicalFiles");
             this.superFilesTab = registry.byId(this.id + "_QuerySetSuperFiles");
+            this.librariesUsedTab = registry.byId(this.id + "_LibrariesUsed");
             this.workunitsTab = registry.byId(this.id + "_Workunit");
             this.testPagesTab = registry.byId(this.id + "_TestPages");
         },
@@ -155,6 +156,12 @@ define([
             } else if (currSel.id == this.superFilesTab.id && !this.superFilesTabLoaded) {
                 this.superFilesTabLoaded = true;
                 this.superFilesTab.init({
+                    QuerySetId:this.params.QuerySetId,
+                    Id: this.params.Id
+                });
+            } else if (currSel.id == this.librariesUsedTab.id && !this.librariesUsedTabLoaded) {
+                this.librariesUsedTabLoaded = true;
+                this.librariesUsedTab.init({
                     QuerySetId:this.params.QuerySetId,
                     Id: this.params.Id
                 });
@@ -241,6 +248,15 @@ define([
                     }
                     this.superFilesTab.set("tooltip", tooltip);
                 }
+            } else if (name === "LibrariesUsed") {
+                this.librariesUsedTab.set("title", this.i18n.LibrariesUsed + " (" + newValue.Item.length + ")");
+                var tooltip = "";
+                for (var i = 0; i < newValue.Item.length; ++i) {
+                    if (tooltip != "")
+                        tooltip += "\n";
+                    tooltip += newValue.Item[i];
+                }
+                this.librariesUsedTab.set("tooltip", tooltip);
             } else if (name === "Clusters") {
                 if (lang.exists("ClusterQueryState.length", newValue)) {
                     this.errorsTab.set("title", this.i18n.ErrorsStatus + " (" + newValue.ClusterQueryState.length + ")");

--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -481,6 +481,7 @@ define({root:
     title_LZBrowse: "Landing Zones",
     title_MemberOf: "Member Of",
     title_Members: "Members",
+    title_LibrariesUsed: "Libraries Used",
     title_QuerySetDetails: "Query Details",
     title_QuerySetErrors: "Errors",
     title_QuerySetLogicalFiles: "Logical Files",

--- a/esp/src/eclwatch/templates/QuerySetDetailsWidget.html
+++ b/esp/src/eclwatch/templates/QuerySetDetailsWidget.html
@@ -69,10 +69,6 @@
                                 <label class="Prompt" for="${id}IsLibrary">${i18n.IsLibrary}:</label>
                                 <div id="${id}IsLibrary"></div>
                             </li>
-                            <li>
-                                <label class="Prompt" for="${id}LibrariesUsed">${i18n.LibrariesUsed}:</label>
-                                <div id="${id}LibrariesUsed"></div>
-                            </li>
                         </ul>
                     </form>
                 </div>
@@ -82,6 +78,8 @@
             <div id="${id}_QuerySetLogicalFiles" title="${i18n.LogicalFiles}" data-dojo-props="delayWidget: 'QuerySetLogicalFilesWidget'" data-dojo-type="DelayLoadWidget">
             </div>
             <div id="${id}_QuerySetSuperFiles" title="${i18n.SuperFiles}" data-dojo-props="delayWidget: 'QuerySetSuperFilesWidget'" data-dojo-type="DelayLoadWidget">
+            </div>
+            <div id="${id}_LibrariesUsed" title="${i18n.LibrariesUsed}" data-dojo-props="delayWidget: 'LibrariesUsedWidget'" data-dojo-type="DelayLoadWidget">
             </div>
             <div id="${id}_Graphs" title="${i18n.Graphs}" data-dojo-props="delayWidget: 'GraphsWidget'" data-dojo-type="DelayLoadWidget">
             </div>


### PR DESCRIPTION
Incorrect value appears when trying to view libraries used in Query Details. The read only field was starting to get clogged up so a tab was needed to house the multiple libraries that can appear.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
