### PR TITLE
HPCC-13249 Do not create temporary expressions for events

### DIFF
--- a/ecl/hqlcpp/hqlcse.cpp
+++ b/ecl/hqlcpp/hqlcse.cpp
@@ -120,6 +120,7 @@ bool canCreateTemporary(IHqlExpression * expr)
     case type_rule:
     case type_pattern:
     case type_token:
+    case type_event:
         return false;
     default:
         return true;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
