### PR TITLE
HPCC-12704 Set measure filter in StatisticsFilter::set()

### DIFF
--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -1619,8 +1619,8 @@ void StatisticsFilter::set(const char * creatorTypeText, const char * scopeTypeT
 void StatisticsFilter::set(const char * _creatorTypeText, const char * _creator, const char * _scopeTypeText, const char * _scope, const char * _measureText, const char * _kindText)
 {
     StatisticMeasure newMeasure = queryMeasure(_measureText);
-    if (measure != SMeasureNone)
-        setMeasure(measure);
+    if (newMeasure != SMeasureNone)
+        setMeasure(newMeasure);
     set(_creatorTypeText, _scopeTypeText, _kindText);
     setCreator(_creator);
     setScope(_scope);


### PR DESCRIPTION
Existing StatisticsFilter::set() does not set measure filter
by input: _measureText.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
