### PR TITLE
HPCC-13333 Add preserve compression flag to copy dialog

### DIFF
--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -344,6 +344,7 @@ define({root:
     Port: "Port",
     Prefix: "Prefix",
     PrefixPlaceholder: "filename{:length}, filesize{:[B|L][1-8]}",
+    PreserveCompression: "Preserve Compression",
     Preview: "Preview",
     Priority: "Priority",
     Process: "Process",

--- a/esp/src/eclwatch/templates/DFUQueryWidget.html
+++ b/esp/src/eclwatch/templates/DFUQueryWidget.html
@@ -66,6 +66,7 @@
                                         <input id="${id}CopyTargetCompress" title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input id="${id}CopyTargetWrap" title="${i18n.Wrap}:" name="Wrap" data-dojo-type="dijit.form.CheckBox" />
                                         <input id="${id}CopyTargetRetainSuperfileStructure" title="${i18n.RetainSuperfileStructure}:" name="superCopy" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}CopyPreserveCompression" title="${i18n.PreserveCompression}:" checked="true" name="preserveCompression" data-dojo-type="dijit.form.CheckBox" />
                                     </div>
                                 </div>
                                 <div class="dijitDialogPaneActionBar">
@@ -152,6 +153,7 @@
                         <input id="${id}Name" title="${i18n.Name}:" name="LogicalName" colspan="2" style="width:100%;" data-dojo-props="trim: true, placeHolder:'${i18n.somefile}'" data-dojo-type="dijit.form.TextBox" />
                         <input id="${id}Description" title="${i18n.Description}:" name="Description" colspan="2" style="width:100%;" data-dojo-props="trim: true, placeHolder:'${i18n.SomeDescription}'" data-dojo-type="dijit.form.TextBox" />
                         <input id="${id}Owner" title="${i18n.Owner}:" name="Owner" colspan="2" data-dojo-props="trim: true, placeHolder:'${i18n.JSmith}'" data-dojo-type="dijit.form.TextBox" />
+                        <input id="${id}Index" title="${i18n.Index}:" value="key" name="ContentType" colspan="2" data-dojo-props="trim: true" data-dojo-type="dijit.form.CheckBox" />
                         <input id="${id}ClusterTargetSelect" title="${i18n.Cluster}:" name="NodeGroup" colspan="2" style="display: inline-block; vertical-align: middle" data-dojo-type="TargetSelectWidget" />
                         <input id="${id}FromSize" title="${i18n.FromSizes}:" name="FileSizeFrom" colspan="2" data-dojo-props="trim: true, placeHolder:'4096'" data-dojo-type="dijit.form.TextBox" />
                         <input id="${id}ToSize" title="${i18n.ToSizes}:" name="FileSizeTo" colspan="2" data-dojo-props="trim: true, placeHolder:'16777216'" data-dojo-type="dijit.form.TextBox" />


### PR DESCRIPTION
Within the copy dialog of ECLWatch set the preserve compression flag on by default for the user.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
