### PR TITLE
HPCC-12900 Merge to 5.2.0

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -59,7 +59,11 @@ class RegressMain:
             else:
                 # We have simple ECL file in parameter list, put it on the eclfile list
                 eclPath = os.path.join(self.regress.dir_ec, ecl)
-                eclfiles.append(eclPath)
+                if os.path.isfile(eclPath):
+                    eclfiles.append(eclPath)
+                else:
+                    logging.error("%s. ECL file '%s' doesn't exist!" % (1,  eclPath))
+                    raise Error("4001")
 
         if len(eclfiles) > 1:
             # Remove duplicates


### PR DESCRIPTION
Merge HPCC-12664 global name 'eclfile' is not defined
to 5.2.0

Signed-off-by: Attila Vamos attila.vamos@gmail.com
