### PR TITLE
HPCC-14034 Fix Search DFU By Cluster in legacy ECLWatch

### DIFF
--- a/esp/eclwatch/ws_XSLT/dfu_search.xslt
+++ b/esp/eclwatch/ws_XSLT/dfu_search.xslt
@@ -182,12 +182,12 @@
 
                                 if (first)
                                 {
-                                    url += "?ClusterName=" + cluster;
+                                    url += "?NodeGroup=" + cluster;
                                     first = false;
                                 }
                                 else
                                 {
-                                    url += "&ClusterName=" + cluster;
+                                    url += "&NodeGroup=" + cluster;
                                 }
                             }
 


### PR DESCRIPTION
In WsDfu.DFUQueryRequest, the request item for Search DFU
By Cluster has been renamed from ClusterName to NodeGroup.
It should be renamed in dfu_search.xslt.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
