### PR TITLE
HPCC-13456 Fixed regression in stop/start of thor

### DIFF
--- a/initfiles/bin/init_thor
+++ b/initfiles/bin/init_thor
@@ -28,7 +28,6 @@ rm -f ${SENTINEL}
 
 killed() {
         echo "Stopping"
-        $deploydir/stop_thor $deploydir
         kill_process ${SENTINEL} ${PID_NAME} 3
         exit 255
 }

--- a/initfiles/componentfiles/thor/run_thor
+++ b/initfiles/componentfiles/thor/run_thor
@@ -92,6 +92,7 @@ while [ 1 ]; do
         fi
     else
         echo failed to start thormaster$LCR, pausing for 30 seconds
+        $deploydir/stop_thor $deploydir
         sleep 30
     fi
     if [ ! -e $SENTINEL ]; then


### PR DESCRIPTION
There was an issue where thor_init and run_thor would both call stop_thor when exiting.  Causing duplicate stop_thor instances.  As such, when hpcc-init saw thor down and went to do the start (for restart) we would run into issues with the extra stop_thor killing off slaves that the new init_thor was spawning.  Meaning the startup of the new thormaster would fail.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
