### PR TITLE
Replaced unicode registered trademark character with (R) in python copy write headers

### DIFF
--- a/initfiles/sbin/cluster_script.py
+++ b/initfiles/sbin/cluster_script.py
@@ -2,7 +2,7 @@
 '''
 /*#############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems(R).
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/initfiles/sbin/hpcc/cluster/host.py
+++ b/initfiles/sbin/hpcc/cluster/host.py
@@ -1,7 +1,7 @@
 '''
 /*#############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems(R).
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/initfiles/sbin/hpcc/cluster/task.py
+++ b/initfiles/sbin/hpcc/cluster/task.py
@@ -1,7 +1,7 @@
 '''
 /*#############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems(R).
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/initfiles/sbin/hpcc/cluster/thread.py
+++ b/initfiles/sbin/hpcc/cluster/thread.py
@@ -1,7 +1,7 @@
 '''
 /*#############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems(R).
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Quick fix for the (R) to ® change that occurred in our copy write headers

We can encode the python files as utf-8 as well, we just have to declare it at the top of each python file or else the python2 interpreter will throw an error.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
