### PR TITLE
HPCC-13564 Reduce packing overrides and fix misaligned atomic access

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -2358,6 +2358,8 @@ static bool suppressedOrphanUnlock=false;
 #undef new
 #endif
 
+//Do not override the packing for this class - otherwise the fixed size allocator will allocate
+//misaligned objects, which can cause problems on some architectures (especially for atomic operations)
 class CServerRemoteTree : public CRemoteTreeBase
 {
     DECL_NAMEDCOUNT;

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -2353,10 +2353,6 @@ CRemoteTreeBase *CRemoteTreeBase::createChild(int pos, const char *childName)
 static CheckedCriticalSection suppressedOrphanUnlockCrit; // to temporarily suppress unlockall
 static bool suppressedOrphanUnlock=false;
 
-#ifdef __64BIT__
-#pragma pack(push,1)    // 64bit pack CServerRemoteTree's    (could do for 32bit also)
-#endif
-
 #if defined(new)
 #define __old_new new
 #undef new
@@ -2816,11 +2812,6 @@ public:
 
 #if defined(_WIN32) && defined(__old_new)
 #define new __old_new
-#endif
-
-
-#ifdef __64BIT__
-#pragma pack(pop)   // 64bit pack CServerRemoteTree's    (could do for 32bit also)
 #endif
 
 

--- a/dali/base/dasds.ipp
+++ b/dali/base/dasds.ipp
@@ -105,12 +105,10 @@ interface ITrackChanges
     virtual void registerPropAppend(size32_t l) = 0;
 };
 
-class ChangeInfo : public CInterface, implements IInterface
+class ChangeInfo : public CInterfaceOf<IInterface>
 {
     DECL_NAMEDCOUNT;
 public:
-    IMPLEMENT_IINTERFACE;
-
     ChangeInfo(IPropertyTree &_owner) : owner(&_owner) { INIT_NAMEDCOUNT; tree.setown(createPTree(RESERVED_CHANGE_NODE)); }
     const IPropertyTree *queryOwner() const { return owner; }
     const void *queryFindParam() const { return &owner; }
@@ -193,7 +191,7 @@ private: // data
 
 ///////////////////
 
-class CPTStack : public CInterface, public IArrayOf<PTree>
+class CPTStack : public IArrayOf<PTree>
 {
     bool _fill(IPropertyTree &root, const char *xpath, IPropertyTree &tail);
 public:
@@ -226,10 +224,6 @@ class CServerConnection;
 class CBranchChange;
 ///////////////////
 class CSubscriberContainerList;
-
-#ifdef __64BIT__
-#pragma pack(push,1)    // 64bit pack CRemoteTree's  (could probably do for 32bit also)
-#endif
 
 class CRemoteTreeBase : public PTree
 {
@@ -266,10 +260,6 @@ public:
 protected: // data
     __int64 serverId;
 };
-
-#ifdef __64BIT__
-#pragma pack(pop)   
-#endif
 
 class CTrackChanges
 {
@@ -581,7 +571,7 @@ public:
     virtual unsigned queryConnections() { return connections.ordinality(); }
 };
 
-class CXPathIterator : public CInterface, implements IPropertyTreeIterator
+class CXPathIterator : public CInterfaceOf<IPropertyTreeIterator>
 {
     DECL_NAMEDCOUNT;
     IPropertyTree *root;
@@ -593,8 +583,6 @@ class CXPathIterator : public CInterface, implements IPropertyTreeIterator
     IPTIteratorCodes flags;
     bool validateServerIds;
 public:
-    IMPLEMENT_IINTERFACE;
-
     CXPathIterator(IPropertyTree *_root, IPropertyTree *_matchTree, IPTIteratorCodes _flags) : root(_root), matchTree(_matchTree), flags(_flags)
     {
         INIT_NAMEDCOUNT;

--- a/system/jlib/jptree.ipp
+++ b/system/jlib/jptree.ipp
@@ -416,13 +416,15 @@ private:
     void replaceSelf(IPropertyTree *val);
 
 protected: // data
-    byte flags;
     IPropertyTree *parent; // ! currently only used if tree embedded into array, used to locate position.
-
     HashKeyElement *name;
     ChildMap *children;
     IPTArrayValue *value;
-    AttrMap attributes;
+    //The packing (#pragma pack) is overridden because very large numbers of these objects are created, and the
+    //following two members currently cause 8 bytes to be wasted.  Refactoring the contents of AttrMap into this
+    //class would allow the fields to pack cleanly.
+    AttrMap attributes;     // this has 2 "extra" bytes - which could pack into the space following the count
+    byte flags;             // this could also pack into the space following the count.
 };
 
 #ifdef __64BIT__
@@ -536,7 +538,7 @@ private: // data
 
 class CPTreeMaker : public CInterfaceOf<IPTreeMaker>
 {
-    bool rootProvided, noRoot;
+    bool rootProvided, noRoot;  // pack into the space following the link count
     IPropertyTree *root;
     ICopyArrayOf<IPropertyTree> ptreeStack;
     IPTreeNodeCreator *nodeCreator;


### PR DESCRIPTION
Also reduce the memory required by some PTree related structures

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
