### PR TITLE
HPCC-12969 Columns resizing incorrectly

### DIFF
--- a/esp/src/eclwatch/ESPUtil.js
+++ b/esp/src/eclwatch/ESPUtil.js
@@ -34,12 +34,11 @@ define([
     "dgrid/Selection",
     "dgrid/extensions/ColumnResizer",
     "dgrid/extensions/ColumnHider",
-    "dgrid/extensions/ColumnReorder",
     "dgrid/extensions/DijitRegistry",
     "dgrid/extensions/Pagination"
 ], function (declare, lang, i18n, nlsHPCC, arrayUtil, domClass, Stateful, query, json, aspect,
     registry, Tooltip,
-    Grid, OnDemandGrid, Keyboard, Selection, ColumnResizer, ColumnHider, ColumnReorder, DijitRegistry, Pagination) {
+    Grid, OnDemandGrid, Keyboard, Selection, ColumnResizer, ColumnHider, DijitRegistry, Pagination) {
 
     var SingletonData = declare([Stateful], {
         //  Attributes  ---
@@ -263,7 +262,7 @@ define([
             var baseClass = [];
             var params = {};
             if (pagination) {
-                baseClass = [Grid, Pagination, ColumnResizer, ColumnHider, ColumnReorder, Keyboard, DijitRegistry];
+                baseClass = [Grid, Pagination, ColumnResizer, ColumnHider, Keyboard, DijitRegistry];
                 lang.mixin(params, {
                     rowsPerPage: 50,
                     pagingLinks: 1,
@@ -272,7 +271,7 @@ define([
                     pageSizeOptions: [25, 50, 100, 1000]
                 });
             } else {
-                baseClass = [OnDemandGrid, ColumnResizer, ColumnHider, ColumnReorder, Keyboard, DijitRegistry];
+                baseClass = [OnDemandGrid, ColumnResizer, ColumnHider, Keyboard, DijitRegistry];
             }
             if (selection) {
                 baseClass.push(Selection);


### PR DESCRIPTION
Due to a recent change within dgrid the ColumnReorder has caused some css issues.
The hover state within the drag and drop event is causing the columns to be re-sized incorrectly.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
