### PR TITLE
HPCC-13802 Fix misleading memory exception - reported K vs bytes

### DIFF
--- a/system/jlib/jbuff.cpp
+++ b/system/jlib/jbuff.cpp
@@ -117,8 +117,8 @@ public:
     { 
         str.append("Jbuff: Out of Memory (").append((unsigned __int64)wanted);
         if (got) 
-            str.append(',').append((unsigned __int64)(got/1024));
-        return str.append("k)");
+            str.append(',').append((unsigned __int64)got);
+        return str.append(")");
     }
     MessageAudience errorAudience() const { return MSGAUD_user; }
 };


### PR DESCRIPTION
Signed-off-by: Jake Smith jake.smith@lexisnexis.com
