### PR TITLE
HPCC-13319 Local slave mode issues

### DIFF
--- a/roxie/ccd/ccdqueue.ipp
+++ b/roxie/ccd/ccdqueue.ipp
@@ -76,17 +76,17 @@ public:
         return false;
     }
 
+
     virtual void *getBuffer(unsigned len, bool variable)
     {
-        data.setLength(lastput);
         if (variable)
         {
-            char *ret = (char *) data.reserve(len + sizeof(RecordLengthType));
+            char *ret = (char *) data.ensureCapacity(len + sizeof(RecordLengthType));
             return ret + sizeof(RecordLengthType);
         }
         else
         {
-            return data.reserve(len);
+            return data.ensureCapacity(len);
         }
     }
 
@@ -98,11 +98,11 @@ public:
             *(RecordLengthType *) buf = len;
             len += sizeof(RecordLengthType);
         }
-        data.setLength(lastput + len);
+        data.setWritePos(lastput + len);
         lastput += len;
     }
 
-    virtual void flush(bool last_message) { data.setLength(lastput); }
+    virtual void flush(bool last_message) { }
     virtual void sendMetaInfo(const void *buf, unsigned len) { throwUnexpected(); }
     virtual unsigned size() const { return lastput; }
 };

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -4316,7 +4316,7 @@ public:
             }
             else
             {
-                if (!anyActivity)
+                if (!anyActivity && !localSlave)
                 {
                     activity.queryLogCtx().CTXLOG("Input has stalled - retry required?");
                     retryPending();

--- a/roxie/udplib/udplib.hpp
+++ b/roxie/udplib/udplib.hpp
@@ -103,10 +103,12 @@ interface ISendManager : extends IInterface
     virtual bool dataQueued(ruid_t ruid, unsigned sequence, unsigned destNodeIndex) = 0;
     virtual bool abortData(ruid_t ruid, unsigned sequence, unsigned destNodeIndex) = 0;
     virtual bool allDone() = 0;
+    virtual void writeOwn(unsigned destNodeIndex, roxiemem::DataBuffer *buffer, unsigned len, unsigned queue) = 0;  // NOTE: takes ownership of the DataBuffer
 };
 
 extern UDPLIB_API IReceiveManager *createReceiveManager(int server_flow_port, int data_port, int client_flow_port, int sniffer_port, const IpAddress &sniffer_multicast_ip, int queue_size, unsigned maxSlotsPerSender, unsigned myNodeIndex);
 extern UDPLIB_API ISendManager *createSendManager(int server_flow_port, int data_port, int client_flow_port, int sniffer_port, const IpAddress &sniffer_multicast_ip, int queue_size_pr_server, int queues_pr_server, unsigned maxRetryData, TokenBucket *rateLimiter, unsigned myNodeIndex);
+extern UDPLIB_API IMessagePacker *createMessagePacker(ruid_t ruid, unsigned msgId, const void *messageHeader, unsigned headerSize, ISendManager &_parent, unsigned _destNode, unsigned _sourceNode, unsigned _msgSeq, unsigned _queue);
 
 extern UDPLIB_API const IpAddress &getNodeAddress(unsigned index);
 extern UDPLIB_API unsigned addRoxieNode(const char *ipString);

--- a/system/jlib/jbuff.cpp
+++ b/system/jlib/jbuff.cpp
@@ -287,10 +287,11 @@ void *MemoryBuffer::insertDirect(unsigned offset, size32_t insertLen)
 }
 
 
-void MemoryBuffer::ensureCapacity(unsigned max)
+void * MemoryBuffer::ensureCapacity(unsigned max)
 {
     if (maxLen - curLen < max)
         _realloc(curLen + max);
+    return buffer + curLen;
 }
 
 void MemoryBuffer::kill()

--- a/system/jlib/jbuff.hpp
+++ b/system/jlib/jbuff.hpp
@@ -197,7 +197,7 @@ public:
     void            swapWith(MemoryBuffer & other);
 
     inline size32_t capacity() { return (maxLen - curLen); }
-    void            ensureCapacity(unsigned max);
+    void *          ensureCapacity (unsigned max);
     inline size32_t length() const { return curLen; }
     inline size32_t remaining() const { return curLen - readPos; }
 


### PR DESCRIPTION
1. Not aborting slave queries if server no longer requires results
2. Out-of-band messages were not sent at front of queue
3. No point resending requests in case of slave failure or network packet loss
4. Very suboptimal usage of MemoryBuffer in DummyMessagePacker

This would appear to be the root cause of:

HPCC-13305 - keyed denormalize test timeouts
HPCC-13306 - Out-of-memory errors in Roxie regression suite runs

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
