### PR TITLE
HPCC-12490 Add getGraphsMeta() to explicitly get the meta info

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -6649,7 +6649,7 @@ IConstWUGraphMetaIterator& CLocalWorkUnit::getGraphsMeta(WUGraphType type) const
             curGraph = &graph;
             SCMStringBuffer graphName;
             curGraph->getName(graphName);
-            if (progressConn->queryRoot())
+            if (progressConn)
                 curGraphProgress.setown(new CConstGraphProgress(wuid, graphName.str(), progressConn->queryRoot()));
         }
     public:


### PR DESCRIPTION
Fix regression introduced by 1st PR (gh-6592)
A workunit without any progress caused a crash.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
