### PR TITLE
HPCC-13247 Delete temporary spill file from smart buffer

### DIFF
--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -284,6 +284,11 @@ public:
         while (out->ordinality()) 
             ReleaseThorRow(out->dequeue());
         delete out;
+        if (fileio)
+        {
+            fileio.clear();
+            file->remove();
+        }
     }
 
     void putRow(const void *row)


### PR DESCRIPTION
Signed-off-by: Jake Smith jake.smith@lexisnexis.com
