### PR TITLE
HPCC-13009 Regression Test Engine doesn't handle well the eclcc warning messages.

### DIFF
--- a/testing/regress/hpcc/common/error.py
+++ b/testing/regress/hpcc/common/error.py
@@ -49,4 +49,4 @@ class Error(Exception):
         return "Error (%s): %s " % (self.code, ERROR[self.code])
         
     def getErrorCode(self):
-        return self.code
+        return int(self.code)

--- a/testing/regress/hpcc/common/shell.py
+++ b/testing/regress/hpcc/common/shell.py
@@ -60,6 +60,7 @@ class Shell:
             exception = CalledProcessError(
                 process.returncode, repr(args))
             exception.output = ''.join(filter(None, [stdout, stderr]))
+            logging.debug("exception.output:'%s'",  exception.output)
             raise Error('1001', err=repr(exception.output))
         return stdout
 

--- a/testing/regress/hpcc/util/ecl/cc.py
+++ b/testing/regress/hpcc/util/ecl/cc.py
@@ -56,13 +56,15 @@ class ECLCC(Shell):
 
         if result.startswith( 'Error()'):
             retVal = False
-            ecl.diff += ecl.getEcl() + '\n  eclcc returns with:\n\t'
+            ecl.diff += ("%3d. Test: %s\n") % (ecl.getTaskId(), ecl.getBaseEclRealName())
+            ecl.diff += '  eclcc returns with:\n\t'
             try:
                 lines = repr(self.makeArchiveError).replace('\\n',  '\n\t').splitlines(True)
                 for line in lines:
-                    if  "Error" in line:
+                    lowerLine = line.lower()
+                    if  (": error " in lowerLine) or (": warning " in lowerLine):
                         ecl.diff += line.replace("'",  "")
-                    if "): error " in  line:
+                    if ("): error " in  line) or ("): warning " in lowerLine):
                         ecl.diff += line.replace("\\'", "'")
                 #ecl.diff += repr(self.makeArchiveError).replace('\\n',  '\n\t')
             except Exception as ex:


### PR DESCRIPTION
Add code to handle eclcc stderr stream.
Add code to put eclcc warning messages into the result log.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
