### PR TITLE
HPCC-13297 Replace '-' with '~' for rc build on DEB systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,9 +138,15 @@ else()
     set(CPACK_PACKAGE_NAME "hpccsystems-clienttools-${majorver}.${minorver}")
     set(PACKAGE_FILE_NAME_PREFIX  "hpccsystems-clienttools-${projname}")
 endif()
+
+set (VER_SEPARATOR "-")
+if ("${stagever}" MATCHES "^rc[0-9]+$")
+    set (VER_SEPARATOR "~")
+endif()
+
 SET(CPACK_PACKAGE_VERSION_MAJOR ${majorver})
 SET(CPACK_PACKAGE_VERSION_MINOR ${minorver})
-SET(CPACK_PACKAGE_VERSION_PATCH ${point}-${stagever})
+SET(CPACK_PACKAGE_VERSION_PATCH ${point}${VER_SEPARATOR}${stagever})
 set ( CPACK_PACKAGE_CONTACT "HPCCSystems <ossdevelopment@lexisnexis.com>" )
 set( CPACK_SOURCE_GENERATOR TGZ )
 
@@ -158,6 +164,8 @@ set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CPACK_RPM_PACKAGE_ARCHITECTURE}")
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     set(CPACK_STRIP_FILES TRUE)
 endif()
+
+
 if ( APPLE )
 elseif ( UNIX )
     EXECUTE_PROCESS (
@@ -195,7 +203,7 @@ elseif ( UNIX )
     endif ()
 endif ()
 MESSAGE ( "-- Current release version is ${CPACK_PACKAGE_FILE_NAME}" )
-set( CPACK_SOURCE_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}-${version}" )
+set( CPACK_SOURCE_PACKAGE_FILE_NAME "${PACKAGE_FILE_NAME_PREFIX}_${CPACK_RPM_PACKAGE_VERSION}-${stagever}" )
 set( CPACK_SOURCE_GENERATOR TGZ )
 set( CPACK_SOURCE_IGNORE_FILES
         "~$"


### PR DESCRIPTION
This will help deb system to correctly compare the different versions. i.e.
final release version should be greater than rc builds.

@Michael-Gardner please help to review

Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexis.com 
