### PR TITLE
HPCC-13701 Add systemd service files on Ubuntu 15.04

### DIFF
--- a/initfiles/bash/etc/init.d/CMakeLists.txt
+++ b/initfiles/bash/etc/init.d/CMakeLists.txt
@@ -29,6 +29,10 @@ FOREACH( oFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/lock.sh
     ${CMAKE_CURRENT_SOURCE_DIR}/init-functions
     ${CMAKE_CURRENT_SOURCE_DIR}/export-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/hpcc-init.service
+    ${CMAKE_CURRENT_SOURCE_DIR}/hpcc-init@.service
+    ${CMAKE_CURRENT_SOURCE_DIR}/dafilesrv.service
+    ${CMAKE_CURRENT_SOURCE_DIR}/dafilesrv@.service
 )
     install ( PROGRAMS ${oFILES} DESTINATION etc/init.d COMPONENT Runtime )
 ENDFOREACH ( oFILES )

--- a/initfiles/bash/etc/init.d/dafilesrv.service
+++ b/initfiles/bash/etc/init.d/dafilesrv.service
@@ -1,0 +1,18 @@
+# HPCC Systems Systemd Script
+# Load to systemd:  sudo systemctl daemon-reload
+# Start/stop HPCC: sudo service dafilesrv <start|stop|restart>
+#                  or sudo systemctl <start|stop|restart> dafilesrv
+# Query status: journal -u dafilesrv -t dafilesrv -f  (CRL-C to return)
+# Alternatively user can directly invoke /etc/init.d/dafilesrv <start|stop|status>
+
+[Unit]
+Description=HPCC Systems dafilesrv service
+
+[Service]
+Type=oneshot
+ExecStart=/etc/init.d/dafilesrv start
+ExecStop=/etc/init.d/dafilesrv stop
+RemainAfterExit=yes
+#StandardOutput=tty
+#StandardError=tty
+#TTYPath=/dev/pts/0

--- a/initfiles/bash/etc/init.d/dafilesrv@.service
+++ b/initfiles/bash/etc/init.d/dafilesrv@.service
@@ -1,0 +1,20 @@
+# HPCC Systems Systemd Script
+# Load to systemd:  sudo systemctl daemon-reload
+# Start/stop HPCC: run tty to get terminal file name, for example /dev/pts/1
+#           sudo service dafilesrv@<terminal file name without /dev> <start|stop|restart> or
+#           sudo systemctl <start|stop|restart> dafilesrv@<terminal file name without /dev>.service
+#           For example sudo service dafilesrv@pts/1 start
+# Query status: journal -u dafilesrv -t dafilesrv -f  (To return: CRL-C)
+# Alternatively user can directly invoke /etc/init.d/dafilesrv <start|stop|status>
+
+[Unit]
+Description=HPCC Systems dafilesrv service
+
+[Service]
+Type=oneshot
+ExecStart=/etc/init.d/dafilesrv start
+ExecStop=/etc/init.d/dafilesrv stop
+RemainAfterExit=yes
+StandardOutput=tty
+StandardError=tty
+TTYPath=/dev/%I

--- a/initfiles/bash/etc/init.d/hpcc-init.service
+++ b/initfiles/bash/etc/init.d/hpcc-init.service
@@ -1,0 +1,18 @@
+# HPCC Systems Systemd Script
+# Load to systemd:  sudo systemctl daemon-reload
+# Start/stop HPCC: sudo service hpcc-init <start|stop|restart>
+#                  or sudo systemctl <start|stop|restart> hpcc-init
+# Query status: journal -u hpcc-init -t hpcc-init -f  (CRL-C to return)
+# Alternatively user can directly invoke /etc/init.d/hpcc-init <start|stop|status>
+
+[Unit]
+Description=HPCC Systems
+
+[Service]
+Type=oneshot
+ExecStart=/etc/init.d/hpcc-init start
+ExecStop=/etc/init.d/hpcc-init stop
+RemainAfterExit=yes
+#StandardOutput=tty
+#StandardError=tty
+#TTYPath=/dev/pts/0

--- a/initfiles/bash/etc/init.d/hpcc-init@.service
+++ b/initfiles/bash/etc/init.d/hpcc-init@.service
@@ -1,0 +1,20 @@
+# HPCC Systems Systemd Script
+# Load to systemd:  sudo systemctl daemon-reload
+# Start/stop HPCC: run tty to get terminal file name, for example /dev/pts/1
+#           sudo service hpcc-init@<terminal file name without /dev> <start|stop|restart> or
+#           sudo systemctl <start|stop|restart> hpcc-init@<terminal file name without /dev>.service
+#           For example sudo service hpcc-init@pts/1 start
+# Query status: journal -u hpcc-init -t hpcc-init -f  (To return: CRL-C)
+# Alternatively user can directly invoke /etc/init.d/hpcc-init <start|stop|status>
+
+[Unit]
+Description=HPCC Systems
+
+[Service]
+Type=oneshot
+ExecStart=/etc/init.d/hpcc-init start
+ExecStop=/etc/init.d/hpcc-init stop
+RemainAfterExit=yes
+StandardOutput=tty
+StandardError=tty
+TTYPath=/dev/%I

--- a/initfiles/bash/etc/init.d/init-functions
+++ b/initfiles/bash/etc/init.d/init-functions
@@ -376,6 +376,26 @@ log_action_end_msg () {
     log_action_end_msg_post "$@"
 }
 
+distrib_check () {
+  DISTRIB_NAME=
+  DISTRIB_VERSION=
+
+  local tmp_file=/tmp/distrib_check_$$
+  cat /etc/*release > $tmp_file
+
+  if grep -q -i ubuntu $tmp_file; then
+     DISTRIB_NAME=ubuntu
+     DISTRIB_VERSION=$(grep -e "DISTRIB_RELEASE" $tmp_file | head -n 1 | sed -n "s/^[[:space:]]*DISTRIB_RELEASE=\(.*\)/\1/p")
+  elif grep -q -i centos $tmp_file; then
+     DISTRIB_NAME=centos
+     DISTRIB_VERSION=$(grep -e "^[[:space:]]*CentOS" $tmp_file | head -1 | awk '{ print $3 }')
+  fi
+  DISTRIB_MAJOR_VERSION=$(echo $DISTRIB_VERSION | cut -d'.' -f1)
+  DISTRIB_MINOR_VERSION=$(echo $DISTRIB_VERSION | cut -d'.' -f2)
+
+  rm -rf $tmp_file
+}
+
 # Hooks for /etc/lsb-base-logging.sh
 log_daemon_msg_pre () { :; }
 log_daemon_msg_post () { :; }

--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -20,7 +20,7 @@
 source ${INSTALL_DIR}/etc/init.d/hpcc_common
 source ${INSTALL_DIR}/etc/init.d/init-functions
 
-installConfs () 
+installConfs ()
 {
     fileName=$1
     configPath=$2
@@ -281,6 +281,21 @@ fi
 chown root:$group ${configs}
 chown -R $user:$group ${configs}/*
 chmod 775 ${configs}
+
+# Add systemd support
+distrib_check
+if [ "${DISTRIB_NAME}" = "ubuntu" ] &&
+   [ ${DISTRIB_MAJOR_VERSION} -ge 15 ]; then
+
+   dpkg -l | grep -q -e "^ii[[:space:]]*systemd "
+   if [ $? -eq 0 ]; then
+      cp ${INSTALL_DIR}/etc/init.d/hpcc-init.service /lib/systemd/system/
+      cp ${INSTALL_DIR}/etc/init.d/hpcc-init@.service /lib/systemd/system/
+      cp ${INSTALL_DIR}/etc/init.d/dafilesrv.service /lib/systemd/system/
+      cp ${INSTALL_DIR}/etc/init.d/dafilesrv@.service /lib/systemd/system/
+      systemctl daemon-reload
+   fi
+fi
 
 if [ -d ${CONFIG_DIR} ]; then
     date > ${CONFIG_DIR}/installed

--- a/initfiles/bash/etc/init.d/uninstall-init.in
+++ b/initfiles/bash/etc/init.d/uninstall-init.in
@@ -61,3 +61,27 @@ if [ -d ${INSTALL_DIR}/etc/init.d/uninstall ]; then
         source ${INSTALL_DIR}/etc/init.d/uninstall/${subUnInstall}
     done
 fi
+
+# Remove systemd service
+distrib_check
+if [ "${DISTRIB_NAME}" = "ubuntu" ] &&
+   [ ${DISTRIB_MAJOR_VERSION} -ge 15 ]; then
+
+   dpkg -l | grep -q -e "^ii[[:space:]]*systemd "
+   if [ $? -eq 0 ]; then
+      systemctl list-units | grep hpcc-init | while read hpcc_service rest
+      do
+         systemctl stop ${hpcc_service}
+      done
+      systemctl list-units | grep dafilesrv | while read hpcc_service rest
+      do
+         systemctl stop ${hpcc_service}
+      done
+      systemctl reset-failed
+
+      [ -e /lib/systemd/system/hpcc-init.service ] && rm -rf /lib/systemd/system/hpcc-init.service
+      [ -e /lib/systemd/system/hpcc-init@.service ] && rm -rf /lib/systemd/system/hpcc-init@.service
+      [ -e /lib/systemd/system/dafilesrv.service ] && rm -rf /lib/systemd/system/dafilesrv.service
+      [ -e /lib/systemd/system/dafilesrv@.service ] && rm -rf /lib/systemd/system/dafilesrv@.service
+   fi
+fi

--- a/initfiles/componentfiles/launcher/hpcc-systems.desktop
+++ b/initfiles/componentfiles/launcher/hpcc-systems.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=3.8.x
+Version=5.x
 Name=HPCC Systems
 GenericName=HPCC Systems
 Comment=HPCC Cluster Administration
@@ -12,20 +12,20 @@ X-Ayatana-Desktop-Shortcuts=Start;Stop;Restart;Status
 
 [Start Shortcut Group]
 Name=Start HPCC Cluster
-Exec=xterm -T "Starting HPCC Cluster" -e sudo service hpcc-init start
+Exec=xterm -T "Starting HPCC Cluster" -e sudo /etc/init.d/hpcc-init start
 TargetEnvironment=Unity
 
 [Stop Shortcut Group]
 Name=Stop HPCC Cluster
-Exec=xterm -T "Stopping HPCC Cluster" -e sudo service hpcc-init stop
+Exec=xterm -T "Stopping HPCC Cluster" -e sudo /etc/init.d/hpcc-init stop
 TargetEnvironment=Unity
 
 [Restart Shortcut Group]
 Name=Restart HPCC Cluster
-Exec=xterm -T "Restarting HPCC Cluster" -e sudo service hpcc-init restart
+Exec=xterm -T "Restarting HPCC Cluster" -e sudo /etc/init.d/hpcc-init restart
 TargetEnvironment=Unity
 
 [Status Shortcut Group]
 Name=HPCC Cluster Status
-Exec=xterm -T "HPCC Status" -hold -e sudo service hpcc-init status
+Exec=xterm -T "HPCC Status" -hold -e sudo /etc/init.d/hpcc-init status
 TargetEnvironment=Unity

--- a/initfiles/sbin/complete-uninstall.sh.in
+++ b/initfiles/sbin/complete-uninstall.sh.in
@@ -19,6 +19,7 @@
 ###<REPLACE>###
 
 source  ${INSTALL_DIR}/etc/init.d/hpcc_common
+source  ${INSTALL_DIR}/etc/init.d/init-functions
 
 usage() {
    cat << EOF
@@ -122,6 +123,31 @@ elif [ -e /etc/redhat-release -o -e /etc/SuSE-release ]; then
        rpm -e --nodeps hpccsystems-platform
     fi
 fi
+
+distrib_check
+if [ "${DISTRIB_NAME}" = "ubuntu" ] &&
+   [ ${DISTRIB_MAJOR_VERSION} -ge 15 ]; then
+
+   dpkg -l | grep -q -e "^ii[[:space:]]*systemd "
+   if [ $? -eq 0 ]; then
+      echo "Remove systemd service"
+      systemctl list-units | grep hpcc-init | while read hpcc_service rest
+      do
+         systemctl stop ${hpcc_service}
+      done
+      systemctl list-units | grep dafilesrv | while read hpcc_service rest
+      do
+         systemctl stop ${hpcc_service}
+      done
+      systemctl reset-failed
+
+      [ -e /lib/systemd/system/hpcc-init.service ] && rm -rf /lib/systemd/system/hpcc-init.service
+      [ -e /lib/systemd/system/hpcc-init@.service ] && rm -rf /lib/systemd/system/hpcc-init@.service
+      [ -e /lib/systemd/system/dafilesrv.service ] && rm -rf /lib/systemd/system/dafilesrv.service
+      [ -e /lib/systemd/system/dafilesrv@.service ] && rm -rf /lib/systemd/system/dafilesrv@.service
+   fi
+fi
+
 
 echo "Removing Directory - ${path}"
 removedir ${path}


### PR DESCRIPTION
Add four systemd service files hpcc-init.service, hpcc-init@.service, dafilesrv.service and
dafilesrv@.service to <INSTALL_DIR>/etc/init.d/
On Ubuntu 15.04: <ol><li>install: copy these files to /lib/systemd/system and run systemctl daemon-reload.</li><li>uninstall: remove the service and files.</li></ol>

Usage: 
hpcc-init systemd service usage:

<ol><li> Start/stop HPCC with hpcc-init without STDOUT/STDERR output</li><ol><li>Start:  sudo service hpcc-init start or sudo systemctl start hpcc-init.service</li><li> Check: sudo journalctl -u hpcc-init -f</li><li>Stop: sudo service hpcc-init stop or sudo systemctl stop hpcc-init.service</li></ol><li> Start/stop HPCC with hpcc-init with STDOUT/STDERR output</li>
<ol><li>< Get current tty by run "tty". For example, tty -> /dev/pts/1. "pts/1" will be used in following commands.</li><li>Start:  sudo service hpcc-init@pts/1 start or sudo systemctl start hpcc-init@pts/1.service</li><li>Stop:  sudo service hpcc-init@pts/1 stop or sudo systemctl stop hpcc-init@pts/1.service</li></ol></ol>


dafilesrv will be similar as hpcc-init. Just replace hpcc-init with dafilesrv.

For detail see JIRA HPCC-13703 for detail

@Michael-Gardner please review the code
@g-pan please review the text at top of files *.service

Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexi.com 
