### PR TITLE
HPCC-12633 Improve contention cost in splitter

### DIFF
--- a/system/jlib/jqueue.tpp
+++ b/system/jlib/jqueue.tpp
@@ -236,9 +236,9 @@ public:
         }
         return (unsigned)-1;
     }
-    void dequeue(BASE *e)
+    BASE *dequeue(BASE *e)
     {
-        dequeue(find(e));
+        return dequeue(find(e));
     }
     inline unsigned ordinality() const { return num; }
 };

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -66,7 +66,8 @@ class NSplitterSlaveActivity : public CSlaveActivity
     bool spill;
     bool eofHit;
     bool inputsConfigured;
-    CriticalSection startLock;
+    bool pendingWrite;
+    CriticalSection startLock, writeAheadCrit1, writeAheadCrit2;
     unsigned nstopped;
     rowcount_t recsReady;
     IThorDataLink *input;
@@ -74,44 +75,27 @@ class NSplitterSlaveActivity : public CSlaveActivity
     Owned<IException> startException, writeAheadException;
     Owned<ISharedSmartBuffer> smartBuf;
 
+    // NB: CWriter only used by 'balanced' splitter, which blocks write when too far ahead
     class CWriter : public CSimpleInterface, IThreaded
     {
         NSplitterSlaveActivity &parent;
         CThreadedPersistent threaded;
-        Semaphore sem;
         bool stopped;
-        rowcount_t writerMax;
-        unsigned requestN;
-        SpinLock recLock;
 
     public:
         CWriter(NSplitterSlaveActivity &_parent) : parent(_parent), threaded("CWriter", this)
         {
             stopped = true;
-            writerMax = 0;
-            requestN = 1000;
         }
         ~CWriter() { stop(); }
         virtual void main()
         {
-            loop
-            {
-                sem.wait();
-                if (stopped) break;
-                rowcount_t request;
-                {
-                    SpinBlock block(recLock);
-                    request = writerMax;
-                }
-                parent.writeahead(request, stopped);
-                if (parent.eofHit)
-                    break;
-            }
+            while (!stopped && !parent.eofHit)
+                parent.writeahead(0, stopped); // intentional to avoid 'current' check and write as much as possible, it will block in smartBuf..
         }
         void start()
         {
             stopped = false;
-            writerMax = 0;
             threaded.start();
         }
         virtual void stop()
@@ -119,20 +103,8 @@ class NSplitterSlaveActivity : public CSlaveActivity
             if (!stopped)
             {
                 stopped = true;
-                sem.signal();
                 threaded.join();
             }
-        }
-        void more(rowcount_t &max) // called if output hit it's max, returns new max
-        {
-            if (stopped) return;
-            SpinBlock block(recLock);
-            if (writerMax <= max)
-            {
-                writerMax += requestN;
-                sem.signal();
-            }
-            max = writerMax;
         }
     } writer;
     class CNullInput : public CSplitterOutputBase
@@ -240,6 +212,7 @@ public:
         nstopped = 0;
         eofHit = inputsConfigured = false;
         recsReady = 0;
+        pendingWrite = false;
     }
     void ensureInputsConfigured()
     {
@@ -247,6 +220,7 @@ public:
         if (inputsConfigured)
             return;
         inputsConfigured = true;
+        pendingWrite = false;
         unsigned noutputs = container.connectedOutputs.getCount();
         ActPrintLog("Number of connected outputs: %d", noutputs);
         if (1 == noutputs)
@@ -309,11 +283,6 @@ public:
         else
             spill = dV>0;
     }
-    inline void more(rowcount_t &max)
-    {
-        ActivityTimer t(totalCycles, queryTimeActivities());
-        writer.more(max);
-    }
     void prepareInput(unsigned output)
     {
         CriticalBlock block(startLock);
@@ -348,7 +317,8 @@ public:
                             smartBuf->queryOutput(o)->stop();
                     }
                 }
-                writer.start();
+                if (spill)
+                    writer.start(); // writer keeps writing ahead as much as possible, the readahead impl. will block when has too much
             }
             catch (IException *e) { 
                 startException.setown(e); 
@@ -362,15 +332,32 @@ public:
             throw LINK(writeAheadException);
         return row.getClear();
     }
-    void writeahead(const rowcount_t &requested, const bool &stopped)
+    rowcount_t writeahead(rowcount_t current, const bool &stopped)
     {
         if (eofHit)
-            return;
-        
+            return recsReady;
+
+        ActivityTimer t(totalCycles, queryTimeActivities());
+        {
+            CriticalBlock b(writeAheadCrit1);
+            if (current < recsReady || pendingWrite)
+                return recsReady;
+
+            pendingWrite = true;
+        }
+        CriticalBlock b(writeAheadCrit2);
+        class CSharedSmartCallback : implements ISharedSmartBufferCallback
+        {
+            bool pagedOut;
+        public:
+            CSharedSmartCallback() { pagedOut = false; }
+            virtual void paged() { pagedOut = true; }
+            bool done() const { return pagedOut; }
+        } cb;
         OwnedConstThorRow row;
         loop
         {
-            if (abortSoon || stopped || requested<recsReady)
+            if (abortSoon || stopped || cb.done())
                 break;
             try
             {
@@ -381,7 +368,7 @@ public:
                     if (row)
                     {
                         ++recsReady;
-                        smartBuf->putRow(NULL);
+                        smartBuf->putRow(NULL, &cb);
                     }
                 }
             }
@@ -394,8 +381,10 @@ public:
                 break;
             }
             ++recsReady;
-            smartBuf->putRow(row.getClear()); // can block if mem limited, but other readers can progress which is the point
+            smartBuf->putRow(row.getClear(), &cb); // can block if mem limited, but other readers can progress which is the point
         }
+        pendingWrite = false;
+        return recsReady;
     }
     void inputStopped()
     {
@@ -457,7 +446,7 @@ void CSplitterOutput::stop()
 const void *CSplitterOutput::nextRow()
 {
     if (rec == max)
-        activity.more(max);
+        max = activity.writeahead(max, activity.queryAbortSoon());
     ActivityTimer t(totalCycles, activity.queryTimeActivities());
     const void *row = activity.nextRow(output); // pass ptr to max if need more
     ++rec;

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -61,13 +61,13 @@ public:
 // NSplitterSlaveActivity
 //
 
-class NSplitterSlaveActivity : public CSlaveActivity
+class NSplitterSlaveActivity : public CSlaveActivity, implements ISharedSmartBufferCallback
 {
     bool spill;
     bool eofHit;
     bool inputsConfigured;
-    bool pendingWrite;
-    CriticalSection startLock, writeAheadCrit;
+    bool writeBlocked, pagedOut;
+    CriticalSection startLock, writeAheadCrit, writeBlockedCrit;
     unsigned nstopped;
     rowcount_t recsReady;
     IThorDataLink *input;
@@ -75,6 +75,40 @@ class NSplitterSlaveActivity : public CSlaveActivity
     Owned<IException> startException, writeAheadException;
     Owned<ISharedSmartBuffer> smartBuf;
 
+    // NB: CWriter only used by 'balanced' splitter, which blocks write when too far ahead
+    class CWriter : public CSimpleInterface, IThreaded
+    {
+        NSplitterSlaveActivity &parent;
+        CThreadedPersistent threaded;
+        bool stopped;
+        rowcount_t current;
+
+    public:
+        CWriter(NSplitterSlaveActivity &_parent) : parent(_parent), threaded("CWriter", this)
+        {
+            current = 0;
+            stopped = true;
+        }
+        ~CWriter() { stop(); }
+        virtual void main()
+        {
+            while (!stopped && !parent.eofHit)
+                current = parent.writeahead(current, stopped);
+        }
+        void start()
+        {
+            stopped = false;
+            threaded.start();
+        }
+        virtual void stop()
+        {
+            if (!stopped)
+            {
+                stopped = true;
+                threaded.join();
+            }
+        }
+    } writer;
     class CNullInput : public CSplitterOutputBase
     {
     public:
@@ -172,14 +206,13 @@ class NSplitterSlaveActivity : public CSlaveActivity
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
-    NSplitterSlaveActivity(CGraphElementBase *container) : CSlaveActivity(container)
+    NSplitterSlaveActivity(CGraphElementBase *container) : CSlaveActivity(container), writer(*this)
     {
         spill = false;
         input = NULL;
         nstopped = 0;
-        eofHit = inputsConfigured = false;
+        eofHit = inputsConfigured = writeBlocked = pagedOut = false;
         recsReady = 0;
-        pendingWrite = false;
     }
     void ensureInputsConfigured()
     {
@@ -187,7 +220,6 @@ public:
         if (inputsConfigured)
             return;
         inputsConfigured = true;
-        pendingWrite = false;
         unsigned noutputs = container.connectedOutputs.getCount();
         ActPrintLog("Number of connected outputs: %d", noutputs);
         if (1 == noutputs)
@@ -228,6 +260,7 @@ public:
         grouped = false;
         eofHit = false;
         recsReady = 0;
+        writeBlocked = false;
         if (inputsConfigured)
         {
             // ensure old inputs cleared, to avoid being reused before re-setup on subsequent executions
@@ -285,6 +318,8 @@ public:
                             smartBuf->queryOutput(o)->stop();
                     }
                 }
+                if (!spill)
+                    writer.start(); // writer keeps writing ahead as much as possible, the readahead impl. will block when has too much
             }
             catch (IException *e)
             {
@@ -301,30 +336,35 @@ public:
     }
     rowcount_t writeahead(rowcount_t current, const bool &stopped)
     {
-        if (eofHit)
-            return recsReady;
-
+        // NB: readers call writeahead, which will block others
+        CriticalBlock b(writeAheadCrit);
+        loop
         {
-            CriticalBlock b(writeAheadCrit);
-            if (current < recsReady || pendingWrite)
+            if (eofHit)
                 return recsReady;
-
-            // NB: readers returning because pendingWrite is true, will block on smartBuf->nextRow until rows appear
-            pendingWrite = true;
+            if (current < recsReady)
+                return recsReady;
+            else if (writeBlocked)
+            {
+                // NB: When here, writeAheadCrit has been released _and_ writeBlockedCrit will be held until the writer is unblocked
+                {
+                    CriticalUnblock ub(writeAheadCrit);
+                    {
+                        CriticalBlock b(writeBlockedCrit); // This will block until the thread that is writing ahead has done
+                        // Once writeBlockCrit gained, writeBlocked is always 'false'
+                    }
+                }
+                // recsReady or eofHit will have been updated by the blocking thread by now, loop and re-check
+            }
+            else
+                break;
         }
         ActivityTimer t(totalCycles, queryTimeActivities());
-        class CSharedSmartCallback : implements ISharedSmartBufferCallback
-        {
-            bool pagedOut;
-        public:
-            CSharedSmartCallback() { pagedOut = false; }
-            virtual void paged() { pagedOut = true; }
-            bool done() const { return pagedOut; }
-        } cb;
+        pagedOut = false;
         OwnedConstThorRow row;
         loop
         {
-            if (abortSoon || stopped || cb.done())
+            if (abortSoon || stopped || pagedOut)
                 break;
             try
             {
@@ -334,8 +374,8 @@ public:
                     row.setown(input->nextRow());
                     if (row)
                     {
+                        smartBuf->putRow(NULL, this);
                         ++recsReady;
-                        smartBuf->putRow(NULL, &cb);
                     }
                 }
             }
@@ -347,16 +387,16 @@ public:
                 smartBuf->flush(); // signals no more rows will be written.
                 break;
             }
+            smartBuf->putRow(row.getClear(), this); // can block if mem limited, but other readers can progress which is the point
             ++recsReady;
-            smartBuf->putRow(row.getClear(), &cb); // can block if mem limited, but other readers can progress which is the point
         }
-        pendingWrite = false;
         return recsReady;
     }
     void inputStopped()
     {
         if (nstopped && --nstopped==0) 
         {
+            writer.stop();
             stopInput(input);
             input = NULL;
         }
@@ -377,7 +417,20 @@ public:
         }
         return _totalCycles;
     }
-
+// ISharedSmartBufferCallback impl.
+    virtual void paged() { pagedOut = true; }
+    virtual void blocked()
+    {
+        writeBlockedCrit.enter(); // enter before unblocking writeahead
+        writeBlocked = true; // Prevent other users getting beyond checking recsReady in writeahead()
+        writeAheadCrit.leave();
+    }
+    virtual void unblocked()
+    {
+        writeAheadCrit.enter();
+        writeBlocked = false;
+        writeBlockedCrit.leave(); // leave after re-blocking writer
+    }
 friend class CInputWrapper;
 friend class CSplitterOutput;
 friend class CWriter;

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -62,8 +62,13 @@ extern graph_decl ISmartRowBuffer * createSmartInMemoryBuffer(CActivityBase *act
                                                       size32_t buffsize);
 
 // Multiple readers, one writer
+interface ISharedSmartBufferCallback
+{
+    virtual void paged() = 0;
+};
 interface ISharedSmartBuffer : extends IRowWriter
 {
+    virtual void putRow(const void *row, ISharedSmartBufferCallback *callback) = 0; // extended form of putRow, which signals when pages out via callback
     virtual IRowStream *queryOutput(unsigned output) = 0;
     virtual void cancel()=0;
     virtual void reset() = 0;

--- a/thorlcr/thorutil/thbuf.hpp
+++ b/thorlcr/thorutil/thbuf.hpp
@@ -65,9 +65,12 @@ extern graph_decl ISmartRowBuffer * createSmartInMemoryBuffer(CActivityBase *act
 interface ISharedSmartBufferCallback
 {
     virtual void paged() = 0;
+    virtual void blocked() = 0;
+    virtual void unblocked() = 0;
 };
 interface ISharedSmartBuffer : extends IRowWriter
 {
+    using IRowWriter::putRow;
     virtual void putRow(const void *row, ISharedSmartBufferCallback *callback) = 0; // extended form of putRow, which signals when pages out via callback
     virtual IRowStream *queryOutput(unsigned output) = 0;
     virtual void cancel()=0;


### PR DESCRIPTION
In cases where the consumers keep pace and are waiting on the
produce side of the splitter, the cost of waiting was costly.
The change here, introduces a callback mechanism into the shared
write ahead, such that the producer [optionally] only triggers
the readers that there is something to consumer per page flush.
In the memory variety of the shared writer which blocks when it
is far enough ahead, the producer will write (and page) as fast
as possible on a async thread, and block when full.
All of this savs the cosumers, entering crits, waiting on
semaphores and waking up and re-entering crits etc. on a per row
basis when they are consuming quickly.

Add a memory pool of a few chunks to disk write too.
This substantially speeds up splitter that can spill, when the
arms are actually close to each other.

Also change QueueOf::dequeue(element) to return element.
It makes it a little cleaner when disposing of a link counted
item.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
