### PR TITLE
HPCC-14022 Cannot view logs on multi-node env

### DIFF
--- a/esp/src/eclwatch/LogWidget.js
+++ b/esp/src/eclwatch/LogWidget.js
@@ -231,7 +231,7 @@ define([
         refreshGrid: function (clearSelection) {
             this.rawText.setText(this.i18n.loadingMessage);
             var filter = lang.mixin(this.getFilter(), {
-                Name: this.params.getLogDirectory() + "/" + this.logTargetSelect.get("value"),
+                Name: "//" + this.params.getNetaddress()+this.params.getLogDirectory() + "/" + this.logTargetSelect.get("value"),
                 Type: "tpcomp_log",
                 LoadData: 1
             });


### PR DESCRIPTION
Whenever navigating to the log viewer within the topology area within ecl watch a "Cannot find logfile.log" message would appear when clicking on the "logs" tab. This request was missing the NetAdress for each request being made therefore throwing this exception.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
