### PR TITLE
HPCC-12815 Dynamically detect JSON file root format when reading in ECL

### DIFF
--- a/common/thorhelper/thorxmlread.cpp
+++ b/common/thorhelper/thorxmlread.cpp
@@ -1732,7 +1732,7 @@ class CXMLParse : public CInterface, implements IXMLParse
         }
         virtual void newAttribute(const char *tag, const char *value)
         {
-            if (stack.ordinality() && stack.tos().keep)
+            if (stack.tos().keep)
                 maker->newAttribute(tag, value);
         }
         virtual void beginNodeContent(const char *tag)
@@ -1929,6 +1929,11 @@ class CXMLParse : public CInterface, implements IXMLParse
         {
             if (!checkSkipRoot(tag))
                 CMakerBase::beginNode(tag, startOffset);
+        }
+        virtual void newAttribute(const char *tag, const char *value)
+        {
+            if (stack.ordinality() && stack.tos().keep)
+                maker->newAttribute(tag, value);
         }
         virtual void beginNodeContent(const char *tag)
         {

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -6927,12 +6927,12 @@ public:
                     case '{':
                         state=objAttributes;
                         readNext();
-                        beginNode("__root__", curOffset, elementTypeObject);
+                        beginNode("__object__", curOffset, elementTypeObject);
                         break;
                     case '[':
                         state=valueStart;
                         readNext();
-                        beginNode("__root__", curOffset, elementTypeArray);
+                        beginNode("__array__", curOffset, elementTypeArray);
                         break;
                     default:
                         expecting("{ or [");

--- a/testing/regress/ecl/jsonout.ecl
+++ b/testing/regress/ecl/jsonout.ecl
@@ -59,14 +59,14 @@ namesTable := dataset([
         ], personRecord);
 
 output(namesTable,,'REGRESS::TEMP::output_object_namedArray.json',overwrite, json);
-readObjectNamedArray := dataset(DYNAMIC('REGRESS::TEMP::output_object_namedArray.json'), personRecord, json('*/Row'));
+readObjectNamedArray := dataset(DYNAMIC('REGRESS::TEMP::output_object_namedArray.json'), personRecord, json('Row'));
 output(readObjectNamedArray, named('ObjectNamedArray'));
 
 output(namesTable,,'REGRESS::TEMP::output_array.json',overwrite, json('', heading('[', ']')));
-readArrayOfRows := dataset(DYNAMIC('REGRESS::TEMP::output_array.json'), personRecord, json('*/*'));
+readArrayOfRows := dataset(DYNAMIC('REGRESS::TEMP::output_array.json'), personRecord, json(''));
 output(readArrayOfRows, named('ArrayOfRows'));
 
 output(namesTable,,'REGRESS::TEMP::output_noroot.json',overwrite, json('', heading('','')));
-readNoRootRows := dataset(DYNAMIC('REGRESS::TEMP::output_noroot.json'), personRecord, json('*', NOROOT));
+readNoRootRows := dataset(DYNAMIC('REGRESS::TEMP::output_noroot.json'), personRecord, json('', NOROOT));
 output(readNoRootRows, named('noRootRows'));
 


### PR DESCRIPTION
XPath will now more intuitively start after the opening [{, or {.  When
no xpath the row is the first {.

Reading of JSON files is new to 5.2.  So this doesn't affect previous
releases or prior documentation.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
