### PR TITLE
HPCC-12803 Dropzone list not showing all dropzones

### DIFF
--- a/esp/src/eclwatch/FileSpray.js
+++ b/esp/src/eclwatch/FileSpray.js
@@ -145,7 +145,7 @@ define([
                 OS: row.Linux === "true" ? 2 : 0
             });
             lang.mixin(row, {
-                calculatedID: row.NetAddress,
+                calculatedID: row.NetAddress+row.Name,
                 displayName: row.Name,
                 type: "dropzone",
                 partialPath: "",


### PR DESCRIPTION
When there is multiple dropzones only the last one added shows up. Modified the unique indentifier to allow more than one in the list.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
