### PR TITLE
HPCC-12960 Fix stepping3.ecl by reintroducing a fully keyed index

### DIFF
--- a/testing/regress/ecl/key/setup.xml
+++ b/testing/regress/ecl/key/setup.xml
@@ -26,3 +26,5 @@
 </Dataset>
 <Dataset name='Result 14'>
 </Dataset>
+<Dataset name='Result 15'>
+</Dataset>

--- a/testing/regress/ecl/setup/files.ecl
+++ b/testing/regress/ecl/setup/files.ecl
@@ -134,6 +134,8 @@ EXPORT DG_indexFile      := INDEX(DG_NormalIndexFile, indexName);
 indexName := IF(useTranslation, __nameof__(DG_TransIndexFileEvens), __nameof__(DG_NormalIndexFileEvens));
 EXPORT DG_indexFileEvens := INDEX(DG_NormalIndexFileEvens, indexName);
 
+EXPORT DG_KeyedIndexFile      := INDEX(DG_FlatFile, { DG_firstname, DG_lastname, DG_Prange}, { filepos }, DG_IndexOut+'KEYED_INDEX');
+
 EXPORT DG_CSVFile   := DATASET(DG_FileOut+'CSV',DG_OutRec,CSV);
 EXPORT DG_XMLFile   := DATASET(DG_FileOut+'XML',DG_OutRec,XML);
 

--- a/testing/regress/ecl/setup/setup.ecl
+++ b/testing/regress/ecl/setup/setup.ecl
@@ -88,7 +88,8 @@ SEQUENTIAL(
     PARALLEL(buildindex(Files.DG_NormalIndexFile,overwrite),
              buildindex(Files.DG_NormalIndexFileEvens,overwrite),
              buildindex(Files.DG_TransIndexFile,overwrite),
-             buildindex(Files.DG_TransIndexFileEvens,overwrite))
+             buildindex(Files.DG_TransIndexFileEvens,overwrite),
+             buildindex(Files.DG_KeyedIndexFile,overwrite))
     );
 
     fileServices.AddFileRelationship( __nameof__(Files.DG_FlatFile), __nameof__(Files.DG_NormalIndexFile), '', '', 'view', '1:1', false);

--- a/testing/regress/ecl/setup/thor/setup.xml
+++ b/testing/regress/ecl/setup/thor/setup.xml
@@ -38,3 +38,5 @@
 </Dataset>
 <Dataset name='Result 20'>
 </Dataset>
+<Dataset name='Result 21'>
+</Dataset>

--- a/testing/regress/ecl/stepping3.ecl
+++ b/testing/regress/ecl/stepping3.ecl
@@ -27,6 +27,8 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 
 //--- end of version configuration ---
 
+#onwarning (4126, ignore);
+
 import $.setup;
 Files := setup.Files(multiPart, useLocal, useTranslation);
 
@@ -34,6 +36,5 @@ Files := setup.Files(multiPart, useLocal, useTranslation);
 //Stepped global joins unsupported, see issue HPCC-8148
 //skip type==thorlcr TBD
 
-#onwarning (4126, ignore);
 // should be equivalent to OUTPUT(SORT(Files.DG_IndexFile(DG_firstname = 'DAVID'), DG_Prange));
-OUTPUT(STEPPED(Files.DG_IndexFile(KEYED(DG_firstname = 'DAVID')), DG_Prange));
+OUTPUT(STEPPED(Files.DG_KeyedIndexFile(KEYED(DG_firstname = 'DAVID')), DG_Prange));


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
