### PR TITLE
HPCC-13857 Fix issue with distrubte using compressors with large rows

### DIFF
--- a/system/jlib/jbuff.hpp
+++ b/system/jlib/jbuff.hpp
@@ -214,7 +214,7 @@ public:
     void *          insertDirect(unsigned offset, size32_t len); // insert len bytes at offset returning address to area inserted
     inline void     Release() const                         { delete this; }    // for consistency even though not link counted
 
-    inline void *   bufferBase() const { return curLen ? buffer : NULL; }
+    inline void *   bufferBase() const { return buffer; }
 
 
 protected:

--- a/system/jlib/jlzw.hpp
+++ b/system/jlib/jlzw.hpp
@@ -26,7 +26,8 @@
 
 interface jlib_decl ICompressor : public IInterface
 {
-    virtual void   open(void *blk,size32_t blksize)=0;                   // fixed size output
+    virtual void   open(MemoryBuffer &mb, size32_t initialSize=0)=0; // variable internally sized buffer
+    virtual void   open(void *blk, size32_t blksize)=0;              // fixed size output
     virtual void   close()=0;
     virtual size32_t write(const void *buf,size32_t len)=0;             
                                                                             

--- a/system/jlib/jlzw.ipp
+++ b/system/jlib/jlzw.ipp
@@ -46,6 +46,7 @@ public:
 
     CLZWCompressor(bool _supportbigendian);
     virtual         ~CLZWCompressor();
+    virtual void    open(MemoryBuffer &mb, size32_t initialSize);
     virtual void    open(void *blk,size32_t blksize);
     virtual void    close();
     virtual size32_t    write(const void *buf,size32_t len);
@@ -56,6 +57,8 @@ public:
 
 protected:
     void flushbuf();
+    void initCommon();
+    void ensure(size32_t sz);
     virtual void initdict();
     size32_t inlen;
     size32_t inlenblk;
@@ -67,10 +70,11 @@ protected:
     unsigned char *outbytes;  // byte output
     unsigned char *outbits;   // for trailing bits
     unsigned char *outnext;   // next block
-    unsigned char *inlast;    // for xoring
     unsigned char inuseflag;
     unsigned char outbitbuf;
     unsigned curShift;
+    size32_t outBufStart;
+    MemoryBuffer *outBufMb;
 
     LZWDictionary dict;
     unsigned char dictinuse[LZW_HASH_TABLE_SIZE];

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -226,8 +226,7 @@ protected:
             size32_t compSz = 0;
             size32_t dstPos = dstMb.length();
             dstMb.append(compSz); // placeholder
-            void *dst = dstMb.reserve(owner.bucketSendSize * 2); // allow for worst case
-            compressor.open(dst, owner.bucketSendSize * 2);
+            compressor.open(dstMb, owner.bucketSendSize * 2);
             loop
             {
                 OwnedConstThorRow row = nextRow();

--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -478,9 +478,6 @@ public:
         size32_t sz = 0;
         if (row) {
             sz = thorRowMemoryFootprint(rowIf->queryRowSerializer(), row);
-#ifdef _DEBUG
-            assertex(sz<0x1000000);
-#endif
             assertex((int)sz>=0); // trap invalid sizes a bit earlier
 
 #ifdef _TRACE_SMART_PUTGET


### PR DESCRIPTION
Allow compressors to use a resizing MemoryBuffer, to cater for
variable sized large rows.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
