### PR TITLE
HPCC-12645 Don't generate internal errors looking at old workunits

### DIFF
--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -338,7 +338,11 @@ const char * queryMeasureName(StatisticMeasure measure)
 StatisticMeasure queryMeasure(const char *  measure)
 {
     //MORE: Use a hash table??
-    return (StatisticMeasure)matchString(measureNames, measure);
+    StatisticMeasure ret = (StatisticMeasure)matchString(measureNames, measure);
+    //Legacy support for an unusual statistic - pretend the sizes are in bytes instead of kb.
+    if ((ret == SMeasureNone) && measure && streq(measure, "kb"))
+        ret = SMeasureSize;
+    return ret;
 }
 
 StatsMergeAction queryMergeMode(StatisticMeasure measure)


### PR DESCRIPTION
The "kb" stats kind was only used in 5.0.4 to record the peak memory used
by a workunit.  This allows those workunits to be read, but sizes will be
out by a factor of 1000.  Not worth providing full support since it
hasn't been used for anything afaik.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
