### PR TITLE
HPCC-13331 Should be able to despray XML without rowTag specification.

### DIFF
--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -37,6 +37,10 @@ interface INamedGroupStore;
 
 #define MAX_REPLICATION_LEVELS 4
 
+#define DEFAULTXMLROWTAG "Row"
+#define DEFAULTXMLHEADER "<Dataset>"
+#define DEFAULTXMLFOOTER "</Dataset>"
+
 enum DFD_OS
 {
     DFD_OSdefault,

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -262,6 +262,7 @@ protected:
     void updateSizeRead();
     void waitForTransferSem(Semaphore & sem);
     void addPrefix(size32_t len, const void * data, unsigned idx, PartitionPointArray & partitionWork);
+    bool isSameSizeHeaderFooter();
     
 private:
     bool calcUsePull();
@@ -317,6 +318,8 @@ protected:
     StringAttr              encryptKey;
     StringAttr              decryptKey;
     bool                    preserveCompression;
+    offset_t                headerSize;
+    offset_t                footerSize;
 };
 
 

--- a/dali/ft/ftbase.cpp
+++ b/dali/ft/ftbase.cpp
@@ -34,33 +34,6 @@
 #include "dalienv.hpp"
 #include "rmtspawn.hpp"
 
-#define DEFAULT_MAX_CSV_SIZE     8096
-
-//Use hash defines for properties so I can't mis-spell them....
-#define ANinput             "@input"
-#define ANinputDirect       "@inputDirect"
-#define ANinputLength       "@inputLength"
-#define ANinputOffset       "@inputOffset"
-#define ANlength            "@length"
-#define ANoutput            "@output"
-#define ANoutputDirect      "@outputDirect"
-#define ANoutputLength      "@outputLength"
-#define ANoutputOffset      "@outputOffset"
-
-//File attributes
-#define FPrecordSize        "@recordSize"
-#define FPformat            "@format"
-#define FPmaxRecordSize     "@maxRecordSize"
-#define FPcsvSeparate       "@csvSeparate"
-#define FPcsvQuote          "@csvQuote"
-#define FPcsvTerminate      "@csvTerminate"
-#define FPcsvEscape         "@csvEscape"
-#define FProwTag            "@rowTag"
-#define FPkind              "@kind"
-#define FPheaderLength      "@headerLength"
-#define FPfooterLength      "@footerLength"
-
-
 
 //----------------------------------------------------------------------------
 

--- a/dali/ft/ftbase.ipp
+++ b/dali/ft/ftbase.ipp
@@ -23,6 +23,32 @@
 #include "daft.hpp"
 #include "ftbase.hpp"
 
+#define DEFAULT_MAX_CSV_SIZE     8096
+
+//Use hash defines for properties so I can't mis-spell them....
+#define ANinput             "@input"
+#define ANinputDirect       "@inputDirect"
+#define ANinputLength       "@inputLength"
+#define ANinputOffset       "@inputOffset"
+#define ANlength            "@length"
+#define ANoutput            "@output"
+#define ANoutputDirect      "@outputDirect"
+#define ANoutputLength      "@outputLength"
+#define ANoutputOffset      "@outputOffset"
+
+//File attributes
+#define FPrecordSize        "@recordSize"
+#define FPformat            "@format"
+#define FPmaxRecordSize     "@maxRecordSize"
+#define FPcsvSeparate       "@csvSeparate"
+#define FPcsvQuote          "@csvQuote"
+#define FPcsvTerminate      "@csvTerminate"
+#define FPcsvEscape         "@csvEscape"
+#define FProwTag            "@rowTag"
+#define FPkind              "@kind"
+#define FPheaderLength      "@headerLength"
+#define FPfooterLength      "@footerLength"
+
 class DALIFT_API PartitionPoint : public CInterface
 {
 public:

--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -80,6 +80,7 @@
 #define DFTERR_WrongRECFMvRecordSize            8107
 #define DFTERR_WrongSplitRecordSize             8108
 #define DFTERR_CannotFindFirstJsonRecord        8109
+#define DFTERR_InvalidXmlPartSize               8110
 
 //Internal errors
 #define DFTERR_UnknownFormatType                8190
@@ -147,6 +148,7 @@
 #define DFTERR_WrongRECFMvbBlockSize_Text       "Invalid RECFMvb file Block Size (%d) or the file is not RECFMvb format!"
 #define DFTERR_WrongRECFMvRecordSize_Text       "Invalid RECFMv file Record Size (%d) or the file is not RECFMv format!"
 #define DFTERR_WrongSplitRecordSize_Text        "Invalid Record Size (%d, 0x%08x)!"
+#define DFTERR_InvalidXmlPartSize_Text          "Invalid XML part size:%" I64F "d! Size is less than XML Header (%" I64F "d) + Footer (%" I64F "d)) size!"
 
 #define DFTERR_UnknownFormatType_Text           "INTERNAL: Save unknown format type"
 #define DFTERR_OutputOffsetMismatch_Text        "INTERNAL: Output offset does not match expected (%" I64F "d expected %" I64F "d) at %s of block %d"

--- a/ecl/hthor/CMakeLists.txt
+++ b/ecl/hthor/CMakeLists.txt
@@ -66,6 +66,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/ecl/schedulectrl
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ${HPCC_SOURCE_DIR}/dali/ft
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DHTHOR_EXPORTS -DSTARTQUERY_EXPORTS )

--- a/roxie/ccd/CMakeLists.txt
+++ b/roxie/ccd/CMakeLists.txt
@@ -83,6 +83,7 @@ include_directories (
          ./../../testing/unittests
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ${HPCC_SOURCE_DIR}/dali/ft
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DCCD_EXPORTS -DSTARTQUERY_EXPORTS )

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -42,6 +42,7 @@
 
 #include "dafdesc.hpp"
 #include "dautils.hpp"
+#include "ftbase.ipp"
 
 namespace ccdserver_hqlhelper
 {
@@ -11224,7 +11225,7 @@ public:
         CRoxieServerDiskWriteActivity::start(parentExtractSize, parentExtract, paused);
         OwnedRoxieString xmlpath(xmlHelper.getXmlIteratorPath());
         if (!xmlpath)
-            rowTag.set("Row");
+            rowTag.set(DEFAULTXMLROWTAG);
         else
         {
             const char *path = xmlpath;
@@ -11239,14 +11240,13 @@ public:
         StringBuffer header;
         OwnedRoxieString suppliedHeader(xmlHelper.getHeader());
         if (kind==TAKjsonwrite)
-        {
             buildJsonHeader(header, suppliedHeader, rowTag);
-            headerLength = header.length();
-        }
         else if (suppliedHeader)
             header.set(suppliedHeader);
         else
-            header.set("<Dataset>\n");
+            header.append(DEFAULTXMLHEADER).newline();
+
+        headerLength = header.length();
         diskout->write(header.length(), header.str());
 
         Owned<IXmlWriterExt> writer = createIXmlWriterExt(xmlHelper.getXmlFlags(), 0, NULL, (kind==TAKjsonwrite) ? WTJSON : WTStandard);
@@ -11271,15 +11271,13 @@ public:
         OwnedRoxieString suppliedFooter(xmlHelper.getFooter());
         StringBuffer footer;
         if (kind==TAKjsonwrite)
-        {
             buildJsonFooter(footer.newline(), suppliedFooter, rowTag);
-            footerLength=footer.length();
-        }
         else if (suppliedFooter)
             footer.append(suppliedFooter);
         else
-            footer.append("</Dataset>");
+            footer.append(DEFAULTXMLFOOTER);
 
+        footerLength=footer.length();
         diskout->write(footer.length(), footer);
     }
 
@@ -11295,10 +11293,9 @@ public:
         desc->queryProperties().setProp("@format","utf8n");
         desc->queryProperties().setProp("@rowTag",rowTag.get());
         desc->queryProperties().setProp("@kind", (kind==TAKjsonwrite) ? "json" : "xml");
-        if (headerLength)
-            desc->queryProperties().setPropInt("@headerLength", headerLength);
-        if (footerLength)
-            desc->queryProperties().setPropInt("@footerLength", footerLength);
+
+        desc->queryProperties().setPropInt(FPheaderLength, headerLength);
+        desc->queryProperties().setPropInt(FPfooterLength, footerLength);
     }
 
     virtual bool isOutputTransformed() const { return true; }
@@ -19991,7 +19988,7 @@ public:
                     if (response->mlFmt==MarkupFmt_JSON)
                         writeFlags |= XWFnoindent;
                     writer.setown(createIXmlWriterExt(writeFlags, 1, response, (response->mlFmt==MarkupFmt_JSON) ? WTJSON : WTStandard));
-                    writer->outputBeginArray("Row");
+                    writer->outputBeginArray(DEFAULTXMLROWTAG);
                 }
             }
 
@@ -20068,9 +20065,9 @@ public:
                 }
                 else if (writer)
                 {
-                    writer->outputBeginNested("Row", false);
+                    writer->outputBeginNested(DEFAULTXMLROWTAG, false);
                     helper.serializeXml((byte *) row, *writer);
-                    writer->outputEndNested("Row");
+                    writer->outputEndNested(DEFAULTXMLROWTAG);
                 }
                 else
                 {
@@ -20097,7 +20094,7 @@ public:
             }
         }
         if (writer)
-            writer->outputEndArray("Row");
+            writer->outputEndArray(DEFAULTXMLROWTAG);
         if (saveInContext)
             serverContext->appendResultDeserialized(storedName, sequence, builder.getcount(), builder.linkrows(), (helper.getFlags() & POFextend) != 0, LINK(meta.queryOriginal()));
         if (workunit)

--- a/thorlcr/activities/activitymasters_lcr.cmake
+++ b/thorlcr/activities/activitymasters_lcr.cmake
@@ -89,7 +89,8 @@ include_directories (
          ./../mfilemanager 
          ./../../common/thorhelper 
          ./../activities 
-         ./../../rtl/eclrtl 
+         ./../../rtl/eclrtl
+         ${HPCC_SOURCE_DIR}/dali/ft
     )
 
 HPCC_ADD_LIBRARY( activitymasters_lcr SHARED ${SRCS} )

--- a/thorlcr/activities/activityslaves_lcr.cmake
+++ b/thorlcr/activities/activityslaves_lcr.cmake
@@ -106,6 +106,7 @@ include_directories (
          ./../activities 
          ./../../rtl/eclrtl 
          ./../../roxie/roxiemem
+         ${HPCC_SOURCE_DIR}/dali/ft
     )
 
 HPCC_ADD_LIBRARY( activityslaves_lcr SHARED ${SRCS} )

--- a/thorlcr/activities/xmlwrite/thxmlwrite.cpp
+++ b/thorlcr/activities/xmlwrite/thxmlwrite.cpp
@@ -23,6 +23,7 @@
 #include "eclhelper.hpp"
 #include "deftype.hpp"
 #include "thxmlwrite.ipp"
+#include "ftbase.ipp"
 
 class CXmlWriteActivityMaster : public CWriteMasterBase
 {
@@ -45,7 +46,7 @@ public:
         StringBuffer rowTag;
         OwnedRoxieString xmlpath(helper->getXmlIteratorPath());
         if (!xmlpath)
-            rowTag.append("Row");
+            rowTag.append(DEFAULTXMLROWTAG);
         else
         {
             const char *path = xmlpath;
@@ -61,10 +62,26 @@ public:
         {
             StringBuffer s;
             OwnedRoxieString supplied(helper->getHeader());
-            props.setPropInt("@headerLength", buildJsonHeader(s, supplied, rowTag).length());
+            props.setPropInt(FPheaderLength, buildJsonHeader(s, supplied, rowTag).length());
 
             supplied.set(helper->getFooter());
-            props.setPropInt("@footerLength", buildJsonFooter(s.clear(), supplied, rowTag).length());
+            props.setPropInt(FPfooterLength, buildJsonFooter(s.clear(), supplied, rowTag).length());
+        }
+        else
+        {
+            StringBuffer supplied(helper->getHeader());
+            size32_t headerLength = supplied.length();
+            if (headerLength == 0 )
+                headerLength = supplied.set(DEFAULTXMLHEADER).newline().length();
+
+            props.setPropInt(FPheaderLength, headerLength);
+
+            supplied.set(helper->getFooter());
+            size32_t footerLength = supplied.length();
+            if (footerLength == 0 )
+                footerLength = supplied.set(DEFAULTXMLFOOTER).newline().length();
+
+            props.setPropInt(FPfooterLength, footerLength);
         }
     }
 };

--- a/thorlcr/activities/xmlwrite/thxmlwriteslave.cpp
+++ b/thorlcr/activities/xmlwrite/thxmlwriteslave.cpp
@@ -44,7 +44,7 @@ public:
         OwnedRoxieString xmlpath(helper->getXmlIteratorPath());
         if (!xmlpath)
         {
-            rowTag.append("Row");
+            rowTag.append(DEFAULTXMLROWTAG);
         }
         else
         {
@@ -63,7 +63,7 @@ public:
             else if (suppliedHeader)
                 out.set(suppliedHeader);
             else
-                out.set("<Dataset>").newline();
+                out.set(DEFAULTXMLHEADER).newline();
             outraw->write(out.length(), out.toCharArray());
             if (calcFileCrc)
                 fileCRC.tally(out.length(), out.toCharArray());
@@ -91,7 +91,7 @@ public:
             else if (suppliedFooter)
                 out.set(suppliedFooter);
             else
-                out.set("</Dataset>").newline();
+                out.set(DEFAULTXMLFOOTER).newline();
             outraw->write(out.length(), out.toCharArray());
             if (calcFileCrc)
                 fileCRC.tally(out.length(), out.toCharArray());


### PR DESCRIPTION
Add code to store xml header/footer lenght into the file part metadata on
hthor, thor and roxie when:
- spray xml file or files (with different xml header/footer)
- output data in XML format w/wo custom header/footer/ row tag

Add code to use stored header/footer lenght in despray XML data

Signed-off-by: Attila Vamos attila.vamos@gmail.com
