### PR TITLE
HPCC-13465 Disable refresh on activity page

### DIFF
--- a/esp/src/eclwatch/ActivityWidget.js
+++ b/esp/src/eclwatch/ActivityWidget.js
@@ -23,6 +23,7 @@ define([
 
     "dijit/registry",
     "dijit/form/Button",
+    "dijit/form/ToggleButton",
     "dijit/ToolbarSeparator",
     "dijit/layout/ContentPane",
 
@@ -36,7 +37,7 @@ define([
     "hpcc/ESPUtil"
 
 ], function (declare, lang, i18n, nlsHPCC, arrayUtil, on,
-                registry, Button, ToolbarSeparator, ContentPane,
+                registry, Button, ToggleButton, ToolbarSeparator, ContentPane,
                 selector, tree,
                 GridDetailsWidget, ESPRequest, ESPActivity, DelayLoadWidget, ESPUtil) {
     return declare("ActivityWidget", [GridDetailsWidget], {
@@ -44,6 +45,10 @@ define([
         i18n: nlsHPCC,
         gridTitle: nlsHPCC.title_Activity,
         idProperty: "__hpcc_id",
+
+        _onAutoRefresh: function (event) {
+            this.activity.disableMonitor(!this.autoRefreshButton.get("checked"));
+        },
 
         _onPause: function (event, params) {
             arrayUtil.forEach(this.grid.getSelected(), function (item, idx) {
@@ -187,6 +192,8 @@ define([
                 return;
 
             var context = this;
+            this.autoRefreshButton = registry.byId(this.id + "AutoRefresh");
+            this.activity.disableMonitor(true);
             this.activity.watch("__hpcc_changedCount", function (item, oldValue, newValue) {
                 context.grid.set("query", {});
                 context._refreshActionState();
@@ -204,6 +211,18 @@ define([
             var context = this;
 
             this.openButton = registry.byId(this.id + "Open");
+            this.refreshButton = registry.byId(this.id + "Refresh");
+            
+            this.autoRefreshButton = new ToggleButton({
+                id: this.id + "AutoRefresh",
+                iconClass:'iconAutoRefresh',
+                showLabel: false,
+                checked: false,
+                onClick: function (event) {
+                    context._onAutoRefresh(event);
+                }
+            }).placeAt(this.refreshButton.domNode, "before");
+            tmpSplitter = new ToolbarSeparator().placeAt(this.refreshButton.domNode, "before");
             this.clusterPauseButton = new Button({
                 id: this.id + "PauseButton",
                 label: this.i18n.Pause,


### PR DESCRIPTION
By default, the activity page automatically refreshes which causes performance issues in some production environments. Add a auto-refresh button to give the user the flexibility to enable constant refreshing if needed.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
