### PR TITLE
HPCC-12534 Fix regression introduced in last commit for this issue

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -7390,7 +7390,7 @@ void CCovenSDSManager::createConnection(SessionId sessionId, unsigned mode, unsi
             try
             {
                 loop
-                {                       
+                {
                     try
                     {
                         Owned<IPropertyTreeIterator> iter = root->getElements(xpath+1);
@@ -7405,8 +7405,13 @@ void CCovenSDSManager::createConnection(SessionId sessionId, unsigned mode, unsi
                                 freeExistingLocks.add(existing);
                                 {
                                     unsigned remaining;
-                                    if (tm.timedout(&remaining))
-                                        throw MakeSDSException(SDSExcpt_LockTimeout, "Failed to establish lock to %s, timeout whilst retrying connection to orphaned connection path", xpath);
+                                    if (timeout)
+                                    {
+                                        if (tm.timedout(&remaining))
+                                            throw MakeSDSException(SDSExcpt_LockTimeout, "Failed to establish lock to %s, timeout whilst retrying connection to orphaned connection path", xpath);
+                                    }
+                                    else
+                                        remaining = 0; // a timeout of 0 means fail immediately if locked
                                     CConnectExistingLockCallback connectLockCallback(xpath, connectionId, existing, &connectCrit);
                                     lock(existing, xpath, connectionId, sessionId, mode, remaining, connectLockCallback);
                                 }


### PR DESCRIPTION
SDS didn't like 0 timeout on a connect.
changeMode was fine, and is used to establish the exclusive lock
for a file after it has looked it up in non-exclusive mode.
However, DFS also updates the FS to remove empty scopes, which
with the previous change was using a connect with a 0 timeout and
failing, due to a spurious check before it had tried.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
