### PR TITLE
HPCC-13731 WorkunitsService does not always go via workunit.hpp

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -950,6 +950,9 @@ interface IConstWorkUnitInfo : extends IInterface
     virtual const char *queryStateDesc() const = 0;
     virtual WUAction getAction() const = 0;
     virtual const char *queryActionDesc() const = 0;
+    virtual WUPriorityClass getPriority() const = 0;
+    virtual const char *queryPriorityDesc() const = 0;
+    virtual int getPriorityLevel() const = 0;
     virtual bool isProtected() const = 0;
     virtual IJlibDateTime & getTimeScheduled(IJlibDateTime & val) const = 0;
 
@@ -989,8 +992,6 @@ interface IConstWorkUnit : extends IConstWorkUnitInfo
     virtual IConstWUPlugin * getPluginByName(const char * name) const = 0;
     virtual IConstWUPluginIterator & getPlugins() const = 0;
     virtual IConstWULibraryIterator & getLibraries() const = 0;
-    virtual WUPriorityClass getPriority() const = 0;
-    virtual int getPriorityLevel() const = 0;
     virtual IConstWUQuery * getQuery() const = 0;
     virtual bool getRescheduleFlag() const = 0;
     virtual IConstWUResult * getResultByName(const char * name) const = 0;
@@ -1192,6 +1193,7 @@ enum WUSortField
     WUSFecl = 13,
     // WUSFcustom = 14, obsolete
     WUSFappvalue=15,
+    WUSFfilewritten = 16,
     WUSFterm = 0,
     WUSFreverse = 256,
     WUSFnocase = 512,

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -262,6 +262,7 @@ public:
     virtual IConstWUPluginIterator & getPlugins() const;
     virtual IConstWULibraryIterator & getLibraries() const;
     virtual WUPriorityClass getPriority() const;
+    virtual const char *queryPriorityDesc() const;
     virtual int getPriorityLevel() const;
     virtual int getPriorityValue() const;
     virtual IConstWUQuery * getQuery() const;
@@ -552,6 +553,7 @@ protected:
     virtual void _lockRemote() {};
     virtual void _unlockRemote() {};
     virtual void _loadFilesRead() const;
+    virtual void _loadFilesWritten() const;
     virtual void _loadGraphs(bool heavy) const;
     virtual void _loadResults() const;
     virtual void _loadVariables() const;

--- a/ecl/wutest/CMakeLists.txt
+++ b/ecl/wutest/CMakeLists.txt
@@ -39,6 +39,14 @@ include_directories (
          ./../../testing/unittests 
     )
 
+if ( USE_CPPUNIT )
+  include_directories(
+         ./../../plugins/workunitservices
+         ./../../rtl/include
+         ./../../rtl/eclrtl
+    )
+endif()
+
 ADD_DEFINITIONS( -D_CONSOLE )
 if ( FORCE_WORKUNITS_TO_CASSANDRA )
   ADD_DEFINITIONS( -DFORCE_WORKUNITS_TO_CASSANDRA )
@@ -63,3 +71,6 @@ if ( FORCE_WORKUNITS_TO_CASSANDRA )
   target_link_libraries ( wutest cassandraembed )
 endif ()
 
+if ( USE_CPPUNIT )
+  target_link_libraries ( wutest workunitservices )
+endif()

--- a/plugins/workunitservices/workunitservices.hpp
+++ b/plugins/workunitservices/workunitservices.hpp
@@ -39,7 +39,7 @@ WORKUNITSERVICES_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb);
 WORKUNITSERVICES_API void setPluginContext(IPluginContext * _ctx);
 WORKUNITSERVICES_API char * WORKUNITSERVICES_CALL wsGetBuildInfo(void);
 
-WORKUNITSERVICES_API bool WORKUNITSERVICES_CALL wsWorkunitExists(const char *wuid, bool online, bool archived);
+WORKUNITSERVICES_API bool WORKUNITSERVICES_CALL wsWorkunitExists(ICodeContext *ctx, const char *wuid, bool online, bool archived);
 
 WORKUNITSERVICES_API void WORKUNITSERVICES_CALL wsWorkunitList(
                                                                 ICodeContext *ctx,

--- a/plugins/workunitservices/workunitservices.ipp
+++ b/plugins/workunitservices/workunitservices.ipp
@@ -65,6 +65,19 @@ inline void varAppend(MemoryBuffer &mb,unsigned w,IPropertyTree &pt,const char *
     mb.append(sz).append(sz,s.str());
 }
 
+inline void varAppendMax(MemoryBuffer &mb,unsigned w,const char *str, size32_t l=0)
+{
+    if (!str)
+        l = 0;
+    else if (l==0)
+        l = strlen(str);
+    if (l>w)
+        l = w;
+    mb.append(l).append(l, str);
+}
+
+// This is use by sasha - it's a real mess
+
 inline bool serializeWUSrow(IPropertyTree &pt,MemoryBuffer &mb, bool isonline)
 {
     mb.setEndian(__LITTLE_ENDIAN);


### PR DESCRIPTION
Removed the code that tried to fetch workunit subtrees from sasha - it was not
correct and thus could never have worked.

All workUnitsService code - unless explicitly querying Sasha - now uses
proper workunit.cpp interface and should work against Cassandra too.

Extended the lightweight workunit interface to include priority values since
they are part of the API implemented by this plugin.

Extended workunit API's getWorkUnitsSorted() capabilities to allow filtering
by files written.

Updated Cassandra workunit support to handle filesWritten and the new priority
values in the lightweight interface.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
