### PR TITLE
HPCC-11949 - Add ability to modify WU scope in ECLWatch

### DIFF
--- a/esp/src/eclwatch/WUDetailsWidget.js
+++ b/esp/src/eclwatch/WUDetailsWidget.js
@@ -141,6 +141,7 @@ define([
             var protectedCheckbox = registry.byId(this.id + "Protected");
             var context = this;
             this.wu.update({
+                Scope: dom.byId(context.id + "Scope").value,
                 Description: dom.byId(context.id + "Description").value,
                 Jobname: dom.byId(context.id + "Jobname").value,
                 Protected: protectedCheckbox.get("value")
@@ -432,6 +433,9 @@ define([
                 this.refreshActionState();
             } else if (name === "hasCompleted") {
                 this.checkIfComplete();
+            } else if (name === "Scope" && newValue) {
+                domClass.remove("scopeOptional", "hidden");
+                domClass.add("scopeOptional", "show");
             }
             if (name === "changedCount" && newValue > 0) {
                 var getInt = function (item) {

--- a/esp/src/eclwatch/templates/WUDetailsWidget.html
+++ b/esp/src/eclwatch/templates/WUDetailsWidget.html
@@ -63,9 +63,9 @@
                                 <label class="Prompt" for="${id}Owner">${i18n.Owner}:</label>
                                 <div id="${id}Owner"></div>
                             </li>
-                            <li>
+                            <li id="scopeOptional" class="hidden">
                                 <label class="Prompt" for="${id}Scope">${i18n.Scope}:</label>
-                                <div id="${id}Scope"></div>
+                                <div><input id="${id}Scope" data-dojo-props="trim:true" data-dojo-type="dijit.form.TextBox"/></div>
                             </li>
                             <li>
                                 <label class="Prompt" for="${id}Jobname">${i18n.JobName}:</label>


### PR DESCRIPTION
Add a text field for users to be able to modify Workunit scope rather than
read-only. Also, hide it for un-authenticated systems.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
