### PR TITLE
HPCC-13156 Modification of jlib and thor signal handling

### DIFF
--- a/common/fileview2/fvserver.cpp
+++ b/common/fileview2/fvserver.cpp
@@ -27,7 +27,7 @@
 Semaphore sem;
 
 
-bool myAbortHandler()
+bool myAbortHandler(int sig)
 {
     sem.signal();
     return false;

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -62,7 +62,7 @@ void usage()
 
 
 
-static bool exitDFUserver()
+static bool exitDFUserver(int sig)
 {
     engine->abortListeners();
     return false;

--- a/dali/ft/ftbase.cpp
+++ b/dali/ft/ftbase.cpp
@@ -748,7 +748,7 @@ size32_t CrcIOStream::write(size32_t len, const void * data)
 //---------------------------------------------------------------------------
 
 static int breakCount;
-bool daftAbortHandler()
+bool daftAbortHandler(int sig)
 {
     LOG(MCprogress, unknownJob, "Aborting...");
     // hit ^C 3 times to really stop it...

--- a/dali/ft/ftbase.hpp
+++ b/dali/ft/ftbase.hpp
@@ -30,6 +30,6 @@
 
 typedef __int32 crc32_t;
 
-bool daftAbortHandler();
+bool daftAbortHandler(int);
 
 #endif

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -88,7 +88,7 @@ static void stopServer()
 }
 
 
-static bool actionOnAbort()
+static bool actionOnAbort(int sig)
 {
     LOG(MCprogress, unknownJob, "Stop signalled");
     if (stopped)

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -118,7 +118,7 @@ static void stopServer()
     stopMPServer();
 }
 
-bool actionOnAbort()
+bool actionOnAbort(int sig)
 {
     stopServer();
     return true;

--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -241,7 +241,7 @@ int CEclAgentExecutionServer::executeWorkunit(const char * wuid)
 
 //---------------------------------------------------------------------------------
 
-bool ControlHandler() 
+bool ControlHandler(int sig) 
 { 
     if (execSvr)
     {

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3149,7 +3149,7 @@ void printStart(int argc, const char *argv[])
 
 //--------------------------------------------------------------
 
-bool ControlHandler()
+bool ControlHandler(int sig)
 {
     LOG(MCevent,"ControlHandler Stop signalled");
     return true;

--- a/system/jlib/jmisc.cpp
+++ b/system/jlib/jmisc.cpp
@@ -710,7 +710,7 @@ public:
         installer = GetCurrentThreadId();
     }
 
-    bool handle()
+    bool handle(int sig=0)
     {
 #ifndef _WIN32
         if (installer == GetCurrentThreadId())
@@ -718,7 +718,7 @@ public:
         {
 //          DBGLOG("handle abort %x", GetCurrentThreadId());
             if (handler)
-                return handler();
+                return handler(sig);
             else
                 return ihandler->onAbort();
         }
@@ -731,7 +731,7 @@ public:
 
 CIArrayOf<AbortHandlerInfo> handlers;
 
-bool notifyOnAbort()
+bool notifyOnAbort(int sig)
 {
 //  DBGLOG("notifyOnAbort %x", GetCurrentThreadId());
 //      CriticalBlock c(abortCrit); You would think that this was needed, but it locks up.
@@ -739,7 +739,7 @@ bool notifyOnAbort()
     bool doExit = false;
     ForEachItemInRev(idx, handlers)
     {
-        if (handlers.item(idx).handle())
+        if (handlers.item(idx).handle(sig))
             doExit = true;
     }
 //  DBGLOG("notifyOnAbort returning %d", (int) doExit);
@@ -785,7 +785,7 @@ BOOL WINAPI ModuleExitHandler ( DWORD dwCtrlType )
 static void UnixAbortHandler(int sig)
 {
     hadAbortSignal = true;
-    if (handlers.length()==0 || notifyOnAbort())
+    if (handlers.length()==0 || notifyOnAbort(sig))
     {
         _exit(0);
     }

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -246,7 +246,7 @@ inline unsigned __int32 low(__int64 n)
 
 //MORE - We really should restructure this file.  Also would this be better with a class interface?
 //Handle ^C/break from a console program.
-typedef bool (*AbortHandler)();                                                 // return true to exit program
+typedef bool (*AbortHandler)(int);                                                 // return true to exit program
 
 interface IAbortHandler : public IInterface
 {

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -784,12 +784,15 @@ void abortThor(IException *e, unsigned errCode, bool abortCurrentJob)
     if (0 == aborting)
     {
         aborting = 1;
-        if (!e)
+        if (errCode)
         {
-            _e.setown(MakeThorException(TE_AbortException, "THOR ABORT"));
-            e = _e;
+            if (!e)
+            {
+                _e.setown(MakeThorException(TE_AbortException, "THOR ABORT"));
+                e = _e;
+            }
+            EXCLOG(e,"abortThor");
         }
-        EXCLOG(e,"abortThor");
         LOG(MCdebugProgress, thorJob, "abortThor called");
         if (jM)
             jM->stop();

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -192,7 +192,7 @@ void UnregisterSelf(IException *e)
     }
 }
 
-bool ControlHandler() 
+bool ControlHandler(int sig) 
 { 
     LOG(MCdebugProgress, thorJob, "CTRL-C pressed");
     if (masterNode) UnregisterSelf(NULL);


### PR DESCRIPTION
In our current implementation of signal handling in jmisc we rely on a prototype for our signal handlers that is

``` C++
typedef bool (*AbortHandler)();
```

This means that we can't differentiate between different SIGINT/SIGTERM/SIGQUIT because of how the Abort code is written.  This is a simple fix that allows us to pass the signo through to the list of handlers that gets called.  It has been replaced with

``` C++
typedef bool (*AbortHandler)(int);
```

The abortThor code is also modified, so that when we are calling abortThor(NULL, TEC_Clean); we can exit without an exception being logged.  

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
