### PR TITLE
HPCC-13061 Allow users to resubmit other users workunits

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -876,18 +876,6 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
                 if(!cw)
                     throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid.str());
 
-                //Dont allow resubmit of someone else's workunit
-                if (context.querySecManager())
-                {
-                    IUserDescriptor * owner = cw->queryUserDescriptor();
-                    if (!owner)
-                        throw MakeStringException(ECLWATCH_CANNOT_SUBMIT_WORKUNIT,"Workunit User Descriptor missing on %s", wuid.str());
-                    StringBuffer ownerUserName;
-                    owner->getUserName(ownerUserName);
-                    if (strcmp(context.queryUser()->getName(), ownerUserName.str()))
-                        throw MakeStringException(ECLWATCH_CANNOT_SUBMIT_WORKUNIT,"Cannot resubmit another user's workunit %s.", wuid.str());
-                }
-
                 WsWuHelpers::submitWsWorkunit(context, cw, NULL, NULL, 0, req.getRecompile(), req.getResetWorkflow(), false);
 
                 if (version < 1.40)


### PR DESCRIPTION
Revert "HPCC-10370 Resubmit workunit uses the original user's id"

This reverts commit a138f17d38340c36ab8d7adf059850f75e9a2f74.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com

Conflicts:
    esp/services/ws_workunits/ws_workunitsService.cpp
