### PR TITLE
HPCC-12463 Cannot paste into search field

### DIFF
--- a/esp/src/eclwatch/css/hpcc.css
+++ b/esp/src/eclwatch/css/hpcc.css
@@ -712,6 +712,10 @@ margin-left:-20px;
     width: 64em;
 }
 
+.dijitPlaceHolder {
+    pointer-events: none;
+}
+
 .smallForm .dijitValidationTextBoxLabel {
     width: auto;
 }


### PR DESCRIPTION
ECL Watch entry fields with placeholder text display the wrong context menu.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
