### PR TITLE
HPCC-13510 Exclude childds4, 5, 6 and 7 tests from Hthor in Regression Suite

### DIFF
--- a/testing/regress/ecl/childds4.ecl
+++ b/testing/regress/ecl/childds4.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+//nohthor
+
 idRec := { unsigned id; };
 mainRec := { unsigned seq, dataset(idRec) ids };
 

--- a/testing/regress/ecl/childds5.ecl
+++ b/testing/regress/ecl/childds5.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+//nohthor
+
 idRec := { unsigned id; };
 mainRec := { unsigned seq, dataset(idRec) ids };
 

--- a/testing/regress/ecl/childds6.ecl
+++ b/testing/regress/ecl/childds6.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+//nohthor
+
 idRec := { unsigned id; };
 mainRec := { unsigned seq, dataset(idRec) ids };
 

--- a/testing/regress/ecl/childds7.ecl
+++ b/testing/regress/ecl/childds7.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+//nohthor
+
 idRec := { unsigned id; };
 mainRec := { unsigned seq, dataset(idRec) ids };
 


### PR DESCRIPTION
Add //nohthor tag to avoid execute them on Hthor.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
