### PR TITLE
HPCC-12351 Avoid compiler error - ensure both branches are const char *

### DIFF
--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -334,7 +334,7 @@ IPropertyTree *ReferencedFile::getRemoteFileTree(IUserDescriptor *user, INode *r
     StringBuffer remoteLFN;
     if (remotePrefix && *remotePrefix)
         remoteLFN.append(remotePrefix).append("::").append(logicalName);
-    return queryDistributedFileDirectory().getFileTree(remoteLFN.length() ? remoteLFN : logicalName, user, remote, WF_LOOKUP_TIMEOUT, false, false);
+    return queryDistributedFileDirectory().getFileTree(remoteLFN.length() ? remoteLFN.str() : logicalName.str(), user, remote, WF_LOOKUP_TIMEOUT, false, false);
 }
 
 IPropertyTree *ReferencedFile::getSpecifiedOrRemoteFileTree(IUserDescriptor *user, INode *remote, const char *remotePrefix)


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
