### PR TITLE
HPCC-14058 Workunit services not honouring #option('slaveDaliClient',true)

### DIFF
--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1028,7 +1028,7 @@ public:
     virtual bool allowDaliAccess() const
     {
         // NB. includes access to foreign Dalis.
-        return globals->getPropBool("Debug/@slaveDaliClient");
+        return globals->getPropBool("Debug/@slaveDaliClient") || job.getWorkUnitValueBool("slaveDaliClient", false);
     }
 };
 


### PR DESCRIPTION
Since fixing some instances when workunit services plugin did not check that
dali access was permitted (as part of the Cassandra migration), it was
revealed that the check was incorrectly ignoring any per-job overrides.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
