### PR TITLE
HPCC-13147 Build errors on Windows 64 bit

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -892,7 +892,7 @@ unsigned getAffinityCpus()
 {
     unsigned numCpus = 0;
     DWORD ProcessAffinityMask, SystemAffinityMask;
-    if (GetProcessAffinityMask(GetCurrentProcess(), &ProcessAffinityMask, &SystemAffinityMask))
+    if (GetProcessAffinityMask(GetCurrentProcess(), (PDWORD_PTR)&ProcessAffinityMask, (PDWORD_PTR)&SystemAffinityMask))
     {
         unsigned i = 0;
         while (ProcessAffinityMask)

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -2745,12 +2745,12 @@ public:
             m_ldapconfig->getLdapHost(server);
             fullserver.append(server.str());
             LPWSTR whost = (LPWSTR)alloca((fullserver.length() +1) * sizeof(WCHAR));
-            ConvertCToW(whost, fullserver.str());
+            ConvertCToW((unsigned short *)whost, fullserver.str());
 
             LPWSTR wusername = (LPWSTR)alloca((strlen(username) + 1) * sizeof(WCHAR));
-            ConvertCToW(wusername, username);
+            ConvertCToW((unsigned short *)wusername, username);
             LPWSTR wnewpasswd = (LPWSTR)alloca((strlen(newPassword) + 1) * sizeof(WCHAR));
-            ConvertCToW(wnewpasswd, newPassword);
+            ConvertCToW((unsigned short *)wnewpasswd, newPassword);
             usriSetPassword.usri1003_password  = wnewpasswd;
             nStatus = NetUserSetInfo(whost, wusername,  1003, (LPBYTE)&usriSetPassword, NULL);
 


### PR DESCRIPTION
When building windows 64 bit, there are several simple compile errors.
jdebug.cpp line 895 (GetProcessAffinityMask)
ldapconnection.cpp 2747,2751,2753 (ConvertCToW)
This PR fixes the ones in JLIB and esphttp lib

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
