### PR TITLE
HPCC-13238 Memcached - change default timeout from 5s to 1s

### DIFF
--- a/plugins/memcached/memcachedplugin.cpp
+++ b/plugins/memcached/memcachedplugin.cpp
@@ -562,7 +562,9 @@ void MemCachedPlugin::MCached::setPoolSettings()
     assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_REMOVE_FAILED_SERVERS, 1), msg);
 #endif
     assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_NO_BLOCK, 0), msg);
-    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_CONNECT_TIMEOUT, 100), msg);//units of ms MORE: What should I set this to or get from?
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_CONNECT_TIMEOUT, 1000), msg);//units of ms.
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_SND_TIMEOUT, 1000000), msg);//units of mu-s.
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_RCV_TIMEOUT, 1000000), msg);//units of mu-s.
     assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_BUFFER_REQUESTS, 0), msg);// Buffering does not work with the ecl runtime paradigm
 }
 


### PR DESCRIPTION
This also changes the timeout to connect such that all timeouts are the same and conform with the redis defaults.

Signed-off-by: James Noss james.noss@lexisnexis.com
