### PR TITLE
HPCC-12399 Address cleaner lib socket updates

### DIFF
--- a/system/jlib/jsocket.hpp
+++ b/system/jlib/jsocket.hpp
@@ -267,6 +267,7 @@ public:
                            unsigned timeout) = 0;
     virtual void   read(void* buf, size32_t size) = 0;
     virtual size32_t write(void const* buf, size32_t size) = 0; // returns amount written normally same as in size (see set_nonblock)
+    virtual size32_t writetms(void const* buf, size32_t size, unsigned timeoutms=WAIT_FOREVER) = 0;
 
     virtual size32_t get_max_send_size() = 0;
 

--- a/system/security/securesocket/securesocket.cpp
+++ b/system/security/securesocket/securesocket.cpp
@@ -154,6 +154,7 @@ public:
     virtual void read(void* buf, size32_t min_size, size32_t max_size, size32_t &size_read,unsigned timeoutsecs);
     virtual void readtms(void* buf, size32_t min_size, size32_t max_size, size32_t &size_read, unsigned timeoutms);
     virtual size32_t write(void const* buf, size32_t size);
+    virtual size32_t writetms(void const* buf, size32_t size, unsigned timeoutms=WAIT_FOREVER);
 
     void readTimeout(void* buf, size32_t min_size, size32_t max_size, size32_t &size_read, unsigned timeout, bool useSeconds);
 
@@ -730,6 +731,13 @@ void CSecureSocket::read(void* buf, size32_t min_size, size32_t max_size, size32
 
 size32_t CSecureSocket::write(void const* buf, size32_t size)
 {
+    int numwritten = SSL_write(m_ssl, buf, size);
+    return numwritten;
+}
+
+size32_t CSecureSocket::writetms(void const* buf, size32_t size, unsigned timeoutms)
+{
+    // timeoutms not implemented yet ...
     int numwritten = SSL_write(m_ssl, buf, size);
     return numwritten;
 }


### PR DESCRIPTION
NOTE: LN PR ln12399 is also required and dependent on this PR

Added non blocking writetms to prevent [very unlikely] write from blocking and causing address cleaner thread to block, which when there is only one socket in the cleaner pool would cause other address cleaner requests to also block.  LN address cleaner code PR uses this new function.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
