### PR TITLE
HPCC-12957 JS Graph Subgraphs are Solid Blue

### DIFF
--- a/esp/src/eclwatch/css/hpcc.css
+++ b/esp/src/eclwatch/css/hpcc.css
@@ -1033,12 +1033,12 @@ margin-left:-20px;
     fill: white;
 }
 
-.claro .graph_Graph .graphVertex > .common_Shape {
+.claro .graph_Graph .graphVertex > .common_Shape .common_Shape {
     stroke: black;
     fill: none;
 }
 
-.claro .graph_Graph .graphVertex > .common_Shape.selected {
+.claro .graph_Graph .graphVertex > .common_Shape.selected .common_Shape {
     stroke: #1f77b4;
 }
 


### PR DESCRIPTION
Change style sheet to make them black rectangles with no content.

Fixes HPCC-12957

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
