### PR TITLE
HPCC-14030 Preserve compression on single file

### DIFF
--- a/esp/src/eclwatch/templates/DFUQueryWidget.html
+++ b/esp/src/eclwatch/templates/DFUQueryWidget.html
@@ -67,6 +67,7 @@
                                         <input id="${id}CopyTargetWrap" title="${i18n.Wrap}:" name="Wrap" data-dojo-type="dijit.form.CheckBox" />
                                         <input id="${id}CopyTargetRetainSuperfileStructure" title="${i18n.RetainSuperfileStructure}:" name="superCopy" data-dojo-type="dijit.form.CheckBox" />
                                         <input id="${id}CopyPreserveCompression" title="${i18n.PreserveCompression}:" checked="true" name="preserveCompression" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}CopyTargetReplicate" title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                     </div>
                                 </div>
                                 <div class="dijitDialogPaneActionBar">

--- a/esp/src/eclwatch/templates/LFDetailsWidget.html
+++ b/esp/src/eclwatch/templates/LFDetailsWidget.html
@@ -28,6 +28,7 @@
                                         <input id="${id}CopyTargetCompress" title="${i18n.Compress}:" name="compress" data-dojo-type="dijit.form.CheckBox" />
                                         <input id="${id}CopyTargetWrap" title="${i18n.Wrap}:" name="Wrap" data-dojo-type="dijit.form.CheckBox" />
                                         <input id="${id}CopyTargetRetainSuperfileStructure" title="${i18n.RetainSuperfileStructure}:" name="superCopy" data-dojo-type="dijit.form.CheckBox" />
+                                        <input id="${id}CopyPreserveCompression" title="${i18n.PreserveCompression}:" checked="true" name="preserveCompression" data-dojo-type="dijit.form.CheckBox" />
                                     </div>
                                 </div>
                                 <div class="dijitDialogPaneActionBar">


### PR DESCRIPTION
We recently added preserve compression on the copy dialog within the list view of files. We should also add this to the dialog within the details view. Also, adding replicate to list view which appeared in the details dialog only.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
