### PR TITLE
HPCC-12506 Avoid getGraphs and esp service grabbing data too early

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -208,7 +208,6 @@ interface IConstWUGraph : extends IInterface
     virtual WUGraphType getType() const = 0;
     virtual IPropertyTree * getXGMMLTree(bool mergeProgress) const = 0;
     virtual IPropertyTree * getXGMMLTreeRaw() const = 0;
-    virtual bool isValid() const = 0;
 };
 
 
@@ -975,6 +974,7 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual void deschedule() = 0;
     virtual unsigned addLocalFileUpload(LocalFileUploadType type, const char * source, const char * destination, const char * eventTag) = 0;
     virtual IWUResult * updateGlobalByName(const char * name) = 0;
+    virtual IWUGraph * createGraph(const char * name, WUGraphType type, IPropertyTree *xgmml) = 0;
     virtual IWUGraph * updateGraph(const char * name) = 0;
     virtual IWUQuery * updateQuery() = 0;
     virtual IWUWebServicesInfo * updateWebServicesInfo(bool create) = 0;

--- a/ecl/hqlcpp/hqlgraph.cpp
+++ b/ecl/hqlcpp/hqlgraph.cpp
@@ -260,9 +260,7 @@ void LogicalGraphCreator::createLogicalGraph(HqlExprArray & exprs)
         createRootGraphActivity(&exprs.item(i));
 //  endSubGraph();
 
-    Owned<IWUGraph> wug = wu->updateGraph("Logical");
-    wug->setXGMMLTree(graph.getClear());
-    wug->setType(GraphTypeEcl);
+    Owned<IWUGraph> wug = wu->createGraph("Logical", GraphTypeEcl, graph.getClear());
 }
 
 

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -5666,9 +5666,7 @@ bool HqlCppTranslator::buildCpp(IHqlCppInstance & _code, HqlQueryContext & query
         ForEachItemIn(i2, graphs)
         {
             GeneratedGraphInfo & cur = graphs.item(i2);
-            Owned<IWUGraph> wug = wu()->updateGraph(cur.name);
-            wug->setXGMMLTree(cur.xgmml.getClear());
-            wug->setType(GraphTypeActivities);
+            Owned<IWUGraph> wug = wu()->createGraph(cur.name, GraphTypeActivities, cur.xgmml.getClear());
             wug->setLabel(cur.label);
         }
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -711,8 +711,6 @@ void WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
         ForEach(*it)
         {
             IConstWUGraph &graph = it->query();
-            if(!graph.isValid())
-                continue;
 
             SCMStringBuffer name, label, type;
             graph.getName(name);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3503,8 +3503,6 @@ bool CWsWorkunitsEx::onWUGetGraph(IEspContext& context, IEspWUGetGraphRequest& r
         ForEach(*it)
         {
             IConstWUGraph &graph = it->query();
-            if(!graph.isValid())
-                continue;
 
             SCMStringBuffer name, label, type;
             graph.getName(name);

--- a/esp/smc/SMCLib/WUXMLInfo.cpp
+++ b/esp/smc/SMCLib/WUXMLInfo.cpp
@@ -178,31 +178,29 @@ bool CWUXMLInfo::buildXmlWuidInfo(IConstWorkUnit &wu, StringBuffer& wuStructure,
 bool CWUXMLInfo::buildXmlGraphList(IConstWorkUnit &wu,IPropertyTree& XMLStructure)
 {
     try {
-      SCMStringBuffer buf;
+        SCMStringBuffer buf;
 
         IPropertyTree* resultTree = XMLStructure.addPropTree("WUGraphs", createPTree(ipt_caseInsensitive));
         Owned<IConstWUGraphIterator> graphs = &wu.getGraphs(GraphTypeAny);
         ForEach(*graphs)
         {
             IConstWUGraph &graph = graphs->query();
-            if(!graph.isValid())
-                continue;
-            IPropertyTree * p   =   resultTree->addPropTree("WUGraph", createPTree(ipt_caseInsensitive));
-            p->setProp("Wuid",      wu.getWuid(buf).str());
-         buf.clear();
-            p->setProp("Name",      graph.getName(buf).str());
-         buf.clear();
-         // MORE? (debugging)
-            p->setPropInt("Running",    (((wu.getState() == WUStateRunning)||(wu.getState() == WUStateDebugPaused)||(wu.getState() == WUStateDebugRunning)) ? 1 : 0));
+            IPropertyTree * p = resultTree->addPropTree("WUGraph", createPTree(ipt_caseInsensitive));
+            p->setProp("Wuid", wu.getWuid(buf).str());
+            buf.clear();
+            p->setProp("Name", graph.getName(buf).str());
+            buf.clear();
+            // MORE? (debugging)
+            p->setPropInt("Running", (((wu.getState() == WUStateRunning)||(wu.getState() == WUStateDebugPaused)||(wu.getState() == WUStateDebugRunning)) ? 1 : 0));
         }
     }
-    catch(IException* e){   
-      StringBuffer msg;
-      e->errorMessage(msg);
+    catch(IException* e) {
+        StringBuffer msg;
+        e->errorMessage(msg);
         WARNLOG("%s", msg.str());
         e->Release();
     }
-    catch(...){
+    catch(...) {
         WARNLOG("Unknown Exception caught within CWUXMLInfo::buildXmlGraphList");
     }
     return true;


### PR DESCRIPTION
A odd 'isValid()' was used in a couple of places to check that
a graph was 'valid' by probing into it's guts.. In doing so
callers, e.g. esp WUInfo service, would end up pullin all the
graph data (instead of leaving it to be lazy fetched when
required).
This changes removes the isValid() which was pointless anyway
and also changes the graph creation so that the xgmml is supplied
explitly at graph create time.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
