### PR TITLE
HPCC-14090 Suppress MP connection closed msg for 0 bytes sent

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -24,6 +24,7 @@ allow_pgcache_flush=true
 mpStart=7101
 mpEnd=7500
 mpSoMaxConn=128
+mpTraceLevel=0
 #enable SSL for dafilesrv remote file access
 #dfsUseSSL=false
 #dfsSSLCertFile=/certfilepath/certfile

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -18,6 +18,7 @@
   <mpStart>7101</mpStart>
   <mpEnd>7500</mpEnd>
   <mpSoMaxConn>128</mpSoMaxConn>
+  <mpTraceLevel>0</mpTraceLevel>
  </EnvSettings>
  <Hardware>
   <Computer computerType="linuxmachine"

--- a/testing/regress/environment.xml.in
+++ b/testing/regress/environment.xml.in
@@ -18,6 +18,7 @@
   <mpStart>7101</mpStart>
   <mpEnd>7500</mpEnd>
   <mpSoMaxConn>128</mpSoMaxConn>
+  <mpTraceLevel>0</mpTraceLevel>
  </EnvSettings>
  <Hardware>
   <Computer computerType="linuxmachine"


### PR DESCRIPTION
Added mpTraceLevel (defaults to 0) setting to the env as an option so that if enabled MP connection attempts like this can be monitored.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
