### PR TITLE
HPCC-13264 Ensure CSV, XML files do not use run-length compression

### DIFF
--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -315,9 +315,12 @@ void CDiskWriteSlaveActivityBase::open()
     if (extend)
         ActPrintLog("Extending file %s", fName.get());
 
+    /* Fixed length record size is used when outputting compressed stream to determine run-length compression vs default LZW compression.
+     * NB: only for FLAT files, not CSV or XML
+     */
     size32_t diskRowMinSz = 0;
     IOutputMetaData *diskRowMeta = diskHelperBase->queryDiskRecordSize()->querySerializedDiskMeta();
-    if (diskRowMeta->isFixedSize())
+    if (diskRowMeta->isFixedSize() && (TAKdiskwrite == container.getKind()))
     {
         diskRowMinSz = diskRowMeta->getMinRecordSize();
         if (grouped)


### PR DESCRIPTION
CSV and XML outputs that had fixed length record definitions were
using run-length compression, which effectively corrupted the
output.
Regression since HPCC-13168.

Ensure only flat files with fixed length outputs use run-length.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
