### PR TITLE
HPCC-14056 Make command line ecl-roxie-reload use of forceRetry optional

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -91,6 +91,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_DELETE_FILES "--delete"
 #define ECLOPT_DELETE_SUBFILES "--delete-subfiles"
 #define ECLOPT_DELETE_RECURSIVE "--delete-recursive"
+#define ECLOPT_RETRY "--retry"
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -313,7 +313,8 @@ ESPenum RoxieControlCmd : string
     ATTACH("Attach"),
     DETACH("Detach"),
     STATE("State"),
-    RELOAD("Reload")
+    RELOAD("Reload"),
+    RELOAD_RETRY("ReloadRetry")
 };
 
 ESPrequest RoxieControlCmdRequest

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -2036,6 +2036,8 @@ inline const char *controlCmdMessage(int cmd)
     case CRoxieControlCmd_DETACH:
         return "<control:lockDali/>";
     case CRoxieControlCmd_RELOAD:
+        return "<control:reload/>";
+    case CRoxieControlCmd_RELOAD_RETRY:
         return "<control:reload forceRetry='1' />";
     case CRoxieControlCmd_STATE:
         return "<control:state/>";


### PR DESCRIPTION
Must now specify "ecl roxie reload myroxie --retry" to do a forceRetry.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
