### PR TITLE
HPCC-14098 eclcmd errors from calling should not display usage

### DIFF
--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -663,7 +663,7 @@ bool EclCmdWithEclTarget::finalizeOptions(IProperties *globals)
     {
         ConvertEclParameterToArchive conversion(*this);
         if (!conversion.process())
-            return false;
+            exit(1); //rare case, not a usage error
     }
     if (optResultLimit == (unsigned)-1)
         extractEclCmdOption(optResultLimit, globals, ECLOPT_RESULT_LIMIT_ENV, ECLOPT_RESULT_LIMIT_INI, 0);


### PR DESCRIPTION
Regression in 5.4, ecl command displays usage when ecl syntax or other issue causes error returned from eclcc.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
