### PR TITLE
HPCC-12745 Move interface of esp logging service to CE

### DIFF
--- a/esp/logging/loggingmanager.h
+++ b/esp/logging/loggingmanager.h
@@ -1,0 +1,39 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#if !defined(__LOGGINGMANAGER_H__)
+#define __LOGGINGMANAGER_H__
+
+#include "jiface.hpp"
+#include "esp.hpp"
+#include "ws_loggingservice_esp.ipp"
+
+#define LOGGINGMANAGERLIB "loggingmanager"
+#define LOGGINGDBSINGLEINSERT "SingleInsert"
+
+interface ILoggingManager : implements IInterface
+{
+    virtual bool init(IPropertyTree* loggingConfig, const char* service) = 0;
+    virtual bool updateLog(const char* option, const char* logContent, StringBuffer& status) = 0;
+    virtual bool updateLog(IEspUpdateLogRequest& req, IEspUpdateLogResponse& resp) = 0;
+    virtual bool getTransactionSeed(StringBuffer& transactionSeed, StringBuffer& status) = 0;
+    virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp) = 0;
+};
+
+typedef ILoggingManager* (*newLoggingManager_t_)();
+
+#endif // !defined(__LOGGINGMANAGER_H__)

--- a/esp/scm/espscm.cmake
+++ b/esp/scm/espscm.cmake
@@ -43,6 +43,7 @@ set ( ESPSCM_SRCS
       ws_workunits.ecm
       ws_packageprocess.ecm
       ws_esdlconfig.ecm
+      ws_loggingservice.ecm
     )
 
 foreach ( loop_var ${ESPSCM_SRCS} )

--- a/esp/scm/ws_loggingservice.ecm
+++ b/esp/scm/ws_loggingservice.ecm
@@ -1,0 +1,62 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+ESPStruct LogItem
+{
+    string Name;
+    string Value;
+};
+
+ESPrequest [] GetTransactionSeedRequest
+{
+};
+
+ESPresponse [exceptions_inline] LoggingServiceResponse
+{
+    int StatusCode;
+    string StatusMessage;
+};
+
+ESPresponse [exceptions_inline] GetTransactionSeedResponse
+{
+    string SeedId;
+    int StatusCode;
+    string StatusMessage;
+};
+
+ESPrequest [nil_remove] UpdateLogRequest
+{
+    string Option;
+    string LogContent;
+};
+
+ESPresponse [exceptions_inline] UpdateLogResponse
+{
+    string Response;
+    int StatusCode;
+    string StatusMessage;
+};
+
+ESPService [version("1.0"), default_client_version("1.0"), noforms, use_method_name] WsLoggingService
+{
+    ESPmethod GetTransactionSeed(GetTransactionSeedRequest, GetTransactionSeedResponse);
+    ESPmethod UpdateLog(UpdateLogRequest, UpdateLogResponse);
+};
+
+SCMexportdef(WSLOGGING);
+
+SCMapi(WSLOGGING) IClientWsLoggingService *createWsLoggingServiceClient();


### PR DESCRIPTION
For the logging service clients on CE to access the
interface, the interface code of the logging service
should be moved from EE to CE.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
