### PR TITLE
HPCC-13577 Publish and testing published library fails in OBT

### DIFF
--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -44,7 +44,6 @@ class ECLcmd(Shell):
         server = kwargs.pop('server', False)
         if server:
             args.append('--server=' + server)
-            args.append('-XTargetIP=' + server)
 
         username = kwargs.pop('username', False)
         if username:
@@ -78,6 +77,8 @@ class ECLcmd(Shell):
             args = args + eclfile.getDParameters()
 
             args = args + eclfile.getStoredInputParameters()
+
+            args.append('-XTargetIP=' + server)
 
             args.append(eclfile.getArchive())
 


### PR DESCRIPTION
Move stored variable creation code into the 'ecl run' code.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
