### PR TITLE
HPCC-12779 Avoid dedupping distributor, sorting on all threads

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -137,7 +137,12 @@ protected:
             for (unsigned i=0; i<c; i++)
                 dedupList.append(rows.item(i));
             rows.clear(); // NB: dedupList took ownership
-            dedupList.sort(*iCompare, owner.activity->queryMaxCores());
+
+            /* Relatively small sets and senders are parallel so use a single thread
+             * Using the default of a thread per core, would mean contention when all senders are sorting.
+             */
+            dedupList.sort(*iCompare, 1);
+
             OwnedConstThorRow prev;
             for (unsigned i = c; i>0;)
             {


### PR DESCRIPTION
Distribute uses a pool of threads to send to targets, if it is
also dedupping, the buckets are sorted.
These sorts use a parallel quick sort and (by default) use a thread
per core.

The # of rows being sorted is relatively small (depending on rows
size), so the parallel sort is not hugely beneficial per sort, and
when all senders are competing to sort, it is counterproductive,
overcommitting threads to cores.
In tests using a single threaded sort here (whilst still allowing
the parallel senders to sort in parallel) derived the best results.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
