### PR TITLE
HPCC-13519 Fix crash if keyed denormalize in child query.

### DIFF
--- a/testing/regress/ecl/key/keyed_denormalize.xml
+++ b/testing/regress/ecl/key/keyed_denormalize.xml
@@ -656,9 +656,42 @@
  <Row><name>Keyed, Outer limit(3,skip)    </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
 <Dataset name='Result 17'>
- <Row><Result_17>Keyed DenormalizeGroup</Result_17></Row>
+ <Row><Result_17>Child Keyed Denormalize</Result_17></Row>
 </Dataset>
 <Dataset name='Result 18'>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><kidcount>16</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BILLINGTON</dg_lastname><kidcount>16</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>DOLSON    </dg_lastname><kidcount>16</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>SMITH     </dg_lastname><kidcount>16</kidcount></Row>
+</Dataset>
+<Dataset name='Result 19'>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><kidcount>48</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BILLINGTON</dg_lastname><kidcount>48</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>DOLSON    </dg_lastname><kidcount>48</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>SMITH     </dg_lastname><kidcount>48</kidcount></Row>
+</Dataset>
+<Dataset name='Result 20'>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><kidcount>64</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BILLINGTON</dg_lastname><kidcount>64</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>DOLSON    </dg_lastname><kidcount>64</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>SMITH     </dg_lastname><kidcount>64</kidcount></Row>
+</Dataset>
+<Dataset name='Result 21'>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><kidcount>64</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BILLINGTON</dg_lastname><kidcount>64</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>DOLSON    </dg_lastname><kidcount>64</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>SMITH     </dg_lastname><kidcount>64</kidcount></Row>
+</Dataset>
+<Dataset name='Result 22'>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><kidcount>32</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>BILLINGTON</dg_lastname><kidcount>32</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>DOLSON    </dg_lastname><kidcount>32</kidcount></Row>
+ <Row><dg_firstname>DAVID     </dg_firstname><dg_lastname>SMITH     </dg_lastname><kidcount>32</kidcount></Row>
+</Dataset>
+<Dataset name='Result 23'>
+ <Row><Result_23>Keyed DenormalizeGroup</Result_23></Row>
+</Dataset>
+<Dataset name='Result 24'>
  <Row><name>KeyedGroup                    </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup                    </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup                    </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -724,7 +757,7 @@
  <Row><name>KeyedGroup                    </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup                    </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 19'>
+<Dataset name='Result 25'>
  <Row><name>KeyedGroup skip               </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup skip               </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup skip               </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -774,7 +807,7 @@
  <Row><name>KeyedGroup skip               </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup skip               </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 20'>
+<Dataset name='Result 26'>
  <Row><name>KeyedGroup keep(2)            </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup keep(2)            </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup keep(2)            </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -840,7 +873,7 @@
  <Row><name>KeyedGroup keep(2)            </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup keep(2)            </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 21'>
+<Dataset name='Result 27'>
  <Row><name>KeyedGroup atmost(3))         </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup atmost(3))         </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup atmost(3))         </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -906,7 +939,7 @@
  <Row><name>KeyedGroup atmost(3))         </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup atmost(3))         </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 22'>
+<Dataset name='Result 28'>
  <Row><name>KeyedGroup LIMIT(3,SKIP))     </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup LIMIT(3,SKIP))     </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup LIMIT(3,SKIP))     </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -940,7 +973,7 @@
  <Row><name>KeyedGroup LIMIT(3,SKIP))     </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup LIMIT(3,SKIP))     </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 23'>
+<Dataset name='Result 29'>
  <Row><name>KeyedGroup, Inner             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -974,7 +1007,7 @@
  <Row><name>KeyedGroup, Inner             </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner             </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 24'>
+<Dataset name='Result 30'>
  <Row><name>KeyedGroup, Inner skip        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner skip        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner skip        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -992,7 +1025,7 @@
  <Row><name>KeyedGroup, Inner skip        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>350</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner skip        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>375</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 25'>
+<Dataset name='Result 31'>
  <Row><name>KeyedGroup, Inner keep(2)     </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner keep(2)     </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner keep(2)     </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -1026,11 +1059,11 @@
  <Row><name>KeyedGroup, Inner keep(2)     </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Inner keep(2)     </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 26'>
+<Dataset name='Result 32'>
 </Dataset>
-<Dataset name='Result 27'>
+<Dataset name='Result 33'>
 </Dataset>
-<Dataset name='Result 28'>
+<Dataset name='Result 34'>
  <Row><name>KeyedGroup, Outer             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Outer             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Outer             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -1096,7 +1129,7 @@
  <Row><name>KeyedGroup, Outer             </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Outer             </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 29'>
+<Dataset name='Result 35'>
  <Row><name>KeyedGroup, Outer skip        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Outer skip        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Outer skip        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -1146,7 +1179,7 @@
  <Row><name>KeyedGroup, Outer skip        </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup, Outer skip        </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 30'>
+<Dataset name='Result 36'>
  <Row><name>KeyedGroup, Outer keep(2)     </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Outer keep(2)     </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Outer keep(2)     </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -1212,7 +1245,7 @@
  <Row><name>KeyedGroup, Outer keep(2)     </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>KeyedGroup, Outer keep(2)     </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 31'>
+<Dataset name='Result 37'>
  <Row><name>KeyedGroup, Outer atmost(3))  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup, Outer atmost(3))  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup, Outer atmost(3))  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -1278,7 +1311,7 @@
  <Row><name>KeyedGroup, Outer atmost(3))  </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup, Outer atmost(3))  </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 32'>
+<Dataset name='Result 38'>
  <Row><name>KeyedGroup, Outer LIMIT(3,SKIP</name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup, Outer LIMIT(3,SKIP</name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup, Outer LIMIT(3,SKIP</name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -1312,10 +1345,10 @@
  <Row><name>KeyedGroup, Outer LIMIT(3,SKIP</name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>KeyedGroup, Outer LIMIT(3,SKIP</name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 33'>
- <Row><Result_33>Unkeyed Denormalize</Result_33></Row>
+<Dataset name='Result 39'>
+ <Row><Result_39>Unkeyed Denormalize</Result_39></Row>
 </Dataset>
-<Dataset name='Result 34'>
+<Dataset name='Result 40'>
  <Row><name>Unkeyed                       </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed                       </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed                       </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -1381,7 +1414,7 @@
  <Row><name>Unkeyed                       </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed                       </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 35'>
+<Dataset name='Result 41'>
  <Row><name>Unkeyed skip                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed skip                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed skip                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -1431,7 +1464,7 @@
  <Row><name>Unkeyed skip                  </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed skip                  </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 36'>
+<Dataset name='Result 42'>
  <Row><name>Unkeyed keep(2)               </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed keep(2)               </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed keep(2)               </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -1497,7 +1530,7 @@
  <Row><name>Unkeyed keep(2)               </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed keep(2)               </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 37'>
+<Dataset name='Result 43'>
  <Row><name>Unkeyed atmost(3)             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed atmost(3)             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed atmost(3)             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -1563,7 +1596,7 @@
  <Row><name>Unkeyed atmost(3)             </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed atmost(3)             </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 38'>
+<Dataset name='Result 44'>
  <Row><name>Unkeyed limit(3,skip)         </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed limit(3,skip)         </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed limit(3,skip)         </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -1597,7 +1630,7 @@
  <Row><name>Unkeyed limit(3,skip)         </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed limit(3,skip)         </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 39'>
+<Dataset name='Result 45'>
  <Row><name>Unkeyed, Inner                </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner                </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner                </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -1631,7 +1664,7 @@
  <Row><name>Unkeyed, Inner                </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner                </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 40'>
+<Dataset name='Result 46'>
  <Row><name>Unkeyed, Inner skip           </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner skip           </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner skip           </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -1649,7 +1682,7 @@
  <Row><name>Unkeyed, Inner skip           </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>350</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner skip           </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>375</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 41'>
+<Dataset name='Result 47'>
  <Row><name>Unkeyed, Inner keep(2)        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner keep(2)        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner keep(2)        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -1683,11 +1716,11 @@
  <Row><name>Unkeyed, Inner keep(2)        </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, Inner keep(2)        </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 42'>
+<Dataset name='Result 48'>
 </Dataset>
-<Dataset name='Result 43'>
+<Dataset name='Result 49'>
 </Dataset>
-<Dataset name='Result 44'>
+<Dataset name='Result 50'>
  <Row><name>Unkeyed, OUTER                </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, OUTER                </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, OUTER                </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -1753,7 +1786,7 @@
  <Row><name>Unkeyed, OUTER                </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, OUTER                </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 45'>
+<Dataset name='Result 51'>
  <Row><name>Unkeyed, OUTER skip           </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, OUTER skip           </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, OUTER skip           </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -1803,7 +1836,7 @@
  <Row><name>Unkeyed, OUTER skip           </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed, OUTER skip           </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 46'>
+<Dataset name='Result 52'>
  <Row><name>Unkeyed, OUTER keep(2)        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, OUTER keep(2)        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, OUTER keep(2)        </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -1869,7 +1902,7 @@
  <Row><name>Unkeyed, OUTER keep(2)        </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>Unkeyed, OUTER keep(2)        </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 47'>
+<Dataset name='Result 53'>
  <Row><name>Unkeyed, OUTER atmost(3)      </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed, OUTER atmost(3)      </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed, OUTER atmost(3)      </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -1935,7 +1968,7 @@
  <Row><name>Unkeyed, OUTER atmost(3)      </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed, OUTER atmost(3)      </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 48'>
+<Dataset name='Result 54'>
  <Row><name>Unkeyed, OUTER limit(3,skip)  </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed, OUTER limit(3,skip)  </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed, OUTER limit(3,skip)  </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -1969,10 +2002,10 @@
  <Row><name>Unkeyed, OUTER limit(3,skip)  </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Unkeyed, OUTER limit(3,skip)  </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 49'>
- <Row><Result_49>Unkeyed DenormalizeGroup</Result_49></Row>
+<Dataset name='Result 55'>
+ <Row><Result_55>Unkeyed DenormalizeGroup</Result_55></Row>
 </Dataset>
-<Dataset name='Result 50'>
+<Dataset name='Result 56'>
  <Row><name>Group                         </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Group                         </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group                         </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -2038,7 +2071,7 @@
  <Row><name>Group                         </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>Group                         </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 51'>
+<Dataset name='Result 57'>
  <Row><name>Group skip                    </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Group skip                    </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group skip                    </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -2088,7 +2121,7 @@
  <Row><name>Group skip                    </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group skip                    </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 52'>
+<Dataset name='Result 58'>
  <Row><name>Group keep(2)                 </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group keep(2)                 </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group keep(2)                 </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -2154,7 +2187,7 @@
  <Row><name>Group keep(2)                 </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>Group keep(2)                 </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 53'>
+<Dataset name='Result 59'>
  <Row><name>Group atmost(3))              </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group atmost(3))              </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group atmost(3))              </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -2220,7 +2253,7 @@
  <Row><name>Group atmost(3))              </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group atmost(3))              </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 54'>
+<Dataset name='Result 60'>
  <Row><name>Group LIMIT(3,SKIP))          </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group LIMIT(3,SKIP))          </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group LIMIT(3,SKIP))          </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -2254,7 +2287,7 @@
  <Row><name>Group LIMIT(3,SKIP))          </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group LIMIT(3,SKIP))          </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 55'>
+<Dataset name='Result 61'>
  <Row><name>Group, Inner                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -2288,7 +2321,7 @@
  <Row><name>Group, Inner                  </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner                  </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 56'>
+<Dataset name='Result 62'>
  <Row><name>Group, Inner skip             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner skip             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner skip             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -2306,7 +2339,7 @@
  <Row><name>Group, Inner skip             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>350</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner skip             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>375</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 57'>
+<Dataset name='Result 63'>
  <Row><name>Group, Inner keep(2)          </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner keep(2)          </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner keep(2)          </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -2340,11 +2373,11 @@
  <Row><name>Group, Inner keep(2)          </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>Group, Inner keep(2)          </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 58'>
+<Dataset name='Result 64'>
 </Dataset>
-<Dataset name='Result 59'>
+<Dataset name='Result 65'>
 </Dataset>
-<Dataset name='Result 60'>
+<Dataset name='Result 66'>
  <Row><name>Group, Outer                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Group, Outer                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group, Outer                  </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -2410,7 +2443,7 @@
  <Row><name>Group, Outer                  </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><filepos>750</filepos></Row></rightrecs></Row>
  <Row><name>Group, Outer                  </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><filepos>775</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 61'>
+<Dataset name='Result 67'>
  <Row><name>Group, Outer skip             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row></rightrecs></Row>
  <Row><name>Group, Outer skip             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group, Outer skip             </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><filepos>50</filepos></Row></rightrecs></Row>
@@ -2460,7 +2493,7 @@
  <Row><name>Group, Outer skip             </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group, Outer skip             </name><dg_firstname>KELLY     </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 62'>
+<Dataset name='Result 68'>
  <Row><name>Group, Outer keep(2)          </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group, Outer keep(2)          </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
  <Row><name>Group, Outer keep(2)          </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><filepos>0</filepos></Row><Row><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><filepos>25</filepos></Row></rightrecs></Row>
@@ -2526,7 +2559,7 @@
  <Row><name>Group, Outer keep(2)          </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
  <Row><name>Group, Outer keep(2)          </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>1</dg_prange><filepos>700</filepos></Row><Row><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>2</dg_prange><filepos>725</filepos></Row></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 63'>
+<Dataset name='Result 69'>
  <Row><name>Group, Outer atmost(3))       </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group, Outer atmost(3))       </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group, Outer atmost(3))       </name><dg_firstname>CLAIRE    </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
@@ -2592,7 +2625,7 @@
  <Row><name>Group, Outer atmost(3))       </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group, Outer atmost(3))       </name><dg_firstname>KIMBERLY  </dg_firstname><dg_lastname>SMITH     </dg_lastname><dg_prange>4</dg_prange><rightrecs></rightrecs></Row>
 </Dataset>
-<Dataset name='Result 64'>
+<Dataset name='Result 70'>
  <Row><name>Group, Outer LIMIT(3,SKIP))   </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group, Outer LIMIT(3,SKIP))   </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange><rightrecs></rightrecs></Row>
  <Row><name>Group, Outer LIMIT(3,SKIP))   </name><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>3</dg_prange><rightrecs></rightrecs></Row>

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -600,6 +600,8 @@ void CMasterGraphElement::doCreateActivity(size32_t parentExtractSz, const byte 
         case TAKdiskwrite:
         case TAKfetch:
         case TAKkeyedjoin:
+        case TAKkeyeddenormalize:
+        case TAKkeyeddenormalizegroup:
         case TAKworkunitwrite:
         case TAKworkunitread:
         case TAKdictionaryworkunitwrite:


### PR DESCRIPTION
A Keyed Denormalize inside a child query wasn't being initialized
correctly and crashing the slave(s).

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
