### PR TITLE
HPCC-13708 Streamed datasets from Python not thread-safe

### DIFF
--- a/testing/regress/ecl/key/streame.xml
+++ b/testing/regress/ecl/key/streame.xml
@@ -15,5 +15,11 @@
  <Row><name>Generate:</name><value>9</value></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><Result_3>Yo</Result_3></Row>
+ <Row><Result_3>500</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>499</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>Yo</Result_5></Row>
 </Dataset>

--- a/testing/regress/ecl/streame.ecl
+++ b/testing/regress/ecl/streame.ecl
@@ -65,6 +65,11 @@ ENDEMBED;
 output(streamedNames(d'AA', u'là'));
 output (testGenerator(10));
 
+// Test what happens when two threads pull from a generator
+c := testGenerator(1000);
+count(c(value < 500));
+count(c(value > 500));
+
 // Test Python code returning named tuples
 childrec tnamed(string s) := EMBED(Python)
   import collections;


### PR DESCRIPTION
There are two issues - we need to ensure that we get the Python
interpreter lock before releasing the iterator object, and we should not
assume that we are operating on the same thread as the one that originally
created the iterator.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
