### PR TITLE
HPCC-13470 memory leaks in ldapsecurity code

### DIFF
--- a/system/security/shared/authmap.ipp
+++ b/system/security/shared/authmap.ipp
@@ -46,6 +46,15 @@ public:
     IMPLEMENT_IINTERFACE;
 
     CAuthMap(ISecManager* secmgr) {m_secmgr = secmgr;};
+    virtual ~CAuthMap()
+    {
+        ForEachItemIn(x, m_resourcelists)
+        {
+            ISecResourceList* rlist = m_resourcelists.item(x).list();
+            if (rlist)
+                rlist->Release();
+        }
+    }
     int add(const char* path, ISecResourceList* resourceList);
     bool shouldAuth(const char* path);
     ISecResourceList* queryResourceList(const char* path);


### PR DESCRIPTION
CLdapSecManager::createResourceList allocates resources that are stored
by the CAuthMap object in an IArrayOf<CSecResourceListHolder> m_resourcelists
object. When the CAuthMap gets destroyed, and its m_resourcelists array, the
contents of that array are not released and therefore leak. This pull request
adds a virtual destructor to CAuthMap that iterates over the list and releases
each one.

The other leak referenced in the Jira bug was confirmed not to be a leak. To
prove, I added PROGLOG messages to the CTOR and DTOR of CLdapSecUser, and
ensured that the CLdapSecResource::clone() was called (hundreds of times).
Ran this test many times/variations, and in all cases the objects were
correctly destroyed

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
