### PR TITLE
HPCC-13713 daftformat.cpp Inverted Code For XML Splitter Header Length Calculation

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -1497,7 +1497,6 @@ offset_t XmlSplitter::getHeaderLength(BufferedDirectReader & reader)
                 }
             }
             break;
-            return startOfLine - startOfHeader;
         case NEWLINE:
             startOfLine = reader.tell()+matchLen;
             resetStartOfLine = false;


### PR DESCRIPTION
Remove dead code.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
