### PR TITLE
HPCC-13573 Improve throttling and diagnostic statistics

### DIFF
--- a/common/remote/remoteerr.hpp
+++ b/common/remote/remoteerr.hpp
@@ -59,6 +59,7 @@
 #define RFSERR_NoConnectSlaveXY                 8046
 #define RFSERR_VersionMismatch                  8047
 #define RFSERR_SetThrottleFailed                8048
+#define RFSERR_MaxQueueRequests                 8049
 
 //---- Text for all errors (make it easy to internationalise) ---------------------------
 

--- a/common/remote/rmtfile.cpp
+++ b/common/remote/rmtfile.cpp
@@ -504,7 +504,7 @@ extern REMOTE_API int setDafileSvrTraceFlags(const SocketEndpoint &_ep,byte flag
     return -2;
 }
 
-extern REMOTE_API int setDafileSvrThrottleLimit(const SocketEndpoint &_ep, unsigned throttleLimit, unsigned throttleDelayMs, unsigned throttleCPULimit)
+extern REMOTE_API int setDafileSvrThrottleLimit(const SocketEndpoint &_ep, ThrottleClass throttleClass, unsigned throttleLimit, unsigned throttleDelayMs, unsigned throttleCPULimit, unsigned queueLimit, StringBuffer *errMsg)
 {
     SocketEndpoint ep(_ep);
     setDafsEndpointPort(ep);
@@ -512,7 +512,7 @@ extern REMOTE_API int setDafileSvrThrottleLimit(const SocketEndpoint &_ep, unsig
         return -3;
     try {
         Owned<ISocket> socket = ISocket::connect_wait(ep,5000);
-        return setDafsThrottleLimit(socket, throttleLimit, throttleDelayMs, throttleCPULimit);
+        return setDafsThrottleLimit(socket, throttleClass, throttleLimit, throttleDelayMs, throttleCPULimit, queueLimit, errMsg);
     }
     catch (IException *e)
     {
@@ -522,7 +522,7 @@ extern REMOTE_API int setDafileSvrThrottleLimit(const SocketEndpoint &_ep, unsig
     return -2;
 }
 
-extern REMOTE_API int getDafileSvrInfo(const SocketEndpoint &_ep,StringBuffer &retstr)
+extern REMOTE_API int getDafileSvrInfo(const SocketEndpoint &_ep, unsigned level, StringBuffer &retstr)
 {
     SocketEndpoint ep(_ep);
     setDafsEndpointPort(ep);
@@ -530,7 +530,7 @@ extern REMOTE_API int getDafileSvrInfo(const SocketEndpoint &_ep,StringBuffer &r
         return false;
     try {
         Owned<ISocket> socket = ISocket::connect_wait(ep,5000);
-        return getDafsInfo(socket, retstr);
+        return getDafsInfo(socket, level, retstr);
     }
     catch (IException *e)
     {

--- a/common/remote/rmtfile.hpp
+++ b/common/remote/rmtfile.hpp
@@ -21,6 +21,8 @@
 #include "jsocket.hpp"
 #include "jfile.hpp"
 
+#include "sockfile.hpp"
+
 #ifdef REMOTE_EXPORTS
 #define REMOTE_API __declspec(dllexport)
 #else
@@ -68,8 +70,8 @@ extern REMOTE_API int remoteExec(const SocketEndpoint &ep,const char *cmdline, c
 extern REMOTE_API void remoteExtractBlobElements(const char * prefix, const RemoteFilename &file, ExtractedBlobArray & extracted);
 
 extern REMOTE_API int setDafileSvrTraceFlags(const SocketEndpoint &ep,byte flags);
-extern REMOTE_API int setDafileSvrThrottleLimit(const SocketEndpoint &_ep, unsigned throttleLimit, unsigned throttleDelayMs, unsigned throttleCPULimit);
-extern REMOTE_API int getDafileSvrInfo(const SocketEndpoint &ep,StringBuffer &retstr);
+extern REMOTE_API int setDafileSvrThrottleLimit(const SocketEndpoint &_ep, ThrottleClass throttleClass, unsigned throttleLimit, unsigned throttleDelayMs, unsigned throttleCPULimit, unsigned queueLimit, StringBuffer *errMsg=NULL);
+extern REMOTE_API int getDafileSvrInfo(const SocketEndpoint &ep, unsigned level, StringBuffer &retstr);
 
 extern REMOTE_API void disconnectRemoteFile(IFile *file);
 extern REMOTE_API void disconnectRemoteIoOnExit(IFileIO *fileio,bool set=true);

--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -65,7 +65,9 @@ public:
         else
             listenep.getUrlStr(eps);
         enableDafsAuthentication(requireauthenticate);
-        server.setown(createRemoteFileServer(0)); // no throttle limiting
+        server.setown(createRemoteFileServer());
+        server->setThrottle(ThrottleStd, 0); // disable throttling
+        server->setThrottle(ThrottleSlow, 0); // disable throttling
     }
 
     int run()


### PR DESCRIPTION
- Split throttling into 2 categories (slow/fast).
- Allow throttle items to queue rather than block
- Improve error reporting/feedback to client
- Improve configurability over limits
- Improve statistics, # clients, # reqeusts, throttling and allow
  to be requested via dafscontrol

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
