### PR TITLE
HPCC-14156 Modified preflight query to use new thor naming scheme

### DIFF
--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1120,15 +1120,18 @@ void Cws_machineEx::buildPreflightCommand(IEspContext& context, CMachineInfoThre
         if (!process.getName() || !*process.getName())
             continue;
 
-        if (idx < 1)
-            preflightCommand.appendf(" -n=%s", process.getName());
+        StringBuffer procName;
+        if (streq(process.getType(), eqThorSlaveProcess))
+            procName.appendf("thorslave_%s_%d,%s_slave_%d", process.getName(), process.getProcessNumber(), process.getName(), process.getProcessNumber());
+        else if (streq(process.getType(), eqThorMasterProcess))
+            procName.appendf("%s,%s_master", process.getName(), process.getName());
         else
-            preflightCommand.appendf(",%s", process.getName());
+            procName.append(process.getName());
 
-        if (process.getType() && streq(process.getType(), eqThorMasterProcess))
-            preflightCommand.append("_master");
-        else if (process.getType() && streq(process.getType(), eqThorSlaveProcess))
-            preflightCommand.appendf("_slave_%d", process.getProcessNumber());
+        if (idx < 1)
+            preflightCommand.appendf(" -n=%s", procName.str());
+        else
+            preflightCommand.appendf(",%s", procName.str());
 
         if (!process.getDependencies().empty())
             checkDependency = true;
@@ -1487,6 +1490,14 @@ bool Cws_machineEx::readStorageSpace(const char *line, StringBuffer& title, __in
     return true;
 }
 
+void Cws_machineEx::buildProcessPath(StringBuffer &processPath, const char * processName, CMachineInfoThreadParam * pParam)
+{
+    if (environmentConfData.m_pidPath.charAt(environmentConfData.m_pidPath.length() - 1) != pParam->m_machineData.getPathSep())
+        processPath.setf("%s%c%s:", environmentConfData.m_pidPath.str(), pParam->m_machineData.getPathSep(), processName);
+    else
+        processPath.setf("%s%s:", environmentConfData.m_pidPath.str(), processName);
+}
+
 void Cws_machineEx::readProcessData(const char* response, CMachineInfoThreadParam* pParam)
 {
     if (!response || !*response)
@@ -1499,19 +1510,44 @@ void Cws_machineEx::readProcessData(const char* response, CMachineInfoThreadPara
         if (!process.getName() || !*process.getName())
             continue;
 
-        StringBuffer processData, processPath;
-        if (environmentConfData.m_pidPath.charAt(environmentConfData.m_pidPath.length() - 1) != pParam->m_machineData.getPathSep())
-            processPath.appendf("%s%c%s", environmentConfData.m_pidPath.str(), pParam->m_machineData.getPathSep(), process.getName());
+        StringBuffer procName, catError, processPath, processData;
+        if (streq(process.getType(), eqThorSlaveProcess))
+        {
+            procName.appendf("thorslave_%s_%d", process.getName(), process.getProcessNumber());
+            buildProcessPath(processPath,procName.str(),pParam);
+            catError.setf("cat: %s",processPath.str());
+            catError.insert(catError.length()-1,".pid");
+            if (!strstr(response,catError.str()))
+                readALineFromResult(response, processPath.str(), processData, true);
+            else
+            {
+                procName.setf("%s_slave_%d", process.getName(), process.getProcessNumber());
+                buildProcessPath(processPath,procName.str(),pParam);
+                readALineFromResult(response, processPath.str(), processData, true);
+            }
+        }
+        else if (streq(process.getType(), eqThorMasterProcess))
+        {
+            procName.appendf("%s", process.getName());
+            buildProcessPath(processPath,procName.str(),pParam);
+            catError.setf("cat: %s",processPath.str());
+            catError.insert(catError.length()-1,".pid");
+            if (!strstr(response,catError.str()))
+                readALineFromResult(response, processPath.str(), processData, true);
+            else
+            {
+                procName.setf("%s_master", process.getName());
+                buildProcessPath(processPath,procName.str(),pParam);
+                readALineFromResult(response, processPath.str(), processData, true);
+            }
+        }
         else
-            processPath.appendf("%s%s", environmentConfData.m_pidPath.str(), process.getName());
+        {
+            procName.append(process.getName());
+            buildProcessPath(processPath,procName.str(),pParam);
+            readALineFromResult(response, processPath.str(), processData, true);
+        }
 
-        if (process.getType() && streq(process.getType(), eqThorMasterProcess))
-            processPath.append("_master");
-        else if (process.getType() && streq(process.getType(), eqThorSlaveProcess))
-            processPath.appendf("_slave_%d", process.getProcessNumber());
-        processPath.append(":");
-
-        readALineFromResult(response, processPath.str(), processData, true);
         if (processData.length() < 1)
         {
             DBGLOG("Information for process %s not found", processPath.str());

--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -783,6 +783,7 @@ private:
     void parseAddresses(const char *address, StringBuffer& address1, StringBuffer& address2);
     void readPreflightResponse(IEspContext& context, CMachineInfoThreadParam* pParam, const char *response,int error);
     void readStorageData(const char* response, CMachineInfoThreadParam* pParam);
+    void buildProcessPath(StringBuffer &buf, const char * procName,CMachineInfoThreadParam * pParam);
     void readProcessData(const char* response, CMachineInfoThreadParam* pParam);
     void readRunningProcesses(const char* response, CMachineInfoThreadParam* pParam);
     bool readStorageSpace(const char *line, StringBuffer& title, __int64& free, __int64& total, int& percentAvail);


### PR DESCRIPTION
The changes that were made in 5.4 to clean up duplicate files in /var/run/HPCCSystems had an unintended consequence of making preflight queries from eclwatch fail for thor.  Reverted the thor naming scheme for it's pid files.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
