### PR TITLE
HPCC-13321 Add ecl-packagemap-add cli "--preload-all" option

### DIFF
--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -498,7 +498,7 @@ private:
 class EclCmdPackageAdd : public EclCmdCommon
 {
 public:
-    EclCmdPackageAdd() : optActivate(false), optOverWrite(false), optGlobalScope(false), optAllowForeign(false)
+    EclCmdPackageAdd() : optActivate(false), optOverWrite(false), optGlobalScope(false), optAllowForeign(false), optPreloadAll(false)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -538,6 +538,8 @@ public:
             if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
                 continue;
             if (iter.matchFlag(optAllowForeign, ECLOPT_ALLOW_FOREIGN))
+                continue;
+            if (iter.matchFlag(optPreloadAll, ECLOPT_PRELOAD_ALL_PACKAGES))
                 continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
@@ -595,6 +597,7 @@ public:
         request->setGlobalScope(optGlobalScope);
         request->setSourceProcess(optSourceProcess);
         request->setAllowForeignFiles(optAllowForeign);
+        request->setPreloadAllPackages(optPreloadAll);
 
         Owned<IClientAddPackageResponse> resp = packageProcessClient->AddPackage(request);
         if (resp->getExceptions().ordinality())
@@ -627,6 +630,7 @@ public:
                     "   --global-scope              The specified packagemap can be shared across multiple targets\n"
                     "   --source-process            Process cluster to copy files from\n"
                     "   --allow-foreign             Do not fail if foreign files are used in packagemap\n"
+                    "   --preload-all               Set preload files option for all packages\n"
                     "   <target>                    Name of target to use when adding package map information\n"
                     "   <filename>                  Name of file containing package map information\n",
                     stdout);
@@ -645,6 +649,7 @@ private:
     bool optOverWrite;
     bool optGlobalScope;
     bool optAllowForeign;
+    bool optPreloadAll;
 };
 
 class EclCmdPackageValidate : public EclCmdCommon

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -109,6 +109,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_COMMENT "--comment"
 
 #define ECLOPT_CHECK_PACKAGEMAPS "--check-packagemaps"
+#define ECLOPT_PRELOAD_ALL_PACKAGES "--preload-all"
 
 #define ECLOPT_EXCEPTION_LEVEL "--exception-level"
 #define ECLOPT_RESULT_LIMIT "--limit"

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -37,6 +37,7 @@ ESPrequest AddPackageRequest
     bool GlobalScope(0);
     string SourceProcess;
     bool AllowForeignFiles(true);
+    [min_ver("1.02")] bool PreloadAllPackages(false);
 };
 
 
@@ -232,7 +233,7 @@ ESPresponse [exceptions_inline] GetPackageMapSelectOptionsResponse
     ESParray<string> ProcessFilters;
 };
 
-ESPservice [version("1.01"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsPackageProcess
+ESPservice [version("1.02"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsPackageProcess
 {
     ESPmethod Echo(EchoRequest, EchoResponse);
     ESPmethod AddPackage(AddPackageRequest, AddPackageResponse);

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -184,7 +184,7 @@ void makePackageActive(IPropertyTree *pkgSet, IPropertyTree *psEntryNew, const c
 
 //////////////////////////////////////////////////////////
 
-void addPackageMapInfo(const char *xml, StringArray &filesNotFound, const char *process, const char *target, const char *pmid, const char *packageSetName, const char *lookupDaliIp, const char *srcCluster, const char *prefix, bool activate, bool overWrite, IUserDescriptor* userdesc, bool allowForeignFiles)
+void addPackageMapInfo(const char *xml, StringArray &filesNotFound, const char *process, const char *target, const char *pmid, const char *packageSetName, const char *lookupDaliIp, const char *srcCluster, const char *prefix, bool activate, bool overWrite, IUserDescriptor* userdesc, bool allowForeignFiles, bool preloadAll)
 {
     if (!xml || !*xml)
         throw MakeStringExceptionDirect(PKG_INFO_NOT_DEFINED, "PackageMap info not provided");
@@ -211,6 +211,8 @@ void addPackageMapInfo(const char *xml, StringArray &filesNotFound, const char *
     ForEach(*iter)
     {
         IPropertyTree &item = iter->query();
+        if (preloadAll)
+            item.setPropBool("@preload", true);
         Owned<IPropertyTreeIterator> superFiles = item.getElements("SuperFile");
         ForEach(*superFiles)
         {
@@ -563,7 +565,7 @@ bool CWsPackageProcessEx::onAddPackage(IEspContext &context, IEspAddPackageReque
     buildPkgSetId(pkgSetId, processName.get());
 
     StringArray filesNotFound;
-    addPackageMapInfo(req.getInfo(), filesNotFound, processName, target, pmid, pkgSetId, daliip, srcCluster, prefix, activate, overWrite, userdesc, req.getAllowForeignFiles());
+    addPackageMapInfo(req.getInfo(), filesNotFound, processName, target, pmid, pkgSetId, daliip, srcCluster, prefix, activate, overWrite, userdesc, req.getAllowForeignFiles(), req.getPreloadAllPackages());
     resp.setFilesNotFound(filesNotFound);
 
     StringBuffer msg;


### PR DESCRIPTION
When using command line "ecl packgemap add" new option --preload-all
will set all packages in the packagemap to preload files.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
