### PR TITLE
HPCC-13021 Fix CMake 3.x warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@
 #########################################################
 
 project (hpccsystems-platform)
-cmake_minimum_required (VERSION 2.8.3)
+cmake_minimum_required (VERSION 2.8.11)
 
 include(CTest)
 ENABLE_TESTING()

--- a/ecl/ecl-package/CMakeLists.txt
+++ b/ecl/ecl-package/CMakeLists.txt
@@ -56,7 +56,8 @@ include_directories (
 ADD_DEFINITIONS( -D_CONSOLE )
 
 HPCC_ADD_EXECUTABLE ( ecl-packagemap ${SRCS} )
-add_dependencies ( ecl-packagemap espscm ws_packageprocess )
+
+add_dependencies ( ecl-packagemap espscm )
 install ( TARGETS ecl-packagemap RUNTIME DESTINATION ${EXEC_DIR} )
 target_link_libraries ( ecl-packagemap
         jlib

--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -67,8 +67,9 @@ include_directories (
 
 ADD_DEFINITIONS( -D_CONSOLE )
 
+
 HPCC_ADD_EXECUTABLE ( ecl ${SRCS} )
-add_dependencies ( ecl espscm workunit ws_workunits )
+add_dependencies ( ecl espscm workunit)
 install ( TARGETS ecl RUNTIME DESTINATION ${EXEC_DIR} )
 target_link_libraries ( ecl
         jlib

--- a/ecl/eclcmd/queries/CMakeLists.txt
+++ b/ecl/eclcmd/queries/CMakeLists.txt
@@ -44,7 +44,7 @@ include_directories (
 ADD_DEFINITIONS( -D_CONSOLE )
 
 HPCC_ADD_EXECUTABLE ( ecl-queries ${SRCS} )
-add_dependencies ( ecl-queries espscm ws_workunits )
+add_dependencies ( ecl-queries espscm)
 install ( TARGETS ecl-queries RUNTIME DESTINATION ${EXEC_DIR} )
 target_link_libraries ( ecl-queries
         jlib

--- a/ecl/eclcmd/roxie/CMakeLists.txt
+++ b/ecl/eclcmd/roxie/CMakeLists.txt
@@ -46,7 +46,7 @@ include_directories (
 ADD_DEFINITIONS( -D_CONSOLE )
 
 HPCC_ADD_EXECUTABLE ( ecl-roxie ${SRCS} )
-add_dependencies ( ecl-roxie espscm ws_workunits )
+add_dependencies ( ecl-roxie espscm )
 install ( TARGETS ecl-roxie RUNTIME DESTINATION ${EXEC_DIR} )
 target_link_libraries ( ecl-roxie
         jlib

--- a/esp/scm/additional.cmake
+++ b/esp/scm/additional.cmake
@@ -22,8 +22,6 @@
 
 set ( ESPSCM_SOURCE_DIR ${HPCC_SOURCE_DIR}/esp/scm )
 set ( ESPSCM_GENERATED_DIR ${CMAKE_BINARY_DIR}/generated )
-GET_TARGET_PROPERTY(HIDL_EXE hidl LOCATION)
-GET_TARGET_PROPERTY(ESDL-XML_EXE esdl-xml LOCATION)
 
 set ( ESPSCM_SRCS
       ws_config.ecm
@@ -38,11 +36,11 @@ foreach ( loop_var ${ESPSCM_SRCS} )
     if (SCM_BUILD)
       add_custom_command ( DEPENDS hidl ${ESPSCM_SOURCE_DIR}/${loop_var}
                            OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.esp ${ESPSCM_GENERATED_DIR}/${result}.hpp ${ESPSCM_GENERATED_DIR}/${result}.int ${ESPSCM_GENERATED_DIR}/${result}.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp.cpp ${ESPSCM_GENERATED_DIR}/${result}_esp.ipp
-                           COMMAND ${HIDL_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                           COMMAND $<TARGET_FILE:hidl> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                          )
       add_custom_command ( DEPENDS esdl-xml ${ESPSCM_SOURCE_DIR}/${loop_var}
                            OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.xml
-                           COMMAND ${ESDL-XML_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                           COMMAND $<TARGET_FILE:esdl-xml> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                          )
     endif ()
     set_source_files_properties(${ESPSCM_GENERATED_DIR}/${result}.esp PROPERTIES GENERATED TRUE)

--- a/esp/scm/espscm.cmake
+++ b/esp/scm/espscm.cmake
@@ -22,8 +22,6 @@
 
 set ( ESPSCM_SOURCE_DIR ${HPCC_SOURCE_DIR}/esp/scm )
 set ( ESPSCM_GENERATED_DIR ${CMAKE_BINARY_DIR}/generated )
-GET_TARGET_PROPERTY(HIDL_EXE hidl LOCATION)
-GET_TARGET_PROPERTY(ESDL-XML_EXE esdl-xml LOCATION)
 
 set ( ESPSCM_SRCS
       common.ecm
@@ -51,11 +49,11 @@ foreach ( loop_var ${ESPSCM_SRCS} )
     if (SCM_BUILD)
       add_custom_command ( DEPENDS hidl ${ESPSCM_SOURCE_DIR}/${loop_var}
                            OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.esp ${ESPSCM_GENERATED_DIR}/${result}.hpp ${ESPSCM_GENERATED_DIR}/${result}.int ${ESPSCM_GENERATED_DIR}/${result}.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp.cpp ${ESPSCM_GENERATED_DIR}/${result}_esp.ipp
-                           COMMAND ${HIDL_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                           COMMAND $<TARGET_FILE:hidl> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                          )
       add_custom_command ( DEPENDS esdl-xml ${ESPSCM_SOURCE_DIR}/${loop_var}
                            OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.xml
-                           COMMAND ${ESDL-XML_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                           COMMAND $<TARGET_FILE:esdl-xml> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                          )
     endif ()
     set_source_files_properties(${ESPSCM_GENERATED_DIR}/${result}.esp PROPERTIES GENERATED TRUE)

--- a/esp/scm/ncmscm.cmake
+++ b/esp/scm/ncmscm.cmake
@@ -22,8 +22,6 @@
 
 set ( ESPSCM_SOURCE_DIR ${HPCC_SOURCE_DIR}/esp/scm )
 set ( ESPSCM_GENERATED_DIR ${CMAKE_BINARY_DIR}/generated )
-GET_TARGET_PROPERTY(HIDL_EXE hidl LOCATION)
-GET_TARGET_PROPERTY(ESDL-XML_EXE esdl-xml LOCATION)
 
 set ( ECMCSM_SRCS 
       ws_riskwise.ncm
@@ -37,11 +35,11 @@ foreach ( loop_var ${ESPSCM_SRCS} )
     string(  REGEX REPLACE "[.]ncm" "" result ${loop_var} )
     add_custom_command ( DEPENDS hidl ${ESPSCM_SOURCE_DIR}/${loop_var}
                          OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.esp ${ESPSCM_GENERATED_DIR}/${result}.hpp ${ESPSCM_GENERATED_DIR}/${result}.int ${ESPSCM_GENERATED_DIR}/${result}.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp.cpp ${ESPSCM_GENERATED_DIR}/${result}_esp.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp_ng.cpp ${ESPSCM_GENERATED_DIR}/${result}_esp_ng.ipp
-                         COMMAND ${HIDL_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ncm ${ESPSCM_GENERATED_DIR}
+                         COMMAND $<TARGET_FILE:hidl> ${ESPSCM_SOURCE_DIR}/${result}.ncm ${ESPSCM_GENERATED_DIR}
                        )
     add_custom_command ( DEPENDS esdl-xml ${ESPSCM_SOURCE_DIR}/${loop_var}
                          OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.xml 
-                         COMMAND ${ESDL-XML_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                         COMMAND $<TARGET_FILE:esdl-xml> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                        )
     set_source_files_properties(${ESPSCM_GENERATED_DIR}/${result}.esp PROPERTIES ESPSCM_GENERATED_DIR TRUE)
     set_source_files_properties(${ESPSCM_GENERATED_DIR}/${result}.hpp PROPERTIES ESPSCM_GENERATED_DIR TRUE)

--- a/esp/scm/smcscm.cmake
+++ b/esp/scm/smcscm.cmake
@@ -23,8 +23,6 @@
 
 set ( ESPSCM_SOURCE_DIR ${HPCC_SOURCE_DIR}/esp/scm )
 set ( ESPSCM_GENERATED_DIR ${CMAKE_BINARY_DIR}/generated )
-GET_TARGET_PROPERTY(HIDL_EXE hidl LOCATION)
-GET_TARGET_PROPERTY(ESDL-XML_EXE esdl-xml LOCATION)
 
 set ( ESPSCM_SRCS
       common.ecm
@@ -44,11 +42,11 @@ foreach ( loop_var ${ESPSCM_SRCS} )
     if (SCM_BUILD)
       add_custom_command ( DEPENDS hidl ${ESPSCM_SOURCE_DIR}/${loop_var}
                            OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.esp ${ESPSCM_GENERATED_DIR}/${result}.hpp ${ESPSCM_GENERATED_DIR}/${result}.int ${ESPSCM_GENERATED_DIR}/${result}.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp.cpp ${ESPSCM_GENERATED_DIR}/${result}_esp.ipp
-                           COMMAND ${HIDL_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                           COMMAND $<TARGET_FILE:hidl> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                          )
       add_custom_command ( DEPENDS esdl-xml ${ESPSCM_SOURCE_DIR}/${loop_var}
                            OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.xml
-                           COMMAND ${ESDL-XML_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                           COMMAND $<TARGET_FILE:esdl-xml> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                          )
     endif ()
     set_source_files_properties(${ESPSCM_GENERATED_DIR}/${result}.esp PROPERTIES GENERATED TRUE)

--- a/initfiles/CMakeLists.txt
+++ b/initfiles/CMakeLists.txt
@@ -21,14 +21,13 @@ if ( PLATFORM AND UNIX )
     HPCC_ADD_EXECUTABLE(processor processor.cpp)
 
     MACRO(GENERATE_BASH processor bash-vars in out)
-        GET_TARGET_PROPERTY(processorLocation processor LOCATION)
         MESSAGE(STATUS "Process file: ${in}")
         STRING(REGEX REPLACE ".in\$" "" outfileName "${in}")
         SET(outfile "${CMAKE_CURRENT_BINARY_DIR}/${outfileName}")
         MESSAGE(STATUS "Output file: ${outfile}")
         SET(infile "${CMAKE_CURRENT_SOURCE_DIR}/${in}")
         ADD_CUSTOM_COMMAND(OUTPUT "${outfile}"
-            COMMAND ${processorLocation}
+            COMMAND $<TARGET_FILE:processor>
             "${bash-vars}" "${infile}" "${outfile}"
             COMMAND chmod 0755 ${outfile}
             DEPENDS "${infile}" processor # depends on the 'processor'

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,9 +14,9 @@
 #    limitations under the License.
 ################################################################################
 HPCC_ADD_SUBDIRECTORY (esdlcomp)
-HPCC_ADD_SUBDIRECTORY (esdlcmd)
-HPCC_ADD_SUBDIRECTORY (esdlcmd-xml)
 HPCC_ADD_SUBDIRECTORY (hidl)
+HPCC_ADD_SUBDIRECTORY (esdlcmd-xml)
+HPCC_ADD_SUBDIRECTORY (esdlcmd)
 HPCC_ADD_SUBDIRECTORY (backupnode "PLATFORM")
 IF (USE_OPENLDAP)
 HPCC_ADD_SUBDIRECTORY (addScopes "PLATFORM")


### PR DESCRIPTION
Replace GET_TARGET_PROPERTY(..., LOCATION) with $&lt;TARGET_FILE:variable_name&gt; (CMake CMP0026)

Remove Clienttools dependencies on targets with prefix "ws_".

@Michael-Gardner please review

Signed-off-by: Xiaoming wang xiaoming.wang@lexisnexis.com 
