### PR TITLE
HPCC-14067 Avoid possible deadlock if spilling + callback called

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -1041,7 +1041,7 @@ void CUtfPartitioner::storeFieldName(const char * start, unsigned len)
     }
     else
     {
-        fieldName.append("field").append(fieldCount);
+        fieldName.set("field").append(fieldCount);
     }
 
     // Check discovered field name uniqueness


### PR DESCRIPTION
When the memory manager is actively trying to free memory at the
same time that a spilling stream is spilling and in the process
of deregistering it's callback a deadlock can occur - it can
block on a rows lock.
Avoid by checking if already spilt upfront in the callback and
exiting.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
