### PR TITLE
HPCC-13310 checkPid logic is replicated in checkPidExist call within check_status

### DIFF
--- a/initfiles/bash/etc/init.d/pid.sh
+++ b/initfiles/bash/etc/init.d/pid.sh
@@ -145,10 +145,6 @@ check_status() {
     COMPPIDFILEPATH=$3
     SENTINELFILECHK=$4
 
-    checkPid $PIDFILEPATH
-    local pidfilepathExists=$__flagPid
-    checkPid $COMPPIDFILEPATH
-    local comppidfilepathExists=$__flagPid
     locked $LOCKFILEPATH
     local componentLocked=$flagLocked
     checkPidExist $PIDFILEPATH
@@ -159,12 +155,12 @@ check_status() {
     local sentinelFlag=$?
 
     # check if running and healthy
-    if [ $pidfilepathExists -eq 1 ] && [ $comppidfilepathExists -eq 1 ] && [ $componentLocked -eq 1 ] && [ $initRunning -eq 1 ] && [ $compRunning -eq 1 ]; then
+    if [ $componentLocked -eq 1 ] && [ $initRunning -eq 1 ] && [ $compRunning -eq 1 ]; then
       if [ ${DEBUG} != "NO_DEBUG" ]; then
         echo "everything is up except sentinel"
       fi
       if [ ${SENTINELFILECHK} -eq 1 ]; then
-        if [ ${sentinelFlag} -eq 0 ]; then
+        if [ ${sentinelFlag} -eq 1 ]; then
           if [ ${DEBUG} != "NO_DEBUG" ]; then
             echo "Sentinel is now up"
           fi
@@ -179,9 +175,9 @@ check_status() {
         return 0
       fi
     # check if shutdown and healthy
-    elif [ $pidfilepathExists -eq 0 ] && [ $comppidfilepathExists -eq 0 ] && [ $componentLocked -eq 0 ] && [ $initRunning -eq 0 ] && [ $compRunning -eq 0 ]; then
+    elif [ $componentLocked -eq 0 ] && [ $initRunning -eq 0 ] && [ $compRunning -eq 0 ]; then
       if [ ${SENTINELFILECHK} -eq 1 ]; then
-        if [ ${sentinelFlag} -eq 0 ]; then
+        if [ ${sentinelFlag} -eq 1 ]; then
           if [ ${DEBUG} != "NO_DEBUG" ]; then
             echo "Sentinel is up but orphaned"
           fi
@@ -197,8 +193,6 @@ check_status() {
       fi
     else
       if [ "${DEBUG}" != "NO_DEBUG" ]; then
-        [ $pidfilepathExists -eq 0 ]     && log_failure_msg "pid file path does not exist: $1"
-        [ $comppidfilepathExists -eq 0 ] && log_failure_msg "comp pid file path does not exist: $3"
         [ $componentLocked -eq 0 ]       && log_failure_msg "component is not locked: $2"
         [ $initRunning -eq 0 ]           && log_failure_msg "process for ${compName}_init.pid is not running"
         [ $compRunning -eq 0 ]           && log_failure_msg "process for ${compName}.pid is not running"
@@ -212,11 +206,11 @@ checkSentinelFile() {
     if [ -d ${FILEPATH} ];then
        fileCheckOP=`find ${FILEPATH} -name "*senti*"`
        if [ ! -z "${fileCheckOP}" ]; then
-         return 0
+         return 1
        else
-         return 3
+         return 0
        fi
     else
-       return 3
+       return 0
     fi
 }

--- a/initfiles/bash/etc/init.d/pid.sh
+++ b/initfiles/bash/etc/init.d/pid.sh
@@ -14,112 +14,89 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ################################################################################
+
+# Checks if Pid Directory exists and creates if it doesn't exist
 checkPidDir () {
-    
-    # Checks if Pid Directory exists and creates if it doesn't exist
     PIDFILEPATH=$1
-    #echo -n "Pid Path exists"
-    if [ -e ${PIDFILEPATH} ]; then
+    if [[ -e ${PIDFILEPATH} ]]; then
         log_success_msg ""
     else
         log_failure_msg "" 
         echo "Creating a Pid directory"
         /bin/mkdir -P ${PIDFILEPATH} 
-        if [ !-e ${PIDFILEPATH} ]; then
+        if [[ ! -e ${PIDFILEPATH} ]]; then
             echo "Can not create a Pid directory $PIDFILEPATH"
         else
             log_success_msg
         fi
     fi
-
 }
 
+# Creats a Pid file
 createPid () {
-
-    # Creats a Pid file
     PIDFILEPATH=$1
     PIDNO=$2
-    #echo -n "Creating Pid file $PIDFILEPATH"
     checkPid ${PIDFILEPATH}
-    if [ $__flagPid -eq 1 ]; then
-        if [ ${DEBUG} != "NO_DEBUG" ]; then
-            log_failure_msg "Pid file already exists"
-        fi
+    if [[ $__flagPid -eq 1 ]]; then
+        [[ ${DEBUG} != "NO_DEBUG" ]] && log_failure_msg "Pid file already exists"
         __pidCreated=0
     else
-        echo $PIDNO > ${PIDFILEPATH} 
+        echo $PIDNO > ${PIDFILEPATH}
         checkPid ${PIDFILEPATH}
-        if [ $__flagPid -eq 1 ]; then
-            if [ ${DEBUG} != "NO_DEBUG" ]; then
-                log_success_msg 
-            fi
+        if [[ $__flagPid -eq 1 ]]; then
+            [[ ${DEBUG} != "NO_DEBUG" ]] && log_success_msg 
             __pidCreated=1
         else
-            if [ ${DEBUG} != "NO_DEBUG" ]; then
-                log_failure_msg "Failed to create Pid"
-            fi
+            [[ ${DEBUG} != "NO_DEBUG" ]] && log_failure_msg "Failed to create Pid"
             __pidCreated=0
         fi
     fi
-
 }
 
+# Checks if Pid file exists
 checkPid () {
-
-    # Checks if Pid file exists
     PIDFILEPATH=$1
-    if [ -e ${PIDFILEPATH} ]; then
+    if [[ -e ${PIDFILEPATH} ]]; then
         __flagPid=1
     else
         __flagPid=0
     fi
-
 }
 
+# Reads the Pid file if Pidfile exists
 getPid () {
-    
-    # Reads the Pid file if Pidfile exists
     PIDFILEPATH=$1
     checkPid ${PIDFILEPATH}
-    if [ $__flagPid -eq 1 ]; then
-        __pidValue=`/bin/cat $PIDFILEPATH`
+    if [[ $__flagPid -eq 1 ]]; then
+        __pidValue=$(/bin/cat $PIDFILEPATH)
     else
         __pidValue=0
     fi
-
 }
 
+# Removes a Pid file 
 removePid () {
-
-    # Removes a Pid file 
     PIDFILEPATH=$1
-    #echo -n "Removing Pid file $PIDFILEPATH"
     checkPid ${PIDFILEPATH}
-    if [ $__flagPid -eq 0 ]; then
-        if [ ${DEBUG} != "NO_DEBUG" ]; then
-            log_failure_msg "Pidfile doesn't exist"
-        fi
+    if [[ $__flagPid -eq 0 ]]; then
+        [[ ${DEBUG} != "NO_DEBUG" ]] && log_failure_msg "Pidfile doesn't exist"
         __pidRemoved=0
     else
-        /bin/rm -rf ${PIDFILEPATH}
-        if [ ! -e ${PIDFILEPATH} ]; then
+        rm -rf ${PIDFILEPATH} > /dev/null 2>&1
+        if [[ ! -e ${PIDFILEPATH} ]]; then
             __pidRemoved=1
         else
-            if [ ${DEBUG} != "NO_DEBUG" ]; then
-                log_failure_msg "Failed to remove pid"
-            fi
+            [[ ${DEBUG} != "NO_DEBUG" ]] && log_failure_msg "Failed to remove pid"
             __pidRemoved=0
         fi
     fi
-
- 
 }
     
 checkPidExist() {
-        PIDFILEPATH=$1
+    PIDFILEPATH=$1
     getPid ${PIDFILEPATH}
-    if [ $__pidValue -ne 0 ]; then
-        ! /bin/kill -0 $__pidValue > /dev/null 2>&1 
+    if [[ $__pidValue -ne 0 ]]; then
+        ! kill -0 $__pidValue > /dev/null 2>&1 
         __pidExists=$?
     else
         __pidExists=0
@@ -155,62 +132,41 @@ check_status() {
     local sentinelFlag=$?
 
     # check if running and healthy
-    if [ $componentLocked -eq 1 ] && [ $initRunning -eq 1 ] && [ $compRunning -eq 1 ]; then
-      if [ ${DEBUG} != "NO_DEBUG" ]; then
-        echo "everything is up except sentinel"
-      fi
-      if [ ${SENTINELFILECHK} -eq 1 ]; then
-        if [ ${sentinelFlag} -eq 1 ]; then
-          if [ ${DEBUG} != "NO_DEBUG" ]; then
-            echo "Sentinel is now up"
-          fi
-          return 0
-        else
-          if [ ${DEBUG} != "NO_DEBUG" ]; then
-            echo "Sentinel not yet located, process currently unhealthy"
-          fi
-          return 2
+    if [[ $componentLocked -eq 1 ]] && [[ $initRunning -eq 1 ]] && [[ $compRunning -eq 1 ]]; then
+        [[ ${DEBUG} != "NO_DEBUG" ]] && echo "everything is up except sentinel"
+        if [[ ${SENTINELFILECHK} -eq 1 ]]; then
+            if [[ ${sentinelFlag} -eq 0 ]]; then
+                [[ ${DEBUG} != "NO_DEBUG" ]] && echo "Sentinel not yet located, process currently unhealthy"
+                return 2 
+            fi
+            [[ ${DEBUG} != "NO_DEBUG" ]] && echo "Sentinel is now up"
         fi
-      else
         return 0
-      fi
     # check if shutdown and healthy
-    elif [ $componentLocked -eq 0 ] && [ $initRunning -eq 0 ] && [ $compRunning -eq 0 ]; then
-      if [ ${SENTINELFILECHK} -eq 1 ]; then
-        if [ ${sentinelFlag} -eq 1 ]; then
-          if [ ${DEBUG} != "NO_DEBUG" ]; then
-            echo "Sentinel is up but orphaned"
-          fi
-          return 3
-        else
-          if [ ${DEBUG} != "NO_DEBUG" ]; then
-            echo "Sentinel is now down"
-          fi
-          return 1
+    elif [[ $componentLocked -eq 0 ]] && [[ $initRunning -eq 0 ]] && [[ $compRunning -eq 0 ]]; then
+        if [[ ${SENTINELFILECHK} -eq 1 ]]; then
+            if [[ ${sentinelFlag} -eq 1 ]]; then
+                [[ ${DEBUG} != "NO_DEBUG" ]] && echo "Sentinel is up but orphaned"
+                return 3
+            fi
+            [[ ${DEBUG} != "NO_DEBUG" ]] && echo "Sentinel is now down"
         fi
-      else
         return 1
-      fi
     else
-      if [ "${DEBUG}" != "NO_DEBUG" ]; then
-        [ $componentLocked -eq 0 ]       && log_failure_msg "component is not locked: $2"
-        [ $initRunning -eq 0 ]           && log_failure_msg "process for ${compName}_init.pid is not running"
-        [ $compRunning -eq 0 ]           && log_failure_msg "process for ${compName}.pid is not running"
-      fi
-      return 4
+        if [[ "${DEBUG}" != "NO_DEBUG" ]]; then
+            [[ $componentLocked -eq 0 ]] && log_failure_msg "component is not locked: $2"
+            [[ $initRunning -eq 0 ]]     && log_failure_msg "process for ${compName}_init.pid is not running"
+            [[ $compRunning -eq 0 ]]     && log_failure_msg "process for ${compName}.pid is not running"
+        fi
+        return 4
     fi
 }
 
 checkSentinelFile() {
     FILEPATH="${runtime}/${compName}"
-    if [ -d ${FILEPATH} ];then
-       fileCheckOP=`find ${FILEPATH} -name "*senti*"`
-       if [ ! -z "${fileCheckOP}" ]; then
-         return 1
-       else
-         return 0
-       fi
-    else
-       return 0
+    if [[ -d ${FILEPATH} ]]; then
+       fileCheckOP=$(find ${FILEPATH} -name "*senti*")
+       [[ ! -z "${fileCheckOP}" ]] && return 1
     fi
+    return 0
 }


### PR DESCRIPTION
The check_status function checks for the existence of the pidfile and comppidfile.  This is unnecessary because it is done within the getPid call, that is nested within the checkPidExist call.  If the file doesn't exist, then checkPidExist will return a __pidExists value of 0 by default.  

I also took the time to go through and make the code a bit more concise and easy to read, as well as fix checkSentinelFile so that it's return value would mimic all the other functions return values.  (1 for true, 0 for false)

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
