### PR TITLE
HPCC-13858 CMake not detecting MySQL include directory

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -668,7 +668,6 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
         endif()
       else()
         add_definitions (-D_NO_MYSQL_REPOSITORY)
-        set(MYSQL_INCLUDE_DIR "")
       endif(USE_MYSQL_REPOSITORY)
 
       if(USE_APR)


### PR DESCRIPTION
Clear MYSQL_INCLUDE_DIR so that FIND_PATH is able to assign detected MySQL include path
