### PR TITLE
HPCC-13322 Check Cached CPECacheElem point before using it

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -1983,7 +1983,7 @@ IRemoteConnection *getElementsPaged( IElementsPager *elementsPager,
         if (elem)
             postfilter = elem->postFilter; // reuse cached postfilter
     }
-    else
+    if (!elem)
     {
         elem.setown(new CPECacheElem(owner, postfilter));
         elem->conn.setown(elementsPager->getElements(elem->totalres));


### PR DESCRIPTION
The CPECacheElem is used to store cached WU list or logical
file list for paging. After ESP server is restarted, the
cache will not be valid even though the cache hint is still
sent by ECLwatch page. ESP should check CPECacheElem point
before using it.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
