### PR TITLE
HPCC-12594 Allow DATASET(value) in a record to add a dataset field

### DIFF
--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -639,6 +639,7 @@ public:
     void addDatasetField(const attribute &errpos, IIdAtom * name, ITypeInfo * type, IHqlExpression *value, IHqlExpression * attrs);
     void addDictionaryField(const attribute &errpos, IIdAtom * name, ITypeInfo * type, IHqlExpression *value, IHqlExpression * attrs);
     void addField(const attribute &errpos, IIdAtom * name, ITypeInfo *type, IHqlExpression *value, IHqlExpression *attrs);
+    void addFieldFromValue(const attribute &errpos, attribute & valueAttr);
     void addFields(const attribute &errpos, IHqlExpression *record, IHqlExpression * dataset, bool clone);
     void addIfBlockToActive(const attribute &errpos, IHqlExpression * ifblock);
     void addToActiveRecord(IHqlExpression * newField);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -4224,15 +4224,11 @@ fieldDefs
 
 fieldDef
     : expression        {
-                            parser->normalizeExpression($1);
-                            IHqlExpression *value = $1.getExpr();
-
-                            IIdAtom * name = parser->createFieldNameFromExpr(value);
-
-                            IHqlExpression * attrs = extractAttrsFromExpr(value);
-
-                            ITypeInfo * type = value->queryType();
-                            parser->addField($1, name, LINK(type), value, attrs);
+                            parser->addFieldFromValue($1, $1);
+                            $$.clear();
+                        }
+    | DATASET '(' dataSet ')' {
+                            parser->addFieldFromValue($1, $3);
                             $$.clear();
                         }
     | VALUE_ID_REF      {
@@ -4296,7 +4292,7 @@ fieldDef
                             parser->addField($1, $1.getId(), makeRowType(LINK(value->queryRecordType())), value, attrs);
                             $$.clear();
                         }
-    | typeDef knownOrUnknownId optFieldAttrs defaultValue
+    | typeDef knownOrUnknownId optFieldAttrs optDefaultValue
                         {
                             $$.clear($1);
                             IHqlExpression *value = $4.getExpr();
@@ -4307,7 +4303,7 @@ fieldDef
                                 type.setown(makeRowType(type.getClear()));
                             parser->addField($2, $2.getId(), type.getClear(), value, $3.getExpr());
                         }
-    | ANY knownOrUnknownId optFieldAttrs defaultValue
+    | ANY knownOrUnknownId optFieldAttrs optDefaultValue
                         {
                             $$.clear($1);
                             IHqlExpression *value = $4.getExpr();
@@ -4316,7 +4312,7 @@ fieldDef
                             OwnedITypeInfo type = makeAnyType();
                             parser->addField($2, $2.getId(), type.getClear(), value, $3.getExpr());
                         }
-    | typeDef knownOrUnknownId '[' expression ']' optFieldAttrs defaultValue
+    | typeDef knownOrUnknownId '[' expression ']' optFieldAttrs optDefaultValue
                         {
                             $$.clear($1);
                             parser->normalizeExpression($4, type_int, false);
@@ -4336,7 +4332,7 @@ fieldDef
                             Owned<ITypeInfo> datasetType = makeTableType(makeRowType(createRecordType(record)));
                             parser->addDatasetField($2, $2.getId(), datasetType, value, attrs.getClear());
                         }
-    | setType knownOrUnknownId optFieldAttrs defaultValue
+    | setType knownOrUnknownId optFieldAttrs optDefaultValue
                         {
                             $$.clear($1);
                             IHqlExpression *value = $4.getExpr();
@@ -4344,7 +4340,7 @@ fieldDef
                             ITypeInfo *type = $1.getType();
                             parser->addField($2, $2.getId(), type, value, $3.getExpr());
                         }
-    | explicitDatasetType knownOrUnknownId optFieldAttrs defaultValue
+    | explicitDatasetType knownOrUnknownId optFieldAttrs optDefaultValue
                         {
                             $$.clear($1);
                             Owned<ITypeInfo> type = $1.getType();
@@ -4356,7 +4352,7 @@ fieldDef
                             parser->addDatasetField($1, $1.getId(), NULL, value, $2.getExpr());
                             $$.clear();
                         }
-    | explicitDictionaryType knownOrUnknownId optFieldAttrs defaultValue
+    | explicitDictionaryType knownOrUnknownId optFieldAttrs optDefaultValue
                         {
                             $$.clear($1);
                             Owned<ITypeInfo> type = $1.getType();
@@ -4368,7 +4364,7 @@ fieldDef
                             parser->addDictionaryField($1, $1.getId(), value->queryType(), value, $2.getExpr());
                             $$.clear();
                         }
-    | alienTypeInstance knownOrUnknownId optFieldAttrs defaultValue
+    | alienTypeInstance knownOrUnknownId optFieldAttrs optDefaultValue
                         {
                             $$.clear($1);
                             parser->addField($2, $2.getId(), $1.getType(), $4.getExpr(), $3.getExpr());
@@ -4381,15 +4377,7 @@ fieldDef
                             $$.clear();
                         }
     | dictionary        {
-                            parser->normalizeExpression($1);
-                            IHqlExpression *value = $1.getExpr();
-
-                            IIdAtom * name = parser->createFieldNameFromExpr(value);
-
-                            IHqlExpression * attrs = extractAttrsFromExpr(value);
-
-                            ITypeInfo * type = value->queryType();
-                            parser->addField($1, name, LINK(type), value, attrs);
+                            parser->addFieldFromValue($1, $1);
                             $$.clear();
                         }
     | dataSet               {
@@ -4397,12 +4385,8 @@ fieldDef
                             parser->addFields($1, e->queryRecord(), e, true);
                             $$.clear();
                         }
-    | dataRow               {
-                            IHqlExpression *e = $1.getExpr();
-                            IHqlExpression * attrs = extractAttrsFromExpr(e);
-                            IIdAtom * name = parser->createFieldNameFromExpr(e);
-                            parser->addField($1, name, makeRowType(LINK(e->queryRecordType())), e, attrs);
-                            //e->Release();
+    | dataRow           {
+                            parser->addFieldFromValue($1, $1);
                             $$.clear();
                         }
     | ifblock
@@ -4594,6 +4578,14 @@ optParams
     |                   {   $$.setNullExpr();   }
     ;
 
+optDefaultValue
+    : defaultValue
+    |                       
+                        {
+                            $$.setNullExpr();
+                        }
+    ;
+    
 defaultValue
     : ASSIGN expression 
                         {
@@ -4615,10 +4607,6 @@ defaultValue
     | ASSIGN abstractModule
                         {
                             $$.inherit($2);
-                        }
-    |                       
-                        {
-                            $$.setNullExpr();
                         }
     ;
 

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -2528,6 +2528,20 @@ void HqlGram::addDictionaryField(const attribute &errpos, IIdAtom * name, ITypeI
     addToActiveRecord(newField);
 }
 
+void HqlGram::addFieldFromValue(const attribute &errpos, attribute & valueAttr)
+{
+    normalizeExpression(valueAttr);
+    IHqlExpression *value = valueAttr.getExpr();
+
+    IIdAtom * name = createFieldNameFromExpr(value);
+    IHqlExpression * attrs = extractAttrsFromExpr(value);
+
+    if (value->isDataset())
+        addDatasetField(errpos, name, NULL, value, attrs);
+    else
+        addField(errpos, name, value->getType(), value, attrs);
+}
+
 void HqlGram::addIfBlockToActive(const attribute &errpos, IHqlExpression * ifblock)
 {
     activeRecords.tos().addOperand(LINK(ifblock));

--- a/ecl/regress/indexcrc.ecl
+++ b/ecl/regress/indexcrc.ecl
@@ -61,9 +61,9 @@ ds1 := DATASET('crcbug1.d00', {prec, UNSIGNED8 fp{virtual(fileposition)}}, FLAT)
 ds2 := DATASET('crcbug2.d00', {prec_combined, UNSIGNED8 fp{virtual(fileposition)}}, FLAT);
 ds3 := DATASET('crcbug3.d00', {prec_mod, UNSIGNED8 fp{virtual(fileposition)}}, FLAT);
 
-idx1 := INDEX(ds1, {i}, {DATASET chld := chld, fp}, 'crcbug1.idx');
-idx2 := INDEX(ds2, {i}, {DATASET chld := chld, fp}, 'crcbug2.idx');
-idx3 := INDEX(ds3, {i}, {DATASET chld := chld, fp}, 'crcbug3.idx');
+idx1 := INDEX(ds1, {i}, { DATASET(chld), fp}, 'crcbug1.idx');
+idx2 := INDEX(ds2, {i}, { DATASET(chld), fp}, 'crcbug2.idx');
+idx3 := INDEX(ds3, {i}, { DATASET chld := chld, fp}, 'crcbug3.idx');
 
 SEQUENTIAL(
     OUTPUT(baseds, , 'crcbug1.d00', OVERWRITE),


### PR DESCRIPTION
By default using a dataset in a record implicitly expands all the fields out

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
