### PR TITLE
HPCC-3011 std.file.sprayVariable and "No Separator"

### DIFF
--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -1341,7 +1341,7 @@ public:
     void setCsvOptions(const char *separate,const char *terminate,const char *quote,const char *escape,bool quotedTerminator)
     {
         IPropertyTree *t = queryUpdateProperties();
-        if (separate && *separate)
+        if (separate) //Enable to pass zero string to override default separator
             t->setProp("@csvSeparate",separate);
         if (terminate && *terminate)
             t->setProp("@csvTerminate",terminate);

--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -372,8 +372,14 @@ bool CDfuPlusHelper::variableSpray(const char* srcxml,const char* srcip,const ch
             throw MakeStringException(-1, "You can't use rowtag option with csv/delimited format");
 
         const char* separator = globals->queryProp("separator");
-        if(separator && *separator)
+        if(separator)
+        {
+            // Pass separator definition string from command line if defined
+            // even it is empty to override default value
             req->setSourceCsvSeparate(separator);
+            if (*separator == '\0')
+                req->setNoSourceCsvSeparator(true);
+        }
         const char* terminator = globals->queryProp("terminator");
         if(terminator && *terminator)
             req->setSourceCsvTerminate(terminator);

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -633,7 +633,10 @@ CCsvPartitioner::CCsvPartitioner(const FileFormat & _format) : CInputBasePartiti
 {
     maxElementLength = 1;
     format.set(_format);
-    addActionList(matcher, format.separate.get() ? format.separate.get() : "\\,", SEPARATOR, &maxElementLength);
+    const char * separator = format.separate.get();
+    if (separator && *separator)
+        addActionList(matcher, separator, SEPARATOR, &maxElementLength);
+
     addActionList(matcher, format.quote.get() ? format.quote.get() : "\"", QUOTE, &maxElementLength);
     addActionList(matcher, format.terminate.get() ? format.terminate.get() : "\\n,\\r\\n", TERMINATOR, &maxElementLength);
     const char * escape = format.escape.get();

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -695,6 +695,8 @@ static char * implementSprayVariable(ICodeContext *ctx, const char * sourceIP, c
     req->setSourceMaxRecordSize(sourceMaxRecordSize);
     req->setSourceFormat(DFUff_csv);
     req->setSourceCsvSeparate(sourceCsvSeparate);
+    if (sourceCsvSeparate && *sourceCsvSeparate == '\0')
+        req->setNoSourceCsvSeparator(true);
     req->setSourceCsvTerminate(sourceCsvTerminate);
     req->setSourceCsvQuote(sourceCsvQuote);
     if (sourceCsvEscape && *sourceCsvEscape)


### PR DESCRIPTION
Add code to enable "No separator" in
- dfuplus command with separator='' parameter
- ECL code with pass '' (empty string) in separater parameter value
  for FileServices.SprayVariable()

(It is already implemented in EClWatch on Spray -> Delimitted dialog with
 "Omit Separator:" checkbox.)

Signed-off-by: Attila Vamos attila.vamos@gmail.com
