### PR TITLE
HPCC-13939 Add WUGetGraphNameAndTypes for graph name/types

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -6307,6 +6307,11 @@ mapEnums graphTypes[] = {
    { GraphTypeSize,  NULL },
 };
 
+WUGraphType getGraphTypeFromString(const char* type)
+{
+    return (WUGraphType) getEnum(type, graphTypes);
+}
+
 CLocalWUGraph::CLocalWUGraph(const CLocalWorkUnit &_owner, IPropertyTree *props) : p(props), owner(_owner)
 {
     wuidVersion = owner.getWuidVersion();

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1335,6 +1335,7 @@ extern WORKUNIT_API void getRoxieProcessServers(const char *process, SocketEndpo
 extern WORKUNIT_API bool isProcessCluster(const char *remoteDali, const char *process);
 extern WORKUNIT_API bool isProcessCluster(const char *process);
 extern WORKUNIT_API IStatisticGatherer * createGlobalStatisticGatherer(IWorkUnit * wu);
+extern WORKUNIT_API WUGraphType getGraphTypeFromString(const char* type);
 
 extern WORKUNIT_API bool getWorkUnitCreateTime(const char *wuid,CDateTime &time); // based on WUID
 extern WORKUNIT_API bool restoreWorkUnit(const char *base,const char *wuid);

--- a/esp/scm/common.ecm
+++ b/esp/scm/common.ecm
@@ -20,3 +20,10 @@ ESPStruct [nil_remove] NamedValue
     string Name;
     string Value;
 };
+
+ESPStruct [nil_remove] NameAndType
+{
+    string Name;
+    string Type;
+};
+

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -862,6 +862,17 @@ ESPresponse [exceptions_inline] WUGraphTimingResponse
     ESPstruct ECLWorkunit Workunit;
 };
 
+ESPrequest WUGetGraphNameAndTypesRequest
+{
+    string Wuid;
+    string Type;
+};
+
+ESPresponse [encode(0), exceptions_inline] WUGetGraphNameAndTypesResponse
+{
+    ESParray<ESPstruct NameAndType, GraphNameAndType> GraphNameAndTypes;
+};
+
 ESPrequest WUProcessGraphRequest
 {
     string Wuid;
@@ -1708,6 +1719,7 @@ ESPservice [
     //ESPmethod WUAction(WUActionRequest, WUActionResponse); 
     ESPmethod WUFile(WULogFileRequest, WULogFileResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/graphStats.xslt")] WUProcessGraph(WUProcessGraphRequest, WUProcessGraphResponse); 
+    ESPmethod WUGetGraphNameAndTypes(WUGetGraphNameAndTypesRequest, WUGetGraphNameAndTypesResponse);
     ESPmethod WUGetGraph(WUGetGraphRequest, WUGetGraphResponse);
     ESPmethod WUQueryGetGraph(WUQueryGetGraphRequest, WUQueryGetGraphResponse);
     ESPmethod WUGetDependancyTrees(WUGetDependancyTreesRequest, WUGetDependancyTreesResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -732,7 +732,7 @@ void WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
             graph.getTypeName(type);
             WUGraphState graphState = graph.getState();
 
-            Owned<IEspECLGraph> g= createECLGraph("","");
+            Owned<IEspECLGraph> g= createECLGraph();
             g->setName(name.str());
             g->setLabel(label.str());
             g->setType(type.str());
@@ -743,7 +743,7 @@ void WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
                 g->setRunning(true);
                 g->setRunningId(id);
             }
-            else if (version > 1.13 && (WUGraphFailed == graphState))
+            else if (WUGraphFailed == graphState)
                 g->setFailed(true);
 
             if (version >= 1.53)
@@ -756,14 +756,6 @@ void WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
                 if (whenGraphFinished)
                     g->setWhenFinished(whenGraphFinished->getFormattedValue(s).str());
             }
-
-            WUGraphState graphstate = cw->queryGraphState(name.str());
-            if (graphstate == WUGraphComplete)
-                g->setComplete(true);
-            if (version > 1.13 && graphstate == WUGraphFailed)
-            {
-                g->setFailed(true);
-            }
             graphs.append(*g.getLink());
         }
         info.setGraphs(graphs);
@@ -774,6 +766,20 @@ void WsWuInfo::getGraphInfo(IEspECLWorkunit &info, unsigned flags)
         ERRLOG("%s", e->errorMessage(eMsg).str());
         info.setGraphsDesc(eMsg.str());
         e->Release();
+    }
+}
+
+void WsWuInfo::getWUGraphNameAndTypes(WUGraphType graphType, IArrayOf<IEspNameAndType>& graphNameAndTypes)
+{
+    Owned<IConstWUGraphMetaIterator> it = &cw->getGraphsMeta(graphType);
+    ForEach(*it)
+    {
+        SCMStringBuffer name, type;
+        IConstWUGraphMeta &graph = it->query();
+        Owned<IEspNameAndType> nameAndType = createNameAndType();
+        nameAndType->setName(graph.getName(name).str());
+        nameAndType->setType(graph.getTypeName(type).str());
+        graphNameAndTypes.append(*nameAndType.getLink());
     }
 }
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -168,6 +168,7 @@ public:
     void getTimers(IEspECLWorkunit &info, unsigned flags);
     void getHelpers(IEspECLWorkunit &info, unsigned flags);
     void getGraphInfo(IEspECLWorkunit &info, unsigned flags);
+    void getWUGraphNameAndTypes(WUGraphType graphType, IArrayOf<IEspNameAndType>& graphNameAndTypes);
     void getGraphTimingData(IArrayOf<IConstECLTimingData> &timingData, unsigned flags);
     bool getFileSize(const char* fileName, const char* IPAddress, offset_t& fileSize);
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3313,6 +3313,31 @@ void getClusterConfig(char const * clusterType, char const * clusterName, char c
     return;
 }
 
+bool CWsWorkunitsEx::onWUGetGraphNameAndTypes(IEspContext &context,IEspWUGetGraphNameAndTypesRequest &req, IEspWUGetGraphNameAndTypesResponse &resp)
+{
+    try
+    {
+        StringBuffer wuid = req.getWuid();
+        WsWuHelpers::checkAndTrimWorkunit("WUGraphQuery", wuid);
+
+        StringBuffer type = req.getType();
+        WUGraphType graphType = GraphTypeAny;
+        if (type.trim().length())
+            graphType = getGraphTypeFromString(type.str());
+
+        IArrayOf<IEspNameAndType> graphNameAndTypes;
+        WsWuInfo winfo(context, wuid.str());
+        winfo.getWUGraphNameAndTypes(graphType, graphNameAndTypes);
+        resp.setGraphNameAndTypes(graphNameAndTypes);
+    }
+
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
 bool CWsWorkunitsEx::onWUProcessGraph(IEspContext &context,IEspWUProcessGraphRequest &req, IEspWUProcessGraphResponse &resp)
 {
     try

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -206,6 +206,7 @@ public:
     bool onWUResultBin(IEspContext &context, IEspWUResultBinRequest &req, IEspWUResultBinResponse &resp);
     bool onWUGraphInfo(IEspContext &context,IEspWUGraphInfoRequest &req, IEspWUGraphInfoResponse &resp);
     bool onWUGVCGraphInfo(IEspContext &context,IEspWUGVCGraphInfoRequest &req, IEspWUGVCGraphInfoResponse &resp);
+    bool onWUGetGraphNameAndTypes(IEspContext &context,IEspWUGetGraphNameAndTypesRequest &req, IEspWUGetGraphNameAndTypesResponse &resp);
     bool onWUProcessGraph(IEspContext &context,IEspWUProcessGraphRequest &req, IEspWUProcessGraphResponse &resp);
     bool onGVCAjaxGraph(IEspContext &context, IEspGVCAjaxGraphRequest &req, IEspGVCAjaxGraphResponse &resp);
 


### PR DESCRIPTION
This is a new WsWorkunits method which returns a list of graph
names/types in an ECL workunit. The method has an option to
say what kind of graphs you want listed.

Also cleaned the existing getGraphInfo().

Signed-off-by: wangkx kevin.wang@lexisnexis.com
