### PR TITLE
HPCC-13514 Java plugin should detect insufficient arguments

### DIFF
--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -2222,6 +2222,8 @@ public:
     }
     virtual void callFunction()
     {
+        if (*argsig != ')')
+            throw MakeStringException(0, "javaembed: Too few ECL parameters passed for Java signature %s", sharedCtx->querySignature());
         sharedCtx->callFunction(result, args);
     }
 


### PR DESCRIPTION
Passing too few arguments to a Java function may segfault at
present.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
