### PR TITLE
HPCC-13304 Assert failure in localSlave mode

### DIFF
--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -2439,7 +2439,7 @@ public:
         IMessageCollator *ret = collators.getValue(id);
         if (!ret)
             ret = defaultCollator;
-        return QUERYINTERFACE(ret, ILocalMessageCollator);
+        return LINK(QUERYINTERFACE(ret, ILocalMessageCollator));
     }
 
 };
@@ -2449,7 +2449,7 @@ void LocalMessagePacker::flush(bool last_message)
     data.setLength(lastput);
     if (last_message)
     {
-        ILocalMessageCollator *collator = rm->lookupCollator(id);
+        Owned<ILocalMessageCollator> collator = rm->lookupCollator(id);
         if (collator)
         {
             unsigned datalen = data.length();


### PR DESCRIPTION
If local packet discarder is deleted while packets are being discarded, can
end up with an assert failure (and/or memory corruption). This affects local
slave mode only.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
