### PR TITLE
HPCC-13587 Add -Wc and -Wl parameters to ecl command to allow passing parameter to underlying C++ compiler.

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -1635,6 +1635,14 @@ public:
             { c->setResultDecimal(name, sequence, len,  precision, isSigned, val); }
     virtual void setResultDataset(const char * name, unsigned sequence, size32_t len, const void *val, unsigned numRows, bool extend)
             { c->setResultDataset(name, sequence, len, val, numRows, extend); }
+    virtual bool getCppOption(const char * propname, bool defVal) const
+            { return c->getCppOption(propname, defVal); }
+    virtual IStringIterator & getCppOptions() const
+            { return c->getCppOptions(NULL); }
+    virtual IStringIterator & getCppOptions(const char * prop) const
+            { return c->getCppOptions(prop); }
+    virtual void setCppOption(const char * propname, bool value, bool overwrite)
+            { c->setCppOption(propname, value, overwrite); }
 };
 
 class CLocalWUAssociated : public CInterface, implements IConstWUAssociatedFile
@@ -5356,6 +5364,36 @@ IStringVal& CLocalWorkUnit::getDebugValue(const char *propname, IStringVal &str)
     return str;
 }
 
+bool CLocalWorkUnit::getCppOption(const char * propname, bool defVal) const
+{
+    StringBuffer lower;
+    lower.append(propname).toLowerCase();
+    CriticalBlock block(crit);
+    StringBuffer prop("CppOpt/");
+    prop.append(lower);
+    return p->getPropBool(prop.str(), defVal);
+}
+
+IStringIterator & CLocalWorkUnit::getCppOptions() const
+{
+    return getCppOptions(NULL);
+}
+
+IStringIterator & CLocalWorkUnit::getCppOptions(const char * prop) const
+{
+    CriticalBlock block(crit);
+        StringBuffer path("CppOpt/");
+        if (prop)
+        {
+            StringBuffer lower;
+            lower.append(prop).toLowerCase();
+            path.append(lower);
+        }
+        else
+            path.append("*");
+        return *new CStringPTreeTagIterator(p->getElements(path.str()));
+}
+
 IStringIterator& CLocalWorkUnit::getDebugValues() const
 {
     return getDebugValues(NULL);
@@ -5474,6 +5512,21 @@ void CLocalWorkUnit::setDebugValue(const char *propname, const char *value, bool
         // MORE - not sure this line should be needed....
         p->setProp("Debug", ""); 
         p->setProp(prop.str(), value); 
+    }
+}
+
+void CLocalWorkUnit::setCppOption(const char * propname, bool value, bool overwrite)
+{
+    StringBuffer lower;
+    lower.append(propname).toLowerCase();
+    CriticalBlock block(crit);
+    StringBuffer prop("CppOpt/");
+    prop.append(lower);
+    if (overwrite || !p->hasProp(prop.str()))
+    {
+        // MORE - not sure this line should be needed....
+        p->setProp("CppOpt", "");
+        p->setPropBool(prop.str(), value);
     }
 }
 

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1077,6 +1077,9 @@ interface IConstWorkUnit : extends IConstWorkUnitInfo
     virtual IStringIterator *getLogs(const char *type, const char *instance=NULL) const = 0;
     virtual IStringIterator *getProcesses(const char *type) const = 0;
     virtual IPropertyTreeIterator* getProcesses(const char *type, const char *instance) const = 0;
+    virtual bool getCppOption(const char * propname, bool defVal) const = 0;
+    virtual IStringIterator & getCppOptions() const = 0;
+    virtual IStringIterator & getCppOptions(const char * prop) const = 0;
 };
 
 
@@ -1167,6 +1170,7 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual void setResultBool(const char *name, unsigned sequence, bool val) = 0;
     virtual void setResultDecimal(const char *name, unsigned sequence, int len, int precision, bool isSigned, const void *val) = 0;
     virtual void setResultDataset(const char * name, unsigned sequence, size32_t len, const void *val, unsigned numRows, bool extend) = 0;
+    virtual void setCppOption(const char * propname, bool value, bool overwrite) = 0;
 };
 
 

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -504,6 +504,11 @@ public:
         }
     }
 
+    virtual void setCppOption(const char * propname, bool value, bool overwrite);
+    virtual bool getCppOption(const char * propname, bool defVal) const;
+    virtual IStringIterator & getCppOptions() const;
+    virtual IStringIterator & getCppOptions(const char * prop) const;
+
 protected:
     IWUResult *updateResult(const char *name, unsigned sequence)
     {

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -355,6 +355,22 @@ class EclccCompileThread : public CInterface, implements IPooledThread, implemen
             workunit->getDebugValue(debugStr.str(), valueStr);
             processOption(debugStr.str(), valueStr.str(), eclccCmd, eclccProgName, *pipe, true);
         }
+        // Process cpp options
+        Owned<IStringIterator> cppOptions = &workunit->getCppOptions();
+        ForEach (*cppOptions)
+        {
+            SCMStringBuffer cppOptStr;
+            cppOptions->str(cppOptStr);
+            const char * opt = cppOptStr.str();
+            if ( workunit->getCppOption(opt, false))
+            {
+                if ('f' == *opt)
+                    eclccCmd.appendf(" -Wc,-").appendf(opt);
+                else if ('l' == *opt)
+                    eclccCmd.appendf(" -Wl,-").appendf(opt);
+            }
+        }
+
         if (workunit->getResultLimit())
         {
             eclccCmd.appendf(" -fapplyInstantEclTransformations=1 -fapplyInstantEclTransformationsLimit=%u", workunit->getResultLimit());

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -418,6 +418,18 @@ public:
                     cmdLine.append('=').append(value);
             }
         }
+        if (cmd.cppOptions.length())
+        {
+            ForEachItemIn(i, cmd.cppOptions)
+            {
+                IEspNamedValue &item = cmd.cppOptions.item(i);
+                const char *name = item.getName();
+                const char *value = item.getValue();
+                cmdLine.append(" ").append(name);
+                if (value)
+                    cmdLine.append(value);
+            }
+        }
         if (cmd.definitions.length())
         {
             ForEachItemIn(i, cmd.definitions)
@@ -551,6 +563,17 @@ bool matchVariableOption(ArgvIterator &iter, const char prefix, IArrayOf<IEspNam
     addNamedValue(arg, values);
     return true;
 }
+
+bool matchVariableCompilerOption(ArgvIterator &iter, const char prefix, IArrayOf<IEspNamedValue> &values)
+{
+    // -Wc,xxx or -Wl,xx parameter pass it as is
+    const char *arg = iter.query();
+    if (*arg!='-' || *(arg+1)!=prefix || !*(arg+2))
+        return false;
+    addNamedValue(arg, values);
+    return true;
+}
+
 eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvIterator &iter, bool finalAttempt)
 {
     const char *arg = iter.query();
@@ -577,6 +600,8 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     }
     if (matchVariableOption(iter, 'f', debugValues))
+        return EclCmdOptionMatch;
+    if (matchVariableCompilerOption(iter, 'W', cppOptions))
         return EclCmdOptionMatch;
     if (matchVariableOption(iter, 'D', definitions))
         return EclCmdOptionMatch;

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -264,6 +264,8 @@ public:
             "   --limit=<limit>        Sets the result limit for the query, defaults to 100\n"
             "   -f<option>[=value]     Set an ECL option (equivalent to #option)\n"
             "   -Dname=value           Override the definition of a global attribute 'name'\n"
+            "   -Wc,xx                 Pass option xx to the c++ compiler\n"
+            "   -Wl,xx                 Pass option xx to the c++ linker\n"
             " eclcc options (everything following):\n"
         );
         for (unsigned line=0; line < _elements_in(helpText); line++)
@@ -300,6 +302,7 @@ public:
     StringAttr optSnapshot;
     IArrayOf<IEspNamedValue> debugValues;
     IArrayOf<IEspNamedValue> definitions;
+    IArrayOf<IEspNamedValue> cppOptions;
     unsigned optResultLimit;
     bool optNoArchive;
     bool optLegacy;

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -135,6 +135,11 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
     if (cmd.optSnapshot.length())
         req->setSnapshot(cmd.optSnapshot);
     expandDefintionsAsDebugValues(cmd.definitions, cmd.debugValues);
+    if (cmd.cppOptions.length())
+    {
+        req->setCppOptions(cmd.cppOptions);
+        cmd.cppOptions.kill();
+    }
     if (cmd.debugValues.length())
     {
         req->setDebugValues(cmd.debugValues);

--- a/ecl/hqlcpp/hqlecl.cpp
+++ b/ecl/hqlcpp/hqlecl.cpp
@@ -570,6 +570,16 @@ bool HqlDllGenerator::doCompile(ICppCompiler * compiler)
     wu->getDebugValue("compileOptions", optionAdaptor);
     compiler->addCompileOption(options.str());
 
+    // Get CppOptions from WU (for coverage generation)
+    if ( wu->getCppOption("fprofile-arcs", false) )
+        compiler->addCompileOption("-fprofile-arcs");
+
+    if ( wu->getCppOption("ftest-coverage", false) )
+        compiler->addCompileOption("-ftest-coverage");
+
+    if ( wu->getCppOption("lgcov", false) )
+        compiler->addLinkOption("-lgcov");
+
     if (okToAbort)
         compiler->setAbortChecker(this);
 

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -324,6 +324,7 @@ ESPrequest [nil_remove] WUDeployWorkunitRequest
     string QueryMainDefinition;
     string Snapshot;
     ESParray<ESPstruct NamedValue> DebugValues;
+    [min_ver("1.56")] ESParray<ESPstruct NamedValue> CppOptions;
 };
 
 ESPresponse [exceptions_inline] WUDeployWorkunitResponse
@@ -537,6 +538,7 @@ ESPrequest WURunRequest
     ESParray<ESPstruct NamedValue> DebugValues;
     ESParray<ESPstruct NamedValue> Variables;
     ESPenum WUExceptionSeverity ExceptionSeverity("info");
+    [min_ver("1.56")] ESParray<ESPstruct NamedValue> CppOptions;
 };
 
 ESPresponse [exceptions_inline] WURunResponse
@@ -1610,7 +1612,7 @@ ESPresponse [exceptions_inline] WUGetStatsResponse
 };
 
 ESPservice [
-    version("1.55"), default_client_version("1.55"),
+    version("1.56"), default_client_version("1.56"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -2898,7 +2898,7 @@ void WsWuHelpers::setXmlParameters(IWorkUnit *wu, const char *xml, IArrayOf<ICon
 }
 
 void WsWuHelpers::submitWsWorkunit(IEspContext& context, IConstWorkUnit* cw, const char* cluster, const char* snapshot, int maxruntime, bool compile, bool resetWorkflow, bool resetVariables,
-    const char *paramXml, IArrayOf<IConstNamedValue> *variables, IArrayOf<IConstNamedValue> *debugs)
+    const char *paramXml, IArrayOf<IConstNamedValue> *variables, IArrayOf<IConstNamedValue> *debugs, IArrayOf<IConstNamedValue> *cppOptions)
 {
     ensureWsWorkunitAccess(context, *cw, SecAccess_Write);
     switch(cw->getState())
@@ -2952,6 +2952,25 @@ void WsWuHelpers::submitWsWorkunit(IEspContext& context, IConstWorkUnit* cw, con
             wu->setDebugValue(name, value, true);
         }
     }
+    if (cppOptions && cppOptions->length())
+        {
+            ForEachItemIn(i, *cppOptions)
+            {
+                IConstNamedValue &item = cppOptions->item(i);
+                const char *name = item.getName();
+                // Skip 'Wc-,-' or 'Wl,-' part of the option name
+                name += 5;
+                const char *value = item.getValue();
+                if (!name || !*name)
+                    continue;
+                if (!value)
+                {
+                    wu->setCppOption(name, true, true);
+                    continue;
+                }
+                wu->setCppOption(name, value, true);
+            }
+        }
 
     if (resetWorkflow)
         wu->resetWorkflow();
@@ -2987,13 +3006,13 @@ void WsWuHelpers::submitWsWorkunit(IEspContext& context, IConstWorkUnit* cw, con
 }
 
 void WsWuHelpers::submitWsWorkunit(IEspContext& context, const char *wuid, const char* cluster, const char* snapshot, int maxruntime, bool compile, bool resetWorkflow, bool resetVariables,
-    const char *paramXml, IArrayOf<IConstNamedValue> *variables, IArrayOf<IConstNamedValue> *debugs)
+    const char *paramXml, IArrayOf<IConstNamedValue> *variables, IArrayOf<IConstNamedValue> *debugs, IArrayOf<IConstNamedValue> *cppOptions)
 {
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
     Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid, false);
     if(!cw)
         throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid);
-    return submitWsWorkunit(context, cw, cluster, snapshot, maxruntime, compile, resetWorkflow, resetVariables, paramXml, variables, debugs);
+    return submitWsWorkunit(context, cw, cluster, snapshot, maxruntime, compile, resetWorkflow, resetVariables, paramXml, variables, debugs, cppOptions);
 }
 
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -370,10 +370,10 @@ namespace WsWuHelpers
 {
     void setXmlParameters(IWorkUnit *wu, const char *xml, bool setJobname=false);
     void submitWsWorkunit(IEspContext& context, IConstWorkUnit* cw, const char* cluster, const char* snapshot, int maxruntime, bool compile, bool resetWorkflow, bool resetVariables,
-            const char *paramXml=NULL, IArrayOf<IConstNamedValue> *variables=NULL, IArrayOf<IConstNamedValue> *debugs=NULL);
+            const char *paramXml=NULL, IArrayOf<IConstNamedValue> *variables=NULL, IArrayOf<IConstNamedValue> *debugs=NULL, IArrayOf<IConstNamedValue> *cppOptions=NULL);
     void setXmlParameters(IWorkUnit *wu, const char *xml, IArrayOf<IConstNamedValue> *variables, bool setJobname=false);
     void submitWsWorkunit(IEspContext& context, const char *wuid, const char* cluster, const char* snapshot, int maxruntime, bool compile, bool resetWorkflow, bool resetVariables,
-            const char *paramXml=NULL, IArrayOf<IConstNamedValue> *variables=NULL, IArrayOf<IConstNamedValue> *debugs=NULL);
+            const char *paramXml=NULL, IArrayOf<IConstNamedValue> *variables=NULL, IArrayOf<IConstNamedValue> *debugs=NULL, IArrayOf<IConstNamedValue> *cppOptions=NULL);
     void copyWsWorkunit(IEspContext &context, IWorkUnit &wu, const char *srcWuid);
     void runWsWorkunit(IEspContext &context, StringBuffer &wuid, const char *srcWuid, const char *cluster, const char *paramXml=NULL,
             IArrayOf<IConstNamedValue> *variables=NULL, IArrayOf<IConstNamedValue> *debugs=NULL);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3736,7 +3736,7 @@ void deployEclOrArchive(IEspContext &context, IEspWUDeployWorkunitRequest & req,
     wu->commit();
     wu.clear();
 
-    WsWuHelpers::submitWsWorkunit(context, wuid.str(), req.getCluster(), NULL, 0, true, false, false, NULL, NULL, &req.getDebugValues());
+    WsWuHelpers::submitWsWorkunit(context, wuid.str(), req.getCluster(), NULL, 0, true, false, false, NULL, NULL, &req.getDebugValues(), &req.getCppOptions());
     waitForWorkUnitToCompile(wuid.str(), req.getWait());
 
     WsWuInfo winfo(context, wuid.str());


### PR DESCRIPTION
Add code to handle -Wc,xxx and -Wl,xxx CPP compiler parameters in
ecl command

Add code to pass CPP compiler parameters to ECLServer

Add code to use CPP compiler parameters to generate binary.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
