### PR TITLE
HPCC-13529 Regression could cause some early spilling

### DIFF
--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -179,7 +179,8 @@ class CSpillableStreamBase : public CSimpleInterface, implements roxiemem::IBuff
 protected:
     CActivityBase &activity;
     IRowInterfaces *rowIf;
-    bool preserveNulls, ownsRows, useCompression, spillPriority;
+    bool preserveNulls, ownsRows, useCompression;
+    unsigned spillPriority;
     CThorSpillableRowArray rows;
     OwnedIFile spillFile;
 


### PR DESCRIPTION
A regression introduced by HPCC-11928, where a boolean was
incorrectly used to store a spilling priority, could cause some
spilling to occur too early.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
