### PR TITLE
HPCC-13820 Fix WsEcl form ignoring password format option

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -1157,7 +1157,7 @@ void CWsEclBinding::SOAPSectionToXsd(WsEclWuInfo &wuinfo, IPropertyTree *parmTre
             }
 
             schema.appendf("<xsd:element minOccurs=\"0\" maxOccurs=\"1\" name=\"%s\" type=\"%s\"", name, type.str());
-            if (part.hasProp("@width") || part.hasProp("@height"))
+            if (part.hasProp("@width") || part.hasProp("@height") || part.hasProp("@password"))
             {
                 schema.append("><xsd:annotation><xsd:appinfo><form");
                 unsigned rows = part.getPropInt("@height");


### PR DESCRIPTION
When password is used alone as the only stored(format(..))
option it was being ignored by the WsEcl form.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
