### PR TITLE
HPCC-13591 Tell user abort active WU before deleting

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3542,12 +3542,12 @@ void CLocalWorkUnit::cleanupAndDelete(bool deldll, bool deleteOwned, const Strin
         break;
     case WUStateCompiled:
         if (getAction()==WUActionRun || getAction()==WUActionUnknown)
-            throw MakeStringException(WUERR_WorkunitActive, "%s: Workunit is active",p->queryName());
+            throw MakeStringException(WUERR_WorkunitActive, "%s: Workunit is active. Please abort before deleting this workunit.",p->queryName());
         break;
     case WUStateWait:
         throw MakeStringException(WUERR_WorkunitScheduled, "%s: Workunit is scheduled",p->queryName());
     default:
-        throw MakeStringException(WUERR_WorkunitActive, "%s: Workunit is active",p->queryName());
+        throw MakeStringException(WUERR_WorkunitActive, "%s: Workunit is active. Please abort before deleting this workunit.",p->queryName());
         break;
     }
     if (getIsQueryService())

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -260,28 +260,11 @@ bool doAction(IEspContext& context, StringArray& wuids, int action, IProperties*
                 case ActionDelete:
                     ensureWsWorkunitAccess(context, *cw, SecAccess_Full);
                     {
-                        int state = cw->getState();
-                        switch (state)
-                        {
-                            case WUStateWait:
-                            case WUStateAborted:
-                            case WUStateCompleted:
-                            case WUStateFailed:
-                            case WUStateArchived:
-                            case WUStateCompiled:
-                            case WUStateUploadingFiles:
-                                break;
-                            default:
-                            {
-                                WorkunitUpdate wu(&cw->lock());
-                                wu->setState(WUStateFailed);
-                            }
-                        }
                         cw.clear();
                         factory->deleteWorkUnit(wuid);
                         AuditSystemAccess(context.queryUserId(), true, "Deleted %s", wuid);
                     }
-                   break;
+                    break;
                 case ActionAbort:
                     ensureWsWorkunitAccess(context, *cw, SecAccess_Full);
                     {


### PR DESCRIPTION
When a user wants to delete an active WU, the existing code
sets the WU state to failed and, then, deletes it. That may
get other weird behaviour like running workunits unable to
load their DLLs, etc. This fix removes the code for setting
the WU state to failed and tells the user to abort the
active WU before deleting.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
