### PR TITLE
HPCC-12478 Remove "RowTag" from non XML Sprays

### DIFF
--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -286,7 +286,6 @@ define([
                     lang.mixin(request, {
                         sourceIP: item.DropZone.NetAddress,
                         sourcePath: item.fullPath,
-                        sourceRowTag: item.targetRowTag,
                         destLogicalName: request.namePrefix + item.targetName
                     });
                     doSpray(request, item);


### PR DESCRIPTION
Fixes HPCC-12478

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
