### PR TITLE
HPCC-12282 Move roxie query stats to use new mechanism

### DIFF
--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -466,6 +466,7 @@ void SlaveContextLogger::set(IRoxieQueryPacket *packet)
     intercept = false;
     debuggerActive = false;
     checkingHeap = false;
+    aborted = false;
     stats.reset();
     start = msTick();
     if (packet)


### PR DESCRIPTION
Prior checkin was not resetting aborted flag, meaning all slave queries would
fail after any one did.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
