### PR TITLE
hpcc-13997 Added red error message to cluster_script.py error output

### DIFF
--- a/initfiles/sbin/cluster_script.py
+++ b/initfiles/sbin/cluster_script.py
@@ -215,7 +215,7 @@ class ScriptExecution(object):
                 no_error_found = False
         script_name = os.path.basename(self.script_file)
         if not no_error_found:
-            print("\n\nError found during " + script_name + " execution. ")
+            print("\n\n\033[91mError found during " + script_name + " execution.\033[0m")
             print("Reference following log for more information: ")
             print(self.log_file)
         else:


### PR DESCRIPTION
A really simple fix to alleviate the issue where some users don't notice an error that has occurred with hpcc-push.sh.  This modification adds red text to the error message to help alert the user to the issue, and it works for hpcc-push.sh as well as hpcc-run.sh failures.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
