### PR TITLE
HPCC-14103 Remove extra client connection log msgs in DEBUG mode

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -853,11 +853,6 @@ class CRemoteBase: public CInterface
     bool                    useSSL;
     void connectSocket(SocketEndpoint &ep)
     {
-#ifdef _DEBUG
-        StringBuffer sb;
-        ep.getUrlStr(sb);
-        DBGLOG("Client connecting %sto dafilesrv %s", useSSL?"SECURE ":"", sb.str());
-#endif
         sRFTM tm;
         // called in CConnectionTable::crit
         unsigned retries = 3;


### PR DESCRIPTION
Retargeted to 5.4.0

Removed extra DEBUG logging for client connection which was recently added.
This msg is already logged if traceFlags bit 0x8 (TF_TRACE_CLIENT_CONN) is set at build time.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
