### PR TITLE
HPCC-12819 Crash in roxie when no library is deployed

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -1410,8 +1410,14 @@ public:
                     StringBuffer s;
                     CTXLOG("Exception thrown in query - cleaning up: %d: %s", e->errorCode(), e->errorMessage(s).str());
                 }
-                if (created)
+                if (created)  // Partially-created graphs are liable to crash if you call abort() on them...
                     endGraph(startCycles, true);
+                else
+                {
+                    // Bit of a hack... needed to avoid pure virtual calls if these are left to the CRoxieContextBase destructor
+                    graph.clear();
+                    childGraphs.kill();
+                }
                 CTXLOG("Done cleaning up");
                 throw;
             }
@@ -1420,6 +1426,12 @@ public:
                 CTXLOG("Exception thrown in query - cleaning up");
                 if (created)
                     endGraph(startCycles, true);
+                else
+                {
+                    // Bit of a hack... needed to avoid pure virtual calls if these are left to the CRoxieContextBase destructor
+                    graph.clear();
+                    childGraphs.kill();
+                }
                 CTXLOG("Done cleaning up");
                 throw;
             }


### PR DESCRIPTION
An exception thrown during graph creation (there may be other places that can
throw an exception, but library not found is probably the most common) would
cause the graph not to be cleaned up prior to the destructor of the base
context. If it is left until then you get a pure virtual call error.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
