### PR TITLE
HPCC-13901 Fix Ambiguous xPath Error when binding 2 ECLWatch

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -442,11 +442,6 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
     getConfigurationDirectory(directories, "query", "esp", name ? name : "esp", queryDirectory);
     recursiveCreateDirectory(queryDirectory.str());
 
-    xpath.setf("Software/EspProcess[@name=\"%s\"]/EspBinding[@service=\"%s\"]/Authenticate", process, service);
-    Owned<IPropertyTree> authCFG = cfg->getPropTree(xpath.str());
-    if(authCFG)
-        authMethod.set(authCFG->queryProp("@method"));
-
     dataCache.setown(new DataCache(DATA_SIZE));
     archivedWuCache.setown(new ArchivedWuCache(AWUS_CACHE_SIZE));
     wuArchiveCache.setown(new WUArchiveCache(WUARCHIVE_CACHE_SIZE));
@@ -1563,7 +1558,12 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
             resp.setCanCompile(notEmpty(context.queryUserId()));
             if (version > 1.24 && notEmpty(req.getThorSlaveIP()))
                 resp.setThorSlaveIP(req.getThorSlaveIP());
-            resp.setSecMethod(authMethod.get());
+
+            ISecManager* secmgr = context.querySecManager();
+            if (!secmgr)
+                resp.setSecMethod(NULL);
+            else
+                resp.setSecMethod(secmgr->querySecMgrTypeName());
         }
     }
     catch(IException* e)

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -287,7 +287,6 @@ private:
     Owned<IPropertyTree> directories;
     int maxRequestEntityLength;
     Owned<IThreadPool> clusterQueryStatePool;
-    StringAttr authMethod;
 public:
     QueryFilesInUse filesInUse;
 };

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -443,6 +443,7 @@ public:
     virtual bool clearPermissionsCache(ISecUser &user);
     virtual bool authenticateUser(ISecUser & user, bool &superUser);
     virtual secManagerType querySecMgrType() { return SMT_LDAP; }
+    inline virtual const char* querySecMgrTypeName() { return "LdapSecurity"; }
 };
 
 #endif

--- a/system/security/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/htpasswdSecurity/htpasswdSecurity.cpp
@@ -42,6 +42,8 @@ public:
 		return SMT_HTPasswd;
 	}
 
+	inline virtual const char* querySecMgrTypeName() { return "htpasswd"; }
+
 	IAuthMap * createAuthMap(IPropertyTree * authconfig)
 	{
 		CAuthMap* authmap = new CAuthMap(this);

--- a/system/security/shared/defaultsecuritymanager.hpp
+++ b/system/security/shared/defaultsecuritymanager.hpp
@@ -83,6 +83,7 @@ public:
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) { return 0; }
     virtual int queryDefaultPermission(ISecUser& user) { return SecAccess_Full; }
     virtual secManagerType querySecMgrType() { return SMT_Default; }
+    inline virtual const char* querySecMgrTypeName() { return "Default"; }
 };
 
 class CLocalSecurityManager : public CDefaultSecurityManager
@@ -95,6 +96,7 @@ public:
 protected:
     virtual bool IsPasswordValid(ISecUser& sec_user);
     virtual secManagerType querySecMgrType() { return SMT_Local; }
+    inline virtual const char* querySecMgrTypeName() { return "Local"; }
 };
 
 

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -311,6 +311,7 @@ interface ISecManager : extends IInterface
     virtual bool clearPermissionsCache(ISecUser & user) = 0;
     virtual bool authenticateUser(ISecUser & user, bool &superUser) = 0;
     virtual secManagerType querySecMgrType() = 0;
+    virtual const char* querySecMgrTypeName() = 0;
 };
 
 interface IExtSecurityManager


### PR DESCRIPTION
When an ESP has 2+ ECLWatch instances, ESP cannot be started due
to Ambiguous xPath Error. The problem happens when WsWorkunits
tries to read security method from the binding section of esp.xml.
If an ESP has 2+ ECLWatch instances, 2+ binding sections exist in
esp.xml. In this fix, WsWorkunits does not read security setting
from the binding sections. WsWorkunits checks the security method
through ISecManager.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
