### PR TITLE
HPCC-12855 Add GetSprayTargets() to ESP FileSpray

### DIFF
--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -88,6 +88,12 @@ ESPStruct [nil_remove] DFUWorkunit
     [min_ver("1.10")] bool quotedTerminator(true);
 };
 
+ESPStruct [nil_remove] GroupNode
+{
+    string Name;
+    string ClusterType;
+};
+
 ESPStruct DFUException
 {
     int Code;
@@ -610,6 +616,15 @@ ESPresponse [exceptions_inline] UploadFilesResponse
     ESParray<ESPstruct DFUActionResult> UploadFileResults;
 };
 
+ESPrequest GetSprayTargetsRequest
+{
+};
+
+ESPresponse [exceptions_inline, nil_remove] GetSprayTargetsResponse
+{
+    ESParray<ESPstruct GroupNode, GroupNode> GroupNodes; 
+};
+
 ESPservice [
     version("1.10"), default_client_version("1.10"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
@@ -644,6 +659,7 @@ ESPservice [
     ESPmethod [resp_xsl_default("/esp/xslt/opensave.xslt")] OpenSave(OpenSaveRequest, OpenSaveResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/dropzonefile.xslt")] DropZoneFiles(DropZoneFilesRequest, DropZoneFilesResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/dfuwuaction_results.xslt")] DeleteDropZoneFiles(DeleteDropZoneFilesRequest, DFUWorkunitsActionResponse);
+    ESPmethod GetSprayTargets(GetSprayTargetsRequest, GetSprayTargetsResponse);
 };
 
 SCMexportdef(FileSpray);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -3182,6 +3182,85 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
         resp.setDFUActionResults(results);
     }
     catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
+    }
+
+    return true;
+}
+
+void CFileSprayEx::appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType)
+{
+    Owned<IEspGroupNode> node = createGroupNode();
+    node->setName(nodeName);
+    node->setClusterType(clusterType);
+    groupNodes.append(*node.getClear());
+}
+
+bool CFileSprayEx::onGetSprayTargets(IEspContext &context, IEspGetSprayTargetsRequest &req, IEspGetSprayTargetsResponse &resp)
+{
+    try
+    {
+        if (!context.validateFeatureAccess(FILE_SPRAY_URL, SecAccess_Read, false))
+            throw MakeStringException(ECLWATCH_FILE_SPRAY_ACCESS_DENIED, "Permission denied.");
+
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IConstEnvironment> environment = factory->openEnvironment();
+        Owned<IPropertyTree> root = &environment->getPTree();
+        if (!root)
+            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
+
+        IArrayOf<IEspGroupNode> sprayTargets;
+        //Fetch all the group names for all the thor instances (and dedup them)
+        BoolHash uniqueThorClusterGroupNames;
+        Owned<IPropertyTreeIterator> it = root->getElements("Software/ThorCluster");
+        ForEach(*it)
+        {
+            IPropertyTree& cluster = it->query();
+
+            StringBuffer thorClusterGroupName;
+            getClusterGroupName(cluster, thorClusterGroupName);
+            if (!thorClusterGroupName.length())
+                continue;
+
+            bool* found = uniqueThorClusterGroupNames.getValue(thorClusterGroupName.str());
+            if (!found || !*found)
+                appendGroupNode(sprayTargets, thorClusterGroupName.str(), "thor");
+        }
+
+        //Fetch all the group names for all the hthor instances
+        it.setown(root->getElements("Software/EclAgentProcess"));
+        ForEach(*it)
+        {
+            IPropertyTree &cluster = it->query();
+            const char* name = cluster.queryProp("@name");
+            if (!name || !*name)
+                continue;
+
+            unsigned ins = 0;
+            Owned<IPropertyTreeIterator> insts = cluster.getElements("Instance");
+            ForEach(*insts)
+            {
+                const char *na = insts->query().queryProp("@netAddress");
+                if (!na || !*na)
+                    continue;
+
+                SocketEndpoint ep(na);
+                if (ep.isNull())
+                    continue;
+
+                ins++;
+                VStringBuffer gname("hthor__%s", name);
+                if (ins>1)
+                    gname.append('_').append(ins);
+
+                appendGroupNode(sprayTargets, gname.str(), "hthor");
+            }
+        }
+
+        resp.setGroupNodes(sprayTargets);
+    }
+    catch(IException* e)
     {   
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -94,6 +94,7 @@ public:
     virtual bool onOpenSave(IEspContext &context, IEspOpenSaveRequest &req, IEspOpenSaveResponse &resp);
     virtual bool onDropZoneFiles(IEspContext &context, IEspDropZoneFilesRequest &req, IEspDropZoneFilesResponse &resp);
     virtual bool onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZoneFilesRequest &req, IEspDFUWorkunitsActionResponse &resp);
+    virtual bool onGetSprayTargets(IEspContext &context, IEspGetSprayTargetsRequest &req, IEspGetSprayTargetsResponse &resp);
 
 protected:
     StringBuffer m_QueueLabel;
@@ -111,6 +112,7 @@ protected:
     bool ParseLogicalPath(const char * pLogicalPath, StringBuffer &title);
     bool ParseLogicalPath(const char * pLogicalPath, const char *group, const char* cluster, StringBuffer &folder, StringBuffer &title, StringBuffer &defaultFolder, StringBuffer &defaultReplicateFolder);
     StringBuffer& getAcceptLanguage(IEspContext& context, StringBuffer& acceptLanguage);
+    void appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType);
 };
 
 #endif //_ESPWIZ_FileSpray_HPP__


### PR DESCRIPTION
The FileSpray.GetSprayTargets is added for new ECLWatch
to display the unique Groups of Thor/HThor as spray
targets. A sample return is:
<GetSprayTargetsResponse>
<Targets>
<Item>mythor</Item>
<Item>hthor__myeclagent</Item>
</Targets>
</GetSprayTargetsResponse>

Signed-off-by: wangkx kevin.wang@lexisnexis.com
