### PR TITLE
HPCC-13555 Changes to hpcc-init.in and hpcc_common.in for Force stop

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -49,6 +49,7 @@ function print_usage {
     echo "Usage: $0 [-c component] {start|stop|restart|status|setup}
        $0 [--componentlist] Display node component name list.
        $0 [--typelist] Display node component type list.
+       $0 [-f] [--force] Force hard kill on orphaned process groups
        $0 [-h] [--help] Display help"
     echo
     print_components
@@ -104,7 +105,7 @@ TRACE=${TRACE:-0}
 VERBOSE=${VERBOSE:-0}
 COMP_BY_TYPE=${COMP_BY_TYPE:-0}
 DAFILESRV=${DAFILESRV:-0}
-
+FORCE=${FORCE:-NO_FORCE}
 
 set_environmentvars
 envfile=$configs/$environment
@@ -218,7 +219,7 @@ component=""
 runSetupOnly=0
 dafilesrvflag=0
 
-TEMP=`/usr/bin/getopt -o c:hd --long help,componentlist,typelist,debug -n 'hpcc-init' -- "$@"`
+TEMP=`/usr/bin/getopt -o c:hdf --long help,componentlist,typelist,debug,force -n 'hpcc-init' -- "$@"`
 if [ $? != 0 ] ; then echo "Failure to parse commandline." >&2 ; exit 1 ; fi
 eval set -- "$TEMP"
 while true ; do
@@ -250,6 +251,8 @@ while true ; do
             fi
             shift 2 ;;
         -d|--debug) DEBUG="DEBUG"
+                    shift ;;
+        -f|--force) FORCE="FORCE"
                     shift ;;
         -h|--help)  print_usage
                     shift ;;

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -389,11 +389,10 @@ startCmd() {
     # Creating logfiles for component
     logDir=$log/${compName}
 
-    if [ ${noStatusCheck} -ne 1 ]; then
+    if [[ ${noStatusCheck} -ne 1 ]]; then
         check_status ${PIDPATH} ${LOCKPATH} ${COMPPIDPATH} 1
         RCSTART=$?
-        if [ ${RCSTART} -gt 1 ];then
-            # take care of failure message in check_status function
+        if [[ ${RCSTART} -eq 4 ]];then
             checkPidExist $PIDPATH
             local initRunning=$__pidExists
             checkPidExist $COMPPIDPATH
@@ -402,17 +401,36 @@ startCmd() {
                 log "Orphaned Process"
                 cleanup_component
                 if [[ $? -eq 1 ]]; then
+                    log "Attempt to clean up component has failed"
+                    log_failure_msg
+                    return 1
+                fi
+            fi
+            # do cleanup on successful cleanup_component return
+            # and if RCSTART -eq 4 due to lockfile still being present
+            log "Attempt to clean up component was successful"
+            cleanupRuntimeEnvironment
+        elif [[ ${RCSTART} -eq 2 ]]; then
+            log "The component $compName was previously started but is in an unhealthy state"
+            log "   Could possibly still be attempting to start.  Use the force flag to attmpt a restart"
+            if [[ ${FORCE:-NO_FORCE} == "FORCE" ]]; then
+                cleanup_component
+                if [[ $? -eq 1 ]]; then
+                    log "Attempt to clean up unleathy state of $compName failed"
                     log_failure_msg
                     return 1
                 else
-                     cleanupRuntimeEnvironment
+                    cleanupRuntimeEnvironment
                 fi
+            else
+                # component is already started but waiting to become healthy
+                log_success_msg "Waiting on sentinel file creation"
+                return 0
             fi
-        fi
-        if [ ${RCSTART} -eq 0 ]; then
+        elif [[ ${RCSTART} -eq 0 ]]; then
             #Since component is already started but current script is failed till returning 0
             log "$compName ---> already started"
-            log_success_msg "Already Started"
+            log_success_msg
             return ${RCSTART}
         fi
     fi
@@ -517,12 +535,23 @@ stop_component() {
     FAILED=0
     check_status ${PIDPATH} ${LOCKPATH} ${COMPPIDPATH} 0
     RCSTOP=$?
-    if [ $RCSTOP -ne 0 ];then
-      log "Already stopped"
-      log_success_msg "Already stopped"
-      cleanup_component
-      cleanupRuntimeEnvironment
-      return 0
+    if [[ ${RCSTOP} -eq 1 ]];then
+        log "Already stopped"
+        log_success_msg
+        return 0
+    elif [[ ${RCSTOP} -eq 4 ]]; then
+        log "Orphaned process found"
+        cleanup_component
+        local ccReturn=$?
+        if [[ ${ccReturn} -eq 0 ]]; then
+            cleanupRuntimeEnvironment
+            log_success_msg
+            return 0
+        else
+            log "Failed to clean up orphans for $compName"
+            log_failure_msg
+            return 1
+        fi
     fi
 
     stopcmd="${START_STOP_DAEMON} -K -p ${PIDPATH} >> tmp.txt 2>&1"
@@ -947,31 +976,39 @@ cleanup_component() {
         mpid=$__pidValue
     fi
 
-    # start with SIGTERM and then follow up with SIGKILL if unsuccessful
+    # start with SIGTERM and then follow up with SIGKILL if unsuccessful and force flag is set
     if [ $mpid -ne 0 ] ; then
         # use the mpid we collected to grab the group pid of the process, to kill off all siblings at once
         local pgid=$( ps -p $mpid -o pid,pgid | grep $mpid | awk '{ print $2 }' )
 
-        kill -15 -$pgid
+        kill -SIGTERM -$pgid > /dev/null 2>&1
         sleep 1
-        local WAITTIME=5
+        local WAITTIME=60
         local RUNNING=1
         while [[ ${WAITTIME} -gt 0 ]]; do
-            WAITTIME=`expr ${WAITTIME} - 1`
+            ((WAITTIME--))
             kill -0 -$pgid &> /dev/null
-            if [ $? -ne 0 ];then
+            if [[ $? -ne 0 ]];then
                 log "${compName} orphans cleaned up"
                 RUNNING=0
                 break;
             else
-                log "Waiting for ${compName} orphans to cleanup gracefully"
+                [[ "((WAITTIME % 5))" -eq 0 ]] && log "Waiting for ${compName} orphans to cleanup gracefully"
                 sleep 1
             fi
         done
 
-        if [[ ${RUNNING} -eq 1 ]]; then
-            log "sending SIGKILL to ${compName} orphans"
-            kill -9 -$pgid
+        # if still running and Force option is set, send sigkill
+        if [[ ${RUNNING} -eq 1 && ${FORCE:-NO_FORCE} == "FORCE" ]]; then
+            log "WARNING Force flag is set"
+            log "WARNING sending SIGKILL to orphans in pid group for ${compName}"
+            log "INFO    If sockets used by the process are still in a TIME_WAIT state"
+            log "INFO       due to unclean shutdown, the operating system possibly will"
+            log "INFO       not release them until 60 seconds after SIGKILL was sent"
+            kill -SIGKILL -$pgid > /dev/null 2>&1
+            [[ $? -eq 0 ]] && RUNNING=0
+        elif [[ ${RUNNING} -eq 1 && ${FORCE:-NO_FORCE} == "NO_FORCE" ]]; then
+            log "INFO    Unable to kill with SIGTERM.  Use --force|-f to attempt SIGKILL"
         fi
     fi
     return $RUNNING

--- a/initfiles/sbin/hpcc-run.sh.in
+++ b/initfiles/sbin/hpcc-run.sh.in
@@ -34,6 +34,8 @@ print_usage(){
     echo "  -n|--concurrent: How many concurrent instances to run. The default is equal to the number of nodes present."
     echo "  -S|--sequentially: For the command to run sequentially. i.e. one host a time. (overrides -n)"
     echo "  -s|--save: Save the result to a file named by ip."
+    echo "  -f|--force: Force kill orphaned process groups"
+    echo "  -d|--debug: set debug flag for hpcc-init on each node in the cluster"
     echo
     end 1
 }
@@ -69,23 +71,19 @@ createIPListFileExcludeDIP(){
 doOneIP(){
     local _ip=$1
     local _action=$2
-    local _cmd=$3
-    local _comp=$4
+    shift 2
+    local _args=$(echo "$@" | tr '\n' ' ')
 
     if ping -c 1 -w 5 -n $_ip > /dev/null 2>&1; then
         #echo "$_ip: Host is alive."
         local CAN_SSH="`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@$_ip exit > /dev/null 2>&1; echo $?`"
         if [[ "$CAN_SSH" -eq 255 ]]; then
-            echo "$_ip: Cannot SSH to host.";
+            echo "$_ip: Cannot SSH to host."
             return 1
         else
             hpccStatusFile=/tmp/hpcc_status_$$
-            if [[ -z "${_comp}" ]]; then
-                local CMD="sudo /etc/init.d/$_action $_cmd"
-            else
-                local CMD="sudo /etc/init.d/$_action -c $_comp $_cmd"
-            fi
-            echo "$_ip: Running $CMD";
+            local CMD="sudo /etc/init.d/$_action $_args"
+            echo "$_ip: Running $CMD"
             local CMD="$CMD | tee ${hpccStatusFile}"
 
             ssh -i $home/$user/.ssh/id_rsa $user@$_ip $CMD;
@@ -106,8 +104,8 @@ doOneIP(){
 createScript(){
     local _scriptFile=$1
     local _action=$2
-    local _cmd=$3
-    local _comp=$4
+    shift 2
+    local _args=$( echo "$@" | tr '\n' ' ')
     local hpccStatusFile=/tmp/hpcc_status_${dateTime}_$$
 
     cat > $_scriptFile <<SCRIPTFILE
@@ -117,15 +115,11 @@ if ping -c 1 -w 5 -n \$IP > /dev/null 2>&1; then
     echo "\$IP: Host is alive."
     CAN_SSH="\`ssh -i $home/$user/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $user@\$IP exit > /dev/null 2>&1; echo \$?\`"
     if [[ "\$CAN_SSH" -eq 255 ]]; then
-        echo "\$IP: Cannot SSH to host.";
+        echo "\$IP: Cannot SSH to host."
         exit 1
     else
-        if [[ -z "${_comp}" ]]; then
-            CMD="sudo /etc/init.d/$_action $_cmd"
-        else
-            CMD="sudo /etc/init.d/$_action -c $_comp $_cmd"
-        fi
-        echo "\$IP: Running \$CMD";
+        CMD="sudo /etc/init.d/$_action $_args"
+        echo "\$IP: Running \$CMD"
         CMD="\$CMD | tee $hpccStatusFile"
         ssh -i $home/$user/.ssh/id_rsa $user@\$IP \$CMD;
         rc=\${PIPESTATUS[0]}
@@ -166,7 +160,7 @@ runScript() {
 doSetup() {
     init setup
     scriptFile=/tmp/${action}_setup_$$
-    createScript $scriptFile $action "setup" $comp
+    createScript $scriptFile $action $args setup
     runScript
     report "${action} setup"
 }
@@ -174,7 +168,7 @@ doSetup() {
 doStatus() {
     init status
     scriptFile=/tmp/${action}_status_$$
-    createScript $scriptFile $action "status" $comp
+    createScript $scriptFile $action $args status
     runScript
     report "${action} status"
 }
@@ -183,19 +177,22 @@ doStop() {
     echo "$action stop in the cluster ..."
     init stop
     scriptFile=/tmp/${action}_stop_$$
-    createScript $scriptFile $action "stop" $comp
+    createScript $scriptFile $action $args stop
     if [[ -n "${comp}" ]]; then
         OPTIONS="${DEFAULT_OPTIONS} -h $IPsFile"
         runScript $IPsFile
         report "${action} stop"
     else
         if [[ -e $IPsExcludeDIP ]]; then
-            OPTIONS="${DEFAULT_OPTIONS} -h $IPsExcludeDIP"
-            runScript $IPsExcludeDIP
-            report "${action} stop" $DIP
+            local numIPs=$(wc -l $IPsExcludeDIP | awk '{ print $1 }')
+            if [[ $numIPs -gt 0 ]]; then
+                OPTIONS="${DEFAULT_OPTIONS} -h $IPsExcludeDIP"
+                runScript $IPsExcludeDIP
+                report "${action} stop" $DIP
+            fi
         fi
         for _dip in $DIP; do
-            doOneIP $_dip $action "stop" $comp || end 1
+            doOneIP $_dip $action $args stop || end 1
         done
     fi
 }
@@ -214,22 +211,25 @@ doStart() {
         local startFile=$IPsFile
     else
         for _dip in $DIP; do
-            doOneIP $_dip $action "start" $comp || end 1
+            doOneIP $_dip $action $args start || end 1
         done
         local startFile=$IPsExcludeDIP
     fi
     if [[ -e $startFile ]]; then
-        echo "$action start in the cluster ..."
-        scriptFile=/tmp/${action}_start_$$
-        createScript $scriptFile $action "start" $comp
-        OPTIONS="${DEFAULT_OPTIONS} -h $startFile"
-        runScript $startFile
-        if [[ -n "${comp}" ]]; then
-            report "${action} start"
-        else
-            report "${action} start" $DIP
+        local numIPs=$(wc -l $startFile | awk '{ print $1 }')
+        if [[ $numIPs -gt 0 ]]; then
+            echo "$action start in the cluster ..."
+            scriptFile=/tmp/${action}_start_$$
+            createScript $scriptFile $action $args start
+            OPTIONS="${DEFAULT_OPTIONS} -h $startFile"
+            runScript $startFile
+            if [[ -n "${comp}" ]]; then
+                report "${action} start"
+            else
+                report "${action} start" $DIP
+            fi
+            [[ $rc -ne 0 ]] && end $rc
         fi
-        [[ $rc -ne 0 ]] && end $rc
     fi
 }
 
@@ -296,7 +296,6 @@ fi
 envfile=$configs/$environment
 configfile=${CONFIG_DIR}/${ENV_CONF_FILE}
 
-
 hasPython=0
 save=0
 expected_python_version=2.6
@@ -307,12 +306,17 @@ RUN_CLUSTER_DISPLAY_OUTPUT=FALSE
 
 DEFAULT_OPTIONS="-e $configfile -s ${SECTION:-DEFAULT}"
 
-TEMP=`/usr/bin/getopt -o a:c:n:sSh --long help,comp:,action:,save,concurrent:,sequentially -n 'hpcc-run' -- "$@"`
+TEMP=`/usr/bin/getopt -o a:c:n:sShfd --long help,comp:,action:,save,concurrent:,sequentially,force,debug -n 'hpcc-run' -- "$@"`
 if [[ $? != 0 ]] ; then echo "Failure to parse commandline." >&2 ; end 1 ; fi
 eval set -- "$TEMP"
 while true ; do
     case "$1" in
         -c|--comp) comp=$2
+            if [[ -z ${args} ]]; then
+                args="-c $2"
+            else
+                args="${args} -c $2"
+            fi
             shift 2 ;;
         -a|--action) action=$2
             shift 2 ;;
@@ -327,6 +331,18 @@ while true ; do
             shift ;;
         -s|--save) save=1
             shift ;;
+        -f|--force) if [[ -z ${args} ]]; then
+                        args="-f"
+                    else
+                        args="${args} -f"
+                    fi
+                    shift ;;
+        -d|--debug) if [[ -z ${args} ]]; then
+                        args="-d"
+                    else
+                        args="${args} -d"
+                    fi
+                    shift ;;
         -h|--help) print_usage
             shift ;;
         --) shift ; break ;;

--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -54,14 +54,8 @@ function pidwait_fn () {
     done
 
     if [[ $TIMEOUT -le 0 ]] && ps -p $WATCH_PID -o command= | grep "${PROCESS}" &>/dev/null ; then
-      echo "Failed to kill ${PROCESS} gracefully, sending SIGKILL"
-      kill -9 $WATCH_PID &>/dev/null
-      sleep 1
-      kill -0 $WATCH_PID &>/dev/null
-      # if still alive
-      if [[ $? -eq 0 ]]; then
-        return 1
-      fi
+      log "Failed to kill ${PROCESS} with SIGTERM"
+      return 1
     fi
 
     rm -f $PID > /dev/null 2>&1


### PR DESCRIPTION
Added a force option to cleanup_component that gets ran depending on the check_status return before the bulk of stop_component or startCmd are ran.  If we don't explicitly state -f|--force then the cleanup_component code will only use SIGTERM and not attempt to do a SIGKILL on the pgid of the process.  Allows for use in hpcc-init as well as in hpcc-run.sh

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
