### PR TITLE
HPCC-12911 change regression output to no longer use legacy eclwatch

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -496,7 +496,7 @@ class Regression:
 
         if wuid and wuid.startswith("W"):
             url = "http://" + self.config.ip+self.config.espSocket
-            url += "/WsWorkunits/WUInfo?Wuid="
+            url += "/?Widget=WUDetailsWidget&Wuid="
             url += wuid
         else:
             url = "N/A"


### PR DESCRIPTION
Change workunit link to point to new ECL Watch

Signed-off-by: Attila Vamos attila.vamos@gmail.com
