### PR TITLE
HPCC-13374 Potential Distribute send stall if many targets stop

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -562,6 +562,7 @@ class CDistributorBase : public CSimpleInterface, implements IHashDistributor, i
             if (target->getSenderFinished())
             {
                 HDSendPrintLog2("CSender::add disposing of bucket [finished(%d)]", dest);
+                decTotal(bucket->querySize());
                 bucket->Release();
             }
             else
@@ -688,7 +689,7 @@ class CDistributorBase : public CSimpleInterface, implements IHashDistributor, i
                         loop
                         {
                             if (timer.elapsedCycles() >= queryOneSecCycles()*10)
-                                owner.ActPrintLog("HD sender, waiting for space, inactive writers = %d, totalSz = %d", queryInactiveWriters(), queryTotalSz());
+                                owner.ActPrintLog("HD sender, waiting for space, inactive writers = %d, totalSz = %d, numFinished = %d", queryInactiveWriters(), queryTotalSz(), atomic_read(&numFinished));
                             timer.reset();
 
                             if (senderFullSem.wait(10000))


### PR DESCRIPTION
If the target nodes signal they have stopped, send buckets that
are about to be sent are discarded, however the nominal space they
used was not being subtracted from the overall limited send buffer
total, as a consequence if many targets stopped and many buckets
were discarded in this fashion, the sender could remain full and
deadlock.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
