### PR TITLE
HPCC-13818 Improvements for outputting directly to external logical files

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -454,6 +454,16 @@ void CHThorDiskWriteActivity::resolve()
                         throw MakeStringException(99, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", full.str());
                     file->remove();
                 }
+
+                //Ensure target folder exists
+                StringBuffer drive, path, fn, ext;
+                splitFilename(filename.get(), &drive, &path, &fn, &ext);
+                drive.append(path);
+                if (!recursiveCreateDirectory(drive.str()))
+                {
+                    throw MakeStringException(99, "Cannot create file folder %s", drive.str());
+                }
+
                 PROGLOG("Writing to file %s", filename.get());
             }
             f.clear();

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -456,12 +456,9 @@ void CHThorDiskWriteActivity::resolve()
                 }
 
                 //Ensure target folder exists
-                StringBuffer drive, path, fn, ext;
-                splitFilename(filename.get(), &drive, &path, &fn, &ext);
-                drive.append(path);
-                if (!recursiveCreateDirectory(drive.str()))
+                if (!recursiveCreateDirectoryForFile(filename.get()))
                 {
-                    throw MakeStringException(99, "Cannot create file folder %s", drive.str());
+                    throw MakeStringException(99, "Cannot create file folder for %s", filename.str());
                 }
 
                 PROGLOG("Writing to file %s", filename.get());


### PR DESCRIPTION
Currently if creating an external file in a folder that does not exist, HThor
will fail.  This PR ensures that folder is created before attempting to
create the file

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
