### PR TITLE
HPCC-13821 Ensure owner activity initialized on child query init

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -554,7 +554,13 @@ void CGraphElementBase::onCreate()
     if (!nullAct)
     {
         CGraphElementBase *ownerActivity = owner->queryOwner() ? owner->queryOwner()->queryElement(ownerId) : NULL;
-        baseHelper->onCreate(queryCodeContext(), ownerActivity ? ownerActivity->queryHelper() : NULL, haveCreateCtx?&createCtxMb:NULL);
+        if (ownerActivity)
+        {
+            ownerActivity->onCreate(); // ensure owner created, might not be if this is child query inside another child query.
+            baseHelper->onCreate(queryCodeContext(), ownerActivity->queryHelper(), haveCreateCtx?&createCtxMb:NULL);
+        }
+        else
+            baseHelper->onCreate(queryCodeContext(), NULL, haveCreateCtx?&createCtxMb:NULL);
     }
 }
 


### PR DESCRIPTION
If a child query initialization is dependent on an owner activity
and that owner is in a higher child activity, need to ensure it
too is initialized.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
