### PR TITLE
HPCC-13343 Check group's 'kind' attr before using it

### DIFF
--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -1338,7 +1338,7 @@ void CTpWrapper::getGroupList(double espVersion, const char* kindReq, IArrayOf<I
                 IEspTpGroup* pGroup = createTpGroup("","");
                 const char* name = group.queryProp("@name");
                 pGroup->setName(name);
-                if (espVersion >= 1.21)
+                if (kind && *kind && (espVersion >= 1.21))
                 {
                     pGroup->setKind(kind);
                     pGroup->setReplicateOutputs(checkGroupReplicateOutputs(name, kind));


### PR DESCRIPTION
The 'kind' attribute for Group stores information about
which cluster type a group belongs to. The information is
returned by WsTopology.TpGroupQuery. The existing code of
the TpGroupQuery may crash when the 'kind' attribute is
not specified for a group. The crash should be fixed now.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
