### PR TITLE
HPCC-14166 Ensure indexcount row manager cleared

### DIFF
--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -952,12 +952,10 @@ public:
                     }
                 }
                 else
-                {
                     totalCount += (rowcount_t)klManager->getCount();
-                    if ((totalCount > choosenLimit))
-                        break;
-                }
                 callback.clearManager();
+                if ((totalCount > choosenLimit))
+                    break;
             }
             if (!container.queryLocalOrGrouped())
             {


### PR DESCRIPTION
When an indexcount choosen limit is reached, it failed to clear
the row manager and could subsequently crashed.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
