### PR TITLE
HPCC-13265 Read file part size using getPropInt64 in ws_dfu

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1704,7 +1704,7 @@ void CWsDfuEx::getFilePartsOnClusters(IEspContext &context, const char* clusterR
                 partSizeStr.set("<N/A>");
             else
             {
-                __uint64 size = partPropertyTree->getPropInt("@size");
+                __uint64 size = partPropertyTree->getPropInt64("@size");
                 comma c4(size);
                 partSizeStr<<c4;
 


### PR DESCRIPTION
The existing ws_dfu code reads te file part size using the
getPropInt(). For a large file, the file part size could be a
64-bit integer and should be read using getPropInt64().

Signed-off-by: wangkx kevin.wang@lexisnexis.com
