### PR TITLE
HPCC-12822 Make command line target parameters more intuitive

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -261,6 +261,12 @@ eclObjParameterType EclObjectParameter::set(const char *param)
         loadFile();
     else if (looksLikeOnlyAWuid(param))
         type = eclObjWuid;
+    else if (accept & eclObjQuery)
+    {
+        query.set(value.get());
+        type = eclObjQuery;
+        value.clear();
+    }
     return type;
 }
 
@@ -278,6 +284,8 @@ const char *EclObjectParameter::queryTypeName()
         return "ECL Manifest";
     case eclObjSharedObject:
         return "ECL Shared Object";
+    case eclObjQuery:
+        return "ECL Query";
     default:
         return "Unknown Type";
     }
@@ -551,29 +559,46 @@ bool matchVariableOption(ArgvIterator &iter, const char prefix, IArrayOf<IEspNam
     addNamedValue(arg, values);
     return true;
 }
+
+bool EclCmdWithEclTarget::setTarget(const char *target)
+{
+    if (!optTargetCluster.isEmpty())
+        return streq(optTargetCluster, target);
+    optTargetCluster.set(target);
+    return true;
+ }
+
+bool EclCmdWithEclTarget::setParam(const char *in, bool final)
+{
+    bool success = true;
+    if (++paramCount>2)
+        success = false;
+    else if (!param.isEmpty())
+        success = setTarget(param);
+    if (!success)
+    {
+        fprintf(stderr, "\nunrecognized argument %s\n", in);
+        return false;
+    }
+    if (final) //a 'final' parameter is always last
+        paramCount=2;
+    param.set(in);
+    return true;
+ }
+
 eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvIterator &iter, bool finalAttempt)
 {
     const char *arg = iter.query();
     if (streq(arg, "-"))
     {
-        optObj.set("stdin");
+        if (!setParam("stdin", true))
+            return EclCmdOptionCompletion;
         return EclCmdOptionMatch;
     }
     if (*arg!='-')
     {
-        if (optObj.value.length())
-        {
-            if (optObj.type==eclObjTypeUnknown && (optObj.accept & eclObjQuery) && !optObj.query.length())
-            {
-                optObj.type=eclObjQuery;
-                optObj.query.set(arg);
-                return EclCmdOptionMatch;
-            }
-
-            fprintf(stderr, "\nunrecognized argument %s\n", arg);
+        if (!setParam(arg, false))
             return EclCmdOptionCompletion;
-        }
-        optObj.set(arg);
         return EclCmdOptionMatch;
     }
     if (matchVariableOption(iter, 'f', debugValues))
@@ -600,8 +625,16 @@ eclCmdOptionMatchIndicator EclCmdWithEclTarget::matchCommandLineOption(ArgvItera
         return EclCmdOptionMatch;
     if (iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED)||iter.matchOption(optTargetCluster, ECLOPT_CLUSTER_DEPRECATED_S))
         return EclCmdOptionMatch;
-    if (iter.matchOption(optTargetCluster, ECLOPT_TARGET)||iter.matchOption(optTargetCluster, ECLOPT_TARGET_S))
+    StringAttr target;
+    if (iter.matchOption(target, ECLOPT_TARGET)||iter.matchOption(target, ECLOPT_TARGET_S))
+    {
+        if (!setTarget(target))
+        {
+            fprintf(stderr, "\nTarget names do not match %s != %s\n", optTargetCluster.str(), target.str());
+            return EclCmdOptionCompletion;
+        }
         return EclCmdOptionMatch;
+    }
 
     return EclCmdCommon::matchCommandLineOption(iter, finalAttempt);
 }
@@ -610,7 +643,8 @@ bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
 {
     if (!EclCmdCommon::finalizeOptions(globals))
         return false;
-
+    if (!param.isEmpty())
+        optObj.set(param);
     if (optObj.type == eclObjTypeUnknown)
     {
         if (optAttributePath.length())
@@ -634,7 +668,7 @@ bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
     if (optResultLimit == (unsigned)-1)
         extractEclCmdOption(optResultLimit, globals, ECLOPT_RESULT_LIMIT_ENV, ECLOPT_RESULT_LIMIT_INI, 0);
 
-    if (optObj.value.isEmpty() && optAttributePath.isEmpty())
+    if (optObj.value.isEmpty() && optObj.query.isEmpty() && optAttributePath.isEmpty())
     {
         fprintf(stderr, "\nMust specify a Query, WUID, ECL File, Archive, or shared object\n");
         return false;

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -249,11 +249,13 @@ public:
 class EclCmdWithEclTarget : public EclCmdCommon
 {
 public:
-    EclCmdWithEclTarget() : optLegacy(false), optNoArchive(false), optResultLimit((unsigned)-1), optDebug(false)
+    EclCmdWithEclTarget() : optLegacy(false), optNoArchive(false), optResultLimit((unsigned)-1), optDebug(false), paramCount(0)
     {
     }
     virtual eclCmdOptionMatchIndicator matchCommandLineOption(ArgvIterator &iter, bool finalAttempt=false);
     virtual bool finalizeOptions(IProperties *globals);
+    bool setTarget(const char *target);
+    bool setParam(const char *in, bool final);
 
     virtual void usage()
     {
@@ -292,6 +294,7 @@ public:
         }
     }
 public:
+    StringAttr param;
     StringAttr optTargetCluster;
     EclObjectParameter optObj;
     StringBuffer optLibPath;
@@ -302,6 +305,7 @@ public:
     IArrayOf<IEspNamedValue> debugValues;
     IArrayOf<IEspNamedValue> definitions;
     unsigned optResultLimit;
+    unsigned paramCount;
     bool optNoArchive;
     bool optLegacy;
     bool optDebug;

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -262,15 +262,15 @@ public:
             "text, file, archive, shared object, or dll.  The workunit will be created in\n"
             "the 'compiled' state.\n"
             "\n"
-            "ecl deploy --target=<val> --name=<val> <ecl_file|->\n"
-            "ecl deploy --target=<val> --name=<val> <archive|->\n"
-            "ecl deploy [--target=<val>] [--name=<val>] <so|dll|->\n\n"
+            "ecl deploy <target> <file> [--name=<val>]\n"
+            "ecl deploy <target> <archive> [--name=<val>]\n"
+            "ecl deploy <target> <so|dll> [--name=<val>]\n"
+            "ecl deploy <target> - [--name=<val>]\n\n"
             "   -                      specifies object should be read from stdin\n"
-            "   <ecl_file|->           ecl text file to deploy\n"
-            "   <archive|->            ecl archive to deploy\n"
-            "   <so|dll|->             workunit dll or shared object to deploy\n"
+            "   <file>                 ecl text file to deploy\n"
+            "   <archive>              ecl archive to deploy\n"
+            "   <so|dll>               workunit dll or shared object to deploy\n"
             " Options:\n"
-            "   -t, --target=<val>     target cluster to associate workunit with\n"
             "   -n, --name=<val>       workunit job name\n",
             stdout);
         EclCmdWithEclTarget::usage();
@@ -456,18 +456,17 @@ public:
             "If the query is being created from an ECL file, archive, shared object, dll,\n"
             "or text, a workunit is first created and then published to the queryset.\n"
             "\n"
-            "ecl publish [--target=<val>] [--name=<val>] [--activate] <wuid>\n"
-            "ecl publish [--target=<val>] [--name=<val>] [--activate] <so|dll|->\n"
-            "ecl publish --target=<val> --name=<val> [--activate] <archive|->\n"
-            "ecl publish --target=<val> --name=<val> [--activate] <ecl_file|->\n\n"
+            "ecl publish <target> <wuid> --name=<val>\n"
+            "ecl publish <target> <so|dll> --name=<val>\n"
+            "ecl publish <target> <archive> --name=<val>\n"
+            "ecl publish <target> <file> --name=<val>\n"
+            "ecl publish <target> - --name=<val>\n\n"
             "   -                      specifies object should be read from stdin\n"
             "   <wuid>                 workunit to publish\n"
-            "   <archive|->            archive to publish\n"
-            "   <ecl_file|->           ECL text file to publish\n"
-            "   <so|dll|->             workunit dll or shared object to publish\n"
+            "   <archive>              archive to publish\n"
+            "   <file>                 ECL text file to publish\n"
+            "   <so|dll>               workunit dll or shared object to publish\n"
             " Options:\n"
-            "   -t, --target=<val>     target cluster to publish workunit to\n"
-            "                          (defaults to cluster defined inside workunit)\n"
             "   -n, --name=<val>       query name to use for published workunit\n"
             "   -A, --activate         Activate query when published (default)\n"
             "   -sp, --suspend-prev    Suspend previously active query\n"
@@ -572,7 +571,6 @@ public:
 
         StringBuffer wuid;
         StringBuffer wuCluster;
-        StringBuffer queryset;
         StringBuffer query;
 
         if (optObj.type==eclObjWuid)
@@ -583,10 +581,10 @@ public:
         }
         else if (optObj.type==eclObjQuery)
         {
-            req->setQuerySet(queryset.set(optObj.value.get()).str());
+            req->setQuerySet(optTargetCluster);
             req->setQuery(query.set(optObj.query.get()).str());
             if (optVerbose)
-                fprintf(stdout, "Running query %s/%s\n", queryset.str(), query.str());
+                fprintf(stdout, "Running query %s/%s\n", optTargetCluster.str(), query.str());
         }
         else
         {
@@ -631,25 +629,24 @@ public:
     {
         fputs("\nUsage:\n"
             "\n"
-            "The 'run' command exectues an ECL workunit, text, file, archive, shared\n"
-            "object, or dll on the specified HPCC target cluster.\n"
+            "The 'run' command exectues an ECL workunit, text, file, archive, query,\n"
+            "shared object, or dll on the specified HPCC target cluster.\n"
             "\n"
             "Query input can be provided in xml form via the --input parameter.  Input\n"
             "xml can be provided directly or by refrencing a file\n"
             "\n"
-            "ecl run [--target=<val>][--input=<file|xml>][--wait=<ms>] <wuid>\n"
-            "ecl run [--target=<c>][--input=<file|xml>][--wait=<ms>] <queryset> <query>\n"
-            "ecl run [--target=<c>][--name=<nm>][--input=<file|xml>][--wait=<i>] <dll|->\n"
-            "ecl run --target=<c> --name=<nm> [--input=<file|xml>][--wait=<i>] <archive|->\n"
-            "ecl run --target=<c> --name=<nm> [--input=<file|xml>][--wait=<i>] <eclfile|->\n\n"
+            "ecl run <target> <wuid> [--input=<file|xml>][--wait=<ms>]\n"
+            "ecl run <target> <query> [--input=<file|xml>][--wait=<ms>]\n"
+            "ecl run <target> <dll> [--name=<nm>][--input=<file|xml>][--wait=<i>]\n"
+            "ecl run <target> <archive> --name=<nm> [--input=<file|xml>][--wait=<i>]\n"
+            "ecl run <target> <eclfile> --name=<nm> [--input=<file|xml>][--wait=<i>]\n"
+            "ecl run <target> - --name=<nm> [--input=<file|xml>][--wait=<i>]\n\n"
             "   -                      specifies object should be read from stdin\n"
             "   <wuid>                 workunit to publish\n"
-            "   <archive|->            archive to publish\n"
-            "   <ecl_file|->           ECL text file to publish\n"
-            "   <so|dll|->             workunit dll or shared object to publish\n"
+            "   <archive>              archive to publish\n"
+            "   <eclfile>              ECL text file to publish\n"
+            "   <so|dll>               workunit dll or shared object to publish\n"
             " Options:\n"
-            "   -t, --target=<val>        target cluster to run job on\n"
-            "                             (defaults to cluster defined inside workunit)\n"
             "   -n, --name=<val>          job name\n"
             "   -in,--input=<file|xml>    file or xml content to use as query input\n"
             "   -X<name>=<value>          sets the stored input value (stored('name'))\n"
@@ -721,9 +718,9 @@ public:
             "The 'activate' command assigns a query to the active alias with the same\n"
             "name as the query.\n"
             "\n"
-            "ecl activate <queryset> <query_id>\n"
+            "ecl activate <target> <query_id>\n"
             " Options:\n"
-            "   <queryset>             name of queryset containing query to activate\n"
+            "   <target>               name of target queryset containing query to activate\n"
             "   <query_id>             query to activate\n",
             stdout);
         EclCmdWithQueryTarget::usage();
@@ -765,11 +762,11 @@ public:
     {
         fputs("\nUsage:\n"
             "\n"
-            "The 'unpublish' command removes a query from a queryset.\n"
+            "The 'unpublish' command removes a query from a target queryset.\n"
             "\n"
-            "ecl unpublish <queryset> <query_id>\n"
+            "ecl unpublish <target> <query_id>\n"
             " Options:\n"
-            "   <queryset>             name of queryset containing the query to remove\n"
+            "   <target>               name of target queryset containing the query to remove\n"
             "   <query_id>             query to remove from the queryset\n",
             stdout);
         EclCmdWithQueryTarget::usage();
@@ -817,12 +814,12 @@ public:
     {
         fputs("\nUsage:\n"
             "\n"
-            "The 'deactivate' command removes an active query alias from the given queryset.\n"
+            "The 'deactivate' command removes an active query alias from the given target.\n"
             "\n"
-            "ecl deactivate <queryset> <active_alias>\n"
+            "ecl deactivate <target> <active_alias>\n"
             "\n"
             " Options:\n"
-            "   <queryset>             queryset containing alias to deactivate\n"
+            "   <target>               target queryset containing alias to deactivate\n"
             "   <active_alias>         active alias to be removed from the queryset\n",
             stdout);
         EclCmdWithQueryTarget::usage();


### PR DESCRIPTION
Command will now use and document form:

`ecl run <target> <file>`

rather than using an option:

`ecl run <file> --target=hthor`

Old form will continue to work, but won't be documented
(encouraged) in Usage.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
