### PR TITLE
HPCC-13648 Fix end-user specific code imported into esdl_svc_engine

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -529,13 +529,7 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
         soapmsg.append("<soap:Body>").append(req).append("</soap:Body>");
     }
     soapmsg.append("</soap:Envelope>");
-    IProperties* pProperties = context.queryRequestParameters();
 
-    if( !pProperties )
-        throw makeWsException( ERR_ESDL_BINDING_INTERNERR, WSERR_SERVER, "ESP",
-                    "EsdlServiceImpl::handleFinalRequest() queryRequestParameters missing");
-
-    const char *querytype = tgtcfg->queryProp("@querytype");
     const char *tgtUrl = tgtcfg->queryProp("@url");
     if (tgtUrl && *tgtUrl)
         sendTargetSOAP(context, tgtcfg.get(), soapmsg.str(), out, isproxy, NULL);

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -500,7 +500,6 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">");
 
-    StringBuffer hashedReq;
 
     if(isroxie)
     {
@@ -521,14 +520,12 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
     }
     else
     {
-        generateHashFromReq(srvdef,mthdef,req,hashedReq);
-        context.addTraceSummaryValue("hashkey",hashedReq.str());
         StringBuffer headers;
         processHeaders(context, srvdef, mthdef, ns, req,headers);
         if (headers.length() > 0 )
             soapmsg.append("<soap:Header>").append(headers).append("</soap:Header>");
 
-        processRequest(context, srvdef, mthdef, ns, req, hashedReq);
+        processRequest(context, srvdef, mthdef, ns, req);
         soapmsg.append("<soap:Body>").append(req).append("</soap:Body>");
     }
     soapmsg.append("</soap:Envelope>");
@@ -538,31 +535,17 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
         throw makeWsException( ERR_ESDL_BINDING_INTERNERR, WSERR_SERVER, "ESP",
                     "EsdlServiceImpl::handleFinalRequest() queryRequestParameters missing");
 
-    pProperties->setProp(MCACHE_OBJECT_KEY,hashedReq.str());
-
-    if( pProperties->hasProp(CACHED_RESULT_NAME) &&
-        stricmp(pProperties->queryProp(CACHED_RESULT_NAME),"yes" ) == 0)
-    {
-        // The "req" should have the response from cache.
-        out.clear().append(req);
-        context.addTraceSummaryValue("cache", "true");
-        // we got the result from cache no need to proceed further
-    }
+    const char *querytype = tgtcfg->queryProp("@querytype");
+    const char *tgtUrl = tgtcfg->queryProp("@url");
+    if (tgtUrl && *tgtUrl)
+        sendTargetSOAP(context, tgtcfg.get(), soapmsg.str(), out, isproxy, NULL);
     else
     {
-        const char *querytype = tgtcfg->queryProp("@querytype");
-        const char *tgtUrl = tgtcfg->queryProp("@url");
-        if (tgtUrl && *tgtUrl)
-            sendTargetSOAP(context, tgtcfg.get(), soapmsg.str(), out, isproxy, NULL);
-        else
-        {
-            ESPLOG(LogMax,"No target URL configured for %s",mthdef.queryMethodName());
-            throw makeWsException( ERR_ESDL_BINDING_BADREQUEST, WSERR_CLIENT, "ESP",
-                        "No target URL configured for %s!", mthdef.queryMethodName());
-        }
-        context.addTraceSummaryValue("cache", "false");
+        ESPLOG(LogMax,"No target URL configured for %s",mthdef.queryMethodName());
+        throw makeWsException( ERR_ESDL_BINDING_BADREQUEST, WSERR_CLIENT, "ESP",
+                   "No target URL configured for %s!", mthdef.queryMethodName());
     }
-    processResponse(context,srvdef,mthdef,ns,out,hashedReq);
+    processResponse(context,srvdef,mthdef,ns,out);
 
 }
 

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -124,18 +124,14 @@ public:
     virtual void getTargetResponseFile(IEspContext & context, IPropertyTree *srvinfo, const char * req, StringBuffer &resp);
     virtual void esdl_log(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg, IPropertyTree *tgtctx, IPropertyTree *req_pt, const char *xmlresp, const char *logdata, unsigned int timetaken){}
     virtual void processHeaders(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req, StringBuffer &headers){};
-    virtual void processRequest(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req, StringBuffer &hashedReq) {};
-    virtual void processResponse(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &resp,StringBuffer &hashedReq) {};
+    virtual void processRequest(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req) {};
+    virtual void processResponse(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &resp) {};
     virtual void createServersList(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, StringBuffer &servers) {};
     virtual bool handleResultLogging(IEspContext &espcontext, IPropertyTree * reqcontext, IPropertyTree * request,  const char * rawresp, const char * finalresp);
     void handleEchoTest(const char *mthName, IPropertyTree *req, StringBuffer &soapResp, unsigned flags=0);
     virtual void handleFinalRequest(IEspContext &context, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer& req, StringBuffer &out, bool isroxie, bool isproxy);
     void getSoapBody(StringBuffer& out,StringBuffer& soapresp);
     void getSoapError(StringBuffer& out,StringBuffer& soapresp,const char *,const char *);
-    virtual void generateHashFromReq(IEsdlDefService &srvdef,
-                                    IEsdlDefMethod &mthdef,
-                                    const StringBuffer &req,
-                                    StringBuffer &hashedReq) {};
 };
 
 //RODRIGO: BASE URN should be configurable.

--- a/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
@@ -39,38 +39,6 @@ CEsdlSvcEngineSoapBindingEx::CEsdlSvcEngineSoapBindingEx(IPropertyTree* cfg, con
 {
 }
 
-void CEsdlSvcEngineSoapBindingEx::handleSoapRequestException(IException *e, const char *source)
-{
-    WsErrorType  errorType = WSERR_NOERR;
-
-    const int    errorcode = e->errorCode();
-    StringBuffer errorMessage;
-    e->errorMessage(errorMessage);
-
-    ESPLOG(LogMax,"EsdlBindingImpl:HandleSoapRequest response error code: %d /nmerror message: %s",  errorcode, errorMessage.str());
-
-    IWsException *wsex = dynamic_cast<IWsException *> (e);
-
-    switch (errorcode){
-    case ERR_ESDL_BINDING_AUTHERROR: case ERR_ESDL_BINDING_BADACCOUNT: case ERR_ESDL_BINDING_BADABI:
-    case ERR_ESDL_BINDING_BADBRAND:  case ERR_ESDL_BINDING_BADBROKER:  case ERR_ESDL_BINDING_TESTCASE:
-        errorType = WSERR_CLIENT ;
-        break;
-    case 2:
-        e->Release();
-        wsex = makeWsException(ERR_ESDL_BINDING_BADREQUEST, WSERR_CLIENT, source, errorMessage.str());
-        break;
-    default:
-        errorType = WSERR_SERVER;
-        break;
-    }
-
-    if ( wsex )
-        throw wsex;
-    else
-        throw makeWsException( *e, errorType, source );
-}
-
 IPropertyTree *CEsdlSvcEngine::createTargetContext(IEspContext &context, IPropertyTree *tgtcfg, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *req_pt)
 {
     const char *querytype = tgtcfg->queryProp("@querytype");

--- a/esp/services/esdl_svc_engine/esdl_svc_engine.hpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.hpp
@@ -62,7 +62,6 @@ public:
     }
 
     virtual const char *queryServiceType(){return  m_pESDLService->getServiceType();}
-    virtual void handleSoapRequestException(IException *e, const char *source);
 };
 
 #endif //_ESPWIZ_Esdl_SVC_Engine_HPP__


### PR DESCRIPTION
Remove CEsdlSvcEngineSoapBindingEx::handleSoapRequestException() from esdl_svc_engine.cpp as this is used to generate custom soap messages.  Removal will mean the default soap messages will be produced.
