### PR TITLE
HPCC-13469 Roxie sets incorrect file part CRC when outputting XML file.

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -11056,7 +11056,7 @@ public:
             fileProps.setPropInt64("@size", uncompressedBytesWritten);
             partProps.setPropInt64("@size", uncompressedBytesWritten);
         }
-        else if (tallycrc)
+        else if (tallycrc && crc.get())
             partProps.setPropInt64("@fileCrc", crc.get());
 
         if (encrypted)


### PR DESCRIPTION
If the CRC has not been calculated, it should leave it unset rather than
setting 0.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
