### PR TITLE
HPCC-13055 OSX support

### DIFF
--- a/plugins/Rembed/CMakeLists.txt
+++ b/plugins/Rembed/CMakeLists.txt
@@ -50,7 +50,7 @@ if (USE_RINSIDE)
     HPCC_ADD_LIBRARY( Rembed SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")
       message("WARNING: Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    else()
+    elif(NOT APPLE)
       set_target_properties( Rembed PROPERTIES NO_SONAME 1 )
     endif()
 

--- a/plugins/cassandra/CMakeLists.txt
+++ b/plugins/cassandra/CMakeLists.txt
@@ -89,7 +89,7 @@ if (USE_CASSANDRA)
     HPCC_ADD_LIBRARY( cassandraembed SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")
       message("WARNING: Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    else()
+    elif(NOT APPLE)
       set_target_properties( cassandraembed PROPERTIES NO_SONAME 1 )
     endif()
 

--- a/plugins/javaembed/CMakeLists.txt
+++ b/plugins/javaembed/CMakeLists.txt
@@ -50,7 +50,7 @@ if (USE_JNI)
     HPCC_ADD_LIBRARY( javaembed SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")
       message("WARNING: Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    else()
+    elif(NOT APPLE)
       set_target_properties( javaembed PROPERTIES NO_SONAME 1 )
     endif()
 

--- a/plugins/memcached/CMakeLists.txt
+++ b/plugins/memcached/CMakeLists.txt
@@ -50,7 +50,7 @@ if (USE_MEMCACHED)
     HPCC_ADD_LIBRARY( memcached SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")
       message("WARNING: Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    else()
+    elif(NOT APPLE)
       set_target_properties( memcached PROPERTIES NO_SONAME 1 )
     endif()
 

--- a/plugins/mysql/CMakeLists.txt
+++ b/plugins/mysql/CMakeLists.txt
@@ -48,7 +48,7 @@ if (USE_MYSQL)
     HPCC_ADD_LIBRARY( mysqlembed SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")
       message("WARNING: Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    else()
+    elif(NOT APPLE)
       set_target_properties( mysqlembed PROPERTIES NO_SONAME 1 )
     endif()
 

--- a/plugins/pyembed/CMakeLists.txt
+++ b/plugins/pyembed/CMakeLists.txt
@@ -54,7 +54,7 @@ if (USE_PYTHON)
     HPCC_ADD_LIBRARY( pyembed SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")
       message("WARNING: Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    else()
+    elif(NOT APPLE)
       set_target_properties( pyembed PROPERTIES NO_SONAME 1 )
     endif()
 

--- a/plugins/sqlite3/CMakeLists.txt
+++ b/plugins/sqlite3/CMakeLists.txt
@@ -47,7 +47,7 @@ if (USE_SQLITE3)
     HPCC_ADD_LIBRARY( sqlite3embed SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")
       message("WARNING: Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    else()
+    elif(NOT APPLE)
       set_target_properties( sqlite3embed PROPERTIES NO_SONAME 1 )
     endif()
 

--- a/plugins/v8embed/CMakeLists.txt
+++ b/plugins/v8embed/CMakeLists.txt
@@ -48,7 +48,7 @@ if (USE_V8)
     HPCC_ADD_LIBRARY( v8embed SHARED ${SRCS} )
     if (${CMAKE_VERSION} VERSION_LESS "2.8.9")
       message("WARNING: Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    else()
+    elif(NOT APPLE)
       set_target_properties( v8embed PROPERTIES NO_SONAME 1 )
     endif()
 


### PR DESCRIPTION
NO_SONAME causes issues for non-installed builds in OSX. Implications for
installed builds will have to be determined if/when we attempt to create such
a thing.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
