### PR TITLE
HPCC-13188 Dependency helper file not displayed

### DIFF
--- a/esp/src/eclwatch/HelpersWidget.js
+++ b/esp/src/eclwatch/HelpersWidget.js
@@ -196,6 +196,7 @@ define([
                             break;
                         case "Workunit XML":
                         case "Archive Query":
+                        case "xml":
                             sourceMode = "xml";
                             break;
                     }
@@ -208,7 +209,7 @@ define([
                             params: {
                                 Wuid: Wuid,
                                 sourceMode: sourceMode,
-                                sourceURL: this._getURL(row)
+                                sourceURL: this._getURL(row, id)
                             }
                         }
                     });


### PR DESCRIPTION
Within workunit details a helper file was not being displayed. Added expected parameter and it corrects the issue.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
