### PR TITLE
HPCC-12626 workunit reload could lose uncommitted writes

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3971,6 +3971,7 @@ void CLocalWorkUnit::forceReload()
 
 bool CLocalWorkUnit::reload()
 {
+    synchronized sync(locked); // protect locked workunits (uncommited writes) from reload
     CriticalBlock block(crit);
     if (dirty)
     {


### PR DESCRIPTION
A thread that had a workunit locked to update it, could have its
changes lost, by another thread forcing an update with reload.
It should have waited until the lock was relinquished.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
