### PR TITLE
HPCC-12940 DOCS:Update VM doc for a VMPlayer image

### DIFF
--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -256,6 +256,11 @@
                     </listitem>
                   </varlistentry>
                 </variablelist></para>
+
+              <para>Choose the VM Image file for the VMware player. The
+              <emphasis>filename</emphasis>-<emphasis
+              role="bold">vmx</emphasis>.ova file is appropriate for the
+              VMware player.</para>
             </listitem>
 
             <listitem>
@@ -519,6 +524,10 @@
                     </listitem>
                   </varlistentry>
                 </variablelist></para>
+
+              <para>Choose the VM Image file for VirtualBox. The
+              <emphasis>filename</emphasis>.ova file is appropriate for the
+              VirtualBox.</para>
             </listitem>
 
             <listitem>


### PR DESCRIPTION
FIX HPCC-12940 DOCS:Update VM doc for a VMPlayer image
Update Documenation to reflect that there will be multiple
VM Images available, one for VirtualBox and one for VMPlayer

Signed-off-by: G Panagiotatos g.pan3.14@gmail.com

@JamesDeFabia please review
