### PR TITLE
HPCC-13050 Forward ReplicateOutputs to ECLWatch Spray

### DIFF
--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -92,6 +92,7 @@ ESPStruct [nil_remove] GroupNode
 {
     string Name;
     string ClusterType;
+    bool ReplicateOutputs;
 };
 
 ESPStruct DFUException

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -3189,11 +3189,14 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
     return true;
 }
 
-void CFileSprayEx::appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType)
+void CFileSprayEx::appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType,
+    bool replicateOutputs)
 {
     Owned<IEspGroupNode> node = createGroupNode();
     node->setName(nodeName);
     node->setClusterType(clusterType);
+    if (replicateOutputs)
+        node->setReplicateOutputs(replicateOutputs);
     groupNodes.append(*node.getClear());
 }
 
@@ -3225,7 +3228,7 @@ bool CFileSprayEx::onGetSprayTargets(IEspContext &context, IEspGetSprayTargetsRe
 
             bool* found = uniqueThorClusterGroupNames.getValue(thorClusterGroupName.str());
             if (!found || !*found)
-                appendGroupNode(sprayTargets, thorClusterGroupName.str(), "thor");
+                appendGroupNode(sprayTargets, thorClusterGroupName.str(), "thor", cluster.getPropBool("@replicateOutputs", false));
         }
 
         //Fetch all the group names for all the hthor instances
@@ -3254,7 +3257,7 @@ bool CFileSprayEx::onGetSprayTargets(IEspContext &context, IEspGetSprayTargetsRe
                 if (ins>1)
                     gname.append('_').append(ins);
 
-                appendGroupNode(sprayTargets, gname.str(), "hthor");
+                appendGroupNode(sprayTargets, gname.str(), "hthor", false);
             }
         }
 

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -112,7 +112,7 @@ protected:
     bool ParseLogicalPath(const char * pLogicalPath, StringBuffer &title);
     bool ParseLogicalPath(const char * pLogicalPath, const char *group, const char* cluster, StringBuffer &folder, StringBuffer &title, StringBuffer &defaultFolder, StringBuffer &defaultReplicateFolder);
     StringBuffer& getAcceptLanguage(IEspContext& context, StringBuffer& acceptLanguage);
-    void appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType);
+    void appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType, bool replicateOutputs);
 };
 
 #endif //_ESPWIZ_FileSpray_HPP__


### PR DESCRIPTION
In ECLWatch Spray form, the Replicate option should be
only available when the ReplicateOutputs is configured
to true for a thor. This fix checks the ReplicateOutputs
for each thor configuration. If it is set to true, the
flag is forwarded to ECLWatch UI code through the
GetSprayTargets method.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
