### PR TITLE
HPCC-13496 Fix compilation Error: 'this' pointer and references cannot be null

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -262,7 +262,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
       SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Werror=bitwise-op-parentheses -Werror=tautological-compare")
       SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wno-switch-enum -Wno-format-zero-length -Wno-switch")
       if (CLANG_VERSION VERSION_GREATER 3.6 OR CLANG_VERSION VERSION_EQUAL 3.6)
-        SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-bool-conversion -Wno-pointer-bool-conversion -Wno-tautological-compare")
+        SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pointer-bool-conversion")
       endif()
     endif()
     # All of these are defined in platform.h too, but need to be defned before any system header is included

--- a/common/deftype/deffield.cpp
+++ b/common/deftype/deffield.cpp
@@ -284,7 +284,7 @@ static void addElementToPTree(IPropertyTree * root, IDefRecordElement * elem)
     case DEKfield:
         {
             branchName.set("Field");
-            branch->setProp("@name", elem->queryName()->str());
+            branch->setProp("@name", str(elem->queryName()));
             branch->setPropInt("@maxSize", elem->getMaxSize());
             StringBuffer type;
             elem->queryType()->getDescriptiveType(type);

--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -856,13 +856,13 @@ unsigned CStringTypeInfo::getCrc()
     unsigned crc = CTypeInfo::getCrc();
     if (charset)
     {
-        const char * name = charset->queryName()->str();
+        const char * name = str(charset->queryName());
         //MORE: This and following should really be case insensitive, but we get away with it at the moment because the atoms are created very early
         crc = hashc((const byte *)name, (size32_t)strlen(name), crc);
     }
     if (collation)
     {
-        const char * name = collation->queryName()->str();
+        const char * name = str(collation->queryName());
         crc = hashc((const byte *)name, (size32_t)strlen(name), crc);
     }
     return crc;
@@ -886,9 +886,9 @@ StringBuffer &CStringTypeInfo::getDescriptiveType(StringBuffer &out)
     if(charset || collation)
     {
         out.append(" (");
-        if(charset) out.append("charset:").append(charset->queryName()->str());
+        if(charset) out.append("charset:").append(str(charset->queryName()));
         if(charset && collation) out.append(", ");
-        if(collation) out.append("collation:").append(collation->queryName()->str());
+        if(collation) out.append("collation:").append(str(collation->queryName()));
         out.append(")");
     }
     return out;
@@ -920,7 +920,7 @@ IValue * CUnicodeTypeInfo::castFrom(double value)
 
 IValue * CUnicodeTypeInfo::castFrom(size32_t len, const char * text)
 {
-    Owned<IValue> unicodeValue = createUnicodeValue(text, len, locale->str(), false);
+    Owned<IValue> unicodeValue = createUnicodeValue(text, len, str(locale), false);
     return unicodeValue->castTo(this);
 }
 
@@ -932,8 +932,8 @@ IValue * CUnicodeTypeInfo::castFrom(size32_t len, const UChar * uchars)
 StringBuffer &CUnicodeTypeInfo::getECLType(StringBuffer &out)
 {
     out.append("unicode");
-    if(locale && *locale->str())
-        out.append('_').append(locale->str());
+    if(locale && *str(locale))
+        out.append('_').append(str(locale));
     if(length != UNKNOWN_LENGTH)
         out.append(length/2);
     return out;
@@ -964,7 +964,7 @@ CVarUnicodeTypeInfo::CVarUnicodeTypeInfo(unsigned len, IAtom * _locale) : CUnico
 
 IValue * CVarUnicodeTypeInfo::castFrom(size32_t len, const char * text)
 {
-    Owned<IValue> unicodeValue = createVarUnicodeValue(text, len, locale->str(), false);
+    Owned<IValue> unicodeValue = createVarUnicodeValue(text, len, str(locale), false);
     return unicodeValue->castTo(this);
 }
 
@@ -976,8 +976,8 @@ IValue * CVarUnicodeTypeInfo::castFrom(size32_t len, const UChar * uchars)
 StringBuffer & CVarUnicodeTypeInfo::getECLType(StringBuffer & out)
 {
     out.append("varunicode");
-    if(locale && *locale->str())
-        out.append('_').append(locale->str());
+    if(locale && *str(locale))
+        out.append('_').append(str(locale));
     if(length != UNKNOWN_LENGTH)
         out.append(length/2-1);
     return out;
@@ -999,8 +999,8 @@ IValue * CUtf8TypeInfo::castFrom(size32_t len, const UChar * uchars)
 StringBuffer &CUtf8TypeInfo::getECLType(StringBuffer &out)
 {
     out.append("utf8");
-    if(locale && *locale->str())
-        out.append('_').append(locale->str());
+    if(locale && *str(locale))
+        out.append('_').append(str(locale));
     if(length != UNKNOWN_LENGTH)
         out.append('_').append(length/4);
     return out;
@@ -1067,9 +1067,9 @@ StringBuffer &CVarStringTypeInfo::getDescriptiveType(StringBuffer &out)
     if(charset || collation)
     {
         out.append(" (");
-        if(charset) out.append("charset:").append(charset->queryName()->str());
+        if(charset) out.append("charset:").append(str(charset->queryName()));
         if(charset && collation) out.append(", ");
-        if(collation) out.append("collation:").append(collation->queryName()->str());
+        if(collation) out.append("collation:").append(str(collation->queryName()));
         out.append(")");
     }
     return out;
@@ -3010,7 +3010,7 @@ ICharsetInfo * getCharset(IAtom * atom)
 ICollationInfo * getCollation(IAtom * atom)
 {
 #if _DEBUG
-    const char* name = atom->str();
+    const char* name = str(atom);
 #endif
 
     if ((atom == NULL) || (atom == asciiAtom) || (atom == dataAtom) || (atom == utf8Atom))
@@ -3140,7 +3140,7 @@ ITypeInfo * getBorType(ITypeInfo * lType, ITypeInfo * rType)
 
 bool hasDefaultLocale(ITypeInfo * type)
 {
-    return ((type->queryLocale() == 0) || (*type->queryLocale()->str() == 0));
+    return ((type->queryLocale() == 0) || (*str(type->queryLocale()) == 0));
 }
 
 bool haveCommonLocale(ITypeInfo * type1, ITypeInfo * type2)

--- a/common/deftype/deftype.ipp
+++ b/common/deftype/deftype.ipp
@@ -161,7 +161,7 @@ public:
     virtual bool isInteger()                    { return false; };
     virtual bool isScalar()                     { return true; }
 
-    virtual void serialize(MemoryBuffer &tgt)   { CTypeInfo::serialize(tgt); tgt.append(getStringLen()).append(locale->str()); }
+    virtual void serialize(MemoryBuffer &tgt)   { CTypeInfo::serialize(tgt); tgt.append(getStringLen()).append(str(locale)); }
 protected:
     IAtom * locale;
 };
@@ -883,11 +883,11 @@ public:
     virtual IAtom * queryName()                           { return name; }
     virtual ICollationInfo * queryDefaultCollation();
     virtual unsigned char queryFillChar()               { return fillChar; }
-    virtual char const * queryCodepageName()            { return codepage->str(); }
+    virtual char const * queryCodepageName()            { return str(codepage); }
 
     virtual void serialize(MemoryBuffer &tgt) 
     { 
-        tgt.append(name->getAtomNamePtr());
+        tgt.append(str(name));
     }
     virtual void deserialize(MemoryBuffer &) { UNIMPLEMENTED; }
 protected:
@@ -909,7 +909,7 @@ public:
 
     virtual void serialize(MemoryBuffer &tgt) 
     { 
-        tgt.append(name->getAtomNamePtr());
+        tgt.append(str(name));
     }
     virtual void deserialize(MemoryBuffer &) { UNIMPLEMENTED; }
 protected:

--- a/common/deftype/defvalue.cpp
+++ b/common/deftype/defvalue.cpp
@@ -688,14 +688,14 @@ int UnicodeValue::compare(IValue * to)
     ITypeInfo * toType = to->queryType();
     assertex(toType->getTypeCode()==type->getTypeCode());
     assertex(haveCommonLocale(type, toType));
-    char const * locale = getCommonLocale(type, toType)->str();
+    char const * locale = str(getCommonLocale(type, toType));
     return rtlCompareUnicodeUnicode(type->getStringLen(), (const UChar *)val.get(), toType->getStringLen(), (const UChar *)to->queryValue(), locale);
 }
 
 int UnicodeValue::compare(const void *mem)
 {
     size32_t len = type->getStringLen();
-    return rtlCompareUnicodeUnicode(len, (const UChar *)val.get(), len, (const UChar *)mem, type->queryLocale()->str());
+    return rtlCompareUnicodeUnicode(len, (const UChar *)val.get(), len, (const UChar *)mem, str(type->queryLocale()));
 }
 
 bool UnicodeValue::getBoolValue()
@@ -781,7 +781,7 @@ IValue *createUnicodeValue(char const * value, ITypeInfo * type)
     if(type->getSize() == UNKNOWN_LENGTH)
     {
         type->Release();
-        return createUnicodeValue(value, (size32_t)strlen(value), type->queryLocale()->str(), false);
+        return createUnicodeValue(value, (size32_t)strlen(value), str(type->queryLocale()), false);
     }
     return createUnicodeValue(value, type, type->getStringLen());
 }
@@ -791,7 +791,7 @@ IValue *createUnicodeValue(char const * value, ITypeInfo * type, unsigned srclen
     if(type->getSize() == UNKNOWN_LENGTH)
     {
         type->Release();
-        return createUnicodeValue(value, srclen, type->queryLocale()->str(), false);
+        return createUnicodeValue(value, srclen, str(type->queryLocale()), false);
     }
     UChar * buff = (UChar *)checked_malloc(type->getSize(), DEFVALUE_MALLOC_FAILED);
     rtlCodepageToUnicode(type->getStringLen(), buff, srclen, value, "US-ASCII");
@@ -917,7 +917,7 @@ int VarUnicodeValue::compare(IValue * to)
     ITypeInfo * toType = to->queryType();
     assertex(toType->getTypeCode()==type->getTypeCode());
     assertex(haveCommonLocale(type, toType));
-    char const * locale = getCommonLocale(type, toType)->str();
+    char const * locale = str(getCommonLocale(type, toType));
     UChar const * rhs = (UChar const *) to->queryValue();
     return rtlCompareUnicodeUnicode(val.length(), val.get(), rtlUnicodeStrlen(rhs), rhs, locale);
 }
@@ -925,7 +925,7 @@ int VarUnicodeValue::compare(IValue * to)
 int VarUnicodeValue::compare(const void * mem)
 {
     UChar const * rhs = (UChar const *) mem;
-    return rtlCompareUnicodeUnicode(val.length(), val.get(), rtlUnicodeStrlen(rhs), rhs, type->queryLocale()->str());
+    return rtlCompareUnicodeUnicode(val.length(), val.get(), rtlUnicodeStrlen(rhs), rhs, str(type->queryLocale()));
 }
 
 bool VarUnicodeValue::getBoolValue()
@@ -1101,7 +1101,7 @@ IValue *Utf8Value::castTo(ITypeInfo *t)
     case type_unicode:
     case type_varunicode:
         {
-            Owned<IValue> temp = createUnicodeValue(data, rtlUtf8Size(olen, data), t->queryLocale()->str(), true, false);
+            Owned<IValue> temp = createUnicodeValue(data, rtlUtf8Size(olen, data), str(t->queryLocale()), true, false);
             return temp->castTo(t);
         }
     case type_utf8:
@@ -1142,14 +1142,14 @@ int Utf8Value::compare(IValue * to)
     ITypeInfo * toType = to->queryType();
     assertex(toType->getTypeCode()==type->getTypeCode());
     assertex(haveCommonLocale(type, toType));
-    char const * locale = getCommonLocale(type, toType)->str();
+    char const * locale = str(getCommonLocale(type, toType));
     return rtlCompareUtf8Utf8(type->getStringLen(), (const char *)val.get(), toType->getStringLen(), (const char *)to->queryValue(), locale);
 }
 
 int Utf8Value::compare(const void *mem)
 {
     size32_t len = type->getStringLen();
-    return rtlCompareUtf8Utf8(len, (const char *)val.get(), len, (const char *)mem, type->queryLocale()->str());
+    return rtlCompareUtf8Utf8(len, (const char *)val.get(), len, (const char *)mem, str(type->queryLocale()));
 }
 
 bool Utf8Value::getBoolValue()

--- a/common/fileview2/fvtransform.cpp
+++ b/common/fileview2/fvtransform.cpp
@@ -320,7 +320,7 @@ void ViewTransformerRegistry::addPlugins(const char * name)
         }
         catch (IException * e)
         {
-            const char * name = scope->queryName()->str();
+            const char * name = str(scope->queryName());
             VStringBuffer msg("Error loading plugin %s", name);
             EXCLOG(e, msg.str());
         }
@@ -409,7 +409,7 @@ ViewFieldTransformer * ViewTransformerRegistry::createTransformer(IHqlExpression
 void ViewTransformerRegistry::addServiceDefinition(IHqlExpression * service)
 {
     Owned<ViewServiceEntry> entry = new ViewServiceEntry;
-    entry->name.set(service->queryName()->str());
+    entry->name.set(str(service->queryName()));
 
     HqlExprArray symbols;
     service->queryScope()->getSymbols(symbols);

--- a/common/fileview2/fvtransform.ipp
+++ b/common/fileview2/fvtransform.ipp
@@ -65,7 +65,7 @@ public:
         : name(_name)
     {}
 
-    inline bool matches(IIdAtom * search) const { return name == search->lower(); }
+    inline bool matches(IIdAtom * search) const { return name == lower(search); }
     inline IAtom * queryName() const { return name; }
     
     virtual ViewFieldTransformer * bind(const HqlExprArray & args);

--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -209,7 +209,7 @@ public:
     ~ArchiveFileIO()
     {
 #if (ARCHIVE_VERSION_NUMBER >= 3000000)
-        //archive_read_free(archive);
+        archive_read_free(archive);
 #else
         archive_read_finish(archive);
 #endif
@@ -535,7 +535,7 @@ public:
             archive_entry_free(entry);
         }
 #if (ARCHIVE_VERSION_NUMBER >= 3000000)
-        //archive_read_free(archive);
+        archive_read_free(archive);
 #else
         archive_read_finish(archive);
 #endif

--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -209,7 +209,7 @@ public:
     ~ArchiveFileIO()
     {
 #if (ARCHIVE_VERSION_NUMBER >= 3000000)
-        archive_read_free(archive);
+        //archive_read_free(archive);
 #else
         archive_read_finish(archive);
 #endif
@@ -535,7 +535,7 @@ public:
             archive_entry_free(entry);
         }
 #if (ARCHIVE_VERSION_NUMBER >= 3000000)
-        archive_read_free(archive);
+        //archive_read_free(archive);
 #else
         archive_read_finish(archive);
 #endif

--- a/common/thorhelper/layouttrans.cpp
+++ b/common/thorhelper/layouttrans.cpp
@@ -41,7 +41,7 @@ RLTFailure * RLTFailure::appendFieldName(char const * scope, IDefRecordElement c
 {
     if(scope)
         detail.append(scope).append(scopeSeparator);
-    detail.append(field->queryName()->str());
+    detail.append(str(field->queryName()));
     return this;
 }
 
@@ -174,7 +174,7 @@ void MappingLevel::attemptMapping(IDefRecordElement const * diskRecord, unsigned
         else
         {
             Owned<FieldMapping> mapping(new FieldMapping(FieldMapping::ChildDataset, diskRecord, diskFieldNum, false, activityRecord, activityFieldNum, false));
-            MappingLevel childMappingLevel(this, diskField->queryName()->str(), mapping->queryChildMappings());
+            MappingLevel childMappingLevel(this, str(diskField->queryName()), mapping->queryChildMappings());
             childMappingLevel.calculateMappings(diskChild, 0, activityChild, 0);
             mappings.append(*mapping.getClear());
         }

--- a/common/thorhelper/layouttrans.ipp
+++ b/common/thorhelper/layouttrans.ipp
@@ -54,12 +54,12 @@ public:
         : type(_type), diskRecord(_diskRecord), diskFieldNum(_diskFieldNum), activityRecord(_activityRecord), activityFieldNum(_activityFieldNum), diskFieldKeyed(_diskFieldKeyed), activityFieldKeyed(_activityFieldKeyed) {}
     List & queryChildMappings() { return childMappings; }
     Type queryType() const { return type; }
-    char const * queryDiskFieldName() const { return diskRecord->queryChild(diskFieldNum)->queryName()->str(); }
+    char const * queryDiskFieldName() const { return str(diskRecord->queryChild(diskFieldNum)->queryName()); }
     unsigned queryDiskFieldNum() const { return diskFieldNum; }
     size32_t queryDiskFieldSize() const { return diskRecord->queryChild(diskFieldNum)->queryType()->getSize(); }
     bool isDiskFieldFpos() const { return ((type != ChildDataset) && !diskFieldKeyed && (diskFieldNum == diskRecord->numChildren()-1) && diskRecord->queryChild(diskFieldNum)->queryType()->isInteger()); }
     bool isDiskFieldSet() const { return (diskRecord->queryChild(diskFieldNum)->queryType()->getTypeCode() == type_set); }
-    char const * queryActivityFieldName() const { return activityRecord->queryChild(activityFieldNum)->queryName()->str(); }
+    char const * queryActivityFieldName() const { return str(activityRecord->queryChild(activityFieldNum)->queryName()); }
     unsigned queryActivityFieldNum() const { return activityFieldNum; }
     size32_t queryActivityFieldSize() const { return activityRecord->queryChild(activityFieldNum)->queryType()->getSize(); }
     bool isActivityFieldFpos() const { return ((type == Simple) && !activityFieldKeyed && (activityFieldNum == activityRecord->numChildren()-1) && activityRecord->queryChild(activityFieldNum)->queryType()->isInteger()); }

--- a/common/thorhelper/roxiedebug.cpp
+++ b/common/thorhelper/roxiedebug.cpp
@@ -382,7 +382,7 @@ public:
                 if (canMatchAny(childType))
                     sawMatch = true;
             }
-            if (stricmp(fields[0]->name->getAtomNamePtr(), searchFieldName)==0)
+            if (stricmp(str(fields[0]->name), searchFieldName)==0)
                 sawMatch = true;
             fields++;
         }

--- a/common/thorhelper/thorrparse.cpp
+++ b/common/thorhelper/thorrparse.cpp
@@ -2022,7 +2022,7 @@ void RegexNamedPattern::toXMLattr(StringBuffer & out, RegexXmlState & state)
 {
     RegexPattern::toXMLattr(out, state);
     if (def->queryName())
-        out.appendf(" name=\"%s\"", def->queryName()->str());
+        out.appendf(" name=\"%s\"", str(def->queryName()));
     out.appendf(" body=\"%d\"", state.named.find(*def));
 }
 
@@ -2947,11 +2947,11 @@ void RegexNamed::serializePattern(MemoryBuffer & out)
     if (name)
     {
         StringBuffer lowerName;
-        lowerName.append(name->str()).toLowerCase();
+        lowerName.append(str(name)).toLowerCase();
         out.append(lowerName.str());
     }
     else
-        out.append(name->str());
+        out.append(str(name));
 
     out.append(id);
 }
@@ -2979,7 +2979,7 @@ void graphToXML(StringBuffer & out, RegexXmlState & state, RegexPattern * first)
 void RegexNamed::toXML(StringBuffer & out, RegexXmlState & state)
 {
     StringBuffer lowerName;
-    lowerName.append(name->str()).toLowerCase();
+    lowerName.append(str(name)).toLowerCase();
     out.appendf("<named id=\"%d\" name=\"%s\" matchid=\"%d\" first=\"%d\">", state.named.find(*this), lowerName.str(), id, state.patterns.find(*first)).newline();
     graphToXML(out, state, first);
     //first->toXML(out, state);

--- a/common/thorhelper/thorrparse.cpp
+++ b/common/thorhelper/thorrparse.cpp
@@ -2022,7 +2022,7 @@ void RegexNamedPattern::toXMLattr(StringBuffer & out, RegexXmlState & state)
 {
     RegexPattern::toXMLattr(out, state);
     if (def->queryName())
-        out.appendf(" name=\"%s\"", str(def->queryName()));
+        out.appendf(" name=\"%s\"", def->queryName()->queryStr());
     out.appendf(" body=\"%d\"", state.named.find(*def));
 }
 

--- a/common/thorhelper/thortalgo.cpp
+++ b/common/thorhelper/thortalgo.cpp
@@ -629,7 +629,7 @@ void LRProduction::serialize(MemoryBuffer & out)
     if (transformClonesFirstSymbol)
         numSymbolsMask |= NSFclonesFirstSymbol;
     out.append(ruleId).append(numSymbolsMask).append(penalty);
-    ::serialize(out, ruleName->str());
+    ::serialize(out, str(ruleName));
     feature.serialize(out);
     validator.serialize(out);
 }

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2207,7 +2207,7 @@ private:
         int perm;
         if (!perms)
         {
-            perm = secmgr->authorizeWorkunitScope(*secuser, scopeName);
+            perm = secuser.get() ? secmgr->authorizeWorkunitScope(*secuser, scopeName):-1;
             scopePermissions.setValue(scopeName, perm);
         }
         else

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -150,8 +150,6 @@ public:
                 ForEach(*iter)
                 {
                     IPropertyTree &attr = iter->query();
-                    if (!&attr)
-                        continue;
                     const char *name = attr.queryProp("@name");
                     if (!name||!*name)
                         continue;
@@ -2305,8 +2303,6 @@ IClusterFileScanIterator *getClusterFileScanIterator(
     StringBuffer gname;
     ForEach(*iter) {
         IPropertyTree &attr = iter->query();
-        if (!&attr)
-            continue;
         const char *name = attr.queryProp("@name");
         if (!name||!*name)
             continue;

--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -1568,13 +1568,9 @@ int CDfuPlusHelper::updatejobname(const char* wuid, const char* jobname)
 
 void CDfuPlusHelper::exc(const IMultiException& excep,const char *title)
 {
-    if(&excep!=NULL) {
-        StringBuffer errmsg;
-        excep.errorMessage(errmsg);
-        error("%s\n",errmsg.str());
-    }
-    else
-        throw MakeStringException(-1, "unknown error %s",title);
+    StringBuffer errmsg;
+    excep.errorMessage(errmsg);
+    error("%s\n",errmsg.str());
 }
 
 void CDfuPlusHelper::info(const char *fmt, ...) 

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1091,7 +1091,7 @@ void EclCC::processSingleQuery(EclCompileInstance & instance,
     bool syntaxChecking = instance.wu->getDebugValueBool("syntaxCheck", false);
     size32_t prevErrs = errorProcessor.errCount();
     cycle_t startCycles = get_cycles_now();
-    const char * sourcePathname = queryContents ? queryContents->querySourcePath()->str() : NULL;
+    const char * sourcePathname = queryContents ? str(queryContents->querySourcePath()) : NULL;
     const char * defaultErrorPathname = sourcePathname ? sourcePathname : queryAttributePath;
 
     //The following is only here to provide information about the source file being compiled when reporting leaks

--- a/ecl/eclplus/DeleteHelper.cpp
+++ b/ecl/eclplus/DeleteHelper.cpp
@@ -93,7 +93,7 @@ bool AbortHelper::doit(FILE * fp)
         Owned<IClientWUInfoRequest> inforeq = wuclient->createWUInfoRequest();
         inforeq->setWuid(wuid);
         Owned<IClientWUInfoResponse> inforesp = wuclient->WUInfo(inforeq);
-        if(!inforesp || &inforesp->getWorkunit() == NULL)
+        if(!inforesp)
         {
             printf("Workunit %s not found\n", wuid);
             return false;

--- a/ecl/eclplus/DumpHelper.cpp
+++ b/ecl/eclplus/DumpHelper.cpp
@@ -41,7 +41,7 @@ bool DumpHelper::doit(FILE * fp)
                 Owned<IClientWUInfoRequest> inforeq = wuclient->createWUInfoRequest();
                 inforeq->setWuid(wuid);
                 Owned<IClientWUInfoResponse> inforesp = wuclient->WUInfo(inforeq);
-                if(!inforesp || &inforesp->getWorkunit() == NULL)
+                if(!inforesp)
                 {
                     printf("Workunit %s not found\n", wuid);
                     return false;

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -448,7 +448,7 @@ extern HQL_API IAtom * xmlnsAtom;
 extern HQL_API IAtom * _xmlParse_Atom;
 extern HQL_API IAtom * xpathAtom;
 
-inline bool isInternalAttributeName(IAtom * name) { return (name->str()[0] == '$'); }
+inline bool isInternalAttributeName(IAtom * name) { return (str(name)[0] == '$'); }
 
 /*
  * This is part of an experiment to make identifiers in the language case sensitive - at least optionally, possibly only for syntax checking.

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -448,7 +448,7 @@ extern HQL_API IAtom * xmlnsAtom;
 extern HQL_API IAtom * _xmlParse_Atom;
 extern HQL_API IAtom * xpathAtom;
 
-inline bool isInternalAttributeName(IAtom * name) { return (str(name)[0] == '$'); }
+inline bool isInternalAttributeName(IAtom * name) { return (name->queryStr()[0] == '$'); }
 
 /*
  * This is part of an experiment to make identifiers in the language case sensitive - at least optionally, possibly only for syntax checking.

--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -1399,7 +1399,7 @@ IHqlExpression * HqlUnadornedNormalizer::createTransformed(IHqlExpression * expr
             IIdAtom * id = expr->queryId();
             //Fields names compare case-insignificantly therefore the field name is converted to lower case so that
             //equivalent fields are mapped to the same normalized expression.
-            IIdAtom * newid = createIdAtom(id->lower()->str());
+            IIdAtom * newid = createIdAtom(str(lower(id)));
             if ((type != newType) || (id != newid))
                 return createField(newid, newType.getClear(), children);
 

--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -114,7 +114,7 @@ CEclSource * CEclCollection::find(IIdAtom * name)
     ForEachItemIn(i, contents)
     {
         IEclSource & cur = contents.item(i);
-        if (cur.queryEclId()->lower() == name->lower())
+        if (lower(cur.queryEclId()) == lower(name))
             return &static_cast<CEclSource &>(cur);
     }
     return NULL;
@@ -236,7 +236,7 @@ static IIdAtom * deriveEclName(const char * filename)
     else
         id = createIdAtom(tailname);
 
-    if (!isCIdentifier(id->str()))
+    if (!isCIdentifier(str(id)))
         return NULL;
     return id;
 }
@@ -333,9 +333,9 @@ IProperties * FileSystemFile::getProperties()
     case ESTplugin:
         {
             properties.setown(createProperties());
-            properties->setProp(flagsAtom->str(), extraFlags);
-            properties->setProp(versionAtom->str(), version.get());
-            properties->setProp(pluginAtom->str(), file->queryFilename());
+            properties->setProp(str(flagsAtom), extraFlags);
+            properties->setProp(str(versionAtom), version.get());
+            properties->setProp(str(pluginAtom), file->queryFilename());
             break;
         }
     case ESTmodule:
@@ -344,7 +344,7 @@ IProperties * FileSystemFile::getProperties()
             if (extraFlags)
             {
                 properties.setown(createProperties());
-                properties->setProp(flagsAtom->str(), extraFlags);
+                properties->setProp(str(flagsAtom), extraFlags);
             }
             break;
         }
@@ -642,7 +642,7 @@ void CXmlEclElement::getFullName(StringBuffer & target)
         if (target.length() != prev)
             target.append('.');
     }
-    target.append(eclId->str());
+    target.append(str(eclId));
 }
 
 IFileContents * CXmlEclElement::queryFileContents()
@@ -681,9 +681,9 @@ IProperties * CXmlEclElement::getProperties()
     case ESTplugin:
         {
             properties.setown(createProperties());
-            properties->setProp(flagsAtom->str(), extraFlags);
-            properties->setProp(versionAtom->str(), elemTree->queryProp("@version"));
-            properties->setProp(pluginAtom->str(), elemTree->queryProp("@fullname"));
+            properties->setProp(str(flagsAtom), extraFlags);
+            properties->setProp(str(versionAtom), elemTree->queryProp("@version"));
+            properties->setProp(str(pluginAtom), elemTree->queryProp("@fullname"));
             break;
         }
     default:
@@ -691,7 +691,7 @@ IProperties * CXmlEclElement::getProperties()
             if (extraFlags)
             {
                 properties.setown(createProperties());
-                properties->setProp(flagsAtom->str(), extraFlags);
+                properties->setProp(str(flagsAtom), extraFlags);
             }
             break;
         }
@@ -717,7 +717,7 @@ CXmlEclElement * CXmlEclElement::select(IIdAtom * _name, EclSourceType _type, IP
     else if (_tree)
     {
         //Some old archives seeem to contain duplicate definitions.  Clean then up then delete this code
-        DBGLOG("Source Seems to have duplicate definition of %s", _name->str());
+        DBGLOG("Source Seems to have duplicate definition of %s", str(_name));
         //throwUnexpected();
     }
 
@@ -795,7 +795,7 @@ IEclSourceCollection * createSingleDefinitionEclCollection(const char * moduleNa
     module->setProp("@name", moduleName);
     IPropertyTree * attr = module->addPropTree("Attribute", createPTree("Attribute"));
     attr->setProp("@name", attrName);
-    const char * filename = contents->querySourcePath()->str();
+    const char * filename = str(contents->querySourcePath());
     if (filename)
         attr->setProp("@sourcePath", filename);
 

--- a/ecl/hql/hqldesc.cpp
+++ b/ecl/hql/hqldesc.cpp
@@ -29,7 +29,7 @@ void getFullName(StringBuffer & name, IHqlExpression * expr)
     }
     else
     {
-        const char * module = expr->queryFullContainerId()->str();
+        const char * module = str(expr->queryFullContainerId());
         if (module && *module)
             name.append(module).append(".");
         name.append(expr->queryName());
@@ -54,7 +54,7 @@ void setFullNameProp(IPropertyTree * tree, const char * prop, IHqlExpression * e
     if (scope)
         tree->setProp(prop, scope->queryFullName());
     else
-        setFullNameProp(tree, prop, expr->queryFullContainerId()->lower()->str(), expr->queryName()->str());
+        setFullNameProp(tree, prop, str(lower(expr->queryFullContainerId())), str(expr->queryName()));
 }
 
 static int compareSymbolsByPosition(IInterface * const * pleft, IInterface * const * pright)
@@ -66,7 +66,7 @@ static int compareSymbolsByPosition(IInterface * const * pleft, IInterface * con
     int startRight = right->getStartLine();
     if (startLeft != startRight)
         return startLeft < startRight ? -1 : +1;
-    return stricmp(left->queryName()->str(), right->queryName()->str());
+    return stricmp(str(left->queryName()), str(right->queryName()));
 }
 
 static void setNonZeroPropInt(IPropertyTree * tree, const char * path, int value)
@@ -89,7 +89,7 @@ static void expandRecordSymbolsMeta(IPropertyTree * metaTree, IHqlExpression * r
         case no_field:
             {
                 IPropertyTree * field = metaTree->addPropTree("Field", createPTree("Field"));
-                field->setProp("@name", cur->queryName()->str());
+                field->setProp("@name", str(cur->queryName()));
                 StringBuffer ecltype;
                 cur->queryType()->getECLType(ecltype);
                 field->setProp("@type", ecltype);
@@ -106,7 +106,7 @@ static void expandRecordSymbolsMeta(IPropertyTree * metaTree, IHqlExpression * r
         case no_attr_expr:
             {
                 IPropertyTree * attr = metaTree->addPropTree("Attr", createPTree("Attr"));
-                attr->setProp("@name", cur->queryName()->str());
+                attr->setProp("@name", str(cur->queryName()));
                 break;
             }
         }
@@ -131,7 +131,7 @@ void expandSymbolMeta(IPropertyTree * metaTree, IHqlExpression * expr)
     if (def)
     {
         IHqlNamedAnnotation * symbol = queryNameAnnotation(expr);
-        def->setProp("@name", expr->queryName()->str());
+        def->setProp("@name", str(expr->queryName()));
         def->setPropInt("@line", expr->getStartLine());
         if (expr->isExported())
             def->setPropBool("@exported", true);

--- a/ecl/hql/hqldsparam.cpp
+++ b/ecl/hql/hqldsparam.cpp
@@ -66,7 +66,7 @@ IHqlExpression* HqlGram::processAbstractDataset(IHqlExpression* _expr, IHqlExpre
                 getFriendlyTypeStr(kid,fromType);
                 getFriendlyTypeStr(match,toType);
                 reportError(ERR_DSPARAM_TYPEMISMATCH, errpos, "Can not mapping type %s(field '%s') to %s(field '%s')",
-                    fromType.str(), kid->queryName()->str(), toType.str(), match->queryName()->str());
+                    fromType.str(), str(kid->queryName()), toType.str(), str(match->queryName()));
                 hadError = true;
             }
             //MORE: This should really be mapped in a single go
@@ -75,7 +75,7 @@ IHqlExpression* HqlGram::processAbstractDataset(IHqlExpression* _expr, IHqlExpre
         }
         else if (errorIfNotFound)
         {
-            reportError(ERR_DSPARM_MISSINGFIELD,errpos,"Dataset %s has no field named '%s'", actual->queryName()->str(), mapto->str());
+            reportError(ERR_DSPARM_MISSINGFIELD,errpos,"Dataset %s has no field named '%s'", str(actual->queryName()), str(mapto));
             hadError = true;
         }
     }       
@@ -137,7 +137,7 @@ IIdAtom * HqlGram::fieldMapTo(IHqlExpression* mapping, IIdAtom * id)
     if (!mapping)
         return id;
 
-    IAtom * name = id->lower();
+    IAtom * name = lower(id);
     ForEachChild(i, mapping)
     {
         IHqlExpression * map = mapping->queryChild(i);
@@ -154,7 +154,7 @@ IIdAtom * HqlGram::fieldMapFrom(IHqlExpression* mapping, IIdAtom * id)
     if (!mapping)
         return id;
 
-    IAtom * name = id->lower();
+    IAtom * name = lower(id);
     ForEachChild(i, mapping)
     {
         IHqlExpression * map = mapping->queryChild(i);

--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -206,7 +206,7 @@ public:
 
         StringBuffer msg;
         error->errorMessage(msg);
-        if (!filename) filename = isError(severity) ? "" : *unknownAtom;
+        if (!filename) filename = isError(severity) ? "" : str(unknownAtom);
         fprintf(f, "%s(%d,%d): %s C%04d: %s\n", filename, line, column, severityText, code, msg.str());
     }
 
@@ -255,9 +255,9 @@ void reportErrorVa(IErrorReceiver * errors, int errNo, const ECLlocation & loc, 
     StringBuffer msg;
     msg.valist_appendf(format, args);
     if (errors)
-        errors->reportError(errNo, msg.str(), loc.sourcePath->str(), loc.lineno, loc.column, loc.position);
+        errors->reportError(errNo, msg.str(), str(loc.sourcePath), loc.lineno, loc.column, loc.position);
     else
-        throw createError(errNo, msg.str(), loc.sourcePath->str(), loc.lineno, loc.column, loc.position);
+        throw createError(errNo, msg.str(), str(loc.sourcePath), loc.lineno, loc.column, loc.position);
 }
 
 void reportError(IErrorReceiver * errors, int errNo, const ECLlocation & loc, const char * format, ...)

--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -206,7 +206,7 @@ public:
 
         StringBuffer msg;
         error->errorMessage(msg);
-        if (!filename) filename = isError(severity) ? "" : str(unknownAtom);
+        if (!filename) filename = isError(severity) ? "" : unknownAtom->queryStr();
         fprintf(f, "%s(%d,%d): %s C%04d: %s\n", filename, line, column, severityText, code, msg.str());
     }
 

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -697,7 +697,7 @@ static void setDefinitionText(IPropertyTree * target, const char * prop, IFileCo
     target->setProp(prop, sillyTempBuffer);
 
     ISourcePath * sourcePath = contents->querySourcePath();
-    target->setProp("@sourcePath", sourcePath->str());
+    target->setProp("@sourcePath", str(sourcePath));
 }
 
 void HqlParseContext::noteBeginAttribute(IHqlScope * scope, IFileContents * contents, IIdAtom * name)
@@ -707,9 +707,9 @@ void HqlParseContext::noteBeginAttribute(IHqlScope * scope, IFileContents * cont
         const char * moduleName = scope->queryFullName();
 
         IPropertyTree * module = queryEnsureArchiveModule(moduleName, scope);
-        IPropertyTree * attr = queryArchiveAttribute(module, name->str());
+        IPropertyTree * attr = queryArchiveAttribute(module, str(name));
         if (!attr)
-            attr = createArchiveAttribute(module, name->str());
+            attr = createArchiveAttribute(module, str(name));
 
         setDefinitionText(attr, "", contents);
     }
@@ -719,8 +719,8 @@ void HqlParseContext::noteBeginAttribute(IHqlScope * scope, IFileContents * cont
     if (checkBeginMeta())
     {
         IPropertyTree * attr = metaTree->addPropTree("Source", createPTree("Source"));
-        setFullNameProp(attr, "@name", scope->queryFullName(), name->str());
-        attr->setProp("@sourcePath", sourcePath->str());
+        setFullNameProp(attr, "@name", scope->queryFullName(), str(name));
+        attr->setProp("@sourcePath", str(sourcePath));
         metaState.nesting.append(attr);
     }
 
@@ -728,8 +728,8 @@ void HqlParseContext::noteBeginAttribute(IHqlScope * scope, IFileContents * cont
     {
         IPropertyTree * attr = globalDependTree->addPropTree("Attribute", createPTree("Attribute"));
         attr->setProp("@module", scope->queryFullName());
-        attr->setProp("@name", name->str());
-        attr->setProp("@sourcePath", sourcePath->str());
+        attr->setProp("@name", str(name));
+        attr->setProp("@sourcePath", str(sourcePath));
         //attr->setPropInt("@flags", symbol->getObType());  MORE
     }
 }
@@ -751,7 +751,7 @@ void HqlParseContext::noteBeginQuery(IHqlScope * scope, IFileContents * contents
         ISourcePath * sourcePath = contents->querySourcePath();
 
         IPropertyTree * attr = metaTree->addPropTree("Query", createPTree("Query"));
-        attr->setProp("@sourcePath", sourcePath->str());
+        attr->setProp("@sourcePath", str(sourcePath));
         metaState.nesting.append(attr);
     }
 }
@@ -773,7 +773,7 @@ void HqlParseContext::noteBeginModule(IHqlScope * scope, IFileContents * content
         ISourcePath * sourcePath = contents->querySourcePath();
 
         IPropertyTree * attr = metaTree->addPropTree("Source", createPTree("Source"));
-        attr->setProp("@sourcePath", sourcePath->str());
+        attr->setProp("@sourcePath", str(sourcePath));
         metaState.nesting.append(attr);
     }
 }
@@ -948,13 +948,13 @@ void HqlLookupContext::noteExternalLookup(IHqlScope * parentScope, IHqlExpressio
             const char * moduleName = parentScope->queryFullName();
             if (moduleName)
             {
-                VStringBuffer xpath("Depend[@module=\"%s\"][@name=\"%s\"]", moduleName, expr->queryName()->str());
+                VStringBuffer xpath("Depend[@module=\"%s\"][@name=\"%s\"]", moduleName, str(expr->queryName()));
 
                 if (!curAttrTree->queryPropTree(xpath.str()))
                 {
                     IPropertyTree * depend = curAttrTree->addPropTree("Depend", createPTree());
                     depend->setProp("@module", moduleName);
-                    depend->setProp("@name", expr->queryName()->str());
+                    depend->setProp("@name", str(expr->queryName()));
                 }
             }
         }
@@ -965,7 +965,7 @@ void HqlLookupContext::noteExternalLookup(IHqlScope * parentScope, IHqlExpressio
 void HqlLookupContext::createDependencyEntry(IHqlScope * parentScope, IIdAtom * id)
 {
     const char * moduleName = parentScope->queryFullName();
-    const char * nameText = id->lower()->str();
+    const char * nameText = str(lower(id));
 
     StringBuffer xpath;
     xpath.append("Attr[@module=\"").append(moduleName).append("\"][@name=\"").append(nameText).append("\"]");
@@ -4051,7 +4051,7 @@ unsigned CHqlExpression::getCachedEclCRC()
             IAtom * name = queryName();
             if (name)
             {
-                const char * nameText = name->str();
+                const char * nameText = str(name);
                 if ((nameText[0] != '_') || (nameText[1] != '_'))
                     crc = hashnc((const byte *)nameText, strlen(nameText), crc);
             }
@@ -4071,7 +4071,7 @@ unsigned CHqlExpression::getCachedEclCRC()
             const IAtom * name = queryBody()->queryName();
             if (name == _uid_Atom)
                 return 0;
-            const char * nameText = name->str();
+            const char * nameText = str(name);
             crc = hashnc((const byte *)nameText, strlen(nameText), crc);
             break;
         }
@@ -5863,7 +5863,7 @@ IHqlExpression *CHqlField::clone(HqlExprArray &newkids)
 
 StringBuffer &CHqlField::toString(StringBuffer &ret)
 {
-    ret.append(id->str());
+    ret.append(str(id));
     return ret;
 }
 
@@ -6552,7 +6552,7 @@ CHqlRecord::~CHqlRecord()
 /* return: linked */
 IHqlExpression *CHqlRecord::lookupSymbol(IIdAtom * fieldName)
 {
-    IHqlExpression *ret = fields.getValue(fieldName->lower());
+    IHqlExpression *ret = fields.getValue(lower(fieldName));
     ::Link(ret);
     return ret;
 }
@@ -7879,14 +7879,14 @@ void CHqlScope::defineSymbol(IHqlExpression * expr)
 
 void CHqlScope::removeSymbol(IIdAtom * _id)
 {
-    symbols.remove(_id->lower());
+    symbols.remove(lower(_id));
     //in general infoFlags needs recalculating - although currently I think this can only occur when a constant has been added
 }
 
 
 IHqlExpression *CHqlScope::lookupSymbol(IIdAtom * searchName, unsigned lookupFlags, HqlLookupContext & ctx)
 {
-    OwnedHqlExpr ret = symbols.getLinkedValue(searchName->lower());
+    OwnedHqlExpr ret = symbols.getLinkedValue(lower(searchName));
 
     if (!ret)
         return NULL; 
@@ -7920,7 +7920,7 @@ void CHqlScope::getSymbols(HqlExprArray& exprs) const
         if (!cur)
         {
             IAtom * name = * static_cast<IAtom * const *>(iter.query().getKey());
-            throw MakeStringException(ERR_INTERNAL_NOEXPR, "INTERNAL: getSymbol %s has no associated expression", name ? name->str() : "");
+            throw MakeStringException(ERR_INTERNAL_NOEXPR, "INTERNAL: getSymbol %s has no associated expression", name ? str(name) : "");
         }
 
         cur->Link();
@@ -7944,10 +7944,10 @@ void CHqlScope::throwRecursiveError(IIdAtom * searchName)
     StringBuffer filename;
     if (fullName)
         filename.append(fullName).append('.');
-    filename.append(*searchName);
+    filename.append(*str(searchName));
 
     StringBuffer msg("Definition of ");
-    msg.append(*searchName).append(" contains a recursive dependency");
+    msg.append(*str(searchName)).append(" contains a recursive dependency");
     throw createError(ERR_RECURSIVE_DEPENDENCY, msg.str(), filename, 0, 0, 1);
 }
 
@@ -8136,13 +8136,13 @@ IHqlExpression *CHqlRemoteScope::lookupSymbol(IIdAtom * searchName, unsigned loo
     StringBuffer filename;
     if (fullName)
         filename.append(fullName).append('.');
-    filename.append(*searchName);
+    filename.append(*str(searchName));
 
     IFileContents * contents = ret->queryDefinitionText();
     if (!contents || (contents->length() == 0))
     {
         StringBuffer msg("Definition for ");
-        msg.append(*searchName).append(" contains no text");
+        msg.append(*str(searchName)).append(" contains no text");
         throw createError(ERR_EXPORT_OR_SHARE, msg.str(), filename, 0, 0, 1);
     }
 
@@ -8168,7 +8168,7 @@ IHqlExpression *CHqlRemoteScope::lookupSymbol(IIdAtom * searchName, unsigned loo
         if (newSymbol)
             resolved->removeSymbol(searchName);
         StringBuffer msg("Definition must contain EXPORT or SHARED value for ");
-        msg.append(*searchName);
+        msg.append(*str(searchName));
         throw createError(ERR_EXPORT_OR_SHARE, msg.str(), filename, 0, 0, 1);
     }
 
@@ -8210,14 +8210,14 @@ IFileContents * CHqlRemoteScope::queryDefinitionText() const
 int CHqlRemoteScope::getPropInt(IAtom * a, int def) const
 {
     if (props)
-        return props->getPropInt(a->getAtomNamePtr(), def);
+        return props->getPropInt(str(a), def);
     else
         return def;
 }
 
 bool CHqlRemoteScope::getProp(IAtom * a, StringBuffer &ret) const
 { 
-    return (props != NULL && props->getProp(a->getAtomNamePtr(), ret));
+    return (props != NULL && props->getProp(str(a), ret));
 }
 
 
@@ -8226,14 +8226,14 @@ void CHqlRemoteScope::setProp(IAtom * a, int val)
 {
     if (!props)
         props = createProperties();
-    props->setProp(a->getAtomNamePtr(), val);
+    props->setProp(str(a), val);
 }
 
 void CHqlRemoteScope::setProp(IAtom * a, const char * val)
 {
     if (!props)
         props = createProperties();
-    props->setProp(a->getAtomNamePtr(), val);
+    props->setProp(str(a), val);
 }
 
 
@@ -8289,7 +8289,7 @@ void exportSymbols(IPropertyTree* data, IHqlScope * scope, HqlLookupContext & ct
         if (cur && !isImport(cur) && (cur->getOperator() != no_remotescope))
         {
             IPropertyTree * attr=createPTree("Attribute", ipt_caseInsensitive);
-            attr->setProp("@name", *cur->queryName());
+            attr->setProp("@name", str(cur->queryName()));
             unsigned symbolFlags = cur->getSymbolFlags();
             if (cur->isExported())
                 symbolFlags |= ob_exported;
@@ -8518,7 +8518,7 @@ void CHqlMergedScope::ensureSymbolsDefined(HqlLookupContext & ctx)
             IHqlExpression & cur = scopeSymbols.item(iSym);
             IIdAtom * curName = cur.queryId();
 
-            OwnedHqlExpr prev = symbols.getLinkedValue(curName->lower());
+            OwnedHqlExpr prev = symbols.getLinkedValue(lower(curName));
             if (prev)
             {
                 //Unusual - check that this hasn't already been resolved by a call to lookupSymbol()
@@ -8709,7 +8709,7 @@ public:
             if (match == visited)
             {
                 IIdAtom * id = expr->queryId();
-                const char * idText = id ? id->str() : "";
+                const char * idText = id ? str(id) : "";
                 ECLlocation loc(searchModule->queryAttribute(_location_Atom));
                 reportError(errors, HQLERR_CycleWithModuleDefinition, loc, HQLERR_CycleWithModuleDefinition_Text, idText);
             }
@@ -8778,7 +8778,7 @@ public:
 
     virtual IHqlExpression * getVirtualReplacement(IIdAtom * name)
     {
-        OwnedHqlExpr value = symbols.getLinkedValue(name->lower());
+        OwnedHqlExpr value = symbols.getLinkedValue(lower(name));
         return transform(value);
     }
 
@@ -9107,7 +9107,7 @@ IHqlExpression *CHqlVirtualScope::lookupSymbol(IIdAtom * searchName, unsigned lo
         {
             //Select from a parameter where the item is not defined in the parameter's scope => error
             if (match->getOperator() == no_unboundselect)
-                throwError1(HQLERR_MemberXContainsVirtualRef, searchName->str());
+                throwError1(HQLERR_MemberXContainsVirtualRef, str(searchName));
 
             if (containsInternalSelect(match))
             {
@@ -9142,7 +9142,7 @@ IHqlExpression *CHqlVirtualScope::lookupSymbol(IIdAtom * searchName, unsigned lo
             //Select from a parameter where the item is not defined in the parameter's scope => error
             node_operator matchOp = match->getOperator();
             if (matchOp == no_unboundselect || matchOp == no_purevirtual)
-                throwError1(HQLERR_MemberXContainsVirtualRef, searchName->str());
+                throwError1(HQLERR_MemberXContainsVirtualRef, str(searchName));
 
             if (containsInternalSelect(match))
             {
@@ -9228,7 +9228,7 @@ void CHqlVirtualScope::resolveUnboundSymbols()
                         //Select from a parameter where the item is not defined in the parameter's scope => error
                         node_operator resolvedOp = resolved->getOperator();
                         if (resolvedOp == no_unboundselect || resolvedOp == no_purevirtual)
-                            throwError1(HQLERR_MemberXContainsVirtualRef, searchName->str());
+                            throwError1(HQLERR_MemberXContainsVirtualRef, str(searchName));
 
                         match.setown(quickFullReplaceExpression(resolved, child->queryAttribute(_virtualSeq_Atom), virtualAttr));
                         break;
@@ -9339,9 +9339,9 @@ IHqlExpression *CHqlForwardScope::lookupSymbol(IIdAtom * searchName, unsigned lo
         IHqlNamedAnnotation * oldSymbol = queryNameAnnotation(ret);
         assertex(oldSymbol);
         resolved->removeSymbol(searchName);
-        const char * filename = parentCtx->sourcePath->str();
+        const char * filename = str(parentCtx->sourcePath);
         StringBuffer msg("Definition must contain EXPORT or SHARED value for ");
-        msg.append(*searchName);
+        msg.append(str(searchName));
         throw createError(ERR_EXPORT_OR_SHARE, msg.str(), filename, oldSymbol->getStartLine(), oldSymbol->getStartColumn(), 1);
     }
 
@@ -9395,7 +9395,7 @@ void addForwardDefinition(IHqlScope * scope, IIdAtom * symbolName, IIdAtom * mod
 //==============================================================================================================
 
 CHqlMultiParentScope::CHqlMultiParentScope(IIdAtom * _name, ...)
- : CHqlScope(no_privatescope, _name, _name->str())
+ : CHqlScope(no_privatescope, _name, str(_name))
 {
     va_list args;
     va_start(args, _name);
@@ -9446,7 +9446,7 @@ CHqlContextScope::CHqlContextScope(IHqlScope* _scope) : CHqlScope(no_privatescop
         {
             IIdAtom * valueId = value->queryId();
             //debug.appendf(" %s",name->str());
-            defined.setValue(valueId->lower(),value);
+            defined.setValue(lower(valueId),value);
         }
     }
     //PrintLog(debug.str());
@@ -9529,7 +9529,7 @@ IHqlExpression *CHqlParameter::clone(HqlExprArray &newkids)
 StringBuffer &CHqlParameter::toString(StringBuffer &ret)
 {
     ret.append('%');
-    ret.append(id->str());
+    ret.append(str(id));
     ret.append('-');
     ret.append(idx);
     return ret;
@@ -9538,7 +9538,7 @@ StringBuffer &CHqlParameter::toString(StringBuffer &ret)
 //==============================================================================================================
 
 CHqlScopeParameter::CHqlScopeParameter(IIdAtom * _id, unsigned _idx, ITypeInfo *_type)
- : CHqlScope(no_param, _id, _id->str())
+ : CHqlScope(no_param, _id, str(_id))
 {
     type = _type;
     idx = _idx;
@@ -9589,7 +9589,7 @@ void CHqlScopeParameter::sethash()
 StringBuffer &CHqlScopeParameter::toString(StringBuffer &ret)
 {
     ret.append('%');
-    ret.append(id->str());
+    ret.append(str(id));
     ret.append('-');
     ret.append(idx);
     return ret;
@@ -13154,8 +13154,8 @@ unsigned exportField(IPropertyTree *table, IHqlExpression *field, unsigned & off
     if (type->getTypeCode() == type_row)
         type = type->queryChildType();
 
-    f->setProp("@label", field->queryName()->getAtomNamePtr());
-    f->setProp("@name", field->queryName()->getAtomNamePtr());
+    f->setProp("@label", str(field->queryName()));
+    f->setProp("@name", str(field->queryName()));
     f->setPropInt("@position", offset++);
 
     if (defValue && !defValue->isAttribute() && defValue->getOperator()!=no_field && defValue->getOperator() != no_select)
@@ -13203,7 +13203,7 @@ unsigned exportField(IPropertyTree *table, IHqlExpression *field, unsigned & off
 
             IPropertyTree *end = createPTree("Field", ipt_caseInsensitive);
             end->setPropBool("@isEnd", true);
-            end->setProp("@name", field->queryName()->getAtomNamePtr());
+            end->setProp("@name", str(field->queryName()));
             table->addPropTree(end->queryName(), end);
         }
         else
@@ -15634,7 +15634,7 @@ static bool getBoolAttributeValue(IHqlExpression * attr)
     if (folded->queryValue())
         return getBoolValue(folded, true);
 
-    throwError1(HQLERR_PropertyArgumentNotConstant, attr->queryName()->str());
+    throwError1(HQLERR_PropertyArgumentNotConstant, str(attr->queryName()));
 }
 
 bool getBoolAttribute(IHqlExpression * expr, IAtom * name, bool dft)
@@ -15859,7 +15859,7 @@ extern HQL_API IHqlExpression * createSortList(HqlExprArray & elements)
 IHqlExpression * cloneFieldMangleName(IHqlExpression * field)
 {
     StringBuffer newName;
-    newName.append(field->queryId()->str()).append("_").append(getUniqueId());
+    newName.append(str(field->queryId())).append("_").append(getUniqueId());
     HqlExprArray children;
     unwindChildren(children, field);
     return createField(createIdAtom(newName), field->getType(), children);

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -7944,10 +7944,10 @@ void CHqlScope::throwRecursiveError(IIdAtom * searchName)
     StringBuffer filename;
     if (fullName)
         filename.append(fullName).append('.');
-    filename.append(*str(searchName));
+    filename.append(str(searchName));
 
     StringBuffer msg("Definition of ");
-    msg.append(*str(searchName)).append(" contains a recursive dependency");
+    msg.append(str(searchName)).append(" contains a recursive dependency");
     throw createError(ERR_RECURSIVE_DEPENDENCY, msg.str(), filename, 0, 0, 1);
 }
 
@@ -8136,13 +8136,13 @@ IHqlExpression *CHqlRemoteScope::lookupSymbol(IIdAtom * searchName, unsigned loo
     StringBuffer filename;
     if (fullName)
         filename.append(fullName).append('.');
-    filename.append(*str(searchName));
+    filename.append(str(searchName));
 
     IFileContents * contents = ret->queryDefinitionText();
     if (!contents || (contents->length() == 0))
     {
         StringBuffer msg("Definition for ");
-        msg.append(*str(searchName)).append(" contains no text");
+        msg.append(str(searchName)).append(" contains no text");
         throw createError(ERR_EXPORT_OR_SHARE, msg.str(), filename, 0, 0, 1);
     }
 
@@ -8168,7 +8168,7 @@ IHqlExpression *CHqlRemoteScope::lookupSymbol(IIdAtom * searchName, unsigned loo
         if (newSymbol)
             resolved->removeSymbol(searchName);
         StringBuffer msg("Definition must contain EXPORT or SHARED value for ");
-        msg.append(*str(searchName));
+        msg.append(str(searchName));
         throw createError(ERR_EXPORT_OR_SHARE, msg.str(), filename, 0, 0, 1);
     }
 

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -399,7 +399,7 @@ protected:
 
 public:
     virtual IHqlExpression *clone(HqlExprArray &newkids);
-    virtual IAtom * queryName() const { return id->lower(); }
+    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL; }
     virtual IIdAtom * queryId() const { return id; }
 };
 
@@ -593,7 +593,7 @@ class HQL_API CHqlSymbolAnnotation : public CHqlAnnotation, public IHqlNamedAnno
 public:
     IMPLEMENT_IINTERFACE_USING(CHqlAnnotation)
 
-    virtual IAtom * queryName() const { return id->lower(); }
+    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL; }
     virtual IIdAtom * queryId() const { return id; }
     virtual IIdAtom * queryFullContainerId() const { return moduleId; }
     virtual IHqlExpression *queryFunctionDefinition() const;
@@ -799,7 +799,7 @@ public:
 //  virtual StringBuffer &toSQL(StringBuffer &, bool paren, IHqlDataset *scope, bool useAliases, node_operator op = no_none);
     virtual IHqlExpression *clone(HqlExprArray &newkids);
     virtual StringBuffer &printAliases(StringBuffer &s, unsigned, bool &) { return s; }
-    virtual IAtom * queryName() const { return id->lower(); }
+    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL; }
     virtual IIdAtom * queryId() const { return id; }
 };
 
@@ -826,7 +826,7 @@ class CHqlExternal: public CHqlExpressionWithType
     virtual bool equals(const IHqlExpression & other) const;
 public:
     static CHqlExternal *makeExternalReference(IIdAtom * id, ITypeInfo *, HqlExprArray &_ownedOperands);
-    virtual IAtom * queryName() const { return id->lower(); }
+    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL;  }
     virtual IIdAtom * queryId() const { return id; }
 };
 
@@ -952,7 +952,7 @@ typedef HashIterator SymbolTableIterator;
 
 inline IHqlExpression * lookupSymbol(SymbolTable & symbols, IIdAtom * searchName, bool sharedOK)
 {
-    OwnedHqlExpr ret = symbols.getLinkedValue(searchName->lower());
+    OwnedHqlExpr ret = symbols.getLinkedValue(searchName ? searchName->queryLower() : NULL );
 
     if (!ret)
         return NULL; 
@@ -1078,7 +1078,7 @@ public:
 
     virtual IHqlExpression *lookupSymbol(IIdAtom * searchName, unsigned lookupFlags, HqlLookupContext & ctx);
 
-    virtual IAtom * queryName() const {return id->lower();}
+    virtual IAtom * queryName() const {return id ? id->queryLower() : NULL;}
     virtual IIdAtom * queryId() const { return id; }
     virtual const char * queryFullName() const  { return fullName; }
     virtual IIdAtom * queryFullContainerId() const { return containerId; }
@@ -1110,7 +1110,7 @@ public:
     virtual IValue * castFrom(size32_t len, const UChar * text)  { return NULL; }
     virtual StringBuffer &getECLType(StringBuffer & out)  { return out.append("MODULE"); }
     virtual StringBuffer &getDescriptiveType(StringBuffer & out)  { return out.append("MODULE"); }
-    virtual const char *queryTypeName()         { return id->str(); }
+    virtual const char *queryTypeName()         { return str(id); }
     virtual unsigned getCardinality()           { return 0; }
     virtual bool isInteger()                    { return false; }
     virtual bool isReference()                  { return false; }
@@ -1291,10 +1291,10 @@ public:
     CHqlContextScope(IHqlScope* scope);
 
     virtual void defineSymbol(IIdAtom * id, IIdAtom * moduleName, IHqlExpression *value,bool exported, bool shared, unsigned symbolFlags)
-    {  defined.setValue(id->lower(),value);  }
+    {  defined.setValue(id ? id->queryLower() : NULL,value);  }
 
     virtual IHqlExpression *lookupSymbol(IIdAtom * searchName, unsigned lookupFlags, HqlLookupContext & ctx)
-    {  return defined.getLinkedValue(searchName->lower()); }
+{  return defined.getLinkedValue(searchName ? searchName->queryLower() : NULL ); }
 
     virtual IHqlScope * queryConcreteScope()    { return this; }
     virtual bool allBasesFullyBound() const { return false; }
@@ -1366,7 +1366,7 @@ public:
     StringBuffer &toString(StringBuffer &ret);
     virtual IHqlExpression *clone(HqlExprArray &newkids);
     virtual IHqlSimpleScope *querySimpleScope();
-    virtual IAtom * queryName() const { return id->lower(); }
+    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL;  }
     virtual IIdAtom * queryId() const { return id; }
     virtual unsigned __int64 querySequenceExtra() { return idx; }
 };
@@ -1630,7 +1630,7 @@ public:
     virtual IHqlExpression *addOperand(IHqlExpression *field);
     virtual IHqlExpression *clone(HqlExprArray &newkids);
     virtual bool equals(const IHqlExpression & other) const;
-    virtual IAtom * queryName() const { return unnamedId->lower(); }
+virtual IAtom * queryName() const { return unnamedId ? unnamedId->queryLower() : NULL; }
     virtual void sethash();
     virtual ITypeInfo *queryType() const;
     virtual ITypeInfo *getType();
@@ -1652,7 +1652,7 @@ public:
     virtual StringBuffer &getDescriptiveType(StringBuffer & out) { return getECLType(out); }
     virtual unsigned getCrc();
 
-    virtual const char *queryTypeName()  { return queryName()->str(); }
+    virtual const char *queryTypeName()  { return str(queryName()); }
     virtual IHqlExpression * castToExpression() { return this; }
     virtual IHqlScope * castToScope() { return NULL; }
     
@@ -1776,9 +1776,9 @@ public:
     virtual IValue * castFrom(double value)  { return NULL; }
     virtual IValue * castFrom(size32_t len, const char * text)  { return NULL; }
     virtual IValue * castFrom(size32_t len, const UChar * text)  { return NULL; }
-    virtual StringBuffer &getECLType(StringBuffer & out)  { return out.append(id->lower()); }
+    virtual StringBuffer &getECLType(StringBuffer & out)  { return out.append(id ? id->queryLower() : NULL); }
     virtual StringBuffer &getDescriptiveType(StringBuffer & out)  { return getECLType(out); }
-    virtual const char *queryTypeName()         { return id->lower()->str(); }
+    virtual const char *queryTypeName()         { return id ? str(id->queryLower()) : NULL ; }
     virtual unsigned getCardinality();
     virtual bool isInteger()                    { return logical->isInteger(); }
     virtual bool isReference()                  { return false; }
@@ -1788,7 +1788,7 @@ public:
     virtual ICharsetInfo * queryCharset()       { return logical->queryCharset(); }
     virtual ICollationInfo * queryCollation()   { return logical->queryCollation(); }
     virtual IAtom * queryLocale()                 { return logical->queryLocale(); }
-    virtual IAtom * queryName() const { return id->lower(); }
+    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL;  }
     virtual IIdAtom * queryId() const { return id; }
     virtual ITypeInfo * queryChildType() { return logical; }
     virtual ITypeInfo * queryPromotedType()     { return logical->queryPromotedType(); }

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -593,7 +593,7 @@ class HQL_API CHqlSymbolAnnotation : public CHqlAnnotation, public IHqlNamedAnno
 public:
     IMPLEMENT_IINTERFACE_USING(CHqlAnnotation)
 
-    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL; }
+    virtual IAtom * queryName() const { return lower(id); }
     virtual IIdAtom * queryId() const { return id; }
     virtual IIdAtom * queryFullContainerId() const { return moduleId; }
     virtual IHqlExpression *queryFunctionDefinition() const;
@@ -799,7 +799,7 @@ public:
 //  virtual StringBuffer &toSQL(StringBuffer &, bool paren, IHqlDataset *scope, bool useAliases, node_operator op = no_none);
     virtual IHqlExpression *clone(HqlExprArray &newkids);
     virtual StringBuffer &printAliases(StringBuffer &s, unsigned, bool &) { return s; }
-    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL; }
+    virtual IAtom * queryName() const { return lower(id); }
     virtual IIdAtom * queryId() const { return id; }
 };
 
@@ -826,7 +826,7 @@ class CHqlExternal: public CHqlExpressionWithType
     virtual bool equals(const IHqlExpression & other) const;
 public:
     static CHqlExternal *makeExternalReference(IIdAtom * id, ITypeInfo *, HqlExprArray &_ownedOperands);
-    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL;  }
+    virtual IAtom * queryName() const { return lower(id);  }
     virtual IIdAtom * queryId() const { return id; }
 };
 
@@ -952,7 +952,7 @@ typedef HashIterator SymbolTableIterator;
 
 inline IHqlExpression * lookupSymbol(SymbolTable & symbols, IIdAtom * searchName, bool sharedOK)
 {
-    OwnedHqlExpr ret = symbols.getLinkedValue(searchName ? searchName->queryLower() : NULL );
+    OwnedHqlExpr ret = symbols.getLinkedValue(lower(searchName));
 
     if (!ret)
         return NULL; 
@@ -1078,7 +1078,7 @@ public:
 
     virtual IHqlExpression *lookupSymbol(IIdAtom * searchName, unsigned lookupFlags, HqlLookupContext & ctx);
 
-    virtual IAtom * queryName() const {return id ? id->queryLower() : NULL;}
+    virtual IAtom * queryName() const {return lower(id);}
     virtual IIdAtom * queryId() const { return id; }
     virtual const char * queryFullName() const  { return fullName; }
     virtual IIdAtom * queryFullContainerId() const { return containerId; }
@@ -1291,10 +1291,10 @@ public:
     CHqlContextScope(IHqlScope* scope);
 
     virtual void defineSymbol(IIdAtom * id, IIdAtom * moduleName, IHqlExpression *value,bool exported, bool shared, unsigned symbolFlags)
-    {  defined.setValue(id ? id->queryLower() : NULL,value);  }
+    {  defined.setValue(lower(id),value);  }
 
     virtual IHqlExpression *lookupSymbol(IIdAtom * searchName, unsigned lookupFlags, HqlLookupContext & ctx)
-{  return defined.getLinkedValue(searchName ? searchName->queryLower() : NULL ); }
+{  return defined.getLinkedValue(lower(searchName)); }
 
     virtual IHqlScope * queryConcreteScope()    { return this; }
     virtual bool allBasesFullyBound() const { return false; }
@@ -1366,7 +1366,7 @@ public:
     StringBuffer &toString(StringBuffer &ret);
     virtual IHqlExpression *clone(HqlExprArray &newkids);
     virtual IHqlSimpleScope *querySimpleScope();
-    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL;  }
+    virtual IAtom * queryName() const { return lower(id);  }
     virtual IIdAtom * queryId() const { return id; }
     virtual unsigned __int64 querySequenceExtra() { return idx; }
 };
@@ -1630,7 +1630,7 @@ public:
     virtual IHqlExpression *addOperand(IHqlExpression *field);
     virtual IHqlExpression *clone(HqlExprArray &newkids);
     virtual bool equals(const IHqlExpression & other) const;
-virtual IAtom * queryName() const { return unnamedId ? unnamedId->queryLower() : NULL; }
+    virtual IAtom * queryName() const { return lower(unnamedId); }
     virtual void sethash();
     virtual ITypeInfo *queryType() const;
     virtual ITypeInfo *getType();
@@ -1776,7 +1776,7 @@ public:
     virtual IValue * castFrom(double value)  { return NULL; }
     virtual IValue * castFrom(size32_t len, const char * text)  { return NULL; }
     virtual IValue * castFrom(size32_t len, const UChar * text)  { return NULL; }
-    virtual StringBuffer &getECLType(StringBuffer & out)  { return out.append(id ? id->queryLower() : NULL); }
+    virtual StringBuffer &getECLType(StringBuffer & out)  { return out.append(lower(id)); }
     virtual StringBuffer &getDescriptiveType(StringBuffer & out)  { return getECLType(out); }
     virtual const char *queryTypeName()         { return id ? str(id->queryLower()) : NULL ; }
     virtual unsigned getCardinality();
@@ -1788,7 +1788,7 @@ public:
     virtual ICharsetInfo * queryCharset()       { return logical->queryCharset(); }
     virtual ICollationInfo * queryCollation()   { return logical->queryCollation(); }
     virtual IAtom * queryLocale()                 { return logical->queryLocale(); }
-    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL;  }
+    virtual IAtom * queryName() const { return lower(id);  }
     virtual IIdAtom * queryId() const { return id; }
     virtual ITypeInfo * queryChildType() { return logical; }
     virtual ITypeInfo * queryPromotedType()     { return logical->queryPromotedType(); }

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -399,7 +399,7 @@ protected:
 
 public:
     virtual IHqlExpression *clone(HqlExprArray &newkids);
-    virtual IAtom * queryName() const { return id ? id->queryLower() : NULL; }
+    virtual IAtom * queryName() const { return lower(id); }
     virtual IIdAtom * queryId() const { return id; }
 };
 

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -580,14 +580,14 @@ IValue * foldExternalCall(IHqlExpression* expr, unsigned foldOptions, ITemplateC
     {
         if (foldOptions & HFOthrowerror)
             throw MakeStringException(ERR_PARAM_TOOMANY,"Too many parameters passed to function '%s': expected %d, given %d", 
-                                      expr->queryName()->str(), numParam, numArg);
+                                      str(expr->queryName()), numParam, numArg);
         return NULL;
     }
     else if(numParam < numArg) 
     {
         if (foldOptions & HFOthrowerror)
             throw MakeStringException(ERR_PARAM_TOOFEW,"Not enough parameters passed to function '%s': expected %d, given %d", 
-                                      expr->queryName()->str(), numParam, numArg);
+                                      str(expr->queryName()), numParam, numArg);
         return NULL;
     }
 
@@ -4233,9 +4233,9 @@ IHqlExpression * getLowerCaseConstant(IHqlExpression * expr)
     MemoryAttr lower(size);
     memcpy(lower.bufferBase(), data, size);
     if (type->getTypeCode() == type_utf8)
-        rtlUtf8ToLower(stringLen, (char *)lower.get(), type->queryLocale()->str());
+        rtlUtf8ToLower(stringLen, (char *)lower.get(), str(type->queryLocale()));
     else if (isUnicodeType(type))
-        rtlUnicodeToLower(stringLen, (UChar *)lower.get(), type->queryLocale()->str());
+        rtlUnicodeToLower(stringLen, (UChar *)lower.get(), str(type->queryLocale()));
     else
     {
         if (type->queryCharset()->queryName() == ebcdicAtom)
@@ -4739,7 +4739,7 @@ IHqlExpression * CExprFolderTransformer::doFoldTransformed(IHqlExpression * unfo
                                 //Following would be sensible, but can't call transform at this point, so replace arg, and wait for it to re-iterate
                                 IIdAtom * nameF = expr->queryId();
                                 IIdAtom * nameP = child->queryId();
-                                DBGLOG("Folder: Combining FILTER %s with %s %s produces constant filter", nameF ? nameF->str() : "", getOpString(child->getOperator()), nameP ? nameP->str() : "");
+                                DBGLOG("Folder: Combining FILTER %s with %s %s produces constant filter", nameF ? str(nameF) : "", getOpString(child->getOperator()), nameP ? str(nameP) : "");
                                 expandedFilter.setown(transformExpanded(expandedFilter));
                                 IValue * value = expandedFilter->queryValue();
                                 if (value)

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -809,7 +809,7 @@ protected:
 
     IHqlScope * queryTemplateContext();
     bool insideTemplateFunction() { return queryTemplateContext() != NULL; }
-    inline const char * querySourcePathText()   { return sourcePath->str(); } // safe if null
+    inline const char * querySourcePathText()   { return str(sourcePath); } // safe if null
 
     bool areSymbolsCompatible(IHqlExpression * expr, bool isParametered, HqlExprArray & parameters, IHqlExpression * prevValue);
     IHqlExpression * extractBranchMatch(const attribute & errpos, IHqlExpression & curSym, HqlExprArray & values);
@@ -1047,7 +1047,7 @@ class HqlLex
         StringBuffer &getTokenText(StringBuffer &);
         HqlLex* getParentLex() { return parentLex; }
         void setParentLex(HqlLex* pLex) { parentLex = pLex; }
-        const char* getMacroName() { return (macroExpr) ? macroExpr->queryName()->str() : "<param>"; }
+        const char* getMacroName() { return (macroExpr) ? str(macroExpr->queryName()) : "<param>"; }
         IPropertyTree * getClearJavadoc();
 
         void loadXML(const YYSTYPE & errpos, const char * value, const char * child = NULL);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -1287,7 +1287,7 @@ defineid
                         }
     | UNKNOWN_ID UNKNOWN_ID
                         {
-                            parser->reportError(ERR_UNKNOWN_TYPE, $1, "Unknown type '%s'", $1.getId()->str());
+                            parser->reportError(ERR_UNKNOWN_TYPE, $1, "Unknown type '%s'", str($1.getId()));
                             parser->beginDefineId($2.getId(), NULL);
                             $$.setType(NULL);
                             $$.setPosition($1);
@@ -2092,7 +2092,7 @@ transformDst
                         {
                             OwnedHqlExpr lhs = $1.getExpr();
                             if (lhs->isDataset())
-                                parser->reportError(ERR_ASSIGN_MEMBER_DATASET, $1, "Cannot directly assign to field %s within a child dataset", $3.queryExpr()->queryName()->str());
+                                parser->reportError(ERR_ASSIGN_MEMBER_DATASET, $1, "Cannot directly assign to field %s within a child dataset", str($3.queryExpr()->queryName()));
                             $$.setExpr(parser->createSelect(lhs.getClear(), $3.getExpr(), $3), $1);
                         }
     ;
@@ -2103,7 +2103,7 @@ transformDstRecord
                         {
                             OwnedHqlExpr lhs = $1.getExpr();
                             if (lhs->isDataset())
-                                parser->reportError(ERR_ASSIGN_MEMBER_DATASET, $1, "Cannot directly assign to field %s within a child dataset", $3.queryExpr()->queryName()->str());
+                                parser->reportError(ERR_ASSIGN_MEMBER_DATASET, $1, "Cannot directly assign to field %s within a child dataset", str($3.queryExpr()->queryName()));
                             $$.setExpr(parser->createSelect(lhs.getClear(), $3.getExpr(), $3), $1);
                         }
     | transformDstRecord '.' transformDstSelect leaveScope '[' expression ']'
@@ -3007,14 +3007,14 @@ hintList
 hintItem
     : hintName
                         {
-                            $$.setExpr(createExprAttribute($1.getId()->lower()));
+                            $$.setExpr(createExprAttribute(lower($1.getId())));
                             $$.setPosition($1);
                         }
     | hintName '(' beginList hintExprList ')'
                         {
                             HqlExprArray args;
                             parser->endList(args);
-                            $$.setExpr(createExprAttribute($1.getId()->lower(), args));
+                            $$.setExpr(createExprAttribute(lower($1.getId()), args));
                             $$.setPosition($1);
                         }
     ;
@@ -3060,7 +3060,7 @@ hintExpr
                         }
     | UNKNOWN_ID
                         {
-                            $$.setExpr(createAttribute($1.getId()->lower()), $1);
+                            $$.setExpr(createAttribute(lower($1.getId())), $1);
                         }
     ;
 
@@ -3931,22 +3931,22 @@ attrib
     : knownOrUnknownId EQ UNKNOWN_ID        
                         {
                             parser->reportWarning(CategoryDeprecated, SeverityError, WRN_OBSOLETED_SYNTAX,$1.pos,"Syntax obsoleted; use alternative: id = '<string constant>'");
-                            $$.setExpr(createAttribute($1.getId()->lower(), createConstant(*$3.getId())));
+                            $$.setExpr(createAttribute(lower($1.getId()), createConstant(*str($3.getId()))));
                         }
     | knownOrUnknownId EQ expr %prec reduceAttrib
                         {
                             //NOTE %prec is there to prevent a s/r error from the "SERVICE : attrib" production
-                            $$.setExpr(createExprAttribute($1.getId()->lower(), $3.getExpr()), $1);
+                            $$.setExpr(createExprAttribute(lower($1.getId()), $3.getExpr()), $1);
                         }
     | knownOrUnknownId                  
-                        {   $$.setExpr(createAttribute($1.getId()->lower()));  }
+                        {   $$.setExpr(createAttribute(lower($1.getId())));  }
     | knownOrUnknownId '(' expr ')'
                         {
-                            $$.setExpr(createExprAttribute($1.getId()->lower(), $3.getExpr()), $1);
+                            $$.setExpr(createExprAttribute(lower($1.getId()), $3.getExpr()), $1);
                         }
     | knownOrUnknownId '(' expr ',' expr ')'
                         {
-                            $$.setExpr(createExprAttribute($1.getId()->lower(), $3.getExpr(), $5.getExpr()), $1);
+                            $$.setExpr(createExprAttribute(lower($1.getId()), $3.getExpr(), $5.getExpr()), $1);
                         }
     ;
 
@@ -6237,7 +6237,7 @@ primexpr1
     | KEYUNICODE '(' expression ')'
                         {
                             parser->normalizeExpression($3, type_unicode, false);
-                            $$.setExpr(createValue(no_keyunicode, makeDataType(UNKNOWN_LENGTH), $3.getExpr(), createConstant($3.queryExprType()->queryLocale()->str()), createConstant(3)));
+                            $$.setExpr(createValue(no_keyunicode, makeDataType(UNKNOWN_LENGTH), $3.getExpr(), createConstant(str($3.queryExprType()->queryLocale())), createConstant(3)));
                         }
     | KEYUNICODE '(' expression ',' expression ')'
                         {
@@ -6253,7 +6253,7 @@ primexpr1
                         {
                             parser->normalizeExpression($3, type_unicode, false);
                             parser->normalizeExpression($6, type_int, false);
-                            $$.setExpr(createValue(no_keyunicode, makeDataType(UNKNOWN_LENGTH), $3.getExpr(), createConstant($3.queryExprType()->queryLocale()->str()), $6.getExpr()));
+                            $$.setExpr(createValue(no_keyunicode, makeDataType(UNKNOWN_LENGTH), $3.getExpr(), createConstant(str($3.queryExprType()->queryLocale())), $6.getExpr()));
                         }
     | KEYUNICODE '(' expression ',' expression ',' expression ')'
                         {
@@ -6551,7 +6551,7 @@ primexpr1
                             parser->normalizeExpression($5, type_unicode, false);
                             ::Release(parser->checkPromoteType($3, $5));
                             IAtom * locale = parser->ensureCommonLocale($3, $5);
-                            $$.setExpr(createValue(no_unicodeorder, makeIntType(4, true), $3.getExpr(), $5.getExpr(), createConstant(locale->str()), createConstant(3)));
+                            $$.setExpr(createValue(no_unicodeorder, makeIntType(4, true), $3.getExpr(), $5.getExpr(), createConstant(str(locale)), createConstant(3)));
                         }
     | UNICODEORDER '(' expression ',' expression ',' expression ')'
                         {
@@ -6572,7 +6572,7 @@ primexpr1
                             IAtom * locale = parser->ensureCommonLocale($3, $5);
                             parser->normalizeExpression($8, type_int, false);
                             ::Release(parser->checkPromoteType($3, $5));
-                            $$.setExpr(createValue(no_unicodeorder, makeIntType(4, true), $3.getExpr(), $5.getExpr(), createConstant(locale->str()), $8.getExpr()));
+                            $$.setExpr(createValue(no_unicodeorder, makeIntType(4, true), $3.getExpr(), $5.getExpr(), createConstant(str(locale)), $8.getExpr()));
                         }
     | UNICODEORDER '(' expression ',' expression ',' expression ',' expression ')'
                         {
@@ -6670,7 +6670,7 @@ alienTypeInstance
                             else
                             {
                                 if (args)
-                                    parser->reportError(ERR_TYPE_NOPARAMNEEDED, $1, "Type does not require parameters: %s", $1.queryExpr()->queryName()->str());
+                                    parser->reportError(ERR_TYPE_NOPARAMNEEDED, $1, "Type does not require parameters: %s", str($1.queryExpr()->queryName()));
                                 alienExpr.setown($1.getExpr());
                             }
                             $$.setType(makeModifier(alienExpr->getType(), typemod_indirect, LINK(alienExpr)));
@@ -7015,7 +7015,7 @@ globalValueAttribute
                             else
                             {
                                 IIdAtom * name = parser->createFieldNameFromExpr(rhs);
-                                const char * text = name ? name->str() : "?";
+                                const char * text = name ? str(name) : "?";
                                 parser->reportError(ERR_OBJ_NOACTIVEDATASET, $1, "No active dataset to resolve field '%s'", text);
                                 $$.setExpr(createNullExpr(rhs));
                             }

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -3931,7 +3931,7 @@ attrib
     : knownOrUnknownId EQ UNKNOWN_ID        
                         {
                             parser->reportWarning(CategoryDeprecated, SeverityError, WRN_OBSOLETED_SYNTAX,$1.pos,"Syntax obsoleted; use alternative: id = '<string constant>'");
-                            $$.setExpr(createAttribute(lower($1.getId()), createConstant(*str($3.getId()))));
+                            $$.setExpr(createAttribute(lower($1.getId()), createConstant(str($3.getId()))));
                         }
     | knownOrUnknownId EQ expr %prec reduceAttrib
                         {

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -243,7 +243,7 @@ void ActiveScopeInfo::newPrivateScope()
 
 IHqlExpression * ActiveScopeInfo::queryParameter(IIdAtom * id)
 {
-    IAtom * name = id->lower();
+    IAtom * name = lower(id);
     ForEachItemIn(idx, activeParameters)
     {
         IHqlExpression &parm = activeParameters.item(idx);
@@ -268,7 +268,7 @@ static IError * createErrorVA(WarnErrorCategory category, ErrorSeverity severity
 {
     StringBuffer msg;
     msg.valist_appendf(format, args);
-    return createError(category, severity, errNo, msg.str(), pos.sourcePath->str(), pos.lineno, pos.column, pos.position);
+    return createError(category, severity, errNo, msg.str(), str(pos.sourcePath), pos.lineno, pos.column, pos.position);
 }
 
 IHqlExpression * HqlGram::createSetRange(attribute & array, attribute & range)
@@ -773,7 +773,7 @@ static StringBuffer& getFldName(IHqlExpression* field, StringBuffer& s)
         break;
     case no_field:
     default:
-        s.append(field->queryName()->str());
+        s.append(str(field->queryName()));
         break;
     case no_self:
     case no_left:
@@ -804,7 +804,7 @@ IHqlExpression * HqlGram::translateFieldsToNewScope(IHqlExpression * expr, IHqlS
                 newField.setown(record->lookupSymbol(name));
             if (!newField)
             {
-                reportError(ERR_FIELD_NOT_FOUND, err, "Could not find field %s", name->str());
+                reportError(ERR_FIELD_NOT_FOUND, err, "Could not find field %s", str(name));
                 return LINK(expr);
             }
             return createSelectExpr(newDs.getClear(), newField.getClear());
@@ -827,13 +827,13 @@ IHqlExpression * HqlGram::translateFieldsToNewScope(IHqlExpression * expr, IHqlS
 
 void HqlGram::checkSensibleId(const attribute & attr, IIdAtom * id)
 {
-    IAtom * name = id->lower();
+    IAtom * name = lower(id);
     if (name == skipAtom || name == eventExtraAtom || name == eventNameAtom || name == failCodeAtom ||
         name == failMessageAtom || name == countAtom || name == counterAtom ||
         name == matchedAtom || name == matchTextAtom || name == matchUnicodeAtom ||
         name == matchUtf8Atom || name == matchLengthAtom || name == matchPositionAtom
         )
-        reportError(ERR_DUBIOUS_NAME, attr.pos, "Identifier '%s' clashes with a reserved symbol", name->str());
+        reportError(ERR_DUBIOUS_NAME, attr.pos, "Identifier '%s' clashes with a reserved symbol", str(name));
 }
 
 DefineIdSt * HqlGram::createDefineId(int scope, ITypeInfo * ownedType)
@@ -909,11 +909,11 @@ IHqlExpression * HqlGram::processEmbedBody(const attribute & errpos, IHqlExpress
         if (!moduleId)
             moduleId = unnamedId;
         if (!getEmbedContextFunc)
-            reportError(ERR_PluginNoScripting, errpos, "Module %s does not export getEmbedContext() function", moduleId->getAtomNamePtr());
+            reportError(ERR_PluginNoScripting, errpos, "Module %s does not export getEmbedContext() function", str(moduleId));
         bool isImport = queryAttributeInList(importAtom, attribs) != NULL;
         OwnedHqlExpr checkSupport = pluginScope->lookupSymbol(isImport ? supportsImportId : supportsScriptId, LSFpublic, lookupCtx);
         if (!matchesBoolean(checkSupport, true))
-            reportError(ERR_PluginNoScripting, errpos, "Module %s does not support %s", moduleId->getAtomNamePtr(), isImport ? "import" : "script");
+            reportError(ERR_PluginNoScripting, errpos, "Module %s does not support %s", str(moduleId), isImport ? "import" : "script");
         OwnedHqlExpr syntaxCheckFunc = pluginScope->lookupSymbol(syntaxCheckId, LSFpublic, lookupCtx);
         if (syntaxCheckFunc && !isImport)
         {
@@ -2295,7 +2295,7 @@ void HqlGram::addFields(const attribute &errpos, IHqlExpression *e, IHqlExpressi
         if (match)
         {
             if (!clone)
-                reportWarning(CategorySyntax, ERR_REC_DUPFIELD, errpos.pos, "A field called %s is already defined in this record",id->str());
+                reportWarning(CategorySyntax, ERR_REC_DUPFIELD, errpos.pos, "A field called %s is already defined in this record",str(id));
             continue;
         }
 
@@ -2468,7 +2468,7 @@ void HqlGram::addField(const attribute &errpos, IIdAtom * name, ITypeInfo *_type
         name = createUnnamedFieldId();
 
     checkFieldnameValid(errpos, name);
-    if(isUnicodeType(fieldType) && (*fieldType->queryLocale()->str() == 0))
+    if(isUnicodeType(fieldType) && (*str(fieldType->queryLocale()) == 0))
     {
         StringBuffer locale;
         IAtom * localeAtom = createLowerCaseAtom(queryDefaultLocale()->queryValue()->getStringValue(locale));
@@ -2492,9 +2492,9 @@ void HqlGram::addField(const attribute &errpos, IIdAtom * name, ITypeInfo *_type
     if (fieldSize != UNKNOWN_LENGTH)
     {
         if (fieldSize > MAX_SENSIBLE_FIELD_LENGTH)
-            reportWarning(CategoryEfficiency, SeverityError, ERR_BAD_FIELD_SIZE, errpos.pos, "Field %s is larger than max sensible size", name->str());
+            reportWarning(CategoryEfficiency, SeverityError, ERR_BAD_FIELD_SIZE, errpos.pos, "Field %s is larger than max sensible size", str(name));
         else if (fieldSize > MAX_POSSIBLE_FIELD_LENGTH)
-            reportError(ERR_BAD_FIELD_SIZE, errpos.pos, "Field %s is too large", name->str());
+            reportError(ERR_BAD_FIELD_SIZE, errpos.pos, "Field %s is too large", str(name));
     }
 
     OwnedHqlExpr newField = createField(name, fieldType.getClear(), value.getClear(), attrs);
@@ -2622,7 +2622,7 @@ void HqlGram::checkFieldnameValid(const attribute &errpos, IIdAtom * name)
     IHqlSimpleScope *recordScope = self->querySimpleScope();
     OwnedHqlExpr t(recordScope->lookupSymbol(name));
     if (t.get())
-        reportError(ERR_REC_DUPFIELD, errpos, "A field called %s is already defined in this record",name->str());
+        reportError(ERR_REC_DUPFIELD, errpos, "A field called %s is already defined in this record",str(name));
 }
 
 /* Linkage: not affected */
@@ -2723,14 +2723,14 @@ void HqlGram::enterVirtualScope()
         {
             if (fullName.length())
                 fullName.append(".");
-            fullName.append(id->str());
+            fullName.append(str(id));
         }
     }
     if (current_id)
     {
         if (fullName.length())
             fullName.append(".");
-        fullName.append(current_id->str());
+        fullName.append(str(current_id));
     }
 
     ActiveScopeInfo & next = * new ActiveScopeInfo;
@@ -2916,7 +2916,7 @@ void HqlGram::processForwardModuleDefinition(const attribute & errpos)
         case UNKNOWN_ID:
             {
                 IIdAtom * id = nextToken.getId();
-                IAtom * name = id->lower();
+                IAtom * name = lower(id);
                 if ((braNesting == 0) && (endNesting == 0))             // last identifier seen, but don't include parameters, or record members
                     prevId = id;
                 if (name == ruleAtom)
@@ -3194,7 +3194,7 @@ IHqlExpression * HqlGram::implementInterfaceFromModule(const attribute & modpos,
                 if (match)
                     syms.append(*match.getClear());
                 else
-                    reportError(ERR_EXPECTED_ATTRIBUTE, ipos, "Interface does not define %s", id->str());
+                    reportError(ERR_EXPECTED_ATTRIBUTE, ipos, "Interface does not define %s", str(id));
             }
         }
         else
@@ -3214,7 +3214,7 @@ IHqlExpression * HqlGram::implementInterfaceFromModule(const attribute & modpos,
                 newScope->defineSymbol(LINK(match));
             }
             else if (!optional)
-                reportError(ERR_EXPECTED_ATTRIBUTE, modpos, "Module does not define %s", id->str());
+                reportError(ERR_EXPECTED_ATTRIBUTE, modpos, "Module does not define %s", str(id));
         }
     }
 
@@ -3356,7 +3356,7 @@ IHqlExpression *HqlGram::lookupSymbol(IIdAtom * searchName, const attribute& err
                     IHqlExpression* ds = dotScope->queryChild(0);
                     ret = ds->queryRecord()->querySimpleScope()->lookupSymbol(searchName);
                     if (!ret)
-                        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a field named '%s'", ds->queryName()->str(), searchName->str());
+                        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a field named '%s'", str(ds->queryName()), str(searchName));
                 }
                 else
                 {
@@ -3365,7 +3365,7 @@ IHqlExpression *HqlGram::lookupSymbol(IIdAtom * searchName, const attribute& err
                     {
                         StringBuffer s;
                         getExprECL(dotScope, s);
-                        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a field named '%s'", s.str(), searchName->str());
+                        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a field named '%s'", s.str(), str(searchName));
                     }
                 }
             }
@@ -3381,12 +3381,12 @@ IHqlExpression *HqlGram::lookupSymbol(IIdAtom * searchName, const attribute& err
             if (!resolved)
             {
                 if (modScope->queryName())
-                    reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a member named '%s'", modScope->queryName()->str(), searchName->str());
+                    reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a member named '%s'", str(modScope->queryName()), str(searchName));
                 else
-                    reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object does not have a member named '%s'", searchName->str());
+                    reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object does not have a member named '%s'", str(searchName));
             }
             else if ((modScope != containerScope) && !isExported(resolved))
-                reportError(HQLERR_CannotAccessShared, errpos, "Cannot access SHARED symbol '%s' in another module", searchName->str());
+                reportError(HQLERR_CannotAccessShared, errpos, "Cannot access SHARED symbol '%s' in another module", str(searchName));
             return resolved.getClear();
         }
 
@@ -3478,7 +3478,7 @@ IHqlExpression *HqlGram::lookupSymbol(IIdAtom * searchName, const attribute& err
             return recordLookupInTemplateContext(searchName, ret, templateScope);
 
         // finally comes the local scope
-        if (legacyImportSemantics && searchName->lower()==globalScope->queryName())
+        if (legacyImportSemantics && lower(searchName)==globalScope->queryName())
             return LINK(recordLookupInTemplateContext(searchName, queryExpression(globalScope), templateScope));
 
         ForEachItemIn(idx2, defaultScopes)
@@ -3577,7 +3577,7 @@ void HqlGram::checkMaxCompatible(IHqlExpression * sortOrder, IHqlExpression * va
 void HqlGram::checkSvcAttrNoValue(IHqlExpression* attr, const attribute& errpos)
 {
     if (attr->numChildren()>0)
-        reportWarning(CategorySyntax, WRN_SVC_ATTRNEEDNOVALUE, errpos.pos,"Service attribute '%s' requires no value; ignored",attr->queryName()->str());
+        reportWarning(CategorySyntax, WRN_SVC_ATTRNEEDNOVALUE, errpos.pos,"Service attribute '%s' requires no value; ignored",str(attr->queryName()));
 }
 
 void cleanupService(IHqlScope*& serviceScope)
@@ -3597,7 +3597,7 @@ IHqlExpression* HqlGram::checkServiceDef(IHqlScope* serviceScope,IIdAtom * name,
     // already defined?
     OwnedHqlExpr def = serviceScope->lookupSymbol(name, LSFsharedOK|LSFignoreBase, lookupCtx);
     if (def)
-        reportError(ERR_SVC_FUNCDEFINED,errpos, "Function is already defined in service: %s",name->str());
+        reportError(ERR_SVC_FUNCDEFINED,errpos, "Function is already defined in service: %s",str(name));
 
     // gather the attrs
     HqlExprArray attrArray;
@@ -3616,7 +3616,7 @@ IHqlExpression* HqlGram::checkServiceDef(IHqlScope* serviceScope,IIdAtom * name,
             IHqlExpression* attr = &attrArray.item(i);
             IAtom * name = attr->queryName();
             if (attr->queryChild(0) && !attr->queryChild(0)->queryValue())
-                reportError(ERR_EXPECTED_CONST, errpos.pos, "Expected a constant argument for service attribute: '%s';", name->str());
+                reportError(ERR_EXPECTED_CONST, errpos.pos, "Expected a constant argument for service attribute: '%s';", str(name));
 
             // check duplication
             unsigned j;
@@ -3626,7 +3626,7 @@ IHqlExpression* HqlGram::checkServiceDef(IHqlScope* serviceScope,IIdAtom * name,
                 if (cur.queryName()==name)
                 {
                     if (&cur != attr)
-                        reportError(ERR_SVC_ATTRDEFINED, errpos, "Service has duplicate attribute with different value: %s", name->str());
+                        reportError(ERR_SVC_ATTRDEFINED, errpos, "Service has duplicate attribute with different value: %s", str(name));
                     break;
                 }
             }
@@ -3676,7 +3676,7 @@ IHqlExpression* HqlGram::checkServiceDef(IHqlScope* serviceScope,IIdAtom * name,
                 }
 
                 if (invalid)
-                    reportError(ERR_SVC_INVALIDLIBRARY,errpos,"Invalid %s: can not be empty", name->getAtomNamePtr());
+                    reportError(ERR_SVC_INVALIDLIBRARY,errpos,"Invalid %s: can not be empty", str(name));
             }
             else if (name == includeAtom)
             {
@@ -3728,7 +3728,7 @@ IHqlExpression* HqlGram::checkServiceDef(IHqlScope* serviceScope,IIdAtom * name,
                 //backward compatibility
             }
             else // unsupported
-                reportWarning(CategorySyntax,WRN_SVC_UNSUPPORTED_ATTR, errpos.pos, "Unsupported service attribute: '%s'; ignored", name->str());
+                reportWarning(CategorySyntax,WRN_SVC_UNSUPPORTED_ATTR, errpos.pos, "Unsupported service attribute: '%s'; ignored", str(name));
         }
 
         // check attribute conflicts
@@ -3742,7 +3742,7 @@ IHqlExpression* HqlGram::checkServiceDef(IHqlScope* serviceScope,IIdAtom * name,
 
     if (!hasEntrypoint)
     {
-        IHqlExpression *nameAttr = createAttribute(entrypointAtom, createConstant(name->str()));
+        IHqlExpression *nameAttr = createAttribute(entrypointAtom, createConstant(str(name)));
         attrs = createComma(attrs, nameAttr);
     }
     attrs = createComma(attrs, LINK(serviceExtraAttributes));
@@ -4224,7 +4224,7 @@ IHqlExpression * HqlGram::createIndirectSelect(IHqlExpression * lhs, IHqlExpress
         }
     }
 
-    reportError(ERR_DATASET_NOT_CONTAIN_X, errpos, "Dataset doesn't contain a field %s", field->queryName()->str());
+    reportError(ERR_DATASET_NOT_CONTAIN_X, errpos, "Dataset doesn't contain a field %s", str(field->queryName()));
     lhs->Release();
     return createNullExpr(rhs);
 }
@@ -4412,7 +4412,7 @@ IAtom * HqlGram::ensureCommonLocale(attribute &a, attribute &b)
 void HqlGram::ensureUnicodeLocale(attribute & a, char const * locale)
 {
     Owned<ITypeInfo> type = a.queryExpr()->getType();
-    if(strcmp(locale, type->queryLocale()->str()) != 0)
+    if(strcmp(locale, str(type->queryLocale())) != 0)
     {
         switch (type->getTypeCode())
         {
@@ -5784,7 +5784,7 @@ IHqlExpression * HqlGram::createDistributeCond(IHqlExpression * leftDs, IHqlExpr
             IHqlExpression * leftField = leftScope->lookupSymbol(rightField->queryId());
             if (!leftField)
             {
-                reportError(ERR_FIELD_NOT_FOUND, err, "Could not find a field %s in the dataset", rightField->queryName()->str());
+                reportError(ERR_FIELD_NOT_FOUND, err, "Could not find a field %s in the dataset", str(rightField->queryName()));
                 leftField = LINK(rightField);
             }
             IHqlExpression * test = createBoolExpr(no_eq, createSelectExpr(LINK(left), leftField), createSelectExpr(LINK(right), LINK(rightField)));
@@ -5850,7 +5850,7 @@ void HqlGram::reportError(int errNo, const ECLlocation & pos, const char* format
 
 void HqlGram::reportErrorUnexpectedX(const attribute& errpos, IAtom * unexpected)
 {
-    reportError(ERR_UNEXPECTED_ATTRX, errpos, "Unexpected attribute %s", unexpected->str());
+    reportError(ERR_UNEXPECTED_ATTRX, errpos, "Unexpected attribute %s", str(unexpected));
 }
 
 void HqlGram::doReportWarning(WarnErrorCategory category, int warnNo, const char *msg, const char *filename, int lineno, int column, int pos)
@@ -5874,9 +5874,9 @@ void HqlGram::reportMacroExpansionPosition(IError * warning, HqlLex * lexer)
     expandingMacroPosition = true;
     unsigned code = warning->errorCode();
     if (warning->getSeverity() == SeverityFatal)
-        errorHandler->reportError(code, s.str(), lexer->querySourcePath()->str(), lexer->get_yyLineNo(), lexer->get_yyColumn(), 0);
+        errorHandler->reportError(code, s.str(), str(lexer->querySourcePath()), lexer->get_yyLineNo(), lexer->get_yyColumn(), 0);
     else
-        doReportWarning(warning->getCategory(), code, s.str(), lexer->querySourcePath()->str(), lexer->get_yyLineNo(), lexer->get_yyColumn(), 0);
+        doReportWarning(warning->getCategory(), code, s.str(), str(lexer->querySourcePath()), lexer->get_yyLineNo(), lexer->get_yyColumn(), 0);
     expandingMacroPosition = false;
 }
 
@@ -5890,7 +5890,7 @@ void HqlGram::reportError(int errNo, const char *msg, int lineno, int column, in
 {
     if (errorHandler && !errorDisabled)
     {
-        Owned<IError> error = createError(errNo, msg, lexObject->queryActualSourcePath()->str(), lineno, column, position);
+        Owned<IError> error = createError(errNo, msg, str(lexObject->queryActualSourcePath()), lineno, column, position);
         report(error);
     }
 }
@@ -6031,7 +6031,7 @@ void HqlGram::checkFormals(IIdAtom * name, HqlExprArray& parms, HqlExprArray& de
         IHqlExpression* parm = (IHqlExpression*)&parms.item(idx);
 
         if (isMacro && !parm->hasAttribute(noTypeAtom))
-            reportError(ERR_MACRO_NOPARAMTYPE, object, "Type is not allowed for macro: parameter %d of %s", idx+1, name->str());
+            reportError(ERR_MACRO_NOPARAMTYPE, object, "Type is not allowed for macro: parameter %d of %s", idx+1, str(name));
 
         //
         // check default value
@@ -6042,7 +6042,7 @@ void HqlGram::checkFormals(IIdAtom * name, HqlExprArray& parms, HqlExprArray& de
             if ((def->getOperator() != no_omitted) && !def->isConstant()) 
             {
                 if (def->queryType()->getTypeCode() != type_string)                 
-                    reportError(ERR_MACRO_CONSTDEFPARAM, object, "Default parameter to macro must be constant string: parameter %d of %s",idx+1,name->str());
+                    reportError(ERR_MACRO_CONSTDEFPARAM, object, "Default parameter to macro must be constant string: parameter %d of %s",idx+1,str(name));
             }   
         } 
     }   
@@ -6314,7 +6314,7 @@ IHqlExpression * HqlGram::checkParameter(const attribute * errpos, IHqlExpressio
         ((actualType->getTypeCode() == type_void) && !actual->isFunction()))
     {
         if (errpos)
-            reportError(ERR_PARAM_NOTYPEORVOID, *errpos, "Non-typed or void type expression can not used: parameter %s", formalName->str());
+            reportError(ERR_PARAM_NOTYPEORVOID, *errpos, "Non-typed or void type expression can not used: parameter %s", str(formalName));
         return NULL;
     }
 
@@ -6328,9 +6328,9 @@ IHqlExpression * HqlGram::checkParameter(const attribute * errpos, IHqlExpressio
                 if (errpos)
                 {
                     if (isGrouped(formal) != isGrouped(actual))
-                        reportError(ERR_PARAM_TYPEMISMATCH, *errpos, "Grouping for functional parameter %s does not match", formalName->str());
+                        reportError(ERR_PARAM_TYPEMISMATCH, *errpos, "Grouping for functional parameter %s does not match", str(formalName));
                     else
-                        reportError(ERR_PARAM_TYPEMISMATCH, *errpos, "Types for functional parameter %s does not match exactly", formalName->str());
+                        reportError(ERR_PARAM_TYPEMISMATCH, *errpos, "Types for functional parameter %s does not match exactly", str(formalName));
                 }
                 return NULL;
             }
@@ -6340,12 +6340,12 @@ IHqlExpression * HqlGram::checkParameter(const attribute * errpos, IHqlExpressio
         if (formal->isFunction())
         {
             if (errpos)
-                reportError(ERR_PARAM_TYPEMISMATCH, *errpos, "Parameter %s requires an unbound functional argument", formalName->str());
+                reportError(ERR_PARAM_TYPEMISMATCH, *errpos, "Parameter %s requires an unbound functional argument", str(formalName));
             return NULL;
         }
 
         if (errpos)
-            reportError(ERR_PARAM_TYPEMISMATCH, *errpos, "Cannot pass a functional definition to parameter %s", formalName->str());
+            reportError(ERR_PARAM_TYPEMISMATCH, *errpos, "Cannot pass a functional definition to parameter %s", str(formalName));
         return NULL;
     }
 
@@ -6393,13 +6393,13 @@ IHqlExpression * HqlGram::checkParameter(const attribute * errpos, IHqlExpressio
                 StringBuffer s,tp1,tp2;
                 if (isDefault)
                 {
-                    s.appendf("Default for parameter %s type mismatch - expected %s, given %s",formalName->str(),
+                    s.appendf("Default for parameter %s type mismatch - expected %s, given %s",str(formalName),
                             getFriendlyTypeStr(formal,tp1).str(),
                             getFriendlyTypeStr(actual,tp2).str());
                 }
                 else
                 {
-                    s.appendf("Parameter %s type mismatch - expected %s, given %s",formalName->str(),
+                    s.appendf("Parameter %s type mismatch - expected %s, given %s",str(formalName),
                             getFriendlyTypeStr(formal,tp1).str(),
                             getFriendlyTypeStr(actual,tp2).str());
                 }
@@ -6419,7 +6419,7 @@ IHqlExpression * HqlGram::checkParameter(const attribute * errpos, IHqlExpressio
         if (!isValidFieldReference(actual))
         {
             if (errpos)
-                reportError(ERR_EXPECTED_FIELD, *errpos, "Expected a field reference to be passed to parameter %s", formalName->str());
+                reportError(ERR_EXPECTED_FIELD, *errpos, "Expected a field reference to be passed to parameter %s", str(formalName));
             return NULL;
         }
         if (ret->getOperator() != no_indirect)
@@ -6430,7 +6430,7 @@ IHqlExpression * HqlGram::checkParameter(const attribute * errpos, IHqlExpressio
         if (isFieldSelectedFromRecord(ret))
         {
             if (errpos)
-                reportError(ERR_EXPECTED, *errpos, "Expression expected for parameter %s.  Fields from records can only be passed to field references", formalName->str());
+                reportError(ERR_EXPECTED, *errpos, "Expression expected for parameter %s.  Fields from records can only be passed to field references", str(formalName));
             return NULL;
         }
     }
@@ -6440,7 +6440,7 @@ IHqlExpression * HqlGram::checkParameter(const attribute * errpos, IHqlExpressio
         if (!isValidFieldReference(actual) && actualTC != type_sortlist)
         {
             if (errpos)
-                reportError(ERR_EXPECTED_FIELD, *errpos, "Expected a field reference to be passed to parameter %s", formalName->str());
+                reportError(ERR_EXPECTED_FIELD, *errpos, "Expected a field reference to be passed to parameter %s", str(formalName));
             return NULL;
         }
     }
@@ -6450,7 +6450,7 @@ IHqlExpression * HqlGram::checkParameter(const attribute * errpos, IHqlExpressio
 
 static unsigned findParameterByName(IHqlExpression * formals, IIdAtom * searchId)
 {
-    IAtom * searchName = searchId->lower();
+    IAtom * searchName = lower(searchId);
     ForEachChild(i, formals)
     {
         if (formals->queryChild(i)->queryName() == searchName)
@@ -6501,13 +6501,13 @@ bool HqlGram::processParameter(FunctionCallInfo & call, IIdAtom * name, IHqlExpr
         targetActual = findParameterByName(formals, name);
         if (targetActual == (unsigned)-1)
         {
-            reportError(ERR_NAMED_PARAM_NOT_FOUND, errpos, "Could not find a parameter named %s", name->str());
+            reportError(ERR_NAMED_PARAM_NOT_FOUND, errpos, "Could not find a parameter named %s", str(name));
             return false;
         }
 
         if (call.actuals.isItem(targetActual) && call.actuals.item(targetActual).getOperator() != no_omitted)
         {
-            reportError(ERR_NAMED_ALREADY_HAS_VALUE, errpos, "Parameter %s already has a value supplied", name->str());
+            reportError(ERR_NAMED_ALREADY_HAS_VALUE, errpos, "Parameter %s already has a value supplied", str(name));
             return false;
         }
         call.hadNamed = true;
@@ -6546,7 +6546,7 @@ bool HqlGram::processParameter(FunctionCallInfo & call, IIdAtom * name, IHqlExpr
         if (isOmitted(actual))
             return true;
 
-        reportError(ERR_PARAM_TOOMANY, errpos, "Too many parameters passed to function %s (expected %d)", funcName->str(), call.numFormals);
+        reportError(ERR_PARAM_TOOMANY, errpos, "Too many parameters passed to function %s (expected %d)", str(funcName), call.numFormals);
         return false;
     }
 
@@ -6582,7 +6582,7 @@ bool HqlGram::checkParameters(IHqlExpression* func, HqlExprArray& actuals, const
     if (!func->isFunction())
     {
         if (actuals.length())
-            reportError(ERR_TYPE_NOPARAMNEEDED, errpos, "Type does not require parameters: %s", funcName->str());
+            reportError(ERR_TYPE_NOPARAMNEEDED, errpos, "Type does not require parameters: %s", str(funcName));
         return false; 
     }
 
@@ -6601,7 +6601,7 @@ bool HqlGram::checkParameters(IHqlExpression* func, HqlExprArray& actuals, const
             if (!defvalue)
             {
                 IIdAtom * formalName = formal->queryId();
-                reportError(ERR_PARAM_NODEFVALUE, errpos, "Omitted parameter %s has no default value", formalName->str());
+                reportError(ERR_PARAM_NODEFVALUE, errpos, "Omitted parameter %s has no default value", str(formalName));
                 return false;
             }
 //          actuals.replace(*LINK(defvalue), idx);
@@ -6851,7 +6851,7 @@ bool HqlGram::doCheckValidFieldValue(const attribute &errpos, IHqlExpression *va
             } while (value->getOperator() == no_select);
             if (value->getOperator() == no_selfref)
             {
-                reportError(ERR_BAD_FIELD_ATTR, errpos, "SELF cannot be used to provide a value for field '%s'", field->queryName()->str());
+                reportError(ERR_BAD_FIELD_ATTR, errpos, "SELF cannot be used to provide a value for field '%s'", str(field->queryName()));
                 return false;
             }
             return true;
@@ -6924,7 +6924,7 @@ IHqlExpression * HqlGram::checkOutputRecord(IHqlExpression *record, const attrib
                 {
 
                     IIdAtom * name = field->queryId();
-                    reportError(ERR_REC_FIELDNODEFVALUE, errpos, REC_FLD_ERR_STR, name ? name->str() : "?");
+                    reportError(ERR_REC_FIELDNODEFVALUE, errpos, REC_FLD_ERR_STR, name ? str(name) : "?");
                     allConstant = false;                                        // no point reporting this as well.
 
                     HqlExprArray args;
@@ -7017,7 +7017,7 @@ void HqlGram::reportUnsupportedFieldType(ITypeInfo * type, const attribute & err
 
 void HqlGram::reportInvalidIndexFieldType(IHqlExpression * expr, bool isKeyed, const attribute & errpos)
 {
-    const char * id = expr->queryId()->str();
+    const char * id = str(expr->queryId());
     StringBuffer s;
     getFriendlyTypeStr(expr, s);
     if (isKeyed)
@@ -7075,7 +7075,7 @@ void HqlGram::checkIndexFieldType(IHqlExpression * expr, bool isPayload, bool in
                 {
                     if (type->isSigned() ||
                         ((tc == type_littleendianint) && (type->getSize() != 1)))
-                        reportError(ERR_INDEX_BADTYPE, errpos.pos, "Signed or little-endian field %s is not supported inside a keyed record field ", id->str());
+                        reportError(ERR_INDEX_BADTYPE, errpos.pos, "Signed or little-endian field %s is not supported inside a keyed record field ", str(id));
                 }
                 break;
             default:
@@ -7083,7 +7083,7 @@ void HqlGram::checkIndexFieldType(IHqlExpression * expr, bool isPayload, bool in
                     reportInvalidIndexFieldType(expr, false, errpos);
                 else if ((type->getSize() == UNKNOWN_LENGTH) && !variableOk)
                 {
-                    reportError(ERR_INDEX_BADTYPE, errpos, "Variable size fields (%s) are not supported inside indexes", id->str());
+                    reportError(ERR_INDEX_BADTYPE, errpos, "Variable size fields (%s) are not supported inside indexes", str(id));
                     break;
                 }
             }
@@ -7125,7 +7125,7 @@ void HqlGram::checkIndexRecordTypes(IHqlExpression * index, const attribute & er
     {
         if (filename->getOperator() == no_select)
             reportError(ERR_INDEX_DEPEND_DATASET, errpos, "INDEX Filename cannot be dependent on the input dataset.  Field '%s' used from the index.",
-                    filename->queryChild(1)->queryId()->str());
+                    str(filename->queryChild(1)->queryId()));
         else
             reportError(ERR_INDEX_DEPEND_DATASET, errpos, "INDEX filename cannot be dependent on the input dataset.");
     }
@@ -7195,7 +7195,7 @@ public:
         if (!match)
             return true;
         if (field->queryType() != match->queryType())
-            gram.reportError(ERR_TYPEMISMATCH_RECORD, errpos, "Field %s has different type in records", id->str());
+            gram.reportError(ERR_TYPEMISMATCH_RECORD, errpos, "Field %s has different type in records", str(id));
         return false;
     }
 protected:
@@ -7217,7 +7217,7 @@ public:
         ForEachItemIn(i, names)
         {
             if (!matchedName.item(i))
-                gram.reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Record doesn't contain a field called %s", names.item(i).str());
+                gram.reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Record doesn't contain a field called %s", str(&names.item(i)));
         }
     }
     void expand(IHqlExpression * list)
@@ -7261,7 +7261,7 @@ public:
         if (match)
         {
             if (field->queryType() != match->queryType())
-                gram.reportError(ERR_TYPEMISMATCH_RECORD, errpos, "Field %s has different type in records", id->str());
+                gram.reportError(ERR_TYPEMISMATCH_RECORD, errpos, "Field %s has different type in records", str(id));
             return true;
         }
         return false;
@@ -7555,7 +7555,7 @@ void HqlGram::checkGrouping(const attribute& errpos, HqlExprArray & parms, IHqlE
 
                         StringBuffer msg("Field ");
                         if (id)
-                            msg.append("'").append(id->str()).append("' ");
+                            msg.append("'").append(str(id)).append("' ");
                         msg.append("in TABLE does not appear to be properly defined by grouping conditions");
                         reportWarning(CategoryUnexpected, ERR_GROUP_BADSELECT,errpos.pos, "%s", msg.str());
                     }
@@ -7642,7 +7642,7 @@ void HqlGram::checkConditionalAggregates(IIdAtom * name, IHqlExpression * value,
     }
 
     if (cond)
-        reportError(ERR_AGG_FIELD_AFTER_VAR, errpos, "Field %s: Conditional aggregates cannot follow a variable length field", name ? name->str() : "");
+        reportError(ERR_AGG_FIELD_AFTER_VAR, errpos, "Field %s: Conditional aggregates cannot follow a variable length field", name ? str(name) : "");
 }
 
 
@@ -7668,7 +7668,7 @@ void HqlGram::checkProjectedFields(IHqlExpression * e, attribute & errpos)
                 if (isVariableSize)
                 {
                     if (hadVariableAggregate)
-                        reportError(ERR_AGG_FIELD_AFTER_VAR, errpos, "Field %s: Fields cannot follow a variable length aggregate in the record", id ? id->str() : "");
+                        reportError(ERR_AGG_FIELD_AFTER_VAR, errpos, "Field %s: Fields cannot follow a variable length aggregate in the record", id ? str(id) : "");
 
                     if (value->isGroupAggregateFunction())
                         hadVariableAggregate = true;
@@ -7758,7 +7758,7 @@ static bool isFromFile(IHqlExpression * expr)
 static const char * getName(IHqlExpression * e)
 {
     if (e->queryName())
-        return e->queryName()->str();
+        return str(e->queryName());
     return "";
 }
 
@@ -8095,7 +8095,7 @@ void HqlGram::expandPayload(HqlExprArray & fields, IHqlExpression * payload, IHq
                     if (curValue)
                         curValue = queryStripCasts(curValue->queryNormalizedSelector());
                     if (matchValue != curValue)
-                        reportError(ERR_REC_DUPFIELD, errpos, "Field %s is already defined in the key portion", cur->queryName()->str());
+                        reportError(ERR_REC_DUPFIELD, errpos, "Field %s is already defined in the key portion", str(cur->queryName()));
                 }
                 else
                 {
@@ -8380,7 +8380,7 @@ void HqlGram::checkValidCsvRecord(const attribute & errpos, IHqlExpression * rec
     {
         IHqlExpression * badField = queryInvalidCsvRecordField(record);
         if (badField)
-            reportError(ERR_INVALID_CSV_RECORD, errpos, "CSV cannot be used on this record structure (field %s)", badField->queryName()->str());
+            reportError(ERR_INVALID_CSV_RECORD, errpos, "CSV cannot be used on this record structure (field %s)", str(badField->queryName()));
     }
 }
 
@@ -8444,11 +8444,11 @@ int HqlGram::checkRecordTypesSimilar(IHqlExpression *left, IHqlExpression *right
                 if (lAlien && rAlien && 
                     queryExpression(lType)->queryFunctionDefinition() == queryExpression(rType)->queryFunctionDefinition())
                 {
-                    reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Fields %s and %s use incompatible instances of the same user type %s",lfield->queryName()->str(), rfield->queryName()->str(), ltype.str());
+                    reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Fields %s and %s use incompatible instances of the same user type %s",str(lfield->queryName()), str(rfield->queryName()), ltype.str());
                 }
                 else
                 {
-                    reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Type mismatch for corresponding fields %s (%s) vs %s (%s)",lfield->queryName()->str(), ltype.str(), rfield->queryName()->str(), rtype.str());
+                    reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Type mismatch for corresponding fields %s (%s) vs %s (%s)",str(lfield->queryName()), ltype.str(), str(rfield->queryName()), rtype.str());
                 }
             }
         }
@@ -8514,7 +8514,7 @@ bool HqlGram::checkRecordCreateTransform(HqlExprArray & assigns, IHqlExpression 
             IAtom * rightName = rightExpr->queryName();
             if (leftName != rightName)
             {
-                reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Name mismatch for corresponding fields %s vs %s",leftName->str(), rightName->str());
+                reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Name mismatch for corresponding fields %s vs %s",str(leftName), str(rightName));
                 return false;
             }
 
@@ -8527,10 +8527,10 @@ bool HqlGram::checkRecordCreateTransform(HqlExprArray & assigns, IHqlExpression 
                     StringBuffer ltype, rtype;
                     getFriendlyTypeStr(leftExpr, ltype);
                     getFriendlyTypeStr(rightExpr, rtype);
-                    reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Type mismatch for corresponding fields %s (%s) vs %s (%s)",leftName->str(), ltype.str(), rightName->str(), rtype.str());
+                    reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Type mismatch for corresponding fields %s (%s) vs %s (%s)",str(leftName), ltype.str(), str(rightName), rtype.str());
                 }
                 else
-                    reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Datasets must have the same types for field %s vs %s: one is Record, the other is not", leftName->str(), rightName->str());
+                    reportError(ERR_TYPEMISMATCH_DATASET, errPos, "Datasets must have the same types for field %s vs %s: one is Record, the other is not", str(leftName), str(rightName));
                 return false;
             }
 
@@ -8763,9 +8763,9 @@ void HqlGram::checkNotAlreadyDefined(IIdAtom * name, IHqlScope * scope, const at
     if (expr)
     {
         if (legacyImportSemantics && isImport(expr))
-            reportWarning(CategoryConfuse, ERR_ID_REDEFINE, idattr.pos, "Identifier '%s' hides previous import", name->str());
+            reportWarning(CategoryConfuse, ERR_ID_REDEFINE, idattr.pos, "Identifier '%s' hides previous import", str(name));
         else
-            reportError(ERR_ID_REDEFINE, idattr, "Identifier '%s' is already defined", name->str());
+            reportError(ERR_ID_REDEFINE, idattr, "Identifier '%s' is already defined", str(name));
     }
 }
 
@@ -8778,7 +8778,7 @@ void HqlGram::checkNotAlreadyDefined(IIdAtom * name, const attribute & idattr)
     checkNotAlreadyDefined(name, activeScope.privateScope, idattr);
     unsigned numScopes = defineScopes.ordinality();
     if ((numScopes > 1) && defineScopes.item(numScopes-2).queryParameter(name))
-        reportError(ERR_ID_REDEFINE, idattr, "Identifier '%s' is already defined as a parameter", name->str());
+        reportError(ERR_ID_REDEFINE, idattr, "Identifier '%s' is already defined as a parameter", str(name));
 }
 
 
@@ -9004,11 +9004,11 @@ void HqlGram::checkDerivedCompatible(IIdAtom * name, IHqlExpression * scope, IHq
             if (match)
             {
                 if (!canBeVirtual(match))
-                    reportError(ERR_MISMATCH_PROTO, errpos, "Definition %s, cannot override this kind of definition", name->str());
+                    reportError(ERR_MISMATCH_PROTO, errpos, "Definition %s, cannot override this kind of definition", str(name));
                 else
                 {
                     if (!areSymbolsCompatible(expr, isParametered, parameters, match))
-                        reportError(ERR_MISMATCH_PROTO, errpos, "Prototypes for %s in base and derived modules must match", name->str());
+                        reportError(ERR_MISMATCH_PROTO, errpos, "Prototypes for %s in base and derived modules must match", str(name));
                 }
             }
         }
@@ -9065,7 +9065,7 @@ IHqlExpression * HqlGram::associateSideEffects(IHqlExpression * expr, const ECLl
             {
                 if (expr->isScope())
                 {
-                    Owned<IError> error = createError(CategorySyntax, SeverityError, ERR_RESULT_IGNORED_SCOPE, "Cannot associate a side effect with a module - action will be lost", errpos.sourcePath->str(), errpos.lineno, errpos.column, errpos.position);
+                    Owned<IError> error = createError(CategorySyntax, SeverityError, ERR_RESULT_IGNORED_SCOPE, "Cannot associate a side effect with a module - action will be lost", str(errpos.sourcePath), errpos.lineno, errpos.column, errpos.position);
                     //Unusual processing.  Create a warning and save it in the parse context
                     //The reason is that this error is reporting "the associated side-effects will be lost" - but
                     //the same will apply to the warning, and if it's lost there will be no way to report it later...
@@ -9113,18 +9113,18 @@ void HqlGram::doDefineSymbol(DefineIdSt * defineid, IHqlExpression * _expr, IHql
         // define the symbol
         if (defineid->scope & (EXPORT_FLAG | SHARED_FLAG))
         {
-            if (expectedAttribute && (expectedAttribute->lower() != name->lower()) && (activeScope.localScope == parseScope))
+            if (expectedAttribute && (lower(expectedAttribute) != lower(name)) && (activeScope.localScope == parseScope))
             {
                 OwnedHqlExpr resolved = parseScope->lookupSymbol(expectedAttribute, LSFsharedOK, lookupCtx);
                 if (resolved)
                 {
-                    reportError(ERR_UNEXPECTED_PUBLIC_ID, idattr.pos, "Definition of '%s' has a trailing public definition '%s'", expectedAttribute->str(), name->str());
+                    reportError(ERR_UNEXPECTED_PUBLIC_ID, idattr.pos, "Definition of '%s' has a trailing public definition '%s'", str(expectedAttribute), str(name));
                 }
                 else
                 {
                     //Make this warning come out now - otherwise a subsequent error about an undefined symbol makes less sense.
                     RestoreValueBlock<bool> block(associateWarnings, false);
-                    reportWarning(CategorySyntax, ERR_UNEXPECTED_PUBLIC_ID, idattr.pos, "Name of exported symbol '%s' does not match the expected name '%s'", name->str(), expectedAttribute->str());
+                    reportWarning(CategorySyntax, ERR_UNEXPECTED_PUBLIC_ID, idattr.pos, "Name of exported symbol '%s' does not match the expected name '%s'", str(name), str(expectedAttribute));
                 }
                 defineid->scope = 0;
             }
@@ -9326,7 +9326,7 @@ void HqlGram::defineSymbolProduction(attribute & nameattr, attribute & paramattr
         if (etype && etype->getTypeCode()==type_record)
         {
             IHqlExpression *recordDef = queryExpression(etype);
-            expr.setown(createDatasetF(no_table, createConstant(*name), LINK(recordDef), LINK(expr), NULL));
+            expr.setown(createDatasetF(no_table, createConstant(str(name)), LINK(recordDef), LINK(expr), NULL));
         }
         break;
 
@@ -9368,13 +9368,13 @@ void HqlGram::defineSymbolProduction(attribute & nameattr, attribute & paramattr
             {
                 //only report error in base class clash, others will be reported later.
                 if (!localMatch)
-                    reportError(ERR_SHOULD_BE_EXPORTED, nameattr, "Private symbol %s clashes with public symbol in base module", name->str());
+                    reportError(ERR_SHOULD_BE_EXPORTED, nameattr, "Private symbol %s clashes with public symbol in base module", str(name));
             }
 
             if (localScopeExpr->hasAttribute(interfaceAtom))
             {
 //              defineid->scope |= EXPORT_FLAG;
-                reportError(ERR_SHOULD_BE_EXPORTED, nameattr, "Symbol %s in INTERFACE should be EXPORTed or SHARED", name->str());
+                reportError(ERR_SHOULD_BE_EXPORTED, nameattr, "Symbol %s in INTERFACE should be EXPORTed or SHARED", str(name));
             }
         }
         else
@@ -9382,7 +9382,7 @@ void HqlGram::defineSymbolProduction(attribute & nameattr, attribute & paramattr
             if (anyMatch && !localScopeExpr->hasAttribute(_virtualSeq_Atom))
             {
                 //Not quite right - it is a problem if the place it is defined in isn't virtual
-                reportError(ERR_CANNOT_REDEFINE, nameattr, "Cannot redefine definition %s from a non-virtual MODULE", name->str());
+                reportError(ERR_CANNOT_REDEFINE, nameattr, "Cannot redefine definition %s from a non-virtual MODULE", str(name));
             }
             else if (anyMatch && !localMatch)
             {
@@ -9398,7 +9398,7 @@ void HqlGram::defineSymbolProduction(attribute & nameattr, attribute & paramattr
                         //allow dataset with no record to match, as long as base type is the same
                         if (queryRecord(type) != queryNullRecord() || (type->getTypeCode() != matchType->getTypeCode()))
                         {
-                            reportError(ERR_SAME_TYPE_REQUIRED, nameattr, "Explicit type for %s doesn't match definition in base module", name->str());
+                            reportError(ERR_SAME_TYPE_REQUIRED, nameattr, "Explicit type for %s doesn't match definition in base module", str(name));
                         }
                         else
                         {
@@ -9541,7 +9541,7 @@ bool HqlGram::checkCompatibleSymbol(const attribute & errpos, IHqlExpression * p
 IHqlExpression * HqlGram::extractBranchMatch(const attribute & errpos, IHqlExpression & curSym, HqlExprArray & values)
 {
     IIdAtom * id = curSym.queryId();
-    IAtom * name = id->lower();
+    IAtom * name = lower(id);
     ForEachItemIn(i, values)
     {
         IHqlExpression & cur = values.item(i);
@@ -9565,7 +9565,7 @@ IHqlExpression * HqlGram::extractBranchMatch(const attribute & errpos, IHqlExpre
         // The following test is no good though, we need to check if reused only in this branch.
 //      if (curSym.isShared())
 //          return NULL;
-        reportWarning(CategoryMistake, WRN_COND_ASSIGN_NO_PREV, errpos.pos, "Conditional assignment to %s isn't defined in all branches, and has no previous definition", id->str());
+        reportWarning(CategoryMistake, WRN_COND_ASSIGN_NO_PREV, errpos.pos, "Conditional assignment to %s isn't defined in all branches, and has no previous definition", str(id));
         return NULL;
     }
 
@@ -9650,7 +9650,7 @@ void HqlGram::processIfScope(const attribute & errpos, IHqlExpression * cond, IH
                 {
                     OwnedHqlExpr match = activeScope.localScope->lookupSymbol(id, LSFsharedOK|LSFignoreBase, lookupCtx);
                     if (match)
-                        reportError(ERR_ID_REDEFINE, errpos, "Identifier '%s' is already defined as a public symbol in this context", id->str());
+                        reportError(ERR_ID_REDEFINE, errpos, "Identifier '%s' is already defined as a public symbol in this context", str(id));
                 }
                 defineScope->defineSymbol(newSym.getClear());
             }
@@ -9683,7 +9683,7 @@ void HqlGram::cloneInheritedAttributes(IHqlScope * scope, const attribute & errp
             ForEachItemIn(iSym, syms)
             {
                 IIdAtom * id = syms.item(iSym).queryId();
-                IAtom * name = id->lower();
+                IAtom * name = lower(id);
                 OwnedHqlExpr baseSym = curBase->lookupSymbol(id, LSFsharedOK|LSFfromderived, lookupCtx);
                 OwnedHqlExpr match  = scope->lookupSymbol(id, LSFsharedOK|LSFignoreBase, lookupCtx);
 
@@ -9701,7 +9701,7 @@ void HqlGram::cloneInheritedAttributes(IHqlScope * scope, const attribute & errp
                         if (mapped->queryBody() != match->queryBody())
                         {
                             //MORE: Could allow it to be ambiguous (by creating a no_purevirtual), but better to require immediate resolution
-                            reportError(ERR_AMBIGUOUS_DEF, errpos, "Definition %s must be specified, it has different definitions in base modules", id->str());
+                            reportError(ERR_AMBIGUOUS_DEF, errpos, "Definition %s must be specified, it has different definitions in base modules", str(id));
                         }
                     }
                 }
@@ -9747,17 +9747,17 @@ void HqlGram::checkExportedModule(const attribute & errpos, IHqlExpression * sco
             if (value)
             {
                 if (value->isFunction())
-                    reportError(ERR_BAD_LIBRARY_SYMBOL, errpos, "Library modules cannot export functional definition %s", id->str());
+                    reportError(ERR_BAD_LIBRARY_SYMBOL, errpos, "Library modules cannot export functional definition %s", str(id));
                 else if (value->isDataset() || value->isDatarow() || value->queryType()->isScalar())
                 {
                 }
                 else if (value->isList())
-                    reportError(ERR_BAD_LIBRARY_SYMBOL, errpos, "Library modules cannot export list definition %s (use a dataset instead)", id->str());
+                    reportError(ERR_BAD_LIBRARY_SYMBOL, errpos, "Library modules cannot export list definition %s (use a dataset instead)", str(id));
                 else
                 {
                     //Should we report an error, or should we just ignore it?  Probably doesn't cause any problems as long as caught
                     //on invalid use.
-                    //reportError(ERR_BAD_LIBRARY_SYMBOL, errpos, "Library modules cannot export functional definition %s", name->str());
+                    //reportError(ERR_BAD_LIBRARY_SYMBOL, errpos, "Library modules cannot export functional definition %s", str(name));
                 }
             }
         }
@@ -9779,7 +9779,7 @@ void HqlGram::checkLibraryParametersMatch(const attribute & errpos, bool isParam
                     IHqlExpression & cur = activeParameters.item(i);
                     IHqlExpression * expected = formals->queryChild(i);
                     if ((cur.queryName() != expected->queryName()) || (cur.queryType() != expected->queryType()))
-                        reportError(ERR_PROTOTYPE_MISMATCH, errpos, "Parameter %s does not match the appropriate parameter as the LIBRARY interface it implements", cur.queryName()->str());
+                        reportError(ERR_PROTOTYPE_MISMATCH, errpos, "Parameter %s does not match the appropriate parameter as the LIBRARY interface it implements", str(cur.queryName()));
                 }
             }
             else
@@ -10063,7 +10063,7 @@ IIdAtom * HqlGram::getNameFromExpr(attribute& attr)
         default:
             {
                 IIdAtom * id = expr->queryId();
-                if (id && (id->lower() != unnamedId->lower()))
+                if (id && (lower(id) != lower(unnamedId)))
                     return id;
                 reportError(ERR_EXPECTED_IDENTIFIER, attr, "Expected an identifier");
                 return unknownId;
@@ -10103,7 +10103,7 @@ IIdAtom * HqlGram::createFieldNameFromExpr(IHqlExpression * expr)
                 StringBuffer temp;
                 temp.append("_unnamed_").append(getOpString(expr->getOperator())).append("_");
                 temp.toLowerCase();
-                temp.append(createFieldNameFromExpr(expr->queryChild(0))->lower());
+                temp.append(lower(createFieldNameFromExpr(expr->queryChild(0))));
                 name = createUnnamedFieldId(temp.str());
             }
             break;
@@ -10113,9 +10113,9 @@ IIdAtom * HqlGram::createFieldNameFromExpr(IHqlExpression * expr)
                 StringBuffer temp;
                 temp.append("_unnamed_").append(getOpString(expr->getOperator())).append("_");
                 temp.toLowerCase();
-                temp.append(createFieldNameFromExpr(expr->queryChild(0))->lower());
+                temp.append(lower(createFieldNameFromExpr(expr->queryChild(0))));
                 temp.append("_");
-                temp.append(createFieldNameFromExpr(expr->queryChild(1))->lower());
+                temp.append(lower(createFieldNameFromExpr(expr->queryChild(1))));
                 name = createUnnamedFieldId(temp.str());
             }
             break;
@@ -10166,9 +10166,9 @@ IHqlExpression * HqlGram::resolveImportModule(const attribute & errpos, IHqlExpr
 
             StringBuffer msg;
             if (!importMatch)
-                msg.appendf("Import names unknown module \"%s\"", id->getAtomNamePtr());
+                msg.appendf("Import names unknown module \"%s\"", str(id));
             else
-                msg.appendf("Import item  \"%s\" is not a module", id->getAtomNamePtr());
+                msg.appendf("Import item  \"%s\" is not a module", str(id));
             reportError(ERR_MODULE_UNKNOWN, msg.str(),
                         lexObject->getActualLineNo(), 
                         lexObject->getActualColumn(), 
@@ -10183,10 +10183,10 @@ IHqlExpression * HqlGram::resolveImportModule(const attribute & errpos, IHqlExpr
     if (!parent)
         return NULL;
 
-    const char * parentName = parent->queryId()->str();
+    const char * parentName = str(parent->queryId());
     if (name == _container_Atom)
     {
-        const char * containerName = parent->queryFullContainerId()->str();
+        const char * containerName = str(parent->queryFullContainerId());
         //This is a bit ugly - remove the last qualified module, and resolve the name again.  A more "correct" method
         //saving container pointers hit problems because remote scopes within CHqlMergedScope containers have a remote
         //scope as the parent, rather than the merged scope...
@@ -10216,13 +10216,13 @@ IHqlExpression * HqlGram::resolveImportModule(const attribute & errpos, IHqlExpr
     {
         if (!parentName)
             parentName = "$";
-        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a field named '%s'", parentName, childId->str());
+        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "Object '%s' does not have a field named '%s'", parentName, str(childId));
         return NULL;
     }
     IHqlScope * ret = resolved->queryScope();
     if (!ret)
     {
-        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "'%s' is not a module", childId->str());
+        reportError(ERR_OBJ_NOSUCHFIELD, errpos, "'%s' is not a module", str(childId));
         return NULL;
     }
     return resolved.getClear();
@@ -10325,7 +10325,7 @@ void HqlGram::processImport(attribute & membersAttr, attribute & modulesAttr, II
             defineImport(membersAttr, resolved, newName);
         }
         else
-            reportError(ERR_OBJ_NOSUCHFIELD, modulesAttr, "Module '%s' does not contain a definition named '%s'", module->queryName()->str(), id->str());
+            reportError(ERR_OBJ_NOSUCHFIELD, modulesAttr, "Module '%s' does not contain a definition named '%s'", str(module->queryName()), str(id));
     }
 }
 
@@ -11532,7 +11532,7 @@ void HqlGram::checkFieldMap(IHqlExpression* map, attribute& errpos)
     {
         for (unsigned j=i+2;j<mapCount; j+=2)
             if (maps.item(i).queryName()==maps.item(j).queryName())
-                reportError(ERR_DSPARM_MAPDUPLICATE, errpos, "Field '%s' is mapped more than once", maps.item(i).queryName()->str());
+                reportError(ERR_DSPARM_MAPDUPLICATE, errpos, "Field '%s' is mapped more than once", str(maps.item(i).queryName()));
     }
 
     // Note: a->b, b->c is allowed. Even the following are allowed:
@@ -11585,7 +11585,7 @@ PseudoPatternScope::PseudoPatternScope(IHqlExpression * _patternList) : CHqlScop
 
 IHqlExpression * PseudoPatternScope::lookupSymbol(IIdAtom * name, unsigned lookupFlags, HqlLookupContext & ctx)
 {
-    const char * text = name->str();
+    const char * text = str(name);
     if (*text == '$')
     {
         unsigned index = atoi(text+1);
@@ -11631,13 +11631,13 @@ extern HQL_API IHqlExpression * parseQuery(IHqlScope *scope, IFileContents * con
             if (E->errorCode()==0)
             {
                 StringBuffer s;
-                ctx.errs->reportError(ERR_INTERNALEXCEPTION, E->errorMessage(s).str(), sourcePath->str(), 0, 0, 1);
+                ctx.errs->reportError(ERR_INTERNALEXCEPTION, E->errorMessage(s).str(), str(sourcePath), 0, 0, 1);
             }
             else
             {
                 StringBuffer s("Internal error: ");
                 E->errorMessage(s);
-                ctx.errs->reportError(ERR_INTERNALEXCEPTION, s.str(), sourcePath->str(), 0, 0, 1);
+                ctx.errs->reportError(ERR_INTERNALEXCEPTION, s.str(), str(sourcePath), 0, 0, 1);
             }
         }
         E->Release();
@@ -11667,13 +11667,13 @@ extern HQL_API void parseModule(IHqlScope *scope, IFileContents * contents, HqlL
             if (E->errorCode()==0)
             {
                 StringBuffer s;
-                ctx.errs->reportError(ERR_INTERNALEXCEPTION, E->errorMessage(s).str(), sourcePath->str(), 0, 0, 1);
+                ctx.errs->reportError(ERR_INTERNALEXCEPTION, E->errorMessage(s).str(), str(sourcePath), 0, 0, 1);
             }
             else
             {
                 StringBuffer s("Internal error: ");
                 E->errorMessage(s);
-                ctx.errs->reportError(ERR_INTERNALEXCEPTION, s.str(), sourcePath->str(), 0, 0, 1);
+                ctx.errs->reportError(ERR_INTERNALEXCEPTION, s.str(), str(sourcePath), 0, 0, 1);
             }
         }
         E->Release();

--- a/ecl/hql/hqlir.cpp
+++ b/ecl/hql/hqlir.cpp
@@ -1447,9 +1447,9 @@ protected:
     {
         line.append(getOperatorIRText(op));
         if (info.id)
-            line.append("#").append(info.id->str());
+            line.append("#").append(str(info.id));
         else if (info.name)
-            line.append("#").append(info.name->str());
+            line.append("#").append(str(info.name));
         if (info.sequence)
             line.append("[seq(").append(info.sequence).append(")]");
 
@@ -1855,12 +1855,12 @@ id_t ExpressionIRPlayer::doProcessType(ITypeInfo * type)
         case type_varunicode:
         case type_utf8:
             info.length = type->getStringLen();
-            info.locale = type->queryLocale()->str();
+            info.locale = str(type->queryLocale());
             break;;
         case type_string:
         case type_varstring:
             info.length = type->getStringLen();
-            info.locale = type->queryCharset()->queryName()->str();
+            info.locale = str(type->queryCharset()->queryName());
             break;
         case type_bitfield:
             return target->addUnknownType(tc);
@@ -2074,7 +2074,7 @@ id_t ExpressionIRPlayer::doProcessAnnotation(IHqlExpression * expr)
     case annotate_symbol:
         {
             IHqlNamedAnnotation * annotation = static_cast<IHqlNamedAnnotation *>(expr->queryAnnotation());
-            info.name = expr->queryId()->str();
+            info.name = str(expr->queryId());
             info.value = annotation->isExported() ? ob_exported : annotation->isShared() ? ob_shared : 0;
             if (annotation->isVirtual())
                 info.value |= ob_virtual;
@@ -2083,7 +2083,7 @@ id_t ExpressionIRPlayer::doProcessAnnotation(IHqlExpression * expr)
             break;
         }
     case annotate_location:
-        info.name = expr->querySourcePath()->str();
+        info.name = str(expr->querySourcePath());
         info.line = expr->getStartLine();
         info.col = expr->getStartColumn();
         break;

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -75,7 +75,7 @@ int HqlLex::lookupIdentifierToken(YYSTYPE & returnToken, HqlLex * lexer, bool lo
     if (lexer->macroParms)
     {
         StringBuffer macroval;
-        if (lexer->macroParms->getProp(name->str(), macroval))
+        if (lexer->macroParms->getProp(str(name), macroval))
         {
             lexer->pushText(macroval.str());
             return lexer->yyLex(returnToken, lookup, activeState);
@@ -99,7 +99,7 @@ int HqlLex::lookupIdentifierToken(YYSTYPE & returnToken, HqlLex * lexer, bool lo
         StringBuffer alternativeText;
         if (alternative && alternative->queryValue())
             alternative->queryValue()->getStringValue(alternativeText);
-        lexer->reportWarning(CategoryDeprecated, returnToken, ERR_DEPRECATED_ATTR, "Definition %s is marked as deprecated.  %s", name->str(), alternativeText.str());
+        lexer->reportWarning(CategoryDeprecated, returnToken, ERR_DEPRECATED_ATTR, "Definition %s is marked as deprecated.  %s", str(name), alternativeText.str());
     }                   
     
 #if defined(TRACE_MACRO)

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -6,7 +6,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.04
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -344,7 +344,7 @@ void HqlLex::setMacroParam(const YYSTYPE & errpos, IHqlExpression* funcdef, Stri
     unsigned thisParam = (unsigned)-1;
     if (argumentId)
     {
-        IAtom * argumentName = argumentId->lower();
+        IAtom * argumentName = lower(argumentId);
         unsigned argNum = 0;
         for (unsigned i=0; i < numFormals; i++)
         {
@@ -356,7 +356,7 @@ void HqlLex::setMacroParam(const YYSTYPE & errpos, IHqlExpression* funcdef, Stri
         }
 
         if (argNum == 0)
-            reportError(errpos, ERR_NAMED_PARAM_NOT_FOUND, "Named parameter '%s' not found in macro", argumentId->str());
+            reportError(errpos, ERR_NAMED_PARAM_NOT_FOUND, "Named parameter '%s' not found in macro", str(argumentId));
         else
             thisParam = argNum;
     }
@@ -389,7 +389,7 @@ void HqlLex::setMacroParam(const YYSTYPE & errpos, IHqlExpression* funcdef, Stri
 //      if (macroParms->queryProp(formal->queryName()))
 //          reportError(errpos, ERR_NAMED_ALREADY_HAS_VALUE, "Parameter %s already has a value supplied", argumentName->str());
 //      else
-            macroParms->setProp(formal->queryName()->str(), curParam.str());
+            macroParms->setProp(str(formal->queryName()), curParam.str());
     }
     curParam.clear();
 }
@@ -464,7 +464,7 @@ void HqlLex::pushMacro(IHqlExpression *expr)
                     if (memicmp(text, "NAMED", 5) == 0)
                         text += 5;
                     while (isspace((byte)*text)) text++;
-                    if (strlen(possibleName->str()) == strlen(text))
+                    if (strlen(str(possibleName)) == strlen(text))
                     {
                         argumentName = possibleName;
                         possibleName = NULL;
@@ -504,7 +504,7 @@ void HqlLex::pushMacro(IHqlExpression *expr)
         for (unsigned idx = parmno; idx < formalParmCt; idx++)
         {
             IHqlExpression* formal = formals->queryChild(idx);
-            if (!macroParms->queryProp(formal->queryName()->str()))
+            if (!macroParms->queryProp(str(formal->queryName())))
             {
                 IHqlExpression* def = queryDefaultValue(defaults, idx);
                 if (def)
@@ -518,7 +518,7 @@ void HqlLex::pushMacro(IHqlExpression *expr)
                         msg.append(" should be a constant value");
                         reportError(nextToken, ERR_PARAM_NODEFVALUE, "%s", msg.str());
                     }
-                    macroParms->setProp(formal->queryName()->str(), curParam.str());
+                    macroParms->setProp(str(formal->queryName()), curParam.str());
                     //PrintLog("Set macro parm: %s", curParam.str());
                     curParam.clear();
                 }
@@ -808,7 +808,7 @@ void HqlLex::doDeclare(YYSTYPE & returnToken)
         }
 
         name = returnToken.getId();
-        declareXmlSymbol(returnToken, name->getAtomNamePtr());
+        declareXmlSymbol(returnToken, str(name));
 
         tok = yyLex(returnToken, false,0);
         if (tok == ')')
@@ -902,7 +902,7 @@ void HqlLex::doSet(YYSTYPE & returnToken, bool append)
     {
         StringBuffer buf;
         value->getStringValue(buf);
-        setXmlSymbol(returnToken, name->getAtomNamePtr(), buf.str(), append);
+        setXmlSymbol(returnToken, str(name), buf.str(), append);
         value->Release();
     }
 }
@@ -1048,7 +1048,7 @@ void HqlLex::doExport(YYSTYPE & returnToken, bool toXml)
         }
         catch (...)
         {
-            setXmlSymbol(returnToken, exportname->getAtomNamePtr(), "", false);
+            setXmlSymbol(returnToken, str(exportname), "", false);
             PrintLog("Unexpected exception in doExport()");
         }
         if (!more)
@@ -1057,9 +1057,9 @@ void HqlLex::doExport(YYSTYPE & returnToken, bool toXml)
     StringBuffer buf;
     toXML(data, buf, 0);
     if (toXml)
-        ensureTopXmlScope()->loadXML(buf.str(), exportname->getAtomNamePtr());
+        ensureTopXmlScope()->loadXML(buf.str(), str(exportname));
     else
-        setXmlSymbol(returnToken, exportname->getAtomNamePtr(), buf.str(), false);
+        setXmlSymbol(returnToken, str(exportname), buf.str(), false);
     data->Release();
 }
 
@@ -1169,7 +1169,7 @@ void HqlLex::doFor(YYSTYPE & returnToken, bool doAll)
     }
     ::Release(forLoop);
 
-    forLoop = getSubScopes(returnToken, name->getAtomNamePtr(), doAll);
+    forLoop = getSubScopes(returnToken, str(name), doAll);
     if (forFilterText.length())
         forFilter.setown(createFileContentsFromText(forFilterText, sourcePath));
     forBody.setown(createFileContentsFromText(forBodyText, sourcePath));
@@ -1396,7 +1396,7 @@ void HqlLex::doUniqueName(YYSTYPE & returnToken)
             else
                 reportError(returnToken, ERR_EXPECTED, "string expected");
         }
-        declareUniqueName(name->getAtomNamePtr(), pattern);
+        declareUniqueName(str(name), pattern);
     }
 
     if (tok != ')')

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -6,7 +6,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.04
+       http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/ecl/hql/hqlplugininfo.cpp
+++ b/ecl/hql/hqlplugininfo.cpp
@@ -52,7 +52,7 @@ IPropertyTree * createPluginPropertyTree(IEclRepository * plugins, bool includeM
         unsigned flags = module->getPropInt(flagsAtom, 0);
         IPropertyTree* prop = createPTree("Module", ipt_caseInsensitive);
         prop->setProp("@name", module->queryFullName());
-        prop->setProp("@path", module->querySourcePath()->str());
+        prop->setProp("@path", str(module->querySourcePath()));
         prop->setPropInt("@access", module->getPropInt(accessAtom, 3));
         prop->setPropInt("@timestamp", 1);
         prop->setPropInt("@flags", flags);

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -532,7 +532,7 @@ IHqlExpression * NewProjectMapper2::recursiveExpandSelect(IHqlExpression * expr,
                 dbglogExpr(&targets.item(i));
 #endif
             IHqlExpression * field = expr->queryChild(1);
-            throwError1(HQLERR_SelectedFieldXNotInDataset, field->queryName()->str());
+            throwError1(HQLERR_SelectedFieldXNotInDataset, str(field->queryName()));
         }
         IHqlExpression * expanded = &sources.item(match);
         if ((newDataset == oldParent) || !newDataset)

--- a/ecl/hql/hqlrepository.cpp
+++ b/ecl/hql/hqlrepository.cpp
@@ -283,7 +283,7 @@ static void getFullName(StringBuffer & fullName, IHqlScope * scope, IIdAtom * at
     fullName.append(scope->queryFullName());
     if (fullName.length())
         fullName.append(".");
-    fullName.append(attrName->str());
+    fullName.append(str(attrName));
 }
 
 
@@ -305,7 +305,7 @@ IHqlExpression * CNewEclRepository::createSymbol(IHqlRemoteScope * rScope, IEclS
             Owned<IProperties> props = source->getProperties();
             if (props)
             {
-                unsigned flags = props->getPropInt(flagsAtom->str(), 0);
+                unsigned flags = props->getPropInt(str(flagsAtom), 0);
                 if (flags & ob_sandbox)
                     symbolFlags |= ob_sandbox;
             }

--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -214,7 +214,7 @@ HqltHql::~HqltHql()
 StringBuffer & HqltHql::appendId(StringBuffer & s, IIdAtom * id)
 {
     //MORE: We may want to lose the case conversion and use return s.append(id->str());
-    return s.append(id->lower()->str());
+    return s.append(str(lower(id)));
 }
 
 
@@ -229,7 +229,7 @@ StringBuffer &HqltHql::makeUniqueName(IHqlExpression * expr, StringBuffer &s)
                 appendId(s, moduleName).append(".");
             else
             {
-                const char * moduleNameText = moduleName->lower()->str();
+                const char * moduleNameText = str(lower(moduleName));
                 loop
                 {
                     const char * dot = strchr(moduleNameText, '.');
@@ -286,7 +286,7 @@ IHqlExpression * HqltHql::queryMapped(IHqlExpression * expr)
         IHqlExpression * extra = (IHqlExpression *)expr->queryTransformExtra();
         if (!extra || extra->isAttribute() || extra == expr)
             return expr;
-        if (expr->queryName() == unnamedId->lower())
+        if (expr->queryName() == lower(unnamedId))
             return expr;
         expr = extra;
     }
@@ -410,7 +410,7 @@ IHqlExpression * HqltHql::querySymbolDefined(IHqlExpression * expr)
 
         if(extra->queryName() && xxx.length())
         {
-            if(!stricmp(extra->queryName()->str(), xxx.str()))
+            if(!stricmp(str(extra->queryName()), xxx.str()))
                 return item;
         }
     }
@@ -878,7 +878,7 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
             callEclFunction(s, expr, inType);
         }
     }
-    else if (!expandNamed && !expr->isAttribute() && expr->queryId() && expr->queryId()->lower() != unnamedId->lower() )
+    else if (!expandNamed && !expr->isAttribute() && expr->queryId() && lower(expr->queryId()) != lower(unnamedId) )
     {
         appendId(s, expr->queryId());
     }
@@ -2836,7 +2836,7 @@ StringBuffer &HqltHql::getTypeString(ITypeInfo * i, StringBuffer &s)
         }
 
         StringBuffer tmp;
-        if(expr->queryName()==unnamedId->lower())
+        if(expr->queryName()==lower(unnamedId))
         {
             HqlExprArray * visited = findVisitedArray();
             for (unsigned idx = 0; idx < visited->ordinality(); idx++)

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -3110,7 +3110,7 @@ static void expandHintValue(StringBuffer & s, IHqlExpression * expr)
 
 void getHintNameValue(IHqlExpression * attr, StringBuffer &name, StringBuffer &value)
 {
-    name.set(attr->queryName()->str());
+    name.set(str(attr->queryName()));
     ForEachChild(i, attr)
     {
         if (i)
@@ -3424,7 +3424,7 @@ static void convertRecordToAssigns(HqlExprArray & assigns, IHqlExpression * reco
                 else
                 {
                     if (!value && !canOmit)
-                        throwError1(HQLERR_FieldHasNoDefaultValue, cur->queryId()->str());
+                        throwError1(HQLERR_FieldHasNoDefaultValue, str(cur->queryId()));
                     if (value)
                         assigns.append(*createAssign(LINK(newTargetSelector), LINK(value)));
                 }
@@ -4322,13 +4322,13 @@ int compareAtoms(IInterface * const * pleft, IInterface * const * pright)
     IAtom * left = static_cast<IAtom *>(*pleft);
     IAtom * right = static_cast<IAtom *>(*pright);
 
-    return stricmp(left->str(), right->str());
+    return stricmp(str(left), str(right));
 }
 
 int compareScopesByName(IHqlScope * left, IHqlScope * right)
 {
-    const char * leftName = left->queryName()->str();
-    const char * rightName = right->queryName()->str();
+    const char * leftName = str(left->queryName());
+    const char * rightName = str(right->queryName());
     if (leftName && rightName)
         return stricmp(leftName, rightName);
     if (leftName)
@@ -4340,7 +4340,7 @@ int compareScopesByName(IHqlScope * left, IHqlScope * right)
 
 int compareSymbolsByName(IHqlExpression * left, IHqlExpression * right)
 {
-    return stricmp(left->queryName()->str(), right->queryName()->str());
+    return stricmp(str(left->queryName()), str(right->queryName()));
 }
 
 int compareSymbolsByName(IInterface * const * pleft, IInterface * const * pright)
@@ -4348,7 +4348,7 @@ int compareSymbolsByName(IInterface * const * pleft, IInterface * const * pright
     IHqlExpression * left = static_cast<IHqlExpression *>(*pleft);
     IHqlExpression * right = static_cast<IHqlExpression *>(*pright);
 
-    return stricmp(left->queryName()->str(), right->queryName()->str());
+    return stricmp(str(left->queryName()), str(right->queryName()));
 }
 
 int compareScopesByName(IInterface * const * pleft, IInterface * const * pright)
@@ -4423,7 +4423,7 @@ IHqlExpression * ModuleExpander::createExpanded(IHqlExpression * scopeExpr, IHql
         }
         if (value && isExported(resolved))
         {
-            lowername.clear().append(prefix).append(name->lower()).toLowerCase();
+            lowername.clear().append(prefix).append(lower(name)).toLowerCase();
 
             node_operator op = no_none;
             if (outputOp == no_output)
@@ -4466,7 +4466,7 @@ IHqlExpression * ModuleExpander::createExpanded(IHqlExpression * scopeExpr, IHql
                 if (child->getOperator() != no_null)
                     outputs.append(*child.getClear());
             }
-            else if (!matchId || name->lower()==matchId->lower())
+            else if (!matchId || lower(name)==lower(matchId))
             {
                 if (op != no_none)
                 {
@@ -4516,7 +4516,7 @@ extern HQL_API IHqlExpression * createStoredModule(IHqlExpression * scopeExpr)
                     value.setown(createNullExpr(value));
 
                 IIdAtom * name = symbols.item(i).queryId();
-                OwnedHqlExpr failure = createValue(no_stored, makeVoidType(), createConstant(name->lower()->str()));
+                OwnedHqlExpr failure = createValue(no_stored, makeVoidType(), createConstant(str(lower(name))));
 
                 HqlExprArray meta;
                 value.setown(attachWorkflowOwn(meta, value.getClear(), failure, NULL));
@@ -5747,7 +5747,7 @@ void TempTableTransformer::createTempTableAssign(HqlExprArray & assigns, IHqlExp
                                 src.set(queryAttributeChild(expr, defaultAtom, 0));
                             if (!src)
                             {
-                                ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_NoDefaultProvided, expr->queryName()->str());
+                                ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_NoDefaultProvided, str(expr->queryName()));
                                 return;
                             }
                         }
@@ -5777,7 +5777,7 @@ void TempTableTransformer::createTempTableAssign(HqlExprArray & assigns, IHqlExp
                         {
                             if (!recordTypesMatch(src, target))
                             {
-                                ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, expr->queryName()->str());
+                                ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, str(expr->queryName()));
                                 return;
                             }
                             if (isGrouped(src))
@@ -5788,7 +5788,7 @@ void TempTableTransformer::createTempTableAssign(HqlExprArray & assigns, IHqlExp
                         }
                         else
                         {
-                            ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, expr->queryName()->str());
+                            ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, str(expr->queryName()));
                             return;
                         }
                     }
@@ -5798,7 +5798,7 @@ void TempTableTransformer::createTempTableAssign(HqlExprArray & assigns, IHqlExp
                         {
                             if (!recordTypesMatch(src, target))
                             {
-                                ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, expr->queryName()->str());
+                                ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, str(expr->queryName()));
                                 return;
                             }
                             castValue.set(src);
@@ -5854,24 +5854,24 @@ void TempTableTransformer::createTempTableAssign(HqlExprArray & assigns, IHqlExp
                     if (!src || src->isAttribute())
                     {
                         if (expr->hasAttribute(virtualAtom))
-                            ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_VirtualFieldInTempTable, expr->queryName()->str());
+                            ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_VirtualFieldInTempTable, str(expr->queryName()));
                         else
-                            ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_NoDefaultProvided, expr->queryName()->str());
+                            ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_NoDefaultProvided, str(expr->queryName()));
                         return;
                     }
                     if (src->getOperator() == no_recordlist)
                     {
-                        ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatiableInitailiser, expr->queryName()->str());
+                        ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatiableInitailiser, str(expr->queryName()));
                         return;
                     }
                     else if (type->isScalar() != src->queryType()->isScalar())
                     {
-                        ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, expr->queryName()->str());
+                        ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, str(expr->queryName()));
                         return;
                     }
                     else if (strictTypeChecking && !type->assignableFrom(src->queryType()))
                     {
-                        ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, expr->queryName()->str());
+                        ERRORAT1(curRow->queryAttribute(_location_Atom), HQLERR_IncompatibleTypesForField, str(expr->queryName()));
                     }
                     castValue.setown(ensureExprType(src, type));
                 }
@@ -5929,7 +5929,7 @@ void TempTableTransformer::reportError(IHqlExpression * location, int code,const
     va_start(args, format);
     errorMsg.valist_appendf(format, args);
     va_end(args);
-    Owned<IError> err = createError(code, errorMsg.str(), where->sourcePath->str(), where->lineno, where->column, where->position);
+    Owned<IError> err = createError(code, errorMsg.str(), str(where->sourcePath), where->lineno, where->column, where->position);
     errorProcessor.report(err);
 }
 
@@ -5948,7 +5948,7 @@ void TempTableTransformer::reportWarning(WarnErrorCategory category, IHqlExpress
     va_start(args, format);
     errorMsg.valist_appendf(format, args);
     va_end(args);
-    errorProcessor.reportWarning(category, code, errorMsg.str(), where->sourcePath->str(), where->lineno, where->column, where->position);
+    errorProcessor.reportWarning(category, code, errorMsg.str(), str(where->sourcePath), where->lineno, where->column, where->position);
 }
 
 IHqlExpression *getDictionaryKeyRecord(IHqlExpression *record)
@@ -6098,8 +6098,8 @@ static IHqlExpression * convertTempTableToInline(IErrorReceiver & errorProcessor
                         row.append(*LINK(value));
                     else
                     {
-                        VStringBuffer msg(HQLERR_FieldHasNoDefaultValue_Text, field->queryName()->str());
-                        errorProcessor.reportError(HQLERR_FieldHasNoDefaultValue, msg.str(), location.sourcePath->str(), location.lineno, location.column, location.position);
+                        VStringBuffer msg(HQLERR_FieldHasNoDefaultValue_Text, str(field->queryName()));
+                        errorProcessor.reportError(HQLERR_FieldHasNoDefaultValue, msg.str(), str(location.sourcePath), location.lineno, location.column, location.position);
                     }
                 }
             }
@@ -6367,7 +6367,7 @@ int compareLibraryParameterOrder(IHqlExpression * left, IHqlExpression * right)
     }
 
     //then by name
-    return stricmp(left->queryName()->str(), right->queryName()->str());
+    return stricmp(str(left->queryName()), str(right->queryName()));
 }
 
 
@@ -6430,7 +6430,7 @@ void LibraryInputMapper::expandParameter(IHqlExpression * expr, unsigned & nextP
 
 unsigned LibraryInputMapper::findParameter(IIdAtom * searchId)
 {
-    IAtom * searchName = searchId->lower();
+    IAtom * searchName = lower(searchId);
     ForEachItemIn(i, realParameters)
     {
         if (realParameters.item(i).queryName() == searchName)
@@ -8108,7 +8108,7 @@ extern HQL_API bool expandMissingDefaultsAsStoreds(HqlExprArray & args, IHqlExpr
             else
             {
                 OwnedHqlExpr nullValue = createNullExpr(formal->queryType());
-                OwnedHqlExpr storedName = createConstant(formal->queryName()->str());
+                OwnedHqlExpr storedName = createConstant(str(formal->queryName()));
                 OwnedHqlExpr stored = createValue(no_stored, makeVoidType(), storedName.getClear());
                 HqlExprArray colonArgs;
                 colonArgs.append(*LINK(nullValue));
@@ -8474,7 +8474,7 @@ IError * annotateExceptionWithLocation(IException * e, IHqlExpression * location
     StringBuffer errorMsg;
     e->errorMessage(errorMsg);
     unsigned code = e->errorCode();
-    return createError(code, errorMsg.str(), location->querySourcePath()->str(), location->getStartLine(), location->getStartColumn(), 0);
+    return createError(code, errorMsg.str(), str(location->querySourcePath()), location->getStartLine(), location->getStartColumn(), 0);
 }
 
 StringBuffer & appendLocation(StringBuffer & s, IHqlExpression * location, const char * suffix)
@@ -8483,7 +8483,7 @@ StringBuffer & appendLocation(StringBuffer & s, IHqlExpression * location, const
     {
         int line = location->getStartLine();
         int column = location->getStartColumn();
-        s.append(location->querySourcePath()->str());
+        s.append(str(location->querySourcePath()));
         if (line)
         {
             s.append("(").append(location->getStartLine());
@@ -8568,7 +8568,7 @@ IHqlExpression * expandMacroDefinition(IHqlExpression * expr, HqlLookupContext &
                     ctx.errs->reportError(HQLERR_CannotSubmitMacroX, "Cannot submit a MACRO with parameters that do no have default values", NULL, 1, 0, 0);
                 return NULL;
             }
-            macroParms->setProp(formal->queryName()->str(), curParam.str());
+            macroParms->setProp(str(formal->queryName()), curParam.str());
         }
         macroBodyExpr = expr->queryChild(0);
     }
@@ -8614,7 +8614,7 @@ static IHqlExpression * transformAttributeToQuery(IHqlExpression * expr, HqlLook
             {
                 //For each parameter that doesn't have a default, create a stored variable of the appropriate type
                 //with a null value as the default value, and use that.
-                const char * name = expr->queryName()->str();
+                const char * name = str(expr->queryName());
                 StringBuffer msg;
                 msg.appendf("Definition %s() does not supply default values for all parameters", name ? name : "");
                 ctx.errs->reportError(HQLERR_CannotSubmitFunction, msg.str(), NULL, 1, 0, 0);

--- a/ecl/hql/hqlvalid.cpp
+++ b/ecl/hql/hqlvalid.cpp
@@ -95,7 +95,7 @@ StringBuffer & ECLlocation::getText(StringBuffer & text) const
     if (!sourcePath && !lineno)
         return text;
 
-    text.append(sourcePath->str());
+    text.append(str(sourcePath));
     if (lineno)
     {
         text.append("(").append(lineno);

--- a/ecl/hql/hqlwuerr.cpp
+++ b/ecl/hql/hqlwuerr.cpp
@@ -19,9 +19,9 @@
 
 static void formatError(StringBuffer & out, int errNo, const char *msg, IIdAtom * modulename, IIdAtom * attributename, int lineno, int column)
 {
-    out.append(modulename->str());
+    out.append(str(modulename));
     if (attributename)
-        out.append('.').append(attributename->str());
+        out.append('.').append(str(attributename));
     
     if(lineno && column)
         out.append('(').append(lineno).append(',').append(column).append(')');

--- a/ecl/hqlcpp/hqlcppcase.cpp
+++ b/ecl/hqlcpp/hqlcppcase.cpp
@@ -500,7 +500,7 @@ void HqlCppCaseInfo::buildLoopChopMap(BuildCtx & ctx, const CHqlBoundTarget & ta
             args.append(*translator.getBoundLength(test));
         args.append(*ensureIndexable(test.expr));
         if ((ctc==type_unicode) || (ctc == type_varunicode) || (ctc == type_utf8))
-            args.append(*createConstant(compareType->queryLocale()->str()));
+            args.append(*createConstant(str(compareType->queryLocale())));
 
         OwnedHqlExpr call = translator.bindTranslatedFunctionCall(func, args);
         OwnedHqlExpr search = createTranslated(call);

--- a/ecl/hqlcpp/hqlgraph.cpp
+++ b/ecl/hqlcpp/hqlgraph.cpp
@@ -176,7 +176,7 @@ void LogicalGraphCreator::addAttribute(const char * name, const char * value)
 void LogicalGraphCreator::addAttribute(const char * name, IAtom * value)
 {
     if (value)
-        addGraphAttribute(activityNode, name, value->str());
+        addGraphAttribute(activityNode, name, str(value));
 }
 
 void LogicalGraphCreator::addAttributeInt(const char * name, __int64 value)
@@ -380,8 +380,8 @@ void LogicalGraphCreator::createGraphActivity(IHqlExpression * expr)
     IHqlExpression * symbol = queryNamedSymbol(expr);
     if (symbol)
     {
-        addAttribute("name", symbol->queryId()->str());
-        addAttribute("module", symbol->queryFullContainerId()->str());
+        addAttribute("name", str(symbol->queryId()));
+        addAttribute("module", str(symbol->queryFullContainerId()));
         addAttributeInt("line", symbol->getStartLine());
         addAttributeInt("column", symbol->getStartColumn());
     }
@@ -580,22 +580,22 @@ const char * LogicalGraphCreator::getActivityText(IHqlExpression * expr, StringB
             {
                 //module and name supplied.  module may be the form <module>.<attr>.  
                 //If so, display <module>.<attr> if the name matches the attr, else <module>.<attr>::<name>
-                const char * dot = strrchr(module->str(), '.');
+                const char * dot = strrchr(str(module), '.');
                 if (dot)
                 {
-                    if (stricmp(dot+1, name->str()) == 0)
-                        header.append(module->str());
+                    if (stricmp(dot+1, str(name)) == 0)
+                        header.append(str(module));
                     else
-                        header.append(module->str()).append("::").append(name->str());
+                        header.append(str(module)).append("::").append(str(name));
                 }
                 else
-                    header.append(module->str()).append(".").append(name->str());
+                    header.append(str(module)).append(".").append(str(name));
             }
             else
-                header.append(module->str());
+                header.append(str(module));
         }
         else if (name)
-            header.append(name->str());
+            header.append(str(name));
 
         if (header.length())
             temp.append(header).append("\n");

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -1847,7 +1847,7 @@ void ActivityInstance::addLocationAttribute(IHqlExpression * location)
     ISourcePath * sourcePath = location->querySourcePath();
     unsigned column = location->getStartColumn();
     StringBuffer s;
-    s.append(sourcePath->str()).append("(").append(line);
+    s.append(str(sourcePath)).append("(").append(line);
     if (column)
         s.append(",").append(column);
     s.append(")");
@@ -1874,7 +1874,7 @@ void ActivityInstance::addNameAttribute(IHqlExpression * symbol)
             return;
     }
     names.append(*symbol);
-    addAttribute("name", name->str());
+    addAttribute("name", str(name));
 }
 
 void ActivityInstance::removeAttribute(const char * name)
@@ -3610,7 +3610,7 @@ unsigned HqlCppTranslator::buildRtlField(StringBuffer * instanceName, IHqlExpres
             if (createConstantField(target, field, defaultValue))
                 appendStringAsQuotedCPP(defaultInitializer, target.length(), target.toByteArray(), false);
             else
-                throwError1(HQLERR_CouldNotGenerateDefault, field->queryName()->str());
+                throwError1(HQLERR_CouldNotGenerateDefault, str(field->queryName()));
         }
 
         StringBuffer definition;
@@ -8046,12 +8046,12 @@ void HqlCppTranslator::doBuildExprRowDiff(BuildCtx & ctx, const CHqlBoundTarget 
                 {
                     StringBuffer typeName;
                     getFriendlyTypeStr(leftType, typeName);
-                    throwError2(HQLERR_UnsupportedRowDiffType, typeName.str(), expr->queryId()->str());
+                    throwError2(HQLERR_UnsupportedRowDiffType, typeName.str(), str(expr->queryId()));
                 }
             }
 
             StringBuffer fullName;
-            fullName.append(selectorText).append(id->str());
+            fullName.append(selectorText).append(str(id));
 
             ITypeInfo * rightType = right->queryType()->queryPromotedType();
             if (!leftType->assignableFrom(rightType))
@@ -8848,7 +8848,7 @@ void HqlCppTranslator::doBuildStmtAssert(BuildCtx & ctx, IHqlExpression * expr)
 
     if (location.sourcePath)
     {
-        const char * filename = location.sourcePath->str();
+        const char * filename = str(location.sourcePath);
         if (options.reportAssertFilenameTail)
             filename = pathTail(filename);
         args.append(*createConstant(filename));
@@ -10645,7 +10645,7 @@ void HqlCppTranslator::addSchemaField(IHqlExpression *field, MemoryBuffer &schem
     StringBuffer schemaName;
     if (name)
     {
-        schemaName.append(name->str());
+        schemaName.append(str(name));
     }
     else
     {
@@ -12291,7 +12291,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityJoinOrDenormalize(BuildCtx & c
                 if (isUnicodeType(lhsType))
                 {
                     func = prefixDiffUnicodeId;
-                    args.append(*createConstant(lhsType->queryLocale()->str()));
+                    args.append(*createConstant(str(lhsType->queryLocale())));
                 }
                 args.append(*getSizetConstant(origin));
                 OwnedHqlExpr diff = bindFunctionCall(func, args);
@@ -17951,7 +17951,7 @@ static bool expandFieldName(StringBuffer & s, IHqlExpression * e)
     {
         if (expandFieldName(s, e->queryChild(0)))
             s.append('.');
-        const char * name = e->queryChild(1)->queryName()->str();
+        const char * name = str(e->queryChild(1)->queryName());
         s.appendLower(strlen(name), name);
         return true;
     }
@@ -18136,13 +18136,13 @@ ABoundActivity * HqlCppTranslator::doBuildActivityDistribution(BuildCtx & ctx, I
         case type_data:
         case type_qstring:
             if (type->getSize() == UNKNOWN_LENGTH)
-                throwError1(HQLERR_DistributionVariableLengthX, cur.queryChild(1)->queryId()->str());
+                throwError1(HQLERR_DistributionVariableLengthX, str(cur.queryChild(1)->queryId()));
             break;
         default:
             {
                 StringBuffer typeName;
                 getFriendlyTypeStr(type, typeName);
-                throwError2(HQLERR_DistributionUnsupportedTypeXX, cur.queryChild(1)->queryId()->str(), typeName.str());
+                throwError2(HQLERR_DistributionUnsupportedTypeXX, str(cur.queryChild(1)->queryId()), typeName.str());
             }
         }
     }

--- a/ecl/hqlcpp/hqllib.cpp
+++ b/ecl/hqlcpp/hqllib.cpp
@@ -108,7 +108,7 @@ unsigned HqlCppLibrary::getHash(const HqlExprArray & values, unsigned crc) const
         IHqlExpression & cur = values.item(i);
 
         //names are significant because inputs/outputs are ordered by name
-        const char * name = cur.queryName()->str();
+        const char * name = str(cur.queryName());
         crc = hashnc((const byte *)name, strlen(name), crc);
 
         ITypeInfo * type = cur.queryType();

--- a/ecl/hqlcpp/hqlnlp.cpp
+++ b/ecl/hqlcpp/hqlnlp.cpp
@@ -114,7 +114,7 @@ void MatchReference::getPath(StringBuffer & path)
     {
         if (idx)
             path.append(".");
-        path.append(queryPatternName(&names.item(idx))->lower());
+        path.append(lower(queryPatternName(&names.item(idx))));
     }
 }
 
@@ -123,10 +123,10 @@ StringBuffer & MatchReference::getDebugText(StringBuffer & out, RegexIdAllocator
     ForEachItemIn(i1, names)
     {
         IHqlExpression & curName = names.item(i1);
-        IAtom * name = queryPatternName(&curName)->lower();
+        IAtom * name = lower(queryPatternName(&curName));
         if (i1)
             out.append("/");
-        out.append(name->str());
+        out.append(str(name));
         out.append("{").append(idAllocator.queryID(curName.queryChild(0), name)).append("}");
         unsigned inst = (unsigned)indices.item(i1).queryValue()->getIntValue();
         if (inst != UNKNOWN_INSTANCE)
@@ -140,7 +140,7 @@ void MatchReference::compileMatched(RegexIdAllocator & idAllocator, UnsignedArra
     ForEachItemIn(idx, names)
     {
         IHqlExpression & curName = names.item(idx);
-        ids.append(idAllocator.queryID(curName.queryChild(0), queryPatternName(&curName)->lower()));
+        ids.append(idAllocator.queryID(curName.queryChild(0), lower(queryPatternName(&curName))));
         indexValues.append((unsigned)indices.item(idx).queryValue()->getIntValue());
     }
 }

--- a/ecl/hqlcpp/hqlregex.cpp
+++ b/ecl/hqlcpp/hqlregex.cpp
@@ -168,7 +168,7 @@ IHqlExpression * RegexIdAllocator::createKey(IHqlExpression * expr, IAtom * name
         return NULL;
     IHqlExpression * body = expr->queryBody();
     if (name)
-        return createSymbol(createIdAtom(name->str()), LINK(body), ob_private);
+        return createSymbol(createIdAtom(str(name)), LINK(body), ob_private);
     return LINK(body);
 }
 

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -4549,7 +4549,7 @@ void EclResourceDependencyGatherer::addDependencyUse(IHqlExpression * search, Re
             //Don't give a warning if get/set is within the same activity (e.g., within a local())
             if (&dependencySource.exprs.item(index) != expr)
                 //errors->reportWarning(HQLWRN_RecursiveDependendencies, HQLWRN_RecursiveDependendencies_Text, *codeGeneratorAtom, 0, 0, 0);
-                errors->reportError(HQLWRN_RecursiveDependendencies, HQLWRN_RecursiveDependendencies_Text, codeGeneratorId->str(), 0, 0, 0);
+                errors->reportError(HQLWRN_RecursiveDependendencies, HQLWRN_RecursiveDependendencies_Text, str(codeGeneratorId), 0, 0, 0);
         }
         else
         {

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -241,7 +241,7 @@ IHqlExpression * getVirtualReplacement(IHqlExpression * field, IHqlExpression * 
         return createValue(no_sizeof, LINK(sizetType), getVirtualSelector(dataset));
     else if (virtualKind == logicalFilenameAtom)
         return createValue(no_implicitcast, field->getType(), getFileLogicalName(dataset));
-    throwError1(HQLERR_UnknownVirtualAttr, virtualKind->str());
+    throwError1(HQLERR_UnknownVirtualAttr, str(virtualKind));
     return NULL;
 }
 
@@ -621,9 +621,9 @@ public:
             IHqlExpression * cur = rawStepping.fields->queryChild(i);
             unsigned thisMatch = monitors.queryKeySelectIndex(cur);
             if (thisMatch == NotFound)
-                throwError1(HQLERR_StepFieldNotKeyed, cur->queryChild(1)->queryName()->str());
+                throwError1(HQLERR_StepFieldNotKeyed, str(cur->queryChild(1)->queryName()));
             if ((prev != NotFound) && (thisMatch != prev+1))
-                throwError1(HQLERR_StepFieldNotContiguous, cur->queryChild(1)->queryName()->str());
+                throwError1(HQLERR_StepFieldNotContiguous, str(cur->queryChild(1)->queryName()));
             prev = thisMatch;
         }
     }
@@ -3570,7 +3570,7 @@ void KeyFailureInfo::reportError(HqlCppTranslator & translator, IHqlExpression *
     case KFRtoocomplex:
         translator.throwError1(HQLERR_KeyedJoinTooComplex, ecl.str());
     case KFRcast:
-        translator.throwError2(HQLERR_KeyAccessNeedCast, ecl.str(), field->queryName()->str());
+        translator.throwError2(HQLERR_KeyAccessNeedCast, ecl.str(), str(field->queryName()));
     case KFRor:
         translator.throwError1(HQLERR_OrMultipleKeyfields, ecl.str());
     }
@@ -4584,7 +4584,7 @@ KeyedKind getKeyedKind(HqlCppTranslator & translator, KeyConditionArray & matche
             if (keyedKind == KeyedNo)
                 keyedKind = cur.keyedKind;
             else
-                translator.throwError1(HQLERR_InconsistentKeyedOpt, cur.selector->queryChild(1)->queryName()->str());
+                translator.throwError1(HQLERR_InconsistentKeyedOpt, str(cur.selector->queryChild(1)->queryName()));
         }
     }
     return keyedKind;
@@ -4633,7 +4633,7 @@ void MonitorExtractor::buildKeySegment(BuildMonitorState & buildState, BuildCtx 
                 else if (buildState.implicitWildField && !ignoreUnkeyed)
                 {
                     StringBuffer s, keyname;
-                    translator.throwError3(HQLERR_WildFollowsGap, getExprECL(field, s).str(), buildState.implicitWildField->queryChild(1)->queryName()->str(), queryKeyName(keyname));
+                    translator.throwError3(HQLERR_WildFollowsGap, getExprECL(field, s).str(), str(buildState.implicitWildField->queryChild(1)->queryName()), queryKeyName(keyname));
                 }
             }
             else
@@ -4643,10 +4643,10 @@ void MonitorExtractor::buildKeySegment(BuildMonitorState & buildState, BuildCtx 
                 {
                     StringBuffer s,keyname;
                     if (cur.isKeyed())
-                        translator.throwError3(HQLERR_KeyedFollowsGap, getExprECL(field, s).str(), buildState.implicitWildField->queryChild(1)->queryName()->str(), queryKeyName(keyname));
+                        translator.throwError3(HQLERR_KeyedFollowsGap, getExprECL(field, s).str(), str(buildState.implicitWildField->queryChild(1)->queryName()), queryKeyName(keyname));
                     else if (!buildState.doneImplicitWarning)
                     {
-                        translator.WARNING3(CategoryEfficiency, HQLWRN_KeyedFollowsGap, getExprECL(field, s).str(), buildState.implicitWildField->queryChild(1)->queryName()->str(), queryKeyName(keyname));
+                        translator.WARNING3(CategoryEfficiency, HQLWRN_KeyedFollowsGap, getExprECL(field, s).str(), str(buildState.implicitWildField->queryChild(1)->queryName()), queryKeyName(keyname));
                         buildState.doneImplicitWarning = true;
                     }
                 }
@@ -4656,7 +4656,7 @@ void MonitorExtractor::buildKeySegment(BuildMonitorState & buildState, BuildCtx 
     if (buildState.wildWasKeyed && (matches.ordinality() == 0))
     {
         StringBuffer keyname;
-        translator.WARNING2(CategoryFolding, HQLWRN_FoldRemoveKeyed, field->queryName()->str(), queryKeyName(keyname));
+        translator.WARNING2(CategoryFolding, HQLWRN_FoldRemoveKeyed, str(field->queryName()), queryKeyName(keyname));
     }
 
     StringBuffer s;

--- a/ecl/hqlcpp/hqltcppc.cpp
+++ b/ecl/hqlcpp/hqltcppc.cpp
@@ -816,7 +816,7 @@ void CMemberInfo::getXPath(StringBuffer & out)
         else
         {
             StringBuffer temp;
-            temp.append(*column->queryName()).toLowerCase();
+            temp.append(str(column->queryName())).toLowerCase();
             out.append(temp);
         }
     }
@@ -1080,7 +1080,7 @@ void CContainerInfo::getContainerXPath(StringBuffer & out)
             if (named)
                 named->queryChild(0)->queryValue()->getStringValue(temp);
             else
-                temp.append(*column->queryName()).toLowerCase();
+                temp.append(str(column->queryName())).toLowerCase();
         }
         unsigned len = temp.length();
         if (len && (temp.charAt(len-1) != '/'))

--- a/ecl/hqlcpp/hqltcppc2.cpp
+++ b/ecl/hqlcpp/hqltcppc2.cpp
@@ -373,7 +373,7 @@ void CChildDatasetColumnInfo::setColumn(HqlCppTranslator & translator, BuildCtx 
 
 AColumnInfo * CChildDatasetColumnInfo::lookupColumn(IHqlExpression * search)
 {
-    throwError1(HQLERR_LookupNotActiveDataset, search->queryName()->str());
+    throwError1(HQLERR_LookupNotActiveDataset, str(search->queryName()));
     return NULL;
 }
 
@@ -613,7 +613,7 @@ void CChildLimitedDatasetColumnInfo::setColumnFromBuilder(HqlCppTranslator & tra
 
 AColumnInfo * CChildLimitedDatasetColumnInfo::lookupColumn(IHqlExpression * search)
 {
-    throwError1(HQLERR_LookupNotActiveDataset, search->queryName()->str());
+    throwError1(HQLERR_LookupNotActiveDataset, str(search->queryName()));
     return NULL;
 }
 
@@ -768,7 +768,7 @@ void CChildLinkedDatasetColumnInfo::setColumn(HqlCppTranslator & translator, Bui
 
 AColumnInfo * CChildLinkedDatasetColumnInfo::lookupColumn(IHqlExpression * search)
 {
-    throwError1(HQLERR_LookupNotActiveDataset, search->queryName()->str());
+    throwError1(HQLERR_LookupNotActiveDataset, str(search->queryName()));
     return NULL;
 }
 

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -6659,7 +6659,7 @@ void WorkflowTransformer::analyseExpr(IHqlExpression * expr)
             {
                 StringBuffer s;
                 if (expr->queryName())
-                    s.appendf(" '%s'", expr->queryName()->str());
+                    s.appendf(" '%s'", str(expr->queryName()));
                 //MORE: Better if we also kept nested track of locations
                 translator.WARNINGAT1(CategoryMistake, queryActiveLocation(expr), HQLWRN_WorkflowSeemsToBeDependent, s.str());
             }
@@ -7509,7 +7509,7 @@ IHqlExpression * ExplicitGlobalTransformer::createTransformed(IHqlExpression * e
                     IHqlExpression * symbol = queryActiveSymbol();
                     StringBuffer s;
                     if (symbol && symbol->queryBody() == expr)
-                        s.appendf(" '%s'", symbol->queryName()->str());
+                        s.appendf(" '%s'", str(symbol->queryName()));
                     else
                     {
                         s.append(" ").append(getOpString(value->getOperator()));
@@ -9052,7 +9052,7 @@ IHqlExpression * HqlLinkedChildRowTransformer::createTransformedBody(IHqlExpress
                 if (recordRequiresLinkCount(transformedRecord))
                 {
                     if (expr->hasAttribute(embeddedAtom) || queryAttribute(type, embeddedAtom) || expr->hasAttribute(countAtom) || expr->hasAttribute(sizeofAtom))
-                        throwError1(HQLERR_InconsistentEmbedded, expr->queryId()->str());
+                        throwError1(HQLERR_InconsistentEmbedded, str(expr->queryId()));
                 }
                 if (expr->hasAttribute(embeddedAtom))
                 {
@@ -9557,7 +9557,7 @@ IHqlExpression * HqlScopeTagger::createTransformed(IHqlExpression * expr)
             if (lhs->isDatarow() && newRhs->isDataset())
             {
                 StringBuffer exprText;
-                VStringBuffer msg("dataset expression (%s) assigned to field '%s' with type row", getECL(rhs, exprText), lhs->queryChild(1)->queryName()->str());
+                VStringBuffer msg("dataset expression (%s) assigned to field '%s' with type row", getECL(rhs, exprText), str(lhs->queryChild(1)->queryName()));
                 reportError(CategoryError, msg.str());
             }
             if (rhs == newRhs)
@@ -9620,7 +9620,7 @@ void HqlScopeTagger::reportError(WarnErrorCategory category, const char * msg)
     int startColumn = location ? location->getStartColumn() : 0;
     ISourcePath * sourcePath = location ? location->querySourcePath() : NULL;
     ErrorSeverity severity = queryDefaultSeverity(category);
-    Owned<IError> err = createError(category, severity, ERR_ASSERT_WRONGSCOPING, msg, sourcePath->str(), startLine, startColumn, 0);
+    Owned<IError> err = createError(category, severity, ERR_ASSERT_WRONGSCOPING, msg, str(sourcePath), startLine, startColumn, 0);
     errors.report(err);        // will throw immediately if it is an error.
 }
 
@@ -10407,9 +10407,9 @@ IHqlExpression * NestedCompoundTransformer::createTransformed(IHqlExpression * e
             {
                 StringBuffer s;
                 if (sideEffect->queryName())
-                    s.appendf(" '%s'", sideEffect->queryName()->str());
+                    s.appendf(" '%s'", str(sideEffect->queryName()));
                 else if (value->queryName())
-                    s.appendf(" '%s'", value->queryName()->str());
+                    s.appendf(" '%s'", str(value->queryName()));
                 else
                     s.append(" ").append(getOpString(sideEffect->getOperator()));
                 IHqlExpression * location = queryLocation(sideEffect);
@@ -10516,7 +10516,7 @@ void spotPotentialDuplicateCode(HqlExprArray & exprs)
 
 static bool isUniqueAttributeName(IAtom * name)
 {
-    const char * nameText = name->str();
+    const char * nameText = str(name);
     unsigned len = strlen(nameText);
     if (len > 3)
     {
@@ -10544,7 +10544,7 @@ static IIdAtom * simplifySymbolName(IIdAtom * name, bool commonUniqueNameAttribu
         return NULL;
 
     //Rename all attributes __x__1234__ to __x__
-    const char * nameText = name->lower()->str();
+    const char * nameText = str(lower(name));
     size_t nameLen = strlen(nameText);
     size_t len = nameLen;
     if (len > 3)
@@ -10570,8 +10570,8 @@ static IIdAtom * simplifySymbolName(IIdAtom * name, bool commonUniqueNameAttribu
 
 static IIdAtom * lowerCaseSymbolName(IIdAtom * name)
 {
-    if (containsUpperCase(name->str()))
-        return createIdAtom(name->lower()->str());
+    if (containsUpperCase(str(name)))
+        return createIdAtom(str(lower(name)));
     return name;
 }
 
@@ -12124,7 +12124,7 @@ IHqlExpression * HqlTreeNormalizer::createTransformedBody(IHqlExpression * expr)
                 else if (cur->getOperator() == no_purevirtual)
                 {
                     IAtom * name = cur->queryName();
-                    throwError1(HQLERR_LibraryMemberArgNotDefined, name ? name->str() : "");
+                    throwError1(HQLERR_LibraryMemberArgNotDefined, name ? str(name) : "");
                 }
                 IHqlExpression * transformed = transform(cur);
                 children.append(*transformed);

--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -132,14 +132,14 @@ void CppWriterTemplate::generate(ISectionWriter & writer, unsigned pass, IProper
             if (output && properties)
             {
                 temp.clear();
-                properties->getProp(cur.id->str(), temp);
+                properties->getProp(str(cur.id), temp);
                 outputQuoted(writer, temp.length(), temp.str());
             }
             break;
         case TplCondition:
             outputStack.append(output);
             if (output)
-                output = (properties && properties->hasProp(cur.id->str()));
+                output = (properties && properties->hasProp(str(cur.id)));
             break;
         case TplEndCondition:
             output = outputStack.popGet();
@@ -950,7 +950,7 @@ void HqlCppWriter::generateParamCpp(IHqlExpression * param, IHqlExpression * att
                 argType.setown(makePointerType(LINK(argType)));
             if (isTypePassedByAddress(argType))
                 argType.setown(makeReferenceModifier(LINK(argType)));
-            generateType(argType, paramName->str());
+            generateType(argType, str(paramName));
             nameappended = true;
             if (isOut)
                 out.append(" &");
@@ -1172,7 +1172,7 @@ StringBuffer & HqlCppWriter::generateExprCpp(IHqlExpression * expr)
                 if (props->hasAttribute(entrypointAtom))
                     getAttribute(props, entrypointAtom, out);
                 else
-                    out.append(funcdef->queryBody()->queryId()->str());
+                    out.append(str(funcdef->queryBody()->queryId()));
                 out.append('(');
                 if (functionBodyUsesContext(props))
                 {

--- a/esp/bindings/SOAP/client/soapclient.cpp
+++ b/esp/bindings/SOAP/client/soapclient.cpp
@@ -168,6 +168,8 @@ int CSoapClient::postRequest(const char* contenttype, const char* soapaction, IR
         }
     }
 
+    if (!soap_request.get() || !soap_response.get())
+        throw MakeStringException(-1, "request or response is NULL");
     m_transportclient->postRequest(*soap_request.get(), *soap_response.get());
 
     int retstatus = soap_response->get_status();
@@ -353,6 +355,8 @@ int CSoapClient::postRequest(IRpcMessage & rpccall, StringBuffer & responsebuf, 
         }
     }
 
+    if (!soap_request.get() || !soap_response.get())
+        throw MakeStringException(-1, "request or response is NULL");
     m_transportclient->postRequest(*soap_request.get(), *soap_response.get());
 
     int retstatus = soap_response->get_status();

--- a/esp/bindings/http/client/httpclient.cpp
+++ b/esp/bindings/http/client/httpclient.cpp
@@ -569,11 +569,8 @@ int CHttpClient::postRequest(ISoapMessage &req, ISoapMessage& resp)
     const char* requeststr = request.get_text();
     CSoapResponse& response = *(dynamic_cast<CSoapResponse*>(&resp));
 
-    if(&request == NULL || &response == NULL)
-        throw MakeStringException(-1, "request or response is NULL");
-
     StringBuffer errmsg;
-    if(connect(errmsg) < 0)
+    if(connect(errmsg) < 0 || !m_socket)
     {
         response.set_status(SOAP_CONNECTION_ERROR);
         response.set_err(errmsg);

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -942,11 +942,8 @@ int CHttpMessage::close()
 
     try
     {
-        if(&m_socket != NULL)
-        {
-            m_socket.shutdown();
-            m_socket.close();
-        }
+        m_socket.shutdown();
+        m_socket.close();
     }
     catch (IException *e) 
     {

--- a/esp/platform/sechandler.cpp
+++ b/esp/platform/sechandler.cpp
@@ -95,6 +95,8 @@ bool SecHandler::authorizeSecFeature(const char * pszFeatureUrl, const char* Use
     if(pSecondaryUser.get()== NULL)
     {
         pSecondaryUser.setown(m_secmgr->createUser(UserID));
+	if (!pSecondaryUser.get())
+	    return false;
         pSecondaryUser->setRealm(CompanyID);
         bool bSecondaryAccessAllowed = m_secmgr->initUser(*pSecondaryUser.get());
         if(bSecondaryAccessAllowed==false)

--- a/esp/platform/sechandler.cpp
+++ b/esp/platform/sechandler.cpp
@@ -95,8 +95,8 @@ bool SecHandler::authorizeSecFeature(const char * pszFeatureUrl, const char* Use
     if(pSecondaryUser.get()== NULL)
     {
         pSecondaryUser.setown(m_secmgr->createUser(UserID));
-	if (!pSecondaryUser.get())
-	    return false;
+        if (!pSecondaryUser)
+            return false;
         pSecondaryUser->setRealm(CompanyID);
         bool bSecondaryAccessAllowed = m_secmgr->initUser(*pSecondaryUser.get());
         if(bSecondaryAccessAllowed==false)

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -727,7 +727,8 @@ bool Cws_accessEx::onAddUser(IEspContext &context, IEspAddUserRequest &req, IEsp
             cred.setPassword(pass1);
         try
         {
-            secmgr->addUser(*user.get());
+	    if (user.get())
+                secmgr->addUser(*user.get());
         }
         catch(IException* e)
         {

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -727,7 +727,7 @@ bool Cws_accessEx::onAddUser(IEspContext &context, IEspAddUserRequest &req, IEsp
             cred.setPassword(pass1);
         try
         {
-	    if (user.get())
+            if (user.get())
                 secmgr->addUser(*user.get());
         }
         catch(IException* e)

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1663,7 +1663,7 @@ bool FindInStringArray(StringArray& clusters, const char *cluster)
     return bFound;
 }
 
-static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser* user, IUserDescriptor* udesc, ISecManager* secmgr, int& permission)
+static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser & user, IUserDescriptor* udesc, ISecManager* secmgr, int& permission)
 {
     if (dlfn.isMulti())
     {
@@ -1686,7 +1686,8 @@ static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser* user, IUserDe
         {
             StringBuffer scopes;
             dlfn.getScopes(scopes);
-            permissionTemp = secmgr->authorizeFileScope(*user, scopes.str());
+
+            permissionTemp = secmgr->authorizeFileScope(user, scopes.str());
         }
 
         //Descrease the permission whenever a component has a lower permission.
@@ -1728,9 +1729,9 @@ bool CWsDfuEx::getUserFilePermission(IEspContext &context, IUserDescriptor* udes
     CDfsLogicalFileName dlfn;
     dlfn.set(logicalName);
 
-    //Start from the SecAccess_Full. Descrease the permission whenever a component has a lower permission.
+    //Start from the SecAccess_Full. Decrease the permission whenever a component has a lower permission.
     permission = SecAccess_Full;
-    getFilePermission(dlfn, user, udesc, secmgr, permission);
+    getFilePermission(dlfn, *user, udesc, secmgr, permission);
 
     return true;
 }

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -182,8 +182,6 @@ static void DeepAssign(IEspContext &context, IConstDFUWorkUnit *src, IEspDFUWork
 {
     if(src == NULL)
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "'Source DFU workunit' doesn't exist.");
-    if(&dest == NULL)
-        throw MakeStringException(ECLWATCH_MISSING_PARAMS, "'Destination DFU workunit' not valid.");
 
     Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();

--- a/plugins/cassandra/cassandraembed.cpp
+++ b/plugins/cassandra/cassandraembed.cpp
@@ -653,7 +653,7 @@ static void typeError(const char *expected, const CassValue *value, const RtlFie
 {
     VStringBuffer msg("cassandra: type mismatch - %s expected", expected);
     if (field)
-        msg.appendf(" for field %s", field->name->str());
+        msg.appendf(" for field %s", str(field->name));
     if (value)
         msg.appendf(", received %s", getTypeName(cass_value_type(value)));
     rtlFail(0, msg.str());
@@ -1047,7 +1047,7 @@ protected:
         else
             ret = cass_row_get_column(stmtInfo->queryRow(), colIdx++);
         if (!ret)
-            failx("Too many fields in ECL output row, reading field %s", field->name->getAtomNamePtr());
+            failx("Too many fields in ECL output row, reading field %s", str(field->name));
         return ret;
     }
     const CassandraStatementInfo *stmtInfo;
@@ -1229,14 +1229,14 @@ protected:
     inline unsigned checkNextParam(const RtlFieldInfo * field)
     {
         if (logctx.queryTraceLevel() > 4)
-            logctx.CTXLOG("Binding %s to %d", field->name->str(), thisParam);
+            logctx.CTXLOG("Binding %s to %d", str(field->name), thisParam);
         return thisParam++;
     }
     inline void checkBind(CassError rc, const RtlFieldInfo * field)
     {
         if (rc != CASS_OK)
         {
-            failx("While binding parameter %s: %s", field->name->getAtomNamePtr(), cass_error_desc(rc));
+            failx("While binding parameter %s: %s", str(field->name), cass_error_desc(rc));
         }
     }
     const RtlTypeInfo *typeInfo;

--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -287,10 +287,10 @@ protected:
             if (inSet)
             {
                 VStringBuffer arraySig("[%s", sig);
-                fieldId = JNIenv->GetFieldID(Class, field->name->getAtomNamePtr(), arraySig.str());
+                fieldId = JNIenv->GetFieldID(Class, str(field->name), arraySig.str());
             }
             else
-                fieldId = JNIenv->GetFieldID(Class, field->name->getAtomNamePtr(), sig);
+                fieldId = JNIenv->GetFieldID(Class, str(field->name), sig);
         }
         else
         {
@@ -301,14 +301,14 @@ protected:
             checkException();
             jmethodID getDeclaredField = JNIenv->GetMethodID(classClass, "getDeclaredField", "(Ljava/lang/String;)Ljava/lang/reflect/Field;" );
             checkException();
-            jstring fieldName = JNIenv->NewStringUTF(field->name->getAtomNamePtr());
+            jstring fieldName = JNIenv->NewStringUTF(str(field->name));
             checkException();
             jobject reflectedField = JNIenv->CallObjectMethod(Class, getDeclaredField, fieldName);
             checkException();
             fieldId = JNIenv->FromReflectedField(reflectedField);
         }
         if (!fieldId && expected)
-            throw MakeStringException(0, "javaembed: Unable to retrieve field %s of type %s", field->name->getAtomNamePtr(), expected);
+            throw MakeStringException(0, "javaembed: Unable to retrieve field %s of type %s", str(field->name), expected);
         if (expected)
             checkException();
         else
@@ -934,7 +934,7 @@ public:
             if (!JNIenv->CallBooleanMethod(arrayClass, isArrayMethod))
             {
                 JNIenv->ExceptionClear();
-                VStringBuffer message("javaembed: Array expected for field %s", field->name->getAtomNamePtr());
+                VStringBuffer message("javaembed: Array expected for field %s", str(field->name));
                 rtlFail(0, message.str());
             }
             // Set up constructor etc for the child rows, so we don't do it per row

--- a/plugins/mysql/mysqlembed.cpp
+++ b/plugins/mysql/mysqlembed.cpp
@@ -318,7 +318,7 @@ static void typeError(const char *expected, const RtlFieldInfo *field)
 {
     VStringBuffer msg("mysql: type mismatch - %s expected", expected);
     if (field)
-        msg.appendf(" for field %s", field->name->str());
+        msg.appendf(" for field %s", field->name->queryStr());
     rtlFail(0, msg.str());
 }
 
@@ -604,7 +604,7 @@ protected:
             fail("Too many fields in ECL output row");
         const MYSQL_BIND &column = resultInfo.queryColumn(colIdx);
         if (*column.error)
-            failx("Error fetching column %s", field->name->str());
+            failx("Error fetching column %s", field->name->queryStr());
         return column;
     }
     const MySQLBindingArray &resultInfo;

--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -347,7 +347,7 @@ public:
             const RtlFieldInfo *field = *fields;
             if (names.length())
                 names.append(',');
-            names.append(field->name->str());
+            names.append(str(field->name));
             fields++;
         }
         OwnedPyObject pnames = PyString_FromString(names.str());
@@ -499,7 +499,7 @@ static void typeError(const char *expected, const RtlFieldInfo *field)
 {
     VStringBuffer msg("pyembed: type mismatch - %s expected", expected);
     if (field)
-        msg.appendf(" for field %s", field->name->str());
+        msg.appendf(" for field %s", str(field->name));
     rtlFail(0, msg.str());
 }
 
@@ -887,7 +887,7 @@ protected:
             elem.setown(pushback.getClear());
         else if (field && named) // If it's named tuple, expect to always resolve fields by name, not position
         {
-            elem.setown(PyObject_GetAttrString(parent, field->name->str()));
+            elem.setown(PyObject_GetAttrString(parent, str(field->name)));
         }
         else if (iter)
             elem.setown(PyIter_Next(iter));

--- a/plugins/sqlite3/sqlite3.cpp
+++ b/plugins/sqlite3/sqlite3.cpp
@@ -94,7 +94,7 @@ static void typeError(const char *expected, const RtlFieldInfo *field)
 {
     VStringBuffer msg("sqlite3: type mismatch - %s expected", expected);
     if (field)
-        msg.appendf(" for field %s", field->name->str());
+        msg.appendf(" for field %s", str(field->name));
     rtlFail(0, msg.str());
 }
 

--- a/plugins/v8embed/v8embed.cpp
+++ b/plugins/v8embed/v8embed.cpp
@@ -72,7 +72,7 @@ static void typeError(const char *expected, const RtlFieldInfo *field)
 {
     VStringBuffer msg("v8embed: type mismatch - %s expected", expected);
     if (field)
-        msg.appendf(" for field %s", field->name->str());
+        msg.appendf(" for field %s", str(field->name));
     rtlFail(0, msg.str());
 }
 
@@ -207,10 +207,10 @@ protected:
         v8::Local<v8::Value> v;
         if (named)
         {
-            v8::Local<v8::String> name = v8::String::New(field->name->str());
+            v8::Local<v8::String> name = v8::String::New(str(field->name));
             if (!row->Has(name))
             {
-                VStringBuffer msg("v8embed: No value for field %s", field->name->str());
+                VStringBuffer msg("v8embed: No value for field %s", str(field->name));
                 rtlFail(0, msg.str());
             }
             v = row->Get(name);
@@ -369,7 +369,7 @@ protected:
         if (inDataset)
             obj->Set(idx++, value);
         else
-            obj->Set(v8::String::New(field->name->str()), value);
+            obj->Set(v8::String::New(str(field->name)), value);
     }
     v8::Local<v8::Object> obj;
     std::vector< v8::Local<v8::Object> > stack;

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -620,13 +620,9 @@ WORKUNITSERVICES_API void wsWorkunitTimeStamps( ICodeContext *ctx, size32_t & __
         Owned<IPropertyTreeIterator> iter = pt->getElements("TimeStamp");
         ForEach(*iter) {
             IPropertyTree &item = iter->query();
-            if (&item==NULL)
-                continue; // paranoia
             Owned<IPropertyTreeIterator> iter2 = item.getElements("*");
             ForEach(*iter2) {
                 IPropertyTree &item2 = iter2->query();
-                if (&item2==NULL)
-                    continue; // paranoia
                 fixedAppend(mb, 32, item, "@application");              // item correct here
                 fixedAppend(mb, 16, item2.queryName());                 // id
                 fixedAppend(mb,  20, item2.queryProp(NULL));            // time
@@ -648,8 +644,6 @@ WORKUNITSERVICES_API void wsWorkunitMessages( ICodeContext *ctx, size32_t & __le
         Owned<IPropertyTreeIterator> iter = pt->getElements("Exception");
         ForEach(*iter) {
             IPropertyTree &item = iter->query();
-            if (&item==NULL)
-                continue; // paranoia
             tmpu = (unsigned)item.getPropInt("@severity");
             mb.append(sizeof(tmpu),&tmpu);
             tmpi = (int)item.getPropInt("@code");
@@ -676,8 +670,6 @@ WORKUNITSERVICES_API void wsWorkunitFilesRead( ICodeContext *ctx, size32_t & __l
         Owned<IPropertyTreeIterator> iter = pt->getElements("File");
         ForEach(*iter) {
             IPropertyTree &item = iter->query();
-            if (&item==NULL)
-                continue; // paranoia
             varAppend(mb, 256, item, "@name");              
             varAppend(mb, 64, item, "@cluster");                
             byte b = item.getPropBool("@super")?1:0;
@@ -698,8 +690,6 @@ WORKUNITSERVICES_API void wsWorkunitFilesWritten( ICodeContext *ctx, size32_t & 
         Owned<IPropertyTreeIterator> iter = pt->getElements("File");
         ForEach(*iter) {
             IPropertyTree &item = iter->query();
-            if (&item==NULL)
-                continue; // paranoia
             varAppend(mb, 256, item, "@name");              
             fixedAppend(mb, 10, item, "@graph");                
             varAppend(mb, 64, item, "@cluster");                

--- a/rtl/eclrtl/rtlds.cpp
+++ b/rtl/eclrtl/rtlds.cpp
@@ -258,7 +258,7 @@ void rtlRowsAttr::dispose()
 void rtlReportFieldOverflow(unsigned size, unsigned max, const RtlFieldInfo * field)
 {
     if (field)
-        rtlReportFieldOverflow(size, max, field->name->str());
+        rtlReportFieldOverflow(size, max, str(field->name));
     else
         rtlReportRowOverflow(size, max);
 }

--- a/rtl/eclrtl/rtlfield.cpp
+++ b/rtl/eclrtl/rtlfield.cpp
@@ -36,13 +36,13 @@ static const char * queryXPath(const RtlFieldInfo * field)
             return xpath;
         return sep+1;
     }
-    return field->name->str();
+    return str(field->name);
 }
 
 static const char * queryScalarXPath(const RtlFieldInfo * field)
 {
     if (field->type->hasNonScalarXpath())
-        return field->name->str();
+        return str(field->name);
     return queryXPath(field);
 }
 
@@ -131,7 +131,7 @@ const RtlTypeInfo * RtlTypeInfoBase::queryChildType() const
 
 size32_t RtlBoolTypeInfo::build(ARowBuilder &builder, size32_t offset, const RtlFieldInfo *field, IFieldSource &source) const
 {
-    builder.ensureCapacity(sizeof(bool)+offset, field->name->str());
+    builder.ensureCapacity(sizeof(bool)+offset, str(field->name));
     bool val = source.getBooleanResult(field);
     * (bool *) (builder.getSelf() + offset) = val;
     offset += sizeof(bool);
@@ -161,7 +161,7 @@ double RtlRealTypeInfo::value(const byte * self) const
 
 size32_t RtlRealTypeInfo::build(ARowBuilder &builder, size32_t offset, const RtlFieldInfo *field, IFieldSource &source) const
 {
-    builder.ensureCapacity(length+offset, field->name->str());
+    builder.ensureCapacity(length+offset, str(field->name));
     double val = source.getRealResult(field);
     byte *dest = builder.getSelf() + offset;
     if (length == 4)
@@ -188,7 +188,7 @@ size32_t RtlRealTypeInfo::toXML(const byte * self, const byte * selfrow, const R
 
 size32_t RtlIntTypeInfo::build(ARowBuilder &builder, size32_t offset, const RtlFieldInfo *field, IFieldSource &source) const
 {
-    builder.ensureCapacity(length+offset, field->name->str());
+    builder.ensureCapacity(length+offset, str(field->name));
     __int64 val = isUnsigned() ? (__int64) source.getUnsignedResult(field) : source.getSignedResult(field);
     rtlWriteInt(builder.getSelf() + offset, val, length);
     offset += length;
@@ -217,7 +217,7 @@ size32_t RtlIntTypeInfo::toXML(const byte * self, const byte * selfrow, const Rt
 
 size32_t RtlSwapIntTypeInfo::build(ARowBuilder &builder, size32_t offset, const RtlFieldInfo *field, IFieldSource &source) const
 {
-    builder.ensureCapacity(length+offset, field->name->str());
+    builder.ensureCapacity(length+offset, str(field->name));
     __int64 val = isUnsigned() ? (__int64) source.getUnsignedResult(field) : source.getSignedResult(field);
     // NOTE - we assume that the value returned from the source is already a swapped int
     rtlWriteInt(builder.getSelf() + offset, val, length);
@@ -254,7 +254,7 @@ size32_t RtlPackedIntTypeInfo::build(ARowBuilder &builder, size32_t offset, cons
 {
     unsigned __int64 value = isUnsigned() ? (__int64) source.getUnsignedResult(field) : source.getSignedResult(field);
     size32_t sizeInBytes = rtlGetPackedSize(&value);
-    builder.ensureCapacity(sizeInBytes+offset, field->name->str());
+    builder.ensureCapacity(sizeInBytes+offset, str(field->name));
     rtlSetPackedUnsigned(builder.getSelf() + offset, value);
     offset += sizeInBytes;
     return offset;
@@ -295,7 +295,7 @@ size32_t RtlStringTypeInfo::build(ARowBuilder &builder, size32_t offset, const R
     source.getStringResult(field, size, value);
     if (!isFixedSize())
     {
-        builder.ensureCapacity(offset+size+sizeof(size32_t), field->name->str());
+        builder.ensureCapacity(offset+size+sizeof(size32_t), str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlWriteInt4(dest, size);
 #if 0
@@ -311,7 +311,7 @@ size32_t RtlStringTypeInfo::build(ARowBuilder &builder, size32_t offset, const R
     }
     else
     {
-        builder.ensureCapacity(offset+length, field->name->str());
+        builder.ensureCapacity(offset+length, str(field->name));
         byte *dest = builder.getSelf()+offset;
 #if 0
         // See above...
@@ -404,7 +404,7 @@ size32_t RtlDataTypeInfo::build(ARowBuilder &builder, size32_t offset, const Rtl
     source.getDataResult(field, size, value);
     if (!isFixedSize())
     {
-        builder.ensureCapacity(offset+size+sizeof(size32_t), field->name->str());
+        builder.ensureCapacity(offset+size+sizeof(size32_t), str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlWriteInt4(dest, size);
         memcpy(dest+sizeof(size32_t), value, size);
@@ -412,7 +412,7 @@ size32_t RtlDataTypeInfo::build(ARowBuilder &builder, size32_t offset, const Rtl
     }
     else
     {
-        builder.ensureCapacity(offset+length, field->name->str());
+        builder.ensureCapacity(offset+length, str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlDataToData(length, dest, size, value);
         offset += length;
@@ -480,7 +480,7 @@ size32_t RtlVarStringTypeInfo::build(ARowBuilder &builder, size32_t offset, cons
     source.getStringResult(field, size, value);
     if (!isFixedSize())
     {
-        builder.ensureCapacity(offset+size+1, field->name->str());
+        builder.ensureCapacity(offset+size+1, str(field->name));
         // See notes re EBCDIC conversion in RtlStringTypeInfo code
         byte *dest = builder.getSelf()+offset;
         memcpy(dest, value, size);
@@ -489,7 +489,7 @@ size32_t RtlVarStringTypeInfo::build(ARowBuilder &builder, size32_t offset, cons
     }
     else
     {
-        builder.ensureCapacity(offset+length, field->name->str());
+        builder.ensureCapacity(offset+length, str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlStrToVStr(length, dest, size, value);
         offset += length;
@@ -561,7 +561,7 @@ size32_t RtlQStringTypeInfo::build(ARowBuilder &builder, size32_t offset, const 
     if (!isFixedSize())
     {
         size32_t sizeInBytes = rtlQStrSize(size) + sizeof(size32_t);
-        builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes, str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlWriteInt4(dest, size);
         rtlStrToQStr(size, (char *) dest+sizeof(size32_t), size, value);
@@ -570,7 +570,7 @@ size32_t RtlQStringTypeInfo::build(ARowBuilder &builder, size32_t offset, const 
     else
     {
         size32_t sizeInBytes = rtlQStrSize(length);
-        builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes, str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlStrToQStr(length, (char *) dest, size, value);
         offset += sizeInBytes;
@@ -640,7 +640,7 @@ size32_t RtlDecimalTypeInfo::build(ARowBuilder &builder, size32_t offset, const 
     Decimal value;
     source.getDecimalResult(field, value);
     size32_t sizeInBytes = calcSize();
-    builder.ensureCapacity(sizeInBytes+offset, field->name->str());
+    builder.ensureCapacity(sizeInBytes+offset, str(field->name));
     if (isUnsigned())
         value.getUDecimal(sizeInBytes, getDecimalPrecision(), builder.getSelf()+offset);
     else
@@ -717,7 +717,7 @@ size32_t RtlUnicodeTypeInfo::build(ARowBuilder &builder, size32_t offset, const 
     if (!isFixedSize())
     {
         size32_t sizeInBytes = sizeInChars * sizeof(UChar);
-        builder.ensureCapacity(offset+sizeInBytes+sizeof(size32_t), field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes+sizeof(size32_t), str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlWriteInt4(dest, sizeInChars);  // NOTE - in chars!
         memcpy(dest+sizeof(size32_t), value, sizeInBytes);
@@ -726,7 +726,7 @@ size32_t RtlUnicodeTypeInfo::build(ARowBuilder &builder, size32_t offset, const 
     else
     {
         size32_t sizeInBytes = length * sizeof(UChar);
-        builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes, str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlUnicodeToUnicode(length, (UChar *) dest, sizeInChars, value);
         offset += sizeInBytes;
@@ -795,7 +795,7 @@ size32_t RtlVarUnicodeTypeInfo::build(ARowBuilder &builder, size32_t offset, con
     if (!isFixedSize())
     {
         size32_t sizeInBytes = (sizeInChars+1) * sizeof(UChar);
-        builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes, str(field->name));
         UChar *dest = (UChar *) builder.getSelf()+offset;
         memcpy(dest, value, sizeInBytes - sizeof(UChar));
         dest[sizeInChars] = 0;
@@ -804,7 +804,7 @@ size32_t RtlVarUnicodeTypeInfo::build(ARowBuilder &builder, size32_t offset, con
     else
     {
         size32_t sizeInBytes = length * sizeof(UChar);
-        builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes, str(field->name));
         byte *dest = builder.getSelf()+offset;
         rtlUnicodeToVUnicode(length, (UChar *) dest, sizeInChars, value);
         offset += sizeInBytes;
@@ -856,7 +856,7 @@ size32_t RtlUtf8TypeInfo::build(ARowBuilder &builder, size32_t offset, const Rtl
     source.getUTF8Result(field, sizeInChars, value);
     size32_t sizeInBytes = rtlUtf8Size(sizeInChars, value);
     assertex(!isFixedSize());
-    builder.ensureCapacity(offset+sizeInBytes+sizeof(size32_t), field->name->str());
+    builder.ensureCapacity(offset+sizeInBytes+sizeof(size32_t), str(field->name));
     byte *dest = builder.getSelf()+offset;
     rtlWriteInt4(dest, sizeInChars);  // NOTE - in chars!
     memcpy(dest+sizeof(size32_t), value, sizeInBytes);
@@ -1000,7 +1000,7 @@ size32_t RtlSetTypeInfo::build(ARowBuilder &builder, size32_t offset, const RtlF
     bool isAll;
     source.processBeginSet(field, isAll);
     size32_t sizeInBytes = sizeof(bool) + sizeof(size32_t);
-    builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+    builder.ensureCapacity(offset+sizeInBytes, str(field->name));
     byte *dest = builder.getSelf()+offset;
     if (isAll)
     {
@@ -1140,7 +1140,7 @@ size32_t RtlDatasetTypeInfo::build(ARowBuilder &builder, size32_t offset, const 
     {
         // a 32-bit record count, and a pointer to an array of record pointers
         size32_t sizeInBytes = sizeof(size32_t) + sizeof(void *);
-        builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes, str(field->name));
         size32_t numRows = 0;
         Owned<IEngineRowAllocator> childAllocator = builder.queryAllocator()->createChildRowAllocator(child);
         byte **childRows = NULL;
@@ -1160,7 +1160,7 @@ size32_t RtlDatasetTypeInfo::build(ARowBuilder &builder, size32_t offset, const 
     {
         // a 32-bit size, then rows inline
         size32_t sizeInBytes = sizeof(size32_t);
-        builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes, str(field->name));
         size32_t newOffset = offset + sizeInBytes;
         RtlFieldStrInfo dummyField("<nested row>", NULL, child);
         while (source.processNextRow(field))
@@ -1275,7 +1275,7 @@ size32_t RtlDictionaryTypeInfo::build(ARowBuilder &builder, size32_t offset, con
     {
         // a 32-bit record count, and a pointer to an hash table with record pointers
         size32_t sizeInBytes = sizeof(size32_t) + sizeof(void *);
-        builder.ensureCapacity(offset+sizeInBytes, field->name->str());
+        builder.ensureCapacity(offset+sizeInBytes, str(field->name));
         Owned<IEngineRowAllocator> childAllocator = builder.queryAllocator()->createChildRowAllocator(child);
         RtlLinkedDictionaryBuilder dictBuilder(childAllocator, hashInfo);
         RtlFieldStrInfo dummyField("<nested row>", NULL, child);

--- a/system/jlib/jhash.cpp
+++ b/system/jlib/jhash.cpp
@@ -176,21 +176,6 @@ MappingKey::MappingKey(const void * inKey, int keysize)
   key = temp;
 }
 
-//-- Default atom implementations --------------------------------------------
-
-const char *IAtom::getAtomNamePtr() const
-{
-   if (!this) return NULL;
-   return getNamePtr();
-}
-
-IAtom * IIdAtom::lower() const
-{
-    if (!this)
-        return NULL;
-    return queryLower();
-}
-
 //-- Mapping ---------------------------------------------------
 
 unsigned MappingBase::getHash() const       { return hash; }

--- a/system/jlib/jhash.hpp
+++ b/system/jlib/jhash.hpp
@@ -48,9 +48,9 @@ interface jlib_decl IMapping : extends IObservable
 interface jlib_decl IAtom : extends IMapping
 {
  public:
-    virtual const char * getNamePtr() const = 0;
+    virtual const char * queryStr() const = 0;
 };
-inline jlib_decl const char * str(const IAtom * atom) { return atom ? atom->getNamePtr() : NULL; }
+inline jlib_decl const char * str(const IAtom * atom) { return atom ? atom->queryStr() : NULL; }
 
 //This interface represents an atom which preserves its case, but also stores a lower case representation
 //for efficient case insensitive comparison.
@@ -58,11 +58,11 @@ inline jlib_decl const char * str(const IAtom * atom) { return atom ? atom->getN
 interface jlib_decl IIdAtom : extends IMapping
 {
  public:
-    virtual const char * getNamePtr() const = 0;
+    virtual const char * queryStr() const = 0;
  public:
     virtual IAtom * queryLower() const = 0;
 };
-inline jlib_decl const char * str(const IIdAtom * atom) { return atom ? atom->getNamePtr() : NULL; }
+inline jlib_decl const char * str(const IIdAtom * atom) { return atom ? atom->queryStr() : NULL; }
 inline jlib_decl IAtom * lower(const IIdAtom * atom) { return atom ? atom->queryLower() : NULL; }
 
 #ifdef _MSC_VER

--- a/system/jlib/jhash.hpp
+++ b/system/jlib/jhash.hpp
@@ -49,11 +49,8 @@ interface jlib_decl IAtom : extends IMapping
 {
  public:
     virtual const char * getNamePtr() const = 0;
-
-    const char *         getAtomNamePtr() const;     // ok if this=NULL
-    inline const char * str() const { return getAtomNamePtr(); }
-    inline operator const char *() const { return getAtomNamePtr(); }
 };
+inline jlib_decl const char * str(const IAtom * atom) { return atom ? atom->getNamePtr() : NULL; }
 
 //This interface represents an atom which preserves its case, but also stores a lower case representation
 //for efficient case insensitive comparison.
@@ -62,15 +59,11 @@ interface jlib_decl IIdAtom : extends IMapping
 {
  public:
     virtual const char * getNamePtr() const = 0;
-
-    const char *         getAtomNamePtr() const { return this ? getNamePtr() : NULL; }
-    inline const char * str() const { return getAtomNamePtr(); }
-    inline operator const char *() const { return getAtomNamePtr(); }
-
  public:
     virtual IAtom * queryLower() const = 0;
-    IAtom * lower() const; // safe if this==NULL
 };
+inline jlib_decl const char * str(const IIdAtom * atom) { return atom ? atom->getNamePtr() : NULL; }
+inline jlib_decl IAtom * lower(const IIdAtom * atom) { return atom ? atom->queryLower() : NULL; }
 
 #ifdef _MSC_VER
 #pragma warning (push)

--- a/system/jlib/jhash.ipp
+++ b/system/jlib/jhash.ipp
@@ -79,7 +79,7 @@ public:
     ~AtomBase()               { free(key); }
 
 //interface:IMapping
-    virtual const char *        getNamePtr() const { return key; }
+    virtual const char *        queryStr() const { return key; }
     virtual const void *        getKey() const;
     virtual unsigned            getHash() const;
     virtual void                setHash(unsigned);
@@ -123,7 +123,7 @@ public:
     ~CaseAtom() { free(text); }
 
 //interface:IMapping
-    virtual const char *        getNamePtr() const { return text; }
+    virtual const char *        queryStr() const { return text; }
     virtual const void *        getKey() const { return text; }
     virtual unsigned            getHash() const { return hash; }
     virtual void                setHash(unsigned _hash) { hash = _hash; }

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -236,7 +236,7 @@ StringBuffer & StringBuffer::append(const char * value, int offset, int len)
 StringBuffer & StringBuffer::append(const IAtom * value)
 {
     if (value)
-        append(value->getAtomNamePtr());
+        append(value->getNamePtr());
     return *this;
 }
 

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -236,7 +236,7 @@ StringBuffer & StringBuffer::append(const char * value, int offset, int len)
 StringBuffer & StringBuffer::append(const IAtom * value)
 {
     if (value)
-        append(value->getNamePtr());
+        append(value->queryStr());
     return *this;
 }
 

--- a/system/jlib/jsuperhash.hpp
+++ b/system/jlib/jsuperhash.hpp
@@ -455,7 +455,6 @@ public:
     const char *get() { return (const char *)keyPtr(); }
     unsigned length() { return (size32_t)strlen((const char *)keyPtr()); }
     unsigned queryHash() const { return hashValue; }
-    operator const char * () { return (NULL==this)?NULL:keyPtr(); }
     unsigned queryReferences() { return linkCount+1; } // 1 implicit
 
 private:        

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -1959,7 +1959,7 @@ IAuthenticatedUser *createAuthenticatedUser() { UNIMPLEMENTED; }
 
 extern jlib_decl void serializeAtom(MemoryBuffer & target, IAtom * name)
 {
-    StringBuffer lower(name->str());
+    StringBuffer lower(str(name));
     lower.toLowerCase();
     serialize(target, lower.str());
 }

--- a/system/security/LdapSecurity/aci.cpp
+++ b/system/security/LdapSecurity/aci.cpp
@@ -909,7 +909,7 @@ bool AciProcessor::getPermissions(ISecUser& user, IArrayOf<CSecurityDescriptor>&
 }
 
 
-CSecurityDescriptor* AciProcessor::createDefaultSD(ISecUser& user, ISecResource* resource, SecPermissionType ptype)
+CSecurityDescriptor* AciProcessor::createDefaultSD(ISecUser * const user, ISecResource* resource, SecPermissionType ptype)
 {
     return createDefaultSD(user, resource->getName(), ptype);   
 }
@@ -919,12 +919,12 @@ StringBuffer& AciProcessor::sec2aci(int secperm, StringBuffer& aciperm)
     throw MakeStringException(-1, "You should call the implementation of the child class");
 }
 
-CSecurityDescriptor* AciProcessor::createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype)
+CSecurityDescriptor* AciProcessor::createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype)
 {
     throw MakeStringException(-1, "You should call the implementation of the child class");
 }
 
-CSecurityDescriptor* AciProcessor::createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd)
+CSecurityDescriptor* AciProcessor::createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd)
 {
     throw MakeStringException(-1, "You should call the implementation of the child class");
 }
@@ -1069,7 +1069,7 @@ StringBuffer& CIPlanetAciProcessor::sec2aci(int secperm, StringBuffer& aciperm)
     return aciperm;
 }
 
-CSecurityDescriptor* CIPlanetAciProcessor::createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype)
+CSecurityDescriptor* CIPlanetAciProcessor::createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype)
 {
     CSecurityDescriptor* csd = new CSecurityDescriptor(name);
     
@@ -1095,7 +1095,7 @@ CSecurityDescriptor* CIPlanetAciProcessor::createDefaultSD(ISecUser& user, const
     return csd;
 }
 
-CSecurityDescriptor* CIPlanetAciProcessor::createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd)
+CSecurityDescriptor* CIPlanetAciProcessor::createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd)
 {
     if(resource == NULL)
         return NULL;
@@ -1114,14 +1114,14 @@ CSecurityDescriptor* CIPlanetAciProcessor::createDefaultSD(ISecUser& user, ISecR
     if(userbasedn == NULL)
         return csd;
 
-    if(&user != NULL && DEFAULT_OWNER_PERMISSION != SecAccess_None)
+    if(user && DEFAULT_OWNER_PERMISSION != SecAccess_None)
     {
         StringBuffer defaultperm;
         sec2aci(DEFAULT_OWNER_PERMISSION, defaultperm);
         StringBuffer default_sd;
         default_sd.append("(targetattr = \"*\") (version 3.0;acl \"default_aci\";allow (").append(defaultperm.str()).append(")");
         default_sd.append("(userdn = \"ldap:///");
-        default_sd.append("uid=").append(user.getName());
+        default_sd.append("uid=").append(user->getName());
         default_sd.append(",").append(userbasedn).append("\");)");
         csd->appendDescriptor(default_sd.length(), (void*)default_sd.str());
     }
@@ -1161,7 +1161,7 @@ StringBuffer& COpenLdapAciProcessor::sec2aci(int secperm, StringBuffer& aciperm)
     return aciperm;
 }
 
-CSecurityDescriptor* COpenLdapAciProcessor::createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype)
+CSecurityDescriptor* COpenLdapAciProcessor::createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype)
 {
     CSecurityDescriptor* csd = new CSecurityDescriptor(name);
     
@@ -1187,7 +1187,7 @@ CSecurityDescriptor* COpenLdapAciProcessor::createDefaultSD(ISecUser& user, cons
     return csd;
 }
 
-CSecurityDescriptor* COpenLdapAciProcessor::createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd)
+CSecurityDescriptor* COpenLdapAciProcessor::createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd)
 {
     if(resource == NULL)
         return NULL;
@@ -1206,12 +1206,12 @@ CSecurityDescriptor* COpenLdapAciProcessor::createDefaultSD(ISecUser& user, ISec
     if(userbasedn == NULL)
         return csd;
 
-    if(&user != NULL && DEFAULT_OWNER_PERMISSION != SecAccess_None)
+    if(user && DEFAULT_OWNER_PERMISSION != SecAccess_None)
     {
         StringBuffer defaultperm;
         sec2aci(DEFAULT_OWNER_PERMISSION, defaultperm);
         StringBuffer default_sd;
-        default_sd.appendf("default_aci#entry#grant;%s;[all]#access-id#uid=%s,%s", defaultperm.str(), user.getName(), userbasedn);
+        default_sd.appendf("default_aci#entry#grant;%s;[all]#access-id#uid=%s,%s", defaultperm.str(), user->getName(), userbasedn);
         csd->appendDescriptor(default_sd.length(), (void*)default_sd.str());
     }
     return csd;

--- a/system/security/LdapSecurity/aci.ipp
+++ b/system/security/LdapSecurity/aci.ipp
@@ -41,9 +41,9 @@ public:
     }
 
     virtual bool getPermissions(ISecUser& user, IArrayOf<CSecurityDescriptor>& sdlist, IArrayOf<ISecResource>& resources);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, ISecResource* resource, SecPermissionType ptype);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, SecPermissionType ptype);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd);
     virtual bool retrieveUserInfo(ISecUser& user);
 
     virtual void getCachedSid(const char* name, MemoryBuffer& sid);
@@ -65,8 +65,8 @@ public:
     }
 
     virtual StringBuffer& sec2aci(int secperm, StringBuffer& aciperm);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd);
 };
 
 class COpenLdapAciProcessor : public AciProcessor
@@ -78,8 +78,8 @@ public:
     }
     
     virtual StringBuffer& sec2aci(int secperm, StringBuffer& aciperm);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd);
 };
 
 #endif

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -4544,7 +4544,7 @@ private:
         MemoryBuffer sdbuf;
         Owned<CSecurityDescriptor> default_sd = NULL;
         if(m_pp !=  NULL)
-            default_sd.setown(m_pp->createDefaultSD(*user, name, ptype));
+            default_sd.setown(m_pp->createDefaultSD(user, name, ptype));
         if(default_sd != NULL)
             sdbuf.append(default_sd->getDescriptor());
 
@@ -4667,12 +4667,12 @@ private:
             MemoryBuffer template_sd_buf;
             template_sd_buf.append(template_sd->getDescriptor());
             if(m_pp != NULL)
-                default_sd.setown(m_pp->createDefaultSD(user, resource, template_sd_buf));
+                default_sd.setown(m_pp->createDefaultSD(&user, resource, template_sd_buf));
         }
         else
         {
             if(m_pp !=  NULL)
-                default_sd.setown(m_pp->createDefaultSD(user, resource, ptype));
+                default_sd.setown(m_pp->createDefaultSD(&user, resource, ptype));
         }
 
         return addResource(rtype, user, resource, ptype, basedn, default_sd.get());

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -910,12 +910,6 @@ bool CLdapSecManager::addResources(ISecUser& sec_user, ISecResourceList * resour
 
 bool CLdapSecManager::addUser(ISecUser & user)
 {
-    if(&user == NULL)
-    {
-        DBGLOG("CLdapSecManager::addUser - user is NULL");
-        return false;
-    }
-
     bool ok = m_ldap_client->addUser(user);
     if(!ok)
         return false;

--- a/system/security/LdapSecurity/permissions.cpp
+++ b/system/security/LdapSecurity/permissions.cpp
@@ -1027,11 +1027,6 @@ bool PermissionProcessor::getPermissions(ISecUser& user, IArrayOf<CSecurityDescr
     if(num_resources <= 0)
         return true;
 
-    if(!(&user))
-    {
-        DBGLOG("user passed in to PermissionProcessor::getPermissions is NULL");
-        return false;
-    }
     const char* username = user.getName();
 
 #ifdef USE_LOGONUSER
@@ -1456,12 +1451,12 @@ CSecurityDescriptor* PermissionProcessor::changePermission(CSecurityDescriptor* 
     return csd;
 }
 
-CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser& user, ISecResource* resource, SecPermissionType ptype)
+CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser * const user, ISecResource* resource, SecPermissionType ptype)
 {
     return createDefaultSD(user, resource->getName(), ptype);   
 }
 
-CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype)
+CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype)
 {
     SECURITY_DESCRIPTOR sd;
     unsigned char aclBuffer[1024];
@@ -1477,10 +1472,10 @@ CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser& user, const 
     if(ptype != PT_ADMINISTRATORS_ONLY)
     {
         MemoryBuffer umb, gmb;
-        if(&user != NULL && DEFAULT_OWNER_PERMISSION != SecAccess_None)
+        if(user && DEFAULT_OWNER_PERMISSION != SecAccess_None)
         {
             //Add SD for given user
-            lookupSid(user.getName(), umb);
+            lookupSid(user->getName(), umb);
             psid = (PSID)(umb.toByteArray());
             if(psid != NULL)
             {
@@ -1518,7 +1513,7 @@ CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser& user, const 
     return csd;
 }
 
-CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd)
+CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd)
 {
     const char* initial_buf = initial_sd.toByteArray();
     PSECURITY_DESCRIPTOR pisd = (PSECURITY_DESCRIPTOR)initial_buf;
@@ -1559,9 +1554,9 @@ CSecurityDescriptor* PermissionProcessor::createDefaultSD(ISecUser& user, ISecRe
     PSID user_psid;
     PACL pnewdacl = NULL;
     MemoryBuffer umb;
-    if(&user != NULL && DEFAULT_OWNER_PERMISSION != SecAccess_None)
+    if(user && DEFAULT_OWNER_PERMISSION != SecAccess_None)
     {
-        lookupSid(user.getName(), umb);
+        lookupSid(user->getName(), umb);
         user_psid = (PSID)(umb.toByteArray());
 
 #ifdef _WIN32

--- a/system/security/LdapSecurity/permissions.hpp
+++ b/system/security/LdapSecurity/permissions.hpp
@@ -91,9 +91,9 @@ interface IPermissionProcessor : implements IInterface
     virtual void setLdapClient(ILdapClient* client) = 0;
     
     virtual bool getPermissions(ISecUser& user, IArrayOf<CSecurityDescriptor>& sdlist, IArrayOf<ISecResource>& resources) = 0;
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, ISecResource* resource, SecPermissionType ptype) = 0;
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype) = 0;
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd) = 0;
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, SecPermissionType ptype) = 0;
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype) = 0;
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd) = 0;
     virtual bool retrieveUserInfo(ISecUser& user) = 0;
 
     virtual void getCachedSid(const char* name, MemoryBuffer& sid) = 0;

--- a/system/security/LdapSecurity/permissions.ipp
+++ b/system/security/LdapSecurity/permissions.ipp
@@ -714,9 +714,9 @@ public:
         m_ldap_client = client;
     }
     virtual bool getPermissions(ISecUser& user, IArrayOf<CSecurityDescriptor>& sdlist, IArrayOf<ISecResource>& resources);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, ISecResource* resource, SecPermissionType ptype);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, const char* name, SecPermissionType ptype);
-    virtual CSecurityDescriptor* createDefaultSD(ISecUser& user, ISecResource* resource, MemoryBuffer& initial_sd);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, SecPermissionType ptype);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype);
+    virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd);
     virtual bool retrieveUserInfo(ISecUser& user);
     virtual bool retrieveGroupInfo(ISecUser& user, BufferArray& groupsids);
 

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -336,7 +336,7 @@ ISecUser* CPermissionsCache::getCachedUser( ISecUser& sec_user)
 }
 void CPermissionsCache::add(ISecUser& sec_user)
 {
-    if(!isCacheEnabled() || &sec_user == NULL)
+    if(!isCacheEnabled())
         return;
     
     const char* username = sec_user.getName();

--- a/system/security/test/ldapsecuritytest/ldapsecuritytest.cpp
+++ b/system/security/test/ldapsecuritytest/ldapsecuritytest.cpp
@@ -326,7 +326,7 @@ int main(int argc, char* argv[])
             if(lastname != NULL)
                 usr->setLastName(lastname);
             usr->credentials().setPassword(passwd);
-            bool ok = secmgr->addUser(*usr);
+            bool ok = usr?secmgr->addUser(*usr):false;
             if(ok)
                 printf("user %s added\n", username);
             else


### PR DESCRIPTION
HPCC-13496 'this' pointer cannot be null in well-defined C++ code

```
Set tautological-compare compiler flag to be an error so 'this==null' comparision is treated as errors
tautlogical-compare also treats &reference==null as errors also
Code to remove &reference==null check by either removing the check where it is unnecessary or converting the reference to a pointer
Remove unnecessary check of IPropertyTree & for nullness that was returned in IPropertyTreeIterator.
ForEach() calls IPropertyTreeIterator's isValid member function to ensure item is vaid.
IAtom: Remove multiple aliases to access getNamePtr() from IAtom
Add global str(IAtom *) function to safely access getNamePtr() even if IAtom * argument is null
IIdAtom: Remove multiple aliases to access getNamePtr() from IAtom
Add global str(IIdAtom *) function to safely access getNamePtr() even if IIdAtom * argument is null
Replace all usages of the aliases removed previously with a call to the newly create str() function
IIdAtom: remove the lower() member variable and replace with global lower(IIdAtom *p) function
Modify cmake commonSetup.cmake to have this==null treated as compilation errors by CLang compilers
Remove checks of reference variable’s address
secuser pointer checked for nullness before passing in argument as reference (working.cpp: CSecureConstWUIterator::checkScope)
user pointer checked for nullness before passing in argument as reference (ws_DfuService.cpp: getFilePermissions)
Change user to reference in getFilePermission() (ws_dfuService.cpp). The caller checks user for nullness, so appropriate to have caller pass user as a reference.
modify declaration of str() and lower() in jhash.cpp with jlib_decl (to expose externally in dlls)
```
