### PR TITLE
HPCC-13978 Fix regression preventing subfiles being removed

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1419,6 +1419,8 @@ class CDistributedFileTransaction: public CInterface, implements IDistributedFil
         }
         bool find(const char *subFile, bool sub)
         {
+            StringBuffer tmp;
+            subFile = normalizeLFN(subFile, tmp);
             HTMapping *match = subFilesByName.find(subFile);
             if (match)
                 return true;


### PR DESCRIPTION
If the subfile being removed was cased, the subfile removal was
ignored. Regression introduced by HPCC-13686.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
