### PR TITLE
HPCC-12471 Fix pull distribute regression

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -1465,6 +1465,7 @@ public:
         : CDistributorBase(activity, doDedup, istop), comm(_comm), tag(_tag)
     {
         pull = true;
+        targetWriterLimit = 1; // >1 target writer can cause packets to be received out of order
         tag = _tag;
         diskcached = (cBuf **)calloc(numnodes,sizeof(cBuf *));
         bufs = new CMessageBuffer[numnodes];


### PR DESCRIPTION
HPCC-12409 introduced a regression whereby the merge stream
could get out of order, because >1 write handler causes the row
packets to arrive in indeterminate order.
Restrict pull distriubute to 1 write handler per target.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
