### PR TITLE
HPCC-12912 - Some examples in regression suite fail on python 2.6

### DIFF
--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -80,7 +80,7 @@ public:
     inline operator PyObject *() const    { return ptr; }
     inline void clear()                     { if (ptr) Py_DECREF(ptr); ptr = NULL; }
     inline void setown(PyObject *_ptr)      { clear(); ptr = _ptr; }
-    inline void set(PyObject *_ptr)         { clear(); ptr = _ptr; if (ptr) Py_INCREF(ptr);}
+    inline void set(PyObject *_ptr)         { if (_ptr) Py_INCREF(_ptr); clear(); ptr = _ptr; }
     inline PyObject *getLink()              { if (ptr) Py_INCREF(ptr); return ptr;}
     inline PyObject **ref()                 { return &ptr; }
 };
@@ -99,7 +99,7 @@ public:
     inline operator X *() const      { return ptr; }
     inline void clear()              { if (ptr) Py_DECREF(ptr); ptr = NULL; }
     inline void setown(X *_ptr)      { clear(); ptr = _ptr; }
-    inline void set(X *_ptr)         { clear(); ptr = _ptr; if (ptr) Py_INCREF(ptr);}
+    inline void set(X *_ptr)         { if (_ptr) Py_INCREF(_ptr); clear(); ptr = _ptr; }
     inline X *getLink()              { if (ptr) Py_INCREF(ptr); return ptr;}
     inline X **ref()                 { return &ptr; }
 };

--- a/testing/regress/ecl/streame.ecl
+++ b/testing/regress/ecl/streame.ecl
@@ -48,7 +48,7 @@ ENDEMBED;
 
 dataset(namesRecord) streamedNames(data d, utf8 u) := EMBED(Python)
   return [  \
-     ("Gavin", "Halliday", [("a", 1),("b", 2),("c", 3)], [("aa", 11)], ("aaa", 111), 250, -1,  U'là',  U'là',  U'là', 0x01000000, d, False, {"1","2"}), \
+     ("Gavin", "Halliday", [("a", 1),("b", 2),("c", 3)], [("aa", 11)], ("aaa", 111), 250, -1,  U'là',  U'là',  U'là', 0x01000000, d, False, set(["1","2"])), \
      ("John", "Smith", [], [], ("c", 3), 250, -1,  U'là',  U'là',  u, 0x02000000, d, True, []) \
      ]
 ENDEMBED;


### PR DESCRIPTION
Can't use { for sets in Python 2.6

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
