### PR TITLE
HPCC-13483 Add space between two weblinks

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -45,6 +45,7 @@
                   <xsl:value-of select="$wuid"/>
                   &nbsp;
                   <a href="/esp/iframe?esp_iframe_title=ECL Workunit XML - {$wuid}&amp;inner=/WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Type%3dXML%26Option%3d0%26SizeLimit%3d5000000" >XML</a>
+                  &nbsp;
                   <a href="/esp/iframe?esp_iframe_title=Download ECL Workunit XML - {$wuid}&amp;inner=/WsWorkunits/WUFile%3fWuid%3d{$wuid}%26Type%3dXML%26Option%3d2" >Download XML</a>
                   &nbsp;
                   <a href="/esp/iframe?esp_iframe_title=ECL Playground - {$wuid}&amp;inner=/esp/files/stub.htm%3fWidget%3dECLPlaygroundWidget%26Wuid%3d{$wuid}%26Target%3d{Cluster}" >ECL Playground</a>


### PR DESCRIPTION
In legacy ECLwatch, a space should be added between the
'XML' weblink and the 'Download XML' weblink in the WU
Details page.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
