### PR TITLE
HPCC-13042 Disable replicate where needed

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -51,6 +51,7 @@ define([
     "hpcc/TargetSelectWidget",
     "hpcc/FilterDropDownWidget",
     "hpcc/SelectionGridWidget",
+    "hpcc/WsTopology",
 
     "put-selector/put",
 
@@ -77,7 +78,7 @@ define([
 ], function (declare, lang, i18n, nlsHPCC, arrayUtil, dom, domAttr, domConstruct, domClass, domForm, date, on, topic,
                 registry, Dialog, Menu, MenuItem, MenuSeparator, PopupMenuItem, Textarea, ValidationTextBox,
                 editor, selector, tree,
-                _TabContainerWidget, WsDfu, FileSpray, ESPUtil, ESPLogicalFile, ESPDFUWorkunit, DelayLoadWidget, TargetSelectWidget, FilterDropDownWidget, SelectionGridWidget,
+                _TabContainerWidget, WsDfu, FileSpray, ESPUtil, ESPLogicalFile, ESPDFUWorkunit, DelayLoadWidget, TargetSelectWidget, FilterDropDownWidget, SelectionGridWidget, WsTopology,
                 put,
                 template) {
     return declare("DFUQueryWidget", [_TabContainerWidget, ESPUtil.FormHelper], {
@@ -102,6 +103,7 @@ define([
             this.desprayForm = registry.byId(this.id + "DesprayForm");
             this.desprayTargetSelect = registry.byId(this.id + "DesprayTargetSelect");
             this.desprayGrid = registry.byId(this.id + "DesprayGrid");
+            this.remoteCopyReplicateCheckbox = registry.byId(this.id + "RemoteCopyReplicate");
         },
 
         startup: function (args) {
@@ -297,6 +299,9 @@ define([
             this.importTargetSelect.init({
                 Groups: true
             });
+             this.importTargetSelect.on('change', function (value){
+                context.checkReplicate(value, context.remoteCopyReplicateCheckbox);
+            });
             this.copyTargetSelect.init({
                 Groups: true
             });
@@ -393,6 +398,27 @@ define([
             }
             pMenu.startup();
         },
+
+        checkReplicate: function (value, checkBoxValue) {
+            var context = this;
+            WsTopology.TpGroupQuery({
+                request: {}
+            }).then(function (response) {
+                if (lang.exists("TpGroupQueryResponse.TpGroups.TpGroup", response)) {
+                    var arr = response.TpGroupQueryResponse.TpGroups.TpGroup;
+                    for (var index in arr) {
+                        if (arr[index].Name === value && arr[index].ReplicateOutputs === true) {
+                            checkBoxValue.set("disabled", false);
+                            break;
+                        } else if (arr[index].Name === value) {
+                            checkBoxValue.set("disabled", true);
+                            break;
+                        }
+                    }
+                }
+            });
+        },
+
 
         initWorkunitsGrid: function () {
             var context = this;

--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -105,6 +105,11 @@ define([
             this.dropZoneFolderSelect = registry.byId(this.id + "DropZoneFolderSelect");
             this.fileListDialog = registry.byId(this.id + "FileListDialog");
             this.overwriteCheckbox = registry.byId(this.id + "FileOverwriteCheckbox");
+            this.fixedSprayReplicateCheckbox = registry.byId(this.id + "FixedSprayReplicate");
+            this.delimitedSprayReplicateCheckbox = registry.byId(this.id + "DelimitedSprayReplicate");
+            this.xmlSprayReplicateCheckbox = registry.byId(this.id + "XMLSprayReplicate");
+            this.variableSprayReplicateCheckbox = registry.byId(this.id + "VariableSprayReplicate");
+            this.blobSprayReplicateCheckbox = registry.byId(this.id + "BlobSprayReplicate");
 
             var context = this;
             this.connect(this.uploader, "onComplete", function (response) {
@@ -468,6 +473,46 @@ define([
             this.dropZoneFolderSelect.init({
                 DropZoneFolders: true,
                 includeBlank: true
+            })
+            
+            this.sprayFixedDestinationSelect.on('change', function (value){
+                context.checkReplicate(value, context.fixedSprayReplicateCheckbox);
+            });
+
+            this.sprayDelimitedDestinationSelect.on('change', function (value){
+                context.checkReplicate(value, context.delimitedSprayReplicateCheckbox);
+            });
+
+            this.sprayXmlDestinationSelect.on('change', function (value){
+                context.checkReplicate(value, context.xmlSprayReplicateCheckbox);
+            });
+
+            this.sprayVariableDestinationSelect.on('change', function (value){
+                context.checkReplicate(value, context.variableSprayReplicateCheckbox);
+            });
+
+            this.sprayBlobDestinationSelect.on('change', function (value){
+                context.checkReplicate(value, context.blobSprayReplicateCheckbox);
+            });
+        },
+
+        checkReplicate: function (value, checkBoxValue) {
+            var context = this;
+            FileSpray.GetSprayTargets({
+                request: {}
+            }).then(function (response) {
+                if (lang.exists("GetSprayTargetsResponse.GroupNodes.GroupNode", response)) {
+                    var arr = response.GetSprayTargetsResponse.GroupNodes.GroupNode;
+                    for (var index in arr) {
+                        if (arr[index].Name === value && arr[index].ReplicateOutputs === true) {
+                            checkBoxValue.set("disabled", false);
+                            break;
+                        } else if (arr[index].Name === value) {
+                            checkBoxValue.set("disabled", true);
+                            break;
+                        }
+                    }
+                }
             });
         },
 

--- a/esp/src/eclwatch/templates/DFUQueryWidget.html
+++ b/esp/src/eclwatch/templates/DFUQueryWidget.html
@@ -35,7 +35,7 @@
                                         <input title="${i18n.NoSplit}:" name="nosplit" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.Wrap}:" name="Wrap" data-dojo-type="dijit.form.CheckBox" />
-                                        <input title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}RemoteCopyReplicate"title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.RetainSuperfileStructure}:" name="superCopy" data-dojo-type="dijit.form.CheckBox" />
                                     </div>
                                 </div>

--- a/esp/src/eclwatch/templates/LZBrowseWidget.html
+++ b/esp/src/eclwatch/templates/LZBrowseWidget.html
@@ -45,7 +45,7 @@
                                     <legend>${i18n.Options}</legend>
                                     <div data-dojo-props="cols:2" data-dojo-type="hpcc.TableContainer">
                                         <input title="${i18n.Overwrite}:" name="overwrite" data-dojo-type="dijit.form.CheckBox" />
-                                        <input title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}FixedSprayReplicate" title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.NoSplit}:" name="nosplit" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.FailIfNoSourceFile}:" name="failIfNoSourceFile" data-dojo-type="dijit.form.CheckBox" />
@@ -91,7 +91,7 @@
                                         <input id="${id}SprayDelimitedTerminators" title="${i18n.LineTerminators}:" name="sourceCsvTerminate" style="width: 95%;" value="\n,\r\n" required="true" colspan="2" data-dojo-props="trim: true, placeHolder:'\\n,\\r\\n'" data-dojo-type="dijit.form.ValidationTextBox" />
                                         <input id="${id}SprayDelimitedQuote" title="${i18n.Quote}:" style="width: 95%;" name="sourceCsvQuote" value='"' data-data-dojo-props="trim: true, placeHolder:'\''" colspan="2" data-dojo-type="dijit.form.TextBox" />
                                         <input title="${i18n.Overwrite}:" name="overwrite" data-dojo-type="dijit.form.CheckBox" />
-                                        <input title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}DelimitedSprayReplicate" title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.NoSplit}:" name="nosplit" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.FailIfNoSourceFile}:" name="failIfNoSourceFile" data-dojo-type="dijit.form.CheckBox" />
@@ -133,7 +133,7 @@
                                         </select>
                                         <input id="${id}SprayXmlMaxRecordLength" title="${i18n.MaxRecordLength}:" value="8192" style="width: 95%;" name="sourceMaxRecordSize" required="true" colspan="2" data-dojo-props="trim: true, placeHolder:'8192'" data-dojo-type="dijit.form.ValidationTextBox" />
                                         <input title="${i18n.Overwrite}:" name="overwrite" data-dojo-type="dijit.form.CheckBox" />
-                                        <input title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}XMLSprayReplicate" title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.NoSplit}:" name="nosplit" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.FailIfNoSourceFile}:" name="failIfNoSourceFile" data-dojo-type="dijit.form.CheckBox" />
@@ -173,7 +173,7 @@
                                         </select>
                                         <input id="${id}SprayJsonMaxRecordLength" title="${i18n.MaxRecordLength}:" value="8192" style="width: 95%;" name="sourceMaxRecordSize" required="true" colspan="2" data-dojo-props="trim: true, placeHolder:'8192'" data-dojo-type="dijit.form.ValidationTextBox" />
                                         <input title="${i18n.Overwrite}:" name="overwrite" data-dojo-type="dijit.form.CheckBox" />
-                                        <input title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}JSONSprayReplicate" title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.NoSplit}:" name="nosplit" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.FailIfNoSourceFile}:" name="failIfNoSourceFile" data-dojo-type="dijit.form.CheckBox" />
@@ -208,7 +208,7 @@
                                             <option value="variablebigendian">${i18n.VariableBigendian}</option>
                                         </select>
                                         <input title="${i18n.Overwrite}:" name="overwrite" data-dojo-type="dijit.form.CheckBox" />
-                                        <input title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}VariableSprayReplicate" title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.NoSplit}:" name="nosplit" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.FailIfNoSourceFile}:" name="failIfNoSourceFile" data-dojo-type="dijit.form.CheckBox" />
@@ -238,7 +238,7 @@
                                     <div data-dojo-props="cols:2" data-dojo-type="hpcc.TableContainer">
                                         <input title="${i18n.BlobPrefix}:" style="width: 95%;" name="prefix" data-dojo-props="trim: true, placeHolder:'${i18n.PrefixPlaceholder}'" colspan="2" data-dojo-type="dijit.form.TextBox" />
                                         <input title="${i18n.Overwrite}:" name="overwrite" data-dojo-type="dijit.form.CheckBox" />
-                                        <input title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}BlobSprayReplicate" title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.NoSplit}:" name="nosplit" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input title="${i18n.FailIfNoSourceFile}:" name="failIfNoSourceFile" data-dojo-type="dijit.form.CheckBox" />


### PR DESCRIPTION
Disable replicate option within spray options and remote copy within logical files when not available.

Signed-off-by: Miguel Vazquez miguel.vazquez@lexisnexis.com
