### PR TITLE
HPCC-13951 Add suspended state to summary page

### DIFF
--- a/esp/src/eclwatch/ESPQuery.js
+++ b/esp/src/eclwatch/ESPQuery.js
@@ -119,7 +119,8 @@ define([
                 request:{
                     QueryId: this.Id,
                     QuerySet: this.QuerySetId,
-                    IncludeSuperFiles: 1
+                    IncludeSuperFiles: 1,
+                    IncludeStateOnClusters: 1
                 }
             }).then(function (response) {
                 if (lang.exists("WUQueryDetailsResponse", response)) {

--- a/esp/src/eclwatch/QuerySetDetailsWidget.js
+++ b/esp/src/eclwatch/QuerySetDetailsWidget.js
@@ -88,6 +88,7 @@ define([
             this.librariesUsedTab = registry.byId(this.id + "_LibrariesUsed");
             this.workunitsTab = registry.byId(this.id + "_Workunit");
             this.testPagesTab = registry.byId(this.id + "_TestPages");
+            this.suspended = registry.byId(this.id + "Suspended");
         },
 
         //  Hitched actions  ---
@@ -262,6 +263,16 @@ define([
                 this.librariesUsedTab.set("tooltip", tooltip);
             } else if (name === "Clusters") {
                 if (lang.exists("ClusterQueryState.length", newValue)) {
+                    var checkIfSuspended = false;
+                    if (newValue.ClusterQueryState[0].MixedNodeStates === true) {
+                        dom.byId(this.id + "SuspendCluster").src = dojoConfig.getImageURL("mixwarn.png");
+                        checkIfSuspended = true;
+                    } else if (newValue.ClusterQueryState[0].State === "Suspended") {
+                        dom.byId(this.id + "SuspendCluster").src = dojoConfig.getImageURL("errwarn.png");
+                        checkIfSuspended = true;
+                    }
+                    this.suspended.set("checked", checkIfSuspended);
+                    this.suspended.set("readOnly", checkIfSuspended);
                     this.errorsTab.set("title", this.i18n.ErrorsStatus + " (" + newValue.ClusterQueryState.length + ")");
                     var tooltip = "";
                     for (var i = 0; i < newValue.ClusterQueryState.length; ++i) {


### PR DESCRIPTION
Give the user the visual cue and checkbox state (read-only) if suspended by anything other than user.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
