### PR TITLE
HPCC-12719 Use 'EclAgentProcess' to get EclAgent Config

### DIFF
--- a/esp/eclwatch/ws_XSLT/services.xslt
+++ b/esp/eclwatch/ws_XSLT/services.xslt
@@ -696,7 +696,7 @@
                               <xsl:value-of select="Netaddress"/>
                               <xsl:text>%26FileType%3dcfg%26Directory%3d</xsl:text>
                               <xsl:value-of select="$absolutePath"/>
-                              <xsl:text>%26CompType%3dAgentExecProcess</xsl:text>
+                              <xsl:text>%26CompType%3dEclAgentProcess</xsl:text>
                               <xsl:text>%26OsType%3d</xsl:text>
                               <xsl:value-of select="OS"/>
                             </xsl:attribute>

--- a/esp/eclwatch/ws_XSLT/targetclusters.xslt
+++ b/esp/eclwatch/ws_XSLT/targetclusters.xslt
@@ -797,7 +797,7 @@
                               <xsl:value-of select="Netaddress"/>
                               <xsl:text disable-output-escaping="yes">%26FileType%3dcfg%26Directory%3d</xsl:text>
                               <xsl:value-of select="$absolutePath"/>
-                              <xsl:text disable-output-escaping="yes">%26CompType%3dAgentExecProcess</xsl:text>
+                              <xsl:text disable-output-escaping="yes">%26CompType%3dEclAgentProcess</xsl:text>
                               <xsl:text disable-output-escaping="yes">%26OsType%3d</xsl:text>
                               <xsl:value-of select="OS"/>
                             </xsl:attribute>

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -1445,14 +1445,12 @@ bool CWsTopologyEx::onTpGetComponentFile(IEspContext &context,
                 fileName = "eclccserver.xml";
             else if (!stricmp(compType, eqEclScheduler))
                 fileName = "eclscheduler.xml";
-            else if (!stricmp(compType, eqAgentExec))
+            else if (!stricmp(compType, eqEclAgent))
                 fileName = "agentexec.xml";
             else if (!stricmp(compType, eqEsp))
                 fileName = "esp.xml";
             else if (!stricmp(compType, eqSashaServer))
                 fileName = "sashaconf.xml";
-            else if (!stricmp(compType, eqEclAgent))
-                fileName = osType==OS_WINDOWS ? "setvars.bat" : NULL;
             else 
             {
                 const unsigned int len = strlen(compType);


### PR DESCRIPTION
In the existing EclWatch code, 'EclAgentProcess' is used
as CompType to get EclAgent log and 'AgentExecProcess'
is used as CompType to get EclAgent config file. We
should use 'EclAgentProcess' as CompType to get EclAgent
config file.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
