### PR TITLE
HPCC-13216 Use relative paths based on exe current path to find resource...

### DIFF
--- a/tools/esdlcmd/esdl2ecl.cpp
+++ b/tools/esdlcmd/esdl2ecl.cpp
@@ -188,8 +188,14 @@ public:
 class Esdl2EclCmd : public EsdlConvertCmd
 {
 public:
-    Esdl2EclCmd() : optGenerateAllIncludes(false), optOutputExpandedXML(false), optHPCCCompFilesDir(COMPONENTFILES_DIR)
-    {}
+    Esdl2EclCmd() : optGenerateAllIncludes(false), optOutputExpandedXML(false)
+    {
+        StringBuffer componentsfolder;
+        if (getComponentFilesRelPathFromBin(componentsfolder))
+            optHPCCCompFilesDir.set(componentsfolder.str());
+        else
+            optHPCCCompFilesDir.set(COMPONENTFILES_DIR);
+    }
 
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
     {

--- a/tools/esdlcmd/esdlcmd_common.hpp
+++ b/tools/esdlcmd/esdlcmd_common.hpp
@@ -320,7 +320,7 @@ static bool getComponentFilesRelPathFromBin(StringBuffer & path)
 {
     if (getCurrentFolder(path))
     {
-        path.append(PATHSEPCHAR).append(HIGHER_DIR_RELATIVE).append(PATHSEPCHAR).append(COMPONENTS_DIR_NAME);
+        path.appendf("%c%s%c%s", PATHSEPCHAR, HIGHER_DIR_RELATIVE,PATHSEPCHAR,COMPONENTS_DIR_NAME);
         return true;
     }
 

--- a/tools/esdlcmd/esdlcmd_common.hpp
+++ b/tools/esdlcmd/esdlcmd_common.hpp
@@ -27,6 +27,9 @@
 #include "ws_esdlconfig_esp.ipp"
 #include "esdl2xml.hpp"
 
+#define COMPONENTS_DIR_NAME "componentfiles"
+#define HIGHER_DIR_RELATIVE ".."
+
 //=========================================================================================
 
 interface IEsdlCommand : extends IInterface
@@ -300,4 +303,27 @@ public:
     virtual void setTransformParams(IProperties *params )=0;
 };
 
+static bool getCurrentFolder(StringBuffer & path)
+{
+    StringBuffer folder;
+    splitDirTail(queryCurrentProcessPath(), folder);
+    removeTrailingPathSepChar(folder);
+    if (folder.length())
+    {
+        path = folder;
+        return true;
+    }
+    return false;
+}
+
+static bool getComponentFilesRelPathFromBin(StringBuffer & path)
+{
+    if (getCurrentFolder(path))
+    {
+        path.append(PATHSEPCHAR).append(HIGHER_DIR_RELATIVE).append(PATHSEPCHAR).append(COMPONENTS_DIR_NAME);
+        return true;
+    }
+
+    return false;
+}
 #endif

--- a/tools/esdlcmd/esdlcmd_core.cpp
+++ b/tools/esdlcmd/esdlcmd_core.cpp
@@ -145,7 +145,13 @@ public:
         }
 
         if (optXsltPath.isEmpty())
-            optXsltPath.set(COMPONENTFILES_DIR);
+        {
+            StringBuffer tmp;
+            if (getComponentFilesRelPathFromBin(tmp))
+                optXsltPath.set(tmp.str());
+            else
+                optXsltPath.set(COMPONENTFILES_DIR);
+        }
 
         fullxsltpath.set(optXsltPath);
         fullxsltpath.append("/xslt/esxdl2xsd.xslt");


### PR DESCRIPTION
Using relative paths based from the current execute location to locate the componentfiles folder
Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
