### PR TITLE
HPCC-12989 Sort queries by target cluster

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2363,7 +2363,7 @@ mapEnums querySortFields[] =
    { WUQSFwarnTimeLimitHi, "@warnTimeLimit" },
    { WUQSFpriority, "@priority" },
    { WUQSFpriorityHi, "@priority" },
-   { WUQSFQuerySet, "../@id" },
+   { WUQSFQuerySet, "@querySetId" },
    { WUQSFActivited, "@activated" },
    { WUQSFSuspendedByUser, "@suspended" },
    { WUQSFLibrary, "Library"},

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1296,6 +1296,8 @@ bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequ
             sortOrder[0] = (WUQuerySortField) (WUQSFwarnTimeLimit | WUQSFnumeric);
         else if (strieq(sortBy, "Priority"))
             sortOrder[0] = (WUQuerySortField) (WUQSFpriority | WUQSFnumeric);
+        else if (strieq(sortBy, "QuerySetId"))
+            sortOrder[0] = WUQSFQuerySet;
         else
             sortOrder[0] = WUQSFId;
 


### PR DESCRIPTION
In onWUListQueries(), if sortBy is "QuerySetId", the sort flag should be set to WUQSFQuerySet which should be linked to xpath "@querySetId".

Signed-off-by: wangkx kevin.wang@lexisnexis.com
