### PR TITLE
HPCC-14097 Add multiple thor logs to ZAP report

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3850,6 +3850,9 @@ void CWsWorkunitsEx::addProcessLogfile(Owned<IConstWorkUnit>& cwu, WsWuInfo& win
         proc.getProp("@log",logSpec);
         if (!logSpec.length())
             continue;
+        const char* processName = proc.queryName();
+        if (isEmpty(processName))
+            continue;
         StringBuffer pid;
         pid.appendf("%d",proc.getPropInt("@pid"));
         MemoryBuffer mb;
@@ -3878,7 +3881,7 @@ void CWsWorkunitsEx::addProcessLogfile(Owned<IConstWorkUnit>& cwu, WsWuInfo& win
             if (*p == '\\' || *p == '/')
                 logName = p+1;
         }
-        VStringBuffer fileName("%s%c%s", path, PATHSEPCHAR, logName);
+        VStringBuffer fileName("%s%c%s_%s", path, PATHSEPCHAR, processName, logName);
         createZAPFile(fileName.str(), mb.length(), mb.bufferBase());
     }
 }


### PR DESCRIPTION
The existing ZAP report can only include one thor log.
If a WU is in >1 thor logs (load balanced Thor), the
last thor log list in WU XML is copied into the ZAP
report. This fix adds multiple thor logs to ZAP report
if related.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
