### PR TITLE
HPCC-13087 Regression Test Engine doesn't handle well the retry count and abort logging when execute test cases one by one.

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -81,10 +81,10 @@ class RegressMain:
                 if len(eclfiles) :
                     #Execute multiple ECL files like RUN to generates summary results and diff report.
                     self.regress.bootstrap(cluster, self.args,  eclfiles)
-                    if  self.args.pq:
-                        self.regress.runSuiteP(cluster, self.regress.suites[cluster])
-                    else:
+                    if (self.args.pq in (0, 1)) or (len(eclfiles) == 1):
                         self.regress.runSuite(cluster, self.regress.suites[cluster])
+                    else:
+                        self.regress.runSuiteP(cluster, self.regress.suites[cluster])
                 else:
                     logging.error("%s. No ECL file match for cluster:'%s'!" % (1,  self.args.target))
                     raise Error("4001")

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -114,8 +114,8 @@ class ECLcmd(Shell):
             logging.error("------" + err + "------")
             raise err
         finally:
+            res = queryWuid(eclfile.getJobname(), eclfile.getTaskId())
             if wuid ==  'N/A':
-                res = queryWuid(eclfile.getJobname(), eclfile.getTaskId())
                 logging.debug("%3d. in finally queryWuid() -> 'result':'%s', 'wuid':'%s', 'state':'%s'", eclfile.getTaskId(),  res['result'],  res['wuid'],  res['state'])
                 wuid = res['wuid']
                 if res['result'] != "OK":
@@ -130,7 +130,7 @@ class ECLcmd(Shell):
                     test = False
                     eclfile.diff = 'Error'
             else:
-                if queryWuid(eclfile.getJobname(), eclfile.getTaskId())['state'] == 'aborted':
+                if (res['state'] == 'aborted') or eclfile.isAborted():
                     eclfile.diff = ("%3d. Test: %s\n") % (eclfile.taskId, eclfile.getBaseEclRealName())
                     eclfile.diff += '\t'+'Aborted ( reason: '+eclfile.getAbortReason()+' )'
                     test = False

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -41,6 +41,7 @@ class ECLFile:
     wuid = None
     elapsTime = 0
     jobname = ''
+    aborted = False
     abortReason = ''
     taskId = -1
     ignoreResult=False
@@ -69,6 +70,7 @@ class ECLFile:
         self.xml_a = 'archive_' + self.baseXml
         self.jobname = self.basename
         self.diff = ''
+        self.aborted = False
         self.abortReason =''
         self.tags={}
         self.tempFile=None
@@ -446,6 +448,10 @@ class ECLFile:
 
     def setAborReason(self,  reason):
         self.abortReason = reason
+        self.aborted = True
+
+    def isAborted(self):
+        return self.aborted
 
     def getAbortReason(self):
         return self.abortReason


### PR DESCRIPTION
and abort logging when execute test cases one by one.

Add code to handle retry count and timeout properly in test-by-test and
    parallel execution as well.

Add code to handle extreme situation when parallel executed test case runs
    timeout after all other test cases scheduled and/or already finished.

Add code to avoid parallel execution if there are only one test case matches
    for a wildcard specification and/or user specified --pq 0|1 in command line.

Improve the abort state handling and logging.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
