### PR TITLE
HPCC-13497 Moved unlock, removePid.  Modified RESULT test, in hpcc_common -> stop_component 

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -564,15 +564,23 @@ stop_component() {
 
     RESULT=0
     local waittime=30
+    [[ $compType = "dali" ]] && waittime=720
     while [[ $RESULT -ne 1 && $waittime -gt 0 ]]; do
         check_status ${PIDPATH} ${LOCKPATH} ${COMPPIDPATH} 0
         RESULT=$?
         ((waittime--))
-        sleep 1
+        if ! ((waittime % 60)); then
+            echo "still stopping ..."
+        fi
+        [[ $RESULT -ne 1 ]] && sleep 1
     done
 
     if [[ $RESULT -ne 1 ]]; then
-        log_failure_msg
+        if [[ $waittime -eq 0 ]]; then
+            log_failure_msg "Process may still be attempting to shut down cleanly"
+        else
+            log_failure_msg
+        fi
     else
         log_success_msg
     fi

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -559,25 +559,23 @@ stop_component() {
 
     eval $stopcmd
 
+    unlock ${LOCKPATH}
+    removePid ${PIDPATH}
+
     RESULT=0
-    local counter=0
-    while [[ $RESULT -eq 0 && $counter -le 20 ]]; do
+    local waittime=30
+    while [[ $RESULT -ne 1 && $waittime -gt 0 ]]; do
         check_status ${PIDPATH} ${LOCKPATH} ${COMPPIDPATH} 0
         RESULT=$?
-        ((counter++))
-        if [[ $RESULT -eq 0 ]]; then
-            sleep 1
-        fi
+        ((waittime--))
+        sleep 1
     done
 
-    if [[ $RESULT -ne 1 && $RESULT -ne 4 ]]; then
+    if [[ $RESULT -ne 1 ]]; then
         log_failure_msg
     else
         log_success_msg
     fi
-
-    removePid ${PIDPATH}
-    unlock ${LOCKPATH}
 
     RCSTOP=0
 


### PR DESCRIPTION
Mark made a necessary change recently that fixed a looping issue in 5.2.0 -> 5.2.2.  In this change we now use check_status as the primary way of seeing the health of a component within the loop.  It made everything much simpler, but it was causing issues where a RETURN value of 4, could mean that a process was still alive, but it would give a success message.

I modified the RESULT test to only show success if the value was '1' (Stopped in healthy state.) and I moved the unlock and removePid to before the loop so it won't immediately fail.  This is what was causing issues I was seeing in 5.4 where dali and dfuserver were having issues on restart (because they were still trying to shut down) and I initially thought it was a problem with the stopdali and dfuserver action=STOP calls.  The bug that Srinivas Sivasubramanian had the other day with 5.2.0 helped me isolate and find the issue when I was testing 5.2.2.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
