### PR TITLE
HPCC-12839 Fix crash when row being looked up in a dictionary is aliased

### DIFF
--- a/ecl/hqlcpp/hqlcset.ipp
+++ b/ecl/hqlcpp/hqlcset.ipp
@@ -93,6 +93,9 @@ public:
     virtual void buildIterateClass(BuildCtx & ctx, StringBuffer & cursorName, BuildCtx * initctx) { throwUnexpected(); }
     virtual void buildCountDict(BuildCtx & ctx, CHqlBoundExpr & tgt);
     virtual void buildExistsDict(BuildCtx & ctx, CHqlBoundExpr & tgt);
+
+private:
+    IHqlExpression * getFirstSearchValue(IHqlExpression * searchExpr, IHqlExpression * searchRecord);
 };
 
 class MultiLevelDatasetCursor : public BaseDatasetCursor

--- a/version.cmake
+++ b/version.cmake
@@ -5,6 +5,6 @@ set ( HPCC_PROJECT "community" )
 set ( HPCC_MAJOR 4 )
 set ( HPCC_MINOR 2 )
 set ( HPCC_POINT 12 )
-set ( HPCC_MATURITY "rc" )
-set ( HPCC_SEQUENCE 5 )
+set ( HPCC_MATURITY "release" )
+set ( HPCC_SEQUENCE 1 )
 ###


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
