### PR TITLE
HPCC-12525 Add QueryLanguage to WU xml for KEL

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -1982,6 +1982,7 @@ public:
     CLocalWUQuery(IPropertyTree *p);
 
     virtual WUQueryType getQueryType() const;
+    virtual WUQueryLanguage getQueryLanguage() const;
     virtual IStringVal& getQueryText(IStringVal &str) const;
     virtual IStringVal& getQueryShortText(IStringVal &str) const;
     virtual IStringVal& getQueryName(IStringVal &str) const;
@@ -1994,6 +1995,7 @@ public:
     virtual IConstWUAssociatedFileIterator& getAssociatedFiles() const;
 
     virtual void        setQueryType(WUQueryType qt);
+    virtual void        setQueryLanguage(WUQueryLanguage ql);
     virtual void        setQueryText(const char *pstr);
     virtual void        setQueryName(const char *);
     virtual void        setQueryMainDefinition(const char * str);
@@ -7543,6 +7545,23 @@ WUQueryType CLocalWUQuery::getQueryType() const
 void CLocalWUQuery::setQueryType(WUQueryType qt) 
 {
     setEnum(p, "@type", qt, queryTypes);
+}
+
+mapEnums queryLanguages[] = {
+   { QueryLanguageUnknown, "unknown" },
+   { QueryLanguageEcl, "ECL" },
+   { QueryLanguageKel, "KEL" },
+   { QueryLanguageSize,  NULL },
+};
+
+WUQueryLanguage CLocalWUQuery::getQueryLanguage() const
+{
+    return (WUQueryLanguage) getEnum(p, "@language", queryLanguages);
+}
+
+void CLocalWUQuery::setQueryLanguage(WUQueryLanguage ql)
+{
+    setEnum(p, "@language", ql, queryLanguages);
 }
 
 IStringVal& CLocalWUQuery::getQueryText(IStringVal &str) const

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -110,7 +110,13 @@ enum WUQueryType
     QueryTypeSize = 5
 };
 
-
+enum WUQueryLanguage
+{
+    QueryLanguageUnknown = 0,
+    QueryLanguageEcl = 1,
+    QueryLanguageKel = 2,
+    QueryLanguageSize = 3
+};
 
 enum WUState
 {
@@ -386,6 +392,7 @@ interface IConstWUAssociatedFileIterator : extends IScmIterator
 interface IConstWUQuery : extends IInterface
 {
     virtual WUQueryType getQueryType() const = 0;
+    virtual WUQueryLanguage getQueryLanguage() const = 0;
     virtual IStringVal & getQueryText(IStringVal & str) const = 0;
     virtual IStringVal & getQueryName(IStringVal & str) const = 0;
     virtual IStringVal & getQueryDllName(IStringVal & str) const = 0;
@@ -402,6 +409,7 @@ interface IConstWUQuery : extends IInterface
 interface IWUQuery : extends IConstWUQuery
 {
     virtual void setQueryType(WUQueryType qt) = 0;
+    virtual void setQueryLanguage(WUQueryLanguage ql) = 0;
     virtual void setQueryText(const char * pstr) = 0;
     virtual void setQueryName(const char * pstr) = 0;
     virtual void addAssociatedFile(WUFileType type, const char * name, const char * ip, const char * desc, unsigned crc) = 0;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -427,6 +427,7 @@ ESPrequest [nil_remove] WUUpdateRequest
     [min_ver("1.22")] string XmlParams;
     [min_ver("1.25")] string ThorSlaveIP;
     [min_ver("1.35")] string QueryMainDefinition;
+    [min_ver("1.56")] int QueryLanguage;
 
     ESParray<ESPstruct DebugValue>       DebugValues;
     ESParray<ESPstruct ApplicationValue> ApplicationValues;
@@ -1609,7 +1610,7 @@ ESPresponse [exceptions_inline] WUGetStatsResponse
 };
 
 ESPservice [
-    version("1.55"), default_client_version("1.55"),
+    version("1.56"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -623,6 +623,8 @@ bool CWsWorkunitsEx::onWUUpdate(IEspContext &context, IEspWUUpdateRequest &req, 
         {
             Owned<IWUQuery> query=wu->updateQuery();
             query->setQueryText(req.getQueryText());
+            if ((version >= 1.56) && !req.getQueryLanguage_isNull())
+                query->setQueryLanguage((WUQueryLanguage) req.getQueryLanguage());
         }
 
         if (version > 1.34 && notEmpty(req.getQueryMainDefinition()))


### PR DESCRIPTION
In WU xml, Query[@language='KEL'] is added to identify the query
is a KEL query (other language flag may be added as needed). The
@language may be set by WsWorkunits.WUUpdate when the query is
set (the WUUpdate could be called by ECLPlayground). Both get/set
methods are added into workunit.cpp.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
