### PR TITLE
HPCC-14072 CUtfPartitioner::storeFieldName() generates invalid field names.

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -1041,7 +1041,7 @@ void CUtfPartitioner::storeFieldName(const char * start, unsigned len)
     }
     else
     {
-        fieldName.append("field").append(fieldCount);
+        fieldName.set("field").append(fieldCount);
     }
 
     // Check discovered field name uniqueness


### PR DESCRIPTION
Remove leftover in field name generation.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
