### PR TITLE
HPCC-13455 Early stop of parallel funnel can cause deadlock.

### DIFF
--- a/thorlcr/activities/funnel/thfunnelslave.cpp
+++ b/thorlcr/activities/funnel/thfunnelslave.cpp
@@ -76,10 +76,6 @@ class CParallelFunnel : public CSimpleInterface, implements IRowStream
             bool started = false;
             try
             {
-                { 
-                    CriticalBlock b(stopCrit);
-                    if (stopping) return;
-                }
                 if (funnel.startInputs)
                 {
                     IThorDataLink *_input = QUERYINTERFACE(input.get(), IThorDataLink);


### PR DESCRIPTION
If a parallel funnel is stopped before it has started an input,
it can cause a global activity that's upstream that dependends on
all slaves being started (e.g. global lookupjoin) to deadlock.

This fix ensures parallel funnel won't stop until all it's inputs
have started

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
