### PR TITLE
HPCC-12462 Share usage info between eclcc and eclcmd

### DIFF
--- a/ecl/ecl-bundle/CMakeLists.txt
+++ b/ecl/ecl-bundle/CMakeLists.txt
@@ -51,6 +51,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/system/include
          ${HPCC_SOURCE_DIR}/system/xmllib
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
+         ${HPCC_SOURCE_DIR}/ecl/eclcc
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/ecl/ecl-package/CMakeLists.txt
+++ b/ecl/ecl-package/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/system/include
          ${HPCC_SOURCE_DIR}/system/xmllib
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
+         ${HPCC_SOURCE_DIR}/ecl/eclcc
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/ecl/eclcc/CMakeLists.txt
+++ b/ecl/eclcc/CMakeLists.txt
@@ -28,6 +28,7 @@ project( eclcc )
 set (    SRCS
          reservedwords.hpp
          reservedwords.cpp
+         eclcc.hpp
          eclcc.cpp
     )
 

--- a/ecl/eclcc/eclcc.hpp
+++ b/ecl/eclcc/eclcc.hpp
@@ -1,0 +1,127 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef ECLCC_HPP
+#define ECLCC_HPP
+
+// The following is used by eclcc and eclcmd (ecl <command>).
+// The primary intention is for eclcc and only a selection are also used by eclcmd for its eclcc options.
+// The markers '!' and '?', present in either the first or first two columns, indicate that lines inclusion.
+// e.g. '?' indicates inclusion in both eclcmd and eclcc).
+//      '?!' indicates inclusion in the verbose usage for both.
+//      '!' indicates inclusion in the verbose usage for eclcc only.
+//      None of the above indicates inclusion in eclcc only.
+
+const char * const helpText[] = {
+    "",
+    "Usage:",
+    "    eclcc <options> queryfile.ecl",
+    "",
+    "General options:",
+    "?   -I <path>     Add path to locations to search for ecl imports",
+    "?   -L <path>     Add path to locations to search for system libraries",
+    "    -o <file>     Specify name of output file (default a.out if linking to",
+    "                  executable, or stdout)",
+    "?   -manifest     Specify path to manifest file listing resources to add",
+    "    -foption[=value] Set an ecl option (#option)",
+    "    -main <ref>   Compile definition <ref> from the source collection",
+    "    -syntax       Perform a syntax check of the ECL",
+    "    -platform=hthor Generate code for hthor executable (default)",
+    "    -platform=roxie Generate code for roxie cluster",
+    "    -platform=thor  Generate code for thor cluster",
+    "",
+    "Output control options",
+    "    -E            Output preprocessed ECL in xml archive form",
+    "!   -M            Output meta information for the ecl files",
+    "!   -Md           Output dependency information",
+    "!   -Me           eclcc should evaluate supplied ecl code rather than generating a workunit",
+    "    -q            Save ECL query text as part of workunit",
+    "    -wu           Only generate workunit information as xml file",
+    "",
+    "c++ options",
+    "    -S            Generate c++ output, but don't compile",
+    "!   -c            compile only (don't link)",
+    "?   -g, --debug   Enable debug symbols in generated code",
+    "    -Wc,xx        Pass option xx to the c++ compiler",
+    "!   -Wl,xx        Pass option xx to the linker",
+    "!   -Wa,xx        Passed straight through to c++ compiler",
+    "!   -Wp,xx        Passed straight through to c++ compiler",
+    "!   -save-cpps    Do not delete generated c++ files (implied if -g)",
+    "!   -save-temps   Do not delete intermediate files",
+    "    -shared       Generate workunit shared object instead of a stand-alone exe",
+    "",
+    "Other options:",
+    "!   -aoption[=value] Set an application option",
+    "!   --allow=str   Allow use of named feature",
+    "!   -b            Batch mode.  Each source file is processed in turn.  Output",
+    "!                 name depends on the input filename",
+    "!   -checkVersion Enable/disable ecl version checking from archives",
+    "!   --component   Set the name of the component this is executing on behalf of",
+#ifdef _WIN32
+    "!   -brk <n>      Trigger a break point in eclcc after nth allocation",
+#endif
+    "!   -Dname=value  Override the definition of a global attribute 'name'",
+    "!   --deny=all    Disallow use of all named features not specifically allowed using --allow",
+    "!   --deny=str    Disallow use of named feature",
+    "    -help, --help Display this message",
+    "    -help -v      Display verbose help message",
+    "!   -internal     Run internal tests",
+    "?!  -legacy       Use legacy import and when semantics (deprecated)",
+    "!   --keywords    Outputs the list of ECL reserved words to ECLKeywords.xml",
+    "!   -legacyimport Use legacy import semantics (deprecated)",
+    "!   -legacywhen   Use legacy when/side-effects semantics (deprecated)",
+    "    --logfile <file> Write log to specified file",
+    "!   --logdetail=n Set the level of detail in the log file",
+    "!   --nologfile   Do not write any logfile",
+#ifdef _WIN32
+    "!   -m            Enable leak checking",
+#endif
+    "    --nosourcepath Compile as if the source came from stdin",
+#ifndef _WIN32
+    "!   -pch          Generate precompiled header for eclinclude4.hpp",
+#endif
+    "!   -P <path>     Specify the path of the output files (only with -b option)",
+    "!   -showpaths    Print information about the searchpaths eclcc is using",
+    "    -specs file   Read eclcc configuration from specified file",
+    "!   -split m:n    Process a subset m of n input files (only with -b option)",
+    "    -v --verbose  Output additional tracing information while compiling",
+    "    -wxxxx=level  Set the severity for a particular warning code or category",
+    "!                 -wall sets default severity for all warnings",
+    "!                 level=ignore|log|warning|error|fail",
+    "    --version     Output version information",
+    "!   --timings     Output additional timing information",
+    "!",
+    "?!#options",
+    "?!  -factivitiesPerCpp      Number of activities in each c++ file",
+    "?!                          (requires -fspanMultipleCpp)",
+    "?!  -fapplyInstantEclTransformations Limit non file outputs with a CHOOSEN",
+    "?!  -fapplyInstantEclTransformationsLimit Number of records to limit to",
+    "?!  -fcheckAsserts          Check ASSERT() statements",
+    "?!  -fexportDependencies    Generate information about inter-definition dependencies",
+    "?!  -fmaxCompileThreads     Number of compiler instances to compile the c++",
+    "?!  -fnoteRecordSizeInGraph Add estimates of record sizes to the graph",
+    "?!  -fpickBestEngine        Allow simple thor queries to be passed to thor",
+    "?!  -freportCppWarnings     Report warnings from c++ compilation",
+    "?!  -fsaveCppTempFiles      Retain the generated c++ files",
+    "?!  -fshowActivitySizeInGraph Show estimates of generated c++ size in the graph",
+    "?!  -fshowMetaInGraph       Add distribution/sort orders to the graph",
+    "?!  -fshowRecordCountInGraph Show estimates of record counts in the graph",
+    "?!  -fspanMultipleCpp       Generate a work unit in multiple c++ files",
+    "",
+};
+
+#endif

--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -58,6 +58,7 @@ include_directories (
          ./../../system/include
          ./../../esp/bindings
          ./../../ecl/hql
+         ./../../ecl/eclcc
          ./../../dali/base
          ./../../esp/platform
          ./../../system/jlib

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -296,6 +296,12 @@ eclCmdOptionMatchIndicator EclCmdCommon::matchCommandLineOption(ArgvIterator &it
     bool boolValue;
     if (iter.matchFlag(boolValue, ECLOPT_HELP))
     {
+        if (!optVerbose && iter.next())
+        {
+            iter.matchFlag(optVerbose, ECLOPT_VERBOSE);
+            if (!optVerbose)
+                iter.matchFlag(optVerbose, ECLOPT_VERBOSE_S);
+        }
         usage();
         return EclCmdOptionCompletion;
     }

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -19,6 +19,7 @@
 #define ECLCMD_COMMON_HPP
 
 #include "ws_workunits.hpp"
+#include "eclcc.hpp"
 
 //=========================================================================================
 
@@ -261,13 +262,31 @@ public:
             "   --limit=<limit>        Sets the result limit for the query, defaults to 100\n"
             "   -f<option>[=value]     Set an ECL option (equivalent to #option)\n"
             "   -Dname=value           Override the definition of a global attribute 'name'\n"
-            " eclcc options:\n"
-            "   -Ipath                 Add path to locations to search for ecl imports\n"
-            "   -Lpath                 Add path to locations to search for system libraries\n"
-            "   --manifest             Specify path to manifest file\n"
-            "   --legacy               Use legacy import semantics (deprecated)\n"
-            "   --debug, -g            Enable debug symbols in generated code\n"
+            " eclcc options (everything following):\n"
         );
+        for (unsigned line=0; line < _elements_in(helpText); line++)
+        {
+            const char * text = helpText[line];
+            StringBuffer wsPrefix;
+            if (*text == '?')
+            {
+                text = text+1;
+                if (*text != ' ')
+                    wsPrefix.append(' ');
+            }
+            else
+                continue;
+            if (*text == '!')
+            {
+                if (optVerbose)
+                {
+                    text = text+1;
+                    fprintf(stdout, "%s%s\n", wsPrefix.str(), text);
+                }
+            }
+            else
+                fprintf(stdout, "%s%s\n", wsPrefix.str(), text);
+        }
     }
 public:
     StringAttr optTargetCluster;

--- a/ecl/eclcmd/queries/CMakeLists.txt
+++ b/ecl/eclcmd/queries/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/system/include
          ${HPCC_SOURCE_DIR}/system/xmllib
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
+         ${HPCC_SOURCE_DIR}/ecl/eclcc
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/ecl/eclcmd/roxie/CMakeLists.txt
+++ b/ecl/eclcmd/roxie/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/system/include
          ${HPCC_SOURCE_DIR}/system/xmllib
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
+         ${HPCC_SOURCE_DIR}/ecl/eclcc
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )


### PR DESCRIPTION
This has two accompanying changes:
- --debug (synonym for -g) was added to eclcc as it is so for eclcmd.
- eclcmd now checks for verbosity after finding --help.
  There was no verbose section of the usage info prior, which is
  why it made no sense to check i.e. '-v' wasn't related to '--help'

Signed-off-by: James Noss james.noss@lexisnexis.com
