### PR TITLE
HPCC-13296 Rename DFUWU not a read-only field

### DIFF
--- a/esp/src/eclwatch/DFUWUDetailsWidget.js
+++ b/esp/src/eclwatch/DFUWUDetailsWidget.js
@@ -283,12 +283,12 @@ define([
 
         refreshActionState: function () {
             this.setDisabled(this.id + "AutoRefresh", this.wu.isComplete(), "iconAutoRefresh", "iconAutoRefreshDisabled");
-            registry.byId(this.id + "Save").set("disabled", !this.wu.isComplete() || this.wu.isDeleted());
+            registry.byId(this.id + "Save").set("disabled", false);
             registry.byId(this.id + "Delete").set("disabled", !this.wu.isComplete() || this.wu.isDeleted());
             registry.byId(this.id + "Abort").set("disabled", this.wu.isComplete() || this.wu.isDeleted());
             registry.byId(this.id + "Resubmit").set("disabled", !this.wu.isComplete() || this.wu.isDeleted());
             registry.byId(this.id + "Modify").set("disabled", true);  //TODO
-            registry.byId(this.id + "JobName").set("readOnly", !this.wu.isComplete() || this.wu.isDeleted());
+            registry.byId(this.id + "JobName").set("readOnly", false);
             registry.byId(this.id + "isProtected").set("readOnly", !this.wu.isComplete() || this.wu.isDeleted());
 
             this.summaryWidget.set("iconClass", this.wu.getStateIconClass());


### PR DESCRIPTION
DFUWU job name currently is read-only based on state of the DFUWU. The monitoring state is not taken into consideration. Appending logic to handle three cases.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
