### PR TITLE
HPCC-12965 Fix xsl:message handling

### DIFF
--- a/deployment/deploy/DeployTask.cpp
+++ b/deployment/deploy/DeployTask.cpp
@@ -333,6 +333,7 @@ public:
    bool transformFile(IXslProcessor& processor, IXslTransform& transform, const char* tempPath)
    {
      m_processed = true;
+     bool bDeleteFile = true;
 
      const char* xsl = getFileSpec(DT_SOURCE);
      const char* target = getFileSpec(DT_TARGET);
@@ -441,6 +442,12 @@ public:
            //UNIMPLEMENTED;
 #endif
          }
+         if (m_warnings.length() > 0)
+         {
+             bDeleteFile = false;
+             throw MakeStringException(-1, "%s", m_warnings.str());
+         }
+
          break;
        }
        catch (IException* e)
@@ -465,7 +472,7 @@ public:
          e->Release();
 
          //remove incomplete (invalid) output file produced thus far
-         if (!DeleteFile(target))
+         if (bDeleteFile && !DeleteFile(target))
            WARNLOG("Couldn't delete file %s", target);
        }
        catch (...)

--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -267,24 +267,7 @@ public:
             m_transform->transform( outputXml );
             m_transform->closeResultTarget();
             
-            const char* msg = m_transform->getMessages();
-            if (msg && *msg)
-            {
-                /*
-                //there may be multiple warnings messages bundled here so process each of them:
-                StringArray msgs;
-                DelimToStringArray(msg, msgs, "\n");
-                
-                ForEachItemIn(idx, msgs)
-                {
-                    msg = msgs.item(idx);
-                    if (msg && *msg)
-                    m_pCallback->printStatus(STATUS_NORMAL, NULL, NULL, NULL, msg);
-                }
-                */
-                m_sValidationErrors.append(msg);
-                m_nValidationErrors++;
-            }
+            m_pCallback->printStatus(STATUS_NORMAL, NULL, NULL, NULL, m_transform->getMessages());
 
             if (!m_nValidationErrors)//this may get filled in by the external function
                 valid = true;

--- a/system/xmllib/libxslt_processor.cpp
+++ b/system/xmllib/libxslt_processor.cpp
@@ -403,6 +403,7 @@ public:
         return exceptions.get();
     }
     void clearExceptions(){exceptions.clear();}
+    void clearMessages(){messages.clear();}
 
 public:
     Owned<IProperties> xslParameters;
@@ -480,6 +481,9 @@ static void libxsltErrorMsgHandler(void *ctx, const char *format, ...)
 {
     if (!ctx)
         return;
+    if (format && *format == '\n')
+        return;
+
     CLibXslTransform *ctrans = (CLibXslTransform*)ctx;//getXsltTransformObject((xsltTransformContextPtr)ctx);
     if (!ctrans)
         return;
@@ -492,6 +496,8 @@ static void libxsltErrorMsgHandler(void *ctx, const char *format, ...)
 int CLibXslTransform::transform(xmlChar **xmlbuff, int &len)
 {
     clearExceptions();
+    clearMessages();
+
     xsltSetGenericErrorFunc(this, libxsltErrorMsgHandler);
     if (!xmlSrc)
         throw MakeStringException(XSLERR_MissingXml, "XSLT Transform missing XML");
@@ -544,6 +550,8 @@ int CLibXslTransform::transform(xmlChar **xmlbuff, int &len)
         throw MakeStringException(XSLERR_TransformFailed, "Failed running xlst using libxslt.");
     }
 
+    xsltTransformState stateAfterTransform = ctxt->state;
+
     try
     {
         xsltFreeTransformContext(ctxt);
@@ -556,8 +564,20 @@ int CLibXslTransform::transform(xmlChar **xmlbuff, int &len)
         throw MakeStringException(XSLERR_TransformFailed, "Failed processing libxslt transform output");
     }
     xmlFreeDoc(res);
+
     if (exceptions && exceptions->ordinality())
-        throw exceptions.getClear();
+    {
+        if (stateAfterTransform != XSLT_STATE_OK)
+        {
+            throw exceptions.getClear();
+        }
+        else
+        {
+            StringBuffer strErrMsg;
+            exceptions.get()->errorMessage(strErrMsg);
+            messages.set(strErrMsg.str());
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION
```
- Handle terminate yes/no properly
- Cleanup user error messages a bit
```

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
