### PR TITLE
HPCC-12852 Update configmgr startup script

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -390,6 +390,15 @@ createRuntime() {
     ulimit -l unlimited
 }
 
+# cleanup all standard files made during runtime
+cleanupRuntimeEnvironment() {
+    unlock ${lock}/${compName}/${compName}.lock
+    removePid ${pid}/${compName}_init.pid
+    removePid ${pid}/${compName}.pid
+    removePid ${pid}/init_${compName}.pid
+}
+
+
 start_dafilesrv() {
    /etc/init.d/dafilesrv status 1>/dev/null 2>/dev/null
    if [ $? -ne 0 ];then
@@ -397,8 +406,7 @@ start_dafilesrv() {
       if [ ${DEBUG} != "NO_DEBUG" ]; then
         log_failure_msg "Pid or lock file exists, but process is not running"
       fi
-      removePid ${PIDPATH}
-      unlock ${LOCKPATH}
+      cleanupRuntimeEnvironment
 
       noStatusCheck=1
       /etc/init.d/dafilesrv setup 1>/dev/null 2>/dev/null
@@ -433,10 +441,7 @@ startCmd() {
       RCSTART=$?
       if [ ${RCSTART} -gt 1 ];then
         # take care of failure message in check_status function
-        cleanup_component
-        removePid ${PIDPATH}
-        removePid ${COMPPIDPATH}
-        unlock ${LOCKPATH}
+        cleanupRuntimeEnvironment
       fi
       if [ ${RCSTART} -eq 0 ]; then
         #Since component is already started but current script is failed till returning 0
@@ -517,9 +522,7 @@ stop_component() {
           log_success_msg "Already stopped"
        fi
        cleanup_component
-       removePid ${PIDPATH}
-       removePid ${COMPPIDPATH}
-       unlock ${LOCKPATH}
+       cleanupRuntimeEnvironment
        return 0
     fi
 
@@ -546,8 +549,7 @@ stop_component() {
                    if [ $__flagPid -eq 1 ];then
                         checkPidExist ${PIDPATH}
                         if [ $__pidExists -ne 1 ];then
-                            removePid ${PIDPATH}
-                            unlock ${LOCKPATH}
+                            cleanupRuntimeEnvironment
                             log_success_msg
                             RCSTOP=0
                             break 2
@@ -559,8 +561,7 @@ stop_component() {
             sleep 1
        done
     else
-        removePid ${PIDPATH}
-        unlock ${LOCKPATH}
+        cleanupRuntimeEnvironment
         log_success_msg
         RCSTOP=0
     fi
@@ -619,9 +620,7 @@ restart_component() {
          /etc/init.d/dafilesrv stop 2>/dev/null
        else
            echo "Component $compName was not running. Will start it now for you ...."
-           removePid ${PIDPATH}
-           removePid ${COMPPIDPATH}
-           unlock ${LOCKPATH}
+           cleanupRuntimeEnvironment
        fi
          /etc/init.d/dafilesrv start 2>/dev/null
     else
@@ -629,9 +628,7 @@ restart_component() {
        RCRESTART=$?
        if [ $RCRESTART -ne 0 ];then
            echo "Component $compName was not running. Will start it now for you ...."
-           removePid ${PIDPATH}
-           removePid ${COMPPIDPATH}
-           unlock ${LOCKPATH}
+           cleanupRuntimeEnvironment
        else
            stop_component ${compName}
        fi

--- a/initfiles/sbin/configmgr.in
+++ b/initfiles/sbin/configmgr.in
@@ -59,36 +59,13 @@ print_usage ()
     exit 0
 }
 
-source  ${INSTALL_DIR}/etc/init.d/lock.sh
-source  ${INSTALL_DIR}/etc/init.d/pid.sh
-source  ${INSTALL_DIR}/etc/init.d/hpcc_common
-source  ${INSTALL_DIR}/etc/init.d/init-functions
-source  ${INSTALL_DIR}/etc/init.d/export-path
-
-HPCC_CONFIG=${HPCC_CONFIG:-${CONFIG_DIR}/${ENV_CONF_FILE}}
-SECTION=${SECTION:-DEFAULT}
-cfg.parser ${HPCC_CONFIG}
-cfg.section.${SECTION}
-
-if [ ${DEBUG:-NO_DEBUG} != "NO_DEBUG" ]; then
-    echo "\$runtime=$runtime"
-    echo "\$path=$path"
-    echo "\$configs=$configs"
-    echo "\$configsbackup=$configsbackup"
-    echo "\$user=$user"
-    echo "\$lock=$lock"
-    echo "\$pid=$pid"
-    echo "\$log=$log"
-    echo "\$environment=$environment"
-    echo "\$interface=$interface"
-    echo "\$sourcedir=$sourcedir"
-    echo
-fi
+set_environmentvars
 
 exec_script_path=${path}/bin
 reg_path=${path}/sbin
 
 compName=configmgr
+compPath=${runtime}/${compName}
 
 is_root
 
@@ -100,18 +77,8 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${path}/lib
 export PATH=${PATH}:${runtime}/bin:${path}/sbin
 
 # Creating runtime environment for ConfigMgr
-mkdir -p ${pid}
-chown -R ${user}:${group} ${pid}
-mkdir -p ${lock}
-chown -R ${user}:${group} ${lock}
-mkdir -p ${runtime}/$compName
-chown -R ${user}:${group} ${runtime}/$compName
-mkdir -p ${log}/$compName
-chown -R ${user}:${group} ${log}/$compName
-mkdir -p ${lock}/$compName
-chown -R ${user}:${group} ${lock}/$compName
-mkdir -p ${pid}/$compName
-chown -R ${user}:${group} ${pid}/$compName
+createRuntime
+
 logFile=${log}/${compName}/${compName}.log
 
 initPidFile=${pid}/${compName}_init.pid
@@ -174,11 +141,7 @@ if [ ${RCSTAT} -eq 0 ]; then
     echo "Configmgr is already running with Pid $__pidValue"
     exit 0
 else
-    #component is not running, If pid/lock file exist remove them
-    if [ ${RCSTAT} -eq 1 ] || [ ${RCSTAT} -eq 2 ]
-    then
-         removePidfiles
-    fi
+    cleanupRuntimeEnvironment
 fi
 
 #-----------------------------------------------------------
@@ -193,11 +156,6 @@ eval ${startcmd}
 started=$?
 
 # Creating a Lock
-lockPath=${lock}/${compName}
-if [ ! -d $lockPath ]; then
-  mkdir -p $lockPath >> $logFile 2>&1
-fi
-chown -c $user:$group $lockPath >> /dev/null 2>&1
 lock $lockFile
 
 if [ ${DEBUG:-NO_DEBUG} != "NO_DEBUG" ]; then

--- a/initfiles/sbin/configmgr.in
+++ b/initfiles/sbin/configmgr.in
@@ -23,19 +23,13 @@
 
 DEBUG=${DEBUG:-NO_DEBUG}
 
+source ${INSTALL_DIR}/etc/init.d/hpcc_common
+
 createConf ()
 {
     awk -f ${reg_path}/regex.awk -v NEW_ENVFILE=$1 -v NEW_PORT=$2 -v NEW_CONFFILE=$3< ${path}${configs}/configmgr/esp.xml >${runtime}/${compName}/esp.xml
 }
 
-removePidfiles ()
-{
-    rm -rf ${runtime}/${compName}.pid
-    rm -rf ${lock}/${compName}/${compName}.lock
-    rm -rf ${pid}/${compName}_init.pid
-    rm -rf ${pid}/${compName}.pid
-    rm -rf ${pid}/init_${compName}.pid
-}
 
 cleanup ()
 {
@@ -46,7 +40,7 @@ cleanup ()
     eval $stopcmd
     sleep 2
     killall -9 configesp >/dev/null 2>&1
-    removePidfiles
+    cleanupRuntimeEnvironment
     exit
 }
 


### PR DESCRIPTION
I have gone ahead and updated the configmgr startup script to reduce complexity and duplication of code.  It still works the same, just calls functions from hpcc_common instead of rewriting them internally with the same logic (while still sourcing hpcc_common.)  I also snuck in a small change to hpcc_common that consolidates the cleanup of all the runtime created pid and lock files.
