### PR TITLE
HPCC-13689 Remove allowed cluster dropdown

### DIFF
--- a/esp/src/eclwatch/WUDetailsWidget.js
+++ b/esp/src/eclwatch/WUDetailsWidget.js
@@ -335,7 +335,7 @@ define([
             }).then(function (response) {
                 if (lang.exists("WUInfoResponse.Workunit.AllowedClusters.AllowedCluster", response)) {
                     var targetData = response.WUInfoResponse.Workunit.AllowedClusters.AllowedCluster;
-                    if (targetData.length >= 1) {
+                    if (targetData.length > 1) {
                         context.allowedClusters.options.push({
                             label: "&nbsp;",
                             value: ""


### PR DESCRIPTION
In the response AllowedClusters.AllowedCluster is always returned. Therefore, >= always returned a dropdown list since the first value in the array is the value of the cluster it was submitted to even if #option('AllowedClusters', cluster2,cluster3,cluster4) is not present.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
