### PR TITLE
HPCC-14050 Fix issue with child filter + varying canMatchAny()

### DIFF
--- a/docs/IMDB/IMDB.xml
+++ b/docs/IMDB/IMDB.xml
@@ -454,15 +454,13 @@ Blankline</programlisting></para>
           <listitem>
             <?dbfo keep-together="always"?>
 
-            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> and
-            <emphasis role="bold">Replicate</emphasis><emphasis role="bold">
-            </emphasis>boxes are checked.</para>
+            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> box
+            is checked. </para>
 
-            <para><emphasis role="bold">Note:</emphasis> The Replicate option
-            is only available on systems where replication has been
-            enabled.</para>
-
-            <para></para>
+            <para>If available, make sure the <emphasis
+            role="bold">Replicate</emphasis> box is checked. (The Replicate
+            option is only available on systems where replication has been
+            enabled.)</para>
           </listitem>
 
           <listitem>

--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -1646,13 +1646,13 @@ OUTPUT(L);</programlisting></para>
           <listitem>
             <?dbfo keep-together="always"?>
 
-            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> and
-            <emphasis role="bold">Replicate</emphasis><emphasis role="bold">
-            </emphasis>boxes are checked.</para>
+            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> box
+            is checked.</para>
 
-            <para><emphasis role="bold">Note:</emphasis> The <emphasis
-            role="bold">Replicate</emphasis> option is only available on
-            systems where replication has been enabled.</para>
+            <para>If available, make sure the <emphasis
+            role="bold">Replicate</emphasis> box is checked. (The Replicate
+            option is only available on systems where replication has been
+            enabled.)</para>
           </listitem>
 
           <listitem>

--- a/docs/InstantCloud/InstantCloud.xml
+++ b/docs/InstantCloud/InstantCloud.xml
@@ -1236,13 +1236,13 @@ OUTPUT(L);</programlisting></para>
           <listitem>
             <?dbfo keep-together="always"?>
 
-            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> and
-            <emphasis role="bold">Replicate</emphasis><emphasis role="bold">
-            </emphasis>boxes are checked.</para>
+            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> box
+            is checked.</para>
 
-            <para><emphasis role="bold">Note:</emphasis> The <emphasis
-            role="bold">Replicate</emphasis> option is only available on
-            systems where replication has been enabled.</para>
+            <para>If available, make sure the <emphasis
+            role="bold">Replicate</emphasis> box is checked. (The Replicate
+            option is only available on systems where replication has been
+            enabled.)</para>
           </listitem>
 
           <listitem>

--- a/docs/One-Click_HPCCinAWS/One-Click_RuningHPCCinAmazonWebServicesEC2.xml
+++ b/docs/One-Click_HPCCinAWS/One-Click_RuningHPCCinAmazonWebServicesEC2.xml
@@ -29,7 +29,7 @@
       message.</para>
 
       <para>LexisNexis and the Knowledge Burst logo are registered trademarks
-      of Reed Elsevier Properties Inc., used under license. </para>
+      of Reed Elsevier Properties Inc., used under license.</para>
 
       <para>HPCC Systems is a registered trademark of LexisNexis Risk Data
       Management Inc.</para>
@@ -40,7 +40,7 @@
       countries.</para>
 
       <para>Other products, logos, and services may be trademarks or
-      registered trademarks of their respective companies. </para>
+      registered trademarks of their respective companies.</para>
 
       <para>All names and example data used in this manual are fictitious. Any
       similarity to actual persons, living or dead, is purely
@@ -1236,9 +1236,11 @@ OUTPUT(L);</programlisting></para>
           </listitem>
 
           <listitem>
-            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> and
-            <emphasis role="bold">Replicate</emphasis><emphasis role="bold">
-            </emphasis>boxes are checked.</para>
+            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> box
+            is checked. If available, make sure the <emphasis
+            role="bold">Replicate</emphasis> box is checked. (The Replicate
+            option is only available on systems where replication has been
+            enabled.)</para>
 
             <para><figure>
                 <title>Spray the File</title>

--- a/docs/RuningHPCCinAmazonWebServicesEC2/RuningHPCCinAmazonWebServicesEC2.xml
+++ b/docs/RuningHPCCinAmazonWebServicesEC2/RuningHPCCinAmazonWebServicesEC2.xml
@@ -2698,9 +2698,11 @@ OUTPUT(L);</programlisting></para>
           </listitem>
 
           <listitem>
-            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> and
-            <emphasis role="bold">Replicate</emphasis><emphasis role="bold">
-            </emphasis>boxes are checked.</para>
+            <para>Make sure the <emphasis role="bold">Overwrite</emphasis> box
+            is checked. If available, make sure the <emphasis
+            role="bold">Replicate</emphasis> box is checked. (The Replicate
+            option is only available on systems where replication has been
+            enabled.)</para>
 
             <para><figure>
                 <title>Spray the File</title>

--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -1478,12 +1478,12 @@ OUTPUT(L);</programlisting></para>
               <?dbfo keep-together="always"?>
 
               <para>Make sure the <emphasis role="bold">Overwrite</emphasis>
-              and <emphasis role="bold">Replicate</emphasis><emphasis
-              role="bold"> </emphasis>boxes are checked.</para>
+              box is checked.</para>
 
-              <para><emphasis role="bold">Note:</emphasis> The <emphasis
-              role="bold">Replicate</emphasis> option is only available on
-              systems where replication has been enabled.</para>
+              <para>If available, make sure the <emphasis
+              role="bold">Replicate</emphasis> box is checked. (The Replicate
+              option is only available on systems where replication has been
+              enabled.)</para>
             </listitem>
 
             <listitem>

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -794,6 +794,7 @@ class CRoxieFileCache : public CInterface, implements ICopyFileProgress, impleme
             IException *E = MakeStringException(ROXIE_DISKSPACE_ERROR, "%s", err.str());
             EXCLOG(MCoperatorError, E);
             E->Release();
+            f->setCopying(false);
         }
         else
         {

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -944,6 +944,8 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         }
         if (!numChannels)
             throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - numChannels calculated at 0");
+        if (numChannels > 1 && localSlave)
+            throw MakeStringException(MSGAUD_operator, ROXIE_INVALID_TOPOLOGY, "Invalid topology file - localSlave requires single channel (%d channels specified)", numChannels);
         // Now we know all the channels, we can open and subscribe the multicast channels
         if (!localSlave)
             openMulticastSocket();

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -985,7 +985,7 @@ public:
                 header.toString(s);
                 logctx.logOperatorException(E, NULL, 0, "%s", s.str());
                 header.setException();
-                if (!header.allChannelsFailed())
+                if (!header.allChannelsFailed() && !localSlave)
                 {
                     if (logctx.queryTraceLevel() > 1) 
                         logctx.CTXLOG("resending packet from slave in case others want to try it");

--- a/thorlcr/activities/null/thnullslave.cpp
+++ b/thorlcr/activities/null/thnullslave.cpp
@@ -75,7 +75,7 @@ public:
 
     virtual bool isGrouped()
     {
-        return queryHelper()->queryOutputMeta()->isGrouped();
+        return false;
     }
 
     void getMetaInfo(ThorDataLinkMetaInfo &info)

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -330,7 +330,6 @@ public:
     IHThorArg *queryHelper() const { return baseHelper; }
 
     IPropertyTree &queryXGMML() const { return *xgmml; }
-    CActivityBase *queryActivity() const { return activity; }
     const activity_id &queryOwnerId() const { return ownerId; }
     void createActivity(size32_t parentExtractSz, const byte *parentExtract);
 //
@@ -343,6 +342,7 @@ public:
     }
     virtual bool prepareContext(size32_t parentExtractSz, const byte *parentExtract, bool checkDependencies, bool shortCircuit, bool async);
 //
+    virtual CActivityBase *queryActivity() { return activity; }
     virtual void initActivity();
     virtual CActivityBase *factory(ThorActivityKind kind) { assertex(false); return NULL; }
     virtual CActivityBase *factory() { return factory(getKind()); }

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -585,10 +585,10 @@ bool CMasterGraphElement::checkUpdate()
 void CMasterGraphElement::initActivity()
 {
     CriticalBlock b(crit);
-    bool first = (NULL == activity);
+    bool first = (NULL == queryActivity());
     CGraphElementBase::initActivity();
-    if (first || activity->needReInit())
-        ((CMasterActivity *)activity.get())->init();
+    if (first || queryActivity()->needReInit())
+        ((CMasterActivity *)queryActivity())->init();
 }
 
 void CMasterGraphElement::doCreateActivity(size32_t parentExtractSz, const byte *parentExtract)
@@ -627,7 +627,7 @@ void CMasterGraphElement::doCreateActivity(size32_t parentExtractSz, const byte 
 
 void CMasterGraphElement::slaveDone(size32_t slaveIdx, MemoryBuffer &mb)
 {
-    ((CMasterActivity *)activity.get())->slaveDone(slaveIdx, mb);
+    ((CMasterActivity *)queryActivity())->slaveDone(slaveIdx, mb);
 }
 
 

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -263,6 +263,8 @@ class CGenericSlaveGraphElement : public CSlaveGraphElement
 {
     bool wuidread2diskread; // master decides after interrogating result and sneaks in info before slave creates
     StringAttr wuidreadFilename;
+    Owned<CActivityBase> nullActivity;
+    CriticalSection nullActivityCs;
 public:
     CGenericSlaveGraphElement(CGraphBase &_owner, IPropertyTree &xgmml) : CSlaveGraphElement(_owner, xgmml)
     {
@@ -286,6 +288,18 @@ public:
                 mb.read(wuidreadFilename);
         }
         haveCreateCtx = true;
+    }
+    virtual CActivityBase *queryActivity()
+    {
+        if (isEof)
+        {
+            CriticalBlock b(nullActivityCs);
+            if (!nullActivity)
+                nullActivity.setown(createNullSlave(this));
+            return nullActivity;
+        }
+        else
+            return activity;
     }
     virtual CActivityBase *factory(ThorActivityKind kind)
     {


### PR DESCRIPTION
A filter with a canMatchAny() evaluating to false, caused the
graph to be truncated at that point. If these appear in a child
query and the canMatchAny() condition varies from run to run, it
causes the graph to incorrectly connected, resulting in an
assert being hit.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
