### PR TITLE
HPCC-13686 Avoid unecessary locking if subfile missing on remove

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -4637,7 +4637,12 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
                     return false;
                 }
                 if (!transaction->isSubFile(parent, subfile, true))
+                {
                     WARNLOG("removeSubFile: File %s is not a subfile of %s", subfile.get(), parent->queryLogicalName());
+                    parent.clear();
+                    sub.clear();
+                    return true; // NB: sub was not a member of super, issue warning and continue without locking
+                }
             }
             // Try to lock all files
             addFileLock(parent);


### PR DESCRIPTION
Signed-off-by: Jake Smith jake.smith@lexisnexis.com
