### PR TITLE
HPCC-13667 DropZone folder loading

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -49,6 +49,7 @@ define([
     "hpcc/ESPDFUWorkunit",
     "hpcc/DelayLoadWidget",
     "hpcc/TargetSelectWidget",
+    "hpcc/TargetComboBoxWidget",
     "hpcc/FilterDropDownWidget",
     "hpcc/SelectionGridWidget",
     "hpcc/WsTopology",
@@ -78,7 +79,7 @@ define([
 ], function (declare, lang, i18n, nlsHPCC, arrayUtil, dom, domAttr, domConstruct, domClass, domForm, date, on, topic,
                 registry, Dialog, Menu, MenuItem, MenuSeparator, PopupMenuItem, Textarea, ValidationTextBox,
                 editor, selector, tree,
-                _TabContainerWidget, WsDfu, FileSpray, ESPUtil, ESPLogicalFile, ESPDFUWorkunit, DelayLoadWidget, TargetSelectWidget, FilterDropDownWidget, SelectionGridWidget, WsTopology,
+                _TabContainerWidget, WsDfu, FileSpray, ESPUtil, ESPLogicalFile, ESPDFUWorkunit, DelayLoadWidget, TargetSelectWidget, TargetComboBoxWidget, FilterDropDownWidget, SelectionGridWidget, WsTopology,
                 put,
                 template) {
     return declare("DFUQueryWidget", [_TabContainerWidget, ESPUtil.FormHelper], {
@@ -102,6 +103,26 @@ define([
             this.addToSuperfileGrid = registry.byId(this.id + "AddToSuperfileGrid");
             this.desprayForm = registry.byId(this.id + "DesprayForm");
             this.desprayTargetSelect = registry.byId(this.id + "DesprayTargetSelect");
+            this.desprayTooltiopDialog = registry.byId(this.id + "DesprayTooltipDialog");
+            var context = this;
+            var origOnOpen = this.desprayTooltiopDialog.onOpen;
+            this.desprayTooltiopDialog.onOpen = function () {
+                if (!context.desprayTargetSelect.initalized) {
+                    context.desprayTargetSelect.init({
+                        DropZones: true,
+                        callback: function (value, item) {
+                            registry.byId(context.id + "DesprayTargetIPAddress").set("value", item.machine.Netaddress);
+                            if (context.desprayTargetPath) {
+                                context.desprayTargetPath.reset();
+                                context.desprayTargetPath._dropZoneTarget = item;
+                                context.desprayTargetPath.defaultValue = context.desprayTargetPath.get("value");
+                                context.desprayTargetPath.loadDropZoneFolders();
+                            }
+                        }
+                    });
+                }
+                origOnOpen.apply(context.desprayTooltiopDialog, arguments);
+            }
             this.desprayTargetPath = registry.byId(this.id + "DesprayTargetPath");
             this.desprayGrid = registry.byId(this.id + "DesprayGrid");
             this.remoteCopyReplicateCheckbox = registry.byId(this.id + "RemoteCopyReplicate");
@@ -232,6 +253,7 @@ define([
                 var context = this;
                 arrayUtil.forEach(this.desprayGrid.store.data, function (item, idx) {
                     var request = domForm.toObject(context.id + "DesprayForm");
+                    request.destPath = context.desprayTargetPath.getDropZoneFolder();
                     if (!context.endsWith(request.destPath, "/")) {
                         request.destPath += "/";
                     }
@@ -308,18 +330,7 @@ define([
             this.copyTargetSelect.init({
                 Groups: true
             });
-            this.desprayTargetSelect.init({
-                DropZones: true,
-                callback: function (value, item) {
-                    registry.byId(context.id + "DesprayTargetIPAddress").set("value", item.machine.Netaddress);
-                    if (context.desprayTargetPath) {
-                        context.desprayTargetPath.reset();
-                        context.desprayTargetPath._dropZoneTarget = item;
-                        context.desprayTargetPath.defaultValue = context.desprayTargetPath.get("value");
-                        context.desprayTargetPath.loadDropZoneFolders();
-                    }
-                }
-            });
+
             this.desprayTargetPath.init({
                 DropZoneFolders: true
             });

--- a/esp/src/eclwatch/LFDetailsWidget.js
+++ b/esp/src/eclwatch/LFDetailsWidget.js
@@ -42,6 +42,7 @@ define([
     "hpcc/_TabContainerWidget",
     "hpcc/DelayLoadWidget",
     "hpcc/TargetSelectWidget",
+    "hpcc/TargetComboBoxWidget",
     "hpcc/ESPLogicalFile",
     "hpcc/ESPDFUWorkunit",
     "hpcc/FileBelongsToWidget",
@@ -58,7 +59,7 @@ define([
 
 ], function (exports, declare, lang, i18n, nlsHPCC, arrayUtil, dom, domAttr, domClass, domForm, query,
                 BorderContainer, TabContainer, ContentPane, Toolbar, TooltipDialog, Form, SimpleTextarea, TextBox, Button, DropDownButton, TitlePane, registry,
-                _TabContainerWidget, DelayLoadWidget, TargetSelectWidget, ESPLogicalFile, ESPDFUWorkunit, FileBelongsToWidget,
+                _TabContainerWidget, DelayLoadWidget, TargetSelectWidget, TargetComboBoxWidget, ESPLogicalFile, ESPDFUWorkunit, FileBelongsToWidget,
                 template) {
     exports.fixCircularDependency = declare("LFDetailsWidget", [_TabContainerWidget], {
         templateString: template,
@@ -180,6 +181,7 @@ define([
             if (this.desprayForm.validate()) {
                 var context = this;
                 var request = domForm.toObject(this.id + "DesprayForm");
+                request.destPath = this.desprayTargetPath.getDropZoneFolder();
                 if (!context.endsWith(request.destPath, "/")) {
                     request.destPath += "/";
                 }

--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -44,6 +44,7 @@ define([
     "hpcc/ESPDFUWorkunit",
     "hpcc/DelayLoadWidget",
     "hpcc/TargetSelectWidget",
+    "hpcc/TargetComboBoxWidget",
     "hpcc/SelectionGridWidget",
 
     "dojo/text!../templates/LZBrowseWidget.html",
@@ -71,7 +72,7 @@ define([
 ], function (declare, lang, i18n, nlsHPCC, arrayUtil, dom, domForm, domClass, iframe, on, topic,
                 registry, Dialog, Menu, MenuItem, MenuSeparator, PopupMenuItem,
                 tree, editor, selector,
-                _TabContainerWidget, FileSpray, ESPUtil, ESPRequest, ESPDFUWorkunit, DelayLoadWidget, TargetSelectWidget, SelectionGridWidget,
+                _TabContainerWidget, FileSpray, ESPUtil, ESPRequest, ESPDFUWorkunit, DelayLoadWidget, TargetSelectWidget, TargetComboBoxWidget, SelectionGridWidget,
                 template) {
     return declare("LZBrowseWidget", [_TabContainerWidget, ESPUtil.FormHelper], {
         templateString: template,
@@ -152,6 +153,20 @@ define([
         },
 
         _onUpload: function (event) {
+            var context = this;
+            if (!this.dropZoneTargetSelect.initalized) {
+                this.dropZoneTargetSelect.init({
+                    DropZones: true,
+                    callback: function (value, row) {
+                        if (context.dropZoneFolderSelect) {
+                            context.dropZoneFolderSelect.reset();
+                            context.dropZoneFolderSelect._dropZoneTarget = row;
+                            context.dropZoneFolderSelect.defaultValue = context.dropZoneFolderSelect.get("value");
+                            context.dropZoneFolderSelect.loadDropZoneFolders();
+                        }
+                    }
+                });
+            }
             var fileList = registry.byId(this.id + "Upload").getFileList();
             var totalFileSize = 0;
 
@@ -226,7 +241,7 @@ define([
         },
 
         getUploadPath: function () {
-            return this.dropZoneFolderSelect.get("row").value;
+            return this.dropZoneFolderSelect.getDropZoneFolder();
         },
 
         _onUploadSubmit: function (event) {
@@ -455,17 +470,6 @@ define([
                 SprayTargets: true
             });
             var context = this;
-            this.dropZoneTargetSelect.init({
-                DropZones: true,
-                callback: function (value, row) {
-                    if (context.dropZoneFolderSelect) {
-                        context.dropZoneFolderSelect.reset();
-                        context.dropZoneFolderSelect._dropZoneTarget = row;
-                        context.dropZoneFolderSelect.defaultValue = context.dropZoneFolderSelect.get("value");
-                        context.dropZoneFolderSelect.loadDropZoneFolders();
-                    }
-                }
-            });
             this.dropZoneFolderSelect.init({
                 DropZoneFolders: true,
                 includeBlank: true

--- a/esp/src/eclwatch/TargetComboBoxWidget.js
+++ b/esp/src/eclwatch/TargetComboBoxWidget.js
@@ -16,12 +16,12 @@
 define([
     "dojo/_base/declare",
 
-    "dijit/form/Select",
+    "dijit/form/ComboBox",
 
     "hpcc/TargetSelectClass"
 ], function (declare,
-    Select,
+    ComboBox,
     TargetSelectClass) {
 
-    return declare("TargetSelectWidget", [Select], TargetSelectClass);
+    return declare("TargetComboBoxWidget", [ComboBox], TargetSelectClass);
 });

--- a/esp/src/eclwatch/TargetSelectClass.js
+++ b/esp/src/eclwatch/TargetSelectClass.js
@@ -1,0 +1,380 @@
+/*##############################################################################
+#    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+############################################################################## */
+define([
+    "dojo/_base/declare",
+    "dojo/_base/lang",
+    "dojo/i18n",
+    "dojo/i18n!./nls/hpcc",
+    "dojo/_base/array",
+    "dojo/_base/xhr",
+    "dojo/_base/Deferred",
+    "dojo/data/ItemFileReadStore",
+    "dojo/promise/all",
+    "dojo/store/Memory",
+    "dojo/on",
+
+    "dijit/registry",
+
+    "hpcc/WsTopology",
+    "hpcc/WsWorkunits",
+    "hpcc/FileSpray"
+], function (declare, lang, i18n, nlsHPCC, arrayUtil, xhr, Deferred, ItemFileReadStore, all, Memory, on,
+    registry,
+    WsTopology, WsWorkunits, FileSpray) {
+
+    return {
+        i18n: nlsHPCC,
+
+        loading: false,
+        defaultValue: "",
+
+        //  Implementation  ---
+        reset: function () {
+            this.initalized = false;
+            this.loading = false;
+            this.defaultValue = "";
+            this.options = [];
+        },
+
+        init: function (params) {
+            if (this.initalized)
+                return;
+            this.initalized = true;
+            this.loading = true;
+            this.options = [];
+
+            if (params.Target) {
+                this.defaultValue = params.Target;
+                this.set("value", params.Target);
+            }
+
+            if (params.includeBlank) {
+                this.includeBlank = params.includeBlank;
+                this.options.push({
+                    label: "&nbsp;",
+                    value: ""
+                });
+            }
+            if (params.Groups === true) {
+                this.loadClusterGroups();
+            } else if (params.SprayTargets === true) {
+                this.loadSprayTargets();
+            } else if (params.DropZones === true) {
+                this.loadDropZones();
+            } else if (params.DropZoneFolders === true) {
+                this.defaultValue = ".";
+                this.set("value", ".");
+                this.loadDropZoneFolders();
+            } else if (params.WUState === true) {
+                this.loadWUState();
+            } else if (params.DFUState === true) {
+                this.loadDFUState();
+            } else if (params.ECLSamples === true) {
+                this.loadECLSamples();
+            } else if (params.Logs === true) {
+                this.loadLogs(params);
+            } else {
+                this.loadTargets();
+            }
+            if (params.callback) {
+                this.callback = params.callback;
+            }
+        },
+
+        _setValueAttr: function (target) {
+            if (target === null)
+                target = "";
+            this.inherited(arguments);
+            if (this.callback) {
+                this.callback(this.value, this._getRowAttr());
+            }
+        },
+
+        _getValueAttr: function () {
+            if (this.loading)
+                return this.defaultValue;
+
+            if (this.textbox)
+                return this.textbox.value;
+
+            return this.value;
+        },
+
+        _getRowAttr: function () {
+            var context = this;
+            var retVal = null;
+            arrayUtil.forEach(this.options, function (item, idx) {
+                if (context.value === item.value) {
+                    retVal = item;
+                    return false;
+                }
+            });
+            return retVal;
+        },
+
+        _postLoad: function () {
+            if (this.defaultValue === "" && this.options.length) {
+                this.defaultValue = this.options[0].value;
+            }
+            this.set("value", this.defaultValue);
+            this.loading = false;
+        },
+
+        loadDropZones: function () {
+            var context = this;
+            WsTopology.TpServiceQuery({
+                load: function (response) {
+                    if (lang.exists("TpServiceQueryResponse.ServiceList.TpDropZones.TpDropZone", response)) {
+                        var targetData = response.TpServiceQueryResponse.ServiceList.TpDropZones.TpDropZone;
+                        for (var i = 0; i < targetData.length; ++i) {
+                            context.options.push({
+                                label: targetData[i].Name,
+                                value: targetData[i].Name,
+                                machine: targetData[i].TpMachines.TpMachine[0]
+                            });
+                        }
+                        context._postLoad();
+                    }
+                }
+            });
+        },
+
+        _loadDropZoneFolders: function (Netaddr, Path, OS, depth) {
+            depth = depth || 0;
+            var retVal = [];
+            retVal.push(Path);
+            var deferred = new Deferred();
+            if (depth > 2) {
+                setTimeout(function () {
+                    deferred.resolve(retVal);
+                }, 20);
+            } else {
+                var context = this;
+                FileSpray.FileList({
+                    request: {
+                        Netaddr: Netaddr,
+                        Path: Path,
+                        OS: OS
+                    },
+                    suppressExceptionToaster: true
+                }).then(function (response) {
+                    var requests = [];
+                    if (lang.exists("FileListResponse.files.PhysicalFileStruct", response)) {
+                        var files = response.FileListResponse.files.PhysicalFileStruct;
+                        for (var i = 0; i < files.length; ++i) {
+                            if (files[i].isDir) {
+                                requests.push(context._loadDropZoneFolders(Netaddr, Path + "/" + files[i].name, OS, ++depth));
+                            }
+                        }
+                    }
+                    all(requests).then(function (responses) {
+                        arrayUtil.forEach(responses, function (response) {
+                            retVal = retVal.concat(response);
+                        });
+                        deferred.resolve(retVal);
+                    });
+                });
+            }
+            return deferred.promise;
+        },
+
+        endsWith: function (str, suffix) {
+            return str.indexOf(suffix, str.length - suffix.length) !== -1;
+        },
+
+        loadDropZoneFolders: function () {
+            var context = this;
+            this.getDropZoneFolder = function () {
+                var baseFolder = this._dropZoneTarget.machine.Directory + (this.endsWith(this._dropZoneTarget.machine.Directory, "/") ? "" : "/");
+                var selectedFolder = this.get("value");
+                return baseFolder + selectedFolder;
+            }
+            if (this._dropZoneTarget) {
+                this._loadDropZoneFolders(this._dropZoneTarget.machine.Netaddress, this._dropZoneTarget.machine.Directory, this._dropZoneTarget.machine.OS).then(function (results) {
+                    results.sort();
+                    var store = new Memory({
+                        data: arrayUtil.map(results, function (_path) {
+                            var path = _path.substring(context._dropZoneTarget.machine.Directory.length);
+                            return {
+                                name: "." + path,
+                                id: _path
+                            };
+                        })
+                    });
+                    context.set("store", store);
+                    context._postLoad();
+                });
+            }
+        },
+
+        loadClusterGroups: function () {
+            var context = this;
+            WsTopology.TpGroupQuery({
+                load: function (response) {
+                    if (lang.exists("TpGroupQueryResponse.TpGroups.TpGroup", response)) {
+                        var targetData = response.TpGroupQueryResponse.TpGroups.TpGroup;
+                        for (var i = 0; i < targetData.length; ++i) {
+                            switch(targetData[i].Kind) {
+                                case "Thor":
+                                case "hthor":
+                                case "Roxie":
+                                    context.options.push({
+                                        label: targetData[i].Name,
+                                        value: targetData[i].Name
+                                    });
+                                    break;
+                            }
+                        }
+                        context._postLoad();
+                    }
+                }
+            });
+        },
+
+        loadSprayTargets: function () {
+            var context = this;
+            FileSpray.GetSprayTargets({
+                load: function (response) {
+                    if (lang.exists("GetSprayTargetsResponse.GroupNodes.GroupNode", response)) {
+                        var targetData = response.GetSprayTargetsResponse.GroupNodes.GroupNode;
+                        for (var i = 0; i < targetData.length; ++i) {
+                            context.options.push({
+                                label: targetData[i].Name,
+                                value: targetData[i].Name
+                            });
+                        }
+                        context._postLoad();
+                    }
+                }
+            });
+        },
+
+        loadWUState: function() {
+            for (var key in WsWorkunits.States) {
+                this.options.push({
+                    label: WsWorkunits.States[key],
+                    value: WsWorkunits.States[key]
+                });
+            }
+            this._postLoad();
+        },
+
+        loadDFUState: function () {
+            for (var key in FileSpray.States) {
+                this.options.push({
+                    label: FileSpray.States[key],
+                    value: FileSpray.States[key]
+                });
+            }
+            this._postLoad();
+        },
+
+        LogicalFileSearchType: function() {
+            this.options.push({
+                label: "Created",
+                value: "Created"
+            });
+            this.options.push({
+                label: "Used",
+                value: "Referenced"
+            });
+            this._postLoad();
+        },
+
+        loadTargets: function () {
+            var context = this;
+            WsTopology.TpLogicalClusterQuery({
+            }).then(function (response) {
+                if (lang.exists("TpLogicalClusterQueryResponse.TpLogicalClusters.TpLogicalCluster", response)) {
+                    var targetData = response.TpLogicalClusterQueryResponse.TpLogicalClusters.TpLogicalCluster;
+                    for (var i = 0; i < targetData.length; ++i) {
+                        context.options.push({
+                            label: targetData[i].Name,
+                            value: targetData[i].Name
+                        });
+                    }
+
+                    if (!context.includeBlank && context._value == "") {
+                        if (response.TpLogicalClusterQueryResponse["default"]) {
+                            context._value = response.TpLogicalClusterQueryResponse["default"].Name;
+                        } else {
+                            context._value = context.options[0].value;
+                        }
+                    }
+                }
+                context._postLoad();
+            });
+        },
+
+        loadECLSamples: function () {
+            var sampleStore = new ItemFileReadStore({
+                url: dojoConfig.getURL("ecl/ECLPlaygroundSamples.json")
+            });
+            this.setStore(sampleStore);
+            var context = this;
+            this.on("change", function (evt) {
+                var filename = this.get("value");
+                xhr.get({
+                    url: dojoConfig.getURL("ecl/" + filename),
+                    handleAs: "text",
+                    load: function (eclText) {
+                        context.onNewSelection(eclText);
+                    },
+                    error: function () {
+                    }
+                });
+            });
+            context._postLoad();
+        },
+
+        loadLogs: function (params) {
+            var context = this;
+            this.set("options", []);
+            FileSpray.FileList({
+                request: {
+                    Mask: "*.log",
+                    Netaddr: params.params.Netaddress,
+                    OS: params.params.OS,
+                    Path: params.params.getLogDirectory()
+                }
+            }).then(function (response) {
+                if (lang.exists("FileListResponse.files.PhysicalFileStruct", response)) {
+                    var options = [];
+                    var targetData = response.FileListResponse.files.PhysicalFileStruct;
+                    var shortestLabelLen = 9999;
+                    var shortestLabel = "";
+                    for (var i = 0; i < targetData.length; ++i) {
+                        options.push({
+                            label: targetData[i].name,// + " " + targetData[i].filesize + " " + targetData[i].modifiedtime,
+                            value: targetData[i].name
+                        });
+                        if (shortestLabelLen > targetData[i].name.length) {
+                            shortestLabelLen = targetData[i].name.length;
+                            shortestLabel = targetData[i].name;
+                        }
+                    }
+                    options.sort(function (l, r) {
+                        return -l.label.localeCompare(r.label);
+                    });
+                    context.set("options", options);
+                    context.defaultValue = shortestLabel;
+                    context._value = shortestLabel;
+                }
+                context._postLoad();
+            });
+        }
+    };
+});

--- a/esp/src/eclwatch/templates/DFUQueryWidget.html
+++ b/esp/src/eclwatch/templates/DFUQueryWidget.html
@@ -121,14 +121,14 @@
                     </div>
                     <div id="${id}DesprayDropDown" data-dojo-type="dijit.form.DropDownButton">
                         <span>${i18n.Despray}</span>
-                        <div data-dojo-type="dijit.TooltipDialog">
+                        <div id="${id}DesprayTooltipDialog" data-dojo-type="dijit.TooltipDialog">
                             <div id="${id}DesprayForm" style="width: 460px;" onsubmit="return false;" data-dojo-type="dijit.form.Form">
                                 <div data-dojo-type="dijit.Fieldset">
                                     <legend>${i18n.Target}</legend>
                                     <div data-dojo-type="hpcc.TableContainer">
                                         <input id="${id}DesprayTargetSelect" title="${i18n.DropZone}:" name="destGroup" style="width: 100%;" data-dojo-type="TargetSelectWidget" />
                                         <input id="${id}DesprayTargetIPAddress" title="${i18n.IPAddress}:" name="destIP" style="width: 100%;" required="true" data-dojo-props="trim: true" data-dojo-type="dijit.form.ValidationTextBox" />
-                                        <input id="${id}DesprayTargetPath" title="${i18n.Path}:" name="destPath" required="true" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="TargetSelectWidget" />
+                                        <input id="${id}DesprayTargetPath" title="${i18n.Path}:" name="destPath" required="true" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="TargetComboBoxWidget" />
                                         <input id="${id}DesprayTargetSplitPrefix" title="${i18n.SplitPrefix}:" name="splitprefix" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="dijit.form.ValidationTextBox" />
                                     </div>
                                     <div id="${id}DesprayGrid" data-dojo-type="SelectionGridWidget">

--- a/esp/src/eclwatch/templates/LFDetailsWidget.html
+++ b/esp/src/eclwatch/templates/LFDetailsWidget.html
@@ -67,7 +67,7 @@
                                     <div data-dojo-props="cols:2" data-dojo-type="hpcc.TableContainer">
                                         <input id="${id}DesprayTargetSelect" title="${i18n.DropZone}:" name="destGroup" colspan="2" style="width: 100%;" data-dojo-type="TargetSelectWidget" />
                                         <input id="${id}DesprayTargetIPAddress" title="${i18n.IPAddress}:" name="destIP" colspan="2" required="true" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="dijit.form.ValidationTextBox" />
-                                        <input id="${id}DesprayTargetPath" title="${i18n.Path}:" name="destPath" colspan="2" required="true" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="TargetSelectWidget" />
+                                        <input id="${id}DesprayTargetPath" title="${i18n.Path}:" name="destPath" colspan="2" required="true" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="TargetComboBoxWidget" />
                                         <input id="${id}DesprayTargetName" title="${i18n.TargetName}:" colspan="2" required="true" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="dijit.form.ValidationTextBox" />
                                         <input id="${id}DesprayTargetSplitPrefix" title="${i18n.SplitPrefix}:" name="splitprefix" colspan="2" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="dijit.form.TextBox" />
                                     </div>

--- a/esp/src/eclwatch/templates/LZBrowseWidget.html
+++ b/esp/src/eclwatch/templates/LZBrowseWidget.html
@@ -264,7 +264,7 @@
         <div class="dijitDialogPaneContentArea">
             <div data-dojo-props="cols:1" data-dojo-type="hpcc.TableContainer">
                 <input id="${id}DropZoneTargetSelect" title="${i18n.LandingZone}:" style="width: 95%;" data-dojo-type="TargetSelectWidget" />
-                <input id="${id}DropZoneFolderSelect" title="${i18n.Folder}:" style="width: 95%;" data-dojo-type="TargetSelectWidget" />
+                <input id="${id}DropZoneFolderSelect" title="${i18n.Folder}:" style="width: 95%;" data-dojo-type="TargetComboBoxWidget" />
             </div>
             <p>
             <div id="${id}UploadFileList" class="dijitDialogPaneContentArea" data-dojo-props="uploaderId: '${id}Upload'" data-dojo-type="dojox.form.uploader.FileList"></div>


### PR DESCRIPTION
Delay DropZone folder loading until it is needed.
Restrict loading to depth of 2.
Convert Folder Select to a ComboBox, so user can add additional subfolders manually.

Fixes HPCC-13667

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
