### PR TITLE
HPCC-11917 Full keyed joins fail or worse unless key was remote

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -26,9 +26,10 @@
 class CKeyedJoinMaster : public CMasterActivity
 {
     IHThorKeyedJoinArg *helper;
+    Owned<IFileDescriptor> dataFileDesc;
     Owned<CSlavePartMapping> dataFileMapping;
     MemoryBuffer offsetMapMb, initMb;
-    bool localKey;
+    bool localKey, remoteDataFiles;
     unsigned numTags;
     mptag_t tags[4];
     ProgressInfoArray progressInfoArr;
@@ -58,6 +59,7 @@ public:
         numTags = 0;
         tags[0] = tags[1] = tags[2] = tags[3] = TAG_NULL;
         reInit = 0 != (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename));
+        remoteDataFiles = false;
     }
     ~CKeyedJoinMaster()
     {
@@ -208,7 +210,7 @@ public:
                         {
                             if (superIndex)
                                 throw MakeActivityException(this, 0, "Superkeys and full keyed joins are not supported");
-                            Owned<IFileDescriptor> dataFileDesc = getConfiguredFileDescriptor(*dataFile);
+                            dataFileDesc.setown(getConfiguredFileDescriptor(*dataFile));
                             void *ekey;
                             size32_t ekeylen;
                             helper->getFileEncryptKey(ekeylen,ekey);
@@ -225,12 +227,26 @@ public:
                             }
                             else if (encrypted)
                                 throw MakeActivityException(this, 0, "File '%s' was published as encrypted but no encryption key provided", dataFile->queryLogicalName());
-                            unsigned dataReadWidth = (unsigned)container.queryJob().getWorkUnitValueInt("KJDRR", 0);
-                            if (!dataReadWidth || dataReadWidth>container.queryJob().querySlaves())
-                                dataReadWidth = container.queryJob().querySlaves();
-                            Owned<IGroup> grp = container.queryJob().querySlaveGroup().subset((unsigned)0, dataReadWidth);
-                            dataFileMapping.setown(getFileSlaveMaps(dataFile->queryLogicalName(), *dataFileDesc, container.queryJob().queryUserDescriptor(), *grp, false, false, NULL));
-                            dataFileMapping->serializeFileOffsetMap(offsetMapMb.clear());
+
+                            /* If fetch file is local to cluster, fetches are sent to be processed to local node, each node has info about it's
+                             * local parts only.
+                             * If fetch file is off cluster, fetches are performed by requesting node directly on fetch part, therefore each nodes
+                             * needs all part descriptors.
+                             */
+                            remoteDataFiles = false;
+                            RemoteFilename rfn;
+                            dataFileDesc->queryPart(0)->getFilename(0, rfn);
+                            if (!rfn.queryIP().ipequals(container.queryJob().querySlaveGroup().queryNode(0).endpoint()))
+                                remoteDataFiles = true;
+                            if (!remoteDataFiles) // local to cluster
+                            {
+                                unsigned dataReadWidth = (unsigned)container.queryJob().getWorkUnitValueInt("KJDRR", 0);
+                                if (!dataReadWidth || dataReadWidth>container.queryJob().querySlaves())
+                                    dataReadWidth = container.queryJob().querySlaves();
+                                Owned<IGroup> grp = container.queryJob().querySlaveGroup().subset((unsigned)0, dataReadWidth);
+                                dataFileMapping.setown(getFileSlaveMaps(dataFile->queryLogicalName(), *dataFileDesc, container.queryJob().queryUserDescriptor(), *grp, false, false, NULL));
+                                dataFileMapping->serializeFileOffsetMap(offsetMapMb.clear());
+                            }
                         }
                         else
                             indexFile.clear();
@@ -258,8 +274,19 @@ public:
             IDistributedFile *dataFile = queryReadFile(1);
             if (dataFile)
             {
-                dataFileMapping->serializeMap(slave, dst);
-                dst.append(offsetMapMb);
+                dst.append(remoteDataFiles);
+                if (remoteDataFiles)
+                {
+                    UnsignedArray parts;
+                    parts.append((unsigned)-1); // weird convention meaning all
+                    dst.append(dataFileDesc->numParts());
+                    dataFileDesc->serializeParts(dst, parts);
+                }
+                else
+                {
+                    dataFileMapping->serializeMap(slave, dst);
+                    dst.append(offsetMapMb);
+                }
             }
             else
             {

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -531,7 +531,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
     CPartDescriptorArray indexParts, dataParts;
     Owned<IKeyIndexSet> tlkKeySet, partKeySet;
     IThorDataLink *input;
-    bool preserveGroups, preserveOrder, eos, inputStopped, needsDiskRead, atMostProvided, dataRemote;
+    bool preserveGroups, preserveOrder, eos, inputStopped, needsDiskRead, atMostProvided, remoteDataFiles;
     unsigned joinFlags, abortLimit, parallelLookups, freeQSize, filePartTotal;
     size32_t fixedRecordSize;
     CJoinGroupPool *pool;
@@ -545,7 +545,8 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
     OwnedConstThorRow defaultRight;
     unsigned portbase, node;
     IArrayOf<IDelayedFile> fetchFiles;
-    FPosTableEntry *fPosToNodeMap; // maps fpos->node for all parts of logical file
+    FPosTableEntry *_fPosToNodeMap; // maps fpos->node for all parts of logical file
+    FPosTableEntry *fPosToNodeMap; // If remoteDataFiles, this will point to fPosToLocalPartMap
     FPosTableEntry *fPosToLocalPartMap; // maps fpos->local part #
     unsigned pendingGroups, superWidth;
     Semaphore pendingGroupSem;
@@ -789,6 +790,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
 
                                 unsigned __int64 localFpos;
                                 unsigned files = owner.dataParts.ordinality();
+                                FPosTableEntry *fPosMap = owner.remoteDataFiles ? owner.fPosToNodeMap : owner.fPosToLocalPartMap;
                                 unsigned filePartIndex = 0;
                                 switch (files)
                                 {
@@ -799,13 +801,13 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                                         if (isLocalFpos(fpos))
                                             localFpos = getLocalFposOffset(fpos);
                                         else
-                                            localFpos = fpos-owner.fPosToLocalPartMap[0].base;
+                                            localFpos = fpos-fPosMap[0].base;
                                         break;
                                     }
                                     default:
                                     {
                                         // which of multiple parts this slave is dealing with.
-                                        FPosTableEntry *result = (FPosTableEntry *)bsearch(&fpos, owner.fPosToLocalPartMap, files, sizeof(FPosTableEntry), partLookup);
+                                        FPosTableEntry *result = (FPosTableEntry *)bsearch(&fpos, fPosMap, files, sizeof(FPosTableEntry), partLookup);
                                         if (isLocalFpos(fpos))
                                             localFpos = getLocalFposOffset(fpos);
                                         else
@@ -949,7 +951,7 @@ class CKeyedJoinSlave : public CSlaveActivity, public CThorDataLink, implements 
                 totalSz = 0;
             }
             unsigned dstNode;
-            if (owner.dataRemote)
+            if (owner.remoteDataFiles)
                 dstNode = owner.node; // JCSMORE - do directly
             else
             {
@@ -1583,9 +1585,9 @@ public:
         additionalStats = 0;
         lastSeeks = lastScans = 0;
         onFailTransform = localKey = keyHasTlk = false;
-        dataRemote = false;
+        remoteDataFiles = false;
         fetchHandler = NULL;
-        fPosToNodeMap = NULL;
+        _fPosToNodeMap = fPosToNodeMap = NULL;
         fPosToLocalPartMap = NULL;
 
 #ifdef TRACE_USAGE
@@ -1599,7 +1601,7 @@ public:
     }
     ~CKeyedJoinSlave()
     {
-        delete [] fPosToNodeMap;
+        delete [] _fPosToNodeMap;
         delete [] fPosToLocalPartMap;
         while (doneGroups.ordinality())
         {
@@ -1815,7 +1817,7 @@ public:
         rowLimit = (rowcount_t)helper->getRowLimit();
         additionalStats = 5; // (seeks, scans, accepted, prefiltered, postfiltered)
         needsDiskRead = helper->diskAccessRequired();
-        fPosToNodeMap = NULL;
+        _fPosToNodeMap = fPosToNodeMap = NULL;
         fPosToLocalPartMap = NULL;
         fetchHandler = NULL;
         filePartTotal = 0;
@@ -1920,17 +1922,12 @@ public:
             }
             if (needsDiskRead)
             {
+                data.read(remoteDataFiles); // if true, all fetch parts will be serialized
                 unsigned numDataParts;
                 data.read(numDataParts);
-                size32_t offsetMapSz = 0;
                 if (numDataParts)
                 {
                     deserializePartFileDescriptors(data, dataParts);
-                    RemoteFilename rfn;
-                    dataParts.item(0).getFilename(0, rfn);
-                    if (!rfn.queryIP().ipequals(container.queryJob().queryJobGroup().queryNode(0).endpoint()))
-                        dataRemote = true;
-
                     fPosToLocalPartMap = new FPosTableEntry[numDataParts];
                     unsigned f;
                     FPosTableEntry *e;
@@ -1942,13 +1939,25 @@ public:
                         e->index = f; // NB: index == which local part in dataParts
                     }
                 }
-                data.read(filePartTotal);
-                if (filePartTotal)
+                if (remoteDataFiles) // global offset map not needed if remote and have all fetch parts inc. map (from above)
                 {
-                    data.read(offsetMapSz);
-                    fPosToNodeMap = new FPosTableEntry[filePartTotal];
-                    const void *offsetMapBytes = (FPosTableEntry *)data.readDirect(offsetMapSz);
-                    memcpy(fPosToNodeMap, offsetMapBytes, offsetMapSz);       
+                    if (numDataParts)
+                    {
+                        filePartTotal = numDataParts;
+                        fPosToNodeMap = fPosToLocalPartMap;
+                    }
+                }
+                else
+                {
+                    data.read(filePartTotal);
+                    if (filePartTotal)
+                    {
+                        size32_t offsetMapSz = 0;
+                        data.read(offsetMapSz);
+                        fPosToNodeMap = _fPosToNodeMap = new FPosTableEntry[filePartTotal];
+                        const void *offsetMapBytes = (FPosTableEntry *)data.readDirect(offsetMapSz);
+                        memcpy(fPosToNodeMap, offsetMapBytes, offsetMapSz);
+                    }
                 }
                 unsigned encryptedKeyLen;
                 void *encryptedKey;


### PR DESCRIPTION
If the key file was remote (not part of cluster the query is
running on), then instead of sending the key fetch request to
the node in the local cluster which has the fetch part locally,
it should access the fetch directly from the requesting slaves.
However, for that to work, each slave had to have the full set
of fetch parts and correctly map the fpos to the correct part.

That logic was misisng, this PR detects if fetch file is remote
and ensures all slaves have access to all parts.

Also, unless the master happened to be on the same IP as slave 1,
it incorrectly thought the key was remote and failed for the
reasons above.

The upshot of above, was that Full Keyed Joins were essentially
broken unless running on a thor cluster with slaves on same IP
as master.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
