### PR TITLE
HPCC-12958 Regression Test Engine doesn't handle well stderr stream of ecl command.

### DIFF
--- a/testing/regress/hpcc/common/shell.py
+++ b/testing/regress/hpcc/common/shell.py
@@ -52,13 +52,11 @@ class Shell:
         argsLog = [self.__hidePassw(i) for i in args if i is not None ]
         logging.debug("Shell _run CMD: " + " ". join(argsLog))
         process = Popen(
-            _args, stdout=kwargs.pop('stdout', PIPE),
-            stderr=kwargs.pop('stderr', PIPE),
-            close_fds=kwargs.pop('close_fds', True), **kwargs)
+            _args, stdout = PIPE, stderr = PIPE, close_fds = True, **kwargs)
         stdout, stderr = process.communicate()
         retCode = process.returncode
-        if retCode:
-            logging.debug("Shell _run retCode:: %d, stdout:'%s', stderr:'%s'",  retCode,  stdout,  stderr)
+        logging.debug("Shell _run retCode:: %d, stdout:'%s', stderr:'%s'",  retCode,  stdout,  stderr)
+        if retCode or len(stderr) > 0:
             exception = CalledProcessError(
                 process.returncode, repr(args))
             exception.output = ''.join(filter(None, [stdout, stderr]))


### PR DESCRIPTION
Fix stderr and ecl 0 return code related problem.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
