### PR TITLE
HPCC-12766 Add comment for ISO C++ 2011 standard

### DIFF
--- a/plugins/memcached/CMakeLists.txt
+++ b/plugins/memcached/CMakeLists.txt
@@ -43,7 +43,10 @@ if (USE_MEMCACHED)
         )
 
     ADD_DEFINITIONS( -D_USRDLL -DECL_MEMCACHED_EXPORTS)
-    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -std=gnu++0x")
+
+    #libmemcached-1.0.18 includes the header <cinttypes> which translates to <bits/cinttypes> requiring ISO C++ 2011 standard to build.
+    #All lesser versions explicitly include <tr1/cinttypes> which does not.
+    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
 
     HPCC_ADD_LIBRARY( memcached SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")


### PR DESCRIPTION
libmemcached-1.0.18 includes the header <cinttypes> which translates to
<bits/cinttypes> requiring ISO C++ 2011 standard to build.
All lesser versions explicitly include <tr1/cinttypes> which does not.

Signed-off-by: James Noss james.noss@lexisnexis.com
