### PR TITLE
HPCC-14047 Default newBalancedSpotter off as deadlock workaround

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1754,7 +1754,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.alwaysUseGraphResults,"alwaysUseGraphResults",false),
         DebugOption(options.noConditionalLinks,"noConditionalLinks",false),
         DebugOption(options.reportAssertFilenameTail,"reportAssertFilenameTail",false),        
-        DebugOption(options.newBalancedSpotter,"newBalancedSpotter",true),
+        DebugOption(options.newBalancedSpotter,"newBalancedSpotter",false),
         DebugOption(options.keyedJoinPreservesOrder,"keyedJoinPreservesOrder",true),
         DebugOption(options.expandSelectCreateRow,"expandSelectCreateRow",false),
         DebugOption(options.optimizeSortAllFields,"optimizeSortAllFields",true),


### PR DESCRIPTION
HPCC-11400 introduced a new scheme for spotting balanced
splitters, unfortunately it seems some graphs, particularly
involving joins down stream still cause the splitters to be
misidentified as balanced and consequently cause deadlock in Thor

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
