### PR TITLE
HPCC-13205 Avoid spilling window in LOCAL LOOKUP JOIN

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1815,7 +1815,12 @@ protected:
                 if (!success)
                 {
                     ActPrintLog("Out of memory trying to allocate [LOCAL] tables for a SMART join (%" RIPF "d rows), will now failover to a std hash join", rhs.ordinality());
-                    Owned<IThorRowCollector> collector = createThorRowCollector(*this, queryRowInterfaces(rightITDL), NULL, stableSort_none, rc_mixed, SPILL_PRIORITY_LOOKUPJOIN);
+                    Owned<IThorRowCollector> collector;
+                    if (isSmart())
+                        collector.setown(createThorRowCollector(*this, queryRowInterfaces(rightITDL), NULL, stableSort_none, rc_mixed, SPILL_PRIORITY_LOOKUPJOIN));
+                    else
+                        collector.setown(createThorRowCollector(*this, queryRowInterfaces(rightITDL), NULL, stableSort_none, rc_allMem, SPILL_PRIORITY_DISABLE));
+
                     collector->setOptions(rcflag_noAllInMemSort); // If fits into memory, don't want it resorted
                     collector->transferRowsIn(rhs); // can spill after this
                     rightStream.setown(collector->getStream());


### PR DESCRIPTION
(This is seperate PR from PR for 5.0.8 - to avoid merge clash)

There was a window, between successfully collecting the local
rows and allocating the HT, where low memory could cause the RHS
to spill on a local lookup join and attempt a std. local join.
It would then crash unless the generated helper contained a
queryCompareLeft() operator.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
