### PR TITLE
HPCC-13942  ConfigMgr wizards fails with "Could not locate filename"

### DIFF
--- a/initfiles/componentfiles/configxml/CMakeLists.txt
+++ b/initfiles/componentfiles/configxml/CMakeLists.txt
@@ -31,6 +31,7 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_BINARY_DIR}/eclagent_config.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/esp.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/espsmcservice.xsd
+    ${CMAKE_CURRENT_BINARY_DIR}/ftslave_linux.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/roxie.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/thor.xsd
     ${CMAKE_CURRENT_BINARY_DIR}/buildset.xml


### PR DESCRIPTION
```
- Fix regression that removed xsd from package
```

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
