### PR TITLE
HPCC-13900 Report 'Replicate' in WsDfu.DFUInfo

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -123,6 +123,7 @@ ESPStruct DFUFileDetail
     [min_ver("1.22")] int64 CompressedFileSize;
     [min_ver("1.22")] bool IsCompressed(false);
     [min_ver("1.28")] bool BrowseData(true);
+    [min_ver("1.31")] bool Replicate;
 };
 
 ESPStruct DFUSpaceItem
@@ -682,7 +683,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUGetFileMetaDataRe
 
 //  ===========================================================================
 ESPservice [
-    version("1.30"),
+    version("1.31"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -80,7 +80,7 @@ ESPStruct DFUFilePartsOnCluster
     ESParray<ESPstruct DFUPart> DFUFileParts;
 };
 
-ESPStruct DFUFileDetail
+ESPStruct [nil_remove] DFUFileDetail
 {
     string Name;
     string Filename;

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1905,6 +1905,25 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     if (version >= 1.28)
         FileDetails.setNumParts(df->numParts());
 
+    if (version >= 1.31)
+    {
+        const char* clusterName = NULL;
+        if (cluster && *cluster)
+            clusterName = cluster;
+        else if (clusters.length() == 1)
+            clusterName = clusters.item(0);
+        if (clusterName)
+        {
+            Owned<IFileDescriptor> fdesc = df->getFileDescriptor();
+            if (fdesc)
+            {
+                IClusterInfo* c = fdesc->queryCluster(clusterName);
+                if (c)
+                    FileDetails.setReplicate(c->queryPartDiskMapping().isReplicated());
+            }
+        }
+    }
+
     //#17430
     {
         IArrayOf<IEspDFULogicalFile> LogicalFiles;


### PR DESCRIPTION
A file may be sprayed with the 'Replicate' option enabled.
This fix reports the 'Replicate' option in WsDfu.DFUInfo
response. Then, the option can be shown in Logical File
Details page.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
