### PR TITLE
HPCC-13239 Release stopped distribute buckets as soon as possible

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -354,7 +354,7 @@ protected:
             }
             bool queryMarkSenderFinished()
             {
-                return (atomic_cas(&senderFinished, 1, 0));
+                return atomic_cas(&senderFinished, 1, 0);
             }
         };
         /*


### PR DESCRIPTION
If some slaves stop early, other slaves that have partially built
up target buffers to those stopped slaves need to release those
buckets, allowing the rest to fully utilize the available shared
send buffer.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
