### PR TITLE
HPCC-12625 subscription notifying erroneously on some changes

### DIFF
--- a/dali/base/dasds.ipp
+++ b/dali/base/dasds.ipp
@@ -209,9 +209,9 @@ public:
             loop
             {
                 str.append(item(i).queryName());
-                str.append('/');
                 if (++i >= ordinality())
                     break;
+                str.append('/');
             }
         }
         return str;

--- a/testing/regress/ecl-test.json
+++ b/testing/regress/ecl-test.json
@@ -22,7 +22,7 @@
             "thor",
             "roxie"
         ],
-        "timeout":"720",
+        "timeout":"72000000",
         "maxAttemptCount":"3",
         "defaultSetupClusters": [
             "all"


### PR DESCRIPTION
If there were >1 subscriber on a parent node, and 1 of the
subscribers was a subscriber with a change below it, but
unrelated to another child subscriber, both were were being
notified, e.g.
/a/b (sub=true)
/a/b/c (sub=false)

change to /a/b/d

/a/b AND /a/b/c were being notified.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
