### PR TITLE
HPCC-14095 Fix race condition on shared spilling stream.

### DIFF
--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -286,12 +286,12 @@ class CSharedSpillableRowSet : public CSpillableStreamBase, implements IInterfac
         {
             pos = 0;
             outputOffset = (offset_t)-1;
-            owner->rows.registerWriteCallback(*this);
+            owner->rows.registerWriteCallback(*this); // NB: CStream constructor called within rows lock
         }
         ~CStream()
         {
             spillStream.clear(); // NB: clear stream 1st
-            owner->rows.unregisterWriteCallback(*this);
+            owner->rows.safeUnregisterWriteCallback(*this);
             owner.clear();
         }
     // IRowStream
@@ -341,17 +341,14 @@ public:
     }
     IRowStream *createRowStream()
     {
+        CRowsLockBlock block(*this);
+        if (spillFile) // already spilled?
         {
-            // already spilled?
-            CRowsLockBlock block(*this);
-            if (spillFile)
-            {
-                block.clearCB = true;
-                unsigned rwFlags = DEFAULT_RWFLAGS;
-                if (preserveNulls)
-                    rwFlags |= rw_grouped;
-                return ::createRowStream(spillFile, rowIf, rwFlags);
-            }
+            block.clearCB = true;
+            unsigned rwFlags = DEFAULT_RWFLAGS;
+            if (preserveNulls)
+                rwFlags |= rw_grouped;
+            return ::createRowStream(spillFile, rowIf, rwFlags);
         }
         return new CStream(*this);
     }
@@ -1197,11 +1194,21 @@ void CThorExpandingRowArray::deserializeExpand(size32_t sz, const void *data)
 
 void CThorSpillableRowArray::registerWriteCallback(IWritePosCallback &cb)
 {
-    CThorArrayLockBlock block(*this);
     writeCallbacks.append(cb); // NB not linked to avoid circular dependency
 }
 
 void CThorSpillableRowArray::unregisterWriteCallback(IWritePosCallback &cb)
+{
+    writeCallbacks.zap(cb);
+}
+
+void CThorSpillableRowArray::safeRegisterWriteCallback(IWritePosCallback &cb)
+{
+    CThorArrayLockBlock block(*this);
+    writeCallbacks.append(cb); // NB not linked to avoid circular dependency
+}
+
+void CThorSpillableRowArray::safeUnregisterWriteCallback(IWritePosCallback &cb)
 {
     CThorArrayLockBlock block(*this);
     writeCallbacks.zap(cb);

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -416,6 +416,8 @@ public:
     }
     void registerWriteCallback(IWritePosCallback &cb);
     void unregisterWriteCallback(IWritePosCallback &cb);
+    void safeRegisterWriteCallback(IWritePosCallback &cb);
+    void safeUnregisterWriteCallback(IWritePosCallback &cb);
     inline void setAllowNulls(bool b) { CThorExpandingRowArray::setAllowNulls(b); }
     inline void setDefaultMaxSpillCost(unsigned defaultMaxSpillCost) { CThorExpandingRowArray::setDefaultMaxSpillCost(defaultMaxSpillCost); }
     inline unsigned queryDefaultMaxSpillCost() const { return CThorExpandingRowArray::queryDefaultMaxSpillCost(); }


### PR DESCRIPTION
There was a small window, where a shared stream is requested
and it has yet not spilled, if during the creation of the stream
it spills, the stream will not have registered its callback and
will not have been told it's relative position in the spill file.
Then when the stream is read an assertion is hit.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
