### PR TITLE
HPCC-14093 Fix regression causing corrupt dafilesrv commands

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -3092,6 +3092,7 @@ class CRemoteFileServer : public CInterface, implements IRemoteFileServer
         Owned<ISocket> socket;
         StringAttr peerName;
         Owned<IAuthenticatedUser> user;
+        MemoryBuffer msg;
         bool selecthandled;
         size32_t left;
         IArrayOf<IFileIO>   openfiles;      // kept in sync with handles
@@ -3136,6 +3137,7 @@ class CRemoteFileServer : public CInterface, implements IRemoteFileServer
             }
             parent = _parent;
             left = 0;
+            msg.setEndian(__BIG_ENDIAN);
             selecthandled = false;
             touch();
         }
@@ -3166,8 +3168,6 @@ class CRemoteFileServer : public CInterface, implements IRemoteFileServer
             size32_t avail = (size32_t)socket->avail_read();
             if (avail)
                 touch();
-            MemoryBuffer msg;
-            msg.setEndian(__BIG_ENDIAN);
             if (left==0)
             {
                 try
@@ -3226,19 +3226,22 @@ class CRemoteFileServer : public CInterface, implements IRemoteFileServer
                     EXCLOG(e,"notifySelected(3)");
                     e->Release();
                     toread = left;
+                    msg.clear();
                 }
             }
             if (TF_TRACE_FULL)
                 PROGLOG("notifySelected %d,%d",toread,left);
-            if ((left!=0)&&(avail==0)) {
+            if ((left!=0)&&(avail==0))
+            {
                 WARNLOG("notifySelected: Closing mid packet, %d remaining", left);
                 toread = left;
+                msg.clear();
             }
             left -= toread;
             if (left==0)
             {
                 // DEBUG
-                parent->notify(this, msg);
+                parent->notify(this, msg); // consumes msg
             }
             return false;
         }
@@ -3755,6 +3758,7 @@ class CRemoteFileServer : public CInterface, implements IRemoteFileServer
 
         struct cCommandProcessorParams
         {
+            cCommandProcessorParams() { msg.setEndian(__BIG_ENDIAN); }
             CRemoteClientHandler *client;
             MemoryBuffer msg;
         };
@@ -5167,7 +5171,8 @@ public:
             PROGLOG("notify %d", msg.length());
         if (msg.length())
         {
-            PROGLOG("notify CRemoteClientHandler(%p), msg length=%u", _client, msg.length());
+            if (TF_TRACE_FULL)
+                PROGLOG("notify CRemoteClientHandler(%p), msg length=%u", _client, msg.length());
             cCommandProcessor::cCommandProcessorParams params;
             params.client = client.getClear();
             params.msg.swapWith(msg);

--- a/dali/dafilesrv/CMakeLists.txt
+++ b/dali/dafilesrv/CMakeLists.txt
@@ -20,3 +20,7 @@ include (dafilesrv.cmake)
 if ( PLATFORM )
     include (dafscontrol.cmake)
 endif()
+
+include_directories ( 
+         ${CMAKE_BINARY_DIR}
+    )

--- a/dali/dafilesrv/dafilesrv.cpp
+++ b/dali/dafilesrv/dafilesrv.cpp
@@ -18,6 +18,7 @@
 #include "platform.h"
 #include "portlist.h"
 
+#include "build-config.h"
 #include "jlib.hpp"
 #include "jiface.hpp"
 #include "jutil.hpp"
@@ -657,6 +658,7 @@ int main(int argc,char **argv)
         lf->beginLogging();
     }
 
+    PROGLOG("Dafilesrv starting - Build %s", BUILD_TAG);
     PROGLOG("Parallel request limit = %d, throttleDelayMs = %d, throttleCPULimit = %d", parallelRequestLimit, throttleDelayMs, throttleCPULimit);
 
     const char * verstring = remoteServerVersionString();


### PR DESCRIPTION
The throttling refactoring (see HPCC-13573), introduced a couple
of issues, which caused commands to be corrupted.
a) The 1st part(s) of partial messages, handled by select
notifier were lost, with only the last fragment being submitted
as a command. Only really noticable for large messages.
b) There was a transfer of MemoryBuffer content using swapWith,
which caused a buffer to subsequently used with the wrong
endianess.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
