### PR TITLE
Dfuplus action=add created file without proper meta information and cause crash in Dali

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -5716,6 +5716,9 @@ void SocketEndpointArray::fromText(const char *text,unsigned defport)
     // only support 'full' IPv6 and no ranges
 
 
+    if ( !text )
+        return;
+
     char *str = strdup(text);
     char *s = str;
     SocketEndpoint ep;

--- a/system/mp/mpbase.cpp
+++ b/system/mp/mpbase.cpp
@@ -556,7 +556,8 @@ public:
     static IGroup *fromText(const char *s,unsigned defport) 
     {
         SocketEndpointArray epa;
-        epa.fromText(s,defport);
+        if ( s )
+            epa.fromText(s,defport);
         return createIGroup(epa);
     }
 


### PR DESCRIPTION
Avoid null pointer dereferencing.

This can happen when a logical file created (in the way described in
the realted JIRA issue) with partially empty metainformation. All attempt
to access or delete this file caused seg fault in the Dali.

With this fix, the wrong file can remove with
    dfuplus action=remove ...
command.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
