### PR TITLE
HPCC-13278

### DIFF
--- a/initfiles/sbin/rm_conf_settings.sh.in
+++ b/initfiles/sbin/rm_conf_settings.sh.in
@@ -26,7 +26,7 @@ PREFIX_PATH=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^path=
 
 source $PREFIX_PATH/sbin/alter_confs.sh
 
-alter_file /etc/sudoers "^Cmnd_Alias HPCC_|^${USER_NAME} ALL =" < /dev/null
+alter_file /etc/sudoers "^Cmnd_Alias HPCC_|^${USER_NAME} ALL =|Defaults:${USER_NAME}" < /dev/null
 
 alter_file /etc/security/limits.conf "^${USER_NAME}" < /dev/null
 


### PR DESCRIPTION
The line > "Defaults:hpcc !requiretty" persists in the sudoers file after removal of the package by the package manager or through the complete-uninstall script.  This is rectified by adding an additional pattern to the alter_file call in rm_conf_settings.sh
