### PR TITLE
HPCC-13582 Fix stop_component to work with reworked check_status for 5.4+

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -563,7 +563,6 @@ stop_component() {
     eval $stopcmd
 
     unlock ${LOCKPATH}
-    removePid ${PIDPATH}
 
     RESULT=0
     local waittime=30


### PR DESCRIPTION
…5.4+

In 5.2 we had to have stop_component setup a specific way due to how check_status worked. Now that check_status has been reworked and simplified, the removePid in stop_component before the check_status loop will cause issues. Removing it solves the problem.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
