### PR TITLE
HPCC-11853 Add ECLWatch UI to call resetquerystats

### DIFF
--- a/esp/eclwatch/ws_XSLT/WUQueryDetails.xslt
+++ b/esp/eclwatch/ws_XSLT/WUQueryDetails.xslt
@@ -59,6 +59,11 @@
                         actionWorkunits('Delete');
                       }
 
+                      function resetQuery() {
+                          if (confirm("Reset This Query?"))
+                              actionWorkunits('ResetQueryStats');
+                      }
+
                       function toggleQuery() {
                         actionWorkunits('ToggleSuspend');
                       }
@@ -77,14 +82,27 @@
                           return soapXML;
                       }
 
+                      function showResetQueryStatsResponse(doc) {
+                          var response = doc.getElementsByTagName('WUQuerySetQueryActionResponse');
+                          if (response == undefined || response.length < 1)
+                              alert('<No result returned>');
+
+                          var results = response[0].getElementsByTagName('Result');
+                          if (results == undefined || results.length < 1)
+                              alert('<No result returned>');
+                          alert(results[0].childNodes[0].nodeValue);
+                      }
+
                       function actionWorkunits(Action) {
                           var connectionCallback = {
                               success: function(o) {
                                   var xmlDoc = o.responseXML;
-                                  if (Action == 'Delete') {
-                                    document.location.replace( "/WsWorkunits/WUQuerysetDetails?QuerySetName=" + querySet);
+                                  if (Action == 'ResetQueryStats') {
+                                      showResetQueryStatsResponse(xmlDoc.documentElement);
+                                  } else if (Action == 'Delete') {
+                                      document.location.replace( "/WsWorkunits/WUQuerysetDetails?QuerySetName=" + querySet);
                                   } else {
-                                    document.location.replace(document.location.href);
+                                      document.location.replace(document.location.href);
                                   }
                               },
                               failure: function(o) {
@@ -294,6 +312,7 @@
                       </xsl:if>
                     </table>
                 </form>
+                <input id="resetBtn" type="button" value="Reset" onclick="resetQuery();"> </input>
                 <input id="deleteBtn" type="button" value="Delete" onclick="deleteQuery();"> </input>
             </body>
         </html>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1403,7 +1403,8 @@ ESPenum QuerySetQueryActionTypes : string
     ToggleSuspend("ToggleSuspend"),
     Activate("Activate"),
     Delete("Delete"),
-    RemoveAllAliases("RemoveAllAliases")
+    RemoveAllAliases("RemoveAllAliases"),
+    ResetQueryStats("ResetQueryStats")
 };
 
 ESPStruct QuerySetQueryClientState

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -262,6 +262,8 @@ private:
     void createZAPECLQueryArchiveFiles(Owned<IConstWorkUnit>& cwu, const char* pathNameStr);
     void createZAPFile(const char* fileName, size32_t len, const void* data);
     void cleanZAPFolder(IFile* zipDir, bool removeFolder);
+    IPropertyTree* sendControlQuery(IEspContext &context, const char* target, const char* query, unsigned timeout);
+    bool resetQueryStats(IEspContext &context, const char* target, IProperties* queryIds, IEspWUQuerySetQueryActionResponse& resp);
 
     unsigned awusCacheMinutes;
     StringBuffer queryDirectory;

--- a/esp/src/eclwatch/QuerySetDetailsWidget.js
+++ b/esp/src/eclwatch/QuerySetDetailsWidget.js
@@ -98,6 +98,12 @@ define([
                 activate: this.query.setActivated(activated)
             });
         },
+
+        _onReset:function(){
+            if (confirm(this.i18n.ResetThisQuery)) {
+                this.query.doReset();
+            }
+        },
         _onDelete: function (event) {
             if (confirm(this.i18n.DeleteSelectedWorkunits)) {
                 this.query.doDelete();

--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -376,6 +376,7 @@ define({root:
     RequestSchema: "Request Schema",
     Reschedule: "Reschedule",
     Reset: "Reset",
+    ResetThisQuery: "Reset This Query?",
     ResetViewToSelection: "Reset View to Selection",
     Resource: "Resource",
     Resources: "Resources",

--- a/esp/src/eclwatch/templates/QuerySetDetailsWidget.html
+++ b/esp/src/eclwatch/templates/QuerySetDetailsWidget.html
@@ -6,6 +6,7 @@
                     <div id="${id}Refresh" data-dojo-attach-event="onClick:_onRefresh" data-dojo-props='iconClass:"iconRefresh"' data-dojo-type="dijit.form.Button">${i18n.Refresh}</div>
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     <div id="${id}Save" data-dojo-attach-event="onClick:_onSave" data-dojo-type="dijit.form.Button">${i18n.Save}</div>
+                    <div id="${id}Reset" data-dojo-attach-event="onClick:_onReset" data-dojo-type="dijit.form.Button">${i18n.Reset}</div>
                     <div id="${id}Delete" data-dojo-attach-event="onClick:_onDelete" data-dojo-type="dijit.form.Button">${i18n.Delete}</div>
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     <div id="${id}NewPage" class="right" data-dojo-attach-event="onClick:_onNewPage" data-dojo-props="iconClass:'iconNewPage', showLabel:false" data-dojo-type="dijit.form.Button">${i18n.OpenInNewPage}</div>


### PR DESCRIPTION
On the Query Details page, a 'Reset' button is added to
send WsWorkunits an HTTP request of WUQuerysetQueryAction
with Action='ResetQueryStats'. After the request is
received, the WsWorkunits resets query stats using
control:resetquerystats.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
