### PR TITLE
HPCC-12823 Add option to not expand any versions

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -24,6 +24,7 @@ Result:
 |                       [-X name1=value1[,name2=value2...]]
 |                       [-f optionA=valueA[,optionB=valueB...]]
 |                       [--pq threadNumber]
+|                       [--noversion]
 |                       [--runclass class[,class,...]]
 |                       [--excludeclass class[,class,...]]
 |                       {list,setup,run,query} ...
@@ -53,6 +54,7 @@ Result:
 |        -f optionA=valueA[,optionB=valueB...]
 |                                 set an ECL option (equivalent to #option).
 |        --pq threadNumber        parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
+|        --noversion              avoid version expansion of queries. Execute them as a standard test.
 |        --runclass class[,class,...], -r class[,class,...]
 |                                 run subclass(es) of the suite. Default value is 'all'
 |        --excludeclass class[,class,...], -e class[,class,...]
@@ -115,6 +117,7 @@ Result:
 |                             [-X name1=value1[,name2=value2...]]
 |                             [-f optionA=valueA[,optionB=valueB...]]
 |                             [--pq threadNumber]
+|                             [--noversion]
 |                             [--runclass class[,class,...]]
 |                             [--excludeclass class[,class,...]]
 |                             [--target [target_cluster_list | all]]
@@ -135,6 +138,7 @@ Result:
 |        -f optionA=valueA[,optionB=valueB...]
 |                                 set an ECL option (equivalent to #option).
 |        --pq threadNumber        parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
+|        --noversion              avoid version expansion of queries. Execute them as a standard test.
 |        --runclass class[,class,...], -r class[,class,...]
 |                                 run subclass(es) of the suite. Default value is 'all'
 |        --excludeclass class[,class,...], -e class[,class,...]
@@ -162,6 +166,7 @@ Result:
 |                           [-X name1=value1[,name2=value2...]]
 |                           [-f optionA=valueA[,optionB=valueB...]]
 |                           [--pq threadNumber]
+|                           [--noversion]
 |                           [--runclass class[,class,...]]
 |                           [--excludeclass class[,class,...]]
 |                           [--target [target_cluster_list | all]]
@@ -183,6 +188,7 @@ Result:
 |        -f optionA=valueA[,optionB=valueB...]
 |                                 set an ECL option (equivalent to #option).
 |        --pq threadNumber        parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
+|        --noversion              avoid version expansion of queries. Execute them as a standard test.
 |        --runclass class[,class,...], -r class[,class,...]
 |                                 run subclass(es) of the suite. Default value is 'all'
 |        --excludeclass class[,class,...], -e class[,class,...]
@@ -212,6 +218,7 @@ Result:
 |                             [-X name1=value1[,name2=value2...]]
 |                             [-f optionA=valueA[,optionB=valueB...]]
 |                             [--pq threadNumber]
+|                             [--noversion]
 |                             [--runclass class[,class,...]]
 |                             [--excludeclass class[,class,...]]
 |                             [--target [target_cluster_list | all]]
@@ -237,6 +244,7 @@ Result:
 |        -f optionA=valueA[,optionB=valueB...]
 |                                 set an ECL option (equivalent to #option).
 |        --pq threadNumber        parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2)
+|        --noversion              avoid version expansion of queries. Execute them as a standard test.
 |        --runclass class[,class,...], -r class[,class,...]
 |                                 run subclass(es) of the suite. Default value is 'all'
 |        --excludeclass class[,class,...], -e class[,class,...]

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -159,6 +159,8 @@ class RegressMain:
                             nargs=1, type=checkXParam,  default='None',  metavar="optionA=valueA[,optionB=valueB...]")
         commonParser.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
                                 type=checkPqParam,  default = 0,   metavar="threadNumber")
+        commonParser.add_argument('--noversion', help="Avoid version expansion of queries. Execute them as a standard test.",
+                                action = 'store_true')
 
         executionParser=argparse.ArgumentParser(add_help=False)
         executionParser.add_argument('--runclass', '-r', help="run subclass(es) of the suite. Default value is 'all'",

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -120,7 +120,7 @@ class Suite:
 
     def addFileToSuite(self, eclfile):
         haveVersions = eclfile.testVesion()
-        if haveVersions:
+        if haveVersions and not self.args.noversion:
             basename = eclfile.getEcl()
             files=[]
             versions = eclfile.getVersions()

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -75,11 +75,12 @@ class ECLFile:
         self.version=''
         self.versionId=0
         self.timeout = 0
+        self.args = args
 
         #If there is a --publish CL parameter then force publish this ECL file
         self.forcePublish=False
-        if 'publish' in args:
-            self.forcePublish=args.publish
+        if 'publish' in self.args:
+            self.forcePublish=self.args.publish
 
         self.optX =[]
         self.optXHash={}
@@ -316,7 +317,7 @@ class ECLFile:
 
     # Test (and read all) //version tag in the ECL file
     def testVesion(self):
-        if self.isVersions == False:
+        if self.isVersions == False and not self.args.noversion:
             tag = b'//version'
             logging.debug("%3d. testVesion (ecl:'%s', tag:'%s')", self.taskId, self.ecl, tag)
             retVal = False


### PR DESCRIPTION
Add nev command line parameter '--noversion' to prevent version expansion.

Add code to handle '--noversion' parameter.

Update README.rst.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
