### PR TITLE
HPCC-9999 Use correct default target directory for despray

### DIFF
--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -113,6 +113,7 @@ protected:
     bool ParseLogicalPath(const char * pLogicalPath, const char *group, const char* cluster, StringBuffer &folder, StringBuffer &title, StringBuffer &defaultFolder, StringBuffer &defaultReplicateFolder);
     StringBuffer& getAcceptLanguage(IEspContext& context, StringBuffer& acceptLanguage);
     void appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType, bool replicateOutputs);
+    const char* getDropZoneDirByIP(const char* destIP, StringBuffer& dir);
 };
 
 #endif //_ESPWIZ_FileSpray_HPP__


### PR DESCRIPTION
The existing ESP code calls the RemoteFilename::setPath()
to set the target directory for despray. If a user does
not specify the target directory, the setPath() uses the
/var/lib/HPCCSystems/myesp as default target directory. In
this fix, If a user does not specify the target directory,
I use the target IP to retrieve the drop zone directory on
that IP and use the drop zone directory to be default
target directory.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
