### PR TITLE
HPCC-13611 Supress Valid Warnings

### DIFF
--- a/esp/src/eclwatch/LFDetailsWidget.js
+++ b/esp/src/eclwatch/LFDetailsWidget.js
@@ -98,6 +98,27 @@ define([
             this.dfuWorkunitWidget = registry.byId(this.id + "_DFUWorkunit");
             this.copyTargetSelect = registry.byId(this.id + "CopyTargetSelect");
             this.desprayTargetSelect = registry.byId(this.id + "DesprayTargetSelect");
+            this.desprayTooltiopDialog = registry.byId(this.id + "DesprayTooltipDialog");
+            var context = this;
+            var origOnOpen = this.desprayTooltiopDialog.onOpen;
+            this.desprayTooltiopDialog.onOpen = function () {
+                if (!context.desprayTargetSelect.initalized) {
+                    context.desprayTargetSelect.init({
+                        DropZones: true,
+                        callback: function (value, item) {
+                            context.updateInput("DesprayTargetIPAddress", null, item.machine.Netaddress);
+                            context.updateInput("DesprayTargetName", null, context.logicalFile.getLeaf());
+                            if (context.desprayTargetPath) {
+                                context.desprayTargetPath.reset();
+                                context.desprayTargetPath._dropZoneTarget = item;
+                                context.desprayTargetPath.defaultValue = context.desprayTargetPath.get("value");
+                                context.desprayTargetPath.loadDropZoneFolders();
+                            }
+                        }
+                    });
+                }
+                origOnOpen.apply(context.desprayTooltiopDialog, arguments);
+            }
             this.desprayTargetPath = registry.byId(this.id + "DesprayTargetPath");
             this.fileBelongsToWidget = registry.byId(this.id + "_FileBelongs");
         },
@@ -191,19 +212,6 @@ define([
             }
             this.copyTargetSelect.init({
                 Groups: true
-            });
-            this.desprayTargetSelect.init({
-                DropZones: true,
-                callback: function (value, item) {
-                    context.updateInput("DesprayTargetIPAddress", null, item.machine.Netaddress);
-                    context.updateInput("DesprayTargetName", null, context.logicalFile.getLeaf());
-                    if (context.desprayTargetPath) {
-                        context.desprayTargetPath.reset();
-                        context.desprayTargetPath._dropZoneTarget = item;
-                        context.desprayTargetPath.defaultValue = context.desprayTargetPath.get("value");
-                        context.desprayTargetPath.loadDropZoneFolders();
-                    }
-                }
             });
             this.desprayTargetPath.init({
                 DropZoneFolders: true

--- a/esp/src/eclwatch/TargetSelectWidget.js
+++ b/esp/src/eclwatch/TargetSelectWidget.js
@@ -157,7 +157,8 @@ define([
                     Netaddr: Netaddr,
                     Path: Path,
                     OS: OS
-                }
+                },
+                suppressExceptionToaster: true
             }).then(function (response) {
                 var requests = [];
                 if (lang.exists("FileListResponse.files.PhysicalFileStruct", response)) {

--- a/esp/src/eclwatch/templates/LFDetailsWidget.html
+++ b/esp/src/eclwatch/templates/LFDetailsWidget.html
@@ -60,7 +60,7 @@
                     </div>
                     <div id="${id}DesprayDropDown" data-dojo-type="dijit.form.DropDownButton">
                         <span>${i18n.Despray}</span>
-                        <div data-dojo-type="dijit.TooltipDialog">
+                        <div id="${id}DesprayTooltipDialog" data-dojo-type="dijit.TooltipDialog">
                             <div id="${id}DesprayForm" style="width: 460px;" onsubmit="return false;" data-dojo-type="dijit.form.Form">
                                 <div data-dojo-type="dijit.Fieldset">
                                     <legend>${i18n.Target}</legend>


### PR DESCRIPTION
Suppress valid warnings while loading logical file target folders.
Delay load logical file despray targets until drop is initiated.

Fixes HPCC-13611

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
