### PR TITLE
HPCC-12712 ECL CLI support for generating debug workunit shared objects

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -380,6 +380,8 @@ public:
         cmdLine.set("eclcc -E");
         if (cmd.optLegacy)
             cmdLine.append(" -legacy");
+        if (cmd.optDebug)
+            cmdLine.append(" -g");
         appendOptPath(cmdLine, 'I', cmd.optImpPath.str());
         appendOptPath(cmdLine, 'L', cmd.optLibPath.str());
         if (cmd.optAttributePath.length())
@@ -585,6 +587,8 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
     if (iter.matchFlag(optNoArchive, ECLOPT_ECL_ONLY))
         return EclCmdOptionMatch;
     if (iter.matchFlag(optLegacy, ECLOPT_LEGACY) || iter.matchFlag(optLegacy, ECLOPT_LEGACY_DASH))
+        return EclCmdOptionMatch;
+    if (iter.matchFlag(optDebug, ECLOPT_DEBUG) || iter.matchFlag(optDebug, ECLOPT_DEBUG_DASH))
         return EclCmdOptionMatch;
     if (iter.matchOption(optResultLimit, ECLOPT_RESULT_LIMIT))
         return EclCmdOptionMatch;

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -146,6 +146,8 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_MANIFEST_DASH "-manifest"
 #define ECLOPT_LEGACY "--legacy"
 #define ECLOPT_LEGACY_DASH "-legacy"
+#define ECLOPT_DEBUG "--debug"
+#define ECLOPT_DEBUG_DASH "-g"
 
 #define ECLOPT_VERBOSE "--verbose"
 #define ECLOPT_VERBOSE_S "-v"
@@ -243,7 +245,7 @@ public:
 class EclCmdWithEclTarget : public EclCmdCommon
 {
 public:
-    EclCmdWithEclTarget() : optLegacy(false), optNoArchive(false), optResultLimit((unsigned)-1)
+    EclCmdWithEclTarget() : optLegacy(false), optNoArchive(false), optResultLimit((unsigned)-1), optDebug(false)
     {
     }
     virtual eclCmdOptionMatchIndicator matchCommandLineOption(ArgvIterator &iter, bool finalAttempt=false);
@@ -264,6 +266,7 @@ public:
             "   -Lpath                 Add path to locations to search for system libraries\n"
             "   --manifest             Specify path to manifest file\n"
             "   --legacy               Use legacy import semantics (deprecated)\n"
+            "   --debug, -g            Enable debug symbols in generated code\n"
         );
     }
 public:
@@ -279,6 +282,7 @@ public:
     unsigned optResultLimit;
     bool optNoArchive;
     bool optLegacy;
+    bool optDebug;
 };
 
 class EclCmdWithQueryTarget : public EclCmdCommon


### PR DESCRIPTION
ecl publish, deploy, and run support for "-g" or "--debug" to generate
debug executable objects.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
