### PR TITLE
HPCC-12675 Prevent Regression Test Engine hangs when ecl command hangs.

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -234,6 +234,7 @@ class Regression:
 
                         self.taskParam[threadId]['timeoutValue'] = self.timeouts[threadId]
                         query = suiteItems[self.taskParam[threadId]['taskId']]
+                        query.setTimeout(self.timeouts[threadId])
                         #logging.debug("self.timeout[%d]:%d", threadId, self.timeouts[threadId])
                         sysThreadId = thread.start_new_thread(self.runQuery, (cluster, query, report, cnt, suite.testPublish(query.ecl),  threadId))
                         time.sleep(0.4)
@@ -337,6 +338,7 @@ class Regression:
             if self.timeouts[thread] == 0:
                 # time out, abort tast
                 wuid =  queryWuid(query.getJobname(),  query.getTaskId())
+                logging.debug("%3d. Abort WUID:'%s'" % (cnt,  str(wuid)),  extra={'taskId':cnt})
                 abortWorkunit(wuid['wuid'])
                 query.setAborReason('Timeout')
                 self.loggermutex.acquire()

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -39,6 +39,7 @@ class ECLcmd(Shell):
         args.append('-fpickBestEngine=false')
         args.append('--target=' + cluster)
         args.append('--cluster=' + cluster)
+        args.append('--wait='+str(eclfile.getTimeout()*1000))
 
         server = kwargs.pop('server', False)
         if server:
@@ -78,7 +79,7 @@ class ECLcmd(Shell):
             args = args + eclfile.getStoredInputParameters()
 
             args.append(eclfile.getArchive())
-            
+
         data = ""
         wuid = "N/A"
         state = ""

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -74,6 +74,7 @@ class ECLFile:
         self.isVersions=False
         self.version=''
         self.versionId=0
+        self.timeout = 0
 
         #If there is a --publish CL parameter then force publish this ECL file
         self.forcePublish=False
@@ -345,20 +346,27 @@ class ECLFile:
 
     def getTimeout(self):
         timeout = 0
-        # Standard string has a problem with unicode characters
-        # use byte arrays and binary file open instead
-        tag = b'//timeout'
-        logging.debug("%3d. getTimeout (ecl:'%s', tag:'%s')", self.taskId,  self.ecl, tag)
-        eclText = open(self.getEcl(), 'rb')
-        for line in eclText:
-            if tag in line:
-                timeoutParts = line.split()
-                if len(timeoutParts) == 2:
-                    if (timeoutParts[1] == '-1') or isPositiveIntNum(timeoutParts[1]) :
-                        timeout = int(timeoutParts[1])
-                break
+        if  self.timeout == 0:
+            # Standard string has a problem with unicode characters
+            # use byte arrays and binary file open instead
+            tag = b'//timeout'
+            logging.debug("%3d. getTimeout (ecl:'%s', tag:'%s')", self.taskId,  self.ecl, tag)
+            eclText = open(self.getEcl(), 'rb')
+            for line in eclText:
+                if tag in line:
+                    timeoutParts = line.split()
+                    if len(timeoutParts) == 2:
+                        if (timeoutParts[1] == '-1') or isPositiveIntNum(timeoutParts[1]) :
+                            timeout = int(timeoutParts[1])
+                            self.timeout = timeout
+                    break
+        else:
+            timeout = self.timeout
         logging.debug("%3d. Timeout is :%d sec",  self.taskId,  timeout)
         return timeout
+
+    def setTimeout(self,  timeout):
+        self.timeout = timeout
 
     def testResults(self):
         d = difflib.Differ()


### PR DESCRIPTION
Add timeout to "ecl run ..." command with --wait parameter.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
