### PR TITLE
HPCC-13520 Previous Cassandra change typo broke plugin

### DIFF
--- a/plugins/cassandra/cassandraembed.cpp
+++ b/plugins/cassandra/cassandraembed.cpp
@@ -1262,7 +1262,7 @@ public:
         cluster.setown(new CassandraCluster(cass_cluster_new()));
         cluster->setOptions(opts);
         session.setown(new CassandraSession(cass_session_new()));
-        CassandraFuture future(cluster->keyspace.isEmpty() ? cass_session_connect_keyspace(*session, *cluster, cluster->keyspace) : cass_session_connect(*session, *cluster));
+        CassandraFuture future(cluster->keyspace.isEmpty() ? cass_session_connect(*session, *cluster) : cass_session_connect_keyspace(*session, *cluster, cluster->keyspace));
         future.wait("connect");
     }
     virtual bool getBooleanResult()


### PR DESCRIPTION
Inverted test means will fail (or crash) if keyspace not supplied.
This regression is not in any released version.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
