### PR TITLE
HPCC-12623 Treat roxie foreign files like other files resolved remotely

### DIFF
--- a/common/thorhelper/roxiehelper.cpp
+++ b/common/thorhelper/roxiehelper.cpp
@@ -1460,8 +1460,35 @@ StringBuffer & mangleLocalTempFilename(StringBuffer & out, char const * in)
     return out;
 }
 
+static const char *skipLfnForeign(const char *lfn)
+{
+    const char *finger = lfn;
+    while (*finger=='~')
+        finger++;
+    const char *scope = strstr(finger, "::");
+    if (scope)
+    {
+        StringBuffer cmp;
+        if (strieq("foreign", cmp.append(scope-finger, finger).trim()))
+        {
+            // foreign scope - need to strip off the ip and port
+            scope += 2;  // skip ::
+            finger = strstr(scope,"::");
+            if (finger)
+            {
+                finger += 2;
+                while (*finger == ' ')
+                    finger++;
+                return finger;
+            }
+        }
+    }
+    return lfn;
+}
+
 StringBuffer & expandLogicalFilename(StringBuffer & logicalName, const char * fname, IConstWorkUnit * wu, bool resolveLocally)
 {
+    fname = skipLfnForeign(fname); //foreign location should already be reflected in local dali dfs meta data
     if (fname[0]=='~')
         logicalName.append(fname+1);
     else if (resolveLocally)

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -689,9 +689,9 @@ void copyQueryFilesToCluster(IEspContext &context, IConstWorkUnit *cw, const cha
         if (queryname && *queryname)
             queryname = queryid.append(queryname).append(".0").str(); //prepublish dummy version number to support fuzzy match like queries="myquery.*" in package
         wufiles->addFilesFromQuery(cw, (ps) ? ps->queryActiveMap(target) : NULL, queryname);
-        wufiles->resolveFiles(process.str(), remoteIP, remotePrefix, srcCluster, !overwrite, true);
+        wufiles->resolveFiles(process.str(), remoteIP, remotePrefix, srcCluster, !overwrite, true, true);
         Owned<IDFUhelper> helper = createIDFUhelper();
-        wufiles->cloneAllInfo(helper, overwrite, true);
+        wufiles->cloneAllInfo(helper, overwrite, true, true);
     }
 }
 
@@ -2242,9 +2242,9 @@ public:
     {
         if (cloneFilesEnabled)
         {
-            wufiles->resolveFiles(process, dfsIP, srcPrefix, srcCluster, !overwriteDfs, true);
+            wufiles->resolveFiles(process, dfsIP, srcPrefix, srcCluster, !overwriteDfs, true, true);
             Owned<IDFUhelper> helper = createIDFUhelper();
-            wufiles->cloneAllInfo(helper, overwriteDfs, true);
+            wufiles->cloneAllInfo(helper, overwriteDfs, true, true);
         }
     }
 private:


### PR DESCRIPTION
EclWatch will now copy foreign DFS information when publishing or
copying the query.  Roxie will treat foreign files exactly as it does
other remotely resolved files.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
