### PR TITLE
HPCC-12480 SSL_connect: incorrect use of return value in securesocket

### DIFF
--- a/system/security/securesocket/securesocket.cpp
+++ b/system/security/securesocket/securesocket.cpp
@@ -593,7 +593,7 @@ int CSecureSocket::secure_accept()
 int CSecureSocket::secure_connect()
 {
     int err = SSL_connect (m_ssl);                     
-    if(err < 0)
+    if(err <= 0)
     {
         char errbuf[512];
         ERR_error_string_n(ERR_get_error(), errbuf, 512);


### PR DESCRIPTION
CSecureSocket::secure_connect() is incorrectly checking the return code from
SSL_connect() by ignoring that fact that a return of 0 is also an error. This
fix changes the check from 'if(err < 0)' to 'if(err <= 0)'

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
