### PR TITLE
HPCC-13608 Return warning message if too many files

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2465,6 +2465,7 @@ IConstQuerySetQueryIterator* CWorkUnitFactory::getQuerySetQueriesSorted( WUQuery
             sortElements(iter, sortOrder.get(), NULL, NULL, unknownAttributes, elements);
             return conn.getClear();
         }
+        virtual bool allMatchingElementsReceived() { return true; } //For now, dali always returns all of matched Queries.
     };
     StringAttr querySet;
     StringBuffer xPath;
@@ -2517,7 +2518,7 @@ IConstQuerySetQueryIterator* CWorkUnitFactory::getQuerySetQueriesSorted( WUQuery
     }
     IArrayOf<IPropertyTree> results;
     Owned<IElementsPager> elementsPager = new CQuerySetQueriesPager(querySet.get(), xPath.str(), so.length()?so.str():NULL, postFilters, unknownAttributes, _subset);
-    Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,"",cachehint,results,total);
+    Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,"",cachehint,results,total,NULL);
     return new CConstQuerySetQueryIterator(results);
 }
 
@@ -2711,6 +2712,7 @@ public:
                 sortElements(iter, sortOrder.get(), nameFilterLo.get(), nameFilterHi.get(), unknownAttributes, elements);
                 return conn.getClear();
             }
+            virtual bool allMatchingElementsReceived() { return true; }//For now, dali always returns all of matched WUs.
         };
         class CScopeChecker : public CSimpleInterface, implements ISortedElementsTreeFilter
         {
@@ -2795,7 +2797,7 @@ public:
         }
         IArrayOf<IPropertyTree> results;
         Owned<IElementsPager> elementsPager = new CWorkUnitsPager(query.str(), so.length()?so.str():NULL, namefilterlo.get(), namefilterhi.get(), unknownAttributes);
-        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,secmgr?sc:NULL,"",cachehint,results,total);
+        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,secmgr?sc:NULL,"",cachehint,results,total,NULL);
         return new CConstWUArrayIterator(results);
     }
 

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -48,7 +48,7 @@ interface IUserDescriptor;
 #define S_LINK_RELATIONSHIP_KIND "link"
 #define S_VIEW_RELATIONSHIP_KIND "view"
 
-
+#define ITERATE_FILTEREDFILES_LIMIT 100000
 
 interface IDistributedSuperFile;
 interface IDistributedFile;
@@ -192,7 +192,8 @@ enum DFUQSerializeFileAttrOption
 enum DFUQSpecialFilter
 {
     DFUQSFFileNameWithPrefix = 1,
-    DFUQSFFileType = 2
+    DFUQSFFileType = 2,
+    DFUQSFMaxFiles = 3
 };
 
 enum DFUQFileTypeFilter
@@ -560,7 +561,7 @@ interface IDistributedFileDirectory: extends IInterface
             // wildname is in form scope/name and may contain wild components for either
     virtual IDFAttributesIterator *getDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive=true, bool includesuper=false, INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
     virtual IPropertyTreeIterator *getDFAttributesTreeIterator(const char *filters, DFUQResultField* localFilters,
-        const char *localFilterBuf, IUserDescriptor *user, INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
+        const char *localFilterBuf, IUserDescriptor *user, bool& allMatchingFilesReceived, INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
     virtual IDFAttributesIterator *getForeignDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive=true, bool includesuper=false, const char *foreigndali="", unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
 
     virtual IDFScopeIterator *getScopeIterator(IUserDescriptor *user, const char *subscope=NULL,bool recursive=true,bool includeempty=false)=0;
@@ -665,7 +666,7 @@ interface IDistributedFileDirectory: extends IInterface
 
     virtual IDFProtectedIterator *lookupProtectedFiles(const char *owner=NULL,bool notsuper=false,bool superonly=false)=0; // if owner = NULL then all
     virtual IDFAttributesIterator* getLogicalFilesSorted(IUserDescriptor* udesc, DFUQResultField *sortOrder, const void* filters, DFUQResultField *localFilters,
-            const void *specialFilterBuf, unsigned startOffset, unsigned maxNum, __int64 *cacheHint, unsigned *total) = 0;
+            const void *specialFilterBuf, unsigned startOffset, unsigned maxNum, __int64 *cacheHint, unsigned *total, bool *allMatchingFilesReceived) = 0;
 
     virtual unsigned setDefaultTimeout(unsigned timems) = 0;                                // sets default timeout for SDS connections and locking
                                                                                             // returns previous value
@@ -733,7 +734,8 @@ enum DistributedFileSystemError
     DFSERR_ClusterNotFound,
     DFSERR_ClusterAlreadyExists,
     DFSERR_LookupConnectionTimout,       // only raised if timeout specified on lookup etc.
-    DFSERR_FailedToDeleteFile
+    DFSERR_FailedToDeleteFile,
+    DFSERR_PassIterateFilesLimit
 };
 
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -1965,6 +1965,7 @@ IRemoteConnection *getElementsPaged( IElementsPager *elementsPager,
                                      __int64 *hint,
                                      IArrayOf<IPropertyTree> &results,
                                      unsigned *total,
+                                     bool *allMatchingElementsReceived,
                                      bool checkConn)
 {
     if ((pagesize==0) || !elementsPager)
@@ -2038,6 +2039,8 @@ IRemoteConnection *getElementsPaged( IElementsPager *elementsPager,
             results.append(item);
         }
     }
+    if (allMatchingElementsReceived)
+        *allMatchingElementsReceived = elementsPager->allMatchingElementsReceived();
     IRemoteConnection *ret = NULL;
     if (elem->conn)
         ret = elem->conn.getLink();

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -271,6 +271,7 @@ interface ISortedElementsTreeFilter : extends IInterface
 interface IElementsPager : extends IInterface
 {
     virtual IRemoteConnection *getElements(IArrayOf<IPropertyTree> &elements) = 0;
+    virtual bool allMatchingElementsReceived() = 0;
 };
 extern da_decl void sortElements( IPropertyTreeIterator* elementsIter,
                                      const char *sortorder, 
@@ -287,6 +288,7 @@ extern da_decl IRemoteConnection *getElementsPaged(IElementsPager *elementsPager
                                      __int64 *hint,                         // if non null points to in/out cache hint
                                      IArrayOf<IPropertyTree> &results,
                                      unsigned *total,
+                                     bool *allMatchingElementsReceived,
                                      bool checkConn = true); // total possible filtered matches, i.e. irrespective of startoffset and pagesize
 
 extern da_decl void clearPagedElementsCache();

--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -3041,6 +3041,7 @@ public:
                 sortElements(iter, sortOrder.get(), nameFilterLo.get(), nameFilterHi.get(), unknownAttributes, elements);
                 return conn.getClear();
             }
+            virtual bool allMatchingElementsReceived() { return true; }//For now, dali always returns all of matched WUs.
         };
 
         StringBuffer query;
@@ -3095,7 +3096,7 @@ public:
         }
         IArrayOf<IPropertyTree> results;
         Owned<IElementsPager> elementsPager = new CDFUWorkUnitsPager(query.str(), so.length()?so.str():NULL, namefilterlo.get(), namefilterhi.get(), unknownAttributes);
-        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,queryowner,cachehint,results,total);
+        Owned<IRemoteConnection> conn=getElementsPaged(elementsPager,startoffset,maxnum,NULL,queryowner,cachehint,results,total, NULL);
         return new CConstDFUWUArrayIterator(this,conn,results);
     }
 

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -172,6 +172,7 @@ ESPrequest [nil_remove] DFUQueryRequest
 
     bool OneLevelDirFileReturn(false);
     [min_ver("1.24")] int64 CacheHint;
+    [min_ver("1.30")] int MaxNumberOfFiles;
     [min_ver("1.30")] bool IncludeSuperOwner;
 };
 
@@ -211,6 +212,8 @@ DFUQueryResponse
     string ParametersForPaging;
     string Filters;
     [min_ver("1.24")] int64 CacheHint;
+    [min_ver("1.30")] bool IsSubsetOfFiles;
+    [min_ver("1.30")] string Warning;
 };
 
 ESPrequest 

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -78,6 +78,7 @@ private:
     bool addDFUQueryFilter(DFUQResultField *filters, unsigned short &count, MemoryBuffer &buff, const char* value, DFUQResultField name);
     void appendDFUQueryFilter(const char *name, DFUQFilterType type, const char *value, StringBuffer& filterBuf);
     void appendDFUQueryFilter(const char *name, DFUQFilterType type, const char *value, const char *valueHigh, StringBuffer& filterBuf);
+    void setFileIterateFilter(unsigned maxFiles, StringBuffer &filterBuf);
     void setFileTypeFilter(const char* fileType, StringBuffer& filterBuf);
     void setFileNameFilter(const char* fname, const char* prefix, StringBuffer &buff);
     void setDFUQueryFilters(IEspDFUQueryRequest& req, StringBuffer& filterBuf);


### PR DESCRIPTION
In some environment with many logical files, the "Jbuf: out of
memory" occurs when sorting the files on ESP for "Browse Logical
Files". As a short term fix, instead of returning all files, dali
will return to client (ESP) N files and a flag which indicates
that the N files are a subset of all matches. (The N value may be
specified by a client). ESP forwards the N files (with paging) to
its client with a warning message about the subset of files.

A long term fix will be done in HPCC-13425 later.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
