### PR TITLE
HPCC-13875 Implement DATE and TIME types for MySQL

### DIFF
--- a/system/include/platform.h
+++ b/system/include/platform.h
@@ -264,6 +264,7 @@ typedef unsigned long MaxCard;
 #define _llseek     ::lseek
 #define _lseeki64   ::lseek
 #define _vsnprintf  vsnprintf
+#define _snprintf   snprintf
 #define strnicmp    strncasecmp
 #define INFINITE    0xFFFFFFFF
 

--- a/testing/regress/ecl/key/mysqlembed.xml
+++ b/testing/regress/ecl/key/mysqlembed.xml
@@ -1,24 +1,24 @@
 <Dataset name='Result 1'>
- <Row><name>name1</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2></Row>
- <Row><name>name2</name><value>2</value><boolval>false</boolval><r8>5.6</r8><r4>7.800000190734863</r4><d>3030</d><ddd>-1234567.89</ddd><u1>là</u1><u2>là      </u2></Row>
- <Row><name>nulls</name><value>99999</value><boolval>true</boolval><r8>99.98999999999999</r8><r4>999.989990234375</r4><d>393939393939</d><ddd>9.99</ddd><u1>9999 ß</u1><u2>9999 ßßß</u2></Row>
- <Row><name>utf8test</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2></Row>
+ <Row><name>name1</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2><dt>1963-11-22 12:30:00</dt></Row>
+ <Row><name>name2</name><value>2</value><boolval>false</boolval><r8>5.6</r8><r4>7.800000190734863</r4><d>3030</d><ddd>-1234567.89</ddd><u1>là</u1><u2>là      </u2><dt>2015-12-25 01:23:45</dt></Row>
+ <Row><name>nulls</name><value>99999</value><boolval>true</boolval><r8>99.98999999999999</r8><r4>999.989990234375</r4><d>393939393939</d><ddd>9.99</ddd><u1>9999 ß</u1><u2>9999 ßßß</u2><dt>1963-11-22 12:30:00</dt></Row>
+ <Row><name>utf8test</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2><dt>2019-02-01 23:59:59</dt></Row>
 </Dataset>
 <Dataset name='Result 2'>
  <Row><Result_2>name1</Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><name>name1</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2></Row>
+ <Row><name>name1</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2><dt>1963-11-22 12:30:00</dt></Row>
 </Dataset>
 <Dataset name='Result 4'>
  <Row><Result_4>utf8test</Result_4></Row>
 </Dataset>
 <Dataset name='Result 5'>
- <Row><name>utf8test</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2></Row>
+ <Row><name>utf8test</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2><dt>2019-02-01 23:59:59</dt></Row>
 </Dataset>
 <Dataset name='Result 6'>
- <Row><name>name1</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2></Row>
- <Row><name>name2</name><value>2</value><boolval>false</boolval><r8>5.6</r8><r4>7.800000190734863</r4><d>3030</d><ddd>-1234567.89</ddd><u1>là</u1><u2>là      </u2></Row>
+ <Row><name>name1</name><value>1</value><boolval>true</boolval><r8>1.2</r8><r4>3.400000095367432</r4><d>6161353561613535</d><ddd>1234567.89</ddd><u1>Straße</u1><u2>Straße  </u2><dt>1963-11-22 12:30:00</dt></Row>
+ <Row><name>name2</name><value>2</value><boolval>false</boolval><r8>5.6</r8><r4>7.800000190734863</r4><d>3030</d><ddd>-1234567.89</ddd><u1>là</u1><u2>là      </u2><dt>2015-12-25 01:23:45</dt></Row>
 </Dataset>
 <Dataset name='Result 7'>
  <Row><Result_7>2</Result_7></Row>
@@ -40,4 +40,10 @@
 </Dataset>
 <Dataset name='Result 13'>
  <Row><Result_13>Straße  </Result_13></Row>
+</Dataset>
+<Dataset name='Result 14'>
+ <Row><dt1>19631122123000</dt1><dt2>1963-11-22 12:30:00</dt2></Row>
+ <Row><dt1>20151225012345</dt1><dt2>2015-12-25 01:23:45</dt2></Row>
+ <Row><dt1>0</dt1><dt2>                   </dt2></Row>
+ <Row><dt1>20190201235959</dt1><dt2>2019-02-01 23:59:59</dt2></Row>
 </Dataset>

--- a/testing/regress/ecl/mysqlembed.ecl
+++ b/testing/regress/ecl/mysqlembed.ecl
@@ -31,7 +31,8 @@ childrec := RECORD
    DATA d {default (D'999999')},
    DECIMAL10_2 ddd {default(9.99)},
    UTF8 u1 {default(U'9999 ß')},
-   UNICODE8 u2 {default(U'9999 ßßßß')}
+   UNICODE8 u2 {default(U'9999 ßßßß')},
+   STRING19 dt {default('1963-11-22 12:30:00')},
 END;
 
 stringrec := RECORD
@@ -43,18 +44,18 @@ stringrec extractName(childrec l) := TRANSFORM
 END;
 
 init := DATASET([{'name1', 1, true, 1.2, 3.4, D'aa55aa55', 1234567.89, U'Straße', U'Straße'},
-                 {'name2', 2, false, 5.6, 7.8, D'00', -1234567.89, U'là', U'là'}], childrec);
+                 {'name2', 2, false, 5.6, 7.8, D'00', -1234567.89, U'là', U'là', '2015-12-25 01:23:45' }], childrec);
 
 drop() := EMBED(mysql : user('rchapman'),database('test'))
   DROP TABLE IF EXISTS tbl1;
 ENDEMBED;
 
 create() := EMBED(mysql : user('rchapman'),database('test'))
-  CREATE TABLE tbl1 ( name VARCHAR(20), value INT, boolval TINYINT, r8 DOUBLE, r4 FLOAT, d BLOB, ddd DECIMAL(10,2), u1 VARCHAR(10), u2 VARCHAR(10) );
+  CREATE TABLE tbl1 ( name VARCHAR(20), value INT, boolval TINYINT, r8 DOUBLE, r4 FLOAT, d BLOB, ddd DECIMAL(10,2), u1 VARCHAR(10), u2 VARCHAR(10), dt DATETIME );
 ENDEMBED;
 
 initialize(dataset(childrec) values) := EMBED(mysql : user(myUser),database(myDb))
-  INSERT INTO tbl1 values (?, ?, ?, ?, ?, ?, ?, ?, ?);
+  INSERT INTO tbl1 values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 ENDEMBED;
 
 initializeNulls() := EMBED(mysql : user('rchapman'),database(myDb))
@@ -62,7 +63,7 @@ initializeNulls() := EMBED(mysql : user('rchapman'),database(myDb))
 ENDEMBED;
 
 initializeUtf8() := EMBED(mysql : user(myUser),database('test'))
-  INSERT INTO tbl1 values ('utf8test', 1, 1, 1.2, 3.4, 'aa55aa55', 1234567.89, 'Straße', 'Straße');
+  INSERT INTO tbl1 values ('utf8test', 1, 1, 1.2, 3.4, 'aa55aa55', 1234567.89, 'Straße', 'Straße', '2019-02-01 23:59:59');
 ENDEMBED;
 
 dataset(childrec) testMySQLDS() := EMBED(mysql : user('rchapman'),database('test'))
@@ -125,6 +126,16 @@ UNICODE testMySQLUnicode() := EMBED(mysql : user('rchapman'),database('test'))
   SELECT max(u2) from tbl1;
 ENDEMBED;
 
+datetimerec := RECORD
+   UNSIGNED8 dt1;
+   STRING19 dt2;
+END;
+
+dataset(datetimerec) testMySQLDateTime() := EMBED(mysql : user('rchapman'),database('test'))
+  SELECT dt, dt from tbl1;
+ENDEMBED;
+
+
 sequential (
   drop(),
   create(),
@@ -143,5 +154,6 @@ sequential (
   OUTPUT(testMySQLReal4()),
   OUTPUT(testMySQLData()),
   OUTPUT(testMySQLUtf8()),
-  OUTPUT(testMySQLUnicode())
+  OUTPUT(testMySQLUnicode()),
+  OUTPUT(testMySQLDateTime())
 );


### PR DESCRIPTION
Previously accessing a dataset containing a time or date field would
corrupt memory because insufficient memory was allocated for the result.

This also fixes HPCC-13873 allowing text blobs to be assigned to strings.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
