### PR TITLE
HPCC-13116 Spurious non-fatal error message from eclcc for unloadable plugin

### DIFF
--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -404,7 +404,7 @@ HINSTANCE LoadSharedObject(const char *name, bool isGlobal, bool raiseOnError)
         if (h == NULL)
         {
             StringBuffer dlErrorMsg(dlerror());
-            DBGLOG("Error loading %s: %s", name, dlErrorMsg.str());
+            DBGLOG("Warning: Could not load %s: %s", name, dlErrorMsg.str());
             if (raiseOnError)
             {
                 if (isCorruptDll(dlErrorMsg.str()))


### PR DESCRIPTION
The error message when a plugin cannot be loaded is unhelpful.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
