### PR TITLE
HPCC-13809 LDAP OU values should allow spaces

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -435,18 +435,8 @@ public:
     {
         if(dn == NULL || dn[0] == '\0')
             return;
-
-        const char* ptr = dn;
-        while(ptr && *ptr != '\0')
-        {
-            char c = *ptr;
-            if(!isspace(c))
-            {
-                c = tolower(c);
-                dnbuf.append(c);
-            }
-            ptr++;
-        }
+        dnbuf.append(dn);
+        dnbuf.toLowerCase();
     }
     
     static bool getDcName(const char* domain, StringBuffer& dc)


### PR DESCRIPTION
When reading the configuration, all spaces are incorrectly removed from OU
values. This is incorrect, for instance the RISK domain specifies
"OU=User Accounts"  This PR allows spaces within the string

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
