### PR TITLE
HPCC-13476 Output dependencies in a consistent order

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -15896,7 +15896,6 @@ extern HQL_API IPropertyTree * gatherAttributeDependencies(IEclRepository * data
     {
         HqlScopeArray scopes;   
         getRootScopes(scopes, dataServer, ctx);
-        scopes.sort(compareScopesByName);
         ForEachItemIn(i, scopes)
         {
             IHqlScope & cur = scopes.item(i);

--- a/ecl/hql/hqlrepository.cpp
+++ b/ecl/hql/hqlrepository.cpp
@@ -23,6 +23,7 @@
 #include "eclrtl.hpp"
 #include "hqlexpr.ipp"
 #include "hqlerror.hpp"
+#include "hqlutil.hpp"
 
 //-------------------------------------------------------------------------------------------------------------------
 
@@ -30,6 +31,7 @@ static void getRootScopes(HqlScopeArray & rootScopes, IHqlScope * scope)
 {
     HqlExprArray rootSymbols;
     scope->getSymbols(rootSymbols);
+    rootSymbols.sort(compareSymbolsByName);
     ForEachItemIn(i, rootSymbols)
     {
         IHqlExpression & cur = rootSymbols.item(i);


### PR DESCRIPTION
This fix ensures that implicit imports are processed alphabetically
instead of in the order of the hash table.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
