### PR TITLE
HPCC-12533 Fix incorrect log when deleting a file

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1207,8 +1207,8 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
                             message.appendf("Cannot delete %s: file not found", fileName);
                         else
                             message.appendf("Cannot delete %s on %s: file not found", fileName, nodeGroup);
+                        PROGLOG("CWsDfuEx::DFUDeleteFiles: %s", message.str());
                         setDeleteFileResults(fileName, nodeGroup, true, message, returnStr, actionResults);
-                        PROGLOG("Deleted Logical File: %s by: %s\n",fileNameAndNodeGroup, username.str());
                         filesCannotBeDeleted.append(fileNameAndNodeGroup);
                         continue;
                     }


### PR DESCRIPTION
When we delete a file and the file cannot be found, the
existing ESP log shows "Deleted Logical File: ...", which
is incorrect.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
