### PR TITLE
HPCC-13618 Add a useful exception toaster message

### DIFF
--- a/esp/src/eclwatch/ESPRequest.js
+++ b/esp/src/eclwatch/ESPRequest.js
@@ -140,6 +140,11 @@ define([
                                         severity = "Info";
                                     }
                                     break;
+                                case "WsWorkunits.WUUpdate":
+                                    if (response.Exceptions.Exception[0].Code === 20049) {
+                                        severity = "Error";
+                                    }
+                                    break;
                             }
                         }
                         topic.publish("hpcc/brToaster", {

--- a/esp/src/eclwatch/ESPWorkunit.js
+++ b/esp/src/eclwatch/ESPWorkunit.js
@@ -312,7 +312,15 @@ define([
             WsWorkunits.WUUpdate({
                 request: request,
                 load: function (response) {
-                    context.updateData(response.WUUpdateResponse.Workunit);
+                    if (lang.exists("Exceptions.Exception", response)) {
+                        dojo.publish("hpcc/brToaster", {
+                            message: "<h4>" + response.Exceptions.Source + "</h4>" + "<p>" + response.Exceptions.Exception[0].Message + "</p>",
+                            type: "error",
+                            duration: -1
+                        });
+                    } else {
+                        context.updateData(response.WUUpdateResponse.Workunit);
+                    }
                     context.onUpdate();
                 }
             });


### PR DESCRIPTION
If a cluster does not exist when choosing an alternative 'allowed cluster' within workunit details the toaster message that appears does not provide clear information as to what the exception is. In this case, it returns "GMT: Invalid cluster name: ClusterName" which is helpful. Improving of exception handling may need to be done in other cases throughout the application.

Signed-off-by: Miguel Vazquez miguel.vazquez@lexisnexis.com
