### PR TITLE
HPCC-12372 Add ESP support for reporting locks

### DIFF
--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -1887,6 +1887,13 @@ StringBuffer &CClientSDSManager::getLocks(StringBuffer &out)
     return getInfo(DIAG_CMD_LOCKINFO, out);
 }
 
+void CClientSDSManager::getFilteredLocks(const char *filters, MemoryBuffer &mb)
+{
+    StringBuffer out;
+    getInfo(DIAG_CMD_LOCKINFO, out);
+    mb.append(out.str());
+}
+
 StringBuffer &CClientSDSManager::getUsageStats(StringBuffer &out)
 {
     return getInfo(DIAG_CMD_STATS, out);

--- a/dali/base/dacsds.ipp
+++ b/dali/base/dacsds.ipp
@@ -406,6 +406,7 @@ public:
     virtual void unsubscribe(SubscriptionId id);
     virtual void unsubscribeExact(SubscriptionId id);
     virtual StringBuffer &getLocks(StringBuffer &out);
+    virtual void getFilteredLocks(const char *filters, MemoryBuffer &mb);
     virtual StringBuffer &getUsageStats(StringBuffer &out);
     virtual StringBuffer &getConnections(StringBuffer &out);
     virtual StringBuffer &getSubscribers(StringBuffer &out);

--- a/dali/base/dadiags.hpp
+++ b/dali/base/dadiags.hpp
@@ -22,9 +22,25 @@
 #define da_decl __declspec(dllimport)
 #endif
 
+#include "jiter.hpp"
+
 extern da_decl StringBuffer & getDaliDiagnosticValue(const char *name,StringBuffer &ret);
 extern da_decl MemoryBuffer & getDaliDiagnosticValue(MemoryBuffer &m);
 
+enum DALockField
+{
+    DALFpath = 0,
+    DALFfile = 1,
+    DALFendpoint = 2,
+    DALFsessId = 3,
+    DALFconnId = 4,
+    DALFmode = 5,
+    DALFduration = 6
+};
+
+typedef IIteratorOf<IPropertyTree> IDALockIterator;
+extern da_decl IDALockIterator* getDALocks(StringBuffer &filters);
+extern da_decl const char* getDALockFieldName(DALockField feild);
 
 // for server use
 interface IDaliServer;

--- a/dali/base/dasds.hpp
+++ b/dali/base/dasds.hpp
@@ -46,6 +46,22 @@
 #define SDS_SVER_MIN_NODESUBSCRIBE "3.12"
 
 
+enum DALockFilterType
+{
+    DALFTLockType = 1,
+    DALFTEndpoint = 2,
+    DALFTDuration = 3
+};
+
+enum DALockTypeFilter
+{
+    DALTFAll = 1,
+    DALTFFileLock = 2,
+    DALTFNonFileLock = 3
+};
+
+#define DALockFilterSeparator '|'
+
 enum SDSNotifyFlags { SDSNotify_None=0x00, SDSNotify_Data=0x01, SDSNotify_Structure=0x02, SDSNotify_Added=(SDSNotify_Structure+0x04), SDSNotify_Deleted=(SDSNotify_Structure+0x08), SDSNotify_Renamed=(SDSNotify_Structure+0x10) };
 interface ISDSSubscription : extends IInterface
 {
@@ -108,6 +124,7 @@ interface ISDSManager
     virtual void unsubscribe(SubscriptionId id) = 0;
     virtual void unsubscribeExact(SubscriptionId id) = 0;
     virtual StringBuffer &getLocks(StringBuffer &out) = 0;
+    virtual void getFilteredLocks(const char *filters, MemoryBuffer &out) = 0;
     virtual StringBuffer &getUsageStats(StringBuffer &out) = 0;
     virtual StringBuffer &getConnections(StringBuffer &out) = 0;
     virtual StringBuffer &getSubscribers(StringBuffer &out) = 0;

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -357,6 +357,36 @@ GetStatusServerInfoResponse
     ESPstruct StatusServerInfo StatusServerInfo;
 };
 
+ESPStruct [nil_remove] LockEndpoint
+{
+    string Endpoint;
+    string SessionID;
+    string ConnectionID;
+    unsigned DurationMS;
+    unsigned Mode;
+};
+
+ESPStruct [nil_remove] Lock
+{
+    string File;
+    string Path;
+    ESParray<ESPstruct LockEndpoint, Endpoint> Endpoints;
+};
+
+ESPrequest [nil_remove] GetLocksRequest
+{
+    string Endpoint;
+    unsigned DurationLow;
+    unsigned DurationHigh;
+    bool FileLockOnly;
+    bool NonFileLockOnly;
+};
+
+ESPresponse [exceptions_inline, nil_remove] GetLocksResponse
+{
+    ESParray<ESPstruct Lock, Lock> Locks;
+};
+
 ESPservice [noforms, version("1.19"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
@@ -383,6 +413,7 @@ ESPservice [noforms, version("1.19"), exceptions_inline("./smc_xslt/exceptions.x
 
     ESPmethod RoxieControlCmd(RoxieControlCmdRequest, RoxieControlCmdResponse);
     ESPmethod GetStatusServerInfo(GetStatusServerInfoRequest, GetStatusServerInfoResponse);
+    ESPmethod GetLocks(GetLocksRequest, GetLocksResponse);
 };
 
 SCMexportdef(WSSMC);

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -192,6 +192,7 @@ public:
     virtual bool onBrowseResources(IEspContext &context, IEspBrowseResourcesRequest & req, IEspBrowseResourcesResponse & resp);
     virtual bool onRoxieControlCmd(IEspContext &context, IEspRoxieControlCmdRequest &req, IEspRoxieControlCmdResponse &resp);
     virtual bool onGetStatusServerInfo(IEspContext &context, IEspGetStatusServerInfoRequest &req, IEspGetStatusServerInfoResponse &resp);
+    virtual bool onGetLocks(IEspContext &context, IEspGetLocksRequest &req, IEspGetLocksResponse &resp);
 private:
     void addCapabilities( IPropertyTree* pFeatureNode, const char* access, IArrayOf<IEspCapability>& capabilities);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName,


### PR DESCRIPTION
A new WsSMC method called GetLocks is added to
report locks/clients. The method calls the
getDaliDiagnosticValue() to retrieve lock data.
The data is parsed into Endpoint, SessionID, etc.

This method is only available for admin users.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
