### PR TITLE
HPCC-13941 Make unicode conversions thread safe.

### DIFF
--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -314,8 +314,12 @@ CriticalSection ucmCrit;
 static void clearUnicodeConverterMap()
 {
     delete unicodeConverterMap;
+    unicodeConverterMap = NULL;  // Important to clear, as this is called when threadpool threads end...
     if (prevThreadTerminator)
+    {
         (*prevThreadTerminator)();
+        prevThreadTerminator = NULL;
+    }
 }
 
 RTLUnicodeConverter * queryRTLUnicodeConverter(char const * codepage)


### PR DESCRIPTION
Previous fix would core if used with threadpools (i.e. in Roxie).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
