### PR TITLE
HPCC-12915 Reset send queue, on lookup/smart restart (in loop)

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -680,6 +680,16 @@ protected:
         bool stopped;
         SimpleInterThreadQueueOf<CSendItem, true> blockQueue;
         Owned<IException> exception;
+
+        void clearQueue()
+        {
+            loop
+            {
+                Owned<CSendItem> sendItem = blockQueue.dequeueNow();
+                if (NULL == sendItem)
+                    break;
+            }
+        }
     public:
         CRowProcessor(CInMemJoinBase &_owner) : threaded("CRowProcessor", this), owner(_owner)
         {
@@ -689,17 +699,13 @@ protected:
         ~CRowProcessor()
         {
             blockQueue.stop();
-            loop
-            {
-                Owned<CSendItem> sendItem = blockQueue.dequeueNow();
-                if (NULL == sendItem)
-                    break;
-            }
+            clearQueue();
             wait();
         }
         void start()
         {
             stopped = false;
+            clearQueue();
             exception.clear();
             threaded.start();
         }


### PR DESCRIPTION
The send block queue was not being reset when lookup/smart join
was reran (inside a loop). As a consequence a terminator
block (NULL) may have still be left on the queue and caused the
row processor to terminate early and cause deadlock on the
producer side.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
