### PR TITLE
HPCC-12557 Show 'Queue Paused' tag for paused ECLServer

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -745,7 +745,7 @@
                 <xsl:when test="$warning !=''">
                     <xsl:value-of select="$warning"/>
                 </xsl:when>
-                <xsl:when test="$clusterType = 'DFUserver' or $clusterType = 'ECLCCserver' or $clusterType = 'ECLagent'">
+                <xsl:when test="$clusterType = 'DFUserver' or $clusterType = 'ECLserver' or $clusterType = 'ECLCCserver' or $clusterType = 'ECLagent'">
                     <xsl:choose>
                         <xsl:when test="$queueStatus='paused'"> Queue paused </xsl:when>
                         <xsl:when test="$queueStatus='stopped'"> Queue stopped </xsl:when>


### PR DESCRIPTION
When a server queue is paused, legacy eclwatch should show
a tag 'Queue Paused' beside the server name. That does not
work when an ECLServer is paused.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
