### PR TITLE
HPCC-12711 Release rowmanager early to prevent leak checking crash

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -560,6 +560,7 @@ EclAgent::EclAgent(IConstWorkUnit *wu, const char *_wuid, bool _checkVersion, bo
 
 EclAgent::~EclAgent()
 {
+    rowManager.clear();
     ::Release(pluginMap);
     abortmonitor->stop();
     ::Release(abortmonitor); // no nead to join


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
