### PR TITLE
HPCC-13078 Auto close password dialog after save

### DIFF
--- a/esp/src/eclwatch/CurrentUserDetailsWidget.js
+++ b/esp/src/eclwatch/CurrentUserDetailsWidget.js
@@ -66,6 +66,7 @@ define([
 
         //  Hitched actions  ---
         _onSave: function (event) {
+            var dialog = dijit.byId("stubUserDialog");
             if (this.userForm.validate()) {
                 var formInfo = domForm.toObject(this.id + "UserForm");
                 WsAccount.UpdateUser({
@@ -77,6 +78,7 @@ define([
                         newpass2: formInfo.newPassword
                     }
                 });
+                dialog.hide();
             }
         },
 

--- a/esp/src/eclwatch/templates/CurrentUserDetailsWidget.html
+++ b/esp/src/eclwatch/templates/CurrentUserDetailsWidget.html
@@ -23,16 +23,16 @@
                     </li>
                     <li>
                         <label class="Prompt" for="${id}OldPassword">${i18n.OldPassword}:</label>
-                        <input name="oldPassword" type="password" data-dojo-type="dijit.form.ValidationTextBox" />
+                        <input name="oldPassword" type="password" required="true" data-dojo-type="dijit.form.ValidationTextBox" />
                     </li>
                     <div name="newPassword" data-dojo-props="required: false" data-dojo-type="dojox.form.PasswordValidator">
                         <li>
                             <label class="Prompt" for="${id}NewPassword">${i18n.NewPassword}:</label>
-                            <input name="newPassword" type="password" pwtype="new" data-dojo-props="invalidMessage:'${i18n.PasswordsDoNotMatch}', placeHolder:'${i18n.MustContainUppercaseAndSymbol}'" data-dojo-type="dijit.form.ValidationTextBox" />
+                            <input name="newPassword" type="password" required="true" pwtype="new" data-dojo-props="invalidMessage:'${i18n.PasswordsDoNotMatch}', placeHolder:'${i18n.MustContainUppercaseAndSymbol}'" data-dojo-type="dijit.form.ValidationTextBox" />
                         </li>
                         <li>
                             <label class="Prompt" for="${id}VerifyPassword">${i18n.ConfirmPassword}:</label>
-                            <input name="newPasswordRetype" type="password" pwtype="verify" data-dojo-props="invalidMessage:'${i18n.PasswordsDoNotMatch}', placeHolder:'${i18n.MustContainUppercaseAndSymbol}'" data-dojo-type="dijit.form.ValidationTextBox" />
+                            <input name="newPasswordRetype" type="password" required="true" pwtype="verify" data-dojo-props="invalidMessage:'${i18n.PasswordsDoNotMatch}', placeHolder:'${i18n.MustContainUppercaseAndSymbol}'" data-dojo-type="dijit.form.ValidationTextBox" />
                         </li>
                     </div>
                     <li>


### PR DESCRIPTION
Close dialog only after save is successful. If the password does not validate keep dialog open so that the user can fix his/her errors.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
