### PR TITLE
HPCC-12925 Save remote DALI IP when resolving file references

### DIFF
--- a/common/workunit/referencedfilelist.cpp
+++ b/common/workunit/referencedfilelist.cpp
@@ -358,6 +358,7 @@ IPropertyTree *ReferencedFile::getSpecifiedOrRemoteFileTree(IUserDescriptor *use
     if (!fileTree)
         return NULL;
     StringAttrBuilder daliipText(daliip);
+    remote->endpoint().getUrlStr(daliipText);
     filePrefix.set(remotePrefix);
     return fileTree.getClear();
 }

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -97,7 +97,6 @@ StringBuffer::StringBuffer(bool useInternal)
 
 StringBuffer::~StringBuffer()
 {
-    dbgassertex(buffer);
     freeBuffer();
 }
 


### PR DESCRIPTION
5.2 Regression from recent StringBuffer changes.  Also fix dbgassert
that is invalid in some scenarios.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
