### PR TITLE
HPCC-12675 Prevent Regression Test Engine hangs when ecl command hangs.

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -384,6 +384,7 @@ class Regression:
                 else:
                     self.timeouts[th] = self.timeout
 
+                query.setTimeout(self.timeouts[th])
                 thread.start_new_thread(self.runQuery, (cluster, query, report, cnt, suite.testPublish(query.ecl),  th))
                 time.sleep(0.1)
                 self.CheckTimeout(cnt, th,  query)

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -90,6 +90,7 @@ class Suite:
                     skipResult = eclfile.testSkip(self.name)
 
                 if not skipResult['skip']:
+                    exclude=False
                     exclusionReason=''
                     if isSetup:
                         exclude = eclfile.testExclusion('setup')


### PR DESCRIPTION
Fix timeout handling problem when the suite executed sequentally.

Fix source merge problem impacted to suite.py

Signed-off-by: Attila Vamos attila.vamos@gmail.com
