### PR TITLE
HPCC-12534 Prevent >1 file delete from deadlocking each other

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1209,16 +1209,39 @@ public:
         if (!checkLogicalName(lfn,user,true,true,true,"remove"))
             ThrowStringException(-1, "Logical Name fails for removal on %s", lfn.get());
 
-        // Transaction files have already been unlocked at this point, delete all remaining files
-        Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lfn, user, true, false, NULL, SDS_SUB_LOCK_TIMEOUT);
-        if (!file.get())
-            return;
-        StringBuffer reason;
-        if (!file->canRemove(reason, false))
-            ThrowStringException(-1, "Can't remove %s: %s", lfn.get(), reason.str());
+        loop
+        {
+            // Transaction files have already been unlocked at this point, delete all remaining files
+            Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lfn, user, true, false, NULL, SDS_SUB_LOCK_TIMEOUT);
+            if (!file.get())
+                return;
+            StringBuffer reason;
+            if (!file->canRemove(reason, false))
+                ThrowStringException(-1, "Can't remove %s: %s", lfn.get(), reason.str());
 
-        // This will do the right thing for either super-files and logical-files.
-        file->detach();
+            // This will do the right thing for either super-files and logical-files.
+            try
+            {
+                file->detach(0); // 0 == timeout immediately if cannot get exclusive lock
+                return;
+            }
+            catch (ISDSException *e)
+            {
+                switch (e->errorCode())
+                {
+                    case SDSExcpt_LockTimeout:
+                    case SDSExcpt_LockHeld:
+                        e->Release();
+                        break;
+                    default:
+                        throw;
+                }
+            }
+            file.clear();
+            PROGLOG("CDelayedDelete: pausing");
+            Sleep(SDS_TRANSACTION_RETRY/2+(getRandom()%SDS_TRANSACTION_RETRY));
+        }
+
     }
 };
 


### PR DESCRIPTION
When DFS delete is called with the default inifinite timeout, it
would 1st lock the file for read then try to detach it which
involves gaining an exclusive lock.
If 2 managed to get a read lock ahead of their attempt to get a
write lock, they would deadlock each other indefinitely.

Add a timeout, random sleep and retry mechanism.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
