### PR TITLE
HPCC-13832 Add description and owner to LDAP Group creation

### DIFF
--- a/esp/scm/ws_access.ecm
+++ b/esp/scm/ws_access.ecm
@@ -26,6 +26,8 @@ ESPstruct GroupInfo
 {
     string name;
     bool deletable;
+    [min_ver("1.09")] string groupOwner;
+    [min_ver("1.09")] string groupDesc;
 };
 
 ESPstruct AccountPermission
@@ -261,6 +263,8 @@ ESPresponse GroupResponse
 ESPrequest GroupAddRequest
 {
     string groupname;
+    [min_ver("1.09")] string groupOwner;
+    [min_ver("1.09")] string groupDesc;
 };
 
 ESPresponse GroupAddResponse
@@ -691,7 +695,7 @@ ESPresponse [nil_remove] UserAccountExportResponse
 };
 
 
-ESPservice [version("1.08"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
+ESPservice [version("1.09"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
 {
     ESPmethod [client_xslt("/esp/xslt/access_users.xslt")] Users(UserRequest, UserResponse);
     ESPmethod [client_xslt("/esp/xslt/access_useredit.xslt")] UserEdit(UserEditRequest, UserEditResponse);

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -532,7 +532,9 @@ bool Cws_accessEx::onUserGroupEditInput(IEspContext &context, IEspUserGroupEditI
         }
 
         StringArray groupnames;
-        ldapsecmgr->getAllGroups(groupnames);
+        StringArray managedBy;
+        StringArray descriptions;
+        ldapsecmgr->getAllGroups(groupnames, managedBy, descriptions);
         IArrayOf<IEspGroupInfo> groups;
         for(i = 0; i < groupnames.length(); i++)
         {
@@ -543,6 +545,8 @@ bool Cws_accessEx::onUserGroupEditInput(IEspContext &context, IEspUserGroupEditI
             {
                 Owned<IEspGroupInfo> onegrp = createGroupInfo();
                 onegrp->setName(grpname);
+                onegrp->setGroupDesc(descriptions.item(i));
+                onegrp->setGroupOwner(managedBy.item(i));
                 groups.append(*onegrp.getLink());
             }
         }
@@ -632,11 +636,13 @@ bool Cws_accessEx::onGroups(IEspContext &context, IEspGroupRequest &req, IEspGro
         checkUser(context);
 
         StringArray groupnames;
+        StringArray groupManagedBy;
+        StringArray groupDescriptions;
         ISecManager* secmgr = context.querySecManager();
         if(secmgr == NULL)
             throw MakeStringException(ECLWATCH_INVALID_SEC_MANAGER, MSG_SEC_MANAGER_IS_NULL);
 
-        secmgr->getAllGroups(groupnames);
+        secmgr->getAllGroups(groupnames, groupManagedBy, groupDescriptions);
         ///groupnames.append("Administrators");
         ///groupnames.append("Full_Access_TestingOnly");
         //groupnames.kill();
@@ -651,6 +657,8 @@ bool Cws_accessEx::onGroups(IEspContext &context, IEspGroupRequest &req, IEspGro
                     continue;
                 Owned<IEspGroupInfo> onegrp = createGroupInfo();
                 onegrp->setName(grpname);
+                onegrp->setGroupDesc(groupDescriptions.item(i));
+                onegrp->setGroupOwner(groupManagedBy.item(i));
                 groups.append(*onegrp.getLink());
             }
 
@@ -821,9 +829,18 @@ bool Cws_accessEx::onGroupAdd(IEspContext &context, IEspGroupAddRequest &req, IE
 
         resp.setGroupname(groupname);
 
+        double version = context.getClientVersion();
+        const char * groupDesc = NULL;
+        const char * groupOwner = NULL;
+        if (version >= 1.09)
+        {
+            groupDesc = req.getGroupDesc();
+            groupOwner = req.getGroupOwner();
+        }
+
         try
         {
-            secmgr->addGroup(groupname);
+            secmgr->addGroup(groupname, groupOwner, groupDesc);
         }
         catch(IException* e)
         {
@@ -1932,7 +1949,9 @@ bool Cws_accessEx::onPermissionsResetInput(IEspContext &context, IEspPermissions
             groups.append(*onegrp.getLink());
         }
         StringArray grpnames;
-        secmgr->getAllGroups(grpnames);
+        StringArray managedBy;
+        StringArray descriptions;
+        secmgr->getAllGroups(grpnames, managedBy, descriptions);
         for(unsigned i = 0; i < grpnames.length(); i++)
         {
             const char* grpname = grpnames.item(i);
@@ -1940,6 +1959,8 @@ bool Cws_accessEx::onPermissionsResetInput(IEspContext &context, IEspPermissions
                 continue;
             Owned<IEspGroupInfo> onegrp = createGroupInfo();
             onegrp->setName(grpname);
+            onegrp->setGroupDesc(descriptions.item(i));
+            onegrp->setGroupOwner(managedBy.item(i));
             groups.append(*onegrp.getLink());
         }
 
@@ -2343,7 +2364,9 @@ bool Cws_accessEx::permissionAddInputOnResource(IEspContext &context, IEspPermis
         groups.append(*onegrp.getLink());
     }
     StringArray grpnames;
-    secmgr->getAllGroups(grpnames);
+    StringArray managedBy;
+    StringArray descriptions;
+    secmgr->getAllGroups(grpnames, managedBy, descriptions);
     for(unsigned i = 0; i < grpnames.length(); i++)
     {
         const char* grpname = grpnames.item(i);
@@ -2351,6 +2374,8 @@ bool Cws_accessEx::permissionAddInputOnResource(IEspContext &context, IEspPermis
             continue;
         Owned<IEspGroupInfo> onegrp = createGroupInfo();
         onegrp->setName(grpname);
+        onegrp->setGroupDesc(descriptions.item(i));
+        onegrp->setGroupOwner(managedBy.item(i));
         groups.append(*onegrp.getLink());
     }
 
@@ -3415,7 +3440,9 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
 
         //Get all groups for input form
         StringArray groupnames;
-        secmgr->getAllGroups(groupnames);
+        StringArray managedBy;
+        StringArray descriptions;
+        secmgr->getAllGroups(groupnames, managedBy, descriptions);
         ///groupnames.append("Authenticated Users");
         ///groupnames.append("Administrators");
         if (groupnames.length() > 0)
@@ -3428,6 +3455,8 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
                     continue;
                 Owned<IEspGroupInfo> onegrp = createGroupInfo();
                 onegrp->setName(grpname);
+                onegrp->setGroupDesc(descriptions.item(i));
+                onegrp->setGroupOwner(managedBy.item(i));
                 groups.append(*onegrp.getLink());
             }
 

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -3446,8 +3446,10 @@ public:
         
         attrs[ind++] = &cn_attr;
         attrs[ind++] = &oc_attr;
-        attrs[ind++] = &owner_attr;
-        attrs[ind++] = &desc_attr;
+        if (groupOwner && *groupOwner)
+            attrs[ind++] = &owner_attr;
+        if (groupDesc && *groupDesc)
+            attrs[ind++] = &desc_attr;
         attrs[ind] = NULL;
 
         Owned<ILdapConnection> lconn = m_connections->getConnection();

--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -162,7 +162,7 @@ interface ILdapClient : extends IInterface
     virtual void setPermissionProcessor(IPermissionProcessor* pp) = 0;
     virtual bool retrieveUsers(IUserArray& users) = 0;
     virtual bool retrieveUsers(const char* searchstr, IUserArray& users) = 0;
-    virtual void getAllGroups(StringArray & groups) = 0;
+    virtual void getAllGroups(StringArray & groups, StringArray & managedBy, StringArray & descriptions) = 0;
     virtual void setResourceBasedn(const char* rbasedn, SecResourceType rtype = RT_DEFAULT) = 0;
     virtual ILdapConfig* getLdapConfig() = 0;
     virtual bool userInGroup(const char* userdn, const char* groupdn) = 0;
@@ -175,7 +175,7 @@ interface ILdapClient : extends IInterface
     virtual bool changePermission(CPermissionAction& action) = 0;
     virtual void changeUserGroup(const char* action, const char* username, const char* groupname) = 0;
     virtual bool deleteUser(ISecUser* user) = 0;
-    virtual void addGroup(const char* groupname) = 0;
+    virtual void addGroup(const char* groupname, const char * groupOwner, const char * groupDesc) = 0;
     virtual void deleteGroup(const char* groupname) = 0;
     virtual void getGroupMembers(const char* groupname, StringArray & users) = 0;
     virtual void deleteResource(SecResourceType rtype, const char* name, const char* basedn) = 0;

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -1124,9 +1124,9 @@ bool CLdapSecManager::updateUserPassword(const char* username, const char* newPa
     return m_ldap_client->updateUserPassword(username, newPassword);
 }
 
-void CLdapSecManager::getAllGroups(StringArray & groups)
+void CLdapSecManager::getAllGroups(StringArray & groups, StringArray & managedBy, StringArray & descriptions)
 {
-    m_ldap_client->getAllGroups(groups);
+    m_ldap_client->getAllGroups(groups, managedBy, descriptions);
 }
 
 bool CLdapSecManager::getPermissionsArray(const char* basedn, SecResourceType rtype, const char* name, IArrayOf<CPermission>& permissions)
@@ -1134,9 +1134,9 @@ bool CLdapSecManager::getPermissionsArray(const char* basedn, SecResourceType rt
     return m_ldap_client->getPermissionsArray(basedn, rtype, name, permissions);
 }
 
-void CLdapSecManager::addGroup(const char* groupname)
+void CLdapSecManager::addGroup(const char* groupname, const char * groupOwner, const char * groupDesc)
 {
-    m_ldap_client->addGroup(groupname);
+    m_ldap_client->addGroup(groupname, groupOwner, groupDesc);
 }
 
 void CLdapSecManager::deleteGroup(const char* groupname)

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -387,12 +387,12 @@ public:
     virtual void cacheSwitch(SecResourceType rtype, bool on);
 
     virtual bool getPermissionsArray(const char* basedn, SecResourceType rtype, const char* name, IArrayOf<CPermission>& permissions);
-    virtual void getAllGroups(StringArray & groups);
+    virtual void getAllGroups(StringArray & groups, StringArray & managedBy, StringArray & descriptions);
     virtual void getGroups(const char* username, StringArray & groups);
     virtual bool changePermission(CPermissionAction& action);
     virtual void changeUserGroup(const char* action, const char* username, const char* groupname);
     virtual bool deleteUser(ISecUser* user);
-    virtual void addGroup(const char* groupname);
+    virtual void addGroup(const char* groupname, const char * groupOwner, const char * groupDesc);
     virtual void deleteGroup(const char* groupname);
     virtual void getGroupMembers(const char* groupname, StringArray & users);
     virtual void deleteResource(SecResourceType rtype, const char * name, const char * basedn);

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -244,7 +244,7 @@ public:
 
     virtual bool updateUserPassword(ISecUser& user, const char* newPassword, const char* currPassword = NULL);
     virtual bool IsPasswordExpired(ISecUser& user){return false;}
-    void getAllGroups(StringArray & groups) { UNIMPLEMENTED;}
+    void getAllGroups(StringArray & groups, StringArray & managedBy, StringArray & descriptions) { UNIMPLEMENTED;}
     
     virtual void deleteResource(SecResourceType rtype, const char * name, const char * basedn)
     {

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -289,7 +289,7 @@ interface ISecManager : extends IInterface
     virtual ISecUser * findUser(const char * username) = 0;
     virtual ISecUser * lookupUser(unsigned uid) = 0;
     virtual ISecUserIterator * getAllUsers() = 0;
-    virtual void getAllGroups(StringArray & groups) = 0;
+    virtual void getAllGroups(StringArray & groups, StringArray & managedBy, StringArray & descriptions ) = 0;
     virtual bool updateUserPassword(ISecUser & user, const char * newPassword, const char* currPassword = 0) = 0;
     virtual bool initUser(ISecUser & user) = 0;
     virtual void setExtraParam(const char * name, const char * value) = 0;


### PR DESCRIPTION
As requested by InfoSec in preparation to the RISK Migration, we need to add
group "description" and "owner" to group entries. This PR adds those fields
to the GroupAdd interface, and also retrieves them via the GroupInfo struct
(where needed)

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
