### PR TITLE
HPCC-12811 When a test case aborted by timeout then it logged with a wrong test id.

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -293,7 +293,7 @@ class Regression:
                                 self.loggermutex.acquire()
                                 query = suiteItems[self.taskParam[threadId]['taskId']]
                                 query.setAborReason('Timeout')
-                                logging.info("%3d. Timeout occured. Force to abort... " % (self.taskParam[threadId]['taskId']),  extra={'taskId':self.taskParam[threadId]['taskId']+1})
+                                logging.info("%3d. Timeout occured. Force to abort... " % (self.taskParam[threadId]['taskId']+1),  extra={'taskId':self.taskParam[threadId]['taskId']+1})
                                 logging.debug("%3d. Task parameters: thread id:%d, wuid:'%s', state:'%s', ecl:'%s'." % (self.taskParam[threadId]['taskId']+1, threadId, wuid['wuid'], wuid['state'],  query.ecl),  extra={'taskId':self.taskParam[threadId]['taskId']+1})
                                 self.loggermutex.release()
                                 self.timeouts[threadId] = -1
@@ -338,6 +338,7 @@ class Regression:
             if self.timeouts[thread] == 0:
                 # time out, abort tast
                 wuid =  queryWuid(query.getJobname(),  query.getTaskId())
+                logging.debug("%3d. Abort WUID:'%s'" % (cnt,  str(wuid)),  extra={'taskId':cnt})
                 abortWorkunit(wuid['wuid'])
                 query.setAborReason('Timeout')
                 self.loggermutex.acquire()


### PR DESCRIPTION
Add fix to log.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
