### PR TITLE
HPCC-13156 Modification of jlib and thor signal handling

### DIFF
--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -241,14 +241,14 @@ int CEclAgentExecutionServer::executeWorkunit(const char * wuid)
 
 //---------------------------------------------------------------------------------
 
-bool ControlHandler() 
-{ 
+bool ControlHandler()
+{
     if (execSvr)
     {
         execSvr->stop();
     }
-    return false; 
-} 
+    return false;
+}
 
 //---------------------------------------------------------------------------------
 

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -246,7 +246,10 @@ inline unsigned __int32 low(__int64 n)
 
 //MORE - We really should restructure this file.  Also would this be better with a class interface?
 //Handle ^C/break from a console program.
-typedef bool (*AbortHandler)();                                                 // return true to exit program
+
+enum ahType { ahTerminate, ahInterrupt};
+typedef bool (*AbortHandler)(ahType);                                       // return true to exit program
+typedef bool (*SimpleAbortHandler)();
 
 interface IAbortHandler : public IInterface
 {
@@ -256,8 +259,10 @@ interface IAbortHandler : public IInterface
 #define JLIBERR_UserAbort       0xffffff00
 
 extern jlib_decl void addAbortHandler(AbortHandler handler=NULL);               // no parameter means just set the flag for later testing.
+extern jlib_decl void addAbortHandler(SimpleAbortHandler handler=NULL);
 extern jlib_decl void addAbortHandler(IAbortHandler & handler);
 extern jlib_decl void removeAbortHandler(AbortHandler handler);
+extern jlib_decl void removeAbortHandler(SimpleAbortHandler handler);
 extern jlib_decl void removeAbortHandler(IAbortHandler & handler);
 extern jlib_decl bool isAborting();
 extern jlib_decl void throwAbortException();
@@ -272,10 +277,12 @@ interface IAbortRequestCallback
 class LocalAbortHandler
 {
 public:
-    LocalAbortHandler(AbortHandler _handler=NULL)   { handler = _handler; addAbortHandler(handler); }
-    ~LocalAbortHandler()                            { removeAbortHandler(handler); }
+    LocalAbortHandler(AbortHandler _handler=NULL)   { handler = _handler; shandler = NULL; addAbortHandler(handler); }
+    LocalAbortHandler(SimpleAbortHandler _handler=NULL) { shandler = _handler; handler = NULL; addAbortHandler(shandler); }
+    ~LocalAbortHandler()                            { if (handler) { removeAbortHandler(handler); } else removeAbortHandler(shandler); }
 private:
     AbortHandler            handler;
+    SimpleAbortHandler        shandler;
 };
 
 class LocalIAbortHandler

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -784,12 +784,15 @@ void abortThor(IException *e, unsigned errCode, bool abortCurrentJob)
     if (0 == aborting)
     {
         aborting = 1;
-        if (!e)
+        if (errCode != TEC_Clean)
         {
-            _e.setown(MakeThorException(TE_AbortException, "THOR ABORT"));
-            e = _e;
+            if (!e)
+            {
+                _e.setown(MakeThorException(TE_AbortException, "THOR ABORT"));
+                e = _e;
+            }
+            EXCLOG(e,"abortThor");
         }
-        EXCLOG(e,"abortThor");
         LOG(MCdebugProgress, thorJob, "abortThor called");
         if (jM)
             jM->stop();

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -401,42 +401,55 @@ bool checkClusterRelicateDAFS(IGroup *grp)
 static bool auditStartLogged = false;
 
 static bool firstCtrlC = true;
-bool ControlHandler() 
-{ 
-    if (firstCtrlC)
+bool ControlHandler(ahType type)
+{
+    if (ahInterrupt == type)
     {
-        LOG(MCdebugProgress, thorJob, "CTRL-C detected");
-        firstCtrlC = false;
+        if (firstCtrlC)
         {
-            Owned<CRegistryServer> registry = CRegistryServer::getRegistryServer();
-            if (registry)
-                registry->stop();
+            LOG(MCdebugProgress, thorJob, "CTRL-C detected");
+            firstCtrlC = false;
+            {
+                Owned<CRegistryServer> registry = CRegistryServer::getRegistryServer();
+                if (registry)
+                    registry->stop();
+            }
+            abortThor(NULL, TEC_CtrlC);
         }
-        abortThor(NULL, TEC_CtrlC);
+        else
+        {
+            LOG(MCdebugProgress, thorJob, "2nd CTRL-C detected - terminating process");
+
+            if (auditStartLogged)
+            {
+                auditStartLogged = false;
+                LOG(daliAuditLogCat,",Progress,Thor,Terminate,%s,%s,%s,ctrlc",
+                    queryServerStatus().queryProperties()->queryProp("@thorname"),
+                    queryServerStatus().queryProperties()->queryProp("@nodeGroup"),
+                    queryServerStatus().queryProperties()->queryProp("@queue"));
+            }
+            queryLogMsgManager()->flushQueue(10*1000);
+#ifdef _WIN32
+            TerminateProcess(GetCurrentProcess(), 1);
+#else
+            //MORE- verify this
+            // why not just raise(SIGKILL);  ?
+            kill(getpid(), SIGKILL);
+#endif
+            _exit(1);
+        }
     }
+    // ahTerminate
     else
     {
-        LOG(MCdebugProgress, thorJob, "2nd CTRL-C detected - terminating process");
-
-        if (auditStartLogged)
-        {
-            auditStartLogged = false;
-            LOG(daliAuditLogCat,",Progress,Thor,Terminate,%s,%s,%s,ctrlc",
-                queryServerStatus().queryProperties()->queryProp("@thorname"),
-                queryServerStatus().queryProperties()->queryProp("@nodeGroup"),
-                queryServerStatus().queryProperties()->queryProp("@queue"));
-        }
-        queryLogMsgManager()->flushQueue(10*1000);
-#ifdef _WIN32
-        TerminateProcess(GetCurrentProcess(), 1);
-#else
-        //MORE- verify this
-        kill(getpid(), SIGKILL);
-#endif
-        _exit(1);
+        LOG(MCdebugProgress, thorJob, "SIGTERM detected, shutting down");
+        Owned<CRegistryServer> registry = CRegistryServer::getRegistryServer();
+        if (registry)
+            registry->stop();
+        abortThor(NULL, TEC_Clean);
     }
-    return false; 
-} 
+    return false;
+}
 
 
 #include "thactivitymaster.hpp"

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -192,12 +192,14 @@ void UnregisterSelf(IException *e)
     }
 }
 
-bool ControlHandler() 
-{ 
-    LOG(MCdebugProgress, thorJob, "CTRL-C pressed");
-    if (masterNode) UnregisterSelf(NULL);
+bool ControlHandler(ahType type)
+{
+    if (ahInterrupt == type)
+        LOG(MCdebugProgress, thorJob, "CTRL-C pressed");
+    if (masterNode)
+        UnregisterSelf(NULL);
     abortSlave();
-    return false; 
+    return false;
 }
 
 void usage()


### PR DESCRIPTION
This change allows us to differentiate between a normal shutdown and an abnormal shutdown within components.  We map os specific signals to a generic type (ahType) from within the default abort handlers (WindowsAbortHandler and UnixAbortHandler within jmisc.cpp.)  This then allows us to modify our components signal handlers so that we can test for which generic signal was sent and act accordingly.  I have modified thor so that it does not through an exception to it's logs if a normal shutdown is handled.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
