### PR TITLE
HPCC-12979 Failed workunits still being displayed on roxie in activity page

### DIFF
--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -1151,7 +1151,8 @@ public:
         catch (IException *E)
         {
             reportException(wu, E, *logctx);
-            throw E;
+            daliHelper->noteWorkunitRunning(wuid.get(), false);
+            throw;
         }
 #ifndef _DEBUG
         catch(...)


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
