### PR TITLE
HPCC-13254 Add backwards compatible constructor to class

### DIFF
--- a/rtl/eclrtl/rtlfield.cpp
+++ b/rtl/eclrtl/rtlfield.cpp
@@ -1460,6 +1460,11 @@ RtlFieldStrInfo::RtlFieldStrInfo(const char * _name, const char * _xpath, const 
 }
 
 
+RtlFieldStrInfo::RtlFieldStrInfo(const char * _name, const char * _xpath, const RtlTypeInfo * _type)
+: RtlFieldInfo(rtlCreateFieldNameAtom(_name), _xpath, _type, NULL)
+{
+}
+
 
 
 /* 

--- a/rtl/eclrtl/rtlfield_imp.hpp
+++ b/rtl/eclrtl/rtlfield_imp.hpp
@@ -315,7 +315,8 @@ public:
 
 struct ECLRTL_API RtlFieldStrInfo : public RtlFieldInfo
 {
-    RtlFieldStrInfo(const char * _name, const char * _xpath, const RtlTypeInfo * _type, const char * _initializer = NULL);
+    RtlFieldStrInfo(const char * _name, const char * _xpath, const RtlTypeInfo * _type);
+    RtlFieldStrInfo(const char * _name, const char * _xpath, const RtlTypeInfo * _type, const char * _initializer);
 };
 
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
