### PR TITLE
HPCC-13156 Modification of jlib and thor signal handling

### DIFF
--- a/common/fileview2/fvserver.cpp
+++ b/common/fileview2/fvserver.cpp
@@ -27,7 +27,7 @@
 Semaphore sem;
 
 
-bool myAbortHandler()
+bool myAbortHandler(ahType aht_val)
 {
     sem.signal();
     return false;

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -62,7 +62,7 @@ void usage()
 
 
 
-static bool exitDFUserver()
+static bool exitDFUserver(ahType aht_val)
 {
     engine->abortListeners();
     return false;

--- a/dali/ft/ftbase.cpp
+++ b/dali/ft/ftbase.cpp
@@ -748,7 +748,7 @@ size32_t CrcIOStream::write(size32_t len, const void * data)
 //---------------------------------------------------------------------------
 
 static int breakCount;
-bool daftAbortHandler()
+bool daftAbortHandler(ahType aht_val)
 {
     LOG(MCprogress, unknownJob, "Aborting...");
     // hit ^C 3 times to really stop it...

--- a/dali/ft/ftbase.hpp
+++ b/dali/ft/ftbase.hpp
@@ -30,6 +30,6 @@
 
 typedef __int32 crc32_t;
 
-bool daftAbortHandler();
+bool daftAbortHandler(ahType);
 
 #endif

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -88,7 +88,7 @@ static void stopServer()
 }
 
 
-static bool actionOnAbort()
+static bool actionOnAbort(ahType aht_val)
 {
     LOG(MCprogress, unknownJob, "Stop signalled");
     if (stopped)

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -118,7 +118,7 @@ static void stopServer()
     stopMPServer();
 }
 
-bool actionOnAbort()
+bool actionOnAbort(ahType aht_val)
 {
     stopServer();
     return true;

--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -241,14 +241,14 @@ int CEclAgentExecutionServer::executeWorkunit(const char * wuid)
 
 //---------------------------------------------------------------------------------
 
-bool ControlHandler() 
-{ 
+bool ControlHandler(ahType aht_val)
+{
     if (execSvr)
     {
         execSvr->stop();
     }
-    return false; 
-} 
+    return false;
+}
 
 //---------------------------------------------------------------------------------
 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3149,7 +3149,7 @@ void printStart(int argc, const char *argv[])
 
 //--------------------------------------------------------------
 
-bool ControlHandler()
+bool ControlHandler(ahType aht_val)
 {
     LOG(MCevent,"ControlHandler Stop signalled");
     return true;

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -246,7 +246,9 @@ inline unsigned __int32 low(__int64 n)
 
 //MORE - We really should restructure this file.  Also would this be better with a class interface?
 //Handle ^C/break from a console program.
-typedef bool (*AbortHandler)();                                                 // return true to exit program
+
+enum ahType { aht_terminate, aht_interrupt};
+typedef bool (*AbortHandler)(ahType);                                       // return true to exit program
 
 interface IAbortHandler : public IInterface
 {

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -784,12 +784,15 @@ void abortThor(IException *e, unsigned errCode, bool abortCurrentJob)
     if (0 == aborting)
     {
         aborting = 1;
-        if (!e)
+        if (errCode)
         {
-            _e.setown(MakeThorException(TE_AbortException, "THOR ABORT"));
-            e = _e;
+            if (!e)
+            {
+                _e.setown(MakeThorException(TE_AbortException, "THOR ABORT"));
+                e = _e;
+            }
+            EXCLOG(e,"abortThor");
         }
-        EXCLOG(e,"abortThor");
         LOG(MCdebugProgress, thorJob, "abortThor called");
         if (jM)
             jM->stop();

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -192,12 +192,14 @@ void UnregisterSelf(IException *e)
     }
 }
 
-bool ControlHandler() 
-{ 
-    LOG(MCdebugProgress, thorJob, "CTRL-C pressed");
-    if (masterNode) UnregisterSelf(NULL);
+bool ControlHandler(ahType aht_val)
+{
+    if (aht_interrupt == aht_val)
+        LOG(MCdebugProgress, thorJob, "CTRL-C pressed");
+    if (masterNode)
+        UnregisterSelf(NULL);
     abortSlave();
-    return false; 
+    return false;
 }
 
 void usage()


### PR DESCRIPTION
ahType is used as an agnostic type for linux/unix signals and windows events/signals.  We map to them in in the WindowsAbortHandler() and UnixAbortHandler() functions within jmisc.cpp.  The signal handler prototype has been changed to accept a parameter of ahType  which someone creating a signal handler within a specific component can then check for to differentiate between signal/event types.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
