### PR TITLE
HPCC-12633 Improve contention cost in splitter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,20 +175,25 @@ elseif ( UNIX )
     message ( "-- Auto Detecting Packaging type")
     message ( "-- distro uses ${packageManagement}, revision is ${packageRevisionArch}" )
     if ( "${packageManagement}" STREQUAL "RPM" AND WITH_PLUGINS )
-        set ( CPACK_RPM_PACKAGE_VERSION "${projname}-with-plugins")
+        set ( CPACK_RPM_PACKAGE_VERSION "${projname}-with-plugins" )
+        set ( CPACK_RPM_SPEC_MORE_DEFINE
+"%define _use_internal_dependency_generator 0
+%define __getdeps() while read file; do /usr/lib/rpm/rpmdeps -%{1} ${file}; done | /bin/sort -u
+%define __find_provides /bin/sh -c '%{__getdeps P}'
+%define __find_requires /bin/sh -c '%{__grep} -v libRembed.so | %{__getdeps R}'" )
     endif()
     if ( "${packageManagement}" STREQUAL "DEB" )
-        set(CPACK_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}${packageRevisionArch}")
+        set( CPACK_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}${packageRevisionArch}" )
     elseif ( "${packageManagement}" STREQUAL "RPM" )
-        set(CPACK_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}.${packageRevisionArch}")
+        set( CPACK_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}.${packageRevisionArch}" )
     else()
-        set(CPACK_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}${CPACK_SYSTEM_NAME}")
+        set( CPACK_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}${CPACK_SYSTEM_NAME}" )
     endif ()
 endif ()
-MESSAGE ("-- Current release version is ${CPACK_PACKAGE_FILE_NAME}")
-set ( CPACK_SOURCE_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}-${version}" )
+MESSAGE ( "-- Current release version is ${CPACK_PACKAGE_FILE_NAME}" )
+set( CPACK_SOURCE_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}-${version}" )
 set( CPACK_SOURCE_GENERATOR TGZ )
-set(CPACK_SOURCE_IGNORE_FILES
+set( CPACK_SOURCE_IGNORE_FILES
         "~$"
         "\\\\.cvsignore$"
         "^${PROJECT_SOURCE_DIR}.*/CVS/"
@@ -255,7 +260,7 @@ if ( UNIX )
         else ( CLIENTTOOLS_ONLY )
             set ( CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/initfiles/bash/sbin/deb/postinst;${CMAKE_CURRENT_BINARY_DIR}/initfiles/sbin/prerm;${CMAKE_CURRENT_BINARY_DIR}/initfiles/bash/sbin/deb/postrm" )
         endif ( CLIENTTOOLS_ONLY )
-    
+
     elseif ( "${packageManagement}" STREQUAL "RPM" )
         set ( CPACK_GENERATOR "${packageManagement}" )
         ###
@@ -319,7 +324,7 @@ else ( PLATFORM )
 
       file(STRINGS "${SIGN_DIRECTORY}/passphrase.txt" PFX_PASSWORD LIMIT_COUNT 1)
 
-      add_custom_target(SIGN 
+      add_custom_target(SIGN
           COMMAND signtool sign /f "${SIGN_DIRECTORY}/hpcc_code_signing.pfx"
 /p "${PFX_PASSWORD}" /t "http://timestamp.verisign.com/scripts/timstamp.dll"
 "${CMAKE_BINARY_DIR}/${PACKAGE_FILE_NAME_PREFIX}*.exe"

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -560,6 +560,7 @@ EclAgent::EclAgent(IConstWorkUnit *wu, const char *_wuid, bool _checkVersion, bo
 
 EclAgent::~EclAgent()
 {
+    rowManager.clear();
     ::Release(pluginMap);
     abortmonitor->stop();
     ::Release(abortmonitor); // no nead to join

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -7003,13 +7003,15 @@ public:
         IHqlExpression *formals = funcdef->queryChild(1);
         ITypeInfo * retType = funcdef->queryType()->queryChildType();
 
-        enum { ServiceApi, RtlApi, BcdApi, CApi, LocalApi } api = ServiceApi;
+        enum { ServiceApi, RtlApi, BcdApi, CApi, CppApi, LocalApi } api = ServiceApi;
         if (body->hasAttribute(eclrtlAtom))
             api = RtlApi;
         else if (body->hasAttribute(bcdAtom))
             api = BcdApi;
         else if (body->hasAttribute(cAtom))
             api = CApi;
+        else if (body->hasAttribute(cppAtom))
+            api = CppApi;
         else if (body->hasAttribute(localAtom))
             api = LocalApi;
 

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -975,8 +975,8 @@ cluster_tools_init() {
    # workaround inconsistency of stat command
    cluster_log_dir_owner=$(ls -ld $CLUSTER_LOG_DIR | awk '{print $3}')
    [ "$cluster_log_dir_owner" != "${user}" ] && ${_cmd_prefix} chown ${user}:${user} $CLUSTER_LOG_DIR
-
 }
+
 ##
 ## Cleanup component
 ##

--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -22,7 +22,7 @@
 # Flow:
 #
 # 1. SSH Keys Generated.
-# 2. Run install-hpcc.sh through cluster-script.py to perform HPCC install and 
+# 2. Run install-hpcc.sh through cluster-script.py to perform HPCC install and
 #        configuration on remote hosts
 # 3. Return.
 #
@@ -114,7 +114,7 @@ createPayload(){
 
     echo "tar -zcvf /tmp/remote_install.tgz ${REMOTE_INSTALL}/*"
     tar -zcvf /tmp/remote_install.tgz ${REMOTE_INSTALL}/*
-    ls -l /tmp/remote_install.tgz 
+    ls -l /tmp/remote_install.tgz
     rm -rf ${REMOTE_INSTALL}
 }
 
@@ -148,7 +148,7 @@ while true ; do
     case "$1" in
         -k|--newkey) NEW_KEY=1
             shift ;;
-        -n|--concurrent) 
+        -n|--concurrent)
             if [ -n "$2" ] && [[ $2 =~ ^[0-9]+$ ]]
             then
                [ $2 -gt 0 ] && OPTOINS="${OPTIONS:+"$OPTIONS "}-n $2"
@@ -196,5 +196,4 @@ else
    echo ""
    run_cluster ${INSTALL_DIR}/sbin/install-hpcc.exp 0
 fi
-
 removePayload;

--- a/initfiles/sbin/install-hpcc.exp
+++ b/initfiles/sbin/install-hpcc.exp
@@ -1,4 +1,4 @@
-#!/usr/bin/env expect 
+#!/usr/bin/env expect
 ################################################################################
 #    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
 #
@@ -53,7 +53,7 @@ proc checkSSHConnection {} {
    global ip user password prompt
 
    set timeout 60
-   spawn ssh ${user}@${ip} 
+   spawn ssh ${user}@${ip}
    expect {
       *?assword:* {
          send "${password}\r";
@@ -68,18 +68,19 @@ proc checkSSHConnection {} {
          exit 1;
       } eof {
          exit 1;
-      }  -re "${prompt}" { 
+      }  -re "${prompt}" {
          puts "Connection is OK"
          send "exit\r"
       }
    }
-   expect -re .*
+
+   expect -re $
    interact;
 }
 
 proc copyPayload {} {
    global ip user password prompt
-   
+
    set timeout 300
    spawn scp /tmp/remote_install.tgz ${user}@${ip}:~;
    expect {
@@ -126,7 +127,7 @@ proc expandPayload {} {
          if { [lindex $result 3] != 0 } {
             exit [lindex $result 3]
          }
-      } 
+      }
    }
    sleep 1
 }
@@ -136,6 +137,8 @@ proc runPayload {} {
 
    set basepkg  [file tail  ${pkg}]
    set timeout 60
+
+   expect -re $
    spawn ssh ${user}@${ip}
    expect {
       *?assword:* {
@@ -153,6 +156,8 @@ proc runPayload {} {
          exit 1;
       } -re "${prompt}" {}
    }
+
+   expect -re $
    send "${cmd_prefix} ${remote_install}/remote-install-engine.sh ${remote_install}/${basepkg}\r"
    expect {
       *?assword:* {
@@ -168,16 +173,24 @@ proc runPayload {} {
       }  -re "${prompt}" {}
    }
 
-   expect  -re .*
+   expect  -re $
    send "echo \$?\r"
    expect   -re "(\r\n| )(\[0-9]*)\r\n" {
       if { [string compare $expect_out(2,string) "0" ] == 0 } {
          puts "${ip}: Done."
+         set remotelog 0
       } else {
-         puts "${ip}: Cannot Ping host? (Host Alive?)"
-         exit 1
+         set remotelog 1
       }
    }
+
+   if { $remotelog == 1 } {
+      expect -re $
+      send "cat ${remote_install}/remote-install.log\r"
+      expect -re "${prompt}" {}
+      exit 1
+   }
+
    send "exit\r"
    interact
 }

--- a/initfiles/sbin/remote-install-engine.sh.in
+++ b/initfiles/sbin/remote-install-engine.sh.in
@@ -58,24 +58,13 @@ checkUser(){
 
 pkgCmd(){
     if [ "$1" == "deb" ]; then
-        if [ "$2" == "install" ]; then
-            PKGCMD="dpkg -i"
-        elif [ "$2" == "upgrade" ]; then
-            PKGCMD="dpkg -i"
-        else
-            echo "Bad option type."
-            exit 1
-        fi
+        PKGCMD="dpkg -i $PKG &> $outputFile; apt-get install -f -y &> $outputFile;"
     elif [ "$1" == "rpm" ]; then
-        if [ "$2" == "install" ]; then
-            PKGCMD="rpm  -ivh"
-        elif [ "$2" == "upgrade" ]; then
-            PKGCMD="rpm -Uvh"
-        else
-            echo "Bad option type."
-            exit 1
+        if [ "$2" == "install" ] || [[ "$2" != "reinstall" ]]; then
+            PKGCMD="yum install --nogpgcheck -y $PKG &> $outputFile"
+        elif [ "$2" == "reinstall" ]; then
+            PKGCMD="yum reinstall --nogpgcheck -y $PKG &> $outputFile"
         fi
-        [ $WITH_PLUGINS -eq 1 ] && PKGCMD="$PKGCMD --nodeps"
     else
         echo "BAD Package type."
         exit 1
@@ -88,37 +77,35 @@ checkInstall(){
     _USER=$?
     if [ "${_FILE}" == 0 ] && [ ${_USER} -eq 1 ]; then
         _INSTALLED=1
-        checkUpgrade
+        checkReinstall
     else
         _INSTALLED=0
     fi
 }
 
-checkUpgrade(){
-    if [ "${_INSTALLED}" == "1" ]; then
-        _VERSION=`cat ${INSTALL_DIR}${CONFIG_DIR}/version`
-        _PKG=`echo $PKG | grep -c "${_VERSION}"`
-        if [ "${_PKG}" == "1" ]; then
-            _UPGRADE=0
-        else
-            _UPGRADE=1
-        fi
+checkReinstall(){
+  if [ "${OSPKG}" == "rpm" ]; then
+    local current=$( yum info hpccsystems-platform | grep "^Release" | awk '{print $3}' )
+    local new=$( rpm -qp --info ${PKG} | grep "^Release" | awk '{print $3}' )
+    if [[ $current == $new ]]; then
+      _REINSTALL=1
+    else
+      _REINSTALL=0
     fi
+  fi
 }
 
 installPkg(){
     checkInstall
     if [ "${_INSTALLED}" == "0" ]; then
         pkgCmd $OSPKG "install"
-        $PKGCMD $PKG 1>/dev/null 2>&1;
-    elif [ "${_UPGRADE}" == "1" ]; then
-        pkgCmd $OSPKG "upgrade"
-        $PKGCMD $PKG 1>/dev/null 2>&1;
+    elif [ "${_REINSTALL}" == "1" ]; then
+        pkgCmd $OSPKG "reinstall"
     fi
-    checkInstall
-    if [ "${_INSTALLED}" == "0" ]; then
-        echo "Failed to install ${PKG} (missing dependencies?)"
-        exit 1
+    eval $PKGCMD
+    if [ $? -ne 0 ]; then
+      echo "FAILED on Package Command: ${PKGCMD}"
+      exit 1
     fi
 }
 
@@ -189,6 +176,10 @@ if [ $# -eq 0 ]; then
 fi
 
 PKG=$1
+outputFile="${REMOTE_INSTALL}/remote-install.log"
+if [ -e ${outputFile} ]; then
+    rm -rf ${outputFile}
+fi
 
 pkgtype=`echo "$PKG" | grep -i rpm`
 if [ -z $pkgtype ]; then

--- a/system/jlib/jqueue.tpp
+++ b/system/jlib/jqueue.tpp
@@ -236,9 +236,9 @@ public:
         }
         return (unsigned)-1;
     }
-    void dequeue(BASE *e)
+    BASE *dequeue(BASE *e)
     {
-        dequeue(find(e));
+        return dequeue(find(e));
     }
     inline unsigned ordinality() const { return num; }
 };

--- a/testing/regress/ecl/issue12644.ecl
+++ b/testing/regress/ecl/issue12644.ecl
@@ -1,0 +1,87 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+sys := SERVICE
+
+integer3 rtlCastInt3(integer4 value) : pure,cpp,library('eclrtl'),entrypoint('rtlCastInt3');
+integer5 rtlCastInt5(integer8 value) : pure,cpp,library('eclrtl'),entrypoint('rtlCastInt5');
+integer7 rtlCastInt7(integer8 value) : pure,cpp,library('eclrtl'),entrypoint('rtlCastInt7');
+unsigned3 rtlCastUInt3(unsigned4 value) : pure,cpp,library('eclrtl'),entrypoint('rtlCastUInt3');
+unsigned5 rtlCastUInt5(unsigned8 value) : pure,cpp,library('eclrtl'),entrypoint('rtlCastUInt5');
+unsigned7 rtlCastUInt7(unsigned8 value) : pure,cpp,library('eclrtl'),entrypoint('rtlCastUInt7');
+    END;
+
+
+'int3';
+output(sys.rtlCastInt3(10));
+output(sys.rtlCastInt3(-10));
+output(sys.rtlCastInt3((0x1000000+10)));
+output(sys.rtlCastInt3(-(0x1000000+10)));
+output(sys.rtlCastInt3(NOFOLD(10)));
+output(sys.rtlCastInt3(NOFOLD(-10)));
+output(sys.rtlCastInt3(NOFOLD((0x1000000+10))));
+output(sys.rtlCastInt3(NOFOLD(-(0x1000000+10))));
+
+'int5';
+output(sys.rtlCastInt5(10));
+output(sys.rtlCastInt5(-10));
+output(sys.rtlCastInt5((0x10000000000+10)));
+output(sys.rtlCastInt5(-(0x10000000000+10)));
+output(sys.rtlCastInt5(NOFOLD(10)));
+output(sys.rtlCastInt5(NOFOLD(-10)));
+output(sys.rtlCastInt5(NOFOLD((0x10000000000+10))));
+output(sys.rtlCastInt5(NOFOLD(-(0x10000000000+10))));
+
+'int7';
+output(sys.rtlCastInt7(10));
+output(sys.rtlCastInt7(-10));
+output(sys.rtlCastInt7((0x100000000000000+10)));
+output(sys.rtlCastInt7(-(0x100000000000000+10)));
+output(sys.rtlCastInt7(NOFOLD(10)));
+output(sys.rtlCastInt7(NOFOLD(-10)));
+output(sys.rtlCastInt7(NOFOLD((0x100000000000000+10))));
+output(sys.rtlCastInt7(NOFOLD(-(0x100000000000000+10))));
+
+'uint3';
+output(sys.rtlCastUInt3(10));
+output(sys.rtlCastUInt3(-10));
+output(sys.rtlCastUInt3((0x1000000+10)));
+output(sys.rtlCastUInt3(-(0x1000000+10)));
+output(sys.rtlCastUInt3(NOFOLD(10)));
+output(sys.rtlCastUInt3(NOFOLD(-10)));
+output(sys.rtlCastUInt3(NOFOLD((0x1000000+10))));
+output(sys.rtlCastUInt3(NOFOLD(-(0x1000000+10))));
+
+'uint5';
+output(sys.rtlCastUInt5(10));
+output(sys.rtlCastUInt5(-10));
+output(sys.rtlCastUInt5((0x10000000000+10)));
+output(sys.rtlCastUInt5(-(0x10000000000+10)));
+output(sys.rtlCastUInt5(NOFOLD(10)));
+output(sys.rtlCastUInt5(NOFOLD(-10)));
+output(sys.rtlCastUInt5(NOFOLD((0x10000000000+10))));
+output(sys.rtlCastUInt5(NOFOLD(-(0x10000000000+10))));
+
+'uint7';
+output(sys.rtlCastUInt7(10));
+output(sys.rtlCastUInt7(-10));
+output(sys.rtlCastUInt7((0x100000000000000+10)));
+output(sys.rtlCastUInt7(-(0x100000000000000+10)));
+output(sys.rtlCastUInt7(NOFOLD(10)));
+output(sys.rtlCastUInt7(NOFOLD(-10)));
+output(sys.rtlCastUInt7(NOFOLD((0x100000000000000+10))));
+output(sys.rtlCastUInt7(NOFOLD(-(0x100000000000000+10))));

--- a/testing/regress/ecl/key/issue12644.xml
+++ b/testing/regress/ecl/key/issue12644.xml
@@ -1,0 +1,162 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>int3</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>10</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>-10</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>10</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>-10</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>10</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><Result_7>-10</Result_7></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>10</Result_8></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><Result_9>-10</Result_9></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><Result_10>int5</Result_10></Row>
+</Dataset>
+<Dataset name='Result 11'>
+ <Row><Result_11>10</Result_11></Row>
+</Dataset>
+<Dataset name='Result 12'>
+ <Row><Result_12>-10</Result_12></Row>
+</Dataset>
+<Dataset name='Result 13'>
+ <Row><Result_13>10</Result_13></Row>
+</Dataset>
+<Dataset name='Result 14'>
+ <Row><Result_14>-10</Result_14></Row>
+</Dataset>
+<Dataset name='Result 15'>
+ <Row><Result_15>10</Result_15></Row>
+</Dataset>
+<Dataset name='Result 16'>
+ <Row><Result_16>-10</Result_16></Row>
+</Dataset>
+<Dataset name='Result 17'>
+ <Row><Result_17>10</Result_17></Row>
+</Dataset>
+<Dataset name='Result 18'>
+ <Row><Result_18>-10</Result_18></Row>
+</Dataset>
+<Dataset name='Result 19'>
+ <Row><Result_19>int7</Result_19></Row>
+</Dataset>
+<Dataset name='Result 20'>
+ <Row><Result_20>10</Result_20></Row>
+</Dataset>
+<Dataset name='Result 21'>
+ <Row><Result_21>-10</Result_21></Row>
+</Dataset>
+<Dataset name='Result 22'>
+ <Row><Result_22>10</Result_22></Row>
+</Dataset>
+<Dataset name='Result 23'>
+ <Row><Result_23>-10</Result_23></Row>
+</Dataset>
+<Dataset name='Result 24'>
+ <Row><Result_24>10</Result_24></Row>
+</Dataset>
+<Dataset name='Result 25'>
+ <Row><Result_25>-10</Result_25></Row>
+</Dataset>
+<Dataset name='Result 26'>
+ <Row><Result_26>10</Result_26></Row>
+</Dataset>
+<Dataset name='Result 27'>
+ <Row><Result_27>-10</Result_27></Row>
+</Dataset>
+<Dataset name='Result 28'>
+ <Row><Result_28>uint3</Result_28></Row>
+</Dataset>
+<Dataset name='Result 29'>
+ <Row><Result_29>10</Result_29></Row>
+</Dataset>
+<Dataset name='Result 30'>
+ <Row><Result_30>16777206</Result_30></Row>
+</Dataset>
+<Dataset name='Result 31'>
+ <Row><Result_31>10</Result_31></Row>
+</Dataset>
+<Dataset name='Result 32'>
+ <Row><Result_32>16777206</Result_32></Row>
+</Dataset>
+<Dataset name='Result 33'>
+ <Row><Result_33>10</Result_33></Row>
+</Dataset>
+<Dataset name='Result 34'>
+ <Row><Result_34>16777206</Result_34></Row>
+</Dataset>
+<Dataset name='Result 35'>
+ <Row><Result_35>10</Result_35></Row>
+</Dataset>
+<Dataset name='Result 36'>
+ <Row><Result_36>16777206</Result_36></Row>
+</Dataset>
+<Dataset name='Result 37'>
+ <Row><Result_37>uint5</Result_37></Row>
+</Dataset>
+<Dataset name='Result 38'>
+ <Row><Result_38>10</Result_38></Row>
+</Dataset>
+<Dataset name='Result 39'>
+ <Row><Result_39>1099511627766</Result_39></Row>
+</Dataset>
+<Dataset name='Result 40'>
+ <Row><Result_40>10</Result_40></Row>
+</Dataset>
+<Dataset name='Result 41'>
+ <Row><Result_41>1099511627766</Result_41></Row>
+</Dataset>
+<Dataset name='Result 42'>
+ <Row><Result_42>10</Result_42></Row>
+</Dataset>
+<Dataset name='Result 43'>
+ <Row><Result_43>1099511627766</Result_43></Row>
+</Dataset>
+<Dataset name='Result 44'>
+ <Row><Result_44>10</Result_44></Row>
+</Dataset>
+<Dataset name='Result 45'>
+ <Row><Result_45>1099511627766</Result_45></Row>
+</Dataset>
+<Dataset name='Result 46'>
+ <Row><Result_46>uint7</Result_46></Row>
+</Dataset>
+<Dataset name='Result 47'>
+ <Row><Result_47>10</Result_47></Row>
+</Dataset>
+<Dataset name='Result 48'>
+ <Row><Result_48>72057594037927926</Result_48></Row>
+</Dataset>
+<Dataset name='Result 49'>
+ <Row><Result_49>10</Result_49></Row>
+</Dataset>
+<Dataset name='Result 50'>
+ <Row><Result_50>72057594037927926</Result_50></Row>
+</Dataset>
+<Dataset name='Result 51'>
+ <Row><Result_51>10</Result_51></Row>
+</Dataset>
+<Dataset name='Result 52'>
+ <Row><Result_52>72057594037927926</Result_52></Row>
+</Dataset>
+<Dataset name='Result 53'>
+ <Row><Result_53>10</Result_53></Row>
+</Dataset>
+<Dataset name='Result 54'>
+ <Row><Result_54>72057594037927926</Result_54></Row>
+</Dataset>

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -66,7 +66,8 @@ class NSplitterSlaveActivity : public CSlaveActivity
     bool spill;
     bool eofHit;
     bool inputsConfigured;
-    CriticalSection startLock;
+    bool pendingWrite;
+    CriticalSection startLock, writeAheadCrit1, writeAheadCrit2;
     unsigned nstopped;
     rowcount_t recsReady;
     IThorDataLink *input;
@@ -74,44 +75,27 @@ class NSplitterSlaveActivity : public CSlaveActivity
     Owned<IException> startException, writeAheadException;
     Owned<ISharedSmartBuffer> smartBuf;
 
+    // NB: CWriter only used by 'balanced' splitter, which blocks write when too far ahead
     class CWriter : public CSimpleInterface, IThreaded
     {
         NSplitterSlaveActivity &parent;
         CThreadedPersistent threaded;
-        Semaphore sem;
         bool stopped;
-        rowcount_t writerMax;
-        unsigned requestN;
-        SpinLock recLock;
 
     public:
         CWriter(NSplitterSlaveActivity &_parent) : parent(_parent), threaded("CWriter", this)
         {
             stopped = true;
-            writerMax = 0;
-            requestN = 1000;
         }
         ~CWriter() { stop(); }
         virtual void main()
         {
-            loop
-            {
-                sem.wait();
-                if (stopped) break;
-                rowcount_t request;
-                {
-                    SpinBlock block(recLock);
-                    request = writerMax;
-                }
-                parent.writeahead(request, stopped);
-                if (parent.eofHit)
-                    break;
-            }
+            while (!stopped && !parent.eofHit)
+                parent.writeahead(0, stopped); // intentional to avoid 'current' check and write as much as possible, it will block in smartBuf..
         }
         void start()
         {
             stopped = false;
-            writerMax = 0;
             threaded.start();
         }
         virtual void stop()
@@ -119,20 +103,8 @@ class NSplitterSlaveActivity : public CSlaveActivity
             if (!stopped)
             {
                 stopped = true;
-                sem.signal();
                 threaded.join();
             }
-        }
-        void more(rowcount_t &max) // called if output hit it's max, returns new max
-        {
-            if (stopped) return;
-            SpinBlock block(recLock);
-            if (writerMax <= max)
-            {
-                writerMax += requestN;
-                sem.signal();
-            }
-            max = writerMax;
         }
     } writer;
     class CNullInput : public CSplitterOutputBase
@@ -240,6 +212,7 @@ public:
         nstopped = 0;
         eofHit = inputsConfigured = false;
         recsReady = 0;
+        pendingWrite = false;
     }
     void ensureInputsConfigured()
     {
@@ -247,6 +220,7 @@ public:
         if (inputsConfigured)
             return;
         inputsConfigured = true;
+        pendingWrite = false;
         unsigned noutputs = container.connectedOutputs.getCount();
         ActPrintLog("Number of connected outputs: %d", noutputs);
         if (1 == noutputs)
@@ -309,11 +283,6 @@ public:
         else
             spill = dV>0;
     }
-    inline void more(rowcount_t &max)
-    {
-        ActivityTimer t(totalCycles, queryTimeActivities());
-        writer.more(max);
-    }
     void prepareInput(unsigned output)
     {
         CriticalBlock block(startLock);
@@ -348,7 +317,8 @@ public:
                             smartBuf->queryOutput(o)->stop();
                     }
                 }
-                writer.start();
+                if (spill)
+                    writer.start(); // writer keeps writing ahead as much as possible, the readahead impl. will block when has too much
             }
             catch (IException *e) { 
                 startException.setown(e); 
@@ -362,15 +332,32 @@ public:
             throw LINK(writeAheadException);
         return row.getClear();
     }
-    void writeahead(const rowcount_t &requested, const bool &stopped)
+    rowcount_t writeahead(rowcount_t current, const bool &stopped)
     {
         if (eofHit)
-            return;
-        
+            return recsReady;
+
+        ActivityTimer t(totalCycles, queryTimeActivities());
+        {
+            CriticalBlock b(writeAheadCrit1);
+            if (current < recsReady || pendingWrite)
+                return recsReady;
+
+            pendingWrite = true;
+        }
+        CriticalBlock b(writeAheadCrit2);
+        class CSharedSmartCallback : implements ISharedSmartBufferCallback
+        {
+            bool pagedOut;
+        public:
+            CSharedSmartCallback() { pagedOut = false; }
+            virtual void paged() { pagedOut = true; }
+            bool done() const { return pagedOut; }
+        } cb;
         OwnedConstThorRow row;
         loop
         {
-            if (abortSoon || stopped || requested<recsReady)
+            if (abortSoon || stopped || cb.done())
                 break;
             try
             {
@@ -381,7 +368,7 @@ public:
                     if (row)
                     {
                         ++recsReady;
-                        smartBuf->putRow(NULL);
+                        smartBuf->putRow(NULL, &cb);
                     }
                 }
             }
@@ -394,8 +381,10 @@ public:
                 break;
             }
             ++recsReady;
-            smartBuf->putRow(row.getClear()); // can block if mem limited, but other readers can progress which is the point
+            smartBuf->putRow(row.getClear(), &cb); // can block if mem limited, but other readers can progress which is the point
         }
+        pendingWrite = false;
+        return recsReady;
     }
     void inputStopped()
     {
@@ -457,7 +446,7 @@ void CSplitterOutput::stop()
 const void *CSplitterOutput::nextRow()
 {
     if (rec == max)
-        activity.more(max);
+        max = activity.writeahead(max, activity.queryAbortSoon());
     ActivityTimer t(totalCycles, activity.queryTimeActivities());
     const void *row = activity.nextRow(output); // pass ptr to max if need more
     ++rec;

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -61,13 +61,13 @@ public:
 // NSplitterSlaveActivity
 //
 
-class NSplitterSlaveActivity : public CSlaveActivity
+class NSplitterSlaveActivity : public CSlaveActivity, implements ISharedSmartBufferCallback
 {
     bool spill;
     bool eofHit;
     bool inputsConfigured;
-    bool pendingWrite;
-    CriticalSection startLock, writeAheadCrit;
+    bool writeBlocked, pagedOut;
+    CriticalSection startLock, writeAheadCrit, writeBlockedCrit;
     unsigned nstopped;
     rowcount_t recsReady;
     IThorDataLink *input;
@@ -75,6 +75,40 @@ class NSplitterSlaveActivity : public CSlaveActivity
     Owned<IException> startException, writeAheadException;
     Owned<ISharedSmartBuffer> smartBuf;
 
+    // NB: CWriter only used by 'balanced' splitter, which blocks write when too far ahead
+    class CWriter : public CSimpleInterface, IThreaded
+    {
+        NSplitterSlaveActivity &parent;
+        CThreadedPersistent threaded;
+        bool stopped;
+        rowcount_t current;
+
+    public:
+        CWriter(NSplitterSlaveActivity &_parent) : parent(_parent), threaded("CWriter", this)
+        {
+            current = 0;
+            stopped = true;
+        }
+        ~CWriter() { stop(); }
+        virtual void main()
+        {
+            while (!stopped && !parent.eofHit)
+                current = parent.writeahead(current, stopped);
+        }
+        void start()
+        {
+            stopped = false;
+            threaded.start();
+        }
+        virtual void stop()
+        {
+            if (!stopped)
+            {
+                stopped = true;
+                threaded.join();
+            }
+        }
+    } writer;
     class CNullInput : public CSplitterOutputBase
     {
     public:
@@ -172,14 +206,13 @@ class NSplitterSlaveActivity : public CSlaveActivity
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    NSplitterSlaveActivity(CGraphElementBase *container) : CSlaveActivity(container)
+    NSplitterSlaveActivity(CGraphElementBase *container) : CSlaveActivity(container), writer(*this)
     {
         spill = false;
         input = NULL;
         nstopped = 0;
-        eofHit = inputsConfigured = false;
+        eofHit = inputsConfigured = writeBlocked = pagedOut = false;
         recsReady = 0;
-        pendingWrite = false;
     }
     void ensureInputsConfigured()
     {
@@ -187,7 +220,6 @@ public:
         if (inputsConfigured)
             return;
         inputsConfigured = true;
-        pendingWrite = false;
         unsigned noutputs = container.connectedOutputs.getCount();
         ActPrintLog("Number of connected outputs: %d", noutputs);
         if (1 == noutputs)
@@ -228,6 +260,7 @@ public:
         grouped = false;
         eofHit = false;
         recsReady = 0;
+        writeBlocked = false;
         if (inputsConfigured)
         {
             // ensure old inputs cleared, to avoid being reused before re-setup on subsequent executions
@@ -285,6 +318,8 @@ public:
                             smartBuf->queryOutput(o)->stop();
                     }
                 }
+                if (!spill)
+                    writer.start(); // writer keeps writing ahead as much as possible, the readahead impl. will block when has too much
             }
             catch (IException *e)
             {
@@ -301,30 +336,35 @@ public:
     }
     rowcount_t writeahead(rowcount_t current, const bool &stopped)
     {
-        if (eofHit)
-            return recsReady;
-
+        // NB: readers call writeahead, which will block others
+        CriticalBlock b(writeAheadCrit);
+        loop
         {
-            CriticalBlock b(writeAheadCrit);
-            if (current < recsReady || pendingWrite)
+            if (eofHit)
                 return recsReady;
-
-            // NB: readers returning because pendingWrite is true, will block on smartBuf->nextRow until rows appear
-            pendingWrite = true;
+            if (current < recsReady)
+                return recsReady;
+            else if (writeBlocked)
+            {
+                // NB: When here, writeAheadCrit has been released _and_ writeBlockedCrit will be held until the writer is unblocked
+                {
+                    CriticalUnblock ub(writeAheadCrit);
+                    {
+                        CriticalBlock b(writeBlockedCrit); // This will block until the thread that is writing ahead has done
+                        // Once writeBlockCrit gained, writeBlocked is always 'false'
+                    }
+                }
+                // recsReady or eofHit will have been updated by the blocking thread by now, loop and re-check
+            }
+            else
+                break;
         }
         ActivityTimer t(totalCycles, queryTimeActivities());
-        class CSharedSmartCallback : implements ISharedSmartBufferCallback
-        {
-            bool pagedOut;
-        public:
-            CSharedSmartCallback() { pagedOut = false; }
-            virtual void paged() { pagedOut = true; }
-            bool done() const { return pagedOut; }
-        } cb;
+        pagedOut = false;
         OwnedConstThorRow row;
         loop
         {
-            if (abortSoon || stopped || cb.done())
+            if (abortSoon || stopped || pagedOut)
                 break;
             try
             {
@@ -334,8 +374,8 @@ public:
                     row.setown(input->nextRow());
                     if (row)
                     {
+                        smartBuf->putRow(NULL, this);
                         ++recsReady;
-                        smartBuf->putRow(NULL, &cb);
                     }
                 }
             }
@@ -347,16 +387,16 @@ public:
                 smartBuf->flush(); // signals no more rows will be written.
                 break;
             }
+            smartBuf->putRow(row.getClear(), this); // can block if mem limited, but other readers can progress which is the point
             ++recsReady;
-            smartBuf->putRow(row.getClear(), &cb); // can block if mem limited, but other readers can progress which is the point
         }
-        pendingWrite = false;
         return recsReady;
     }
     void inputStopped()
     {
         if (nstopped && --nstopped==0) 
         {
+            writer.stop();
             stopInput(input);
             input = NULL;
         }
@@ -377,7 +417,20 @@ public:
         }
         return _totalCycles;
     }
-
+// ISharedSmartBufferCallback impl.
+    virtual void paged() { pagedOut = true; }
+    virtual void blocked()
+    {
+        writeBlockedCrit.enter(); // enter before unblocking writeahead
+        writeBlocked = true; // Prevent other users getting beyond checking recsReady in writeahead()
+        writeAheadCrit.leave();
+    }
+    virtual void unblocked()
+    {
+        writeAheadCrit.enter();
+        writeBlocked = false;
+        writeBlockedCrit.leave(); // leave after re-blocking writer
+    }
 friend class CInputWrapper;
 friend class CSplitterOutput;
 friend class CWriter;

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -62,8 +62,13 @@ extern graph_decl ISmartRowBuffer * createSmartInMemoryBuffer(CActivityBase *act
                                                       size32_t buffsize);
 
 // Multiple readers, one writer
+interface ISharedSmartBufferCallback
+{
+    virtual void paged() = 0;
+};
 interface ISharedSmartBuffer : extends IRowWriter
 {
+    virtual void putRow(const void *row, ISharedSmartBufferCallback *callback) = 0; // extended form of putRow, which signals when pages out via callback
     virtual IRowStream *queryOutput(unsigned output) = 0;
     virtual void cancel()=0;
     virtual void reset() = 0;

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -65,9 +65,12 @@ extern graph_decl ISmartRowBuffer * createSmartInMemoryBuffer(CActivityBase *act
 interface ISharedSmartBufferCallback
 {
     virtual void paged() = 0;
+    virtual void blocked() = 0;
+    virtual void unblocked() = 0;
 };
 interface ISharedSmartBuffer : extends IRowWriter
 {
+    using IRowWriter::putRow;
     virtual void putRow(const void *row, ISharedSmartBufferCallback *callback) = 0; // extended form of putRow, which signals when pages out via callback
     virtual IRowStream *queryOutput(unsigned output) = 0;
     virtual void cancel()=0;

--- a/tools/esdlcmd/esdl-publish.cpp
+++ b/tools/esdlcmd/esdl-publish.cpp
@@ -157,7 +157,7 @@ public:
         request->setServiceName(optESDLService.get());
 
         if (optVerbose)
-            fprintf(stderr,"\nESDL Definition: \n%s\n", esxml.str());
+            fprintf(stdout,"\nESDL Definition: \n%s\n", esxml.str());
 
         request->setXMLDefinition(esxml.str());
         request->setDeletePrevious(optOverWrite);
@@ -213,10 +213,6 @@ public:
                case 1:
                    optSource.set(arg);
                    break;
-               default:
-                   fprintf(stderr, "\nUnrecognized positional argument detected : %s\n", arg);
-                   usage();
-                   return false;
               }
           }
           else
@@ -284,7 +280,7 @@ public:
         Owned<IClientWsESDLConfig> esdlConfigClient = EsdlCmdHelper::getWsESDLConfigSoapService(optWSProcAddress, optWSProcPort, optUser, optPass);
         Owned<IClientPublishESDLBindingRequest> request = esdlConfigClient->createPublishESDLBindingRequest();
 
-        fprintf(stderr,"\nAttempting to configure ESDL Service: '%s'\n", optESDLService.get());
+        fprintf(stdout,"\nAttempting to configure ESDL Service: '%s'\n", optESDLService.get());
 
         request->setEspProcName(optTargetESPProcName);
         request->setEspPort(optTargetPort);
@@ -295,7 +291,7 @@ public:
         request->setOverwrite(optOverWrite);
 
         if (optVerbose)
-            fprintf(stderr,"\nMethod config: %s\n", optInput.get());
+            fprintf(stdout,"\nMethod config: %s\n", optInput.get());
 
         Owned<IClientPublishESDLBindingResponse> resp = esdlConfigClient->PublishESDLBinding(request);
 
@@ -375,10 +371,6 @@ public:
                 case 3:
                     optESDLService.set(arg);
                     break;
-                default:
-                    fprintf(stderr, "\nUnrecognized positional argument detected : %s\n", arg);
-                    usage();
-                    return false;
                }
            }
            else
@@ -466,10 +458,10 @@ public:
         Owned<IClientWsESDLConfig> esdlConfigClient = EsdlCmdHelper::getWsESDLConfigSoapService(optWSProcAddress, optWSProcPort, optUser, optPass);
         Owned<IClientDeleteESDLBindingRequest> request = esdlConfigClient->createDeleteESDLBindingRequest();
 
-        fprintf(stderr,"\nAttempting to un-bind ESDL Service: '%s.%s'\n", optTargetESPProcName.get(), optEspBinding.get());
+        fprintf(stdout,"\nAttempting to un-bind ESDL Service: '%s.%s'\n", optTargetESPProcName.get(), optEspBinding.get());
 
         StringBuffer id;
-        id.set(optTargetESPProcName).append('.').append(optEspBinding);
+        id.setf("%s.%s", optTargetESPProcName.get(), optEspBinding.get());
         request->setId(id);
 
         Owned<IClientDeleteESDLRegistryEntryResponse> resp = esdlConfigClient->DeleteESDLBinding(request);
@@ -492,7 +484,7 @@ public:
                 "   TargetESPProcessName                             The target ESP Process name\n"
                 "   TargetESPBindingPort | TargetESPServiceName      Either target ESP binding port or target ESP service name\n");
 
-                EsdlPublishCmdCommon::usage();
+        EsdlPublishCmdCommon::usage();
 
         printf( "\n   Use this command to unpublish ESDL Service based bindings.\n"
                 "   To unbind an ESDL Service, provide the target ESP process name\n"
@@ -527,10 +519,6 @@ public:
                 case 1:
                     optEspBinding.set(arg);
                     break;
-                default:
-                    fprintf(stderr, "\nUnrecognized positional argument detected : %s\n", arg);
-                    usage();
-                    return false;
                }
            }
            else
@@ -584,10 +572,10 @@ public:
         Owned<IClientWsESDLConfig> esdlConfigClient = EsdlCmdHelper::getWsESDLConfigSoapService(optWSProcAddress, optWSProcPort, optUser, optPass);
         Owned<IClientDeleteESDLDefinitionRequest> request = esdlConfigClient->createDeleteESDLDefinitionRequest();
 
-        fprintf(stderr,"\nAttempting to delete ESDL definition: '%s.%d'\n", optESDLService.get, optVersion);
+        fprintf(stdout,"\nAttempting to delete ESDL definition: '%s.%d'\n", optESDLService.get(), (int)optVersion);
 
         StringBuffer id;
-        id.set(optESDLService.get()).append('.').append(optVersion);
+        id.setf("%s.%d", optESDLService.get(), (int)optVersion);
 
         request->setId(id);
 
@@ -611,7 +599,7 @@ public:
                 "   ESDLServiceDefinitionName         The name of the ESDL service definition to delete\n"
                 "   ESDLServiceDefinitionVersion      The version of the ESDL service definition to delete\n");
 
-                EsdlPublishCmdCommon::usage();
+        EsdlPublishCmdCommon::usage();
 
         printf( "\n   Use this command to delete an ESDL Service definition.\n"
                 "   To delete an ESDL Service definition, provide the definition name and version\n"
@@ -643,10 +631,6 @@ public:
                 case 1:
                     optVersionStr.set(arg);
                     break;
-                default:
-                    fprintf(stderr, "\nUnrecognized positional argument detected : %s\n", arg);
-                    usage();
-                    return false;
                }
            }
            else
@@ -708,7 +692,7 @@ public:
         Owned<IClientWsESDLConfig> esdlConfigClient = EsdlCmdHelper::getWsESDLConfigSoapService(optWSProcAddress, optWSProcPort, optUser, optPass);
         Owned<IClientListESDLDefinitionsRequest> req = esdlConfigClient->createListESDLDefinitionsRequest();
 
-        fprintf(stderr,"\nAttempting to list ESDL definitions.\n");
+        fprintf(stdout,"\nAttempting to list ESDL definitions.\n");
 
         Owned<IClientListESDLDefinitionsResponse> resp = esdlConfigClient->ListESDLDefinitions(req);
 
@@ -776,7 +760,7 @@ public:
         Owned<IClientWsESDLConfig> esdlConfigClient = EsdlCmdHelper::getWsESDLConfigSoapService(optWSProcAddress, optWSProcPort, optUser, optPass);
         Owned<IClientListESDLBindingsRequest> req = esdlConfigClient->createListESDLBindingsRequest();
 
-        fprintf(stderr,"\nAttempting to list ESDL bindings.\n");
+        fprintf(stdout,"\nAttempting to list ESDL bindings.\n");
 
         Owned<IClientListESDLBindingsResponse> resp = esdlConfigClient->ListESDLBindings(req);
 
@@ -849,7 +833,7 @@ public:
         Owned<IClientWsESDLConfig> esdlConfigClient = EsdlCmdHelper::getWsESDLConfigSoapService(optWSProcAddress, optWSProcPort, optUser, optPass);
         Owned<IClientConfigureESDLBindingMethodRequest> request = esdlConfigClient->createConfigureESDLBindingMethodRequest();
 
-        fprintf(stderr,"\nAttempting to configure Method : '%s'.'%s'\n", optService.get(), optMethod.get());
+        fprintf(stdout,"\nAttempting to configure Method : '%s'.'%s'\n", optService.get(), optMethod.get());
         request->setEspProcName(optTargetESPProcName);
         request->setEspBindingName(optBindingName);
         request->setEsdlServiceName(optService.get());
@@ -859,7 +843,7 @@ public:
         request->setOverwrite(optOverWrite);
 
         if (optVerbose)
-            fprintf(stderr,"\nMethod config: %s\n", optInput.get());
+            fprintf(stdout,"\nMethod config: %s\n", optInput.get());
 
         Owned<IClientConfigureESDLBindingMethodResponse> resp = esdlConfigClient->ConfigureESDLBindingMethod(request);
 
@@ -939,10 +923,6 @@ public:
                 case 4:
                     optMethod.set(arg);
                     break;
-                default:
-                    fprintf(stderr, "\nUnrecognized positional argument detected : %s\n", arg);
-                    usage();
-                    return false;
                }
            }
            else
@@ -1033,16 +1013,7 @@ class EsdlGetCmd : public EsdlPublishCmdCommon
                   const char *arg = iter.query();
                   if (*arg != '-')
                   {
-                      switch (cur)
-                      {
-                       case 0:
-                           optId.set(arg);
-                           break;
-                       default:
-                           fprintf(stderr, "\nUnrecognized positional argument detected : %s\n", arg);
-                           usage();
-                           return false;
-                      }
+                      optId.set(arg);
                   }
                   else
                   {

--- a/tools/esdlcmd/esdlcmd_core.cpp
+++ b/tools/esdlcmd/esdlcmd_core.cpp
@@ -613,6 +613,8 @@ IEsdlCommand *createCoreEsdlCommand(const char *cmdname)
         return new Esdl2WSDLCmd();
     if (strieq(cmdname, "PUBLISH"))
         return new EsdlPublishCmd();
+    if (strieq(cmdname, "DELETE"))
+        return new EsdlDeleteESDLDefCmd();
     if (strieq(cmdname, "BIND-SERVICE"))
         return new EsdlBindServiceCmd();
     if (strieq(cmdname, "BIND-METHOD"))
@@ -621,6 +623,13 @@ IEsdlCommand *createCoreEsdlCommand(const char *cmdname)
         return new EsdlGetBindingCmd();
     if (strieq(cmdname, "GET-DEFINITION"))
         return new EsdlGetDefinitionCmd();
+    if (strieq(cmdname, "UNBIND-SERVICE"))
+        return new EsdlUnBindServiceCmd();
+    if (strieq(cmdname, "LIST-DEFINITIONS"))
+        return new EsdlListESDLDefCmd();
+    if (strieq(cmdname, "LIST-BINDINGS"))
+        return new EsdlListESDLBindingsCmd();
+
 
     return NULL;
 }

--- a/tools/esdlcmd/esdlcmd_shell.cpp
+++ b/tools/esdlcmd/esdlcmd_shell.cpp
@@ -180,10 +180,14 @@ void EsdlCMDShell::usage()
            "   xsd               Generate XSD from ESDL definition.\n"
            "   wsdl              Generate WSDL from ESDL definition.\n"
            "   publish           Publish ESDL Definition for ESP use.\n"
+           "   list-definitions  List all ESDL definitions.\n"
+           "   delete            Delete ESDL Definition.\n"
            "   bind-service      Configure ESDL based service on target ESP (with existing ESP Binding).\n"
-           "   new-bind-service  Configure ESDL based service on target ESP (binds with future ESP Binding).\n"
+           "   list-bindings     List all ESDL bindings.\n"
+           "   unbind-service    Remove ESDL based service binding on target ESP.\n"
            "   bind-method       Configure method associated with existing ESDL binding.\n"
            "   get-binding       Get ESDL binding.\n"
+           ""
            "\nRun 'esdl help <command>' for more information on a specific command\n\n"
     );
 }


### PR DESCRIPTION
In cases where the consumers keep pace and are waiting on the
produce side of the splitter, the cost of waiting was costly.
The change here, introduces a callback mechanism into the shared
write ahead, such that the producer [optionally] only triggers
the readers that there is something to consumer per page flush.
In the memory variety of the shared writer which blocks when it
is far enough ahead, the producer will write (and page) as fast
as possible on a async thread, and block when full.
All of this savs the cosumers, entering crits, waiting on
semaphores and waking up and re-entering crits etc. on a per row
basis when they are consuming quickly.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
