### PR TITLE
HPCC-12507 Cli roxie-unused-files --delete improvements

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -89,6 +89,8 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_UPDATE_DFS "--update-dfs"
 #define ECLOPT_GLOBAL_SCOPE "--global-scope"
 #define ECLOPT_DELETE_FILES "--delete"
+#define ECLOPT_DELETE_SUBFILES "--delete-subfiles"
+#define ECLOPT_DELETE_RECURSIVE "--delete-recursive"
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -237,6 +237,8 @@ DFUArrayActionRequest
     bool NoDelete;
     [min_ver("1.04")] string BackToPage;
     ESParray<string> LogicalFiles;
+    bool removeFromSuperfiles(false);
+    bool removeRecursively(false);
 };
 
 ESPresponse 

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1147,9 +1147,8 @@ void setDeleteFileResults(const char* fileName, const char* nodeGroup, bool fail
 
     StringBuffer message;
     if (start)
-        message.append(start);
-    if (fileName && *fileName)
-        message.append(' ').append(fileName);
+        message.append(start).append(' ');
+    message.append(fileName);
     if (nodeGroup && *nodeGroup)
         message.append(" on ").append(nodeGroup);
     if (text && *text)
@@ -1254,7 +1253,7 @@ DeleteActionResult doDeleteFile(const char *fn, IUserDescriptor *userdesc, Strin
     {
         StringBuffer emsg;
         e->errorMessage(emsg);
-        if (removeFromSuperfiles && strstr(emsg, "owned"))
+        if (removeFromSuperfiles && strstr(emsg, "owned by"))
         {
             if (!doRemoveFileFromSuperfiles(lfn, userdesc, superFiles, failedFiles, deleteRecursively, returnStr, actionResults))
                 return DeleteActionFailure;

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -135,8 +135,6 @@ private:
         const char* beforeSubFile, bool existingSuperfile, bool autocreatesuper, bool deleteFile, bool removeSuperfile =  true);
     void getFilePartsOnClusters(IEspContext &context, const char* clusterReq, StringArray& clusters, IDistributedFile* df, IEspDFUFileDetail& FileDetails,
         offset_t& mn, offset_t& mx, offset_t& sum, offset_t& count);
-    void setDeleteFileResults(const char* fileName, const char* nodeGroup, bool failed, const char* message, StringBuffer& resultString,
-        IArrayOf<IEspDFUActionInfo>& actionResults);
 private:
     bool         m_disableUppercaseTranslation;
     StringBuffer m_clusterName;

--- a/initfiles/etc/bash_completion/ecl
+++ b/initfiles/etc/bash_completion/ecl
@@ -112,10 +112,14 @@ _ecl_opts_roxie()
     local subcmdname="${COMP_WORDS[subcmdpos]}"
     case "${subcmdname}" in
         "" | ecl)
-            echo "--help attach detach check reload"
+            echo "--help attach detach check reload unused-files"
             ;;
         attach | detach | check | reload)
             echo -n "--wait= "
+            _ecl_opts_common
+            ;;
+        "unused-files")
+            echo -n "--delete-recursive --delete-subfiles --delete --check-packagemaps --wait="
             _ecl_opts_common
             ;;
          *)


### PR DESCRIPTION
Unused-files will now support three forms of --delete.

--delete deletes unused files if they are not entries in a superfile.

--delete-subfiles will perform --delete, but after first removing the
file from any superfiles to which it belongs.

--delete-recursive will perform --delete-subfiles and also delete any
superfiles that are made empty (after removing those superfiles from
parent superfiles to which they belong, etc).

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
