### PR TITLE
HPCC-12669 Rename platform.h and all references to it

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -239,7 +239,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
       SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Werror=bitwise-op-parentheses -Werror=tautological-compare")
       SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wno-switch-enum -Wno-format-zero-length -Wno-switch")
     endif()
-    # All of these are defined in platform.h too, but need to be defned before any system header is included
+    # All of these are defined in hpccplatform.h too, but need to be defned before any system header is included
     ADD_DEFINITIONS (-D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 -D__USE_LARGEFILE64=1 -D__USE_FILE_OFFSET64=1)
     if ("${GIT_COMMAND}" STREQUAL "")
         set ( GIT_COMMAND "git" )

--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #if defined(_DEBUG) && defined(_WIN32) && !defined(USING_MPATROL)
  #undef new

--- a/common/environment/dalienv.cpp
+++ b/common/environment/dalienv.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jio.hpp"

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jliball.hpp"
 #include "rtlbcd.hpp"
 #include "workunit.hpp"

--- a/common/fileview2/fvsource.cpp
+++ b/common/fileview2/fvsource.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jliball.hpp"
 #include "eclrtl.hpp"
 #include "rtlds_imp.hpp"

--- a/common/fileview2/fvwusource.cpp
+++ b/common/fileview2/fvwusource.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jliball.hpp"
 #include "eclrtl.hpp"
 

--- a/common/remote/hooks/git/gitfile.cpp
+++ b/common/remote/hooks/git/gitfile.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jio.hpp"

--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #ifdef _WIN32
 #define S_ISDIR(m) (((m)&_S_IFDIR)!=0)

--- a/common/remote/rmtfile.cpp
+++ b/common/remote/rmtfile.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "portlist.h"
 
 #include "jlib.hpp"

--- a/common/remote/rmtpass.cpp
+++ b/common/remote/rmtpass.cpp
@@ -17,7 +17,7 @@
 
 #include "jliball.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jsem.hpp"

--- a/common/remote/rmtsmtp.cpp
+++ b/common/remote/rmtsmtp.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jlog.hpp"

--- a/common/remote/rmtspawn.cpp
+++ b/common/remote/rmtspawn.cpp
@@ -17,7 +17,7 @@
 
 #include "jliball.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "portlist.h"
 
 

--- a/common/remote/rmtssh.cpp
+++ b/common/remote/rmtssh.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "portlist.h"
 
 #include "jlib.hpp"

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -18,7 +18,7 @@
 // todo look at IRemoteFileServer stop
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "limits.h"
 
 #include "jlib.hpp"

--- a/common/thorhelper/commonext.cpp
+++ b/common/thorhelper/commonext.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #define CHEAP_UCHAR_DEF
 #ifdef _WIN32
 typedef wchar_t UChar;

--- a/common/thorhelper/csvsplitter.cpp
+++ b/common/thorhelper/csvsplitter.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jregexp.hpp"
 #include "jlib.hpp"
 #include "jexcept.hpp"

--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <algorithm>
 
 #include "jlib.hpp"

--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "thorxmlwrite.hpp"
 #include "eclrtl.hpp"

--- a/common/workunit/package.cpp
+++ b/common/workunit/package.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jprop.hpp"
 #include "jptree.hpp"
 #include "pkgimpl.hpp"

--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -18,7 +18,7 @@
 #ifndef WUPACKAGE_IMPL_HPP
 #define WUPACKAGE_IMPL_HPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jprop.hpp"
 #include "jptree.hpp"
 #include "jregexp.hpp"

--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <algorithm>
 #include "limits.h"
 #include "jlib.hpp"

--- a/dali/base/daaudit.cpp
+++ b/dali/base/daaudit.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jfile.hpp"
 #include "jmisc.hpp"

--- a/dali/base/daclient.cpp
+++ b/dali/base/daclient.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jptree.hpp"

--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include <time.h>
 #include "jlib.hpp"
 #include "jexcept.hpp"

--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include <typeinfo>
 #include "jlib.hpp"
 #include "jfile.hpp"

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -17,7 +17,7 @@
 
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jfile.hpp"
 #include "jlzw.hpp"

--- a/dali/base/dadiags.cpp
+++ b/dali/base/dadiags.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "dacoven.hpp"
 #include "daclient.hpp"

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "portlist.h"
 #include "jlib.hpp"
 #include "jfile.hpp"

--- a/dali/base/dalock.cpp
+++ b/dali/base/dalock.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jsuperhash.hpp"
 #include "jmisc.hpp"

--- a/dali/base/dalock.hpp
+++ b/dali/base/dalock.hpp
@@ -22,7 +22,7 @@
 #define da_decl __declspec(dllimport)
 #endif
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"
 
 #include "dasess.hpp"

--- a/dali/base/danqs.cpp
+++ b/dali/base/danqs.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jsuperhash.hpp"
 #include "dacoven.hpp"

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jhash.hpp"
 #include "jlib.hpp"
 #include "jfile.hpp"

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jfile.hpp"
 #include "jsuperhash.hpp"

--- a/dali/base/dasubs.cpp
+++ b/dali/base/dasubs.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define da_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jsuperhash.hpp"

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -17,7 +17,7 @@
 
 #define da_decl __declspec(dllexport)
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jstring.hpp"
 #include "jfile.hpp"

--- a/dali/dafilesrv/dafilesrv.cpp
+++ b/dali/dafilesrv/dafilesrv.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "portlist.h"
 
 #include "jlib.hpp"

--- a/dali/dafilesrv/dafscontrol.cpp
+++ b/dali/dafilesrv/dafscontrol.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jio.hpp"
 #include "jmisc.hpp"

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "portlist.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"

--- a/dali/dalidiag/dalidiag.cpp
+++ b/dali/dalidiag/dalidiag.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "mpbase.hpp"

--- a/dali/dalistop/dalistop.cpp
+++ b/dali/dalistop/dalistop.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "mpbase.hpp"

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/dali/datest/dfuwutest.cpp
+++ b/dali/datest/dfuwutest.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "dfuwu.hpp"

--- a/dali/datest/floodtest.cpp
+++ b/dali/datest/floodtest.cpp
@@ -21,7 +21,7 @@ remove SEND timings from grid
 calculate top 10
 #endif
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jsuperhash.hpp"

--- a/dali/daunittest/daunittest.cpp
+++ b/dali/daunittest/daunittest.cpp
@@ -1,5 +1,5 @@
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "mpbase.hpp"/*##############################################################################

--- a/dali/daunittest/dautdfs.cpp
+++ b/dali/daunittest/dautdfs.cpp
@@ -1,5 +1,5 @@
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 

--- a/dali/dfu/dfu2.cpp
+++ b/dali/dfu/dfu2.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <stdio.h>
 #include <limits.h>
 #include "jexcept.hpp"

--- a/dali/dfu/dfurepl.cpp
+++ b/dali/dfu/dfurepl.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include "thirdparty.h"
 #include <stdio.h>
 #include <limits.h>

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -21,7 +21,7 @@ test multiclusteradd with replicate
 */
 
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <stdio.h>
 #include <limits.h>
 #include "jexcept.hpp"

--- a/dali/dfu/dfurunkdp.cpp
+++ b/dali/dfu/dfurunkdp.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <stdio.h>
 #include <limits.h>
 #include "jexcept.hpp"

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include "thirdparty.h"
 #include <stdio.h>
 #include <limits.h>

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include "jexcept.hpp"
 #include "jptree.hpp"
 #include "jsocket.hpp"

--- a/dali/dfuXRefLib/XRefNodeManager.cpp
+++ b/dali/dfuXRefLib/XRefNodeManager.cpp
@@ -25,7 +25,7 @@
 #include "jmisc.hpp"
 
 #include "mpcomm.hpp"
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "mpbase.hpp"
 #include "daclient.hpp"

--- a/dali/dfuXRefLib/dfuxreflib.cpp
+++ b/dali/dfuXRefLib/dfuxreflib.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 // DFU XREF Program
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jptree.hpp"

--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -17,7 +17,7 @@
 
 #pragma warning( disable : 4786)
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "portlist.h"
 
 #include "dfuplus.hpp"

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -17,7 +17,7 @@
 
 #include "jliball.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jio.hpp"

--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -17,7 +17,7 @@
 
 #include "jliball.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jio.hpp"

--- a/dali/ft/daftprogress.cpp
+++ b/dali/ft/daftprogress.cpp
@@ -17,7 +17,7 @@
 
 #include "jliball.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 
 #include "jlib.hpp"

--- a/dali/ft/daftsize.cpp
+++ b/dali/ft/daftsize.cpp
@@ -17,7 +17,7 @@
 
 #include "jliball.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jio.hpp"

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -17,7 +17,7 @@
 
 #include "jliball.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <algorithm>
 #include "jlib.hpp"
 #include "jio.hpp"

--- a/dali/ft/ftbase.cpp
+++ b/dali/ft/ftbase.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #include "jliball.hpp"
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jio.hpp"
 #include "jmutex.hpp"

--- a/dali/ft/ftslave.cpp
+++ b/dali/ft/ftslave.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #include "jliball.hpp"
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jio.hpp"
 #include "jmutex.hpp"

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #include "jliball.hpp"
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jio.hpp"
 #include "jmutex.hpp"

--- a/dali/fuse/dafuse.cpp
+++ b/dali/fuse/dafuse.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 
 
 #include "jlib.hpp"

--- a/dali/hellodali/hellodali.cpp
+++ b/dali/hellodali/hellodali.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jptree.hpp"

--- a/dali/sasha/packetstore.cpp
+++ b/dali/sasha/packetstore.cpp
@@ -1,5 +1,5 @@
 #define sa_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jsuperhash.hpp"
 #include "jmisc.hpp"

--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlog.ipp"
 #include "jptree.hpp"

--- a/dali/sasha/sacmd.cpp
+++ b/dali/sasha/sacmd.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jptree.hpp"

--- a/dali/sasha/sacoalescer.cpp
+++ b/dali/sasha/sacoalescer.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlog.ipp"
 #include "jptree.hpp"

--- a/dali/sasha/salds.cpp
+++ b/dali/sasha/salds.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlog.ipp"
 #include "jptree.hpp"

--- a/dali/sasha/saqmon.cpp
+++ b/dali/sasha/saqmon.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlog.ipp"
 #include "jptree.hpp"

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #include "build-config.h"
-#include "platform.h"
+#include "hpccplatform.h"
 #include "thirdparty.h"
 #include "portlist.h"
 #include "jlib.hpp"

--- a/dali/sasha/sasha.cpp
+++ b/dali/sasha/sasha.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include "jlib.hpp"
 #include "jio.hpp"

--- a/dali/sasha/sautil.cpp
+++ b/dali/sasha/sautil.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jptree.hpp"

--- a/dali/sasha/saverify.cpp
+++ b/dali/sasha/saverify.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlog.ipp"
 #include "jptree.hpp"

--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -1,6 +1,6 @@
 //TBD check min time from when *finished*
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jiface.hpp"

--- a/dali/security/capexport.cpp
+++ b/dali/security/capexport.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jfile.hpp"
 #include "mpcomm.hpp"

--- a/dali/security/capimport.cpp
+++ b/dali/security/capimport.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jfile.hpp"
 #include "mpcomm.hpp"

--- a/dali/security/capmaker.cpp
+++ b/dali/security/capmaker.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jfile.hpp"
 #include "mpcomm.hpp"

--- a/dali/security/dacaplib.cpp
+++ b/dali/security/dacaplib.cpp
@@ -19,7 +19,7 @@
 #ifndef DACAP_LINKED_IN
 #define dacaplib_decl __declspec(dllexport)
 #endif
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jmisc.hpp"

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jiface.hpp"
 #include "jencrypt.hpp"

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #include "build-config.h"
-#include "platform.h"
+#include "hpccplatform.h"
 #include "thirdparty.h"
 #include "jlib.hpp"
 #include "jlog.ipp"

--- a/dali/updtdalienv/updtdalienv.cpp
+++ b/dali/updtdalienv/updtdalienv.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jptree.hpp"

--- a/ecl/hql/hqldesc.cpp
+++ b/ecl/hql/hqldesc.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "hql.hpp"
 #include "hqlexpr.hpp"

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "build-config.h"
 
 #if defined(_DEBUG) && defined(_WIN32) && !defined(USING_MPATROL)

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jfile.hpp"
 #include "jexcept.hpp"

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -17,7 +17,7 @@
 #ifndef HQLGRAM_HPP_INCL
 #define HQLGRAM_HPP_INCL
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -32,7 +32,7 @@
 //Adding a comment to reference unused parameters also fails to solve it because it ignores references in comments (and a bit ugly)
 //fixing bison to ignore destructor {} for need use is another alternative - but would take a long time to feed into a public build.
 %{
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "hql.hpp"

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "hql.hpp"

--- a/ecl/hql/hqlmeta.cpp
+++ b/ecl/hql/hqlmeta.cpp
@@ -18,7 +18,7 @@
 #include "hql.hpp"
 #include "eclrtl.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jmisc.hpp"
 #include "jexcept.hpp"
 #include "hqlerrors.hpp"

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -22,7 +22,7 @@
 #endif
 
 #include "hql.hpp"
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -18,7 +18,7 @@
 #include "hql.hpp"
 #include "eclrtl.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hql/hqlvalid.cpp
+++ b/ecl/hql/hqlvalid.cpp
@@ -18,7 +18,7 @@
 #include "hql.hpp"
 #include "eclrtl.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlalias.cpp
+++ b/ecl/hqlcpp/hqlalias.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jset.hpp"
 

--- a/ecl/hqlcpp/hqlcatom.cpp
+++ b/ecl/hqlcpp/hqlcatom.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqlckey.cpp
+++ b/ecl/hqlcpp/hqlckey.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include <algorithm>
 
 #include "jliball.hpp"

--- a/ecl/hqlcpp/hqlcppc.cpp
+++ b/ecl/hqlcpp/hqlcppc.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqlcppcase.cpp
+++ b/ecl/hqlcpp/hqlcppcase.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlcpputil.cpp
+++ b/ecl/hqlcpp/hqlcpputil.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqlcse.cpp
+++ b/ecl/hqlcpp/hqlcse.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlcset.cpp
+++ b/ecl/hqlcpp/hqlcset.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqlgraph.cpp
+++ b/ecl/hqlcpp/hqlgraph.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlhoist.cpp
+++ b/ecl/hqlcpp/hqlhoist.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 
 #include "hqlexpr.hpp"

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlinline.cpp
+++ b/ecl/hqlcpp/hqlinline.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqliter.cpp
+++ b/ecl/hqlcpp/hqliter.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqllib.cpp
+++ b/ecl/hqlcpp/hqllib.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jhash.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqlpopt.cpp
+++ b/ecl/hqlcpp/hqlpopt.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 
 #include "hqlexpr.hpp"

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlstep.cpp
+++ b/ecl/hqlcpp/hqlstep.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlstmt.cpp
+++ b/ecl/hqlcpp/hqlstmt.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqltcppc.cpp
+++ b/ecl/hqlcpp/hqltcppc.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqltcppc2.cpp
+++ b/ecl/hqlcpp/hqltcppc2.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 ############################################################################## */
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jstream.ipp"

--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -17,7 +17,7 @@
 #include "jliball.hpp"
 #include "hql.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jexcept.hpp"
 #include "jmisc.hpp"

--- a/esp/bindings/SOAP/Platform/soapservice.cpp
+++ b/esp/bindings/SOAP/Platform/soapservice.cpp
@@ -24,7 +24,7 @@
 #endif
 
 //ESP Bindings
-#include "platform.h"
+#include "hpccplatform.h"
 #include <xpp/XmlPullParser.h>
 #include "SOAP/Platform/soapservice.hpp"
 #include "http/platform/httpservice.hpp"

--- a/esp/esdllib/wsexcept.cpp
+++ b/esp/esdllib/wsexcept.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "wsexcept.hpp"
 
 class CWsException : public CInterface,

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -23,7 +23,7 @@
 #endif
 #endif
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "espprotocol.hpp"
 #include "espbinding.hpp"
 #ifdef _USE_OPENLDAP

--- a/esp/services/common/wsexcept.cpp
+++ b/esp/services/common/wsexcept.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "wsexcept.hpp"
 
 class CWsException : public CInterface, implements IWsException

--- a/plugins/Rembed/Rembed.cpp
+++ b/plugins/Rembed/Rembed.cpp
@@ -15,7 +15,7 @@
  limitations under the License.
  ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #ifdef RCPP_HEADER_ONLY
 // NOTE - these symbols need to be hidden from being exported from the Rembed .so file as RInside tries to dynamically

--- a/plugins/cassandra/cassandraembed.cpp
+++ b/plugins/cassandra/cassandraembed.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "cassandra.h"
 #include "jexcept.hpp"
 #include "jthread.hpp"

--- a/plugins/debugservices/debugservices.cpp
+++ b/plugins/debugservices/debugservices.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "debugservices.hpp"
 
 #define DEBUGSERVICES_VERSION "DEBUGSERVICES 1.0.1"

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -18,7 +18,7 @@
 #pragma warning (disable : 4786)
 #pragma warning (disable : 4297)  // function assumed not to throw an exception but does
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "fileservices.hpp"
 #include "workunit.hpp"
 #include "agentctx.hpp"

--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <jni.h>
 #include "jexcept.hpp"
 #include "jthread.hpp"

--- a/plugins/memcached/memcachedplugin.cpp
+++ b/plugins/memcached/memcachedplugin.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "memcachedplugin.hpp"
 #include "eclrtl.hpp"
 #include "jexcept.hpp"

--- a/plugins/mysql/mysqlembed.cpp
+++ b/plugins/mysql/mysqlembed.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "mysql.h"
 #include "jexcept.hpp"
 #include "jthread.hpp"

--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "Python.h"
 #include "jexcept.hpp"
 #include "jthread.hpp"

--- a/plugins/sqlite3/sqlite3.cpp
+++ b/plugins/sqlite3/sqlite3.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "sqlite3.h"
 #include "jexcept.hpp"
 #include "jthread.hpp"

--- a/plugins/stringlib/stringlib.cpp
+++ b/plugins/stringlib/stringlib.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <time.h>
 #include <stdlib.h>
 #include <string.h>

--- a/plugins/stringlib/stringlib.hpp
+++ b/plugins/stringlib/stringlib.hpp
@@ -30,7 +30,7 @@
 #define STRINGLIB_API
 #endif
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "hqlplugins.hpp"
 
 extern "C" {

--- a/plugins/timelib/timelib.cpp
+++ b/plugins/timelib/timelib.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <time.h>
 #include <stdlib.h>
 #include <string.h>

--- a/plugins/timelib/timelib.hpp
+++ b/plugins/timelib/timelib.hpp
@@ -32,7 +32,7 @@
 
 #include <time.h>
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "hqlplugins.hpp"
 #include "eclinclude4.hpp"
 #include "eclrtl.hpp"

--- a/plugins/v8embed/v8embed.cpp
+++ b/plugins/v8embed/v8embed.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "v8.h"
 #include "jexcept.hpp"
 #include "jthread.hpp"

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -31,7 +31,7 @@ Persists changed?
 #pragma warning (disable : 4786)
 #pragma warning (disable : 4297)  // function assumed not to throw an exception but does
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 
 

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 
 #include "ccd.hpp"

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 
 #include "wujobq.hpp"

--- a/roxie/ccd/ccddebug.cpp
+++ b/roxie/ccd/ccddebug.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 
 #include "ccd.hpp"

--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jthread.hpp"
 #include "jregexp.hpp"

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <signal.h>
 #include <jlib.hpp>
 #include <jio.hpp>

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <jlib.hpp>
 
 #include "ccd.hpp"

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <jlib.hpp>
 #include <jio.hpp>
 #include <jqueue.tpp>

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <jlib.hpp>
 #include "build-config.h"
 

--- a/roxie/roxie/roxie.cpp
+++ b/roxie/roxie/roxie.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "ccd.hpp"
 
 static void roxie_server_usage()

--- a/roxie/udplib/udpmsgpk.cpp
+++ b/roxie/udplib/udpmsgpk.cpp
@@ -20,7 +20,7 @@
 #pragma warning( disable : 4018)
 #endif
 
-#include "platform.h"
+#include "hpccplatform.h"
 #undef new
 #include <string>
 #include <map>

--- a/rtl/eclrtl/eclinclude4.hpp
+++ b/rtl/eclrtl/eclinclude4.hpp
@@ -54,10 +54,10 @@ typedef unsigned short UChar;
 #endif //__WIN32
 
 #ifdef _WIN32
-typedef unsigned int size32_t; // avoid pulling in platform.h (which pulls in windows.h etc) just for this...
+typedef unsigned int size32_t; // avoid pulling in hpccplatform.h (which pulls in windows.h etc) just for this...
 typedef unsigned __int64 hash64_t;
 #else
-#include "platform.h"
+#include "hpccplatform.h"
 #endif
 
 #include "eclrtl.hpp"

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -17,9 +17,9 @@
 
 #include "limits.h"
 #ifdef _USE_BOOST_REGEX
-#include "boost/regex.hpp" // must precede platform.h ; n.b. this uses a #pragma comment(lib, ...) to link the appropriate .lib in MSVC
+#include "boost/regex.hpp" // must precede hpccplatform.h ; n.b. this uses a #pragma comment(lib, ...) to link the appropriate .lib in MSVC
 #endif
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jexcept.hpp"

--- a/rtl/eclrtl/eclrtl.hpp
+++ b/rtl/eclrtl/eclrtl.hpp
@@ -42,7 +42,7 @@
 #endif
 
 #ifdef _MSC_VER
-#undef __attribute__ // in case platform.h has been included
+#undef __attribute__ // in case hpccplatform.h has been included
 #define __attribute__(param) /* do nothing */
 #endif
 

--- a/rtl/eclrtl/rtlbcd.cpp
+++ b/rtl/eclrtl/rtlbcd.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "rtlbcd.hpp"
 #include "nbcd.hpp"

--- a/rtl/eclrtl/rtlbcdtest.cpp
+++ b/rtl/eclrtl/rtlbcdtest.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlog.hpp"
 #include "rtlbcd.hpp"
 

--- a/rtl/eclrtl/rtldistr.cpp
+++ b/rtl/eclrtl/rtldistr.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jexcept.hpp"

--- a/rtl/eclrtl/rtlds.cpp
+++ b/rtl/eclrtl/rtlds.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jliball.hpp"
 #include "eclrtl.hpp"
 #include "eclhelper.hpp"

--- a/rtl/eclrtl/rtlfield.cpp
+++ b/rtl/eclrtl/rtlfield.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jmisc.hpp"

--- a/rtl/eclrtl/rtlint.cpp
+++ b/rtl/eclrtl/rtlint.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jexcept.hpp"

--- a/rtl/eclrtl/rtlqstr.cpp
+++ b/rtl/eclrtl/rtlqstr.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #include "limits.h"
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jexcept.hpp"

--- a/rtl/eclrtl/rtlrank.cpp
+++ b/rtl/eclrtl/rtlrank.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jmisc.hpp"

--- a/rtl/eclrtl/rtlread.cpp
+++ b/rtl/eclrtl/rtlread.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jliball.hpp"
 #include "junicode.hpp"
 

--- a/rtl/eclrtl/rtlsize.cpp
+++ b/rtl/eclrtl/rtlsize.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jmisc.hpp"

--- a/rtl/eclrtl/rtltype.cpp
+++ b/rtl/eclrtl/rtltype.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jmisc.hpp"

--- a/rtl/eclrtl/rtlxml.cpp
+++ b/rtl/eclrtl/rtlxml.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #include "limits.h"
-#include "platform.h"
+#include "hpccplatform.h"
 #include <math.h>
 #include <stdio.h>
 #include "jexcept.hpp"

--- a/rtl/nbcd/nbcd.cpp
+++ b/rtl/nbcd/nbcd.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "nbcd.hpp"
 #include "jlib.hpp"
 #include "jexcept.hpp"

--- a/services/newagent/newagent.cpp
+++ b/services/newagent/newagent.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h> 
 #include <stdlib.h> 
 #include <string.h>

--- a/services/newagent/newagent_se.cpp
+++ b/services/newagent/newagent_se.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #ifdef _WIN32
 #include <tchar.h> 
 #include <process.h> 

--- a/services/runagent/frunagent.cpp
+++ b/services/runagent/frunagent.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h> 
 #include <stdlib.h> 
 #include <string.h>

--- a/services/runagent/frunssh.cpp
+++ b/services/runagent/frunssh.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jfile.hpp"

--- a/services/winremote/service/svcmsg.hpp
+++ b/services/winremote/service/svcmsg.hpp
@@ -18,7 +18,7 @@
 #ifndef _MSG_H
 #define _MSG_H
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "win32.hpp"
 #include <tchar.h>
 #include <Lmcons.h>

--- a/system/hrpc/hrpc.cpp
+++ b/system/hrpc/hrpc.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "hrpc.hpp"
 #include "hrpc.ipp"

--- a/system/hrpc/hrpc.hpp
+++ b/system/hrpc/hrpc.hpp
@@ -18,7 +18,7 @@
 #ifndef HRPC_HPP
 #define HRPC_HPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jexcept.hpp"
 #include "jiface.hpp"

--- a/system/hrpc/hrpcmp.cpp
+++ b/system/hrpc/hrpcmp.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 // MP transport for HRPC
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "hrpc.hpp"
 #include "hrpc.ipp"

--- a/system/hrpc/hrpcsock.cpp
+++ b/system/hrpc/hrpcsock.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 // TCP/IP transport for HRPC
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "hrpc.hpp"
 #include "hrpc.ipp"

--- a/system/hrpc/hrpcutil.cpp
+++ b/system/hrpc/hrpcutil.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 

--- a/system/include/CMakeLists.txt
+++ b/system/include/CMakeLists.txt
@@ -13,4 +13,4 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ################################################################################
-Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/platform.h DESTINATION componentfiles/cl/include COMPONENT Runtime )
+Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/hpccplatform.h DESTINATION componentfiles/cl/include COMPONENT Runtime )

--- a/system/include/hpccplatform.h
+++ b/system/include/hpccplatform.h
@@ -55,7 +55,7 @@
 #endif
 
 #ifdef _FILE_OFFSET_BITS
-//#error PLATFORM.H must be included first
+//#error hpccplatform.h must be included first
 #endif
 
 #define _FILE_OFFSET_BITS 64

--- a/system/jhtree/ctfile.cpp
+++ b/system/jhtree/ctfile.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/system/jhtree/hlzw.cpp
+++ b/system/jhtree/hlzw.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -38,7 +38,7 @@
 //                12-Apr-00    jcs moved over to jhtree.dll etc.
 //****************************************************************************
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/system/jhtree/jhutil.cpp
+++ b/system/jhtree/jhutil.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/system/jhtree/keydiff.cpp
+++ b/system/jhtree/keydiff.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlzw.hpp"
 #include "jlzma.hpp"
 #include "jexcept.hpp"

--- a/system/jlib/jaio.cpp
+++ b/system/jlib/jaio.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <assert.h>
 #include <stdio.h>
 #include "jaio.hpp"

--- a/system/jlib/jarray.hpp
+++ b/system/jlib/jarray.hpp
@@ -22,7 +22,7 @@
 
 #include <new>
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"
 
 typedef size32_t aindex_t;

--- a/system/jlib/jatomic.hpp
+++ b/system/jlib/jatomic.hpp
@@ -18,7 +18,7 @@
 
 #ifndef JATOMIC_HPP
 #define JATOMIC_HPP
-#include "platform.h"
+#include "hpccplatform.h"
 
 #ifdef _WIN32
 

--- a/system/jlib/jbuff.cpp
+++ b/system/jlib/jbuff.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jmisc.hpp"
 #include "jcomp.hpp"

--- a/system/jlib/jcrc.cpp
+++ b/system/jlib/jcrc.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jcrc.hpp"
 #include "jlib.hpp"
 #include "jfile.hpp"

--- a/system/jlib/jcrc.hpp
+++ b/system/jlib/jcrc.hpp
@@ -22,7 +22,7 @@
 #ifndef __JCRC__
 #define __JCRC__
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include "jiface.hpp"
 #include "jio.hpp"

--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -15,7 +15,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jdebug.hpp"
 #include "jstring.hpp"

--- a/system/jlib/jencrypt.hpp
+++ b/system/jlib/jencrypt.hpp
@@ -19,7 +19,7 @@
 #ifndef JENCRYPT_HPP
 #define JENCRYPT_HPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"
 #include "jbuff.hpp"
 #include "jexcept.hpp"

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <algorithm>
 
 #include "jexcept.hpp"

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -22,7 +22,7 @@
 //#include <winsock.h>  // for TransmitFile
 #endif
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <algorithm>

--- a/system/jlib/jflz.cpp
+++ b/system/jlib/jflz.cpp
@@ -46,7 +46,7 @@
 #if !defined(FASTLZ__COMPRESSOR) && !defined(FASTLZ_DECOMPRESSOR)
 
 // adapted for jlib
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jflz.hpp"
 

--- a/system/jlib/jhash.cpp
+++ b/system/jlib/jhash.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/system/jlib/jhash.hpp
+++ b/system/jlib/jhash.hpp
@@ -20,7 +20,7 @@
 #ifndef JHASH_HPP
 #define JHASH_HPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include "jiface.hpp"
 #include "jobserve.hpp"

--- a/system/jlib/jhash.ipp
+++ b/system/jlib/jhash.ipp
@@ -20,7 +20,7 @@
 #ifndef JHASH_IPP
 #define JHASH_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"
 #include "jobserve.ipp"
 

--- a/system/jlib/jheap.cpp
+++ b/system/jlib/jheap.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jheap.hpp"

--- a/system/jlib/jiface.hpp
+++ b/system/jlib/jiface.hpp
@@ -21,7 +21,7 @@
 #define JIFACE_HPP
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <string.h>
 #include "jscm.hpp"
 #include "jatomic.hpp"

--- a/system/jlib/jio.cpp
+++ b/system/jlib/jio.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <algorithm>
 
 #include "jfile.hpp"

--- a/system/jlib/jkeyboard.cpp
+++ b/system/jlib/jkeyboard.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jutil.hpp"
 #include "jkeyboard.hpp"
 

--- a/system/jlib/jliball.hpp
+++ b/system/jlib/jliball.hpp
@@ -19,7 +19,7 @@
 #ifndef JLIBALL_HPP
 #define JLIBALL_HPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"
 
 #include "jarray.hpp"

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "build-config.h"
 
 #include <algorithm>

--- a/system/jlib/jlzma.cpp
+++ b/system/jlib/jlzma.cpp
@@ -17,7 +17,7 @@
 
 
 // LZMA adapted for jlib
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlzma.hpp"
 

--- a/system/jlib/jlzw.cpp
+++ b/system/jlib/jlzw.cpp
@@ -17,7 +17,7 @@
 
 
 // JLIB LZW compression class 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jmisc.hpp"
 #include "jlib.hpp"
 #include <time.h>

--- a/system/jlib/jmalloc.cpp
+++ b/system/jlib/jmalloc.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlog.hpp"
 #include "jbuff.hpp"

--- a/system/jlib/jmd5.cpp
+++ b/system/jlib/jmd5.cpp
@@ -69,7 +69,7 @@
   1999-05-03 lpd Original version.
  */
 // Following added by Gavin 
-#include "platform.h"               // GH modified
+#include "hpccplatform.h"               // GH modified
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define ARCH_IS_BIG_ENDIAN 0
 #else

--- a/system/jlib/jmisc.cpp
+++ b/system/jlib/jmisc.cpp
@@ -19,7 +19,7 @@
 //#define MINIMALTRACE // a more readable version of the trace file (IMO)
 //#define LOGCLOCK
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "stdio.h"
 #include <time.h>
 #include "jmisc.hpp"

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -20,7 +20,7 @@
 #ifndef __JMISC__
 #define __JMISC__
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include "jiface.hpp"
 #include "jcrc.hpp"

--- a/system/jlib/jmutex.cpp
+++ b/system/jlib/jmutex.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jmutex.hpp"
 #include "jsuperhash.hpp"
 #include "jmisc.hpp"

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -25,11 +25,11 @@
 */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #ifdef _VER_C5
 #include <clwclib.h>
 #else
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #endif
 #include <algorithm>

--- a/system/jlib/jsort.cpp
+++ b/system/jlib/jsort.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <string.h>
 #include <limits.h>
 #include "jsort.hpp"

--- a/system/jlib/jstream.cpp
+++ b/system/jlib/jstream.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jstream.ipp"
 #include "jstring.hpp"
 #include "jexcept.hpp"

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/system/jlib/jtime.cpp
+++ b/system/jlib/jtime.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jmisc.hpp"
 #include "jtime.ipp"

--- a/system/jlib/junicode.cpp
+++ b/system/jlib/junicode.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jliball.hpp"
 #include "jerror.hpp"
 #include "junicode.hpp"

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -20,7 +20,7 @@
 #include "winprocess.hpp"
 #include <conio.h>
 #endif
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jmisc.hpp"
 #include "jutil.hpp"
 #include "jexcept.hpp"

--- a/system/jlib/jvmem.cpp
+++ b/system/jlib/jvmem.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jiface.hpp"
 #include "jexcept.hpp"

--- a/system/mp/mpbase.cpp
+++ b/system/mp/mpbase.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #define mp_decl __declspec(dllexport)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlog.hpp"
 

--- a/system/mp/mpcomm.cpp
+++ b/system/mp/mpcomm.cpp
@@ -24,7 +24,7 @@
     look at all timeouts
 */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "portlist.h"
 #include "jlib.hpp"
 #include <limits.h>

--- a/system/mp/test/mptest.cpp
+++ b/system/mp/test/mptest.cpp
@@ -2,7 +2,7 @@
 
 // CSocketSelectThread error 10038  
 
-#include <platform.h>
+#include "hpccplatform.h"
 #include <jlib.hpp>
 #include <jthread.hpp>
 #include <jmisc.hpp>

--- a/system/security/LdapSecurity/aci.cpp
+++ b/system/security/LdapSecurity/aci.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #pragma warning(disable:4786)
-#include "platform.h"
+#include "hpccplatform.h"
 #include "aci.ipp"
 #include "ldapsecurity.ipp"
 

--- a/system/xmllib/xalan_processor.ipp
+++ b/system/xmllib/xalan_processor.ipp
@@ -19,7 +19,7 @@
 #define XSLPROCESSOR_IPP_INCL
 
 #ifndef _WIN32
-//undefine the stricmp and strnicmp macros defined by platform.h
+//undefine the stricmp and strnicmp macros defined by hpccplatform.h
 //since xerces implements these functions
 #undef stricmp
 #undef strnicmp

--- a/system/xmllib/xerces_validator.cpp
+++ b/system/xmllib/xerces_validator.cpp
@@ -22,7 +22,7 @@
 #include "jexcept.hpp"
 #include "jlog.hpp"
 
-// platform.h's definition of new collides with xerces
+// hpccplatform.h's definition of new collides with xerces
 #undef new 
 
 // xalan has its own definitions and implementations:

--- a/system/xmllib/xmlvalidator.cpp
+++ b/system/xmllib/xmlvalidator.cpp
@@ -22,7 +22,7 @@
 #include "jexcept.hpp"
 #include "jlog.hpp"
 
-// platform.h's definition of new collides with xerces
+// hpccplatform.h's definition of new collides with xerces
 #undef new 
 
 // xalan has its own definitions and implementations:

--- a/testing/unittests/unittests.hpp
+++ b/testing/unittests/unittests.hpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlog.hpp"
 #include "jmisc.hpp"

--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jiface.hpp"       // IInterface defined in jlib
 #include "mpbuff.hpp"

--- a/thorlcr/activities/aggregate/thgroupaggregateslave.ipp
+++ b/thorlcr/activities/aggregate/thgroupaggregateslave.ipp
@@ -19,7 +19,7 @@
 #ifndef _thgroupaggregateslave_ipp
 #define _thgroupaggregateslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"       // IInterface defined in jlib
 #include "eclhelper.hpp"
 #include "slave.ipp"

--- a/thorlcr/activities/choosesets/thchoosesetsslave.ipp
+++ b/thorlcr/activities/choosesets/thchoosesetsslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thchoosesetsslave_ipp
 #define _thchoosesetsslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"
 #include "thactivityutil.ipp"
 #include "slave.ipp"

--- a/thorlcr/activities/countproject/thcountprojectslave.ipp
+++ b/thorlcr/activities/countproject/thcountprojectslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thcountprojectslave_ipp
 #define _thcountprojectslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"
 #include "thactivityutil.ipp"
 #include "slave.ipp"

--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jio.hpp"
 #include "jio.hpp"

--- a/thorlcr/activities/degroup/thdegroupslave.ipp
+++ b/thorlcr/activities/degroup/thdegroupslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thdegroupslave_ipp
 #define _thdegroupslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"          // for IHThorDegroupArg
 #include "slave.ipp"
 #include "thactivityutil.ipp"

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jfile.hpp"
 #include "jio.hpp"

--- a/thorlcr/activities/fetch/thfetch.cpp
+++ b/thorlcr/activities/fetch/thfetch.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"
 #include "thbufdef.hpp"
 #include "mptag.hpp"

--- a/thorlcr/activities/fetch/thfetchslave.cpp
+++ b/thorlcr/activities/fetch/thfetchslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "limits.h"
 #include "slave.ipp"
 

--- a/thorlcr/activities/fetch/thfetchslave.ipp
+++ b/thorlcr/activities/fetch/thfetchslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _THFETCHSLAVE_IPP
 #define _THFETCHSLAVE_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "slave.ipp"
 

--- a/thorlcr/activities/filter/thfilterslave.ipp
+++ b/thorlcr/activities/filter/thfilterslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _THFILTERSLAVE_IPP
 #define _THFILTERSLAVE_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "eclhelper.hpp" // tmp for IHThor..Arg interfaces.
 

--- a/thorlcr/activities/firstn/thfirstn.cpp
+++ b/thorlcr/activities/firstn/thfirstn.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"        // for IHThorFirstNArg
 
 #include "thfirstn.ipp"

--- a/thorlcr/activities/firstn/thfirstnslave.cpp
+++ b/thorlcr/activities/firstn/thfirstnslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 #include "eclhelper.hpp"        // for IHThorFirstNArg
 #include "slave.ipp"

--- a/thorlcr/activities/funnel/thfunnelslave.ipp
+++ b/thorlcr/activities/funnel/thfunnelslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _THFUNNELSLAVE_IPP
 #define _THFUNNELSLAVE_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jmutex.hpp"
 #include "jthread.hpp"

--- a/thorlcr/activities/group/thgroupslave.ipp
+++ b/thorlcr/activities/group/thgroupslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thgroupslave_ipp
 #define _thgroupslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"        // for IHThorGroupArg
 #include "slave.ipp"
 #include "thactivityutil.ipp"

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "limits.h"
 #include <math.h>
 

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.ipp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _THHASHDISTRIBSLAVE_IPP
 #define _THHASHDISTRIBSLAVE_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jsocket.hpp"
 #include "slave.ipp"
 #include "thactivityutil.ipp"

--- a/thorlcr/activities/iterate/thgroupiterateslave.ipp
+++ b/thorlcr/activities/iterate/thgroupiterateslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thgroupiterateslave_ipp
 #define _thgroupiterateslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"        // for IHThorGroupIterateArg
 #include "slave.ipp"
 

--- a/thorlcr/activities/iterate/thiterateslave.ipp
+++ b/thorlcr/activities/iterate/thiterateslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thiterateslave_ipp
 #define _thiterateslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"        // for IHThorIterateArg
 #include "slave.ipp"
 #include "thactivityutil.ipp"

--- a/thorlcr/activities/join/thjoinslave.ipp
+++ b/thorlcr/activities/join/thjoinslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thjoinslave_ipp
 #define _thjoinslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"       // IInterface defined in jlib
 #include "eclhelper.hpp"        // for IHThorJoinArg
 #include "slave.ipp"

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.ipp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _THKEYEDJOINSLAVE_IPP
 #define _THKEYEDJOINSLAVE_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "slave.ipp"
 
 activityslaves_decl CActivityBase *createKeyedJoinSlave(CGraphElementBase *container);

--- a/thorlcr/activities/limit/thlimit.cpp
+++ b/thorlcr/activities/limit/thlimit.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"
 #include "thlimit.ipp"
 

--- a/thorlcr/activities/merge/thmergeslave.cpp
+++ b/thorlcr/activities/merge/thmergeslave.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jfile.hpp"
 #include "thormisc.hpp"
 #include "thexception.hpp"

--- a/thorlcr/activities/merge/thmergeslave.ipp
+++ b/thorlcr/activities/merge/thmergeslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _THMERGESLAVE_IPP
 #define _THMERGESLAVE_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jmutex.hpp"
 #include "jthread.hpp"

--- a/thorlcr/activities/msort/thgroupsortslave.ipp
+++ b/thorlcr/activities/msort/thgroupsortslave.ipp
@@ -19,7 +19,7 @@
 #ifndef _thgroupsortslave_ipp
 #define _thgroupsortslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"        // for IHThorGroupSortArg
 #include "slave.ipp"
 

--- a/thorlcr/activities/msort/thmsortslave.cpp
+++ b/thorlcr/activities/msort/thmsortslave.cpp
@@ -17,7 +17,7 @@
 
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "limits.h"
 #include "slave.ipp"
 #include "thmsortslave.ipp"

--- a/thorlcr/activities/msort/thmsortslave.ipp
+++ b/thorlcr/activities/msort/thmsortslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _THMSORTSLAVE_IPP
 #define _THMSORTSLAVE_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "slave.ipp"
 
 activityslaves_decl CActivityBase *createMSortSlave(CGraphElementBase *container);

--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "limits.h"
 #include "slave.ipp"
 #include "thactivityutil.ipp"

--- a/thorlcr/activities/normalize/thnormalizeslave.cpp
+++ b/thorlcr/activities/normalize/thnormalizeslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"       // IInterface defined in jlib
 
 #include "eclhelper.hpp"        // for IHThorNormalizeArg

--- a/thorlcr/activities/nsplitter/thnsplitterslave.ipp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _THNSPLITTERSLAVE_IPP
 #define _THNSPLITTERSLAVE_IPP
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jmutex.hpp"
 

--- a/thorlcr/activities/null/thnullslave.ipp
+++ b/thorlcr/activities/null/thnullslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thnullslave_ipp
 #define _thnullslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"
 #include "slave.ipp"
 #include "thactivityutil.ipp"

--- a/thorlcr/activities/nullaction/thnullactionslave.cpp
+++ b/thorlcr/activities/nullaction/thnullactionslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 #include "eclhelper.hpp"
 #include "slave.ipp"

--- a/thorlcr/activities/parse/thparseslave.cpp
+++ b/thorlcr/activities/parse/thparseslave.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 #include "eclhelper.hpp"
 #include "slave.ipp"

--- a/thorlcr/activities/project/thprojectslave.ipp
+++ b/thorlcr/activities/project/thprojectslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thprojectslave_ipp
 #define _thprojectslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"       // IInterface defined in jlib
 #include "eclhelper.hpp"        // for IHThorProjectArg
 #include "slave.ipp"

--- a/thorlcr/activities/result/thresultslave.ipp
+++ b/thorlcr/activities/result/thresultslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thresultslave_ipp
 #define _thresultslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "slave.ipp"
 #include "mptag.hpp"
 

--- a/thorlcr/activities/rollup/throllupslave.ipp
+++ b/thorlcr/activities/rollup/throllupslave.ipp
@@ -21,7 +21,7 @@
 #ifndef _throllupslave_ipp
 #define _throllupslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"
 #include "slave.ipp"
 

--- a/thorlcr/activities/selfjoin/thselfjoinslave.ipp
+++ b/thorlcr/activities/selfjoin/thselfjoinslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thselfjoinslave_ipp
 #define _thselfjoinslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp"
 #include "slave.ipp"
 #include "thactivityutil.ipp"

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jprop.hpp"
 #include "thormisc.hpp"
 #include "thtmptableslave.ipp"

--- a/thorlcr/activities/temptable/thtmptableslave.ipp
+++ b/thorlcr/activities/temptable/thtmptableslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thtemptableslave_ipp
 #define _thtemptableslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jiface.hpp"       // IInterface defined in jlib   
 #include "eclhelper.hpp"        // for IHThorInlineTableArg
 #include "slave.ipp"

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jfile.hpp"
 #include "jio.hpp"

--- a/thorlcr/activities/wuidread/thwuidreadslave.cpp
+++ b/thorlcr/activities/wuidread/thwuidreadslave.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 #include "eclhelper.hpp"
 #include "slave.ipp"

--- a/thorlcr/activities/wuidwrite/thwuidwriteslave.cpp
+++ b/thorlcr/activities/wuidwrite/thwuidwriteslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 
 #include "thormisc.hpp"

--- a/thorlcr/activities/wuidwrite/thwuidwriteslave.ipp
+++ b/thorlcr/activities/wuidwrite/thwuidwriteslave.ipp
@@ -18,7 +18,7 @@
 #ifndef _thwuidwriteslave_ipp
 #define _thwuidwriteslave_ipp
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "eclhelper.hpp" // tmp for IHThor..Arg interfaces.
 #include "slave.ipp"
 

--- a/thorlcr/activities/xmlread/thxmlreadslave.cpp
+++ b/thorlcr/activities/xmlread/thxmlreadslave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 #include "jio.hpp"
 #include "jlzw.hpp"

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -28,7 +28,7 @@
     #define graphslave_decl
 #endif
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "slave.hpp"
 #include "thormisc.hpp"
 #include "thorcommon.hpp"

--- a/thorlcr/master/mawatchdog.cpp
+++ b/thorlcr/master/mawatchdog.cpp
@@ -17,7 +17,7 @@
 
 //Master Watchdog Server/Monitor
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include "jlib.hpp"
 #include "jmisc.hpp"

--- a/thorlcr/master/thactivitymaster.cpp
+++ b/thorlcr/master/thactivitymaster.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jprop.hpp"
 #include "jstring.hpp"

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 #include "build-config.h"
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jarray.hpp"
 #include "jfile.hpp"
 #include "jmutex.hpp"

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -17,7 +17,7 @@
 
 // Entrypoint for ThorMaster.EXE
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jfile.hpp"
 #include "jiface.hpp"

--- a/thorlcr/msort/tsorta.cpp
+++ b/thorlcr/msort/tsorta.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>

--- a/thorlcr/msort/tsortl.cpp
+++ b/thorlcr/msort/tsortl.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>

--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -17,7 +17,7 @@
 
 // MSort Master           
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>

--- a/thorlcr/msort/tsortmp.cpp
+++ b/thorlcr/msort/tsortmp.cpp
@@ -1,4 +1,4 @@
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jbuff.hpp"
 #include "tsorts.hpp"
 

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 #include "jlib.hpp"
 #include <mpbase.hpp>

--- a/thorlcr/msort/tsorts1.cpp
+++ b/thorlcr/msort/tsorts1.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 
 #include "jlib.hpp"

--- a/thorlcr/msort/tsorttr.cpp
+++ b/thorlcr/msort/tsorttr.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jptree.hpp"
 

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 
 #include "jlib.hpp"
 #include "jexcept.hpp"

--- a/thorlcr/slave/slwatchdog.cpp
+++ b/thorlcr/slave/slwatchdog.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 // Slave Watchdog
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdio.h>
 #include "jsocket.hpp"
 #include "jmisc.hpp"

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -17,7 +17,7 @@
 
 // Entrypoint for ThorSlave.EXE
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/thorlcr/thorutil/thalloc.cpp
+++ b/thorlcr/thorutil/thalloc.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jlib.hpp"
 #include "jlog.hpp"

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <limits.h>
 #include <stddef.h>
 #include "jlib.hpp"

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "jmisc.hpp"
 #include "jio.hpp"

--- a/thorlcr/thorutil/thorport.cpp
+++ b/thorlcr/thorutil/thorport.cpp
@@ -17,7 +17,7 @@
 
 // Thor Port Allocation
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/tools/backupnode/backupnode.cpp
+++ b/tools/backupnode/backupnode.cpp
@@ -19,7 +19,7 @@
 #define _WIN32_WINNT 0x0400
 #include <windows.h>
 #endif
-#include "platform.h"
+#include "hpccplatform.h"
 #include "thirdparty.h"
 
 #include "jlib.hpp"

--- a/tools/backupnode/backupnode2.cpp
+++ b/tools/backupnode/backupnode2.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jiface.hpp"
 #include "jptree.hpp"

--- a/tools/combine/combine.cpp
+++ b/tools/combine/combine.cpp
@@ -20,7 +20,7 @@
 #include <windows.h>
 #endif
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jio.hpp"
 #include "jfile.hpp"

--- a/tools/copyexp/copyexp.cpp
+++ b/tools/copyexp/copyexp.cpp
@@ -16,7 +16,7 @@
 ############################################################################## */
 
 
-#include "platform.h"
+#include "hpccplatform.h"
 /* Overloaded and redefined operators */
 #include "jlib.hpp"
 #include "jiface.hpp"

--- a/tools/esdlcomp/esdl_utils.cpp
+++ b/tools/esdlcomp/esdl_utils.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include "hpccplatform.h"
 
 #include "esdl_utils.hpp"
 

--- a/tools/esdlcomp/esdl_utils.hpp
+++ b/tools/esdlcomp/esdl_utils.hpp
@@ -19,7 +19,7 @@
 #define __ESDL_UTILS_HPP__
 
 #include "esdldecl.hpp"
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tools/esdlcomp/esdlcomp.cpp
+++ b/tools/esdlcomp/esdlcomp.cpp
@@ -19,7 +19,7 @@
 
 #include "esdl_utils.hpp"
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "esdlcomp.h"
 #undef new
 #include <map>

--- a/tools/esdlcomp/esdlcomp.h
+++ b/tools/esdlcomp/esdlcomp.h
@@ -21,7 +21,7 @@
 #include <stdarg.h>
 #include <assert.h>
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jmutex.hpp"
 #include "jstring.hpp"
 #include "jfile.hpp"

--- a/tools/esdlcomp/esdllex.l
+++ b/tools/esdlcomp/esdllex.l
@@ -1,7 +1,7 @@
 %option nounistd
 %option case-insensitive
 %{
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdlib.h>
 #include <string.h>
 #include "esdlcomp.h"

--- a/tools/fcached/fcached.cpp
+++ b/tools/fcached/fcached.cpp
@@ -17,7 +17,7 @@
 
 // Prints OS cached details for files open by a process
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdio.h>

--- a/tools/genht/genht.cpp
+++ b/tools/genht/genht.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "jlib.hpp"
 #include "jlzw.hpp"
 #include "jfile.hpp"

--- a/tools/hidl/hidl_esp_ng.cpp
+++ b/tools/hidl/hidl_esp_ng.cpp
@@ -17,7 +17,7 @@
 
 #pragma warning(disable:4786)
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tools/hidl/hidl_utils.cpp
+++ b/tools/hidl/hidl_utils.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "hidl_utils.hpp"
 

--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -17,7 +17,7 @@
 
 #pragma warning(disable:4786)
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include "hidl_utils.hpp"
 #include "hidlcomp.h"

--- a/tools/hidl/hidlgram.y
+++ b/tools/hidl/hidlgram.y
@@ -1,7 +1,7 @@
 %{
 #pragma warning(disable:4786)
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tools/hidl/hidllex.l
+++ b/tools/hidl/hidllex.l
@@ -1,7 +1,7 @@
 %option nounistd
 %option case-insensitive
 %{
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/tools/hidl/main.cpp
+++ b/tools/hidl/main.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/swapnode/swapnode.cpp
+++ b/tools/swapnode/swapnode.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "thirdparty.h"
 
 #include "jlib.hpp"

--- a/tools/swapnode/swapnodelib.cpp
+++ b/tools/swapnode/swapnodelib.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include "platform.h"
+#include "hpccplatform.h"
 #include "thirdparty.h"
 
 #include "jlib.hpp"

--- a/tools/testsocket/testsocket.cpp
+++ b/tools/testsocket/testsocket.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
-#include <platform.h>
+#include <hpccplatform.h>
 #include <stdio.h>
 #include "jmisc.hpp"
 #include "jlib.hpp"


### PR DESCRIPTION
The file named system/include/platform.h is somewhat of a common name among
the many SDKs out there, and causes build errors when trying to coexist
with one or more of these SDKs. A better solution would be to rename it to
something less ambiguous like hpcc_platform.h or hpccplatform.h. This PR
renames that file and updates all references to it

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
