### PR TITLE
HPCC-12738 Codegen should not assume Roxie output is always XML

### DIFF
--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -10759,9 +10759,6 @@ IWUResult * HqlCppTranslator::createDatasetResultSchema(IHqlExpression * sequenc
     buildMetaInfo(meta);
     result->setResultRecordSizeEntry(meta.metaFactoryName);
 
-    if (targetRoxie() && (sequence >= 0) && !isFile)
-        result->setResultFormat(ResultFormatXml);
-
     if (createTransformer)
     {
         OwnedHqlExpr noVirtualRecord = removeVirtualAttributes(serialRecord);


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
