### PR TITLE
HPCC-12681 Not show WU Scope if no security setting

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -28,6 +28,7 @@
   <xsl:variable name="isArchived" select="WUInfoResponse/Workunit/Archived"/>
   <xsl:variable name="debugTargetClusterType" select="WUInfoResponse/Workunit/targetclustertype" />
   <xsl:variable name="jobName" select="WUInfoResponse/Workunit/Jobname" />
+  <xsl:variable name="SecMethod" select="WUInfoResponse/SecMethod"/>
   <xsl:include href="/esp/xslt/lib.xslt"/>
   <xsl:include href="/esp/xslt/wuidcommon.xslt"/>
 

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -193,21 +193,23 @@
               <xsl:value-of select="Owner"/>
             </td>
           </tr>
-          <tr>
-            <td class="eclwatch entryprompt">
-              Scope:
-            </td>
-            <td>
-              <xsl:choose>
-                <xsl:when test="State='running'">
-                  <input type="text" name="Scope" value="{Scope}" size="40" disabled="disabled"/>
-                </xsl:when>
-                <xsl:otherwise>
-                  <input type="text" name="Scope" value="{Scope}" size="40"/>
-                </xsl:otherwise>
-              </xsl:choose>
-            </td>
-          </tr>
+          <xsl:if test="$SecMethod='LdapSecurity'">
+            <tr>
+              <td class="eclwatch entryprompt">
+                Scope:
+              </td>
+              <td>
+                <xsl:choose>
+                  <xsl:when test="State='running'">
+                    <input type="text" name="Scope" value="{Scope}" size="40" disabled="disabled"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <input type="text" name="Scope" value="{Scope}" size="40"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </td>
+            </tr>
+          </xsl:if>
           <tr>
               <td colspan="2">
                 <div style="border:1px solid grey;">

--- a/esp/eclwatch/ws_XSLT/wuiddetails.xslt
+++ b/esp/eclwatch/ws_XSLT/wuiddetails.xslt
@@ -26,6 +26,7 @@
   <xsl:variable name="isArchived" select="WUInfoResponse/Workunit/Archived"/>
   <xsl:variable name="havesubgraphtimings" select="WUInfoResponse/Workunit/HaveSubGraphTimings"/>
   <xsl:variable name="thorSlaveIP" select="WUInfoResponse/ThorSlaveIP"/>
+  <xsl:variable name="SecMethod" select="WUInfoResponse/SecMethod"/>
   <xsl:include href="/esp/xslt/lib.xslt"/>
   <xsl:include href="/esp/xslt/wuidcommon.xslt"/>
 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -622,6 +622,7 @@ ESPresponse [exceptions_inline] WUInfoResponse
    bool CanCompile;
    [min_ver("1.25")] string ThorSlaveIP;
    [min_ver("1.34")] ESParray<string, View> ResultViews;
+   [min_ver("1.54")] string SecMethod;
 }; 
 
 ESPrequest WUResultSummaryRequest
@@ -1571,7 +1572,7 @@ ESPresponse [exceptions_inline] WUCheckFeaturesResponse
 };
 
 ESPservice [
-    version("1.53"), default_client_version("1.53"),
+    version("1.54"), default_client_version("1.54"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1020,7 +1020,8 @@ void WsWuInfo::getInfo(IEspECLWorkunit &info, unsigned flags)
     info.setStateEx(cw->getStateEx(s).str());
     info.setPriorityClass(cw->getPriority());
     info.setPriorityLevel(cw->getPriorityLevel());
-    info.setScope(cw->getWuScope(s).str());
+    if (context.querySecManager())
+        info.setScope(cw->getWuScope(s).str());
     info.setActionEx(cw->getActionEx(s).str());
     info.setDescription(cw->getDebugValue("description", s).str());
     if (version > 1.21)

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1603,8 +1603,7 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
             resp.setCanCompile(notEmpty(context.queryUserId()));
             if (version > 1.24 && notEmpty(req.getThorSlaveIP()))
                 resp.setThorSlaveIP(req.getThorSlaveIP());
-            if (version > 1.53)
-                resp.setSecMethod(authMethod.get());
+            resp.setSecMethod(authMethod.get());
         }
     }
     catch(IException* e)

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -460,6 +460,11 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
     getConfigurationDirectory(directories, "query", "esp", name ? name : "esp", queryDirectory);
     recursiveCreateDirectory(queryDirectory.str());
 
+    xpath.setf("Software/EspProcess[@name=\"%s\"]/EspBinding[@service=\"%s\"]/Authenticate", process, service);
+    Owned<IPropertyTree> authCFG = cfg->getPropTree(xpath.str());
+    if(authCFG)
+        authMethod.set(authCFG->queryProp("@method"));
+
     dataCache.setown(new DataCache(DATA_SIZE));
     archivedWuCache.setown(new ArchivedWuCache(AWUS_CACHE_SIZE));
 
@@ -1459,9 +1464,12 @@ bool getWsWuInfoFromSasha(IEspContext &context, SocketEndpoint &ep, const char* 
     const char * cluster = wpt->queryProp("@clusterName");
     if (notEmpty(cluster))
         info->setCluster(cluster);
-    const char * scope = wpt->queryProp("@scope");
-    if (notEmpty(scope))
-        info->setScope(scope);
+    if (context.querySecManager())
+    {
+        const char * scope = wpt->queryProp("@scope");
+        if (notEmpty(scope))
+            info->setScope(scope);
+    }
     const char * jobName = wpt->queryProp("@jobName");
     if (notEmpty(jobName))
         info->setJobname(jobName);
@@ -1593,8 +1601,10 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
             }
 
             resp.setCanCompile(notEmpty(context.queryUserId()));
-            if (context.getClientVersion() > 1.24 && notEmpty(req.getThorSlaveIP()))
+            if (version > 1.24 && notEmpty(req.getThorSlaveIP()))
                 resp.setThorSlaveIP(req.getThorSlaveIP());
+            if (version > 1.53)
+                resp.setSecMethod(authMethod.get());
         }
     }
     catch(IException* e)

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -280,6 +280,7 @@ private:
     Owned<IPropertyTree> directories;
     int maxRequestEntityLength;
     Owned<IThreadPool> clusterQueryStatePool;
+    StringAttr authMethod;
 public:
     QueryFilesInUse filesInUse;
 };


### PR DESCRIPTION
In WsWorkunits service and legacy ECLWatch, check if
a system has set LDAP feature authentication for
WsWorkunits. If not, the ECL WU Details page
should not set/display WU Scope field because the
restricted scope is only valid if the system has set
LDAP feature authentication for WsWorkunits.

The change for new ECLWatch UI will be in a separate
commit.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
