### PR TITLE
HPCC-12257 Faster dafilesrv version check on thor startup when replicate is on

### DIFF
--- a/common/remote/rmtfile.cpp
+++ b/common/remote/rmtfile.cpp
@@ -656,10 +656,14 @@ public:
     }
 };
 
-unsigned validateNodes(const SocketEndpointArray &eps,const char *dataDir, const char *mirrorDir, bool chkver, const char *script, unsigned scripttimeout, SocketEndpointArray &failures, UnsignedArray &failedcodes, StringArray &failedmessages, const char *filename)
+unsigned validateNodes(const SocketEndpointArray &epso,const char *dataDir, const char *mirrorDir, bool chkver, const char *script, unsigned scripttimeout, SocketEndpointArray &failures, UnsignedArray &failedcodes, StringArray &failedmessages, const char *filename)
 {
     // used for detecting duff nodes
     IPointerArrayOf<ISocket> sockets;
+    // dedup nodes
+    SocketEndpointArray eps;
+    ForEachItemIn(i1,epso)
+        eps.appendUniq(epso.element(i1));
     unsigned to=30*1000;
     unsigned n=eps.ordinality();    // use approx log scale (timeout is long but only for failure situation)
     while (n>1) {

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -2598,8 +2598,7 @@ void CRemoteFile::copyTo(IFile *dest, size32_t buffersize, ICopyFileProgress *pr
 
 unsigned getRemoteVersion(ISocket * socket, StringBuffer &ver)
 {
-    static CriticalSection sect;
-    CriticalBlock block(sect);
+    // used to have a global critical section here
     if (!socket)
         return 0;
     unsigned ret;
@@ -2638,8 +2637,7 @@ unsigned getRemoteVersion(ISocket * socket, StringBuffer &ver)
 
 extern unsigned stopRemoteServer(ISocket * socket)
 {
-    static CriticalSection sect;
-    CriticalBlock block(sect);
+    // used to have a global critical section here
     if (!socket)
         return 0;
     MemoryBuffer sendbuf;


### PR DESCRIPTION
Removed global critical section in getRemoteVersion(), cannot see why it was required.
(we could add back in a CS per ISocket if it really is required)
This allows asyncFor in validateNodes() to run multiple threads concurrently.
Also eliminated duplicate endpoints to check when slavesPerNode > 1
On a large cluster with many slavesPerNode this change can reduce thor startup time significantly, especially if dafilesrv has throttled some replies.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
