### PR TITLE
HPCC-13067 DOCS:Add marca registrada symbol

### DIFF
--- a/docs/ECLLanguageReference/ECLR-includer.xml
+++ b/docs/ECLLanguageReference/ECLR-includer.xml
@@ -41,9 +41,10 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <releaseinfo>© 2015 HPCC Systems. All rights reserved. Except where
-    otherwise noted, ECL Language Reference content licensed under Creative
-    Commons public license.</releaseinfo>
+    <releaseinfo>© 2015 HPCC Systems<superscript>®</superscript>. All rights
+    reserved. Except where otherwise noted, ECL Language Reference content
+    licensed under Creative Commons public license.</releaseinfo>
+
     <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <mediaobject role="logo">

--- a/docs/ECLPlayground/ECLPlayground-includer.xml
+++ b/docs/ECLPlayground/ECLPlayground-includer.xml
@@ -17,7 +17,7 @@
 
     <legalnotice>
       <para>We welcome your comments and feedback about this document via
-      email to <email>docfeedback@hpccsystems.com</email> </para>
+      email to <email>docfeedback@hpccsystems.com</email></para>
 
       <para>Please include <emphasis role="bold">Documentation
       Feedback</emphasis> in the subject line and reference the document name,
@@ -25,13 +25,13 @@
       message.</para>
 
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
-      of Reed Elsevier Properties Inc., used under license. </para>
+      of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>�</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLProgrammersGuide/PrGd-Includer.xml
+++ b/docs/ECLProgrammersGuide/PrGd-Includer.xml
@@ -17,7 +17,7 @@
 
     <legalnotice>
       <para>We welcome your comments and feedback about this document via
-      email to <email>docfeedback@hpccsystems.com</email> </para>
+      email to <email>docfeedback@hpccsystems.com</email></para>
 
       <para>Please include <emphasis role="bold">Documentation
       Feedback</emphasis> in the subject line and reference the document name,
@@ -25,13 +25,13 @@
       message.</para>
 
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
-      of Reed Elsevier Properties Inc., used under license. </para>
+      of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLReference/ECLReference.xml
+++ b/docs/ECLReference/ECLReference.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE part PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
-<set >
+<set>
   <title>ECL Reference</title>
 
   <setinfo>
-    <corpauthor>HPCC Systems<superscript>®</superscript></corpauthor>
+    <corpauthor>HPCC Systems<superscript>Â®</superscript></corpauthor>
   </setinfo>
 
-  <xi:include href="../ECLLanguageReference/ECLR-includer.xml" xpointer="element(/1)"
-              xmlns:xi="http://www.w3.org/2001/XInclude" />
-              
-  <xi:include href="../ECLStandardLibraryReference/SLR-includer.xml" xpointer="element(/1)"
+  <xi:include href="../ECLLanguageReference/ECLR-includer.xml"
+              xpointer="element(/1)"
               xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-  <xi:include href="../ECLProgrammersGuide/PrGd-Includer.xml" xpointer="element(/1)"
+  <xi:include href="../ECLStandardLibraryReference/SLR-includer.xml"
+              xpointer="element(/1)"
               xmlns:xi="http://www.w3.org/2001/XInclude" />
-  
+
+  <xi:include href="../ECLProgrammersGuide/PrGd-Includer.xml"
+              xpointer="element(/1)"
+              xmlns:xi="http://www.w3.org/2001/XInclude" />
 </set>

--- a/docs/ECLStandardLibraryReference/SLR-includer.xml
+++ b/docs/ECLStandardLibraryReference/SLR-includer.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLWatch/ECLWTechPrev.xml
+++ b/docs/ECLWatch/ECLWTechPrev.xml
@@ -38,7 +38,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -65,7 +65,8 @@
       <para>This document briefly describes new ECL Watch functionality which
       will be available in HPCC 4.x.</para>
 
-      <para><figure>
+      <para>
+        <figure>
           <title>Tech Preview Link</title>
 
           <mediaobject>
@@ -73,7 +74,8 @@
               <imagedata fileref="images/ECTP001.jpg" vendor="eclwatchSS" />
             </imageobject>
           </mediaobject>
-        </figure></para>
+        </figure>
+      </para>
 
       <para>On the ECL Watch page, there are links in the Navigator panel
       under the <emphasis role="bold">Tech Preview</emphasis> heading. The

--- a/docs/ECLWatch/ECLWa_mods/ECLWatchQueries.xml
+++ b/docs/ECLWatch/ECLWa_mods/ECLWatchQueries.xml
@@ -40,7 +40,7 @@
     <xi:include href="../../common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>xxx</superscript></corpname>
 
     <xi:include href="../../common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLWatch/ECLWa_mods/ECLWatchSrc.xml
+++ b/docs/ECLWatch/ECLWa_mods/ECLWatchSrc.xml
@@ -40,7 +40,7 @@
     <xi:include href="../../common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>xxx</superscript></corpname>
 
     <xi:include href="../../common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLWatch/TheECLWatchMan.xml
+++ b/docs/ECLWatch/TheECLWatchMan.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -39,7 +39,7 @@
       similarity to actual persons, living or dead, is purely
       coincidental.</para>
 
-      <para> </para>
+      <para></para>
     </legalnotice>
 
     <xi:include href="common/Version.xml" xpointer="FooterInfo"
@@ -713,10 +713,10 @@
       to help in the transition.</para>
 
       <para>The <emphasis role="bold">Additional Resources</emphasis> link
-      opens a tab to the HPCC Systems<superscript>®</superscript> download page, where you can browse and
-      download additional HPCC resources: documentation, white papers,
-      training videos, wiki pages, the red book and other HPCC related source
-      code.</para>
+      opens a tab to the HPCC Systems<superscript>®</superscript> download
+      page, where you can browse and download additional HPCC resources:
+      documentation, white papers, training videos, wiki pages, the red book
+      and other HPCC related source code.</para>
 
       <para>The <emphasis role="bold">Release Notes</emphasis> link opens a
       tab with the relevant release notes for the version of HPCC that you are
@@ -843,17 +843,18 @@
     <title>Resources</title>
 
     <para>The resources link can be found under the Operations Icon link. The
-    resources link in ECL Watch provides a link to the HPCC Systems<superscript>®</superscript> web
-    portal. Visit the HPCC Systems<superscript>®</superscript> Web Portal at <ulink
+    resources link in ECL Watch provides a link to the HPCC
+    Systems<superscript>®</superscript> web portal. Visit the HPCC
+    Systems<superscript>®</superscript> Web Portal at <ulink
     url="http://hpccsystems.com/">http://hpccsystems.com/</ulink> for software
     updates, plug-ins, support, documentation, and more. This is where you can
     find resources useful for running and maintaining HPCC on the web
     portal.</para>
 
-    <para>You can also get to the resources link on the HPCC Systems<superscript>®</superscript> web
-    portal page, by clicking on the <emphasis role="bold">Additional
-    Resources</emphasis> link found on the sub-menu of at the top right hand
-    side of navigation bar.</para>
+    <para>You can also get to the resources link on the HPCC
+    Systems<superscript>®</superscript> web portal page, by clicking on the
+    <emphasis role="bold">Additional Resources</emphasis> link found on the
+    sub-menu of at the top right hand side of navigation bar.</para>
 
     <para>ECL Watch provides a link to the HPCC portal's download page: <ulink
     url="http://hpccsystems.com/download">http://hpccsystems.com/download</ulink>.

--- a/docs/HDFSConnector/HDFS_Mods/HDFS_Intro.xml
+++ b/docs/HDFSConnector/HDFS_Mods/HDFS_Intro.xml
@@ -5,9 +5,10 @@
   <title>Introduction</title>
 
   <para>The HDFS to HPCC Connector provides a means to import data from
-  Hadoop's HDFS into an HPCC Systems<superscript>®</superscript> Thor platform. It also supports exporting
-  the data back to HDFS or exporting and merging it. This allows you to use an
-  HPCC cluster in conjunction with your Hadoop-based cluster.</para>
+  Hadoop's HDFS into an HPCC Systems<superscript>Â®</superscript> Thor
+  platform. It also supports exporting the data back to HDFS or exporting and
+  merging it. This allows you to use an HPCC cluster in conjunction with your
+  Hadoop-based cluster.</para>
 
   <para>The H2H Connector is an add-on to an HPCC Cluster and consists of
   server-side components and ECL Macros that invoke them.</para>
@@ -30,7 +31,7 @@
               (/opt/HPCCSystems/etc/HPCCSystems/hdfsconnector.conf)</para>
 
               <para>The configuration file contains the location where Hadoop
-              is installed, as shown in the example below: </para>
+              is installed, as shown in the example below:</para>
 
               <programlisting>HADOOP_LOCATION=/usr/local/hadoop</programlisting>
 
@@ -45,7 +46,7 @@
                     named <emphasis
                     role="bluebold">mydataconnectors</emphasis> in the the
                     HPCC log directory (the HPCC log location can be set using
-                    Configuration Manager). </para>
+                    Configuration Manager).</para>
 
                     <para>The default location is:<programlisting>/var/log/HPCCSystems/mydataconnectors/</programlisting></para>
 

--- a/docs/HDFSConnector/HDFS_to_HPCC_ConnectorIncluder.xml
+++ b/docs/HDFSConnector/HDFS_to_HPCC_ConnectorIncluder.xml
@@ -17,7 +17,7 @@
 
     <legalnotice>
       <para>We welcome your comments and feedback about this document via
-      email to <email>docfeedback@hpccsystems.com</email> </para>
+      email to <email>docfeedback@hpccsystems.com</email></para>
 
       <para>Please include <emphasis role="bold">Documentation
       Feedback</emphasis> in the subject line and reference the document name,
@@ -25,13 +25,13 @@
       message.</para>
 
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
-      of Reed Elsevier Properties Inc., used under license. </para>
+      of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCCertify/certify.xml
+++ b/docs/HPCCCertify/certify.xml
@@ -17,7 +17,7 @@
 
     <legalnotice>
       <para>We welcome your comments and feedback about this document via
-      email to <email>docfeedback@hpccsystems.com</email> </para>
+      email to <email>docfeedback@hpccsystems.com</email></para>
 
       <para>Please include <emphasis role="bold">Documentation
       Feedback</emphasis> in the subject line and reference the document name,
@@ -25,13 +25,13 @@
       message.</para>
 
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
-      of Reed Elsevier Properties Inc., used under license. </para>
+      of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -48,7 +48,7 @@ Copyright is used for the copyright line on title page. The ID attribute is Copy
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCClientTools/CT_Mods/CT_Overview.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Overview.xml
@@ -116,7 +116,8 @@
 
       <orderedlist>
         <listitem>
-          <para>From the HPCC Systems<superscript>®</superscript> download page, <ulink
+          <para>From the HPCC Systems<superscript>Â®</superscript> download
+          page, <ulink
           url="http://hpccsystems.com/download/free-community-edition/client-tools">http://hpccsystems.com/download/free-community-edition/client-tools</ulink></para>
 
           <para>Download the appropriate Client Tools for your Operating

--- a/docs/HPCCClientTools/CT_Mods/CT_Overview_withoutIDE.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Overview_withoutIDE.xml
@@ -102,7 +102,8 @@
 
       <orderedlist>
         <listitem>
-          <para>From the HPCC Systems<superscript>®</superscript> download page, <ulink
+          <para>From the HPCC Systems<superscript>Â®</superscript> download
+          page, <ulink
           url="http://hpccsystems.com/download/free-community-edition/client-tools">http://hpccsystems.com/download/free-community-edition/client-tools</ulink></para>
 
           <para>Download the appropriate Client Tools for your Operating
@@ -158,8 +159,8 @@
           <para>Download the appropriate Client Tools for your Operating
           System and version.</para>
 
-          <para>Client tools can be found at the HPCC Systems<superscript>®</superscript> download
-          page:</para>
+          <para>Client tools can be found at the HPCC
+          Systems<superscript>Â®</superscript> download page:</para>
 
           <para><ulink
           url="http://hpccsystems.com/download/free-community-edition/client-tools">http://hpccsystems.com/download/free-community-edition/client-tools</ulink></para>
@@ -200,7 +201,7 @@
       the one you want to use last. Copy to a different folder or Rename the
       client tools found in /opt/HPCCSystems after installing the older
       version and before installing the newer version. This is to prevent the
-      newer client tools from overwriting the older one. </para>
+      newer client tools from overwriting the older one.</para>
 
       <para>To use the Client tools for the various version number(s)
       explicitly call the client tool you wish to use, or set up an alias to
@@ -222,8 +223,8 @@
 
       <para>Client tools for Windows installs in a directory such as:
       C:\Program Files (x86)\HPCCSystems\4.2.0\clientools where the number
-      (4.2.0 for example) corresponds to the version of the client tools.
-      </para>
+      (4.2.0 for example) corresponds to the version of the client
+      tools.</para>
 
       <para>The Windows installer will prompt you to delete the previous
       version during installation. If you want to keep both, decline the offer

--- a/docs/HPCCClientTools/CT_Mods/ECLCC.xml
+++ b/docs/HPCCClientTools/CT_Mods/ECLCC.xml
@@ -32,14 +32,14 @@
       <para></para>
     </legalnotice>
 
-    <releaseinfo>© 2015 HPCC Systems<superscript>®</superscript>. All rights reserved</releaseinfo>
+    <releaseinfo>© 2015 HPCC Systems<superscript>xxx</superscript>. All rights reserved</releaseinfo>
 
     <date><emphasis role="bold">BETA</emphasis></date>
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>xxx</superscript></corpname>
 
     <copyright>
-      <year>2015 HPCC Systems<superscript>®</superscript>. All rights reserved</year>
+      <year>2015 HPCC Systems<superscript>xxx</superscript>. All rights reserved</year>
     </copyright>
 
     <mediaobject role="logo">

--- a/docs/HPCCClientTools/ClientTools.xml
+++ b/docs/HPCCClientTools/ClientTools.xml
@@ -17,7 +17,7 @@
 
     <legalnotice>
       <para>We welcome your comments and feedback about this document via
-      email to <email>docfeedback@hpccsystems.com</email> </para>
+      email to <email>docfeedback@hpccsystems.com</email></para>
 
       <para>Please include <emphasis role="bold">Documentation
       Feedback</emphasis> in the subject line and reference the document name,
@@ -25,13 +25,13 @@
       message.</para>
 
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
-      of Reed Elsevier Properties Inc., used under license. </para>
+      of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCClientTools/TheECLIDEandHPCCClientTools.xml
+++ b/docs/HPCCClientTools/TheECLIDEandHPCCClientTools.xml
@@ -17,7 +17,7 @@
 
     <legalnotice>
       <para>We welcome your comments and feedback about this document via
-      email to <email>docfeedback@hpccsystems.com</email> </para>
+      email to <email>docfeedback@hpccsystems.com</email></para>
 
       <para>Please include <emphasis role="bold">Documentation
       Feedback</emphasis> in the subject line and reference the document name,
@@ -25,13 +25,13 @@
       message.</para>
 
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
-      of Reed Elsevier Properties Inc., used under license. </para>
+      of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCDataHandling/DataHandling.xml
+++ b/docs/HPCCDataHandling/DataHandling.xml
@@ -17,7 +17,7 @@
 
     <legalnotice>
       <para>We welcome your comments and feedback about this document via
-      email to <email>docfeedback@hpccsystems.com</email> </para>
+      email to <email>docfeedback@hpccsystems.com</email></para>
 
       <para>Please include <emphasis role="bold">Documentation
       Feedback</emphasis> in the subject line and reference the document name,
@@ -25,13 +25,13 @@
       message.</para>
 
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
-      of Reed Elsevier Properties Inc., used under license. </para>
+      of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -141,7 +141,7 @@
 
     <xi:include href="HPCCDataHandling/DH-Mods/DH-Mod1.xml"
                 xpointer="Data_Handling_Using_ECL-Watch"
-                xmlns:xi="http://www.w3.org/2001/XInclude" />  
+                xmlns:xi="http://www.w3.org/2001/XInclude" />
   </chapter>
 
   <chapter>

--- a/docs/HPCCMonitoring/HPCCMonitoringAndReporting.xml
+++ b/docs/HPCCMonitoring/HPCCMonitoringAndReporting.xml
@@ -17,7 +17,7 @@
 
     <legalnotice>
       <para>We welcome your comments and feedback about this document via
-      email to <email>docfeedback@hpccsystems.com</email> </para>
+      email to <email>docfeedback@hpccsystems.com</email></para>
 
       <para>Please include <emphasis role="bold">Documentation
       Feedback</emphasis> in the subject line and reference the document name,
@@ -27,11 +27,11 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para> HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -61,8 +61,8 @@
   <chapter id="GangliaIntroduction">
     <title>Introduction</title>
 
-    <para>The HPCC Systems<superscript>®</superscript> platform supports graphical monitoring and
-    reporting components.</para>
+    <para>The HPCC Systems<superscript>Â®</superscript> platform supports
+    graphical monitoring and reporting components.</para>
 
     <para><emphasis role="bold">Ganglia:</emphasis></para>
 
@@ -266,8 +266,8 @@
           <para>To get the HPCC Monitoring components, find the appropriate
           package for your system.</para>
 
-          <para>Packages are available for download from the HPCC Systems<superscript>®</superscript>
-          site:</para>
+          <para>Packages are available for download from the HPCC
+          Systems<superscript>Â®</superscript> site:</para>
 
           <para><ulink
           url="http://hpccsystems.com/download">hpccsystems.com/download</ulink></para>
@@ -355,8 +355,8 @@
         </listitem>
 
         <listitem>
-          <para>Install the HPCC Systems<superscript>®</superscript> monitoring component on every
-          node.</para>
+          <para>Install the HPCC Systems<superscript>Â®</superscript>
+          monitoring component on every node.</para>
         </listitem>
 
         <listitem>
@@ -581,7 +581,7 @@
       <para>The HPCC Nagios package provides tools and utilities for
       generating Nagios configurations. These configurations check HPCC and
       perform some of the HPCC specific checks. HPCC Nagios installation is
-      provided on the HPCC Systems<superscript>®</superscript> portal.</para>
+      provided on the HPCC Systems<superscript>Â®</superscript> portal.</para>
 
       <sect2 id="HPCC_Nagios_Installation">
         <title>HPCC Nagios Installation Package</title>
@@ -590,8 +590,9 @@
         Installation package. Download the installation package from the HPCC
         Systems portal.</para>
 
-        <para>The HPCC Systems<superscript>®</superscript> web portal is where you can find HPCC
-        resources, downloads, plug-ins, as well as helpful information.</para>
+        <para>The HPCC Systems<superscript>Â®</superscript> web portal is where
+        you can find HPCC resources, downloads, plug-ins, as well as helpful
+        information.</para>
 
         <para><ulink
         url="http://hpccsystems.com/download/free-community-edition/monitoring">http://hpccsystems.com/</ulink></para>

--- a/docs/IMDB/IMDB.xml
+++ b/docs/IMDB/IMDB.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -48,7 +48,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -757,7 +757,7 @@ OUTPUT(IMDB.FileActors);
           </itemizedlist></para>
 
         <para><programlisting>/* ******************************************************************************
-## Copyright 2011 HPCC Systems<superscript>®</superscript>.  All rights reserved.
+## Copyright 2011 HPCC Systems.  All rights reserved.
 ******************************************************************************* */
 
 /**

--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UnityLauncher.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UnityLauncher.xml
@@ -17,7 +17,7 @@
         <listitem>
           <para>This is only useful on a single-node system at this time.
           Future versions may operate in a different manner and support
-          multi-node HPCC systems<superscript>®</superscript>.</para>
+          multi-node HPCC systems<superscript>Â®</superscript>.</para>
         </listitem>
       </varlistentry>
     </variablelist></para>
@@ -27,8 +27,8 @@
 
     <orderedlist numeration="arabic">
       <listitem>
-        <para>Use the search on Dash Home to find the HPCC Systems<superscript>®</superscript> application
-        icon.</para>
+        <para>Use the search on Dash Home to find the HPCC
+        Systems<superscript>Â®</superscript> application icon.</para>
 
         <figure>
           <title>HPCC Application Icon</title>

--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
@@ -11,10 +11,11 @@
   <sect2 id="User_Security_Intro">
     <title>Introduction</title>
 
-    <para>HPCC systems<superscript>�</superscript> maintains security in a number of ways. HPCC Systems<superscript>�</superscript>
-    can be configured to manage users' security rights by pointing either at
-    Microsoft’s Active Directory on a Windows system, or a 389Directory Server
-    on Linux systems.</para>
+    <para>HPCC systems<superscript>®</superscript> maintains security in a
+    number of ways. HPCC Systems<superscript>®</superscript> can be configured
+    to manage users' security rights by pointing either at Microsoft’s Active
+    Directory on a Windows system, or a 389Directory Server on Linux
+    systems.</para>
 
     <para>Using the Permissions interface in ECL Watch, administrators can
     control access to features in ECL IDE, ECL Watch, ECL Plus, DFU Plus, and

--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -767,7 +767,8 @@
         packages will fail to install if their dependencies are missing from
         the target system.</para>
 
-        <para>Packages are available from the HPCC Systems<superscript>®</superscript> website: <ulink
+        <para>Packages are available from the HPCC
+        Systems<superscript>®</superscript> website: <ulink
         url="http://hpccsystems.com/download/free-community-edition">http://hpccsystems.com/download/free-community-edition</ulink></para>
 
         <para>To install the package, follow the appropriate installation
@@ -1278,8 +1279,8 @@
 
         <para>This section details reconfiguring a system to use multiple
         nodes. Before you start this section, you must have already downloaded
-        the correct packages for your distro from the HPCC Systems<superscript>®</superscript> website:
-        <ulink
+        the correct packages for your distro from the HPCC
+        Systems<superscript>®</superscript> website: <ulink
         url="http://hpccsystems.com/download/free-community-edition">http://hpccsystems.com/download/free-community-edition</ulink>.</para>
 
         <orderedlist>
@@ -1850,7 +1851,7 @@ sudo cp /etc/HPCCSystems/source/NewEnvironment.xml /etc/HPCCSystems/environment.
           <listitem>
             <para>Open the ECL IDE (Start <emphasis
             role="bold">&gt;&gt;</emphasis> All Programs <emphasis
-            role="bold">&gt;&gt;</emphasis> HPCC Systems<superscript>®</superscript> <emphasis
+            role="bold">&gt;&gt;</emphasis> HPCC Systems <emphasis
             role="bold"> &gt;&gt;</emphasis> ECL IDE ) and login to your
             HPCC.</para>
           </listitem>
@@ -2547,7 +2548,7 @@ OUTPUT(ValidWords)
     role="bold">Start</emphasis> menu :</para>
 
     <para>Start <emphasis role="bold">&gt;&gt;</emphasis> All Programs
-    <emphasis role="bold">&gt;&gt;</emphasis> HPCC Systems<superscript>®</superscript> <emphasis
+    <emphasis role="bold">&gt;&gt;</emphasis> HPCC Systems <emphasis
     role="bold">&gt;&gt;</emphasis> ECL IDE <emphasis
     role="bold">&gt;&gt;</emphasis> Docs</para>
 
@@ -2573,8 +2574,8 @@ OUTPUT(ValidWords)
         </listitem>
       </itemizedlist></para>
 
-    <para>The HPCC Systems<superscript>®</superscript> Portal is also a valuable resource for more
-    information including:</para>
+    <para>The HPCC Systems<superscript>®</superscript> Portal is also a
+    valuable resource for more information including:</para>
 
     <itemizedlist spacing="compact">
       <listitem>
@@ -3372,8 +3373,9 @@ sudo /sbin/service hpcc-init -c esp start
           </listitem>
 
           <listitem>
-            <para>Start the HPCC Systems<superscript>®</superscript> platform (restart if it is already
-            running) in order to read the new configuration.</para>
+            <para>Start the HPCC Systems<superscript>®</superscript> platform
+            (restart if it is already running) in order to read the new
+            configuration.</para>
 
             <para>For example :</para>
 
@@ -3394,9 +3396,9 @@ sudo /sbin/service hpcc-init -c esp start
 
             <para>Test the Java integration.</para>
 
-            <para>The HPCC Systems<superscript>®</superscript> platform comes with a Java example class.
-            You can execute some Java code either in your ECL IDE or the ECL
-            Playground.</para>
+            <para>The HPCC Systems<superscript>®</superscript> platform comes
+            with a Java example class. You can execute some Java code either
+            in your ECL IDE or the ECL Playground.</para>
 
             <para>For example:</para>
 
@@ -3425,8 +3427,8 @@ add1(10);
       <sect2 id="Add_On_Javascript" role="brk">
         <title>JavaScript</title>
 
-        <para>To enable JavaScript support within the HPCC Systems<superscript>®</superscript>
-        Platform:</para>
+        <para>To enable JavaScript support within the HPCC
+        Systems<superscript>®</superscript> Platform:</para>
 
         <orderedlist>
           <listitem>
@@ -3490,8 +3492,8 @@ add1(10);
       <sect2 id="Add_Python_support" role="brk">
         <title>Python</title>
 
-        <para>To enable Python support within the HPCC Systems<superscript>®</superscript>
-        Platform:</para>
+        <para>To enable Python support within the HPCC
+        Systems<superscript>®</superscript> Platform:</para>
 
         <orderedlist>
           <listitem>
@@ -3548,7 +3550,8 @@ split_words('Once upon a time');
       <sect2 id="R" role="brk">
         <title>R</title>
 
-        <para>To enable R support within The HPCC Systems<superscript>®</superscript> Platform:</para>
+        <para>To enable R support within The HPCC
+        Systems<superscript>®</superscript> Platform:</para>
 
         <orderedlist>
           <listitem>

--- a/docs/RDDERef/RDDERef.xml
+++ b/docs/RDDERef/RDDERef.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -111,7 +111,7 @@
     <para>Typically, Roxie results are returned to the requester rather than
     writing a result to a file. However, Roxie can write data files, although
     you generally would not want to write a file when a query is not
-    workunit-based. </para>
+    workunit-based.</para>
 
     <sect1 id="Roxie_Overview">
       <title>Roxie Overview</title>

--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -39,7 +39,7 @@
       similarity to actual persons, living or dead, is purely
       coincidental.</para>
 
-      <para></para>
+      <para> </para>
     </legalnotice>
 
     <xi:include href="common/Version.xml" xpointer="FooterInfo"
@@ -390,7 +390,7 @@
           operating system for better performance and usability. If you would
           like to use your mouse pointer, and/or other desktop tools with your
           virtual machine, start the X windows display after you log into to
-          your virtual machine. </para>
+          your virtual machine.</para>
 
           <para>Log in with the credentials provided. (user: hpccdemo,
           password: hpccdemo) At the command prompt enter: <emphasis
@@ -1578,10 +1578,11 @@ OUTPUT(ValidWords)
               <listitem>
                 <?dbfo keep-together="always"?>
 
-                <para>Right-click on the <emphasis role="bold">MyFiles</emphasis>
-                folder in the Repository<emphasis role="bold"></emphasis>
-                window, and select <emphasis role="bold">Insert
-                Folder</emphasis> from the pop-up menu.</para>
+                <para>Right-click on the <emphasis
+                role="bold">MyFiles</emphasis> folder in the
+                Repository<emphasis role="bold"></emphasis> window, and select
+                <emphasis role="bold">Insert Folder</emphasis> from the pop-up
+                menu.</para>
 
                 <para><figure>
                     <title>Insert Folder</title>
@@ -2182,8 +2183,8 @@ OUTPUT(ValidWords)
 
           <answer>
             <para>No. If you want to evaluate a multi-node system, you should
-            use the Community version available from the HPCC Systems<superscript>®</superscript> Portal
-            at <ulink
+            use the Community version available from the HPCC
+            Systems<superscript>®</superscript> Portal at <ulink
             url="http://hpccsystems.com">http://hpccsystems.com</ulink>.</para>
           </answer>
         </qandaentry>

--- a/docs/UsingConfigManager/UsingConfigManager.xml
+++ b/docs/UsingConfigManager/UsingConfigManager.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -1411,7 +1411,7 @@ sudo -u hpcc cp /etc/HPCCSystems/source/NewEnvironment.xml /etc/HPCCSystems/envi
             <graphic fileref="images/CM-img08-4.jpg" vendor="configmgrSS" />
           </para>
 
-          <!--MyESP-HTTPS.t5-XXX-->
+          <!--MyESP-HTTPS.t5-Â™-->
 
           <para>
             <xi:include href="UsingConfigManager/CM_Mods/esp.xsd.mod.xml"
@@ -1535,8 +1535,8 @@ sudo -u hpcc cp /etc/HPCCSystems/source/NewEnvironment.xml /etc/HPCCSystems/envi
           <orderedlist>
             <listitem>
               <para>On the <emphasis role="bold">Instances</emphasis> tab,
-              right-click on the table on the right hand side, choose <emphasis
-              role="bold">Add Instances...</emphasis></para>
+              right-click on the table on the right hand side, choose
+              <emphasis role="bold">Add Instances...</emphasis></para>
             </listitem>
 
             <listitem>
@@ -1930,11 +1930,11 @@ sudo -u hpcc cp /etc/HPCCSystems/source/NewEnvironment.xml /etc/HPCCSystems/envi
           <para>On systems with a lot of memory, the default 75% of physical
           memory is probably too conservative and reserving total physical
           minus 2GB (for the OS and other processes) is sensible. You should
-          then divide that number by the number of slavesPerNode. </para>
+          then divide that number by the number of slavesPerNode.</para>
 
           <para>If there are multiple Thors sharing the same nodes, then
-          globalMemorySize must be configured to take that into account.
-          </para>
+          globalMemorySize must be configured to take that into
+          account.</para>
 
           <para>For example, if there are 2 Thors each with 2 slaves per box,
           that will mean there are 4 slaves per physical node. So you should
@@ -1945,8 +1945,8 @@ sudo -u hpcc cp /etc/HPCCSystems/source/NewEnvironment.xml /etc/HPCCSystems/envi
 
           <para>Without any specified setting, Thor assumes it has exclusive
           access to the memory and would therefore use too much (because each
-          Thor is unaware of the other's configuration and memory usage).
-          </para>
+          Thor is unaware of the other's configuration and memory
+          usage).</para>
 
           <para>Although a configuration may be set using upper memory limits
           that exceed total physical memory, Thor will not actually reserve

--- a/docs/Visualizing/Visualizing.xml
+++ b/docs/Visualizing/Visualizing.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -48,7 +48,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/common/Version.xml
+++ b/docs/common/Version.xml
@@ -5,11 +5,12 @@
   <chapterinfo>
     <date id="DateVer">DEVELOPER NON-GENERATED VERSION</date>
 
-    <releaseinfo id="FooterInfo">© 2015 HPCC Systems. All rights
-    reserved</releaseinfo>
+    <releaseinfo id="FooterInfo">© 2015 HPCC
+    Systems<superscript>®</superscript>. All rights reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2015 HPCC Systems. All rights reserved</year>
+      <year>2015 HPCC Systems<superscript>®</superscript>. All rights
+      reserved</year>
     </copyright>
   </chapterinfo>
 

--- a/docs/common/Version.xml.in
+++ b/docs/common/Version.xml.in
@@ -5,11 +5,12 @@
   <chapterinfo>
     <date id="DateVer">2015 Version ${DOC_VERSION}</date>
 
-    <releaseinfo id="FooterInfo">© 2015 HPCC Systems. All rights
-    reserved</releaseinfo>
+    <releaseinfo id="FooterInfo">© 2015 HPCC
+    Systems<superscript>®</superscript>. All rights reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2015 HPCC Systems. All rights reserved</year>
+      <year>2015 HPCC Systems<superscript>®</superscript>. All rights
+      reserved</year>
     </copyright>
   </chapterinfo>
 

--- a/docs/wip/DaliAdmin.xml
+++ b/docs/wip/DaliAdmin.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>Â®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -42,14 +42,15 @@
       <para></para>
     </legalnotice>
 
-    <releaseinfo>Â© 2011 HPCC Systems<superscript>®</superscript>. All rights reserved</releaseinfo>
+    <releaseinfo>Â© 2015 HPCC Systems<superscript>Â®</superscript>. All rights
+    reserved</releaseinfo>
 
     <date>3.0.0_x</date>
 
-    <corpname>HPCC Systems<superscript>®</superscript></corpname>
+    <corpname>HPCC Systems<superscript>Â®</superscript></corpname>
 
     <copyright>
-      <year>May, 2011</year>
+      <year>May, 2015</year>
     </copyright>
 
     <mediaobject role="logo">


### PR DESCRIPTION
FIX HPCC-13067 DOCS:Add marca registrada symbol
Add marca registrada symbol to every instance of
HPCC Systems in the code for all docs.
Also ensured that doing so did not change the encoding
for the docs and result in applications reporting corrupt files.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
@JamesDeFabia please review, note that I verified each file here for any incompatibilities with our entire build process.
