### PR TITLE
HPCC-12839 Fix crash when row being looked up in a dictionary is aliased

### DIFF
--- a/ecl/hqlcpp/hqlcset.ipp
+++ b/ecl/hqlcpp/hqlcset.ipp
@@ -93,6 +93,9 @@ public:
     virtual void buildIterateClass(BuildCtx & ctx, StringBuffer & cursorName, BuildCtx * initctx) { throwUnexpected(); }
     virtual void buildCountDict(BuildCtx & ctx, CHqlBoundExpr & tgt);
     virtual void buildExistsDict(BuildCtx & ctx, CHqlBoundExpr & tgt);
+
+private:
+    IHqlExpression * getFirstSearchValue(IHqlExpression * searchExpr, IHqlExpression * searchRecord);
 };
 
 class MultiLevelDatasetCursor : public BaseDatasetCursor


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
