### PR TITLE
HPCC-13280 Fix incomplete foreign LFN for roxie cache and remote lookup

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -494,6 +494,10 @@ public:
             return NULL;
         StringBuffer foreignLfn("foreign::");
         foreignLfn.append(cloneFrom);
+        const char *cloneFromPrefix = fdesc->queryProperties().queryProp("@cloneFromPrefix");
+        if (cloneFromPrefix && *cloneFromPrefix)
+            foreignLfn.append("::").append(cloneFromPrefix);
+        foreignLfn.append("::").append(_lfn);
         if (!connected())
             return resolveCachedLFN(foreignLfn);  // Note - cache only used when no dali connection available
         try


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
