### PR TITLE
HPCC-13405 Client tools failing to execute sub-commands if not on path

### DIFF
--- a/ecl/eclcmd/eclcmd_shell.cpp
+++ b/ecl/eclcmd/eclcmd_shell.cpp
@@ -54,7 +54,14 @@ int EclCMDShell::callExternal(ArgvIterator &iter)
 #ifdef _WIN32
     if (_spawnvp(_P_WAIT, cmdstr.str(), const_cast<char **>(argv))==-1)
 #else
-    if (execvp(cmdstr.str(), const_cast<char **>(argv))==-1)
+    // First try in same dir as the ecl executable
+    StringBuffer local;
+    splitFilename(queryCurrentProcessPath(), &local, &local, NULL, NULL);
+    local.append(cmdstr);
+    if (execvp(local.str(), const_cast<char **>(argv))!=-1)
+        return 0;
+    // If not found, try the path
+    if (errno!=ENOENT || execvp(cmdstr.str(), const_cast<char **>(argv))==-1)
 #endif
     {
         switch(errno)

--- a/tools/esdlcmd/esdlcmd_shell.cpp
+++ b/tools/esdlcmd/esdlcmd_shell.cpp
@@ -49,7 +49,14 @@ int EsdlCMDShell::callExternal(ArgvIterator &iter)
 #ifdef _WIN32
     if (_spawnvp(_P_WAIT, cmdstr.str(), const_cast<char **>(argv))==-1)
 #else
-    if (execvp(cmdstr.str(), const_cast<char **>(argv))==-1)
+    // First try in same dir as the esdl executable
+    StringBuffer local;
+    splitFilename(queryCurrentProcessPath(), &local, &local, NULL, NULL);
+    local.append(cmdstr);
+    if (execvp(local.str(), const_cast<char **>(argv))!=-1)
+        return 0;
+    // If not found, try the path
+    if (errno!=ENOENT || execvp(cmdstr.str(), const_cast<char **>(argv))==-1)
 #endif
     {
         switch(errno)


### PR DESCRIPTION
In windows, the current process's load dir is automatically on the path, but
in other systems that is not the case.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
