### PR TITLE
HPCC-10811 ECL WU should indicate that an eclagent job is 'spraying'

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -170,26 +170,14 @@ static IConstWorkUnit * getWorkunit(ICodeContext * ctx)
     return factory->openWorkUnit(wuid);
 }
 
-static WUState queryWorkunitState(ICodeContext * ctx, SCMStringBuffer &stateEx)
-{
-    Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
-    Owned<IConstWorkUnit> wu(factory->openWorkUnit(ctx->getWuid()));
-    WUState state = WUStateRunning;
-    if (wu)
-    {
-        state = wu->getState();
-        wu->getStateEx(stateEx);
-    }
-    return state;
-}
-
 static void setWorkunitState(ICodeContext * ctx, WUState state, const char * msg)
 {
     Owned<IWorkUnit> wu = ctx->updateWorkUnit();
     if (wu)
     {
-        wu->setState(state);
-        wu->setStateEx(msg);
+        wu->setState(state);//resets stateEx
+        if (msg)
+            wu->setStateEx(msg);
         wu->commit();
     }
 }
@@ -543,8 +531,7 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
 
     unsigned polltime = 1;
 
-    StringBuffer reason;
-    reason.appendf("Blocked by fileservice activity: %s",label);
+    VStringBuffer reason("Blocked by fileservice activity: %s",label);
     setWorkunitState(ctx, WUStateBlocked, reason.str());
 
     while(true)

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -545,6 +545,7 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
 
     SCMStringBuffer prevStateEx;
     WUState prevState = queryWorkunitState(ctx, prevStateEx);
+    assertex(prevState == WUStateRunning);
 
     StringBuffer reason;
     reason.appendf("Blocked by fileservice activity: %s",label);
@@ -560,7 +561,7 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
         const IMultiException* excep = &result->getExceptions();
         if ((excep != NULL) && (excep->ordinality() > 0))
         {
-            setWorkunitState(ctx, prevState, prevStateEx.str());
+            setWorkunitState(ctx, WUStateRunning, prevStateEx.str());
             StringBuffer errmsg;
             excep->errorMessage(errmsg);
             throw MakeStringExceptionDirect(0, errmsg.str());
@@ -599,18 +600,18 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
         case DFUstate_monitoring:
             if (monitoringok)
             {
-                setWorkunitState(ctx, prevState, prevStateEx.str());
+                setWorkunitState(ctx, WUStateRunning, prevStateEx.str());
                 return;
             }
             break;
 
         case DFUstate_aborted:
         case DFUstate_failed:
-            setWorkunitState(ctx, prevState, prevStateEx.str());
+            setWorkunitState(ctx, WUStateRunning, prevStateEx.str());
             throw MakeStringException(0, "DFUServer Error %s", dfuwu.getSummaryMessage());
 
         case DFUstate_finished:
-            setWorkunitState(ctx, prevState, prevStateEx.str());
+            setWorkunitState(ctx, WUStateRunning, prevStateEx.str());
             return;
         }
 
@@ -620,7 +621,7 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
             abortReq->setWuid(wuid);
             Linked<IClientAbortDFUWorkunitResponse> abortResp = server.AbortDFUWorkunit(abortReq);
 
-            setWorkunitState(ctx, prevState, prevStateEx.str());
+            setWorkunitState(ctx, WUStateRunning, prevStateEx.str());
 
             //  Add warning of DFU Abort Request - should this be information  ---
             StringBuffer s("DFU Workunit Abort Requested for ");
@@ -631,7 +632,7 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
 
         if (time.timedout()) {
             unsigned left = dfuwu.getSecsLeft();
-            setWorkunitState(ctx, prevState, prevStateEx.str());
+            setWorkunitState(ctx, WUStateRunning, prevStateEx.str());
             if (left)
                 throw MakeStringException(0, "%s timed out, DFU Secs left:  %d)", label, left);
             throw MakeStringException(0, "%s timed out)", label);
@@ -645,7 +646,7 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
             polltime = WAIT_SECONDS;
 
     }
-    setWorkunitState(ctx, prevState, prevStateEx.str());
+    setWorkunitState(ctx, WUStateRunning, prevStateEx.str());
 }
 
 


### PR DESCRIPTION
Currently when a workunit is performing a DFU operation, the WUState remains
as "Running" and there is no WUStateEx set.  This PR updates the WUStatus to
"Blocked" and the WUStateEx to "Blocked by fileservice activity: %s" for any
blocking DFU activity, and resets it upon completion

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
