### PR TITLE
HPCC-13985 Fix graph result accessed by generated code on master

### DIFF
--- a/thorlcr/master/thactivitymaster.cpp
+++ b/thorlcr/master/thactivitymaster.cpp
@@ -372,10 +372,10 @@ public:
                 break;
             case TAKlocalresultspill:
             case TAKlocalresultwrite:
-                if (!queryOwner().queryOwner() || queryOwner().isGlobal()) // don't need result in master if in local child query
-                    ret = createLocalResultActivityMaster(this);
-                else
-                    ret = new CMasterActivity(this);
+                /* NB: create even if non-global child graph, because although the result itself
+                 * won't be used, codegen. graph initialization code, may reference the result on the master
+                 */
+                ret = createLocalResultActivityMaster(this);
                 break;
             case TAKgraphloopresultwrite:
                 ret = createGraphLoopResultActivityMaster(this);


### PR DESCRIPTION
A child query may access a result on the master during
initialization, e.g. in onStart() generated code, even though it
will only be used on the slaves. Therefore, need to create the
result on the master to avoid initialization problems.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
