### PR TITLE
HPCC-12522 Do not fetch extra data for WU Details page

### DIFF
--- a/esp/eclwatch/ws_XSLT/workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/workunits.xslt
@@ -475,7 +475,7 @@
                     </a>
                 </xsl:when>
                 <xsl:otherwise>
-                    <a href="javascript:go('/WsWorkunits/WUInfo?Wuid={Wuid}&amp;{$basicquery}&amp;IncludeExceptions=0&amp;IncludeGraphs=0&amp;IncludeSourceFiles=0&amp;IncludeResults=0&amp;IncludeVariables=0&amp;IncludeTimers=0&amp;IncludeDebugValues=0&amp;IncludeApplicationValues=0&amp;IncludeWorkflows=0&amp;SuppressResultSchemas=1')">
+                    <a href="javascript:go('/WsWorkunits/WUInfo?Wuid={Wuid}&amp;Type=archived workunits&amp;IncludeExceptions=0&amp;IncludeGraphs=0&amp;IncludeSourceFiles=0&amp;IncludeResults=0&amp;IncludeVariables=0&amp;IncludeTimers=0&amp;IncludeDebugValues=0&amp;IncludeApplicationValues=0&amp;IncludeWorkflows=0&amp;SuppressResultSchemas=1')">
                         <xsl:value-of select="Wuid"/>
                     </a>
                 </xsl:otherwise>

--- a/esp/eclwatch/ws_XSLT/workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/workunits.xslt
@@ -470,12 +470,12 @@
          <td>
             <xsl:choose>
                 <xsl:when test="not(string-length($archived))">
-                    <a href="javascript:go('/WsWorkunits/WUInfo?Wuid={Wuid}&amp;&amp;IncludeExceptions=0&amp;IncludeGraphs=0&amp;IncludeSourceFiles=0&amp;IncludeResults=0&amp;IncludeVariables=0&amp;IncludeTimers=0&amp;IncludeDebugValues=0&amp;IncludeApplicationValues=0&amp;IncludeWorkflows&amp;SuppressResultSchemas=1')">
+                    <a href="javascript:go('/WsWorkunits/WUInfo?Wuid={Wuid}&amp;IncludeExceptions=0&amp;IncludeGraphs=0&amp;IncludeSourceFiles=0&amp;IncludeResults=0&amp;IncludeVariables=0&amp;IncludeTimers=0&amp;IncludeDebugValues=0&amp;IncludeApplicationValues=0&amp;IncludeWorkflows=0&amp;SuppressResultSchemas=1')">
                        <xsl:value-of select="Wuid"/>
                     </a>
                 </xsl:when>
                 <xsl:otherwise>
-                    <a href="javascript:go('/WsWorkunits/WUInfo?Wuid={Wuid}&amp;{$basicquery}&amp;IncludeExceptions=0&amp;IncludeGraphs=0&amp;IncludeSourceFiles=0&amp;IncludeResults=0&amp;IncludeVariables=0&amp;IncludeTimers=0&amp;IncludeDebugValues=0&amp;IncludeApplicationValues=0&amp;IncludeWorkflows&amp;SuppressResultSchemas=1')">
+                    <a href="javascript:go('/WsWorkunits/WUInfo?Wuid={Wuid}&amp;{$basicquery}&amp;IncludeExceptions=0&amp;IncludeGraphs=0&amp;IncludeSourceFiles=0&amp;IncludeResults=0&amp;IncludeVariables=0&amp;IncludeTimers=0&amp;IncludeDebugValues=0&amp;IncludeApplicationValues=0&amp;IncludeWorkflows=0&amp;SuppressResultSchemas=1')">
                         <xsl:value-of select="Wuid"/>
                     </a>
                 </xsl:otherwise>

--- a/esp/eclwatch/ws_XSLT/wuid_search.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid_search.xslt
@@ -219,11 +219,21 @@
           <xsl:otherwise>
             <h4>Open Workunit:</h4>
                 <form action="/WsWorkunits/WUInfo" method="get" onsubmit="return submit_wuid()">
+                    <input type="hidden" name="IncludeExceptions" value="0"/>
+                    <input type="hidden" name="IncludeGraphs" value="0"/>
+                    <input type="hidden" name="IncludeSourceFiles" value="0"/>
+                    <input type="hidden" name="IncludeResults" value="0"/>
+                    <input type="hidden" name="IncludeVariables" value="0"/>
+                    <input type="hidden" name="IncludeTimers" value="0"/>
+                    <input type="hidden" name="IncludeDebugValues" value="0"/>
+                    <input type="hidden" name="IncludeApplicationValues" value="0"/>
+                    <input type="hidden" name="IncludeWorkflows" value="0"/>
+                    <input type="hidden" name="SuppressResultSchemas" value="1"/>
                     <table>
                         <tr>
                             <td>Wuid:</td>
                             <td>
-                                <input name="Wuid" size="25" type="text"/>
+                                <input id="Wuid" name="Wuid" size="25" type="text"/>
                             </td>
                             <td>
                                 <input type="submit" value="Open" class="sbutton"/>


### PR DESCRIPTION
At the moment, depending on how you access a WU Details page,
e.g. via ECL WU Search page or via Browse ECL WUs page, the
amount of information retrieved from ESP varies. More info
are retrieved in the case of searching it than via browsing
it. Consequently the time taken to bring up the workunit page
is a lot slower via search (if the workunit is big) than it
is via browse.

This fix cleans the code to not retrieve extra data for the
WU Details page.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
