### PR TITLE
HPCC-14066 Modify "Scope" translations to match

### DIFF
--- a/esp/src/eclwatch/nls/es/hpcc.js
+++ b/esp/src/eclwatch/nls/es/hpcc.js
@@ -424,7 +424,7 @@ define(
     SampleRequest: "Ejemplo del requerimiento",
     SampleResponse: "Ejemplo de la respuesta",
     Save: "Guardar",
-    Scope: "Alcance",
+    Scope: "Ámbito",
     SearchResults: "Resultados de búsqueda",
     SecondsRemaining: "Segundos que faltan",
     Security: "Seguridad",


### PR DESCRIPTION
Modify "Scope" translations from 'Alcance' to Ámbito wherever appropriate.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
