### PR TITLE
HPCC-13419 DOCS: Add Config Security to SysAdmin

### DIFF
--- a/docs/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
+++ b/docs/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
@@ -1082,6 +1082,9 @@ lock=/var/lock/HPCCSystems</programlisting>
     </sect1>
 
     <!--Inclusions-As-Sect1-->
+ <xi:include href="Installing_and_RunningTheHPCCPlatform/Inst-Mods/hpcc_ldap.xml"
+                xpointer="element(/1)"
+                xmlns:xi="http://www.w3.org/2001/XInclude" />
 
     <xi:include href="Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml"
                 xpointer="User_Security_Maint"


### PR DESCRIPTION
FIX HPCC-13419 DOCS: Add Config Security to SysAdmin
Add the Configuring for Security section to System Administrators guide.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com

@JamesDeFabia please review
