### PR TITLE
HPCC-13663 Implement a stable merge sort

### DIFF
--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -1124,21 +1124,44 @@ public:
     virtual void performSort();
 };
 
-class CStableQuickSorter : public CSimpleSorterBase
+class CStableSorter : public CSimpleSorterBase
 {
 public:
-    CStableQuickSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta, roxiemem::IBufferedRowCallback * _rowCB) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta), commitDelta(_commitDelta), index(NULL), indexCapacity(0) {}
-    virtual ~CStableQuickSorter() { killSorted(); }
-    IMPLEMENT_IINTERFACE;
+    CStableSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta, roxiemem::IBufferedRowCallback * _rowCB) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta), commitDelta(_commitDelta), index(NULL), indexCapacity(0) {}
+    virtual ~CStableSorter() { killSorted(); }
+
     virtual bool addRow(const void * next);
     virtual void spillSortedToDisk(IDiskMerger * merger);
-    virtual void performSort();
     virtual void killSorted();
 
-private:
+protected:
     void *** index;
     roxiemem::rowidx_t indexCapacity;
     unsigned commitDelta;
+};
+
+class CStableQuickSorter : public CStableSorter
+{
+public:
+    CStableQuickSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta, roxiemem::IBufferedRowCallback * _rowCB) : CStableSorter(_compare, _rowManager, _initialSize, _commitDelta, _rowCB){}
+
+    virtual void performSort();
+};
+
+class CParallelStableQuickSorter : public CStableSorter
+{
+public:
+    CParallelStableQuickSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta, roxiemem::IBufferedRowCallback * _rowCB) : CStableSorter(_compare, _rowManager, _initialSize, _commitDelta, _rowCB){}
+
+    virtual void performSort();
+};
+
+class CStableMergeSorter : public CStableSorter
+{
+public:
+    CStableMergeSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta, roxiemem::IBufferedRowCallback * _rowCB) : CStableSorter(_compare, _rowManager, _initialSize, _commitDelta, _rowCB){}
+
+    virtual void performSort();
 };
 
 class CHeapSorter :  public CSimpleSorterBase
@@ -1146,7 +1169,7 @@ class CHeapSorter :  public CSimpleSorterBase
 public:
     CHeapSorter(ICompare * _compare, roxiemem::IRowManager * _rowManager, size32_t _initialSize, size32_t _commitDelta) : CSimpleSorterBase(_compare, _rowManager, _initialSize, _commitDelta), heapsize(0) {}
     virtual ~CHeapSorter() { killSorted(); }
-    IMPLEMENT_IINTERFACE;
+
     virtual void performSort();
     virtual void spillSortedToDisk(IDiskMerger * merger);
     virtual const void * getNextSorted();

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -509,7 +509,6 @@ public:
 private:
     bool calcNextDedupAll();
     void dedupRange(unsigned first, unsigned last, OwnedRowArray & group);
-    void dedupRangeIndirect(unsigned first, unsigned last, void *** index);
 
 private:
     IHThorDedupArg &helper;
@@ -1134,7 +1133,6 @@ public:
     virtual bool addRow(const void * next);
     virtual void spillSortedToDisk(IDiskMerger * merger);
     virtual void performSort();
-    virtual const void * getNextSorted();
     virtual void killSorted();
 
 private:

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -6684,28 +6684,28 @@ public:
         }
     }
 
-    void dedupRangeIndirect(unsigned first, unsigned last, void *** index)
+    void dedupRange(unsigned first, unsigned last, void ** rows)
     {
         for (unsigned idxL = first; idxL < last; idxL++)
         {
-            void * left = *(index[idxL]);
+            void * left = rows[idxL];
             if (left)
             {
                 for (unsigned idxR = first; idxR < last; idxR++)
                 {
-                    void * right = *(index[idxR]);
+                    void * right = rows[idxR];
                     if ((idxL != idxR) && right)
                     {
                         if (helper.matches(left, right))
                         {
                             if (keepLeft)
                             {
-                                *(index[idxR]) = NULL;
+                                rows[idxR] = NULL;
                                 ReleaseRoxieRow(right);
                             }
                             else
                             {
-                                *(index[idxL]) = NULL;
+                                rows[idxL] = NULL;
                                 ReleaseRoxieRow(left);
                                 break;
                             }
@@ -6732,23 +6732,24 @@ public:
         if (primaryCompare)
         {
             //hard, if not impossible, to hit this code once optimisations in place
-            MemoryAttr indexbuff(max*sizeof(void **));
-            void *** index = (void ***)indexbuff.bufferBase();
-            qsortvecstable(const_cast<void * *>(group.getArray()), max, *primaryCompare, index);
+            MemoryAttr indexbuff(max*sizeof(void *));
+            void ** temp = (void **)indexbuff.bufferBase();
+            void * *rows = const_cast<void * *>(group.getArray());
+            qsortvecstableinplace(rows, max, *primaryCompare, temp);
             unsigned first = 0;
             for (unsigned idx = 1; idx < max; idx++)
             {
-                if (primaryCompare->docompare(*(index[first]), *(index[idx])) != 0)
+                if (primaryCompare->docompare(rows[first], rows[idx]) != 0)
                 {
-                    dedupRangeIndirect(first, idx, index);
+                    dedupRange(first, idx, rows);
                     first = idx;
                 }
             }
-            dedupRangeIndirect(first, max, index);
+            dedupRange(first, max, rows);
 
             for(unsigned idx2=0; idx2<max; ++idx2)
             {
-                void * cur = *(index[idx2]);
+                void * cur = rows[idx2];
                 if(cur)
                     survivors.append(cur);
             }
@@ -7458,13 +7459,7 @@ public:
             void **rows = const_cast<void * *>(sorted.getArray());
             MemoryAttr tempAttr(numRows*sizeof(void **)); // Temp storage for stable sort. This should probably be allocated from roxiemem
             void **temp = (void **) tempAttr.bufferBase();
-            memcpy(temp, rows, numRows*sizeof(void **));
-            qsortvecstable(temp, numRows, *compare, (void ***)rows);
-            for (unsigned i = 0; i < numRows; i++)
-            {
-                *rows = **((void ***)rows);
-                rows++;
-            }
+            qsortvecstableinplace(rows, numRows, *compare, temp);
         }
     }
 };
@@ -7551,13 +7546,7 @@ public:
                 {
                     MemoryAttr tempAttr(numRows*sizeof(void **)); // Temp storage for stable sort. This should probably be allocated from roxiemem
                     void **temp = (void **) tempAttr.bufferBase();
-                    memcpy(temp, rows, numRows*sizeof(void **));
-                    qsortvecstable(temp, numRows, *compare, (void ***)rows);
-                    for (unsigned i = 0; i < numRows; i++)
-                    {
-                        *rows = **((void ***)rows);
-                        rows++;
-                    }
+                    qsortvecstableinplace(rows, numRows, *compare, temp);
                 }
                 else
                     qsortvec(rows, numRows, *compare);
@@ -17771,13 +17760,7 @@ public:
                             MemoryAttr tempAttr(rightord*sizeof(void **)); // Temp storage for stable sort. This should probably be allocated from roxiemem
                             void **temp = (void **) tempAttr.bufferBase();
                             void **_rows = const_cast<void * *>(rightset.getArray());
-                            memcpy(temp, _rows, rightord*sizeof(void **));
-                            qsortvecstable(temp, rightord, *helper.queryCompareRight(), (void ***)_rows);
-                            for (unsigned i = 0; i < rightord; i++)
-                            {
-                                *_rows = **((void ***)_rows);
-                                _rows++;
-                            }
+                            qsortvecstableinplace(_rows, rightord, *helper.queryCompareRight(), temp);
                         }
                     }
                     table.setown(new ManyLookupTable(rightset, helper));  // NOTE - takes ownership of rightset

--- a/system/jlib/jsort.hpp
+++ b/system/jlib/jsort.hpp
@@ -76,6 +76,7 @@ extern jlib_decl void qsortvec(void **a, size32_t n, const ICompare & compare1, 
 
 // Call with n rows of data in rows, index an (uninitialized) array of size n. The function will fill index with a stably sorted index into rows.
 extern jlib_decl void qsortvecstableinplace(void ** rows, size32_t n, const ICompare & compare, void ** temp);
+extern jlib_decl void msortvecstableinplace(void ** rows, size32_t n, const ICompare & compare, void ** temp);
 
 
 extern jlib_decl void parqsortvec(void **a, size32_t n, const ICompare & compare, unsigned ncpus=0); // runs in parallel on multi-core

--- a/system/jlib/jsort.hpp
+++ b/system/jlib/jsort.hpp
@@ -75,12 +75,11 @@ extern jlib_decl void qsortvec(void **a, size32_t n, const ICompare & compare);
 extern jlib_decl void qsortvec(void **a, size32_t n, const ICompare & compare1, const ICompare & compare2);
 
 // Call with n rows of data in rows, index an (uninitialized) array of size n. The function will fill index with a stably sorted index into rows.
-extern jlib_decl void qsortvecstable(void ** const rows, size32_t n, const ICompare & compare, void *** index);
+extern jlib_decl void qsortvecstableinplace(void ** rows, size32_t n, const ICompare & compare, void ** temp);
 
 
 extern jlib_decl void parqsortvec(void **a, size32_t n, const ICompare & compare, unsigned ncpus=0); // runs in parallel on multi-core
-extern jlib_decl void parqsortvec(void **a, size32_t n, const ICompare & compare1, const ICompare & compare2,unsigned ncpus=0);
-extern jlib_decl void parqsortvecstable(void ** const rows, size32_t n, const ICompare & compare, void *** index, unsigned ncpus=0); // runs in parallel on multi-core
+extern jlib_decl void parqsortvecstableinplace(void ** rows, size32_t n, const ICompare & compare, void ** temp, unsigned ncpus=0); // runs in parallel on multi-core
 
 
 // we define the heap property that no element c should be smaller than its parent (unsigned)(c-1)/2

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -513,14 +513,7 @@ void CThorExpandingRowArray::doSort(rowidx_t n, void **const rows, ICompare &com
             dbgassertex(NULL != stableTable);
             stableTablePtr = stableTable;
         }
-        void **_rows = rows;
-        memcpy(stableTablePtr, _rows, n*sizeof(void **));
-        parqsortvecstable(stableTablePtr, n, compare, (void ***)_rows, maxCores);
-        while (n--)
-        {
-            *_rows = **((void ***)_rows);
-            _rows++;
-        }
+        parqsortvecstableinplace(rows, n, compare, stableTablePtr, maxCores);
     }
     else
         parqsortvec((void **const)rows, n, compare, maxCores);


### PR DESCRIPTION
Initial pull request for review.
The commits are separate logical stages, and may be worth reviewing separately.

This was tested sorting 284M rows in hthor, with memory and cpu bound to the same node.  The median times of 5 runs were as follows:

Original: 6m22s
Commit1: 6m14s  Returns rows sorted in place rather than using an index. Slightly surprised this is faster
Commit2: 4m03    First version of merge sort
Commit3: 4m01.2  Optimized version

Commit4, Commit 5:  4m01.1
I was slightly surprised, but the last two commits slightly improve the performance, but possibly not by enough to be worth including.  Especially the 3way compare which adds complexity.

The merge sort example is now spending 50% of its time in the compare function, 20% allocating and freeing rows.  I suspect it is close to optimum, but any bright ideas welcome.
