### PR TITLE
HPCC-13673 Fix Thorslave socket not being freed on shutdown

### DIFF
--- a/initfiles/bin/init_thor
+++ b/initfiles/bin/init_thor
@@ -114,7 +114,7 @@ killed()
 {
     log "Stopping ${component}"
     kill_process ${PID_NAME} thormaster_${component} 30
-    if [[ $? -ne 1 ]]; then
+    if [[ $? -eq 1 ]]; then
         log "could not kill $component"
     else
         log "$component Stopped"
@@ -218,4 +218,3 @@ while [[ 1 ]]; do
         exit 0
     fi
 done
-

--- a/initfiles/bin/init_thorslave
+++ b/initfiles/bin/init_thorslave
@@ -37,7 +37,7 @@ stop_slaves()
     local isAlive=0
 
     log "Attempting to kill $slavename with SIGTERM"
-    killall -15 $slavename > /dev/null 2>&1
+    killall -SIGTERM $slavename > /dev/null 2>&1
     while [[ $isAlive -eq 0 && $timer -gt 0 ]];do
         killall -0 $slavename > /dev/null 2>&1
         isAlive=$?
@@ -47,7 +47,7 @@ stop_slaves()
 
     if [[ $isAlive -eq 0 ]]; then
         log "Failed to kill slaves with SIGTERM. Sending SIGKILL"
-        killall -9 $slavename > /dev/null 2>&1
+        killall -SIGKILL $slavename > /dev/null 2>&1
     fi
 
     rm -f $PID/${slavename}_*.pid > /dev/null 2>&1

--- a/initfiles/bin/init_thorslave
+++ b/initfiles/bin/init_thorslave
@@ -33,11 +33,23 @@ slavename=thorslave_${hpcc_compname}
 
 stop_slaves()
 {
-    killall -0 $slavename > /dev/null 2>&1
-    if [[ $? -eq 0 ]];then
-        log "killing slaves"
+    local timer=15
+    local isAlive=0
+
+    log "Attempting to kill $slavename with SIGTERM"
+    killall -15 $slavename > /dev/null 2>&1
+    while [[ $isAlive -eq 0 && $timer -gt 0 ]];do
+        killall -0 $slavename > /dev/null 2>&1
+        isAlive=$?
+        [[ $isAlive -eq 0 ]] && sleep 0.5
+        ((timer--))
+    done
+
+    if [[ $isAlive -eq 0 ]]; then
+        log "Failed to kill slaves with SIGTERM. Sending SIGKILL"
         killall -9 $slavename > /dev/null 2>&1
     fi
+
     rm -f $PID/${slavename}_*.pid > /dev/null 2>&1
 }
 


### PR DESCRIPTION
Originally we were sending a SIGKILL to all the slaves.  The problem with this is that if they don't release the socket correctly, the socket they use can get into a TIME_WAIT state that won't be released for at least 60 seconds.  This causes restarts to fail because the thorslave binary can't get access to the socket in order to create a connection.  Now what we do is attempt to shut down the thorslaves cleanly with a SIGTERM for 7.5 seconds.  Only if that fails do we send a SIGKILL to the slaves.  We also now do the stop_slaves call in init_thor after the call to kill_process, which means that we no longer interrupt slaves that are properly shutting down by sending them a SIGKILL.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
