### PR TITLE
HPCC-12732 Remove unneeded '#include <malloc.h>'

### DIFF
--- a/rtl/eclrtl/eclinclude4.hpp
+++ b/rtl/eclrtl/eclinclude4.hpp
@@ -41,7 +41,6 @@
 #endif
 
 #include <string.h>
-#include <malloc.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <math.h>


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
