### PR TITLE
HPCC-13801 Place unittests executable in standard HPCC directory

### DIFF
--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -46,7 +46,7 @@ ADD_DEFINITIONS( -D_CONSOLE )
 
 HPCC_ADD_EXECUTABLE ( unittests ${SRCS} )
 
-install ( TARGETS unittests DESTINATION ${OSSDIR}/bin )
+install ( TARGETS unittests RUNTIME DESTINATION ${EXEC_DIR} )
 target_link_libraries ( unittests
          jlib
          remote


### PR DESCRIPTION
Signed-off-by: Jake Smith jake.smith@lexisnexis.com
