### PR TITLE
HPCC-12961 Fix check for JSON BigNumber size too low

### DIFF
--- a/common/thorhelper/roxiehelper.cpp
+++ b/common/thorhelper/roxiehelper.cpp
@@ -1214,7 +1214,7 @@ void FlushingJsonBuffer::setScalarInt(const char *resultName, unsigned sequence,
 void FlushingJsonBuffer::setScalarUInt(const char *resultName, unsigned sequence, unsigned __int64 value, unsigned size)
 {
     startScalar(resultName, sequence);
-    if (size < 6) //JavaScript doesn't support unsigned, and only supports 53 significant bits
+    if (size < 7) //JavaScript doesn't support unsigned, and only supports 53 significant bits
         s.append(value);
     else
         s.append('"').append(value).append('"');

--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -501,7 +501,7 @@ void CommonJsonWriter::outputInt(__int64 field, unsigned size, const char *field
 }
 void CommonJsonWriter::outputUInt(unsigned __int64 field, unsigned size, const char *fieldname)
 {
-    if (size < 6) //JavaScript doesn't support unsigned, and only supports 53 significant bits
+    if (size < 7) //JavaScript doesn't support unsigned, and only supports 53 significant bits
     {
         checkDelimit();
         appendJSONValue(out, checkItemName(fieldname), field);


### PR DESCRIPTION
Check for ecl interger size < 7 rather than size < 6.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
