### PR TITLE
HPCC-13986 Valgrind reporting memory leaks from Roxie re statistics

### DIFF
--- a/roxie/ccd/ccdsnmp.cpp
+++ b/roxie/ccd/ccdsnmp.cpp
@@ -912,7 +912,13 @@ public:
         expirySeconds = _expirySeconds;
         queryStatsAggregators.append(*LINK(this));
     }
-
+    ~CQueryStatsAggregator()
+    {
+        while (recent.ordinality())
+        {
+            recent.dequeue()->Release();
+        }
+    }
     static IPropertyTree *getAllQueryStats(bool includeQueries, time_t from, time_t to)
     {
         Owned<IPTree> result = createPTree("QueryStats");

--- a/roxie/ccd/ccdsnmp.cpp
+++ b/roxie/ccd/ccdsnmp.cpp
@@ -887,10 +887,10 @@ class CQueryStatsAggregator : public CInterface, implements IQueryStatsAggregato
     }
     
     static CQueryStatsAggregator globalStatsAggregator;
-    static CIArrayOf<CQueryStatsAggregator> queryStatsAggregators;
     static SpinLock queryStatsCrit;
 
 public:
+    static CIArrayOf<CQueryStatsAggregator> queryStatsAggregators;
     virtual void Link(void) const { CInterface::Link(); }
     virtual bool Release(void) const    
     {
@@ -1002,8 +1002,8 @@ public:
     }
 };
 
-CQueryStatsAggregator CQueryStatsAggregator::globalStatsAggregator(NULL, SLOT_LENGTH);
 CIArrayOf<CQueryStatsAggregator> CQueryStatsAggregator::queryStatsAggregators;
+CQueryStatsAggregator CQueryStatsAggregator::globalStatsAggregator(NULL, SLOT_LENGTH);
 SpinLock CQueryStatsAggregator::queryStatsCrit;
 
 IQueryStatsAggregator *queryGlobalQueryStatsAggregator()

--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -1316,6 +1316,7 @@ public:
     }
     virtual void endScope()
     {
+        scopes.tos().Release();
         scopes.pop();
     }
     virtual void addStatistic(StatisticKind kind, unsigned __int64 value)

--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -1005,6 +1005,7 @@ public:
         {
             Statistic * next = Statistic::deserialize(in, version);
             stats.append(*next);
+            next->Release();
         }
 
         unsigned numChildren;
@@ -1108,7 +1109,8 @@ public:
 //other public interface functions
     void addStatistic(StatisticKind kind, unsigned __int64 value)
     {
-        stats.append(*new Statistic(kind, value));
+        Statistic s(kind, value);
+        stats.append(s);
     }
 
     void updateStatistic(StatisticKind kind, unsigned __int64 value, StatsMergeAction mergeAction)
@@ -1125,7 +1127,8 @@ public:
                 }
             }
         }
-        stats.append(*new Statistic(kind, value));
+        Statistic s(kind, value);
+        stats.append(s);
     }
 
     CStatisticCollection * ensureSubScope(const StatsScopeId & search, bool hasChildren)


### PR DESCRIPTION
I found 4 separate leaks while investigating this, though none of them are really a big deal for Roxie (possible slightly more so for thor). With these changes valgrind reports Roxie free of accumulating leaks when running a simple workunit query.

Valgrind also gives me some confidence that these changes did not introduce any -ve leans - it would have picked them up - but please still check carefully.

@afishbeck Please review.
