### PR TITLE
HPCC-13521 Regression Test Engine doesn't handle well standard library exception.

### DIFF
--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -94,7 +94,7 @@ class ECLcmd(Shell):
             result = ""
             cnt = 0
             for i in ret:
-                logging.debug("%3d. i:'%s'", eclfile.getTaskId(),  i )
+                logging.debug("%3d. ret:'%s'", eclfile.getTaskId(),  i )
 
                 if "wuid:" in i:
                     logging.debug("------ runCmd:" + repr(i) + "------")
@@ -115,7 +115,7 @@ class ECLcmd(Shell):
             raise err
         finally:
             res = queryWuid(eclfile.getJobname(), eclfile.getTaskId())
-            logging.debug("%3d. in finally -> 'wuid':'%s', 'state':'%s', data':'%s', ", eclfile.getTaskId(), wuid, state, data)
+            logging.debug("%3d. in finally -> 'wuid':'%s', 'state':'%s', data':'%s', ", eclfile.getTaskId(), res['wuid'], res['state'], data)
             if wuid ==  'N/A':
                 logging.debug("%3d. in finally queryWuid() -> 'result':'%s', 'wuid':'%s', 'state':'%s'", eclfile.getTaskId(),  res['result'],  res['wuid'],  res['state'])
                 wuid = res['wuid']
@@ -154,7 +154,7 @@ class ECLcmd(Shell):
                         eclfile.diff = ("%3d. Test: %s\n") % (eclfile.taskId, eclfile.getBaseEclRealName())
                         eclfile.diff += data
                     test = True
-                elif (res['state'] == 'failed') and ('error' in data):
+                elif (res['state'] == 'failed') and (('error' in data) or ('exception' in data.lower())):
                     eclfile.diff = ("%3d. Test: %s\n") % (eclfile.taskId, eclfile.getBaseEclRealName())
                     eclfile.diff += data
                     test = False


### PR DESCRIPTION
Add code to handle this kind of problem.

Improve related debug log items.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
