### PR TITLE
HPCC-13292 Remove (very old) incorrect LIMIT optimization

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -4543,27 +4543,27 @@ IHqlExpression * CompoundActivityTransformer::createTransformed(IHqlExpression *
         {
             if (transformed->hasAttribute(onFailAtom))
                 break;
+
             LinkedHqlExpr dataset = transformed->queryChild(0);
             if (dataset->hasAttribute(limitAtom) || transformed->hasAttribute(skipAtom))
                 break;
+
+            // A limited KEYED-JOIN should never read more than limit rows from the index for each left row
+            // so add a LIMIT attribute onto the keyed join to ensure it doesn't return too many records.
             switch (dataset->getOperator())
             {
             case no_join:
-            case no_denormalize:
-            case no_denormalizegroup:
                 if (isKeyedJoin(dataset))
                     break;
                 return transformed.getClear();
             default:
                 return transformed.getClear();
             }
-            if (!isThorCluster(targetClusterType))
-                return mergeLimitIntoDataset(dataset, transformed);
+
             HqlExprArray args;
             unwindChildren(args, transformed);
             args.replace(*mergeLimitIntoDataset(dataset, transformed), 0);
             return transformed->clone(args);
-
         }
     }
 


### PR DESCRIPTION
LIMIT(KEYD-JOIN, n) was often converted to KEYED-JOIN,LIMIT(n)

However LIMIT on a JOIN is per left record so the transformed expression is
not equivalent.  The effect would be for some limits to not be trapped.
- It transformation would not have occured if the keyed join already had a
  limit or onfail attribute.
- The LIMIT was still retained for THOR so it would not cause limits to be lost.
- The transformation was also applied to DENORMALIZE which could cause
  extra keyed-join failures which would not trigger the original limit.

The issue has been around for more than 11 years.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
