### PR TITLE
HPCC-14028 ECLAgent configuration not displaying

### DIFF
--- a/esp/src/eclwatch/WsTopology.js
+++ b/esp/src/eclwatch/WsTopology.js
@@ -214,9 +214,6 @@ define([
         },
         TpGetComponentFile: function (params) {
             params.handleAs = "text";
-            if (params.request.CompType === "EclAgentProcess") {
-                params.request.CompType = "AgentExecProcess";
-            }
             return ESPRequest.send("WsTopology", "TpGetComponentFile", params);
         },
         TpLogFile: function (params) {


### PR DESCRIPTION
When viewing services/eclagent and clicking on the configuration tab a message was received stating: "Unsupported component or file type specified!".

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
