### PR TITLE
HPCC-13604 Leaking a RowManager in localSlave mode

### DIFF
--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -2466,7 +2466,6 @@ void LocalMessagePacker::flush(bool last_message)
 CLocalMessageCollator::CLocalMessageCollator(IRowManager *_rowManager, ruid_t _ruid) 
     : rowManager(_rowManager), id(_ruid)
 {
-    id = 0;
     totalBytesReceived = 0;
 }
 


### PR DESCRIPTION
ruid was not properly preserved maning that the detach failed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
