### PR TITLE
HPCC-13842 Add WUID filter for searching Archived WUs

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2001,6 +2001,7 @@ void doWUQueryFromArchive(IEspContext &context, const char* sashaServerIP, unsig
 
         void setFilterString()
         {
+            addToFilterString("wuid", req.getWuid());
             addToFilterString("cluster", req.getCluster());
             addToFilterString("owner", req.getOwner());
             addToFilterString("jobName", req.getJobname());
@@ -2024,6 +2025,8 @@ void doWUQueryFromArchive(IEspContext &context, const char* sashaServerIP, unsig
             cmd->setArchived(true);
             cmd->setStart(pageFrom);
             cmd->setLimit(pageSize+1); //read an extra WU to check hasMoreWU
+            if (notEmpty(req.getWuid()))
+                cmd->addId(req.getWuid());
             if (notEmpty(req.getCluster()))
                 cmd->setCluster(req.getCluster());
             if (notEmpty(req.getOwner()))


### PR DESCRIPTION
By this fix, a user may specify the WUID filter to search
Archived WUs on new ECLWatch. The existing UI works now.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
