### PR TITLE
	HPCC-12735 Prevent duplicate IPs for computers

### DIFF
--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -19,6 +19,7 @@
 #include "configengcallback.hpp"
 #include "deploy.hpp"
 #include "build-config.h"
+#include "jutil.hpp"
 
 #define STANDARD_INDIR COMPONENTFILES_DIR"/configxml"
 #define STANDARD_OUTDIR RUNTIME_DIR
@@ -581,12 +582,19 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
   }
   else if (listMachines)
   {
+    StringArray strArrayOfMachinesIPs;
     StringBuffer out;
     Owned<IPropertyTreeIterator> computers = pEnv->getElements("Hardware/Computer");
     ForEach(*computers)
     {
       IPropertyTree* pComputer = &computers->query();
       const char *netAddress = pComputer->queryProp("@netAddress");
+
+      if (strArrayOfMachinesIPs.appendUniq(netAddress) == false)
+      {
+          continue;
+      }
+
       StringBuffer xpath;
       const char* name = pComputer->queryProp(XML_ATTR_NAME);
       bool isNonHPCCNode = true;

--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -20,6 +20,7 @@
 #include "deploy.hpp"
 #include "build-config.h"
 #include "jutil.hpp"
+#include "jhash.ipp"
 
 #define STANDARD_INDIR COMPONENTFILES_DIR"/configxml"
 #define STANDARD_OUTDIR RUNTIME_DIR
@@ -582,7 +583,7 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
   }
   else if (listMachines)
   {
-    StringArray strArrayOfMachinesIPs;
+    MapStringTo<bool> mapOfMachineIPs;
     StringBuffer out;
     Owned<IPropertyTreeIterator> computers = pEnv->getElements("Hardware/Computer");
     ForEach(*computers)
@@ -590,9 +591,13 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
       IPropertyTree* pComputer = &computers->query();
       const char *netAddress = pComputer->queryProp("@netAddress");
 
-      if (strArrayOfMachinesIPs.appendUniq(netAddress) == false)
+      if (mapOfMachineIPs.getValue(netAddress) != NULL)
       {
           continue;
+      }
+      else
+      {
+          mapOfMachineIPs.setValue(netAddress, true);
       }
 
       StringBuffer xpath;

--- a/deployment/deployutils/deployutils.cpp
+++ b/deployment/deployutils/deployutils.cpp
@@ -2998,8 +2998,19 @@ IPropertyTree* getNewRange(const IPropertyTree* pEnv, const char* prefix, const 
    while (count--)
    {
      range.getIpText(sIP.clear());
+
      unsigned x;
-       range.getNetAddress(sizeof(x),&x);
+     range.getNetAddress(sizeof(x),&x);
+
+     StringBuffer strCheckXPath;
+     strCheckXPath.setf("%s/%s[%s=\"%s\"][1]", XML_TAG_HARDWARE, XML_TAG_COMPUTER, XML_ATTR_NETADDRESS, sIP.str());
+
+     if (pEnv->hasProp(strCheckXPath.str()) == true)
+     {
+         range.ipincrement(1);
+         continue;
+     }
+
      sName.clear().appendf("%s%03d%03d", prefix, (x >> 16) & 0xFF, (x >> 24) & 0xFF);
      sNode.appendf("<"XML_TAG_COMPUTER" %s=\"%s\" %s=\"%s\" %s/>",
                       &XML_ATTR_NAME[1], getUniqueName(pEnv, sName, XML_TAG_COMPUTER, XML_TAG_HARDWARE),


### PR DESCRIPTION
```
    - ConfigMgr won't create duplicate computers with same IP
    - Configgen will filter duplicates
```

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
