### PR TITLE
HPCC-14043 CWorkunitResumeHandler reads dali workunit branch directly

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -696,10 +696,20 @@ interface IConstLocalFileUploadIterator : extends IScmIterator
 
 enum WUSubscribeOptions
 {
+    SubscribeOptionState = 1,
     SubscribeOptionAbort = 2,
+    SubscribeOptionAction = 4
 };
 
+interface IWorkUnitSubscriber
+{
+    virtual void notify(WUSubscribeOptions flags) = 0;
+};
 
+interface IWorkUnitWatcher : extends IInterface
+{
+    virtual void unsubscribe() = 0;
+};
 
 interface IWUGraphProgress;
 interface IPropertyTree;
@@ -1259,6 +1269,7 @@ interface IWorkUnitFactory : extends IInterface
     virtual bool isAborting(const char *wuid) const = 0;
     virtual void clearAborting(const char *wuid) = 0;
     virtual WUState waitForWorkUnit(const char * wuid, unsigned timeout, bool compiled, bool returnOnWaitState) = 0;
+    virtual WUAction waitForWorkUnitAction(const char * wuid, WUAction original) = 0;
 
     virtual unsigned validateRepository(bool fixErrors) = 0;
     virtual void deleteRepository(bool recreate) = 0;
@@ -1266,6 +1277,7 @@ interface IWorkUnitFactory : extends IInterface
     virtual const char *queryStoreType() const = 0; // Returns "Dali" or "Cassandra"
 
     virtual StringArray &getUniqueValues(WUSortField field, const char *prefix, StringArray &result) const = 0;
+    virtual IWorkUnitWatcher *getWatcher(IWorkUnitSubscriber *subscriber, WUSubscribeOptions options, const char *wuid) const = 0;
 };
 
 interface IWorkflowScheduleConnection : extends IInterface
@@ -1455,6 +1467,8 @@ void WORKUNIT_API testWorkflow();
 #endif
 
 extern WORKUNIT_API const char * getWorkunitStateStr(WUState state);
+extern WORKUNIT_API const char * getWorkunitActionStr(WUAction action);
+extern WORKUNIT_API WUAction getWorkunitAction(const char * actionStr);
 
 extern WORKUNIT_API void addTimeStamp(IWorkUnit * wu, StatisticScopeType scopeType, const char * scope, StatisticKind kind);
 

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -562,88 +562,23 @@ protected:
     virtual void _loadExceptions() const;
 };
 
-class CPersistedWorkUnit : public CLocalWorkUnit
+class CPersistedWorkUnit : public CLocalWorkUnit, implements IWorkUnitSubscriber
 {
 public:
     CPersistedWorkUnit(ISecManager *secmgr, ISecUser *secuser) : CLocalWorkUnit(secmgr, secuser)
-{
+    {
         abortDirty = true;
         abortState = false;
     }
-
-    virtual void subscribe(WUSubscribeOptions options)
-    {
-        CriticalBlock block(crit);
-        assertex(options==SubscribeOptionAbort);
-        if (!abortWatcher)
-        {
-            abortWatcher.setown(new CWorkUnitAbortWatcher(this, p->queryName()));
-            abortDirty = true;
-        }
-    }
-    virtual void unsubscribe()
-    {
-        CriticalBlock block(crit);
-        if (abortWatcher)
-        {
-            abortWatcher->unsubscribe();
-            abortWatcher.clear();
-        }
-    }
-
-    virtual bool aborting() const
-    {
-        CriticalBlock block(crit);
-        if (abortDirty)
-        {
-            StringBuffer apath;
-            apath.append("/WorkUnitAborts/").append(p->queryName());
-            Owned<IRemoteConnection> acon = querySDS().connect(apath.str(), myProcessSession(), 0, SDS_LOCK_TIMEOUT);
-            if (acon)
-                abortState = acon->queryRoot()->getPropInt(NULL) != 0;
-            else
-                abortState = false;
-            abortDirty = false;
-        }
-        return abortState;
-    }
-
+    virtual void subscribe(WUSubscribeOptions options);
+    virtual void unsubscribe();
+    virtual bool aborting() const;
 protected:
-    class CWorkUnitAbortWatcher : public CInterface, implements ISDSSubscription
-    {
-        CPersistedWorkUnit *parent; // not linked - it links me
-        SubscriptionId abort;
-    public:
-        IMPLEMENT_IINTERFACE;
-        CWorkUnitAbortWatcher(CPersistedWorkUnit *_parent, const char *wuid) : parent(_parent)
-        {
-            StringBuffer wuRoot;
-            wuRoot.append("/WorkUnitAborts/").append(wuid);
-            abort = querySDS().subscribe(wuRoot.str(), *this);
-        }
-        ~CWorkUnitAbortWatcher()
-        {
-            assertex(abort==0);
-        }
-
-        void unsubscribe()
-        {
-            querySDS().unsubscribe(abort);
-            abort = 0;
-        }
-
-        void notify(SubscriptionId id, const char *xpath, SDSNotifyFlags flags, unsigned valueLen, const void *valueData)
-        {
-            parent->abortDirty = true;
-        }
-    };
-
-    Owned<CWorkUnitAbortWatcher> abortWatcher;
+    virtual void notify(WUSubscribeOptions) { abortDirty = true; }
+    Owned<IWorkUnitWatcher> abortWatcher;
     mutable bool abortDirty;
     mutable bool abortState;
 };
-
-interface ISDSManager; // MORE - can remove once dali split out
 
 class CWorkUnitFactory : public CInterface, implements IWorkUnitFactory
 {
@@ -738,24 +673,39 @@ protected:
     unsigned id;
 };
 
-class WorkUnitWaiter : public CInterface, implements ISDSSubscription, implements IAbortHandler
+class CWorkUnitWatcher : public CInterface, implements IWorkUnitWatcher, implements ISDSSubscription
 {
-    Semaphore changed;
-    SubscriptionId change;
-    SDSNotifyFlags watchFor;
+protected:
+    CriticalSection crit;
+    IWorkUnitSubscriber *subscriber; // not linked - it will generally link me
+    SubscriptionId abortId, stateId, actionId;
 public:
     IMPLEMENT_IINTERFACE;
+    CWorkUnitWatcher(IWorkUnitSubscriber *_subscriber, WUSubscribeOptions flags, const char *wuid);
+    ~CWorkUnitWatcher();
+    void unsubscribe();
+    void notify(SubscriptionId id, const char *xpath, SDSNotifyFlags flags, unsigned valueLen, const void *valueData);
+};
 
-    WorkUnitWaiter(const char *xpath, SDSNotifyFlags _watchFor)
-    : watchFor(_watchFor)
+class WorkUnitWaiter : public CInterface, implements IAbortHandler, implements IWorkUnitSubscriber
+{
+    Semaphore changed;
+    Owned<IWorkUnitWatcher> watcher;
+public:
+    IMPLEMENT_IINTERFACE;
+    WorkUnitWaiter(const char *wuid, WUSubscribeOptions watchFor)
     {
-        change = querySDS().subscribe(xpath, *this, false);
+        Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
+        watcher.setown(factory->getWatcher(this, watchFor, wuid));
         aborted = false;
     }
-    void notify(SubscriptionId id, const char *xpath, SDSNotifyFlags flags, unsigned valueLen, const void *valueData)
+    ~WorkUnitWaiter()
     {
-        if (flags & watchFor)
-            changed.signal();
+        unsubscribe();
+    }
+    void notify(WUSubscribeOptions flags)
+    {
+        changed.signal();
     }
     bool wait(unsigned timeout)
     {
@@ -769,8 +719,11 @@ public:
     }
     void unsubscribe()
     {
-        querySDS().unsubscribe(change);
-        change = 0;
+        if (watcher)
+        {
+            watcher->unsubscribe();
+            watcher.clear();
+        }
     }
     bool aborted;
 };


### PR DESCRIPTION
Refactor to use dali subscriptions whenever waiting for workunits, and for
Cassandra workunit repository to ensure that it triggers them when state or
action change.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
