### PR TITLE
HPCC-13477 FLZ compressor fixes (2) for when input buffer > internal buffer

### DIFF
--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -6025,7 +6025,7 @@ public:
     virtual void get(size32_t len, void * ptr)
     {
         if (len>buffer.remaining()) {
-            ERRLOG("CFileSerialStream::get read past end of stream.4(%u,%u)",(unsigned)len,(unsigned)buffer.remaining());
+            ERRLOG("CMemoryBufferSerialStream::get read past end of stream.4(%u,%u)",(unsigned)len,(unsigned)buffer.remaining());
             throw MakeStringException(-1,"CMemoryBufferSerialStream::get read past end of stream (%u,%u)",(unsigned)len,(unsigned)buffer.remaining());
         }
         const void * data = buffer.readDirect(len);

--- a/tools/copyexp/copyexp.cpp
+++ b/tools/copyexp/copyexp.cpp
@@ -70,7 +70,7 @@ static const char *formatTime(unsigned t,StringBuffer &str)
     str.clear();
     if (t>100000)
         str.appendf("%ds",t/1000);
-    else if (t>100000)
+    else
         str.appendf("%dms",t);
     return str.str();
 
@@ -99,7 +99,7 @@ static void printStats(offset_t filesize,unsigned start,unsigned startu)
     if (elapsed<1000)
         printf("%" I64F "d bytes copied, at %.2f MB/s in %s\n",filesize,((((double)filesize)/(1024*1024))/elapsedu)*1000000,formatTimeU(elapsedu,tmp));
     else
-        printf("%" I64F "d bytes copied, at %.2f MB/s in %s\n",filesize,((((double)filesize)/(1024*1024))/elapsed)*1000,formatTime(elapsed*1000,tmp));
+        printf("%" I64F "d bytes copied, at %.2f MB/s in %s\n",filesize,((((double)filesize)/(1024*1024))/elapsed)*1000,formatTime(elapsed,tmp));
 }
 
 int copyExpanded(const char *from, const char *to, bool stats)


### PR DESCRIPTION
This fix is also linked with HPCC-13491 and should address both issues.
1). Compressor write() needs to handle when buffer is larger than internal buffer.
2). If compressed output is same size as input then do not save compressed data.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com

@jakesmith please review
