### PR TITLE
HPCC-11734 Do not retain a read lock to QuerySets in the cache.

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2924,7 +2924,7 @@ public:
                 StringBuffer querySetXPath("QuerySets");
                 if (!querySet.isEmpty())
                     querySetXPath.appendf("/QuerySet[@id=\"%s\"]", querySet.get());
-                Owned<IRemoteConnection> conn = querySDS().connect(querySetXPath.str(), myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT);
+                Owned<IRemoteConnection> conn = querySDS().connect(querySetXPath.str(), myProcessSession(), 0, SDS_LOCK_TIMEOUT);
                 if (!conn)
                     return NULL;
 


### PR DESCRIPTION
The QuerySets cache was keeping a readlock, as a side-effect of
the QuerySet instances being kept in the cache from the SDS
connection.
This caused Esp to retain the lock for long periods, causing
other processes to block when trying to make locked connections
to the QuerySets branch to manipulate (e.g. to add a new Queryset)
QuerySet's will potentially have disappered or changed by the time
their details is interrogated, however this is no different from
other similar caching process, e.g. on the WorkUnits.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
