### PR TITLE
HPCC-13843 ECL Timing Data is missing GID

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -6030,12 +6030,12 @@ bool parseGraphScope(const char *scope, StringAttr &graphName, unsigned & graphN
         return false;
 
     graphNum = atoi(scope + CONST_STRLEN(GraphScopePrefix));
+    subGraphId = 0;
 
     const char * colon = strchr(scope, ':');
     if (!colon)
     {
         graphName.set(scope);
-        subGraphId = 0;
         return true;
     }
 
@@ -6043,7 +6043,6 @@ bool parseGraphScope(const char *scope, StringAttr &graphName, unsigned & graphN
     graphName.set(scope, (size32_t)(colon - scope));
     if (MATCHES_CONST_PREFIX(subgraph, SubGraphScopePrefix))
         subGraphId = atoi(subgraph+CONST_STRLEN(SubGraphScopePrefix));
-
     return true;
 }
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -829,6 +829,7 @@ void WsWuInfo::getGraphTimingData(IArrayOf<IConstECLTimingData> &timingData, uns
             g->setName(name.str());
             g->setGraphNum(graphNum);
             g->setSubGraphNum(subGraphId); // Use the Id - the number is not known
+            g->setGID(subGraphId);
             g->setMS(time);
             g->setMin(time/60000);
             timingData.append(*g.getClear());


### PR DESCRIPTION
Looks like a line was missed in code refactoring. The value returned was also
not always initialized correctly.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
