### PR TITLE
HPCC-13545 Separate exposing data and formating in getLocks

### DIFF
--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -1887,6 +1887,19 @@ StringBuffer &CClientSDSManager::getLocks(StringBuffer &out)
     return getInfo(DIAG_CMD_LOCKINFO, out);
 }
 
+void CClientSDSManager::getLocks(CMessageBuffer &out)
+{
+    out.append((int)DAMP_SDSCMD_DIAGNOSTIC);
+    out.append((int)DIAG_CMD_LOCKINFO);
+
+    if (!queryCoven().sendRecv(out, RANK_RANDOM, MPTAG_DALI_SDS_REQUEST))
+    {
+        out.clear();
+        throw MakeSDSException(SDSExcpt_FailedToCommunicateWithServer, "querying sds diagnositc info");
+    }
+    return;
+}
+
 StringBuffer &CClientSDSManager::getUsageStats(StringBuffer &out)
 {
     return getInfo(DIAG_CMD_STATS, out);

--- a/dali/base/dacsds.ipp
+++ b/dali/base/dacsds.ipp
@@ -406,6 +406,7 @@ public:
     virtual void unsubscribe(SubscriptionId id);
     virtual void unsubscribeExact(SubscriptionId id);
     virtual StringBuffer &getLocks(StringBuffer &out);
+    virtual void getLocks(CMessageBuffer &out);
     virtual StringBuffer &getUsageStats(StringBuffer &out);
     virtual StringBuffer &getConnections(StringBuffer &out);
     virtual StringBuffer &getSubscribers(StringBuffer &out);

--- a/dali/base/dadiags.cpp
+++ b/dali/base/dadiags.cpp
@@ -27,6 +27,7 @@
 #include "daserver.hpp"
 #include "dasds.hpp"
 #include "dasubs.ipp"
+#include "dautils.hpp"
 #include "dadiags.hpp"
 
 #ifdef _MSC_VER
@@ -122,7 +123,7 @@ public:
                     mb.append(getReceiveQueueDetails(buf).str());
                 }
                 else if (0 == stricmp(id, "locks")) {
-                    mb.append(querySDS().getLocks(buf).str());
+                    querySDS().getLocks(mb);
                 }
                 else if (0 == stricmp(id, "sdsstats")) {
                     mb.append(querySDS().getUsageStats(buf).str());
@@ -276,6 +277,16 @@ StringBuffer & getDaliDiagnosticValue(const char *name,StringBuffer &ret)
     mb.read(str);
     ret.append(str);
     return ret;
+}
+
+IPropertyTreeIterator *getLockDataTreeIterator()
+{
+    MemoryBuffer mb;
+    mb.append("locks");
+    getDaliDiagnosticValue(mb);
+
+    CLockDataHelper helper;
+    return helper.getLockDataTreeIterator(mb);
 }
 
 IDaliServer *createDaliDiagnosticsServer()

--- a/dali/base/dadiags.hpp
+++ b/dali/base/dadiags.hpp
@@ -25,6 +25,7 @@
 extern da_decl StringBuffer & getDaliDiagnosticValue(const char *name,StringBuffer &ret);
 extern da_decl MemoryBuffer & getDaliDiagnosticValue(MemoryBuffer &m);
 
+extern da_decl IPropertyTreeIterator *getLockDataTreeIterator();
 
 // for server use
 interface IDaliServer;

--- a/dali/base/dasds.hpp
+++ b/dali/base/dasds.hpp
@@ -108,6 +108,7 @@ interface ISDSManager
     virtual void unsubscribe(SubscriptionId id) = 0;
     virtual void unsubscribeExact(SubscriptionId id) = 0;
     virtual StringBuffer &getLocks(StringBuffer &out) = 0;
+    virtual void getLocks(CMessageBuffer &out) = 0;
     virtual StringBuffer &getUsageStats(StringBuffer &out) = 0;
     virtual StringBuffer &getConnections(StringBuffer &out) = 0;
     virtual StringBuffer &getSubscribers(StringBuffer &out) = 0;


### PR DESCRIPTION
The existing getLocks() calls the getLockInfo() to retrieve lock
data and create a formated string on dali server side. In this
fix, the getLockInfo() is divided into two parts, one for
retrieving lock data and one for creating a formated string. A
new getLocks() is created to call the part for retrieving lock
data only. Both parts are built into a new lock data helper class.
A new getLocks() is created to use the helper class to retrieve
serialized lock data without formating. After the data is
received, the client sides (daliadmin and dalidiag) uses the
helper class to create formatted strings as needed. The
getLockInfo() is still used by dali server for other functions
(such as log),

Signed-off-by: wangkx kevin.wang@lexisnexis.com
