### PR TITLE
HPCC-13979 Configgen cores if env contains elements without @name or @buildset

### DIFF
--- a/deployment/deploy/deploy.cpp
+++ b/deployment/deploy/deploy.cpp
@@ -1142,9 +1142,11 @@ IPropertyTree* getInstances(const IPropertyTree* pEnvRoot, const char* compName,
   {
     IPropertyTree* pComponent = &iter->query();
     const char* type = pComponent->queryName();
-    if (stricmp(type, "Topology")!=0 && stricmp(type, "Directories")!=0 && 
-        ((!compName && !compType) || (compName && pComponent->queryProp("@name") && !strcmp(pComponent->queryProp("@name"), compName)) ||
-        (!compName && compType && pComponent->queryProp("@buildSet") && !strcmp(pComponent->queryProp("@buildSet"), compType))))
+    if (stricmp(type, "Topology")!=0 && stricmp(type, "Directories")!=0 &&
+        pComponent->queryProp("@buildSet") && pComponent->queryProp("@name") &&
+        ((!compName && !compType) ||
+         (compName && !strcmp(pComponent->queryProp("@name"), compName)) ||
+         (!compName && compType && !strcmp(pComponent->queryProp("@buildSet"), compType))))
     {
       const char* name    = pComponent->queryProp("@name");
       const char* build   = pComponent->queryProp("@build");


### PR DESCRIPTION
Configgen will core on certain environment files (including ones where
cassandra has been enabled). In these instances you will get a message
"There are no components configured to run on this node".

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
