### PR TITLE
HPCC-13003 Regression Test Engine system check won't work on remote cluster.

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -28,8 +28,9 @@ import glob
 from hpcc.util import argparse
 from hpcc.regression.regress import Regression
 from hpcc.util.ecl.file import ECLFile
-from hpcc.util.util import checkPqParam, getVersionNumbers, checkXParam, convertPath, getRealIPAddress, parentPath, checkClusters, checkHpccStatus
+from hpcc.util.util import setConfig, checkPqParam, getVersionNumbers, checkXParam, convertPath, getRealIPAddress, parentPath, checkClusters, checkHpccStatus
 from hpcc.common.error import Error
+from hpcc.common.config import Config
 
 # For coverage
 if ('coverage' in os.environ) and (os.environ['coverage'] == '1'):
@@ -113,11 +114,6 @@ class RegressMain:
                 self.regress.runSuite(cluster, self.regress.suites[cluster])
 
     def main(self):
-        try:
-            checkHpccStatus()
-        except Error as e:
-            exit(e.getErrorCode());
-
         prog = "ecl-test"
         description = 'HPCC Platform Regression suite'
         pythonVer = getVersionNumbers()
@@ -199,6 +195,49 @@ class RegressMain:
                                 action='store_true')
 
         self.args = parser.parse_args()
+
+        # Process config parameter
+        self.config = Config(self.args.config).configObj
+        setConfig(self.config)
+
+        # Process target parameter
+        self.targetClusters = []
+        if 'target' in self.args:
+            if '' == self.args.target:
+                # Target not specified, use default from config
+                try:
+                    if self.args.func == 'setup':
+                        defaultTargets = self.config.defaultSetupClusters
+                        targetSet='defaultSetupClusters'
+                    else:
+                        defaultTargets = self.config.defaultTargetClusters
+                        targetSet='defaultTargetClusters'
+
+                    self.targetClusters = checkClusters(defaultTargets, targetSet)
+
+                except AttributeError:
+                    # It seems there is no defaultSetupClusters|defaultTargetClusters array in the config file
+                    # use the first one of cluster list in config file
+                    self.targetClusters.append(self.config.Clusters[0])
+            elif 'all' == self.args.target:
+                for cluster in self.config.Clusters:
+                    self.targetClusters.append(str(cluster))
+            else:
+                if ',' in self.args.target:
+                    # target is a list, process it
+                    targets = self.args.target.split(',')
+                    self.targetClusters = checkClusters(targets, 'target')
+                elif self.args.target in self.config.Clusters:
+                    self.targetClusters.append(self.args.target)
+                else:
+                    logging.error("%s. Unknown target cluster:'%s'!" % (1,  self.args.target))
+                    raise Error("4000")
+
+        try:
+            checkHpccStatus(self.targetClusters)
+        except Error as e:
+            exit(e.getErrorCode());
+
         try:
             self.regress = None
             if self.args.X[0]== "5000":
@@ -221,38 +260,6 @@ class RegressMain:
 
             self.regress = Regression(self.args)
             logging.debug("Suite full path:%s",  regressionSuiteFullPath)
-
-            self.targetClusters = []
-            if 'target' in self.args:
-                if '' == self.args.target:
-                    # Target not specified, use default from config
-                    try:
-                        if self.args.func == 'setup':
-                            defaultTargets = self.regress.config.defaultSetupClusters
-                            targetSet='defaultSetupClusters'
-                        else:
-                            defaultTargets = self.regress.config.defaultTargetClusters
-                            targetSet='defaultTargetClusters'
-
-                        self.targetClusters = checkClusters(defaultTargets, targetSet)
-
-                    except AttributeError:
-                        # It seems there is no defaultSetupClusters|defaultTargetClusters array in the config file
-                        # use the first one of cluster list in config file
-                        self.targetClusters.append(self.regress.config.Clusters[0])
-                elif 'all' == self.args.target:
-                    for cluster in self.regress.config.Clusters:
-                        self.targetClusters.append(str(cluster))
-                else:
-                    if ',' in self.args.target:
-                        # target is a list, process it
-                        targets = self.args.target.split(',')
-                        self.targetClusters = checkClusters(targets, 'target')
-                    elif self.args.target in self.regress.config.Clusters:
-                        self.targetClusters.append(self.args.target)
-                    else:
-                        logging.error("%s. Unknown target cluster:'%s'!" % (1,  self.args.target))
-                        raise Error("4000")
 
             if self.args.func == 'list':
                 self.listClusters()

--- a/testing/regress/hpcc/common/error.py
+++ b/testing/regress/hpcc/common/error.py
@@ -33,6 +33,7 @@ ERROR = {
     "6001": "HPCC System doesn't run!",
     "6002": "OS error when try to call ecl command!",
     "6003": "Parameter error when try to call ecl command!",
+    "6004": "Can't connect to remote HPCC System!",
 }
 
 

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -32,7 +32,7 @@ from ..regression.suite import Suite
 from ..util.ecl.cc import ECLCC
 from ..util.ecl.command import ECLcmd
 from ..util.expandcheck import ExpandCheck
-from ..util.util import setConfig,  queryWuid,  abortWorkunit, getVersionNumbers
+from ..util.util import getConfig, queryWuid,  abortWorkunit, getVersionNumbers
 
 
 class Regression:
@@ -48,8 +48,7 @@ class Regression:
 
     def __init__(self, args):
         self.args = args
-        self.config = Config(args.config).configObj
-        setConfig(self.config)
+        self.config = getConfig()
         self.suites = {}
         self.log = Logger(args.loglevel)
         if args.timeout == '0':


### PR DESCRIPTION
Add code to check the ESP server can reach on every target.

Reorganise ecl-test main to provide targets to checking.

Add new, remote related error code.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
