### PR TITLE
HPCC-12488 LDAP Security core if reference uninitialized member

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -943,6 +943,7 @@ public:
     }
     CLDAPGetValuesLenWrapper(LDAP *ld, LDAPMessage *msg, const char * attr)
     {
+        bvalues = NULL;
         getValues(ld,msg,attr);
     }
 


### PR DESCRIPTION
If the CLDAPGetValuesLenWrapper class gets constructed via the ctor that
accepts arguments, bvalues does not get initialized and can core later when
calling getValues. This fix initializes that member in both constructors.

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
