### PR TITLE
HPCC-9937 Add ecl-roxie-unused-files --delete option

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -87,6 +87,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_CHECK_DFS "--check-dfs"
 #define ECLOPT_UPDATE_DFS "--update-dfs"
 #define ECLOPT_GLOBAL_SCOPE "--global-scope"
+#define ECLOPT_DELETE_FILES "--delete"
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format

--- a/ecl/eclcmd/roxie/CMakeLists.txt
+++ b/ecl/eclcmd/roxie/CMakeLists.txt
@@ -19,6 +19,7 @@ set (    SRCS
          ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_smc_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_dfuXref_esp.cpp
+         ${ESPSCM_GENERATED_DIR}/ws_dfu_esp.cpp
          ecl-roxie.cpp
          ../eclcmd_shell.cpp
          ../eclcmd_common.hpp


### PR DESCRIPTION
When delete is specified ("ecl roxie unused-files myroxie --delete")
the unused files found will be deleted from DFS.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
