### PR TITLE
HPCC-12942 Process standard query responses correctly

### DIFF
--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -246,7 +246,10 @@ void CommonXmlWriter::outputXmlns(const char *name, const char *uri)
 {
     StringBuffer fieldname;
     if (!streq(name, "xmlns"))
-        fieldname.append("xmlns:");
+    {
+        if (!strchr(name, ':'))
+            fieldname.append("xmlns:");
+    }
     outputXmlAttrUtf8(rtlUtf8Length(strlen(uri), uri), uri, fieldname.append(name), out);
 }
 

--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -246,7 +246,7 @@ void CommonXmlWriter::outputXmlns(const char *name, const char *uri)
 {
     StringBuffer fieldname;
     if (!streq(name, "xmlns"))
-            fieldname.append("xmlns:");
+        fieldname.append("xmlns:");
     outputXmlAttrUtf8(rtlUtf8Length(strlen(uri), uri), uri, fieldname.append(name), out);
 }
 

--- a/common/thorhelper/thorxmlwrite.cpp
+++ b/common/thorhelper/thorxmlwrite.cpp
@@ -246,10 +246,7 @@ void CommonXmlWriter::outputXmlns(const char *name, const char *uri)
 {
     StringBuffer fieldname;
     if (!streq(name, "xmlns"))
-    {
-        if (!strchr(name, ':'))
             fieldname.append("xmlns:");
-    }
     outputXmlAttrUtf8(rtlUtf8Length(strlen(uri), uri), uri, fieldname.append(name), out);
 }
 

--- a/esp/esdllib/esdl_transformer2.cpp
+++ b/esp/esdllib/esdl_transformer2.cpp
@@ -1318,7 +1318,7 @@ void Esdl2Response::process(Esdl2TransformerContext &ctx, const char *out_name, 
                     if (ctx.schemaLocation.length() > 0 )
                     {
                         ctx.writer->outputXmlns("xsi", "http://www.w3.org/2001/XMLSchema-instance");
-                        ctx.writer->outputXmlns("xsi:schemaLocation", ctx.schemaLocation.str());
+                        ctx.writer->outputCString(ctx.schemaLocation.str(), "@xsi:schemaLocation");
                     }
 
                     ctx.do_output_ns=false;

--- a/esp/esdllib/esdl_transformer2.cpp
+++ b/esp/esdllib/esdl_transformer2.cpp
@@ -1789,37 +1789,6 @@ void Esdl2Transformer::processHPCCResult(IEspContext &ctx, IEsdlDefMethod &mthde
     {
         while((dataset = gotoNextHPCCDataset(*xpp, stag)) != NULL)
         {
-            /*if (strieq(dataset, resdsname))
-            {
-                Esdl2TransformerContext tctx(*this, writer, *xpp, ctx.getClientVersion(), ctx.queryRequestParameters(), EsdlResponseMode, 0, ns,schema_location);
-                tctx.flags = flags | ESDL_TRANS_ROW_IN;
-                tctx.skip_root = !(flags & ESDL_TRANS_OUTPUT_ROOT);
-                tctx.root_type.set(restype);
-                Esdl2Base* root = queryType(restype);
-                if (root)
-                {
-                    Esdl2Response *resp = dynamic_cast<Esdl2Response *>(root);
-                    if (resp)
-                        resp->process(tctx, restype);
-                }
-            }
-            else if ((subresdsname && strieq(dataset, subresdsname)) //Only allow correctly named dataset?
-                     || stricmp(dataset, "FinalResults")==0
-                     || stricmp(dataset, "Results")==0
-                     )
-            {
-                Esdl2TransformerContext tctx(*this, writer, *xpp, ctx.getClientVersion(), ctx.queryRequestParameters(), EsdlResponseMode, 0, ns,schema_location);
-                tctx.flags = flags | ESDL_TRANS_ROW_IN;
-                tctx.skip_root = !(flags & ESDL_TRANS_OUTPUT_ROOT);
-                tctx.root_type.set(restype);
-                Esdl2Base* root = queryType(restype);
-                if (root)
-                {
-                    Esdl2Response *resp = dynamic_cast<Esdl2Response *>(root);
-                    if (resp)
-                        resp->process(tctx, restype);//resp->processChildNamedResponse(tctx, restype);
-                }
-            }*/
             if ( strieq(dataset, resdsname)
                 ||(subresdsname && strieq(dataset, subresdsname)) //Only allow correctly named dataset?
                 || stricmp(dataset, "FinalResults")==0


### PR DESCRIPTION
- XmlWriter should allow fully qualified ns (don't append xmlns automatically)
- Query responses should be named appropriately
- Remove redundant response processing code

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
