### PR TITLE
HPCC-12705 Check before set measure in StatisticsFilter::setKind()

### DIFF
--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -1687,7 +1687,8 @@ void StatisticsFilter::setKind(const char * _kind)
 {
     if (!_kind || !*_kind || streq(_kind, "*"))
     {
-        measure = SMeasureAll;
+        if (measure == SMeasureNone)
+            measure = SMeasureAll;
         kind = StKindAll;
         return;
     }


### PR DESCRIPTION
The existing StatisticsFilter::setKind(const char \* _kind) sets
the measure to SMeasureAll even if the measure has been set (for
example to 'ns') in StatisticsFilter::set(). In this fix, an if
statement is added before set the measure in the setKind().

Signed-off-by: wangkx kevin.wang@lexisnexis.com
