### PR TITLE
HPCC-13005 Fixed cleanup of slaves on bad startup of thormaster

### DIFF
--- a/initfiles/componentfiles/thor/run_thor
+++ b/initfiles/componentfiles/thor/run_thor
@@ -74,6 +74,7 @@ while [ 1 ]; do
         echo master exited with errorcode = $errcode
         if [ ! -e $SENTINEL ]; then
             echo $SENTINEL 'has been removed (1) - script stopping'
+            $deploydir/stop_thor $deploydir
             exit 0
         fi
 


### PR DESCRIPTION
If the thormaster process had died without writing out it's sentinel file, we would have already started slaves but wouldn't clean them up when we went to exit. This fixes that.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
