### PR TITLE
HPCC-12599 Option in Roxie to bind queries to cores

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -435,6 +435,7 @@ extern unsigned defaultPrefetchProjectPreload;
 extern bool defaultCheckingHeap;
 
 extern unsigned slaveQueryReleaseDelaySeconds;
+extern unsigned coresPerQuery;
 
 extern StringBuffer logDirectory;
 extern StringBuffer pluginDirectory;

--- a/roxie/ccd/ccdlistener.hpp
+++ b/roxie/ccd/ccdlistener.hpp
@@ -39,5 +39,6 @@ extern IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspe
 extern bool suspendRoxieListener(unsigned port, bool suspended);
 extern IArrayOf<IRoxieListener> socketListeners;
 extern void disconnectRoxieQueues();
+extern void updateAffinity(unsigned __int64 affinity);
 
 #endif

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -133,6 +133,7 @@ unsigned dafilesrvLookupTimeout = 10000;
 bool defaultCheckingHeap = false;
 
 unsigned slaveQueryReleaseDelaySeconds = 60;
+unsigned coresPerQuery = 0;
 
 unsigned logQueueLen;
 unsigned logQueueDrop;
@@ -747,6 +748,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         defaultCheckingHeap = topology->getPropBool("@checkingHeap", false);  // NOTE - not in configmgr - too dangerous!
 
         slaveQueryReleaseDelaySeconds = topology->getPropInt("@slaveQueryReleaseDelaySeconds", 60);
+        coresPerQuery = topology->getPropInt("@coresPerQuery", 0);
 
         diskReadBufferSize = topology->getPropInt("@diskReadBufferSize", 0x10000);
         fieldTranslationEnabled = topology->getPropBool("@fieldTranslationEnabled", false);

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -822,6 +822,9 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         blobCacheMB = topology->getPropInt("@blobCacheMem", 0);
         setBlobCacheMem(blobCacheMB * 0x100000);
 
+        unsigned __int64 affinity = topology->getPropInt64("@affinity", 0);
+        updateAffinity(affinity);
+
         minFreeDiskSpace = topology->getPropInt64("@minFreeDiskSpace", (1024 * 0x100000)); // default to 1 GB
         if (topology->getPropBool("@jumboFrames", false))
         {

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -288,6 +288,7 @@ QueryOptions::QueryOptions()
     concatPreload = defaultConcatPreload;
     fetchPreload = defaultFetchPreload;
     prefetchProjectPreload = defaultPrefetchProjectPreload;
+    bindCores = coresPerQuery;
 
     checkingHeap = defaultCheckingHeap;
     disableLocalOptimizations = false;  // No global default for this
@@ -311,6 +312,7 @@ QueryOptions::QueryOptions(const QueryOptions &other)
     concatPreload = other.concatPreload;
     fetchPreload = other.fetchPreload;
     prefetchProjectPreload = other.prefetchProjectPreload;
+    bindCores = other.bindCores;
 
     checkingHeap = other.checkingHeap;
     disableLocalOptimizations = other.disableLocalOptimizations;
@@ -344,6 +346,7 @@ void QueryOptions::setFromWorkUnit(IConstWorkUnit &wu, const IPropertyTree *stat
     updateFromWorkUnit(concatPreload, wu, "concatPreload");
     updateFromWorkUnit(fetchPreload, wu, "fetchPreload");
     updateFromWorkUnit(prefetchProjectPreload, wu, "prefetchProjectPreload");
+    updateFromWorkUnit(bindCores, wu, "bindCores");
 
     updateFromWorkUnit(checkingHeap, wu, "checkingHeap");
     updateFromWorkUnit(disableLocalOptimizations, wu, "disableLocalOptimizations");
@@ -387,6 +390,7 @@ void QueryOptions::setFromContext(const IPropertyTree *ctx)
         updateFromContext(concatPreload, ctx, "@concatPreload", "_ConcatPreload");
         updateFromContext(fetchPreload, ctx, "@fetchPreload", "_FetchPreload");
         updateFromContext(prefetchProjectPreload, ctx, "@prefetchProjectPreload", "_PrefetchProjectPreload");
+        updateFromContext(bindCores, ctx, "@bindCores", "_bindCores");
 
         updateFromContext(checkingHeap, ctx, "@checkingHeap", "_CheckingHeap");
         // Note: disableLocalOptimizations is not permitted at context level (too late)

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -107,6 +107,7 @@ public:
     int concatPreload;
     int fetchPreload;
     int prefetchProjectPreload;
+    int bindCores;
 
     bool checkingHeap;
     bool disableLocalOptimizations;

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -2547,7 +2547,13 @@ private:
             break;
 
         case 'S':
-            if (stricmp(queryName, "control:setCopyResources")==0)
+            if (stricmp(queryName, "control:setAffinity")==0)
+            {
+                __uint64 affinity = control->getPropBool("@val", true);
+                topology->setPropInt64("@affinity", affinity);
+                updateAffinity(affinity);
+            }
+            else if (stricmp(queryName, "control:setCopyResources")==0)
             {
                 copyResources = control->getPropBool("@val", true);
                 topology->setPropBool("@copyResources", copyResources);


### PR DESCRIPTION
Set coresPerQuery in RoxieTopology.xml or bindCores in workunit
debug values ir in query XML to indicate that execution of this
query should be bould to at most N cores out of the ones that
the Roxie process itself is bould to.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
