### PR TITLE
HPCC-14155 Avoid slaves unregistering after clean shutdown request

### DIFF
--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -351,7 +351,7 @@ public:
                 msg.append((unsigned)Shutdown);
                 try
                 {
-                    queryClusterComm().send(msg, i+1, masterSlaveMpTag, MP_ASYNC_SEND);
+                    queryClusterComm().sendRecv(msg, i+1, masterSlaveMpTag, 5000);
                 }
                 catch (IMP_Exception *e) { e->Release(); }
                 catch (IException *e)

--- a/thorlcr/slave/slavmain.hpp
+++ b/thorlcr/slave/slavmain.hpp
@@ -19,7 +19,7 @@
 #define SLAVMAIN_HPP
 
 void abortSlave();
-void slaveMain();
+void slaveMain(bool &jobListenerStopped);
 void enableThorSlaveAsDaliClient();
 void disableThorSlaveAsDaliClient();
 

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -169,6 +169,8 @@ static bool RegisterSelf(SocketEndpoint &masterEp)
     return true;
 }
 
+static bool jobListenerStopped = true;
+
 void UnregisterSelf(IException *e)
 {
     StringBuffer slfStr;
@@ -196,9 +198,12 @@ bool ControlHandler(ahType type)
 {
     if (ahInterrupt == type)
         LOG(MCdebugProgress, thorJob, "CTRL-C pressed");
-    if (masterNode)
-        UnregisterSelf(NULL);
-    abortSlave();
+    if (!jobListenerStopped)
+    {
+        if (masterNode)
+            UnregisterSelf(NULL);
+        abortSlave();
+    }
     return false;
 }
 
@@ -414,7 +419,7 @@ int main( int argc, char *argv[]  )
                 else
                     multiThorMemoryThreshold = 0;
             }
-            slaveMain();
+            slaveMain(jobListenerStopped);
         }
 
         LOG(MCdebugProgress, thorJob, "ThorSlave terminated OK");


### PR DESCRIPTION
The Thor master tells the slaves to shutdown, but doesn't wait for
acknowledgement and quits, the thor scripts then send a SIGTERM
signal to the slaves, which (in a race condition) can cause the
slaves to attempt to unregister from the master, by which time
the master has quit.
As a result the slaves throw an unregistration error and log it.

This change waits for the slaves to acknowledge the shutdown and
flags not to unregister if a signal is subsequently received.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
