### PR TITLE
HPCC-13495 Use correct default target directory for despray

### DIFF
--- a/common/environment/environment.hpp
+++ b/common/environment/environment.hpp
@@ -103,12 +103,21 @@ interface IConstInstanceInfo : extends IConstEnvBase
     virtual bool getRunInfo(IStringVal & progpath, IStringVal & workdir, const char * defaultprogname) const = 0;
 };
 
+interface IConstDropZoneInfo : extends IConstEnvBase
+{
+    virtual IStringVal & getComputerName(IStringVal & str) const = 0;
+    virtual IStringVal & getDescription(IStringVal & str) const = 0;
+    virtual IStringVal & getDirectory(IStringVal & str) const = 0;
+};
 
 interface IConstEnvironment : extends IConstEnvBase
 {
     virtual IConstDomainInfo * getDomain(const char * name) const = 0;
     virtual IConstMachineInfo * getMachine(const char * name) const = 0;
     virtual IConstMachineInfo * getMachineByAddress(const char * netaddress) const = 0;
+    virtual IConstMachineInfo * getMachineForLocalHost() const = 0;
+    virtual IConstDropZoneInfo * getDropZone(const char * name) const = 0;
+    virtual IConstDropZoneInfo * getDropZoneByComputer(const char * computer) const = 0;
     virtual IConstInstanceInfo * getInstance(const char * type, const char * version, const char * domain) const = 0;
     virtual IConstComputerTypeInfo * getComputerType(const char * name) const = 0;
     virtual bool getRunInfo(IStringVal & path, IStringVal & dir, const char * type, const char * version, const char * machineaddr, const char * defaultprogname) const = 0;

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2291,9 +2291,9 @@ const char* CFileSprayEx::getDropZoneDirByIP(const char* ip, StringBuffer& dir)
     Owned<IConstMachineInfo> machine = env->getMachineByAddress(ip);
     if (!machine)
     {
-        StringBuffer localHostIP;
-        queryHostIP().getIpText(localHostIP);
-        if (!strieq(".", ip) && !strieq("localhost", ip) && !strieq("127.0.0.1", ip) && !strieq(ip, localHostIP.str()))
+        IpAddress ipAddr;
+        ipAddr.ipset(ip);
+        if (!ipAddr.isLocal())
             return NULL;
         machine.setown(env->getMachineForLocalHost());
         if (!machine)

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -114,6 +114,7 @@ protected:
     StringBuffer& getAcceptLanguage(IEspContext& context, StringBuffer& acceptLanguage);
     void appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType, bool replicateOutputs);
     bool getOneDFUWorkunit(IEspContext& context, const char* wuid, IEspGetDFUWorkunitsResponse& resp);
+    const char* getDropZoneDirByIP(const char* destIP, StringBuffer& dir);
 };
 
 #endif //_ESPWIZ_FileSpray_HPP__


### PR DESCRIPTION
The existing ESP code calls the RemoteFilename::setPath()
to set the target directory for despray. If a user does
not specify the target directory, the setPath() uses the
/var/lib/HPCCSystems/myesp as default target directory. In
this fix, If a user does not specify the target directory,
I use the target IP to retrieve the drop zone directory on
that IP and use the drop zone directory to be default
target directory.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
