### PR TITLE
HPCC-10359 Embedded Python may fail due to ^M characters in source

### DIFF
--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -381,6 +381,7 @@ PyObject *PythonThreadContext::compileEmbeddedScript(size32_t lenChars, const ch
     if (!prevtext || strcmp(text, prevtext) != 0)
     {
         prevtext.clear();
+        text.stripChar('\r');
         script.setown(globalState.compileScript(text));
         prevtext.set(utf, bytes);
     }


### PR DESCRIPTION
This was fixed in 4.2.0 but the fix was lost in 5.0.2 and 5.0.4.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
