### PR TITLE
HPCC-12767 Regression in splitter, could cause divide by zero.

### DIFF
--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -1049,6 +1049,8 @@ public:
             if (minChunkSize > 0x10000)
                 minChunkSize += 2*(minSize+1);
         }
+        else if (0 == minSize) // unknown
+            minSize = 1;
         maxRows = (minChunkSize / minSize) + 1;
         outputCount = _outputCount;
         unsigned c=0;


### PR DESCRIPTION
Changes in HPCC-12633 meant a divide by zero, if the input had an
unknown min record size (0).

Code generator should generate a min size of 1, when known, see
issue HPCC-12768

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
