### PR TITLE
HPCC-12687 Roxie may retry indefinitely in localSlave mode

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -944,6 +944,8 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         }
         if (!numChannels)
             throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - numChannels calculated at 0");
+        if (numChannels > 1 && localSlave)
+            throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - localSlave requires single channel (%d channels specified)", numChannels);
         // Now we know all the channels, we can open and subscribe the multicast channels
         if (!localSlave)
             openMulticastSocket();

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -985,7 +985,7 @@ public:
                 header.toString(s);
                 logctx.logOperatorException(E, NULL, 0, "%s", s.str());
                 header.setException();
-                if (!header.allChannelsFailed())
+                if (!header.allChannelsFailed() && !localSlave)
                 {
                     if (logctx.queryTraceLevel() > 1) 
                         logctx.CTXLOG("resending packet from slave in case others want to try it");


### PR DESCRIPTION
If localSlave mode is selected and multiple channels are in use, then (a)
any request for a channel other than 1 is likely to result in an
"Unregistered query" exception, and (b) the message is then requeued for
retry and an infinite loop results.

There is no point sending retries to 'buddies' in localSlave mode since there
are no buddies. Also, put in a check at startup that localSlave is not used
with multiple channels.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
