### PR TITLE
HPCC-12882 Fix various warnings and problems with the regression suite

### DIFF
--- a/common/fileview2/fileview.hpp
+++ b/common/fileview2/fileview.hpp
@@ -202,9 +202,9 @@ extern FILEVIEW_API unsigned getResultBin(MemoryBuffer & ret, INewResultSet * cu
 #define WorkUnitXML_NoRoot          0x0002
 #define WorkUnitXML_SeverityTags    0x0004
 
-extern FILEVIEW_API void writeFullWorkUnitResults(const char *username, const char *password, const IConstWorkUnit *cw, IXmlWriter &writer, unsigned flags, WUExceptionSeverity minSeverity, const char *rootTag);
-extern FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *user, const char *pw, const IConstWorkUnit *wu, IStringVal &str, unsigned flags=0, WUExceptionSeverity minSeverity=ExceptionSeverityInformation);
-extern FILEVIEW_API IStringVal& getFullWorkUnitResultsJSON(const char *user, const char *pw, const IConstWorkUnit *wu, IStringVal &str, unsigned flags=0, WUExceptionSeverity minSeverity=ExceptionSeverityInformation);
+extern FILEVIEW_API void writeFullWorkUnitResults(const char *username, const char *password, const IConstWorkUnit *cw, IXmlWriter &writer, unsigned flags, ErrorSeverity minSeverity, const char *rootTag);
+extern FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *user, const char *pw, const IConstWorkUnit *wu, IStringVal &str, unsigned flags=0, ErrorSeverity minSeverity=SeverityInformation);
+extern FILEVIEW_API IStringVal& getFullWorkUnitResultsJSON(const char *user, const char *pw, const IConstWorkUnit *wu, IStringVal &str, unsigned flags=0, ErrorSeverity minSeverity=SeverityInformation);
 
 extern FILEVIEW_API void startRemoteDataSourceServer(const char * queue, const char * cluster);
 extern FILEVIEW_API void stopRemoteDataSourceServer();

--- a/common/fileview2/fverror.hpp
+++ b/common/fileview2/fverror.hpp
@@ -20,41 +20,42 @@
 
 #include "errorlist.h"
 
-//Don't remove items from this list - otherwise the error codes will change
-enum
-{
-    FVERR_CouldNotResolveX = FILEVIEW_ERROR_START,
-    FVERR_NoRecordDescription,
-    FVERR_BadRecordDesc,
-    FVERR_NeedClusterToBrowseX,
-    FVERR_TimeoutRemoteFileView,
-    FVERR_UnknownRemoteCommand,
-    FVERR_UnknownUTFFormat,
-    FVERR_FailedOpenFile,
-    FVERR_CompressedFile,
-    FVERR_CannotViewKey,
-    FVERR_ViewComplexKey,
-    FVERR_FilterTooRestrictive,
-    FVERR_ZeroSizeRecord,
-    FVERR_FailedOpenCompressedFile,
-    FVERR_UnrecognisedJoinFieldSyntax,
-    FVERR_UnrecognisedJoinFieldSyntaxXX,
-    FVERR_UnrecognisedMappingFunctionX,
-    FVERR_UnrecognisedFieldX,
-    FVERR_ExpectedFieldSelectedFromDatasetXX,
-    FVERR_CannotSelectFromDatasetX,
-    FVERR_CannotSelectManyFromDatasetX,
-    FVERR_ExpectedFieldSelectedFromRecordXX,
-    FVERR_NumJoinFieldsMismatchXY,
-    FVERR_ExpectedX,
-    FVERR_FailTransformation,
-    FVERR_UnrecognisedMappingFunctionXY,
-    FVERR_BadStringTermination,
-    FVERR_CannotBrowseFile,
-    FVERR_PluginMismatch,
-    FVERR_RowTooLarge,
-    FVERR_CouldNotProcessSchema,
-};
+//Range 6700..6749 is reserved
+#if (FILEVIEW_ERROR_START != 6700 || FILEVIEW_ERROR_END != 6749)
+#error "FILEVIEW_ERROR_START has changed"
+#endif
+
+#define FVERR_CouldNotResolveX                  6700
+#define FVERR_NoRecordDescription               6701
+#define FVERR_BadRecordDesc                     6702
+#define FVERR_NeedClusterToBrowseX              6703
+#define FVERR_TimeoutRemoteFileView             6704
+#define FVERR_UnknownRemoteCommand              6705
+#define FVERR_UnknownUTFFormat                  6706
+#define FVERR_FailedOpenFile                    6707
+#define FVERR_CompressedFile                    6708
+#define FVERR_CannotViewKey                     6709
+#define FVERR_ViewComplexKey                    6710
+#define FVERR_FilterTooRestrictive              6711
+#define FVERR_ZeroSizeRecord                    6712
+#define FVERR_FailedOpenCompressedFile          6713
+#define FVERR_UnrecognisedJoinFieldSyntax       6714
+#define FVERR_UnrecognisedJoinFieldSyntaxXX     6715
+#define FVERR_UnrecognisedMappingFunctionX      6716
+#define FVERR_UnrecognisedFieldX                6717
+#define FVERR_ExpectedFieldSelectedFromDatasetXX 6718
+#define FVERR_CannotSelectFromDatasetX          6719
+#define FVERR_CannotSelectManyFromDatasetX      6720
+#define FVERR_ExpectedFieldSelectedFromRecordXX 6721
+#define FVERR_NumJoinFieldsMismatchXY           6722
+#define FVERR_ExpectedX                         6723
+#define FVERR_FailTransformation                6724
+#define FVERR_UnrecognisedMappingFunctionXY     6725
+#define FVERR_BadStringTermination              6726
+#define FVERR_CannotBrowseFile                  6727
+#define FVERR_PluginMismatch                    6728
+#define FVERR_RowTooLarge                       6729
+#define FVERR_CouldNotProcessSchema             6730
 
 #define FVERR_CouldNotResolveX_Text             "Could not resolve file '%s' in DFS"
 #define FVERR_NoRecordDescription_Text          "DFS did not contain a record description for '%s'"

--- a/common/fileview2/fverror.hpp
+++ b/common/fileview2/fverror.hpp
@@ -18,41 +18,43 @@
 #ifndef FVERROR_HPP
 #define FVERROR_HPP
 
-#include "jerrorrange.hpp"
+#include "errorlist.h"
 
-#define ERR_FILEVIEW_FIRST  2000
-#define ERR_FILEVIEW_LAST   2049
-
-#define FVERR_CouldNotResolveX                  2000
-#define FVERR_NoRecordDescription               2001
-#define FVERR_BadRecordDesc                     2002
-#define FVERR_NeedClusterToBrowseX              2003
-#define FVERR_TimeoutRemoteFileView             2004
-#define FVERR_UnknownRemoteCommand              2005
-#define FVERR_UnknownUTFFormat                  2006
-#define FVERR_FailedOpenFile                    2007
-#define FVERR_CompressedFile                    2008
-#define FVERR_CannotViewKey                     2009
-#define FVERR_ViewComplexKey                    2010
-#define FVERR_FilterTooRestrictive              2011
-#define FVERR_ZeroSizeRecord                    2012
-#define FVERR_FailedOpenCompressedFile          2013
-#define FVERR_UnrecognisedJoinFieldSyntax       2014
-#define FVERR_UnrecognisedJoinFieldSyntaxXX     2015
-#define FVERR_UnrecognisedMappingFunctionX      2016
-#define FVERR_UnrecognisedFieldX                2017
-#define FVERR_ExpectedFieldSelectedFromDatasetXX 2018
-#define FVERR_CannotSelectFromDatasetX          2019
-#define FVERR_CannotSelectManyFromDatasetX      2020
-#define FVERR_ExpectedFieldSelectedFromRecordXX 2021
-#define FVERR_NumJoinFieldsMismatchXY           2022
-#define FVERR_ExpectedX                         2023
-#define FVERR_FailTransformation                2024
-#define FVERR_UnrecognisedMappingFunctionXY     2025
-#define FVERR_BadStringTermination              2026
-#define FVERR_CannotBrowseFile                  2027
-#define FVERR_PluginMismatch                    2028
-#define FVERR_RowTooLarge                       2029
+//Don't remove items from this list - otherwise the error codes will change
+enum
+{
+    FVERR_CouldNotResolveX = FILEVIEW_ERROR_START,
+    FVERR_NoRecordDescription,
+    FVERR_BadRecordDesc,
+    FVERR_NeedClusterToBrowseX,
+    FVERR_TimeoutRemoteFileView,
+    FVERR_UnknownRemoteCommand,
+    FVERR_UnknownUTFFormat,
+    FVERR_FailedOpenFile,
+    FVERR_CompressedFile,
+    FVERR_CannotViewKey,
+    FVERR_ViewComplexKey,
+    FVERR_FilterTooRestrictive,
+    FVERR_ZeroSizeRecord,
+    FVERR_FailedOpenCompressedFile,
+    FVERR_UnrecognisedJoinFieldSyntax,
+    FVERR_UnrecognisedJoinFieldSyntaxXX,
+    FVERR_UnrecognisedMappingFunctionX,
+    FVERR_UnrecognisedFieldX,
+    FVERR_ExpectedFieldSelectedFromDatasetXX,
+    FVERR_CannotSelectFromDatasetX,
+    FVERR_CannotSelectManyFromDatasetX,
+    FVERR_ExpectedFieldSelectedFromRecordXX,
+    FVERR_NumJoinFieldsMismatchXY,
+    FVERR_ExpectedX,
+    FVERR_FailTransformation,
+    FVERR_UnrecognisedMappingFunctionXY,
+    FVERR_BadStringTermination,
+    FVERR_CannotBrowseFile,
+    FVERR_PluginMismatch,
+    FVERR_RowTooLarge,
+    FVERR_CouldNotProcessSchema,
+};
 
 #define FVERR_CouldNotResolveX_Text             "Could not resolve file '%s' in DFS"
 #define FVERR_NoRecordDescription_Text          "DFS did not contain a record description for '%s'"

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -3265,19 +3265,19 @@ extern FILEVIEW_API unsigned getResultBin(MemoryBuffer & ret, INewResultSet * re
     return getResultCursorBin(ret, cursor, start, count);
 }
 
-inline const char *getSeverityTagname(WUExceptionSeverity severity, unsigned flags)
+inline const char *getSeverityTagname(ErrorSeverity severity, unsigned flags)
 {
     if (flags & WorkUnitXML_SeverityTags)
     {
         switch (severity)
         {
-        case ExceptionSeverityInformation:
+        case SeverityInformation:
             return "Info";
-        case ExceptionSeverityWarning:
+        case SeverityWarning:
             return "Warning";
-        case ExceptionSeverityAlert:
+        case SeverityAlert:
             return "Alert";
-        case ExceptionSeverityError:
+        case SeverityError:
         default:
             break;
         }
@@ -3285,7 +3285,7 @@ inline const char *getSeverityTagname(WUExceptionSeverity severity, unsigned fla
     return "Exception";
 }
 
-extern FILEVIEW_API void writeFullWorkUnitResults(const char *username, const char *password, const IConstWorkUnit *cw, IXmlWriter &writer, unsigned flags, WUExceptionSeverity minSeverity, const char *rootTag)
+extern FILEVIEW_API void writeFullWorkUnitResults(const char *username, const char *password, const IConstWorkUnit *cw, IXmlWriter &writer, unsigned flags, ErrorSeverity minSeverity, const char *rootTag)
 {
     SCMStringBuffer wuid;
     cw->getWuid(wuid);
@@ -3297,7 +3297,7 @@ extern FILEVIEW_API void writeFullWorkUnitResults(const char *username, const ch
     ForEach(*exceptions)
     {
         IConstWUException & exception = exceptions->query();
-        WUExceptionSeverity severity = exception.getSeverity();
+        ErrorSeverity severity = exception.getSeverity();
         if (severity>=minSeverity)
         {
             SCMStringBuffer src, msg, filename;
@@ -3354,7 +3354,7 @@ extern FILEVIEW_API void writeFullWorkUnitResults(const char *username, const ch
         writer.outputEndNested(rootTag);
 }
 
-extern FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *username, const char *password, const IConstWorkUnit *cw, IStringVal &str, unsigned flags, WUExceptionSeverity minSeverity)
+extern FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *username, const char *password, const IConstWorkUnit *cw, IStringVal &str, unsigned flags, ErrorSeverity minSeverity)
 {
     SCMStringBuffer wuid;
     cw->getWuid(wuid);
@@ -3370,7 +3370,7 @@ extern FILEVIEW_API IStringVal& getFullWorkUnitResultsXML(const char *username, 
     return str;
 }
 
-extern FILEVIEW_API IStringVal& getFullWorkUnitResultsJSON(const char *username, const char *password, const IConstWorkUnit *cw, IStringVal &str, unsigned flags, WUExceptionSeverity minSeverity)
+extern FILEVIEW_API IStringVal& getFullWorkUnitResultsJSON(const char *username, const char *password, const IConstWorkUnit *cw, IStringVal &str, unsigned flags, ErrorSeverity minSeverity)
 {
     SCMStringBuffer wuid;
     cw->getWuid(wuid);

--- a/common/fileview2/fvsource.cpp
+++ b/common/fileview2/fvsource.cpp
@@ -1102,7 +1102,7 @@ bool FVDataSource::setReturnedInfoFromResult()
     wuResult->getResultEclSchema(s);
     returnedRecord.setown(parseQuery(s.str()));
     if (!returnedRecord)
-        throw MakeStringException(ERR_FILEVIEW_FIRST+4, "Could not process result schema [%s]", s.str());
+        throw MakeStringException(FVERR_CouldNotProcessSchema, "Could not process result schema [%s]", s.str());
 
     bool isKey = false;
     bool isGrouped = false;     // this isn't strictly true...it could be true for an internal result, but no current flag to test
@@ -1248,7 +1248,7 @@ IFvDataSourceMetaData * createMetaData(IConstWUResult * wuResult)
     wuResult->getResultEclSchema(s);
     OwnedHqlExpr record = parseQuery(s.str());
     if (!record)
-        throw MakeStringException(ERR_FILEVIEW_FIRST+4, "Could not process result schema [%s]", s.str());
+        throw MakeStringException(FVERR_CouldNotProcessSchema, "Could not process result schema [%s]", s.str());
 
     OwnedHqlExpr simplifiedRecord = getFileViewerRecord(record, false);
     bool isGrouped = false;     // more not sure this is strictly true...

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2137,7 +2137,7 @@ public:
     virtual IStringVal& getExceptionSource(IStringVal &str) const;
     virtual IStringVal& getExceptionMessage(IStringVal &str) const;
     virtual unsigned    getExceptionCode() const;
-    virtual WUExceptionSeverity getSeverity() const;
+    virtual ErrorSeverity getSeverity() const;
     virtual IStringVal & getTimeStamp(IStringVal & dt) const;
     virtual IStringVal & getExceptionFileName(IStringVal & str) const;
     virtual unsigned    getExceptionLineNo() const;
@@ -2145,7 +2145,7 @@ public:
     virtual void        setExceptionSource(const char *str);
     virtual void        setExceptionMessage(const char *str);
     virtual void        setExceptionCode(unsigned code);
-    virtual void        setSeverity(WUExceptionSeverity level);
+    virtual void        setSeverity(ErrorSeverity level);
     virtual void        setTimeStamp(const char * dt);
     virtual void        setExceptionFileName(const char *str);
     virtual void        setExceptionLineNo(unsigned r);
@@ -5375,10 +5375,11 @@ void CLocalWorkUnit::setSnapshot(const char * val)
 
 const static mapEnums warningSeverityMap[] =
 {
-    { SeverityIgnore, "ignore" },
-    { SeverityInfo, "info" },
+    { SeverityInformation, "info" },
     { SeverityWarning, "warning" },
     { SeverityError, "error" },
+    { SeverityAlert, "alert" },
+    { SeverityIgnore, "ignore" },
     { SeverityFatal, "fatal" },
     { SeverityUnknown, NULL }
 };
@@ -8794,9 +8795,9 @@ unsigned  CLocalWUException::getExceptionCode() const
     return p->getPropInt("@code", 0);
 }
 
-WUExceptionSeverity CLocalWUException::getSeverity() const
+ErrorSeverity CLocalWUException::getSeverity() const
 {
-    return (WUExceptionSeverity)p->getPropInt("@severity", ExceptionSeverityError);
+    return (ErrorSeverity)p->getPropInt("@severity", SeverityError);
 }
 
 IStringVal & CLocalWUException::getTimeStamp(IStringVal & dt) const
@@ -8836,7 +8837,7 @@ void CLocalWUException::setExceptionCode(unsigned code)
     p->setPropInt("@code", code);
 }
 
-void CLocalWUException::setSeverity(WUExceptionSeverity level)
+void CLocalWUException::setSeverity(ErrorSeverity level)
 {
     p->setPropInt("@severity", level);
 }
@@ -10179,7 +10180,7 @@ extern WORKUNIT_API IExtendedWUInterface * queryExtendedWU(IWorkUnit * wu)
 }
 
 
-extern WORKUNIT_API void addExceptionToWorkunit(IWorkUnit * wu, WUExceptionSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column)
+extern WORKUNIT_API void addExceptionToWorkunit(IWorkUnit * wu, ErrorSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column)
 {
     Owned<IWUException> we = wu->createException();
     we->setSeverity(severity);

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -162,17 +162,6 @@ enum WUResultStatus
 
 
 
-enum WUExceptionSeverity
-{
-    ExceptionSeverityInformation = 0,
-    ExceptionSeverityWarning = 1,
-    ExceptionSeverityError = 2,
-    ExceptionSeverityAlert = 3,
-    ExceptionSeveritySize = 4
-};
-
-
-
 //! IConstWUGraph
 
 enum WUGraphType
@@ -508,7 +497,7 @@ interface IConstWUException : extends IInterface
     virtual IStringVal & getExceptionSource(IStringVal & str) const = 0;
     virtual IStringVal & getExceptionMessage(IStringVal & str) const = 0;
     virtual unsigned getExceptionCode() const = 0;
-    virtual WUExceptionSeverity getSeverity() const = 0;
+    virtual ErrorSeverity getSeverity() const = 0;
     virtual IStringVal & getTimeStamp(IStringVal & dt) const = 0;
     virtual IStringVal & getExceptionFileName(IStringVal & str) const = 0;
     virtual unsigned getExceptionLineNo() const = 0;
@@ -521,7 +510,7 @@ interface IWUException : extends IConstWUException
     virtual void setExceptionSource(const char * str) = 0;
     virtual void setExceptionMessage(const char * str) = 0;
     virtual void setExceptionCode(unsigned code) = 0;
-    virtual void setSeverity(WUExceptionSeverity level) = 0;
+    virtual void setSeverity(ErrorSeverity level) = 0;
     virtual void setTimeStamp(const char * dt) = 0;
     virtual void setExceptionFileName(const char * str) = 0;
     virtual void setExceptionLineNo(unsigned r) = 0;
@@ -1367,7 +1356,7 @@ extern WORKUNIT_API StringBuffer &formatGraphTimerLabel(StringBuffer &str, const
 extern WORKUNIT_API StringBuffer &formatGraphTimerScope(StringBuffer &str, const char *graphName, unsigned subGraphNum, unsigned __int64 subId);
 extern WORKUNIT_API bool parseGraphTimerLabel(const char *label, StringAttr &graphName, unsigned & graphNum, unsigned &subGraphNum, unsigned &subId);
 extern WORKUNIT_API bool parseGraphScope(const char *scope, StringAttr &graphName, unsigned & graphNum, unsigned &subGraphId);
-extern WORKUNIT_API void addExceptionToWorkunit(IWorkUnit * wu, WUExceptionSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column);
+extern WORKUNIT_API void addExceptionToWorkunit(IWorkUnit * wu, ErrorSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column);
 extern WORKUNIT_API IWorkUnitFactory * getWorkUnitFactory();
 extern WORKUNIT_API IWorkUnitFactory * getSecWorkUnitFactory(ISecManager &secmgr, ISecUser &secuser);
 extern WORKUNIT_API IWorkUnitFactory * getWorkUnitFactory(ISecManager *secmgr, ISecUser *secuser);

--- a/common/wuwebview/wuwebview.cpp
+++ b/common/wuwebview/wuwebview.cpp
@@ -71,7 +71,7 @@ public:
     void appendResults(IConstWorkUnit *wu, const char *username, const char *pw)
     {
         StringBufferAdaptor resultXML(buffer);
-        getFullWorkUnitResultsXML(username, pw, wu, resultXML, WorkUnitXML_NoRoot, ExceptionSeverityError);
+        getFullWorkUnitResultsXML(username, pw, wu, resultXML, WorkUnitXML_NoRoot, SeverityError);
     }
 
     void appendSingleResult(IConstWorkUnit *wu, const char *resultname, const char *username, const char *pw)
@@ -667,7 +667,7 @@ void WuWebView::renderResultsJSON(StringBuffer &out, const char *jsonp)
     responseName.append("Response");
     appendJSONName(out, responseName);
     StringBufferAdaptor json(out);
-    getFullWorkUnitResultsJSON(username, pw, cw, json, 0, ExceptionSeverityError);
+    getFullWorkUnitResultsJSON(username, pw, cw, json, 0, SeverityError);
     out.append("}");
     if (jsonp && *jsonp)
         out.append(");");

--- a/ecl/eclagent/agentctx.hpp
+++ b/ecl/eclagent/agentctx.hpp
@@ -17,10 +17,22 @@
 #ifndef AGENTCTX_HPP_INCL
 #define AGENTCTX_HPP_INCL
 
+#include "errorlist.h"
 #include "dautils.hpp"
 #include "eclhelper.hpp"
 #include "workunit.hpp"
 #include "layouttrans.hpp"
+
+//Don't remove items from this list - otherwise the error codes will change
+enum
+{
+    WRN_SkipMissingOptIndex             = ECLAGENT_ERROR_START,
+    WRN_SkipMissingOptFile,
+    WRN_UseLayoutTranslation,
+    WRN_UnsupportedAlgorithm,
+    WRN_MismatchGroupInfo,
+    WRN_MismatchCompressInfo,
+};
 
 struct IHThorGraphResult : extends IInterface
 {

--- a/ecl/eclagent/agentctx.hpp
+++ b/ecl/eclagent/agentctx.hpp
@@ -23,16 +23,16 @@
 #include "workunit.hpp"
 #include "layouttrans.hpp"
 
-//Don't remove items from this list - otherwise the error codes will change
-enum
-{
-    WRN_SkipMissingOptIndex             = ECLAGENT_ERROR_START,
-    WRN_SkipMissingOptFile,
-    WRN_UseLayoutTranslation,
-    WRN_UnsupportedAlgorithm,
-    WRN_MismatchGroupInfo,
-    WRN_MismatchCompressInfo,
-};
+#if (ECLAGENT_ERROR_START != 5400 || ECLAGENT_ERROR_END != 5499)
+#error "ECLAGENT_ERROR_START has changed"
+#endif
+
+#define WRN_SkipMissingOptIndex             5400
+#define WRN_SkipMissingOptFile              5401
+#define WRN_UseLayoutTranslation            5402
+#define WRN_UnsupportedAlgorithm            5403
+#define WRN_MismatchGroupInfo               5404
+#define WRN_MismatchCompressInfo            5405
 
 struct IHThorGraphResult : extends IInterface
 {

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1470,12 +1470,14 @@ char * EclAgent::getExpandLogicalName(const char * logicalName)
 
 void EclAgent::addWuException(const char * text, unsigned code, unsigned severity, char const * source)
 {
-    addException((WUExceptionSeverity)severity, source, code, text, NULL, 0, 0, false, false);
+    ErrorSeverity mappedSeverity = wuRead->getWarningSeverity(code, (ErrorSeverity)severity);
+    if (mappedSeverity != SeverityIgnore)
+        addException(mappedSeverity, source, code, text, NULL, 0, 0, false, false);
 }
 
 void EclAgent::addWuAssertFailure(unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column, bool isAbort)
 {
-    addException(ExceptionSeverityError, "user", code, text, filename, lineno, column, false, false);
+    addException(SeverityError, "user", code, text, filename, lineno, column, false, false);
     if (isAbort)
         rtlFailOnAssert();      // minimal implementation
 }
@@ -1643,10 +1645,10 @@ IHThorGraphResults * EclAgent::createGraphLoopResults()
 
 //---------------------------------------------------------------------------
 
-void addException(IWorkUnit *w, WUExceptionSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column, bool failOnError)
+void addException(IWorkUnit *w, ErrorSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column, bool failOnError)
 {
     PrintLog("%s", text);
-    if ((severity == ExceptionSeverityError) && (w->getState()!=WUStateAborting) && failOnError)
+    if ((severity == SeverityError) && (w->getState()!=WUStateAborting) && failOnError)
         w->setState(WUStateFailed);
     addExceptionToWorkunit(w, severity, source, code, text, filename, lineno, column);
 }
@@ -1961,7 +1963,7 @@ void EclAgent::doProcess()
                     StringBuffer msg;
                     msg.append("Failed to deschedule workunit ").append(wuid.str()).append(": ");
                     e->errorMessage(msg);
-                    logException(ExceptionSeverityWarning, code, msg.str(), false);
+                    logException(SeverityWarning, code, msg.str(), false);
                     e->Release();
                     WARNLOG("%s (%d)", msg.str(), code);
                 }
@@ -2008,7 +2010,7 @@ void EclAgent::doProcess()
             StringBuffer m("System error ");
             m.append(e->errorCode()).append(": ");
             e->errorMessage(m);
-            ::addException(w, ExceptionSeverityError, "eclagent", e->errorCode(), m.str(), NULL, 0, 0, true);
+            ::addException(w, SeverityError, "eclagent", e->errorCode(), m.str(), NULL, 0, 0, true);
         }
         catch (IException *e2)
         {
@@ -2206,7 +2208,7 @@ void EclAgentWorkflowMachine::reportContingencyFailure(char const * type, IExcep
     StringBuffer msg;
     msg.append(type).append(" clause failed (execution will continue): ").append(e->errorCode()).append(": ");
     e->errorMessage(msg);
-    agent.logException(ExceptionSeverityWarning, e->errorCode(), msg.str(), false);
+    agent.logException(SeverityWarning, e->errorCode(), msg.str(), false);
 }
 
 void EclAgentWorkflowMachine::checkForAbort(unsigned wfid, IException * handling)
@@ -2219,7 +2221,7 @@ void EclAgentWorkflowMachine::checkForAbort(unsigned wfid, IException * handling
             msg.append("Abort takes precedence over error: ").append(handling->errorCode()).append(": ");
             handling->errorMessage(msg);
             msg.append(" (in item ").append(wfid).append(")");
-            agent.logException(ExceptionSeverityWarning, handling->errorCode(), msg.str(), false);
+            agent.logException(SeverityWarning, handling->errorCode(), msg.str(), false);
             handling->Release();
         }
         throw new WorkflowException(0, "Workunit abort request received", wfid, WorkflowException::ABORT, MSGAUD_user);
@@ -2316,16 +2318,16 @@ void EclAgent::doNotify(char const * name, char const * text, const char * targe
     pusher->push(name, text, target);
 }
 
-void EclAgent::logException(WUExceptionSeverity severity, unsigned code, const char * text, bool isAbort)
+void EclAgent::logException(ErrorSeverity severity, unsigned code, const char * text, bool isAbort)
 {
     addException(severity, "eclagent", code, text, NULL, 0, 0, true, isAbort);
-    if (severity == ExceptionSeverityError)
+    if (severity == SeverityError)
         ERRLOG(code, "%s", text);
 }
 
-void EclAgent::addException(WUExceptionSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column, bool failOnError, bool isAbort)
+void EclAgent::addException(ErrorSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column, bool failOnError, bool isAbort)
 {
-    if (writeResultsToStdout && (severity != ExceptionSeverityInformation))
+    if (writeResultsToStdout && (severity != SeverityInformation))
     {
         StringBuffer location;
         if (filename)
@@ -2335,7 +2337,7 @@ void EclAgent::addException(WUExceptionSeverity severity, const char * source, u
                 location.append('(').append(lineno).append(")");
             location.append(": ");
         }
-        const char * kind = (severity == ExceptionSeverityError) ? "error" : "warning";
+        const char * kind = (severity == SeverityError) ? "error" : "warning";
         fprintf(stderr, "%s%s: C%04u %s\n", location.str(), kind, code, text);
     }
     try
@@ -2395,7 +2397,7 @@ void EclAgent::logException(WorkflowException *e)
     else    
         m.append("Unknown error");
 
-    logException(ExceptionSeverityError, code, m.str(), isAbort);
+    logException(SeverityError, code, m.str(), isAbort);
 }
 
 void EclAgent::logException(IException *e)
@@ -2415,7 +2417,7 @@ void EclAgent::logException(IException *e)
     else    
         m.append("Unknown error");
 
-    logException(ExceptionSeverityError, code, m.str(), false);
+    logException(SeverityError, code, m.str(), false);
 }
 
 void EclAgent::logException(std::exception & e)
@@ -2425,7 +2427,7 @@ void EclAgent::logException(std::exception & e)
         m.append("out of memory (std::bad_alloc)");
     else
         m.append("standard library exception (std::exception ").append(e.what()).append(")");
-    logException(ExceptionSeverityError, 0, m.str(), false);
+    logException(SeverityError, 0, m.str(), false);
 }
 
 static unsigned __int64 crcLogicalFileTime(IDistributedFile * file, unsigned __int64 crc, const char * filename)
@@ -2611,7 +2613,7 @@ bool EclAgent::isPersistUptoDate(Owned<IRemoteConnection> &persistLock, IRuntime
         {
             StringBuffer msg;
             msg.append("PERSIST('").append(logicalName).append("') is up to date");
-            logException(ExceptionSeverityInformation, 0, msg.str(), false);
+            logException(SeverityInformation, 0, msg.str(), false);
             return true;
         }
 
@@ -2634,12 +2636,12 @@ bool EclAgent::isPersistUptoDate(Owned<IRemoteConnection> &persistLock, IRuntime
     {
         StringBuffer msg;
         msg.append("PERSIST('").append(logicalName).append("') is up to date (after being calculated by another job)");
-        logException(ExceptionSeverityInformation, 0, msg.str(), false);
+        logException(SeverityInformation, 0, msg.str(), false);
         changePersistLockMode(persistLock, RTM_LOCK_READ, logicalName, true);
         return true;
     }
     if (errText.length())
-        logException(ExceptionSeverityInformation, 0, errText.str(), false);
+        logException(SeverityInformation, 0, errText.str(), false);
     return false;
 }
 
@@ -2693,7 +2695,7 @@ void EclAgent::checkPersistMatches(const char * logicalName, unsigned eclCRC)
 
     StringBuffer msg;
     msg.append("Frozen PERSIST('").append(logicalName).append("') is up to date");
-    logException(ExceptionSeverityInformation, 0, msg.str(), false);
+    logException(SeverityInformation, 0, msg.str(), false);
 }
 
 static int comparePersistAccess(IInterface * const *_a, IInterface * const *_b)
@@ -3082,7 +3084,7 @@ void EclAgent::fatalAbort(bool userabort,const char *excepttext)
         if (userabort) 
             w->setState(WUStateAborted);
         if (excepttext&&*excepttext)
-            addException(ExceptionSeverityError, "ECLAGENT", 1000, excepttext, NULL, 0, 0, true, false);
+            addException(SeverityError, "ECLAGENT", 1000, excepttext, NULL, 0, 0, true, false);
         w->deleteTempFiles(NULL, false, true);
         wuRead.clear(); 
         w->commit();        // needed because we can't unlock the workunit in this thread

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -542,11 +542,11 @@ public:
     virtual const char *queryTemporaryFile(const char *fname);
     virtual void deleteFile(const char * logicalName);
 
-    void addException(WUExceptionSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column, bool failOnError, bool isAbort);
+    void addException(ErrorSeverity severity, const char * source, unsigned code, const char * text, const char * filename, unsigned lineno, unsigned column, bool failOnError, bool isAbort);
     void logException(IException *e);  
     void logException(WorkflowException *e);  
     void logException(std::exception & e);
-    void logException(WUExceptionSeverity severity, unsigned code, const char * text, bool isAbort);
+    void logException(ErrorSeverity severity, unsigned code, const char * text, bool isAbort);
 
     void doProcess();
     void runProcess(IEclProcess *process);

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -231,18 +231,18 @@ class EclccCompileThread : public CInterface, implements IPooledThread, implemen
                     err->setExceptionLineNo(atoi(line));
                     err->setExceptionColumn(atoi(col));
                     if (stricmp(errClass, "info")==0)
-                        err->setSeverity(ExceptionSeverityInformation);
+                        err->setSeverity(SeverityInformation);
                     else if (stricmp(errClass, "warning")==0)
-                        err->setSeverity(ExceptionSeverityWarning);
+                        err->setSeverity(SeverityWarning);
                     else
-                        err->setSeverity(ExceptionSeverityError);
+                        err->setSeverity(SeverityError);
                     err->setExceptionCode(atoi(errCode));
                     err->setExceptionMessage(errText);
                     err->setExceptionFileName(file); // any point if it just says stdin?
                 }
                 else
                 {
-                    err->setSeverity(retcode ? ExceptionSeverityError : ExceptionSeverityWarning);
+                    err->setSeverity(retcode ? SeverityError : SeverityWarning);
                     err->setExceptionMessage(errStr);
                     DBGLOG("%s", errStr);
                 }
@@ -490,7 +490,7 @@ public:
         {
             StringBuffer msg;
             e->errorMessage(msg);
-            addExceptionToWorkunit(workunit, ExceptionSeverityError, "eclccserver", e->errorCode(), msg.str(), NULL, 0, 0);
+            addExceptionToWorkunit(workunit, SeverityError, "eclccserver", e->errorCode(), msg.str(), NULL, 0, 0);
             e->Release();
         }
         if (ok)

--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -32,7 +32,7 @@ ErrorSeverity getSeverity(IAtom * name)
     if (name == ignoreAtom)
         return SeverityIgnore;
     if (name == logAtom)
-        return SeverityInfo;
+        return SeverityInformation;
     return SeverityUnknown;
 }
 
@@ -41,7 +41,7 @@ ErrorSeverity queryDefaultSeverity(WarnErrorCategory category)
     if (category == CategoryError)
         return SeverityFatal;
     if (category == CategoryInformation)
-        return SeverityInfo;
+        return SeverityInformation;
     if (category == CategoryMistake)
         return SeverityError;
     return SeverityWarning;
@@ -184,7 +184,7 @@ public:
         {
         case SeverityIgnore:
             return;
-        case SeverityInfo:
+        case SeverityInformation:
             severityText = "info";
             break;
         case SeverityWarning:
@@ -357,14 +357,14 @@ void checkEclVersionCompatible(Shared<IErrorReceiver> & errors, const char * ecl
             else if (minor != LANGUAGE_VERSION_MINOR)
             {
                 VStringBuffer msg("Mismatch in minor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
-                Owned<IError> warning = createError(CategoryUnexpected, SeverityInfo, HQLERR_VersionMismatch, msg.str(), NULL, 0, 0);
+                Owned<IError> warning = createError(CategoryUnexpected, SeverityInformation, HQLERR_VersionMismatch, msg.str(), NULL, 0, 0);
                 errors.setown(new ErrorInserter(*errors, warning));
             }
             else if (subminor != LANGUAGE_VERSION_SUB)
             {
                 //This adds the warning if any other warnings occur.
                 VStringBuffer msg("Mismatch in subminor version number (%s v %s)", eclVersion, LANGUAGE_VERSION);
-                Owned<IError> warning = createError(CategoryUnexpected, SeverityInfo, HQLERR_VersionMismatch, msg.str(), NULL, 0, 0);
+                Owned<IError> warning = createError(CategoryUnexpected, SeverityInformation, HQLERR_VersionMismatch, msg.str(), NULL, 0, 0);
                 errors.setown(new ErrorInserter(*errors, warning));
             }
         }

--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -18,14 +18,7 @@
 #define _HQLERRORS_HPP_
 
 
-/* Error severity: obsoleted */
-
-#define ERR_SEMANTIC                1    /* no resulting expression tree */
-#define ERR_SYNTACTIC               2    /* there is an expression tree, but should not be executed */
-#define ERR_FATAL                   3    /* fatal error: unrecoverable error */
-
 ///////////////////////////////////////////////////////////////////////////////
-/* Warning numbers */
 
 #define WRN_MACROEXPANSION          1001 /* error in macro (see error following this warning) */
 #define WRN_LOCALNONDIST            1004 /* LOCAL specified on dataset that is not distributed */
@@ -75,7 +68,8 @@
 #define WRN_SILLY_EXISTS            1051
 #define WRN_INT_OR_RANGE_EXPECTED   1052 /* Integer or integer range (i.e. 2..3) expected when real detected */
 #define WRN_UNRESOLVED_SYMBOL       1053
-//#define ECL_WARN_END          1100
+
+//Do not define any warnings > 1099 - use the range below instead
 
 ///////////////////////////////////////////////////////////////////////////////
 /* Error numbers */

--- a/ecl/hql/hqlwuerr.cpp
+++ b/ecl/hql/hqlwuerr.cpp
@@ -50,21 +50,21 @@ IError * WorkUnitErrorReceiver::mapError(IError * error)
 
 void WorkUnitErrorReceiver::report(IError* eclError)
 {
-    WUExceptionSeverity wuSeverity = ExceptionSeverityInformation;
+    ErrorSeverity wuSeverity = SeverityInformation;
     ErrorSeverity severity = eclError->getSeverity();
 
     switch (severity)
     {
     case SeverityIgnore:
         return;
-    case SeverityInfo:
+    case SeverityInformation:
         break;
     case SeverityWarning:
-        wuSeverity = ExceptionSeverityWarning;
+        wuSeverity = SeverityWarning;
         break;
     case SeverityError:
     case SeverityFatal:
-        wuSeverity = ExceptionSeverityError;
+        wuSeverity = SeverityError;
         break;
     }
 
@@ -81,7 +81,7 @@ size32_t WorkUnitErrorReceiver::errCount()
     unsigned count = 0;
     Owned<IConstWUExceptionIterator> exceptions = &wu->getExceptions();
     ForEach(*exceptions)
-        if (exceptions->query().getSeverity() == ExceptionSeverityError)
+        if (exceptions->query().getSeverity() == SeverityError)
             count++;
     return count;
 }
@@ -91,7 +91,7 @@ size32_t WorkUnitErrorReceiver::warnCount()
     unsigned count = 0;
     Owned<IConstWUExceptionIterator> exceptions = &wu->getExceptions();
     ForEach(*exceptions)
-        if (exceptions->query().getSeverity() == ExceptionSeverityWarning)
+        if (exceptions->query().getSeverity() == SeverityWarning)
             count++;
     return count;
 }

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -2077,7 +2077,7 @@ void HqlCppTranslator::reportWarning(WarnErrorCategory category, unsigned id, co
     doReportWarning(category, SeverityUnknown, NULL, id, s.str());
 }
 
-void HqlCppTranslator::addWorkunitException(WUExceptionSeverity severity, unsigned code, const char * text, IHqlExpression * location)
+void HqlCppTranslator::addWorkunitException(ErrorSeverity severity, unsigned code, const char * text, IHqlExpression * location)
 {
     Owned<IWUException> msg = wu()->createException();
     msg->setExceptionSource("Code Generator");

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -923,7 +923,7 @@ public:
     void reportWarning(WarnErrorCategory category, ErrorSeverity explicitSeverity, IHqlExpression * location, unsigned id, const char * msg, ...) __attribute__((format(printf, 6, 7)));
     void reportError(IHqlExpression * location, int code, const char *format, ...) __attribute__((format(printf, 4, 5)));
     void reportErrorDirect(IHqlExpression * location, int code,const char *msg, bool alwaysAbort);
-    void addWorkunitException(WUExceptionSeverity severity, unsigned code, const char * msg, IHqlExpression * location);
+    void addWorkunitException(ErrorSeverity severity, unsigned code, const char * msg, IHqlExpression * location);
     void useFunction(IHqlExpression * funcdef);
     void useLibrary(const char * libname);
     void finalizeResources();

--- a/ecl/hqlcpp/hqliproj.cpp
+++ b/ecl/hqlcpp/hqliproj.cpp
@@ -2699,7 +2699,7 @@ void ImplicitProjectTransformer::logChange(const char * message, IHqlExpression 
         {
             StringBuffer messageText;
             messageText.appendf(format, message, name.str(), fieldText.str());
-            translator.addWorkunitException(ExceptionSeverityInformation, 0, messageText.str(), NULL);
+            translator.addWorkunitException(SeverityInformation, 0, messageText.str(), NULL);
         }
     }
 }

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -5976,7 +5976,7 @@ IHqlExpression * WorkflowTransformer::extractCommonWorkflow(IHqlExpression * exp
             s.append("[").append(expr->queryName()).append("] ");
         s.append(" to common up code between workflow items");
         DBGLOG("%s", s.str());
-        translator.addWorkunitException(ExceptionSeverityInformation, HQLWRN_TryAddingIndependent, s.str(), location);
+        translator.addWorkunitException(SeverityInformation, HQLWRN_TryAddingIndependent, s.str(), location);
         if (!translator.queryOptions().performWorkflowCse)
             return LINK(transformed);
     }
@@ -5990,7 +5990,7 @@ IHqlExpression * WorkflowTransformer::extractCommonWorkflow(IHqlExpression * exp
         s.append("[").append(expr->queryName()).append("] ");
     s.append(" to common up between workflow items [").append(wfid).append("]");
     DBGLOG("%s", s.str());
-    translator.addWorkunitException(ExceptionSeverityInformation, 0, s.str(), location);
+    translator.addWorkunitException(SeverityInformation, 0, s.str(), location);
 
     GlobalAttributeInfo info("spill::wfa", "wfa", transformed);
     info.extractGlobal(NULL, translator.getTargetClusterType());       // should really be a slightly different function

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -3853,7 +3853,7 @@ void CHThorGroupSortActivity::createSorter()
     {
         StringBuffer sb;
         sb.appendf("Ignoring unsupported sort order algorithm '%s', using default", algoname.get());
-        agent.addWuException(sb.str(),0,ExceptionSeverityWarning,"hthor");
+        agent.addWuException(sb.str(),WRN_UnsupportedAlgorithm,SeverityWarning,"hthor");
         if((flags & TAFunstable) != 0)
             sorter.setown(new CQuickSorter(helper.queryCompare(), queryRowManager(), InitialSortElements, CommitStep));
         else
@@ -6138,16 +6138,6 @@ CHThorRemoteResultActivity::CHThorRemoteResultActivity(IAgentContext &_agent, un
 void CHThorRemoteResultActivity::execute()
 {
     OwnedConstRoxieRow result(input->nextInGroup());
-#if 0
-    //This isn't correct - it can have a null input - at least until TAKaction is generated for that case.
-    if(!result)
-    {
-        char const * msg = "Remote Result activity had null input, not sending result";
-        WARNLOG(msg);
-        agent.addWuException(msg, 0, ExceptionSeverityWarning, "hthor");
-        return;
-    }
-#endif
     helper.sendResult(result);
 }
 
@@ -7871,7 +7861,7 @@ void CHThorDiskReadBaseActivity::resolve()
             StringBuffer buff;
             buff.appendf("Input file '%s' was missing but declared optional", mangledHelperFileName.str());
             WARNLOG("%s", buff.str());
-            agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+            agent.addWuException(buff.str(), WRN_SkipMissingOptFile, SeverityInformation, "hthor");
         }
     }
 }
@@ -7888,7 +7878,7 @@ void CHThorDiskReadBaseActivity::gatherInfo(IFileDescriptor * fileDesc)
                 StringBuffer msg;
                 msg.append("DFS and code generated group info. differs: DFS(").append(grouped ? "grouped" : "ungrouped").append("), CodeGen(").append(grouped ? "ungrouped" : "grouped").append("), using DFS info");
                 WARNLOG("%s", msg.str());
-                agent.addWuException(msg.str(), 0, ExceptionSeverityWarning, "hthor");
+                agent.addWuException(msg.str(), WRN_MismatchGroupInfo, SeverityError, "hthor");
             }
         }
         else
@@ -7925,7 +7915,7 @@ void CHThorDiskReadBaseActivity::gatherInfo(IFileDescriptor * fileDesc)
                 StringBuffer msg;
                 msg.append("Ignoring compression attribute on file ").append(mangledHelperFileName.str()).append(", which is not published as compressed");
                 WARNLOG("%s", msg.str());
-                agent.addWuException(msg.str(), 0, ExceptionSeverityWarning, "hthor");
+                agent.addWuException(msg.str(), WRN_MismatchCompressInfo, SeverityWarning, "hthor");
                 compressed = true;
             }
         }

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -701,7 +701,7 @@ void CHThorIndexReadActivityBase::getLayoutTranslators()
                 StringBuffer buff;
                 buff.append("Using record layout translation to correct layout mismatch on reading index ").append(f.queryLogicalName());
                 WARNLOG("%s", buff.str());
-                agent.addWuException(buff.str(), 0, ExceptionSeverityWarning, "hthor");
+                agent.addWuException(buff.str(), WRN_UseLayoutTranslation, SeverityWarning, "hthor");
             }
             layoutTransArray.append(layoutTrans.getClear());
         } while(superIterator->next());
@@ -714,7 +714,7 @@ void CHThorIndexReadActivityBase::getLayoutTranslators()
             StringBuffer buff;
             buff.append("Using record layout translation to correct layout mismatch on reading index ").append(df->queryLogicalName());
             WARNLOG("%s", buff.str());
-            agent.addWuException(buff.str(), 0, ExceptionSeverityWarning, "hthor");
+            agent.addWuException(buff.str(), WRN_UseLayoutTranslation, SeverityWarning, "hthor");
         }
     }
 }
@@ -1080,7 +1080,7 @@ extern HTHOR_API IHThorActivity *createIndexReadActivity(IAgentContext &_agent, 
         StringBuffer buff;
         buff.append("Skipping OPT index read of nonexistent file ").append(lfn);
         WARNLOG("%s", buff.str());
-        _agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+        _agent.addWuException(buff.str(), WRN_SkipMissingOptIndex, SeverityInformation, "hthor");
         return new CHThorNullActivity(_agent, _activityId, _subgraphId, arg, _kind);
     }
     _agent.logFileAccess(dFile, "HThor", "READ");
@@ -1262,7 +1262,7 @@ extern HTHOR_API IHThorActivity *createIndexNormalizeActivity(IAgentContext &_ag
         StringBuffer buff;
         buff.append("Skipping OPT index normalize of nonexistent file ").append(lfn);
         WARNLOG("%s", buff.str());
-        _agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+        _agent.addWuException(buff.str(), WRN_SkipMissingOptIndex, SeverityInformation, "hthor");
         return new CHThorNullActivity(_agent, _activityId, _subgraphId, arg, _kind);
     }
     _agent.logFileAccess(dFile, "HThor", "READ");
@@ -1380,7 +1380,7 @@ extern HTHOR_API IHThorActivity *createIndexAggregateActivity(IAgentContext &_ag
         StringBuffer buff;
         buff.append("Skipping OPT index aggregate of nonexistent file ").append(lfn);
         WARNLOG("%s", buff.str());
-        _agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+        _agent.addWuException(buff.str(), WRN_SkipMissingOptIndex, SeverityInformation, "hthor");
         return new CHThorNullAggregateActivity(_agent, _activityId, _subgraphId, arg, arg, _kind);
     }
     _agent.logFileAccess(dFile, "HThor", "READ");
@@ -1486,7 +1486,7 @@ extern HTHOR_API IHThorActivity *createIndexCountActivity(IAgentContext &_agent,
         StringBuffer buff;
         buff.append("Skipping OPT index count of nonexistent file ").append(lfn);
         WARNLOG("%s", buff.str());
-        _agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+        _agent.addWuException(buff.str(), WRN_SkipMissingOptIndex, SeverityInformation, "hthor");
         return new CHThorNullCountActivity(_agent, _activityId, _subgraphId, arg, _kind);
     }
     _agent.logFileAccess(dFile, "HThor", "READ");
@@ -1598,7 +1598,7 @@ extern HTHOR_API IHThorActivity *createIndexGroupAggregateActivity(IAgentContext
         StringBuffer buff;
         buff.append("Skipping OPT index group aggregate of nonexistent file ").append(lfn);
         WARNLOG("%s", buff.str());
-        _agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+        _agent.addWuException(buff.str(), WRN_SkipMissingOptIndex, SeverityInformation, "hthor");
         return new CHThorNullActivity(_agent, _activityId, _subgraphId, arg, _kind);
     }
     _agent.logFileAccess(dFile, "HThor", "READ");
@@ -2217,7 +2217,7 @@ public:
                 StringBuffer buff;
                 buff.append("Skipping OPT fetch of nonexistent file ").append(lfn);
                 WARNLOG("%s", buff.str());
-                agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+                agent.addWuException(buff.str(), WRN_SkipMissingOptFile, SeverityInformation, "hthor");
             }
         }
         inputThread.setown(new InputHandler(this));
@@ -2482,7 +2482,7 @@ public:
             StringBuffer buff;
             buff.append("Skipping OPT fetch of nonexistent file ").append(lfn);
             WARNLOG("%s", buff.str());
-            agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+            agent.addWuException(buff.str(), WRN_SkipMissingOptFile, SeverityInformation, "hthor");
         }
             
         csvSplitter.init(_arg.getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
@@ -3929,7 +3929,7 @@ public:
             StringBuffer buff;
             buff.append("Skipping OPT keyed join against nonexistent file ").append(lfn);
             WARNLOG("%s", buff.str());
-            agent.addWuException(buff.str(), 0, ExceptionSeverityInformation, "hthor");
+            agent.addWuException(buff.str(), WRN_SkipMissingOptFile, SeverityInformation, "hthor");
         }
         CHThorThreadedActivityBase::start();
     }
@@ -4071,14 +4071,6 @@ protected:
     {
         if(!agent.queryWorkUnit()->getDebugValueBool("skipFileFormatCrcCheck", false))
             ::verifyFormatCrcSuper(helper.getDiskFormatCrc(), f, false, true);
-    }
-
-    virtual void warn(char const * msg)
-    {
-        StringBuffer buff;
-        buff.append(msg).append(" for index ").append(dFile->queryLogicalName());
-        WARNLOG("%s", buff.str());
-        agent.addWuException(buff.str(), 0, ExceptionSeverityWarning, "hthor");
     }
 
     virtual void fail(char const * msg)

--- a/esp/services/ecldirect/EclDirectService.cpp
+++ b/esp/services/ecldirect/EclDirectService.cpp
@@ -52,16 +52,16 @@ EclDirectWUExceptions::EclDirectWUExceptions(IConstWorkUnit& cw)
         switch (it->query().getSeverity())
         {
             default:
-            case ExceptionSeverityError:
+            case SeverityError:
                 e->setSeverity("Error");
                 break;
-            case ExceptionSeverityWarning:
+            case SeverityWarning:
                 e->setSeverity("Warning");
                 break;
-            case ExceptionSeverityInformation:
+            case SeverityInformation:
                 e->setSeverity("Info");
                 break;
-            case ExceptionSeverityAlert:
+            case SeverityAlert:
                 e->setSeverity("Alert");
                 break;
         }

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -160,10 +160,10 @@ WsWUExceptions::WsWUExceptions(IConstWorkUnit& wu): numerr(0), numwrn(0), numinf
         switch (it->query().getSeverity())
         {
             default:
-            case ExceptionSeverityError: label = "Error"; numerr++; break;
-            case ExceptionSeverityWarning: label = "Warning"; numwrn++; break;
-            case ExceptionSeverityInformation: label = "Info"; numinf++; break;
-            case ExceptionSeverityAlert: label = "Alert"; numalert++; break;
+            case SeverityError: label = "Error"; numerr++; break;
+            case SeverityWarning: label = "Warning"; numwrn++; break;
+            case SeverityInformation: label = "Info"; numinf++; break;
+            case SeverityAlert: label = "Alert"; numalert++; break;
         }
 
         e->setSeverity(label);
@@ -3052,7 +3052,7 @@ void WsWuHelpers::runWsWorkunit(IEspContext &context, IConstWorkUnit *cw, const 
     submitWsWorkunit(context, cw, cluster, NULL, 0, false, true, true, paramXml, variables, debugs);
 }
 
-IException * WsWuHelpers::noteException(IWorkUnit *wu, IException *e, WUExceptionSeverity level)
+IException * WsWuHelpers::noteException(IWorkUnit *wu, IException *e, ErrorSeverity level)
 {
     if (wu)
     {
@@ -3061,7 +3061,7 @@ IException * WsWuHelpers::noteException(IWorkUnit *wu, IException *e, WUExceptio
         we->setExceptionMessage(e->errorMessage(s).str());
         we->setExceptionSource("WsWorkunits");
         we->setSeverity(level);
-        if (level==ExceptionSeverityError)
+        if (level==SeverityError)
             wu->setState(WUStateFailed);
     }
     return e;

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -379,7 +379,7 @@ namespace WsWuHelpers
             IArrayOf<IConstNamedValue> *variables=NULL, IArrayOf<IConstNamedValue> *debugs=NULL);
     void runWsWorkunit(IEspContext &context, IConstWorkUnit *cw, const char *srcWuid, const char *cluster, const char *paramXml=NULL,
             IArrayOf<IConstNamedValue> *variables=NULL, IArrayOf<IConstNamedValue> *debugs=NULL);
-    IException * noteException(IWorkUnit *wu, IException *e, WUExceptionSeverity level=ExceptionSeverityError);
+    IException * noteException(IWorkUnit *wu, IException *e, ErrorSeverity level=SeverityError);
     StringBuffer & resolveQueryWuid(StringBuffer &wuid, const char *queryset, const char *query, bool notSuspended=true, IWorkUnit *wu=NULL);
     void runWsWuQuery(IEspContext &context, IConstWorkUnit *cw, const char *queryset, const char *query, const char *cluster, const char *paramXml=NULL);
     void runWsWuQuery(IEspContext &context, StringBuffer &wuid, const char *queryset, const char *query, const char *cluster, const char *paramXml=NULL);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1072,18 +1072,18 @@ bool CWsWorkunitsEx::onWUSubmit(IEspContext &context, IEspWUSubmitRequest &req, 
     return true;
 }
 
-WUExceptionSeverity checkGetExceptionSeverity(CWUExceptionSeverity severity)
+ErrorSeverity checkGetExceptionSeverity(CWUExceptionSeverity severity)
 {
     switch (severity)
     {
         case CWUExceptionSeverity_INFO:
-            return ExceptionSeverityInformation;
+            return SeverityInformation;
         case CWUExceptionSeverity_WARNING:
-            return ExceptionSeverityWarning;
+            return SeverityWarning;
         case CWUExceptionSeverity_ERROR:
-            return ExceptionSeverityError;
+            return SeverityError;
         case CWUExceptionSeverity_ALERT:
-            return ExceptionSeverityAlert;
+            return SeverityAlert;
     }
 
     throw MakeStringExceptionDirect(ECLWATCH_INVALID_INPUT,"invalid exception severity");
@@ -1101,7 +1101,7 @@ bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWU
         const char* runWuid = wuidStr.trim().str();
         StringBuffer wuid;
 
-        WUExceptionSeverity severity = checkGetExceptionSeverity(req.getExceptionSeverity());
+        ErrorSeverity severity = checkGetExceptionSeverity(req.getExceptionSeverity());
 
         if (runWuid && *runWuid)
         {
@@ -3996,16 +3996,16 @@ void CWsWorkunitsEx::createZAPWUInfoFile(IEspWUCreateZAPInfoRequest &req, Owned<
     {
         switch (exceptions->query().getSeverity())
         {
-        case ExceptionSeverityInformation:
+        case SeverityInformation:
             info.append("\t").append(exceptions->query().getExceptionMessage(temp)).append("\r\n\r\n");
             break;
-        case ExceptionSeverityWarning:
+        case SeverityWarning:
             warn.append("\t").append(exceptions->query().getExceptionMessage(temp)).append("\r\n\r\n");
             break;
-        case ExceptionSeverityError:
+        case SeverityError:
             err.append("\t").append(exceptions->query().getExceptionMessage(temp)).append("\r\n\r\n");
             break;
-        case ExceptionSeverityAlert:
+        case SeverityAlert:
             alert.append("\t").append(exceptions->query().getExceptionMessage(temp)).append("\r\n\r\n");
             break;
         }

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -270,7 +270,7 @@ StringBuffer & constructLogicalName(ICodeContext * ctx, const char * partialLogi
     return constructLogicalName(wu, partialLogicalName, result);
 }
 
-static void WUmessage(ICodeContext *ctx, WUExceptionSeverity sev, const char *fn, const char *msg)
+static void WUmessage(ICodeContext *ctx, ErrorSeverity sev, const char *fn, const char *msg)
 {
     StringBuffer s("fileservices");
     if (fn)
@@ -331,7 +331,7 @@ FILESERVICES_API void FILESERVICES_CALL fsDeleteLogicalFile(ICodeContext *ctx, c
             s.append("') added to transaction");
         else
             s.append("') done");
-        WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+        WUmessage(ctx,SeverityInformation,NULL,s.str());
         AuditMessage(ctx,"DeleteLogicalFile",lfn.str());
 
     }
@@ -445,14 +445,14 @@ FILESERVICES_API void FILESERVICES_CALL fsRenameLogicalFile(ICodeContext *ctx, c
         queryDistributedFileDirectory().renamePhysical(lfn.str(),nlfn.str(),udesc,transaction);
         StringBuffer s("RenameLogicalFile ('");
         s.append(lfn).append(", '").append(nlfn).append("') done");
-        WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+        WUmessage(ctx,SeverityInformation,NULL,s.str());
         AuditMessage(ctx,"RenameLogicalFile",lfn.str(),nlfn.str());
     }
     catch (IException *e)
     {
         StringBuffer s;
         e->errorMessage(s);
-        WUmessage(ctx,ExceptionSeverityWarning,"RenameLogicalFile",s.str());
+        WUmessage(ctx,SeverityWarning,"RenameLogicalFile",s.str());
         throw e;
      }
 }
@@ -463,7 +463,7 @@ FILESERVICES_API void FILESERVICES_CALL fsSendEmail(ICodeContext * ctx, const ch
     StringArray warnings;
     sendEmail( to, subject, body, mailServer, port, sender, &warnings);
     ForEachItemIn(i,warnings)
-        WUmessage(ctx, ExceptionSeverityWarning, "SendEmail", warnings.item(i));
+        WUmessage(ctx, SeverityWarning, "SendEmail", warnings.item(i));
 }
 
 FILESERVICES_API void FILESERVICES_CALL fsSendEmailAttachText(ICodeContext * ctx, const char * to, const char * subject, const char * body, const char * attachment, const char * mimeType, const char * attachmentName, const char * mailServer, unsigned int port, const char * sender)
@@ -471,7 +471,7 @@ FILESERVICES_API void FILESERVICES_CALL fsSendEmailAttachText(ICodeContext * ctx
     StringArray warnings;
     sendEmailAttachText(to, subject, body, attachment, mimeType, attachmentName, mailServer, port, sender, &warnings);
     ForEachItemIn(i,warnings)
-        WUmessage(ctx, ExceptionSeverityWarning, "SendEmailAttachText", warnings.item(i));
+        WUmessage(ctx, SeverityWarning, "SendEmailAttachText", warnings.item(i));
 }
 
 FILESERVICES_API void FILESERVICES_CALL fsSendEmailAttachData(ICodeContext * ctx, const char * to, const char * subject, const char * body, size32_t lenAttachment, const void * attachment, const char * mimeType, const char * attachmentName, const char * mailServer, unsigned int port, const char * sender)
@@ -479,7 +479,7 @@ FILESERVICES_API void FILESERVICES_CALL fsSendEmailAttachData(ICodeContext * ctx
     StringArray warnings;
     sendEmailAttachData(to, subject, body, lenAttachment, attachment, mimeType, attachmentName, mailServer, port, sender, &warnings);
     ForEachItemIn(i,warnings)
-        WUmessage(ctx, ExceptionSeverityWarning, "SendEmailAttachData", warnings.item(i));
+        WUmessage(ctx, SeverityWarning, "SendEmailAttachData", warnings.item(i));
 }
 
 
@@ -585,7 +585,7 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
             {   //  Add warning of DFU Abort Request - should this be information  ---
                 StringBuffer s("DFU Workunit Abort Requested for ");
                 s.append(wuid);
-                WUmessage(ctx,ExceptionSeverityWarning,"blockUntilComplete",s.str());
+                WUmessage(ctx,SeverityWarning,"blockUntilComplete",s.str());
             }
 
             wu->setState(WUStateAborting);
@@ -1067,7 +1067,7 @@ static void CheckNotInTransaction(ICodeContext *ctx, const char *fn)
     if (transaction->active()) {
         StringBuffer s("Operation not part of transaction : ");
         s.append(fn);
-        WUmessage(ctx,ExceptionSeverityWarning,fn,s.str());
+        WUmessage(ctx,SeverityWarning,fn,s.str());
     }
 }
 
@@ -1082,7 +1082,7 @@ FILESERVICES_API void FILESERVICES_CALL fsCreateSuperFile(ICodeContext *ctx, con
     StringBuffer s("CreateSuperFile ('");
     s.append(lsfn).append("') done");
     AuditMessage(ctx,"CreateSuperFile",lsfn.str());
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
 }
 
 FILESERVICES_API bool FILESERVICES_CALL fsSuperFileExists(ICodeContext *ctx, const char *lsuperfn)
@@ -1111,7 +1111,7 @@ FILESERVICES_API void FILESERVICES_CALL fsDeleteSuperFile(ICodeContext *ctx, con
     } else {
         s.append(" file not found");
     }
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     if (found)
         AuditMessage(ctx,"DeleteSuperFile",lsfn.str());
 }
@@ -1180,7 +1180,7 @@ FILESERVICES_API void FILESERVICES_CALL fslStartSuperFileTransaction(ICodeContex
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
     assertex(transaction);
     transaction->start();
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,"StartSuperFileTransaction");
+    WUmessage(ctx,SeverityInformation,NULL,"StartSuperFileTransaction");
 }
 
 FILESERVICES_API void FILESERVICES_CALL fsAddSuperFile(IGlobalCodeContext *gctx, const char *lsuperfn,const char *_lfn,unsigned atpos,bool addcontents, bool strict)
@@ -1256,7 +1256,7 @@ FILESERVICES_API void FILESERVICES_CALL fslAddSuperFile(ICodeContext *ctx, const
         s.append("trans");
     else
         s.append("done");
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     AuditMessage(ctx,"AddSuperFile",lsfn.str(),lfn.str());
 }
 
@@ -1297,7 +1297,7 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveSuperFile(ICodeContext *ctx, co
         s.append("trans");
     else
         s.append("done");
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     AuditMessage(ctx,"RemoveSuperFile",lsfn.str(),lfn.str());
 }
 
@@ -1336,7 +1336,7 @@ FILESERVICES_API void FILESERVICES_CALL fslRemoveOwnedSubFiles(ICodeContext *ctx
         s.append("trans");
     else
         s.append("done");
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     AuditMessage(ctx,"RemoveOwnedSubFiles",lsfn.str());
 }
 
@@ -1375,7 +1375,7 @@ FILESERVICES_API void FILESERVICES_CALL fslSwapSuperFile(ICodeContext *ctx, cons
         s.append("trans");
     else
         s.append("done");
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     AuditMessage(ctx,"SwapSuperFile",lsfn1.str(),lsfn2.str());
 }
 
@@ -1412,7 +1412,7 @@ FILESERVICES_API void FILESERVICES_CALL fslFinishSuperFileTransaction(ICodeConte
             s.append("rollback");
         else
             s.append("commit");
-        WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+        WUmessage(ctx,SeverityInformation,NULL,s.str());
     }
     else {
         StringBuffer s("Invalid FinishSuperFileTransaction ");
@@ -1421,7 +1421,7 @@ FILESERVICES_API void FILESERVICES_CALL fslFinishSuperFileTransaction(ICodeConte
         else
             s.append("done");
         s.append(", transaction not active");
-        WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+        WUmessage(ctx,SeverityInformation,NULL,s.str());
     }
 }
 
@@ -1470,12 +1470,12 @@ FILESERVICES_API char *  FILESERVICES_CALL fslWaitDfuWorkunit(ICodeContext *ctx,
     setServerAccess(server, wu);
     StringBuffer s("Waiting for DFU Workunit ");
     s.append(wuid);
-    WUmessage(ctx,ExceptionSeverityInformation,"WaitDfuWorkunit",s.str());
+    WUmessage(ctx,SeverityInformation,"WaitDfuWorkunit",s.str());
     StringBuffer state;
     wu.clear();
     blockUntilComplete("WaitDfuWorkunit", server, ctx, wuid, timeout, &state);
     s.clear().append("Finished waiting for DFU Workunit ").append(wuid).append(" state=").append(state.str());
-    WUmessage(ctx,ExceptionSeverityInformation,"WaitDfuWorkunit",s.str());
+    WUmessage(ctx,SeverityInformation,"WaitDfuWorkunit",s.str());
     return state.detach();
 }
 
@@ -1495,7 +1495,7 @@ FILESERVICES_API void FILESERVICES_CALL fslAbortDfuWorkunit(ICodeContext *ctx, c
     Linked<IClientAbortDFUWorkunitResponse> abortResp = server.AbortDFUWorkunit(abortReq);
     StringBuffer s("DFU Workunit Abort Requested for ");
     s.append(wuid);
-    WUmessage(ctx,ExceptionSeverityInformation,"AbortDfuWorkunit",s.str());
+    WUmessage(ctx,SeverityInformation,"AbortDfuWorkunit",s.str());
 }
 
 FILESERVICES_API void  FILESERVICES_CALL fsMonitorLogicalFileName(ICodeContext *ctx, const char *eventname, const char *_lfn,int shotcount, const char * espServerIpPort)
@@ -1521,7 +1521,7 @@ FILESERVICES_API char *  FILESERVICES_CALL fsfMonitorLogicalFileName(ICodeContex
     StringBuffer res(result->getWuid());
     StringBuffer s("MonitorLogicalFileName ('");
     s.append(lfn).append("'): ").append(res);
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     wu.clear();
     if (res.length()!=0)
         blockUntilComplete("MonitorLogicalFileName",server,ctx,res.str(),1000*60*60,NULL,true);
@@ -1551,7 +1551,7 @@ FILESERVICES_API char *  FILESERVICES_CALL fsfMonitorFile(ICodeContext *ctx, con
     StringBuffer res(result->getWuid());
     StringBuffer s("MonitorFile (");
     s.append(ip).append(", '").append(filename).append("'): '").append(res);
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     wu.clear();
     if (res.length()!=0)
         blockUntilComplete("MonitorFile",server,ctx,res.str(),1000*60*60,NULL,true);
@@ -1971,7 +1971,7 @@ FILESERVICES_API void FILESERVICES_CALL fsAddFileRelationship(ICodeContext * ctx
     queryDistributedFileDirectory().addFileRelationship(pfn.str(),sfn.str(),primflds,secflds,kind,cardinality,payload,ctx->queryUserDescriptor(), description);
     StringBuffer s("AddFileRelationship('");
     s.append(pfn.str()).append("','").append(sfn.str()).append("','").append(primflds?primflds:"").append("','").append(secflds?secflds:"").append("','").append(kind?kind:"").append("') done");
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
 
 }
 
@@ -2144,7 +2144,7 @@ FILESERVICES_API void  FILESERVICES_CALL fsMoveExternalFile(ICodeContext * ctx,c
     file->move(topath);
     StringBuffer s("MoveExternalFile ('");
     s.append(location).append(',').append(frompath).append(',').append(topath).append(") done");
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     AuditMessage(ctx,"MoveExternalFile",frompath,topath);
 }
 
@@ -2162,7 +2162,7 @@ FILESERVICES_API void  FILESERVICES_CALL fsDeleteExternalFile(ICodeContext * ctx
     file->remove();
     StringBuffer s("DeleteExternalFile ('");
     s.append(location).append(',').append(path).append(") done");
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     AuditMessage(ctx,"DeleteExternalFile",path);
 }
 
@@ -2180,7 +2180,7 @@ FILESERVICES_API void  FILESERVICES_CALL fsCreateExternalDirectory(ICodeContext 
     file->createDirectory();
     StringBuffer s("CreateExternalDirectory ('");
     s.append(location).append(',').append(path).append(") done");
-    WUmessage(ctx,ExceptionSeverityInformation,NULL,s.str());
+    WUmessage(ctx,SeverityInformation,NULL,s.str());
     AuditMessage(ctx,"CreateExternalDirectory",path);
 }
 
@@ -2317,7 +2317,7 @@ FILESERVICES_API void FILESERVICES_CALL fsDfuPlusExec(ICodeContext * ctx,const c
         void info(const char *msg)
         {
             if (ctx&&(++limit<100))
-                WUmessage(ctx,ExceptionSeverityInformation,NULL,msg);
+                WUmessage(ctx,SeverityInformation,NULL,msg);
         }
         void err(const char *msg)
         {

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -44,9 +44,6 @@
 
 #define PARALLEL_EXECUTE
 
-#define RE_FailedToLoadProcedure    0x1000
-#define RE_FailedToLoadSharedObject 0x2000
-
 #define MAXTRACELEVEL 100     // don't want traceLevel+1 to wrap to 0 in lsb
 #define MAX_CLUSTER_SIZE 1024
 #define UDP_QUEUE_SIZE 100

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3572,9 +3572,9 @@ public:
 
     virtual void addWuException(const char * text, unsigned code, unsigned _severity, const char * source)
     {
-        WUExceptionSeverity severity = (WUExceptionSeverity) _severity;
+        ErrorSeverity severity = (ErrorSeverity) _severity;
         CTXLOG("%s", text);
-        if (severity > ExceptionSeverityInformation)
+        if (severity > SeverityInformation)
             OERRLOG("%d - %s", code, text);
         if (workUnit)
         {
@@ -3589,7 +3589,7 @@ public:
         if (workUnit)
         {
             WorkunitUpdate wu(&workUnit->lock());
-            addExceptionToWorkunit(wu, ExceptionSeverityError, "user", code, text, filename, lineno, column);
+            addExceptionToWorkunit(wu, SeverityError, "user", code, text, filename, lineno, column);
         }
         if (isAbort)
             rtlFailOnAssert();      // minimal implementation

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -888,5 +888,5 @@ extern void addWuException(IConstWorkUnit *workUnit, IException *E)
     unsigned code = E->errorCode();
     OERRLOG("%u - %s", code, message.str());
     WorkunitUpdate w(&workUnit->lock());
-    addExceptionToWorkunit(w, ExceptionSeverityError, "Roxie", code, message.str(), NULL, 0, 0);
+    addExceptionToWorkunit(w, SeverityError, "Roxie", code, message.str(), NULL, 0, 0);
 }

--- a/system/include/errorlist.h
+++ b/system/include/errorlist.h
@@ -21,6 +21,11 @@
 // Define start and end ranges for error codes that may be thrown, written to a log, or returned in any manner
 // create a range that will be big enough
 
+//Error ranges used throughout the system...
+
+#define ERR_EXE_START           1     // All .exes can safely use the same range.
+#define ERR_EXE_END             999   // Codes 1000+ should be used in .dlls.
+
 // actual error codes do not belong in this file
 
 #define ERRORID_UNKNOWN         999      // Right now, this value is used to filter out error messages which have 
@@ -28,16 +33,17 @@
                                                     // example, if an error code is not greater than this value, ECLWatch displays 
                                                     // the error as "internal system error".
 
+//Some legacy ecl warnings appear in the following range, most new ones are in the range below
 #define ECL_WARN_START          1000
 #define ECL_WARN_END            1099
 
 #define ROXIEMM_ERROR_START     1300
 
-#define ROXIE_ERROR_START      1400   // roxie is already using this start value
-#define ROXIE_ERROR_END        1799
+#define ROXIE_ERROR_START       1400   // roxie is already using this start value
+#define ROXIE_ERROR_END         1799
 
-#define ROXIE_MGR_START        1800   // used in esp service to communicate / gather info for roxie
-#define ROXIE_MGR_END          1999
+#define ROXIE_MGR_START         1800   // used in esp service to communicate / gather info for roxie
+#define ROXIE_MGR_END           1999
 
 #define HQL_ERROR_START         2000    // 2000..3999 in hql, 4000..4999 in hqlcpp
 #define HQL_ERROR_END           4999
@@ -45,36 +51,53 @@
 #define WORKUNIT_ERROR_START    5000
 #define WORKUNIT_ERROR_END      5099
 
-#define PACKAGE_ERROR_START    5200
-#define PACKAGE_ERROR_END      5299
+#define PACKAGE_ERROR_START     5200
+#define PACKAGE_ERROR_END       5299
 
-#define THORHELPER_ERROR_START    5300
-#define THORHELPER_ERROR_END      5399
+#define THORHELPER_ERROR_START  5300
+#define THORHELPER_ERROR_END    5399
+
+#define ECLAGENT_ERROR_START    5400
+#define ECLAGENT_ERROR_END      5499
 
 #define WUWEB_ERROR_START       5500
 #define WUWEB_ERROR_END         5599
 
-#define XSLT_ERROR_START       5600
-#define XSLT_ERROR_END         5699
+#define XSLT_ERROR_START        5600
+#define XSLT_ERROR_END          5699
+
+#define THOR_ERROR_START        5700
+#define THOR_ERROR_END          5799
+
+//Jlib
+#define JLIB_ERROR_START        6000
+#define JLIB_ERROR_END          6499
+
+//Ecl runtime library
+#define ECLRTL_ERROR_START      6500
+#define ECLRTL_ERROR_END        6699
+
+//File view
+#define FILEVIEW_ERROR_START    6700
+#define FILEVIEW_ERROR_END      6749
 
 #define REMOTE_ERROR_START      8000    // dafilesrv etc - see common/remote/remoteerr.hpp
 #define REMOTE_ERROR_END        8099
 
-#define DISPATCH_ERROR_START   9000
-#define DISPATCH_ERROR_END     9399
+#define DISPATCH_ERROR_START    9000
+#define DISPATCH_ERROR_END      9399
 
 #define QUERYREGISTRY_ERROR_START   9600
 #define QUERYREGISTRY_ERROR_END     9799
 
-#define JVM_API_ERROR_START    10000
-#define JVM_API_ERROR_END      10499
+#define JVM_API_ERROR_START     10000
+#define JVM_API_ERROR_END       10499
 
-#define PKG_PROCESS_ERROR_START  11000
-#define PKG_PROCESS_ERROR_END    11100
+#define PKG_PROCESS_ERROR_START 11000
+#define PKG_PROCESS_ERROR_END   11100
 
 #define ECLWATCH_ERROR_START    20000
 #define ECLWATCH_ERROR_END      29999
-
 
 
 #endif

--- a/system/jlib/CMakeLists.txt
+++ b/system/jlib/CMakeLists.txt
@@ -96,7 +96,6 @@ set (    INCLUDES
         jelogtype.hpp
         jencrypt.hpp
         jerror.hpp
-        jerrorrange.hpp
         jexcept.hpp
         jfile.hpp
         jfile.ipp

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -23,6 +23,7 @@
 #include "jsem.hpp"
 #include "jexcept.hpp"
 #include "jregexp.hpp"
+#include "jerror.hpp"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -564,9 +565,9 @@ void CppCompiler::extractErrors(IArrayOf<IError> & errors)
                 gccErrorPattern.findstr(msg, 5);
 
                 if (strieq(kind, "error"))
-                    errors.append(*createError(CategoryError, SeverityError, 2999, msg.str(), filename.str(), atoi(line), atoi(column), 0));
+                    errors.append(*createError(CategoryError, SeverityError, JLIBERR_CppCompileError, msg.str(), filename.str(), atoi(line), atoi(column), 0));
                 else
-                    errors.append(*createError(CategoryCpp, SeverityWarning, 2999, msg.str(), filename.str(), atoi(line), atoi(column), 0));
+                    errors.append(*createError(CategoryCpp, SeverityWarning, JLIBERR_CppCompileError, msg.str(), filename.str(), atoi(line), atoi(column), 0));
             }
             else if (gccErrorPattern2.find(next))
             {
@@ -577,9 +578,9 @@ void CppCompiler::extractErrors(IArrayOf<IError> & errors)
                 gccErrorPattern2.findstr(msg, 4);
 
                 if (strieq(kind, "error"))
-                    errors.append(*createError(CategoryError, SeverityError, 2999, msg.str(), filename.str(), atoi(line), 0, 0));
+                    errors.append(*createError(CategoryError, SeverityError, JLIBERR_CppCompileError, msg.str(), filename.str(), atoi(line), 0, 0));
                 else
-                    errors.append(*createError(CategoryCpp, SeverityWarning, 2999, msg.str(), filename.str(), atoi(line), 0, 0));
+                    errors.append(*createError(CategoryCpp, SeverityWarning, JLIBERR_CppCompileError, msg.str(), filename.str(), atoi(line), 0, 0));
             }
             else if (gccLinkErrorPattern.find(next))
             {
@@ -589,14 +590,14 @@ void CppCompiler::extractErrors(IArrayOf<IError> & errors)
                 gccLinkErrorPattern.findstr(msg, 3);
 
                 ErrorSeverity severity = linkFailed ? SeverityError : SeverityWarning;
-                errors.append(*createError(CategoryError, severity, 2999, msg.str(), filename.str(), atoi(line), 0, 0));
+                errors.append(*createError(CategoryError, severity, JLIBERR_CppCompileError, msg.str(), filename.str(), atoi(line), 0, 0));
             }
             else if (gccLinkErrorPattern2.find(next))
             {
                 StringBuffer msg("C++ link error: ");
                 gccLinkErrorPattern2.findstr(msg, 1);
                 ErrorSeverity severity = linkFailed ? SeverityError : SeverityWarning;
-                errors.append(*createError(CategoryError, severity, 2999, msg.str(), NULL, 0, 0, 0));
+                errors.append(*createError(CategoryError, severity, JLIBERR_CppCompileError, msg.str(), NULL, 0, 0, 0));
             }
             else if (vsErrorPattern.find(next))
             {
@@ -604,14 +605,14 @@ void CppCompiler::extractErrors(IArrayOf<IError> & errors)
                 vsErrorPattern.findstr(filename, 1);
                 vsErrorPattern.findstr(line, 2);
                 vsErrorPattern.findstr(msg, 3);
-                errors.append(*createError(CategoryError, SeverityError, 2999, msg.str(), filename.str(), atoi(line), 0, 0));
+                errors.append(*createError(CategoryError, SeverityError, JLIBERR_CppCompileError, msg.str(), filename.str(), atoi(line), 0, 0));
             }
             else if (vsLinkErrorPattern.find(next))
             {
                 StringBuffer filename, msg("C++ link error: ");
                 vsLinkErrorPattern.findstr(filename, 1);
                 vsLinkErrorPattern.findstr(msg, 2);
-                errors.append(*createError(CategoryError, SeverityError, 2999, msg.str(), filename.str(), 0, 0, 0));
+                errors.append(*createError(CategoryError, SeverityError, JLIBERR_CppCompileError, msg.str(), filename.str(), 0, 0, 0));
             }
         } while (cur);
     }

--- a/system/jlib/jerror.hpp
+++ b/system/jlib/jerror.hpp
@@ -22,16 +22,16 @@
 #include "jexcept.hpp"
 #include "errorlist.h"
 
+#if (JLIB_ERROR_START != 6000 || JLIB_ERROR_END != 6499)
+#error "JLIB_ERROR_START has changed"
+#endif
+
 /* Errors generated in jlib */
 
-//Don't remove items from this list - otherwise the error codes will change
-enum
-{
-    JLIBERR_BadlyFormedDateTime = JLIB_ERROR_START,
-    JLIBERR_BadUtf8InArguments,
-    JLIBERR_InternalError,
-    JLIBERR_CppCompileError,
-};
+#define JLIBERR_BadlyFormedDateTime             6000
+#define JLIBERR_BadUtf8InArguments              6001
+#define JLIBERR_InternalError                   6002
+#define JLIBERR_CppCompileError                 6003
 
 //---- Text for all errors (make it easy to internationalise) ---------------------------
 

--- a/system/jlib/jerror.hpp
+++ b/system/jlib/jerror.hpp
@@ -20,13 +20,18 @@
 #define JERROR_HPP
 
 #include "jexcept.hpp"
-#include "jerrorrange.hpp"
+#include "errorlist.h"
 
 /* Errors generated in jlib */
 
-#define JLIBERR_BadlyFormedDateTime             1000
-#define JLIBERR_BadUtf8InArguments              1001
-#define JLIBERR_InternalError                   1002
+//Don't remove items from this list - otherwise the error codes will change
+enum
+{
+    JLIBERR_BadlyFormedDateTime = JLIB_ERROR_START,
+    JLIBERR_BadUtf8InArguments,
+    JLIBERR_InternalError,
+    JLIBERR_CppCompileError,
+};
 
 //---- Text for all errors (make it easy to internationalise) ---------------------------
 

--- a/system/jlib/jexcept.hpp
+++ b/system/jlib/jexcept.hpp
@@ -162,17 +162,20 @@ void  jlib_decl printStackReport();
 
 //---------------------------------------------------------------------------------------------------------------------
 
+//These values are persisted - so should not be reordered.
 enum ErrorSeverity
 {
-    SeverityIgnore,
-    SeverityInfo,
-    SeverityWarning,
-    SeverityError,    // a warning treated as an error
-    SeverityFatal,      // a fatal error - can't be mapped to anything else
+    SeverityInformation = 0,
+    SeverityWarning = 1,
+    SeverityError = 2,
+    SeverityAlert = 3,
+    SeverityIgnore = 4,
+    SeverityFatal = 5,      // a fatal error - can't be mapped to anything else
     SeverityUnknown,
+    SeverityMax = SeverityUnknown
 };
 
-inline bool isError(ErrorSeverity severity) { return severity >= SeverityError; }
+inline bool isError(ErrorSeverity severity) { return severity == SeverityError || severity == SeverityFatal; }
 inline bool isFatal(ErrorSeverity severity) { return severity == SeverityFatal; }
 
 //TBD in a separate commit - add support for warnings to be associated with different categories

--- a/system/jlib/jliball.hpp
+++ b/system/jlib/jliball.hpp
@@ -20,6 +20,7 @@
 #define JLIBALL_HPP
 
 #include "platform.h"
+#include "errorlist.h"
 #include "jiface.hpp"
 
 #include "jarray.hpp"
@@ -29,7 +30,6 @@
 #include "jcrc.hpp"
 #include "jdebug.hpp"
 #include "jencrypt.hpp"
-#include "jerrorrange.hpp"
 #include "jexcept.hpp"
 #include "jfile.hpp"
 #include "jhash.hpp"

--- a/testing/regress/ecl/HeadingExample.ecl
+++ b/testing/regress/ecl/HeadingExample.ecl
@@ -1,0 +1,12 @@
+﻿
+//Sample data
+rec := record
+	string s1;
+	string s2;
+end;
+ds0 := dataset([{'xxx','yyy'},{'xx,x','y,yy'},{'zzz','z'}],rec);
+//Output dataset
+ds0;
+
+//Save dataset to file with heading option
+output(ds0,,'~thor::jas::testout',csv(heading,SEPARATOR(','),quote('"')),overwrite,expire);

--- a/testing/regress/ecl/all_denormalize.ecl
+++ b/testing/regress/ecl/all_denormalize.ecl
@@ -26,6 +26,8 @@ useLocal := #IFDEFINED(root.useLocal, false);
 
 //--- end of version configuration ---
 
+#onwarning (4523, ignore);
+
 import $.setup;
 files := setup.files(multiPart, useLocal);
 

--- a/testing/regress/ecl/bug12130.ecl
+++ b/testing/regress/ecl/bug12130.ecl
@@ -30,6 +30,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4522, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/bug5236.ecl
+++ b/testing/regress/ecl/bug5236.ecl
@@ -30,6 +30,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4522, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/canmatch.ecl
+++ b/testing/regress/ecl/canmatch.ecl
@@ -30,6 +30,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4523, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/childindex.ecl
+++ b/testing/regress/ecl/childindex.ecl
@@ -31,6 +31,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 
 #option ('layoutTranslationEnabled', useTranslation);
 #onwarning (4515, ignore);
+#onwarning (4523, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/countindex.ecl
+++ b/testing/regress/ecl/countindex.ecl
@@ -31,6 +31,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 
 #option ('layoutTranslationEnabled', useTranslation);
 #onwarning (4515, ignore);
+#onwarning (4523, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/dict_keyed.ecl
+++ b/testing/regress/ecl/dict_keyed.ecl
@@ -26,6 +26,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 
 //--- end of version configuration ---
 
+#onwarning (4523, ignore);
+
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);
 

--- a/testing/regress/ecl/fetch.ecl
+++ b/testing/regress/ecl/fetch.ecl
@@ -30,6 +30,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4523, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/fullkeyed.ecl
+++ b/testing/regress/ecl/fullkeyed.ecl
@@ -28,6 +28,7 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4522, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/hthor/layouttrans_disabled.xml
+++ b/testing/regress/ecl/hthor/layouttrans_disabled.xml
@@ -1,0 +1,1 @@
+<Exception><Source>eclagent</Source><Message>System error: 0: Index layout does not match published layout for index regress::multi::dg_fetchindex1</Message></Exception>

--- a/testing/regress/ecl/indexagg.ecl
+++ b/testing/regress/ecl/indexagg.ecl
@@ -19,6 +19,7 @@
 //class=index
 //version multiPart=false
 //version multiPart=true
+//version multiPart=true,useLocal=true
 //version multiPart=true,useTranslation=true,nothor
 
 import ^ as root;
@@ -29,14 +30,14 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);
 
 sequential(
 
-output(max(choosen(Files.DG_FetchIndex, 1,3), Fname));
-output(min(choosen(Files.DG_FetchIndex, 1,3), Fname));
-
-output(count(choosen(Files.DG_FetchIndex, 1,3)))
+output(max(Files.DG_FetchIndex, Fname));
+output(min(Files.DG_FetchIndex, Fname));
+output(count(Files.DG_FetchIndex))
 );

--- a/testing/regress/ecl/indexagg_choosen.ecl
+++ b/testing/regress/ecl/indexagg_choosen.ecl
@@ -15,17 +15,28 @@
     limitations under the License.
 ############################################################################## */
 
+//class=file
+//class=index
+//version multiPart=false
+//version multiPart=true
 
-#ifndef JERRORRANGE_HPP
-#define JERRORRANGE_HPP
+import ^ as root;
+multiPart := #IFDEFINED(root.multiPart, true);
+useLocal := #IFDEFINED(root.useLocal, false);
+useTranslation := #IFDEFINED(root.useTranslation, false);
 
-//Error ranges used throughout the system...
+//--- end of version configuration ---
 
-#define ERR_EXE_FIRST       1     // All .exes can safely use the same range.
-#define ERR_EXE_LAST        999   // Codes 1000+ should be used in .dlls.
+#option ('layoutTranslationEnabled', useTranslation);
+#onwarning (5402, ignore);
 
-#define ERR_JLIB_FIRST      1000
-#define ERR_JLIB_LAST       1999
-#define ERR_FILEVIEW_FIRST  2000
-#define ERR_FILEVIEW_LAST   2049
-#endif
+import $.setup;
+Files := setup.Files(multiPart, useLocal, useTranslation);
+
+sequential(
+
+output(max(choosen(Files.DG_FetchIndex, 1,3), Fname));
+output(min(choosen(Files.DG_FetchIndex, 1,3), Fname));
+
+output(count(choosen(Files.DG_FetchIndex, 1,3)))
+);

--- a/testing/regress/ecl/indexread.ecl
+++ b/testing/regress/ecl/indexread.ecl
@@ -29,6 +29,7 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);
@@ -39,25 +40,6 @@ IMPORT Std;
 
 o1 := output(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),1,SKIP), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
 o2 := output(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),10,SKIP), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
-o3 := output(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),1,SKIP,KEYED), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
-o4 := output(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),10,SKIP,KEYED), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
 
-iresult := Files.DG_FetchIndex(Lname IN ['Anderson', 'Taylor']);
-
-lkresult := LIMIT(iresult,10,KEYED);
-lsresult := LIMIT(lkresult,10,SKIP);
-sresult := IF(Std.System.Thorlib.platform() != 'hthor', SORT(lsresult,Lname), lsresult);
-o5 := output(sresult, {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
-
-// then try with a keyed and unkeyed....
-
-o6 := output(LIMIT(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),1,SKIP,keyed),1,skip), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
-o7 := output(LIMIT(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),10,SKIP,keyed),10,skip), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
-
- o1:independent;
- o2:independent;
- o3:independent;
- o4:independent;
- o5:independent;
- o6:independent;
- o7:independent;
+o1:independent;
+o2:independent;

--- a/testing/regress/ecl/indexread2.ecl
+++ b/testing/regress/ecl/indexread2.ecl
@@ -30,6 +30,9 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4522, ignore);
+#onwarning (4523, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/indexread3.ecl
+++ b/testing/regress/ecl/indexread3.ecl
@@ -30,8 +30,10 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4523, ignore);
 #onwarning (4527, ignore);
 #onwarning (4528, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/indexread4.ecl
+++ b/testing/regress/ecl/indexread4.ecl
@@ -30,6 +30,7 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/indexread6.ecl
+++ b/testing/regress/ecl/indexread6.ecl
@@ -30,6 +30,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4523, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/indexread_keyed.ecl
+++ b/testing/regress/ecl/indexread_keyed.ecl
@@ -1,0 +1,58 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+//class=index
+//version multiPart=false
+//version multiPart=true
+//version multiPart=true,useLocal=true
+
+import ^ as root;
+multiPart := #IFDEFINED(root.multiPart, true);
+useLocal := #IFDEFINED(root.useLocal, false);
+useTranslation := false;    // keyed limits do not produce the same results.
+
+//--- end of version configuration ---
+
+#onwarning (5402, ignore);
+
+import $.setup;
+Files := setup.Files(multiPart, useLocal, useTranslation);
+
+IMPORT Std;
+
+// try it with just one limit
+
+o3 := output(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),1,SKIP,KEYED), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
+o4 := output(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),10,SKIP,KEYED), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
+
+iresult := Files.DG_FetchIndex(Lname IN ['Anderson', 'Taylor']);
+
+lkresult := LIMIT(iresult,10,KEYED);
+lsresult := LIMIT(lkresult,10,SKIP);
+sresult := IF(useTranslation OR Std.System.Thorlib.platform() != 'hthor', SORT(lsresult,Lname), lsresult);
+o5 := output(sresult, {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
+
+// then try with a keyed and unkeyed....
+
+o6 := output(LIMIT(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),1,SKIP,keyed),1,skip), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
+o7 := output(LIMIT(LIMIT(Files.DG_FetchIndex(Lname='Anderson'),10,SKIP,keyed),10,skip), {Lname,Fname,TRIM(tfn),state,TRIM(blobfield)});
+
+ o3:independent;
+ o4:independent;
+ o5:independent;
+ o6:independent;
+ o7:independent;

--- a/testing/regress/ecl/key/HeadingExample.xml
+++ b/testing/regress/ecl/key/HeadingExample.xml
@@ -1,0 +1,7 @@
+<Dataset name='Result 1'>
+ <Row><s1>xxx</s1><s2>yyy</s2></Row>
+ <Row><s1>xx,x</s1><s2>y,yy</s2></Row>
+ <Row><s1>zzz</s1><s2>z</s2></Row>
+</Dataset>
+<Dataset name='Result 2'>
+</Dataset>

--- a/testing/regress/ecl/key/indexagg.xml
+++ b/testing/regress/ecl/key/indexagg.xml
@@ -1,9 +1,9 @@
 <Dataset name='Result 1'>
- <Row><Result_1>John           </Result_1></Row>
+ <Row><Result_1>Zeek           </Result_1></Row>
 </Dataset>
 <Dataset name='Result 2'>
- <Row><Result_2>John           </Result_2></Row>
+ <Row><Result_2>Bridge         </Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><Result_3>1</Result_3></Row>
+ <Row><Result_3>22</Result_3></Row>
 </Dataset>

--- a/testing/regress/ecl/key/indexagg_choosen.xml
+++ b/testing/regress/ecl/key/indexagg_choosen.xml
@@ -1,0 +1,9 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>John           </Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>John           </Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>1</Result_3></Row>
+</Dataset>

--- a/testing/regress/ecl/key/indexread.xml
+++ b/testing/regress/ecl/key/indexread.xml
@@ -7,29 +7,3 @@
  <Row><lname>Anderson                 </lname><fname>Larry          </fname><_unnamed_3>Larry</_unnamed_3><state>FL</state><_unnamed_5>Larry          Anderson</_unnamed_5></Row>
  <Row><lname>Anderson                 </lname><fname>Sue            </fname><_unnamed_3>Sue</_unnamed_3><state>FL</state><_unnamed_5>Sue            Anderson</_unnamed_5></Row>
 </Dataset>
-<Dataset name='Result 3'>
-</Dataset>
-<Dataset name='Result 4'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname><_unnamed_3>Jane</_unnamed_3><state>FL</state><_unnamed_5>Jane           Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname><_unnamed_3>Joe</_unnamed_3><state>FL</state><_unnamed_5>Joe            Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname><_unnamed_3>John</_unnamed_3><state>FL</state><_unnamed_5>John           Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Larry          </fname><_unnamed_3>Larry</_unnamed_3><state>FL</state><_unnamed_5>Larry          Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Sue            </fname><_unnamed_3>Sue</_unnamed_3><state>FL</state><_unnamed_5>Sue            Anderson</_unnamed_5></Row>
-</Dataset>
-<Dataset name='Result 5'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname><_unnamed_3>Jane</_unnamed_3><state>FL</state><_unnamed_5>Jane           Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname><_unnamed_3>Joe</_unnamed_3><state>FL</state><_unnamed_5>Joe            Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname><_unnamed_3>John</_unnamed_3><state>FL</state><_unnamed_5>John           Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Larry          </fname><_unnamed_3>Larry</_unnamed_3><state>FL</state><_unnamed_5>Larry          Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Sue            </fname><_unnamed_3>Sue</_unnamed_3><state>FL</state><_unnamed_5>Sue            Anderson</_unnamed_5></Row>
- <Row><lname>Taylor                   </lname><fname>Frank          </fname><_unnamed_3>Frank</_unnamed_3><state>FL</state><_unnamed_5>Frank          Taylor</_unnamed_5></Row>
-</Dataset>
-<Dataset name='Result 6'>
-</Dataset>
-<Dataset name='Result 7'>
- <Row><lname>Anderson                 </lname><fname>Jane           </fname><_unnamed_3>Jane</_unnamed_3><state>FL</state><_unnamed_5>Jane           Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Joe            </fname><_unnamed_3>Joe</_unnamed_3><state>FL</state><_unnamed_5>Joe            Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>John           </fname><_unnamed_3>John</_unnamed_3><state>FL</state><_unnamed_5>John           Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Larry          </fname><_unnamed_3>Larry</_unnamed_3><state>FL</state><_unnamed_5>Larry          Anderson</_unnamed_5></Row>
- <Row><lname>Anderson                 </lname><fname>Sue            </fname><_unnamed_3>Sue</_unnamed_3><state>FL</state><_unnamed_5>Sue            Anderson</_unnamed_5></Row>
-</Dataset>

--- a/testing/regress/ecl/key/indexread_keyed.xml
+++ b/testing/regress/ecl/key/indexread_keyed.xml
@@ -1,0 +1,26 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname><_unnamed_3>Jane</_unnamed_3><state>FL</state><_unnamed_5>Jane           Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname><_unnamed_3>Joe</_unnamed_3><state>FL</state><_unnamed_5>Joe            Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname><_unnamed_3>John</_unnamed_3><state>FL</state><_unnamed_5>John           Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Larry          </fname><_unnamed_3>Larry</_unnamed_3><state>FL</state><_unnamed_5>Larry          Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Sue            </fname><_unnamed_3>Sue</_unnamed_3><state>FL</state><_unnamed_5>Sue            Anderson</_unnamed_5></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname><_unnamed_3>Jane</_unnamed_3><state>FL</state><_unnamed_5>Jane           Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname><_unnamed_3>Joe</_unnamed_3><state>FL</state><_unnamed_5>Joe            Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname><_unnamed_3>John</_unnamed_3><state>FL</state><_unnamed_5>John           Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Larry          </fname><_unnamed_3>Larry</_unnamed_3><state>FL</state><_unnamed_5>Larry          Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Sue            </fname><_unnamed_3>Sue</_unnamed_3><state>FL</state><_unnamed_5>Sue            Anderson</_unnamed_5></Row>
+ <Row><lname>Taylor                   </lname><fname>Frank          </fname><_unnamed_3>Frank</_unnamed_3><state>FL</state><_unnamed_5>Frank          Taylor</_unnamed_5></Row>
+</Dataset>
+<Dataset name='Result 4'>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><lname>Anderson                 </lname><fname>Jane           </fname><_unnamed_3>Jane</_unnamed_3><state>FL</state><_unnamed_5>Jane           Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Joe            </fname><_unnamed_3>Joe</_unnamed_3><state>FL</state><_unnamed_5>Joe            Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>John           </fname><_unnamed_3>John</_unnamed_3><state>FL</state><_unnamed_5>John           Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Larry          </fname><_unnamed_3>Larry</_unnamed_3><state>FL</state><_unnamed_5>Larry          Anderson</_unnamed_5></Row>
+ <Row><lname>Anderson                 </lname><fname>Sue            </fname><_unnamed_3>Sue</_unnamed_3><state>FL</state><_unnamed_5>Sue            Anderson</_unnamed_5></Row>
+</Dataset>

--- a/testing/regress/ecl/keyed_denormalize.ecl
+++ b/testing/regress/ecl/keyed_denormalize.ecl
@@ -30,6 +30,9 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4522, ignore);
+#onwarning (4523, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/keyed_fetch.ecl
+++ b/testing/regress/ecl/keyed_fetch.ecl
@@ -30,6 +30,7 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 
 #option ('layoutTranslationEnabled', useTranslation);
 #onwarning (4515, ignore);
+#onwarning (4523, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/keyed_join.ecl
+++ b/testing/regress/ecl/keyed_join.ecl
@@ -30,6 +30,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4522, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/keyed_join2.ecl
+++ b/testing/regress/ecl/keyed_join2.ecl
@@ -30,6 +30,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (4522, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/layouttrans.ecl
+++ b/testing/regress/ecl/layouttrans.ecl
@@ -28,6 +28,9 @@ version := #IFDEFINED(root.version, 1);
 
 #option ('layoutTranslationEnabled', true);
 #onwarning (4515, ignore);
+#onwarning (4522, ignore);
+#onwarning (4523, ignore);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, false);
@@ -38,8 +41,8 @@ Files := setup.Files(multiPart, useLocal, false);
 DG_FetchIndex1Alt1 := INDEX(Files.DG_FetchFile,{Fname,Lname,__filepos},Files.DG_FetchIndex1Name);
 DG_FetchIndex1Alt2 := INDEX(Files.DG_FetchFile,{Fname,Lname,__filepos},Files.DG_FetchIndex1Name);
 #ELIF (version=2)
-DG_FetchIndex1Alt1 := INDEX(Files.DG_FetchFile,{Fname,Lname},{state, STRING blobfield {blob}:= fname, STRING tfn := TRIM(Fname), __filepos},Files.DG_FetchIndex1Name);
-DG_FetchIndex1Alt2 := INDEX(Files.DG_FetchFile,{Fname,Lname},{ STRING blobfield {blob}:= fname, __filepos},Files.DG_FetchIndex1Name);
+DG_FetchIndex1Alt1 := INDEX(Files.DG_FetchFile,{Fname,Lname},{state, STRING100 blobfield {blob}:= fname, STRING tfn := TRIM(Fname), __filepos},Files.DG_FetchIndex1Name);
+DG_FetchIndex1Alt2 := INDEX(Files.DG_FetchFile,{Fname,Lname},{ STRING100 blobfield {blob}:= fname, __filepos},Files.DG_FetchIndex1Name);
 #ELSE
 DG_FetchIndex1Alt1 := INDEX(Files.DG_FetchFile,{Fname,Lname},{state ,__filepos},Files.DG_FetchIndex1Name);
 DG_FetchIndex1Alt2 := INDEX(Files.DG_FetchFile,{Fname,Lname},{__filepos},Files.DG_FetchIndex1Name);

--- a/testing/regress/ecl/layouttrans_disabled.ecl
+++ b/testing/regress/ecl/layouttrans_disabled.ecl
@@ -25,6 +25,7 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #onwarning (4515, ignore);
+#onwarning (4523, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/roxie/layouttrans_disabled.xml
+++ b/testing/regress/ecl/roxie/layouttrans_disabled.xml
@@ -1,0 +1,1 @@
+<Exception><Code>1411</Code><Source>Roxie</Source><Message>Key layout mismatch detected for index REGRESS::multi::DG_FetchIndex1 (in Index Read 2)</Message></Exception>

--- a/testing/regress/ecl/serial5a.ecl
+++ b/testing/regress/ecl/serial5a.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4522, ignore);
+
 import Setup.SerialTest;
 
 inDs := DATASET(SerialTest.DsFilename, SerialTest.LibraryDsRec, THOR);

--- a/testing/regress/ecl/serial5b.ecl
+++ b/testing/regress/ecl/serial5b.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4522, ignore);
+
 import Setup.SerialTest;
 
 inDs := DATASET(SerialTest.DsFilename, SerialTest.LibraryDsRec, THOR);

--- a/testing/regress/ecl/serial5c.ecl
+++ b/testing/regress/ecl/serial5c.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4522, ignore);
+
 import Setup.SerialTest;
 
 inDs := DATASET(SerialTest.DictFilename, SerialTest.LibraryDictRec, THOR);

--- a/testing/regress/ecl/serial6a.ecl
+++ b/testing/regress/ecl/serial6a.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4522, ignore);
+
 //Test serializing a dataset to the slave for a remote keyed join
 
 import Setup.SerialTest;

--- a/testing/regress/ecl/serial6b.ecl
+++ b/testing/regress/ecl/serial6b.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4522, ignore);
+
 //Test serializing a dictionary to the slave for a remote keyed join
 
 import Setup.SerialTest;

--- a/testing/regress/ecl/serial6d.ecl
+++ b/testing/regress/ecl/serial6d.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4522, ignore);
+
 import Setup.SerialTest;
 
 inDs := SerialTest.libraryDictionaryFile;

--- a/testing/regress/ecl/serial7a.ecl
+++ b/testing/regress/ecl/serial7a.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4523, ignore);
+
 import Setup.SerialTest;
 
 interestingWords := DICTIONARY([{'elves'},{'cheddar'}], SerialTest.wordRec);

--- a/testing/regress/ecl/serial7b.ecl
+++ b/testing/regress/ecl/serial7b.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4523, ignore);
+
 import Setup.SerialTest;
 
 interestingWords := DICTIONARY([{'elves'},{'cheddar'}], SerialTest.wordRec) : global;

--- a/testing/regress/ecl/serial7c.ecl
+++ b/testing/regress/ecl/serial7c.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4523, ignore);
+
 import Setup.SerialTest;
 
 interestingWords := DICTIONARY([{'elves'},{'cheddar'}], SerialTest.wordRec) : global(few);

--- a/testing/regress/ecl/serial7d.ecl
+++ b/testing/regress/ecl/serial7d.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4523, ignore);
+
 import Setup.SerialTest;
 
 interestingWords := DICTIONARY([{'elves'},{'cheddar'}], SerialTest.wordRec) : once; // Shouldn't need to serialize to slaves in roxie.

--- a/testing/regress/ecl/serial8b.ecl
+++ b/testing/regress/ecl/serial8b.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#onwarning (4523, ignore);
+
 //Test that dictionaries are correctly serialized to nonlocal child queries
 
 import Setup.SerialTest;

--- a/testing/regress/ecl/sqaggds3.ecl
+++ b/testing/regress/ecl/sqaggds3.ecl
@@ -25,6 +25,8 @@ multiPart := #IFDEFINED(root.multiPart, false);
 
 //--- end of version configuration ---
 
+#onwarning (5402, ignore);
+
 import $.setup;
 sq := setup.sq(multiPart);
 

--- a/testing/regress/ecl/sqaggds4.ecl
+++ b/testing/regress/ecl/sqaggds4.ecl
@@ -24,6 +24,8 @@ multiPart := #IFDEFINED(root.multiPart, false);
 
 //--- end of version configuration ---
 
+#onwarning (5402, ignore);
+
 import $.setup;
 sq := setup.sq(multiPart);
 

--- a/testing/regress/ecl/tablecount.ecl
+++ b/testing/regress/ecl/tablecount.ecl
@@ -30,6 +30,7 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/testing/regress/ecl/tablecount2.ecl
+++ b/testing/regress/ecl/tablecount2.ecl
@@ -30,6 +30,7 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslationEnabled', useTranslation);
+#onwarning (5402, ignore);
 
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1130,7 +1130,7 @@ public:
         {
             Owned<IWorkUnit> w = updateWorkUnit();
             Owned<IWUException> we = w->createException();
-            we->setSeverity((WUExceptionSeverity)severity);
+            we->setSeverity((ErrorSeverity)severity);
             we->setExceptionMessage(text);
             we->setExceptionSource(source);
             if (code)
@@ -1154,7 +1154,7 @@ public:
         try
         {
             Owned<IWorkUnit> w = updateWorkUnit();
-            addExceptionToWorkunit(w, ExceptionSeverityError, "user", code, text, filename, lineno, column);
+            addExceptionToWorkunit(w, SeverityError, "user", code, text, filename, lineno, column);
         }
         catch (IException *E)
         {

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -959,7 +959,7 @@ public:
         Owned<IThorException> e = MakeThorException(code, "%s", text);
         e->setOrigin(source);
         e->setAction(tea_warning);
-        e->setSeverity((WUExceptionSeverity)severity);
+        e->setSeverity((ErrorSeverity)severity);
         job.fireException(e);
     }
     virtual unsigned getNodes() { return job.queryJobGroup().ordinality()-1; }
@@ -1001,7 +1001,7 @@ public:
         Owned<IThorException> e = MakeThorException(code, "%s", text);
         e->setAssert(filename, lineno, column);
         e->setOrigin("user");
-        e->setSeverity(ExceptionSeverityError);
+        e->setSeverity(SeverityError);
         if (!isAbort)
             e->setAction(tea_warning);
         job.fireException(e);

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -218,11 +218,11 @@ protected:
     bool notified;
     unsigned line, column;
     StringAttr file, origin;
-    WUExceptionSeverity severity;
+    ErrorSeverity severity;
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
     CThorException(LogMsgAudience _audience,int code, const char *str) 
-        : audience(_audience), errorcode(code), msg(str), action(tea_null), graphId(0), id(0), node(0), line(0), column(0), severity(ExceptionSeverityInformation), kind(TAKnone), notified(false) { };
+        : audience(_audience), errorcode(code), msg(str), action(tea_null), graphId(0), id(0), node(0), line(0), column(0), severity(SeverityInformation), kind(TAKnone), notified(false) { };
     CThorException(MemoryBuffer &mb)
     {
         mb.read((unsigned &)action);
@@ -255,7 +255,7 @@ public:
     void getAssert(StringAttr &_file, unsigned &_line, unsigned &_column) { _file.set(file); _line = line; _column = column; }
     const char *queryOrigin() { return origin; }
     const char *queryMessage() { return msg; }
-    WUExceptionSeverity querySeverity() { return severity; }
+    ErrorSeverity querySeverity() { return severity; }
     bool queryNotified() const { return notified; }
     MemoryBuffer &queryData() { return data; }
     void setNotified() { notified = true; }
@@ -269,7 +269,7 @@ public:
     void setMessage(const char *_msg) { msg.set(_msg); }
     void setAssert(const char *_file, unsigned _line, unsigned _column) { file.set(_file); line = _line; column = _column; }
     void setOrigin(const char *_origin) { origin.set(_origin); }
-    void setSeverity(WUExceptionSeverity _severity) { severity = _severity; }
+    void setSeverity(ErrorSeverity _severity) { severity = _severity; }
 
 // IException
     int errorCode() const { return errorcode; }
@@ -409,7 +409,7 @@ IThorException *MakeActivityWarning(CActivityBase *activity, int code, const cha
     va_start(args, format);
     IThorException *e = _MakeActivityException(activity->queryContainer(), code, format, args);
     e->setAction(tea_warning);
-    e->setSeverity(ExceptionSeverityWarning);
+    e->setSeverity(SeverityWarning);
     va_end(args);
     return e;
 }
@@ -420,7 +420,7 @@ IThorException *MakeActivityWarning(CActivityBase *activity, IException *e, cons
     va_start(args, format);
     IThorException *e2 = _MakeActivityException(activity->queryContainer(), e, format, args);
     e2->setAction(tea_warning);
-    e2->setSeverity(ExceptionSeverityWarning);
+    e2->setSeverity(SeverityWarning);
     va_end(args);
     return e2;
 }
@@ -454,7 +454,7 @@ IThorException *MakeActivityWarning(CGraphElementBase *container, int code, cons
     va_start(args, format);
     IThorException *e = _MakeActivityException(*container, code, format, args);
     e->setAction(tea_warning);
-    e->setSeverity(ExceptionSeverityWarning);
+    e->setSeverity(SeverityWarning);
     va_end(args);
     return e;
 }
@@ -465,7 +465,7 @@ IThorException *MakeActivityWarning(CGraphElementBase *container, IException *e,
     va_start(args, format);
     IThorException *e2 = _MakeActivityException(*container, e, format, args);
     e2->setAction(tea_warning);
-    e2->setSeverity(ExceptionSeverityWarning);
+    e2->setSeverity(SeverityWarning);
     va_end(args);
     return e2;
 }
@@ -730,7 +730,7 @@ void ensureDirectoryForFile(const char *fName)
 }
 
 // Not recommended to be used from slaves as tend to be one or more trying at same time.
-void reportExceptionToWorkunit(IConstWorkUnit &workunit,IException *e, WUExceptionSeverity severity)
+void reportExceptionToWorkunit(IConstWorkUnit &workunit,IException *e, ErrorSeverity severity)
 {
     LOG(MCwarning, thorJob, e, "Reporting exception to WU");
     Owned<IWorkUnit> wu = &workunit.lock();
@@ -1261,7 +1261,7 @@ IPerfMonHook *createThorMemStatsPerfMonHook(CJobBase &job, int maxLevel, IPerfMo
             if ((maxLevel != -1) && (level <= maxLevel)) // maxLevel of -1 means disabled
             {
                 Owned<IThorException> e = MakeThorException(TE_KERN, "%s", msg);
-                e->setSeverity(ExceptionSeverityAlert);
+                e->setSeverity(SeverityAlert);
                 e->setAction(tea_warning);
                 job.fireException(e);
             }

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -299,7 +299,7 @@ interface IThorException : extends IException
     virtual const char *queryJobId() = 0;
     virtual void getAssert(StringAttr &file, unsigned &line, unsigned &column) = 0;
     virtual const char *queryOrigin() = 0;
-    virtual WUExceptionSeverity querySeverity() = 0;
+    virtual ErrorSeverity querySeverity() = 0;
     virtual const char *queryMessage() = 0;
     virtual bool queryNotified() const = 0;
     virtual MemoryBuffer &queryData() = 0;
@@ -314,7 +314,7 @@ interface IThorException : extends IException
     virtual void setMessage(const char *msg) = 0;
     virtual void setAssert(const char *file, unsigned line, unsigned column) = 0;
     virtual void setOrigin(const char *origin) = 0;
-    virtual void setSeverity(WUExceptionSeverity severity) = 0;
+    virtual void setSeverity(ErrorSeverity severity) = 0;
 };
 
 class CGraphElementBase;
@@ -415,7 +415,7 @@ extern graph_decl const char *queryTempDir(bool altdisk=false);
 extern graph_decl void loadCmdProp(IPropertyTree *tree, const char *cmdProp);
 
 extern graph_decl void ensureDirectoryForFile(const char *fName);
-extern graph_decl void reportExceptionToWorkunit(IConstWorkUnit &workunit,IException *e, WUExceptionSeverity severity=ExceptionSeverityWarning);
+extern graph_decl void reportExceptionToWorkunit(IConstWorkUnit &workunit,IException *e, ErrorSeverity severity=SeverityWarning);
 
 extern graph_decl IPropertyTree *globals;
 extern graph_decl mptag_t masterSlaveMpTag;


### PR DESCRIPTION
Changes include
- Merging two error level enumerations
- Merging jerrorrange.h and errorlist.h
- Adding warning numbers to various eclagent/hthor warnings
- Use the warning mappings in eclagent to allow warnings to be removed.
- Add #onwwarning to remove compile and execution warnings
- Fixed/split a few versions of tests that couldn't work with index translation
