### PR TITLE
HPCC-13608 Return warning message if too many files

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2794,6 +2794,7 @@ public:
             StringAttr nameFilterLo;
             StringAttr nameFilterHi;
             StringArray unknownAttributes;
+            unsigned totalWUs;
 
         public:
             IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
@@ -2801,6 +2802,7 @@ public:
             CWorkUnitsPager(const char* _xPath, const char *_sortOrder, const char* _nameFilterLo, const char* _nameFilterHi, StringArray& _unknownAttributes)
                 : xPath(_xPath), sortOrder(_sortOrder), nameFilterLo(_nameFilterLo), nameFilterHi(_nameFilterHi)
             {
+                totalWUs = 0;
                 ForEachItemIn(x, _unknownAttributes)
                     unknownAttributes.append(_unknownAttributes.item(x));
             }
@@ -2813,8 +2815,10 @@ public:
                 if (!iter)
                     return NULL;
                 sortElements(iter, sortOrder.get(), nameFilterLo.get(), nameFilterHi.get(), unknownAttributes, elements);
+                totalWUs = elements.ordinality();
                 return conn.getClear();
             }
+            virtual unsigned getTotalElements() { return totalWUs; }
         };
         class CScopeChecker : public CSimpleInterface, implements ISortedElementsTreeFilter
         {
@@ -2901,7 +2905,7 @@ public:
         }
         IArrayOf<IPropertyTree> results;
         Owned<IElementsPager> elementsPager = new CWorkUnitsPager(query.str(), so.length()?so.str():NULL, namefilterlo.get(), namefilterhi.get(), unknownAttributes);
-        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,secmgr?sc:NULL,queryowner,cachehint,results,total);
+        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,secmgr?sc:NULL,queryowner,cachehint,results,total,NULL);
         return new CConstWUArrayIterator(conn, results, secmgr, secuser);
     }
 
@@ -2946,6 +2950,7 @@ public:
             PostFilters postFilters;
             StringArray unknownAttributes;
             const MapStringTo<bool> *subset;
+            unsigned totalQueries;
 
             void populateQueryTree(const IPropertyTree* querySetTree, IPropertyTree* queryTree)
             {
@@ -3010,6 +3015,7 @@ public:
             CQuerySetQueriesPager(const char* _querySet, const char* _xPath, const char *_sortOrder, PostFilters& _postFilters, StringArray& _unknownAttributes, const MapStringTo<bool> *_subset)
                 : querySet(_querySet), xPath(_xPath), sortOrder(_sortOrder), subset(_subset)
             {
+                totalQueries = 0;
                 postFilters.activatedFilter = _postFilters.activatedFilter;
                 postFilters.suspendedByUserFilter = _postFilters.suspendedByUserFilter;
                 ForEachItemIn(x, _unknownAttributes)
@@ -3025,8 +3031,10 @@ public:
                 if (!iter)
                     return NULL;
                 sortElements(iter, sortOrder.get(), NULL, NULL, unknownAttributes, elements);
+                totalQueries = elements.ordinality();
                 return conn.getClear();
             }
+            virtual unsigned getTotalElements() { return totalQueries; }
         };
         StringAttr querySet;
         StringBuffer xPath;
@@ -3079,7 +3087,7 @@ public:
         }
         IArrayOf<IPropertyTree> results;
         Owned<IElementsPager> elementsPager = new CQuerySetQueriesPager(querySet.get(), xPath.str(), so.length()?so.str():NULL, postFilters, unknownAttributes, _subset);
-        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,"",cachehint,results,total);
+        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,"",cachehint,results,total,NULL);
         return new CConstQuerySetQueryIterator(results);
     }
 

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -48,7 +48,7 @@ interface IUserDescriptor;
 #define S_LINK_RELATIONSHIP_KIND "link"
 #define S_VIEW_RELATIONSHIP_KIND "view"
 
-
+#define ITERATE_FILTEREDFILES_LIMIT 100000
 
 interface IDistributedSuperFile;
 interface IDistributedFile;
@@ -185,7 +185,8 @@ enum DFUQFilterType
 enum DFUQSpecialFilter
 {
     DFUQSFFileNameWithPrefix = 1,
-    DFUQSFFileType = 2
+    DFUQSFFileType = 2,
+    DFUQSFMaxFiles = 3
 };
 
 enum DFUQFileTypeFilter
@@ -551,7 +552,7 @@ interface IDistributedFileDirectory: extends IInterface
             // wildname is in form scope/name and may contain wild components for either
     virtual IDFAttributesIterator *getDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive=true, bool includesuper=false, INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
     virtual IPropertyTreeIterator *getDFAttributesTreeIterator(const char *filters, DFUQResultField* localFilters,
-        const char *localFilterBuf, IUserDescriptor *user, INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
+        const char *localFilterBuf, IUserDescriptor *user, unsigned& totalFiles, INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
     virtual IDFAttributesIterator *getForeignDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive=true, bool includesuper=false, const char *foreigndali="", unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
 
     virtual IDFScopeIterator *getScopeIterator(IUserDescriptor *user, const char *subscope=NULL,bool recursive=true,bool includeempty=false)=0;
@@ -656,7 +657,7 @@ interface IDistributedFileDirectory: extends IInterface
 
     virtual IDFProtectedIterator *lookupProtectedFiles(const char *owner=NULL,bool notsuper=false,bool superonly=false)=0; // if owner = NULL then all
     virtual IDFAttributesIterator* getLogicalFilesSorted(IUserDescriptor* udesc, DFUQResultField *sortOrder, const void* filters, DFUQResultField *localFilters,
-            const void *specialFilterBuf, unsigned startOffset, unsigned maxNum, __int64 *cacheHint, unsigned *total) = 0;
+        const void *specialFilterBuf, unsigned startOffset, unsigned maxNum, __int64 *cacheHint, unsigned *totalReturned, unsigned *total) = 0;
 
     virtual unsigned setDefaultTimeout(unsigned timems) = 0;                                // sets default timeout for SDS connections and locking
                                                                                             // returns previous value

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -271,6 +271,7 @@ interface ISortedElementsTreeFilter : extends IInterface
 interface IElementsPager : extends IInterface
 {
     virtual IRemoteConnection *getElements(IArrayOf<IPropertyTree> &elements) = 0;
+    virtual unsigned getTotalElements() = 0;
 };
 extern da_decl void sortElements( IPropertyTreeIterator* elementsIter,
                                      const char *sortorder, 
@@ -286,6 +287,7 @@ extern da_decl IRemoteConnection *getElementsPaged(IElementsPager *elementsPager
                                      const char *owner,
                                      __int64 *hint,                         // if non null points to in/out cache hint
                                      IArrayOf<IPropertyTree> &results,
+                                     unsigned *returned,
                                      unsigned *total,
                                      bool checkConn = true); // total possible filtered matches, i.e. irrespective of startoffset and pagesize
 

--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -3020,6 +3020,7 @@ public:
             StringAttr nameFilterLo;
             StringAttr nameFilterHi;
             StringArray unknownAttributes;
+            unsigned totalWUs;
 
         public:
             IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
@@ -3027,6 +3028,7 @@ public:
             CDFUWorkUnitsPager(const char* _xPath, const char *_sortOrder, const char* _nameFilterLo, const char* _nameFilterHi, StringArray& _unknownAttributes)
                 : xPath(_xPath), sortOrder(_sortOrder), nameFilterLo(_nameFilterLo), nameFilterHi(_nameFilterHi)
             {
+                totalWUs = 0;
                 ForEachItemIn(x, _unknownAttributes)
                     unknownAttributes.append(_unknownAttributes.item(x));
             }
@@ -3039,8 +3041,10 @@ public:
                 if (!iter)
                     return NULL;
                 sortElements(iter, sortOrder.get(), nameFilterLo.get(), nameFilterHi.get(), unknownAttributes, elements);
+                totalWUs = elements.ordinality();
                 return conn.getClear();
             }
+            virtual unsigned getTotalElements() { return totalWUs; }
         };
 
         StringBuffer query;
@@ -3095,7 +3099,7 @@ public:
         }
         IArrayOf<IPropertyTree> results;
         Owned<IElementsPager> elementsPager = new CDFUWorkUnitsPager(query.str(), so.length()?so.str():NULL, namefilterlo.get(), namefilterhi.get(), unknownAttributes);
-        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,queryowner,cachehint,results,total);
+        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,queryowner,cachehint,results,total,NULL);
         return new CConstDFUWUArrayIterator(this,conn,results);
     }
 

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -170,6 +170,7 @@ ESPrequest [nil_remove] DFUQueryRequest
 
     bool OneLevelDirFileReturn(false);
     [min_ver("1.24")] int64 CacheHint;
+    [min_ver("1.30")] int MaxNumberOfFiles;
 };
 
 ESPresponse 
@@ -208,6 +209,8 @@ DFUQueryResponse
     string ParametersForPaging;
     string Filters;
     [min_ver("1.24")] int64 CacheHint;
+    [min_ver("1.30")] int TotalFiles;
+    [min_ver("1.30")] string Warning;
 };
 
 ESPrequest 

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -76,6 +76,7 @@ private:
     const char* getPrefixFromLogicalName(const char* logicalName, StringBuffer& prefix);
     const char* getShortDescription(const char* description, StringBuffer& shortDesc);
     bool addDFUQueryFilter(DFUQResultField *filters, unsigned short &count, MemoryBuffer &buff, const char* value, DFUQResultField name);
+    void setFileIterateFilter(unsigned maxFiles, StringBuffer &filterBuf);
     void appendDFUQueryFilter(const char *name, DFUQFilterType type, const char *value, StringBuffer& filterBuf);
     void appendDFUQueryFilter(const char *name, DFUQFilterType type, const char *value, const char *valueHigh, StringBuffer& filterBuf);
     void setFileTypeFilter(const char* fileType, StringBuffer& filterBuf);


### PR DESCRIPTION
In some environment with many logical files, the "Jbuf: out of
memory" occurs when sorting the files on ESP for "Browse Logical
Files". As a short term fix, instead of returning all files, dali
will return a random N files with total number of all files to
client (ESP). (dali client may specify the N value). As a dali
client, ESP forwards the N files (with pages) to its client with
a warning message of "More than N files found..." if total number
of files > N.

Changes after review: (1) Set max number (N) of files to return,
not set from/to. Remove the new cache which is no longer needed.
(2) Move IElementsPagerEx::getTotalElements() into IElementsPager.

A long term fix will be done in HPCC-13425 later.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
