### PR TITLE
HPCC-13700 Add option to add a child query count to the graph information

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1759,6 +1759,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.expandSelectCreateRow,"expandSelectCreateRow",false),
         DebugOption(options.obfuscateOutput,"obfuscateOutput",false),
         DebugOption(options.showEclInGraph,"showEclInGraph",true),
+        DebugOption(options.showChildCountInGraph,"showChildCountInGraph",false),
         DebugOption(options.optimizeSortAllFields,"optimizeSortAllFields",true),
         DebugOption(options.optimizeSortAllFieldsStrict,"optimizeSortAllFieldsStrict",false),
         DebugOption(options.alwaysReuseGlobalSpills,"alwaysReuseGlobalSpills",true),

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -746,6 +746,7 @@ struct HqlCppOptions
     bool                expandSelectCreateRow;
     bool                obfuscateOutput;
     bool                showEclInGraph;
+    bool                showChildCountInGraph;
     bool                optimizeSortAllFields;
     bool                optimizeSortAllFieldsStrict;
     bool                alwaysReuseGlobalSpills;

--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -1375,6 +1375,12 @@ ChildGraphBuilder::ChildGraphBuilder(HqlCppTranslator & _translator, IHqlExpress
 
 void ChildGraphBuilder::generateGraph(BuildCtx & ctx)
 {
+    if (translator.queryOptions().showChildCountInGraph)
+    {
+        ActivityInstance * activeActivity = translator.queryCurrentActivity(ctx);
+        if (activeActivity)
+            activeActivity->noteChildQuery();
+    }
     BuildCtx graphctx(ctx);
 
     //Make sure at least one results - because currently that's how we determine if new resourcing is being used

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -1661,7 +1661,7 @@ enum { createPrio = 1000, inputPrio = 3000, readyPrio = 4000, goPrio = 5000, don
 
 ActivityInstance::ActivityInstance(HqlCppTranslator & _translator, BuildCtx & ctx, ThorActivityKind _kind, IHqlExpression * _dataset, const char * _activityArgName) :
     HqlExprAssociation(activeActivityMarkerExpr),
-    translator(_translator), classctx(ctx), startctx(ctx), createctx(ctx), nestedctx(ctx), onstartctx(ctx)
+    translator(_translator), classctx(ctx), startctx(ctx), createctx(ctx), nestedctx(ctx), onstartctx(ctx), numChildQueries(0)
 {
     dataset.set(_dataset);
     kind = _kind;
@@ -2252,6 +2252,9 @@ void ActivityInstance::buildPrefix()
 
 void ActivityInstance::buildSuffix()
 {
+    if (numChildQueries)
+        addAttributeInt("childQueries", numChildQueries);
+
     //Paranoid check to ensure that library classes aren't used when member functions were required
     if (implementationClassName && (initialGroupMarker != classGroup->numChildren()))
         throwUnexpectedX("Implementation class created, but member functions generated");

--- a/ecl/hqlcpp/hqlhtcpp.ipp
+++ b/ecl/hqlcpp/hqlhtcpp.ipp
@@ -136,6 +136,7 @@ public:
     bool isChildActivity()                          { return (containerActivity != NULL); }
     bool         isExternal();
     inline bool isAction() { return dataset->isAction(); }
+    void noteChildQuery()                           { numChildQueries++; }
     void         setLocal(bool value=true)          { isLocal = value; }
     void         setGrouped(bool value=true)        { isGrouped = value; }
 
@@ -180,6 +181,7 @@ protected:
 public:
     HqlCppTranslator & translator;
     unsigned     activityId;
+    unsigned     numChildQueries;
     ThorActivityKind kind;
     HqlExprAttr  dataset;
     LinkedHqlExpr sourceFileSequence;


### PR DESCRIPTION
Use -fshowChildCountInGraph=1 (or a #option) to add the information to a
workunit.  Useful for tracking down canidates for optimizing.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
