### PR TITLE
HPCC-13366 Group denormalie crash fix

### DIFF
--- a/thorlcr/activities/msort/thsortu.cpp
+++ b/thorlcr/activities/msort/thsortu.cpp
@@ -670,7 +670,7 @@ public:
                     case TAKhashdenormalizegroup:
                     case TAKlookupdenormalizegroup:
                     case TAKsmartdenormalizegroup:
-                        gotsz = helper->transform(ret, nextleft, NULL, 0, (const void **)NULL);
+                        gotsz = helper->transform(ret, nextleft, defaultRight, 0, (const void **)NULL);
                         break;
                     case TAKjoin:
                     case TAKhashjoin:


### PR DESCRIPTION
A transform in a group denormalize failed if relying on default
right row.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
