### PR TITLE
HPCC-13134 Record fields with complex xpaths should output valid xml

### DIFF
--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -1013,7 +1013,7 @@ public:
 
     IHqlExpression * getRtlFieldKey(IHqlExpression * expr, IHqlExpression * ownerRecord);
     unsigned buildRtlField(StringBuffer * instanceName, IHqlExpression * fieldKey);
-    unsigned buildRtlType(StringBuffer & instanceName, ITypeInfo * type);
+    unsigned buildRtlType(StringBuffer & instanceName, ITypeInfo * type, unsigned typeFlags);
     unsigned buildRtlRecordFields(StringBuffer & instanceName, IHqlExpression * record, IHqlExpression * rowRecord);
     unsigned expandRtlRecordFields(StringBuffer & fieldListText, IHqlExpression * record, IHqlExpression * rowRecord);
     unsigned buildRtlIfBlockField(StringBuffer & instanceName, IHqlExpression * ifblock, IHqlExpression * rowRecord);

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -3527,22 +3527,6 @@ unsigned HqlCppTranslator::buildRtlField(StringBuffer * instanceName, IHqlExpres
             break;
         }
 
-        StringBuffer typeName;
-        typeFlags = buildRtlType(typeName, fieldType);
-
-        StringBuffer lowerName;
-        lowerName.append(field->queryName()).toLowerCase();
-
-        if (options.debugGeneratedCpp)
-        {
-            name.append("rf_");
-            convertToValidLabel(name, lowerName.str(), lowerName.length());
-            name.append("_").append(++nextFieldId);
-        }
-        else
-            name.append("rf").append(++nextFieldId);
-
-
         StringBuffer xpathName, xpathItem;
         switch (fieldType->getTypeCode())
         {
@@ -3562,8 +3546,28 @@ unsigned HqlCppTranslator::buildRtlField(StringBuffer * instanceName, IHqlExpres
             break;
         }
 
-        if (xpathName.length() && (xpathName.charAt(0) == '@'))
-            typeFlags |= RFTMhasxmlattr;
+        if (xpathName.length())
+        {
+            if (xpathName.charAt(0) == '@')
+                typeFlags |= RFTMhasxmlattr;
+            if (!strpbrk(xpathName, "/?*[]<>"))
+                typeFlags |= RFTMxpathscalar;
+        }
+
+        StringBuffer typeName;
+        typeFlags = buildRtlType(typeName, fieldType, typeFlags); //benefit to adding other flags to generated code as well?
+
+        StringBuffer lowerName;
+        lowerName.append(field->queryName()).toLowerCase();
+
+        if (options.debugGeneratedCpp)
+        {
+            name.append("rf_");
+            convertToValidLabel(name, lowerName.str(), lowerName.length());
+            name.append("_").append(++nextFieldId);
+        }
+        else
+            name.append("rf").append(++nextFieldId);
 
         //Format of the xpath field is (nested-item 0x01 repeated-item)
         StringBuffer xpathFull, xpathCppText;
@@ -3714,14 +3718,15 @@ unsigned HqlCppTranslator::getRtlFieldInfo(StringBuffer & fieldInfoName, IHqlExp
     return buildRtlField(&fieldInfoName, fieldKey);
 }
 
-unsigned HqlCppTranslator::buildRtlType(StringBuffer & instanceName, ITypeInfo * type)
+unsigned HqlCppTranslator::buildRtlType(StringBuffer & instanceName, ITypeInfo * type, unsigned typeFlags)
 {
     assertex(type);
     type_t tc = type->getTypeCode();
     if (tc == type_record)
         type = queryUnqualifiedType(type);
 
-    OwnedHqlExpr search = createVariable("t", LINK(type));
+    VStringBuffer searchKey("t%d", typeFlags);
+    OwnedHqlExpr search = createVariable(searchKey, LINK(type));
     BuildCtx declarectx(*code, declareAtom);
     HqlExprAssociation * match = declarectx.queryMatchExpr(search);
     if (match)
@@ -3743,7 +3748,7 @@ unsigned HqlCppTranslator::buildRtlType(StringBuffer & instanceName, ITypeInfo *
     else
         name.append("ty").append(++nextTypeId);
 
-    unsigned fieldType= 0;
+    unsigned fieldType = typeFlags;
     if (tc == type_alien)
     {
         ITypeInfo * physicalType = queryAlienType(type)->queryPhysicalType();
@@ -3852,7 +3857,7 @@ unsigned HqlCppTranslator::buildRtlType(StringBuffer & instanceName, ITypeInfo *
         {
             className.clear().append("RtlRowTypeInfo");
             arguments.append(",&");
-            childType = buildRtlType(arguments, ::queryRecordType(type));
+            childType = buildRtlType(arguments, ::queryRecordType(type), 0);
 //          fieldType |= (childType & RFTMcontainsifblock);
             if (hasLinkCountedModifier(type))
                 fieldType |= RFTMlinkcounted;
@@ -3863,7 +3868,7 @@ unsigned HqlCppTranslator::buildRtlType(StringBuffer & instanceName, ITypeInfo *
         {
             className.clear().append("RtlDatasetTypeInfo");
             arguments.append(",&");
-            childType = buildRtlType(arguments, ::queryRecordType(type));
+            childType = buildRtlType(arguments, ::queryRecordType(type), 0);
             if (hasLinkCountedModifier(type))
                 fieldType |= RFTMlinkcounted;
             break;
@@ -3872,7 +3877,7 @@ unsigned HqlCppTranslator::buildRtlType(StringBuffer & instanceName, ITypeInfo *
         {
             className.clear().append("RtlDictionaryTypeInfo");
             arguments.append(",&");
-            childType = buildRtlType(arguments, ::queryRecordType(type));
+            childType = buildRtlType(arguments, ::queryRecordType(type), 0);
             if (hasLinkCountedModifier(type))
                 fieldType |= RFTMlinkcounted;
             StringBuffer lookupHelperName;
@@ -3883,7 +3888,7 @@ unsigned HqlCppTranslator::buildRtlType(StringBuffer & instanceName, ITypeInfo *
     case type_set:
         className.clear().append("RtlSetTypeInfo");
         arguments.append(",&");
-        childType = buildRtlType(arguments, type->queryChildType());
+        childType = buildRtlType(arguments, type->queryChildType(), 0);
         break;
     case type_unicode:
         className.clear().append("RtlUnicodeTypeInfo");
@@ -4100,7 +4105,7 @@ void HqlCppTranslator::buildMetaInfo(MetaInstance & instance)
             assertex(!instance.isGrouped());
 
             StringBuffer typeName;
-            unsigned recordTypeFlags = buildRtlType(typeName, record->queryType());
+            unsigned recordTypeFlags = buildRtlType(typeName, record->queryType(), 0);
             s.clear().append("virtual const RtlTypeInfo * queryTypeInfo() const { return &").append(typeName).append("; }");
             metactx.addQuoted(s);
 

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -3487,6 +3487,11 @@ IHqlExpression * HqlCppTranslator::getRtlFieldKey(IHqlExpression * expr, IHqlExp
     return LINK(expr);
 }
 
+bool checkXpathIsNonScalar(const char *xpath)
+{
+    return (strpbrk(xpath, "/?*[]<>")!=NULL); //anything other than a single tag/attr name cannot name a scalar field
+}
+
 unsigned HqlCppTranslator::buildRtlField(StringBuffer * instanceName, IHqlExpression * fieldKey)
 {
     BuildCtx declarectx(*code, declareAtom);
@@ -3550,8 +3555,8 @@ unsigned HqlCppTranslator::buildRtlField(StringBuffer * instanceName, IHqlExpres
         {
             if (xpathName.charAt(0) == '@')
                 typeFlags |= RFTMhasxmlattr;
-            if (!strpbrk(xpathName, "/?*[]<>"))
-                typeFlags |= RFTMxpathscalar;
+            if (checkXpathIsNonScalar(xpathName))
+                typeFlags |= RFTMhasnonscalarxpath;
         }
 
         StringBuffer typeName;

--- a/rtl/eclrtl/rtlfield.cpp
+++ b/rtl/eclrtl/rtlfield.cpp
@@ -41,10 +41,9 @@ static const char * queryXPath(const RtlFieldInfo * field)
 
 static const char * queryScalarXPath(const RtlFieldInfo * field)
 {
-    const char *xpath = queryXPath(field);
-    if (strchr(xpath, '/'))
+    if (field->type && !field->type->xpathIsScalar())
         return field->name->str();
-    return xpath;
+    return queryXPath(field);
 }
 
 static bool hasOuterXPath(const RtlFieldInfo * field)

--- a/rtl/eclrtl/rtlfield.cpp
+++ b/rtl/eclrtl/rtlfield.cpp
@@ -41,7 +41,7 @@ static const char * queryXPath(const RtlFieldInfo * field)
 
 static const char * queryScalarXPath(const RtlFieldInfo * field)
 {
-    if (field->type && !field->type->xpathIsScalar())
+    if (field->type->isValueNonScalarXpath())
         return field->name->str();
     return queryXPath(field);
 }

--- a/rtl/eclrtl/rtlfield.cpp
+++ b/rtl/eclrtl/rtlfield.cpp
@@ -41,7 +41,7 @@ static const char * queryXPath(const RtlFieldInfo * field)
 
 static const char * queryScalarXPath(const RtlFieldInfo * field)
 {
-    if (field->type->isValueNonScalarXpath())
+    if (field->type->hasNonScalarXpath())
         return field->name->str();
     return queryXPath(field);
 }

--- a/rtl/eclrtl/rtlfield.cpp
+++ b/rtl/eclrtl/rtlfield.cpp
@@ -39,6 +39,13 @@ static const char * queryXPath(const RtlFieldInfo * field)
     return field->name->str();
 }
 
+static const char * queryScalarXPath(const RtlFieldInfo * field)
+{
+    const char *xpath = queryXPath(field);
+    if (strchr(xpath, '/'))
+        return field->name->str();
+    return xpath;
+}
 
 static bool hasOuterXPath(const RtlFieldInfo * field)
 {
@@ -140,7 +147,7 @@ size32_t RtlBoolTypeInfo::process(const byte * self, const byte * selfrow, const
 
 size32_t RtlBoolTypeInfo::toXML(const byte * self, const byte * selfrow, const RtlFieldInfo * field, IXmlWriter & target) const
 {
-    target.outputBool(*(const bool *)self, queryXPath(field));
+    target.outputBool(*(const bool *)self, queryScalarXPath(field));
     return sizeof(bool);
 }
 
@@ -174,7 +181,7 @@ size32_t RtlRealTypeInfo::process(const byte * self, const byte * selfrow, const
 
 size32_t RtlRealTypeInfo::toXML(const byte * self, const byte * selfrow, const RtlFieldInfo * field, IXmlWriter & target) const
 {
-    target.outputReal(value(self), queryXPath(field));
+    target.outputReal(value(self), queryScalarXPath(field));
     return length;
 }
 
@@ -201,9 +208,9 @@ size32_t RtlIntTypeInfo::process(const byte * self, const byte * selfrow, const 
 size32_t RtlIntTypeInfo::toXML(const byte * self, const byte * selfrow, const RtlFieldInfo * field, IXmlWriter & target) const
 {
     if (isUnsigned())
-        target.outputUInt(rtlReadUInt(self, length), length, queryXPath(field));
+        target.outputUInt(rtlReadUInt(self, length), length, queryScalarXPath(field));
     else
-        target.outputInt(rtlReadInt(self, length), length, queryXPath(field));
+        target.outputInt(rtlReadInt(self, length), length, queryScalarXPath(field));
     return length;
 }
 
@@ -231,9 +238,9 @@ size32_t RtlSwapIntTypeInfo::process(const byte * self, const byte * selfrow, co
 size32_t RtlSwapIntTypeInfo::toXML(const byte * self, const byte * selfrow, const RtlFieldInfo * field, IXmlWriter & target) const
 {
     if (isUnsigned())
-        target.outputUInt(rtlReadSwapUInt(self, length), length, queryXPath(field));
+        target.outputUInt(rtlReadSwapUInt(self, length), length, queryScalarXPath(field));
     else
-        target.outputInt(rtlReadSwapInt(self, length), length, queryXPath(field));
+        target.outputInt(rtlReadSwapInt(self, length), length, queryScalarXPath(field));
     return length;
 }
 
@@ -267,9 +274,9 @@ size32_t RtlPackedIntTypeInfo::toXML(const byte * self, const byte * selfrow, co
 {
     size32_t fieldsize = rtlGetPackedSize(self);
     if (isUnsigned())
-        target.outputUInt(rtlGetPackedUnsigned(self), fieldsize, queryXPath(field));
+        target.outputUInt(rtlGetPackedUnsigned(self), fieldsize, queryScalarXPath(field));
     else
-        target.outputInt(rtlGetPackedSigned(self), fieldsize, queryXPath(field));
+        target.outputInt(rtlGetPackedSigned(self), fieldsize, queryScalarXPath(field));
     return fieldsize;
 }
 
@@ -373,11 +380,11 @@ size32_t RtlStringTypeInfo::toXML(const byte * self, const byte * selfrow, const
         unsigned lenAscii;
         rtlDataAttr ascii;
         rtlEStrToStrX(lenAscii, ascii.refstr(), thisLength, str);
-        target.outputString(lenAscii, ascii.getstr(), queryXPath(field));
+        target.outputString(lenAscii, ascii.getstr(), queryScalarXPath(field));
     }
     else
     {
-        target.outputString(thisLength, str, queryXPath(field));
+        target.outputString(thisLength, str, queryScalarXPath(field));
     }
     return thisSize;
 }
@@ -453,7 +460,7 @@ size32_t RtlDataTypeInfo::toXML(const byte * self, const byte * selfrow, const R
         thisSize = sizeof(size32_t) + thisLength;
     }
 
-    target.outputData(thisLength, str, queryXPath(field));
+    target.outputData(thisLength, str, queryScalarXPath(field));
     return thisSize;
 }
 
@@ -530,10 +537,10 @@ size32_t RtlVarStringTypeInfo::toXML(const byte * self, const byte * selfrow, co
         unsigned lenAscii;
         rtlDataAttr ascii;
         rtlEStrToStrX(lenAscii, ascii.refstr(), thisLength, str);
-        target.outputString(lenAscii, ascii.getstr(), queryXPath(field));
+        target.outputString(lenAscii, ascii.getstr(), queryScalarXPath(field));
     }
     else
-        target.outputString(thisLength, str, queryXPath(field));
+        target.outputString(thisLength, str, queryScalarXPath(field));
 
     return thisSize;
 }
@@ -611,7 +618,7 @@ size32_t RtlQStringTypeInfo::toXML(const byte * self, const byte * selfrow, cons
         thisSize = sizeof(size32_t) + rtlQStrSize(thisLength);
     }
 
-    target.outputQString(thisLength, str, queryXPath(field));
+    target.outputQString(thisLength, str, queryScalarXPath(field));
     return thisSize;
 }
 
@@ -657,9 +664,9 @@ size32_t RtlDecimalTypeInfo::toXML(const byte * self, const byte * selfrow, cons
 {
     size32_t thisSize = calcSize();
     if (isUnsigned())
-        target.outputUDecimal(self, thisSize, getDecimalPrecision(), queryXPath(field));
+        target.outputUDecimal(self, thisSize, getDecimalPrecision(), queryScalarXPath(field));
     else
-        target.outputDecimal(self, thisSize, getDecimalPrecision(), queryXPath(field));
+        target.outputDecimal(self, thisSize, getDecimalPrecision(), queryScalarXPath(field));
     return thisSize;
 }
 
@@ -690,7 +697,7 @@ size32_t RtlCharTypeInfo::toXML(const byte * self, const byte * selfrow, const R
         rtlEStrToStr(1, &c, 1, str);
     else
         c = *str;
-    target.outputString(1, &c, queryXPath(field));
+    target.outputString(1, &c, queryScalarXPath(field));
     return 1;
 }
 
@@ -767,7 +774,7 @@ size32_t RtlUnicodeTypeInfo::toXML(const byte * self, const byte * selfrow, cons
         thisSize = sizeof(size32_t) + thisLength * sizeof(UChar);
     }
 
-    target.outputUnicode(thisLength, ustr, queryXPath(field));
+    target.outputUnicode(thisLength, ustr, queryScalarXPath(field));
     return thisSize;
 }
 
@@ -831,7 +838,7 @@ size32_t RtlVarUnicodeTypeInfo::toXML(const byte * self, const byte * selfrow, c
     else
         thisSize = (thisLength + 1) * sizeof(UChar);
 
-    target.outputUnicode(thisLength, ustr, queryXPath(field));
+    target.outputUnicode(thisLength, ustr, queryScalarXPath(field));
     return thisSize;
 }
 
@@ -877,7 +884,7 @@ size32_t RtlUtf8TypeInfo::toXML(const byte * self, const byte * selfrow, const R
     unsigned thisLength = rtlReadUInt4(self);
     unsigned thisSize = sizeof(size32_t) + rtlUtf8Size(thisLength, str);
 
-    target.outputUtf8(thisLength, str, queryXPath(field));
+    target.outputUtf8(thisLength, str, queryScalarXPath(field));
     return thisSize;
 }
 
@@ -1420,9 +1427,9 @@ size32_t RtlBitfieldTypeInfo::toXML(const byte * self, const byte * selfrow, con
 {
     size32_t fieldsize = size(self, selfrow);
     if (isUnsigned())
-        target.outputUInt(unsignedValue(self), fieldsize, queryXPath(field));
+        target.outputUInt(unsignedValue(self), fieldsize, queryScalarXPath(field));
     else
-        target.outputInt(signedValue(self), fieldsize, queryXPath(field));
+        target.outputInt(signedValue(self), fieldsize, queryScalarXPath(field));
     return fieldsize;
 }
 

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -364,7 +364,7 @@ struct RtlTypeInfo : public RtlITypeInfo
     inline bool isFixedSize() const { return (fieldType & RFTMunknownsize) == 0; }
     inline bool isLinkCounted() const { return (fieldType & RFTMlinkcounted) != 0; }
     inline bool isUnsigned() const { return (fieldType & RFTMunsigned) != 0; }
-    inline bool isValueNonScalarXpath() const { return (fieldType & RFTMhasnonscalarxpath) != 0; }
+    inline bool hasNonScalarXpath() const { return (fieldType & RFTMhasnonscalarxpath) != 0; }
     inline unsigned getDecimalDigits() const { return (length & 0xffff); }
     inline unsigned getDecimalPrecision() const { return (length >> 16); }
     inline unsigned getBitfieldIntSize() const { return (length & 0xff); }

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -326,6 +326,7 @@ enum RtlFieldTypeMask
 
     RFTMalien               = 0x00000800,                   // this is the physical format of a user defined type, if unknown size we can't calculate it
     RFTMcontainsifblock     = 0x00000800,                   // contains an if block - if set on a record then it contains ifblocks, so can't work out field offsets.
+    RFTMxpathscalar         = 0x00001000,                   // field xpath contains only one node, and is therefore usable for naming scalar fields
 
     RFTMcontainsunknown     = 0x10000000,                   // contains a field of unknown type that we can't process properly
     RFTMinvalidxml          = 0x20000000,                   // cannot be called to generate xml
@@ -363,6 +364,7 @@ struct RtlTypeInfo : public RtlITypeInfo
     inline bool isFixedSize() const { return (fieldType & RFTMunknownsize) == 0; }
     inline bool isLinkCounted() const { return (fieldType & RFTMlinkcounted) != 0; }
     inline bool isUnsigned() const { return (fieldType & RFTMunsigned) != 0; }
+    inline bool xpathIsScalar() const { return (fieldType & RFTMxpathscalar) != 0; }
     inline unsigned getDecimalDigits() const { return (length & 0xffff); }
     inline unsigned getDecimalPrecision() const { return (length >> 16); }
     inline unsigned getBitfieldIntSize() const { return (length & 0xff); }
@@ -375,7 +377,6 @@ public:
                                     // for decimal, numdigits | precision << 16
                                     // if RFTMunknownsize then maxlength (records) [maxcount(datasets)]
 };
-
 
 //Core struct used for representing meta for a field.
 struct RtlFieldInfo

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -326,7 +326,7 @@ enum RtlFieldTypeMask
 
     RFTMalien               = 0x00000800,                   // this is the physical format of a user defined type, if unknown size we can't calculate it
     RFTMcontainsifblock     = 0x00000800,                   // contains an if block - if set on a record then it contains ifblocks, so can't work out field offsets.
-    RFTMxpathscalar         = 0x00001000,                   // field xpath contains only one node, and is therefore usable for naming scalar fields
+    RFTMhasnonscalarxpath   = 0x00001000,                   // field xpath contains only one node, and is therefore usable for naming scalar fields
 
     RFTMcontainsunknown     = 0x10000000,                   // contains a field of unknown type that we can't process properly
     RFTMinvalidxml          = 0x20000000,                   // cannot be called to generate xml
@@ -364,7 +364,7 @@ struct RtlTypeInfo : public RtlITypeInfo
     inline bool isFixedSize() const { return (fieldType & RFTMunknownsize) == 0; }
     inline bool isLinkCounted() const { return (fieldType & RFTMlinkcounted) != 0; }
     inline bool isUnsigned() const { return (fieldType & RFTMunsigned) != 0; }
-    inline bool xpathIsScalar() const { return (fieldType & RFTMxpathscalar) != 0; }
+    inline bool isValueNonScalarXpath() const { return (fieldType & RFTMhasnonscalarxpath) != 0; }
     inline unsigned getDecimalDigits() const { return (length & 0xffff); }
     inline unsigned getDecimalPrecision() const { return (length >> 16); }
     inline unsigned getBitfieldIntSize() const { return (length & 0xff); }

--- a/testing/regress/ecl/key/xmloutScalarXpath.xml
+++ b/testing/regress/ecl/key/xmloutScalarXpath.xml
@@ -1,0 +1,8 @@
+<Dataset name='OriginalReadRow'>
+ <Row><L1><L2><fname>MOE</fname><lname>DOE</lname><pr>1</pr><st>11TH</st><zi>11</zi><ag>31</ag><ix>315367</ix></L2><L2><fname>JOE</fname><lname>POE</lname><pr>2</pr><st>22ND</st><zi>11</zi><ag>32</ag><ix>315370</ix></L2><L2><fname>XOE</fname><lname>ROE</lname><pr>3</pr><st>33RD</st><zi>11</zi><ag>33</ag><ix>315204</ix></L2></L1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+</Dataset>
+<Dataset name='readWrittenDataset'>
+ <Row><L1><L2><fname>MOE</fname><lname>DOE</lname><pr>1</pr><st>11TH</st><zi>11</zi><ag>31</ag><ix>315367</ix></L2><L2><fname>JOE</fname><lname>POE</lname><pr>2</pr><st>22ND</st><zi>11</zi><ag>32</ag><ix>315370</ix></L2><L2><fname>XOE</fname><lname>ROE</lname><pr>3</pr><st>33RD</st><zi>11</zi><ag>33</ag><ix>315204</ix></L2></L1></Row>
+</Dataset>

--- a/testing/regress/ecl/xmloutScalarXpath.ecl
+++ b/testing/regress/ecl/xmloutScalarXpath.ecl
@@ -45,6 +45,6 @@ readL1rec := RECORD
    DATASET(scalarReadRec) deep{xpath('L1/L2')};
 END;
 
-output(Dataset(xrow),,'~REGRESS::TEMP::output_scalar_xpath.xml',overwrite, xml);
+output(Dataset(xrow),,'REGRESS::TEMP::output_scalar_xpath.xml',overwrite, xml);
 readWrittenXml := dataset(DYNAMIC('REGRESS::TEMP::output_scalar_xpath.xml'), readL1Rec, xml('Dataset/Row'));
 output(readWrittenXml, named('readWrittenDataset'));

--- a/testing/regress/ecl/xmloutScalarXpath.ecl
+++ b/testing/regress/ecl/xmloutScalarXpath.ecl
@@ -46,5 +46,5 @@ readL1rec := RECORD
 END;
 
 output(Dataset(xrow),,'~REGRESS::TEMP::output_scalar_xpath.xml',overwrite, xml);
-readWrittenXml := dataset(DYNAMIC('~REGRESS::TEMP::output_scalar_xpath.xml'), readL1Rec, xml('Dataset/Row'));
+readWrittenXml := dataset(DYNAMIC('REGRESS::TEMP::output_scalar_xpath.xml'), readL1Rec, xml('Dataset/Row'));
 output(readWrittenXml, named('readWrittenDataset'));

--- a/testing/regress/ecl/xmloutScalarXpath.ecl
+++ b/testing/regress/ecl/xmloutScalarXpath.ecl
@@ -1,0 +1,50 @@
+origReadRec :=       RECORD
+   string fn {xpath('fname')};
+   string ln {xpath('lname')};
+   string pr {xpath('Rec/prange')};
+   string st {xpath('Rec/street')};
+   string zi {xpath('Rec/zips')};
+   string ag {xpath('Rec/age')};
+   integer8 ix {xpath('Rec/id')};
+END;
+
+L1rec := RECORD
+   DATASET(origReadRec) deep{xpath('L1/L2')};
+END;
+
+
+x := u8'<root><L1>' +
+       u8'<L2><fname>MOE</fname><lname>DOE</lname>' +
+         u8'<Rec><prange>1</prange><street>11TH</street><zips>11</zips><age>31</age><id>315367</id></Rec>' +
+       u8'</L2>' +
+       u8'<L2><fname>JOE</fname><lname>POE</lname>' +
+         u8'<Rec><prange>2</prange><street>22ND</street><zips>11</zips><age>32</age><id>315370</id></Rec>' +
+       u8'</L2>' +
+       u8'<L2><fname>XOE</fname><lname>ROE</lname>' +
+         u8'<Rec><prange>3</prange><street>33RD</street><zips>11</zips><age>33</age><id>315204</id></Rec>' +
+       u8'</L2>' +
+     u8'</L1></root>';
+
+
+xrow := FROMXML(L1Rec, x);
+output(xrow, named('OriginalReadRow'));
+
+
+
+scalarReadRec :=       RECORD
+   string fn {xpath('fname')};
+   string ln {xpath('lname')};
+   string pr;
+   string st;
+   string zi;
+   string ag;
+   integer8 ix;
+END;
+
+readL1rec := RECORD
+   DATASET(scalarReadRec) deep{xpath('L1/L2')};
+END;
+
+output(Dataset(xrow),,'~REGRESS::TEMP::output_scalar_xpath.xml',overwrite, xml);
+readWrittenXml := dataset(DYNAMIC('~REGRESS::TEMP::output_scalar_xpath.xml'), readL1Rec, xml('Dataset/Row'));
+output(readWrittenXml, named('readWrittenDataset'));


### PR DESCRIPTION
This commit will cause scalar record fields with complex xpaths to
use the field name rather than xpath to output xml and json.

The caveat being that the record still can't be used to read the output
back in, but there is no way to guess the original format from the xpath
so it's better not to try to output complex xml when its quite likely
to be wrong.  In any case the output should be valid xml.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
