### PR TITLE
HPCC-13304 Assert failure in localSlave mode

### DIFF
--- a/plugins/redis/README.md
+++ b/plugins/redis/README.md
@@ -79,7 +79,7 @@ DATA          GetData(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED dat
 ```
 BOOLEAN Exists(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000)
 FlushDB(CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000)
-Del(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000)
+Delete(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000)
 Persist(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000)
 Expire(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, UNSIGNED4 expire, CONST VARSTRING password = '', UNSIGNED timeout = 1000)
 INTEGER DBSize(CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000)
@@ -158,7 +158,7 @@ A few notes to point out here:
    * PUB-SUB channels are not disconnected from the keyspace as they are in their native redis usage. The key itself is used as the lock with its value being set as the channel to later
    PUBLISH on or SUBSCRIBE to. This channel is a string, unique by only the *key* and *database*, prefixed with **'redis_ecl_lock'**.
    * The lock itself is set to expire with a duration equal to the `timeout` value passed to the `locking.Exists(<key>` function (default 1s).
-   * It is possible to manually 'unlock' this lock (`DEL` the key) via the `locking.Unlock(<key>)` function. *Note:* this function will fail on any communication or reply error however, 
+   * It is possible to manually 'unlock' this lock (`DELETE` the key) via the `locking.Unlock(<key>)` function. *Note:* this function will fail on any communication or reply error however,
    it will **silently fail**, leaving the lock to expire, if the server observes any change to the key during the function call duration.
    * When the *race-winner* publishes, it actually publishes the value itself and that any subscriber will then obtain the key-value in this fashion. Therefore, not requiring an
     additional `GET` and possible further race conditions in doing so. *Note:* This does however, mean that it is possible for the actual redis `SET` to fail on one client/process,
@@ -177,7 +177,7 @@ A few notes to point out here:
 | Get<type>           | 1       | 5       | new connection   |
 | Set<type>           | 1       | 5       | new connection   |
 | FlushDB             | 1       | 5       | new connection   |
-| Del                 | 1       | 5       | new connection   |
+| Delete              | 1       | 5       | new connection   |
 | Persist             | 1       | 5       | new connection   |
 | Exists              | 1       | 5       | new connection   |
 | DBSize              | 1       | 5       | new connection   |

--- a/plugins/redis/lib_redis.ecllib
+++ b/plugins/redis/lib_redis.ecllib
@@ -37,7 +37,6 @@ EXPORT redis := SERVICE : plugin('redis'), namespace('RedisPlugin')
 
   BOOLEAN Exists(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000) : cpp,once,context,entrypoint='RExist';
   FlushDB(CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000) : cpp,action,context,entrypoint='RClear';
-  Del(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000) : cpp,action,context,entrypoint='RDel';
   Delete(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000) : cpp,action,context,entrypoint='RDel';
   Persist(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, CONST VARSTRING password = '', UNSIGNED timeout = 1000) : cpp,action,context,entrypoint='RPersist';
   Expire(CONST VARSTRING key, CONST VARSTRING options, UNSIGNED database = 0, UNSIGNED4 expire, CONST VARSTRING password = '', UNSIGNED timeout = 1000) : cpp,action,context,entrypoint='RExpire';
@@ -75,7 +74,6 @@ EXPORT RedisServer(VARSTRING options, VARSTRING password = '', UNSIGNED timeout 
 
   EXPORT Exists(VARSTRING key, UNSIGNED database = 0) := redis.Exists(key, options, database, password, timeout);
   EXPORT FlushDB(UNSIGNED database = 0) := redis.FlushDB(options, database, password, timeout);
-  EXPORT Del(VARSTRING key, UNSIGNED database = 0) := redis.Del(key, options, database, password, timeout);
   EXPORT Delete(VARSTRING key, UNSIGNED database = 0) := redis.Delete(key, options, database, password, timeout);
   EXPORT Persist(VARSTRING key, UNSIGNED database = 0) := redis.Persist(key, options, database, password, timeout);
   EXPORT Expire(VARSTRING key, UNSIGNED database = 0, UNSIGNED4 expire)  := redis.Expire(key, options, database, expire, password, timeout);

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -2439,7 +2439,7 @@ public:
         IMessageCollator *ret = collators.getValue(id);
         if (!ret)
             ret = defaultCollator;
-        return QUERYINTERFACE(ret, ILocalMessageCollator);
+        return LINK(QUERYINTERFACE(ret, ILocalMessageCollator));
     }
 
 };
@@ -2449,7 +2449,7 @@ void LocalMessagePacker::flush(bool last_message)
     data.setLength(lastput);
     if (last_message)
     {
-        ILocalMessageCollator *collator = rm->lookupCollator(id);
+        Owned<ILocalMessageCollator> collator = rm->lookupCollator(id);
         if (collator)
         {
             unsigned datalen = data.length();

--- a/testing/regress/ecl/redissynctest.ecl
+++ b/testing/regress/ecl/redissynctest.ecl
@@ -93,7 +93,7 @@ SEQUENTIAL(
     myRedis.SetUtf8('utf8', utf);
     myRedis.GetUtf8('utf8');
     myRedis.Exists('utf8');
-    myRedis.Del('utf8');
+    myRedis.Delete('utf8');
     myRedis.Exists('uft8');
     );
 

--- a/version.cmake
+++ b/version.cmake
@@ -4,7 +4,7 @@
 set ( HPCC_PROJECT "community" )
 set ( HPCC_MAJOR 5 )
 set ( HPCC_MINOR 2 )
-set ( HPCC_POINT 0 )
-set ( HPCC_MATURITY "release" )
-set ( HPCC_SEQUENCE 1 )
+set ( HPCC_POINT 1 )
+set ( HPCC_MATURITY "closedown" )
+set ( HPCC_SEQUENCE 0 )
 ###


### PR DESCRIPTION
If local packet discarder is deleted while packets are being discarded, can
end up with an assert failure (and/or memory corruption). This affects local
slave mode only.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
