### PR TITLE
HPCC-9228 Roxie/hthor join activities should group their inputs

### DIFF
--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -39,8 +39,8 @@ if the supplied pointer was not from the roxiemem heap. Usually an OwnedRoxieStr
 
 //Should be incremented whenever the virtuals in the context or a helper are changed, so
 //that a work unit can't be rerun.  Try as hard as possible to retain compatibility.
-#define ACTIVITY_INTERFACE_VERSION      157
-#define MIN_ACTIVITY_INTERFACE_VERSION  157             //minimum value that is compatible with current interface - without using selectInterface
+#define ACTIVITY_INTERFACE_VERSION      158
+#define MIN_ACTIVITY_INTERFACE_VERSION  158             //minimum value that is compatible with current interface - without using selectInterface
 
 typedef unsigned char byte;
 


### PR DESCRIPTION
Since graphs created by the compiler with this change in place will fail on
older versions of the platform, increase the helper version to ensure that
they fail.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
