### PR TITLE
HPCC-13542 Return new set of results per child query evaluate.

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1977,11 +1977,10 @@ const void * CGraphBase::getLinkedRowResult(unsigned id)
 IEclGraphResults *CGraphBase::evaluate(unsigned _parentExtractSz, const byte *parentExtract)
 {
     CriticalBlock block(evaluateCrit);
-
+    localResults.setown(createThorGraphResults(xgmml->getPropInt("att[@name=\"_numResults\"]/@value", 0)));
     parentExtractSz = _parentExtractSz;
     executeChild(parentExtractSz, parentExtract);
-    //GH->JCS This needs to set up new results rather than returning a link, so helpers are thread safe
-    return LINK(localResults);
+    return localResults.getClear();
 }
 
 static bool isLocalOnly(const CGraphElementBase &activity);


### PR DESCRIPTION
This is to ensure thread-safeness when a child query is being
executed in parallel.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
