### PR TITLE
HPCC-13416 WUID filter should force uppercase

### DIFF
--- a/esp/src/eclwatch/WUQueryWidget.js
+++ b/esp/src/eclwatch/WUQueryWidget.js
@@ -198,6 +198,7 @@ define([
         getFilter: function () {
             var retVal = this.filter.toObject();
             lang.mixin(retVal, {
+                Wuid: retVal.Wuid.toUpperCase().trim(),
                 StartDate: this.getISOString("FromDate", "FromTime"),
                 EndDate: this.getISOString("ToDate", "ToTime")
             });


### PR DESCRIPTION
Modify string entry to always follow uppercase convention.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
