### PR TITLE
HPCC-13905 Return child dataset structure in DFUGetFileMetaData

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -444,6 +444,7 @@ ESPStruct [nil_remove] DFUDataColumn
     [min_ver("1.29")] int ColumnRawSize;
     [min_ver("1.29")] bool IsNaturalColumn;
     [min_ver("1.29")] bool IsKeyedColumn;
+    [min_ver("1.31")] ESParray<ESPstruct DFUDataColumn> DataColumns;
 };
 
 ESPrequest DFUGetDataColumnsRequest


### PR DESCRIPTION
The existing WsDfu.DFUGetFileMetaData only returns meta data of
the top level of fields. In this fix, the DFUGetFileMetaData
can return nested field definitions for child datasets.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
