### PR TITLE
HPCC-13115 Add //fail tag for all 'have to fail' Regression Suite test cases

### DIFF
--- a/testing/regress/ecl/failrestart.ecl
+++ b/testing/regress/ecl/failrestart.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+//fail
+
 //The first time this workunit executes it gets an exception in a conditional workflow item.
 //If it is "recovered" the condition must be re-evaluated (otherwise the false branch is taken the
 //second time.

--- a/testing/regress/ecl/layouttrans_disabled.ecl
+++ b/testing/regress/ecl/layouttrans_disabled.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+//fail
+
 //class=error
 
 import ^ as root;

--- a/testing/regress/ecl/superfile6.ecl
+++ b/testing/regress/ecl/superfile6.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+//fail
+
 import Std.File AS FileServices;
 // Super File added to itself test
 


### PR DESCRIPTION
Add tag to

```
- failrestart.ecl
- layouttrans_disabled.ecl
- superfile6.ecl
```

Signed-off-by: Attila Vamos attila.vamos@gmail.com
