### PR TITLE
HPCC-12552 Show queued job under eclserver/eclccserver

### DIFF
--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -88,6 +88,7 @@ public:
     CWsSMCQueue agentQueue;
     CWsSMCQueue serverQueue;
     StringArray queuedWUIDs;
+    StringArray wuidsOnServerQueue;
 
     CWsSMCTargetCluster(){};
     virtual ~CWsSMCTargetCluster(){};
@@ -130,6 +131,7 @@ class CActivityInfo : public CInterface, implements IInterface
         CIArrayOf<CWsSMCTargetCluster>& targetClusters1, CIArrayOf<CWsSMCTargetCluster>& targetClusters2);
     CWsSMCTargetCluster* findTargetCluster(const char* clusterName, CIArrayOf<CWsSMCTargetCluster>& targetClusters);
     bool checkSetUniqueECLWUID(const char* wuid);
+    void addQueuedServerQueueJob(IEspContext& context, const char* serverName, const char* queueName, const char* instanceName, CIArrayOf<CWsSMCTargetCluster>& targetClusters);
 
 public:
     IMPLEMENT_IINTERFACE;


### PR DESCRIPTION
The code is added to read queued jobs from the .eclserver
JobQueues into buffers. The queued jobs in the buffers are
added under each eclserver/eclccserver if the server is
listenning to the job queue.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
