### PR TITLE
HPCC-13150 Keydiff.ecl fails for multiPart=false

### DIFF
--- a/system/jhtree/keydiff.cpp
+++ b/system/jhtree/keydiff.cpp
@@ -246,7 +246,7 @@ public:
         else if(blobHead != 0)
             throw MakeStringException(0, "Index contains BLOBs, which are currently not supported by keydiff/patch");
         if(keyIndex->queryMetadataHead())
-            throw MakeStringException(0, "Index contains metadata, which is not currently supported by keydiff/patch");
+            WARNLOG("Index contains metadata, which will be ignored by keydiff/patch");
         keyCursor.setown(keyIndex->getCursor(NULL));
         if(keyIndex->hasPayload())
             keyedsize = keyIndex->keyedSize();


### PR DESCRIPTION
Ignore...

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
