### PR TITLE
HPCC 13065 fix empty esdl statemnt core

### DIFF
--- a/tools/esdlcomp/esdlgram.y
+++ b/tools/esdlcomp/esdlgram.y
@@ -995,6 +995,10 @@ Param
      CurParam->flags |= PF_IN;
  }
  |
+ {
+   //There was no Param, make sure CurParam is nulled out
+   CurParam = NULL;
+ }
  ;
 
 TypeModifiers


### PR DESCRIPTION
ESDL grammar allows empty elements but doesn't clean up, we are now nulling out curparam in case of empty element path.
