### PR TITLE
HPCC-12297 Make sure error if SOAPCALL to invalid IP is caught late

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -210,9 +210,13 @@ public:
                 path.append("/");
             }
         }
+        // While the code below would make some sense, there is code that relies on being able to use invalid IP addresses and catching the
+        // errors that result via ONFAIL.
+#if 0
         IpAddress ipaddr(host);
         if ( ipaddr.isNull())
             throw MakeStringException(-1, "Invalid IP address %s", host.str());
+#endif
     }
 };
 


### PR DESCRIPTION
Because some code relies on being able to catch this via ONFAIL, using invalid
ips to indicate gateways that should not be called, don't catch this error
early.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
