### PR TITLE
HPCC-12953 PTree toJSON should escape JSON values

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -5500,7 +5500,10 @@ static void writeJSONValueToStream(IIOStream &out, const char *val, bool &delimi
     if (hidden)
         writeCharsNToStream(out, '*', strlen(val));
     else
-        writeStringToStream(out, val);
+    {
+        StringBuffer s;
+        writeStringToStream(out, encodeJSON(s, val));
+    }
     writeCharToStream(out, '"');
 }
 


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
