### PR TITLE
HPCC-14050 Fix issue with child filter + varying canMatchAny()

### DIFF
--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -129,7 +129,7 @@ void CSlaveActivity::setInput(unsigned index, CActivityBase *inputActivity, unsi
 {
     CActivityBase::setInput(index, inputActivity, inputOutIdx);
     Linked<IThorDataLink> outLink;
-    if (!inputActivity)
+    if (!inputActivity || container.isEof)
     {
         Owned<CActivityBase> nullAct = container.factory(TAKnull);
 


### PR DESCRIPTION
A filter with a canMatchAny() evaluating to false, caused the
graph to be truncated at that point. If these appear in a child
query and the canMatchAny() condition varies from run to run, it
causes the graph to incorrectly connected, resulting in an
assert being hit.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
