### PR TITLE
HPCC-13349 New ECLWatch reports expired HTPASSWD

### DIFF
--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -112,7 +112,7 @@ const StringBuffer &CEspApplicationPort::getAppFrameHtml(time_t &modified, const
 
     if (needRefresh || embedded_url || !appFrameHtml.length())
     {
-        int passwordDaysRemaining = -1;//-1 means dont display change password screen
+        int passwordDaysRemaining = scPasswordExpired;//-1 means dont display change password screen
 #ifdef _USE_OPENLDAP
         ISecUser* user = ctx->queryUser();
         ISecManager* secmgr = ctx->querySecManager();
@@ -120,8 +120,8 @@ const StringBuffer &CEspApplicationPort::getAppFrameHtml(time_t &modified, const
         {
             passwordDaysRemaining = user->getPasswordDaysRemaining();//-1 if expired, -2 if never expires
             int passwordExpirationDays = (int)secmgr->getPasswordExpirationWarningDays();
-            if (passwordDaysRemaining==-2 || passwordDaysRemaining > passwordExpirationDays)
-                passwordDaysRemaining = -1;
+            if (passwordDaysRemaining == scPasswordNeverExpires || passwordDaysRemaining > passwordExpirationDays)
+                passwordDaysRemaining = scPasswordExpired;
         }
 #endif
         StringBuffer xml;

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -440,10 +440,10 @@ bool Cws_accessEx::onUsers(IEspContext &context, IEspUserRequest &req, IEspUserR
                     StringBuffer sb;
                     switch (usr->getPasswordDaysRemaining())//-1 if expired, -2 if never expires
                     {
-                    case -1:
+                    case scPasswordExpired:
                         sb.set("Expired");
                         break;
-                    case -2:
+                    case scPasswordNeverExpires:
                         sb.set("Never");
                         break;
                     default:

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1409,7 +1409,7 @@ public:
                 {
                     //This path is typical if running ESP on Windows. We have no way
                     //to determine if password entered is valid but expired
-                    if (user.getPasswordDaysRemaining() == -1)
+                    if (user.getPasswordDaysRemaining() == scPasswordExpired)
                     {
                         DBGLOG("LDAP: Password Expired(2) for user %s", username);
                         user.setAuthenticateStatus(AS_PASSWORD_EXPIRED);

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -110,13 +110,13 @@ public:
    virtual int getPasswordDaysRemaining()
    {
        if (m_passwordExpiration.isNull())
-           return -2;//-2 if never expires
+           return scPasswordNeverExpires;//-2 if never expires
        CDateTime expiry(m_passwordExpiration);
        CDateTime now;
        now.setNow();
        now.adjustTime(now.queryUtcToLocalDelta());
        if (expiry <= now)
-           return -1;//-1 if already expired
+           return scPasswordExpired;//-1 if already expired
        expiry.setTime(0,0,0,0);
        now.setTime(23,59,59);
        int numDays = 0;

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -200,7 +200,7 @@ public:
 
     virtual CDateTime & getPasswordExpiration(CDateTime& expirationDate){ return expirationDate; }
     virtual bool setPasswordExpiration(CDateTime& expirationDate) { return true; }
-    virtual int getPasswordDaysRemaining() {return -1;}
+    virtual int getPasswordDaysRemaining() {return -2;}//never expires
     virtual authStatus getAuthenticateStatus() {return m_authenticateStatus;}
     virtual void setAuthenticateStatus(authStatus status){m_authenticateStatus = status;}
 

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -200,7 +200,7 @@ public:
 
     virtual CDateTime & getPasswordExpiration(CDateTime& expirationDate){ return expirationDate; }
     virtual bool setPasswordExpiration(CDateTime& expirationDate) { return true; }
-    virtual int getPasswordDaysRemaining() {return -2;}//never expires
+    virtual int getPasswordDaysRemaining() {return scPasswordNeverExpires;}//never expires
     virtual authStatus getAuthenticateStatus() {return m_authenticateStatus;}
     virtual void setAuthenticateStatus(authStatus status){m_authenticateStatus = status;}
 

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -116,6 +116,8 @@ enum SecUserStatus
 };
 
 
+const static int scPasswordExpired = -1;
+const static int scPasswordNeverExpires = -2;
 
 interface ISecCredentials : extends IInterface
 {


### PR DESCRIPTION
Currently any authentication method other than LDAP returns the "Expired"
flag for the password. This PR changes that to return the "Never Expires"
flag

Signed-off-by: William Whitehead william.whitehead@lexisnexis.com
