### PR TITLE
HPCC-13844 Configgen: only list thor/roxie process if also referenced in topology

### DIFF
--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -17,6 +17,7 @@
 #include "deploy.hpp"
 #include "environment.hpp"
 #include "jptree.hpp"
+#include "jarray.hpp"
 #include "jexcept.hpp"
 #include "jencrypt.hpp"
 #include "xslprocessor.hpp"
@@ -1117,6 +1118,21 @@ bool matchDeployAddress(const char *searchIP, const char *envIP)
 IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName, 
                             const char* compType, const char* ipAddr, bool listall)
 {
+  Owned<IPropertyTreeIterator> pClusterIter = pEnvRoot->getElements("Software/Topology/*");
+  StringArray pTopologyComponents;
+ 
+  ForEach(*pClusterIter)
+  {
+    IPropertyTree * pCluster = &pClusterIter->query();
+    IPropertyTreeIterator* pClusterProcessIter = pCluster->getElements("*");
+    ForEach(*pClusterProcessIter)
+    {
+      IPropertyTree * pClusterProcess = &pClusterProcessIter->query();
+      if (!strcmp(pClusterProcess->queryName(),"RoxieCluster") || !strcmp(pClusterProcess->queryName(),"ThorCluster"))
+        pTopologyComponents.appendUniq(pClusterProcess->queryProp("@process"));
+    }
+  }
+
   Owned<IPropertyTree> pSelComps(createPTree("SelectedComponents"));
   Owned<IPropertyTreeIterator> iter = pEnvRoot->getElements("Software/*");
   const char* instanceNodeNames[] = { "Instance", "RoxieServerProcess" };
@@ -1134,6 +1150,9 @@ IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName,
       const char* build   = pComponent->queryProp("@build");
       const char* buildSet= pComponent->queryProp("@buildSet");
       const char* logDir = NULL;
+
+      if ((!strcmp(buildSet,"thor") || !strcmp(buildSet,"roxie")) && !pTopologyComponents.contains(name))
+        continue;
 
       if (listall)
         for (int i = 0; i < sizeof(logDirNames)/sizeof(char*); i++)


### PR DESCRIPTION
This modification is designed to fix instances where a user wants to keep their roxie or thor process settings intact within the environment xml and simply turn off the cluster by removing it from the topology section.

The change is designed to parse the topology section and store the component names for any RoxieCluster or ThorCluster elements.  Then when we are parsing the process section we check any roxie or thor process names against what was found in topology, and only add it if it exists in both.

@garonsky @cloLN Please review when you have time

(currently targeted at 6.0 -i.e master)

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
