### PR TITLE
HPCC-11993 Add URL fetch for bundle install

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -82,7 +82,6 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   option(USE_V8 "Enable V8 JavaScript support" ON)
   option(USE_JNI "Enable Java JNI support" ON)
   option(USE_RINSIDE "Enable R support" ON)
-  option(USE_CURL "Enable curl support" ON)
 
   option(USE_OPTIONAL "Automatically disable requested features with missing dependencies" ON)
 

--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -81,7 +81,8 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   option(USE_PYTHON "Enable Python support" ON)
   option(USE_V8 "Enable V8 JavaScript support" ON)
   option(USE_JNI "Enable Java JNI support" ON)
-  option(USE_RINSIDE "Enable R support support" ON)
+  option(USE_RINSIDE "Enable R support" ON)
+  option(USE_CURL "Enable curl support" ON)
 
   option(USE_OPTIONAL "Automatically disable requested features with missing dependencies" ON)
 

--- a/ecl/ecl-bundle/CMakeLists.txt
+++ b/ecl/ecl-bundle/CMakeLists.txt
@@ -25,6 +25,7 @@
 
 project( ecl-bundle )
 
+
 include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS
@@ -53,6 +54,15 @@ include_directories (
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
     )
 
+if (USE_CURL)
+  ADD_PLUGIN(ecl-bundle-curl PACKAGES CURL OPTION SUPPORT_CURL)
+  IF (${SUPPORT_CURL})
+    ADD_DEFINITIONS( -D_SUPPORT_CURL )
+    message("Include should be at ${CURL_INCLUDE_DIRS}")
+    include_directories(${CURL_INCLUDE_DIRS})
+  ENDIF()
+endif()
+
 ADD_DEFINITIONS( -D_CONSOLE )
 
 HPCC_ADD_EXECUTABLE ( ecl-bundle ${SRCS} )
@@ -62,6 +72,10 @@ target_link_libraries ( ecl-bundle
         esphttp
         workunit
     )
+
+IF (${SUPPORT_CURL})
+  target_link_libraries ( ecl-bundle ${CURL_LIBRARIES})
+ENDIF()
 
 if ( UNIX )
     install ( PROGRAMS ecl-bundle.install DESTINATION etc/init.d/install COMPONENT Runtime )

--- a/ecl/ecl-bundle/CMakeLists.txt
+++ b/ecl/ecl-bundle/CMakeLists.txt
@@ -25,7 +25,6 @@
 
 project( ecl-bundle )
 
-
 include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 
 set (    SRCS
@@ -54,15 +53,6 @@ include_directories (
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
     )
 
-if (USE_CURL)
-  ADD_PLUGIN(ecl-bundle-curl PACKAGES CURL OPTION SUPPORT_CURL)
-  IF (${SUPPORT_CURL})
-    ADD_DEFINITIONS( -D_SUPPORT_CURL )
-    message("Include should be at ${CURL_INCLUDE_DIRS}")
-    include_directories(${CURL_INCLUDE_DIRS})
-  ENDIF()
-endif()
-
 ADD_DEFINITIONS( -D_CONSOLE )
 
 HPCC_ADD_EXECUTABLE ( ecl-bundle ${SRCS} )
@@ -72,10 +62,6 @@ target_link_libraries ( ecl-bundle
         esphttp
         workunit
     )
-
-IF (${SUPPORT_CURL})
-  target_link_libraries ( ecl-bundle ${CURL_LIBRARIES})
-ENDIF()
 
 if ( UNIX )
     install ( PROGRAMS ecl-bundle.install DESTINATION etc/init.d/install COMPONENT Runtime )

--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -1615,8 +1615,6 @@ public:
 
 #define WHITESPACE " \t\n\r"
 
-#define START_FAILURE (199)
-
 static unsigned dowaitpid(HANDLE pid, int mode)
 {
     while (pid != (HANDLE)-1) {

--- a/system/jlib/jthread.hpp
+++ b/system/jlib/jthread.hpp
@@ -246,6 +246,8 @@ extern jlib_decl StringBuffer &getThreadName(int thandle,unsigned logtid,StringB
 // Simple pipe process support
 interface ISimpleReadStream;
 
+#define START_FAILURE (199) // return code if program cannot be started
+
 interface IPipeProcess: extends IInterface
 {
     virtual bool run(const char *title,const char *prog, const char *dir,


### PR DESCRIPTION
ecl-bundle can now accept a url in place of a filename.

If the url ends in .git, it is assumed to be a git repository (fetched using
git clone), otherwise it is assumed to be the url of a file that can be
retrived via curl.

In both cases the file/repository is fetched to a temporary local location,
processed as a local file/directory would be, then removed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
