### PR TITLE
HPCC-13731 WorkunitsService does not always go via workunit.hpp

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -1830,6 +1830,7 @@ mapEnums workunitSortFields[] =
    { WUSFwuidhigh, "@" },
    { WUSFwildwuid, "@" },
    { WUSFappvalue, "Application" },
+   { WUSFfilewritten, "Files/File/@name" },
    { WUSFterm, NULL }
 };
 

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1192,6 +1192,7 @@ enum WUSortField
     WUSFecl = 13,
     // WUSFcustom = 14, obsolete
     WUSFappvalue=15,
+    WUSFfilewritten = 16,
     WUSFterm = 0,
     WUSFreverse = 256,
     WUSFnocase = 512,

--- a/plugins/cassandra/cassandrawu.cpp
+++ b/plugins/cassandra/cassandrawu.cpp
@@ -3011,6 +3011,7 @@ public:
                         mergeFilter(wuidFilters, field, fv);
                     break;
                 case WUSFfileread:
+                case WUSFfilewritten:
                     fileFilters.append(*new PostFilter(field, fv, true));
                     break;
                 case WUSFtotalthortime:
@@ -3048,6 +3049,7 @@ public:
             {
                 // We can't postfilter by these - we COULD in some cases do a join between these and some other filtered set
                 // but we will leave that as an exercise to the reader. So if there is a fileFilter, read it first, and turn it into a merge set of the resulting wus.
+                // MORE read and written are not the same
                 assertex(fileFilters.length()==1);  // If we supported more there would be a join phase here
                 merger->addPostFilters(goodFilters, 0);
                 merger->addPostFilters(poorFilters, 0);

--- a/plugins/workunitservices/workunitservices.hpp
+++ b/plugins/workunitservices/workunitservices.hpp
@@ -39,7 +39,7 @@ WORKUNITSERVICES_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb);
 WORKUNITSERVICES_API void setPluginContext(IPluginContext * _ctx);
 WORKUNITSERVICES_API char * WORKUNITSERVICES_CALL wsGetBuildInfo(void);
 
-WORKUNITSERVICES_API bool WORKUNITSERVICES_CALL wsWorkunitExists(const char *wuid, bool online, bool archived);
+WORKUNITSERVICES_API bool WORKUNITSERVICES_CALL wsWorkunitExists(ICodeContext *ctx, const char *wuid, bool online, bool archived);
 
 WORKUNITSERVICES_API void WORKUNITSERVICES_CALL wsWorkunitList(
                                                                 ICodeContext *ctx,

--- a/plugins/workunitservices/workunitservices.ipp
+++ b/plugins/workunitservices/workunitservices.ipp
@@ -65,6 +65,17 @@ inline void varAppend(MemoryBuffer &mb,unsigned w,IPropertyTree &pt,const char *
     mb.append(sz).append(sz,s.str());
 }
 
+inline void varAppendMax(MemoryBuffer &mb,unsigned w,const char *str, size32_t l=0)
+{
+    if (!str)
+        l = 0;
+    else if (l==0)
+        l = strlen(str);
+    if (l>w)
+        l = w;
+    mb.append(l).append(l, str);
+}
+
 inline bool serializeWUSrow(IPropertyTree &pt,MemoryBuffer &mb, bool isonline)
 {
     mb.setEndian(__LITTLE_ENDIAN);

--- a/plugins/workunitservices/workunitservices.ipp
+++ b/plugins/workunitservices/workunitservices.ipp
@@ -76,6 +76,8 @@ inline void varAppendMax(MemoryBuffer &mb,unsigned w,const char *str, size32_t l
     mb.append(l).append(l, str);
 }
 
+// This is use by sasha - it's a real mess
+
 inline bool serializeWUSrow(IPropertyTree &pt,MemoryBuffer &mb, bool isonline)
 {
     mb.setEndian(__LITTLE_ENDIAN);


### PR DESCRIPTION
I suspect it's going straight to the XML to try to common up between dali and
sasha workunits, but the code that pulled the wu XML from Sasha was broken so
that feature never worked anyway. In the interests of
portability/maintainability I propose to remove the (broken) sasha capability.
With a bit of luck once Cassandra is in widespread use for workunits we won't
need to archive them any more anyway.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
