### PR TITLE
HPCC-12990 Fix wrong function name caused by rebase

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1242,7 +1242,7 @@ bool HqlCppInstance::useFunction(IHqlExpression * func)
     if (include.length())
         useInclude(include.str());
     if (source.length())
-        useSource(source);
+        useSourceFile(source);
     return true;
 }
 
@@ -7463,7 +7463,7 @@ void HqlCppTranslator::processCppBodyDirectives(IHqlExpression * expr)
                 StringBuffer sourceName;
                 getStringValue(sourceName, cur->queryChild(0));
                 if (sourceName.length())
-                    code->useSource(sourceName.str());
+                    code->useSourceFile(sourceName.str());
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
