### PR TITLE
HPCC-12679 Ensure statistics cache is cleared on workunit reload

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3384,8 +3384,11 @@ void CLocalWorkUnit::init()
     libraries.kill();
     exceptions.kill();
     temporaries.kill();
+    appvalues.kill();
+    statistics.kill();
     roxieQueryInfo.clear();
     webServicesInfo.clear();
+
     workflowIteratorCached = false;
     resultsCached = false;
     temporariesCached = false;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
