### PR TITLE
HPCC-12129 Support default values for bitfield fields

### DIFF
--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -3610,8 +3610,12 @@ unsigned HqlCppTranslator::buildRtlField(StringBuffer * instanceName, IHqlExpres
         IHqlExpression *defaultValue = queryAttributeChild(field, defaultAtom, 0);
         if (defaultValue)
         {
+            LinkedHqlExpr targetField = field;
+            if (fieldType->getTypeCode() == type_bitfield)
+                targetField.setown(createField(field->queryId(), LINK(fieldType->queryChildType()), NULL));
+
             MemoryBuffer target;
-            if (createConstantField(target, field, defaultValue))
+            if (createConstantField(target, targetField, defaultValue))
                 appendStringAsQuotedCPP(defaultInitializer, target.length(), target.toByteArray(), false);
             else
                 throwError1(HQLERR_CouldNotGenerateDefault, field->queryName()->str());


### PR DESCRIPTION
Create a constant of the default base type instead.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
