### PR TITLE
HPCC-13909 Deprecated warnings from ldap code

### DIFF
--- a/system/security/LdapSecurity/CMakeLists.txt
+++ b/system/security/LdapSecurity/CMakeLists.txt
@@ -33,6 +33,7 @@ set (    SRCS
          ldapconnection.cpp 
          ldapsecurity.cpp 
          permissions.cpp 
+         ldaputils.cpp
     )
 
 include_directories ( 

--- a/system/security/LdapSecurity/aci.ipp
+++ b/system/security/LdapSecurity/aci.ipp
@@ -19,6 +19,7 @@
 #define __ACI_IPP_
 #include "ldapconnection.hpp"
 #include "permissions.hpp"
+#include "ldaputils.hpp"
 
 class AciProcessor : public CInterface, implements IPermissionProcessor
 {

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -36,6 +36,7 @@
 #if defined(_DEBUG) && defined(_WIN32) && !defined(USING_MPATROL)
  #define new new(_NORMAL_BLOCK, __FILE__, __LINE__)
 #endif
+
 #ifdef _WIN32
 #include <lm.h>
 #define LdapRename ldap_rename_ext_s
@@ -144,6 +145,7 @@ public:
         return (hostArray.item(curindex));
     }
 };
+
 
 inline bool LdapServerDown(int rc)
 {
@@ -596,7 +598,7 @@ public:
     {
         if(m_ld != NULL)
         {
-            ldap_unbind(m_ld);
+            LDAP_UNBIND(m_ld);
         }
     }
 
@@ -637,7 +639,7 @@ public:
         else
         {
             DBGLOG("LDAP: sysuser bind failed - %s", ldap_err2string(rc));
-            ldap_unbind(m_ld);
+            LDAP_UNBIND(m_ld);
             m_ld = NULL;
         }
 
@@ -718,7 +720,7 @@ public:
             {
                 if(m_ld != NULL)
                 {
-                    ldap_unbind(m_ld);
+                    LDAP_UNBIND(m_ld);
                     m_ld = NULL;
                     m_connected = false;
                 }
@@ -928,73 +930,6 @@ struct ltstr
     bool operator()(const char* s1, const char* s2) const { return strcmp(s1, s2) < 0; }
 };
 
-//--------------------------------------------
-// This helper class ensures memory allocate by
-// calls to ldap_get_values gets freed
-//--------------------------------------------
-class CLDAPGetValuesWrapper
-{
-private:
-    char **values;
-public:
-    CLDAPGetValuesWrapper(LDAP *ld, LDAPMessage *msg, const char * attr)
-    {
-#ifdef _WIN32
-        values = ldap_get_values(ld, msg, (const PCHAR)attr);
-#else
-        values = ldap_get_values(ld, msg, attr);
-#endif
-    }
-
-    ~CLDAPGetValuesWrapper()
-    {
-        if (values)
-            ldap_value_free(values);
-    }
-    inline bool hasValues()     { return values != NULL  && *values != (char)NULL; }
-    inline char **queryValues() { return values; }
-};
-
-//--------------------------------------------
-// This helper class ensures memory allocate by
-// calls to ldap_get_values_len gets freed
-//--------------------------------------------
-class CLDAPGetValuesLenWrapper
-{
-private:
-    struct berval** bvalues;
-public:
-    CLDAPGetValuesLenWrapper()
-    {
-        bvalues = NULL;
-    }
-    CLDAPGetValuesLenWrapper(LDAP *ld, LDAPMessage *msg, const char * attr)
-    {
-        bvalues = NULL;
-        getValues(ld,msg,attr);
-    }
-
-    ~CLDAPGetValuesLenWrapper()
-    {
-        if (bvalues)
-            ldap_value_free_len(bvalues);
-    }
-    inline bool hasValues()         { return bvalues != NULL  && *bvalues != NULL; }
-    inline berval **queryValues()   { return bvalues; }
-
-    //Delayed call to ldap_get_values_len
-    void getValues(LDAP *ld, LDAPMessage *msg, const char * attr)
-    {
-        if (bvalues)
-            ldap_value_free_len(bvalues);
-#ifdef _WIN32
-        bvalues = ldap_get_values_len(ld, msg, (const PCHAR)attr);
-#else
-        bvalues = ldap_get_values_len(ld, msg, attr);
-#endif
-    }
-};
-
 
 //--------------------------------------------
 // This helper class ensures memory allocate by calls
@@ -1077,14 +1012,17 @@ static __int64 getMaxPwdAge(Owned<ILdapConnectionPool> _conns, const char * _bas
         return 0;
     }
     maxPwdAge = 0;
-    CLDAPGetValuesWrapper vals(sys_ld, searchResult.msg, "maxPwdAge");
+    CLDAPGetValuesLenWrapper vals(sys_ld, searchResult.msg, "maxPwdAge");
     if (vals.hasValues())
     {
-        char *val = vals.queryValues()[0];
-        if (*val == '-')
-            ++val;
-        for (int x=0; val[x]; x++)
-            maxPwdAge = maxPwdAge * 10 + ( (int)val[x] - '0');
+        const char *val = vals.queryCharValue(0);
+        if (val && *val)
+        {
+            if (*val == '-')
+                ++val;
+            for (int x=0; val[x]; x++)
+                maxPwdAge = maxPwdAge * 10 + ( (int)val[x] - '0');
+        }
     }
     else
         maxPwdAge = PWD_NEVER_EXPIRES;
@@ -1277,28 +1215,28 @@ public:
             {
                 if(stricmp(attribute, "cn") == 0)
                 {
-                    CLDAPGetValuesWrapper vals(sys_ld, entry, attribute);
+                    CLDAPGetValuesLenWrapper vals(sys_ld, entry, attribute);
                     if (vals.hasValues())
-                        user.setFullName(vals.queryValues()[0]);
+                        user.setFullName(vals.queryCharValue(0));
                 }
                 else if((stricmp(attribute, "givenName") == 0))
                 {
-                    CLDAPGetValuesWrapper vals(sys_ld, entry, attribute);
+                    CLDAPGetValuesLenWrapper vals(sys_ld, entry, attribute);
                     if (vals.hasValues())
-                        user.setFirstName(vals.queryValues()[0]);
+                        user.setFirstName(vals.queryCharValue(0));
                 }
                 else if((stricmp(attribute, "sn") == 0))
                 {
-                    CLDAPGetValuesWrapper vals(sys_ld, entry, attribute);
+                    CLDAPGetValuesLenWrapper vals(sys_ld, entry, attribute);
                     if (vals.hasValues())
-                        user.setLastName(vals.queryValues()[0]);
+                        user.setLastName(vals.queryCharValue(0));
                 }
                 else if((stricmp(attribute, "userAccountControl") == 0))
                 {
                     //UF_DONT_EXPIRE_PASSWD 0x10000
-                    CLDAPGetValuesWrapper vals(sys_ld, entry, attribute);
+                    CLDAPGetValuesLenWrapper vals(sys_ld, entry, attribute);
                     if (vals.hasValues())
-                        if (atoi((char*)vals.queryValues()[0]) & 0x10000)//this can be true at the account level, even if domain policy requires password
+                        if (atoi((char*)vals.queryCharValue(0)) & 0x10000)//this can be true at the account level, even if domain policy requires password
                             accountPwdNeverExpires = true;
                 }
                 else if((stricmp(attribute, "pwdLastSet") == 0))
@@ -1315,8 +1253,8 @@ public:
                         CDateTime expiry;
                         if (!m_domainPwdsNeverExpire && !accountPwdNeverExpires)
                         {
-                            struct berval* val = valsLen.queryValues()[0];
-                            calcPWExpiry(expiry, (unsigned)val->bv_len, val->bv_val);
+                            char * val = (char*)valsLen.queryCharValue(0);
+                            calcPWExpiry(expiry, (unsigned)strlen(val), val);
                         }
                         else
                         {
@@ -1363,7 +1301,7 @@ public:
                     rc = LdapUtils::LdapBind(user_ld, m_ldapconfig->getDomain(), username, password, userdnbuf.str(), m_ldapconfig->getServerType(), m_ldapconfig->getAuthMethod());
                     if(rc != LDAP_SUCCESS)
                         ldap_get_option(user_ld, LDAP_OPT_ERROR_STRING, &ldap_errstring);
-                    ldap_unbind(user_ld);
+                    LDAP_UNBIND(user_ld);
                 }
                 DBGLOG("finished LdapBind for user %s, rc=%d", username, rc);
                 if(!LdapServerDown(rc) || retries > LDAPSEC_MAX_RETRIES)
@@ -1387,7 +1325,7 @@ public:
                     rc = LdapUtils::LdapBind(user_ld, m_ldapconfig->getDomain(), username, password, userdnbuf.str(), m_ldapconfig->getServerType(), m_ldapconfig->getAuthMethod());
                     if(rc != LDAP_SUCCESS)
                         ldap_get_option(user_ld, LDAP_OPT_ERROR_STRING, &ldap_errstring);
-                    ldap_unbind(user_ld);
+                    LDAP_UNBIND(user_ld);
                 }
             }
             if(rc != LDAP_SUCCESS)
@@ -1642,15 +1580,15 @@ public:
                   attribute != NULL;
                   attribute = atts.getNext())
             {
-                CLDAPGetValuesWrapper vals(ld, message, attribute);
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                 if (vals.hasValues())
                 {
                     if(stricmp(attribute, "sudoHost") == 0)
-                        ldapuser->setSudoHost(vals.queryValues()[0]);
+                        ldapuser->setSudoHost(vals.queryCharValue(0));
                     else if(stricmp(attribute, "sudoCommand") == 0)
-                        ldapuser->setSudoCommand(vals.queryValues()[0]);
+                        ldapuser->setSudoCommand(vals.queryCharValue(0));
                     else if(stricmp(attribute, "sudoOption") == 0)
-                        ldapuser->setSudoOption(vals.queryValues()[0]);
+                        ldapuser->setSudoOption(vals.queryCharValue(0));
                 }
             }
             return true;
@@ -1696,30 +1634,29 @@ public:
                       attribute != NULL;
                       attribute = atts.getNext())
                 {
-                    CLDAPGetValuesWrapper vals(ld, message, attribute);
+                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())
                     {
                         if(stricmp(attribute, "cn") == 0)
-                            user.setFullName(vals.queryValues()[0]);
+                            user.setFullName(vals.queryCharValue(0));
                         else if(stricmp(attribute, "givenName") == 0)
-                            user.setFirstName(vals.queryValues()[0]);
+                            user.setFirstName(vals.queryCharValue(0));
                         else if(stricmp(attribute, "sn") == 0)
-                            user.setLastName(vals.queryValues()[0]);
+                            user.setLastName(vals.queryCharValue(0));
                         else if(stricmp(attribute, "gidnumber") == 0)
-                            ((CLdapSecUser*)&user)->setGidnumber(vals.queryValues()[0]);
+                            ((CLdapSecUser*)&user)->setGidnumber(vals.queryCharValue(0));
                         else if(stricmp(attribute, "uidnumber") == 0)
-                            ((CLdapSecUser*)&user)->setUidnumber(vals.queryValues()[0]);
+                            ((CLdapSecUser*)&user)->setUidnumber(vals.queryCharValue(0));
                         else if(stricmp(attribute, "homedirectory") == 0)
-                            ((CLdapSecUser*)&user)->setHomedirectory(vals.queryValues()[0]);
+                            ((CLdapSecUser*)&user)->setHomedirectory(vals.queryCharValue(0));
                         else if(stricmp(attribute, "loginshell") == 0)
-                            ((CLdapSecUser*)&user)->setLoginshell(vals.queryValues()[0]);
+                            ((CLdapSecUser*)&user)->setLoginshell(vals.queryCharValue(0));
                         else if(stricmp(attribute, "objectClass") == 0)
                         {
                             int valind = 0;
-                            char ** values = vals.queryValues();
-                            while(values[valind])
+                            while(vals.queryCharValue(valind))
                             {
-                                if(values[valind] && stricmp(values[valind], "posixAccount") == 0)
+                                if(vals.queryCharValue(valind) && stricmp(vals.queryCharValue(valind), "posixAccount") == 0)
                                 {
                                     ((CLdapSecUser*)&user)->setPosixenabled(true);
                                     break;
@@ -1832,13 +1769,13 @@ public:
                   attribute != NULL;
                   attribute = atts.getNext())
             {
-                CLDAPGetValuesWrapper vals(ld, message, attribute);
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                 if (vals.hasValues())
                 {
                     if(stricmp(attribute, "cn") == 0)
-                        ldapuser->setFullName(vals.queryValues()[0]);
+                        ldapuser->setFullName(vals.queryCharValue(0));
                     else if(stricmp(attribute, act_fieldname) == 0)
-                        ldapuser->setName(vals.queryValues()[0]);
+                        ldapuser->setName(vals.queryCharValue(0));
                 }
             }
         }
@@ -1919,21 +1856,21 @@ public:
                   attribute != NULL;
                   attribute = atts.getNext())
             {
-                CLDAPGetValuesWrapper vals(ld, message, attribute);
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                 if (vals.hasValues())
                 {
                     if(stricmp(attribute, act_fieldname) == 0)
-                        act_name.clear().append(vals.queryValues()[0]);
+                        act_name.clear().append(vals.queryCharValue(0));
                     else if(stricmp(attribute, "cn") == 0)
-                        cnbuf.clear().append(vals.queryValues()[0]);
+                        cnbuf.clear().append(vals.queryCharValue(0));
                     else if(stricmp(attribute, "objectClass") == 0)
                     {
                         int i = 0;
-                        while(vals.queryValues()[i] != NULL)
+                        while(vals.queryCharValue(i) != NULL)
                         {
-                            if(stricmp(vals.queryValues()[i], "person") == 0)
+                            if(stricmp(vals.queryCharValue(i), "person") == 0)
                                 act_type = USER_ACT;
-                            if(stricmp(vals.queryValues()[i], "group") == 0)
+                            else if(stricmp(vals.queryCharValue(i), "group") == 0)
                                 act_type = GROUP_ACT;
                             i++;
                         }
@@ -1989,7 +1926,7 @@ public:
                     CLDAPGetValuesLenWrapper valsLen(ld, message, attribute);
                     if (valsLen.hasValues())
                     {
-                        struct berval* val = valsLen.queryValues()[0];
+                        struct berval* val = valsLen.queryBValues()[0];
                         if(val != NULL)
                         {
                             int len = val->bv_len;
@@ -2117,16 +2054,16 @@ public:
             {
                 if(stricmp(attribute, "cn") == 0)
                 {
-                    CLDAPGetValuesWrapper vals(ld, message, attribute);
+                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())
-                        user->setFullName(vals.queryValues()[0]);
+                        user->setFullName(vals.queryCharValue(0));
                 }
                 else if (stricmp(attribute, "userAccountControl") == 0)
                 {
                     //UF_DONT_EXPIRE_PASSWD 0x10000
-                    CLDAPGetValuesWrapper vals(ld, message, attribute);
+                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())
-                        if (atoi((char*)vals.queryValues()[0]) & 0x10000)//this can be true at the account level, even if domain policy requires password
+                        if (atoi((char*)vals.queryCharValue(0)) & 0x10000)//this can be true at the account level, even if domain policy requires password
                             accountPwdNeverExpires = true;
                 }
                 else if(stricmp(attribute, "pwdLastSet") == 0)
@@ -2137,7 +2074,7 @@ public:
                         CLDAPGetValuesLenWrapper valsLen(ld, message, attribute);
                         if (valsLen.hasValues())
                         {
-                            struct berval* val = valsLen.queryValues()[0];
+                            struct berval* val = valsLen.queryBValues()[0];
                             calcPWExpiry(expiry, (unsigned)val->bv_len, val->bv_val);
                         }
                     }
@@ -2147,9 +2084,9 @@ public:
                 }
                 else if(stricmp(attribute, act_fieldname) == 0)
                 {
-                    CLDAPGetValuesWrapper vals(ld, message, attribute);
+                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())
-                        user->setName(vals.queryValues()[0]);
+                        user->setName(vals.queryCharValue(0));
                 }
                 else if(stricmp(attribute, sid_fieldname) == 0)
                 {
@@ -2158,7 +2095,7 @@ public:
                         CLDAPGetValuesLenWrapper valsLen(ld, message, attribute);
                         if (valsLen.hasValues())
                         {
-                            struct berval* val = valsLen.queryValues()[0];
+                            struct berval* val = valsLen.queryBValues()[0];
                             if(val != NULL)
                             {
                                 unsigned uid = val->bv_val[val->bv_len - 4];
@@ -2173,9 +2110,9 @@ public:
                     }
                     else
                     {
-                        CLDAPGetValuesWrapper vals(ld, message, attribute);
+                        CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                         if (vals.hasValues())
-                            ((CLdapSecUser*)user.get())->setUserID(atoi(vals.queryValues()[0]));
+                            ((CLdapSecUser*)user.get())->setUserID(atoi(vals.queryCharValue(0)));
                     }
                 }
             }
@@ -2195,7 +2132,7 @@ public:
         Owned<ILdapConnection> lconn = m_connections->getConnection();
         LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
 
-        int rc = ldap_compare_s(ld, (char*)groupdn, (char*)fldname, (char*)userdn);
+        int rc = LDAP_COMPARE_EXT_S(ld, (char*)groupdn, (char*)fldname, (char*)userdn,0,0,0);
         if(rc == LDAP_COMPARE_TRUE)
             return true;
         else
@@ -2276,7 +2213,7 @@ public:
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
 
-            rc = ldap_modify_s(ld, (char*)userdn.str(), attrs);
+            rc = ldap_modify_ext_s(ld, (char*)userdn.str(), attrs, NULL, NULL);
             if (rc == LDAP_SUCCESS && m_ldapconfig->getServerType() == ACTIVE_DIRECTORY)
             {
                 StringBuffer newrdn("cn=");
@@ -2344,14 +2281,14 @@ public:
             attrs[ind++] = &loginshell_attr;
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
-            int compresult = ldap_compare_s(ld, (char*)userdn.str(), (char*)"objectclass", (char*)"posixAccount");
+            int compresult = LDAP_COMPARE_EXT_S(ld, (char*)userdn.str(), (char*)"objectclass", (char*)"posixAccount",0,0,0);
             if(compresult != LDAP_COMPARE_TRUE)
                 attrs[ind++] = &oc_attr;
-            compresult = ldap_compare_s(ld, (char*)userdn.str(), (char*)"objectclass", (char*)"shadowAccount");
+            compresult = LDAP_COMPARE_EXT_S(ld, (char*)userdn.str(), (char*)"objectclass", (char*)"shadowAccount",0,0,0);
             if(compresult != LDAP_COMPARE_TRUE)
                 attrs[ind++] = &oc1_attr;
             attrs[ind] = NULL;
-            rc = ldap_modify_s(ld, (char*)userdn.str(), attrs);
+            rc = ldap_modify_ext_s(ld, (char*)userdn.str(), attrs, NULL, NULL);
         }
         else if(stricmp(type, "posixdisable") == 0)
         {
@@ -2360,7 +2297,7 @@ public:
 
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
-            int compresult = ldap_compare_s(ld, (char*)userdn.str(), (char*)"objectclass", (char*)"posixAccount");
+            int compresult = LDAP_COMPARE_EXT_S(ld, (char*)userdn.str(), (char*)"objectclass", (char*)"posixAccount",0,0,0);
             if(compresult != LDAP_COMPARE_TRUE)
             {
                 rc = LDAP_SUCCESS;
@@ -2425,7 +2362,7 @@ public:
                 attrs[ind++] = &oc1_attr;
                 attrs[ind] = NULL;
 
-                rc = ldap_modify_s(ld, (char*)userdn.str(), attrs);
+                rc = ldap_modify_ext_s(ld, (char*)userdn.str(), attrs, NULL, NULL);
             }
         }
         else if(stricmp(type, "sudoersadd") == 0)
@@ -2523,7 +2460,7 @@ public:
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
             
-            int rc = ldap_delete_s(ld, (char*)dn.str());
+            int rc = ldap_delete_ext_s(ld, (char*)dn.str(), NULL, NULL);
 
             if ( rc != LDAP_SUCCESS )
             {
@@ -2634,9 +2571,9 @@ public:
             {
                 if(0 == stricmp(attribute, "distinguishedName"))
                 {
-                    CLDAPGetValuesWrapper vals(ld, message, attribute);
+                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())
-                        userdn.set(vals.queryValues()[0]);
+                        userdn.set(vals.queryCharValue(0));
                     break;
                 }
             }
@@ -2670,7 +2607,7 @@ public:
         pwdBerVal.bv_len = quotedPasswd.length() * sizeof(unsigned short);
         pwdBerVal.bv_val = (char*)pszPasswordWithQuotes;
 
-        rc = ldap_modify_s(ld, (char*)userdn.str(), modEntry);
+        rc = ldap_modify_ext_s(ld, (char*)userdn.str(), modEntry, NULL, NULL);
 
         if (rc == LDAP_SUCCESS )
             DBGLOG("User %s's password has been changed successfully", username);
@@ -2702,7 +2639,7 @@ public:
         int rc = LdapUtils::LdapBind(user_ld, m_ldapconfig->getDomain(), username, password, userdn, m_ldapconfig->getServerType(), m_ldapconfig->getAuthMethod());
         if(rc != LDAP_SUCCESS)
             ldap_get_option(user_ld, LDAP_OPT_ERROR_STRING, &ldap_errstring);
-        ldap_unbind(user_ld);
+        LDAP_UNBIND(user_ld);
 
         //Error string ""80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 532, v1db0."
         //is returned if pw valid but expired
@@ -2862,7 +2799,7 @@ public:
             };
 
             LDAPMod* pmods[] = {&pmod, NULL};
-            rc = ldap_modify_s(ld, (char*)userdn.str(), pmods);
+            rc = ldap_modify_ext_s(ld, (char*)userdn.str(), pmods, NULL, NULL);
 
             if (rc == LDAP_SUCCESS )
                 DBGLOG("User %s's password has been changed successfully", username);
@@ -2919,10 +2856,10 @@ public:
                   attribute != NULL;
                   attribute = atts.getNext())
             {
-                CLDAPGetValuesWrapper vals(ld, message, attribute);
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                 if (vals.hasValues())
                 {
-                    char* val = vals.queryValues()[0];
+                    const char* val = vals.queryCharValue(0);
                     if(val != NULL)
                     {
                         if(stricmp(attribute, fldname) == 0)
@@ -3004,10 +2941,10 @@ public:
                   attribute != NULL;
                   attribute = atts.getNext())
             {
-                CLDAPGetValuesWrapper vals(ld, message, attribute);
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                 if (vals.hasValues())
                 {
-                    char* val = vals.queryValues()[0];
+                    const char * val = vals.queryCharValue(0);
                     if(val != NULL)
                     {
                         if(stricmp(attribute, fldname) == 0)
@@ -3111,19 +3048,19 @@ public:
                   attribute != NULL;
                   attribute = atts.getNext())
             {
-                CLDAPGetValuesWrapper vals(ld, message, attribute);
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                 if (!vals.hasValues())
                     continue;
                 if(stricmp(attribute, "cn") == 0)
                 {
-                    groups.append(vals.queryValues()[0]);
+                    groups.append(vals.queryCharValue(0));
                     managedBy.append("");
                     descriptions.append("");
                 }
                 else if(stricmp(attribute, "managedBy") == 0)
-                    managedBy.replace(vals.queryValues()[0], groups.length() - 1);
+                    managedBy.replace(vals.queryCharValue(0), groups.length() - 1);
                 else if(stricmp(attribute, "description") == 0)
-                    descriptions.replace(vals.queryValues()[0], groups.length() - 1);
+                    descriptions.replace(vals.queryCharValue(0), groups.length() - 1);
             }
         }
     }
@@ -3227,10 +3164,10 @@ public:
 
         Owned<ILdapConnection> lconn = m_connections->getConnection();
         LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
-        int rc = ldap_modify_s(ld, (char*)normdnbuf.str(), attrs);
+        int rc = ldap_modify_ext_s(ld, (char*)normdnbuf.str(), attrs, NULL, NULL);
         if ( rc != LDAP_SUCCESS )
         {
-            throw MakeStringException(-1, "ldap_modify_s error: %d %s", rc, ldap_err2string( rc ));
+            throw MakeStringException(-1, "ldap_modify_ext_s error: %d %s", rc, ldap_err2string( rc ));
         }
 
         return true;
@@ -3286,13 +3223,13 @@ public:
                 {
                     if(0 == stricmp(attribute, "memberOf"))
                     {
-                        CLDAPGetValuesWrapper vals(ld, message, attribute);
+                        CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                         if (vals.hasValues())
                         {
-                            for (int i = 0; vals.queryValues()[ i ] != NULL; i++ )
+                            for (int i = 0; vals.queryBValues()[ i ] != NULL; i++ )
                             {
-                                char* val = vals.queryValues()[i];
-                                char* comma = strchr(val, ',');
+                                const char* val = vals.queryCharValue(i);
+                                char* comma = strchr((char*)val, ',');
                                 StringBuffer groupname;
                                 groupname.append(comma - val -3, val+3);
                                 groups.append(groupname.str());
@@ -3346,7 +3283,7 @@ public:
         Owned<ILdapConnection> lconn = m_connections->getConnection();
         LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
         
-        int rc = ldap_delete_s(ld, (char*)userdn.str());
+        int rc = ldap_delete_ext_s(ld, (char*)userdn.str(), NULL, NULL);
 
         if ( rc != LDAP_SUCCESS )
         {
@@ -3503,7 +3440,7 @@ public:
         Owned<ILdapConnection> lconn = m_connections->getConnection();
         LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
         
-        int rc = ldap_delete_s(ld, (char*)dn.str());
+        int rc = ldap_delete_ext_s(ld, (char*)dn.str(), NULL, NULL);
 
         if ( rc != LDAP_SUCCESS )
         {
@@ -3577,12 +3514,12 @@ public:
                   attribute != NULL;
                   attribute = atts.getNext())
             {
-                CLDAPGetValuesWrapper vals(ld, message, attribute);
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                 if (vals.hasValues())
                 {
-                    for (int i = 0; vals.queryValues()[ i ] != NULL; i++ )
+                    for (int i = 0; vals.queryBValues()[ i ] != NULL; i++ )
                     {
-                        char* val = vals.queryValues()[i];
+                        const char* val = vals.queryCharValue(i);
                         StringBuffer uid;
                         getUidFromDN(val, uid);
                         if(uid.length() > 0)
@@ -3604,7 +3541,7 @@ public:
         Owned<ILdapConnection> lconn = m_connections->getConnection();
         LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
         
-        int rc = ldap_delete_s(ld, (char*)dn.str());
+        int rc = ldap_delete_ext_s(ld, (char*)dn.str(), NULL, NULL);
 
         if ( rc != LDAP_SUCCESS )
         {
@@ -3642,7 +3579,7 @@ public:
             attrs[0] = &uncname_attr;
             attrs[1] = NULL;
 
-            int rc = ldap_modify_s(ld, (char*)olddn.str(), attrs);
+            int rc = ldap_modify_ext_s(ld, (char*)olddn.str(), attrs, NULL, NULL);
 
             if (rc != LDAP_SUCCESS )
             {
@@ -3776,18 +3713,19 @@ public:
                 
                 char* pw_attrs[] = {"nsslapd-rootpwstoragescheme", NULL};
                 CLDAPMessage msg;
-                int err = ldap_search_s(ld, "cn=config", LDAP_SCOPE_BASE, "objectClass=*", pw_attrs, false, &msg.msg);
+                TIMEVAL timeOut = {LDAPTIMEOUT,0};
+                int err = ldap_search_ext_s(ld, "cn=config", LDAP_SCOPE_BASE, "objectClass=*", pw_attrs, false, NULL, NULL, &timeOut, LDAP_NO_LIMIT, &msg.msg);
                 if(err != LDAP_SUCCESS)
                 {
-                    DBGLOG("ldap_search_s error: %s", ldap_err2string( err ));
+                    DBGLOG("ldap_search_ext_s error: %s", ldap_err2string( err ));
                     return NULL;
                 }
                 LDAPMessage* entry = LdapFirstEntry(ld, msg);
                 if(entry != NULL)
                 {
-                    CLDAPGetValuesWrapper vals(ld, entry, "nsslapd-rootpwstoragescheme");
+                    CLDAPGetValuesLenWrapper vals(ld, entry, "nsslapd-rootpwstoragescheme");
                     if (vals.hasValues())
-                        m_pwscheme.append(vals.queryValues()[0]);
+                        m_pwscheme.append(vals.queryCharValue(0));
                 }
                 ldap_msgfree(msg);
             }
@@ -3904,9 +3842,9 @@ private:
                 attribute = atts.getFirst();
                 if(attribute != NULL)
                 {
-                    CLDAPGetValuesWrapper vals(ld, message, attribute);
+                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())
-                        userdn.append(vals.queryValues()[0]);
+                        userdn.append(vals.queryCharValue(0));
                 }
             }
             if(userdn.length() == 0)
@@ -3966,9 +3904,9 @@ private:
             attribute = atts.getFirst();
             if(attribute != NULL)
             {
-                CLDAPGetValuesWrapper vals(ld, message, attribute);
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                 if (vals.hasValues())
-                    uid.append(vals.queryValues()[0]);
+                    uid.append(vals.queryCharValue(0));
             }
         }
     }
@@ -4294,13 +4232,13 @@ private:
             {
                 if(stricmp(attribute, id_fieldname) == 0)
                 {
-                    CLDAPGetValuesWrapper vals(ld, message, attribute);
+                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())
-                        resourcename.append(vals.queryValues()[0]);
+                        resourcename.append(vals.queryCharValue(0));
                 }
                 else if(stricmp(attribute, des_fieldname) == 0) 
                 {
-                    valsLen.getValues(ld, message, attribute);
+                    valsLen.retrieveBValues(ld, message, attribute);
                 }
             }
             for(i = 0; i < len; i++)
@@ -4312,7 +4250,7 @@ private:
                     {
                         if(m_ldapconfig->getServerType() == ACTIVE_DIRECTORY)
                         {
-                            struct berval* val = valsLen.queryValues()[0];
+                            struct berval* val = valsLen.queryBValues()[0];
                             if(val != NULL)
                             {
                                 CSecurityDescriptor& sd = sdlist.item(i);
@@ -4323,7 +4261,7 @@ private:
                         {
                             MemoryBuffer allvals;
                             int valseq = 0;
-                            struct berval* val = valsLen.queryValues()[valseq++];
+                            struct berval* val = valsLen.queryBValues()[valseq++];
                             while(val != NULL)
                             {
                                 if(val->bv_len > 0)
@@ -4331,7 +4269,7 @@ private:
                                     allvals.append(val->bv_len, val->bv_val);
                                     allvals.append('\0'); // my separator between ACIs
                                 }
-                                val = valsLen.queryValues()[valseq++];
+                                val = valsLen.queryBValues()[valseq++];
                             }
                             if(allvals.length() > 0)
                             {
@@ -4466,7 +4404,7 @@ private:
             {
                 if(stricmp(attribute, sd_fieldname) == 0) 
                 {
-                    valsLen.getValues(ld, message, attribute);
+                    valsLen.retrieveBValues(ld, message, attribute);
                 }
             }
             for(i = 0; i < len; i++)
@@ -4478,7 +4416,7 @@ private:
                     {
                         if(m_ldapconfig->getServerType() == ACTIVE_DIRECTORY)
                         {
-                            struct berval* val = valsLen.queryValues()[0];
+                            struct berval* val = valsLen.queryBValues()[0];
                             if(val != NULL)
                             {
                                 CSecurityDescriptor& sd = sdlist.item(i);
@@ -4489,7 +4427,7 @@ private:
                         {
                             MemoryBuffer allvals;
                             int valseq = 0;
-                            struct berval* val = valsLen.queryValues()[valseq++];
+                            struct berval* val = valsLen.queryBValues()[valseq++];
                             while(val != NULL)
                             {
                                 if(val->bv_len > 0)
@@ -4497,7 +4435,7 @@ private:
                                     allvals.append(val->bv_len, val->bv_val);
                                     allvals.append('\0'); // my separator between ACIs
                                 }
-                                val = valsLen.queryValues()[valseq++];
+                                val = valsLen.queryBValues()[valseq++];
                             }
                             if(allvals.length() > 0)
                             {
@@ -4946,10 +4884,10 @@ private:
             {
                 if(0 == stricmp(attribute, "userAccountControl"))
                 {
-                    CLDAPGetValuesWrapper vals(ld, message, attribute);
+                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())
                     {
-                        act_ctrl.append(vals.queryValues()[0]);
+                        act_ctrl.append(vals.queryCharValue(0));
                         break;
                     }
                 }
@@ -5230,104 +5168,6 @@ private:
             return -2;
     }
 };
-
-int LdapUtils::getServerInfo(const char* ldapserver, int ldapport, StringBuffer& domainDN, LdapServerType& stype, const char* domainname)
-{
-    LdapServerType deducedSType = LDAPSERVER_UNKNOWN;
-    LDAP* ld = LdapInit("ldap", ldapserver, ldapport, 636); 
-    if(ld == NULL)
-    {
-        ERRLOG("ldap init error");
-        return false;
-    }
-    
-    int err = LdapSimpleBind(ld, NULL, NULL);
-    if(err != LDAP_SUCCESS)
-    {
-        DBGLOG("ldap anonymous bind error (%d) - %s", err, ldap_err2string(err));
-
-        // for new versions of openldap, version 2.2.*
-        if(err == LDAP_PROTOCOL_ERROR)
-            DBGLOG("If you're trying to connect to an OpenLdap server, make sure you have \"allow bind_v2\" enabled in slapd.conf");
-
-        return err;
-    }
-
-    LDAPMessage* msg = NULL;
-    char* attrs[] = {"namingContexts", NULL};
-    err = ldap_search_s(ld, NULL, LDAP_SCOPE_BASE, "objectClass=*", attrs, false, &msg);
-    if(err != LDAP_SUCCESS)
-    {
-        DBGLOG("ldap_search_s error: %s", ldap_err2string( err ));
-        if (msg)
-            ldap_msgfree(msg);
-        return err;
-    }
-    LDAPMessage* entry = LdapFirstEntry(ld, msg);
-    if(entry != NULL)
-    {
-        CLDAPGetValuesWrapper vals(ld, entry, "namingContexts");
-        char** domains = vals.queryValues();
-        if(domains != NULL)
-        {
-            int i = 0;
-            char* curdn;
-            StringBuffer onedn;
-            while((curdn = domains[i]) != NULL)
-            {
-                if(*curdn != '\0' && (strncmp(curdn, "dc=", 3) == 0 || strncmp(curdn, "DC=", 3) == 0) && strstr(curdn,"DC=ForestDnsZones")==0 && strstr(curdn,"DC=DomainDnsZones")==0 )
-                {
-                    if(domainDN.length() == 0)
-                    {
-                        StringBuffer curdomain;
-                        LdapUtils::getName(curdn, curdomain);
-                        if(onedn.length() == 0)
-                        {
-                            DBGLOG("Queried '%s', selected basedn '%s'",curdn, curdomain.str());
-                            onedn.append(curdomain.str());
-                        }
-                        else
-                            DBGLOG("Ignoring %s", curdn);
-                        if(!domainname || !*domainname || stricmp(curdomain.str(), domainname) == 0)
-                            domainDN.append(curdn);
-                    }
-                }
-                else if(*curdn != '\0' && strcmp(curdn, "o=NetscapeRoot") == 0)
-                {
-                    PROGLOG("Deduced LDAP Server Type 'iPlanet'");
-                    deducedSType = IPLANET;
-                }
-                i++;
-            }
-            
-            if(domainDN.length() == 0)
-                domainDN.append(onedn.str());
-
-            if (deducedSType == LDAPSERVER_UNKNOWN)
-            {
-                if(i <= 1)
-                {
-                    PROGLOG("Deduced LDAP Server Type 'OpenLDAP'");
-                    deducedSType = OPEN_LDAP;
-                }
-                else
-                {
-                    PROGLOG("Deduced LDAP Server Type 'Active Directory'");
-                    deducedSType = ACTIVE_DIRECTORY;
-                }
-            }
-        }
-    }
-    ldap_msgfree(msg);
-    ldap_unbind(ld);
-
-    if (stype == LDAPSERVER_UNKNOWN)
-        stype = deducedSType;
-    else if (deducedSType != stype)
-        WARNLOG("Ignoring deduced LDAP Server Type, does not match config LDAPServerType");
-
-    return err;
-}
 
 #ifdef _WIN32
 bool verifyServerCert(LDAP* ld, PCCERT_CONTEXT pServerCert)

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1656,7 +1656,7 @@ public:
                             int valind = 0;
                             while(vals.queryCharValue(valind))
                             {
-                                if(vals.queryCharValue(valind) && stricmp(vals.queryCharValue(valind), "posixAccount") == 0)
+                                if(stricmp(vals.queryCharValue(valind), "posixAccount") == 0)
                                 {
                                     ((CLdapSecUser*)&user)->setPosixenabled(true);
                                     break;

--- a/system/security/LdapSecurity/ldaputils.cpp
+++ b/system/security/LdapSecurity/ldaputils.cpp
@@ -153,13 +153,13 @@ int LdapUtils::LdapBind(LDAP* ld, const char* domain, const char* username, cons
             DBGLOG("userdn can't be NULL in order to bind to ldap server.");
             return LDAP_INVALID_CREDENTIALS;
         }
-        int rc = LdapUtils::LdapSimpleBind(ld, (char*)userdn, (char*)password);
+        int rc = LdapSimpleBind(ld, (char*)userdn, (char*)password);
         if (rc != LDAP_SUCCESS && server_type == OPEN_LDAP && strchr(userdn,','))
         {   //Fedora389 is happier without the domain component specified
             StringBuffer cn(userdn);
             cn.replace(',',(char)NULL);
             if (cn.length())//disallow call if no cn
-                rc = LdapUtils::LdapSimpleBind(ld, (char*)cn.str(), (char*)password);
+                rc = LdapSimpleBind(ld, (char*)cn.str(), (char*)password);
         }
         if (rc != LDAP_SUCCESS )
         {
@@ -168,7 +168,7 @@ int LdapUtils::LdapBind(LDAP* ld, const char* domain, const char* username, cons
             {
                 StringBuffer logonname;
                 logonname.append(domain).append("\\").append(username);
-                rc = LdapUtils::LdapSimpleBind(ld, (char*)logonname.str(), (char*)password);
+                rc = LdapSimpleBind(ld, (char*)logonname.str(), (char*)password);
                 if(rc != LDAP_SUCCESS)
                 {
 #ifdef LDAP_OPT_DIAGNOSTIC_MESSAGE
@@ -203,7 +203,7 @@ int LdapUtils::getServerInfo(const char* ldapserver, int ldapport, StringBuffer&
         return false;
     }
 
-    int err = LdapUtils::LdapSimpleBind(ld, NULL, NULL);
+    int err = LdapSimpleBind(ld, NULL, NULL);
     if(err != LDAP_SUCCESS)
     {
         DBGLOG("ldap anonymous bind error (%d) - %s", err, ldap_err2string(err));
@@ -242,7 +242,7 @@ int LdapUtils::getServerInfo(const char* ldapserver, int ldapport, StringBuffer&
                     if(domainDN.length() == 0)
                     {
                         StringBuffer curdomain;
-                        LdapUtils::getName(curdn, curdomain);
+                        getName(curdn, curdomain);
                         if(onedn.length() == 0)
                         {
                             DBGLOG("Queried '%s', selected basedn '%s'",curdn, curdomain.str());

--- a/system/security/LdapSecurity/ldaputils.cpp
+++ b/system/security/LdapSecurity/ldaputils.cpp
@@ -1,0 +1,378 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+// LDAP prototypes use char* where they should be using const char *, resulting in lots of spurious warnings
+#pragma warning( disable : 4786 )
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+#endif
+
+#include "ldaputils.hpp"
+
+
+//------------------------------------
+// LdapUtils implementation
+//------------------------------------
+LDAP* LdapUtils::LdapInit(const char* protocol, const char* host, int port, int secure_port)
+{
+    LDAP* ld = NULL;
+    if(stricmp(protocol, "ldaps") == 0)
+    {
+#ifdef _WIN32
+        ld = ldap_sslinit((char*)host, secure_port, 1);
+        if (ld == NULL )
+            throw MakeStringException(-1, "ldap_sslinit error" );
+
+        int rc = 0;
+        unsigned long version = LDAP_VERSION3;
+        long lv = 0;
+
+        rc = ldap_set_option(ld,
+            LDAP_OPT_PROTOCOL_VERSION,
+            (void*)&version);
+        if (rc != LDAP_SUCCESS)
+            throw MakeStringException(-1, "ldap_set_option error - %s", ldap_err2string(rc));
+
+        rc = ldap_get_option(ld,LDAP_OPT_SSL,(void*)&lv);
+        if (rc != LDAP_SUCCESS)
+            throw MakeStringException(-1, "ldap_get_option error - %s", ldap_err2string(rc));
+
+        // If SSL is not enabled, enable it.
+        if ((void*)lv != LDAP_OPT_ON)
+        {
+            rc = ldap_set_option(ld, LDAP_OPT_SSL, LDAP_OPT_ON);
+            if (rc != LDAP_SUCCESS)
+                throw MakeStringException(-1, "ldap_set_option error - %s", ldap_err2string(rc));
+        }
+
+        ldap_set_option(ld, LDAP_OPT_SERVER_CERTIFICATE, verifyServerCert);
+#else
+        // Initialize an LDAP session for TLS/SSL
+#ifndef HAVE_TLS
+        //throw MakeStringException(-1, "openldap client library libldap not compiled with TLS support");
+#endif
+        StringBuffer uri("ldaps://");
+        uri.appendf("%s:%d", host, secure_port);
+        DBGLOG("connecting to %s", uri.str());
+        int rc = ldap_initialize(&ld, uri.str());
+        if(rc != LDAP_SUCCESS)
+        {
+            DBGLOG("ldap_initialize error %s", ldap_err2string(rc));
+            throw MakeStringException(-1, "ldap_initialize error %s", ldap_err2string(rc));
+        }
+        int reqcert = LDAP_OPT_X_TLS_NEVER;
+        ldap_set_option(NULL, LDAP_OPT_X_TLS_REQUIRE_CERT, &reqcert);
+#endif
+    }
+    else
+    {
+        // Initialize an LDAP session
+        StringBuffer uri;
+        uri.appendf("ldap://%s:%d", host, port);
+        DBGLOG("connecting to %s", uri.str());
+        int rc = ldap_initialize(&ld, uri.str());
+        if(rc != LDAP_SUCCESS)
+        {
+            throw MakeStringException(-1, "ldap_initialize(%s) error %s", uri.str(), ldap_err2string(rc));
+        }
+    }
+    return ld;
+}
+
+int LdapUtils::LdapSimpleBind(LDAP* ld, char* userdn, char* password)
+{
+#ifndef _WIN32
+    TIMEVAL timeout = {LDAPTIMEOUT, 0};
+    ldap_set_option(ld, LDAP_OPT_TIMEOUT, &timeout);
+    ldap_set_option(ld, LDAP_OPT_NETWORK_TIMEOUT, &timeout);
+#endif
+    return ldap_bind_s(ld, userdn, password, LDAP_AUTH_SIMPLE);
+}
+
+// userdn is required for ldap_simple_bind_s, not really necessary for ldap_bind_s.
+int LdapUtils::LdapBind(LDAP* ld, const char* domain, const char* username, const char* password, const char* userdn, LdapServerType server_type, const char* method)
+{
+    bool binddone = false;
+    int rc = LDAP_SUCCESS;
+    // By default, use kerberos authentication
+    if((method == NULL) || (strlen(method) == 0) || (stricmp(method, "kerberos") == 0))
+    {
+#ifdef _WIN32
+        if(server_type == ACTIVE_DIRECTORY)
+        {
+            if(username != NULL)
+            {
+                SEC_WINNT_AUTH_IDENTITY secIdent;
+                secIdent.User = (unsigned char*)username;
+                secIdent.UserLength = strlen(username);
+                secIdent.Password = (unsigned char*)password;
+                secIdent.PasswordLength = strlen(password);
+                // Somehow, setting the domain makes it slower
+                secIdent.Domain = (unsigned char*)domain;
+                secIdent.DomainLength = strlen(domain);
+                secIdent.Flags = SEC_WINNT_AUTH_IDENTITY_ANSI;
+                int rc = ldap_bind_s(ld, (char*)userdn, (char*)&secIdent, LDAP_AUTH_NEGOTIATE);
+                if(rc != LDAP_SUCCESS)
+                {
+                    DBGLOG("ldap_bind_s for user %s failed with %d - %s.", username, rc, ldap_err2string(rc));
+                    return rc;
+                }
+            }
+            else
+            {
+                int rc = ldap_bind_s(ld, NULL, NULL, LDAP_AUTH_NEGOTIATE);
+                if(rc != LDAP_SUCCESS)
+                {
+                    DBGLOG("User Authentication Failed - ldap_bind_s for current user failed with %d - %s.", rc, ldap_err2string(rc));
+                    return rc;
+                }
+            }
+            binddone = true;
+        }
+#endif
+    }
+
+    if(!binddone)
+    {
+        if(userdn == NULL)
+        {
+            DBGLOG("userdn can't be NULL in order to bind to ldap server.");
+            return LDAP_INVALID_CREDENTIALS;
+        }
+        int rc = LdapUtils::LdapSimpleBind(ld, (char*)userdn, (char*)password);
+        if (rc != LDAP_SUCCESS && server_type == OPEN_LDAP && strchr(userdn,','))
+        {   //Fedora389 is happier without the domain component specified
+            StringBuffer cn(userdn);
+            cn.replace(',',(char)NULL);
+            if (cn.length())//disallow call if no cn
+                rc = LdapUtils::LdapSimpleBind(ld, (char*)cn.str(), (char*)password);
+        }
+        if (rc != LDAP_SUCCESS )
+        {
+            // For Active Directory, try binding with NT format username
+            if(server_type == ACTIVE_DIRECTORY)
+            {
+                StringBuffer logonname;
+                logonname.append(domain).append("\\").append(username);
+                rc = LdapUtils::LdapSimpleBind(ld, (char*)logonname.str(), (char*)password);
+                if(rc != LDAP_SUCCESS)
+                {
+#ifdef LDAP_OPT_DIAGNOSTIC_MESSAGE
+                    char *msg=NULL;
+                    ldap_get_option(ld, LDAP_OPT_DIAGNOSTIC_MESSAGE, (void*)&msg);
+                    DBGLOG("LDAP bind error for user %s with %d - %s. %s", logonname.str(), rc, ldap_err2string(rc), msg&&*msg?msg:"");
+                    ldap_memfree(msg);
+#else
+                    DBGLOG("LDAP bind error for user %s with 0x%" I64F "x - %s", username, (unsigned __int64) rc, ldap_err2string(rc));
+#endif
+                    return rc;
+                }
+            }
+            else
+            {
+                DBGLOG("LDAP bind error for user %s with 0x%" I64F "x - %s", username, (unsigned __int64) rc, ldap_err2string(rc));
+                return rc;
+            }
+        }
+    }
+
+    return rc;
+}
+
+int LdapUtils::getServerInfo(const char* ldapserver, int ldapport, StringBuffer& domainDN, LdapServerType& stype, const char* domainname)
+{
+    LdapServerType deducedSType = LDAPSERVER_UNKNOWN;
+    LDAP* ld = LdapInit("ldap", ldapserver, ldapport, 636);
+    if(ld == NULL)
+    {
+        ERRLOG("ldap init error");
+        return false;
+    }
+
+    int err = LdapUtils::LdapSimpleBind(ld, NULL, NULL);
+    if(err != LDAP_SUCCESS)
+    {
+        DBGLOG("ldap anonymous bind error (%d) - %s", err, ldap_err2string(err));
+
+        // for new versions of openldap, version 2.2.*
+        if(err == LDAP_PROTOCOL_ERROR)
+            DBGLOG("If you're trying to connect to an OpenLdap server, make sure you have \"allow bind_v2\" enabled in slapd.conf");
+
+        return err;
+    }
+
+    LDAPMessage* msg = NULL;
+    char* attrs[] = {"namingContexts", NULL};
+    TIMEVAL timeOut = {LDAPTIMEOUT,0};
+    err = ldap_search_ext_s(ld, NULL, LDAP_SCOPE_BASE, "objectClass=*", attrs, false, NULL, NULL, &timeOut, LDAP_NO_LIMIT, &msg);
+    if(err != LDAP_SUCCESS)
+    {
+        DBGLOG("ldap_search_ext_s error: %s", ldap_err2string( err ));
+        if (msg)
+            ldap_msgfree(msg);
+        return err;
+    }
+    LDAPMessage* entry = ldap_first_entry(ld, msg);
+    if(entry != NULL)
+    {
+        CLDAPGetValuesLenWrapper vals(ld, entry, "namingContexts");
+        if(vals.hasValues())
+        {
+            int i = 0;
+            const char* curdn;
+            StringBuffer onedn;
+            while((curdn = vals.queryCharValue(i)) != NULL)
+            {
+                if(*curdn != '\0' && (strncmp(curdn, "dc=", 3) == 0 || strncmp(curdn, "DC=", 3) == 0) && strstr(curdn,"DC=ForestDnsZones")==0 && strstr(curdn,"DC=DomainDnsZones")==0 )
+                {
+                    if(domainDN.length() == 0)
+                    {
+                        StringBuffer curdomain;
+                        LdapUtils::getName(curdn, curdomain);
+                        if(onedn.length() == 0)
+                        {
+                            DBGLOG("Queried '%s', selected basedn '%s'",curdn, curdomain.str());
+                            onedn.append(curdomain.str());
+                        }
+                        else
+                            DBGLOG("Ignoring %s", curdn);
+                        if(!domainname || !*domainname || stricmp(curdomain.str(), domainname) == 0)
+                            domainDN.append(curdn);
+                    }
+                }
+                else if(*curdn != '\0' && strcmp(curdn, "o=NetscapeRoot") == 0)
+                {
+                    PROGLOG("Deduced LDAP Server Type 'iPlanet'");
+                    deducedSType = IPLANET;
+                }
+                i++;
+            }
+
+            if(domainDN.length() == 0)
+                domainDN.append(onedn.str());
+
+            if (deducedSType == LDAPSERVER_UNKNOWN)
+            {
+                if(i <= 1)
+                {
+                    PROGLOG("Deduced LDAP Server Type 'OpenLDAP'");
+                    deducedSType = OPEN_LDAP;
+                }
+                else
+                {
+                    PROGLOG("Deduced LDAP Server Type 'Active Directory'");
+                    deducedSType = ACTIVE_DIRECTORY;
+                }
+            }
+        }
+    }
+    ldap_msgfree(msg);
+    LDAP_UNBIND(ld);
+
+    if (stype == LDAPSERVER_UNKNOWN)
+        stype = deducedSType;
+    else if (deducedSType != stype)
+        WARNLOG("Ignoring deduced LDAP Server Type, does not match config LDAPServerType");
+
+    return err;
+}
+
+void LdapUtils::bin2str(MemoryBuffer& from, StringBuffer& to)
+{
+    const char* frombuf = from.toByteArray();
+    char tmp[3];
+    for(unsigned i = 0; i < from.length(); i++)
+    {
+        unsigned char c = frombuf[i];
+        sprintf(tmp, "%02X", c);
+        tmp[2] = 0;
+        to.append("\\").append(tmp);
+    }
+}
+
+void LdapUtils::normalizeDn(const char* dn, const char* basedn, StringBuffer& dnbuf)
+{
+    dnbuf.clear();
+    cleanupDn(dn, dnbuf);
+    if(!containsBasedn(dnbuf.str()))
+        dnbuf.append(",").append(basedn);
+}
+
+bool LdapUtils::containsBasedn(const char* str)
+{
+    if(str == NULL || str[0] == '\0')
+        return false;
+    else
+        return (strstr(str, "dc=") != NULL);
+}
+
+void LdapUtils::cleanupDn(const char* dn, StringBuffer& dnbuf)
+{
+    if(dn == NULL || dn[0] == '\0')
+        return;
+    dnbuf.append(dn);
+    dnbuf.toLowerCase();
+}
+
+bool LdapUtils::getDcName(const char* domain, StringBuffer& dc)
+{
+    bool ret = false;
+#ifdef _WIN32
+    PDOMAIN_CONTROLLER_INFO psInfo = NULL;
+    DWORD dwErr = DsGetDcName(NULL, domain, NULL, NULL, DS_FORCE_REDISCOVERY | DS_DIRECTORY_SERVICE_REQUIRED, &psInfo);
+    if( dwErr == NO_ERROR)
+    {
+        const char* dcname = psInfo->DomainControllerName;
+        if(dcname != NULL)
+        {
+            while(*dcname == '\\')
+                dcname++;
+
+            dc.append(dcname);
+            ret = true;
+        }
+        NetApiBufferFree(psInfo);
+    }
+    else
+    {
+        DBGLOG("Error getting domain controller, error = %d", dwErr);
+        ret = false;
+    }
+#endif
+    return ret;
+}
+
+void LdapUtils::getName(const char* dn, StringBuffer& name)
+{
+    const char* bptr = dn;
+    while(*bptr != '\0' && *bptr != '=')
+        bptr++;
+
+    if(*bptr == '\0')
+    {
+        name.append(dn);
+        return;
+    }
+    else
+        bptr++;
+
+    const char* colon = strstr(bptr, ",");
+    if(colon == NULL)
+        name.append(bptr);
+    else
+        name.append(colon - bptr, bptr);
+}

--- a/system/security/LdapSecurity/ldaputils.hpp
+++ b/system/security/LdapSecurity/ldaputils.hpp
@@ -1,0 +1,53 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef __LDAPUTILS_HPP
+#define __LDAPUTILS_HPP
+
+#include "ldapconnection.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winldap.h>
+#include <winber.h>
+#include <rpc.h>
+#include <rpcdce.h>
+#include "dsgetdc.h"
+#include <lm.h>
+#else
+#define LDAP_DEPRECATED 1
+#include <ldap_cdefs.h>
+#include <ldap.h>
+#endif
+
+class LdapUtils
+{
+public:
+    static LDAP* LdapInit(const char* protocol, const char* host, int port, int secure_port);
+    static int LdapSimpleBind(LDAP* ld, char* userdn, char* password);
+    // userdn is required for ldap_simple_bind_s, not really necessary for ldap_bind_s.
+    static int LdapBind(LDAP* ld, const char* domain, const char* username, const char* password, const char* userdn, LdapServerType server_type, const char* method="kerberos");
+    static void bin2str(MemoryBuffer& from, StringBuffer& to);
+    static int getServerInfo(const char* ldapserver, int ldapport, StringBuffer& domainDN, LdapServerType& stype, const char* domainname);
+    static void normalizeDn(const char* dn, const char* basedn, StringBuffer& dnbuf);
+    static bool containsBasedn(const char* str);
+    static void cleanupDn(const char* dn, StringBuffer& dnbuf);
+    static bool getDcName(const char* domain, StringBuffer& dc);
+    static void getName(const char* dn, StringBuffer& name);
+};
+
+#endif

--- a/tools/addScopes/CMakeLists.txt
+++ b/tools/addScopes/CMakeLists.txt
@@ -27,6 +27,7 @@ project( addScopes )
 
 set (    SRCS 
          addScopes.cpp 
+         ./../../system/security/LdapSecurity/ldaputils.cpp
     )
 
 include_directories ( 


### PR DESCRIPTION
The following deprecated functions are still being called by our LDAP code
and need to be updated

 CURRENT               NEWEST
 ldap_init          -> ldap_initialize
 ldap_simple_bind_s -> ldap_sasl_bind_s
 ldap_unbind            -> ldap_unbind_ext
 ldap_get_values       -> ldap_get_values_len
 ldap_value_free       -> ldap_value_free_len
 ldap_compare_s     -> ldap_compare_ext_s
 ldap_modify_s       -> ldap_modify_ext_s
 ldap_delete_s       -> ldap_delete_ext_s
 ldap_search_s       -> ldap_search_ext_s

This PR makes the above changes, with the exception of the simple bind, which
is a change to the way we authenticate and is out of the scope of this bug.
However, I did move those calls to a new "ldaputils" source file so they
warnings would not appear when the headers were included

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
