### PR TITLE
HPCC-14063 Nagios toolbar icon out of sync

### DIFF
--- a/esp/src/eclwatch/HPCCPlatformWidget.js
+++ b/esp/src/eclwatch/HPCCPlatformWidget.js
@@ -232,7 +232,7 @@ define([
 
         checkMonitoring: function (status) {
             if (status) {
-                domClass.remove("MonitorStatus", status);
+                domClass.remove("MonitorStatus");
                 domClass.add("MonitorStatus", status);
             }
         },


### PR DESCRIPTION
Whenever ECL Watch was fetching the latest nagios status if a state change was present the toolbar icon would not update. This was due to removing a class that was possibly not present. Therefore, we will remove all classes and set the class based on the response.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
