### PR TITLE
HPCC-12992 Avoid out of disk follow on issues

### DIFF
--- a/system/jlib/jlzw.cpp
+++ b/system/jlib/jlzw.cpp
@@ -2055,7 +2055,14 @@ public:
     virtual ~CCompressedFile()
     {
         if (!writeException)
-            close();
+        {
+            try { close(); }
+            catch (IException *e)
+            {
+                EXCLOG(e, "~CCompressedFile");
+                e->Release();
+            }
+        }
     }
 
     virtual offset_t size()                                             

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1260,7 +1260,7 @@ rowidx_t CThorSpillableRowArray::save(IFile &iFile, bool useCompression, const c
                 while (i == nextCBI); // loop as may be >1 IWritePosCallback at same pos
             }
             rows[i++] = NULL;
-            writer->putRow(row);
+            writer->putRow(row); // NB: putRow takes ownership/should avoid leaking if fails
         }
         writer->flush();
     }


### PR DESCRIPTION
1) An exception whilst using a compressor, caused a subsequent
follow on exception in the compressor destructor, causing the
process to die.
2) An exception whilst spilling in the sort on the OOM callback,
caused nulls to be left in the row array, which subsequently
caused sort to throw spurious follow-on errors before the query
could abort.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
