### PR TITLE
HPCC-12728 The memcached plugin does not compile on Ubuntu 12.04

### DIFF
--- a/cmake_modules/FindMEMCACHED.cmake
+++ b/cmake_modules/FindMEMCACHED.cmake
@@ -30,7 +30,7 @@ IF (NOT LIBMEMCACHED_FOUND)
     SET (libmemcachedUtil_lib "memcachedutil")
   ENDIF()
 
-  FIND_PATH(LIBMEMCACHED_INCLUDE_DIR memcached.hpp PATHS /usr/include /usr/share/include /usr/local/include PATH_SUFFIXES libmemcached)
+  FIND_PATH(LIBMEMCACHED_INCLUDE_DIR libmemcached/memcached.hpp PATHS /usr/include /usr/share/include /usr/local/include PATH_SUFFIXES libmemcached)
 
   FIND_LIBRARY (LIBMEMCACHEDCORE_LIBRARY NAMES ${libmemcached_lib} PATHS /usr/lib usr/lib/libmemcached /usr/share /usr/lib64 /usr/local/lib /usr/local/lib64)
   FIND_LIBRARY (LIBMEMCACHEDUTIL_LIBRARY NAMES ${libmemcachedUtil_lib} PATHS /usr/lib /usr/share /usr/lib64 /usr/local/lib /usr/local/lib64)


### PR DESCRIPTION
Because the version of libmemcached headers is too old.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
