### PR TITLE
HPCC-14155 Do not log errors contacting master when slave ending cleanly

### DIFF
--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -407,6 +407,7 @@ public:
                     }
                     case Shutdown:
                     {
+                        PROGLOG("Shutdown received");
                         doReply = false;
                         stopped = true;
                         break;


### PR DESCRIPTION
Error msgs about not being to contact master during shutdown can occur not just when idle timeout is reached but also when shutting down from service.
This prevents error msgs from this case being logged if SIGTERM is received.
Perhaps ultimately master should wait for all slaves to reply back before it ends to prevent this.
Please reveiw @jakesmith @Michael-Gardner 
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
