### PR TITLE
HPCC-12762 Multi filenames using wildcards allocate large amounts of memory

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -138,8 +138,6 @@ public:
             return;
         StringArray lfnExpanded;
         StringBuffer tmp;
-        const char * s = prefix.str();
-        const char *start = strchr(s,'{');
         for (unsigned idx=0; idx < dlfns.size(); idx++)
         {
             const char *suffix = dlfns.at(idx).get();
@@ -152,7 +150,6 @@ public:
                     tmp.append(suffix);
                 tmp.clip().toLowerCase();
                 Owned<IDFAttributesIterator> iter=queryDistributedFileDirectory().getDFAttributesIterator(tmp.str(),_udesc,false,true,NULL);
-                prefix.setLength(start-s);
                 ForEach(*iter)
                 {
                     IPropertyTree &attr = iter->query();


### PR DESCRIPTION
Due to a bug in the filename resolution code it tries to resize a string to
around 4gb or so. If it succeeds (as it will on may 64bit systems) then there
is no observable symptom (and the memory will be released later). But on
smaller systems this will result in realloc failed error messages.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
