### PR TITLE
HPCC-12694 DOCS:Update Copyright info

### DIFF
--- a/docs/common/Version.xml
+++ b/docs/common/Version.xml
@@ -5,11 +5,11 @@
   <chapterinfo>
     <date id="DateVer">DEVELOPER NON-GENERATED VERSION</date>
 
-    <releaseinfo id="FooterInfo">© 2014 HPCC Systems. All rights
+    <releaseinfo id="FooterInfo">© 2015 HPCC Systems. All rights
     reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2014 HPCC Systems. All rights reserved</year>
+      <year>2015 HPCC Systems. All rights reserved</year>
     </copyright>
   </chapterinfo>
 
@@ -23,7 +23,7 @@
     and that is to store the chapterinfo the above sections that are being
     used by several other documents.</para>
 
-    <para id="CHMVer">2014 Version X.X</para>
+    <para id="CHMVer">2015 Version X.X</para>
 
     <para>The following line is the code to be put into the document you wish
     to include the above version info in:</para>

--- a/docs/common/Version.xml.in
+++ b/docs/common/Version.xml.in
@@ -1,15 +1,15 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <chapter>
   <chapterinfo>
-    <date id="DateVer">2014 Version ${DOC_VERSION}</date>
+    <date id="DateVer">2015 Version ${DOC_VERSION}</date>
 
-    <releaseinfo id="FooterInfo">© 2014 HPCC Systems. All rights
+    <releaseinfo id="FooterInfo">© 2015 HPCC Systems. All rights
     reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2014 HPCC Systems. All rights reserved</year>
+      <year>2015 HPCC Systems. All rights reserved</year>
     </copyright>
   </chapterinfo>
 
@@ -23,7 +23,7 @@
     serve one purpose and that is to store the chapterinfo the above sections
     that are being used by several other documents.</para>
 
-    <para id="CHMVer">2014 Version ${DOC_VERSION}</para>
+    <para id="CHMVer">2015 Version ${DOC_VERSION}</para>
 
     <para>The following line is the code to be put into the document you wish
     to include the above version info in:</para>


### PR DESCRIPTION
FIX HPCC-12694 DOCS:Update Copyright info
Update the components that generate the copyright date
for all docs for 2015.
Please note this change should get merged into every candidate branch.

@JamesDeFabia please review

Signed-off-by: G Panagiotatos g.pan3.14@gmail.com
