### PR TITLE
HPCC-13067 DOCS:Add marca registrada symbol

### DIFF
--- a/docs/ECLLanguageReference/ECLR-includer.xml
+++ b/docs/ECLLanguageReference/ECLR-includer.xml
@@ -41,11 +41,11 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <releaseinfo>© 2014 HPCC Systems. All rights reserved. Except where
-    otherwise noted, ECL Language Reference content licensed under Creative
-    Commons public license.</releaseinfo>
+    <releaseinfo>© 2015 HPCC Systems<superscript>®</superscript>. All rights
+    reserved. Except where otherwise noted, ECL Language Reference content
+    licensed under Creative Commons public license.</releaseinfo>
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <mediaobject role="logo">
       <imageobject>

--- a/docs/ECLPlayground/ECLPlayground-includer.xml
+++ b/docs/ECLPlayground/ECLPlayground-includer.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license. </para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies. </para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLProgrammersGuide/PrGd-Includer.xml
+++ b/docs/ECLProgrammersGuide/PrGd-Includer.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license. </para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies. </para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLReference/ECLReference.xml
+++ b/docs/ECLReference/ECLReference.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE part PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
-<set >
+<set>
   <title>ECL Reference</title>
 
   <setinfo>
-    <corpauthor>HPCC Systems</corpauthor>
+    <corpauthor>HPCC Systems<superscript>®</superscript></corpauthor>
   </setinfo>
 
-  <xi:include href="../ECLLanguageReference/ECLR-includer.xml" xpointer="element(/1)"
-              xmlns:xi="http://www.w3.org/2001/XInclude" />
-              
-  <xi:include href="../ECLStandardLibraryReference/SLR-includer.xml" xpointer="element(/1)"
+  <xi:include href="../ECLLanguageReference/ECLR-includer.xml"
+              xpointer="element(/1)"
               xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-  <xi:include href="../ECLProgrammersGuide/PrGd-Includer.xml" xpointer="element(/1)"
+  <xi:include href="../ECLStandardLibraryReference/SLR-includer.xml"
+              xpointer="element(/1)"
               xmlns:xi="http://www.w3.org/2001/XInclude" />
-  
+
+  <xi:include href="../ECLProgrammersGuide/PrGd-Includer.xml"
+              xpointer="element(/1)"
+              xmlns:xi="http://www.w3.org/2001/XInclude" />
 </set>

--- a/docs/ECLStandardLibraryReference/SLR-includer.xml
+++ b/docs/ECLStandardLibraryReference/SLR-includer.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLWatch/ECLWTechPrev.xml
+++ b/docs/ECLWatch/ECLWTechPrev.xml
@@ -38,7 +38,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLWatch/ECLWa_mods/ECLWatchQueries.xml
+++ b/docs/ECLWatch/ECLWa_mods/ECLWatchQueries.xml
@@ -40,7 +40,7 @@
     <xi:include href="../../common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="../../common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -304,11 +304,11 @@ depending on where they wind up.-->
           Files tab. To view more detail about a logical file listed here,
           check the box next to the file, and then press the <emphasis
           role="bold">Open</emphasis> action button. You can also just double
-          click on the logical file you want to view. </para>
+          click on the logical file you want to view.</para>
 
           <para>Once open, you can select any of the tabs to see Summary,
-          Contents, ECL, DEF, XML, File Parts, Queries, or the Workunit.
-          </para>
+          Contents, ECL, DEF, XML, File Parts, Queries, or the
+          Workunit.</para>
 
           <figure>
             <title>Queries:Logical Files:Contents Tab</title>

--- a/docs/ECLWatch/ECLWa_mods/ECLWatchSrc.xml
+++ b/docs/ECLWatch/ECLWa_mods/ECLWatchSrc.xml
@@ -40,7 +40,7 @@
     <xi:include href="../../common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="../../common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/ECLWatch/TheECLWatchMan.xml
+++ b/docs/ECLWatch/TheECLWatchMan.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -39,7 +39,7 @@
       similarity to actual persons, living or dead, is purely
       coincidental.</para>
 
-      <para> </para>
+      <para></para>
     </legalnotice>
 
     <xi:include href="common/Version.xml" xpointer="FooterInfo"
@@ -48,7 +48,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -236,7 +236,7 @@
       please see the ECL Language reference. A copy of which can be found
       online at <ulink
       url="http://hpccsystems.com/download/docs/learning-ecl">http://hpccsystems.com/download/docs/learning-ecl</ulink>
-      on the HPCC Systems web site.</para>
+      on the HPCC Systems<superscript>®</superscript> web site.</para>
 
       <!--***NOTE: Be sure to UPDATE these images when they find a home in ECLWATCH***-->
     </sect1>
@@ -713,10 +713,10 @@
       to help in the transition.</para>
 
       <para>The <emphasis role="bold">Additional Resources</emphasis> link
-      opens a tab to the HPCC Systems download page, where you can browse and
-      download additional HPCC resources: documentation, white papers,
-      training videos, wiki pages, the red book and other HPCC related source
-      code.</para>
+      opens a tab to the HPCC Systems<superscript>®</superscript> download
+      page, where you can browse and download additional HPCC resources:
+      documentation, white papers, training videos, wiki pages, the red book
+      and other HPCC related source code.</para>
 
       <para>The <emphasis role="bold">Release Notes</emphasis> link opens a
       tab with the relevant release notes for the version of HPCC that you are
@@ -843,17 +843,18 @@
     <title>Resources</title>
 
     <para>The resources link can be found under the Operations Icon link. The
-    resources link in ECL Watch provides a link to the HPCC Systems web
-    portal. Visit the HPCC Systems Web Portal at <ulink
+    resources link in ECL Watch provides a link to the HPCC
+    Systems<superscript>®</superscript> web portal. Visit the HPCC
+    Systems<superscript>®</superscript> Web Portal at <ulink
     url="http://hpccsystems.com/">http://hpccsystems.com/</ulink> for software
     updates, plug-ins, support, documentation, and more. This is where you can
     find resources useful for running and maintaining HPCC on the web
     portal.</para>
 
-    <para>You can also get to the resources link on the HPCC Systems web
-    portal page, by clicking on the <emphasis role="bold">Additional
-    Resources</emphasis> link found on the sub-menu of at the top right hand
-    side of navigation bar.</para>
+    <para>You can also get to the resources link on the HPCC
+    Systems<superscript>®</superscript> web portal page, by clicking on the
+    <emphasis role="bold">Additional Resources</emphasis> link found on the
+    sub-menu of at the top right hand side of navigation bar.</para>
 
     <para>ECL Watch provides a link to the HPCC portal's download page: <ulink
     url="http://hpccsystems.com/download">http://hpccsystems.com/download</ulink>.

--- a/docs/HDFSConnector/HDFS_Mods/HDFS_Intro.xml
+++ b/docs/HDFSConnector/HDFS_Mods/HDFS_Intro.xml
@@ -5,9 +5,10 @@
   <title>Introduction</title>
 
   <para>The HDFS to HPCC Connector provides a means to import data from
-  Hadoop's HDFS into an HPCC Systems Thor platform. It also supports exporting
-  the data back to HDFS or exporting and merging it. This allows you to use an
-  HPCC cluster in conjunction with your Hadoop-based cluster.</para>
+  Hadoop's HDFS into an HPCC Systems<superscript>®</superscript> Thor
+  platform. It also supports exporting the data back to HDFS or exporting and
+  merging it. This allows you to use an HPCC cluster in conjunction with your
+  Hadoop-based cluster.</para>
 
   <para>The H2H Connector is an add-on to an HPCC Cluster and consists of
   server-side components and ECL Macros that invoke them.</para>

--- a/docs/HDFSConnector/HDFS_to_HPCC_ConnectorIncluder.xml
+++ b/docs/HDFSConnector/HDFS_to_HPCC_ConnectorIncluder.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license. </para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies. </para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCCertify/certify.xml
+++ b/docs/HPCCCertify/certify.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license. </para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies. </para>
@@ -48,7 +48,7 @@ Copyright is used for the copyright line on title page. The ID attribute is Copy
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCClientTools/CT_Mods/CT_Overview.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Overview.xml
@@ -116,7 +116,8 @@
 
       <orderedlist>
         <listitem>
-          <para>From the HPCC Systems download page, <ulink
+          <para>From the HPCC Systems<superscript>®</superscript> download
+          page, <ulink
           url="http://hpccsystems.com/download/free-community-edition/client-tools">http://hpccsystems.com/download/free-community-edition/client-tools</ulink></para>
 
           <para>Download the appropriate Client Tools for your Operating

--- a/docs/HPCCClientTools/CT_Mods/CT_Overview_withoutIDE.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Overview_withoutIDE.xml
@@ -102,7 +102,8 @@
 
       <orderedlist>
         <listitem>
-          <para>From the HPCC Systems download page, <ulink
+          <para>From the HPCC Systems<superscript>®</superscript> download
+          page, <ulink
           url="http://hpccsystems.com/download/free-community-edition/client-tools">http://hpccsystems.com/download/free-community-edition/client-tools</ulink></para>
 
           <para>Download the appropriate Client Tools for your Operating
@@ -158,8 +159,8 @@
           <para>Download the appropriate Client Tools for your Operating
           System and version.</para>
 
-          <para>Client tools can be found at the HPCC Systems download
-          page:</para>
+          <para>Client tools can be found at the HPCC
+          Systems<superscript>®</superscript> download page:</para>
 
           <para><ulink
           url="http://hpccsystems.com/download/free-community-edition/client-tools">http://hpccsystems.com/download/free-community-edition/client-tools</ulink></para>

--- a/docs/HPCCClientTools/CT_Mods/ECLCC.xml
+++ b/docs/HPCCClientTools/CT_Mods/ECLCC.xml
@@ -32,14 +32,16 @@
       <para></para>
     </legalnotice>
 
-    <releaseinfo>© 2011 HPCC Systems. All rights reserved</releaseinfo>
+    <releaseinfo>© 2015 HPCC Systems<superscript>®</superscript>. All rights
+    reserved</releaseinfo>
 
     <date><emphasis role="bold">BETA</emphasis></date>
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <copyright>
-      <year>2011 HPCC Systems. All rights reserved</year>
+      <year>2015 HPCC Systems<superscript>®</superscript>. All rights
+      reserved</year>
     </copyright>
 
     <mediaobject role="logo">

--- a/docs/HPCCClientTools/ClientTools.xml
+++ b/docs/HPCCClientTools/ClientTools.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license. </para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies. </para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCClientTools/TheECLIDEandHPCCClientTools.xml
+++ b/docs/HPCCClientTools/TheECLIDEandHPCCClientTools.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license. </para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies. </para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCDataHandling/DataHandling.xml
+++ b/docs/HPCCDataHandling/DataHandling.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license. </para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies. </para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/HPCCDataTutorial/DataTutorial.xml
+++ b/docs/HPCCDataTutorial/DataTutorial.xml
@@ -29,7 +29,7 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark of LexisNexis Risk Data
       Management Inc.</para>
 
       <para>Other products and services may be trademarks or registered
@@ -52,7 +52,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <!--corpname never prints-->
 
@@ -272,7 +272,7 @@
 
         <orderedlist>
           <listitem>
-            <para>Download the sample data file from the HPCC Systems
+            <para>Download the sample data file from the HPCC Systems<superscript>®</superscript>
             portal.</para>
 
             <para>The data file is available from links found on <ulink

--- a/docs/HPCCMonitoring/HPCCMonitoringAndReporting.xml
+++ b/docs/HPCCMonitoring/HPCCMonitoringAndReporting.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para> HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies. </para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -61,8 +61,8 @@
   <chapter id="GangliaIntroduction">
     <title>Introduction</title>
 
-    <para>The HPCC systems platform supports graphical monitoring and
-    reporting components.</para>
+    <para>The HPCC Systems<superscript>®</superscript> platform supports
+    graphical monitoring and reporting components.</para>
 
     <para><emphasis role="bold">Ganglia:</emphasis></para>
 
@@ -266,8 +266,8 @@
           <para>To get the HPCC Monitoring components, find the appropriate
           package for your system.</para>
 
-          <para>Packages are available for download from the HPCC Systems
-          site:</para>
+          <para>Packages are available for download from the HPCC
+          Systems<superscript>®</superscript> site:</para>
 
           <para><ulink
           url="http://hpccsystems.com/download">hpccsystems.com/download</ulink></para>
@@ -355,8 +355,8 @@
         </listitem>
 
         <listitem>
-          <para>Install the HPCC Systems monitoring component on every
-          node.</para>
+          <para>Install the HPCC Systems<superscript>®</superscript>
+          monitoring component on every node.</para>
         </listitem>
 
         <listitem>
@@ -581,7 +581,7 @@
       <para>The HPCC Nagios package provides tools and utilities for
       generating Nagios configurations. These configurations check HPCC and
       perform some of the HPCC specific checks. HPCC Nagios installation is
-      provided on the HPCC Systems portal.</para>
+      provided on the HPCC Systems<superscript>®</superscript> portal.</para>
 
       <sect2 id="HPCC_Nagios_Installation">
         <title>HPCC Nagios Installation Package</title>
@@ -590,8 +590,9 @@
         Installation package. Download the installation package from the HPCC
         Systems portal.</para>
 
-        <para>The HPCC Systems web portal is where you can find HPCC
-        resources, downloads, plug-ins, as well as helpful information.</para>
+        <para>The HPCC Systems<superscript>®</superscript> web portal is where
+        you can find HPCC resources, downloads, plug-ins, as well as helpful
+        information.</para>
 
         <para><ulink
         url="http://hpccsystems.com/download/free-community-edition/monitoring">http://hpccsystems.com/</ulink></para>

--- a/docs/IMDB/IMDB.xml
+++ b/docs/IMDB/IMDB.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -48,7 +48,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UnityLauncher.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UnityLauncher.xml
@@ -17,7 +17,7 @@
         <listitem>
           <para>This is only useful on a single-node system at this time.
           Future versions may operate in a different manner and support
-          multi-node HPCC systems.</para>
+          multi-node HPCC systems<superscript>®</superscript>.</para>
         </listitem>
       </varlistentry>
     </variablelist></para>
@@ -27,8 +27,8 @@
 
     <orderedlist numeration="arabic">
       <listitem>
-        <para>Use the search on Dash Home to find the HPCC Systems application
-        icon.</para>
+        <para>Use the search on Dash Home to find the HPCC
+        Systems<superscript>®</superscript> application icon.</para>
 
         <figure>
           <title>HPCC Application Icon</title>

--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
@@ -11,10 +11,11 @@
   <sect2 id="User_Security_Intro">
     <title>Introduction</title>
 
-    <para>HPCC systems maintains security in a number of ways. HPCC Systems
-    can be configured to manage users' security rights by pointing either at
-    Microsoft’s Active Directory on a Windows system, or a 389Directory Server
-    on Linux systems.</para>
+    <para>HPCC systems<superscript>®</superscript> maintains security in a
+    number of ways. HPCC Systems<superscript>®</superscript> can be configured
+    to manage users' security rights by pointing either at Microsoft’s Active
+    Directory on a Windows system, or a 389Directory Server on Linux
+    systems.</para>
 
     <para>Using the Permissions interface in ECL Watch, administrators can
     control access to features in ECL IDE, ECL Watch, ECL Plus, DFU Plus, and

--- a/docs/RDDERef/RDDERef.xml
+++ b/docs/RDDERef/RDDERef.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -48,7 +48,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -2126,7 +2126,7 @@ OUTPUT(ValidWords)
           </listitem>
 
           <listitem>
-            <para>The HPCC Systems Portal (<ulink
+            <para>The HPCC Systems<superscript>®</superscript> Portal (<ulink
             url="http://hpccsystems.com">http://hpccsystems.com</ulink>) is
             another valuable resource for more information including:</para>
 
@@ -2182,8 +2182,8 @@ OUTPUT(ValidWords)
 
           <answer>
             <para>No. If you want to evaluate a multi-node system, you should
-            use the Community version available from the HPCC Systems Portal
-            at <ulink
+            use the Community version available from the HPCC
+            Systems<superscript>®</superscript> Portal at <ulink
             url="http://hpccsystems.com">http://hpccsystems.com</ulink>.</para>
           </answer>
         </qandaentry>
@@ -2313,7 +2313,7 @@ OUTPUT(ValidWords)
           </question>
 
           <answer>
-            <para>Visit the HPCC Systems Portal at
+            <para>Visit the HPCC Systems<superscript>®</superscript> Portal at
             http://HPCCsystems.com.</para>
           </answer>
         </qandaentry>

--- a/docs/UsingConfigManager/UsingConfigManager.xml
+++ b/docs/UsingConfigManager/UsingConfigManager.xml
@@ -27,8 +27,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -46,7 +46,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/Visualizing/Visualizing.xml
+++ b/docs/Visualizing/Visualizing.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -48,7 +48,7 @@
     <xi:include href="common/Version.xml" xpointer="DateVer"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <corpname>HPCC Systems</corpname>
+    <corpname>HPCC Systems<superscript>®</superscript></corpname>
 
     <xi:include href="common/Version.xml" xpointer="Copyright"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/common/Version.xml
+++ b/docs/common/Version.xml
@@ -5,11 +5,12 @@
   <chapterinfo>
     <date id="DateVer">DEVELOPER NON-GENERATED VERSION</date>
 
-    <releaseinfo id="FooterInfo">© 2015 HPCC Systems. All rights
-    reserved</releaseinfo>
+    <releaseinfo id="FooterInfo">© 2015 HPCC
+    Systems<superscript>®</superscript>. All rights reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2015 HPCC Systems. All rights reserved</year>
+      <year>2015 HPCC Systems<superscript>®</superscript>. All rights
+      reserved</year>
     </copyright>
   </chapterinfo>
 

--- a/docs/common/Version.xml.in
+++ b/docs/common/Version.xml.in
@@ -5,11 +5,12 @@
   <chapterinfo>
     <date id="DateVer">2015 Version ${DOC_VERSION}</date>
 
-    <releaseinfo id="FooterInfo">© 2015 HPCC Systems. All rights
-    reserved</releaseinfo>
+    <releaseinfo id="FooterInfo">© 2015 HPCC
+    Systems<superscript>®</superscript>. All rights reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2015 HPCC Systems. All rights reserved</year>
+      <year>2015 HPCC Systems<superscript>®</superscript>. All rights
+      reserved</year>
     </copyright>
   </chapterinfo>
 

--- a/docs/wip/DaliAdmin.xml
+++ b/docs/wip/DaliAdmin.xml
@@ -29,8 +29,8 @@
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
       of Reed Elsevier Properties Inc., used under license.</para>
 
-      <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
-      Management Inc.</para>
+      <para>HPCC Systems<superscript>®</superscript> is a registered trademark
+      of LexisNexis Risk Data Management Inc.</para>
 
       <para>Other products, logos, and services may be trademarks or
       registered trademarks of their respective companies.</para>
@@ -42,14 +42,15 @@
       <para></para>
     </legalnotice>
 
-    <releaseinfo>© 2011 HPCC Systems. All rights reserved</releaseinfo>
+    <releaseinfo>© 2015 HPCC Systems<superscript>®</superscript>. All rights
+    reserved</releaseinfo>
 
     <date>3.0.0_x</date>
 
     <corpname>HPCC Systems</corpname>
 
     <copyright>
-      <year>May, 2011</year>
+      <year>May, 2015</year>
     </copyright>
 
     <mediaobject role="logo">


### PR DESCRIPTION
FIX HPCC-13067 DOCS:Add marca registrada symbol
Add marca registrada symbol to every instance of
HPCC Systems in the code for all docs.
Also ensured that doing so did not change the encoding
for the docs and result in applications reporting corrupt files.
REBASED OFF Candidate-5.2.0 to Resolve potential merger conflicts.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com

@JamesDeFabia please review
