### PR TITLE
HPCC-12978 Modified stop_thor

### DIFF
--- a/initfiles/bin/init_configesp
+++ b/initfiles/bin/init_configesp
@@ -31,7 +31,7 @@ rm -f ${SENTINEL}
 SNMPID=$$
 
 killed() {
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} configesp 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_configesp
+++ b/initfiles/bin/init_configesp
@@ -31,7 +31,7 @@ rm -f ${SENTINEL}
 SNMPID=$$
 
 killed() {
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_dafilesrv.in
+++ b/initfiles/bin/init_dafilesrv.in
@@ -41,7 +41,7 @@ export SENTINEL="dafilesrv.sentinel"
 rm -f ${SENTINEL}
 
 killed(){
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} dafilesrv 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_dafilesrv.in
+++ b/initfiles/bin/init_dafilesrv.in
@@ -41,7 +41,7 @@ export SENTINEL="dafilesrv.sentinel"
 rm -f ${SENTINEL}
 
 killed(){
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_dali
+++ b/initfiles/bin/init_dali
@@ -30,7 +30,7 @@ rm -f ${SENTINEL}
 
 killed(){
     dalistop .
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} daserver 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_dali
+++ b/initfiles/bin/init_dali
@@ -30,7 +30,7 @@ rm -f ${SENTINEL}
 
 killed(){
     dalistop .
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_dfuserver
+++ b/initfiles/bin/init_dfuserver
@@ -32,7 +32,7 @@ rm -f ${SENTINEL}
 killed() {
     dfuserver stop=1
     sleep 5
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} dfuserver 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_dfuserver
+++ b/initfiles/bin/init_dfuserver
@@ -32,7 +32,7 @@ rm -f ${SENTINEL}
 killed() {
     dfuserver stop=1
     sleep 5
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_eclagent.in
+++ b/initfiles/bin/init_eclagent.in
@@ -30,7 +30,7 @@ rm -f ${SENTINEL}
 rm -f ${PID_DIR}/hthortemp/*
 
 killed (){
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_eclagent.in
+++ b/initfiles/bin/init_eclagent.in
@@ -30,7 +30,7 @@ rm -f ${SENTINEL}
 rm -f ${PID_DIR}/hthortemp/*
 
 killed (){
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} agentexec 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_eclccserver
+++ b/initfiles/bin/init_eclccserver
@@ -28,7 +28,7 @@ rm -f ${SENTINEL}
 
 
 killed() {
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} eclccserver 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_eclccserver
+++ b/initfiles/bin/init_eclccserver
@@ -28,7 +28,7 @@ rm -f ${SENTINEL}
 
 
 killed() {
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_eclscheduler
+++ b/initfiles/bin/init_eclscheduler
@@ -26,7 +26,7 @@ export SENTINEL="eclscheduler.sentinel"
 rm -f ${SENTINEL}
 
 killed(){
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_eclscheduler
+++ b/initfiles/bin/init_eclscheduler
@@ -26,7 +26,7 @@ export SENTINEL="eclscheduler.sentinel"
 rm -f ${SENTINEL}
 
 killed(){
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} eclscheduler 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_esp
+++ b/initfiles/bin/init_esp
@@ -30,7 +30,7 @@ rm -f ${SENTINEL}
 SNMPID=$$
 
 killed() {
-    kill_process ${SENTINEL} ${PID_NAME} 15
+    kill_process ${PID_NAME} 15 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_esp
+++ b/initfiles/bin/init_esp
@@ -30,7 +30,7 @@ rm -f ${SENTINEL}
 SNMPID=$$
 
 killed() {
-    kill_process ${PID_NAME} 15 ${SENTINEL}
+    kill_process ${PID_NAME} esp 15 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_roxie
+++ b/initfiles/bin/init_roxie
@@ -47,7 +47,7 @@ killed() {
     if [ -n "$1" ]; then
         cd $1
     fi
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} roxie 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_roxie
+++ b/initfiles/bin/init_roxie
@@ -47,7 +47,7 @@ killed() {
     if [ -n "$1" ]; then
         cd $1
     fi
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_sasha
+++ b/initfiles/bin/init_sasha
@@ -49,7 +49,7 @@ killed() {
             kill -9 $pid
         fi
     fi
-    kill_process ${SENTINEL} ${PID_NAME} 3
+    kill_process ${PID_NAME} 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_sasha
+++ b/initfiles/bin/init_sasha
@@ -49,7 +49,7 @@ killed() {
             kill -9 $pid
         fi
     fi
-    kill_process ${PID_NAME} 3 ${SENTINEL}
+    kill_process ${PID_NAME} saserver 3 ${SENTINEL}
     exit 255
 }
 

--- a/initfiles/bin/init_thor
+++ b/initfiles/bin/init_thor
@@ -29,7 +29,6 @@ rm -f ${SENTINEL}
 killed() {
         echo "Stopping"
         $deploydir/stop_thor $deploydir
-        kill_process ${PID_NAME} 3 ${SENTINEL}
         exit 255
 }
 

--- a/initfiles/bin/init_thor
+++ b/initfiles/bin/init_thor
@@ -29,7 +29,7 @@ rm -f ${SENTINEL}
 killed() {
         echo "Stopping"
         $deploydir/stop_thor $deploydir
-        kill_process ${SENTINEL} ${PID_NAME} 3
+        kill_process ${PID_NAME} 3 ${SENTINEL}
         exit 255
 }
 

--- a/initfiles/componentfiles/thor/stop_thor
+++ b/initfiles/componentfiles/thor/stop_thor
@@ -47,7 +47,7 @@ if [ "$#" -lt "2" ] || [ "$2" != "keep_sentinel" ]; then
     sleep 1
 fi
 
-kill_process ${MASTER_PID_NAME} 8
+kill_process ${MASTER_PID_NAME} thormaster_${comp_base} 8
 if [ $? -eq 1 ]; then
     echo "unable to kill ${THORNAME}, in zombie state"
 fi

--- a/initfiles/componentfiles/thor/stop_thor
+++ b/initfiles/componentfiles/thor/stop_thor
@@ -47,22 +47,9 @@ if [ "$#" -lt "2" ] || [ "$2" != "keep_sentinel" ]; then
     sleep 1
 fi
 
-masterpid=`cat ${MASTER_PID_NAME} 2> /dev/null`
-if [ ! -z $masterpid ]; then
-  while :
-  do
-    kill -0 $masterpid >& /dev/null
-    masterRunning=$(( $? == 0 ? 1 : 0 ))
-    if [ 0 == $masterRunning ]; then
-      break
-    fi
-    echo --------------------------
-    echo stopping thormaster $THORMASTER 
-    kill $masterpid >& /dev/null
-    sleep 8
-    kill -9 $masterpid >& /dev/null
-    sleep 1
-  done
+kill_process ${MASTER_PID_NAME} 8
+if [ $? -eq 1 ]; then
+    echo "unable to kill ${THORNAME}, in zombie state"
 fi
 
 echo --------------------------

--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -32,6 +32,8 @@ function kill_process () {
     fi
     if [[ -e $PID ]]; then
         pidwait_fn $PID $PROCESS $TIMEOUT
+        local RC_PIDWAIT=$?
+        return $RC_PIDWAIT
     fi
 }
 
@@ -42,7 +44,7 @@ function pidwait_fn () {
     local TIMEOUT=$(($3*1000))
 
     if ps -p $WATCH_PID -o command= | grep -v "${PROCESS}" &>/dev/null ; then
-      exit 1
+      return 0
     fi
 
     kill $WATCH_PID
@@ -52,6 +54,7 @@ function pidwait_fn () {
     done
 
     if [[ $TIMEOUT -le 0 ]] && ps -p $WATCH_PID -o command= | grep "${PROCESS}" &>/dev/null ; then
+      echo "Failed to kill ${PROCESS} gracefully, sending SIGKILL"
       kill -9 $WATCH_PID &>/dev/null
       sleep 1
       kill -0 $WATCH_PID &>/dev/null

--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -23,29 +23,35 @@
 ###<REPLACE>###
 
 function kill_process () {
-    PID=$1
-    TIMEOUT=$2
-    if [[ $# -eq 3 ]]; then
-      SENTINEL=$3
+    local PID=$1
+    local PROCESS=$2
+    local TIMEOUT=$3
+    if [[ $# -eq 4 ]]; then
+      SENTINEL=$4
       [[ -e $SENTINEL ]] && rm -f $SENTINEL
     fi
     if [[ -e $PID ]]; then
-        pidwait_fn $PID $TIMEOUT
+        pidwait_fn $PID $PROCESS $TIMEOUT
     fi
 }
 
 function pidwait_fn () {
-    PID=$1
-    WATCH_PID=$( cat $PID )
-    TIMEOUT=$(($2*1000))
-    COMM=$( ps -p $WATCH_PID -o command= )
+    local PID=$1
+    local WATCH_PID=$( cat $PID )
+    local PROCESS=$2
+    local TIMEOUT=$(($3*1000))
+
+    if ps -p $WATCH_PID -o command= | grep -v "${PROCESS}" &>/dev/null ; then
+      exit 1
+    fi
+
     kill $WATCH_PID
     while [[ -d /proc/$WATCH_PID ]] && [[ $TIMEOUT -gt 0 ]]; do
       sleep 0.2
-      TIMEOUT=$(($TIMEOUT-200))
+      local TIMEOUT=$(($TIMEOUT-200))
     done
-    COMM_CHECK=$( ps -p $WATCH_PID -o command= )
-    if [[ $TIMEOUT -le 0 ]] && [[ $COMM == $COMM_CHECK ]]; then
+
+    if [[ $TIMEOUT -le 0 ]] && ps -p $WATCH_PID -o command= | grep "${PROCESS}" &>/dev/null ; then
       kill -9 $WATCH_PID &>/dev/null
       sleep 1
       kill -0 $WATCH_PID &>/dev/null
@@ -54,6 +60,7 @@ function pidwait_fn () {
         return 1
       fi
     fi
+
     rm -f $PID
     return 0
 }

--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -23,30 +23,39 @@
 ###<REPLACE>###
 
 function kill_process () {
-    SENTINEL=$1
-    PID=$2
-    TIMEOUT=$3
-    if [ -e $SENTINEL ]; then
-        rm -f $SENTINEL
+    PID=$1
+    TIMEOUT=$2
+    if [[ $# -eq 3 ]]; then
+      SENTINEL=$3
+      [[ -e $SENTINEL ]] && rm -f $SENTINEL
     fi
-    if [ -e $PID ]; then
+    if [[ -e $PID ]]; then
         pidwait_fn $PID $TIMEOUT
     fi
 }
 
 function pidwait_fn () {
     PID=$1
-    WATCH_PID=`cat $PID`
+    WATCH_PID=$( cat $PID )
     TIMEOUT=$(($2*1000))
+    COMM=$( ps -p $WATCH_PID -o command= )
     kill $WATCH_PID
-    while [ -d /proc/$WATCH_PID -a $TIMEOUT -gt 0 ]; do
-            sleep 0.2
-            TIMEOUT=$(($TIMEOUT-200))
+    while [[ -d /proc/$WATCH_PID ]] && [[ $TIMEOUT -gt 0 ]]; do
+      sleep 0.2
+      TIMEOUT=$(($TIMEOUT-200))
     done
-    if [ $TIMEOUT -le 0 ]; then
-            kill -9 $WATCH_PID
+    COMM_CHECK=$( ps -p $WATCH_PID -o command= )
+    if [[ $TIMEOUT -le 0 ]] && [[ $COMM == $COMM_CHECK ]]; then
+      kill -9 $WATCH_PID &>/dev/null
+      sleep 1
+      kill -0 $WATCH_PID &>/dev/null
+      # if still alive
+      if [[ $? -eq 0 ]]; then
+        return 1
+      fi
     fi
     rm -f $PID
+    return 0
 }
 
 platform='unknown'


### PR DESCRIPTION
Now deletes the $MASTER_PID_NAME file after we stop the process.
Changed the logic around killing the process to mimic the kill_process function used in other scripts, making the shutdown at most take 8 seconds (which used to be hard coded.)

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
