### PR TITLE
HPCC-12653 Std.Date should not use %F, %T, %R

### DIFF
--- a/ecllibrary/std/Date.ecl
+++ b/ecllibrary/std/Date.ecl
@@ -613,8 +613,6 @@ EXPORT Seconds_t SecondsFromDateTimeRec(DateTime_rec datetime, BOOLEAN is_local_
     %y          year within century (00-99)
     %Y          Full year (yyyy)
     %j          Julian day (1-366)
-    %D          Same as %m/%d/%y
-    %F          Same as %Y-%m-%d
 
 Common date formats
     American    '%m/%d/%Y'  mm/dd/yyyy
@@ -656,8 +654,6 @@ EXPORT Date_t FromString(STRING date_text, VARSTRING format) :=
     %M          Minute (two digits)
     %S          Second (two digits)
     %t          Whitespace
-    %R          Same as %H:%M
-    %T          Same as %H:%M:%S
  */
 
 EXPORT Time_t FromStringToTime(STRING time_text, VARSTRING format) :=
@@ -701,12 +697,12 @@ EXPORT Time_t MatchTimeString(STRING time_text, SET OF VARSTRING formats) :=
  * @param format        The format template to use for the conversion;
  *                      see strftime() for appropriate values.  The maximum
  *                      length of the resulting string is 255 characters.
- *                      Optional; defaults to '%F' which is YYYY-MM-DD.
+ *                      Optional; defaults to '%Y-%m-%d' which is YYYY-MM-DD.
  * @return              Blank if date cannot be formatted, or the date in the
  *                      requested format.
  */
 
-EXPORT STRING DateToString(Date_t date, VARSTRING format = '%F') :=
+EXPORT STRING DateToString(Date_t date, VARSTRING format = '%Y-%m-%d') :=
     TimeLib.DateToString(date, format);
 
 
@@ -717,12 +713,12 @@ EXPORT STRING DateToString(Date_t date, VARSTRING format = '%F') :=
  * @param format        The format template to use for the conversion;
  *                      see strftime() for appropriate values.  The maximum
  *                      length of the resulting string is 255 characters.
- *                      Optional; defaults to '%T' which is HH:MM:SS.
+ *                      Optional; defaults to '%H:%M:%S' which is HH:MM:SS.
  * @return              Blank if the time cannot be formatted, or the time
  *                      in the requested format.
  */
 
-EXPORT STRING TimeToString(Time_t time, VARSTRING format = '%T') :=
+EXPORT STRING TimeToString(Time_t time, VARSTRING format = '%H:%M:%S') :=
     TimeLib.TimeToString(time, format);
 
 
@@ -733,11 +729,11 @@ EXPORT STRING TimeToString(Time_t time, VARSTRING format = '%T') :=
  * @param format        The format template to use for the conversion; see
  *                      strftime() for appropriate values.  The maximum length
  *                      of the resulting string is 255 characters.
- *                      Optional; defaults to '%FT%T' which is YYYY-MM-DDTHH:MM:SS.
+ *                      Optional; defaults to '%Y-%m-%dT%H:%M:%S' which is YYYY-MM-DDTHH:MM:SS.
  * @return              The converted seconds as a string.
  */
 
-EXPORT STRING SecondsToString(Seconds_t seconds, VARSTRING format = '%FT%T') :=
+EXPORT STRING SecondsToString(Seconds_t seconds, VARSTRING format = '%Y-%m-%dT%H:%M:%S') :=
     TimeLib.SecondsToString(seconds, format);
 
 

--- a/ecllibrary/teststd/Date/TestFormat.ecl
+++ b/ecllibrary/teststd/Date/TestFormat.ecl
@@ -7,7 +7,7 @@ IMPORT Std.Date;
 EXPORT TestFormat := MODULE
 
   SHARED DateFormats := ['%d %b %Y', '%Y %b %d', '%Y%m%d', '%Y-%m-%d', '%d/%m/%Y', '%m/%d/%Y'];
-  SHARED TimeFormats := ['%H%M%S', '%T', '%R'];
+  SHARED TimeFormats := ['%H%M%S', '%H:%M:%S', '%H:%M'];
 
   EXPORT TestConstant := [
     ASSERT(Date.FromStringToDate('19700001', '%Y%m%d') = 0, CONST);
@@ -20,11 +20,9 @@ EXPORT TestFormat := MODULE
     ASSERT(Date.FromStringToDate('31 \t jAN 12', '%d %b %Y') = 120131, CONST);
     ASSERT(Date.FromStringToDate('1 \t De   2056', '%d %b %Y') = 0, CONST);
     ASSERT(Date.FromStringToDate('1December1', '%d%b%Y') = 00011201, CONST);
-    ASSERT(Date.FromStringToDate('1970-02-01', '%F') = 19700201, CONST);
+    ASSERT(Date.FromStringToDate('1970-02-01', '%Y-%m-%d') = 19700201, CONST);
 
     ASSERT(Date.FromStringToTime('12:34:56', '%H:%M:%S') = 123456, CONST);
-    ASSERT(Date.FromStringToTime('12:34:56', '%T') = 123456, CONST);
-    ASSERT(Date.FromStringToTime('12:34', '%R') = 123400, CONST);
 
     ASSERT(TRUE)
   ];
@@ -55,19 +53,19 @@ EXPORT TestFormat := MODULE
     ASSERT(Date.MatchTimeString('12:34:56',TimeFormats) = 123456);
     ASSERT(Date.MatchTimeString('12:34',TimeFormats) = 123400);
 
-    ASSERT(Date.DateToString(19990201,'%F') = '1999-02-01');
+    ASSERT(Date.DateToString(19990201,'%Y-%m-%d') = '1999-02-01');
 
-    ASSERT(Date.TimeToString(123456,'%T') = '12:34:56');
+    ASSERT(Date.TimeToString(123456,'%H:%M:%S') = '12:34:56');
 
-    ASSERT(Date.SecondsToString(917872496,'%FT%T') = '1999-02-01T12:34:56');
+    ASSERT(Date.SecondsToString(917872496,'%Y-%m-%dT%H:%M:%S') = '1999-02-01T12:34:56');
 
-    ASSERT(Date.ConvertDateFormat('1/12/2011','%m/%d/%Y','%F') = '2011-01-12');
+    ASSERT(Date.ConvertDateFormat('1/12/2011','%m/%d/%Y','%Y-%m-%d') = '2011-01-12');
 
-    ASSERT(Date.ConvertTimeFormat('123456','%H%M%S','%T') = '12:34:56');
+    ASSERT(Date.ConvertTimeFormat('123456','%H%M%S','%H:%M:%S') = '12:34:56');
 
-    ASSERT(Date.ConvertDateFormatMultiple('1/31/2011',DateFormats,'%F') = '2011-01-31');
+    ASSERT(Date.ConvertDateFormatMultiple('1/31/2011',DateFormats,'%Y-%m-%d') = '2011-01-31');
 
-    ASSERT(Date.ConvertTimeFormatMultiple('123456',TimeFormats,'%T') = '12:34:56');
+    ASSERT(Date.ConvertTimeFormatMultiple('123456',TimeFormats,'%H:%M:%S') = '12:34:56');
 
     ASSERT(TRUE)
   ];

--- a/testing/regress/ecl/date2str.ecl
+++ b/testing/regress/ecl/date2str.ecl
@@ -46,7 +46,7 @@ ASSERT(std.date.datetostring(20140824, '%G') = '2014', CONST);
 ASSERT(std.date.datetostring(20140824, '%g') = '14', CONST);
 
 // Test the %Y-%m-%d (the ISO 8601 date format)
-ASSERT(std.date.datetostring(20140824, '%F') = '2014-08-24', CONST);
+ASSERT(std.date.datetostring(20140824, '%Y-%m-%d') = '2014-08-24', CONST);
 
 // Test the day of the year as a decimal number (range 001 to 366)
 ASSERT(std.date.datetostring(20140824, '%j') = '236', CONST);


### PR DESCRIPTION
These format specifiers are not available on all systems (in particular using
them on Windows may cause premature termination.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
