### PR TITLE
HPCC-13839 Delete empty superfile

### DIFF
--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -810,11 +810,11 @@ public:
                     else
                         throwError1(DFUERR_DSuperFileDoesntContainSub, subfiles[i1]);
         }
+        if (removesuperfile && toremove.ordinality()!=superfile->numSubFiles())
+            removesuperfile = false;
         // Do we have something to delete?
-        if (toremove.ordinality()) {
+        if (toremove.ordinality() || removesuperfile) {
             transaction->start();
-            if (removesuperfile && toremove.ordinality()!=superfile->numSubFiles())
-                removesuperfile = false;
             ForEachItemIn(i2,toremove)
                 superfile->removeSubFile(toremove.item(i2).text.get(),delsub,false,transaction);
             // Delete superfile if empty


### PR DESCRIPTION
The code for deleting superfile is moved into the
delete transaction. But, the code only starts the
transaction if there is subfile to be deleted.
Empty superfile cannot be deleted. In this fix,
the transaction will be started for deleting empty
superfile.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
