### PR TITLE
HPCC-12240 Update Cassandra driver to latest

### DIFF
--- a/plugins/cassandra/CMakeLists.txt
+++ b/plugins/cassandra/CMakeLists.txt
@@ -56,7 +56,7 @@ if (USE_CASSANDRA)
     option(CASS_INSTALL_HEADER "Install header file" OFF)
     option(CASS_BUILD_STATIC "Build static library" OFF)
     option(CASS_BUILD_EXAMPLES "Build examples" OFF)
-
+    set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS FALSE)
     SET (_SAVE_Boost_FOUND "${Boost_FOUND}")  # Working around a bug in the cassandra cmake file
     UNSET(Boost_FOUND)
     add_subdirectory (cpp-driver ${PROJECT_BINARY_DIR}/cassandra)


### PR DESCRIPTION
We don't use the lib64 convention for the libraries we ship

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
