### PR TITLE
HPCC-13554 Add TargetIP as stored variable for ecl-test case ecl

### DIFF
--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -44,6 +44,7 @@ class ECLcmd(Shell):
         server = kwargs.pop('server', False)
         if server:
             args.append('--server=' + server)
+            args.append('-XTargetIP=' + server)
 
         username = kwargs.pop('username', False)
         if username:


### PR DESCRIPTION
Add TargetIP as stored variable to test cases run via ecl-test.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
