### PR TITLE
HPCC-12598 Configgen ldapserver enumeration map incorrectly updated

### DIFF
--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -427,12 +427,11 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
         //If this is ldap server name, lookup and add its IP address
         if (0==strcmp(attrs->queryName(), "@name"))
         {
-          StringBuffer sb(attrs->queryValue());
-          StringBuffer * ldapIP = ldapServers.getValue(sb);
-          if (ldapIP->str())
+          StringBuffer * ldapIP = ldapServers.getValue(attrs->queryValue());
+          if (ldapIP)
           {
             out.appendf("@ldapAddress,%s\n",ldapIP->str());
-            ldapServers.setValue(attrs->queryValue(), NULL);
+            ldapServers.remove(attrs->queryValue());//ensure this server only listed once
           }
           else
           {


### PR DESCRIPTION
When "-listldapservers" specified in configgen, there is some code in the
ldapServers string map that incorrectly removes an entry after it has been
processed. Currently it sets that value to NULL, when in reality it should
be calling the remove() method. This fix changes that to use remove

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
