### PR TITLE
HPCC-12856  remove "su <user> -c" for ssh/scp with a no-empty password

### DIFF
--- a/initfiles/sbin/install-cluster.sh.in
+++ b/initfiles/sbin/install-cluster.sh.in
@@ -61,7 +61,9 @@ getUserAndPasswd(){
        read -s PASS
        echo ""
 
-       echo "You entered user $ADMIN_USER and a password ($(echo $PASS | sed 's/./\./g'))."
+       password_string="and a password ($(echo $PASS | sed 's/./\./g'))."
+       [ -z "$password" ] && password_string="with an empty password for passwordless login."
+       echo "You entered user $ADMIN_USER $password_string"
        read -p  "Are these correct? [Y|n] " answer
        if [ "$answer" = "Y" ] || [ "$answer" = "y" ]
        then

--- a/initfiles/sbin/install-hpcc.exp
+++ b/initfiles/sbin/install-hpcc.exp
@@ -34,6 +34,21 @@ proc print_usage {} {
     exit 1
 }
 
+proc sshcmd { cmd params_string } {
+  global password user
+  if {[string length $password] == 0 } {
+     set cmd2 "$cmd -o BatchMode=yes -o StrictHostKeyChecking=no"
+     if {[string compare $::env(USER) $user] == 0} {
+        return "$cmd2 $params_string"
+     } else {
+        return "su $user -c \"$cmd2  [regsub -all "\"" $params_string \\\"]\""
+     }
+  } else {
+     return "$cmd $params_string"
+  }
+}
+
+
 
 proc testWithPing {} {
    global ip
@@ -54,7 +69,7 @@ proc checkSSHConnection {} {
 
    set timeout 60
    # JIRA 12585 in chance root user cannot ssh with key pairs
-   spawn su ${user} -c "ssh ${user}@${ip}"
+   eval "spawn [sshcmd ssh "${user}@${ip}"]"
    expect {
       *?assword:* {
          send "${password}\r";
@@ -83,7 +98,7 @@ proc copyPayload {} {
    global ip user password prompt
 
    set timeout 300
-   spawn su ${user} -c "scp /tmp/remote_install.tgz ${user}@${ip}:~;"
+   eval "spawn [sshcmd scp "/tmp/remote_install.tgz ${user}@${ip}:~;"]"
    expect {
       *?assword:* {
          send "${password}\r";
@@ -110,7 +125,7 @@ proc expandPayload {} {
    global ip user password prompt
 
    set timeout 180
-   spawn su ${user} -c "ssh ${user}@${ip} \"cd /; tar -zxf ~/remote_install.tgz\""
+   eval "spawn [sshcmd ssh "${user}@${ip} \"cd /; tar -zxf ~/remote_install.tgz\""]"
    expect {
       *?assword:* {
          send "${password}\r"
@@ -140,7 +155,7 @@ proc runPayload {} {
    set timeout 60
 
    expect -re $
-   spawn su ${user} -c "ssh ${user}@${ip}"
+   eval "spawn [sshcmd ssh ${user}@${ip}]"
    expect {
       *?assword:* {
          send "${password}\r"


### PR DESCRIPTION
"su <user> -c" has no TTY.  For ssh/scp login with password a window will be prompted which is not
good for automation. If the window can not be prompted login will immediately fails with "permission denied".

The fix is to remove "su <user> -c" if not empty user password is provided.
"su <user> -c" is still needed for passwordless login when current user and provided user are different.

@Michael-Gardner please review
