### PR TITLE
HPCC-13496 Add backwards compatible str() and lower() to aid merging

### DIFF
--- a/system/jlib/jhash.hpp
+++ b/system/jlib/jhash.hpp
@@ -49,11 +49,14 @@ interface jlib_decl IAtom : extends IMapping
 {
  public:
     virtual const char * getNamePtr() const = 0;
+    inline const char * queryStr() const { return getNamePtr(); }
 
     const char *         getAtomNamePtr() const;     // ok if this=NULL
     inline const char * str() const { return getAtomNamePtr(); }
     inline operator const char *() const { return getAtomNamePtr(); }
 };
+inline jlib_decl const char * str(const IAtom * atom) { return atom ? atom->queryStr() : NULL; }
+
 
 //This interface represents an atom which preserves its case, but also stores a lower case representation
 //for efficient case insensitive comparison.
@@ -62,6 +65,7 @@ interface jlib_decl IIdAtom : extends IMapping
 {
  public:
     virtual const char * getNamePtr() const = 0;
+    inline const char * queryStr() const { return getNamePtr(); }
 
     const char *         getAtomNamePtr() const { return this ? getNamePtr() : NULL; }
     inline const char * str() const { return getAtomNamePtr(); }
@@ -71,6 +75,10 @@ interface jlib_decl IIdAtom : extends IMapping
     virtual IAtom * queryLower() const = 0;
     IAtom * lower() const; // safe if this==NULL
 };
+inline jlib_decl const char * str(const IIdAtom * atom) { return atom ? atom->queryStr() : NULL; }
+inline jlib_decl IAtom * lower(const IIdAtom * atom) { return atom ? atom->queryLower() : NULL; }
+
+
 
 #ifdef _MSC_VER
 #pragma warning (push)


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
