### PR TITLE
HPCC-13642 Ensure temp wuid directory is created upfront

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -1778,6 +1778,10 @@ void EclAgent::executeGraph(const char * graphName, bool realThor, size32_t pare
             unsigned guillotineTimeout = queryWorkUnit()->getDebugValueInt("maxRunTime", 0);
             if (guillotineTimeout)
                 abortmonitor->setGuillotineTimeout(guillotineTimeout);
+            StringBuffer jobTempDir;
+            getTempfileBase(jobTempDir);
+            if (!recursiveCreateDirectory(jobTempDir))
+                throw MakeStringException(0, "Failed to create temporary directory: %s", jobTempDir.str());
             activeGraph->execute(NULL);
             updateWULogfile();//Update workunit logfile name in case of rollover
             if (guillotineTimeout)


### PR DESCRIPTION
A side-effect of HPCC-9228, exposed a bug in the handling of
spills from the spilling sorter.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
