### PR TITLE
HPCC-14149 Roxie does not clear copying flag on insufficient space

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -794,6 +794,7 @@ class CRoxieFileCache : public CInterface, implements ICopyFileProgress, impleme
             IException *E = MakeStringException(ROXIE_DISKSPACE_ERROR, "%s", err.str());
             EXCLOG(MCoperatorError, E);
             E->Release();
+            f->setCopying(false);
         }
         else
         {


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
