### PR TITLE
HPCC-12064 New preload option in a package copies all files

### DIFF
--- a/common/workunit/package.cpp
+++ b/common/workunit/package.cpp
@@ -80,6 +80,11 @@ ISimpleSuperFileEnquiry *CPackageNode::resolveSuperFile(const char *superFileNam
     return NULL;
 }
 
+void CPackageNode::checkPreload()
+{
+    // Only implemented in derived classes
+}
+
 // Load mergedEnvironment from local XML node
 void CPackageNode::loadEnvironment()
 {

--- a/common/workunit/package.h
+++ b/common/workunit/package.h
@@ -39,6 +39,7 @@ interface IHpccPackage : extends IInterface
     virtual const char *queryEnv(const char *varname) const = 0;
     virtual bool getEnableFieldTranslation() const = 0;
     virtual bool isCompulsory() const = 0;
+    virtual bool isPreload() const = 0;
     virtual const IPropertyTree *queryTree() const = 0;
     virtual hash64_t queryHash() const = 0;
     virtual const char *queryId() const = 0;

--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -106,6 +106,11 @@ protected:
         return (node) ? node->getPropBool("@compulsory", false) : false;
     }
 
+    virtual bool isPreload() const
+    {
+        return (node) ? node->getPropBool("@preload", false) : false;
+    }
+
     virtual bool resolveLocally() const
     {
         if (isCompulsory())
@@ -161,6 +166,8 @@ public:
     {
         return node;
     }
+
+    virtual void checkPreload();
 
     virtual bool validate(StringArray &warn, StringArray &err) const;
 };
@@ -232,6 +239,7 @@ public:
                 }
                 while(baseIterator->next());
             }
+            TYPE::checkPreload();
             baseResolution=basesResolved;
         }
     }

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1849,7 +1849,7 @@ public:
     {
         return isSuper;
     }
-    inline bool isKey() const
+    virtual bool isKey() const
     {
         return fileType==ROXIE_KEY;
     }
@@ -2011,21 +2011,24 @@ public:
             }
 
             IDefRecordMeta *thisDiskMeta = diskMeta.item(subFile);
-            if (fdesc && thisDiskMeta && activityMeta && !thisDiskMeta->equals(activityMeta))
-                if (allowFieldTranslation)
-                    translators->append(createRecordLayoutTranslator(lfn, thisDiskMeta, activityMeta));
+            if (translators)
+            {
+                if (fdesc && thisDiskMeta && activityMeta && !thisDiskMeta->equals(activityMeta))
+                    if (allowFieldTranslation)
+                        translators->append(createRecordLayoutTranslator(lfn, thisDiskMeta, activityMeta));
+                    else
+                    {
+                        DBGLOG("Key layout mismatch: %s", lfn.get());
+                        StringBuffer q, d;
+                        getRecordMetaAsString(q, activityMeta);
+                        getRecordMetaAsString(d, thisDiskMeta);
+                        DBGLOG("Activity: %s", q.str());
+                        DBGLOG("Disk: %s", d.str());
+                        throw MakeStringException(ROXIE_MISMATCH, "Key layout mismatch detected for index %s", lfn.get());
+                    }
                 else
-                {
-                    DBGLOG("Key layout mismatch: %s", lfn.get());
-                    StringBuffer q, d;
-                    getRecordMetaAsString(q, activityMeta);
-                    getRecordMetaAsString(d, thisDiskMeta);
-                    DBGLOG("Activity: %s", q.str());
-                    DBGLOG("Disk: %s", d.str());
-                    throw MakeStringException(ROXIE_MISMATCH, "Key layout mismatch detected for index %s", lfn.get());
-                }
-            else
-                translators->append(NULL);
+                    translators->append(NULL);
+            }
         }
         CriticalBlock b(lock);
         IKeyArray *ret = keyArrayMap.get(channel);

--- a/roxie/ccd/ccdfile.hpp
+++ b/roxie/ccd/ccdfile.hpp
@@ -111,6 +111,7 @@ interface IResolvedFile : extends ISimpleSuperFileEnquiry
     virtual void remove() = 0;
     virtual bool exists() const = 0;
     virtual bool isSuperFile() const = 0;
+    virtual bool isKey() const = 0;
 };
 
 interface IResolvedFileCreator : extends IResolvedFile


### PR DESCRIPTION
If you set preload="1" in a package file then all files referenced in the
package will be resolved when the package is loaded - this will cause files to
be loaded and locked even if they are not referenced by any query.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
