### PR TITLE
HPCC-12672 The //noxxxxxx tag won't work together with the --runclass/--excludecalss parameters

### DIFF
--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -103,7 +103,7 @@ class Suite:
                             excluded = eclfile.testInClass(classExcluded)
                         exclude = (not included )  or excluded
                         exclusionReason=' class member excluded'
-                    else:
+                    if not exclude:
                         exclude = eclfile.testExclusion(self.name)
                         exclusionReason=' ECL excluded'
 


### PR DESCRIPTION
Add code to check exclusion tag.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
