### PR TITLE
HPCC-13140 Packet size exceeded on one-way Roxie with dynamic file lookup

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -148,10 +148,11 @@ private:
     RoxiePacketHeader(const RoxiePacketHeader &source);
 
 public:
-    unsigned short packetlength;
+    unsigned packetlength;
     unsigned short retries;         // how many retries on this query, the high bits are used as flags, see above
     unsigned short overflowSequence;// Used if more than one packet-worth of data from server - eg keyed join. We don't mind if we wrap...
     unsigned short continueSequence;// Used if more than one chunk-worth of data from slave. We don't mind if we wrap 
+    unsigned short channel;         // multicast family to send on
     unsigned activityId;            // identifies the helper factory to be used (activityId in graph)
     hash64_t queryHash;             // identifies the query
 
@@ -160,7 +161,6 @@ public:
 #ifdef TIME_PACKETS
     unsigned tick;
 #endif
-    unsigned short channel;         // multicast family to send on
 
     inline RoxiePacketHeader(const RemoteActivityId &_remoteId, ruid_t _uid, unsigned _channel, unsigned _overflowSequence)
     {

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -429,7 +429,7 @@ public:
 
 extern IRoxieQueryPacket *createRoxiePacket(void *_data, unsigned _len)
 {
-    if ((unsigned short)_len != _len)
+    if ((unsigned short)_len != _len && !localSlave)
     {
         StringBuffer s;
         RoxiePacketHeader *header = (RoxiePacketHeader *) _data;


### PR DESCRIPTION
No need to enforce a packet size limit when localSlave set, and should render
this issue moot (for all common usage cases)

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
