### PR TITLE
HPCC-12483 Set MALLOC_ARENA_MAX=8 to lower heap usage

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -423,6 +423,9 @@ startCmd() {
         echo "compName=$compName compPath=$compPath compProcessName=$compType"
     fi
 
+    # use less heap when threaded
+    export MALLOC_ARENA_MAX=8
+
     # Creating logfiles for component
     logDir=$log/${compName}
     logFile=$log/${compName}/${compName}_init.log


### PR DESCRIPTION
After much testing on Ubuntu and CentOS a setting of 8 will not affect performance and can mitigate large heap usage from threads creating excessive memory pools.
Could set this lower for programs that do not malloc/new/free/delete with high contention, but this is a single location setting for all programs.
Several different memory allocators are available and show vast performance and heap size differences, it would be good to evaluate those in HPCC at some time in the future.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
