### PR TITLE
HPCC-13800 Avoid potential Dali crash, as nodes being destroyed.

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -2506,8 +2506,8 @@ public:
     {
         if (!_child)
             return false;
-        Linked<CServerRemoteTree> child = QUERYINTERFACE(_child, CServerRemoteTree);
-        assertex(child);
+        dbgassertex(QUERYINTERFACE(_child, CServerRemoteTree));
+        Linked<CServerRemoteTree> child = static_cast<CServerRemoteTree *>(_child);
         if (!CRemoteTreeBase::removeTree(child))
             return false;
         CHECKEDCRITICALBLOCK(SDSManager->treeRegCrit, fakeCritTimeout);


### PR DESCRIPTION
Avoid leaving deleted SDS nodes in the tree table, which can be
looked up and then destroyed asynchronously, potentially causing
a crash.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
