### PR TITLE
HPCC-13043 Add explicit dependency

### DIFF
--- a/esp/esdllib/CMakeLists.txt
+++ b/esp/esdllib/CMakeLists.txt
@@ -47,7 +47,7 @@ HPCC_ADD_LIBRARY( esdllib SHARED ${SRCS}
 
 install ( TARGETS esdllib RUNTIME DESTINATION bin LIBRARY DESTINATION lib )
 
-add_dependencies ( esdllib jlib)
+add_dependencies ( esdllib jlib espscm)
 
 target_link_libraries ( esdllib
     jlib


### PR DESCRIPTION
Esdllib should explicitly name espscm as dependency in order to generate esp.hpp

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
