### PR TITLE
HPCC-13384 WUQuery/WUDetails need schedule buttons

### DIFF
--- a/esp/src/eclwatch/ESPWorkunit.js
+++ b/esp/src/eclwatch/ESPWorkunit.js
@@ -263,6 +263,9 @@ define([
         isComplete: function () {
             return this.hasCompleted;
         },
+        isFailed: function () {
+            return this.StateID === 4;
+        },
         isDeleted: function () {
             return this.StateID === 999;
         },
@@ -280,6 +283,14 @@ define([
                     }
                 });
             }
+        },
+        doDeschedule: function () {
+            return this._action("Deschedule").then(function(response) {
+            });
+        },
+        doReschedule: function () {
+            return this._action("Reschedule").then(function(response) {
+            });
         },
         create: function (ecl) {
             var context = this;

--- a/esp/src/eclwatch/WUDetailsWidget.js
+++ b/esp/src/eclwatch/WUDetailsWidget.js
@@ -179,6 +179,12 @@ define([
         _onRecover: function (event) {
             this.wu.recover();
         },
+        _onDeschedule: function (event) {
+            this.wu.doDeschedule();
+        },
+        _onReschedule: function (event) {
+            this.wu.doReschedule();
+        },
         _onPublish: function (event) {
             var allowForeign = registry.byId(this.id + "AllowForeignFiles");
             if (allowForeign.checked == true) {
@@ -496,6 +502,8 @@ define([
             registry.byId(this.id + "Recover").set("disabled", isArchived || !this.wu.isComplete() || this.wu.isDeleted());
             registry.byId(this.id + "Publish").set("disabled", isArchived || !this.wu.isComplete() || this.wu.isDeleted());
             registry.byId(this.id + "ZapReport").set("disabled", this.wu.isDeleted());
+            registry.byId(this.id + "Reschedule").set("disabled", !this.wu.isComplete() || this.wu.isFailed());
+            registry.byId(this.id + "Deschedule").set("disabled", this.wu.isComplete() || this.wu.isFailed());
 
             registry.byId(this.id + "Jobname").set("readOnly", !this.wu.isComplete() || this.wu.isDeleted());
             registry.byId(this.id + "Description").set("readOnly", !this.wu.isComplete() || this.wu.isDeleted());

--- a/esp/src/eclwatch/WUQueryWidget.js
+++ b/esp/src/eclwatch/WUQueryWidget.js
@@ -155,9 +155,11 @@ define([
         },
 
         _onReschedule: function (event) {
+            WsWorkunits.WUAction(this.workunitsGrid.getSelected(), "Reschedule");
         },
 
         _onDeschedule: function (event) {
+            WsWorkunits.WUAction(this.workunitsGrid.getSelected(), "Deschedule");
         },
 
         _onRowDblClick: function (wuid) {
@@ -473,6 +475,8 @@ define([
             var hasNotFailed = false;
             var hasCompleted = false;
             var hasNotCompleted = false;
+            var isScheduled = false;
+            var isNotScheduled = false;
             for (var i = 0; i < selection.length; ++i) {
                 hasSelection = true;
                 if (selection[i] && selection[i].Protected !== null) {
@@ -494,6 +498,11 @@ define([
                         hasNotCompleted = true;
                     }
                 }
+                if (selection[i].EventSchedule === 2) {
+                    isScheduled = true;
+                } else if (selection[i].EventSchedule === 1) {
+                    isNotScheduled = true;
+                }
             }
 
             registry.byId(this.id + "Open").set("disabled", !hasSelection);
@@ -502,8 +511,8 @@ define([
             registry.byId(this.id + "SetToFailed").set("disabled", !hasNotProtected);
             registry.byId(this.id + "Protect").set("disabled", !hasNotProtected);
             registry.byId(this.id + "Unprotect").set("disabled", !hasProtected);
-            registry.byId(this.id + "Reschedule").set("disabled", true);    //TODO
-            registry.byId(this.id + "Deschedule").set("disabled", true);    //TODO
+            registry.byId(this.id + "Reschedule").set("disabled", !isNotScheduled);
+            registry.byId(this.id + "Deschedule").set("disabled", !isScheduled);
 
             this.menuProtect.set("disabled", !hasNotProtected);
             this.menuUnprotect.set("disabled", !hasProtected);

--- a/esp/src/eclwatch/templates/WUDetailsWidget.html
+++ b/esp/src/eclwatch/templates/WUDetailsWidget.html
@@ -10,6 +10,9 @@
                     <div id="${id}Delete" data-dojo-attach-event="onClick:_onDelete" data-dojo-type="dijit.form.Button">${i18n.Delete}</div>
                     <div id="${id}Restore" data-dojo-attach-event="onClick:_onRestore" data-dojo-type="dijit.form.Button">${i18n.Restore}</div>
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
+                    <div id="${id}Reschedule" data-dojo-attach-event="onClick:_onReschedule" data-dojo-type="dijit.form.Button">${i18n.Reschedule}</div>
+                    <div id="${id}Deschedule" data-dojo-attach-event="onClick:_onDeschedule" data-dojo-type="dijit.form.Button">${i18n.Deschedule}</div>
+                    <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     <div id="${id}SetToFailed" data-dojo-attach-event="onClick:_onSetToFailed" data-dojo-type="dijit.form.Button">${i18n.SetToFailed}</div>
                     <div id="${id}Abort" data-dojo-attach-event="onClick:_onAbort" data-dojo-type="dijit.form.Button">${i18n.Abort}</div>
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>


### PR DESCRIPTION
WUDetailsWidget and WUQuery needs to have Reschedule/Deschedule buttons to allow user to deschedule and reschedule workunits.

Signed-off-by: Miguel Vazquez miguel.vazquez@lexisnexis.com
