### PR TITLE
HPCC-14051 WsEcl empty form fields should be treated as null

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -7229,8 +7229,10 @@ IPropertyTree *createPTreeFromHttpParameters(const char *name, IProperties *para
         StringBuffer key = props->getPropKey();
         if (!key.length() || key.charAt(key.length()-1)=='!')
             continue;
-        const char *value = parameters->queryProp(key);
         if (skipLeadingDotParameters && key.charAt(0)=='.')
+            continue;
+        const char *value = parameters->queryProp(key);
+        if (!value || !*value)
             continue;
         ensureHttpParameter(pt, key, value);
     }


### PR DESCRIPTION
Another regression introduced when switching to common
createPTreeFromHttpParameters() method.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
