### PR TITLE
HPCC-14005 WuTest selftest is not deleting one of the wus

### DIFF
--- a/ecl/wutest/wutest.cpp
+++ b/ecl/wutest/wutest.cpp
@@ -766,6 +766,7 @@ protected:
             query->setQueryMainDefinition("fred");
             query->setQueryType(QueryTypeEcl);
             query->addAssociatedFile(FileTypeCpp, "myfile", "1.2.3.4", "Description", 53);
+            createWu->setState(WUStateCompleted);
             createWu.clear();
         }
 
@@ -785,7 +786,16 @@ protected:
         ASSERT(file->getCrc()==53);
         ASSERT(file->getType()==FileTypeCpp);
         ASSERT(streq(file->getIp(s).str(), "1.2.3.4"));
+        query.clear();
         wu.clear();
+
+        Owned<IWorkUnit> lockedWu = factory->updateWorkUnit(wuid);
+        Owned<IWUQuery> uQuery = lockedWu->updateQuery();
+        ASSERT(uQuery);
+        uQuery->removeAssociatedFiles();
+        uQuery.clear();
+        lockedWu.clear();
+
         factory->deleteWorkUnit(wuid);
     }
 


### PR DESCRIPTION
Added code to set the state to completed so that the WU can be deleted - this
revealed another issue in that the program blocks on exist waiting for a
response from 1.2.3.4 where it is trying to delete a file.

Added code to remove the file info from the query before deleting - this
revealed another issue where information could only be added to child tables
in Cassandra and was never deleted.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
