### PR TITLE
HPCC-13046 Pass back fatal slave init exceptions to master

### DIFF
--- a/thorlcr/master/mawatchdog.cpp
+++ b/thorlcr/master/mawatchdog.cpp
@@ -144,7 +144,7 @@ void CMasterWatchdogBase::checkMachineStatus()
             StringBuffer epstr;
             mstate->ep.getUrlStr(epstr);
             if (mstate->markdead)
-                abortThor(MakeThorOperatorException(TE_AbortException, "Watchdog has lost contact with Thor slave: %s (Process terminated or node down?)", epstr.str()));
+                abortThor(MakeThorOperatorException(TE_AbortException, "Watchdog has lost contact with Thor slave: %s (Process terminated or node down?)", epstr.str()), TEC_Watchdog);
             else
             {
                 mstate->markdead = true;
@@ -208,7 +208,7 @@ void CMasterWatchdogBase::main()
                 const SocketEndpoint &ep = e->queryEndpoint();
                 StringBuffer epStr;
                 ep.getUrlStr(epStr);
-                abortThor(MakeThorOperatorException(TE_AbortException, "Watchdog has lost connectivity with Thor slave: %s (Process terminated or node down?)", epStr.str()));
+                abortThor(MakeThorOperatorException(TE_AbortException, "Watchdog has lost connectivity with Thor slave: %s (Process terminated or node down?)", epStr.str()), TEC_Watchdog);
             }
             if (stopped)
                 break;

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -189,7 +189,7 @@ public:
     virtual void main()
     {
         if (!sem.wait(timeout)) // feeling neglected, restarting..
-            abortThor(MakeThorException(TE_IdleRestart, "Thor has been idle for %d minutes, restarting", timeout/60000));
+            abortThor(MakeThorException(TE_IdleRestart, "Thor has been idle for %d minutes, restarting", timeout/60000), TEC_Idle, false);
     }
     void stop() { sem.signal(); }
 };
@@ -318,10 +318,9 @@ void CJobManager::run()
                 msg.read(cmd);
                 if (0 == stricmp("stop", cmd))
                 {
-                    setExitCode(0);
                     bool stopCurrentJob;
                     msg.read(stopCurrentJob);
-                    abortThor(NULL, stopCurrentJob);
+                    abortThor(NULL, TEC_Clean, stopCurrentJob);
                     break;
                 }
                 else
@@ -648,7 +647,7 @@ void CJobManager::reply(IConstWorkUnit *workunit, const char *wuid, IException *
     //GH->JCS Should this be using getEnvironmentFactory()->openEnvironment()?
     Owned<IRemoteConnection> conn = querySDS().connect("/Environment", myProcessSession(), RTM_LOCK_READ, MEDIUMTIMEOUT);
     if (checkThorNodeSwap(globals->queryProp("@name"),e?wuid:NULL,(unsigned)-1))
-        abortThor(e,false);
+        abortThor(e, TEC_Swap, false);
 }
 
 bool CJobManager::executeGraph(IConstWorkUnit &workunit, const char *graphName, const SocketEndpoint &agentEp)
@@ -777,9 +776,9 @@ void setExitCode(int code) { exitCode = code; }
 int queryExitCode() { return exitCode; }
 
 static unsigned aborting = 99;
-void abortThor(IException *e, bool abortCurrentJob)
+void abortThor(IException *e, unsigned errCode, bool abortCurrentJob)
 {
-    if (-1 == queryExitCode()) setExitCode(1);
+    if (-1 == queryExitCode()) setExitCode(errCode);
     Owned<CJobManager> jM = ((CJobManager *)getJobManager());
     Owned<IException> _e;
     if (0 == aborting)
@@ -822,7 +821,7 @@ public:
             if (stopped) break;
             if (!verifyCovenConnection(pollDelay)) // use poll delay time for verify connection timeout
             {
-                abortThor(MakeThorOperatorException(TE_AbortException, "Detected lost connectivity with dali server, aborting thor"));
+                abortThor(MakeThorOperatorException(TE_AbortException, "Detected lost connectivity with dali server, aborting thor"), TEC_DaliDown);
                 break;
             }
         }

--- a/thorlcr/master/thgraphmanager.hpp
+++ b/thorlcr/master/thgraphmanager.hpp
@@ -24,7 +24,10 @@ CSDSServerStatus &queryServerStatus();
 CSDSServerStatus &openThorServerStatus();
 void closeThorServerStatus();
 void thorMain(ILogMsgHandler *logHandler);
-void abortThor(IException *e=NULL, bool abortCurrentJob=true);
+
+enum ThorExitCodes { TEC_Clean, TEC_CtrlC, TEC_Idle, TEC_Watchdog, TEC_SlaveInit, TEC_Swap, TEC_DaliDown };
+
+void abortThor(IException *e, unsigned errCode, bool abortCurrentJob=true);
 void setExitCode(int code);
 int queryExitCode();
 

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -169,7 +169,7 @@ static bool RegisterSelf(SocketEndpoint &masterEp)
     return true;
 }
 
-void UnregisterSelf()
+void UnregisterSelf(IException *e)
 {
     StringBuffer slfStr;
     slfEp.getUrlStr(slfStr);
@@ -178,6 +178,7 @@ void UnregisterSelf()
     {
         CMessageBuffer msg;
         msg.append((int)rc_deregister);
+        serializeException(e, msg); // NB: allows exception to be NULL
         if (!queryWorldCommunicator().send(msg, masterNode, MPTAG_THORREGISTRATION, 60*1000))
         {
             LOG(MCerror, thorJob, "Failed to unregister slave : %s", slfStr.toCharArray());
@@ -194,7 +195,7 @@ void UnregisterSelf()
 bool ControlHandler() 
 { 
     LOG(MCdebugProgress, thorJob, "CTRL-C pressed");
-    if (masterNode) UnregisterSelf();
+    if (masterNode) UnregisterSelf(NULL);
     abortSlave();
     return false; 
 }
@@ -265,7 +266,10 @@ int main( int argc, char *argv[]  )
         globals = iFile->exists() ? createPTree(*iFile, ipt_caseInsensitive) : createPTree("Thor", ipt_caseInsensitive);
     }
     unsigned multiThorMemoryThreshold = 0;
-    try {
+
+    Owned<IException> unregisterException;
+    try
+    {
         if (argc==1)
         {
             usage();
@@ -416,17 +420,16 @@ int main( int argc, char *argv[]  )
     catch (IException *e) 
     {
         FLLOG(MCexception(e), thorJob, e,"ThorSlave");
-        e->Release();
-    }
-    catch (CATCHALL)
-    {
-        FLLOG(MCerror, thorJob, "ThorSlave exiting because of uncaught exception");
+        unregisterException.setown(e);
     }
     ClearTempDirs();
 
     if (multiThorMemoryThreshold)
         setMultiThorMemoryNotify(0,NULL);
     roxiemem::releaseRoxieHeap();
+
+    if (unregisterException.get())
+        UnregisterSelf(unregisterException);
 
     if (globals->getPropBool("Debug/@slaveDaliClient"))
         disableThorSlaveAsDaliClient();


### PR DESCRIPTION
Ensure fatal exception at slave startup time, cause the master
to be notified.
Also changed return code depending on shutdown reason, so that
scripts can decided how to treat it.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
