### PR TITLE
HPCC-13042 Set WsTopology.default_client_version to 1.21

### DIFF
--- a/esp/scm/ws_topology.ecm
+++ b/esp/scm/ws_topology.ecm
@@ -583,7 +583,7 @@ ESPresponse [exceptions_inline,encode(0)] TpGetServicePluginsResponse
     ESParray<ESPstruct TpEspServicePlugin, Plugin> Plugins;
 };
 
-ESPservice [noforms, version("1.21"), default_client_version("1.20"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsTopology
+ESPservice [noforms, version("1.21"), default_client_version("1.21"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsTopology
 {
     ESPuses ESPStruct TpBinding;
     ESPuses ESPstruct TpCluster;


### PR DESCRIPTION
Existing ECLWatch UI uses the default_client_version to
access ESP service. The WsTopology.default_client_version
has to be set to 1.21 in order for ECLWatch to get the
replicateOutputs option.

Right now, if a SOAP client does not specify its version
inside a SOAP call, ESP will use 0 as the version. Therefore,
incrementing the default_client_version will not break SOAP
client even if the SOAP client does not send its version.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
