### PR TITLE
HPCC-13632 Drop Down Filter Width

### DIFF
--- a/esp/src/eclwatch/FilterDropDownWidget.js
+++ b/esp/src/eclwatch/FilterDropDownWidget.js
@@ -46,7 +46,7 @@ define([
         baseClass: "FilterDropDownWidget",
         i18n: nlsHPCC,
 
-        _width:"460px",
+        _width:"100%",
         iconFilter: null,
         filterDropDown: null,
         filterForm: null,


### PR DESCRIPTION
Drop Down Filter for ResultView could be too narrow if the field names are
very long.

Fixes HPCC-13632

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
