### PR TITLE
HPCC-13464 Display allowed clusters in ECLWatch

### DIFF
--- a/esp/src/eclwatch/templates/WUDetailsWidget.html
+++ b/esp/src/eclwatch/templates/WUDetailsWidget.html
@@ -82,6 +82,7 @@
                             <li>
                                 <label class="Prompt" for="${id}Cluster">${i18n.Cluster}:</label>
                                 <div id="${id}Cluster"></div>
+                                <div id="${id}AllowedClusters" data-dojo-type="dijit.form.Select"/></div>
                             </li>
                             <li>
                                 <label class="Prompt" for="${id}TotalClusterTime">${i18n.TotalClusterTime}:</label>


### PR DESCRIPTION
When using #option('AllowedCluster') ECLWatch is not displaying the additional clusters within the interface.

Signed-off-by: Miguel Vazquez miguel.vazquez@lexisnexis.com
