### PR TITLE
HPCC-14104 Check getWorkflowItems() return before using

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1257,8 +1257,11 @@ void WsWuInfo::getWorkflow(IEspECLWorkunit &info, unsigned flags)
         return;
     try
     {
-        IArrayOf<IConstECLWorkflow> workflows;
         Owned<IConstWorkflowItemIterator> it = cw->getWorkflowItems();
+        if (!it)
+            return;
+
+        IArrayOf<IConstECLWorkflow> workflows;
         ForEach(*it)
         {
             IConstWorkflowItem* r = it->query();


### PR DESCRIPTION
The 6.0 ESP crashes when running ecl in ECLPLayground.
It happens when ECLPlayground calls WsWorkunits.WUINfo.
The getWorkflowItems() returns NULL when it is called in
WUInfo. WUINfo should check the return before using it.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
