### PR TITLE
HPCC-13637 Make eclcc --keywords print to stdout rather than to file

### DIFF
--- a/ecl/eclcc/reservedwords.cpp
+++ b/ecl/eclcc/reservedwords.cpp
@@ -572,13 +572,6 @@ void printKeywordsToXml()
          }
          buffer.append("  </cat>\n");
      }
-     buffer.append("</xml>\n");
-
-     Owned<IFile> treeFile = createIFile("ECLKeywords.xml");
-     assertex(treeFile);
-     Owned<IFileIO> io = treeFile->open(IFOcreaterw);
-     assertex(io);
-     Owned<IIOStream> out = createIOStream(io);
-     assertex(out);
-     out->write(buffer.length(), buffer.str());
+     buffer.append("</xml>");
+     fprintf(stdout, "%s\n", buffer.str());
 }


### PR DESCRIPTION
Signed-off-by: James Noss james.noss@lexisnexis.com
