### PR TITLE
HPCC-13301 Added python to ubuntu/debian releases as dependency

### DIFF
--- a/cmake_modules/dependencies/lenny.cmake
+++ b/cmake_modules/dependencies/lenny.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo, openssh-client, openssh-server, expect, libarchive, rsync, libapr1, libaprutil1, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.34.1, libicu38, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, sudo, openssh-client, openssh-server, expect, libarchive, rsync, libapr1, libaprutil1, zip, python")

--- a/cmake_modules/dependencies/lucid.cmake
+++ b/cmake_modules/dependencies/lucid.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.40.0, libicu42, libxslt1.1, libxml2, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1, rsync, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.40.0, libicu42, libxslt1.1, libxml2, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1, rsync, zip, python")

--- a/cmake_modules/dependencies/natty.cmake
+++ b/cmake_modules/dependencies/natty.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.42.0, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1, rsync, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.42.0, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1, rsync, zip, python")

--- a/cmake_modules/dependencies/oneiric.cmake
+++ b/cmake_modules/dependencies/oneiric.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.46.1, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1, rsync, libapr1, libaprutil1, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.46.1, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1, rsync, libapr1, libaprutil1, zip, python")

--- a/cmake_modules/dependencies/precise.cmake
+++ b/cmake_modules/dependencies/precise.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.46.1, libicu48, libxslt1.1, libxml2, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive12, rsync, libapr1, libaprutil1, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.46.1, libicu48, libxslt1.1, libxml2, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive12, rsync, libapr1, libaprutil1, zip, python")

--- a/cmake_modules/dependencies/quantal.cmake
+++ b/cmake_modules/dependencies/quantal.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.49.0, libicu48, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive12, rsync, libapr1, libaprutil1, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.49.0, libicu48, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive12, rsync, libapr1, libaprutil1, zip, python")

--- a/cmake_modules/dependencies/saucy.cmake
+++ b/cmake_modules/dependencies/saucy.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.53.0, libicu48, libxalan-c111, libxerces-c3.1, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync, libapr1, libaprutil1, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.53.0, libicu48, libxalan-c111, libxerces-c3.1, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync, libapr1, libaprutil1, zip, python")

--- a/cmake_modules/dependencies/squeeze.cmake
+++ b/cmake_modules/dependencies/squeeze.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.42.0, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1, rsync, libapr1, libaprutil1, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.42.0, libicu44, libxalan110, libxerces-c28, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive1, rsync, libapr1, libaprutil1, zip, python")

--- a/cmake_modules/dependencies/trusty.cmake
+++ b/cmake_modules/dependencies/trusty.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.54.0, libicu52, libxslt1.1, libxml2, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync, libapr1, libaprutil1, zip")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.54.0, libicu52, libxslt1.1, libxml2, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync, libapr1, libaprutil1, zip, python")

--- a/cmake_modules/dependencies/utopic.cmake
+++ b/cmake_modules/dependencies/utopic.cmake
@@ -1,1 +1,1 @@
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.55.0, libicu52, libxslt1.1, libxml2, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync, libapr1, libaprutil1")
+set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-regex1.55.0, libicu52, libxslt1.1, libxml2, binutils, libldap-2.4-2, openssl, zlib1g, g++, openssh-client, openssh-server, expect, libarchive13, rsync, libapr1, libaprutil1, python")


### PR DESCRIPTION
Added python as a dependency to the debian and ubuntu CPACK_DEBIAN_PACKAGE_DEPENDS option.

This will add python 2.5 to Debian 5.0.10 (lenny) and 2.6+ on all supported distributions of Ubuntu.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
