### PR TITLE
HPCC-12754 Remove an extra variable in WsTopology.TpLogFile

### DIFF
--- a/esp/scm/ws_topology.ecm
+++ b/esp/scm/ws_topology.ecm
@@ -515,7 +515,6 @@ ESPresponse [exceptions_inline] TpLogFileResponse
     [min_ver("1.05")] int NextPage(-1);
     [min_ver("1.06")] int TotalPages;
     [min_ver("1.20")] string AcceptLanguage;
-    [http_content("application/octet-stream")] binary thefile;
 };
 
 ESPrequest [nil_remove] SystemLogRequest


### PR DESCRIPTION
The WsTopology.TpLogFile returns a chuck of a log file
(LogData) in the TpLogFileResponse. An old http_content
variable (thefile) defined inside the TpLogFileResponse
causes the response not work for a json request. Since the
thefile is not used any more, this fix removes the old
variable.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
