### PR TITLE
HPCC-13683 Safeguard against cleared socket on file disconnect

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -1201,13 +1201,17 @@ public:
     {
         CriticalBlock block(crit);
         CriticalBlock block2(CConnectionTable::crit); // this shouldn't ever block
-        ISocket *s = socket.getClear();
-        if (ConnectionTable) {
-            SocketEndpoint tep(ep);
-            setDafsEndpointPort(tep);
-            ConnectionTable->remove(tep,s);
+        if (socket)
+        {
+            ISocket *s = socket.getClear();
+            if (ConnectionTable)
+            {
+                SocketEndpoint tep(ep);
+                setDafsEndpointPort(tep);
+                ConnectionTable->remove(tep,s);
+            }
+            ::Release(s);
         }
-        ::Release(s);
     }
 
     const char *queryLocalName()


### PR DESCRIPTION
The socket can be cleared by killSocket during exception handling
The remote file disconnect needs to check if socket hasn't
already been cleared to prevent hittng an assert if the NULL
socket is passed to the connection table remove method.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
