### PR TITLE
HPCC-13885 Unnecessary code in jlib recursiveCreateDirectory

### DIFF
--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -3967,11 +3967,6 @@ void setDefaultUser(const char * username,const char *password)
 
 bool recursiveCreateDirectory(const char * path)
 {
-#ifndef _WIN32
-#ifdef USE_SAMBA
-    return localCreateDirectory(path);
-#endif
-#endif
     Owned<IFile> file = createIFile(path);
     return file->createDirectory();
 }

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -245,8 +245,8 @@ extern jlib_decl void setPasswordProvider(IPasswordProvider * provider);
 extern jlib_decl size32_t read(IFileIO * in, offset_t pos, size32_t len, MemoryBuffer & buffer);
 extern jlib_decl void copyFile(const char *target, const char *source, size32_t buffersize=DEFAULT_COPY_BLKSIZE, ICopyFileProgress *progress=NULL,CFflags copyFlags=CFnone);
 extern jlib_decl void copyFile(IFile * target, IFile * source,size32_t buffersize=DEFAULT_COPY_BLKSIZE, ICopyFileProgress *progress=NULL,CFflags copyFlags=CFnone);
-extern jlib_decl bool recursiveCreateDirectory(const char * path);              // only works locally, use IFile::createDirectory() for remote
-extern jlib_decl bool recursiveCreateDirectoryForFile(const char *filename);    // only works locally, use IFile::createDirectory() for remote
+extern jlib_decl bool recursiveCreateDirectory(const char * path);
+extern jlib_decl bool recursiveCreateDirectoryForFile(const char *filename);
 
 extern jlib_decl void splitFilename(const char * filename, StringBuffer * drive, StringBuffer * path, StringBuffer * tail, StringBuffer * ext, bool longExt = false);
 extern jlib_decl bool splitUNCFilename(const char * filename, StringBuffer * machine, StringBuffer * path, StringBuffer * tail, StringBuffer * ext);


### PR DESCRIPTION
Removed misleading comments and incorrect call to localCreateDirectory

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
