### PR TITLE
HPCC-13424 Roxie may segfault on startup if no querySets specified

### DIFF
--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -568,7 +568,7 @@ public:
 
     virtual void commitCache()
     {
-        if (isConnected)
+        if (isConnected && cache)
         {
             CriticalBlock b(cacheCrit);
             if (!recursiveCreateDirectory(queryDirectory))


### PR DESCRIPTION
This can happen if trying to test a standalone query with a dali connection,
or if the configuration is messed up.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
