### PR TITLE
HPCC-13404 Fix memory leak when in ECLWatch (ESP get graph)

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -265,6 +265,8 @@ private:
     void cleanZAPFolder(IFile* zipDir, bool removeFolder);
     IPropertyTree* sendControlQuery(IEspContext &context, const char* target, const char* query, unsigned timeout);
     bool resetQueryStats(IEspContext &context, const char* target, IProperties* queryIds, IEspWUQuerySetQueryActionResponse& resp);
+    void readGraph(IEspContext& context, const char* subGraphId, WUGraphIDType& id, bool running,
+        IConstWUGraph* graph, IArrayOf<IEspECLGraphEx>& graphs);
 
     unsigned awusCacheMinutes;
     StringBuffer queryDirectory;


### PR DESCRIPTION
Memory leak is reported when WsWorkunits.WUGetGraph is called.
The leak is due to an un-released IConstWUGraph point. This
fix modifies the WUGetGraph so that the point is released.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
