### PR TITLE
HPCC-13958 Return CanReplicate in WsDfu.DFUInfo

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -82,6 +82,7 @@ ESPStruct [nil_remove] DFUFilePartsOnCluster
     [min_ver("1.31")] string BaseDir;
     [min_ver("1.31")] string ReplicateDir;
     [min_ver("1.31")] bool Replicate;
+    [min_ver("1.32")] bool CanReplicate;
     ESParray<ESPstruct DFUPart> DFUFileParts;
 };
 
@@ -691,7 +692,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUGetFileMetaDataRe
 
 //  ===========================================================================
 ESPservice [
-    version("1.31"),
+    version("1.32"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -71,15 +71,51 @@ static const char* FEATURE_URL="DfuAccess";
 
 #define REMOVE_FILE_SDS_CONNECT_TIMEOUT (1000*15)  // 15 seconds
 
+const unsigned NODE_GROUP_CACHE_MIN_DEFAULT = 30;
+
 const int DESCRIPTION_DISPLAY_LENGTH = 12;
 const unsigned MAX_VIEWKEYFILE_ROWS = 1000;
 const unsigned MAX_KEY_ROWS = 20;
 
 short days[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
+CThorNodeGroup* CThorNodeGroupCache::readNodeGroup(const char* _groupName)
+{
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IConstEnvironment> env = factory->openEnvironment();
+    if (!env)
+        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
+
+    Owned<IPropertyTree> root = &env->getPTree();
+    Owned<IPropertyTreeIterator> it= root->getElements("Software/ThorCluster");
+    ForEach(*it)
+    {
+        IPropertyTree& cluster = it->query();
+        StringBuffer groupName;
+        getClusterGroupName(cluster, groupName);
+        if (groupName.length() && strieq(groupName.str(), _groupName))
+            return new CThorNodeGroup(_groupName, cluster.getCount("ThorSlaveProcess"), cluster.getPropBool("@replicateOutputs", false));
+    }
+
+    return NULL;
+}
+
+CThorNodeGroup* CThorNodeGroupCache::lookup(const char* groupName, unsigned timeOutMinutes)
+{
+    CriticalBlock block(sect);
+    CThorNodeGroup* item=SuperHashTableOf<CThorNodeGroup, const char>::find(groupName);
+    if (item && !item->checkTimeOut(timeOutMinutes))
+        return LINK(item);
+
+    Owned<CThorNodeGroup> e = readNodeGroup(groupName);
+    if (e)
+        replace(*e.getLink()); //if not exists, will be added.
+
+    return e.getClear();
+}
+
 void CWsDfuEx::init(IPropertyTree *cfg, const char *process, const char *service)
 {
-
     StringBuffer xpath;
     
     DBGLOG("Initializing %s service [process = %s]", service, process);
@@ -110,6 +146,10 @@ void CWsDfuEx::init(IPropertyTree *cfg, const char *process, const char *service
     m_disableUppercaseTranslation = false;
     if (streq(disableUppercaseTranslation.str(), "true"))
         m_disableUppercaseTranslation = true;
+
+    xpath.clear().appendf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/NodeGroupCacheMinutes", process, service);
+    nodeGroupCacheMinutes = cfg->getPropInt(xpath.str(), NODE_GROUP_CACHE_MIN_DEFAULT);
+    thorNodeGroupCache.setown(new CThorNodeGroupCache());
 
     if (!daliClientActive())
         throw MakeStringException(-1, "No Dali Connection Active. Please Specify a Dali to connect to in you configuration file");
@@ -1795,6 +1835,9 @@ void CWsDfuEx::getFilePartsOnClusters(IEspContext &context, const char* clusterR
             if (clusterInfo) //Should be valid. But, check it just in case.
             {
                 partsOnCluster->setReplicate(clusterInfo->queryPartDiskMapping().isReplicated());
+                Owned<CThorNodeGroup> nodeGroup = thorNodeGroupCache->lookup(clusterName, nodeGroupCacheMinutes);
+                if (nodeGroup)
+                    partsOnCluster->setCanReplicate(nodeGroup->queryCanReplicate());
                 const char* defaultDir = fdesc->queryDefaultDir();
                 if (defaultDir && *defaultDir)
                 {

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -278,6 +278,9 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
         </xsl:variable>
 
         <EspService name="{$serviceName}" type="{$serviceType}" plugin="{$servicePlugin}">
+            <xsl:if test="string(@NodeGroupCacheMinutes) != ''">
+                <NodeGroupCacheMinutes><xsl:value-of select="@NodeGroupCacheMinutes"/></NodeGroupCacheMinutes>
+            </xsl:if>
             <xsl:if test="string(@disableUppercaseTranslation) != ''">
                 <DisableUppercaseTranslation><xsl:value-of select="@disableUppercaseTranslation"/></DisableUppercaseTranslation>
             </xsl:if>

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -90,6 +90,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="NodeGroupCacheMinutes" type="xs:nonNegativeInteger" use="optional" default="30">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>timeout for node group cache (in minutes).</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="ActivityInfoCacheSeconds" type="xs:nonNegativeInteger" use="optional" default="10">
                 <xs:annotation>
                     <xs:appinfo>


### PR DESCRIPTION
This fix checks and returns whether a logical file can
be replicated on a cluster or not. The information will
be used by new ECLWatch to show a Replicate button on
the Logical File Details page. The file can only be
replicated on a cluster if: 1. the cluster is a thor
cluster; 2. the cluster has multiple nodes; and 3. the
@replicateOutputs attribute is set to true.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
