### PR TITLE
HPCC-13576 Removed remote call to dfuserver process

### DIFF
--- a/initfiles/bin/init_dfuserver
+++ b/initfiles/bin/init_dfuserver
@@ -24,9 +24,7 @@ rm -f ${SENTINEL}
 
 killed()
 {
-    dfuserver stop=1
-    sleep 5
-    kill_process ${PID_NAME} dfuserver 3 ${SENTINEL}
+    kill_process ${PID_NAME} dfuserver 15 ${SENTINEL}
     exit 255
 }
 


### PR DESCRIPTION
So I have been testing this and from what I can tell, the call to engine->abortListeners() that is in the signal handler will cleanly shut down all the threads that dfuserver has spawned.  The only reason that the "dfuserver stop=1" call is useful is if you want to send a remote shutdown signal (by using the stopDFUserver(<queuename>) call that is found in dfurun.cpp.  So for shutdown by our init system, the "dfuserver stop=1" and the "sleep 5" call afterwards is unnecessary.  I have removed them and increased the amount of time that we wait for dfuserver to cleanly shut down within the kill_process before doing a SIGKILL.  @richardkchapman I'm not entirely certain who should review this.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
