### PR TITLE
HPCC-12829 Fix JSON escaping of character '\0'

### DIFF
--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -2003,6 +2003,9 @@ inline StringBuffer &encodeJSONChar(StringBuffer &s, const char *&ch, unsigned &
             s.append('\\');
             s.append(next);
             break;
+        case '\0':
+            s.append("\\u0000");
+            break;
         default:
             if (next >= ' ' && next < 128)
                 s.append(next);


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
