### PR TITLE
HPCC-11759 - Admin not recognized on OpenLDAP

### DIFF
--- a/esp/src/eclwatch/HPCCPlatformWidget.js
+++ b/esp/src/eclwatch/HPCCPlatformWidget.js
@@ -272,7 +272,7 @@ define([
                 }).then(function (response) {
                     if (lang.exists("UserEditResponse.Groups.Group", response)) {
                         arrayUtil.some(response.UserEditResponse.Groups.Group, function (item, idx) {
-                            if(item.name == "Administrators"){
+                            if(item.name == "Administrators" || "Directory Administrators"){
                                 dojoConfig.isAdmin = true;
                                 registry.byId(context.id + "SetBanner").set("disabled", false);
                                 if (context.widget._OPS.refresh) {


### PR DESCRIPTION
ECLWatch was only checking for "Administrators" and was missing
OpenLDAP implementations where the group is called "Directory Administrators".

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
