### PR TITLE
HPCC-13007 LandingZone Download Name Wrong

### DIFF
--- a/esp/src/eclwatch/FileSpray.js
+++ b/esp/src/eclwatch/FileSpray.js
@@ -91,10 +91,13 @@ define([
         preProcessRow: function (row) {
             var partialPath = this.parent.partialPath + row.name + (row.isDir ? "/" : "");
             var fullPath = this.parent.fullPath + row.name + (row.isDir ? "/" : "");
+            var fullFolderPathParts = fullPath.split("/");
+            fullFolderPathParts.pop();
             lang.mixin(row, {
                 calculatedID: this.parent.DropZone.NetAddress + fullPath,
                 partialPath: partialPath,
                 fullPath: fullPath,
+                fullFolderPath: fullFolderPathParts.join("/"),
                 DropZone: this.parent.DropZone,
                 displayName: row.name,
                 type: row.isDir ? "folder" : "file"

--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -244,7 +244,7 @@ define([
             arrayUtil.forEach(this.landingZonesGrid.getSelected(), function (item, idx) {
                 var downloadIframeName = "downloadIframe_" + item.calculatedID;
                 var frame = iframe.create(downloadIframeName);
-                var url = ESPRequest.getBaseURL("FileSpray") + "/DownloadFile?Name=" + encodeURIComponent(item.partialPath) + "&NetAddress=" + item.DropZone.NetAddress + "&Path=" + encodeURIComponent(item.DropZone.Path) + "&OS=" + item.DropZone.OS;
+                var url = ESPRequest.getBaseURL("FileSpray") + "/DownloadFile?Name=" + encodeURIComponent(item.name) + "&NetAddress=" + item.DropZone.NetAddress + "&Path=" + encodeURIComponent(item.fullFolderPath) + "&OS=" + item.DropZone.OS;
                 iframe.setSrc(frame, url, true);
             });
         },


### PR DESCRIPTION
Downloading files from the landing zone has folder paths prepended to the
download name.

Fixes HPCC-13007

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
