### PR TITLE
HPCC-13890 GetXXXcount workunit methods should be made more efficient

### DIFF
--- a/ecl/wutest/wutest.cpp
+++ b/ecl/wutest/wutest.cpp
@@ -1191,6 +1191,7 @@ protected:
         for (i = 0; i < testSize; i++)
         {
             Owned<IConstWorkUnit> wu = factory->openWorkUnit(wuids.item(i));
+            ASSERT(wu->getResultCount()==1);
             Owned<IConstWUResult> result = wu->getResultByName("Result 1");
             ASSERT(result);
             ASSERT(result->isResultScalar());


### PR DESCRIPTION
Actually they would not work correctly in Cassandra prior to this fix unless
the results had been previously loaded.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
