### PR TITLE
HPCC-12995 Fix extra semicolon causing function to return early

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
+++ b/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
@@ -133,7 +133,7 @@ int orderParts(IInterface * const * pLeft, IInterface * const * pRight)
     bool hasLeftSeq = left->hasProp("@sequence");
     if (hasRightSeq && hasLeftSeq)
         return left->getPropInt("@sequence") - right->getPropInt("@sequence");
-    if (hasRightSeq);
+    if (hasRightSeq)
         return -1;
     if (hasLeftSeq)
         return 1;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
